### PR TITLE
Evil Dataset Proof of Concept

### DIFF
--- a/evil-dataset/minidemo.py
+++ b/evil-dataset/minidemo.py
@@ -1,140 +1,157 @@
 import random
 from base64 import b64encode
 import json
+from os import urandom
 
 
 class BaseFieldProvider():
-	_field_name = None
+    _field_name = None
 
-	def __init__(self, seed=None):
-		self.random = random.Random(seed) # Each class having its own random instance is important becasue it means you get the 
-		self.value_generator = self.generate_field()
-		self._count = 0
+    def __init__(self, seed):
+        # Each class having its own random instance is important becasue it means you get the same
+        # values when you rerun it, even if new values have been added in the meantime.
+        self.random = random.Random(seed)
+        self.value_generator = self.generate_field()
+        self._count = 0
 
-	def generate(self):
-		pass
+    def generate(self):
+        pass
 
-	def generate_field(self):
-		while True:
-			yield {self._field_name: self.generate()}
+    def generate_field(self):
+        while True:
+            yield {self._field_name: self.generate()}
 
-	def generate_queries(self, version=None) -> str:
-		pass
+    def generate_queries(self, version=None) -> str:
+        pass
 
-	def generate_type_mapping(self) -> str:
-		pass
+    def generate_type_mapping(self) -> str:
+        pass
 
-	def field_name(self) -> str:
-		return self._field_name
+    def field_name(self) -> str:
+        return self._field_name
 
 
 class DocumentProvider():
-	def __init__(self, field_providers):
-		self.field_providers = field_providers
-		self.generators = [fp.value_generator for fp in self.field_providers]
+    def __init__(self, field_providers):
+        self.field_providers = field_providers
+        self.generators = [fp.value_generator for fp in self.field_providers]
 
-	def generate_document(self):
-		doc = {}
-		for field in self.generators:
-			try:
-				doc.update(next(field))
-			except StopIteration:
-				continue
-		return doc
+    def generate_document(self):
+        doc = {}
+        for field in self.generators:
+            try:
+                doc.update(next(field))
+            except StopIteration:
+                continue
+        return doc
 
-	def generate_type_mapping(self):
-		return {
-			"mappings": {
-				"properties": {
-					fp.field_name(): fp.generate_type_mapping() for fp in self.field_providers if fp.generate_type_mapping() is not None
-				}
-			}
-		}
-
+    def generate_type_mapping(self):
+        return {
+            "mappings": {
+                "properties": {
+                    fp.field_name(): fp.generate_type_mapping() for fp in self.field_providers if fp.generate_type_mapping() is not None
+                }
+            }
+        }
 
 
 class BinaryValueFieldProvider(BaseFieldProvider):
-	_field_name = "binary_value"
-	_type_mapping = {"type": "binary"}
+    _field_name = "binary_value"
+    _type_mapping = {"type": "binary"}
 
-	def __init__(self, seed=None):
-		super().__init__(seed)
+    def __init__(self, seed=None):
+        super().__init__(seed)
 
-	def generate(self) -> str:
-		length = self.random.randint(0,1000)
-		value = self.random.randbytes(length)
-		return b64encode(value).decode()
+    def generate(self) -> str:
+        length = self.random.randint(0, 1000)
+        value = self.random.randbytes(length)
+        return b64encode(value).decode()
 
-	def generate_type_mapping(self) -> dict:
-		return self._type_mapping
+    def generate_type_mapping(self) -> dict:
+        return self._type_mapping
 
 
 class ByteValueFieldProvider(BaseFieldProvider):
-	_field_name = "byte_value"
-	_type_mapping = {"type": "byte"}
+    _field_name = "byte_value"
+    _type_mapping = {"type": "byte"}
 
-	def __init__(self, seed=None):
-		super().__init__(seed)
+    def __init__(self, seed=None):
+        super().__init__(seed)
 
-	def generate(self) -> int:
-		return self.random.randrange(-128, 127, 1)
+    def generate(self) -> int:
+        return self.random.randrange(-128, 127, 1)
 
-	def generate_type_mapping(self) -> dict:
-		return self._type_mapping
+    def generate_type_mapping(self) -> dict:
+        return self._type_mapping
 
 
 class FieldNameWithDotsProvider(BaseFieldProvider):
-	_field_name = "field.with.dots"
+    _field_name = "field.with.dots"
 
-	def __init__(self, seed=None):
-		super().__init__(seed)
+    def __init__(self, seed=None):
+        super().__init__(seed)
 
-	def generate(self) -> str:
-		return "hello world"
+    def generate(self) -> str:
+        return "hello world"
 
-	def generate_field(self):
-		yield {self._field_name: self.generate()}
+    def generate_field(self):
+        yield {self._field_name: self.generate()}
 
 
 FIELDS = {
-	'data_type_coverage': [
-		BinaryValueFieldProvider,
-		ByteValueFieldProvider
-	],
-	'edge_cases': [
-		FieldNameWithDotsProvider
-	]
+    'data_type_coverage': [
+        BinaryValueFieldProvider,
+        ByteValueFieldProvider
+    ],
+    'edge_cases': [
+        FieldNameWithDotsProvider
+    ]
 }
 
 
-def main(index, n_rows, data_output_file, mapping_output_file, seed=None):
-	field_providers = [field_provider(seed) for field_provider in FIELDS['data_type_coverage'] + FIELDS['edge_cases']]
-	doc_provider = DocumentProvider(field_providers)
+def main(index, n_docs, data_output_file, mapping_output_file, field_set=None, seed=None):
+    # Python doesn't have a random.getseed() type method, so it's necessary to specifically set a seed.
+    if seed is None:
+        seed = int.from_bytes(urandom(64))
 
-	docs = []
-	for i in range(n_rows):
-		doc = doc_provider.generate_document()
-		docs.append(doc)
+    print("To reproduce this run, seed is: ", seed)
 
-	type_mapping = doc_provider.generate_type_mapping()
+    # If field_set is None, use all fields, otherwise only the selected one.
+    if field_set is None:
+        # (I know this is an ugly way to do this)
+        field_providers = [field_provider(seed) for field_provider
+                           in FIELDS['data_type_coverage'] + FIELDS['edge_cases']]
+    else:
+        field_providers = [field_provider(seed) for field_provider
+                           in FIELDS[field_set]]
 
-	index_row = {'index': {'_index': index}}
+    doc_provider = DocumentProvider(field_providers)
 
-	with open(data_output_file, 'w') as f:
-		for doc in docs:
-			f.write(json.dumps(index_row))
-			f.write("\n")
-			f.write(json.dumps(doc))
-			f.write("\n")
+    docs = []
+    for i in range(n_docs):
+        doc = doc_provider.generate_document()
+        docs.append(doc)
 
-	with open(mapping_output_file, 'w') as f:
-		json.dump(type_mapping, f)
+    # Generate type mapping and write to file.
+    type_mapping = doc_provider.generate_type_mapping()
+    with open(mapping_output_file, 'w') as f:
+        json.dump(type_mapping, f)
+
+    # Write all docs to file, formatted for an index bulk upload
+    index_row = {'index': {'_index': index}}
+    with open(data_output_file, 'w') as f:
+        for doc in docs:
+            f.write(json.dumps(index_row))
+            f.write("\n")
+            f.write(json.dumps(doc))
+            f.write("\n")
 
 
 if __name__ == "__main__":
-	main("sample_index", 10, "dataset.json", "mapping.json")
+    print("Simple use case where all fields are included and no seed is provided. Data output to `dataset.json` and `mapping.json`")
+    main("sample_index", 10, "dataset.json", "mapping.json")
 
-# curl -XPUT 'https://localhost:9202/sample_index?pretty' -ku "admin:admin" -H "Content-Type: application/x-ndjson" --data-binary @mapping.json
-# curl -XPOST 'https://localhost:9202/_bulk?pretty' -ku "admin:admin" -H "Content-Type: application/x-ndjson" --data-binary @dataset.json
-# curl 'https://localhost:9202/sample_index/_count?pretty' -ku "admin:admin"
-# curl 'https://localhost:9202/sample_index/_mappings?pretty' -ku "admin:admin"
+    print()
+    print("Example with only the data_type_coverage fields. Data output to `data_type_coverage_dataset.json` and `data_type_coverage_mapping.json`")
+    main("data_type_coverage_index", 20, "data_type_coverage_dataset.json",
+         "data_type_coverage_mapping.json", field_set='data_type_coverage', seed=10)

--- a/evil-dataset/minidemo.py
+++ b/evil-dataset/minidemo.py
@@ -1,0 +1,140 @@
+import random
+from base64 import b64encode
+import json
+
+
+class BaseFieldProvider():
+	_field_name = None
+
+	def __init__(self, seed=None):
+		self.random = random.Random(seed) # Each class having its own random instance is important becasue it means you get the 
+		self.value_generator = self.generate_field()
+		self._count = 0
+
+	def generate(self):
+		pass
+
+	def generate_field(self):
+		while True:
+			yield {self._field_name: self.generate()}
+
+	def generate_queries(self, version=None) -> str:
+		pass
+
+	def generate_type_mapping(self) -> str:
+		pass
+
+	def field_name(self) -> str:
+		return self._field_name
+
+
+class DocumentProvider():
+	def __init__(self, field_providers):
+		self.field_providers = field_providers
+		self.generators = [fp.value_generator for fp in self.field_providers]
+
+	def generate_document(self):
+		doc = {}
+		for field in self.generators:
+			try:
+				doc.update(next(field))
+			except StopIteration:
+				continue
+		return doc
+
+	def generate_type_mapping(self):
+		return {
+			"mappings": {
+				"properties": {
+					fp.field_name(): fp.generate_type_mapping() for fp in self.field_providers if fp.generate_type_mapping() is not None
+				}
+			}
+		}
+
+
+
+class BinaryValueFieldProvider(BaseFieldProvider):
+	_field_name = "binary_value"
+	_type_mapping = {"type": "binary"}
+
+	def __init__(self, seed=None):
+		super().__init__(seed)
+
+	def generate(self) -> str:
+		length = self.random.randint(0,1000)
+		value = self.random.randbytes(length)
+		return b64encode(value).decode()
+
+	def generate_type_mapping(self) -> dict:
+		return self._type_mapping
+
+
+class ByteValueFieldProvider(BaseFieldProvider):
+	_field_name = "byte_value"
+	_type_mapping = {"type": "byte"}
+
+	def __init__(self, seed=None):
+		super().__init__(seed)
+
+	def generate(self) -> int:
+		return self.random.randrange(-128, 127, 1)
+
+	def generate_type_mapping(self) -> dict:
+		return self._type_mapping
+
+
+class FieldNameWithDotsProvider(BaseFieldProvider):
+	_field_name = "field.with.dots"
+
+	def __init__(self, seed=None):
+		super().__init__(seed)
+
+	def generate(self) -> str:
+		return "hello world"
+
+	def generate_field(self):
+		yield {self._field_name: self.generate()}
+
+
+FIELDS = {
+	'data_type_coverage': [
+		BinaryValueFieldProvider,
+		ByteValueFieldProvider
+	],
+	'edge_cases': [
+		FieldNameWithDotsProvider
+	]
+}
+
+
+def main(index, n_rows, data_output_file, mapping_output_file, seed=None):
+	field_providers = [field_provider(seed) for field_provider in FIELDS['data_type_coverage'] + FIELDS['edge_cases']]
+	doc_provider = DocumentProvider(field_providers)
+
+	docs = []
+	for i in range(n_rows):
+		doc = doc_provider.generate_document()
+		docs.append(doc)
+
+	type_mapping = doc_provider.generate_type_mapping()
+
+	index_row = {'index': {'_index': index}}
+
+	with open(data_output_file, 'w') as f:
+		for doc in docs:
+			f.write(json.dumps(index_row))
+			f.write("\n")
+			f.write(json.dumps(doc))
+			f.write("\n")
+
+	with open(mapping_output_file, 'w') as f:
+		json.dump(type_mapping, f)
+
+
+if __name__ == "__main__":
+	main("sample_index", 10, "dataset.json", "mapping.json")
+
+# curl -XPUT 'https://localhost:9202/sample_index?pretty' -ku "admin:admin" -H "Content-Type: application/x-ndjson" --data-binary @mapping.json
+# curl -XPOST 'https://localhost:9202/_bulk?pretty' -ku "admin:admin" -H "Content-Type: application/x-ndjson" --data-binary @dataset.json
+# curl 'https://localhost:9202/sample_index/_count?pretty' -ku "admin:admin"
+# curl 'https://localhost:9202/sample_index/_mappings?pretty' -ku "admin:admin"


### PR DESCRIPTION
### Description
This is a proof of concept for some basic functionality for the Evil Dataset (see issue #9).

Start at line 150 to follow the code flow. It creates two sets of documents. One is fully randomized and tests the three field types provided: a binary value, a byte value, and a field name with dots. It produces two files: `mapping.json` is the field mappings for each of these, and `dataset.json` is not actually a true json file, but  a file formatted for the bulk insert api (alternating "instruction" rows and document rows).

As an example of very basic usage:
```sh
> python minidemo.py
Simple use case where all fields are included and no seed is provided. Data output to `dataset.json` and `mapping.json`
To reproduce this run, seed is:  3108564913880669063593428298077914683726321598472525757388134157032495358457298518880697504552004819469647996251925412984152210312993115214881529317039488

Example with only the data_type_coverage fields. Data output to `data_type_coverage_dataset.json` and `data_type_coverage_mapping.json`
To reproduce this run, seed is:  10

# Create a new index ("sample_index") with the generated mapping file.
> cat mapping.json
{"mappings": {"properties": {"binary_value": {"type": "binary"}, "byte_value": {"type": "byte"}}}}

> curl -XPUT 'https://localhost:9200/sample_index?pretty' -ku "admin:admin" -H "Content-Type: application/x-ndjson" --data-binary @mapping.json
{
  "acknowledged" : true,
  "shards_acknowledged" : true,
  "index" : "sample_index"
}

# Load the data.
> curl -XPOST 'https://localhost:9200/_bulk?pretty' -ku "admin:admin" -H "Content-Type: application/x-ndjson" --data-binary @dataset.json
[skipping output here]

# Verify the data was loaded 
> curl 'https://localhost:9200/sample_index/_count?pretty' -ku "admin:admin"
{
  "count" : 10,
  "_shards" : {
    "total" : 1,
    "successful" : 1,
    "skipped" : 0,
    "failed" : 0
  }
}
```

A few notes about this POC:
- It doesn't generate queries to accompany the data, which would be an integral part of the real solution.  This is sketched out in BaseFieldProvider, but I haven't gone deep enough to actually build it out.
- The second example situation uses the categorization of fields (lines 101 to 109) to create a partial dataset (i.e. limit the width). A more fully-formed solution here might use tags instead of categories to provide a bit more flexibility here.
- The `field.with.dots` example is trivial but demonstrates a simple case where a field is included in the first document generated, but not in subsequent documents (examine the generated `dataset.json` file to see this).


### Issues Resolved
Related to #9 , but doesn't resolve.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
