### PR TITLE
Add initial maintainer files and templates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# This should match the owning team set up in https://github.com/orgs/opensearch-project/teams
+*   @opensearch-project/opensearch-migrations

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,22 @@
+### Description
+[Describe what this change achieves]
+* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)
+* Why these changes are required?
+* What is the old behavior before changes and new behavior after changes?
+
+### Issues Resolved
+[List any issues this PR will resolve]
+
+Is this a backport? If so, please add backport PR # and/or commits #
+
+### Testing
+[Please provide details of testing done: unit testing, integration testing and manual testing]
+
+### Check List
+- [ ] New functionality includes testing
+  - [ ] All tests pass, including unit test, integration test and doctest
+- [ ] New functionality has been documented
+- [ ] Commits are signed per the DCO using --signoff
+
+By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
+For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

--- a/.github/release-notes-drafter-config.yml
+++ b/.github/release-notes-drafter-config.yml
@@ -1,0 +1,24 @@
+# Configuration for Release Drafter: https://github.com/toolmantim/release-drafter
+template: |
+  Compatible with OpenSearch (set version here).
+  $CHANGES
+
+# Setting the formatting and sorting for the release notes body
+name-template: Version (set version here)
+change-template: '* $TITLE ([#$NUMBER](https://github.com/opensearch-project/opensearch-migrations/pull/$NUMBER))'
+sort-by: merged_at
+sort-direction: ascending
+replacers:
+  - search: "##"
+    replace: "###"
+
+# Organizing the tagged PRs into unified ODFE categories
+categories:
+  - title: "Enhancements"
+    labels: "enhancement"
+
+  - title: "Bug fixes"
+    labels: "bug"
+
+  - title: "Maintenance"
+    labels: "maintenance"


### PR DESCRIPTION
Signed-off-by: Omar Khasawneh <okhasawn@amazon.com>

### Description
The purpose of this PR is to add initial maintainer files and templates to OS Migrations repo.

### Issues Resolved
Closes [#19]

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
