### PR TITLE
Add basic container create/remove for docker lib

### DIFF
--- a/upgrades/run_docker_lib_demo.py
+++ b/upgrades/run_docker_lib_demo.py
@@ -1,0 +1,81 @@
+import logging
+import sys
+from docker.types import Ulimit
+from upgrade_testing_framework.core.docker_framework_client import DockerFrameworkClient
+
+
+'''
+Sample demo file to start a three node cluster with attached volumes, network, and default environment settings. To be deleted once docker 
+library is in good state
+
+'''
+def gen_default_opensearch_env(manager_nodes: str, node_name: str, discovery_seed_hosts: str,
+                               security_disabled='false', cluster_name='opensearch-cluster', additional_settings=None) -> dict:
+    env_settings = {'cluster.initial_cluster_manager_nodes': manager_nodes,
+                    'plugins.security.disabled': security_disabled,
+                    'cluster.name': cluster_name,
+                    'node.name': node_name,
+                    'discovery.seed_hosts': discovery_seed_hosts,
+                    'bootstrap.memory_lock': 'true',
+                    'OPENSEARCH_JAVA_OPTS': '-Xms512m -Xmx512m'}
+    if type(additional_settings) is dict:
+        env_settings.update(additional_settings)
+    return env_settings
+
+
+def gen_default_opensearch_ulimits() -> list:
+    ulimits = [Ulimit(name='memlock', soft=-1, hard=-1),
+               Ulimit(name='nofile', soft=65536, hard=65536)]
+    return ulimits
+
+
+
+def main():
+    # Will use custom logger in future, shortcut for log visibility now
+    logger = logging.getLogger()
+    logger.setLevel(logging.DEBUG)
+    handler = logging.StreamHandler(sys.stdout)
+    handler.setLevel(logging.DEBUG)
+    formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
+
+    docker_client = DockerFrameworkClient(logger=logger)
+
+    network = docker_client.create_network("opensearch-net")
+    volume1 = docker_client.create_volume("os-data1")
+    volume2 = docker_client.create_volume("os-data2")
+    volume3 = docker_client.create_volume("os-data3")
+    master_nodes = "opensearch-node1, opensearch-node2, opensearch-node3"
+    container1 = docker_client.create_container('opensearchproject/opensearch:2.3.0', 'opensearch-node1', 'opensearch-net',
+                                                {'9200': '9200', '9600': '9600'},
+                                                {'os-data1': {'bind': '/usr/share/opensearch/data', 'mode': 'rw'}},
+                                                gen_default_opensearch_ulimits(),
+                                                gen_default_opensearch_env(master_nodes, "opensearch-node1", master_nodes,
+                                                                           security_disabled='true'))
+    container2 = docker_client.create_container('opensearchproject/opensearch:2.3.0', 'opensearch-node2', 'opensearch-net',
+                                                None, {'os-data2': {'bind': '/usr/share/opensearch/data', 'mode': 'rw'}},
+                                                gen_default_opensearch_ulimits(),
+                                                gen_default_opensearch_env(master_nodes, "opensearch-node2", master_nodes,
+                                                                           security_disabled='true'))
+    container3 = docker_client.create_container('opensearchproject/opensearch:2.3.0', 'opensearch-node3', 'opensearch-net',
+                                                None, {'os-data3': {'bind': '/usr/share/opensearch/data', 'mode': 'rw'}},
+                                                gen_default_opensearch_ulimits(),
+                                                gen_default_opensearch_env(master_nodes, "opensearch-node3", master_nodes,
+                                                                           security_disabled='true'))
+
+    # Additional demo code to wait and clean up resources as containers are manually stopped
+    container1.wait()
+    docker_client.remove_container(container1)
+    docker_client.remove_volume(volume1)
+    container2.wait()
+    docker_client.remove_container(container2)
+    docker_client.remove_volume(volume2)
+    container3.wait()
+    docker_client.remove_container(container3)
+    docker_client.remove_volume(volume3)
+    docker_client.remove_network(network)
+
+
+if __name__ == "__main__":
+    main()

--- a/upgrades/setup.py
+++ b/upgrades/setup.py
@@ -9,6 +9,7 @@ setuptools.setup(
     packages=setuptools.find_packages(where="upgrade_testing_framework"),
     install_requires=[
         "coloredlogs",
+        "docker",
         "pexpect",
         "py",
         "pytest"

--- a/upgrades/tests/test_docker_framework_client.py
+++ b/upgrades/tests/test_docker_framework_client.py
@@ -1,0 +1,97 @@
+import pytest
+import unittest.mock as mock
+from docker.types import Ulimit
+from docker.errors import ImageNotFound, NotFound
+from upgrade_testing_framework.core.docker_framework_client import DockerFrameworkClient, RemoveRunningContainerException, ExistingContainerException
+
+
+class EndTestExpectedException(Exception):
+    pass
+
+
+@mock.patch('upgrade_testing_framework.core.docker_framework_client.docker.client.DockerClient')
+def test_WHEN_create_container_called_THEN_executes_normally(mock_sdk_client):
+    # Test values
+    mock_sdk_client.containers.get.side_effect = NotFound(message="Not found")
+    mock_sdk_client.images.get.return_value = None
+    mock_sdk_client.containers.run.side_effect = EndTestExpectedException()
+    docker_client = DockerFrameworkClient(docker_client=mock_sdk_client)
+
+    # Run our test
+    with pytest.raises(EndTestExpectedException):
+        docker_client.create_container('opensearchproject/sample:1.0.0', 'test-node1', None, {'9200': '9200'}, {'bind': '/test'},
+                                       [Ulimit(name='memlock', soft=-1, hard=-1)], {'cluster.name': 'test-cluster'})
+
+    # Check our results
+    assert mock_sdk_client.containers.get.called
+    assert mock_sdk_client.images.get.called
+    assert mock_sdk_client.containers.run.called
+    expected_calls = [mock.call('opensearchproject/sample:1.0.0', name='test-node1', network=None, ports={'9200': '9200'},
+                                volumes={'bind': '/test'}, ulimits=[{'Name': 'memlock', 'Soft': -1, 'Hard': -1}], detach=True,
+                                environment={'cluster.name': 'test-cluster'})]
+    assert expected_calls == mock_sdk_client.containers.run.call_args_list
+
+
+@mock.patch('upgrade_testing_framework.core.docker_framework_client.docker.client.DockerClient')
+def test_WHEN_create_container_called_AND_container_name_exists_THEN_throws_error(mock_sdk_client):
+    # Test values
+    mock_sdk_client.containers.get.return_value = None
+    docker_client = DockerFrameworkClient(docker_client=mock_sdk_client)
+
+    # Run our test
+    with pytest.raises(ExistingContainerException):
+        docker_client.create_container('opensearchproject/sample:1.0.0', 'test-node1', None, None, None,None, None)
+
+    # Check our results
+    assert mock_sdk_client.containers.get.called
+
+
+@mock.patch('upgrade_testing_framework.core.docker_framework_client.docker.client.DockerClient')
+def test_WHEN_create_container_called_AND_image_does_not_exist_locally_THEN_fetches_image(mock_sdk_client):
+    # Test values
+    mock_sdk_client.containers.get.side_effect = NotFound(message="Not found")
+    mock_sdk_client.images.get.side_effect = ImageNotFound(message="Image not found")
+    mock_sdk_client.images.pull.side_effect = EndTestExpectedException()
+    docker_client = DockerFrameworkClient(docker_client=mock_sdk_client)
+
+    # Run our test
+    with pytest.raises(EndTestExpectedException):
+        docker_client.create_container('opensearchproject/sample:1.0.0', 'test-node1', None, None, None,None, None)
+
+    # Check our results
+    assert mock_sdk_client.images.get.called
+    assert mock_sdk_client.images.pull.called
+
+
+@mock.patch('upgrade_testing_framework.core.docker_framework_client.docker.models.containers.Container')
+def test_WHEN_remove_container_called_THEN_executes_normally(mock_container):
+    # Test values
+    docker_client = DockerFrameworkClient()
+
+    # Run our test
+    docker_client.remove_container(mock_container)
+
+    # Check our results
+    expected_calls = [mock.call()]
+    assert expected_calls == mock_container.remove.call_args_list
+
+
+@mock.patch('upgrade_testing_framework.core.docker_framework_client.docker.models.containers.Container')
+def test_WHEN_remove_container_called_AND_container_is_running_THEN_throws_error(mock_container):
+    # Test values
+    mock_container.attrs = {'State': 'running'}
+    docker_client = DockerFrameworkClient()
+
+    # Run our test/Check result
+    with pytest.raises(RemoveRunningContainerException):
+        docker_client.remove_container(mock_container)
+
+
+def test_WHEN_remove_container_called_AND_container_is_wrong_type_THEN_throws_error():
+    # Test values
+    container_none = None
+    docker_client = DockerFrameworkClient()
+
+    # Run our test/Check result
+    with pytest.raises(TypeError):
+        docker_client.remove_container(container_none)

--- a/upgrades/upgrade_testing_framework/core/docker_framework_client.py
+++ b/upgrades/upgrade_testing_framework/core/docker_framework_client.py
@@ -1,0 +1,115 @@
+import logging
+import docker.client
+from docker.errors import ImageNotFound, NotFound
+from docker.models.networks import Network
+from docker.models.containers import Container
+from docker.models.volumes import Volume
+
+
+class RemoveRunningContainerException(Exception):
+    def __init__(self, container: Container):
+        self.container = container
+        super().__init__("A running container should be stopped before attempting to remove: {}".format(container.id))
+
+
+class ExistingContainerException(Exception):
+    def __init__(self, container_name: str):
+        self.container_name = container_name
+        super().__init__("There already exists a container with the name: {}".format(container_name))
+
+
+class DockerFrameworkClient:
+
+    def __init__(self, logger=logging.getLogger(__name__), docker_client=docker.from_env()):
+        # TODO: Use a custom logger
+        self.logger = logger
+        self.docker_client = docker_client
+
+    def is_container_running(self, container: Container) -> bool:
+        # TODO: Make more robust, case where this attr is not valid
+        if container is None:
+            raise TypeError("Provided argument is not of type docker.models.containers.Container")
+        container_state = container.attrs['State']
+        return container_state == 'running'
+
+    def does_container_exist(self, container_name: str) -> bool:
+        try:
+            self.docker_client.containers.get(container_id=container_name)
+        except NotFound:
+            return False
+        else:
+            return True
+
+    def does_image_exist_locally(self, image: str) -> bool:
+        try:
+            self.docker_client.images.get(image)
+        except ImageNotFound:
+            return False
+        else:
+            return True
+
+    def create_container(self, image: str, container_name: str, network_name: str, ports: dict, volumes: dict, ulimits: list,
+                         environment: dict) -> Container:
+        """
+        After performing some basic sanity checks, this function will create and start a Docker container with the supplied parameters
+
+        :param image: The docker image to run, i.e. opensearchproject/opensearch:2.4.0
+        :param container_name: The docker container name
+        :param network_name: The existing network this container will connect to at creation time, i.e. opensearch-net
+        :param ports: A dictionary of ports to bind inside container, i.e. {'9200': '9200', '9600': '9600'}
+        :param volumes: A dictionary of volumes to mount, i.e. {'vol1': {'bind': '/usr/share/opensearch/data', 'mode': 'rw'}}
+        :param ulimits: A list of docker.types.Ulimit instances to limit resource utilization, i.e. [Ulimit(name='memlock', soft=-1, hard=-1)]
+        :param environment: A dictionary of environment fields to be used by the container process, i.e. {'node.name': 'opensearch-node1'}
+        :return: Container object for the running container
+
+        For Docker specific details on parameters see: https://docker-py.readthedocs.io/en/stable/containers.html
+        """
+
+        # Further checks to add:
+        # Check if volume exists
+        # Sanity on image str
+        # Check that docker service is up
+        # Check docker sanity
+        # Check for adequate disk space
+        # Check for restricted ports
+        # Check for necessary environment fields
+
+        if self.does_container_exist(container_name):
+            raise ExistingContainerException(container_name)
+
+        if not self.does_image_exist_locally(image):
+            self.logger.info("Docker image {} not found locally. Attempting to fetch from remote repository...".format(image))
+            self.docker_client.images.pull(image)
+
+        self.logger.debug("Creating container named: {}".format(container_name))
+        container = self.docker_client.containers.run(image, name=container_name, network=network_name, ports=ports, volumes=volumes,
+                                                      ulimits=ulimits,
+                                                      detach=True,
+                                                      environment=environment)
+        return container
+
+    def remove_container(self, container: Container):
+        if container is None:
+            raise TypeError("Provided argument is not of type docker.models.containers.Container")
+        if self.is_container_running(container):
+            raise RemoveRunningContainerException(container)
+        self.logger.debug("Removing container: {}".format(container.id))
+        container.remove()
+
+    def create_network(self, name: str, driver="bridge") -> Network:
+        # TODO: Additional checks and testing needed
+        network = self.docker_client.networks.create(name, driver=driver)
+        return network
+
+    def remove_network(self, network: Network):
+        # TODO: Additional checks and testing needed
+        network.remove()
+
+    def create_volume(self, name: str) -> Volume:
+        # TODO: Additional checks and testing needed
+        volume = self.docker_client.volumes.create(name)
+        return volume
+
+    def remove_volume(self, volume: Volume):
+        # TODO: Additional checks and testing needed
+        volume.remove()


### PR DESCRIPTION
### Description
This change is to outline a bare-bones docker library to be used in this framework for starting and stopping a definable cluster. The `create_container` and `remove_container` have been fleshed out a little more to give a better picture of how these functions are planned to be expanded on. Also included is a sample script to run and demo these functions.

The goals of this PR are:
* To set direction early as to what would be helpful to have for this docker library (or maybe isn't necessary)
* What you would like to see added outside of the basic functions here
* Solicit critique for Python usage and best practices for a noob :smiley:

### Issues Resolved
* https://github.com/opensearch-project/opensearch-migrations/issues/16

### Testing
* Added unit tests for the code
* Added demo script for starting a cluster using this library

### Check List
- [x] New functionality includes testing
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
