### PR TITLE
Add python tests with coverage workflow

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,0 +1,31 @@
+name: python-tests
+
+on: [push, pull_request]
+
+jobs:
+  test-linux:
+    strategy:
+      matrix:
+        python-version: ['3.10']
+        os: [ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        working-directory: ./upgrades
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install Dependencies for Framework and Test Coverage
+        run: |
+          python -m pip install -r requirements.txt coverage pytest-cov
+      - name: Run Tests with Coverage
+        run: |
+          python -m pytest tests/ --cov=upgrade_testing_framework --cov-report=xml --cov-branch
+      - name: Upload Coverage Report
+        uses: codecov/codecov-action@v3
+        with:
+          files: upgrades/coverage.xml


### PR DESCRIPTION
Signed-off-by: Tanner Lewis <lewijacn@amazon.com>

### Description
This change is to execute our python unit tests on opening of a PR and updates to a PR. It will also include code coverage to be added as a comment to the PR

### Issues Resolved

### Testing
Verified workflow is successful on personal fork
* https://github.com/lewijacn/opensearch-migrations/actions/runs/3641127326/jobs/6146687419

### Items of Note
Two things I have noticed which are not blockers but may warrant minor additions in future
* Code coverage should be uploaded to the issue without token on codecov/codecov-action@v3 for public repos but this was not the case for my personal fork. This does not fail the Upload Coverage Report step as can be seen, but if this occurs for our migrations repo as well we may need a codecov repo upload token to work properly. I have seen other repos in OS which have included this and some that have not.
* Although using the same trigger `on: [push, pull_request]` seen in other OS projects, my personal fork would run this workflow twice whenever an open PR received an additional commit (once for both triggers). If this is the case, I have a fix in mind to limit this but other repos do not appear to have additional logic for this.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
