### PR TITLE
Migrate in csv-to-os tool & snapshot-and-restore docker walkthrough

### DIFF
--- a/dev-tools/csv-to-os/README.md
+++ b/dev-tools/csv-to-os/README.md
@@ -1,0 +1,44 @@
+# CSV-to-OS Tool
+
+This is a python tool that helps to load a csv into an OpenSearch/ElasticSearch cluster.
+
+## Functions
+- Load a csv and reformat into doc-based json, suitable for upload to an OpenSearch cluster.
+- Accept a cluster hostname/port and auth info and load the data using the bulk upload api.
+- Identify whether the destination index already exists and create it if not, including using provided settings/data mappings
+- Break large datasets up into manageable pieces for uploading.
+
+## Usage
+```
+> pip install requirements.txt
+> ./csv_to_os.py --help
+usage: csv_to_os.py [-h] [--index-settings INDEX_SETTINGS] --index INDEX --host HOST --port PORT [--user [USER]] input_file
+
+positional arguments:
+  input_file            CSV file to be sent to ES/OS.
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --index-settings INDEX_SETTINGS
+                        JSON file with mappings and/or settings to create an index.
+  --index INDEX         Name of the index to add the data to.
+  --host HOST           Host of the ES/OS cluster
+  --port PORT           Port to reach the ES/OS cluster
+  --user [USER]         If authentication to the cluster is necessary, a USERNAME:PASSWORD string.
+```
+
+The input file must be a CSV where the first row is column headers with the field names you'd like to use. It may be necessary to do pre-processing on the data to prepare it to be used by this script.
+The other required fields are the name of the index and the host and port to reach the cluster.
+When invoked with just those fields, the script will create a connection to the cluster, create the index if necessary, reformat the data (doc-oriented, add `_index` and `_id`) and use the `_bulk` upload API to load up to 10,000 rows at a time.
+
+An index settings file is a json that can include `settings` and `mappings` sections to specify the number/types of shards and the field mappings for the documents (see `examples/nyc-taxi-settings.json`).
+
+The username/password is necessary to authenticate to the cluster in some cases (specifically including the default setup of the managed service).
+
+
+## Todos
+- Refactor to keep data-reformmating and data-uploading seperate and independently invokable
+- Support more robust mechanism to assign `_id` to docs (current method is suceptible to overwriting docs)
+- Other necessary authentication mechanisms?
+- More robust mechanism to determine data rows per request (and configurable on command line)
+- Check size of csv and don't load it all into memory if it's huge (not sure what defaults Pandas has around this)

--- a/dev-tools/csv-to-os/csv_to_os.py
+++ b/dev-tools/csv-to-os/csv_to_os.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+import argparse
+import pathlib
+import json
+import sys
+
+import pandas as pd
+import numpy as np
+from opensearchpy import OpenSearch
+import opensearchpy
+from tqdm import tqdm
+
+
+MAX_ROWS_PER_REQUEST = 10000  # This is a total guess! Adjust it to your data.
+# On my test sample, this meant ~150 seperate requests or a bit less than 1 Mb each, so that seemed reasonable.
+MAX_RETRIES = 3
+
+parser = argparse.ArgumentParser()
+parser.add_argument('input_file', type=pathlib.Path,
+                    help='CSV file to be sent to ES/OS.')
+parser.add_argument('--index-settings', type=pathlib.Path,
+                    help='JSON file with mappings and/or settings to create an index.')
+parser.add_argument('--index', required=True,
+                    help='Name of the index to add the data to.')
+parser.add_argument('--host', required=True, help='Host of the ES/OS cluster')
+parser.add_argument('--port', required=True, type=int,
+                    help='Port to reach the ES/OS cluster')
+parser.add_argument('--user', nargs='?', default=None,
+                    help='If authentication to the cluster is necessary, a USERNAME:PASSWORD string.')
+
+
+class OpenSearchClientSetupError(Exception):
+    def __init__(self, failure_reason: str):
+        self.failure_reason = failure_reason
+        super().__init__(
+            f"Setup of OpenSearch client failed; ping check unsuccessful.  Reason: {self.failure_reason}"
+        )
+
+
+def _create_client(host, port, user=None, password=None):
+    if user and password:
+        auth = (user, password)
+    else:
+        auth = None
+    client = OpenSearch(
+        hosts=[f"{host}:{port}"],
+        host_compress=True,
+        http_auth=auth,
+        use_ssl=True if 'https' in host else False,
+        verify_certs=True if not 'localhost' in host else False,
+        ssl_show_warn=False
+    )
+    # Test whether client connection works (fail fast)
+    try:
+        if not client.ping():
+            raise OpenSearchClientSetupError(
+                "Cluster did not respond and may not be running.")
+    except opensearchpy.exceptions.ConnectionError as ex:
+        raise OpenSearchClientSetupError(ex.info)
+    return client
+
+
+def _does_index_exist(client, index):
+    return client.indices.exists(index)
+
+
+def _load_index_settings(index_settings_file):
+    with index_settings_file.open() as source:
+        body = json.load(source)
+    return body
+
+
+def _create_index(client, index_name, index_settings=None):
+    response = client.indices.create(
+        index_name, body=index_settings if index_settings else "")
+    print(response)
+
+
+def _load_to_dataframe(input_file):
+    df = pd.read_csv(input_file)
+    print(df.info(verbose=False))
+    return df
+
+
+def _add_os_columns_to_df(df, index):
+    """ Add _index and _id columns to a dataframe and remap the numpy NaN (not a number) values to 'None'.
+
+    OpenSearch docs using the bulk upload (can) have two additional fields. _index is required if it's not
+    present in the _bulk api request path and _id is optional but if it's not present, OS will automatically
+    assign an id. Assigning it intentionally allows this script to be idempotent.
+    If there is an `id` field in the dataframe, it is used as the _id, otherwise the dataframe index (generally
+    equivalent to the row number) is used.
+
+    # TODO: using the df index as _id has high collision potential if there is already data in the OS index.
+    """
+    df = df.replace({np.nan: None})
+    df['_index'] = index
+    if 'id' in df.columns:
+        df = df.rename(columns={"id": "_id"})
+    else:
+        df['_id'] = df.index
+    return df
+
+
+def _create_page_of_records(df, starting_index, page_size):
+    return df.iloc[starting_index:starting_index+page_size].to_dict('records')
+
+
+def _simple_bulk_insert(client, index, df):
+    response = opensearchpy.helpers.bulk(client,
+                                         df.to_dict('records'),
+                                         max_retries=MAX_RETRIES)
+    print(response)
+
+
+def _paginated_bulk_insert(client, index, df):
+    n_pages = len(df) // MAX_ROWS_PER_REQUEST + 1
+    print(
+        f"The records will be split into {n_pages} pages of up to {MAX_ROWS_PER_REQUEST} records."
+    )
+    for page in tqdm(range(n_pages)):
+        response = opensearchpy.helpers.bulk(
+            client,
+            _create_page_of_records(
+                df, page*MAX_ROWS_PER_REQUEST, MAX_ROWS_PER_REQUEST),
+            max_retries=MAX_RETRIES
+        )
+
+
+if __name__ == "__main__":
+    args = parser.parse_args()
+    print("Args:")
+    for k, v in vars(args).items():
+        print(f"{k}: {v}")
+    print()
+
+    # Create the OpenSearch client
+    print("Creating the OpenSearch client.")
+    try:
+        client = _create_client(
+            args.host, args.port, *(args.user.split(':')) if args.user else (None, None))
+    except OpenSearchClientSetupError as ex:
+        print("Setting up the client failed.")
+        print(ex)
+        sys.exit(1)
+
+    # If index settings are being specified, check whether the index exists and create it if not.
+    if args.index_settings:
+        index_exists = _does_index_exist(client, args.index)
+        if index_exists:
+            raise ValueError(
+                'Cannot use index_settings file because the index already exists.')
+        else:
+            print("Creating index.")
+            index_settings = _load_index_settings(args.index_settings)
+            _create_index(client, args.index, index_settings)
+
+    # Load input_file in pandas.
+    print("Loading csv.")
+    df = _load_to_dataframe(args.input_file)
+    df = _add_os_columns_to_df(df, args.index)
+    if len(df) <= MAX_ROWS_PER_REQUEST:
+        print("Sending a single bulk insert.")
+        _simple_bulk_insert(client, args.index, df)
+    else:
+        print("Preparing paginated bulk inserts.")
+        _paginated_bulk_insert(client, args.index, df)

--- a/dev-tools/csv-to-os/example/README.md
+++ b/dev-tools/csv-to-os/example/README.md
@@ -1,0 +1,26 @@
+# NYC Taxi Data
+
+A nice sample dataset is the NYC Taxi Data available and already cleaned up on Kaggle.
+https://www.kaggle.com/competitions/nyc-taxi-trip-duration/data
+
+This data requires a bit of pre-processing to best take advantage of OS. Specifically, the latitude and longitude fields need to be combined so that OS can interpret them as a geopoint. I also dropped the `store_and_fwd_flag` field because I wasn't interested in it.
+
+The following code can be run on the dataset to prepare it in this way.
+
+```
+#!/usr/bin/env python
+import pandas as pd
+
+df = pd.read_csv('train.csv')
+df['dropoff_location'] = df.apply(lambda x: '%s,%s' % (x['dropoff_latitude'], x['dropoff_longitude']), axis=1)
+df['pickup_location'] = df.apply(lambda x: '%s,%s' % (x['pickup_latitude'], x['pickup_longitude']), axis=1)
+df = df.drop(['pickup_longitude', 'pickup_latitude', 'dropoff_longitude', 'dropoff_latitude', 'store_and_fwd_flag'], axis=1)
+df.to_csv('nyc-taxi-data.csv', index=False)
+```
+
+In this directory there's also the `index-settings` file that I used in creating the index. Additional shards probably aren't strictly necessary here, and some of the type mappings could likely be determined dynamically, but I went with directly specifying it all for the sake of education.
+
+The csv-to-os script was invoked as follows: (`LBE` was my current load balancer endpoint to reach the cluster)
+```
+./csv_to_os.py nyc-taxi-data.csv --host "http://${LBE}" --port 80 --index taxi-data --index-settings nyc-taxi-settings.json
+``` 

--- a/dev-tools/csv-to-os/example/nyc-taxi-settings.json
+++ b/dev-tools/csv-to-os/example/nyc-taxi-settings.json
@@ -1,0 +1,48 @@
+{
+    "mappings":
+    {
+        "properties":
+        {
+            "vendor_id":
+            {
+                "type": "integer"
+            },
+            "pickup_datetime":
+            {
+                "type": "date",
+                "format": "YYY-MM-dd HH:mm:ss"
+            },
+            "dropoff_datetime":
+            {
+                "type": "date",
+                "format": "YYY-MM-dd HH:mm:ss"
+            },
+            "passenger_count":
+            {
+                "type": "integer"
+            },
+            "pickup_location":
+            {
+                "type": "geo_point",
+                "ignore_malformed": "true"
+            },
+            "dropoff_location":
+            {
+                "type": "geo_point",
+                "ignore_malformed": "true"
+            },
+            "trip_duration":
+            {
+                "type": "integer"
+            }
+        }
+    },
+    "settings":
+    {
+        "index":
+        {
+            "number_of_shards": 1,
+            "number_of_replicas": 2
+        }
+    }
+}

--- a/dev-tools/csv-to-os/requirements.txt
+++ b/dev-tools/csv-to-os/requirements.txt
@@ -1,0 +1,12 @@
+certifi==2022.9.24
+charset-normalizer==2.1.1
+idna==3.4
+numpy==1.23.4
+opensearch-py==2.0.0
+pandas==1.5.1
+python-dateutil==2.8.2
+pytz==2022.5
+requests==2.28.1
+six==1.16.0
+tqdm==4.64.1
+urllib3==1.26.12

--- a/dev-tools/snapshot-upgrade/README.md
+++ b/dev-tools/snapshot-upgrade/README.md
@@ -1,0 +1,306 @@
+# Snapshot & Restore in Docker
+
+## Setup
+
+- Docker running
+- Two docker-compose files--one with your source image, second with your destination image.
+	- Both should be using a volume called--in this case `elasticsearch-snapshot` (because the source cluster in this example is elasticsearch)
+	- Specify the ports for at least one of the clusters (e.g. `9202:9200`) so that they can be addressed independently. In this particular case, the default setting for ES is to have security off and for OS is to have security on, so the ES cluster can be reached at `http://localhost:9200` and the OS cluster at `https://localhost:9202`. Because of the default security settings, a username and password are required to talk to the OS cluster, but not the ES cluster.
+- Sample data set, etc. etc.
+
+## Steps
+
+For this example, I'm using the files:
+`docker-compose.example.es_7_10_2.yaml` as the source and `docker-compose.example.os_1_0.yaml` as the destination
+
+
+### Step 0
+Start with a clean slate.
+```
+docker container stop $(docker container ls -aq) ; docker container rm $(docker container ls -aq) ; docker volume rm -f $(docker volume ls -q) ; docker network rm $(docker network ls -q)
+```
+
+### Step 1
+Stand up the source cluster and verify that it's running. The `docker-compose` command sets the project name with `-p` and `--detach` runs the containers in the background.
+```
+--> docker-compose -f docker-compose.example.es_7_10_2.yaml -p snapshot-test up --detach
+
+--> curl 'localhost:9200/_cat/nodes?pretty' -ku 'admin:admin'
+172.19.0.2 10 82 4 0.23 0.18 0.07 dimr - elasticsearch-node1
+172.19.0.3 13 82 2 0.23 0.18 0.07 dimr * elasticsearch-node2
+
+--> curl 'localhost:9200?pretty'
+{
+  "name" : "elasticsearch-node1",
+  "cluster_name" : "es-cluster",
+  "cluster_uuid" : "zmv4zOp2SY21fo8v2dybOA",
+  "version" : {
+    "number" : "7.10.2",
+    "build_flavor" : "oss",
+    "build_type" : "docker",
+    "build_hash" : "747e1cc71def077253878a59143c1f785afa92b9",
+    "build_date" : "2021-01-13T00:42:12.435326Z",
+    "build_snapshot" : false,
+    "lucene_version" : "8.7.0",
+    "minimum_wire_compatibility_version" : "6.8.0",
+    "minimum_index_compatibility_version" : "6.0.0-beta1"
+  },
+  "tagline" : "You Know, for Search"
+}
+```
+
+### Step 2
+Add permssions for the container user to access the snapshot volume.
+```
+──> docker exec -u 0:0 elasticsearch-node1 chown -R elasticsearch /opt/elasticsearch/snapshots
+```
+
+### Step 3
+Add data to the source cluster and verify that it's present.
+
+```
+──> ./csv_to_os.py mini-nyc-taxi-data.csv --index taxi --host "http://localhost" --port 9200 --index-settings example/nyc-taxi-settings.json
+Args:
+input_file: mini-nyc-taxi-data.csv
+index_settings: example/nyc-taxi-settings.json
+index: taxi
+host: http://localhost
+port: 9200
+user: admin:admin
+
+Creating the OpenSearch client.
+Creating index.
+{'acknowledged': True, 'shards_acknowledged': True, 'index': 'taxi'}
+Loading csv.
+<class 'pandas.core.frame.DataFrame'>
+RangeIndex: 49999 entries, 0 to 49998
+Columns: 8 entries, id to pickup_location
+dtypes: int64(3), object(5)
+memory usage: 3.1+ MB
+None
+Preparing paginated bulk inserts.
+The records will be split into 5 pages of up to 10000 records.
+100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 5/5 [00:07<00:00,  1.43s/it]
+
+──> curl 'localhost:9200/taxi/_count?pretty' -ku 'admin:admin'
+{
+  "count" : 49999,
+  "_shards" : {
+    "total" : 1,
+    "successful" : 1,
+    "skipped" : 0,
+    "failed" : 0
+  }
+}
+```
+
+### Step 4
+Register the snapshot location
+```
+──> curl -XPUT 'localhost:9200/_snapshot/es_backup' -H 'Content-Type: application/json' -d '{
+	"type": "fs",
+		"settings": {
+			"location": "/opt/elasticsearch/snapshots"
+	}
+}'
+{"acknowledged":true}%
+```
+
+### Step 5
+Create a snapshot. (In the example here, I actually have 2 snapshots--one with two indices, and a second where I deleted one of the indices)
+```
+--> curl -XPUT 'localhost:9200/_snapshot/es_backup/1'
+{"accepted":true}%
+
+──> curl 'localhost:9200/_snapshot/es_backup/1?pretty' -ku 'admin:admin'
+{
+  "snapshots" : [
+    {
+      "snapshot" : "1",
+      "uuid" : "Qynez6hhQLmC7UIlNHMVzQ",
+      "version_id" : 7100299,
+      "version" : "7.10.2",
+      "indices" : [
+        "taxi",
+        "nyc-taxi-data"
+      ],
+      "data_streams" : [ ],
+      "include_global_state" : true,
+      "state" : "SUCCESS",
+      "start_time" : "2022-10-28T17:24:27.653Z",
+      "start_time_in_millis" : 1666977867653,
+      "end_time" : "2022-10-28T17:24:28.255Z",
+      "end_time_in_millis" : 1666977868255,
+      "duration_in_millis" : 602,
+      "failures" : [ ],
+      "shards" : {
+        "total" : 2,
+        "failed" : 0,
+        "successful" : 2
+      }
+    }
+  ]
+}
+
+──> curl 'localhost:9200/_snapshot/es_backup/_all?pretty' -ku 'admin:admin'
+{
+  "snapshots" : [
+    {
+      "snapshot" : "1",
+      "uuid" : "Qynez6hhQLmC7UIlNHMVzQ",
+      "version_id" : 7100299,
+      "version" : "7.10.2",
+      "indices" : [
+        "taxi",
+        "nyc-taxi-data"
+      ],
+      "data_streams" : [ ],
+      "include_global_state" : true,
+      "state" : "SUCCESS",
+      "start_time" : "2022-10-28T17:24:27.653Z",
+      "start_time_in_millis" : 1666977867653,
+      "end_time" : "2022-10-28T17:24:28.255Z",
+      "end_time_in_millis" : 1666977868255,
+      "duration_in_millis" : 602,
+      "failures" : [ ],
+      "shards" : {
+        "total" : 2,
+        "failed" : 0,
+        "successful" : 2
+      }
+    },
+    {
+      "snapshot" : "2",
+      "uuid" : "7h1Qw3OBRwe2ZV4y7QJO_A",
+      "version_id" : 7100299,
+      "version" : "7.10.2",
+      "indices" : [
+        "taxi"
+      ],
+      "data_streams" : [ ],
+      "include_global_state" : true,
+      "state" : "SUCCESS",
+      "start_time" : "2022-10-28T17:26:10.783Z",
+      "start_time_in_millis" : 1666977970783,
+      "end_time" : "2022-10-28T17:26:10.783Z",
+      "end_time_in_millis" : 1666977970783,
+      "duration_in_millis" : 0,
+      "failures" : [ ],
+      "shards" : {
+        "total" : 1,
+        "failed" : 0,
+        "successful" : 1
+      }
+    }
+  ]
+}
+```
+
+### Step 6
+Stand up the destination cluster and verify that it's running (note that I'm addressing port 9202 (and that SSL is enabled in this case)).
+```
+--> docker-compose -f docker-compose.example.os_1_0.yaml -p snapshot-test up --detach
+
+--> curl 'https://localhost:9202/?pretty' -ku 'admin:admin'                                                                                         7 ↵ ──(Fri,Oct28)─┘
+{
+  "name" : "opensearch-node1",
+  "cluster_name" : "opensearch-cluster",
+  "cluster_uuid" : "Kqrq24KPTKmqx7XoqvluAg",
+  "version" : {
+    "distribution" : "opensearch",
+    "number" : "1.0.0",
+    "build_type" : "tar",
+    "build_hash" : "34550c5b17124ddc59458ef774f6b43a086522e3",
+    "build_date" : "2021-07-02T23:22:21.383695Z",
+    "build_snapshot" : false,
+    "lucene_version" : "8.8.2",
+    "minimum_wire_compatibility_version" : "6.8.0",
+    "minimum_index_compatibility_version" : "6.0.0-beta1"
+  },
+  "tagline" : "The OpenSearch Project: https://opensearch.org/"
+}
+```
+
+### Step 7
+Register the snapshot repo for the destination cluster, and verify that it can see the previously created snapshots.
+```
+──> curl -XPUT 'https://localhost:9202/_snapshot/es_backup' -ku 'admin:admin' -H 'Content-Type: application/json' -d '{
+"type": "fs",
+	"settings": {
+	 	"location": "/opt/elasticsearch/snapshots"
+	}
+}'
+
+──> curl 'https://localhost:9202/_snapshot/es_backup/_all?pretty' -ku 'admin:admin'
+{
+  "snapshots" : [
+    {
+      "snapshot" : "1",
+      "uuid" : "Qynez6hhQLmC7UIlNHMVzQ",
+      "version_id" : 7100299,
+      "version" : "7.10.2",
+      "indices" : [
+        "taxi",
+        "nyc-taxi-data"
+      ],
+      "data_streams" : [ ],
+      "include_global_state" : true,
+      "state" : "SUCCESS",
+      "start_time" : "2022-10-28T17:24:27.653Z",
+      "start_time_in_millis" : 1666977867653,
+      "end_time" : "2022-10-28T17:24:28.255Z",
+      "end_time_in_millis" : 1666977868255,
+      "duration_in_millis" : 602,
+      "failures" : [ ],
+      "shards" : {
+        "total" : 2,
+        "failed" : 0,
+        "successful" : 2
+      }
+    },
+    {
+      "snapshot" : "2",
+      "uuid" : "7h1Qw3OBRwe2ZV4y7QJO_A",
+      "version_id" : 7100299,
+      "version" : "7.10.2",
+      "indices" : [
+        "taxi"
+      ],
+      "data_streams" : [ ],
+      "include_global_state" : true,
+      "state" : "SUCCESS",
+      "start_time" : "2022-10-28T17:26:10.783Z",
+      "start_time_in_millis" : 1666977970783,
+      "end_time" : "2022-10-28T17:26:10.783Z",
+      "end_time_in_millis" : 1666977970783,
+      "duration_in_millis" : 0,
+      "failures" : [ ],
+      "shards" : {
+        "total" : 1,
+        "failed" : 0,
+        "successful" : 1
+      }
+    }
+  ]
+}
+```
+
+### Step 8
+Restore the snapshot to the destination cluster and verify that the data is present.
+```
+──> curl -XPOST 'https://localhost:9202/_snapshot/es_backup/2/_restore?pretty' -ku 'admin:admin'
+{
+  "accepted" : true
+}
+
+──> curl 'https://localhost:9202/taxi/_count?pretty' -ku 'admin:admin'
+{
+  "count" : 49999,
+  "_shards" : {
+    "total" : 1,
+    "successful" : 1,
+    "skipped" : 0,
+    "failed" : 0
+  }
+}
+```

--- a/dev-tools/snapshot-upgrade/docker-compose.example.es_7_10_2.yaml
+++ b/dev-tools/snapshot-upgrade/docker-compose.example.es_7_10_2.yaml
@@ -1,0 +1,62 @@
+# This docker-compose demos a basic mixed OpenSearch 1.0 cluster with two nodes.
+version: '3'
+services:
+  elasticsearch-node1:
+    image: docker.elastic.co/elasticsearch/elasticsearch-oss:7.10.2
+    container_name: elasticsearch-node1
+    environment:
+      - cluster.name=es-cluster
+      - node.name=elasticsearch-node1
+      - discovery.seed_hosts=elasticsearch-node1,elasticserach-node2
+      - cluster.initial_master_nodes=elasticsearch-node1,elasticsearch-node2
+      - bootstrap.memory_lock=true # along with the memlock settings below, disables swapping
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m" # minimum and maximum Java heap size, recommend setting both to 50% of system RAM
+      - path.repo=/opt/elasticsearch/snapshots
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+      nofile:
+        soft: 65536 # maximum number of open files for the OpenSearch user, set to at least 65536 on modern systems
+        hard: 65536
+    volumes:
+      - elasticsearch-data1:/usr/share/elasticsearch/data
+      - elasticsearch-snapshot:/opt/elasticsearch/snapshots
+    ports:
+      - 9200:9200
+    networks:
+      - elasticsearch-net
+
+  elasticsearch-node2:
+    image: docker.elastic.co/elasticsearch/elasticsearch-oss:7.10.2
+    container_name: elasticsearch-node2
+    environment:
+      - cluster.name=es-cluster
+      - node.name=elasticsearch-node2
+      - discovery.seed_hosts=elasticsearch-node1,elasticserach-node2
+      - cluster.initial_master_nodes=elasticsearch-node1,elasticsearch-node2
+      - bootstrap.memory_lock=true # along with the memlock settings below, disables swapping
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m" # minimum and maximum Java heap size, recommend setting both to 50% of system RAM
+      - path.repo=/opt/elasticsearch/snapshots
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+      nofile:
+        soft: 65536 # maximum number of open files for the OpenSearch user, set to at least 65536 on modern systems
+        hard: 65536
+    volumes:
+      - elasticsearch-data2:/usr/share/elasticsearch/data
+      - elasticsearch-snapshot:/opt/elasticsearch/snapshots
+    ports:
+      - 9201:9200
+    networks:
+      - elasticsearch-net
+
+volumes:
+  elasticsearch-data1:
+  elasticsearch-data2:
+  elasticsearch-snapshot:
+
+networks:
+  elasticsearch-net:

--- a/dev-tools/snapshot-upgrade/docker-compose.example.os_1_0.yaml
+++ b/dev-tools/snapshot-upgrade/docker-compose.example.os_1_0.yaml
@@ -1,0 +1,62 @@
+# This docker-compose demos a basic mixed OpenSearch 1.0 cluster with two nodes.
+version: '3'
+services:
+  opensearch-node1:
+    image: opensearchproject/opensearch:1.0.0
+    container_name: opensearch-node1
+    environment:
+      - cluster.name=opensearch-cluster
+      - node.name=opensearch-node1
+      - discovery.seed_hosts=opensearch-node1,opensearch-node2
+      - cluster.initial_master_nodes=opensearch-node1,opensearch-node2
+      - bootstrap.memory_lock=true # along with the memlock settings below, disables swapping
+      - "OPENSEARCH_JAVA_OPTS=-Xms512m -Xmx512m" # minimum and maximum Java heap size, recommend setting both to 50% of system RAM
+      - path.repo=/opt/elasticsearch/snapshots
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+      nofile:
+        soft: 65536 # maximum number of open files for the OpenSearch user, set to at least 65536 on modern systems
+        hard: 65536
+    volumes:
+      - opensearch-data1:/usr/share/opensearch/data
+      - elasticsearch-snapshot:/opt/elasticsearch/snapshots
+    ports:
+      - 9202:9200
+    networks:
+      - opensearch-net
+
+  opensearch-node2:
+    image: opensearchproject/opensearch:1.0.0
+    container_name: opensearch-node2
+    environment:
+      - cluster.name=opensearch-cluster
+      - node.name=opensearch-node2
+      - discovery.seed_hosts=opensearch-node1,opensearch-node2
+      - cluster.initial_master_nodes=opensearch-node1,opensearch-node2
+      - bootstrap.memory_lock=true
+      - "OPENSEARCH_JAVA_OPTS=-Xms512m -Xmx512m"
+      - path.repo=/opt/elasticsearch/snapshots
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+      nofile:
+        soft: 65536
+        hard: 65536
+    volumes:
+      - opensearch-data2:/usr/share/opensearch/data
+      - elasticsearch-snapshot:/opt/elasticsearch/snapshots
+    ports:
+      - 9203:9200
+    networks:
+      - opensearch-net
+
+volumes:
+  opensearch-data1:
+  opensearch-data2:
+  elasticsearch-snapshot:
+
+networks:
+  opensearch-net:


### PR DESCRIPTION
These commits migrate in two pieces of previous work:
- the csv-to-os tool uses the python client to load a csv, reformat it to documents in json, and upload it to an OS cluster, optionally using specified field mappings and creating a new index (see [README](https://github.com/opensearch-project/opensearch-migrations/blob/9b3e26f0103182dfd9528643f26902223b4d478c/dev-tools/csv-to-os/README.md)).

- a walkthrough of doing a snapshot-and-restore based upgrade in docker (see [README](https://github.com/opensearch-project/opensearch-migrations/blob/9b3e26f0103182dfd9528643f26902223b4d478c/dev-tools/snapshot-upgrade/README.md))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
