### PR TITLE
Add linting (flake8) workflow to repo

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,10 @@
+[flake8]
+# pep8 codes - http://pep8.readthedocs.io/en/release-1.7.x/intro.html#error-codes
+# E501 - line too long
+# E265 - block comment should start with '# '
+# E402 - module level import not at top of file
+# E999 - SyntaxError: EOL while scanning string literal
+# W504 - Line break occurred after a binary operator
+ignore = E265,E402,E999,W504
+max-line-length = 120
+exclude = .tox,.git,*/migrations/*,*/static/CACHE/*,docs,node_modules

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10"]
+    steps:
+     - name: Checkout Repository
+       uses: actions/checkout@v3
+
+     - name: Set up Python ${{ matrix.python-version }}
+       uses: actions/setup-python@v3
+       with:
+         python-version: ${{ matrix.python-version }}
+     - name: Install dependencies
+       run: |
+        python -m pip install --upgrade pip
+        pip install flake8
+     - name: Analysing the code with flake8
+       run: |
+        flake8 $(git ls-files '*.py')


### PR DESCRIPTION
Signed-off-by: Omar Khasawneh <okhasawn@amazon.com>

### Description
This change applies linting on .py files, to preserve clean style of code.

### Issues Resolved

Closes [#41]

### Check List
- [ ] New functionality includes testing
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
