### PR TITLE
Add default backport behavior

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,0 +1,29 @@
+name: Backport
+on:
+  pull_request_target:
+    types:
+      - closed
+      - labeled
+
+jobs:
+  backport:
+    if: ${{ contains(github.event.label.name, 'backport') }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    name: Backport
+    steps:
+      - name: GitHub App token
+        id: github_app_token
+        uses: tibdex/github-app-token@v1.5.0
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.APP_PRIVATE_KEY }}
+          installation_id: 22958780
+
+      - name: Backport
+        uses: VachaShah/backport@v2.1.0
+        with:
+          github_token: ${{ steps.github_app_token.outputs.token }}
+          head_template: backport/backport-<%= number %>-to-<%= base %>

--- a/.github/workflows/delete_backport_branch.yml
+++ b/.github/workflows/delete_backport_branch.yml
@@ -1,0 +1,15 @@
+name: Delete merged branch of the backport PRs
+on: 
+  pull_request:
+    types:
+      - closed
+  
+jobs:
+  delete-branch:
+    runs-on: ubuntu-latest
+    if: startsWith(github.event.pull_request.head.ref,'backport/')
+    steps:
+      - name: Delete merged branch
+        uses: SvanBoxel/delete-merged-branch@main
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Signed-off-by: Tanner Lewis <lewijacn@amazon.com>

### Description
This change is to setup the workflow structure for creating backport PRs when a backport label is applied to a PR that has been merged as well as a workflow to delete these backport branches once their respective backport PR is closed.

Only the default behavior has been added for now to set the structure, which is usually sufficient for most repos. However,  as the repo evolves we can adjust to meet our use case.

### Issues Resolved
* https://github.com/opensearch-project/opensearch-migrations/issues/43

### Testing
Tested in local fork of this repo by creating a sample Github app that is integrated into the repo (To generate APP_ID and APP_PRIVATE_KEY) and adding backport labels to a merged PR. Will try to document this process for others who may want to follow in future.

Original PR: https://github.com/lewijacn/opensearch-migrations/pull/10

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
