### PR TITLE
Updated UTF to use a REST Client instead of curl

### DIFF
--- a/upgrades/setup.py
+++ b/upgrades/setup.py
@@ -12,7 +12,8 @@ setuptools.setup(
         "docker",
         "pexpect",
         "py",
-        "pytest"
+        "pytest",
+        "requests"
     ],
     python_requires=">=3.6",
 )

--- a/upgrades/unit_tests/clients/test_rest_client_base.py
+++ b/upgrades/unit_tests/clients/test_rest_client_base.py
@@ -1,0 +1,191 @@
+import json
+import unittest.mock as mock
+
+from upgrade_testing_framework.clients.rest_ops import RESTPath
+from upgrade_testing_framework.clients.rest_client_default import RESTClientDefault
+
+TEST_DIR = "/path/to/dir"
+TEST_DOC_ID = "Beren"
+TEST_DOC = {"quote": "My fate, O King, led me hither, through perils such as few even of the Elves would dare."}
+TEST_INDEX = "Silmarillion"
+TEST_PORT = 9200
+TEST_REPO = "repo"
+TEST_SNAPSHOT_ID = "snapshot"
+
+@mock.patch("upgrade_testing_framework.clients.rest_ops.perform_get")
+def test_WHEN_get_node_info_THEN_as_expected(mock_get):
+    # Set up test
+    mock_response = mock.Mock()
+    mock_get.return_value = mock_response
+
+    # Run our test
+    test_client = RESTClientDefault()
+    actual_value = test_client.get_node_info(TEST_PORT)
+
+    # Check the results
+    assert mock_response == actual_value
+
+    expected_calls = [mock.call(
+        rest_path = RESTPath(port = TEST_PORT)
+    )]
+    assert expected_calls == mock_get.call_args_list
+
+@mock.patch("upgrade_testing_framework.clients.rest_ops.perform_get")
+def test_WHEN_get_nodes_status_THEN_as_expected(mock_get):
+    # Set up test
+    mock_response = mock.Mock()
+    mock_get.return_value = mock_response
+
+    # Run our test
+    test_client = RESTClientDefault()
+    actual_value = test_client.get_nodes_status(TEST_PORT)
+
+    # Check the results
+    assert mock_response == actual_value
+
+    expected_calls = [mock.call(
+        rest_path = RESTPath(port = TEST_PORT, suffix = "_cat/nodes"),
+        params = {"v": "true", "pretty": "true"}
+    )]
+    assert expected_calls == mock_get.call_args_list
+
+@mock.patch("upgrade_testing_framework.clients.rest_ops.perform_get")
+def test_WHEN_get_doc_by_id_THEN_as_expected(mock_get):
+    # Set up test
+    mock_response = mock.Mock()
+    mock_get.return_value = mock_response
+
+    # Run our test
+    test_client = RESTClientDefault()
+    actual_value = test_client.get_doc_by_id(TEST_PORT, TEST_INDEX, TEST_DOC_ID)
+
+    # Check the results
+    assert mock_response == actual_value
+
+    expected_calls = [mock.call(
+        rest_path = RESTPath(port = TEST_PORT, suffix = f"{TEST_INDEX}/_doc/{TEST_DOC_ID}"),
+        params = {"pretty": "true"}
+    )]
+    assert expected_calls == mock_get.call_args_list
+
+@mock.patch("upgrade_testing_framework.clients.rest_ops.perform_post")
+def test_WHEN_post_doc_to_index_THEN_as_expected(mock_post):
+    # Set up test
+    mock_response = mock.Mock()
+    mock_post.return_value = mock_response
+
+    # Run our test
+    test_client = RESTClientDefault()
+    actual_value = test_client.post_doc_to_index(TEST_PORT, TEST_INDEX, TEST_DOC)
+
+    # Check the results
+    assert mock_response == actual_value
+
+    expected_calls = [mock.call(
+        rest_path = RESTPath(port = TEST_PORT, suffix = f"{TEST_INDEX}/_doc"),
+        data = json.dumps(TEST_DOC),
+        params = {"pretty": "true"},
+        headers = {"Content-Type": "application/json"}
+    )]
+    assert expected_calls == mock_post.call_args_list
+
+@mock.patch("upgrade_testing_framework.clients.rest_ops.perform_post")
+def test_WHEN_create_snapshot_THEN_as_expected(mock_post):
+    # Set up test
+    mock_response = mock.Mock()
+    mock_post.return_value = mock_response
+
+    # Run our test
+    test_client = RESTClientDefault()
+    actual_value = test_client.create_snapshot(TEST_PORT, TEST_REPO, TEST_SNAPSHOT_ID)
+
+    # Check the results
+    assert mock_response == actual_value
+
+    expected_calls = [mock.call(
+        rest_path = RESTPath(port = TEST_PORT, suffix = f"_snapshot/{TEST_REPO}/{TEST_SNAPSHOT_ID}"),
+        params = {"pretty": "true", "wait_for_completion": "true"}
+    )]
+    assert expected_calls == mock_post.call_args_list
+
+@mock.patch("upgrade_testing_framework.clients.rest_ops.perform_get")
+def test_WHEN_get_snapshot_by_id_THEN_as_expected(mock_get):
+    # Set up test
+    mock_response = mock.Mock()
+    mock_get.return_value = mock_response
+
+    # Run our test
+    test_client = RESTClientDefault()
+    actual_value = test_client.get_snapshot_by_id(TEST_PORT, TEST_REPO, TEST_SNAPSHOT_ID)
+
+    # Check the results
+    assert mock_response == actual_value
+
+    expected_calls = [mock.call(
+        rest_path = RESTPath(port = TEST_PORT, suffix = f"_snapshot/{TEST_REPO}/{TEST_SNAPSHOT_ID}"),
+        params = {"pretty": "true"}
+    )]
+    assert expected_calls == mock_get.call_args_list
+
+@mock.patch("upgrade_testing_framework.clients.rest_ops.perform_get")
+def test_WHEN_get_snapshots_all_THEN_as_expected(mock_get):
+    # Set up test
+    mock_response = mock.Mock()
+    mock_get.return_value = mock_response
+
+    # Run our test
+    test_client = RESTClientDefault()
+    actual_value = test_client.get_snapshots_all(TEST_PORT, TEST_REPO)
+
+    # Check the results
+    assert mock_response == actual_value
+
+    expected_calls = [mock.call(
+        rest_path = RESTPath(port = TEST_PORT, suffix = f"_snapshot/{TEST_REPO}/_all"),
+        params = {"pretty": "true"}
+    )]
+    assert expected_calls == mock_get.call_args_list
+
+@mock.patch("upgrade_testing_framework.clients.rest_ops.perform_post")
+def test_WHEN_register_snapshot_dir_THEN_as_expected(mock_post):
+    # Set up test
+    mock_response = mock.Mock()
+    mock_post.return_value = mock_response
+
+    # Run our test
+    test_client = RESTClientDefault()
+    actual_value = test_client.register_snapshot_dir(TEST_PORT, TEST_REPO, TEST_DIR)
+
+    # Check the results
+    assert mock_response == actual_value
+
+    expected_calls = [mock.call(
+        rest_path = RESTPath(port = TEST_PORT, suffix = f"_snapshot/{TEST_REPO}"),
+        data = json.dumps({
+            "type": "fs",
+                "settings": {
+                    "location": TEST_DIR
+            }
+        }),
+        headers = {"Content-Type": "application/json"}
+    )]
+    assert expected_calls == mock_post.call_args_list
+
+@mock.patch("upgrade_testing_framework.clients.rest_ops.perform_post")
+def test_WHEN_restore_snapshot_THEN_as_expected(mock_post):
+    # Set up test
+    mock_response = mock.Mock()
+    mock_post.return_value = mock_response
+
+    # Run our test
+    test_client = RESTClientDefault()
+    actual_value = test_client.restore_snapshot(TEST_PORT, TEST_REPO, TEST_SNAPSHOT_ID)
+
+    # Check the results
+    assert mock_response == actual_value
+
+    expected_calls = [mock.call(
+        rest_path = RESTPath(port = TEST_PORT, suffix = f"_snapshot/{TEST_REPO}/{TEST_SNAPSHOT_ID}/_restore"),
+        params = {"pretty": "true"}
+    )]
+    assert expected_calls == mock_post.call_args_list

--- a/upgrades/unit_tests/clients/test_rest_client_default.py
+++ b/upgrades/unit_tests/clients/test_rest_client_default.py
@@ -104,7 +104,7 @@ def test_WHEN_create_snapshot_THEN_as_expected(mock_post):
 
     expected_calls = [mock.call(
         rest_path = RESTPath(port = TEST_PORT, suffix = f"_snapshot/{TEST_REPO}/{TEST_SNAPSHOT_ID}"),
-        params = {"pretty": "true", "wait_for_completion": "true"}
+        params = {"pretty": "true"}
     )]
     assert expected_calls == mock_post.call_args_list
 

--- a/upgrades/unit_tests/clients/test_rest_ops.py
+++ b/upgrades/unit_tests/clients/test_rest_ops.py
@@ -1,0 +1,103 @@
+import json
+import pytest
+import unittest.mock as mock
+
+import upgrade_testing_framework.clients.rest_ops as ops
+
+REST_PATH = ops.RESTPath(9200, "http://gondolin", "turgon")
+
+@pytest.fixture
+def success_response():
+    response = mock.Mock()
+    response.json.return_value = {"key": "value"}
+    response.status_code = 200
+    response.reason = "fate"
+    response.text = str(response.json())
+    response.url = str(REST_PATH)
+    return response
+
+@pytest.fixture
+def failure_response():
+    response = mock.Mock()
+    response.json.side_effect = json.JSONDecodeError("", "", 1)
+    response.status_code = 404
+    response.reason = "fate"
+    response.text = "Not Found"
+    response.url = str(REST_PATH)
+    return response
+
+@mock.patch("upgrade_testing_framework.clients.rest_ops.requests")
+def test_WHEN_perform_get_AND_success_THEN_as_expected(mock_requests, success_response):
+    # Set up test
+    mock_requests.get.return_value = success_response
+
+    # Run our test
+    actual_value = ops.perform_get(rest_path = REST_PATH)
+
+    # Check the results
+    expected_value = {
+        "response_json": success_response.json(),
+        "response_text": success_response.text,
+        "status_code": success_response.status_code,
+        "status_reason": success_response.reason,
+        "succeeded": True,
+        "url": str(REST_PATH)
+    }
+    assert expected_value == actual_value.to_dict()
+
+@mock.patch("upgrade_testing_framework.clients.rest_ops.requests")
+def test_WHEN_perform_get_AND_failed_THEN_as_expected(mock_requests, failure_response):
+    # Set up test
+    mock_requests.get.return_value = failure_response
+
+    # Run our test
+    actual_value = ops.perform_get(rest_path = REST_PATH)
+
+    # Check the results
+    expected_value = {
+        "response_json": None,
+        "response_text": failure_response.text,
+        "status_code": failure_response.status_code,
+        "status_reason": failure_response.reason,
+        "succeeded": False,
+        "url": str(REST_PATH)
+    }
+    assert expected_value == actual_value.to_dict()
+
+@mock.patch("upgrade_testing_framework.clients.rest_ops.requests")
+def test_WHEN_perform_post_AND_success_THEN_as_expected(mock_requests, success_response):
+    # Set up test
+    mock_requests.post.return_value = success_response
+
+    # Run our test
+    actual_value = ops.perform_post(rest_path = REST_PATH)
+
+    # Check the results
+    expected_value = {
+        "response_json": success_response.json(),
+        "response_text": success_response.text,
+        "status_code": success_response.status_code,
+        "status_reason": success_response.reason,
+        "succeeded": True,
+        "url": str(REST_PATH)
+    }
+    assert expected_value == actual_value.to_dict()
+
+@mock.patch("upgrade_testing_framework.clients.rest_ops.requests")
+def test_WHEN_perform_put_AND_success_THEN_as_expected(mock_requests, success_response):
+    # Set up test
+    mock_requests.put.return_value = success_response
+
+    # Run our test
+    actual_value = ops.perform_put(rest_path = REST_PATH)
+
+    # Check the results
+    expected_value = {
+        "response_json": success_response.json(),
+        "response_text": success_response.text,
+        "status_code": success_response.status_code,
+        "status_reason": success_response.reason,
+        "succeeded": True,
+        "url": str(REST_PATH)
+    }
+    assert expected_value == actual_value.to_dict()

--- a/upgrades/unit_tests/cluster_management/test_node_configuration.py
+++ b/upgrades/unit_tests/cluster_management/test_node_configuration.py
@@ -24,6 +24,7 @@ def test_WHEN_create_NodeConfiguration_AND_elasticsearch_THEN_has_expected_value
             "k1": "v1"
         },
         "data_dir": "/usr/share/elasticsearch/data",
+        "engine_version": str(test_engine_version),
         "user": "elasticsearch"
     }
     assert expected_value == actual_value.to_dict()
@@ -51,6 +52,7 @@ def test_WHEN_create_NodeConfiguration_AND_opensearch_THEN_has_expected_values()
             "k1": "v1"
         },
         "data_dir": "/usr/share/opensearch/data",
+        "engine_version": str(test_engine_version),
         "user": "elasticsearch"
     }
     assert expected_value == actual_value.to_dict()

--- a/upgrades/upgrade_testing_framework/clients/__init__.py
+++ b/upgrades/upgrade_testing_framework/clients/__init__.py
@@ -1,0 +1,10 @@
+# Pull in all our client versions
+from upgrade_testing_framework.clients.rest_client_base import RESTClientBase
+from upgrade_testing_framework.clients.rest_client_default import RESTClientDefault
+
+# Now do regular imports
+from upgrade_testing_framework.core.versions_engine import EngineVersion
+
+def get_rest_client(engine_version: EngineVersion) -> RESTClientBase:
+    # Only have one for now; update when that's no longer true :-)
+    return RESTClientDefault()

--- a/upgrades/upgrade_testing_framework/clients/rest_client_base.py
+++ b/upgrades/upgrade_testing_framework/clients/rest_client_base.py
@@ -1,0 +1,51 @@
+from abc import ABC, abstractmethod
+import logging
+
+import upgrade_testing_framework.clients.rest_ops as ops
+
+class RESTClientBase(ABC):
+    """
+    Abstract base class for the REST clients that inferface w/ the cluster.
+    """
+
+    def __init__(self):
+        self.logger = logging.getLogger(__name__)
+
+    # Node operations
+    @abstractmethod
+    def get_node_info(self, port: int) -> ops.RESTResponse:
+        pass
+
+    @abstractmethod
+    def get_nodes_status(self, port: int) -> ops.RESTResponse:
+        pass
+
+    # Doc operations
+    @abstractmethod
+    def get_doc_by_id(self, port: int, index: str, doc_id: int) -> ops.RESTResponse:
+        pass
+
+    @abstractmethod
+    def post_doc_to_index(self, port: int, index: str, doc: dict) -> ops.RESTResponse:
+        pass
+
+    # Snapshot operations
+    @abstractmethod
+    def create_snapshot(self, port: int, repo: str) -> ops.RESTResponse:
+        pass
+
+    @abstractmethod
+    def get_snapshot_by_id(self, port: int, repo: str, snapshot_id: int) -> ops.RESTResponse:
+        pass
+    
+    @abstractmethod
+    def get_snapshots_all(self, port: int, repo: str) -> ops.RESTResponse:
+        pass
+
+    @abstractmethod
+    def register_snapshot_dir(self, port: int, repo: str, dir_path: str) -> ops.RESTResponse:
+        pass
+
+    @abstractmethod
+    def restore_snapshot(self, port: int, repo: str, snapshot_id: int) -> ops.RESTResponse:
+        pass

--- a/upgrades/upgrade_testing_framework/clients/rest_client_default.py
+++ b/upgrades/upgrade_testing_framework/clients/rest_client_default.py
@@ -1,0 +1,105 @@
+import json
+
+from upgrade_testing_framework.clients.rest_client_base import RESTClientBase
+import upgrade_testing_framework.clients.rest_ops as ops
+
+class RESTClientDefault(RESTClientBase):
+    """
+    Default REST client for interfacing w/ Elasticsearch and OpenSearch clusters.
+
+    Given our current limited knowledge of where REST incompatibilities will pop up between versions, we will
+    arbitrarily assume that the interface that OpenSearch 1.3.6 presents is our baseline that all other versions will
+    conform to/deviate from.  If this later turns out to be a poor assumption, we can iterate on this code.  We'll know
+    we need to re-examine this assumption if we end up with a large number of version-specific client implementations.
+
+    You might ask, "why make a rest client at all instead of using one of the client SDKs?"  The answer to that is
+    we're trying to avoid introducing another source of bugs/incompatibility (language-specific SDKs) on top of those
+    found in the core engine's REST interface.  Additionally, we believe that many customers write their own clients
+    against the REST interface, so writing one for the UTF mimics their use-case more closely.  As always, additional
+    experience and feedback may dictate we pivot in the future.
+    """
+
+    def get_node_info(self, port: int) -> ops.RESTResponse:
+        """
+        Get basic about the specific node you hit, such as version.
+        """
+        rest_path = ops.RESTPath(port = port)
+        return ops.perform_get(rest_path = rest_path)
+
+    def get_nodes_status(self, port: int) -> ops.RESTResponse:
+        """
+        Get info on the cluster's nodes.
+        """
+        rest_path = ops.RESTPath(port = port, suffix = "_cat/nodes")
+        params = {"v": "true", "pretty": "true"}
+        return ops.perform_get(rest_path = rest_path, params = params)
+
+    def get_doc_by_id(self, port: int, index: str, doc_id: str) -> ops.RESTResponse:
+        """
+        Get a document by its ID
+        """
+        rest_path = ops.RESTPath(port = port, suffix = f"{index}/_doc/{doc_id}")
+        params = {"pretty": "true"}
+        return ops.perform_get(rest_path = rest_path, params = params)
+
+    def post_doc_to_index(self, port: int, index: str, doc: dict) -> ops.RESTResponse:
+        """
+        Post a single document to an index
+        """
+        rest_path = ops.RESTPath(port = port, suffix = f"{index}/_doc")
+        params = {"pretty": "true"}
+        headers={"Content-Type": "application/json"}
+
+        return ops.perform_post(rest_path = rest_path, data = json.dumps(doc), headers = headers, params = params)
+
+    def create_snapshot(self, port: int, repo: str, snapshot_id: str) -> ops.RESTResponse:
+        """
+        Create a snapshot of the cluster into a repo
+        """
+        rest_path = ops.RESTPath(port = port, suffix = f"_snapshot/{repo}/{snapshot_id}")
+        params = {"pretty": "true", "wait_for_completion": "true"}
+
+        return ops.perform_post(rest_path = rest_path, params = params)
+
+    def get_snapshot_by_id(self, port: int, repo: str, snapshot_id: str) -> ops.RESTResponse:
+        """
+        Get a snapshot by its ID
+        """
+        rest_path = ops.RESTPath(port = port, suffix = f"_snapshot/{repo}/{snapshot_id}")
+        params = {"pretty": "true"}
+        return ops.perform_get(rest_path = rest_path, params = params)    
+
+    def get_snapshots_all(self, port: int, repo: str) -> ops.RESTResponse:
+        """
+        Get all snapshots from a repo
+        """
+        rest_path = ops.RESTPath(port = port, suffix = f"_snapshot/{repo}/_all")
+        params = {"pretty": "true"}
+        return ops.perform_get(rest_path = rest_path, params = params)
+    
+    def register_snapshot_dir(self, port: int, repo: str, dir_path: str) -> ops.RESTResponse:
+        """
+        Register a directory on the node as the place to store snapshots for an snapshot repo
+        """
+        rest_path = ops.RESTPath(port = port, suffix = f"_snapshot/{repo}")
+        headers={"Content-Type": "application/json"}
+
+        register_args = {
+            "type": "fs",
+                "settings": {
+                    "location": dir_path
+            }
+        }
+
+        return ops.perform_post(rest_path = rest_path, data = json.dumps(register_args), headers = headers)
+
+    def restore_snapshot(self, port: int, repo: str, snapshot_id: int) -> ops.RESTResponse:
+        """
+        Restore a snapshot
+        """
+        rest_path = ops.RESTPath(port = port, suffix = f"_snapshot/{repo}/{snapshot_id}/_restore")
+        params = {"pretty": "true"}
+        return ops.perform_post(rest_path = rest_path, params = params)    
+
+
+

--- a/upgrades/upgrade_testing_framework/clients/rest_client_default.py
+++ b/upgrades/upgrade_testing_framework/clients/rest_client_default.py
@@ -57,7 +57,7 @@ class RESTClientDefault(RESTClientBase):
         Create a snapshot of the cluster into a repo
         """
         rest_path = ops.RESTPath(port = port, suffix = f"_snapshot/{repo}/{snapshot_id}")
-        params = {"pretty": "true", "wait_for_completion": "true"}
+        params = {"pretty": "true"}
 
         return ops.perform_post(rest_path = rest_path, params = params)
 
@@ -100,6 +100,3 @@ class RESTClientDefault(RESTClientBase):
         rest_path = ops.RESTPath(port = port, suffix = f"_snapshot/{repo}/{snapshot_id}/_restore")
         params = {"pretty": "true"}
         return ops.perform_post(rest_path = rest_path, params = params)    
-
-
-

--- a/upgrades/upgrade_testing_framework/clients/rest_ops.py
+++ b/upgrades/upgrade_testing_framework/clients/rest_ops.py
@@ -1,0 +1,93 @@
+from dataclasses import dataclass
+
+import json
+import logging
+import requests
+from requests.auth import HTTPBasicAuth
+
+logger = logging.getLogger(__name__)
+
+class RESTOperationFailedException(Exception):
+    def __init__(self, operation: str, url: str, status_code: int, text: str):
+        self.operation = operation
+        self.url = url
+        self.status_code = status_code
+        self.text = text
+        super().__init__(f"REST operation {operation} to {url} failed with code {status_code}.  Message: {text}")
+
+@dataclass
+class RESTPath:
+    port: int = 9200
+    prefix: str = "http://localhost"
+    suffix: str = ""
+    
+    def __str__(self):
+        # Something like: "http://localhost:9200/"
+        base_path = f"{self.prefix}:{self.port}"
+        return "/".join([base_path, self.suffix])
+
+@dataclass
+class RESTResponse:
+    def __init__(self, response: requests.Response):
+        self.response_text = response.text
+        self.status_code = response.status_code
+        self.status_reason = response.reason
+        self.url = response.url
+
+        self.response_json: dict = None
+        try:
+            self.response_json = response.json()
+        except json.JSONDecodeError:
+            pass
+
+        self.succeeded = response.status_code in [200, 201]
+
+    def to_dict(self):
+        return {
+            "response_json": self.response_json,
+            "response_text": self.response_text,
+            "status_code": self.status_code,
+            "status_reason": self.status_reason,
+            "succeeded": self.succeeded,
+            "url": self.url
+        }
+
+    def __str__(self):
+        return json.dumps(self.to_dict())
+
+def perform_get(rest_path: RESTPath = RESTPath(), params={}, auth=HTTPBasicAuth("admin", "admin")) -> RESTResponse:
+    raw_reponse = requests.get(
+        url=str(rest_path),
+        auth=auth,
+        params=params
+    )
+
+    rest_response = RESTResponse(raw_reponse)
+    logger.debug(f"REST GET Response : {rest_response}")
+    return rest_response
+
+def perform_post(rest_path: RESTPath = RESTPath(), data="", params={}, headers={}, auth=HTTPBasicAuth("admin", "admin")) -> RESTResponse:
+    raw_reponse = requests.post(
+        url=str(rest_path),
+        auth=auth,
+        data=data,
+        params=params,
+        headers=headers
+    )
+
+    rest_response = RESTResponse(raw_reponse)
+    logger.debug(f"REST POST Response : {rest_response}")
+    return rest_response
+
+def perform_put(rest_path: RESTPath = RESTPath(), data="", params={}, headers={}, auth=HTTPBasicAuth("admin", "admin")) -> RESTResponse:
+    raw_reponse = requests.put(
+        url=str(rest_path),
+        auth=auth,
+        data=data,
+        params=params,
+        headers=headers
+    )
+
+    rest_response = RESTResponse(raw_reponse)
+    logger.debug(f"REST PUT Response : {rest_response}")
+    return rest_response

--- a/upgrades/upgrade_testing_framework/clients/rest_ops.py
+++ b/upgrades/upgrade_testing_framework/clients/rest_ops.py
@@ -42,7 +42,7 @@ class RESTResponse:
 
         self.succeeded = response.status_code in [200, 201]
 
-    def to_dict(self):
+    def to_dict(self) -> dict:
         return {
             "response_json": self.response_json,
             "response_text": self.response_text,
@@ -55,7 +55,7 @@ class RESTResponse:
     def __str__(self):
         return json.dumps(self.to_dict())
 
-def perform_get(rest_path: RESTPath = RESTPath(), params={}, auth=HTTPBasicAuth("admin", "admin")) -> RESTResponse:
+def perform_get(rest_path: RESTPath = RESTPath(), params: dict = {}, auth = HTTPBasicAuth("admin", "admin")) -> RESTResponse:
     raw_reponse = requests.get(
         url=str(rest_path),
         auth=auth,
@@ -66,7 +66,8 @@ def perform_get(rest_path: RESTPath = RESTPath(), params={}, auth=HTTPBasicAuth(
     logger.debug(f"REST GET Response : {rest_response}")
     return rest_response
 
-def perform_post(rest_path: RESTPath = RESTPath(), data="", params={}, headers={}, auth=HTTPBasicAuth("admin", "admin")) -> RESTResponse:
+def perform_post(rest_path: RESTPath = RESTPath(), data: str = "", params: dict = {}, headers: dict = {}, 
+        auth = HTTPBasicAuth("admin", "admin")) -> RESTResponse:
     raw_reponse = requests.post(
         url=str(rest_path),
         auth=auth,
@@ -79,7 +80,8 @@ def perform_post(rest_path: RESTPath = RESTPath(), data="", params={}, headers={
     logger.debug(f"REST POST Response : {rest_response}")
     return rest_response
 
-def perform_put(rest_path: RESTPath = RESTPath(), data="", params={}, headers={}, auth=HTTPBasicAuth("admin", "admin")) -> RESTResponse:
+def perform_put(rest_path: RESTPath = RESTPath(), data: str = "", params: dict = {}, headers: dict = {}, 
+        auth = HTTPBasicAuth("admin", "admin")) -> RESTResponse:
     raw_reponse = requests.put(
         url=str(rest_path),
         auth=auth,

--- a/upgrades/upgrade_testing_framework/cluster_management/cluster.py
+++ b/upgrades/upgrade_testing_framework/cluster_management/cluster.py
@@ -63,6 +63,14 @@ class Cluster:
 
         self._cluster_state = STATE_NOT_STARTED
 
+    @property
+    def nodes(self) -> List[Node]:
+        return list(self._nodes.values())
+
+    @property
+    def rest_ports(self) -> List[int]:
+        return [node.rest_port for node in self._nodes.values()]
+
     def to_dict(self) -> dict:
         return {
             "cluster_config": self._cluster_config.to_dict(),
@@ -206,7 +214,3 @@ class Cluster:
         self.logger.debug(f"Cleaned up cluster {self.name}")
 
         self._cluster_state = STATE_CLEANED
-
-    @property
-    def rest_ports(self) -> List[int]:
-        return [node.rest_port for node in self._nodes.values()]

--- a/upgrades/upgrade_testing_framework/cluster_management/cluster_objects.py
+++ b/upgrades/upgrade_testing_framework/cluster_management/cluster_objects.py
@@ -1,0 +1,6 @@
+from dataclasses import dataclass
+
+@dataclass
+class ClusterSnapshot:
+    repo_name: str
+    snapshot_id: str

--- a/upgrades/upgrade_testing_framework/cluster_management/node.py
+++ b/upgrades/upgrade_testing_framework/cluster_management/node.py
@@ -6,6 +6,8 @@ from upgrade_testing_framework.cluster_management.container_configuration import
 from upgrade_testing_framework.cluster_management.docker_framework_client import DockerFrameworkClient
 from upgrade_testing_framework.cluster_management.node_configuration import NodeConfiguration
 
+from upgrade_testing_framework.core.versions_engine import EngineVersion
+
 STATE_NOT_STARTED = "NOT_STARTED"
 STATE_RUNNING = "RUNNING"
 STATE_STOPPED = "STOPPED"
@@ -32,13 +34,20 @@ class Node:
             docker_client: DockerFrameworkClient, container: Container = None):
         self.logger = logging.getLogger(__name__)
         self.name = name
-        self.rest_port = container_config.rest_port
         self._container = container
         self._container_config = container_config
         self._docker_client = docker_client
         self._node_config = node_config
 
         self._node_state = STATE_NOT_STARTED
+
+    @property
+    def engine_version(self) -> EngineVersion:
+        return self._node_config.engine_version
+
+    @property
+    def rest_port(self) -> int:
+        return self._container_config.rest_port
 
     def to_dict(self) -> dict:
         return {

--- a/upgrades/upgrade_testing_framework/cluster_management/node_configuration.py
+++ b/upgrades/upgrade_testing_framework/cluster_management/node_configuration.py
@@ -16,6 +16,8 @@ class NodeConfiguration:
     def __init__(self, engine_version: ev.EngineVersion, node_name: str, cluster_name: str, master_nodes: List[str], 
             seed_hosts: List[str], additional_config: Dict[str, str] = {}):
 
+        self.engine_version = engine_version
+
         self.data_dir: str = _get_engine_data_dir_for_version(engine_version)
         self.user: str = _get_engine_user_for_version(engine_version)
 
@@ -35,6 +37,7 @@ class NodeConfiguration:
         return {
             "config": self.config,
             "data_dir": self.data_dir,
+            "engine_version": str(self.engine_version),
             "user": self.user
         }
 

--- a/upgrades/upgrade_testing_framework/core/framework_runner.py
+++ b/upgrades/upgrade_testing_framework/core/framework_runner.py
@@ -37,7 +37,7 @@ class FrameworkRunner:
             for step_index in range(starting_step_index, len(self.step_order)):
                 current_step = self.step_order[step_index]
                 state.set_key('current_step', current_step.cls_name())
-                self.logger.info(f"Running Step: {current_step.cls_name()}")
+                self.logger.info(f"============ Running Step: {current_step.cls_name()} ============")
                 current_step(state).run()
                 self.logger.info(f"Step Succeeded: {current_step.cls_name()}")
             self.logger.info("Ran through all steps successfully")

--- a/upgrades/upgrade_testing_framework/core/framework_state.py
+++ b/upgrades/upgrade_testing_framework/core/framework_state.py
@@ -3,6 +3,7 @@ from typing import List
 
 from upgrade_testing_framework.cluster_management.docker_framework_client import DockerFrameworkClient, DockerVolume
 from upgrade_testing_framework.cluster_management.cluster import Cluster
+from upgrade_testing_framework.cluster_management.cluster_objects import ClusterSnapshot
 from upgrade_testing_framework.core.test_config_wrangling import TestConfig
 
 """
@@ -27,6 +28,7 @@ class FrameworkState:
         # order to support multiple upgrade types.  Since we're only supporting Snapshot/Restore for now, we can solve
         # that problem later.
         self.shared_volume: DockerVolume = None
+        self.snapshot: ClusterSnapshot = None
 
     def to_dict(self) -> dict:
         return {

--- a/upgrades/upgrade_testing_framework/steps/step_create_source_snapshot.py
+++ b/upgrades/upgrade_testing_framework/steps/step_create_source_snapshot.py
@@ -1,7 +1,6 @@
-import json
-
+import upgrade_testing_framework.clients as clients
+from upgrade_testing_framework.cluster_management.cluster_objects import ClusterSnapshot
 from upgrade_testing_framework.core.framework_step import FrameworkStep
-import upgrade_testing_framework.core.shell_interactions as shell
 
 class CreateSourceSnapshot(FrameworkStep):
     """
@@ -9,41 +8,30 @@ class CreateSourceSnapshot(FrameworkStep):
     """
 
     def _run(self):
-        """
-        The contents of this are quick/dirty.  Instead of raw curl commands we should probably be using the Python SDK
-        for Elasticsearch/OpenSearch.  At the very least, we should wrap the curl commands in our own pseudo-client.
-        """
-
         # Get the state we need
         shared_volume = self.state.shared_volume
         source_cluster = self.state.source_cluster
 
         # Begin the step body
         self.logger.info("Creating snapshot of source cluster...")
-        port = source_cluster.rest_ports[0]
+        node = source_cluster.nodes[0] # shouldn't matter which node we pick
+        port = node.rest_port
+        engine_version = node.engine_version
+        rest_client = clients.get_rest_client(engine_version)
+        repo_name, snapshot_id = ("noldor_repo", "test_snapshot")
 
-        register_cmd = f"""curl -XPUT 'localhost:{port}/_snapshot/noldor' -H 'Content-Type: application/json' -d '{{
-            "type": "fs",
-                "settings": {{
-                    "location": "{shared_volume.mount_point}"
-            }}
-        }}'
-        """
-        _, _ = shell.call_shell_command(register_cmd)
-
-        create_cmd = f"curl -XPUT 'localhost:{port}/_snapshot/noldor/1'"
-        _, _ = shell.call_shell_command(create_cmd)
+        rest_client.register_snapshot_dir(port, repo_name, shared_volume.mount_point)
+        rest_client.create_snapshot(port, repo_name, snapshot_id)
 
         self.logger.info("Confirming snapshot of source cluster exists...")
-        confirm_cmd = f"curl 'localhost:{port}/_snapshot/noldor/1?pretty' -ku 'admin:admin'"
-        _, output = shell.call_shell_command(confirm_cmd)
-        if "noldor" in "\n".join(output):
+        response_confirm = rest_client.get_snapshot_by_id(port, repo_name, snapshot_id)
+        if response_confirm.succeeded:
             self.logger.info("Source snapshot created successfully")
-            snapshot_get = json.loads("".join(output))
-            self.logger.info(json.dumps(snapshot_get, sort_keys=True, indent=4))
+            self.logger.info(response_confirm.response_text)
         else:
+            self.logger.info(response_confirm.response_text)
             self.fail("Snapshot creation failed")
         
         # Update our state
-        # N/A
+        self.state.snapshot = ClusterSnapshot(repo_name, snapshot_id)
         

--- a/upgrades/upgrade_testing_framework/steps/step_test_source_cluster.py
+++ b/upgrades/upgrade_testing_framework/steps/step_test_source_cluster.py
@@ -1,12 +1,11 @@
-import json
-
+from upgrade_testing_framework.clients.rest_client_default import RESTClientDefault
 from upgrade_testing_framework.core.framework_step import FrameworkStep
-import upgrade_testing_framework.core.shell_interactions as shell
 
 
 class TestSourceCluster(FrameworkStep):
     """
-    This step is where you run tests on the source cluster
+    This step is where you run tests on the source cluster.  The code currently in here is for demo purposes only, and
+    will be deleted once we've incorporated the Robot tests into the UTF.
     """
 
     def _run(self):
@@ -14,25 +13,27 @@ class TestSourceCluster(FrameworkStep):
         source_cluster = self.state.source_cluster
 
         # Begin the step body
-        self.logger.info("Querying cluster status...")
         port = source_cluster.rest_ports[0]
-        _, output = shell.call_shell_command(f"curl -X GET \"localhost:{port}/_cat/nodes?v=true&pretty\"")
-        self.logger.info("\n".join(output))
+        rest_client = RESTClientDefault()
+
+        self.logger.info("Querying cluster status...")
+        response_status = rest_client.get_nodes_status(port)
+        self.logger.info(response_status.response_text)
         
         self.logger.info("Uploading sample document...")
-        put_command = f"curl -X PUT 'localhost:{port}/noldor/_doc/1?pretty' -H 'Content-Type: application/json' -d'{{\"name\": \"Finwe\"}}'"
-        _, _ = shell.call_shell_command(put_command)
+        sample_doc = {"name": "Finwe"}
+        response_doc_post = rest_client.post_doc_to_index(port, "noldor", sample_doc)
+        self.logger.info(response_doc_post.response_text)
 
         self.logger.info("Retrieving uploaded document...")
-        get_command = f"curl -X GET 'localhost:{port}/noldor/_doc/1?pretty'"
-        _, output = shell.call_shell_command(get_command)
-        if "Finwe" in "\n".join(output):
+        sample_doc_id = response_doc_post.response_json["_id"]
+        response_status = rest_client.get_doc_by_id(port, "noldor", sample_doc_id)
+        if "Finwe" in response_status.response_text:
             self.logger.info("Retrieved uploaded doc sucessfully")
-            snapshot_get = json.loads("".join(output))
-            self.logger.info(json.dumps(snapshot_get, sort_keys=True, indent=4))
+            self.logger.info(response_status.response_text)
         else:
             self.fail("Unable to retrieve uploaded doc")
         
         # Update our state
-        # N/A
+        self.state.source_doc_id = sample_doc_id # Quick hack, will replace w/ better solution
         

--- a/upgrades/upgrade_testing_framework/steps/step_test_target_cluster.py
+++ b/upgrades/upgrade_testing_framework/steps/step_test_target_cluster.py
@@ -1,11 +1,11 @@
-from upgrade_testing_framework.cluster_management.cluster import Cluster
+from upgrade_testing_framework.clients.rest_client_default import RESTClientDefault
 from upgrade_testing_framework.core.framework_step import FrameworkStep
-import upgrade_testing_framework.core.shell_interactions as shell
 
 
 class TestTargetCluster(FrameworkStep):
     """
-    This step is where you run tests on the target cluster
+    This step is where you run tests on the target cluster.  The code currently in here is for demo purposes only, and
+    will be deleted once we've incorporated the Robot tests into the UTF.
     """
 
     def _run(self):
@@ -14,8 +14,10 @@ class TestTargetCluster(FrameworkStep):
 
         # Begin the step body
         port = target_cluster.rest_ports[0]
-        _, output = shell.call_shell_command(f"curl -X GET \"localhost:{port}/_cat/nodes?v=true&pretty\"")
-        self.logger.info("\n".join(output))
+        rest_client = RESTClientDefault()
+
+        response_status = rest_client.get_nodes_status(port)
+        self.logger.info(response_status.response_text)
         
         # Update our state
         # N/A


### PR DESCRIPTION
Signed-off-by: Chris Helma <chelma+github@amazon.com>

### Description
Adds a basic REST client library we can expand on to the UTF

### Issues Resolved
* https://github.com/opensearch-project/opensearch-migrations/issues/50

### Testing
Added Unit Tests:
```
(.venv) chelma@3c22fba4e266 upgrades % python -m pytest unit_tests/
========================================== test session starts ===========================================
platform darwin -- Python 3.10.6, pytest-7.2.0, pluggy-1.0.0
rootdir: /Users/chelma/workspace/Migration-Fork/opensearch-migrations/upgrades
collected 92 items                                                                                       

unit_tests/clients/test_rest_client_base.py .........                                              [  9%]
unit_tests/clients/test_rest_ops.py ....                                                           [ 14%]
unit_tests/cluster_management/test_cluster.py ...........                                          [ 26%]
unit_tests/cluster_management/test_container_configuration.py .                                    [ 27%]
unit_tests/cluster_management/test_docker_framework_client.py ...............                      [ 43%]
unit_tests/cluster_management/test_node.py ...........                                             [ 55%]
unit_tests/cluster_management/test_node_configuration.py ..                                        [ 57%]
unit_tests/core/test_exception_base.py ...                                                         [ 60%]
unit_tests/core/test_framework_runner.py ......                                                    [ 67%]
unit_tests/core/test_framework_state.py ...                                                        [ 70%]
unit_tests/core/test_framework_step.py ....                                                        [ 75%]
unit_tests/core/test_logging_wrangler.py .                                                         [ 76%]
unit_tests/core/test_shell_interactions.py .......                                                 [ 83%]
unit_tests/core/test_test_config_wrangling.py .........                                            [ 93%]
unit_tests/core/test_versions_engine.py .....                                                      [ 98%]
unit_tests/core/test_workspace_wrangler.py .                                                       [100%]

=========================================== 92 passed in 1.99s ===========================================
```

Ran the UTF:
```
(.venv) chelma@3c22fba4e266 upgrades % ./run_utf.py --test_config ./test_configs/snapshot_restore_es_7_10_2_to_os_1_3_6.json
[FrameworkRunner] ============ Running Step: LoadTestConfig ============
[LoadTestConfig] Loading test config file...
[LoadTestConfig] Loaded test config file successfully
[FrameworkRunner] Step Succeeded: LoadTestConfig
[FrameworkRunner] ============ Running Step: BootstrapDocker ============
[BootstrapDocker] Checking if Docker is installed and available...
[BootstrapDocker] Docker appears to be installed and available
[BootstrapDocker] Ensuring the Docker image docker.elastic.co/elasticsearch/elasticsearch-oss:7.10.2 is available either locally or remotely...
[BootstrapDocker] Docker image docker.elastic.co/elasticsearch/elasticsearch-oss:7.10.2 is available
[BootstrapDocker] Ensuring the Docker image opensearchproject/opensearch:1.3.6 is available either locally or remotely...
[BootstrapDocker] Docker image opensearchproject/opensearch:1.3.6 is available
[FrameworkRunner] Step Succeeded: BootstrapDocker
[FrameworkRunner] ============ Running Step: SnapshotRestoreSetup ============
[SnapshotRestoreSetup] Creating shared Docker volume to share snapshots...
[SnapshotRestoreSetup] Created shared Docker volume cluster-snapshots-volume
[FrameworkRunner] Step Succeeded: SnapshotRestoreSetup
[FrameworkRunner] ============ Running Step: StartSourceCluster ============
[StartSourceCluster] Creating source cluster...
[StartSourceCluster] Waiting up to 30 sec for cluster to be active...
Node source-cluster-node-1 is now active
Node source-cluster-node-2 is now active
[StartSourceCluster] Cluster source-cluster is active
[FrameworkRunner] Step Succeeded: StartSourceCluster
[FrameworkRunner] ============ Running Step: TestSourceCluster ============
[TestSourceCluster] Querying cluster status...
[TestSourceCluster] ip         heap.percent ram.percent cpu load_1m load_5m load_15m node.role master name
172.28.0.2            9          57  64    1.39    0.31     0.10 dimr      -      source-cluster-node-1
172.28.0.3            9          57  56    1.39    0.31     0.10 dimr      *      source-cluster-node-2

[TestSourceCluster] Uploading sample document...
[TestSourceCluster] {
  "_index" : "noldor",
  "_type" : "_doc",
  "_id" : "17U8NoUBl5tvL7Xnz8x5",
  "_version" : 1,
  "result" : "created",
  "_shards" : {
    "total" : 2,
    "successful" : 1,
    "failed" : 0
  },
  "_seq_no" : 0,
  "_primary_term" : 1
}

[TestSourceCluster] Retrieving uploaded document...
[TestSourceCluster] Retrieved uploaded doc sucessfully
[TestSourceCluster] {
  "_index" : "noldor",
  "_type" : "_doc",
  "_id" : "17U8NoUBl5tvL7Xnz8x5",
  "_version" : 1,
  "_seq_no" : 0,
  "_primary_term" : 1,
  "found" : true,
  "_source" : {
    "name" : "Finwe"
  }
}

[FrameworkRunner] Step Succeeded: TestSourceCluster
[FrameworkRunner] ============ Running Step: CreateSourceSnapshot ============
[CreateSourceSnapshot] Creating snapshot of source cluster...
[CreateSourceSnapshot] Confirming snapshot of source cluster exists...
[CreateSourceSnapshot] Source snapshot created successfully
[CreateSourceSnapshot] {
  "snapshots" : [
    {
      "snapshot" : "test_snapshot",
      "uuid" : "x2L7FKFTSS6iiEUgS3ivlw",
      "version_id" : 7100299,
      "version" : "7.10.2",
      "indices" : [
        "noldor"
      ],
      "data_streams" : [ ],
      "include_global_state" : true,
      "state" : "SUCCESS",
      "start_time" : "2022-12-21T19:50:33.290Z",
      "start_time_in_millis" : 1671652233290,
      "end_time" : "2022-12-21T19:50:33.491Z",
      "end_time_in_millis" : 1671652233491,
      "duration_in_millis" : 201,
      "failures" : [ ],
      "shards" : {
        "total" : 1,
        "failed" : 0,
        "successful" : 1
      }
    }
  ]
}

[FrameworkRunner] Step Succeeded: CreateSourceSnapshot
[FrameworkRunner] ============ Running Step: StartTargetCluster ============
[StartTargetCluster] Creating target cluster...
[StartTargetCluster] Waiting up to 30 sec for cluster to be active...
Node target-cluster-node-1 is now active
Node target-cluster-node-2 is now active
[StartTargetCluster] Cluster target-cluster is active
[FrameworkRunner] Step Succeeded: StartTargetCluster
[FrameworkRunner] ============ Running Step: TestTargetCluster ============
[TestTargetCluster] ip         heap.percent ram.percent cpu load_1m load_5m load_15m node.role master name
172.29.0.3           21          97  69    3.11    0.80     0.27 dimr      *      target-cluster-node-2
172.29.0.2           20          97  72    3.11    0.80     0.27 dimr      -      target-cluster-node-1

[FrameworkRunner] Step Succeeded: TestTargetCluster
[FrameworkRunner] ============ Running Step: RestoreSourceSnapshot ============
[RestoreSourceSnapshot] Checking if source snapshots are visible on target...
[RestoreSourceSnapshot] Source snapshot visible to target cluster
[RestoreSourceSnapshot] Restoring source snapshot onto target...
[RestoreSourceSnapshot] Waiting a few seconds for the snapshot to be restored...
[RestoreSourceSnapshot] Attempting to retrieve source doc from target cluster...
[RestoreSourceSnapshot] Document retrieved, snapshot restored successfully
[RestoreSourceSnapshot] {
  "_index" : "noldor",
  "_type" : "_doc",
  "_id" : "17U8NoUBl5tvL7Xnz8x5",
  "_version" : 1,
  "_seq_no" : 0,
  "_primary_term" : 1,
  "found" : true,
  "_source" : {
    "name" : "Finwe"
  }
}

[FrameworkRunner] Step Succeeded: RestoreSourceSnapshot
[FrameworkRunner] ============ Running Step: StopSourceCluster ============
[StopSourceCluster] Stopping cluster source-cluster...
[StopSourceCluster] Cleaning up underlying resources for cluster source-cluster...
[FrameworkRunner] Step Succeeded: StopSourceCluster
[FrameworkRunner] ============ Running Step: StopTargetCluster ============
[StopTargetCluster] Stopping cluster target-cluster...
[StopTargetCluster] Cleaning up underlying resources for cluster target-cluster...
[FrameworkRunner] Step Succeeded: StopTargetCluster
[FrameworkRunner] ============ Running Step: SnapshotRestoreTeardown ============
[SnapshotRestoreTeardown] Removing shared Docker volume cluster-snapshots-volume...
[SnapshotRestoreTeardown] Removed shared Docker volume cluster-snapshots-volume
[FrameworkRunner] Step Succeeded: SnapshotRestoreTeardown
[FrameworkRunner] Ran through all steps successfully
[FrameworkRunner] Saving application state to file...
[FrameworkRunner] Application state saved
[FrameworkRunner] Application state saved to: /tmp/utf/state-file
[FrameworkRunner] Full run details logged to: /tmp/utf/logs/run.log.2022-12-21_13_50_15
```

### Check List
- [X] New functionality includes testing
  - [X] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
