### PR TITLE
Add prototype of Expectation model to UTF

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ coverage.xml
 __pycache__
 *.egg-info*
 temp-storage.txt
+.python-version

--- a/knowledge_base/consistent-document-count.json
+++ b/knowledge_base/consistent-document-count.json
@@ -1,0 +1,4 @@
+{
+    "id": "consistent-document-count",
+    "description": "There should be the same number of documents in the each index before and after a migration or upgrade."
+}

--- a/knowledge_base/doy-format-date-range-query.json
+++ b/knowledge_base/doy-format-date-range-query.json
@@ -1,0 +1,24 @@
+[
+    {
+        "id": "doy-format-date-range-query-bug",
+        "description": "Given 1/ an index created in ES 7.x; 2/ documents with dates uploaded in a yyyy-DDD (day of year) format, and a query that uses an inclusive date range, the results of the query will fail to include documents where the date of the document is the same day as the inclusive endpoint of the range. See https://github.com/opensearch-project/OpenSearch/issues/4285",
+        "versions":
+        {
+            "gte": "ES_7_0_0",
+            "lt": "OS_2_4_0"
+        }
+    },
+    {
+        "id": "doy-format-date-range-query-bug-fix",
+        "description": "In contrast to `doy-format-date-range-query-bug`, inclusive date range queries on documents with yyyy-DDD (day of year) date formats behave correctly after OS 2.4.0, and before ES 7.x (when the bug was introduced).",
+        "versions":
+        [
+            {
+                "gte": "OS_2_4_0"
+            },
+            {
+                "lt": "ES_7_0_0"
+            }
+        ]
+    }
+]

--- a/knowledge_base/doy-format-date-range-query.json
+++ b/knowledge_base/doy-format-date-range-query.json
@@ -3,10 +3,10 @@
         "id": "doy-format-date-range-query-bug",
         "description": "Given 1/ an index created in ES 7.x; 2/ documents with dates uploaded in a yyyy-DDD (day of year) format, and a query that uses an inclusive date range, the results of the query will fail to include documents where the date of the document is the same day as the inclusive endpoint of the range. See https://github.com/opensearch-project/OpenSearch/issues/4285",
         "versions":
-        {
+        [{
             "gte": "ES_7_0_0",
             "lt": "OS_2_4_0"
-        }
+        }]
     },
     {
         "id": "doy-format-date-range-query-bug-fix",

--- a/upgrades/README.md
+++ b/upgrades/README.md
@@ -37,3 +37,8 @@ python -m pytest unit_tests/
 
 You can read more about running unit tests with Pytest [here](https://docs.pytest.org/en/7.2.x/how-to/usage.html).  
 
+### Step 3 - Run UTF Framework
+Run the UTF framework with the `run_utf.py` script and a test config file. For the default snapshot/restore upgrade from Elasticsearch 7.10.2 to OpenSearch 1.3.6, it can be invoked with:
+```
+./run_utf.py --test_config test_configs/snapshot_restore_es_7_10_2_to_os_1_3_6.json
+```

--- a/upgrades/unit_tests/core/test_expectation.py
+++ b/upgrades/unit_tests/core/test_expectation.py
@@ -2,6 +2,8 @@ import json
 import pytest
 
 from upgrade_testing_framework.core.expectation import Expectation, load_knowledge_base
+import upgrade_testing_framework.core.expectation as expectations
+
 
 TEST_EXPECTATION = {
     "id": "expectation-id",
@@ -9,10 +11,10 @@ TEST_EXPECTATION = {
 }
 
 TEST_EXPECTATION_WITH_VERSION = TEST_EXPECTATION | {
-    "versions": {
+    "versions": [{
         "gt": "ES_7_10_2",
         "lte": "OS_1_3_6"
-    }
+    }]
 }
 
 TEST_EXPECTATION_COMPLEX_VERSION = TEST_EXPECTATION | {
@@ -29,9 +31,9 @@ TEST_EXPECTATION_COMPLEX_VERSION = TEST_EXPECTATION | {
 
 TEST_EXPECTATION_MISSING_ID = {
     "description": "hello world",
-    "versions": {
+    "versions": [{
         "gt": "OS_1_0_0"
-    }
+    }]
 }
 
 
@@ -45,10 +47,49 @@ def valid_knowledge_base_dir(tmpdir):
     expectation_file_2.write(json.dumps([TEST_EXPECTATION_WITH_VERSION, TEST_EXPECTATION_COMPLEX_VERSION]))
     return test_kb_dir
 
-# TODO: construct fixtures & tests to check all the json file error conditions (see test_test_config_wrangling)
+
+@pytest.fixture
+def knowledge_base_dir_with_non_parsable_file(tmpdir):
+    test_kb_dir = tmpdir / "knowledge_base"
+    test_kb_dir.mkdir()
+    expectation_file = test_kb_dir / "ex.json"
+    expectation_file.write("{[}")
+    return test_kb_dir
 
 
-def test_WHEN_load_test_config_called_AND_valid_THEN_returns_it(valid_knowledge_base_dir):
+@pytest.fixture
+def knowledge_base_dir_with_empty_file(tmpdir):
+    test_kb_dir = tmpdir / "knowledge_base"
+    test_kb_dir.mkdir()
+    expectation_file = test_kb_dir / "ex.json"
+    expectation_file.write(json.dumps({}))
+    return test_kb_dir
+
+
+@pytest.fixture
+def knowledge_base_dir_with_expectation_missing_id(tmpdir):
+    test_kb_dir = tmpdir / "knowledge_base"
+    test_kb_dir.mkdir()
+    expectation_file = test_kb_dir / "ex.json"
+    expectation_file.write(json.dumps(TEST_EXPECTATION_MISSING_ID))
+    return test_kb_dir
+
+
+@pytest.fixture
+def knowledge_base_not_a_dir(tmpdir):
+    test_kb = tmpdir / "knowledge_base"
+    test_kb.write("")
+    return test_kb
+
+
+@pytest.fixture
+def knowledge_base_doesnt_exist(tmpdir):
+    test_kb = tmpdir / "knowledge_base"
+    test_kb.write("")
+    return test_kb
+
+
+def test_WHEN_load_knowledge_base_called_AND_valid_THEN_returns_it(valid_knowledge_base_dir):
     actual_value = load_knowledge_base(valid_knowledge_base_dir)
 
     # Check the results
@@ -59,23 +100,55 @@ def test_WHEN_load_test_config_called_AND_valid_THEN_returns_it(valid_knowledge_
     assert expected_value == actual_value
 
 
+def test_WHEN_load_knowledge_base_called_AND_non_readable_file_THEN_raises(valid_knowledge_base_dir):
+    # Set up our test
+    unreadable_file = valid_knowledge_base_dir / "unreadable.json"
+    unreadable_file.write("")
+    unreadable_file.chmod(0o200)  # Make the file unreadable
+
+    # Run our test
+    with pytest.raises(expectations.ExpectationCantReadFileException):
+        load_knowledge_base(valid_knowledge_base_dir)
+
+
+def test_WHEN_load_knowledge_base_called_AND_non_valid_json_THEN_raises(knowledge_base_dir_with_non_parsable_file):
+    with pytest.raises(expectations.ExpectationFileNotJSONException):
+        load_knowledge_base(knowledge_base_dir_with_non_parsable_file)
+
+
+def test_WHEN_load_knowledge_base_called_AND_no_expectation_id_THEN_raises(
+        knowledge_base_dir_with_expectation_missing_id):
+    with pytest.raises(expectations.ExpectationMissingIdException):
+        load_knowledge_base(knowledge_base_dir_with_expectation_missing_id)
+
+
+def test_WHEN_load_knowledge_base_called_AND_not_a_dir_THEN_raises(knowledge_base_not_a_dir):
+    with pytest.raises(expectations.KnowledgeBaseDirectoryDoesntExistException):
+        load_knowledge_base(knowledge_base_not_a_dir)
+
+
+def test_WHEN_load_knowledge_base_called_AND_doesnt_exist_THEN_raises(knowledge_base_doesnt_exist):
+    with pytest.raises(expectations.KnowledgeBaseDirectoryDoesntExistException):
+        load_knowledge_base(knowledge_base_doesnt_exist)
+
+
 def test_WHEN_no_version_filter_THEN_matches_all():
     expectation = Expectation(TEST_EXPECTATION)
     for version in ["ES_2_5_0", "ES_7_10_2", "OS_1_0_0", "OS_1_3_6", "OS_2_0_0"]:
-        assert expectation.is_relevant_to_version(version)
+        assert expectation.applies_to_version(version)
 
 
 def test_WHEN_version_filter_THEN_matches_correctly():
     expectation = Expectation(TEST_EXPECTATION_WITH_VERSION)
     for version in ["ES_7_10_3", "OS_1_0_0", "OS_1_3_6"]:
-        assert expectation.is_relevant_to_version(version)
+        assert expectation.applies_to_version(version)
     for version in ["ES_2_5_0", "ES_7_10_2", "OS_1_3_7", "OS_2_4_0"]:
-        assert not expectation.is_relevant_to_version(version)
+        assert not expectation.applies_to_version(version)
 
 
 def test_WHEN_complex_version_filter_THEN_matches_correctly():
     expectation = Expectation(TEST_EXPECTATION_COMPLEX_VERSION)
     for version in ["ES_2_5_1", "ES_6_10_2", "OS_2_0_0", "OS_2_4_0"]:
-        assert expectation.is_relevant_to_version(version)
+        assert expectation.applies_to_version(version)
     for version in ["ES_2_5_0", "ES_7_0_0", "ES_7_10_3", "OS_1_0_0"]:
-        assert not expectation.is_relevant_to_version(version)
+        assert not expectation.applies_to_version(version)

--- a/upgrades/unit_tests/core/test_expectation.py
+++ b/upgrades/unit_tests/core/test_expectation.py
@@ -1,7 +1,5 @@
 import json
-import os
 import pytest
-import py
 
 from upgrade_testing_framework.core.expectation import Expectation, load_knowledge_base
 
@@ -36,6 +34,7 @@ TEST_EXPECTATION_MISSING_ID = {
     }
 }
 
+
 @pytest.fixture
 def valid_knowledge_base_dir(tmpdir):
     test_kb_dir = tmpdir / "knowledge_base"
@@ -47,6 +46,7 @@ def valid_knowledge_base_dir(tmpdir):
     return test_kb_dir
 
 # TODO: construct fixtures & tests to check all the json file error conditions (see test_test_config_wrangling)
+
 
 def test_WHEN_load_test_config_called_AND_valid_THEN_returns_it(valid_knowledge_base_dir):
     actual_value = load_knowledge_base(valid_knowledge_base_dir)
@@ -76,7 +76,6 @@ def test_WHEN_version_filter_THEN_matches_correctly():
 def test_WHEN_complex_version_filter_THEN_matches_correctly():
     expectation = Expectation(TEST_EXPECTATION_COMPLEX_VERSION)
     for version in ["ES_2_5_1", "ES_6_10_2", "OS_2_0_0", "OS_2_4_0"]:
-        assert expectation.is_relevant_to_version(version)       
+        assert expectation.is_relevant_to_version(version)
     for version in ["ES_2_5_0", "ES_7_0_0", "ES_7_10_3", "OS_1_0_0"]:
         assert not expectation.is_relevant_to_version(version)
-

--- a/upgrades/unit_tests/core/test_expectation.py
+++ b/upgrades/unit_tests/core/test_expectation.py
@@ -1,0 +1,82 @@
+import json
+import os
+import pytest
+import py
+
+from upgrade_testing_framework.core.expectation import Expectation, load_knowledge_base
+
+TEST_EXPECTATION = {
+    "id": "expectation-id",
+    "description": "expectation description",
+}
+
+TEST_EXPECTATION_WITH_VERSION = TEST_EXPECTATION | {
+    "versions": {
+        "gt": "ES_7_10_2",
+        "lte": "OS_1_3_6"
+    }
+}
+
+TEST_EXPECTATION_COMPLEX_VERSION = TEST_EXPECTATION | {
+    "versions": [
+        {
+            "gte": "OS_2_0_0"
+        },
+        {
+            "gt": "ES_2_5_0",
+            "lt": "ES_7_0_0"
+        }
+    ]
+}
+
+TEST_EXPECTATION_MISSING_ID = {
+    "description": "hello world",
+    "versions": {
+        "gt": "OS_1_0_0"
+    }
+}
+
+@pytest.fixture
+def valid_knowledge_base_dir(tmpdir):
+    test_kb_dir = tmpdir / "knowledge_base"
+    test_kb_dir.mkdir()
+    expectation_file_1 = test_kb_dir / "ex1.json"
+    expectation_file_2 = test_kb_dir / "ex2.json"
+    expectation_file_1.write(json.dumps(TEST_EXPECTATION))
+    expectation_file_2.write(json.dumps([TEST_EXPECTATION_WITH_VERSION, TEST_EXPECTATION_COMPLEX_VERSION]))
+    return test_kb_dir
+
+# TODO: construct fixtures & tests to check all the json file error conditions (see test_test_config_wrangling)
+
+def test_WHEN_load_test_config_called_AND_valid_THEN_returns_it(valid_knowledge_base_dir):
+    actual_value = load_knowledge_base(valid_knowledge_base_dir)
+
+    # Check the results
+    expected_value = [Expectation(TEST_EXPECTATION),
+                      Expectation(TEST_EXPECTATION_WITH_VERSION),
+                      Expectation(TEST_EXPECTATION_COMPLEX_VERSION)]
+
+    assert expected_value == actual_value
+
+
+def test_WHEN_no_version_filter_THEN_matches_all():
+    expectation = Expectation(TEST_EXPECTATION)
+    for version in ["ES_2_5_0", "ES_7_10_2", "OS_1_0_0", "OS_1_3_6", "OS_2_0_0"]:
+        assert expectation.is_relevant_to_version(version)
+
+
+def test_WHEN_version_filter_THEN_matches_correctly():
+    expectation = Expectation(TEST_EXPECTATION_WITH_VERSION)
+    for version in ["ES_7_10_3", "OS_1_0_0", "OS_1_3_6"]:
+        assert expectation.is_relevant_to_version(version)
+    for version in ["ES_2_5_0", "ES_7_10_2", "OS_1_3_7", "OS_2_4_0"]:
+        assert not expectation.is_relevant_to_version(version)
+
+
+def test_WHEN_complex_version_filter_THEN_matches_correctly():
+    expectation = Expectation(TEST_EXPECTATION_COMPLEX_VERSION)
+    for version in ["ES_2_5_1", "ES_6_10_2", "OS_2_0_0", "OS_2_4_0"]:
+        assert expectation.is_relevant_to_version(version)       
+    for version in ["ES_2_5_0", "ES_7_0_0", "ES_7_10_3", "OS_1_0_0"]:
+        assert not expectation.is_relevant_to_version(version)
+

--- a/upgrades/unit_tests/core/test_versions_engine.py
+++ b/upgrades/unit_tests/core/test_versions_engine.py
@@ -32,3 +32,15 @@ def test_WHEN_get_version_AND_version_not_int_THEN_raises():
     # Run our test
     with pytest.raises(versions.CouldNotParseEngineVersionException):
         versions.get_version("OS_1_3b_6")
+
+def test_WHEN_version_comparison_AND_same_engine_THEN_compares():
+    # Major versions are different
+    assert versions.get_version("ES_7_0_2") > versions.get_version("ES_3_5_0")
+    # Major versions are same
+    assert versions.get_version("ES_7_10_2") > versions.get_version("ES_7_0_0")
+    assert versions.get_version("OS_2_0_0") < versions.get_version("OS_2_4_0")
+    assert versions.get_version("OS_2_4_0") >= versions.get_version("OS_2_4_0")
+
+def test_WHEN_version_comparison_AND_different_engine_THEN_compares():
+    assert versions.get_version("ES_7_10_2") < versions.get_version("OS_1_0_0")
+    assert versions.get_version("OS_2_4_0") >= versions.get_version("ES_3_5_0")

--- a/upgrades/unit_tests/core/test_versions_engine.py
+++ b/upgrades/unit_tests/core/test_versions_engine.py
@@ -2,6 +2,7 @@ import pytest
 
 import upgrade_testing_framework.core.versions_engine as versions
 
+
 def test_WHEN_get_version_AND_valid_es_THEN_returns():
     # Run our test
     actual_value = versions.get_version("ES_7_10_2")
@@ -9,6 +10,7 @@ def test_WHEN_get_version_AND_valid_es_THEN_returns():
     # Check our results
     expected_value = versions.EngineVersion(versions.ENGINE_ELASTICSEARCH, 7, 10, 2)
     assert expected_value == actual_value
+
 
 def test_WHEN_get_version_AND_valid_os_THEN_returns():
     # Run our test
@@ -18,20 +20,24 @@ def test_WHEN_get_version_AND_valid_os_THEN_returns():
     expected_value = versions.EngineVersion(versions.ENGINE_OPENSEARCH, 1, 3, 6)
     assert expected_value == actual_value
 
+
 def test_WHEN_get_version_AND_engine_weird_THEN_raises():
     # Run our test
     with pytest.raises(versions.CouldNotParseEngineVersionException):
         versions.get_version("OSS_1_3_6")
+
 
 def test_WHEN_get_version_AND_not_enough_fields_THEN_raises():
     # Run our test
     with pytest.raises(versions.CouldNotParseEngineVersionException):
         versions.get_version("OS_1_3")
 
+
 def test_WHEN_get_version_AND_version_not_int_THEN_raises():
     # Run our test
     with pytest.raises(versions.CouldNotParseEngineVersionException):
         versions.get_version("OS_1_3b_6")
+
 
 def test_WHEN_version_comparison_AND_same_engine_THEN_compares():
     # Major versions are different
@@ -40,6 +46,7 @@ def test_WHEN_version_comparison_AND_same_engine_THEN_compares():
     assert versions.get_version("ES_7_10_2") > versions.get_version("ES_7_0_0")
     assert versions.get_version("OS_2_0_0") < versions.get_version("OS_2_4_0")
     assert versions.get_version("OS_2_4_0") >= versions.get_version("OS_2_4_0")
+
 
 def test_WHEN_version_comparison_AND_different_engine_THEN_compares():
     assert versions.get_version("ES_7_10_2") < versions.get_version("OS_1_0_0")

--- a/upgrades/upgrade_testing_framework/cluster_management/cluster_objects.py
+++ b/upgrades/upgrade_testing_framework/cluster_management/cluster_objects.py
@@ -4,3 +4,9 @@ from dataclasses import dataclass
 class ClusterSnapshot:
     repo_name: str
     snapshot_id: str
+
+    def to_dict(self) -> dict:
+        return {
+            "repo_name": self.repo_name,
+            "snapshot_id": self.snapshot_id
+        }

--- a/upgrades/upgrade_testing_framework/core/expectation.py
+++ b/upgrades/upgrade_testing_framework/core/expectation.py
@@ -1,0 +1,96 @@
+from pathlib import Path
+import json
+from typing import List
+import operator
+
+from upgrade_testing_framework.core.versions_engine import EngineVersion
+
+class KnowledgeBaseDoesntExistException(Exception):
+    def __init__(self, knowledge_base_path):
+        super().__init__(f"The path specified for the knowledge base doesn't exist or is not a directory: {knowledge_base_path}")
+
+class ExpectationCantReadFileException(Exception):
+    def __init__(self, expecation_path, original_exception):
+        super().__init__(f"Unable to read test config file at path {expecation_path}.  Details: {str(original_exception)}")
+
+class ExpectationFileNotJSONException(Exception):
+    def __init__(self, expecation_path, original_exception):
+        super().__init__(f"The test config at path {expecation_path} is not parsible as JSON.  Details: {str(original_exception)}")
+
+class ExpectationMissingIdException(Exception):
+    def __init__(self):
+        super().__init__("An expectation was missing its id") # TODO make this better
+
+
+COMP_OPERATION = {
+    "gt": operator.gt,
+    "lt": operator.lt,
+    "gte": operator.ge,
+    "lte": operator.le
+}
+
+
+class Expectation:
+    def __init__(self, raw_expectation: dict):
+        self.id = raw_expectation.get("id", None)
+        if self.id is None:
+            raise ExpectationMissingIdException()
+        self.description = raw_expectation.get("description", None)
+        self.version_filter = raw_expectation.get("versions", None)
+        
+
+    def is_relevant_to_version(self, version: EngineVersion) -> bool:
+        # If no version_filter, assume relevant to all versions
+        if self.version_filter is None:
+            return True
+
+        version_filters = self.version_filter if type(self.version_filter) is list else [self.version_filter]
+
+        # Version filters have sections which are ORed together, each of which has
+        # components (gt/gte and/or lt/lte), which are ANDed together.
+        for section in version_filters:
+            section_valid = True
+            for op, comp_value in section.items():
+                if not COMP_OPERATION[op](version, comp_value):
+                    section_valid = False
+                    break
+            if section_valid:
+                return True
+        return False
+
+    def to_dict(self) -> dict:
+        return {
+            "id": self.id,
+            "description": self.description,
+            "versions": self.version_filter
+        }    
+
+    def __eq__(self, other):
+        return self.to_dict() == other.to_dict()
+
+
+
+def load_knowledge_base(knowledge_base_path: str) -> List[Expectation]:
+    expectations: List[Expectation] = []
+
+    kb_path = Path(knowledge_base_path).absolute()
+
+    # Confirm the Knowledge Base directory exists
+    if not (kb_path.exists() and kb_path.is_dir()):
+        raise KnowledgeBaseDoesntExistException(knowledge_base_path)
+
+    # Open each json file in the directory and load it as an Expectation
+    for expectation_file in [ef for ef in kb_path.iterdir() if ef.match("*.json")]:
+        try:
+            with expectation_file.open('r') as file_handle:
+                raw_expectation = json.load(file_handle)
+        except json.JSONDecodeError as exception:
+            raise ExpectationFileNotJSONException(expectation_file, exception)
+        except IOError as exception:
+            raise ExpectationCantReadFileException(expectation_file, exception)
+        if type(raw_expectation) is dict:
+            expectations.append(Expectation(raw_expectation))
+        else:
+            expectations += [Expectation(e) for e in raw_expectation]
+
+    return expectations

--- a/upgrades/upgrade_testing_framework/core/framework_state.py
+++ b/upgrades/upgrade_testing_framework/core/framework_state.py
@@ -22,7 +22,7 @@ class FrameworkState:
         self.source_cluster: Cluster = None
         self.target_cluster: Cluster = None
         self.test_config: TestConfig = None
-        self.eligible_expectations = []
+        self.eligible_expectations: List[str] = []
         self._app_state = state
 
         # The fact that we need to store this in our FrameworkState means we probably need to be more sophisticated in
@@ -37,6 +37,7 @@ class FrameworkState:
             "shared_volume": self.shared_volume.to_dict() if self.shared_volume else None,
             "source_cluster": self.source_cluster.to_dict() if self.source_cluster else None,
             "target_cluster": self.target_cluster.to_dict() if self.target_cluster else None,
+            "snapshot": self.snapshot.to_dict() if self.snapshot else None,
             "test_config": self.test_config.to_dict() if self.test_config else None,
             "eligible_expectations": self.eligible_expectations
         }

--- a/upgrades/upgrade_testing_framework/core/test_config_wrangling.py
+++ b/upgrades/upgrade_testing_framework/core/test_config_wrangling.py
@@ -41,7 +41,7 @@ class ClustersDef:
         return {
             "source": self.source.to_dict(),
             "target": self.target.to_dict()
-        }    
+        }
 
     def __eq__(self, other):
         return self.to_dict() == other.to_dict()

--- a/upgrades/upgrade_testing_framework/core/versions_engine.py
+++ b/upgrades/upgrade_testing_framework/core/versions_engine.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from functools import total_ordering
 
 ENGINE_ELASTICSEARCH = "Elasticsearch"
 ENGINE_OPENSEARCH = "OpenSearch"
@@ -10,11 +11,21 @@ class CouldNotParseEngineVersionException(Exception):
         )
 
 @dataclass
+@total_ordering
 class EngineVersion:
     engine: str
     major: int
     minor: int
     patch: int
+
+    def __lt__(self, other) -> bool:
+        # TODO: Check for post-fork ES versions, which can't be compared.
+        if self.engine == other.engine:
+            # If the engines are the same, lexically compare the versions
+            return (self.major, self.minor, self.patch) < (other.major, other.minor, other.patch)
+        # otherwise, ES < OS
+        return self.engine == ENGINE_ELASTICSEARCH and other.engine == ENGINE_OPENSEARCH
+
 
 def get_version(version_string: str) -> EngineVersion:
     # expected an input string like: "ES_7_10_2"

--- a/upgrades/upgrade_testing_framework/core/versions_engine.py
+++ b/upgrades/upgrade_testing_framework/core/versions_engine.py
@@ -4,11 +4,13 @@ from functools import total_ordering
 ENGINE_ELASTICSEARCH = "Elasticsearch"
 ENGINE_OPENSEARCH = "OpenSearch"
 
+
 class CouldNotParseEngineVersionException(Exception):
     def __init__(self, version_string: str):
         super().__init__(f"Could not parse version string: {version_string}.  Expected something like 'ES_7_10_2' or"
-            " 'OS_1_3_6'."
-        )
+                         " 'OS_1_3_6'."
+                         )
+
 
 @dataclass
 @total_ordering

--- a/upgrades/upgrade_testing_framework/steps/step_load_test_config.py
+++ b/upgrades/upgrade_testing_framework/steps/step_load_test_config.py
@@ -8,7 +8,7 @@ class LoadTestConfig(FrameworkStep):
 
     def _run(self):
         # Get the state we need
-        test_config_path = self._get_state_value("test_config_path") 
+        test_config_path = self._get_state_value("test_config_path")
 
         # Begin the step body
         self.logger.info("Loading test config file...")

--- a/upgrades/upgrade_testing_framework/steps/step_select_expectations.py
+++ b/upgrades/upgrade_testing_framework/steps/step_select_expectations.py
@@ -1,4 +1,8 @@
+from pathlib import Path
+
 from upgrade_testing_framework.core.framework_step import FrameworkStep
+from upgrade_testing_framework.core.expectation import Expectation, load_knowledge_base
+
 
 class SelectExpectations(FrameworkStep):
     """
@@ -7,11 +11,21 @@ class SelectExpectations(FrameworkStep):
 
     def _run(self):
         # Get the state we need
+        source_version = self.state.test_config.clusters_def.source.engine_version
+        target_version = self.state.test_config.clusters_def.target.engine_version
+        # path_to_knowledge_base = self.state.test_config.path_to_knowledge_base
+        path_to_knowledge_base = Path("../knowledge_base")
 
         # Begin the step body
-        # Query the expectation knowledge base
-        self.logger.info("Querying applicable expectations...")
+        # Load all expectations
+        self.logger.info("Loading Knowledge Base and filtering for relevant expectations")
+        expectations = load_knowledge_base(path_to_knowledge_base)
+        # Filter for relevant ones
+        relevant_expectation_ids = [e.id for e in expectations
+            if e.is_relevant_to_version(source_version) or e.is_relevant_to_version(target_version)]
+        self.logger.info(f"Found {len(relevant_expectation_ids)} relevant expectations.")
+        self.logger.debug(f"Relevant expectations: {relevant_expectation_ids}")
 
         # Update our state
         # TODO Temporary measure until this step queries for expectations
-        self.state.eligible_expectations = ['consistent-document-count']
+        self.state.eligible_expectations = relevant_expectation_ids

--- a/upgrades/upgrade_testing_framework/steps/step_select_expectations.py
+++ b/upgrades/upgrade_testing_framework/steps/step_select_expectations.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 from upgrade_testing_framework.core.framework_step import FrameworkStep
-from upgrade_testing_framework.core.expectation import Expectation, load_knowledge_base
+from upgrade_testing_framework.core.expectation import load_knowledge_base
 
 
 class SelectExpectations(FrameworkStep):
@@ -22,7 +22,8 @@ class SelectExpectations(FrameworkStep):
         expectations = load_knowledge_base(path_to_knowledge_base)
         # Filter for relevant ones
         relevant_expectation_ids = [e.id for e in expectations
-            if e.is_relevant_to_version(source_version) or e.is_relevant_to_version(target_version)]
+                                    if e.is_relevant_to_version(source_version) or
+                                    e.is_relevant_to_version(target_version)]
         self.logger.info(f"Found {len(relevant_expectation_ids)} relevant expectations.")
         self.logger.debug(f"Relevant expectations: {relevant_expectation_ids}")
 

--- a/upgrades/upgrade_testing_framework/steps/step_select_expectations.py
+++ b/upgrades/upgrade_testing_framework/steps/step_select_expectations.py
@@ -13,7 +13,7 @@ class SelectExpectations(FrameworkStep):
         # Get the state we need
         source_version = self.state.test_config.clusters_def.source.engine_version
         target_version = self.state.test_config.clusters_def.target.engine_version
-        # path_to_knowledge_base = self.state.test_config.path_to_knowledge_base
+
         path_to_knowledge_base = Path("../knowledge_base")
 
         # Begin the step body
@@ -22,8 +22,8 @@ class SelectExpectations(FrameworkStep):
         expectations = load_knowledge_base(path_to_knowledge_base)
         # Filter for relevant ones
         relevant_expectation_ids = [e.id for e in expectations
-                                    if e.is_relevant_to_version(source_version) or
-                                    e.is_relevant_to_version(target_version)]
+                                    if e.applies_to_version(source_version) or
+                                    e.applies_to_version(target_version)]
         self.logger.info(f"Found {len(relevant_expectation_ids)} relevant expectations.")
         self.logger.debug(f"Relevant expectations: {relevant_expectation_ids}")
 


### PR DESCRIPTION
Signed-off-by: Mikayla Thompson <thomika@amazon.com>

### Description
This PR begins to prototype the Expectation system -- following design issue #24 .
Generally, it adds:
- an Expectation model
- new features to the EngineVersion model that allow versions to be compared
- code in the SelectExpectations that loads the expectations in the knowledge base and filter them for relevant versions

There are a few major caveats with this PR:
1. It uses the original versioning system I laid out in the design (#24) --  but there's an ongoing discussion about making the system clearer, and changes to incorporate that haven't been included here yet.
2. Test coverage/error handling is not complete at this point. There's more work to be done (ongoing) on testing the non-happy paths (I will have another commit coming today with this and other cleanup work)
3. There's additional feedback on the design that should be incorporated into this--I haven't taken the step back to rework the design & then let that ripple out to this work.
4. There's definitely a lot more documentation that should be created around the knowledge base. That will be one of the most user-facing pieces of this project and it needs to be easy to understand and contribute to. This is an issue for another PR.
5. The reporting system is non-existent so far (beyond the robot test output). The biggest feature that's missing is showing which expectations apply but were not tested or failed their tests. This requires pulling data back from the robot framework, which I'm working on now.

Demo of code in action:
(note the `SelectExpectations` section)
```
└─(23:16:19 on expectation-prototype ✹ ✭)──> ./run_utf.py --test_config test_configs/snapshot_restore_es_7_10_2_to_os_1_3_6.json
[FrameworkRunner] ============ Running Step: LoadTestConfig ============
[LoadTestConfig] Loading test config file...
[LoadTestConfig] Loaded test config file successfully
[FrameworkRunner] Step Succeeded: LoadTestConfig
[FrameworkRunner] ============ Running Step: BootstrapDocker ============
[BootstrapDocker] Checking if Docker is installed and available...
[BootstrapDocker] Docker appears to be installed and available
[BootstrapDocker] Ensuring the Docker image docker.elastic.co/elasticsearch/elasticsearch-oss:7.10.2 is available either locally or remotely...
[BootstrapDocker] Docker image docker.elastic.co/elasticsearch/elasticsearch-oss:7.10.2 is available
[BootstrapDocker] Ensuring the Docker image opensearchproject/opensearch:1.3.6 is available either locally or remotely...
[BootstrapDocker] Docker image opensearchproject/opensearch:1.3.6 is available
[FrameworkRunner] Step Succeeded: BootstrapDocker
[FrameworkRunner] ============ Running Step: SnapshotRestoreSetup ============
[SnapshotRestoreSetup] Creating shared Docker volume to share snapshots...
[SnapshotRestoreSetup] Created shared Docker volume cluster-snapshots-volume
[FrameworkRunner] Step Succeeded: SnapshotRestoreSetup
[FrameworkRunner] ============ Running Step: SelectExpectations ============
[SelectExpectations] Loading Knowledge Base and filtering for relevant expectations
[SelectExpectations] Found 2 relevant expectations.
[FrameworkRunner] Step Succeeded: SelectExpectations
[FrameworkRunner] ============ Running Step: StartSourceCluster ============
[StartSourceCluster] Creating source cluster...
[StartSourceCluster] Waiting up to 30 sec for cluster to be active...
Node source-cluster-node-1 is now active
Node source-cluster-node-2 is now active
[StartSourceCluster] Cluster source-cluster is active
[FrameworkRunner] Step Succeeded: StartSourceCluster
[FrameworkRunner] ============ Running Step: PerformPreUpgradeTest ============
==============================================================================
Tests
==============================================================================
Tests.Common Upgrade Test
==============================================================================
Perform pre-upgrade setup of "consistent-document-count" expectation  PUT http://localhost:9200/sample-index [status:200 request:0.505s]
.POST http://localhost:9200/sample-index/_doc [status:201 request:0.394s]
.POST http://localhost:9200/sample-index/_doc [status:201 request:0.013s]
.POST http://localhost:9200/sample-index/_refresh [status:200 request:0.083s]
.POST http://localhost:9200/sample-index/_count [status:200 request:0.102s]
Perform pre-upgrade setup of "consistent-document-count" expectation  | PASS |
------------------------------------------------------------------------------
Tests.Common Upgrade Test                                             | PASS |
1 test, 1 passed, 0 failed
==============================================================================
Tests                                                                 | PASS |
1 test, 1 passed, 0 failed
==============================================================================
Output:  /tmp/utf/test-results/pre_upgrade/output.xml
Log:     /tmp/utf/test-results/pre_upgrade/log.html
Report:  /tmp/utf/test-results/pre_upgrade/report.html
[FrameworkRunner] Step Succeeded: PerformPreUpgradeTest
[FrameworkRunner] ============ Running Step: CreateSourceSnapshot ============
[CreateSourceSnapshot] Creating snapshot of source cluster...
[CreateSourceSnapshot] Confirming snapshot of source cluster exists...
[CreateSourceSnapshot] Source snapshot created successfully
[FrameworkRunner] Step Succeeded: CreateSourceSnapshot
[FrameworkRunner] ============ Running Step: StartTargetCluster ============
[StartTargetCluster] Creating target cluster...
[StartTargetCluster] Waiting up to 30 sec for cluster to be active...
Node target-cluster-node-1 is now active
Node target-cluster-node-2 is now active
[StartTargetCluster] Cluster target-cluster is active
[FrameworkRunner] Step Succeeded: StartTargetCluster
[FrameworkRunner] ============ Running Step: RestoreSourceSnapshot ============
[RestoreSourceSnapshot] Checking if source snapshots are visible on target...
[RestoreSourceSnapshot] Source snapshot visible to target cluster
[RestoreSourceSnapshot] Restoring source snapshot onto target...
[RestoreSourceSnapshot] Snapshot restored successfully
[FrameworkRunner] Step Succeeded: RestoreSourceSnapshot
[FrameworkRunner] ============ Running Step: PerformPostUpgradeTest ============
==============================================================================
Tests
==============================================================================
Tests.Common Upgrade Test
==============================================================================
Perform post-upgrade assertion of "consistent-document-count" expe... .POST http://localhost:9202/sample-index/_count [status:200 request:0.124s]
Perform post-upgrade assertion of "consistent-document-count" expe... | PASS |
------------------------------------------------------------------------------
Tests.Common Upgrade Test                                             | PASS |
1 test, 1 passed, 0 failed
==============================================================================
Tests                                                                 | PASS |
1 test, 1 passed, 0 failed
==============================================================================
Output:  /tmp/utf/test-results/post_upgrade/output.xml
Log:     /tmp/utf/test-results/post_upgrade/log.html
Report:  /tmp/utf/test-results/post_upgrade/report.html
[FrameworkRunner] Step Succeeded: PerformPostUpgradeTest
[FrameworkRunner] ============ Running Step: StopSourceCluster ============
[StopSourceCluster] Stopping cluster source-cluster...
[StopSourceCluster] Cleaning up underlying resources for cluster source-cluster...
[FrameworkRunner] Step Succeeded: StopSourceCluster
[FrameworkRunner] ============ Running Step: StopTargetCluster ============
[StopTargetCluster] Stopping cluster target-cluster...
[StopTargetCluster] Cleaning up underlying resources for cluster target-cluster...
[FrameworkRunner] Step Succeeded: StopTargetCluster
[FrameworkRunner] ============ Running Step: SnapshotRestoreTeardown ============
[SnapshotRestoreTeardown] Removing shared Docker volume cluster-snapshots-volume...
[SnapshotRestoreTeardown] Removed shared Docker volume cluster-snapshots-volume
[FrameworkRunner] Step Succeeded: SnapshotRestoreTeardown
[FrameworkRunner] Ran through all steps successfully
[FrameworkRunner] Saving application state to file...
[FrameworkRunner] Application state saved
[FrameworkRunner] Application state saved to: /tmp/utf/state-file
[FrameworkRunner] Full run details logged to: /tmp/utf/logs/run.log.2022-12-22_23_18_18

─(23:19:08 on expectation-prototype ✹ ✭)──> cat /tmp/utf/state-file| head -n 13
{
    "app_state": {
        "current_step": "SnapshotRestoreTeardown",
        "exit_type": "Succeeded",
        "log_file": "/tmp/utf/logs/run.log.2022-12-22_23_18_18",
        "state_file": "/tmp/utf/state-file",
        "test_config_path": "test_configs/snapshot_restore_es_7_10_2_to_os_1_3_6.json",
        "test_results_directory": "/tmp/utf/test-results"
    },
    "eligible_expectations": [
        "consistent-document-count",
        "doy-format-date-range-query-bug"
    ],
```

### Issues Resolved
Resolves #15 

### Testing
There's unit testing for the Expectation model & the changes to the EngineVersion model, but there's some TODOs with increasing the testing outside of the happy path.

### Check List
- [x] New functionality includes testing
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
