### PR TITLE
Robot tests use EngineVersion for REST client and minor fixes

### DIFF
--- a/cluster_migration_core/README.md
+++ b/cluster_migration_core/README.md
@@ -1,6 +1,6 @@
 # Cluster Migration Core
 
-Core library to assist with testing migrations/upgrades between versions of ElasticSearch and OpenSearch
+This core library assists with testing migrations/upgrades between versions of ElasticSearch and OpenSearch
 
 ## Running Unit Tests
 

--- a/cluster_migration_core/cluster_migration_core/core/versions_engine.py
+++ b/cluster_migration_core/cluster_migration_core/core/versions_engine.py
@@ -3,6 +3,8 @@ from functools import total_ordering
 
 ENGINE_ELASTICSEARCH = "Elasticsearch"
 ENGINE_OPENSEARCH = "OpenSearch"
+ENGINE_ELASTICSEARCH_SHORT = "ES"
+ENGINE_OPENSEARCH_SHORT = "OS"
 
 
 class CouldNotParseEngineVersionException(Exception):
@@ -28,6 +30,10 @@ class EngineVersion:
         # otherwise, ES < OS
         return self.engine == ENGINE_ELASTICSEARCH and other.engine == ENGINE_OPENSEARCH
 
+    def __str__(self) -> str:
+        engine_short = ENGINE_ELASTICSEARCH_SHORT if self.engine == ENGINE_ELASTICSEARCH else ENGINE_OPENSEARCH_SHORT
+        return f"{engine_short}_{self.major}_{self.minor}_{self.patch}"
+
 
 def get_version(version_string: str) -> EngineVersion:
     # expected an input string like: "ES_7_10_2"
@@ -36,9 +42,9 @@ def get_version(version_string: str) -> EngineVersion:
     except:  # noqa: E722
         raise CouldNotParseEngineVersionException(version_string)
 
-    if "ES" == raw_engine:
+    if ENGINE_ELASTICSEARCH_SHORT == raw_engine:
         engine = ENGINE_ELASTICSEARCH
-    elif "OS" == raw_engine:
+    elif ENGINE_OPENSEARCH_SHORT == raw_engine:
         engine = ENGINE_OPENSEARCH
     else:
         raise CouldNotParseEngineVersionException(version_string)

--- a/cluster_migration_core/cluster_migration_core/robot_actions/cluster_action_executor.py
+++ b/cluster_migration_core/cluster_migration_core/robot_actions/cluster_action_executor.py
@@ -8,9 +8,10 @@ class ClusterActionExecutor(ActionExecutor):
     Use this class to execute operations against a cluster
     """
 
-    def __init__(self, hostname: str, port: int, *args, **kwargs):
+    def __init__(self, hostname: str, port: int, engine_version: str, *args, **kwargs):
         self.hostname = hostname
         self.port = port
+        self.engine_version = engine_version
         super().__init__(*args, **kwargs)
 
     def _execute(self) -> None:
@@ -19,7 +20,7 @@ class ClusterActionExecutor(ActionExecutor):
             include=self.include_tags,
             exclude=self.exclude_tags,
             outputdir=self.output_dir,
-            variable=[f"host:{self.hostname}", f"port:{self.port}"],
+            variable=[f"host:{self.hostname}", f"port:{self.port}", f"engine_version:{self.engine_version}"],
             consolewidth=self.console_width,
             loglevel=self.log_level
         )

--- a/cluster_migration_core/unit_tests/core/test_expectation.py
+++ b/cluster_migration_core/unit_tests/core/test_expectation.py
@@ -113,7 +113,9 @@ def test_WHEN_load_knowledge_base_called_AND_valid_THEN_returns_it(valid_knowled
                       Expectation(TEST_EXPECTATION_WITH_VERSION),
                       Expectation(TEST_EXPECTATION_COMPLEX_VERSION)]
 
-    assert expected_value == actual_value
+    assert len(actual_value) == len(expected_value)
+    for e in expected_value:
+        assert e in actual_value
 
 
 def test_WHEN_load_knowledge_base_called_AND_non_readable_file_THEN_raises(valid_knowledge_base_dir):

--- a/cluster_migration_core/unit_tests/core/test_versions_engine.py
+++ b/cluster_migration_core/unit_tests/core/test_versions_engine.py
@@ -51,3 +51,8 @@ def test_WHEN_version_comparison_AND_same_engine_THEN_compares():
 def test_WHEN_version_comparison_AND_different_engine_THEN_compares():
     assert versions.get_version("ES_7_10_2") < versions.get_version("OS_1_0_0")
     assert versions.get_version("OS_2_4_0") >= versions.get_version("ES_3_5_0")
+
+
+def test_WHEN_version_to_str_THEN_returns():
+    assert str(versions.EngineVersion(versions.ENGINE_ELASTICSEARCH, 7, 10, 2)) == "ES_7_10_2"
+    assert str(versions.EngineVersion(versions.ENGINE_OPENSEARCH, 2, 1, 0)) == "OS_2_1_0"

--- a/cluster_migration_core/unit_tests/robot_actions/test_cluster_action_executor.py
+++ b/cluster_migration_core/unit_tests/robot_actions/test_cluster_action_executor.py
@@ -9,6 +9,7 @@ def test_WHEN_execute_called_THEN_invokes_my_implementation(mock_robot):
     # Test values
     hostname = "thingol"
     port = "1"
+    engine_version = "AABB_1_2_3"
     actions_dir = Path("/actions")
     include_tags = ["include"]
     exclude_tags = ["exclude"]
@@ -19,6 +20,7 @@ def test_WHEN_execute_called_THEN_invokes_my_implementation(mock_robot):
     test_executor = cae.ClusterActionExecutor(
         hostname,
         port,
+        engine_version,
         actions_dir,
         output_dir,
         include_tags=include_tags,
@@ -36,7 +38,7 @@ def test_WHEN_execute_called_THEN_invokes_my_implementation(mock_robot):
         include=include_tags,
         exclude=exclude_tags,
         outputdir=output_dir,
-        variable=[f"host:{hostname}", f"port:{port}"],
+        variable=[f"host:{hostname}", f"port:{port}", f"engine_version:{engine_version}"],
         consolewidth=console_width,
         loglevel=log_level
     )]

--- a/upgrades/upgrade_testing_framework/robot_lib/OpenSearchRESTActions.py
+++ b/upgrades/upgrade_testing_framework/robot_lib/OpenSearchRESTActions.py
@@ -15,7 +15,8 @@ class CouldNotRetrieveAttributeFromRESTResponseException(Exception):
 
 class OpenSearchRESTActions(object):
 
-    def __init__(self, engine_version: str, host="localhost", port=9200, temp_storage_directory=DEFAULT_TEMP_STORAGE_DIR):
+    def __init__(self, engine_version: str, host="localhost", port=9200,
+                 temp_storage_directory=DEFAULT_TEMP_STORAGE_DIR):
         self._rest_client = clients.get_rest_client(ev.get_version(engine_version))
         self._temp_storage_directory = Path(temp_storage_directory)
         self._temp_storage_location = Path(os.path.join(temp_storage_directory, 'robot_data.json'))

--- a/upgrades/upgrade_testing_framework/robot_lib/OpenSearchRESTActions.py
+++ b/upgrades/upgrade_testing_framework/robot_lib/OpenSearchRESTActions.py
@@ -1,7 +1,8 @@
 from pathlib import Path
 import json
 from typing import Any
-from cluster_migration_core.clients.rest_client_default import RESTClientDefault
+import cluster_migration_core.core.versions_engine as ev
+import cluster_migration_core.clients as clients
 import os
 
 DEFAULT_TEMP_STORAGE_DIR = "/tmp/utf"
@@ -14,8 +15,8 @@ class CouldNotRetrieveAttributeFromRESTResponseException(Exception):
 
 class OpenSearchRESTActions(object):
 
-    def __init__(self, host="localhost", port=9200, temp_storage_directory=DEFAULT_TEMP_STORAGE_DIR):
-        self._rest_client = RESTClientDefault()
+    def __init__(self, engine_version: str, host="localhost", port=9200, temp_storage_directory=DEFAULT_TEMP_STORAGE_DIR):
+        self._rest_client = clients.get_rest_client(ev.get_version(engine_version))
         self._temp_storage_directory = Path(temp_storage_directory)
         self._temp_storage_location = Path(os.path.join(temp_storage_directory, 'robot_data.json'))
         self._port = port
@@ -55,8 +56,8 @@ class OpenSearchRESTActions(object):
                     stored_data = {}
         else:
             #This ensures the parent directory exists
-            if not os.path.exists(self._temp_directory):
-                os.makedirs(self._temp_directory)
+            if not os.path.exists(self._temp_storage_directory):
+                os.makedirs(self._temp_storage_directory)
             stored_data = {}
         stored_data[label] = data
         with self._temp_storage_location.open('w') as file_pointer:

--- a/upgrades/upgrade_testing_framework/robot_test_defs/common_upgrade_test.robot
+++ b/upgrades/upgrade_testing_framework/robot_test_defs/common_upgrade_test.robot
@@ -1,5 +1,5 @@
 *** Settings ***
-Library    ../robot_lib/OpenSearchRESTActions.py  ${host}  ${port}
+Library    ../robot_lib/OpenSearchRESTActions.py  ${engine_version}  ${host}  ${port}
 
 *** Keywords ***
 #Create document

--- a/upgrades/upgrade_testing_framework/steps/step_perform_post_upgrade_test.py
+++ b/upgrades/upgrade_testing_framework/steps/step_perform_post_upgrade_test.py
@@ -18,6 +18,8 @@ class PerformPostUpgradeTest(FrameworkStep):
     def _run(self):
         # Get the state we need
         target_cluster = self.state.target_cluster
+        node = target_cluster.nodes[0]  # shouldn't matter which node we pick
+        engine_version = str(node.engine_version)
         port = target_cluster.rest_ports[0]
         eligible_expectations = self.state.eligible_expectations
         output_directory = f"{self.state.get_key('test_results_directory')}/{STAGE_TAG}"
@@ -31,7 +33,8 @@ class PerformPostUpgradeTest(FrameworkStep):
             port=port,
             actions_dir=path_to_actions,
             output_dir=path_to_outputs,
-            include_tags=included_tags
+            include_tags=included_tags,
+            engine_version=engine_version
         )
         
         post_upgrade_executor.execute()

--- a/upgrades/upgrade_testing_framework/steps/step_perform_pre_upgrade_test.py
+++ b/upgrades/upgrade_testing_framework/steps/step_perform_pre_upgrade_test.py
@@ -18,6 +18,8 @@ class PerformPreUpgradeTest(FrameworkStep):
     def _run(self):
         # Get the state we need
         source_cluster = self.state.source_cluster
+        node = source_cluster.nodes[0]  # shouldn't matter which node we pick
+        engine_version = str(node.engine_version)
         port = source_cluster.rest_ports[0]
         eligible_expectations = self.state.eligible_expectations
         output_directory = f"{self.state.get_key('test_results_directory')}/{STAGE_TAG}"
@@ -31,7 +33,8 @@ class PerformPreUpgradeTest(FrameworkStep):
             port=port,
             actions_dir=path_to_actions,
             output_dir=path_to_outputs,
-            include_tags=included_tags
+            include_tags=included_tags,
+            engine_version=engine_version
         )
         
         pre_upgrade_executor.execute()


### PR DESCRIPTION
Signed-off-by: Tanner Lewis <lewijacn@amazon.com>

### Description
Changes include
* Passing EngineVersion string to robot REST library to ensure proper REST client is used
* Minor fix to failing python test
* Robot tests additional documentation
* Minor fixes

### Issues Resolved
None


### Testing
UTF sample run 
```
(.venv) (09:25:13) local [/Volumes/workplace/opensearch/lewijacn-migrations/opensearch-migrations/upgrades] -> ./run_utf.py --test_config test_configs/snapshot_restore_es_7_10_2_to_os_1_3_6.json
[FrameworkRunner] ============ Running Step: LoadTestConfig ============
[LoadTestConfig] Loading test config file...
[LoadTestConfig] Loaded test config file successfully
[FrameworkRunner] Step Succeeded: LoadTestConfig
[FrameworkRunner] ============ Running Step: BootstrapDocker ============
[BootstrapDocker] Checking if Docker is installed and available...
[BootstrapDocker] Docker appears to be installed and available
[BootstrapDocker] Ensuring the Docker image docker.elastic.co/elasticsearch/elasticsearch-oss:7.10.2 is available either locally or remotely...
[BootstrapDocker] Docker image docker.elastic.co/elasticsearch/elasticsearch-oss:7.10.2 is available
[BootstrapDocker] Ensuring the Docker image opensearchproject/opensearch:1.3.6 is available either locally or remotely...
[BootstrapDocker] Docker image opensearchproject/opensearch:1.3.6 is available
[FrameworkRunner] Step Succeeded: BootstrapDocker
[FrameworkRunner] ============ Running Step: SnapshotRestoreSetup ============
[SnapshotRestoreSetup] Creating shared Docker volume to share snapshots...
[SnapshotRestoreSetup] Created shared Docker volume cluster-snapshots-volume
[FrameworkRunner] Step Succeeded: SnapshotRestoreSetup
[FrameworkRunner] ============ Running Step: SelectExpectations ============
[SelectExpectations] Loading Knowledge Base and filtering for relevant expectations
[SelectExpectations] Found 2 relevant expectations.
[FrameworkRunner] Step Succeeded: SelectExpectations
[FrameworkRunner] ============ Running Step: StartSourceCluster ============
[StartSourceCluster] Creating source cluster...
[StartSourceCluster] Waiting up to 30 sec for cluster to be active...
Node source-cluster-node-1 is now active
Node source-cluster-node-2 is now active
[StartSourceCluster] Cluster source-cluster is active
[FrameworkRunner] Step Succeeded: StartSourceCluster
[FrameworkRunner] ============ Running Step: PerformPreUpgradeTest ============
====================================================================================================
Robot Test Defs                                                                                     
====================================================================================================
Robot Test Defs.Common Upgrade Test                                                                 
====================================================================================================
Perform pre-upgrade setup of "consistent-document-count" expectation                        | PASS |
----------------------------------------------------------------------------------------------------
Robot Test Defs.Common Upgrade Test                                                         | PASS |
1 test, 1 passed, 0 failed
====================================================================================================
Robot Test Defs                                                                             | PASS |
1 test, 1 passed, 0 failed
====================================================================================================
Output:  /tmp/utf/test-results/pre-upgrade/output.xml
Log:     /tmp/utf/test-results/pre-upgrade/log.html
Report:  /tmp/utf/test-results/pre-upgrade/report.html
[FrameworkRunner] Step Succeeded: PerformPreUpgradeTest
[FrameworkRunner] ============ Running Step: CreateSourceSnapshot ============
[CreateSourceSnapshot] Creating snapshot of source cluster...
[CreateSourceSnapshot] Confirming snapshot of source cluster exists...
[CreateSourceSnapshot] Source snapshot created successfully
[FrameworkRunner] Step Succeeded: CreateSourceSnapshot
[FrameworkRunner] ============ Running Step: StartTargetCluster ============
[StartTargetCluster] Creating target cluster...
[StartTargetCluster] Waiting up to 30 sec for cluster to be active...
Node target-cluster-node-1 is now active
Node target-cluster-node-2 is now active
[StartTargetCluster] Cluster target-cluster is active
[FrameworkRunner] Step Succeeded: StartTargetCluster
[FrameworkRunner] ============ Running Step: RestoreSourceSnapshot ============
[RestoreSourceSnapshot] Checking if source snapshots are visible on target...
[RestoreSourceSnapshot] Source snapshot visible to target cluster
[RestoreSourceSnapshot] Restoring source snapshot onto target...
[RestoreSourceSnapshot] Snapshot restored successfully
[FrameworkRunner] Step Succeeded: RestoreSourceSnapshot
[FrameworkRunner] ============ Running Step: PerformPostUpgradeTest ============
====================================================================================================
Robot Test Defs                                                                                     
====================================================================================================
Robot Test Defs.Common Upgrade Test                                                                 
====================================================================================================
Perform post-upgrade assertion of "consistent-document-count" expectation                   | PASS |
----------------------------------------------------------------------------------------------------
Robot Test Defs.Common Upgrade Test                                                         | PASS |
1 test, 1 passed, 0 failed
====================================================================================================
Robot Test Defs                                                                             | PASS |
1 test, 1 passed, 0 failed
====================================================================================================
Output:  /tmp/utf/test-results/post-upgrade/output.xml
Log:     /tmp/utf/test-results/post-upgrade/log.html
Report:  /tmp/utf/test-results/post-upgrade/report.html
[FrameworkRunner] Step Succeeded: PerformPostUpgradeTest
[FrameworkRunner] ============ Running Step: StopSourceCluster ============
[StopSourceCluster] Stopping cluster source-cluster...
[StopSourceCluster] Cleaning up underlying resources for cluster source-cluster...
[FrameworkRunner] Step Succeeded: StopSourceCluster
[FrameworkRunner] ============ Running Step: StopTargetCluster ============
[StopTargetCluster] Stopping cluster target-cluster...
[StopTargetCluster] Cleaning up underlying resources for cluster target-cluster...
[FrameworkRunner] Step Succeeded: StopTargetCluster
[FrameworkRunner] ============ Running Step: SnapshotRestoreTeardown ============
[SnapshotRestoreTeardown] Removing shared Docker volume cluster-snapshots-volume...
[SnapshotRestoreTeardown] Removed shared Docker volume cluster-snapshots-volume
[FrameworkRunner] Step Succeeded: SnapshotRestoreTeardown
[FrameworkRunner] ============ Running Step: ReportResults ============
[ReportResults] 
========================================== FINAL RESULTS ==========================================
{
    "failing_expectations": [],
    "passing_expectations": [
        "consistent-document-count"
    ],
    "untested_expectations": [
        "doy-format-date-range-query-bug"
    ]
}
[ReportResults] For more information about how to interpret these results, please consult the Upgrade Testing Framework's README file: https://github.com/opensearch-project/opensearch-migrations/blob/main/upgrades/README.md
[ReportResults] You can find the expectation definitions here: https://github.com/opensearch-project/opensearch-migrations/tree/main/knowledge_base
[FrameworkRunner] Step Succeeded: ReportResults
[FrameworkRunner] Ran through all 14 steps successfully
[FrameworkRunner] Saving application state to file...
[FrameworkRunner] Application state saved
[FrameworkRunner] Application state saved to: /tmp/utf/state-file
[FrameworkRunner] Full run details logged to: /tmp/utf/logs/run.log.2023-01-18_21_28_39

```

### Check List
- [ ] New functionality includes testing
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
