### PR TITLE
Scrappy commit to see some json differences as edits via xmldiff.

### DIFF
--- a/edit_scripts/README.md
+++ b/edit_scripts/README.md
@@ -1,0 +1,7 @@
+```
+python3 -m venv .venv
+source .venv/bin/activate
+pip install pytest 
+pip install xmldiff
+pip install json2xml
+```

--- a/edit_scripts/calculate_edit_script/run_diff.py
+++ b/edit_scripts/calculate_edit_script/run_diff.py
@@ -1,0 +1,55 @@
+from json2xml import json2xml
+from json2xml.utils import readfromjson, readfromstring
+from xmldiff import formatting as xmlformatting
+
+import argparse
+
+
+def get_command_line_args():
+    parser = argparse.ArgumentParser(description="Script to compare json files.")
+    parser.add_argument('filenames', metavar='filename', type=str, nargs=2,
+                        help='filenames to evaluate for differences')
+    return parser.parse_args()
+
+
+def get_xml_str_from_file(filename: str):
+    # get the xml from a json string
+    data = readfromjson(filename)
+    return get_xml_str(data)
+
+
+def get_xml_str_from_str(text: str):
+    data = readfromstring(text)
+    return get_xml_str(data)
+
+
+def get_xml_str(jsonStr: str):
+    # get the xml from a json string
+    return json2xml.Json2xml(jsonStr).to_xml()
+
+
+def emit_edit_script(jsonStr1: str, jsonStr2: str, callback):
+    from lxml import etree
+    parser = etree.XMLParser(remove_blank_text=True)
+    left_tree = etree.fromstring(jsonStr1, parser)
+    right_tree = etree.fromstring(jsonStr2, parser)
+
+    from xmldiff import diff
+    differ = diff.Differ(ratio_mode='accurate', F=0.01)
+    diffResult = differ.diff(left_tree, right_tree)
+    if (callback is not None):
+        callback(left_tree, right_tree, diffResult)
+    return diffResult
+
+
+def main():
+    args = get_command_line_args()
+    leftXmlStr = get_xml_str(args.filenames[0])
+    rightXmlStr = get_xml_str(args.filenames[1])
+
+    formatter = xmlformatting.DiffFormatter()
+    emit_edit_script(leftXmlStr, rightXmlStr, lambda l, r, diff: print(formatter.format(diff, l)))
+
+
+if __name__ == "__main__":
+    main()

--- a/edit_scripts/calculate_edit_script/run_diff.py
+++ b/edit_scripts/calculate_edit_script/run_diff.py
@@ -44,8 +44,8 @@ def emit_edit_script(jsonStr1: str, jsonStr2: str, callback):
 
 def main():
     args = get_command_line_args()
-    leftXmlStr = get_xml_str(args.filenames[0])
-    rightXmlStr = get_xml_str(args.filenames[1])
+    leftXmlStr = get_xml_str_from_file(args.filenames[0])
+    rightXmlStr = get_xml_str_from_file(args.filenames[1])
 
     formatter = xmlformatting.DiffFormatter()
     emit_edit_script(leftXmlStr, rightXmlStr, lambda leftTree, rightTree, diff: print(formatter.format(diff, leftTree)))

--- a/edit_scripts/calculate_edit_script/run_diff.py
+++ b/edit_scripts/calculate_edit_script/run_diff.py
@@ -48,7 +48,7 @@ def main():
     rightXmlStr = get_xml_str(args.filenames[1])
 
     formatter = xmlformatting.DiffFormatter()
-    emit_edit_script(leftXmlStr, rightXmlStr, lambda l, r, diff: print(formatter.format(diff, l)))
+    emit_edit_script(leftXmlStr, rightXmlStr, lambda leftTree, rightTree, diff: print(formatter.format(diff, leftTree)))
 
 
 if __name__ == "__main__":

--- a/edit_scripts/unit_tests/test_diff.py
+++ b/edit_scripts/unit_tests/test_diff.py
@@ -3,7 +3,7 @@ import xmldiff
 from edit_scripts.calculate_edit_script.run_diff import emit_edit_script, get_xml_str_from_str
 
 
-def checkResultsSame(diff, l):
+def checkResultsSame(diff, leftTree):
     ldiff = list(diff)
     assert len(ldiff) == 0
 
@@ -24,10 +24,10 @@ def test_diff_on_same_is_empty():
     }"""
 
     emit_edit_script(get_xml_str_from_str(json1), get_xml_str_from_str(json1),
-                     lambda l, r, diff: checkResultsSame(diff, l))
+                     lambda leftTree, rightTree, diff: checkResultsSame(diff, leftTree))
 
 
-def checkResultsDiff(diff, l):
+def checkResultsDiff(diff, leftTree):
     ldiff = list(diff)
     assert len(ldiff) == 1
     assert ldiff[0].__class__ == xmldiff.actions.MoveNode
@@ -62,4 +62,4 @@ def test_easy_rotate_works():
     }"""
 
     emit_edit_script(get_xml_str_from_str(json1), get_xml_str_from_str(json2),
-                     lambda l, r, diff: checkResultsDiff(diff, l))
+                     lambda leftTree, rightTree, diff: checkResultsDiff(diff, leftTree))

--- a/edit_scripts/unit_tests/test_diff.py
+++ b/edit_scripts/unit_tests/test_diff.py
@@ -1,0 +1,65 @@
+import xmldiff
+
+from edit_scripts.calculate_edit_script.run_diff import emit_edit_script, get_xml_str_from_str
+
+
+def checkResultsSame(diff, l):
+    ldiff = list(diff)
+    assert len(ldiff) == 0
+
+
+def test_diff_on_same_is_empty():
+    json1 = """
+    {
+      "buckets" : [  {
+        "key" : "AL",
+        "doc_count" : 25
+      }, {
+        "key" : "MD",
+        "doc_count" : 25
+      }, {
+        "key" : "TN",
+        "doc_count" : 23
+      } ]
+    }"""
+
+    emit_edit_script(get_xml_str_from_str(json1), get_xml_str_from_str(json1),
+                     lambda l, r, diff: checkResultsSame(diff, l))
+
+
+def checkResultsDiff(diff, l):
+    ldiff = list(diff)
+    assert len(ldiff) == 1
+    assert ldiff[0].__class__ == xmldiff.actions.MoveNode
+
+
+def test_easy_rotate_works():
+    json1 = """
+    {
+      "buckets" : [  {
+        "key" : "A",
+        "doc_count" : 1
+      }, {
+        "key" : "B",
+        "doc_count" : 2
+      }, {
+        "key" : "C",
+        "doc_count" : 3
+      } ]
+    }"""
+    json2 = """
+    {
+      "buckets" : [  {
+        "key" : "B",
+        "doc_count" : 2
+      }, {
+        "key" : "C",
+        "doc_count" : 3
+      }, {
+        "key" : "A",
+        "doc_count" : 1
+      } ]
+    }"""
+
+    emit_edit_script(get_xml_str_from_str(json1), get_xml_str_from_str(json2),
+                     lambda l, r, diff: checkResultsDiff(diff, l))

--- a/edit_scripts/unit_tests/test_diff.py
+++ b/edit_scripts/unit_tests/test_diff.py
@@ -1,6 +1,8 @@
+from pprint import pprint
+
 import xmldiff
 
-from edit_scripts.calculate_edit_script.run_diff import emit_edit_script, get_xml_str_from_str
+from calculate_edit_script.run_diff import emit_edit_script, get_xml_str_from_str
 
 
 def checkResultsSame(diff, leftTree):
@@ -63,3 +65,54 @@ def test_easy_rotate_works():
 
     emit_edit_script(get_xml_str_from_str(json1), get_xml_str_from_str(json2),
                      lambda leftTree, rightTree, diff: checkResultsDiff(diff, leftTree))
+
+
+def checkResultsRotateUpdate(diff, leftTree):
+    ldiff = list(diff)
+    pprint(ldiff)
+    assert len(ldiff) == 2
+    assert ldiff[0].__class__ == xmldiff.actions.MoveNode
+
+
+def test_easy_rotate_with_update_works():
+    json1 = """
+    {
+      "buckets" : [  {
+        "key" : "A",
+        "doc_count" : 1000
+      }, {
+        "key" : "B",
+        "doc_count" : 2
+      }, {
+        "key" : "C",
+        "doc_count" : 3
+      } ]
+    }"""
+    json2 = """
+    {
+      "buckets" : [  {
+        "key" : "B",
+        "doc_count" : 2
+      }, {
+        "key" : "C",
+        "doc_count" : 3
+      }, {
+        "key" : "A",
+        "doc_count" : 1001
+      } ]
+    }"""
+
+    xml1 = get_xml_str_from_str(json1)
+    xml2 = get_xml_str_from_str(json2)
+    pprint(xml1)
+    pprint(xml2)
+    emit_edit_script(xml1, xml2,
+                     lambda leftTree, rightTree, diff: checkResultsRotateUpdate(diff, leftTree))
+
+
+def main():
+    test_easy_rotate_with_update_works()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This commit includes some unit tests to show when no changes were made that the edit script is empty and that a simply rotation is encoded as a move.

Signed-off-by: Greg Schohn <schohn@amazon.com>

### Description1

### Issues Resolved
[MIGRATIONS-875](https://opensearch.atlassian.net/browse/MIGRATIONS-875)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
