### PR TITLE
MIGRATIONS-867 Switched to HAProxy 2.7

### DIFF
--- a/cluster_traffic_capture/docker_config_capture/Dockerfile
+++ b/cluster_traffic_capture/docker_config_capture/Dockerfile
@@ -1,4 +1,4 @@
-FROM haproxytech/haproxy-ubuntu:2.8 AS haproxy-base
+FROM haproxytech/haproxy-ubuntu:2.7 AS haproxy-base
 
 # Ensure we have the latest package listing (doesn't inherit from base image's invocation)
 RUN apt-get update
@@ -25,10 +25,6 @@ CMD service rsyslog start && haproxy -f /usr/local/etc/haproxy/haproxy.cfg
 # ====== Leverage Multi-Stage Docker Builds to re-use the base HAProxy image ======
 FROM haproxy-base AS haproxy-w-mirror
 
-# Copy our configuration over
-COPY haproxy_w_mirror.cfg /usr/local/etc/haproxy/haproxy.cfg
-COPY mirror.conf /usr/local/etc/haproxy/mirror.conf
-
 # Install the traffic mirroring SPOE Agent
 # See: https://www.haproxy.com/blog/haproxy-traffic-mirroring-for-real-world-testing/
 RUN apt install -y autoconf automake build-essential git libcurl4-openssl-dev libev-dev libpthread-stubs0-dev pkg-config
@@ -38,6 +34,10 @@ RUN cd spoa-mirror && \
     ./configure && \
     make all && \
     cp ./src/spoa-mirror /usr/local/bin/
+
+# Copy our configuration over.  Do this after SPOA installation to prevent rebuilding that layer when config changes.
+COPY mirror.conf /usr/local/etc/haproxy/mirror.conf
+COPY haproxy_w_mirror.cfg /usr/local/etc/haproxy/haproxy.cfg
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD service rsyslog start && haproxy -f /usr/local/etc/haproxy/haproxy.cfg


### PR DESCRIPTION
Signed-off-by: Chris Helma <chelma+github@amazon.com>

### Description
The mirroring SPOA suddenly stopped working, and switching from HAProxy 2.8 to 2.7 seemed to fix it.

Specifically, the HAProxy Primary w/ mirroring spun up fine and lived until you sent a request to it, at which point HAProxy dies with this message:

```
root@def18754cf21:/# haproxy -f /usr/local/etc/haproxy/haproxy.cfg
[NOTICE]   (125) : New program 'mirror' (127) forked
[NOTICE]   (125) : New worker (128) forked
[NOTICE]   (125) : Loading success.
[ALERT]    (128) : A bogus APPCTX [0x5651c586b880] is spinning at 4528372 calls per second and refuses to die, aborting now! Please report this error to developers [strm=0x5651c586b36
0,8 src=<SPOE> fe=mirror be=mirroragents dst=<SPOE> txn=(nil),0 txn.req=-,0 txn.rsp=-,0 rqf=80c020 rqa=0 rpf=8040a060 rpa=0 scf=0x5651c5738180,CLO,40 scb=0x5651c57368f0,EST,1 af=0x565
1c586af60,9 sab=0x5651c586b880,0 cof=(nil),0:NONE((nil))/NONE((nil))/NONE(-1) cob=(nil),0:NONE((nil))/NONE((nil))/NONE(-1) filters={} applet=0x5651c52eb180(spoe_applet) handler=0x5651
c511a770(main+0xf1930)]
A bogus APPCTX [0x5651c586b880] is spinning at 4528372 calls per second and refuses to die, aborting now! Please report this error to developers [strm=0x5651c586b360,8 src=<SPOE> fe=m
irror be=mirroragents dst=<SPOE> txn=(nil),0 txn.req=-,0 txn.rsp=-,0 rqf=80c020 rqa=0 rpf=8040a060 rpa=0 scf=0x5651c5738180,CLO,40 scb=0x5651c57368f0,EST,1 af=0x5651c586af60,9 sab=0x5
651c586b880,0 cof=(nil),0:NONE((nil))/NONE((nil))/NONE(-1) cob=(nil),0:NONE((nil))/NONE((nil))/NONE(-1) filters={} applet=0x5651c52eb180(spoe_applet) handler=0x5651c511a770(main+0xf19
30)]
  call trace(11):
  | 0x5651c5024e92 [c6 04 25 01 00 00 00 00]: main-0x3fae
  | 0x5651c51ff256 [e9 6d fe ff ff 0f 1f 44]: task_run_applet+0x2f6/0x7fb
  | 0x5651c51b5e5a [49 89 c7 eb 0f 90 4c 89]: run_tasks_from_lists+0x40a/0x89e
  | 0x5651c51b666c [29 44 24 1c 8b 4c 24 1c]: process_runnable_tasks+0x37c/0x6f1
  | 0x5651c5184aea [83 3d 6f fb 3e 00 01 0f]: run_poll_loop+0x13a/0x554
  | 0x5651c5185129 [48 8b 1d 70 14 17 00 4c]: main+0x15c2e9
  | 0x5651c502a87d [31 c0 e8 5c 00 1d 00 31]: main+0x1a3d/0x2eb7
[NOTICE]   (125) : haproxy version is 2.8-dev3-e74d77b
[NOTICE]   (125) : path to executable is /usr/local/sbin/haproxy
[ALERT]    (125) : Current worker (128) exited with code 139 (Segmentation fault)
[ALERT]    (125) : exit-on-failure: killing every processes with SIGTERM
[ALERT]    (125) : Current program 'mirror' (127) exited with code 0 (Exit)
[WARNING]  (125) : All workers exited. Exiting... (139)
```

### Issues Resolved
N/A

### Testing
Ran the demo, hit the HAProxy primary w/ traffic.

```
(.venv) chelma@3c22fba4e266 cluster_traffic_capture % ./demo_haproxy.py
Creating primary cluster...
Waiting up to 30 sec for cluster to be active...
Cluster primary-cluster is active
Creating shadow cluster...
Waiting up to 30 sec for cluster to be active...
Cluster shadow-cluster is active
Building HAProxy Docker images for Primary and Shadow HAProxy containers...
Executing command to build Docker images: ./build_docker_images.py --primary-image haproxy-primary --primary-nodes host.docker.internal:9200 host.docker.internal:9201 --shadow-haproxy host.docker.internal:81 --shadow-image haproxy-shadow --shadow-nodes host.docker.internal:9202 host.docker.internal:9203 --internal-port 9200
Subshell> Copying Docker-related files to: /tmp/cluster_traffic_capture
Subshell> Writing HAProxy Config to: /tmp/cluster_traffic_capture/haproxy_no_mirror.cfg
Subshell> Writing HAProxy Config to: /tmp/cluster_traffic_capture/haproxy_w_mirror.cfg
Subshell> Building HAProxy Docker image for Primary Cluster...
Subshell> Primary HAProxy image available locally w/ tag: haproxy-primary
Subshell> Building HAProxy Docker image for Shadow Cluster...
Subshell> Shadow HAProxy image available locally w/ tag: haproxy-shadow
Starting HAProxy container for Shadow Cluster...
Starting HAProxy container for Primary Cluster...

HAProxy is currently running in a Docker container, available at 127.0.0.1:80, and configured to pass traffic to an
ES 7.10.2 cluster of two nodes (each running in their own Docker containers).  The requests/responses passed to the
cluster via the HAProxy container will be logged to the container at /var/log/haproxy-traffic.log.  The requests are
mirrored to an identical shadow cluster.

Some example commands you can run to demonstrate the behavior are:
curl -X GET 'localhost:80'
curl -X GET 'localhost:80/_cat/nodes?v=true&pretty'
curl -X PUT 'localhost:80/noldor/_doc/1' -H 'Content-Type: application/json' -d'{"name": "Finwe"}'
curl -X GET 'localhost:80/noldor/_doc/1'

When you are done playing with the setup, hit the RETURN key in this terminal window to shut down and clean up the
demo containers.

Stopping cluster primary-cluster...
Cleaning up underlying resources for cluster primary-cluster...
Stopping cluster shadow-cluster...
Cleaning up underlying resources for cluster shadow-cluster...
Cleaning up underlying resources for the Primary HAProxy container...
Cleaning up underlying resources for the Shadow HAProxy container...
```

```
chelma@3c22fba4e266 cluster_traffic_capture % curl -X PUT 'localhost:80/noldor/_doc/1' -H 'Content-Type: application/json' -d'{"name": "Finwe"}'
{"_index":"noldor","_type":"_doc","_id":"1","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":0,"_primary_term":1}%
chelma@3c22fba4e266 cluster_traffic_capture % curl -X GET 'localhost:9203/noldor/_doc/1'
{"_index":"noldor","_type":"_doc","_id":"1","_version":1,"_seq_no":0,"_primary_term":1,"found":true,"_source":{"name": "Finwe"}}%
```

### Check List
- [ ] New functionality includes testing
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
