### PR TITLE
Pre-demo fixes for HAProxy mirroring, logging, testing

### DIFF
--- a/cluster_traffic_capture/cluster_traffic_capture/gen_haproxy_cfg.py
+++ b/cluster_traffic_capture/cluster_traffic_capture/gen_haproxy_cfg.py
@@ -31,6 +31,11 @@ global
     log 127.0.0.1:514 len 65535 local0 # syslogd, facility local0
     log stdout format raw local0 debug # stdout too
 
+    # Increase the buffer size to allow both logging and spoa to forward large requests
+    tune.bufsize 1048576
+    tune.h2.max-frame-size 1048576
+    maxconn 65536
+
     # Turn on Master/Worker mode.  Required to use SPOE Mirroring.  While hardly an expert, I've attempted to configure
     # this so that the HAProxy container will exit if a process associated w/ the proxy mechanism runs into trouble.
     # This will ensure problems are surfaced quickly/obviously, possibly at the expense of resilience at the container

--- a/cluster_traffic_capture/cluster_traffic_capture/gen_haproxy_cfg.py
+++ b/cluster_traffic_capture/cluster_traffic_capture/gen_haproxy_cfg.py
@@ -74,7 +74,7 @@ frontend haproxy
     declare capture response len 1048576
     http-request capture req.hdrs id 0
     http-request capture req.body id 1
-    log-format '%{{+Q}}o {{"request": {{"timestamp":%Ts, "uri":%[capture.req.uri,json('utf8ps')], "method":%[capture.req.method], "headers":%[capture.req.hdr(0),json('utf8ps')], "body":%[capture.req.hdr(1),json('utf8ps')]}}, "response":  {{"response_time_ms":%Tr, "body":%[capture.res.hdr(1),json('utf8ps')], "headers":%[capture.req.hdr(0),json('utf8ps')], "status_code": %ST}}}}'
+    log-format '%{{+Q}}o {{"request": {{"timestamp":%Ts, "uri":%[capture.req.uri,json('utf8ps')], "method":%[capture.req.method], "headers":%[capture.req.hdr(0),json('utf8ps')], "body":%[capture.req.hdr(1),json('utf8ps')]}}, "response":  {{"response_time_ms":%Tr, "body":%[capture.res.hdr(1),json('utf8ps')], "headers":%[capture.res.hdr(0),json('utf8ps')], "status_code": %ST}}}}'
     # Associate this frontend with the primary cluster
     default_backend primary_cluster
 

--- a/cluster_traffic_capture/cluster_traffic_capture/gen_haproxy_cfg.py
+++ b/cluster_traffic_capture/cluster_traffic_capture/gen_haproxy_cfg.py
@@ -68,11 +68,13 @@ frontend haproxy
     bind :{haproxy_port}
 
     # Set up the logging for the req/res stream to the primary cluster
-    declare capture request len 80000
-    declare capture response len 80000
-    http-request capture req.body id 0
-    log-format Request-URI:\\ %[capture.req.uri]\\nRequest-Method:\\ %[capture.req.method]\\nRequest-Body:\\ %[capture.req.hdr(0)]\\nResponse-Body:\\ %[capture.res.hdr(0)]
-    
+    declare capture request len 1048576
+    declare capture request len 1048576
+    declare capture response len 1048576
+    declare capture response len 1048576
+    http-request capture req.hdrs id 0
+    http-request capture req.body id 1
+    log-format '%{{+Q}}o {{"request": {{"timestamp":%Ts, "uri":%[capture.req.uri,json('utf8ps')], "method":%[capture.req.method], "headers":%[capture.req.hdr(0),json('utf8ps')], "body":%[capture.req.hdr(1),json('utf8ps')]}}, "response":  {{"response_time_ms":%Tr, "body":%[capture.res.hdr(1),json('utf8ps')], "headers":%[capture.req.hdr(0),json('utf8ps')], "status_code": %ST}}}}'
     # Associate this frontend with the primary cluster
     default_backend primary_cluster
 
@@ -111,7 +113,8 @@ def _gen_be_config_cluster(cluster_nodes: List[HostAddress]) -> str:
 # These are the primary Cluster's Nodes; traffic will be sent to them synchronously.  The default round robin LB
 # pattern is in effect.
 backend primary_cluster
-    http-response capture res.body id 0
+    http-response capture res.hdrs id 0
+    http-response capture res.body id 1
 {backend_server_section}
 """
     return config

--- a/cluster_traffic_capture/docker_config_traffic_gen/Dockerfile
+++ b/cluster_traffic_capture/docker_config_traffic_gen/Dockerfile
@@ -8,10 +8,10 @@ RUN apt-get update && \
 
 # In my testing, running all four of these took ~1.5 minutes on my Mac
 CMD echo "Running opensearch-benchmark w/ 'geonames' workload..." && \
-    opensearch-benchmark execute_test --distribution-version=1.0.0 --target-host=host.docker.internal:80 --workload=geonames --pipeline=benchmark-only --test-mode --kill-running-processes && \
+    opensearch-benchmark execute_test --distribution-version=1.0.0 --target-host=host.docker.internal:80 --workload=geonames --pipeline=benchmark-only --test-mode --kill-running-processes --workload-params "bulk_size=100,target_throughput=5" && \
     echo "Running opensearch-benchmark w/ 'http_logs' workload..." && \
-    opensearch-benchmark execute_test --distribution-version=1.0.0 --target-host=host.docker.internal:80 --workload=http_logs --pipeline=benchmark-only --test-mode --kill-running-processes && \
+    opensearch-benchmark execute_test --distribution-version=1.0.0 --target-host=host.docker.internal:80 --workload=http_logs --pipeline=benchmark-only --test-mode --kill-running-processes --workload-params "bulk_size=100,target_throughput=5" && \
     echo "Running opensearch-benchmark w/ 'nested' workload..." && \
-    opensearch-benchmark execute_test --distribution-version=1.0.0 --target-host=host.docker.internal:80 --workload=nested --pipeline=benchmark-only --test-mode --kill-running-processes && \
+    opensearch-benchmark execute_test --distribution-version=1.0.0 --target-host=host.docker.internal:80 --workload=nested --pipeline=benchmark-only --test-mode --kill-running-processes --workload-params "bulk_size=100,target_throughput=5" && \
     echo "Running opensearch-benchmark w/ 'nyc_taxis' workload..." && \
-    opensearch-benchmark execute_test --distribution-version=1.0.0 --target-host=host.docker.internal:80 --workload=nyc_taxis --pipeline=benchmark-only --test-mode --kill-running-processes
+    opensearch-benchmark execute_test --distribution-version=1.0.0 --target-host=host.docker.internal:80 --workload=nyc_taxis --pipeline=benchmark-only --test-mode --kill-running-processes --workload-params "bulk_size=100,target_throughput=5"

--- a/cluster_traffic_capture/docker_config_traffic_gen/Dockerfile
+++ b/cluster_traffic_capture/docker_config_traffic_gen/Dockerfile
@@ -8,10 +8,10 @@ RUN apt-get update && \
 
 # In my testing, running all four of these took ~1.5 minutes on my Mac
 CMD echo "Running opensearch-benchmark w/ 'geonames' workload..." && \
-    opensearch-benchmark execute_test --distribution-version=1.0.0 --target-host=host.docker.internal:80 --workload=geonames --pipeline=benchmark-only --test-mode --kill-running-processes --workload-params "bulk_size=100,target_throughput=5" && \
+    opensearch-benchmark execute_test --distribution-version=1.0.0 --target-host=host.docker.internal:80 --workload=geonames --pipeline=benchmark-only --test-mode --kill-running-processes --workload-params "target_throughput:1,bulk_size:50,bulk_indexing_clients:1,search_clients:1" && \
     echo "Running opensearch-benchmark w/ 'http_logs' workload..." && \
-    opensearch-benchmark execute_test --distribution-version=1.0.0 --target-host=host.docker.internal:80 --workload=http_logs --pipeline=benchmark-only --test-mode --kill-running-processes --workload-params "bulk_size=100,target_throughput=5" && \
+    opensearch-benchmark execute_test --distribution-version=1.0.0 --target-host=host.docker.internal:80 --workload=http_logs --pipeline=benchmark-only --test-mode --kill-running-processes --workload-params "target_throughput:1,bulk_size:50,bulk_indexing_clients:1,search_clients:1" && \
     echo "Running opensearch-benchmark w/ 'nested' workload..." && \
-    opensearch-benchmark execute_test --distribution-version=1.0.0 --target-host=host.docker.internal:80 --workload=nested --pipeline=benchmark-only --test-mode --kill-running-processes --workload-params "bulk_size=100,target_throughput=5" && \
+    opensearch-benchmark execute_test --distribution-version=1.0.0 --target-host=host.docker.internal:80 --workload=nested --pipeline=benchmark-only --test-mode --kill-running-processes --workload-params "target_throughput:1,bulk_size:50,bulk_indexing_clients:1,search_clients:1" && \
     echo "Running opensearch-benchmark w/ 'nyc_taxis' workload..." && \
-    opensearch-benchmark execute_test --distribution-version=1.0.0 --target-host=host.docker.internal:80 --workload=nyc_taxis --pipeline=benchmark-only --test-mode --kill-running-processes --workload-params "bulk_size=100,target_throughput=5"
+    opensearch-benchmark execute_test --distribution-version=1.0.0 --target-host=host.docker.internal:80 --workload=nyc_taxis --pipeline=benchmark-only --test-mode --kill-running-processes --workload-params "target_throughput:1,bulk_size:50,bulk_indexing_clients:1,search_clients:1"

--- a/cluster_traffic_capture/docker_config_traffic_gen/Dockerfile
+++ b/cluster_traffic_capture/docker_config_traffic_gen/Dockerfile
@@ -8,10 +8,10 @@ RUN apt-get update && \
 
 # In my testing, running all four of these took ~1.5 minutes on my Mac
 CMD echo "Running opensearch-benchmark w/ 'geonames' workload..." && \
-    opensearch-benchmark execute_test --distribution-version=1.0.0 --target-host=host.docker.internal:80 --workload=geonames --pipeline=benchmark-only --test-mode --kill-running-processes --workload-params "target_throughput:1,bulk_size:50,bulk_indexing_clients:1,search_clients:1" && \
+    opensearch-benchmark execute_test --distribution-version=1.0.0 --target-host=host.docker.internal:80 --workload=geonames --pipeline=benchmark-only --test-mode --kill-running-processes --workload-params "target_throughput:0.5,bulk_size:10,bulk_indexing_clients:1,search_clients:1" && \
     echo "Running opensearch-benchmark w/ 'http_logs' workload..." && \
-    opensearch-benchmark execute_test --distribution-version=1.0.0 --target-host=host.docker.internal:80 --workload=http_logs --pipeline=benchmark-only --test-mode --kill-running-processes --workload-params "target_throughput:1,bulk_size:50,bulk_indexing_clients:1,search_clients:1" && \
+    opensearch-benchmark execute_test --distribution-version=1.0.0 --target-host=host.docker.internal:80 --workload=http_logs --pipeline=benchmark-only --test-mode --kill-running-processes --workload-params "target_throughput:0.5,bulk_size:10,bulk_indexing_clients:1,search_clients:1" && \
     echo "Running opensearch-benchmark w/ 'nested' workload..." && \
-    opensearch-benchmark execute_test --distribution-version=1.0.0 --target-host=host.docker.internal:80 --workload=nested --pipeline=benchmark-only --test-mode --kill-running-processes --workload-params "target_throughput:1,bulk_size:50,bulk_indexing_clients:1,search_clients:1" && \
+    opensearch-benchmark execute_test --distribution-version=1.0.0 --target-host=host.docker.internal:80 --workload=nested --pipeline=benchmark-only --test-mode --kill-running-processes --workload-params "target_throughput:0.5,bulk_size:10,bulk_indexing_clients:1,search_clients:1" && \
     echo "Running opensearch-benchmark w/ 'nyc_taxis' workload..." && \
-    opensearch-benchmark execute_test --distribution-version=1.0.0 --target-host=host.docker.internal:80 --workload=nyc_taxis --pipeline=benchmark-only --test-mode --kill-running-processes --workload-params "target_throughput:1,bulk_size:50,bulk_indexing_clients:1,search_clients:1"
+    opensearch-benchmark execute_test --distribution-version=1.0.0 --target-host=host.docker.internal:80 --workload=nyc_taxis --pipeline=benchmark-only --test-mode --kill-running-processes --workload-params "target_throughput:0.5,bulk_size:10,bulk_indexing_clients:1,search_clients:1"


### PR DESCRIPTION
Signed-off-by: Mikayla Thompson <thomika@amazon.com>

### Description
This PR includes a variety of fixes for minor (or major) issues we've discovered with our current HAProxy setup.
1. Reformats the logs by using the request and response capture slots to fully capture & escape the body and headers for requests and responses and log them as json.
2. Increase the buffer size to attempt to solve an issue where bodies were being dropped or truncated when logging them (and possibly when mirroring them as well) (see this github issue in the haproxy spoa-mirror repo for the solution to a similar issue: https://github.com/haproxytech/spoa-mirror/issues/17#issuecomment-683848851)
3. Add some extra params to the workload generation docker command to slow down the benchmarks. While the target TPS is set to 0.5, that doesn't appear to actually take effect the way I'd expect. The effective average rate on my latest run was 8.85 TPS.

### Issues Resolved
[MIGRATIONS-993 - JSON-escaping the headers of a request/response](https://opensearch.atlassian.net/browse/MIGRATIONS-993)
[MIGRATIONS-992 - Separate body from headers within the log-format](https://opensearch.atlassian.net/browse/MIGRATIONS-992)


### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]

### Check List
- [ ] New functionality includes testing
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
