### PR TITLE
Allow reading from stdin & writing to stdout.  Also pulled log4j2 and beust.jcommander

### DIFF
--- a/TrafficReplayer/TrafficReplayer.iml
+++ b/TrafficReplayer/TrafficReplayer.iml
@@ -85,5 +85,18 @@
     <orderEntry type="library" name="Maven: org.apiguardian:apiguardian-api:1.1.2" level="project" />
     <orderEntry type="library" name="Maven: org.apache.commons:commons-lang3:3.1" level="project" />
     <orderEntry type="library" name="Maven: org.json:json:20220924" level="project" />
+    <orderEntry type="library" name="json" level="project" />
+    <orderEntry type="library" name="beust.jcommander" level="project" />
+    <orderEntry type="module-library">
+      <library>
+        <CLASSES>
+          <root url="jar://$MAVEN_REPOSITORY$/org/projectlombok/lombok/1.18.22/lombok-1.18.22.jar!/" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES />
+      </library>
+    </orderEntry>
+    <orderEntry type="library" name="apache.logging.log4j.core" level="project" />
+    <orderEntry type="library" name="apache.logging.log4j.api" level="project" />
   </component>
 </module>

--- a/TrafficReplayer/src/log4j2.properties
+++ b/TrafficReplayer/src/log4j2.properties
@@ -1,0 +1,17 @@
+status = error
+
+
+appender.console.type = Console
+appender.console.name = STDOUT
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = [%-5level] %d{yyyy-MM-dd HH:mm:ss.SSS} [%t] %c{1} - %msg%n
+
+appender.file.type = File
+appender.file.name = LOGFILE
+appender.file.fileName=${filename}/propertieslogs.log
+appender.file.layout.type=PatternLayout
+appender.file.layout.pattern=[%-5level] %d{yyyy-MM-dd HH:mm:ss.SSS} [%t] %c{1} - %msg%n
+
+rootLogger.level = warn
+rootLogger.appenderRefs = stdout
+rootLogger.appenderRef.stdout.ref = STDOUT

--- a/TrafficReplayer/src/org/opensearch/migrations/replay/CloseableStringStreamWrapper.java
+++ b/TrafficReplayer/src/org/opensearch/migrations/replay/CloseableStringStreamWrapper.java
@@ -1,0 +1,36 @@
+package org.opensearch.migrations.replay;
+
+import java.io.BufferedReader;
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+public class CloseableStringStreamWrapper implements Closeable {
+    private final Closeable underlyingCloseableResource;
+    private final Stream<String> underlyingStream;
+
+    public CloseableStringStreamWrapper(Closeable underlyingCloseableResource, Stream<String> underlyingStream) {
+        this.underlyingCloseableResource = underlyingCloseableResource;
+        this.underlyingStream = underlyingStream;
+    }
+
+    static CloseableStringStreamWrapper generateStreamFromBufferedReader(BufferedReader br) {
+        return new CloseableStringStreamWrapper(br, Stream.generate((Supplier) () -> {
+            try {
+                return br.readLine();
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }).takeWhile(s -> s != null));
+    }
+
+    @Override
+    public void close() throws IOException {
+        underlyingCloseableResource.close();
+    }
+
+    public Stream<String> stream() {
+        return underlyingStream;
+    }
+}

--- a/TrafficReplayer/src/org/opensearch/migrations/replay/netty/BacksideHttpWatcherHandler.java
+++ b/TrafficReplayer/src/org/opensearch/migrations/replay/netty/BacksideHttpWatcherHandler.java
@@ -3,10 +3,12 @@ package org.opensearch.migrations.replay.netty;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.handler.codec.http.FullHttpResponse;
+import lombok.extern.log4j.Log4j2;
 import org.opensearch.migrations.replay.AggregatedRawResponse;
 
 import java.util.function.Consumer;
 
+@Log4j2
 public class BacksideHttpWatcherHandler extends SimpleChannelInboundHandler<FullHttpResponse> {
 
     private final AggregatedRawResponse.Builder aggregatedRawResponseBuilder;
@@ -38,7 +40,7 @@ public class BacksideHttpWatcherHandler extends SimpleChannelInboundHandler<Full
 
     @Override
     public void channelInactive(ChannelHandlerContext ctx) throws Exception {
-        System.err.println("inactive channel - closing");
+        log.trace("inactive channel - closing");
         super.channelInactive(ctx);
     }
 

--- a/TrafficReplayer/tst/org/opensearch/migrations/replay/TrafficReplayerTest.java
+++ b/TrafficReplayer/tst/org/opensearch/migrations/replay/TrafficReplayerTest.java
@@ -32,7 +32,7 @@ class TrafficReplayerTest {
     }
 
     @Test
-    public void testReader() throws IOException, URISyntaxException {
+    public void testReader() throws IOException, URISyntaxException, InterruptedException {
         var tr = new TrafficReplayer(new URI("http://localhost:9200"));
         List<List<byte[]>> byteArrays = new ArrayList<>();
         TrafficReplayer.ReplayEngine re = new TrafficReplayer.ReplayEngine(rrpp -> {
@@ -41,9 +41,12 @@ class TrafficReplayerTest {
             Assertions.assertTrue(ms > 0);
 
         });
+        
         try (var sr = new StringReader(SampleFile.contents)) {
             try (var br = new BufferedReader(sr)) {
-                tr.consumeLinesForReader(br, re);
+                try (var cssw = CloseableStringStreamWrapper.generateStreamFromBufferedReader(br)) {
+                    tr.runReplay(cssw.stream(), re);
+                }
             }
         }
         Assertions.assertEquals(1, byteArrays.size());


### PR DESCRIPTION
I had to convert all existing System.err.printlns to appropriate log statements.  Same goes for removing rogue System.out lines since that may now be the "triples" output stream. To simplify handling the nature of the input stream, I've modeled input in the form of a java.util.stream.Stream (instead of an InputStream directly).  I've wrapped that Stream in a class that is Closeable so that callers can be responsible for closing it upon completion so that the underlying IOStream can be freed.

### Description
MIGRATIONS-1020 - allow this to read from stdin and write outputs to stdout

### Issues Resolved
https://opensearch.atlassian.net/browse/MIGRATIONS-1020

### Testing
Updated the unit test, but also tested manually by comparing that the output to stdout didn't contain spurious lines.  Line count matched when using a file & all lines began with '{"request'.

### Check List
- [x] New functionality includes testing
  - [] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented (via command line args)
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
