### PR TITLE
Migrations-1028 - Add script to pull CW logs

### DIFF
--- a/TrafficReplayer/build.gradle
+++ b/TrafficReplayer/build.gradle
@@ -1,0 +1,60 @@
+buildscript {
+    dependencies {
+        classpath 'org.junit.platform:junit-platform-gradle-plugin:1.0.1'
+    }
+}
+
+plugins {
+    id 'java'
+    id 'checkstyle'
+}
+
+checkstyle {
+    toolVersion = '8.1'
+    configFile = new File(rootDir, 'config/checkstyle/checkstyle.xml')
+    System.setProperty('checkstyle.cache.file', String.format('%s/%s',
+            buildDir, 'checkstyle.cachefile'))
+}
+
+repositories {
+    mavenCentral()
+}
+dependencies {
+    implementation group: 'io.netty', name: 'netty-all', version: '4.1.89.Final'
+    implementation group: 'org.json', name: 'json', version: '20220924'
+    implementation group: 'org.junit.jupiter', name: 'junit-jupiter', version: '5.8.1'
+    implementation group: 'com.google.guava', name: 'guava', version: '31.1-jre'
+}
+
+sourceSets {
+    main {
+        java {
+            srcDirs = ['src/org/opensearch/migrations/replay','src/org/opensearch/migrations/replay/netty']
+        }
+    }
+
+    unitTests {
+        java {
+            compileClasspath += main.output + test.output
+            runtimeClasspath += main.output + test.output
+            resources.srcDir file('tst/org/opensearch/migrations/replay')
+        }
+    }
+}
+
+task unitTests(type: Test) {
+    testClassesDirs = sourceSets.unitTests.output.classesDirs
+    classpath = sourceSets.unitTests.runtimeClasspath
+}
+
+tasks.assemble.dependsOn {
+    project.tasks.findAll { task ->
+        task.name.startsWith('unitTests')
+    }
+}
+
+tasks.assemble.dependsOn {
+    project.tasks.findAll { task ->
+        task.name.startsWith('checkstyleMain')
+    }
+}

--- a/TrafficReplayer/build.gradle
+++ b/TrafficReplayer/build.gradle
@@ -6,7 +6,12 @@ buildscript {
 
 plugins {
     id 'java'
+    id "com.github.spotbugs" version "4.7.2"
     id 'checkstyle'
+}
+
+spotbugs {
+    includeFilter = file('config/spotbugs/spotbugs-include.xml')
 }
 
 checkstyle {

--- a/TrafficReplayer/build.gradle
+++ b/TrafficReplayer/build.gradle
@@ -63,3 +63,9 @@ tasks.assemble.dependsOn {
         task.name.startsWith('checkstyleMain')
     }
 }
+
+tasks.assemble.dependsOn {
+    project.tasks.findAll { task ->
+        task.name.startsWith('spotbugsMain')
+    }
+}

--- a/TrafficReplayer/build.gradle
+++ b/TrafficReplayer/build.gradle
@@ -1,3 +1,15 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+
 buildscript {
     dependencies {
         classpath 'org.junit.platform:junit-platform-gradle-plugin:1.0.1'

--- a/TrafficReplayer/config/checkstyle/checkstyle.xml
+++ b/TrafficReplayer/config/checkstyle/checkstyle.xml
@@ -1,0 +1,310 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE module PUBLIC
+        "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+        "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+
+<!-- This is a checkstyle configuration file. For descriptions of
+what the following rules do, please see the checkstyle configuration
+page at http://checkstyle.sourceforge.net/config.html -->
+
+<module name="Checker">
+
+    <module name="FileTabCharacter">
+        <!-- Checks that there are no tab characters in the file.
+        -->
+    </module>
+
+    <module name="NewlineAtEndOfFile">
+        <property name="lineSeparator" value="lf"/>
+    </module>
+
+    <module name="RegexpSingleline">
+        <!-- Checks that FIXME is not used in comments.  TODO is preferred.
+        -->
+        <property name="format" value="((//.*)|(\*.*))FIXME" />
+        <property name="message" value='TODO is preferred to FIXME.  e.g. "TODO(johndoe): Refactor when v2 is released."' />
+    </module>
+
+    <module name="RegexpSingleline">
+        <!-- Checks that TODOs are named.  (Actually, just that they are followed
+             by an open paren.)
+        -->
+        <property name="format" value="((//.*)|(\*.*))TODO[^(]" />
+        <property name="message" value='All TODOs should be named.  e.g. "TODO(johndoe): Refactor when v2 is released."' />
+    </module>
+
+    <module name="JavadocPackage">
+        <!-- Checks that each Java package has a Javadoc file used for commenting.
+          Only allows a package-info.java, not package.html. -->
+    </module>
+
+    <!-- All Java AST specific tests live under TreeWalker module. -->
+    <module name="TreeWalker">
+
+        <!--
+        IMPORT CHECKS
+        -->
+
+        <module name="RedundantImport">
+            <!-- Checks for redundant import statements. -->
+            <property name="severity" value="error"/>
+        </module>
+
+        <module name="ImportOrder">
+            <!-- Checks for out of order import statements. -->
+
+            <property name="severity" value="warning"/>
+            <property name="groups" value="com.google,android,junit,net,org,java,javax"/>
+            <!-- This ensures that static imports go first. -->
+            <property name="option" value="top"/>
+            <property name="tokens" value="STATIC_IMPORT, IMPORT"/>
+        </module>
+
+        <!--
+        JAVADOC CHECKS
+        -->
+
+        <!-- Checks for Javadoc comments.                     -->
+        <!-- See http://checkstyle.sf.net/config_javadoc.html -->
+        <module name="JavadocMethod">
+            <property name="scope" value="protected"/>
+            <property name="severity" value="warning"/>
+            <property name="allowMissingJavadoc" value="true"/>
+            <property name="allowMissingParamTags" value="true"/>
+            <property name="allowMissingReturnTag" value="true"/>
+            <property name="allowMissingThrowsTags" value="true"/>
+            <property name="allowThrowsTagsForSubclasses" value="true"/>
+            <property name="allowUndeclaredRTE" value="true"/>
+        </module>
+
+        <module name="JavadocType">
+            <property name="scope" value="protected"/>
+            <property name="severity" value="error"/>
+        </module>
+
+        <module name="JavadocStyle">
+            <property name="severity" value="warning"/>
+        </module>
+
+        <!--
+        NAMING CHECKS
+        -->
+
+        <!-- Item 38 - Adhere to generally accepted naming conventions -->
+
+        <module name="PackageName">
+            <!-- Validates identifiers for package names against the
+              supplied expression. -->
+            <!-- Here the default checkstyle rule restricts package name parts to
+              seven characters, this is not in line with common practice at Google.
+            -->
+            <property name="format" value="^[a-z]+(\.[a-z][a-z0-9]{1,})*$"/>
+            <property name="severity" value="warning"/>
+        </module>
+
+        <module name="TypeNameCheck">
+            <!-- Validates static, final fields against the
+            expression "^[A-Z][a-zA-Z0-9]*$". -->
+            <metadata name="altname" value="TypeName"/>
+            <property name="severity" value="warning"/>
+        </module>
+
+        <module name="ConstantNameCheck">
+            <!-- Validates non-private, static, final fields against the supplied
+            public/package final fields "^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$". -->
+            <metadata name="altname" value="ConstantName"/>
+            <property name="applyToPublic" value="true"/>
+            <property name="applyToProtected" value="true"/>
+            <property name="applyToPackage" value="true"/>
+            <property name="applyToPrivate" value="false"/>
+            <property name="format" value="^([A-Z][A-Z0-9]*(_[A-Z0-9]+)*|FLAG_.*)$"/>
+            <message key="name.invalidPattern"
+                     value="Variable ''{0}'' should be in ALL_CAPS (if it is a constant) or be private (otherwise)."/>
+            <property name="severity" value="warning"/>
+        </module>
+
+        <module name="StaticVariableNameCheck">
+            <!-- Validates static, non-final fields against the supplied
+            expression "^[a-z][a-zA-Z0-9]*_?$". -->
+            <metadata name="altname" value="StaticVariableName"/>
+            <property name="applyToPublic" value="true"/>
+            <property name="applyToProtected" value="true"/>
+            <property name="applyToPackage" value="true"/>
+            <property name="applyToPrivate" value="true"/>
+            <property name="format" value="^[a-z][a-zA-Z0-9]*_?$"/>
+            <property name="severity" value="warning"/>
+        </module>
+
+        <module name="MemberNameCheck">
+            <!-- Validates non-static members against the supplied expression. -->
+            <metadata name="altname" value="MemberName"/>
+            <property name="applyToPublic" value="true"/>
+            <property name="applyToProtected" value="true"/>
+            <property name="applyToPackage" value="true"/>
+            <property name="applyToPrivate" value="true"/>
+            <property name="format" value="^[a-z][a-zA-Z0-9]*$"/>
+            <property name="severity" value="warning"/>
+        </module>
+
+        <module name="MethodNameCheck">
+            <!-- Validates identifiers for method names. -->
+            <metadata name="altname" value="MethodName"/>
+            <property name="format" value="^[a-z][a-zA-Z0-9]*(_[a-zA-Z0-9]+)*$"/>
+            <property name="severity" value="warning"/>
+        </module>
+
+        <module name="ParameterName">
+            <!-- Validates identifiers for method parameters against the
+              expression "^[a-z][a-zA-Z0-9]*$". -->
+            <property name="severity" value="warning"/>
+        </module>
+
+        <module name="LocalFinalVariableName">
+            <!-- Validates identifiers for local final variables against the
+              expression "^[a-z][a-zA-Z0-9]*$". -->
+            <property name="severity" value="warning"/>
+        </module>
+
+        <module name="LocalVariableName">
+            <!-- Validates identifiers for local variables against the
+              expression "^[a-z][a-zA-Z0-9]*$". -->
+            <property name="severity" value="warning"/>
+        </module>
+
+
+        <!--
+        LENGTH and CODING CHECKS
+        -->
+
+        <module name="LineLength">
+            <!-- Checks if a line is too long. -->
+            <property name="max" value="${com.puppycrawl.tools.checkstyle.checks.sizes.LineLength.max}" default="100"/>
+            <property name="severity" value="error"/>
+
+            <!--
+              The default ignore pattern exempts the following elements:
+                - import statements
+                - long URLs inside comments
+            -->
+
+            <property name="ignorePattern"
+                      value="${com.puppycrawl.tools.checkstyle.checks.sizes.LineLength.ignorePattern}"
+                      default="^(package .*;\s*)|(import .*;\s*)|( *(\*|//).*https?://.*)$"/>
+        </module>
+
+        <module name="LeftCurly">
+            <!-- Checks for placement of the left curly brace ('{'). -->
+            <property name="severity" value="warning"/>
+        </module>
+
+        <module name="RightCurly">
+            <!-- Checks right curlies on CATCH, ELSE, and TRY blocks are on
+            the same line. e.g., the following example is fine:
+            <pre>
+              if {
+                ...
+              } else
+            </pre>
+            -->
+            <!-- This next example is not fine:
+            <pre>
+              if {
+                ...
+              }
+              else
+            </pre>
+            -->
+            <property name="option" value="same"/>
+            <property name="severity" value="warning"/>
+        </module>
+
+        <!-- Checks for braces around if and else blocks -->
+        <module name="NeedBraces">
+            <property name="severity" value="warning"/>
+            <property name="tokens" value="LITERAL_IF, LITERAL_ELSE, LITERAL_FOR, LITERAL_WHILE, LITERAL_DO"/>
+        </module>
+
+        <module name="UpperEll">
+            <!-- Checks that long constants are defined with an upper ell.-->
+            <property name="severity" value="error"/>
+        </module>
+
+        <module name="FallThrough">
+            <!-- Warn about falling through to the next case statement.  Similar to
+            javac -Xlint:fallthrough, but the check is suppressed if a single-line comment
+            on the last non-blank line preceding the fallen-into case contains 'fall through' (or
+            some other variants which we don't publicized to promote consistency).
+            -->
+            <property name="reliefPattern"
+                      value="fall through|Fall through|fallthru|Fallthru|falls through|Falls through|fallthrough|Fallthrough|No break|NO break|no break|continue on"/>
+            <property name="severity" value="error"/>
+        </module>
+
+
+        <!--
+        MODIFIERS CHECKS
+        -->
+
+        <module name="ModifierOrder">
+            <!-- Warn if modifier order is inconsistent with JLS3 8.1.1, 8.3.1, and
+                 8.4.3.  The prescribed order is:
+                 public, protected, private, abstract, static, final, transient, volatile,
+                 synchronized, native, strictfp
+              -->
+        </module>
+
+
+        <!--
+        WHITESPACE CHECKS
+        -->
+
+        <module name="WhitespaceAround">
+            <!-- Checks that various tokens are surrounded by whitespace.
+                 This includes most binary operators and keywords followed
+                 by regular or curly braces.
+            -->
+            <property name="tokens" value="ASSIGN, BAND, BAND_ASSIGN, BOR,
+        BOR_ASSIGN, BSR, BSR_ASSIGN, BXOR, BXOR_ASSIGN, COLON, DIV, DIV_ASSIGN,
+        EQUAL, GE, GT, LAND, LE, LITERAL_CATCH, LITERAL_DO, LITERAL_ELSE,
+        LITERAL_FINALLY, LITERAL_FOR, LITERAL_IF, LITERAL_RETURN,
+        LITERAL_SYNCHRONIZED, LITERAL_TRY, LITERAL_WHILE, LOR, LT, MINUS,
+        MINUS_ASSIGN, MOD, MOD_ASSIGN, NOT_EQUAL, PLUS, PLUS_ASSIGN, QUESTION,
+        SL, SL_ASSIGN, SR_ASSIGN, STAR, STAR_ASSIGN"/>
+            <property name="severity" value="error"/>
+        </module>
+
+        <module name="WhitespaceAfter">
+            <!-- Checks that commas, semicolons and typecasts are followed by
+                 whitespace.
+            -->
+            <property name="tokens" value="COMMA, SEMI, TYPECAST"/>
+        </module>
+
+        <module name="NoWhitespaceAfter">
+            <!-- Checks that there is no whitespace after various unary operators.
+                 Linebreaks are allowed.
+            -->
+            <property name="tokens" value="BNOT, DEC, DOT, INC, LNOT, UNARY_MINUS,
+        UNARY_PLUS"/>
+            <property name="allowLineBreaks" value="true"/>
+            <property name="severity" value="error"/>
+        </module>
+
+        <module name="NoWhitespaceBefore">
+            <!-- Checks that there is no whitespace before various unary operators.
+                 Linebreaks are allowed.
+            -->
+            <property name="tokens" value="SEMI, DOT, POST_DEC, POST_INC"/>
+            <property name="allowLineBreaks" value="true"/>
+            <property name="severity" value="error"/>
+        </module>
+
+        <module name="ParenPad">
+            <!-- Checks that there is no whitespace before close parens or after
+                 open parens.
+            -->
+            <property name="severity" value="warning"/>
+        </module>
+
+    </module>
+</module>

--- a/TrafficReplayer/config/spotbugs/spotbugs-include.xml
+++ b/TrafficReplayer/config/spotbugs/spotbugs-include.xml
@@ -1,0 +1,5 @@
+<FindBugsFilter>
+    <Match>
+        <Bug category="I18N" />
+    </Match>
+</FindBugsFilter>

--- a/TrafficReplayer/pull_then_poll_cw_logs.py
+++ b/TrafficReplayer/pull_then_poll_cw_logs.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+import os
+import time
+import sys
+
+import boto3
+
+DEFAULT_REGION = "us-east-1"
+DEFAULT_LOG_GROUP = sys.argv[1]
+DEFAULT_LOG_STREAM = sys.argv[2]
+DEFAULT_FILE = "/tmp/logfile.log"
+
+
+def main():
+    logs_client = boto3.client(
+        'logs',
+        aws_access_key_id=os.environ["AWS_ACCESS_KEY_ID"],
+        aws_secret_access_key=os.environ["AWS_SECRET_ACCESS_KEY"],
+        aws_session_token=os.environ["AWS_SESSION_TOKEN"],
+        region_name=DEFAULT_REGION
+    )
+
+    messages = []
+
+    # Continuously get events and add them to our final list until we see a repeat of the "nextForwardToken"
+    # Then script will start checking periodically
+    print(f"Pulling CW events from {DEFAULT_LOG_GROUP}:{DEFAULT_LOG_STREAM}...")
+    current_response = logs_client.get_log_events(logGroupName=DEFAULT_LOG_GROUP,
+                                                  logStreamName=DEFAULT_LOG_STREAM, startFromHead=True)
+    current_events_raw = current_response["events"]
+    messages.extend([event["message"] for event in current_events_raw])
+    current_token = current_response["nextForwardToken"]
+
+    next_response = logs_client.get_log_events(logGroupName=DEFAULT_LOG_GROUP,
+                                               logStreamName=DEFAULT_LOG_STREAM,
+                                               startFromHead=True, nextToken=current_token)
+    next_token = next_response["nextForwardToken"]
+
+    while current_token != next_token:
+        print("More events to pull...")
+        current_response = next_response
+        current_events_raw = current_response["events"]
+        messages.extend([event["message"] for event in current_events_raw])
+        current_token = current_response["nextForwardToken"]
+
+        next_response = logs_client.get_log_events(logGroupName=DEFAULT_LOG_GROUP,
+                                                   logStreamName=DEFAULT_LOG_STREAM,
+                                                   startFromHead=True, nextToken=current_token)
+        next_token = next_response["nextForwardToken"]
+
+    print(f"Pulled {len(messages)} events")
+
+    print(f"Writing events to file: {DEFAULT_FILE}")
+    with open(DEFAULT_FILE, 'w') as output_file:
+        output_file.write("\n".join(messages))
+        output_file.write("\n")
+
+    # Now that all currently available CloudWatch events were logged.
+    # We start checking for new events every now and then, and append new ones to already existing file, if available
+
+    while True:
+        messages.clear()
+
+        next_response = logs_client.get_log_events(logGroupName=DEFAULT_LOG_GROUP,
+                                                   logStreamName=DEFAULT_LOG_STREAM,
+                                                   startFromHead=False, nextToken=current_token)
+        next_token = next_response["nextForwardToken"]
+
+        if current_token != next_token:
+            current_response = next_response
+            current_events_raw = current_response["events"]
+            messages.extend([event["message"] for event in current_events_raw])
+            current_token = current_response["nextForwardToken"]
+
+            next_response = logs_client.get_log_events(logGroupName=DEFAULT_LOG_GROUP,
+                                                       logStreamName=DEFAULT_LOG_STREAM,
+                                                       startFromHead=False, nextToken=current_token)
+            next_token = next_response["nextForwardToken"]
+
+            if len(messages):
+                print(f"Found new log events. Writing events to file: {DEFAULT_FILE} - Checking again in 10 seconds")
+                with open(DEFAULT_FILE, 'a') as output_file:
+                    output_file.write("\n".join(messages))
+
+        if not len(messages):
+            print("No new log events found, sleeping for 10 seconds then checking again")
+
+        time.sleep(10)
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
### Description
This script will pull all available log events in a CloudWatch log group and save them to a file, then start polling for any new events and append them to said file.

As this script's purpose (for now?) is to run from a docker container, it assumes that the user has already acquired the credentials with permissions to access the CW log group provided. @lewijacn is working on a way to properly allow a container to assume an IAM role.

To run the script, use the following command:
`python pull_then_poll_cw_logs.py YOUR_CLOUDWATCH_LOG_GROUP YOUR_CLOUDWATCH_LOG_STREAM`

### Issues Resolved
[Migrations-1028](https://opensearch.atlassian.net/browse/MIGRATIONS-1028)

### Check List
- [ ] New functionality includes testing
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
