### PR TITLE
MIGRATIONS-1042  - Remove github team from CODEOWNERS and replace wit…

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # This should match the owning team set up in https://github.com/orgs/opensearch-project/teams
-*   @opensearch-project/opensearch-migrations
+*   @chelma @gregschohn @kartg @lewijacn @mikaylathompson @okhasawn @sumobrian


### PR DESCRIPTION
…h individual aliases

### Description
[Describe what this change achieves]
This changes replaces the github team within the CODEOWNERS file with individual team member aliases. 

### Issues Resolved
[List any issues this PR will resolve]
https://github.com/opensearch-project/opensearch-migrations/issues/106

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]

### Check List
- [ ] New functionality includes testing
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
