### PR TITLE
[Traffic Capture] Add multipart support for offloading messages

### DIFF
--- a/TrafficCapture/captureKafkaOffloader/build.gradle
+++ b/TrafficCapture/captureKafkaOffloader/build.gradle
@@ -17,4 +17,6 @@ dependencies {
     implementation 'software.amazon.msk:aws-msk-iam-auth:1.1.6'
     implementation 'org.slf4j:slf4j-api:2.0.7'
     testImplementation project(':captureProtobufs')
+    testImplementation 'org.mockito:mockito-core:4.6.1'
+    testImplementation 'org.mockito:mockito-junit-jupiter:4.6.1'
 }

--- a/TrafficCapture/captureKafkaOffloader/src/test/java/org/opensearch/migrations/trafficcapture/kafkaoffloader/KafkaCaptureFactoryTest.java
+++ b/TrafficCapture/captureKafkaOffloader/src/test/java/org/opensearch/migrations/trafficcapture/kafkaoffloader/KafkaCaptureFactoryTest.java
@@ -1,0 +1,71 @@
+package org.opensearch.migrations.trafficcapture.kafkaoffloader;
+
+import io.netty.buffer.Unpooled;
+import org.apache.kafka.clients.producer.Callback;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.migrations.trafficcapture.IChannelConnectionCaptureSerializer;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class KafkaCaptureFactoryTest {
+
+    @Mock
+    private Producer<String, byte[]> mockProducer;
+
+    @Test
+    public void testOngoingFuturesAreAggregated() throws IOException {
+
+        String connectionId = "test1234";
+
+        KafkaCaptureFactory kafkaCaptureFactory = new KafkaCaptureFactory(mockProducer);
+        IChannelConnectionCaptureSerializer offloader = kafkaCaptureFactory.createOffloader(connectionId);
+
+        List<Callback> recordSentCallbacks = new ArrayList<>(3);
+        when(mockProducer.send(any(), any())).thenAnswer(invocation -> {
+            Object[] args = invocation.getArguments();
+            ProducerRecord<String, byte[]> record = (ProducerRecord) args[0];
+            Callback recordSentCallback = (Callback) args[1];
+            recordSentCallbacks.add(recordSentCallback);
+            return null;
+        });
+
+        Instant ts = Instant.now();
+        byte[] fakeDataBytes = "FakeData".getBytes(StandardCharsets.UTF_8);
+        var bb = Unpooled.wrappedBuffer(fakeDataBytes);
+        offloader.addReadEvent(ts, bb);
+        CompletableFuture cf1 = offloader.flushCommitAndResetStream(false);
+        offloader.addReadEvent(ts, bb);
+        CompletableFuture cf2 = offloader.flushCommitAndResetStream(false);
+        offloader.addReadEvent(ts, bb);
+        CompletableFuture cf3 = offloader.flushCommitAndResetStream(false);
+        bb.release();
+
+        // Assert that even though particular final producer record has finished sending, its predecessors are incomplete
+        // and thus this wrapper cf is also incomplete
+        recordSentCallbacks.get(2).onCompletion(null, null);
+        Assertions.assertEquals(false, cf3.isDone());
+
+        recordSentCallbacks.get(1).onCompletion(null, null);
+        Assertions.assertEquals(false, cf3.isDone());
+
+        recordSentCallbacks.get(0).onCompletion(null, null);
+        Assertions.assertEquals(true, cf3.isDone());
+
+        mockProducer.close();
+    }
+}

--- a/TrafficCapture/captureKafkaOffloader/src/test/java/org/opensearch/migrations/trafficcapture/kafkaoffloader/KafkaCaptureFactoryTest.java
+++ b/TrafficCapture/captureKafkaOffloader/src/test/java/org/opensearch/migrations/trafficcapture/kafkaoffloader/KafkaCaptureFactoryTest.java
@@ -27,12 +27,59 @@ public class KafkaCaptureFactoryTest {
     @Mock
     private Producer<String, byte[]> mockProducer;
 
+    private String connectionId = "test1234";
+
+
+    @Test
+    public void testLinearOffloadingIsSuccessful() throws IOException {
+        KafkaCaptureFactory kafkaCaptureFactory = new KafkaCaptureFactory(mockProducer, 1024*1024);
+        IChannelConnectionCaptureSerializer offloader = kafkaCaptureFactory.createOffloader(connectionId);
+
+        List<Callback> recordSentCallbacks = new ArrayList<>(3);
+        when(mockProducer.send(any(), any())).thenAnswer(invocation -> {
+            Object[] args = invocation.getArguments();
+            ProducerRecord<String, byte[]> record = (ProducerRecord) args[0];
+            Callback recordSentCallback = (Callback) args[1];
+            recordSentCallbacks.add(recordSentCallback);
+            return null;
+        });
+
+        Instant ts = Instant.now();
+        byte[] fakeDataBytes = "FakeData".getBytes(StandardCharsets.UTF_8);
+        var bb = Unpooled.wrappedBuffer(fakeDataBytes);
+        offloader.addReadEvent(ts, bb);
+        CompletableFuture cf1 = offloader.flushCommitAndResetStream(false);
+        offloader.addReadEvent(ts, bb);
+        CompletableFuture cf2 = offloader.flushCommitAndResetStream(false);
+        offloader.addReadEvent(ts, bb);
+        CompletableFuture cf3 = offloader.flushCommitAndResetStream(false);
+        bb.release();
+
+        Assertions.assertEquals(false, cf1.isDone());
+        Assertions.assertEquals(false, cf2.isDone());
+        Assertions.assertEquals(false, cf3.isDone());
+        recordSentCallbacks.get(0).onCompletion(null, null);
+
+        Assertions.assertEquals(true, cf1.isDone());
+        Assertions.assertEquals(false, cf2.isDone());
+        Assertions.assertEquals(false, cf3.isDone());
+        recordSentCallbacks.get(1).onCompletion(null, null);
+
+        Assertions.assertEquals(true, cf1.isDone());
+        Assertions.assertEquals(true, cf2.isDone());
+        Assertions.assertEquals(false, cf3.isDone());
+        recordSentCallbacks.get(2).onCompletion(null, null);
+
+        Assertions.assertEquals(true, cf1.isDone());
+        Assertions.assertEquals(true, cf2.isDone());
+        Assertions.assertEquals(true, cf3.isDone());
+
+        mockProducer.close();
+    }
+
     @Test
     public void testOngoingFuturesAreAggregated() throws IOException {
-
-        String connectionId = "test1234";
-
-        KafkaCaptureFactory kafkaCaptureFactory = new KafkaCaptureFactory(mockProducer);
+        KafkaCaptureFactory kafkaCaptureFactory = new KafkaCaptureFactory(mockProducer, 1024*1024);
         IChannelConnectionCaptureSerializer offloader = kafkaCaptureFactory.createOffloader(connectionId);
 
         List<Callback> recordSentCallbacks = new ArrayList<>(3);

--- a/TrafficCapture/captureKafkaOffloader/src/test/java/org/opensearch/migrations/trafficcapture/kafkaoffloader/KafkaCaptureFactoryTest.java
+++ b/TrafficCapture/captureKafkaOffloader/src/test/java/org/opensearch/migrations/trafficcapture/kafkaoffloader/KafkaCaptureFactoryTest.java
@@ -55,15 +55,25 @@ public class KafkaCaptureFactoryTest {
         CompletableFuture cf3 = offloader.flushCommitAndResetStream(false);
         bb.release();
 
+        Assertions.assertEquals(false, cf1.isDone());
+        Assertions.assertEquals(false, cf2.isDone());
+        Assertions.assertEquals(false, cf3.isDone());
+        recordSentCallbacks.get(2).onCompletion(null, null);
+
         // Assert that even though particular final producer record has finished sending, its predecessors are incomplete
         // and thus this wrapper cf is also incomplete
-        recordSentCallbacks.get(2).onCompletion(null, null);
+        Assertions.assertEquals(false, cf1.isDone());
+        Assertions.assertEquals(false, cf2.isDone());
         Assertions.assertEquals(false, cf3.isDone());
-
         recordSentCallbacks.get(1).onCompletion(null, null);
-        Assertions.assertEquals(false, cf3.isDone());
 
+        Assertions.assertEquals(false, cf1.isDone());
+        Assertions.assertEquals(false, cf2.isDone());
+        Assertions.assertEquals(false, cf3.isDone());
         recordSentCallbacks.get(0).onCompletion(null, null);
+
+        Assertions.assertEquals(true, cf1.isDone());
+        Assertions.assertEquals(true, cf2.isDone());
         Assertions.assertEquals(true, cf3.isDone());
 
         mockProducer.close();

--- a/TrafficCapture/captureOffloader/src/main/java/org/opensearch/migrations/trafficcapture/CodedOutputStreamSizeUtil.java
+++ b/TrafficCapture/captureOffloader/src/main/java/org/opensearch/migrations/trafficcapture/CodedOutputStreamSizeUtil.java
@@ -1,0 +1,46 @@
+package org.opensearch.migrations.trafficcapture;
+
+import com.google.protobuf.CodedOutputStream;
+import com.google.protobuf.Timestamp;
+import org.opensearch.migrations.trafficcapture.protos.TrafficObservation;
+import org.opensearch.migrations.trafficcapture.protos.TrafficStream;
+
+import java.nio.ByteBuffer;
+import java.time.Instant;
+
+/**
+ * Utility functions for computing sizes of fields to be added to a CodedOutputStream
+ */
+public class CodedOutputStreamSizeUtil {
+
+    public static int getSizeOfTimestamp(Instant t) {
+        long seconds = t.getEpochSecond();
+        int nanos = t.getNano();
+        var secSize = CodedOutputStream.computeInt64Size(Timestamp.SECONDS_FIELD_NUMBER, seconds);
+        var nanoSize = nanos == 0 ? 0 : CodedOutputStream.computeInt32Size(Timestamp.NANOS_FIELD_NUMBER, nanos);
+        return secSize + nanoSize;
+    }
+
+    public static int totalBytesNeededForMessage(Instant timestamp, int observationFieldNumber, int dataFieldNumber,
+        int dataCountFieldNumber, int dataCount,  ByteBuffer buffer, int flushes) {
+        // Timestamp closure bytes
+        int tsContentSize = getSizeOfTimestamp(timestamp);
+        int tsClosureSize = CodedOutputStream.computeInt32Size(TrafficObservation.TS_FIELD_NUMBER, tsContentSize) + tsContentSize;
+
+        // Capture closure bytes
+        int dataSize = CodedOutputStream.computeByteBufferSize(dataFieldNumber, buffer);
+        int dataCountSize = dataCountFieldNumber > 0 ? CodedOutputStream.computeInt32Size(dataCountFieldNumber, dataCount) : 0;
+        int captureContentSize = dataSize + dataCountSize;
+        int captureClosureSize = CodedOutputStream.computeInt32Size(observationFieldNumber, captureContentSize) + captureContentSize;
+
+        // Observation tag and closure size needed bytes
+        int observationTagAndClosureSize = CodedOutputStream.computeInt32Size(TrafficStream.SUBSTREAM_FIELD_NUMBER, tsClosureSize + captureClosureSize);
+
+        // Size for closing index, use arbitrary field to calculate
+        int indexSize = CodedOutputStream.computeInt32Size(TrafficStream.NUMBER_FIELD_NUMBER, flushes);
+
+        return observationTagAndClosureSize + tsClosureSize + captureClosureSize + indexSize;
+    }
+
+
+}

--- a/TrafficCapture/captureOffloader/src/main/java/org/opensearch/migrations/trafficcapture/CodedOutputStreamSizeUtil.java
+++ b/TrafficCapture/captureOffloader/src/main/java/org/opensearch/migrations/trafficcapture/CodedOutputStreamSizeUtil.java
@@ -21,7 +21,11 @@ public class CodedOutputStreamSizeUtil {
         return secSize + nanoSize;
     }
 
-    public static int totalBytesNeededForMessage(Instant timestamp, int observationFieldNumber, int dataFieldNumber,
+    /**
+     * This function calculates the maximum bytes needed to store a message ByteBuffer and its associated
+     * Traffic Stream overhead into a CodedOutputStream. The actual required bytes could be marginally smaller.
+     */
+    public static int maxBytesNeededForMessage(Instant timestamp, int observationFieldNumber, int dataFieldNumber,
         int dataCountFieldNumber, int dataCount,  ByteBuffer buffer, int flushes) {
         // Timestamp closure bytes
         int tsContentSize = getSizeOfTimestamp(timestamp);

--- a/TrafficCapture/captureOffloader/src/main/java/org/opensearch/migrations/trafficcapture/FileConnectionCaptureFactory.java
+++ b/TrafficCapture/captureOffloader/src/main/java/org/opensearch/migrations/trafficcapture/FileConnectionCaptureFactory.java
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Arrays;
 import java.util.WeakHashMap;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -48,7 +49,8 @@ public class FileConnectionCaptureFactory implements IConnectionCaptureFactory {
         return CompletableFuture.runAsync(() -> {
             try {
                 FileOutputStream fs = outputStreamCreator.apply(connectionId, callCounter);
-                fs.write(byteBuffer.array());
+                byte[] filledBytes = Arrays.copyOfRange(byteBuffer.array(), 0, byteBuffer.position());
+                fs.write(filledBytes);
                 fs.flush();
                 log.warn("NOT removing the CodedOutputStream from the WeakHashMap, which is a memory leak.  Doing this until the system knows when to properly flush buffers");
                 //codedStreamToFileStreamMap.remove(stream);

--- a/TrafficCapture/captureOffloader/src/main/java/org/opensearch/migrations/trafficcapture/FileConnectionCaptureFactory.java
+++ b/TrafficCapture/captureOffloader/src/main/java/org/opensearch/migrations/trafficcapture/FileConnectionCaptureFactory.java
@@ -6,11 +6,13 @@ import lombok.extern.slf4j.Slf4j;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.WeakHashMap;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiFunction;
 
 /**
@@ -42,24 +44,37 @@ public class FileConnectionCaptureFactory implements IConnectionCaptureFactory {
         this(Paths.get(path));
     }
 
-    @Override
-    public IChannelConnectionCaptureSerializer createOffloader(String connectionId) throws IOException {
-        AtomicInteger supplierCallCounter = new AtomicInteger();
-        WeakHashMap<CodedOutputStream, FileOutputStream> codedStreamToFileStreamMap = new WeakHashMap<>();
-        return new StreamChannelConnectionCaptureSerializer(connectionId, () -> {
-            var fs = outputStreamCreator.apply(connectionId, supplierCallCounter.incrementAndGet());
-            var cos = CodedOutputStream.newInstance(fs);
-            codedStreamToFileStreamMap.put(cos, fs);
-            return cos;
-        }, (codedOutputStream) -> CompletableFuture.runAsync(() -> {
+    private CompletableFuture closeHandler(String connectionId, ByteBuffer byteBuffer, CodedOutputStream codedOutputStream, int callCounter) {
+        return CompletableFuture.runAsync(() -> {
             try {
-                var fs = codedStreamToFileStreamMap.get(codedOutputStream);
+                FileOutputStream fs = outputStreamCreator.apply(connectionId, callCounter);
+                fs.write(byteBuffer.array());
                 fs.flush();
                 log.warn("NOT removing the CodedOutputStream from the WeakHashMap, which is a memory leak.  Doing this until the system knows when to properly flush buffers");
                 //codedStreamToFileStreamMap.remove(stream);
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }
-        }));
+        });
+    }
+
+    @Override
+    public IChannelConnectionCaptureSerializer createOffloader(String connectionId) throws IOException {
+        AtomicInteger supplierCallCounter = new AtomicInteger();
+        AtomicReference<CompletableFuture> aggregateCf = new AtomicReference<>(CompletableFuture.completedFuture(null));
+        WeakHashMap<CodedOutputStream, ByteBuffer> codedStreamToFileStreamMap = new WeakHashMap<>();
+        return new StreamChannelConnectionCaptureSerializer(connectionId, 100,
+            () -> {
+                ByteBuffer bb = ByteBuffer.allocate(1024 * 1024);
+                var cos = CodedOutputStream.newInstance(bb);
+                codedStreamToFileStreamMap.put(cos, bb);
+                return cos;
+            },
+            (codedOutputStream) -> {
+                CompletableFuture cf = closeHandler(connectionId, codedStreamToFileStreamMap.get(codedOutputStream), codedOutputStream, supplierCallCounter.incrementAndGet());
+                aggregateCf.set(aggregateCf.get().isDone() ? cf : CompletableFuture.allOf(aggregateCf.get(), cf));
+                return aggregateCf.get();
+            }
+        );
     }
 }

--- a/TrafficCapture/captureOffloader/src/main/java/org/opensearch/migrations/trafficcapture/FileConnectionCaptureFactory.java
+++ b/TrafficCapture/captureOffloader/src/main/java/org/opensearch/migrations/trafficcapture/FileConnectionCaptureFactory.java
@@ -13,7 +13,6 @@ import java.util.Arrays;
 import java.util.WeakHashMap;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiFunction;
 
 /**
@@ -26,23 +25,25 @@ import java.util.function.BiFunction;
 @Deprecated
 public class FileConnectionCaptureFactory implements IConnectionCaptureFactory {
     private final BiFunction<String, Integer, FileOutputStream> outputStreamCreator;
+    private final int bufferSize;
 
-    public FileConnectionCaptureFactory(BiFunction<String, Integer, FileOutputStream> outputStreamCreator) {
+    public FileConnectionCaptureFactory(BiFunction<String, Integer, FileOutputStream> outputStreamCreator, int bufferSize) {
         this.outputStreamCreator = outputStreamCreator;
+        this.bufferSize = bufferSize;
     }
 
-    public FileConnectionCaptureFactory(Path rootPath) {
+    public FileConnectionCaptureFactory(Path rootPath, int bufferSize) {
         this((id, n) -> {
             try {
                 return new FileOutputStream(rootPath.resolve(id + "_" + n.toString() + ".protocap").toString());
             } catch (FileNotFoundException e) {
                 throw new RuntimeException(e);
             }
-        });
+        }, bufferSize);
     }
 
-    public FileConnectionCaptureFactory(String path) {
-        this(Paths.get(path));
+    public FileConnectionCaptureFactory(String path, int bufferSize) {
+        this(Paths.get(path), bufferSize);
     }
 
     private CompletableFuture closeHandler(String connectionId, ByteBuffer byteBuffer, CodedOutputStream codedOutputStream, int callCounter) {
@@ -63,19 +64,21 @@ public class FileConnectionCaptureFactory implements IConnectionCaptureFactory {
     @Override
     public IChannelConnectionCaptureSerializer createOffloader(String connectionId) throws IOException {
         AtomicInteger supplierCallCounter = new AtomicInteger();
-        AtomicReference<CompletableFuture> aggregateCf = new AtomicReference<>(CompletableFuture.completedFuture(null));
+        // This array is only an indirection to work around Java's constraint that lambda values are final
+        CompletableFuture[] singleAggregateCfRef = new CompletableFuture[1];
+        singleAggregateCfRef[0] = CompletableFuture.completedFuture(null);
         WeakHashMap<CodedOutputStream, ByteBuffer> codedStreamToFileStreamMap = new WeakHashMap<>();
-        return new StreamChannelConnectionCaptureSerializer(connectionId, 100,
+        return new StreamChannelConnectionCaptureSerializer(connectionId,
             () -> {
-                ByteBuffer bb = ByteBuffer.allocate(1024 * 1024);
+                ByteBuffer bb = ByteBuffer.allocate(bufferSize);
                 var cos = CodedOutputStream.newInstance(bb);
                 codedStreamToFileStreamMap.put(cos, bb);
                 return cos;
             },
             (codedOutputStream) -> {
                 CompletableFuture cf = closeHandler(connectionId, codedStreamToFileStreamMap.get(codedOutputStream), codedOutputStream, supplierCallCounter.incrementAndGet());
-                aggregateCf.set(aggregateCf.get().isDone() ? cf : CompletableFuture.allOf(aggregateCf.get(), cf));
-                return aggregateCf.get();
+                singleAggregateCfRef[0] = singleAggregateCfRef[0].isDone() ? cf : CompletableFuture.allOf(singleAggregateCfRef[0], cf);
+                return singleAggregateCfRef[0];
             }
         );
     }

--- a/TrafficCapture/captureOffloader/src/main/java/org/opensearch/migrations/trafficcapture/StreamChannelConnectionCaptureSerializer.java
+++ b/TrafficCapture/captureOffloader/src/main/java/org/opensearch/migrations/trafficcapture/StreamChannelConnectionCaptureSerializer.java
@@ -59,7 +59,7 @@ public class StreamChannelConnectionCaptureSerializer implements IChannelConnect
             return currentCodedOutputStreamOrNull;
         } else {
             currentCodedOutputStreamOrNull = codedOutputStreamSupplier.get();
-            // 1: "1234ABCD"
+            // i.e. 1: "1234ABCD"
             currentCodedOutputStreamOrNull.writeString(TrafficStream.ID_FIELD_NUMBER, idString);
             return currentCodedOutputStreamOrNull;
         }
@@ -76,7 +76,7 @@ public class StreamChannelConnectionCaptureSerializer implements IChannelConnect
     }
 
     private void beginWritingObservationToCurrentStream(Instant timestamp, int tag, int bodySize) throws IOException {
-        // 2 {
+        // i.e. 2 {
         writeTrafficStreamTag(TrafficStream.SUBSTREAM_FIELD_NUMBER);
         final var tsSize = CodedOutputStreamSizeUtil.getSizeOfTimestamp(timestamp);
         final var observationTagSize = CodedOutputStream.computeTagSize(tag);
@@ -85,9 +85,9 @@ public class StreamChannelConnectionCaptureSerializer implements IChannelConnect
             CodedOutputStream.computeInt32Size(TrafficObservation.TS_FIELD_NUMBER, tsSize) +
             observationTagSize +
             bodySize);
-        // 1 { 1: .. 2: .. }
+        // i.e. 1 { 1: .. 2: .. }
         writeTimestampForNowToCurrentStream(timestamp);
-        // 4 {
+        // i.e. 4 {
         writeObservationTag(tag);
     }
 
@@ -125,7 +125,7 @@ public class StreamChannelConnectionCaptureSerializer implements IChannelConnect
         }
         CodedOutputStream currentStream = getOrCreateCodedOutputStream();
         var fieldNum = isFinal ? TrafficStream.NUMBEROFTHISLASTCHUNK_FIELD_NUMBER : TrafficStream.NUMBER_FIELD_NUMBER;
-        // 3: 1
+        // i.e. 3: 1
         currentStream.writeInt32(fieldNum, ++numFlushesSoFar);
         currentStream.flush();
         var future = closeHandler.apply(currentStream);
@@ -253,12 +253,10 @@ public class StreamChannelConnectionCaptureSerializer implements IChannelConnect
         int segmentCountSize = 0;
         int lengthSize = 1;
         CodedOutputStream codedOutputStream = getOrCreateCodedOutputStream();
-        // Calculate segment count size
         if (dataCountFieldNumber > 0) {
             segmentCountSize = CodedOutputStream.computeInt32Size(dataCountFieldNumber, dataCount);
         }
         if (byteBuffer.remaining() > 0) {
-            // These combined are everything but the capture tag for the capture closure
             dataSize = CodedOutputStream.computeByteBufferSize(dataFieldNumber, byteBuffer);
             lengthSize = CodedOutputStream.computeInt32SizeNoTag(dataSize + segmentCountSize);
         }
@@ -267,7 +265,7 @@ public class StreamChannelConnectionCaptureSerializer implements IChannelConnect
             // Write size of data after observation tag
             codedOutputStream.writeInt32NoTag(dataSize + segmentCountSize);
         }
-        // Write segment count field
+        // Write segment count field for segment observations
         if (dataCountFieldNumber > 0) {
             codedOutputStream.writeInt32(dataCountFieldNumber, dataCount);
         }

--- a/TrafficCapture/captureOffloader/src/test/java/org/opensearch/migrations/trafficcapture/StreamChannelConnectionCaptureSerializerTest.java
+++ b/TrafficCapture/captureOffloader/src/test/java/org/opensearch/migrations/trafficcapture/StreamChannelConnectionCaptureSerializerTest.java
@@ -31,7 +31,7 @@ class StreamChannelConnectionCaptureSerializerTest {
     private final static String FAKE_READ_PACKET_DATA = "ABCDEFGHIJKLMNOP";
     public static final String TEST_TRAFFIC_STREAM_ID_STRING = "Test";
 
-    private static TrafficStream makeEmptyTrafficStream(Instant t) {
+    private static TrafficStream makeSampleTrafficStream(Instant t) {
         return TrafficStream.newBuilder()
                 .setId(TEST_TRAFFIC_STREAM_ID_STRING)
                 .setNumberOfThisLastChunk(1)
@@ -168,7 +168,7 @@ class StreamChannelConnectionCaptureSerializerTest {
     public void testThatReadCanBeDeserialized() throws IOException, ExecutionException, InterruptedException {
         final var referenceTimestamp = Instant.now(Clock.systemUTC());
         // these are only here as a debugging aid
-        var groundTruth = makeEmptyTrafficStream(referenceTimestamp);
+        var groundTruth = makeSampleTrafficStream(referenceTimestamp);
         System.err.println("groundTruth: "+groundTruth);
         // Pasting this into `base64 -d | protoc --decode_raw` will also show the structure
         var groundTruthBytes = groundTruth.toByteArray();
@@ -202,7 +202,7 @@ class StreamChannelConnectionCaptureSerializerTest {
         WeakHashMap<CodedOutputStream, ByteBuffer> codedStreamToByteBuffersMap = new WeakHashMap<>();
         CompletableFuture[] singleAggregateCfRef = new CompletableFuture[1];
         singleAggregateCfRef[0] = CompletableFuture.completedFuture(null);
-        return new StreamChannelConnectionCaptureSerializer(TEST_TRAFFIC_STREAM_ID_STRING, 1,
+        return new StreamChannelConnectionCaptureSerializer(TEST_TRAFFIC_STREAM_ID_STRING,
             () -> {
                 ByteBuffer bytes = ByteBuffer.allocate(bufferSize);
                 var rval = CodedOutputStream.newInstance(bytes);

--- a/TrafficCapture/captureOffloader/src/test/java/org/opensearch/migrations/trafficcapture/StreamChannelConnectionCaptureSerializerTest.java
+++ b/TrafficCapture/captureOffloader/src/test/java/org/opensearch/migrations/trafficcapture/StreamChannelConnectionCaptureSerializerTest.java
@@ -19,6 +19,8 @@ import java.time.Clock;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Base64;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.WeakHashMap;
 import java.util.concurrent.CompletableFuture;
@@ -84,26 +86,7 @@ class StreamChannelConnectionCaptureSerializerTest {
     public void testLargeReadPacketIsSplit() throws IOException, ExecutionException, InterruptedException {
         final var referenceTimestamp = Instant.now(Clock.systemUTC());
         List<ByteBuffer> outputBuffersCreated = new ArrayList<>();
-        WeakHashMap<CodedOutputStream, ByteBuffer> codedStreamToByteBuffersMap = new WeakHashMap<>();
-        var serializer = new StreamChannelConnectionCaptureSerializer(TEST_TRAFFIC_STREAM_ID_STRING, 100,
-            () -> {
-                ByteBuffer bytes = ByteBuffer.allocate(1024*1024);
-                var rval = CodedOutputStream.newInstance(bytes);
-                codedStreamToByteBuffersMap.put(rval, bytes);
-                return rval;
-            },
-            (codedOutputStream) -> CompletableFuture.runAsync(() -> {
-                try {
-                    codedOutputStream.flush();
-                    var bb = codedStreamToByteBuffersMap.get(codedOutputStream);
-                    bb.position(0);
-                    var bytesWritten = codedOutputStream.getTotalBytesWritten();
-                    bb.limit(bytesWritten);
-                    outputBuffersCreated.add(bb);
-                } catch (IOException e) {
-                    throw new RuntimeException(e);
-                }
-            }));
+        var serializer = createSerializerWithTestHandler(outputBuffersCreated, 1024 * 1024);
 
         StringBuilder sb = new StringBuilder();
         // Create over 1MB packet
@@ -113,7 +96,8 @@ class StreamChannelConnectionCaptureSerializerTest {
         byte[] fakeDataBytes = sb.toString().getBytes(StandardCharsets.UTF_8);
         var bb = Unpooled.wrappedBuffer(fakeDataBytes);
         serializer.addReadEvent(referenceTimestamp, bb);
-        serializer.flushCommitAndResetStream(true);
+        CompletableFuture future = serializer.flushCommitAndResetStream(true);
+        future.get();
         bb.release();
 
         TrafficStream reconstitutedTrafficStreamPart1 = TrafficStream.parseFrom(outputBuffersCreated.get(0));
@@ -128,6 +112,59 @@ class StreamChannelConnectionCaptureSerializerTest {
     }
 
     @Test
+    public void testBasicDataConsistencyWhenChunking() throws IOException, ExecutionException, InterruptedException {
+        final var referenceTimestamp = Instant.now(Clock.systemUTC());
+        String packetData = "";
+        for (int i = 0; i < 5; i++) {
+            packetData += "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+        }
+        byte[] packetBytes = packetData.getBytes(StandardCharsets.UTF_8);
+        List<ByteBuffer> outputBuffersCreated = new ArrayList<>();
+        // Arbitrarily picking small buffer that can hold the overhead TrafficStream bytes as well as some
+        // data bytes but not all the data bytes and require chunking
+        var serializer = createSerializerWithTestHandler(outputBuffersCreated, 50);
+
+        var bb = Unpooled.wrappedBuffer(packetBytes);
+        serializer.addWriteEvent(referenceTimestamp, bb);
+        CompletableFuture future = serializer.flushCommitAndResetStream(true);
+        future.get();
+        bb.release();
+
+        List<TrafficObservation> observations = new ArrayList<>();
+        for (ByteBuffer buffer : outputBuffersCreated) {
+            observations.add(TrafficStream.parseFrom(buffer).getSubStream(0));
+        }
+
+        // Sort observations, as buffers in our close handler are written async and may not be executed in order
+        Collections.sort(observations, Comparator.comparingInt(observation -> observation.getWriteSegment().getCount()));
+        String reconstructedData = "";
+        for (TrafficObservation observation : observations) {
+            reconstructedData += observation.getWriteSegment().getData().toStringUtf8();
+        }
+        Assertions.assertEquals(packetData, reconstructedData);
+    }
+
+    @Test
+    public void testEmptyPacketIsHandledForSmallCodedOutputStream()
+        throws IOException, ExecutionException, InterruptedException {
+        final var referenceTimestamp = Instant.now(Clock.systemUTC());
+        List<ByteBuffer> outputBuffersCreated = new ArrayList<>();
+        // Arbitrarily picking small buffer size that can only hold one empty message
+        var serializer = createSerializerWithTestHandler(outputBuffersCreated, 40);
+        var bb = Unpooled.buffer(0);
+        serializer.addWriteEvent(referenceTimestamp, bb);
+        serializer.addWriteEvent(referenceTimestamp, bb);
+        CompletableFuture future = serializer.flushCommitAndResetStream(true);
+        future.get();
+        bb.release();
+
+        TrafficStream reconstitutedTrafficStreamPart1 = TrafficStream.parseFrom(outputBuffersCreated.get(0));
+        Assertions.assertEquals(0, reconstitutedTrafficStreamPart1.getSubStream(0).getWrite().getData().size());
+        TrafficStream reconstitutedTrafficStreamPart2 = TrafficStream.parseFrom(outputBuffersCreated.get(1));
+        Assertions.assertEquals(0, reconstitutedTrafficStreamPart2.getSubStream(0).getWrite().getData().size());
+    }
+
+    @Test
     public void testThatReadCanBeDeserialized() throws IOException, ExecutionException, InterruptedException {
         final var referenceTimestamp = Instant.now(Clock.systemUTC());
         // these are only here as a debugging aid
@@ -138,26 +175,7 @@ class StreamChannelConnectionCaptureSerializerTest {
         System.err.println("groundTruth Bytes: "+Base64.getEncoder().encodeToString(groundTruthBytes));
 
         List<ByteBuffer> outputBuffersCreated = new ArrayList<>();
-        WeakHashMap<CodedOutputStream, ByteBuffer> codedStreamToByteBuffersMap = new WeakHashMap<>();
-        var serializer = new StreamChannelConnectionCaptureSerializer(TEST_TRAFFIC_STREAM_ID_STRING, 100,
-                () -> {
-                    ByteBuffer bytes = ByteBuffer.allocate(1024*1024);
-                    var rval = CodedOutputStream.newInstance(bytes);
-                    codedStreamToByteBuffersMap.put(rval, bytes);
-                    return rval;
-                },
-            (codedOutputStream) -> CompletableFuture.runAsync(() -> {
-                    try {
-                        codedOutputStream.flush();
-                        var bb = codedStreamToByteBuffersMap.get(codedOutputStream);
-                        bb.position(0);
-                        var bytesWritten = codedOutputStream.getTotalBytesWritten();
-                        bb.limit(bytesWritten);
-                        outputBuffersCreated.add(bb);
-                    } catch (IOException e) {
-                        throw new RuntimeException(e);
-                    }
-                }));
+        var serializer = createSerializerWithTestHandler(outputBuffersCreated, 1024 * 1024);
         var bb = Unpooled.wrappedBuffer(FAKE_READ_PACKET_DATA.getBytes(StandardCharsets.UTF_8));
         serializer.addReadEvent(referenceTimestamp, bb);
         bb.clear();
@@ -178,5 +196,35 @@ class StreamChannelConnectionCaptureSerializerTest {
         Assertions.assertFalse(reconstitutedTrafficStream.hasNumber());
 
         Assertions.assertEquals(groundTruth, reconstitutedTrafficStream);
+    }
+
+    private StreamChannelConnectionCaptureSerializer createSerializerWithTestHandler(List<ByteBuffer> outputBuffers, int bufferSize) throws IOException {
+        WeakHashMap<CodedOutputStream, ByteBuffer> codedStreamToByteBuffersMap = new WeakHashMap<>();
+        CompletableFuture[] singleAggregateCfRef = new CompletableFuture[1];
+        singleAggregateCfRef[0] = CompletableFuture.completedFuture(null);
+        return new StreamChannelConnectionCaptureSerializer(TEST_TRAFFIC_STREAM_ID_STRING, 1,
+            () -> {
+                ByteBuffer bytes = ByteBuffer.allocate(bufferSize);
+                var rval = CodedOutputStream.newInstance(bytes);
+                codedStreamToByteBuffersMap.put(rval, bytes);
+                return rval;
+            },
+            (codedOutputStream) -> {
+                CompletableFuture cf = CompletableFuture.runAsync(() -> {
+                    try {
+                        codedOutputStream.flush();
+                        var bb = codedStreamToByteBuffersMap.get(codedOutputStream);
+                        bb.position(0);
+                        var bytesWritten = codedOutputStream.getTotalBytesWritten();
+                        bb.limit(bytesWritten);
+                        outputBuffers.add(bb);
+                    } catch (IOException e) {
+                        throw new RuntimeException(e);
+                    }
+                });
+                singleAggregateCfRef[0] = CompletableFuture.allOf(singleAggregateCfRef[0], cf);
+                return singleAggregateCfRef[0];
+            }
+        );
     }
 }

--- a/TrafficCapture/trafficCaptureProxyServer/src/main/java/org/opensearch/migrations/trafficcapture/proxyserver/Main.java
+++ b/TrafficCapture/trafficCaptureProxyServer/src/main/java/org/opensearch/migrations/trafficcapture/proxyserver/Main.java
@@ -49,7 +49,7 @@ public class Main {
             return new IConnectionCaptureFactory() {
                 @Override
                 public IChannelConnectionCaptureSerializer createOffloader(String connectionId) throws IOException {
-                    return new StreamChannelConnectionCaptureSerializer(connectionId, () ->
+                    return new StreamChannelConnectionCaptureSerializer(connectionId, 100, () ->
                             CodedOutputStream.newInstance(NullOutputStream.getInstance()),
                             cos -> CompletableFuture.completedFuture(null));
                 }

--- a/TrafficCapture/trafficCaptureProxyServer/src/test/java/org/opensearch/migrations/trafficcapture/InMemoryConnectionCaptureFactory.java
+++ b/TrafficCapture/trafficCaptureProxyServer/src/test/java/org/opensearch/migrations/trafficcapture/InMemoryConnectionCaptureFactory.java
@@ -9,10 +9,10 @@ import java.util.Arrays;
 import java.util.WeakHashMap;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentLinkedQueue;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicReference;
 
 public class InMemoryConnectionCaptureFactory implements IConnectionCaptureFactory {
+
+    private final int bufferSize;
 
     @AllArgsConstructor
     public static class RecordedTrafficStream {
@@ -22,7 +22,8 @@ public class InMemoryConnectionCaptureFactory implements IConnectionCaptureFacto
     @Getter
     ConcurrentLinkedQueue<RecordedTrafficStream> recordedStreams = new ConcurrentLinkedQueue<>();
 
-    public InMemoryConnectionCaptureFactory() {
+    public InMemoryConnectionCaptureFactory(int bufferSize) {
+        this.bufferSize = bufferSize;
     }
 
     private CompletableFuture closeHandler(ByteBuffer byteBuffer) {
@@ -34,19 +35,20 @@ public class InMemoryConnectionCaptureFactory implements IConnectionCaptureFacto
 
     @Override
     public IChannelConnectionCaptureSerializer createOffloader(String connectionId) throws IOException {
-        AtomicInteger supplierCallCounter = new AtomicInteger();
-        AtomicReference<CompletableFuture> aggregateCf = new AtomicReference<>(CompletableFuture.completedFuture(null));
+        // This array is only an indirection to work around Java's constraint that lambda values are final
+        CompletableFuture[] singleAggregateCfRef = new CompletableFuture[1];
+        singleAggregateCfRef[0] = CompletableFuture.completedFuture(null);
         WeakHashMap<CodedOutputStream, ByteBuffer> codedStreamToByteBufferMap = new WeakHashMap<>();
-        return new StreamChannelConnectionCaptureSerializer(connectionId, 100, () -> {
-            ByteBuffer bb = ByteBuffer.allocate(1024 * 1024);
+        return new StreamChannelConnectionCaptureSerializer(connectionId, () -> {
+            ByteBuffer bb = ByteBuffer.allocate(bufferSize);
             var cos = CodedOutputStream.newInstance(bb);
             codedStreamToByteBufferMap.put(cos, bb);
             return cos;
         }, (codedOutputStream) -> {
             CompletableFuture cf = closeHandler(codedStreamToByteBufferMap.get(codedOutputStream));
             codedStreamToByteBufferMap.remove(codedOutputStream);
-            aggregateCf.set(aggregateCf.get().isDone() ? cf : CompletableFuture.allOf(aggregateCf.get(), cf));
-            return aggregateCf.get();
+            singleAggregateCfRef[0] = singleAggregateCfRef[0].isDone() ? cf : CompletableFuture.allOf(singleAggregateCfRef[0], cf);
+            return singleAggregateCfRef[0];
         });
     }
 }

--- a/TrafficCapture/trafficCaptureProxyServer/src/test/java/org/opensearch/migrations/trafficcapture/InMemoryConnectionCaptureFactory.java
+++ b/TrafficCapture/trafficCaptureProxyServer/src/test/java/org/opensearch/migrations/trafficcapture/InMemoryConnectionCaptureFactory.java
@@ -3,23 +3,13 @@ package org.opensearch.migrations.trafficcapture;
 import com.google.protobuf.CodedOutputStream;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import org.opensearch.migrations.trafficcapture.IChannelConnectionCaptureSerializer;
-import org.opensearch.migrations.trafficcapture.IConnectionCaptureFactory;
-import org.opensearch.migrations.trafficcapture.StreamChannelConnectionCaptureSerializer;
-
-import java.io.ByteArrayOutputStream;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
 import java.io.IOException;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.List;
+import java.nio.ByteBuffer;
 import java.util.WeakHashMap;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.BiFunction;
+import java.util.concurrent.atomic.AtomicReference;
 
 public class InMemoryConnectionCaptureFactory implements IConnectionCaptureFactory {
 
@@ -34,24 +24,27 @@ public class InMemoryConnectionCaptureFactory implements IConnectionCaptureFacto
     public InMemoryConnectionCaptureFactory() {
     }
 
+    private CompletableFuture closeHandler(ByteBuffer byteBuffer) {
+        return CompletableFuture.runAsync(() -> {
+            recordedStreams.add(new RecordedTrafficStream(byteBuffer.array()));
+        });
+    }
+
     @Override
     public IChannelConnectionCaptureSerializer createOffloader(String connectionId) throws IOException {
         AtomicInteger supplierCallCounter = new AtomicInteger();
-        WeakHashMap<CodedOutputStream, ByteArrayOutputStream> codedStreamToFileStreamMap = new WeakHashMap<>();
-        return new StreamChannelConnectionCaptureSerializer(connectionId, () -> {
-            var baos = new ByteArrayOutputStream();
-            var cos = CodedOutputStream.newInstance(baos);
-            codedStreamToFileStreamMap.put(cos, baos);
+        AtomicReference<CompletableFuture> aggregateCf = new AtomicReference<>(CompletableFuture.completedFuture(null));
+        WeakHashMap<CodedOutputStream, ByteBuffer> codedStreamToByteBufferMap = new WeakHashMap<>();
+        return new StreamChannelConnectionCaptureSerializer(connectionId, 100, () -> {
+            ByteBuffer bb = ByteBuffer.allocate(1024 * 1024);
+            var cos = CodedOutputStream.newInstance(bb);
+            codedStreamToByteBufferMap.put(cos, bb);
             return cos;
-        }, (codedOutputStream) -> CompletableFuture.runAsync(() -> {
-            try {
-                ByteArrayOutputStream baos = codedStreamToFileStreamMap.get(codedOutputStream);
-                baos.close();
-                recordedStreams.add(new RecordedTrafficStream(baos.toByteArray()));
-                codedStreamToFileStreamMap.remove(codedOutputStream);
-            } catch (IOException e) {
-                throw new RuntimeException(e);
-            }
-        }));
+        }, (codedOutputStream) -> {
+            CompletableFuture cf = closeHandler(codedStreamToByteBufferMap.get(codedOutputStream));
+            codedStreamToByteBufferMap.remove(codedOutputStream);
+            aggregateCf.set(aggregateCf.get().isDone() ? cf : CompletableFuture.allOf(aggregateCf.get(), cf));
+            return aggregateCf.get();
+        });
     }
 }

--- a/TrafficCapture/trafficCaptureProxyServer/src/test/java/org/opensearch/migrations/trafficcapture/InMemoryConnectionCaptureFactory.java
+++ b/TrafficCapture/trafficCaptureProxyServer/src/test/java/org/opensearch/migrations/trafficcapture/InMemoryConnectionCaptureFactory.java
@@ -5,6 +5,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.Arrays;
 import java.util.WeakHashMap;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -26,7 +27,8 @@ public class InMemoryConnectionCaptureFactory implements IConnectionCaptureFacto
 
     private CompletableFuture closeHandler(ByteBuffer byteBuffer) {
         return CompletableFuture.runAsync(() -> {
-            recordedStreams.add(new RecordedTrafficStream(byteBuffer.array()));
+            byte[] filledBytes = Arrays.copyOfRange(byteBuffer.array(), 0, byteBuffer.position());
+            recordedStreams.add(new RecordedTrafficStream(filledBytes));
         });
     }
 

--- a/TrafficCapture/trafficCaptureProxyServer/src/test/java/org/opensearch/migrations/trafficcapture/proxyserver/netty/NettyScanningHttpProxyTest.java
+++ b/TrafficCapture/trafficCaptureProxyServer/src/test/java/org/opensearch/migrations/trafficcapture/proxyserver/netty/NettyScanningHttpProxyTest.java
@@ -36,7 +36,7 @@ class NettyScanningHttpProxyTest {
         while (true) {
             try {
                 int port = (abs(random.nextInt()) % (2 ^ 16 - 1025)) + 1025;
-                r.accept(new Integer(port));
+                r.accept(Integer.valueOf(port));
                 return port;
             } catch (Exception e) {
                 System.err.println("Exception: "+e);
@@ -48,7 +48,7 @@ class NettyScanningHttpProxyTest {
 
     @Test
     public void testRoundTrip() throws IOException, InterruptedException {
-        var captureFactory = new InMemoryConnectionCaptureFactory();
+        var captureFactory = new InMemoryConnectionCaptureFactory(1024*1024);
         var servers = startServers(captureFactory);
 
         String responseBody;


### PR DESCRIPTION
### Description
Some incoming packets will be larger than what our offloading protocols (e.g. Kafka) can handle.  This change chops those messages into pieces (while retaining proper protobuf format) and sends them to the offloader. The offloader will provide the `CodedOutputStream` and thus can set the max desired size of the message which will be determined by the size of the `CodedOutputStream` ~~and can also provide the minimum chunk size which will limit the maximum number of data bytes that will be chunked~~. This functionality required minimal change for offloaders (Kafka, File, InMemory) and was mainly rooted in the Serializer.

### Issues Resolved
https://opensearch.atlassian.net/browse/MIGRATIONS-1061

### Testing
Manual testing with local kafka cluster and file directory and unit tests

### Check List
- [x] New functionality includes testing
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
