### PR TITLE
Replayer - Moving away from UberJar to classpath

### DIFF
--- a/TrafficCapture/trafficReplayer/build.gradle
+++ b/TrafficCapture/trafficReplayer/build.gradle
@@ -67,18 +67,21 @@ jar {
     }
 }
 
-task uberJar(type: Jar) {
-    manifest {
-        attributes 'Main-Class': application.mainClass
-    }
-    from {
-        configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) }
-    }
-    archiveBaseName = project.name + "-uber"
-    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
-    with jar
-}
-
 tasks.named('test') {
     useJUnitPlatform()
 }
+
+task unzip(type: Copy) {
+    def zipFile = file('build/distributions/trafficReplayer.zip')
+    def outputDir = file("extracted")
+
+    from zipTree(zipFile)
+    into outputDir
+}
+
+task cleanUp(type: Delete) {
+    delete 'extracted'
+}
+
+assemble.finalizedBy(unzip)
+clean.finalizedBy(cleanUp)

--- a/deployment/docker/traffic-replayer/Dockerfile
+++ b/deployment/docker/traffic-replayer/Dockerfile
@@ -10,7 +10,6 @@ RUN git clone https://github.com/opensearch-project/opensearch-migrations.git
 WORKDIR /opensearch-migrations/TrafficCapture
 
 RUN ./gradlew assemble -p trafficReplayer
-RUN ./gradlew uberJar -p trafficReplayer
 
 
 FROM openjdk:17-jdk-slim
@@ -23,7 +22,7 @@ WORKDIR ./replay-app
 RUN apt-get update && apt-get install -y netcat
 RUN apt-get install -y expect
 
-COPY --from=builder /opensearch-migrations/TrafficCapture/trafficReplayer/build/libs/*.jar .
+COPY --from=builder /opensearch-migrations/TrafficCapture/trafficReplayer/ .
 COPY ./run_app.sh .
 
 CMD ./run_app.sh ${TARGET_CLUSTER_ENDPOINT}

--- a/deployment/docker/traffic-replayer/run_app.sh
+++ b/deployment/docker/traffic-replayer/run_app.sh
@@ -4,6 +4,7 @@
 # Traffic Comparator (TC) as connections get setup and restarted
 
 target_endpoint="$1"
+jars=$(ls extracted/*/*/*.jar | tr \\n :)
 
 while true
 do
@@ -23,7 +24,7 @@ do
   # process with the Replayer jar before ultimately printing the produced triples to stdout via tee and sending to TC via netcat
   # Note: Unbuffer has not been verified to actually be effective here. stdbuf was ruled out for its caveat with tee (https://linux.die.net/man/1/stdbuf)
   unbuffer tail -f triples.log | tee /dev/stderr | nc -v localhost 9220 &
-  nc -v -l -p 9210 | java -jar trafficReplayer-uber.jar "$target_endpoint" -o triples.log --insecure
+  nc -v -l -p 9210 | java -cp build/libs/KafkaPrinter.jar:"$jars" org.opensearch.migrations.replay.TrafficReplayer "$target_endpoint" -o triples.log --insecure
 
   rm triple.log
   >&2 echo "Command has encountered error. Restarting now ..."

--- a/deployment/docker/traffic-replayer/run_app.sh
+++ b/deployment/docker/traffic-replayer/run_app.sh
@@ -24,7 +24,7 @@ do
   # process with the Replayer jar before ultimately printing the produced triples to stdout via tee and sending to TC via netcat
   # Note: Unbuffer has not been verified to actually be effective here. stdbuf was ruled out for its caveat with tee (https://linux.die.net/man/1/stdbuf)
   unbuffer tail -f triples.log | tee /dev/stderr | nc -v localhost 9220 &
-  nc -v -l -p 9210 | java -cp build/libs/KafkaPrinter.jar:"$jars" org.opensearch.migrations.replay.TrafficReplayer "$target_endpoint" -o triples.log --insecure
+  nc -v -l -p 9210 | java -cp build/libs/trafficReplayer.jar:"$jars" org.opensearch.migrations.replay.TrafficReplayer "$target_endpoint" -o triples.log --insecure
 
   rm triple.log
   >&2 echo "Command has encountered error. Restarting now ..."


### PR DESCRIPTION
### Description
This PR removes the usage of an UberJar to run the replayer and instead uses the classpath.


### Check List
- [ ] New functionality includes testing
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
