### PR TITLE
Capture proxy container with tls and command line args

### DIFF
--- a/TrafficCapture/dockerSolution/build.gradle
+++ b/TrafficCapture/dockerSolution/build.gradle
@@ -11,13 +11,13 @@ dependencies {
     implementation project(':trafficReplayer')
 }
 
-
 def containerServices = [
         "trafficCaptureProxyServer": "capture_proxy",
         "trafficReplayer": "traffic_replayer"
 ]
+
 containerServices.each { projectName, dockerImageName ->
-    def dockerBuildDir = "${project}/docker/${projectName}"
+    def dockerBuildDir = "build/docker/${projectName}"
     def artifactsDir = "${dockerBuildDir}/jars";
     task("copyArtifact_${projectName}", type: Copy) {
         dependsOn ":${projectName}:build"
@@ -51,35 +51,16 @@ containerServices.each { projectName, dockerImageName ->
         inputDir = project.file("${dockerBuildDir}")
         images.add("migrations/${dockerImageName}:latest")
     }
-//
-//    docker {
-//        dependsOn "copyArtifact${projectName}"
-//        javaApplication {
-//            baseImage = 'openjdk:11-jre'
-//            maintainer = '"OpenSearch Migrations"'
-//            tags = ["project$proj:latest"]
-//            jvmArgs = ['-Xmx512m']
-//            applicationName = "${projectName}"
-//            applicationJar = file("${projectDir}/artifacts${projectName}/project${projectName}.jar")
-//            // other settings as needed...
-//        }
-//    }
+}
 
-
-//    task("buildImage_${projectName}", type: DockerBuildImage) {
-//        dependsOn "copyArtifact${projectName}"
-//        group = 'docker'
-//
-//        javaApplication {
-//            maintainer = 'OpenSearch Migrations'
-//            tags = ['latest']
-////            jvmArgs = ['-Xmx512m', '-Xms512m']
-////            args = ['arg1', 'arg2']
-//        }
-//        inputDir = file("src/main/docker/${projectName}/")
-//        dockerFile = file("src/main/docker/${projectName}/Dockerfile")
-//        images.add("migrations/${dockerImageName}:latest")
-//    }
+def dockerFilesForExternalServices =
+        ["elasticsearchWithSearchGuard": "elasticsearch_searchguard"]
+// Create the static docker files that aren't hosting migrations java code from this repo
+dockerFilesForExternalServices.each { projectName, dockerImageName ->
+    task "dockerBuildImage_${projectName}"(type: com.bmuschko.gradle.docker.tasks.image.DockerBuildImage) {
+        inputDir = project.file("src/main/docker/${projectName}")
+        images.add("migrations/${dockerImageName}:latest")
+    }
 }
 
 dockerCompose {
@@ -89,6 +70,8 @@ dockerCompose {
 task buildAllDockerImages {
     dependsOn dockerBuildImage_trafficReplayer
     dependsOn dockerBuildImage_trafficCaptureProxyServer
+    dependsOn dockerBuildImage_elasticsearchWithSearchGuard
+    //dependsOn dockerBuildImage_
 }
 
 tasks.getByName('composeUp').dependsOn(tasks.getByName('buildAllDockerImages'))

--- a/TrafficCapture/dockerSolution/build.gradle
+++ b/TrafficCapture/dockerSolution/build.gradle
@@ -4,16 +4,53 @@ plugins {
     id "com.bmuschko.docker-java-application" version "9.3.1"
 }
 
+import java.security.MessageDigest
 import com.bmuschko.gradle.docker.tasks.image.DockerBuildImage
+import com.bmuschko.gradle.docker.tasks.image.DockerTagImage
+
+def calculateHash(File file) {
+}
+
+def calculateDockerHash(String projectName) {
+    MessageDigest digest = MessageDigest.getInstance('SHA-256')
+    fileTree("src/main/docker/${projectName}")
+            .each( file ->
+            file.withInputStream { is ->
+                var buffer = new byte[1024]
+                int read
+                while ((read = is.read(buffer)) != -1) {
+                    digest.update(buffer, 0, read)
+                }
+            }
+    )
+    return digest.digest().encodeHex().toString()
+}
 
 dependencies {
     implementation project(':trafficCaptureProxyServer')
     implementation project(':trafficReplayer')
 }
 
+def dockerFilesForExternalServices =
+        ["elasticsearchWithSearchGuard": "elasticsearch_searchguard"]
+// Create the static docker files that aren't hosting migrations java code from this repo
+dockerFilesForExternalServices.each { projectName, dockerImageName ->
+    task("dockerBuildImage_${projectName}", type: DockerBuildImage) {
+        println "making a task for dockerBuildImage_${projectName}"
+        def hash = calculateDockerHash(projectName)
+        println "in docker build - $projectName hash==$hash"
+        images.add("migrations/elasticsearch_searchguard:$hash")
+        images.add("migrations/elasticsearch_searchguard:latest")
+        inputDir = project.file("src/main/docker/${projectName}")
+    }
+}
+
 def containerServices = [
         "trafficCaptureProxyServer": "capture_proxy",
         "trafficReplayer": "traffic_replayer"
+]
+def baseImageProjectOverrides = [
+        "trafficCaptureProxyServer": "elasticsearchWithSearchGuard"
 ]
 
 containerServices.each { projectName, dockerImageName ->
@@ -32,7 +69,16 @@ containerServices.each { projectName, dockerImageName ->
     task "createDockerfile_${projectName}"(type: com.bmuschko.gradle.docker.tasks.image.Dockerfile) {
         dependsOn "copyArtifact_${projectName}"
         destFile = project.file("${dockerBuildDir}/Dockerfile")
-        from 'openjdk:11-jre'
+        def baseImageOverrideProjectName = baseImageProjectOverrides.get(projectName)
+        if (baseImageOverrideProjectName) {
+            def dependentDockerImageName = dockerFilesForExternalServices.get(baseImageOverrideProjectName)
+            def hashNonce = calculateDockerHash(baseImageOverrideProjectName)
+            from "migrations/${dependentDockerImageName}:${hashNonce}"
+            dependsOn "dockerBuildImage_${baseImageOverrideProjectName}"
+        } else {
+            from 'openjdk:11-jre'
+        }
+
         copyFile("jars", "/jars")
         // can't set the environment variable from the runtimeClasspath because the Dockerfile is
         // constructed in the configuration phase and the classpath won't be realized until the
@@ -45,20 +91,10 @@ containerServices.each { projectName, dockerImageName ->
         //defaultCommand('/runJavaWithClasspath.sh', '...')
     }
 
-    // Create a Docker image for the project
-    task "dockerBuildImage_${projectName}"(type: com.bmuschko.gradle.docker.tasks.image.DockerBuildImage) {
+    task "dockerBuildImage_${projectName}"(type: DockerBuildImage) {
         dependsOn "createDockerfile_${projectName}"
         inputDir = project.file("${dockerBuildDir}")
-        images.add("migrations/${dockerImageName}:latest")
-    }
-}
-
-def dockerFilesForExternalServices =
-        ["elasticsearchWithSearchGuard": "elasticsearch_searchguard"]
-// Create the static docker files that aren't hosting migrations java code from this repo
-dockerFilesForExternalServices.each { projectName, dockerImageName ->
-    task "dockerBuildImage_${projectName}"(type: com.bmuschko.gradle.docker.tasks.image.DockerBuildImage) {
-        inputDir = project.file("src/main/docker/${projectName}")
+        images.add("migrations/${dockerImageName}:${version}")
         images.add("migrations/${dockerImageName}:latest")
     }
 }

--- a/TrafficCapture/dockerSolution/src/main/docker/docker-compose.yml
+++ b/TrafficCapture/dockerSolution/src/main/docker/docker-compose.yml
@@ -3,13 +3,15 @@ services:
 
   capture_proxy:
     image: 'migrations/capture_proxy:latest'
-    command: /run.sh org.opensearch.migrations.trafficcapture.proxyserver.Main
-#
-#  elasticsearch_7.10:
-#    image: 'docker.elastic.co/elasticsearch/elasticsearch-oss:7.10.2'
 #    ports:
-#      - '9200:9200'
+#      - "9203:9203"
+    #command: /runJavaWithClasspath.sh org.opensearch.migrations.trafficcapture.proxyserver.Main --traceDirectory ./traceLogs --destinationPort 19200 --listenPort 9200
 
+  elasticsearch_7.10:
+    image: 'migrations/elasticsearch_searchguard:latest'
+    ports:
+      - '19200:9200'
+#
 #  zookeeper:
 #    image: docker.io/bitnami/zookeeper:3.8
 #    ports:
@@ -18,8 +20,8 @@ services:
 #      - "zookeeper_data:/bitnami"
 #    environment:
 #      - ALLOW_ANONYMOUS_LOGIN=yes
-
-
+#
+#
 #  kafka:
 #    image: docker.io/bitnami/kafka:3.4
 #    ports:

--- a/TrafficCapture/dockerSolution/src/main/docker/docker-compose.yml
+++ b/TrafficCapture/dockerSolution/src/main/docker/docker-compose.yml
@@ -3,12 +3,16 @@ services:
 
   capture_proxy:
     image: 'migrations/capture_proxy:latest'
-#    ports:
-#      - "9203:9203"
-    #command: /runJavaWithClasspath.sh org.opensearch.migrations.trafficcapture.proxyserver.Main --traceDirectory ./traceLogs --destinationPort 19200 --listenPort 9200
+    networks:
+      - migrations
+    ports:
+      - "9200:9200"
+    command: /runJavaWithClasspath.sh org.opensearch.migrations.trafficcapture.proxyserver.Main --traceDirectory ./traceLogs --destinationHost  elasticsearch --destinationPort 9200 --listenPort 9200
 
-  elasticsearch_7.10:
+  elasticsearch:
     image: 'migrations/elasticsearch_searchguard:latest'
+    networks:
+      - migrations
     ports:
       - '19200:9200'
 #
@@ -45,6 +49,8 @@ services:
 
   replayer:
     image: 'migrations/traffic_replayer:latest'
+    networks:
+      - migrations
 
 #  traffic_comparator:
 #    image: '''
@@ -55,3 +61,7 @@ services:
 #    driver: local
 #  kafka_data:
 #    driver: local
+
+networks:
+  migrations:
+    driver: bridge

--- a/TrafficCapture/dockerSolution/src/main/docker/docker-compose.yml
+++ b/TrafficCapture/dockerSolution/src/main/docker/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - migrations
     ports:
       - "9200:9200"
-    command: /runJavaWithClasspath.sh org.opensearch.migrations.trafficcapture.proxyserver.Main --traceDirectory ./traceLogs --destinationHost  elasticsearch --destinationPort 9200 --listenPort 9200
+    command: /runJavaWithClasspath.sh org.opensearch.migrations.trafficcapture.proxyserver.Main --traceDirectory /root/traceLogs --destinationHost  elasticsearch --destinationPort 9200 --listenPort 9200 --sslConfigFile /usr/share/elasticsearch/config/proxy_tls.yml
 
   elasticsearch:
     image: 'migrations/elasticsearch_searchguard:latest'

--- a/TrafficCapture/dockerSolution/src/main/docker/elasticsearchWithSearchGuard/Dockerfile
+++ b/TrafficCapture/dockerSolution/src/main/docker/elasticsearchWithSearchGuard/Dockerfile
@@ -1,0 +1,9 @@
+FROM docker.elastic.co/elasticsearch/elasticsearch-oss:7.10.2
+
+RUN echo y | /usr/share/elasticsearch/bin/elasticsearch-plugin install https://maven.search-guard.com/search-guard-suite-release/com/floragunn/search-guard-suite-plugin/7.10.2-53.5.0/search-guard-suite-plugin-7.10.2-53.5.0.zip
+RUN cd /usr/share/elasticsearch/plugins/search-guard-7/tools ; chmod ugo+x ./install_demo_configuration.sh ; yes | ./install_demo_configuration.sh
+ENV configFile=/usr/share/elasticsearch/config/elasticsearch.yml
+RUN echo "discovery.type: single-node" >> configFile
+
+CMD tail -f /dev/null
+#CMD /usr/local/bin/docker-entrypoint.sh eswrapper

--- a/TrafficCapture/dockerSolution/src/main/docker/elasticsearchWithSearchGuard/Dockerfile
+++ b/TrafficCapture/dockerSolution/src/main/docker/elasticsearchWithSearchGuard/Dockerfile
@@ -1,9 +1,20 @@
 FROM docker.elastic.co/elasticsearch/elasticsearch-oss:7.10.2
 
 RUN echo y | /usr/share/elasticsearch/bin/elasticsearch-plugin install https://maven.search-guard.com/search-guard-suite-release/com/floragunn/search-guard-suite-plugin/7.10.2-53.5.0/search-guard-suite-plugin-7.10.2-53.5.0.zip
-RUN cd /usr/share/elasticsearch/plugins/search-guard-7/tools ; chmod ugo+x ./install_demo_configuration.sh ; yes | ./install_demo_configuration.sh
+# add search-guard, which provides TLS, as well as other features that we don't need to consider
+RUN pushd /usr/share/elasticsearch/plugins/search-guard-7/tools ; chmod ugo+x ./install_demo_configuration.sh ; yes | ./install_demo_configuration.sh ; popd
 ENV configFile=/usr/share/elasticsearch/config/elasticsearch.yml
-RUN echo "discovery.type: single-node" >> configFile
+# without this line, elasticsearch will complain that there aren't enough nodes
+RUN echo "discovery.type: single-node" >> $configFile
+COPY disableTlsConfig.sh enableTlsConfig.sh /root/
+RUN chmod ugo+x /root/disableTlsConfig.sh /root/enableTlsConfig.sh
+ENV PATH=${PATH}:/usr/share/elasticsearch/jdk/bin/
 
-CMD tail -f /dev/null
-#CMD /usr/local/bin/docker-entrypoint.sh eswrapper
+# The following two commands are more convenient for development purposes,
+# but maybe not for a demo to show individual steps
+RUN /root/disableTlsConfig.sh $configFile
+# Do this to disable HTTP auth
+RUN echo "searchguard.disabled: true" >> $configFile
+
+#CMD tail -f /dev/null
+CMD /usr/local/bin/docker-entrypoint.sh eswrapper

--- a/TrafficCapture/dockerSolution/src/main/docker/elasticsearchWithSearchGuard/Dockerfile
+++ b/TrafficCapture/dockerSolution/src/main/docker/elasticsearchWithSearchGuard/Dockerfile
@@ -3,18 +3,21 @@ FROM docker.elastic.co/elasticsearch/elasticsearch-oss:7.10.2
 RUN echo y | /usr/share/elasticsearch/bin/elasticsearch-plugin install https://maven.search-guard.com/search-guard-suite-release/com/floragunn/search-guard-suite-plugin/7.10.2-53.5.0/search-guard-suite-plugin-7.10.2-53.5.0.zip
 # add search-guard, which provides TLS, as well as other features that we don't need to consider
 RUN pushd /usr/share/elasticsearch/plugins/search-guard-7/tools ; chmod ugo+x ./install_demo_configuration.sh ; yes | ./install_demo_configuration.sh ; popd
-ENV configFile=/usr/share/elasticsearch/config/elasticsearch.yml
+ENV ELASTIC_SEARCH_CONFIG_FILE=/usr/share/elasticsearch/config/elasticsearch.yml
+ENV PROXY_TLS_CONFIG_FILE=/usr/share/elasticsearch/config/proxy_tls.yml
 # without this line, elasticsearch will complain that there aren't enough nodes
-RUN echo "discovery.type: single-node" >> $configFile
+RUN echo "discovery.type: single-node" >> $ELASTIC_SEARCH_CONFIG_FILE
 COPY disableTlsConfig.sh enableTlsConfig.sh /root/
 RUN chmod ugo+x /root/disableTlsConfig.sh /root/enableTlsConfig.sh
 ENV PATH=${PATH}:/usr/share/elasticsearch/jdk/bin/
+RUN sed 's/searchguard/plugins.security/g' $ELASTIC_SEARCH_CONFIG_FILE |  \
+    grep ssl.http > $PROXY_TLS_CONFIG_FILE
 
 # The following two commands are more convenient for development purposes,
 # but maybe not for a demo to show individual steps
-RUN /root/disableTlsConfig.sh $configFile
+RUN /root/disableTlsConfig.sh $ELASTIC_SEARCH_CONFIG_FILE
 # Do this to disable HTTP auth
-RUN echo "searchguard.disabled: true" >> $configFile
+RUN echo "searchguard.disabled: true" >> $ELASTIC_SEARCH_CONFIG_FILE
 
 #CMD tail -f /dev/null
 CMD /usr/local/bin/docker-entrypoint.sh eswrapper

--- a/TrafficCapture/dockerSolution/src/main/docker/elasticsearchWithSearchGuard/disableTlsConfig.sh
+++ b/TrafficCapture/dockerSolution/src/main/docker/elasticsearchWithSearchGuard/disableTlsConfig.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+sed -i "s/searchguard.ssl.http.enabled: *true/searchguard.ssl.http.enabled: false/g" "$@"

--- a/TrafficCapture/dockerSolution/src/main/docker/elasticsearchWithSearchGuard/enableTlsConfig.sh
+++ b/TrafficCapture/dockerSolution/src/main/docker/elasticsearchWithSearchGuard/enableTlsConfig.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+sed -i "s/searchguard.ssl.http.enabled: *false/searchguard.ssl.http.enabled: true/g" "$@"

--- a/TrafficCapture/dockerSolution/src/main/docker/elasticsearchWithSearchGuardDisabled/Dockerfile
+++ b/TrafficCapture/dockerSolution/src/main/docker/elasticsearchWithSearchGuardDisabled/Dockerfile
@@ -1,0 +1,5 @@
+FROM migrations/elasticsearch_searchguard:latest
+
+RUN echo "discovery.type: single-node" >> configFile
+
+CMD tail -f /dev/null

--- a/TrafficCapture/dockerSolution/src/main/docker/elasticsearchWithSearchGuardDisabled/Dockerfile
+++ b/TrafficCapture/dockerSolution/src/main/docker/elasticsearchWithSearchGuardDisabled/Dockerfile
@@ -1,5 +1,0 @@
-FROM migrations/elasticsearch_searchguard:latest
-
-RUN echo "discovery.type: single-node" >> configFile
-
-CMD tail -f /dev/null

--- a/TrafficCapture/settings.gradle
+++ b/TrafficCapture/settings.gradle
@@ -15,5 +15,5 @@ include('captureOffloader',
         'trafficCaptureProxyServer',
         'trafficCaptureProxyServerTest',
         'trafficReplayer',
-        'captureEndToEndDocker'
+        'dockerSolution'
 )

--- a/TrafficCapture/trafficCaptureProxyServer/kafka.properties
+++ b/TrafficCapture/trafficCaptureProxyServer/kafka.properties
@@ -1,0 +1,1 @@
+key.serializer=nothing

--- a/TrafficCapture/trafficCaptureProxyServer/src/main/java/org/opensearch/migrations/trafficcapture/proxyserver/Main.java
+++ b/TrafficCapture/trafficCaptureProxyServer/src/main/java/org/opensearch/migrations/trafficcapture/proxyserver/Main.java
@@ -77,7 +77,7 @@ public class Main {
                 description = "The maximum number of bytes that will be written to a single TrafficStream object.")
         int maximumTrafficStreamSize = 1024*1024;
         @Parameter(required = false,
-                names = {"--destinationHostname"},
+                names = {"--destinationHost"},
                 arity = 1,
                 description = "Hostname of the server that the proxy is capturing traffic for.")
         String backsideHostname = "localhost";
@@ -192,7 +192,7 @@ public class Main {
         var proxy = new NettyScanningHttpProxy(params.frontsidePort);
 
         try {
-            proxy.start("localhost", params.backsidePort,
+            proxy.start(params.backsideHostname, params.backsidePort,
                     sksOp.map(sks-> (Supplier<SSLEngine>) () -> {
                         try {
                             var sslEngine = sks.createHTTPSSLEngine();

--- a/TrafficCapture/trafficCaptureProxyServer/src/main/java/org/opensearch/migrations/trafficcapture/proxyserver/Main.java
+++ b/TrafficCapture/trafficCaptureProxyServer/src/main/java/org/opensearch/migrations/trafficcapture/proxyserver/Main.java
@@ -1,5 +1,8 @@
 package org.opensearch.migrations.trafficcapture.proxyserver;
 
+import com.beust.jcommander.JCommander;
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.ParameterException;
 import com.google.protobuf.CodedOutputStream;
 import lombok.NonNull;
 import lombok.SneakyThrows;
@@ -25,11 +28,89 @@ import java.util.Optional;
 import java.util.Properties;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
+import java.util.stream.Stream;
 
 @Slf4j
 public class Main {
 
     private final static String HTTPS_CONFIG_PREFIX = "plugins.security.ssl.http.";
+
+    static class Parameters {
+        @Parameter(required = false,
+                names = {"--traceDirectory"},
+                arity = 1,
+                description = "Directory to store trace files in.")
+        String traceDirectory;
+        @Parameter(required = false,
+                names = {"--noCapture"},
+                arity = 0,
+                description = "Directory to store trace files in.")
+        boolean noCapture;
+        @Parameter(required = false,
+                names = {"--kafkaConfigFile"},
+                arity = 1,
+                description = "Kafka properties file")
+        String kafkaPropertiesFile;
+        @Parameter(required = false,
+                names = {"--kafkaClientId"},
+                arity = 1,
+                description = "clientId to use for interfacing with Kafka.")
+        String kafkaClientId = "KafkaLoggingProducer";
+        @Parameter(required = false,
+                names = {"--kafkaConnection"},
+                arity = 1,
+                description = "Sequence of <HOSTNAME:PORT> values delimited by ','.")
+        String kafkaConnection;
+        @Parameter(required = false,
+                names = {"--sslConfigFile"},
+                arity = 1,
+                description = "YAML configuration of the HTTPS settings.  When this is not set, the proxy will not use TLS.")
+        String sslConfigFilePath;
+        @Parameter(required = false,
+                names = {"--configDirectory"},
+                arity = 1,
+                description = "Directory that all sslConfigFile resources will be relative to.")
+        String sslConfigWorkingDirectoryPath;
+        @Parameter(required = false,
+                names = {"--maxTrafficBufferSize"},
+                arity = 1,
+                description = "The maximum number of bytes that will be written to a single TrafficStream object.")
+        int maximumTrafficStreamSize = 1024*1024;
+        @Parameter(required = false,
+                names = {"--destinationHostname"},
+                arity = 1,
+                description = "Hostname of the server that the proxy is capturing traffic for.")
+        String backsideHostname = "localhost";
+        @Parameter(required = true,
+                names = {"--destinationPort"},
+                arity = 1,
+                description = "Port of the server that the proxy is capturing traffic for.")
+        int backsidePort = 0;
+        @Parameter(required = true,
+                names = {"--listenPort"},
+                arity = 1,
+                description = "Port of the server that the proxy is capturing traffic for.")
+        int frontsidePort = 0;
+    }
+
+    public static Parameters parseArgs(String[] args) {
+        Parameters p = new Parameters();
+        JCommander jCommander = new JCommander(p);
+        try {
+            jCommander.parse(args);
+            if (Stream.of(p.traceDirectory, p.kafkaPropertiesFile, p.kafkaConnection, (p.noCapture?"":null))
+                    .mapToInt(s->s!=null?1:0).sum() != 1) {
+                throw new ParameterException("Expected exactly one of '--traceDirectory', '--kafkaConfigFile', " +
+                        "'--kafkaConnection', or '--noCapture' to be set");
+            }
+            return p;
+        } catch (ParameterException e) {
+            System.err.println(e.getMessage());
+            System.err.println("Got args: "+ String.join("; ", args));
+            jCommander.usage();
+            return null;
+        }
+    }
 
     @SneakyThrows
     private static Settings getSettings(@NonNull String configFile) {
@@ -48,52 +129,70 @@ public class Main {
         return builder.build();
     }
 
-    private static IConnectionCaptureFactory getTraceConnectionCaptureFactory(String traceLogsDirectory) {
-        if (traceLogsDirectory == null) {
-            System.err.println("No trace log directory specified.  Logging to /dev/null");
-            return new IConnectionCaptureFactory() {
-                @Override
-                public IChannelConnectionCaptureSerializer createOffloader(String connectionId) throws IOException {
-                    return new StreamChannelConnectionCaptureSerializer(connectionId, () ->
-                            CodedOutputStream.newInstance(NullOutputStream.getInstance()),
-                            cos -> CompletableFuture.completedFuture(null));
-                }
-            };
-        } else {
-            return new FileConnectionCaptureFactory(traceLogsDirectory, 1024 * 1024 * 1024);
-        }
+    private static IConnectionCaptureFactory getNullConnectionCaptureFactory() {
+        System.err.println("No trace log directory specified.  Logging to /dev/null");
+        return connectionId -> new StreamChannelConnectionCaptureSerializer(connectionId, () ->
+                CodedOutputStream.newInstance(NullOutputStream.getInstance()),
+                cos -> CompletableFuture.completedFuture(null));
     }
 
-    private static IConnectionCaptureFactory getKafkaConnectionFactory(String kafkaPropsPath, int bufferSize) throws IOException {
+    private static IConnectionCaptureFactory
+    getTraceConnectionCaptureFactory(String traceLogsDirectory, int maxBufferSize) {
+        return new FileConnectionCaptureFactory(traceLogsDirectory, maxBufferSize);
+    }
+
+    private static IConnectionCaptureFactory getKafkaConnectionFactory(String kafkaPropsPath, int bufferSize)
+            throws IOException {
         Properties producerProps = new Properties();
-        try {
-            producerProps.load(new FileReader(kafkaPropsPath));
-        } catch (IOException e) {
-            log.error("Unable to locate provided Kafka producer properties file path: " + kafkaPropsPath);
-            throw e;
+        if (kafkaPropsPath != null) {
+            try {
+                producerProps.load(new FileReader(kafkaPropsPath));
+            } catch (IOException e) {
+                log.error("Unable to locate provided Kafka producer properties file path: " + kafkaPropsPath);
+                throw e;
+            }
         }
         return new KafkaCaptureFactory(new KafkaProducer<>(producerProps), bufferSize);
     }
 
-    private static IConnectionCaptureFactory getConnectionCaptureFactory(String kafkaPropsPath, int bufferSize) throws IOException {
-        //return new FileConnectionCaptureFactory("./traceLogs", 1024 * 1024 * 1024);
-        return getKafkaConnectionFactory(kafkaPropsPath, bufferSize);
+    private static IConnectionCaptureFactory getConnectionCaptureFactory(Parameters params) throws IOException {
+        // TODO - it might eventually be a requirement to do multiple types of offloading.
+        // Resist the urge for now though until it comes in as a request/need.
+        if (params.traceDirectory != null) {
+            return new FileConnectionCaptureFactory(params.traceDirectory, params.maximumTrafficStreamSize);
+        } else if (params.kafkaPropertiesFile != null) {
+            return getKafkaConnectionFactory(params.kafkaPropertiesFile, params.maximumTrafficStreamSize);
+        } else if (params.kafkaConnection != null) {
+            var kafkaProps = new Properties();
+            kafkaProps.put("bootstrap.servers", params.kafkaConnection);
+            kafkaProps.put("client.id", params.kafkaClientId);
+            kafkaProps.put("key.serializer", "org.apache.kafka.common.serialization.StringSerializer");
+            kafkaProps.put("value.serializer", "org.apache.kafka.common.serialization.ByteArraySerializer");
+
+            return new KafkaCaptureFactory(new KafkaProducer<>(kafkaProps), params.maximumTrafficStreamSize);
+        } else if (params.noCapture) {
+            return getNullConnectionCaptureFactory();
+        } else {
+            throw new RuntimeException("Must specify some connection capture factory options");
+        }
     }
 
     public static void main(String[] args) throws InterruptedException, IOException {
 
-        String kafkaPropsPath = args[0];
+        var params = parseArgs(args);
+
         // This should be added to the argument parser when added in
-        int bufferSize = 1024 * 1024;
-        var sksOp = Optional.ofNullable(args.length <= 1 ? null : Optional.class)
-                .map(o->new DefaultSecurityKeyStore(getSettings(args[1]),
-                        args.length > 1 ? Paths.get(args[2]) : null));
+        var sksOp = Optional.ofNullable(params.sslConfigFilePath)
+                .map(o->new DefaultSecurityKeyStore(getSettings(o),
+                        Optional.ofNullable(params.sslConfigWorkingDirectoryPath)
+                                .map(wd->Paths.get(wd))
+                                .orElse(null)));
 
         sksOp.ifPresent(x->x.initHttpSSLConfig());
-        var proxy = new NettyScanningHttpProxy(sksOp.isPresent() ? 443 : 80);
+        var proxy = new NettyScanningHttpProxy(params.frontsidePort);
 
         try {
-            proxy.start("localhost", 9200,
+            proxy.start("localhost", params.backsidePort,
                     sksOp.map(sks-> (Supplier<SSLEngine>) () -> {
                         try {
                             var sslEngine = sks.createHTTPSSLEngine();
@@ -101,7 +200,7 @@ public class Main {
                         } catch (Exception e) {
                             throw new RuntimeException(e);
                         }
-                    }).orElse(null), getConnectionCaptureFactory(kafkaPropsPath, bufferSize));
+                    }).orElse(null), getConnectionCaptureFactory(params));
         } catch (Exception e) {
             System.err.println(e);
             e.printStackTrace();

--- a/TrafficCapture/trafficCaptureProxyServer/src/test/java/org/opensearch/migrations/trafficcapture/proxyserver/netty/NettyScanningHttpProxyTest.java
+++ b/TrafficCapture/trafficCaptureProxyServer/src/test/java/org/opensearch/migrations/trafficcapture/proxyserver/netty/NettyScanningHttpProxyTest.java
@@ -64,7 +64,8 @@ class NettyScanningHttpProxyTest {
         }
 
         Assertions.assertEquals(UPSTREAM_SERVER_RESPONSE_BODY, responseBody);
-        Thread.sleep(1000*10);
+        // TODO - replace this with a better signalling facility! (shame on me for writing it like this in the first place)
+        Thread.sleep(1000);
         var recordedStreams = captureFactory.getRecordedStreams();
         Assertions.assertEquals(1, recordedStreams.size());
         var recordedTrafficStreams =


### PR DESCRIPTION
### Description

This change sets up an ES 7.10 image with search-guard so that a Capture Proxy image can be built upon that to use the TLS configs from the base image.  Additional command line arguments were used to be able to more easily manage starting the proxy in different contexts.

Search-Guard is installed (from a remote zip plugin) and is configured with the plugin's 'install_demo_configuration' script.
The elasticsearch.yml file is configured to support it coming up as a single node.

Additional changes are made to support our uses cases. Two simple scripts are added to the container to toggle TLS on/off via the configuration. TLS and HTTP auth are both disabled, as these are most useful for us at the moment.
Lastly, the image that is built from this docker file (which can also be done via gradle) is the base image for the capture proxy image. That gets us the same TLS configurations and JDK. We can choose then to run the logging proxy and Elasticsearch together in a single container, which already has all of the elasticsearch+search-guard artifacts, or to run them separately, using the base image for one container and the capture proxy image for the other.

To facilitate better dependency tracking of the 'external' docker images (those that aren't triggered by other gradle dependencies), I'm using a hash value of the Dockerfile's directory. The dependent images now use the base image of a specific tag that matches that hash value. That works well, but the docker compose file, nor anybody else, should ever have to know that tag, so two tags are created for each image, 'latest' and the hash value.

### Check List
- [ ] New functionality includes testing
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
