### PR TITLE
Replayer state model bugfixes

### DIFF
--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/CloseableTrafficStreamWrapper.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/CloseableTrafficStreamWrapper.java
@@ -23,7 +23,7 @@ public class CloseableTrafficStreamWrapper implements Closeable {
                     return null;
                 }
                 var ts = builder.build();
-                log.warn("Parsed traffic stream: "+ts);
+                log.trace("Parsed traffic stream: "+ts);
                 return ts;
             } catch (IOException e) {
                 throw new RuntimeException(e);

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/CloseableTrafficStreamWrapper.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/CloseableTrafficStreamWrapper.java
@@ -1,5 +1,6 @@
 package org.opensearch.migrations.replay;
 
+import lombok.extern.slf4j.Slf4j;
 import org.opensearch.migrations.trafficcapture.protos.TrafficStream;
 
 import java.io.Closeable;
@@ -9,6 +10,7 @@ import java.io.InputStream;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
+@Slf4j
 public class CloseableTrafficStreamWrapper implements Closeable {
     private final Closeable underlyingCloseableResource;
     private final Stream<TrafficStream> underlyingStream;
@@ -21,6 +23,7 @@ public class CloseableTrafficStreamWrapper implements Closeable {
                     return null;
                 }
                 var ts = builder.build();
+                log.warn("Parsed traffic stream: "+ts);
                 return ts;
             } catch (IOException e) {
                 throw new RuntimeException(e);

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/HttpMessageAndTimestamp.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/HttpMessageAndTimestamp.java
@@ -1,0 +1,35 @@
+package org.opensearch.migrations.replay;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.stream.Stream;
+
+public class HttpMessageAndTimestamp {
+    private Instant firstPacketTimestamp;
+    @Getter
+    @Setter
+    private Instant lastPacketTimestamp;
+
+    public final ArrayList<byte[]> packetBytes;
+
+    public HttpMessageAndTimestamp(Instant firstPacketTimestamp) {
+        this.firstPacketTimestamp = firstPacketTimestamp;
+        this.packetBytes = new ArrayList<>();
+    }
+
+    public Duration getTotalDuration() {
+        return Duration.between(firstPacketTimestamp, lastPacketTimestamp);
+    }
+
+    public void add(byte[] b) {
+        packetBytes.add(b);
+    }
+
+    public Stream<byte[]> stream() {
+        return packetBytes.stream();
+    }
+}

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/ReplayEngine.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/ReplayEngine.java
@@ -1,5 +1,6 @@
 package org.opensearch.migrations.replay;
 
+import lombok.extern.slf4j.Slf4j;
 import org.opensearch.migrations.trafficcapture.protos.TrafficObservation;
 
 import java.time.Instant;
@@ -8,58 +9,76 @@ import java.util.Map;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
+@Slf4j
 public class ReplayEngine implements BiConsumer<String, TrafficObservation> {
-    private final Map<String, RequestResponsePacketPair> liveStreams;
+    enum State {
+        NOTHING_SENT,
+        REQUEST_SENT
+    }
+    public static class Accumulation {
+        RequestResponsePacketPair rrPair = new RequestResponsePacketPair();
+        State state = State.NOTHING_SENT;
+    }
+    private final Map<String, Accumulation> liveStreams;
+    private final Consumer<HttpMessageAndTimestamp> requestHandler;
     private final Consumer<RequestResponsePacketPair> fullDataHandler;
 
-    public ReplayEngine(Consumer<RequestResponsePacketPair> fullDataHandler) {
+    public ReplayEngine(Consumer<HttpMessageAndTimestamp> requestReceivedHandler,
+                        Consumer<RequestResponsePacketPair> fullDataHandler) {
         liveStreams = new HashMap<>();
+        this.requestHandler = requestReceivedHandler;
         this.fullDataHandler = fullDataHandler;
     }
 
     @Override
     public void accept(String id, TrafficObservation observation) {
-        boolean updateFirstResponseTimestamp = false;
-        RequestResponsePacketPair runningList = null;
         var pbts = observation.getTs();
         var timestamp = Instant.ofEpochSecond(pbts.getSeconds(), pbts.getNanos());
         if (observation.hasEndOfMessageIndicator()) {
-            publishAndClear(id);
+            handleEndOfMessage(id);
         } else if (observation.hasRead()) {
-            runningList = liveStreams.putIfAbsent(id, new RequestResponsePacketPair());
-            if (runningList == null) {
-                runningList = liveStreams.get(id);
-                // TODO - eliminate the byte[] and use the underlying nio buffer
-                runningList.addRequestData(timestamp, observation.getRead().getData().toByteArray());
+            var accum = liveStreams.computeIfAbsent(id, k -> new Accumulation());
+            if (accum.state == State.REQUEST_SENT) {
+                handleEndOfMessage(id);
+                accum = new Accumulation();
+                liveStreams.put(id, accum);
             }
+            var runningList = accum.rrPair;
+            // TODO - eliminate the byte[] and use the underlying nio buffer
+            runningList.addRequestData(timestamp, observation.getRead().getData().toByteArray());
         } else if (observation.hasReadSegment()) {
             throw new RuntimeException("Not implemented yet.");
         } else if (observation.hasWrite()) {
-            updateFirstResponseTimestamp = true;
-            runningList = liveStreams.get(id);
+            var runningList = liveStreams.get(id).rrPair;
             if (runningList == null) {
                 throw new RuntimeException("Apparent out of order exception - " +
                         "found a purported write to a socket before a read!");
             }
             runningList.addResponseData(timestamp, observation.getWrite().toByteArray());
         } else if (observation.hasWriteSegment()) {
-            updateFirstResponseTimestamp = true;
             throw new RuntimeException("Not implemented yet.");
         } else if (observation.hasRequestReleasedDownstream()) {
-            updateFirstResponseTimestamp = true;
-        }
-        if (updateFirstResponseTimestamp && runningList != null) {
-            if (runningList.firstTimeStampForResponse == null) {
-                runningList.firstTimeStampForResponse = timestamp;
-            }
+
         }
     }
 
-    private void publishAndClear(String id) {
+    private void handleEndOfMessage(String id) {
         var priorBuffers = liveStreams.get(id);
-        if (priorBuffers != null) {
-            fullDataHandler.accept(priorBuffers);
-            liveStreams.remove(id);
+        if (priorBuffers == null) {
+            log.warn("No prior messages, but received an EOM.  " +
+                    "Considering that as nothing to do, but it indicates either a corruption or logical error " +
+                    "here or in the capture");
+            return;
+        }
+        switch (priorBuffers.state) {
+            case NOTHING_SENT:
+                requestHandler.accept(priorBuffers.rrPair.requestData);
+                priorBuffers.state = State.REQUEST_SENT;
+                break;
+            case REQUEST_SENT:
+                fullDataHandler.accept(priorBuffers.rrPair);
+                liveStreams.remove(id);
+                break;
         }
     }
 }

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/RequestResponsePacketPair.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/RequestResponsePacketPair.java
@@ -10,45 +10,30 @@ import java.util.stream.Stream;
 
 @Slf4j
 public class RequestResponsePacketPair {
-    Instant firstTimeStampForRequest;
-    Instant lastTimeStampForRequest;
-    Instant firstTimeStampForResponse;
-    Instant lastTimeStampForResponse;
 
-    final ArrayList<byte[]> requestData;
-    final ArrayList<byte[]> responseData;
-
-    public Duration getTotalRequestDuration() {
-        return Duration.between(firstTimeStampForRequest, lastTimeStampForRequest);
-    }
-
-    public Duration getTotalResponseDuration() {
-        return Duration.between(firstTimeStampForResponse, lastTimeStampForResponse);
-    }
-
-    public RequestResponsePacketPair() {
-        this.requestData = new ArrayList<>();
-        this.responseData = new ArrayList<>();
-    }
+    HttpMessageAndTimestamp requestData;
+    HttpMessageAndTimestamp responseData;
 
     public void addRequestData(Instant packetTimeStamp, byte[] data) {
         if (log.isTraceEnabled()) {
             log.trace(this + " Adding request data: " + new String(data, Charset.defaultCharset()));
         }
-        requestData.add(data);
-        if (firstTimeStampForRequest == null) {
-            firstTimeStampForRequest = packetTimeStamp;
+        if (requestData == null) {
+            requestData = new HttpMessageAndTimestamp(packetTimeStamp);
         }
-        lastTimeStampForRequest = packetTimeStamp;
+        requestData.add(data);
+        requestData.setLastPacketTimestamp(packetTimeStamp);
     }
 
     public void addResponseData(Instant packetTimeStamp, byte[] data) {
         if (log.isTraceEnabled()) {
-            log.trace(this + " Adding response data (len=" + responseData.size() + "): " +
-                    new String(data, Charset.defaultCharset()));
+            log.trace(this + " Adding response data: " + new String(data, Charset.defaultCharset()));
+        }
+        if (responseData == null) {
+            responseData = new HttpMessageAndTimestamp(packetTimeStamp);
         }
         responseData.add(data);
-        lastTimeStampForResponse = packetTimeStamp;
+        responseData.setLastPacketTimestamp(packetTimeStamp);
     }
 
     public Stream<byte[]> getRequestDataStream() {

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/SourceTargetCaptureTuple.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/SourceTargetCaptureTuple.java
@@ -11,6 +11,7 @@ import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.Base64;
 import java.util.List;
+import java.util.Map;
 import java.util.Scanner;
 
 @Slf4j
@@ -30,7 +31,11 @@ public class SourceTargetCaptureTuple {
     public static class TupleToFileWriter {
         OutputStream outputStream;
 
-        private JSONObject jsonFromHttpData(List<byte[]> data) throws IOException {
+        public TupleToFileWriter(OutputStream outputStream){
+            this.outputStream = outputStream;
+        }
+
+        private JSONObject jsonFromHttpDataUnsafe(List<byte[]> data) throws IOException {
 
             SequenceInputStream collatedStream = ReplayUtils.byteArraysToInputStream(data);
             Scanner scanner = new Scanner(collatedStream, StandardCharsets.UTF_8);
@@ -53,6 +58,16 @@ public class SourceTargetCaptureTuple {
             return message;
         }
 
+        private JSONObject jsonFromHttpData(List<byte[]> data) {
+            try {
+                return jsonFromHttpDataUnsafe(data);
+            } catch (Exception e) {
+                log.warn("Putting what may be a bogus value in the output because transforming it " +
+                        "into json threw an exception");
+                return new JSONObject(Map.of("Exception", e.toString()));
+            }
+        }
+
         private JSONObject jsonFromHttpData(List<byte[]> data, Duration latency) throws IOException {
             JSONObject message = jsonFromHttpData(data);
             message.put("response_time_ms", latency.toMillis());
@@ -69,10 +84,6 @@ public class SourceTargetCaptureTuple {
                     triple.shadowResponseDuration));
 
             return meta;
-        }
-
-        public TupleToFileWriter(OutputStream outputStream){
-            this.outputStream = outputStream;
         }
 
         /**
@@ -112,8 +123,8 @@ public class SourceTargetCaptureTuple {
         public void writeJSON(SourceTargetCaptureTuple triple) throws IOException {
             JSONObject jsonObject = toJSONObject(triple);
 
-            outputStream.write(jsonObject.toString().getBytes(StandardCharsets.UTF_8));
-            outputStream.write("\n".getBytes(StandardCharsets.UTF_8));
+            log.warn("Writing json tuple to output stream");
+            outputStream.write((jsonObject.toString()+"\n").getBytes(StandardCharsets.UTF_8));
             outputStream.flush();
         }
     }

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/SourceTargetCaptureTuple.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/SourceTargetCaptureTuple.java
@@ -61,10 +61,10 @@ public class SourceTargetCaptureTuple {
 
         private JSONObject toJSONObject(SourceTargetCaptureTuple triple) throws IOException {
             JSONObject meta = new JSONObject();
-            meta.put("request", jsonFromHttpData(triple.sourcePair.requestData));
+            meta.put("request", jsonFromHttpData(triple.sourcePair.requestData.packetBytes));
             log.warn("TODO: These durations are not measuring the same values!");
-            meta.put("primaryResponse", jsonFromHttpData(triple.sourcePair.responseData,
-                    triple.sourcePair.getTotalResponseDuration()));
+            meta.put("primaryResponse", jsonFromHttpData(triple.sourcePair.responseData.packetBytes,
+                    triple.sourcePair.responseData.getTotalDuration()));
             meta.put("shadowResponse", jsonFromHttpData(triple.shadowResponseData,
                     triple.shadowResponseDuration));
 

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/NettyPacketToHttpHandler.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/NettyPacketToHttpHandler.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.time.Instant;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 
 @Log4j2
 public class NettyPacketToHttpHandler implements IPacketToHttpHandler {
@@ -36,7 +37,7 @@ public class NettyPacketToHttpHandler implements IPacketToHttpHandler {
                 .channel(NioSocketChannel.class)
                 .handler(new BacksideSnifferHandler(responseBuilder))
                 .option(ChannelOption.AUTO_READ, false);
-        log.trace("Active - setting up backend connection");
+        log.debug("Active - setting up backend connection");
         outboundChannelFuture = b.connect(serverUri.getHost(), serverUri.getPort());
         //outboundChannel = outboundChannelFuture.channel();
         responseWatchHandler = new BacksideHttpWatcherHandler(responseBuilder);
@@ -44,7 +45,7 @@ public class NettyPacketToHttpHandler implements IPacketToHttpHandler {
         outboundChannelFuture.addListener((ChannelFutureListener) future -> {
             if (future.isSuccess()) {
                 // connection complete start to read first data
-                log.trace("Done setting up backend channel & it was successful");
+                log.debug("Done setting up backend channel & it was successful");
                 var pipeline = future.channel().pipeline();
                 pipeline.addLast(new HttpResponseDecoder());
                 // TODO - switch this out to use less memory.
@@ -55,44 +56,72 @@ public class NettyPacketToHttpHandler implements IPacketToHttpHandler {
             } else {
                 // Close the connection if the connection attempt has failed.
                 log.error("closing outbound channel because CONNECT future was not successful");
+                log.error(future.cause());
             }
         });
     }
 
     @Override
     public CompletableFuture<Void> consumeBytes(ByteBuf packetData) {
-        log.trace("Writing packetData["+packetData+"]");
-        var completableFuture = new CompletableFuture<Void>();
+        log.debug("Scheduling write of packetData["+packetData+"]" +
+                " hash=" + System.identityHashCode(packetData));
+        final var completableFuture = new CompletableFuture<Void>();
         if (outboundChannelFuture.isDone()) {
             Channel channel = outboundChannelFuture.channel();
             if (!channel.isActive()) {
                 log.warn("Channel is not active - future packets for this connection will be dropped.");
                 log.warn("Need to do more sophisticated tracking of progress and retry further up the stack");
-                return null;
+                completableFuture.completeExceptionally(
+                        new RuntimeException("The outbound channel's future has completed but " +
+                                "the channel is not in an active state - dropping data"));
+                return completableFuture;
             }
-            log.trace("Writing data to backside handler");
+            log.trace("Writing data to backside handler and will return future = "+completableFuture);
             channel.writeAndFlush(packetData)
                     .addListener((ChannelFutureListener) future -> {
-                        if (future.isSuccess()) {
-                            log.trace("packet write was successful: "+packetData);
+                        Throwable cause = null;
+                        try {
+                            if (!future.isSuccess()) {
+                                log.warn("closing outbound channel because WRITE future was not successful " +
+                                        future.cause() + " hash=" + System.identityHashCode(packetData));
+                                future.channel().close(); // close the backside
+                                cause = future.cause();
+                            }
+                        } catch (Exception e) {
+                            cause = e;
+                        }
+                        if (cause == null) {
+                            log.debug("Signaling previously returned CompletableFuture packet write was successful: "
+                                    + packetData + " hash=" + System.identityHashCode(packetData));
                             completableFuture.complete(null);
                         } else {
-                            log.warn("closing outbound channel because WRITE future was not successful "+future.cause());
-                            future.channel().close(); // close the backside
-                            completableFuture.completeExceptionally(future.cause());
+                            log.trace("Signaling previously returned CompletableFuture packet write had an exception : "
+                                    + packetData + " hash=" + System.identityHashCode(packetData));
+                            completableFuture.completeExceptionally(cause);
                         }
                     });
         } else {
+            log.trace("Channel isn't ready yet for writes chaining a callback to the channel's future " +
+                    packetData + " hash=" + System.identityHashCode(packetData));
+            log.trace("deferred future being returned = "+completableFuture);
             outboundChannelFuture.addListener(f-> {
                     if (outboundChannelFuture.isSuccess()) {
+                        log.trace("outboundChannelFuture has finished - retriggering consumeBytes" +
+                                " hash=" + System.identityHashCode(packetData));
                         consumeBytes(packetData).whenComplete((x,t)-> {
-                            if (x != null) {
-                                completableFuture.complete(x);
-                            } else {
+                            if (t != null) {
+                                log.warn("inner consumeBytes has finished w/ exception t="+t +
+                                        " hash=" + System.identityHashCode(packetData));
                                 completableFuture.completeExceptionally(t);
+                            } else {
+                                log.trace("inner consumeBytes has finished w/ x="+x +
+                                        " hash=" + System.identityHashCode(packetData));
+                                completableFuture.complete(x);
                             }
                         });
                     } else {
+                        log.warn("outbound channel was not set up successfully, NOT writing bytes " +
+                                " hash=" + System.identityHashCode(packetData));
                         completableFuture.completeExceptionally(outboundChannelFuture.cause());
                     }
             });

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/http/NettyDecodedHttpRequestHandler.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/http/NettyDecodedHttpRequestHandler.java
@@ -55,7 +55,7 @@ public class NettyDecodedHttpRequestHandler extends ChannelInboundHandlerAdapter
                     statusWatcher.accept(HTTP_CONSUMPTION_STATUS.DONE);
                     // TODO - there might be a memory leak here.
                     // I'm not sure if I should be releasing the HttpRequest `msg`.
-                    log.warn("TODO - there might be a memory leak here.  " +
+                    log.info("TODO - there might be a memory leak here.  " +
                             "I'm not sure if I should be releasing the HttpRequest `msg`.");
                     pipelineOrchestrator.addBaselineHandlers(pipeline);
                     ctx.fireChannelRead(httpJsonMessage);

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/http/RequestPipelineOrchestrator.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/http/RequestPipelineOrchestrator.java
@@ -98,7 +98,7 @@ public class RequestPipelineOrchestrator {
         //  IN: ByteBufs(2) + HttpJsonMessage(4) with headers only + HttpContent(1) (if the repackaging handlers were skipped)
         // OUT: ByteBufs(3) which are sized similarly to how they were received
         pipeline.addLast(new NettyJsonToByteBufHandler(Collections.unmodifiableList(chunkSizes)));
-        pipeline.addLast(new LoggingHandler(LogLevel.INFO, ByteBufFormat.HEX_DUMP));
+        //pipeline.addLast(new LoggingHandler(LogLevel.INFO, ByteBufFormat.HEX_DUMP));
         // IN:  ByteBufs(3)
         // OUT: nothing - terminal!  ByteBufs are routed to the packet handler!
         pipeline.addLast(new NettySendByteBufsToPacketHandlerHandler(packetReceiver));

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/transform/JoltJsonTransformBuilder.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/transform/JoltJsonTransformBuilder.java
@@ -18,6 +18,7 @@ public class JoltJsonTransformBuilder {
     public enum CANNED_OPERATIONS {
         ADD_GZIP("addGzip"),
         MAKE_CHUNKED("makeChunked"),
+        ADD_ADMIN_AUTH("addAdminAuth"),
         PASS_THRU("passThru");
 
         private final String value;
@@ -38,6 +39,7 @@ public class JoltJsonTransformBuilder {
     static final TypeReference<LinkedHashMap<String, Object>> TYPE_REFERENCE_FOR_MAP_TYPE =
             new TypeReference<LinkedHashMap<String, Object>>(){};
     public static final String RESOURCE_HOST_SWITCH_OPERATION = "hostSwitch.jolt";
+    public static final String ADD_ADMIN_AUTH_OPERATION = "addAdminAuth.jolt";
     public static final String RESOURCE_PASS_THRU_OPERATION = "passThru.jolt";
 
     ObjectMapper mapper = new ObjectMapper();

--- a/TrafficCapture/trafficReplayer/src/main/resources/jolt/operations/addAdminAuth.jolt
+++ b/TrafficCapture/trafficReplayer/src/main/resources/jolt/operations/addAdminAuth.jolt
@@ -1,0 +1,8 @@
+{
+  "operation": "modify-overwrite-beta",
+  "spec": {
+    "headers": {
+      "Authorization": "Basic YWRtaW46YWRtaW4="
+    }
+  }
+}

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/HeaderTransformerTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/HeaderTransformerTest.java
@@ -85,7 +85,8 @@ public class HeaderTransformerTest {
                 contentLength -> "GET / HTTP/1.1\n" +
                         "HoSt: " + SOURCE_CLUSTER_NAME + "\n" +
                         "content-type: application/json\n" +
-                        "content-length: " + contentLength + "\n");
+                        "content-length: " + contentLength + "\n" +
+                        "Authorization: Basic YWRtaW46YWRtaW4=\n");
     }
 
     /**


### PR DESCRIPTION
### Description

This change fixes issues due to switching from the Log4J log lines to the protobuf captures.  Some of the events and signaling is different now.  As such, the state model to determine when a request and response has been fully received had to be updated.

NettyPacketToHttpHandler now handles its CompletableFutures more carefully.  null is no longer returned.  Instead values and exceptions are pushed back via the CompletableFutures value (or exceptionally prong).  I've also refactored the Request/Response packet arrays and friends into a helper HttpMessageAndTImestamp object to canonicalize the handling.  There's also a more formal state machine to track how data is accumulated.

There was also at least one bug within the JsonTuple writing code that was caused by headers that threw exceptions.  Now, a tuple will be output with an Object/Map with the key "Exception" and the exception representation of it.  I don't know if that's an issue for the comparator, but it lets us get some data out of the replayer for those messages as opposed to none.

The ReplayEngine now does a better job of closing out all of the asynchronous jobs before closing the netty pipeline/client to the target server.  It does that by maintaining a concurrent hashmap of the futures that still need to be processed and waits on all of them.  All of them is still only aggregated when the stream has finished processing, so for a long-running process, this is moot.  However, for testing and demos, it is every run.  We don't have any facilities yet to monitor how deep the queues of still-ongoing work is or how to cull it earlier by observing timeouts.  Related issues are already in Jira, but they aren't extremely explicit about it.

This includes a simple transform (hack/kludge) to add basic HTTP auth for "admin:admin" and a number of edits to reduce the verbosity of logging too.  The HTTP auth change has been fully parameterized at the command line in a future commit.

### Issues Resolved
[No Jira](https://opensearch.atlassian.net/browse/MIGRATIONS-1100)

### Testing
Unit tests were added

### Check List
- [ ] New functionality includes testing (no new functionality)
  - [x] All tests pass, including unit test
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
