### PR TITLE
Replayer insecure flag and kafka benchmark compose integrations

### DIFF
--- a/TrafficCapture/dockerSolution/build.gradle
+++ b/TrafficCapture/dockerSolution/build.gradle
@@ -32,7 +32,8 @@ dependencies {
 }
 
 def dockerFilesForExternalServices = [
-        "elasticsearchWithSearchGuard": "elasticsearch_searchguard"
+        "elasticsearchWithSearchGuard": "elasticsearch_searchguard",
+        "openSearchBenchmark": "open_search_benchmark"
 ]
 // Create the static docker files that aren't hosting migrations java code from this repo
 dockerFilesForExternalServices.each { projectName, dockerImageName ->
@@ -111,10 +112,11 @@ dockerCompose {
 
 task buildDockerImages {
     dependsOn buildDockerImage_elasticsearchWithSearchGuard
+    dependsOn buildDockerImage_openSearchBenchmark
 
+    dependsOn buildDockerImage_kafkaPrinter
     dependsOn buildDockerImage_trafficCaptureProxyServer
     dependsOn buildDockerImage_trafficReplayer
-    dependsOn buildDockerImage_kafkaPrinter
     //dependsOn buildDockerImage_
 }
 

--- a/TrafficCapture/dockerSolution/src/main/docker/docker-compose.yml
+++ b/TrafficCapture/dockerSolution/src/main/docker/docker-compose.yml
@@ -51,26 +51,23 @@ services:
     image: 'migrations/kafka_capture_puller:latest'
     networks:
       - migrations
-    command: /runJavaWithClasspath.sh org.opensearch.migrations.KafkaPrinter --group-id default-logging-group --broker-address kafka:9092 --topic-name logging-traffic-topic | nc -v replayer 10001
     depends_on:
       - kafka
       - replayer
+    command: /bin/sh -c "/runJavaWithClasspath.sh org.opensearch.migrations.KafkaPrinter --group-id default-logging-group --broker-address kafka:9092 --topic-name logging-traffic-topic | nc -v replayer 10001"
 
   replayer:
     image: 'migrations/traffic_replayer:latest'
-    ports:
-      - "10001:10001"
     networks:
       - migrations
-    #command: nc -v -l -p 10001 | tee /dev/stderr | /runJavaWithClasspath.sh org.opensearch.migrations.replay.TrafficReplayer https://opensearchtarget:9200
-    #command: /runJavaWithClasspath.sh org.opensearch.migrations.replay.TrafficReplayer https://opensearchtarget:9200
+    ports:
+      - "10001:10001"
+    depends_on:
+      - opensearchtarget
+    command: /bin/sh -c "nc -v -l -p 10001 | /runJavaWithClasspath.sh org.opensearch.migrations.replay.TrafficReplayer https://opensearchtarget:9200 --insecure"
 
   opensearchtarget:
     image: 'opensearchproject/opensearch:latest'
-#    volumes:
-#      - "./opensearch/esnode-key.pem:/usr/share/opensearch/config/esnode-key.pem"
-#      - "./opensearch/esnode.pem:/usr/share/opensearch/config/root-ca.pem"
-#      - "./opensearch/esnode.pem:/usr/share/opensearch/config/esnode.pem"
     environment:
       - discovery.type=single-node
     networks:

--- a/TrafficCapture/dockerSolution/src/main/docker/docker-compose.yml
+++ b/TrafficCapture/dockerSolution/src/main/docker/docker-compose.yml
@@ -62,15 +62,15 @@ services:
       - "10001:10001"
     networks:
       - migrations
-    #command: nc -v -l -p 10001 | tee /dev/stderr | /runJavaWithClasspath.sh org.opensearch.migrations.replay.TrafficReplayer opensearch_target:9200
-    #command: /runJavaWithClasspath.sh org.opensearch.migrations.replay.TrafficReplayer opensearch_target:9200
+    #command: nc -v -l -p 10001 | tee /dev/stderr | /runJavaWithClasspath.sh org.opensearch.migrations.replay.TrafficReplayer https://opensearchtarget:9200
+    #command: /runJavaWithClasspath.sh org.opensearch.migrations.replay.TrafficReplayer https://opensearchtarget:9200
 
-  opensearch_target:
+  opensearchtarget:
     image: 'opensearchproject/opensearch:latest'
-    volumes:
-      - "./opensearch/esnode-key.pem:/usr/share/opensearch/config/esnode-key.pem"
-      - "./opensearch/esnode.pem:/usr/share/opensearch/config/root-ca.pem"
-      - "./opensearch/esnode.pem:/usr/share/opensearch/config/esnode.pem"
+#    volumes:
+#      - "./opensearch/esnode-key.pem:/usr/share/opensearch/config/esnode-key.pem"
+#      - "./opensearch/esnode.pem:/usr/share/opensearch/config/root-ca.pem"
+#      - "./opensearch/esnode.pem:/usr/share/opensearch/config/esnode.pem"
     environment:
       - discovery.type=single-node
     networks:

--- a/TrafficCapture/dockerSolution/src/main/docker/docker-compose.yml
+++ b/TrafficCapture/dockerSolution/src/main/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.7'
 services:
 
-  capture_proxy:
+  captureproxy:
     image: 'migrations/capture_proxy:latest'
     networks:
       - migrations
@@ -78,8 +78,22 @@ services:
 #  traffic_comparator:
 #    image: ''
 
-#  opensearch-benchmarks:
-#    image: ''
+  opensearch-benchmarks:
+    image: 'migrations/open_search_benchmark:latest'
+    networks:
+      - migrations
+    command:
+      - /bin/sh
+      - -c
+      - >
+        echo "Running opensearch-benchmark w/ 'geonames' workload..." &&
+        opensearch-benchmark execute-test --distribution-version=1.0.0 --target-host=https://captureproxy:9200 --workload=geonames --pipeline=benchmark-only --test-mode --kill-running-processes --workload-params "target_throughput:0.5,bulk_size:10,bulk_indexing_clients:1,search_clients:1"  --client-options="use_ssl:true,verify_certs:false" &&
+        echo "Running opensearch-benchmark w/ 'http_logs' workload..." &&
+        opensearch-benchmark execute-test --distribution-version=1.0.0 --target-host=https://captureproxy:9200 --workload=http_logs --pipeline=benchmark-only --test-mode --kill-running-processes --workload-params "target_throughput:0.5,bulk_size:10,bulk_indexing_clients:1,search_clients:1"  --client-options="use_ssl:true,verify_certs:false" &&
+        echo "Running opensearch-benchmark w/ 'nested' workload..." &&
+        opensearch-benchmark execute-test --distribution-version=1.0.0 --target-host=https://captureproxy:9200 --workload=nested --pipeline=benchmark-only --test-mode --kill-running-processes --workload-params "target_throughput:0.5,bulk_size:10,bulk_indexing_clients:1,search_clients:1"  --client-options="use_ssl:true,verify_certs:false" &&
+        echo "Running opensearch-benchmark w/ 'nyc_taxis' workload..." &&
+        opensearch-benchmark execute-test --distribution-version=1.0.0 --target-host=https://captureproxy:9200 --workload=nyc_taxis --pipeline=benchmark-only --test-mode --kill-running-processes --workload-params "target_throughput:0.5,bulk_size:10,bulk_indexing_clients:1,search_clients:1"  --client-options="use_ssl:true,verify_certs:false"
 
 volumes:
   zookeeper_data:

--- a/TrafficCapture/dockerSolution/src/main/docker/openSearchBenchmark/Dockerfile
+++ b/TrafficCapture/dockerSolution/src/main/docker/openSearchBenchmark/Dockerfile
@@ -1,0 +1,9 @@
+FROM ubuntu:focal
+
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends python3.9 python3-pip python3-dev gcc libc-dev git curl && \
+    pip3 install opensearch-benchmark
+
+CMD tail -f /dev/null

--- a/TrafficCapture/dockerSolution/src/main/docker/opensearch/makeCerts.sh
+++ b/TrafficCapture/dockerSolution/src/main/docker/opensearch/makeCerts.sh
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-openssl req -x509 -newkey rsa:4096 -keyout esnode-key.pem -out esnode.pem -days 3650 -nodes -subj "/CN=opensearch_target"
-

--- a/TrafficCapture/nettyWireLogging/build.gradle
+++ b/TrafficCapture/nettyWireLogging/build.gradle
@@ -12,6 +12,10 @@ dependencies {
     implementation project(':captureOffloader')
     api group: 'io.netty', name: 'netty-all', version: '4.1.89.Final'
     implementation group: 'org.slf4j', name: 'slf4j-api', version: '2.0.7'
-    testImplementation group: 'org.slf4j', name: 'slf4j-api', version: '2.0.7'
+
+    testImplementation project(':captureProtobufs')
     testImplementation group: 'org.apache.httpcomponents.client5', name: 'httpclient5', version: '5.2.1'
+    testImplementation group: 'org.slf4j', name: 'slf4j-api', version: '2.0.7'
+    testImplementation group: 'com.google.guava', name: 'guava', version: '31.1-jre'
+    testImplementation group: 'com.google.protobuf', name: 'protobuf-java', version:'3.22.2'
 }

--- a/TrafficCapture/nettyWireLogging/src/test/java/org/opensearch/migrations/trafficcapture/netty/ConditionallyReliableLoggingHttpRequestHandlerTest.java
+++ b/TrafficCapture/nettyWireLogging/src/test/java/org/opensearch/migrations/trafficcapture/netty/ConditionallyReliableLoggingHttpRequestHandlerTest.java
@@ -1,0 +1,86 @@
+package org.opensearch.migrations.trafficcapture.netty;
+
+import com.google.common.primitives.Bytes;
+import com.google.protobuf.CodedOutputStream;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.embedded.EmbeddedChannel;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.opensearch.migrations.trafficcapture.IChannelConnectionCaptureOffloader;
+import org.opensearch.migrations.trafficcapture.IChannelConnectionCaptureSerializer;
+import org.opensearch.migrations.trafficcapture.StreamChannelConnectionCaptureSerializer;
+import org.opensearch.migrations.trafficcapture.protos.TrafficStream;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.SequenceInputStream;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ConditionallyReliableLoggingHttpRequestHandlerTest {
+
+    @Test
+    public void testThatSinglePacketPostBlocks() throws IOException {
+        byte[] fullTrafficBytes = SimpleRequests.SMALL_POST.getBytes(StandardCharsets.UTF_8);
+        var bigBuff = Unpooled.wrappedBuffer(fullTrafficBytes);
+        writeMessageAndVerify(fullTrafficBytes, w -> {
+            w.writeInbound(bigBuff);
+        });
+    }
+
+    private static void writeMessageAndVerify(byte[] fullTrafficBytes, Consumer<EmbeddedChannel> channelWriter)
+            throws IOException {
+        AtomicReference<ByteBuffer> outputByteBuffer = new AtomicReference<>();
+        byte[] scratchBytes = new byte[1024*1024];
+        AtomicInteger flushCount = new AtomicInteger();
+        var offloader = new StreamChannelConnectionCaptureSerializer("Test",
+                () -> CodedOutputStream.newInstance(scratchBytes),
+                cos -> {
+                    outputByteBuffer.set(ByteBuffer.wrap(scratchBytes, 0, cos.getTotalBytesWritten()));
+                    try {
+                        cos.flush();
+                    } catch (IOException e) {
+                        throw new RuntimeException();
+                    }
+                    return CompletableFuture.completedFuture(flushCount.incrementAndGet());
+                });
+
+        EmbeddedChannel channel = new EmbeddedChannel(new ConditionallyReliableLoggingHttpRequestHandler(offloader,
+                x->true));
+        channelWriter.accept(channel);
+
+        var trafficStream = TrafficStream.parseFrom(outputByteBuffer.get());
+        Assertions.assertTrue(trafficStream.getSubStreamCount() > 0 &&
+                trafficStream.getSubStream(0).hasRead());
+        var combinedTrafficPacketsSteam = new SequenceInputStream(Collections.enumeration(trafficStream.getSubStreamList().stream()
+                .filter(to->to.hasRead())
+                .map(to->new ByteArrayInputStream(to.getRead().getData().toByteArray()))
+                .collect(Collectors.toList())));
+        Assertions.assertArrayEquals(fullTrafficBytes, combinedTrafficPacketsSteam.readAllBytes());
+        Assertions.assertEquals(1, flushCount.get());
+    }
+
+    //@Test
+    public void testThatTinyPacketsPostBlocks() throws IOException {
+        byte[] fullTrafficBytes = SimpleRequests.SMALL_POST.getBytes(StandardCharsets.UTF_8);
+        writeMessageAndVerify(fullTrafficBytes, w -> {
+            for (int i=0; i<fullTrafficBytes.length; ++i) {
+                var singleByte = Unpooled.wrappedBuffer(fullTrafficBytes, i, 1);
+                w.writeInbound(singleByte);
+            }
+        });
+    }
+}

--- a/TrafficCapture/nettyWireLogging/src/test/java/org/opensearch/migrations/trafficcapture/netty/SimpleRequests.java
+++ b/TrafficCapture/nettyWireLogging/src/test/java/org/opensearch/migrations/trafficcapture/netty/SimpleRequests.java
@@ -1,0 +1,10 @@
+package org.opensearch.migrations.trafficcapture.netty;
+
+public class SimpleRequests {
+    public static String SMALL_POST = "POST / HTTP/1.1\n" +
+            "Host: localhost\n" +
+            "Content-Type: application/x-www-form-urlencoded\n" +
+            "Content-Length: 27\n" +
+            "\n" +
+            "field1=value1&field2=value2";
+}

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/CloseableTrafficStreamWrapper.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/CloseableTrafficStreamWrapper.java
@@ -23,7 +23,7 @@ public class CloseableTrafficStreamWrapper implements Closeable {
                     return null;
                 }
                 var ts = builder.build();
-                log.warn("Parsed traffic stream: "+ts);
+                log.trace("Parsed traffic stream: "+ts);
                 return ts;
             } catch (IOException e) {
                 throw new RuntimeException(e);

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/CloseableTrafficStreamWrapper.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/CloseableTrafficStreamWrapper.java
@@ -1,5 +1,6 @@
 package org.opensearch.migrations.replay;
 
+import lombok.extern.slf4j.Slf4j;
 import org.opensearch.migrations.trafficcapture.protos.TrafficStream;
 
 import java.io.Closeable;
@@ -9,6 +10,7 @@ import java.io.InputStream;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
+@Slf4j
 public class CloseableTrafficStreamWrapper implements Closeable {
     private final Closeable underlyingCloseableResource;
     private final Stream<TrafficStream> underlyingStream;
@@ -21,6 +23,7 @@ public class CloseableTrafficStreamWrapper implements Closeable {
                     return null;
                 }
                 var ts = builder.build();
+                log.warn("Parsed traffic stream: "+ts);
                 return ts;
             } catch (IOException e) {
                 throw new RuntimeException(e);

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/HttpMessageAndTimestamp.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/HttpMessageAndTimestamp.java
@@ -1,0 +1,35 @@
+package org.opensearch.migrations.replay;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.stream.Stream;
+
+public class HttpMessageAndTimestamp {
+    private Instant firstPacketTimestamp;
+    @Getter
+    @Setter
+    private Instant lastPacketTimestamp;
+
+    public final ArrayList<byte[]> packetBytes;
+
+    public HttpMessageAndTimestamp(Instant firstPacketTimestamp) {
+        this.firstPacketTimestamp = firstPacketTimestamp;
+        this.packetBytes = new ArrayList<>();
+    }
+
+    public Duration getTotalDuration() {
+        return Duration.between(firstPacketTimestamp, lastPacketTimestamp);
+    }
+
+    public void add(byte[] b) {
+        packetBytes.add(b);
+    }
+
+    public Stream<byte[]> stream() {
+        return packetBytes.stream();
+    }
+}

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/PacketToTransformingProxyHandlerFactory.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/PacketToTransformingProxyHandlerFactory.java
@@ -1,6 +1,8 @@
 package org.opensearch.migrations.replay;
 
 import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslContextBuilder;
 import org.opensearch.migrations.replay.datahandlers.IPacketToHttpHandler;
 import org.opensearch.migrations.replay.datahandlers.NettyPacketToHttpHandler;
 import org.opensearch.migrations.replay.datahandlers.http.HttpJsonTransformer;
@@ -12,15 +14,18 @@ public class PacketToTransformingProxyHandlerFactory {
     private final NioEventLoopGroup eventLoopGroup;
     private final URI serverUri;
     private final JsonTransformer jsonTransformer;
+    private final SslContext sslContext;
 
-    public PacketToTransformingProxyHandlerFactory(URI serverUri, JsonTransformer jsonTransformer) {
+    public PacketToTransformingProxyHandlerFactory(URI serverUri, JsonTransformer jsonTransformer,
+                                                   SslContext sslContext) {
         this.jsonTransformer = jsonTransformer;
         this.eventLoopGroup = new NioEventLoopGroup();
         this.serverUri = serverUri;
+        this.sslContext = sslContext;
     }
 
     public IPacketToHttpHandler createNettyHandler() {
-        return new NettyPacketToHttpHandler(eventLoopGroup, serverUri);
+        return new NettyPacketToHttpHandler(eventLoopGroup, serverUri, sslContext);
     }
 
     public IPacketToHttpHandler create() {

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/ReplayEngine.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/ReplayEngine.java
@@ -1,5 +1,6 @@
 package org.opensearch.migrations.replay;
 
+import lombok.extern.slf4j.Slf4j;
 import org.opensearch.migrations.trafficcapture.protos.TrafficObservation;
 
 import java.time.Instant;
@@ -8,58 +9,76 @@ import java.util.Map;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
+@Slf4j
 public class ReplayEngine implements BiConsumer<String, TrafficObservation> {
-    private final Map<String, RequestResponsePacketPair> liveStreams;
+    enum State {
+        NOTHING_SENT,
+        REQUEST_SENT
+    }
+    public static class Accumulation {
+        RequestResponsePacketPair rrPair = new RequestResponsePacketPair();
+        State state = State.NOTHING_SENT;
+    }
+    private final Map<String, Accumulation> liveStreams;
+    private final Consumer<HttpMessageAndTimestamp> requestHandler;
     private final Consumer<RequestResponsePacketPair> fullDataHandler;
 
-    public ReplayEngine(Consumer<RequestResponsePacketPair> fullDataHandler) {
+    public ReplayEngine(Consumer<HttpMessageAndTimestamp> requestReceivedHandler,
+                        Consumer<RequestResponsePacketPair> fullDataHandler) {
         liveStreams = new HashMap<>();
+        this.requestHandler = requestReceivedHandler;
         this.fullDataHandler = fullDataHandler;
     }
 
     @Override
     public void accept(String id, TrafficObservation observation) {
-        boolean updateFirstResponseTimestamp = false;
-        RequestResponsePacketPair runningList = null;
         var pbts = observation.getTs();
         var timestamp = Instant.ofEpochSecond(pbts.getSeconds(), pbts.getNanos());
         if (observation.hasEndOfMessageIndicator()) {
-            publishAndClear(id);
+            handleEndOfMessage(id);
         } else if (observation.hasRead()) {
-            runningList = liveStreams.putIfAbsent(id, new RequestResponsePacketPair());
-            if (runningList == null) {
-                runningList = liveStreams.get(id);
-                // TODO - eliminate the byte[] and use the underlying nio buffer
-                runningList.addRequestData(timestamp, observation.getRead().getData().toByteArray());
+            var accum = liveStreams.computeIfAbsent(id, k -> new Accumulation());
+            if (accum.state == State.REQUEST_SENT) {
+                handleEndOfMessage(id);
+                accum = new Accumulation();
+                liveStreams.put(id, accum);
             }
+            var runningList = accum.rrPair;
+            // TODO - eliminate the byte[] and use the underlying nio buffer
+            runningList.addRequestData(timestamp, observation.getRead().getData().toByteArray());
         } else if (observation.hasReadSegment()) {
             throw new RuntimeException("Not implemented yet.");
         } else if (observation.hasWrite()) {
-            updateFirstResponseTimestamp = true;
-            runningList = liveStreams.get(id);
+            var runningList = liveStreams.get(id).rrPair;
             if (runningList == null) {
                 throw new RuntimeException("Apparent out of order exception - " +
                         "found a purported write to a socket before a read!");
             }
             runningList.addResponseData(timestamp, observation.getWrite().toByteArray());
         } else if (observation.hasWriteSegment()) {
-            updateFirstResponseTimestamp = true;
             throw new RuntimeException("Not implemented yet.");
         } else if (observation.hasRequestReleasedDownstream()) {
-            updateFirstResponseTimestamp = true;
-        }
-        if (updateFirstResponseTimestamp && runningList != null) {
-            if (runningList.firstTimeStampForResponse == null) {
-                runningList.firstTimeStampForResponse = timestamp;
-            }
+
         }
     }
 
-    private void publishAndClear(String id) {
+    private void handleEndOfMessage(String id) {
         var priorBuffers = liveStreams.get(id);
-        if (priorBuffers != null) {
-            fullDataHandler.accept(priorBuffers);
-            liveStreams.remove(id);
+        if (priorBuffers == null) {
+            log.warn("No prior messages, but received an EOM.  " +
+                    "Considering that as nothing to do, but it indicates either a corruption or logical error " +
+                    "here or in the capture");
+            return;
+        }
+        switch (priorBuffers.state) {
+            case NOTHING_SENT:
+                requestHandler.accept(priorBuffers.rrPair.requestData);
+                priorBuffers.state = State.REQUEST_SENT;
+                break;
+            case REQUEST_SENT:
+                fullDataHandler.accept(priorBuffers.rrPair);
+                liveStreams.remove(id);
+                break;
         }
     }
 }

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/RequestResponsePacketPair.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/RequestResponsePacketPair.java
@@ -10,45 +10,30 @@ import java.util.stream.Stream;
 
 @Slf4j
 public class RequestResponsePacketPair {
-    Instant firstTimeStampForRequest;
-    Instant lastTimeStampForRequest;
-    Instant firstTimeStampForResponse;
-    Instant lastTimeStampForResponse;
 
-    final ArrayList<byte[]> requestData;
-    final ArrayList<byte[]> responseData;
-
-    public Duration getTotalRequestDuration() {
-        return Duration.between(firstTimeStampForRequest, lastTimeStampForRequest);
-    }
-
-    public Duration getTotalResponseDuration() {
-        return Duration.between(firstTimeStampForResponse, lastTimeStampForResponse);
-    }
-
-    public RequestResponsePacketPair() {
-        this.requestData = new ArrayList<>();
-        this.responseData = new ArrayList<>();
-    }
+    HttpMessageAndTimestamp requestData;
+    HttpMessageAndTimestamp responseData;
 
     public void addRequestData(Instant packetTimeStamp, byte[] data) {
         if (log.isTraceEnabled()) {
             log.trace(this + " Adding request data: " + new String(data, Charset.defaultCharset()));
         }
-        requestData.add(data);
-        if (firstTimeStampForRequest == null) {
-            firstTimeStampForRequest = packetTimeStamp;
+        if (requestData == null) {
+            requestData = new HttpMessageAndTimestamp(packetTimeStamp);
         }
-        lastTimeStampForRequest = packetTimeStamp;
+        requestData.add(data);
+        requestData.setLastPacketTimestamp(packetTimeStamp);
     }
 
     public void addResponseData(Instant packetTimeStamp, byte[] data) {
         if (log.isTraceEnabled()) {
-            log.trace(this + " Adding response data (len=" + responseData.size() + "): " +
-                    new String(data, Charset.defaultCharset()));
+            log.trace(this + " Adding response data: " + new String(data, Charset.defaultCharset()));
+        }
+        if (responseData == null) {
+            responseData = new HttpMessageAndTimestamp(packetTimeStamp);
         }
         responseData.add(data);
-        lastTimeStampForResponse = packetTimeStamp;
+        responseData.setLastPacketTimestamp(packetTimeStamp);
     }
 
     public Stream<byte[]> getRequestDataStream() {

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/SourceTargetCaptureTuple.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/SourceTargetCaptureTuple.java
@@ -11,6 +11,7 @@ import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.Base64;
 import java.util.List;
+import java.util.Map;
 import java.util.Scanner;
 
 @Slf4j
@@ -30,7 +31,11 @@ public class SourceTargetCaptureTuple {
     public static class TupleToFileWriter {
         OutputStream outputStream;
 
-        private JSONObject jsonFromHttpData(List<byte[]> data) throws IOException {
+        public TupleToFileWriter(OutputStream outputStream){
+            this.outputStream = outputStream;
+        }
+
+        private JSONObject jsonFromHttpDataUnsafe(List<byte[]> data) throws IOException {
 
             SequenceInputStream collatedStream = ReplayUtils.byteArraysToInputStream(data);
             Scanner scanner = new Scanner(collatedStream, StandardCharsets.UTF_8);
@@ -53,6 +58,16 @@ public class SourceTargetCaptureTuple {
             return message;
         }
 
+        private JSONObject jsonFromHttpData(List<byte[]> data) {
+            try {
+                return jsonFromHttpDataUnsafe(data);
+            } catch (Exception e) {
+                log.warn("Putting what may be a bogus value in the output because transforming it " +
+                        "into json threw an exception");
+                return new JSONObject(Map.of("Exception", e.toString()));
+            }
+        }
+
         private JSONObject jsonFromHttpData(List<byte[]> data, Duration latency) throws IOException {
             JSONObject message = jsonFromHttpData(data);
             message.put("response_time_ms", latency.toMillis());
@@ -69,10 +84,6 @@ public class SourceTargetCaptureTuple {
                     triple.shadowResponseDuration));
 
             return meta;
-        }
-
-        public TupleToFileWriter(OutputStream outputStream){
-            this.outputStream = outputStream;
         }
 
         /**
@@ -112,8 +123,8 @@ public class SourceTargetCaptureTuple {
         public void writeJSON(SourceTargetCaptureTuple triple) throws IOException {
             JSONObject jsonObject = toJSONObject(triple);
 
-            outputStream.write(jsonObject.toString().getBytes(StandardCharsets.UTF_8));
-            outputStream.write("\n".getBytes(StandardCharsets.UTF_8));
+            log.warn("Writing json tuple to output stream");
+            outputStream.write((jsonObject.toString()+"\n").getBytes(StandardCharsets.UTF_8));
             outputStream.flush();
         }
     }

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/SourceTargetCaptureTuple.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/SourceTargetCaptureTuple.java
@@ -61,10 +61,10 @@ public class SourceTargetCaptureTuple {
 
         private JSONObject toJSONObject(SourceTargetCaptureTuple triple) throws IOException {
             JSONObject meta = new JSONObject();
-            meta.put("request", jsonFromHttpData(triple.sourcePair.requestData));
+            meta.put("request", jsonFromHttpData(triple.sourcePair.requestData.packetBytes));
             log.warn("TODO: These durations are not measuring the same values!");
-            meta.put("primaryResponse", jsonFromHttpData(triple.sourcePair.responseData,
-                    triple.sourcePair.getTotalResponseDuration()));
+            meta.put("primaryResponse", jsonFromHttpData(triple.sourcePair.responseData.packetBytes,
+                    triple.sourcePair.responseData.getTotalDuration()));
             meta.put("shadowResponse", jsonFromHttpData(triple.shadowResponseData,
                     triple.shadowResponseDuration));
 

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/NettyPacketToHttpHandler.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/NettyPacketToHttpHandler.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.time.Instant;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 
 @Log4j2
 public class NettyPacketToHttpHandler implements IPacketToHttpHandler {
@@ -36,7 +37,7 @@ public class NettyPacketToHttpHandler implements IPacketToHttpHandler {
                 .channel(NioSocketChannel.class)
                 .handler(new BacksideSnifferHandler(responseBuilder))
                 .option(ChannelOption.AUTO_READ, false);
-        log.trace("Active - setting up backend connection");
+        log.debug("Active - setting up backend connection");
         outboundChannelFuture = b.connect(serverUri.getHost(), serverUri.getPort());
         //outboundChannel = outboundChannelFuture.channel();
         responseWatchHandler = new BacksideHttpWatcherHandler(responseBuilder);
@@ -44,7 +45,7 @@ public class NettyPacketToHttpHandler implements IPacketToHttpHandler {
         outboundChannelFuture.addListener((ChannelFutureListener) future -> {
             if (future.isSuccess()) {
                 // connection complete start to read first data
-                log.trace("Done setting up backend channel & it was successful");
+                log.debug("Done setting up backend channel & it was successful");
                 var pipeline = future.channel().pipeline();
                 pipeline.addLast(new HttpResponseDecoder());
                 // TODO - switch this out to use less memory.
@@ -55,44 +56,72 @@ public class NettyPacketToHttpHandler implements IPacketToHttpHandler {
             } else {
                 // Close the connection if the connection attempt has failed.
                 log.error("closing outbound channel because CONNECT future was not successful");
+                log.error(future.cause());
             }
         });
     }
 
     @Override
     public CompletableFuture<Void> consumeBytes(ByteBuf packetData) {
-        log.trace("Writing packetData["+packetData+"]");
-        var completableFuture = new CompletableFuture<Void>();
+        log.debug("Scheduling write of packetData["+packetData+"]" +
+                " hash=" + System.identityHashCode(packetData));
+        final var completableFuture = new CompletableFuture<Void>();
         if (outboundChannelFuture.isDone()) {
             Channel channel = outboundChannelFuture.channel();
             if (!channel.isActive()) {
                 log.warn("Channel is not active - future packets for this connection will be dropped.");
                 log.warn("Need to do more sophisticated tracking of progress and retry further up the stack");
-                return null;
+                completableFuture.completeExceptionally(
+                        new RuntimeException("The outbound channel's future has completed but " +
+                                "the channel is not in an active state - dropping data"));
+                return completableFuture;
             }
-            log.trace("Writing data to backside handler");
+            log.trace("Writing data to backside handler and will return future = "+completableFuture);
             channel.writeAndFlush(packetData)
                     .addListener((ChannelFutureListener) future -> {
-                        if (future.isSuccess()) {
-                            log.trace("packet write was successful: "+packetData);
+                        Throwable cause = null;
+                        try {
+                            if (!future.isSuccess()) {
+                                log.warn("closing outbound channel because WRITE future was not successful " +
+                                        future.cause() + " hash=" + System.identityHashCode(packetData));
+                                future.channel().close(); // close the backside
+                                cause = future.cause();
+                            }
+                        } catch (Exception e) {
+                            cause = e;
+                        }
+                        if (cause == null) {
+                            log.debug("Signaling previously returned CompletableFuture packet write was successful: "
+                                    + packetData + " hash=" + System.identityHashCode(packetData));
                             completableFuture.complete(null);
                         } else {
-                            log.warn("closing outbound channel because WRITE future was not successful "+future.cause());
-                            future.channel().close(); // close the backside
-                            completableFuture.completeExceptionally(future.cause());
+                            log.trace("Signaling previously returned CompletableFuture packet write had an exception : "
+                                    + packetData + " hash=" + System.identityHashCode(packetData));
+                            completableFuture.completeExceptionally(cause);
                         }
                     });
         } else {
+            log.trace("Channel isn't ready yet for writes chaining a callback to the channel's future " +
+                    packetData + " hash=" + System.identityHashCode(packetData));
+            log.trace("deferred future being returned = "+completableFuture);
             outboundChannelFuture.addListener(f-> {
                     if (outboundChannelFuture.isSuccess()) {
+                        log.trace("outboundChannelFuture has finished - retriggering consumeBytes" +
+                                " hash=" + System.identityHashCode(packetData));
                         consumeBytes(packetData).whenComplete((x,t)-> {
-                            if (x != null) {
-                                completableFuture.complete(x);
-                            } else {
+                            if (t != null) {
+                                log.warn("inner consumeBytes has finished w/ exception t="+t +
+                                        " hash=" + System.identityHashCode(packetData));
                                 completableFuture.completeExceptionally(t);
+                            } else {
+                                log.trace("inner consumeBytes has finished w/ x="+x +
+                                        " hash=" + System.identityHashCode(packetData));
+                                completableFuture.complete(x);
                             }
                         });
                     } else {
+                        log.warn("outbound channel was not set up successfully, NOT writing bytes " +
+                                " hash=" + System.identityHashCode(packetData));
                         completableFuture.completeExceptionally(outboundChannelFuture.cause());
                     }
             });

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/http/NettyDecodedHttpRequestHandler.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/http/NettyDecodedHttpRequestHandler.java
@@ -55,7 +55,7 @@ public class NettyDecodedHttpRequestHandler extends ChannelInboundHandlerAdapter
                     statusWatcher.accept(HTTP_CONSUMPTION_STATUS.DONE);
                     // TODO - there might be a memory leak here.
                     // I'm not sure if I should be releasing the HttpRequest `msg`.
-                    log.warn("TODO - there might be a memory leak here.  " +
+                    log.info("TODO - there might be a memory leak here.  " +
                             "I'm not sure if I should be releasing the HttpRequest `msg`.");
                     pipelineOrchestrator.addBaselineHandlers(pipeline);
                     ctx.fireChannelRead(httpJsonMessage);

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/http/RequestPipelineOrchestrator.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/http/RequestPipelineOrchestrator.java
@@ -98,7 +98,7 @@ public class RequestPipelineOrchestrator {
         //  IN: ByteBufs(2) + HttpJsonMessage(4) with headers only + HttpContent(1) (if the repackaging handlers were skipped)
         // OUT: ByteBufs(3) which are sized similarly to how they were received
         pipeline.addLast(new NettyJsonToByteBufHandler(Collections.unmodifiableList(chunkSizes)));
-        pipeline.addLast(new LoggingHandler(LogLevel.INFO, ByteBufFormat.HEX_DUMP));
+        //pipeline.addLast(new LoggingHandler(LogLevel.INFO, ByteBufFormat.HEX_DUMP));
         // IN:  ByteBufs(3)
         // OUT: nothing - terminal!  ByteBufs are routed to the packet handler!
         pipeline.addLast(new NettySendByteBufsToPacketHandlerHandler(packetReceiver));

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/transform/JoltJsonTransformBuilder.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/transform/JoltJsonTransformBuilder.java
@@ -18,6 +18,7 @@ public class JoltJsonTransformBuilder {
     public enum CANNED_OPERATIONS {
         ADD_GZIP("addGzip"),
         MAKE_CHUNKED("makeChunked"),
+        ADD_ADMIN_AUTH("addAdminAuth"),
         PASS_THRU("passThru");
 
         private final String value;
@@ -38,6 +39,7 @@ public class JoltJsonTransformBuilder {
     static final TypeReference<LinkedHashMap<String, Object>> TYPE_REFERENCE_FOR_MAP_TYPE =
             new TypeReference<LinkedHashMap<String, Object>>(){};
     public static final String RESOURCE_HOST_SWITCH_OPERATION = "hostSwitch.jolt";
+    public static final String ADD_ADMIN_AUTH_OPERATION = "addAdminAuth.jolt";
     public static final String RESOURCE_PASS_THRU_OPERATION = "passThru.jolt";
 
     ObjectMapper mapper = new ObjectMapper();

--- a/TrafficCapture/trafficReplayer/src/main/resources/jolt/operations/addAdminAuth.jolt
+++ b/TrafficCapture/trafficReplayer/src/main/resources/jolt/operations/addAdminAuth.jolt
@@ -1,0 +1,8 @@
+{
+  "operation": "modify-overwrite-beta",
+  "spec": {
+    "headers": {
+      "Authorization": "Basic YWRtaW46YWRtaW4="
+    }
+  }
+}

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/HeaderTransformerTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/HeaderTransformerTest.java
@@ -85,7 +85,8 @@ public class HeaderTransformerTest {
                 contentLength -> "GET / HTTP/1.1\n" +
                         "HoSt: " + SOURCE_CLUSTER_NAME + "\n" +
                         "content-type: application/json\n" +
-                        "content-length: " + contentLength + "\n");
+                        "content-length: " + contentLength + "\n" +
+                        "Authorization: Basic YWRtaW46YWRtaW4=\n");
     }
 
     /**

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/TrafficReplayerTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/TrafficReplayerTest.java
@@ -102,7 +102,7 @@ class TrafficReplayerTest {
 
     @Test
     public void testReader() throws IOException, URISyntaxException, InterruptedException {
-        var tr = new TrafficReplayer(new URI("http://localhost:9200"));
+        var tr = new TrafficReplayer(new URI("http://localhost:9200"), false);
         List<List<byte[]>> byteArrays = new ArrayList<>();
         ReplayEngine re = new ReplayEngine(request -> {
             var bytesList = request.stream().collect(Collectors.toList());


### PR DESCRIPTION
### Description
Allow the TrafficReplayer to connect to an self-signed HTTPS target.  I've also updated the docker solution some more to facilitate more E2E traffic flow

### Testing
Manual testing with docker compose

### Check List
- [ ] New functionality includes testing
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
