### PR TITLE
Minor fixes may24

### DIFF
--- a/TrafficCapture/dockerSolution/src/main/docker/docker-compose.yml
+++ b/TrafficCapture/dockerSolution/src/main/docker/docker-compose.yml
@@ -64,7 +64,7 @@ services:
       - "10001:10001"
     depends_on:
       - opensearchtarget
-    command: /bin/sh -c "nc -v -l -p 10001 | /runJavaWithClasspath.sh org.opensearch.migrations.replay.TrafficReplayer https://opensearchtarget:9200 --auth-header-value \"Basic YWRtaW46YWRtaW4=\" --insecure"
+    command: /bin/sh -c "nc -v -l -p 10001 | /runJavaWithClasspath.sh org.opensearch.migrations.replay.TrafficReplayer https://opensearchtarget:9200 --auth-header-value Basic\\ YWRtaW46YWRtaW4= --insecure"
 
   opensearchtarget:
     image: 'opensearchproject/opensearch:latest'
@@ -76,7 +76,7 @@ services:
       - "29200:9200"
 
 #  traffic_comparator:
-#    image: ''
+#    image: 'migrations/opensearch_migrations_comparator:latest'
 
   opensearch-benchmarks:
     image: 'migrations/open_search_benchmark:latest'
@@ -100,6 +100,8 @@ volumes:
     driver: local
   kafka_data:
     driver: local
+  traffic_comparator:
+
 
 networks:
   migrations:

--- a/TrafficCapture/trafficCaptureProxyServer/build.gradle
+++ b/TrafficCapture/trafficCaptureProxyServer/build.gradle
@@ -18,29 +18,31 @@ dependencies {
     opensearchSecurityPlugin 'org.opensearch.plugin:opensearch-security:2.6.0.0'
     implementation files(zipTree("$configurations.opensearchSecurityPlugin.singleFile").matching {
         include "*.jar"
+        exclude "slf*.jar"
     })
-
-    implementation group: 'org.slf4j', name: 'slf4j-api', version: '2.0.7'
 
     implementation project(':captureOffloader')
     implementation project(':nettyWireLogging')
+    implementation project(':captureKafkaOffloader')
+
     implementation group: 'io.netty', name: 'netty-all', version: '4.1.89.Final'
-    implementation 'com.google.protobuf:protobuf-java:3.22.2'
     implementation 'org.opensearch:opensearch-common:2.6.0'
     implementation 'org.opensearch:opensearch-core:2.6.0'
     implementation 'org.opensearch:opensearch:2.6.0'
-    implementation group: 'com.beust', name: 'jcommander', version: '1.82'
-//    implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.20.0'
-//    implementation group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.20.0'
 
+    implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.20.0'
+    implementation group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.20.0'
+    implementation group: 'org.apache.logging.log4j', name: 'log4j-slf4j2-impl', version: '2.20.0'
+    implementation group: 'org.slf4j', name: 'slf4j-api', version: '2.0.7'
+
+    implementation group: 'com.beust', name: 'jcommander', version: '1.82'
+    implementation 'com.google.protobuf:protobuf-java:3.22.2'
 
     testImplementation project(':captureProtobufs')
     testImplementation 'com.google.protobuf:protobuf-java:3.22.2'
 
     testImplementation 'org.junit.jupiter:junit-jupiter:5.9.2'
     testImplementation "com.google.protobuf:protobuf-java:3.22.2"
-    implementation project(':captureOffloader')
-    implementation project(':captureKafkaOffloader')
 }
 
 tasks.withType(Tar){

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/TrafficReplayer.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/TrafficReplayer.java
@@ -47,6 +47,13 @@ public class TrafficReplayer {
     }
 
     public TrafficReplayer(URI serverUri, String authorizationHeader, boolean allowInsecureConnections)
+            throws SSLException {
+        this(serverUri, authorizationHeader, allowInsecureConnections, 
+                buildDefaultJsonTransformer(serverUri.getHost(), authorizationHeader));
+    }
+    
+    public TrafficReplayer(URI serverUri, String authorizationHeader, boolean allowInsecureConnections,
+                           JsonTransformer jsonTransformer)
             throws SSLException
     {
         if (serverUri.getPort() < 0) {
@@ -58,7 +65,6 @@ public class TrafficReplayer {
         if (serverUri.getScheme() == null) {
             throw new RuntimeException("Scheme (http|https) is not present for URI: "+serverUri);
         }
-        var jsonTransformer = buildDefaultJsonTransformer(serverUri.getHost(), authorizationHeader);
         packetHandlerFactory = new PacketToTransformingProxyHandlerFactory(serverUri, jsonTransformer,
                 loadSslContext(serverUri, allowInsecureConnections));
     }
@@ -113,6 +119,7 @@ public class TrafficReplayer {
             System.err.println(e.getMessage());
             System.err.println("Got args: "+ String.join("; ", args));
             jCommander.usage();
+            System.exit(2);
             return null;
         }
     }
@@ -126,7 +133,7 @@ public class TrafficReplayer {
         } catch (Exception e) {
             System.err.println("Exception parsing "+params.targetUriString);
             System.err.println(e.getMessage());
-            System.exit(2);
+            System.exit(3);
             return;
         }
 


### PR DESCRIPTION
### Description
Enable logging in the proxy server by striking slf4j jar files from the opensearch-security plugin zipfile from making it into the final build directory.  The proxy now exits after getting a parameter exception.  One of the command line args in the docker-compose config was off and it wasn't very noticeable - now it is...  and docker-compose has been updated too

### Issues Resolved
No Jira

### Testing
Manual testing

### Check List
- [ ] New functionality includes testing
  - [ ] All tests pass, including unit test
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
