### PR TITLE
Http json redrives

### DIFF
--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/AggregatedRawResponse.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/AggregatedRawResponse.java
@@ -1,17 +1,31 @@
 package org.opensearch.migrations.replay;
 
 
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.Setter;
+
 import java.io.Serializable;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.AbstractMap;
 import java.util.ArrayList;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 public class AggregatedRawResponse implements Serializable {
+
+    public enum HttpRequestTransformationStatus {
+        SKIPPED, COMPLETED, ERROR
+    }
+
     private final int responseSizeInBytes;
     private final Duration responseDuration;
     private final ArrayList<AbstractMap.SimpleEntry<Instant, byte[]>> responsePackets;
+
+    @Getter
+    @Setter
+    private HttpRequestTransformationStatus transformationStatus;
 
     public static Builder builder(Instant i) {
         return new Builder(i);
@@ -25,25 +39,42 @@ public class AggregatedRawResponse implements Serializable {
             receiptTimeAndResponsePackets = new ArrayList<>();
             this.requestSendTime = requestSendTime;
         }
+
         public AggregatedRawResponse build() {
             var totalBytes = receiptTimeAndResponsePackets.stream().mapToInt(kvp->kvp.getValue().length).sum();
             return new AggregatedRawResponse(totalBytes, Duration.between(requestSendTime, Instant.now()),
                     receiptTimeAndResponsePackets);
         }
 
-        public void addPacket(byte[] packet) {
-            addPacket(packet, Instant.now());
+        public AggregatedRawResponse.Builder addPacket(byte[] packet) {
+            return addPacket(packet, Instant.now());
         }
 
-        public void addPacket(byte[] packet, Instant timestamp) {
+        public AggregatedRawResponse.Builder addPacket(byte[] packet, Instant timestamp) {
             receiptTimeAndResponsePackets.add(new AbstractMap.SimpleEntry<>(timestamp, packet));
+            return this;
         }
     }
 
-    public AggregatedRawResponse(int responseSizeInBytes, Duration responseDuration, ArrayList<AbstractMap.SimpleEntry<Instant, byte[]>> packets) {
+    public AggregatedRawResponse(int responseSizeInBytes, Duration responseDuration,
+                                 ArrayList<AbstractMap.SimpleEntry<Instant, byte[]>> packets) {
+        this(responseSizeInBytes, responseDuration, packets, HttpRequestTransformationStatus.SKIPPED);
+    }
+
+    public AggregatedRawResponse(int responseSizeInBytes, Duration responseDuration,
+                                 ArrayList<AbstractMap.SimpleEntry<Instant, byte[]>> packets,
+                                 HttpRequestTransformationStatus requestTransformationStatus) {
         this.responseSizeInBytes = responseSizeInBytes;
         this.responseDuration = responseDuration;
         this.responsePackets = packets;
+        this.transformationStatus = requestTransformationStatus;
+    }
+
+    public static AggregatedRawResponse addStatusIfPresent(AggregatedRawResponse existing,
+                                                           HttpRequestTransformationStatus status) {
+        return Optional.ofNullable(existing).map(o->
+                new AggregatedRawResponse(o.responseSizeInBytes, o.responseDuration, o.responsePackets, status))
+                .orElse(null);
     }
 
     int getResponseSizeInBytes() {
@@ -61,7 +92,8 @@ public class AggregatedRawResponse implements Serializable {
         final StringBuilder sb = new StringBuilder("IResponseSummary{");
         sb.append("responseSizeInBytes=").append(responseSizeInBytes);
         sb.append(", responseDuration=").append(responseDuration);
-        sb.append(", # of responsePackets=").append(""+this.responsePackets.size());
+        sb.append(", # of responsePackets=").append(""+
+                (this.responsePackets==null ? "-1" : "" + this.responsePackets.size()));
         sb.append('}');
         return sb.toString();
     }

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/PacketToTransformingProxyHandlerFactory.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/PacketToTransformingProxyHandlerFactory.java
@@ -28,7 +28,7 @@ public class PacketToTransformingProxyHandlerFactory {
         return new NettyPacketToHttpHandler(eventLoopGroup, serverUri, sslContext);
     }
 
-    public IPacketToHttpHandler create() {
+    public HttpJsonTransformer create() {
         return new HttpJsonTransformer(jsonTransformer, createNettyHandler());
     }
 

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/TrafficReplayer.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/TrafficReplayer.java
@@ -128,6 +128,7 @@ public class TrafficReplayer {
         var params = parseArgs(args);
         URI uri;
         System.err.println("Starting Traffic Replayer");
+        System.err.println("Got args: "+ String.join("; ", args));
         try {
             uri = new URI(params.targetUriString);
         } catch (Exception e) {

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/Utils.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/Utils.java
@@ -1,0 +1,19 @@
+package org.opensearch.migrations.replay;
+
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.stream.Collector;
+import java.util.stream.Collectors;
+
+public class Utils {
+    public static <A, B> Collector<A, ?, B>
+    foldLeft(final B seedValue, final BiFunction<? super B, ? super A, ? extends B> f) {
+        return Collectors.collectingAndThen(
+                Collectors.reducing(
+                        Function.<B>identity(),
+                        a -> b -> f.apply(b, a),
+                        Function::andThen),
+                finisherArg -> finisherArg.apply(seedValue)
+        );
+    }
+}

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/NettyPacketToHttpHandler.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/NettyPacketToHttpHandler.java
@@ -37,8 +37,10 @@ public class NettyPacketToHttpHandler implements IPacketToHttpHandler {
                 .channel(NioSocketChannel.class)
                 .handler(new BacksideSnifferHandler(responseBuilder))
                 .option(ChannelOption.AUTO_READ, false);
-        log.debug("Active - setting up backend connection");
-        outboundChannelFuture = b.connect(serverUri.getHost(), serverUri.getPort());
+        String host = serverUri.getHost();
+        int port = serverUri.getPort();
+        log.debug("Active - setting up backend connection to " + host + ":" + port);
+        outboundChannelFuture = b.connect(host, port);
         //outboundChannel = outboundChannelFuture.channel();
         responseWatchHandler = new BacksideHttpWatcherHandler(responseBuilder);
 
@@ -135,7 +137,8 @@ public class NettyPacketToHttpHandler implements IPacketToHttpHandler {
     }
 
     @Override
-    public CompletableFuture<AggregatedRawResponse> finalizeRequest() {
+    public CompletableFuture<AggregatedRawResponse>
+    finalizeRequest() {
         var future = new CompletableFuture();
         responseWatchHandler.addCallback(arr -> future.complete(arr));
         return future;

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/http/HttpJsonTransformer.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/http/HttpJsonTransformer.java
@@ -4,16 +4,40 @@ import io.netty.buffer.ByteBuf;
 import io.netty.channel.embedded.EmbeddedChannel;
 import lombok.extern.slf4j.Slf4j;
 import org.opensearch.migrations.replay.AggregatedRawResponse;
+import org.opensearch.migrations.replay.Utils;
 import org.opensearch.migrations.replay.datahandlers.IPacketToHttpHandler;
 import org.opensearch.migrations.transform.JsonTransformer;
 
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.function.Function;
 
+/**
+ * This class implements a packet consuming interface by using an EmbeddedChannel to write individual
+ * packets through handlers that will parse the request's HTTP headers, determine what may need to
+ * be done with the message, and continue to parse/handle/serialize the contents according to the
+ * transformation and the headers present (such as for gzipped or chunked encodings).
+ *
+ * There will be a number of reasons that we need to reuse the source captured packets - both today
+ * (for the output to the comparator) and in the future (for retrying transient network errors or
+ * transformation errors).  With that in mind, the HttpJsonTransformer now keeps track of all of
+ * the ByteBufs passed into it and can redrive them through the underlying network packet handler.
+ * Cases where that would happen with this edit are where the payload wasn't being modified, nor
+ * were the headers changed.  In those cases, the entire pipeline gets removed and the "baseline"
+ * ones never get activated.  This class detects that the baseline (NettySendByteBufsToPacketHandlerHandler)
+ * never processed data and will re-run the messages that it already had accumulated.
+ *
+ * A bigger question will be how to deal with network errors, where some packets have been sent to
+ * the network.  If a partial response comes back, should that be reported to the user?  What if the
+ * error was due to transformation, how would we be able to tell?
+ */
 @Slf4j
 public class HttpJsonTransformer implements IPacketToHttpHandler {
+    private final RequestPipelineOrchestrator pipelineOrchestrator;
     private final EmbeddedChannel channel;
     /**
      * Roughly try to keep track of how big each data chunk was that came into the transformer.  These values
@@ -21,40 +45,66 @@ public class HttpJsonTransformer implements IPacketToHttpHandler {
      * Divide the chunk tracking into headers (index=0) and payload (index=1).
      */
     private final List<List<Integer>> chunkSizes;
-
-    HTTP_CONSUMPTION_STATUS handlerStatus;
+    // This is here for recovery, in case anything goes wrong with a transformation & we want to
+    // just dump it directly.  Notice that we're already storing all of the bytes until the response
+    // comes back so that we can format the output that goes to the comparator.  These should be
+    // backed by the exact same byte[] arrays, so the memory consumption should already be absorbed.
+    private final List<ByteBuf> chunks;
 
     public HttpJsonTransformer(JsonTransformer transformer, IPacketToHttpHandler transformedPacketReceiver) {
         chunkSizes = new ArrayList<>(2);
         chunkSizes.add(new ArrayList<>(4));
+        chunks = new ArrayList<>(64);
         channel = new EmbeddedChannel();
-        var pipelineOrchestrator = new RequestPipelineOrchestrator(chunkSizes, transformedPacketReceiver);
-        pipelineOrchestrator.addInitialHandlers(channel.pipeline(), transformer,  s -> {handlerStatus = s;});
+        pipelineOrchestrator = new RequestPipelineOrchestrator(chunkSizes, transformedPacketReceiver);
+        pipelineOrchestrator.addInitialHandlers(channel.pipeline(), transformer);
     }
 
-    private NettySendByteBufsToPacketHandlerHandler getEndOfConsumptionHandler() {
-        var last = channel.pipeline().last();
-        return (NettySendByteBufsToPacketHandlerHandler) last;
+    private NettySendByteBufsToPacketHandlerHandler getOffloadingHandler() {
+        return Optional.ofNullable(channel).map(c -> (NettySendByteBufsToPacketHandlerHandler) c.pipeline()
+                        .get(RequestPipelineOrchestrator.OFFLOADING_HANDLER_NAME))
+                .orElse(null);
     }
 
     public CompletableFuture<Void> consumeBytes(ByteBuf nextRequestPacket) {
-        chunkSizes.get(chunkSizes.size()-1).add(nextRequestPacket.readableBytes());
+        chunks.add(nextRequestPacket.duplicate().readerIndex(0).retain());
+        chunkSizes.get(chunkSizes.size() - 1).add(nextRequestPacket.readableBytes());
         if (log.isDebugEnabled()) {
             byte[] copy = new byte[nextRequestPacket.readableBytes()];
             nextRequestPacket.duplicate().readBytes(copy);
             log.debug("Writing into embedded channel: " + new String(copy, StandardCharsets.UTF_8));
         }
-        return CompletableFuture.completedFuture(null).thenAccept(x->
-            channel.writeInbound(nextRequestPacket));
+        return CompletableFuture.completedFuture(null).thenAccept(x ->
+                channel.writeInbound(nextRequestPacket));
     }
 
-    @Override
     public CompletableFuture<AggregatedRawResponse> finalizeRequest() {
-        var consumerHandler = getEndOfConsumptionHandler();
+        var offloadingHandler = getOffloadingHandler();
         channel.close();
-        if (handlerStatus != HTTP_CONSUMPTION_STATUS.DONE) {
-            return CompletableFuture.failedFuture(new MalformedRequestException());
+        if (offloadingHandler == null) {
+            // the NettyDecodedHttpRequestHandler gave up and didn't bother installing the baseline handlers -
+            // redrive the chunks
+            return redriveWithoutTransformation(pipelineOrchestrator.packetReceiver);
         }
-        return consumerHandler.packetReceiverCompletionFuture;
+        return offloadingHandler.getPacketReceiverCompletionFuture()
+                .handle((v, t) -> {
+                    if (t != null) {
+                        if (t instanceof NoContentException) {
+                            return redriveWithoutTransformation(offloadingHandler.packetReceiver);
+                        } else {
+                            throw new CompletionException(t);
+                        }
+                    } else {
+                        return CompletableFuture.completedFuture(v);
+                    }
+                }).thenCompose(Function.identity());
+    }
+
+    private CompletableFuture<AggregatedRawResponse> redriveWithoutTransformation(IPacketToHttpHandler packetConsumer) {
+        CompletableFuture<Void> consumptionChainedFuture =
+                chunks.stream().collect(
+                        Utils.foldLeft(CompletableFuture.completedFuture(null),
+                                (cf, bb) -> cf.thenCompose(v -> packetConsumer.consumeBytes(bb))));
+        return consumptionChainedFuture.thenCompose(v -> packetConsumer.finalizeRequest());
     }
 }

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/http/NettyDecodedHttpRequestHandler.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/http/NettyDecodedHttpRequestHandler.java
@@ -2,10 +2,10 @@ package org.opensearch.migrations.replay.datahandlers.http;
 
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.ChannelPipeline;
 import io.netty.handler.codec.DecoderException;
 import io.netty.handler.codec.http.HttpContent;
 import io.netty.handler.codec.http.HttpRequest;
-import io.netty.handler.codec.http.LastHttpContent;
 import lombok.extern.slf4j.Slf4j;
 import org.opensearch.migrations.replay.datahandlers.IPacketToHttpHandler;
 import org.opensearch.migrations.replay.datahandlers.PayloadFaultMap;
@@ -15,7 +15,6 @@ import org.opensearch.migrations.transform.JsonTransformer;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -28,57 +27,77 @@ public class NettyDecodedHttpRequestHandler extends ChannelInboundHandlerAdapter
     final IPacketToHttpHandler packetReceiver;
     final JsonTransformer transformer;
     final List<List<Integer>> chunkSizes;
-    //HttpJsonMessageWithFaultablePayload httpJsonMessage;
-    Consumer<HTTP_CONSUMPTION_STATUS> statusWatcher;
 
     public NettyDecodedHttpRequestHandler(JsonTransformer transformer, List<List<Integer>> chunkSizes,
-                                          IPacketToHttpHandler packetReceiver,
-                                          Consumer<HTTP_CONSUMPTION_STATUS> statusWatcher) {
+                                          IPacketToHttpHandler packetReceiver) {
         this.packetReceiver = packetReceiver;
         this.transformer = transformer;
         this.chunkSizes = chunkSizes;
-        this.statusWatcher = statusWatcher;
     }
 
     @Override
     public void channelRead(ChannelHandlerContext ctx, Object msg) {
         if (msg instanceof HttpRequest) {
+            // TODO - this is super ugly and sloppy - this has to be improved
             chunkSizes.add(new ArrayList<>(32));
             var request = (HttpRequest) msg;
             var httpJsonMessage = parseHeadersIntoMessage(request);
             var pipelineOrchestrator = new RequestPipelineOrchestrator(chunkSizes, packetReceiver);
             var pipeline = ctx.pipeline();
             try {
-                transformer.transformJson(httpJsonMessage);
-                if (headerFieldIsIdentical("content-encoding", request, httpJsonMessage) &&
-                        headerFieldIsIdentical("transfer-encoding", request, httpJsonMessage)) {
-                    statusWatcher.accept(HTTP_CONSUMPTION_STATUS.DONE);
-                    // TODO - there might be a memory leak here.
-                    // I'm not sure if I should be releasing the HttpRequest `msg`.
-                    log.info("TODO - there might be a memory leak here.  " +
-                            "I'm not sure if I should be releasing the HttpRequest `msg`.");
-                    pipelineOrchestrator.addBaselineHandlers(pipeline);
-                    ctx.fireChannelRead(httpJsonMessage);
-                    pipelineOrchestrator.removeThisAndPreviousHandlers(pipeline, this);
-                    return;
-                } else {
-                    pipelineOrchestrator.addContentRepackingHandlers(pipeline);
-                }
+                handlePayloadNeutralTransformation(ctx, request, httpJsonMessage, pipelineOrchestrator);
             } catch (PayloadNotLoadedException pnle) {
+                log.debug("The transforms for this message require payload manipulation, " +
+                        "all content handlers are being loaded.");
                 // make a fresh message and its headers
                 httpJsonMessage = parseHeadersIntoMessage(request);
                 pipelineOrchestrator.addJsonParsingHandlers(pipeline, transformer);
+                ctx.fireChannelRead(httpJsonMessage);
             }
-            // send both!  We'll allow some built-in netty http handlers to do their thing & then
-            // reunify any additions with our headers model before serializing
-            ctx.fireChannelRead(request);
-            ctx.fireChannelRead(httpJsonMessage);
         } else if (msg instanceof HttpContent) {
-            if (msg instanceof LastHttpContent) {
-                statusWatcher.accept(HTTP_CONSUMPTION_STATUS.DONE);
-            }
             ctx.fireChannelRead(msg);
         }
+    }
+
+    private void handlePayloadNeutralTransformation(ChannelHandlerContext ctx,
+                                                    HttpRequest request,
+                                                    HttpJsonMessageWithFaultablePayload httpJsonMessage,
+                                                    RequestPipelineOrchestrator pipelineOrchestrator)
+            throws PayloadNotLoadedException
+    {
+        var pipeline = ctx.pipeline();
+        transformer.transformJson(httpJsonMessage);
+        if (headerFieldsAreIdentical(request, httpJsonMessage)) {
+            log.info("Transformation isn't necessary.  " +
+                    "Clearing pipeline to let the parent context redrive directly.");
+            while (pipeline.first() != null) {
+                pipeline.removeFirst();
+            }
+        } else if (headerFieldIsIdentical("content-encoding", request, httpJsonMessage) &&
+                headerFieldIsIdentical("transfer-encoding", request, httpJsonMessage)) {
+            log.info("There were changes to the headers that will be reformatted through this pipeline, " +
+                    "but the content (payload) doesn't need to be transformed.  Content Handlers are not " +
+                    "being added to the pipeline");
+            pipelineOrchestrator.addBaselineHandlers(pipeline);
+            ctx.fireChannelRead(httpJsonMessage);
+            pipelineOrchestrator.removeThisAndPreviousHandlers(pipeline, this);
+        } else {
+            pipelineOrchestrator.addContentRepackingHandlers(pipeline);
+            ctx.fireChannelRead(httpJsonMessage);
+        }
+    }
+
+    private boolean headerFieldsAreIdentical(HttpRequest request, HttpJsonMessageWithFaultablePayload httpJsonMessage) {
+        if (!request.uri().equals(httpJsonMessage.uri()) ||
+                !request.method().toString().equals(httpJsonMessage.method())) {
+            return false;
+        }
+        for (var headerName : httpJsonMessage.headers().keySet()) {
+            if (!headerFieldIsIdentical(headerName, request, httpJsonMessage)) {
+                return false;
+            }
+        }
+        return true;
     }
 
     @Override

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/http/NettyJsonBodyAccumulateHandler.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/http/NettyJsonBodyAccumulateHandler.java
@@ -2,7 +2,9 @@ package org.opensearch.migrations.replay.datahandlers.http;
 
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.handler.codec.http.DefaultLastHttpContent;
 import io.netty.handler.codec.http.HttpContent;
+import io.netty.handler.codec.http.LastHttpContent;
 import lombok.SneakyThrows;
 import org.opensearch.migrations.replay.datahandlers.JsonAccumulator;
 import org.opensearch.migrations.replay.datahandlers.PayloadFaultMap;

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/http/NettyJsonContentCompressor.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/http/NettyJsonContentCompressor.java
@@ -77,7 +77,7 @@ public class NettyJsonContentCompressor extends ChannelInboundHandlerAdapter {
                 contentBuf.readBytes(compressorStream, contentBuf.readableBytes());
                 if (msg instanceof LastHttpContent) {
                     closeStream();
-                    ctx.fireChannelRead(msg);
+                    ctx.fireChannelRead(DefaultLastHttpContent.EMPTY_LAST_CONTENT);
                 }
                 return; // fireChannelRead will be fired on the compressed contents via the compressorStream.
             } else {

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/http/NettyJsonContentStreamToByteBufHandler.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/http/NettyJsonContentStreamToByteBufHandler.java
@@ -6,10 +6,12 @@ import io.netty.buffer.CompositeByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.handler.codec.http.DefaultLastHttpContent;
 import io.netty.handler.codec.http.HttpContent;
 import io.netty.handler.codec.http.LastHttpContent;
 
 import java.nio.charset.StandardCharsets;
+import java.util.function.Consumer;
 
 public class NettyJsonContentStreamToByteBufHandler extends ChannelInboundHandlerAdapter {
     private static final String TRANSFER_ENCODING_CHUNKED_VALUE = "chunked";
@@ -77,6 +79,7 @@ public class NettyJsonContentStreamToByteBufHandler extends ChannelInboundHandle
         // make this a singleton
         var lastChunkByteBuf = Unpooled.wrappedBuffer("0\r\n\r\n".getBytes(StandardCharsets.UTF_8));
         ctx.fireChannelRead(lastChunkByteBuf);
+        ctx.fireChannelRead(DefaultLastHttpContent.EMPTY_LAST_CONTENT);
     }
 
     private void finalizeFixedContentStream(ChannelHandlerContext ctx) {
@@ -84,7 +87,6 @@ public class NettyJsonContentStreamToByteBufHandler extends ChannelInboundHandle
         ctx.fireChannelRead(bufferedJsonMessage);
         bufferedJsonMessage = null;
         ctx.fireChannelRead(bufferedContents);
+        ctx.fireChannelRead(DefaultLastHttpContent.EMPTY_LAST_CONTENT);
     }
-
-
 }

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/http/NettyJsonToByteBufHandler.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/http/NettyJsonToByteBufHandler.java
@@ -24,8 +24,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 @Slf4j
 public class NettyJsonToByteBufHandler extends ChannelInboundHandlerAdapter {
-    public static final int MAX_CHUNK_SIZE = 1024 * 1024;
-    //private final HttpJsonTransformerHandler httpJsonTransformerHandler;
     List<List<Integer>> sharedInProgressChunkSizes;
     ByteBuf inProgressByteBuf;
     int payloadBufferIndex;
@@ -46,6 +44,7 @@ public class NettyJsonToByteBufHandler extends ChannelInboundHandlerAdapter {
                 ctx.fireChannelRead(inProgressByteBuf);
                 inProgressByteBuf = null;
                 ++payloadBufferIndex;
+                ctx.fireChannelRead(LastHttpContent.EMPTY_LAST_CONTENT);
             }
         } else {
             super.channelRead(ctx, msg);

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/http/NoContentException.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/http/NoContentException.java
@@ -1,0 +1,4 @@
+package org.opensearch.migrations.replay.datahandlers.http;
+
+public class NoContentException extends Exception {
+}

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/AddCompressionEncodingTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/AddCompressionEncodingTest.java
@@ -7,7 +7,6 @@ import org.junit.jupiter.api.Test;
 import org.opensearch.migrations.replay.datahandlers.http.HttpJsonTransformer;
 import org.opensearch.migrations.transform.JoltJsonTransformBuilder;
 import org.opensearch.migrations.transform.JoltJsonTransformer;
-import org.opensearch.migrations.transform.JsonTransformer;
 
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
@@ -29,7 +28,8 @@ public class AddCompressionEncodingTest {
     public void addingCompressionRequestHeaderCompressesPayload() throws ExecutionException, InterruptedException, IOException {
         ResourceLeakDetector.setLevel(ResourceLeakDetector.Level.PARANOID);
 
-        final var dummyAggregatedResponse = new AggregatedRawResponse(17, null, null);
+        final var dummyAggregatedResponse = new AggregatedRawResponse(17, null,
+                null, AggregatedRawResponse.HttpRequestTransformationStatus.COMPLETED);
         var testPacketCapture = new TestCapturePacketToHttpHandler(Duration.ofMillis(100), dummyAggregatedResponse);
         var compressingTransformer = new HttpJsonTransformer(
                 JoltJsonTransformer.newBuilder()

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/HeaderTransformerTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/HeaderTransformerTest.java
@@ -26,7 +26,8 @@ public class HeaderTransformerTest {
     @Test
     public void testTransformer() throws Exception {
         // mock object.  values don't matter at all - not what we're testing
-        final var dummyAggregatedResponse = new AggregatedRawResponse(17, null, null);
+        final var dummyAggregatedResponse = new AggregatedRawResponse(17, null,
+                null, AggregatedRawResponse.HttpRequestTransformationStatus.COMPLETED);
         var testPacketCapture = new TestCapturePacketToHttpHandler(Duration.ofMillis(100), dummyAggregatedResponse);
         var jsonHandler = JoltJsonTransformer.newBuilder()
                 .addHostSwitchOperation(SILLY_TARGET_CLUSTER_NAME)
@@ -76,7 +77,8 @@ public class HeaderTransformerTest {
     public void testMalformedPayloadIsPassedThrough() throws Exception {
         var referenceStringBuilder = new StringBuilder();
         // mock object.  values don't matter at all - not what we're testing
-        final var dummyAggregatedResponse = new AggregatedRawResponse(12, null, null);
+        final var dummyAggregatedResponse = new AggregatedRawResponse(12, null,
+                null, AggregatedRawResponse.HttpRequestTransformationStatus.COMPLETED);
         var testPacketCapture = new TestCapturePacketToHttpHandler(Duration.ofMillis(100), dummyAggregatedResponse);
         var transformingHandler = new HttpJsonTransformer(
                 TrafficReplayer.buildDefaultJsonTransformer(SILLY_TARGET_CLUSTER_NAME, "Basic YWRtaW46YWRtaW4="),  testPacketCapture);
@@ -98,7 +100,8 @@ public class HeaderTransformerTest {
     public void testMalformedPayload_andTypeMappingUri_IsPassedThrough() throws Exception {
         var referenceStringBuilder = new StringBuilder();
         // mock object.  values don't matter at all - not what we're testing
-        final var dummyAggregatedResponse = new AggregatedRawResponse(12, null, null);
+        final var dummyAggregatedResponse = new AggregatedRawResponse(12, null,
+                null, AggregatedRawResponse.HttpRequestTransformationStatus.COMPLETED);
         var testPacketCapture = new TestCapturePacketToHttpHandler(Duration.ofMillis(100), dummyAggregatedResponse);
         var transformingHandler = new HttpJsonTransformer(
 

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/TestCapturePacketToHttpHandler.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/TestCapturePacketToHttpHandler.java
@@ -14,7 +14,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicInteger;
 
 @Slf4j
-class TestCapturePacketToHttpHandler implements IPacketToHttpHandler {
+public class TestCapturePacketToHttpHandler implements IPacketToHttpHandler {
     private final Duration consumeDuration;
     private final AtomicInteger numFinalizations;
     @Getter

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/TestUtils.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/TestUtils.java
@@ -31,12 +31,6 @@ import java.util.stream.Collectors;
 
 @Slf4j
 public class TestUtils {
-    public static <A, B> Collector<A, ?, B> foldLeft(final B init, final BiFunction<? super B, ? super A, ? extends B> f) {
-        return Collectors.collectingAndThen(
-                Collectors.reducing(Function.<B>identity(), a -> b -> f.apply(b, a), Function::andThen),
-                finisherArg -> finisherArg.apply(init)
-        );
-    }
 
     static String resolveReferenceString(StringBuilder referenceStringBuilder) {
         return resolveReferenceString(referenceStringBuilder, List.of());
@@ -70,7 +64,7 @@ public class TestUtils {
                                                                                StringBuilder referenceStringAccumulator,
                                                                                String headers) {
         return stringParts.stream().collect(
-                foldLeft(packetConsumer.consumeBytes(headers.getBytes(StandardCharsets.UTF_8)),
+                Utils.foldLeft(packetConsumer.consumeBytes(headers.getBytes(StandardCharsets.UTF_8)),
                         (cf, s) -> cf.thenCompose(v -> writeStringToBoth(s, referenceStringAccumulator, packetConsumer))));
     }
 

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/UtilsTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/UtilsTest.java
@@ -1,0 +1,29 @@
+package org.opensearch.migrations.replay;
+
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Slf4j
+class UtilsTest {
+    @Test
+    public void testFoldLeft() {
+        var groundTruth =
+                IntStream.range('A','F')
+                        .mapToObj(c->(char)c+"")
+                        .collect(Collectors.joining());
+
+        var foldedValue =
+                IntStream.range('A','F').mapToObj(c->(char)c+"").collect(Utils.foldLeft("", (a,b) -> a+b));
+
+        log.info("stream concatenated value: " + foldedValue);
+        Assertions.assertEquals(groundTruth, foldedValue);
+
+    }
+}

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/datahandlers/http/HttpJsonTransformerTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/datahandlers/http/HttpJsonTransformerTest.java
@@ -1,0 +1,34 @@
+package org.opensearch.migrations.replay.datahandlers.http;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.opensearch.migrations.replay.AggregatedRawResponse;
+import org.opensearch.migrations.replay.TestCapturePacketToHttpHandler;
+import org.opensearch.migrations.replay.TestUtils;
+import org.opensearch.migrations.transform.JoltJsonTransformer;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.concurrent.ExecutionException;
+
+class HttpJsonTransformerTest {
+    @Test
+    public void testPassThroughSinglePacketPost() throws Exception {
+        final var dummyAggregatedResponse = new AggregatedRawResponse(17, null, null);
+        var testPacketCapture = new TestCapturePacketToHttpHandler(Duration.ofMillis(100), dummyAggregatedResponse);
+        var transformingHandler = new HttpJsonTransformer(JoltJsonTransformer.newBuilder().build(), testPacketCapture);
+        byte[] testBytes;
+        try (var sampleStream = HttpJsonTransformer.class.getResourceAsStream(
+                "/requests/raw/post_formUrlEncoded_withFixedLength.txt")) {
+            testBytes = sampleStream.readAllBytes();
+        }
+        transformingHandler.consumeBytes(testBytes);
+        var returnedResponse = transformingHandler.finalizeRequest().get();
+        Assertions.assertEquals(new String(testBytes, StandardCharsets.UTF_8),
+                testPacketCapture.getCapturedAsString());
+        Assertions.assertArrayEquals(testBytes, testPacketCapture.getBytesCaptured());
+        Assertions.assertEquals(AggregatedRawResponse.HttpRequestTransformationStatus.SKIPPED,
+                returnedResponse.getTransformationStatus());
+    }
+}

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/transform/JsonTransformerTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/transform/JsonTransformerTest.java
@@ -14,7 +14,6 @@ import java.util.Map;
 @Slf4j
 class JsonTransformerTest {
     public static final String DUMMY_HOSTNAME_TEST_STRING = "THIS_IS_A_TEST_STRING_THAT_ONLY_EXISTS_IN_ONE_PLACE";
-    public static final String RESOURCE_DECREASE_SHARDS_OPERATION = "decreaseShards.jolt";
     ObjectMapper mapper = new ObjectMapper();
 
     public JsonTransformerTest() {
@@ -52,12 +51,6 @@ class JsonTransformerTest {
         Assertions.assertEquals(TEST_DOCUMENT, finalOutputStr);
     }
 
-
-    private static String chainSpecs(String... specs) {
-        var joinedSpecs = String.join(",", specs);
-        return "{\"spec\": ["+joinedSpecs+"]}";
-    }
-
     @Test
     public void testHttpTransform() throws IOException {
         var testResourceName = "parsed/post_formUrlEncoded_withFixedLength.json";
@@ -69,33 +62,6 @@ class JsonTransformerTest {
         String transformedJsonOutputStr = emitOrderedJson(transformedDocument);
         log.error("transformed json document: "+transformedJsonOutputStr);
         Assertions.assertTrue(transformedJsonOutputStr.contains(DUMMY_HOSTNAME_TEST_STRING));
-
-//        var checkit = HTTP.toJSONObject("" +
-//                "POST /test HTTP/1.1\n"+
-//                "Host: foo.example\n" +
-//                "Content-Type: application/x-www-form-urlencoded\n" +
-//                "Content-Length: 27");
-        //var parsedTransformedHeaders = HTTP.toJSONObject(transformedJsonOutputStr);
-        //Map<String, Object> transformedHeaders = (Map<String, Object>) parsedTransformedHeaders.get("headers");
-        //Assertions.assertEquals("testcluster.org", transformedHeaders.get("Host"));
-
-        //transformedHeaders.put("Host", "sourcecluster.org");
-        //Assertions.assertEquals(parseSampleRequestFromResource(testResourceName).toString(), transformedHeaders.toString());
     }
 
-//    @Test
-//    public void testThatLazyPayloadsAreLazy() throws IOException {
-//        Map<String, Object> jsonRequest;
-//        var httpParser = new HttpJsonTransformer();
-//        try (var is = getClass().getResourceAsStream("/requests/raw/post_formUrlEncoded_withFixedLength.txt")) {
-//            httpParser.acceptRawRequestBytes(is.readAllBytes());
-//        }
-//        jsonRequest = httpParser.asJsonDocument();
-//        //var payloadJson = ((Map)jsonRequest.get("payload")).get("inlinedJsonBody");
-//        var transformer = JsonTransformer.newBuilder()
-//                .addHostSwitchOperation(DUMMY_HOSTNAME_TEST_STRING)
-//                .build();
-//        var transformedDocument = transformer.transformJson(jsonRequest);
-//        log.error(transformedDocument.toString());
-//    }
 }


### PR DESCRIPTION
### Description
The HttpJsonTransformer builds up a netty pipeline on an EmbeddedChannel.  Early in the process (after NettyDecodedHttpRequestHandler receives the parsed header), it might be determined that the incoming HTTP message doesn't need any kind of transformation.  At that point, previously all of the subsequent handlers were removed and we attempted to just pass the raw packets directly through.

This was problematic for messages that had bodies in the same ByteBuf as headers.  That meant that some of the contents were being processed still by the previous handler, which hadn't yet fired them through the pipeline.  When the handler was removed, the extra parsed bytes/HttpContent/etc were dropped and we picked up on the last packet boundary NOT consumed by the handlers.

This code attempts to give us a better way to back out of the transformation code and send the original packets exactly as we received them to the target.  There are other reasons that we might need to back off of the netty pipeline too - like if the request was completely garbled (it isn't a fair performance test if there's a DOS attack & we filter the attack away).

To support all of those cases, the HttpJsonTransformer now preserves all of the original incoming bytes for its lifetime.  If processing yields a NoContentException or we haven't finished running all of the data through the pipeline after we've flushed it, the pipeline is abandoned and we send the packets directly using the new `redriveWithoutTransformation` method.  To show the status of message processing, that is now included in the AggregateRawResponse - though we don't do much with it yet.

### Issues Resolved
No Jira

### Testing
Manual testing and new unit tests

### Check List
- [x] New functionality includes testing
  - [x] All tests pass, including unit test
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
