### PR TITLE
Add medium and large tests to the JsonAccumulator using the new random tree code

### DIFF
--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/PruferTreeGenerator.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/PruferTreeGenerator.java
@@ -4,15 +4,12 @@ import lombok.Builder;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 
-import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.PriorityQueue;
-import java.util.Random;
-import java.util.Stack;
 import java.util.TreeMap;
 import java.util.function.Function;
 import java.util.function.IntFunction;
@@ -21,7 +18,7 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 /**
- * See https://en.wikipedia.org/wiki/Pr%C3%BCfer_sequence.
+ * See https://en.wikipedia.org/wiki/Prufer_sequence
  * @param <T>
  */
 @Slf4j
@@ -49,33 +46,6 @@ public class PruferTreeGenerator<T> {
     public interface Visitor<T> {
         void pushTreeNode(SimpleNode<T> node);
         void popTreeNode(SimpleNode<T> node);
-    }
-
-    public static void main(String[] args) {
-        PruferTreeGenerator ptg = new PruferTreeGenerator<String>();
-        //var edges = new int[]{7,5,7,7,5,1};
-        Random random = new Random(5);
-        final int numNodes = 5;
-        var edges = IntStream.range(0, numNodes-2).map(x->random.nextInt(numNodes)+1).toArray();
-        var tree = ptg.makeTree(vn -> Integer.toString(vn), edges);
-        ptg.printTree(System.out, tree);
-    }
-
-    private void printTree(PrintStream out, SimpleNode<T> tree) {
-        preOrderVisitTree(tree, new Visitor<T>() {
-            int nodeDepth;
-            @Override
-            public void pushTreeNode(SimpleNode<T> node) {
-                out.println(" ".repeat(nodeDepth++) + node.value + (node.hasChildren() ? ": {" : ""));
-            }
-            @Override
-            public void popTreeNode(SimpleNode<T> node) {
-                nodeDepth--;
-                if (node.hasChildren()) {
-                    out.println(" ".repeat(nodeDepth) + "}");
-                }
-            }
-        });
     }
 
     public void preOrderVisitTree(SimpleNode<T> treeNode, Visitor visitor) {
@@ -155,10 +125,14 @@ public class PruferTreeGenerator<T> {
         for (int i = 0; i < pruferLen; i++) {
             var parent = pruferSequenceArray[i];
             var child = nodesWithOneLinkLeft.poll();
-            log.trace("Adding link from {} -> {}", child, parent);
+            if (log.isTraceEnabled()) {
+                log.trace("Adding link from {} -> {}", child, parent);
+            }
             edges.add(Link.builder().from(child).to(parent).build());
             removeLinkForNode(parent, nodeDegrees, nodesWithOneLinkLeft);
-            log.trace("degrees: "+ arrayAsString(nodeDegrees));
+            if (log.isTraceEnabled()) {
+                log.trace("degrees: " + arrayAsString(nodeDegrees));
+            }
         }
 
         edges.add(Link.builder().from(nodesWithOneLinkLeft.poll()).to(nodesWithOneLinkLeft.poll()).build());

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/PruferTreeGenerator.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/PruferTreeGenerator.java
@@ -1,0 +1,183 @@
+package org.opensearch.migrations;
+
+import lombok.Builder;
+import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.PrintStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.PriorityQueue;
+import java.util.Random;
+import java.util.Stack;
+import java.util.TreeMap;
+import java.util.function.Function;
+import java.util.function.IntFunction;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+/**
+ * See https://en.wikipedia.org/wiki/Pr%C3%BCfer_sequence.
+ * @param <T>
+ */
+@Slf4j
+public class PruferTreeGenerator<T> {
+    @Builder
+    @ToString
+    private static class Link { int from; int to; }
+
+    public static class SimpleNode<T> {
+        public final T value;
+
+        public SimpleNode(T value) {
+            this.value = value;
+        }
+
+        List<SimpleNode<T>> children;
+        public boolean hasChildren() { return children != null && children.size() > 0; }
+        public Stream<SimpleNode<T>> getChildren() { return children == null ? Stream.of() : children.stream(); }
+    }
+
+    public interface NodeValueGenerator<T> {
+        T makeValue(int vertexNumber);
+    }
+
+    public interface Visitor<T> {
+        void pushTreeNode(SimpleNode<T> node);
+        void popTreeNode(SimpleNode<T> node);
+    }
+
+    public static void main(String[] args) {
+        PruferTreeGenerator ptg = new PruferTreeGenerator<String>();
+        //var edges = new int[]{7,5,7,7,5,1};
+        Random random = new Random(5);
+        final int numNodes = 5;
+        var edges = IntStream.range(0, numNodes-2).map(x->random.nextInt(numNodes)+1).toArray();
+        var tree = ptg.makeTree(vn -> Integer.toString(vn), edges);
+        ptg.printTree(System.out, tree);
+    }
+
+    private void printTree(PrintStream out, SimpleNode<T> tree) {
+        preOrderVisitTree(tree, new Visitor<T>() {
+            int nodeDepth;
+            @Override
+            public void pushTreeNode(SimpleNode<T> node) {
+                out.println(" ".repeat(nodeDepth++) + node.value + (node.hasChildren() ? ": {" : ""));
+            }
+            @Override
+            public void popTreeNode(SimpleNode<T> node) {
+                nodeDepth--;
+                if (node.hasChildren()) {
+                    out.println(" ".repeat(nodeDepth) + "}");
+                }
+            }
+        });
+    }
+
+    public void preOrderVisitTree(SimpleNode<T> treeNode, Visitor visitor) {
+        visitor.pushTreeNode(treeNode);
+        if (treeNode.hasChildren()) {
+            treeNode.children.forEach(child->preOrderVisitTree(child, visitor));
+        }
+        visitor.popTreeNode(treeNode);
+    }
+
+    public SimpleNode<T> makeTree(NodeValueGenerator<T> nodeGenerator, int...pruferSequence) {
+        List<Link> edges = makeLinks(pruferSequence);
+        return convertLinksToTree(nodeGenerator, edges);
+    }
+
+    private SimpleNode<T> getMemoizedNode(TreeMap<Integer, SimpleNode<T>> nodeMap,
+                                          HashSet<SimpleNode> nodesWithoutParents,
+                                          int key,
+                                          IntFunction<T> valueGenerator) {
+        var node = nodeMap.get(key);
+        if (node == null) {
+            node = new SimpleNode<>(valueGenerator.apply(key));
+            nodesWithoutParents.add(node);
+            nodeMap.put(key, node);
+        }
+        return node;
+    }
+
+    private SimpleNode<T> convertLinksToTree(NodeValueGenerator<T> valueGenerator, List<Link> edges) {
+        var nodeMap = new TreeMap<Integer, SimpleNode<T>>();
+        var nodesWithoutParents = new HashSet<SimpleNode>();
+        edges.stream().forEach(e->{
+            var childNode = getMemoizedNode(nodeMap, nodesWithoutParents, e.from, x->valueGenerator.makeValue(x));
+            var parent = getMemoizedNode(nodeMap, nodesWithoutParents, e.to, x->valueGenerator.makeValue(x));
+            if (parent.children == null) {
+                parent.children = new ArrayList<>();
+            }
+            parent.children.add(childNode);
+            nodesWithoutParents.remove(childNode);
+        });
+        return nodeMap.lastEntry().getValue();
+    }
+
+    /**
+     * Implement the algorithm as shown in https://www.youtube.com/watch?v=7s44l7gWEVk.
+     *
+     * There are 3 interesting number of degrees left to connect for each node.
+     * 0: No more items in the remaining pruferSequenceArray will link to this item
+     * 1: Exactly one more will link to it.  The index will NOT be found in pruferSequenceArray BUT
+     *    the next value in pruferSequenceArray will have a link node whose index is the first item == 1
+     *    in this set
+     * >1: This indicates how many more instances will be found in the pruferSequenceArray and
+     *     will be decremented each time that an item is found
+     * @param pruferSequenceArray
+     * @return
+     */
+    private List<Link> makeLinks(final int[] pruferSequenceArray) {
+        //assert Arrays.stream(pruferSequenceArray).allMatch(x -> x<pruferSequenceArray.length+2);
+        int pruferLen = pruferSequenceArray.length;
+        List<Link> edges = new ArrayList<>();
+        // ids are sequential integers.  We will map them to something else outside of this function.
+        // Using just ints here are more convenient because we can use them as keys to do lookups in arrays.
+        int numNodeIds = pruferLen + 2;
+        // This collection captures items with degree > 1
+        var nodeDegrees =
+                Arrays.stream(pruferSequenceArray)
+                        // initialize the nodeDegrees values to the number of occurrences (inflows) + 1
+                        .mapToObj(i->i)
+                        .collect(Collectors.groupingBy(Function.identity(), Collectors.counting()));
+        // This collection captures items with degree == 1 with a PQueue because we only ever need to get the top item
+        var nodesWithOneLinkLeft = new PriorityQueue<Integer>(
+                IntStream.range(1, numNodeIds + 1)
+                        .filter(i->nodeDegrees.get(i)==null)
+                        .boxed()
+                        .collect(Collectors.toList()));
+
+        for (int i = 0; i < pruferLen; i++) {
+            var parent = pruferSequenceArray[i];
+            var child = nodesWithOneLinkLeft.poll();
+            log.trace("Adding link from {} -> {}", child, parent);
+            edges.add(Link.builder().from(child).to(parent).build());
+            removeLinkForNode(parent, nodeDegrees, nodesWithOneLinkLeft);
+            log.trace("degrees: "+ arrayAsString(nodeDegrees));
+        }
+
+        edges.add(Link.builder().from(nodesWithOneLinkLeft.poll()).to(nodesWithOneLinkLeft.poll()).build());
+        return edges;
+    }
+
+    private void removeLinkForNode(int parent, Map<Integer, Long> nodeDegrees, PriorityQueue<Integer> nodesWithOneLinkLeft) {
+        var oldDegreeVal = nodeDegrees.get(parent);
+        if (oldDegreeVal == 1) {
+            nodeDegrees.remove(parent);
+            nodesWithOneLinkLeft.add(parent);
+        } else {
+            nodeDegrees.put(parent, oldDegreeVal-1);
+        }
+    }
+
+    private static String arrayAsString(Map<Integer, Long> nodeDegrees) {
+        return nodeDegrees.entrySet().stream().map(kvp -> kvp.toString())
+                .collect(Collectors.joining(","));
+    }
+
+}

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/PruferTreeGeneratorTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/PruferTreeGeneratorTest.java
@@ -1,0 +1,49 @@
+package org.opensearch.migrations;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Random;
+import java.util.stream.IntStream;
+
+public class PruferTreeGeneratorTest {
+
+    @Test
+    public void testThatArbitrarySequencePrintsExpectedTree() throws IOException {
+        PruferTreeGenerator ptg = new PruferTreeGenerator<String>();
+        Random random = new Random(5);
+        final int numNodes = 5;
+        var edges = IntStream.range(0, numNodes-2).map(x->random.nextInt(numNodes)+1).toArray();
+        var tree = ptg.makeTree(vn -> Integer.toString(vn), edges);
+        try (var baos = new ByteArrayOutputStream(); var printStream = new PrintStream(baos)) {
+            printTree(ptg, printStream, tree);
+            printStream.flush();
+            var expectedOutput = "5: { 3: {  1  2 } 4}";
+            var generatedOutput = new String(baos.toByteArray(), StandardCharsets.UTF_8);
+            Assertions.assertEquals(expectedOutput, generatedOutput);
+        }
+    }
+
+    private static void printTree(PruferTreeGenerator<String> ptg, PrintStream out,
+                                  PruferTreeGenerator.SimpleNode<String> tree) {
+        ptg.preOrderVisitTree(tree, new PruferTreeGenerator.Visitor<String>() {
+            int nodeDepth;
+            @Override
+            public void pushTreeNode(PruferTreeGenerator.SimpleNode<String> node) {
+                out.print(" ".repeat(nodeDepth++) + node.value + (node.hasChildren() ? ": {" : ""));
+            }
+            @Override
+            public void popTreeNode(PruferTreeGenerator.SimpleNode<String> node) {
+                nodeDepth--;
+                if (node.hasChildren()) {
+                    out.print(" ".repeat(nodeDepth) + "}");
+                }
+            }
+        });
+    }
+
+}

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/GenerateRandomNestedJsonObject.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/GenerateRandomNestedJsonObject.java
@@ -1,0 +1,90 @@
+package org.opensearch.migrations.replay;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.SneakyThrows;
+import org.opensearch.migrations.PruferTreeGenerator;
+
+import java.util.AbstractMap;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.PriorityQueue;
+import java.util.Random;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+public class GenerateRandomNestedJsonObject {
+
+    public static final String KEY_PREFIX = "keyPrefix-";
+    public static final String VALUE_PREFIX = "VALUE_";
+    ObjectMapper objectMapper;
+
+
+    public GenerateRandomNestedJsonObject() {
+        objectMapper = new ObjectMapper();
+    }
+
+    public String getRandomTreeFormattedAsString(boolean pretty, int seed, int numNodes, int numArrays)
+            throws JsonProcessingException
+    {
+        Random random = new Random(seed);
+        var jsonObj = makeRandomJsonObject(random, numNodes, numArrays);
+        if (pretty) {
+            return objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(jsonObj);
+        } else {
+            return objectMapper.writeValueAsString(jsonObj);
+        }
+    }
+
+    @SneakyThrows
+    public static Object makeRandomJsonObject(Random random, int numNodes, int numArrays) {
+        assert numArrays < numNodes;
+        PruferTreeGenerator ptg = new PruferTreeGenerator<String>();
+        var edges = IntStream.range(0, numNodes-3).map(x->random.nextInt(numNodes-1)+1).sorted().toArray();
+        var tree = ptg.makeTree(vn -> Integer.toString(vn), edges);
+        PriorityQueue<AbstractMap.Entry<Map<String,Object>,String>> parentAndBiggestChildPQ =
+                new PriorityQueue<>(Comparator.comparingInt(kvp->
+                        -1 * getSize(kvp.getKey().get(kvp.getValue()))
+                ));
+        var rval = convertSimpleNodeToJsonTree(tree, parentAndBiggestChildPQ);
+        replaceTopItemsForArrays(numArrays, parentAndBiggestChildPQ);
+        return rval;
+    }
+
+    private static int getSize(Object o) {
+        return o instanceof Map ?  ((Map) o).size() : 1;
+    }
+
+    private static void replaceTopItemsForArrays(int numArrays,
+                                                 PriorityQueue<AbstractMap.Entry<Map<String,Object>,String>>
+                                                         parentAndBiggestChildPQ) {
+        for (int i=0; i<numArrays; ++i) {
+            var pairToEdit = parentAndBiggestChildPQ.poll();
+            var parentMap = pairToEdit.getKey();
+            var key = pairToEdit.getValue();
+            parentMap.put(key, makeArray(parentMap.get(key)));
+        }
+    }
+
+    private static Object makeArray(Object o) {
+        return o instanceof Map ? ((Map) o).values().toArray() : new Object[]{o};
+    }
+
+    public static Object
+    convertSimpleNodeToJsonTree(PruferTreeGenerator.SimpleNode<String> treeNode,
+                                PriorityQueue<AbstractMap.Entry<Map<String,Object>,String>>
+                                        parentAndBiggestChildPQ) {
+        if (treeNode.hasChildren()) {
+            var myMap = new LinkedHashMap<String, Object>();
+            myMap.putAll(treeNode.getChildren()
+                    .collect(Collectors.toMap(child-> KEY_PREFIX + child.value,
+                            child->convertSimpleNodeToJsonTree(child, parentAndBiggestChildPQ))));
+            myMap.entrySet().stream().forEach(kvp->
+                    parentAndBiggestChildPQ.add(new AbstractMap.SimpleEntry<>(myMap, kvp.getKey())));
+            return myMap;
+        } else {
+            return VALUE_PREFIX + treeNode.value;
+        }
+    }
+}

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/datahandlers/JsonAccumulatorTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/datahandlers/JsonAccumulatorTest.java
@@ -15,6 +15,7 @@ public class JsonAccumulatorTest {
     public static final String TINY = "tiny";
     public static final String MEDIUM = "medium";
     public static final String LARGE = "large";
+    public static final String LARGE_PACKED = "largeAndPacked";
     GenerateRandomNestedJsonObject randomJsonGenerator = new GenerateRandomNestedJsonObject();
 
     private static Object readJson(byte[] testFileBytes, int chunkBound) throws IOException {
@@ -45,7 +46,10 @@ public class JsonAccumulatorTest {
                 return randomJsonGenerator.getRandomTreeFormattedAsString(false, 2, 200, 50)
                         .getBytes(StandardCharsets.UTF_8);
             case LARGE:
-                return randomJsonGenerator.getRandomTreeFormattedAsString(true, 2, 2000, 400)
+                return randomJsonGenerator.getRandomTreeFormattedAsString(true, 3, 2000, 400)
+                        .getBytes(StandardCharsets.UTF_8);
+            case LARGE_PACKED:
+                return randomJsonGenerator.getRandomTreeFormattedAsString(false, 4, 2000, 400)
                         .getBytes(StandardCharsets.UTF_8);
             default:
                 throw new RuntimeException("Unknown key: "+key);
@@ -62,7 +66,8 @@ public class JsonAccumulatorTest {
     @ParameterizedTest
     @CsvSource({"tiny,2", "tiny,20000",
             "medium,2", "medium,20000",
-            "large,2", "large,20000"
+            "large,2", "large,20000",
+            "largeAndPacked,2", "largeAndPacked,20000"
     })
     public void testAccumulation(String dataName, int chunkBound) throws IOException {
         var testFileBytes = getData(dataName);

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/datahandlers/JsonAccumulatorTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/datahandlers/JsonAccumulatorTest.java
@@ -1,32 +1,21 @@
 package org.opensearch.migrations.replay.datahandlers;
 
-import com.fasterxml.jackson.core.JsonFactory;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonToken;
-import com.fasterxml.jackson.core.async.ByteBufferFeeder;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.netty.buffer.Unpooled;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.CsvSource;
-import org.junit.jupiter.params.provider.MethodSource;
+import org.opensearch.migrations.replay.GenerateRandomNestedJsonObject;
 
-import java.io.BufferedInputStream;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.io.StringReader;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
-import java.util.LinkedHashMap;
-import java.util.Map;
 import java.util.Random;
 
 public class JsonAccumulatorTest {
-
-    public static final String TOY = "toy";
+    public static final String TINY = "tiny";
+    public static final String MEDIUM = "medium";
+    public static final String LARGE = "large";
+    GenerateRandomNestedJsonObject randomJsonGenerator = new GenerateRandomNestedJsonObject();
 
     private static Object readJson(byte[] testFileBytes, int chunkBound) throws IOException {
         var jsonParser = new JsonAccumulator();
@@ -50,8 +39,14 @@ public class JsonAccumulatorTest {
 
     byte[] getData(String key) throws IOException {
         switch (key) {
-            case TOY:
+            case TINY:
                 return "{\"name\":\"John\", \"age\":30}".getBytes(StandardCharsets.UTF_8);
+            case MEDIUM:
+                return randomJsonGenerator.getRandomTreeFormattedAsString(false, 2, 200, 50)
+                        .getBytes(StandardCharsets.UTF_8);
+            case LARGE:
+                return randomJsonGenerator.getRandomTreeFormattedAsString(true, 2, 2000, 400)
+                        .getBytes(StandardCharsets.UTF_8);
             default:
                 throw new RuntimeException("Unknown key: "+key);
         }
@@ -65,7 +60,10 @@ public class JsonAccumulatorTest {
      * @throws IOException
      */
     @ParameterizedTest
-    @CsvSource({"toy,2", "toy,20000"})
+    @CsvSource({"tiny,2", "tiny,20000",
+            "medium,2", "medium,20000",
+            "large,2", "large,20000"
+    })
     public void testAccumulation(String dataName, int chunkBound) throws IOException {
         var testFileBytes = getData(dataName);
         var outputJson = readJson(testFileBytes, 2);


### PR DESCRIPTION
### Description
Category: New tests and new test infrastructure

This change includes the ability to generate a random json tree (object) and to use random trees to do some additional tests on the JsonAccumulator.  The random tree generation uses a Prufer sequence transformation to create a random sequence of integers and then maps that into a unique tree. There are a couple simple transformation layers placed on top of that to produce json w/ arrays and objects. This new functionality is used to drive the medium and large tests that the JsonAccumulator uses. All tests pass.

### Issues Resolved
https://opensearch.atlassian.net/browse/MIGRATIONS-1142 

### Testing
Additional unit tests were verified by hand

### Check List
- [x] New functionality includes testing
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
