### PR TITLE
MIGRATIONS-1080 - Stop directly using an HttpObjectDecoder

### DIFF
--- a/TrafficCapture/nettyWireLogging/src/main/java/org/opensearch/migrations/trafficcapture/netty/ConditionallyReliableLoggingHttpRequestHandler.java
+++ b/TrafficCapture/nettyWireLogging/src/main/java/org/opensearch/migrations/trafficcapture/netty/ConditionallyReliableLoggingHttpRequestHandler.java
@@ -2,6 +2,7 @@ package org.opensearch.migrations.trafficcapture.netty;
 
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http.DefaultHttpRequest;
+import io.netty.handler.codec.http.HttpRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.opensearch.migrations.trafficcapture.IChannelConnectionCaptureSerializer;
 
@@ -9,16 +10,16 @@ import java.util.function.Predicate;
 
 @Slf4j
 public class ConditionallyReliableLoggingHttpRequestHandler extends LoggingHttpRequestHandler {
-    private final Predicate<DefaultHttpRequest> shouldBlockPredicate;
+    private final Predicate<HttpRequest> shouldBlockPredicate;
 
     public ConditionallyReliableLoggingHttpRequestHandler(IChannelConnectionCaptureSerializer trafficOffloader,
-                                                          Predicate<DefaultHttpRequest> headerPredicateForWhenToBlock) {
+                                                          Predicate<HttpRequest> headerPredicateForWhenToBlock) {
         super(trafficOffloader);
         this.shouldBlockPredicate = headerPredicateForWhenToBlock;
     }
 
     @Override
-    protected void channelFinishedReadingAnHttpMessage(ChannelHandlerContext ctx, Object msg, DefaultHttpRequest httpRequest) throws Exception {
+    protected void channelFinishedReadingAnHttpMessage(ChannelHandlerContext ctx, Object msg, HttpRequest httpRequest) throws Exception {
         if (shouldBlockPredicate.test(httpRequest)) {
             trafficOffloader.flushCommitAndResetStream(false).whenComplete((result, t) -> {
                 if (t != null) {

--- a/TrafficCapture/nettyWireLogging/src/main/java/org/opensearch/migrations/trafficcapture/netty/LoggingHttpRequestHandler.java
+++ b/TrafficCapture/nettyWireLogging/src/main/java/org/opensearch/migrations/trafficcapture/netty/LoggingHttpRequestHandler.java
@@ -3,11 +3,15 @@ package org.opensearch.migrations.trafficcapture.netty;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.http.DefaultHttpRequest;
 import io.netty.handler.codec.http.HttpMessage;
 import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpRequestDecoder;
 import io.netty.handler.codec.http.HttpVersion;
+import io.netty.handler.codec.http.LastHttpContent;
+import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.opensearch.migrations.trafficcapture.IChannelConnectionCaptureSerializer;
 
@@ -19,24 +23,6 @@ import java.util.List;
 @Slf4j
 public class LoggingHttpRequestHandler extends ChannelInboundHandlerAdapter {
     static class SimpleHttpRequestDecoder extends HttpRequestDecoder {
-        /**
-         * Override to broaden the visibility.
-         *
-         * @param ctx    the {@link ChannelHandlerContext} which this {@link ByteToMessageDecoder} belongs to
-         * @param buffer the {@link ByteBuf} from which to read data
-         * @param out    the {@link List} to which decoded messages should be added
-         * @throws Exception
-         */
-        @Override
-        public void decode(ChannelHandlerContext ctx, ByteBuf buffer, List<Object> out) throws Exception {
-            super.decode(ctx, buffer, out);
-        }
-
-        @Override
-        public void decodeLast(ChannelHandlerContext ctx, ByteBuf in, List<Object> out) throws Exception {
-            super.decodeLast(ctx, in, out);
-        }
-
         @Override
         public HttpMessage createMessage(String[] initialLine) throws Exception {
             return new DefaultHttpRequest(HttpVersion.valueOf(initialLine[2]),
@@ -44,19 +30,50 @@ public class LoggingHttpRequestHandler extends ChannelInboundHandlerAdapter {
                     , new PassThruHttpHeaders()
             );
         }
+
+        @Override
+        public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+            super.channelRead(ctx, msg);
+        }
+    }
+
+    static class SimpleDecodedHttpRequestHandler extends ChannelInboundHandlerAdapter {
+        @Getter
+        private HttpRequest currentRequest;
+        boolean isDone;
+        @Override
+        public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+            if (msg instanceof HttpRequest) {
+                currentRequest = (HttpRequest) msg;
+            } else if (msg instanceof LastHttpContent) {
+                isDone = true;
+            }
+            super.channelRead(ctx, msg);
+        }
+
+        public HttpRequest resetCurrentRequest() {
+            var old = currentRequest;
+            currentRequest = null;
+            return old;
+        }
     }
 
     protected final IChannelConnectionCaptureSerializer trafficOffloader;
 
-    protected final SimpleHttpRequestDecoder httpDecoder;
+    protected final EmbeddedChannel httpDecoderChannel;
+    SimpleHttpRequestDecoder requestDecoder;
 
-    private DefaultHttpRequest currentHttpRequest;
 
     public LoggingHttpRequestHandler(IChannelConnectionCaptureSerializer trafficOffloader) {
         this.trafficOffloader = trafficOffloader;
-        httpDecoder = new SimpleHttpRequestDecoder();
-        currentHttpRequest = null;
+        requestDecoder = new SimpleHttpRequestDecoder(); // as a field for easier debugging
+        httpDecoderChannel = new EmbeddedChannel(
+                requestDecoder,
+                new SimpleDecodedHttpRequestHandler()
+        );
     }
+
+
 
     protected HttpCaptureSerializerUtil.HttpProcessedState
     onHttpObjectsDecoded(List<Object> parsedMsgs) throws IOException {
@@ -64,30 +81,27 @@ public class LoggingHttpRequestHandler extends ChannelInboundHandlerAdapter {
                 .filter(o -> o instanceof DefaultHttpRequest)
                 .map(o -> (DefaultHttpRequest) o)
                 .findAny()
-                .ifPresent(req -> this.currentHttpRequest = req);
+                .ifPresent(req -> getHttpRequestReceiverHandler().currentRequest = req);
         return HttpCaptureSerializerUtil.addRelevantHttpMessageIndicatorEvents(trafficOffloader, parsedMsgs);
     }
 
     private HttpCaptureSerializerUtil.HttpProcessedState parseHttpMessageParts(ChannelHandlerContext ctx, ByteBuf msg) throws Exception {
         var bb = msg;
+        // Preserve ownership of this ByteBuf because the HttpRequestDecoder will take ownership of the
+        // ByteBuf, releasing it once the data has been copied into its cumulation buffer.  However,
+        // this handler still fires ByteBufs through the pipeline.  It's up to a future handler to perform
+        // the release, as it would have been if this method was implemented any other way.
+        bb.retain();
         bb.markReaderIndex();
-        // todo - move this into a pool
-        var rval = HttpCaptureSerializerUtil.HttpProcessedState.ONGOING;
-        var parsedMsgs = new ArrayList<>(4);
-        while (bb.readableBytes() > 0) {
-            var lastIdx = bb.readerIndex();
-            log.warn("Parsing from idx="+lastIdx+" readableBytes="+ bb.readableBytes());
-            httpDecoder.decode(ctx, bb, parsedMsgs);
-            rval = onHttpObjectsDecoded(parsedMsgs);
-            if (rval == HttpCaptureSerializerUtil.HttpProcessedState.FULL_MESSAGE || // got what we needed
-                    lastIdx == bb.readerIndex()) { // no progress
-                break;
-            }
-            parsedMsgs.clear();
-        }
-        log.trace("Resetting index");
+        httpDecoderChannel.writeInbound(bb);
         bb.resetReaderIndex();
-        return rval;
+        return getHttpRequestReceiverHandler().isDone ?
+                HttpCaptureSerializerUtil.HttpProcessedState.FULL_MESSAGE :
+                HttpCaptureSerializerUtil.HttpProcessedState.ONGOING;
+    }
+
+    private SimpleDecodedHttpRequestHandler getHttpRequestReceiverHandler() {
+        return (SimpleDecodedHttpRequestHandler) httpDecoderChannel.pipeline().last();
     }
 
     @Override
@@ -121,18 +135,18 @@ public class LoggingHttpRequestHandler extends ChannelInboundHandlerAdapter {
         super.channelInactive(ctx);
     }
 
-    protected void channelFinishedReadingAnHttpMessage(ChannelHandlerContext ctx, Object msg, DefaultHttpRequest httpRequest) throws Exception {
+    protected void channelFinishedReadingAnHttpMessage(ChannelHandlerContext ctx, Object msg, HttpRequest httpRequest) throws Exception {
         super.channelRead(ctx, msg);
     }
 
     @Override
     public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
-        trafficOffloader.addReadEvent(Instant.now(), (ByteBuf) msg);
+        var bb = (ByteBuf) msg;
+        trafficOffloader.addReadEvent(Instant.now(), bb);
 
-        var httpProcessedState = parseHttpMessageParts(ctx, (ByteBuf) msg);
+        var httpProcessedState = parseHttpMessageParts(ctx, bb);
         if (httpProcessedState == HttpCaptureSerializerUtil.HttpProcessedState.FULL_MESSAGE) {
-            var httpRequest = currentHttpRequest;
-            currentHttpRequest = null;
+            var httpRequest = getHttpRequestReceiverHandler().resetCurrentRequest();
             channelFinishedReadingAnHttpMessage(ctx, msg, httpRequest);
         } else {
             super.channelRead(ctx, msg);
@@ -157,6 +171,7 @@ public class LoggingHttpRequestHandler extends ChannelInboundHandlerAdapter {
     @Override
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
         trafficOffloader.addExceptionCaughtEvent(Instant.now(), cause);
+        httpDecoderChannel.close();
         super.exceptionCaught(ctx, cause);
     }
 

--- a/TrafficCapture/nettyWireLogging/src/test/java/org/opensearch/migrations/trafficcapture/netty/ConditionallyReliableLoggingHttpRequestHandlerTest.java
+++ b/TrafficCapture/nettyWireLogging/src/test/java/org/opensearch/migrations/trafficcapture/netty/ConditionallyReliableLoggingHttpRequestHandlerTest.java
@@ -1,38 +1,26 @@
 package org.opensearch.migrations.trafficcapture.netty;
 
-import com.google.common.primitives.Bytes;
 import com.google.protobuf.CodedOutputStream;
-import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
-import io.netty.util.ResourceLeakDetector;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.opensearch.migrations.trafficcapture.IChannelConnectionCaptureOffloader;
-import org.opensearch.migrations.trafficcapture.IChannelConnectionCaptureSerializer;
 import org.opensearch.migrations.trafficcapture.StreamChannelConnectionCaptureSerializer;
 import org.opensearch.migrations.trafficcapture.protos.TrafficStream;
 
 import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.SequenceInputStream;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
-import java.time.Instant;
 import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
-import static org.junit.jupiter.api.Assertions.*;
-
-@Slf4j
 class ConditionallyReliableLoggingHttpRequestHandlerTest {
 
     @Test

--- a/TrafficCapture/trafficCaptureProxyServer/src/main/java/org/opensearch/migrations/trafficcapture/proxyserver/netty/FrontsideHandler.java
+++ b/TrafficCapture/trafficCaptureProxyServer/src/main/java/org/opensearch/migrations/trafficcapture/proxyserver/netty/FrontsideHandler.java
@@ -68,7 +68,8 @@ public class FrontsideHandler extends ChannelInboundHandlerAdapter {
                         if (future.isSuccess()) {
                             ctx.channel().read(); // kickoff another read for the frontside
                         } else {
-                            log.debug("closing outbound channel because WRITE future was not successful");
+                            log.debug("closing outbound channel because WRITE future was not successful due",
+                                    future.cause());
                             future.channel().close(); // close the backside
                         }
                     });

--- a/TrafficCapture/trafficCaptureProxyServer/src/main/java/org/opensearch/migrations/trafficcapture/proxyserver/netty/FrontsideHandler.java
+++ b/TrafficCapture/trafficCaptureProxyServer/src/main/java/org/opensearch/migrations/trafficcapture/proxyserver/netty/FrontsideHandler.java
@@ -68,7 +68,7 @@ public class FrontsideHandler extends ChannelInboundHandlerAdapter {
                         if (future.isSuccess()) {
                             ctx.channel().read(); // kickoff another read for the frontside
                         } else {
-                            log.debug("closing outbound channel because WRITE future was not successful due",
+                            log.debug("closing outbound channel because WRITE future was not successful due to: ",
                                     future.cause());
                             future.channel().close(); // close the backside
                         }

--- a/TrafficCapture/trafficCaptureProxyServer/src/main/java/org/opensearch/migrations/trafficcapture/proxyserver/netty/ProxyChannelInitializer.java
+++ b/TrafficCapture/trafficCaptureProxyServer/src/main/java/org/opensearch/migrations/trafficcapture/proxyserver/netty/ProxyChannelInitializer.java
@@ -5,6 +5,7 @@ import io.netty.channel.socket.SocketChannel;
 import io.netty.handler.codec.http.DefaultHttpRequest;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpObjectDecoder;
+import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.logging.LogLevel;
 import io.netty.handler.logging.LoggingHandler;
 import io.netty.handler.ssl.SslHandler;
@@ -32,7 +33,7 @@ public class ProxyChannelInitializer extends ChannelInitializer<SocketChannel> {
         this.connectionCaptureFactory = connectionCaptureFactory;
     }
 
-    public boolean shouldGuaranteeMessageOffloading(DefaultHttpRequest httpRequest) {
+    public boolean shouldGuaranteeMessageOffloading(HttpRequest httpRequest) {
         return (httpRequest != null &&
                 (httpRequest.method().equals(HttpMethod.POST) ||
                         httpRequest.method().equals(HttpMethod.PUT) ||

--- a/TrafficCapture/trafficCaptureProxyServer/src/test/java/org/opensearch/migrations/trafficcapture/proxyserver/netty/NettyScanningHttpProxyTest.java
+++ b/TrafficCapture/trafficCaptureProxyServer/src/test/java/org/opensearch/migrations/trafficcapture/proxyserver/netty/NettyScanningHttpProxyTest.java
@@ -5,8 +5,10 @@ import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
 import com.sun.net.httpserver.HttpServer;
 import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.http.ProtocolVersion;
 import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Assumptions;
@@ -16,16 +18,64 @@ import org.opensearch.migrations.trafficcapture.IConnectionCaptureFactory;
 import org.opensearch.migrations.trafficcapture.InMemoryConnectionCaptureFactory;
 import org.opensearch.migrations.trafficcapture.protos.TrafficStream;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Random;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
 import static java.lang.Math.abs;
 
+@Slf4j
 class NettyScanningHttpProxyTest {
+
+    private final static String EXPECTED_REQUEST_STRING =
+    "GET / HTTP/1.1\r\n" +
+            "Host: localhost\r\n" +
+            "DumbAndLongHeaderValue-0: 0\r\n" +
+            "DumbAndLongHeaderValue-1: 1\r\n" +
+            "DumbAndLongHeaderValue-2: 2\r\n" +
+            "DumbAndLongHeaderValue-3: 3\r\n" +
+            "DumbAndLongHeaderValue-4: 4\r\n" +
+            "DumbAndLongHeaderValue-5: 5\r\n" +
+            "DumbAndLongHeaderValue-6: 6\r\n" +
+            "DumbAndLongHeaderValue-7: 7\r\n" +
+            "DumbAndLongHeaderValue-8: 8\r\n" +
+            "DumbAndLongHeaderValue-9: 9\r\n" +
+            "DumbAndLongHeaderValue-10: 10\r\n" +
+            "DumbAndLongHeaderValue-11: 11\r\n" +
+            "DumbAndLongHeaderValue-12: 12\r\n" +
+            "DumbAndLongHeaderValue-13: 13\r\n" +
+            "DumbAndLongHeaderValue-14: 14\r\n" +
+            "DumbAndLongHeaderValue-15: 15\r\n" +
+            "DumbAndLongHeaderValue-16: 16\r\n" +
+            "DumbAndLongHeaderValue-17: 17\r\n" +
+            "DumbAndLongHeaderValue-18: 18\r\n" +
+            "DumbAndLongHeaderValue-19: 19\r\n" +
+            "Connection: Keep-Alive\r\n" +
+            "User-Agent: Apache-HttpClient/4.5.13 (Java/17.0.7)\r\n" +
+            "Accept-Encoding: gzip,deflate\r\n" +
+            "\r\n";
+    private final static String EXPECTED_RESPONSE_STRING =
+            "HTTP/1.1 200 OK\r\n" +
+                    "Content-transfer-encoding: chunked\r\n" +
+                    "Date: Thu, 08 Jun 2023 23:06:23 GMT\r\n" +
+                    "Transfer-encoding: chunked\r\n" +
+                    "Content-type: text/plain\r\n" +
+                    "Funtime: checkIt!\r\n" +
+                    "\r\n" +
+                    "e\r\n" +
+                    "Hello tester!\n" +
+                    "\r\n" +
+                    "0\r\n" +
+                    "\r\n";
+
     private static final int MAX_PORT_TRIES = 100;
     private static final Random random = new Random();
     public static final String LOCALHOST = "localhost";
@@ -48,24 +98,21 @@ class NettyScanningHttpProxyTest {
 
     @Test
     public void testRoundTrip() throws IOException, InterruptedException {
-        var captureFactory = new InMemoryConnectionCaptureFactory(1024*1024);
+        final int NUM_EXPECTED_TRAFFIC_STREAMS = 1;
+        final int NUM_INTERACTIONS = 3;
+        CountDownLatch interactionsCapturedCountdown = new CountDownLatch(NUM_EXPECTED_TRAFFIC_STREAMS);
+        var captureFactory = new InMemoryConnectionCaptureFactory(1024*1024,
+                () -> interactionsCapturedCountdown.countDown());
         var servers = startServers(captureFactory);
 
-        String responseBody;
         try (var client = HttpClientBuilder.create().build()) {
             var nettyEndpoint = URI.create("http://localhost:" + servers.v1().getProxyPort() + "/");
-            var request = new HttpGet(nettyEndpoint);
-            request.setProtocolVersion(new ProtocolVersion("HTTP", 1, 1));
-            for (int i = 0; i < 20; i++) {
-                request.setHeader("DumbAndLongHeaderValue-" + i, "" + i);
+            for (int i=0; i<NUM_INTERACTIONS; ++i) {
+                var responseBody = makeTestRequestViaClient(client, nettyEndpoint);
+                Assertions.assertEquals(UPSTREAM_SERVER_RESPONSE_BODY, responseBody);
             }
-            var response = client.execute(request);
-            responseBody = new String(response.getEntity().getContent().readAllBytes());
         }
-
-        Assertions.assertEquals(UPSTREAM_SERVER_RESPONSE_BODY, responseBody);
-        // TODO - replace this with a better signalling facility! (shame on me for writing it like this in the first place)
-        Thread.sleep(1000);
+        interactionsCapturedCountdown.await();
         var recordedStreams = captureFactory.getRecordedStreams();
         Assertions.assertEquals(1, recordedStreams.size());
         var recordedTrafficStreams =
@@ -77,9 +124,62 @@ class NettyScanningHttpProxyTest {
                                 throw new RuntimeException(e);
                             }
                         })
-                        .toArray();
-        Assertions.assertEquals(1, recordedTrafficStreams.length);
-        System.out.println(recordedTrafficStreams[0]);
+                        .toArray(TrafficStream[]::new);
+        Assertions.assertEquals(NUM_EXPECTED_TRAFFIC_STREAMS, recordedTrafficStreams.length);
+        log.info("Recorded traffic stream:\n" + recordedTrafficStreams[0]);
+        var coalescedTrafficList = coalesceObservations(recordedTrafficStreams[0]);
+        Assertions.assertEquals(NUM_INTERACTIONS*2, coalescedTrafficList.size());
+        int counter = 0;
+        final var expectedMessages = new String[]{
+                normalizeMessage(EXPECTED_REQUEST_STRING),
+                normalizeMessage(EXPECTED_RESPONSE_STRING)
+        };
+        for (var httpMessage : coalescedTrafficList) {
+            Assertions.assertEquals(expectedMessages[(counter++)%2],
+                    normalizeMessage(new String(httpMessage, StandardCharsets.UTF_8)));
+        }
+    }
+
+    private static String normalizeMessage(String s) {
+        return s.replaceAll("Date: .*", "Date: SOMETHING")
+                .replaceAll("User-Agent: .*", "User-Agent: Something");
+    }
+
+    private List<byte[]> coalesceObservations(TrafficStream recordedTrafficStream) throws IOException {
+        var rval = new ArrayList<byte[]>();
+        boolean lastWasRead = true;
+        try (var accumOutputStream = new ByteArrayOutputStream()) {
+            for (var obs : recordedTrafficStream.getSubStreamList()) {
+                if (!obs.hasRead() && !obs.hasTs()) {
+                    continue;
+                }
+                if (lastWasRead != obs.hasRead()) {
+                    lastWasRead = obs.hasRead();
+                    rval.add(accumOutputStream.toByteArray());
+                    accumOutputStream.reset();
+                }
+                accumOutputStream.write((obs.hasRead() ? obs.getRead().getData() : obs.getWrite().getData())
+                        .toByteArray());
+            }
+            var remaining = accumOutputStream.toByteArray();
+            if (remaining.length > 0) {
+                rval.add(remaining);
+            }
+        }
+        return rval;
+    }
+
+    private static String makeTestRequestViaClient(CloseableHttpClient client, URI nettyEndpoint) throws IOException {
+        String responseBody;
+        var request = new HttpGet(nettyEndpoint);
+        request.setProtocolVersion(new ProtocolVersion("HTTP", 1, 1));
+        request.setHeader("Host", "localhost");
+        for (int i = 0; i < 20; i++) {
+            request.setHeader("DumbAndLongHeaderValue-" + i, "" + i);
+        }
+        var response = client.execute(request);
+        responseBody = new String(response.getEntity().getContent().readAllBytes());
+        return responseBody;
     }
 
     private static Tuple<NettyScanningHttpProxy, HttpServer>

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/UtilsTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/UtilsTest.java
@@ -4,11 +4,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import java.nio.charset.StandardCharsets;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-
-import static org.junit.jupiter.api.Assertions.*;
 
 @Slf4j
 class UtilsTest {

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/datahandlers/JsonEmitterTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/datahandlers/JsonEmitterTest.java
@@ -5,14 +5,10 @@ import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.StringReader;
 import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
-import java.util.function.Supplier;
-
-import static org.junit.jupiter.api.Assertions.*;
 
 @Slf4j
 class JsonEmitterTest {

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/datahandlers/http/ListKeyAdaptingCaseInsensitiveHeadersMapTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/datahandlers/http/ListKeyAdaptingCaseInsensitiveHeadersMapTest.java
@@ -7,8 +7,6 @@ import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.*;
-
 class ListKeyAdaptingCaseInsensitiveHeadersMapTest {
 
     private static final String COOKIE = "cookie";


### PR DESCRIPTION
### Description
* **_Category_**: Bug fix
* _**Why these changes are required**_?: To fix bugs when packet boundaries may be anywhere within an HTTP request.
* **_What is the old behavior before changes and new behavior after changes?_**: The TrafficStream recording would be incomplete and/or we would indefinitely hang on requests to ConditionallyReliableLoggingHttpRequestHandler that should have been stopped for the last bytes before flushing.  The old code would get confused and the state model would break.

This change replaces direct usage an HttpObjectDecoder for an HttpRequestDecoder.

ByteBufs are now passed through an EmbeddedChannel that has an HttpRequestDecoder (SImpleHttpRequestDecoder to be specific, which is a bit lighter on memory retention) followed by a SimpleDecodedHttpRequestHandler. When the second handler gets notification that the HttpRequest and LastHttpContent objects are received, that triggers different callbacks. This allows the HttpRequestDecoder object to do the intra-line buffering that the Decoder by itself doesn't do. We're still able to use the decoder in a lightweight way by overriding createMessage() to use a new PassThroughHeaders as opposed to DefaultHttpHeaders(). Both of the tests within ConditionallyReliableLoggingHttpRequestHandlerTest now pass.

### Issues Resolved
MIGRATIONS-1080

### Testing
Unit tests pass.  :dockerSolution:composeUp shows tuples being output by the comparator w/ responses (spot-checked).

### Check List
- [x] New functionality includes testing
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
