### PR TITLE
Integrate the traffic comparator and jupyter notebooks to the docker-compose solution

### DIFF
--- a/TrafficCapture/dockerSolution/README.md
+++ b/TrafficCapture/dockerSolution/README.md
@@ -1,0 +1,19 @@
+# Overview
+
+To use launch the end-2-end (E2E) services in containers, simply run `./gradlew :dockerSolution:composeUp` from the
+TrafficCapture directory (parent of this directory). That will build all java artifacts and create the necessary images
+for each service.  `./gradlew :dockerSolution:composeDown` will tear everything (volumes, networks, containers) back
+down again.
+
+Notice that most of the Dockerfiles are dynamically constructed in the build hierarchy. Some efforts have been made
+to ensure that changes will make it into containers to be launched.
+
+If a user wants to use their own checkout of the traffic-comparator repo, just set the environment variable "
+TRAFFIC_COMPARATOR_DIRECTORY" to the directory that contains `setup.py`. Otherwise, if that isn't set, the traffic
+comparator repo will be checked out to the build directory and that will be used. Notice that the checkout happens when
+the directory wasn't present and there wasn't an environment variable specifying a directory. Once a directory exists,
+it will be mounted to the traffic-comparator and jupyter services.
+
+Netcat is still used to connect several of the components and we're still working on improving the resiliency story
+between these containers. The long term approach is to replace fixed streams with message bus approaches directly (i.e.
+Kafka).  In the short term, we can and are beginning, to leverage things like conditions on dependent services.

--- a/TrafficCapture/dockerSolution/build.gradle
+++ b/TrafficCapture/dockerSolution/build.gradle
@@ -6,6 +6,20 @@ plugins {
 
 import java.security.MessageDigest
 import com.bmuschko.gradle.docker.tasks.image.DockerBuildImage
+import org.apache.tools.ant.taskdefs.condition.Os
+
+def getTrafficComparatorDirectory() {
+    String overrideTrafficComparatorDirectory = System.getenv(TRAFFIC_COMPARATOR_DIRECTORY_ENV)
+    String rval = overrideTrafficComparatorDirectory != null ?
+            overrideTrafficComparatorDirectory : TRAFFIC_COMPARATOR_REPO_DIRECTORY;
+    return rval
+}
+
+ext {
+    TRAFFIC_COMPARATOR_REPO_DIRECTORY = "build/traffic-comparator"
+    TRAFFIC_COMPARATOR_DIRECTORY_ENV = "TRAFFIC_COMPARATOR_DIRECTORY"
+    REALIZED_TRAFFIC_COMPARATOR_DIRECTORY = project.file(getTrafficComparatorDirectory())
+ }
 
 def calculateDockerHash(String projectName) {
     MessageDigest digest = MessageDigest.getInstance('SHA-256')
@@ -27,6 +41,17 @@ dependencies {
     implementation project(':trafficReplayer')
 }
 
+task cloneComparatorRepoIfNeeded(type: Exec) {
+    String comparatorDirectory = project.file(REALIZED_TRAFFIC_COMPARATOR_DIRECTORY);
+    String repo = 'https://github.com/opensearch-project/traffic-comparator.git'
+    onlyIf {
+        !(new File(comparatorDirectory).exists())
+    }
+    commandLine = Os.isFamily(Os.FAMILY_WINDOWS) ?
+            ['git', 'clone', repo, TRAFFIC_COMPARATOR_REPO_DIRECTORY ] :
+            ['/bin/sh', '-c', "git clone ${repo} ${TRAFFIC_COMPARATOR_REPO_DIRECTORY}"]
+}
+
 def dockerFilesForExternalServices = [
         "elasticsearchWithSearchGuard": "elasticsearch_searchguard",
         "openSearchBenchmark": "open_search_benchmark"
@@ -41,7 +66,33 @@ dockerFilesForExternalServices.each { projectName, dockerImageName ->
     }
 }
 
-def containerServices = [
+def trafficComparatorServices = [
+        "trafficComparator": "traffic_comparator",
+        "jupyterNotebook": "jupyter_notebook"
+]
+trafficComparatorServices.forEach {projectName, dockerImageName ->
+    def dockerBuildDir = "build/docker/${projectName}"
+    task("copyArtifact_${projectName}", type: Copy) {
+        dependsOn(tasks.getByName('cloneComparatorRepoIfNeeded'))
+        from REALIZED_TRAFFIC_COMPARATOR_DIRECTORY
+        into dockerBuildDir
+        include 'setup.py'
+        System.out.println("Setting up copy of setup.py into " + projectDir + " from " + REALIZED_TRAFFIC_COMPARATOR_DIRECTORY)
+    }
+
+    task "createDockerfile_${projectName}"(type: com.bmuschko.gradle.docker.tasks.image.Dockerfile) {
+        dependsOn "copyArtifact_${projectName}"
+        destFile = project.file("${dockerBuildDir}/Dockerfile")
+        from 'python:3.10.10'
+        runCommand("apt-get update && apt-get install -y netcat lsof")
+        copyFile("setup.py", "/setup.py")
+        runCommand("pip3 install --editable \".[data]\"")
+        // container stay-alive
+        defaultCommand('tail', '-f', '/dev/null')
+    }
+}
+
+def javaContainerServices = [
         "trafficCaptureProxyServer": "capture_proxy",
         "kafkaPrinter": "kafka_capture_puller",
         "trafficReplayer": "traffic_replayer"
@@ -50,7 +101,7 @@ def baseImageProjectOverrides = [
         "trafficCaptureProxyServer": "elasticsearchWithSearchGuard"
 ]
 
-containerServices.each { projectName, dockerImageName ->
+javaContainerServices.each { projectName, dockerImageName ->
     def dockerBuildDir = "build/docker/${projectName}"
     def artifactsDir = "${dockerBuildDir}/jars";
     task("copyArtifact_${projectName}", type: Copy) {
@@ -93,7 +144,10 @@ containerServices.each { projectName, dockerImageName ->
         defaultCommand('tail', '-f', '/dev/null')
         //defaultCommand('/runJavaWithClasspath.sh', '...')
     }
+}
 
+(javaContainerServices + trafficComparatorServices).forEach { projectName, dockerImageName ->
+    def dockerBuildDir = "build/docker/${projectName}"
     task "buildDockerImage_${projectName}"(type: DockerBuildImage) {
         dependsOn "createDockerfile_${projectName}"
         inputDir = project.file("${dockerBuildDir}")
@@ -103,6 +157,12 @@ containerServices.each { projectName, dockerImageName ->
 }
 
 dockerCompose {
+        String overrideTrafficComparatorDirectory = System.getenv(TRAFFIC_COMPARATOR_DIRECTORY_ENV)
+        if (overrideTrafficComparatorDirectory == null) {
+            System.out.println("setting environment variable ${TRAFFIC_COMPARATOR_DIRECTORY_ENV}=${overrideTrafficComparatorDirectory}")
+            environment.put(TRAFFIC_COMPARATOR_DIRECTORY_ENV, REALIZED_TRAFFIC_COMPARATOR_DIRECTORY)
+            exposeAsEnvironment(this)
+        }
     useComposeFiles.add("src/main/docker/docker-compose.yml")
 }
 
@@ -113,7 +173,10 @@ task buildDockerImages {
     dependsOn buildDockerImage_kafkaPrinter
     dependsOn buildDockerImage_trafficCaptureProxyServer
     dependsOn buildDockerImage_trafficReplayer
-    //dependsOn buildDockerImage_
+    dependsOn buildDockerImage_trafficComparator
+    dependsOn buildDockerImage_jupyterNotebook
 }
 
-tasks.getByName('composeUp').dependsOn(tasks.getByName('buildDockerImages'))
+tasks.getByName('composeUp')
+        .dependsOn(tasks.getByName('buildDockerImages'))
+        .dependsOn(tasks.getByName('cloneComparatorRepoIfNeeded'))

--- a/TrafficCapture/dockerSolution/src/main/docker/docker-compose.yml
+++ b/TrafficCapture/dockerSolution/src/main/docker/docker-compose.yml
@@ -61,11 +61,14 @@ services:
     image: 'migrations/traffic_replayer:latest'
     networks:
       - migrations
+    depends_on:
+      opensearchtarget:
+        condition: service_started
+      trafficcomparator:
+        condition: service_healthy
     ports:
       - "10001:10001"
-    depends_on:
-      - opensearchtarget
-    command: /bin/sh -c "nc -v -l -p 10001 | /runJavaWithClasspath.sh org.opensearch.migrations.replay.TrafficReplayer https://opensearchtarget:9200 --auth-header-value Basic\\ YWRtaW46YWRtaW4= --insecure"
+    command: /bin/sh -c "nc -v -l -p 10001 | /runJavaWithClasspath.sh org.opensearch.migrations.replay.TrafficReplayer https://opensearchtarget:9200 --auth-header-value Basic\\ YWRtaW46YWRtaW4= --insecure | nc trafficcomparator 9220"
 
   opensearchtarget:
     image: 'opensearchproject/opensearch:latest'
@@ -76,35 +79,59 @@ services:
     ports:
       - "29200:9200"
 
-#  traffic_comparator:
-#    image: 'migrations/opensearch_migrations_comparator:latest'
-
-  opensearch-benchmarks:
-    image: 'migrations/open_search_benchmark:latest'
+  trafficcomparator:
+    image: 'migrations/traffic_comparator:latest'
     networks:
       - migrations
-    depends_on:
-      - captureproxy
-    command:
-      - /bin/sh
-      - -c
-      - >
-        echo "Running opensearch-benchmark w/ 'geonames' workload..." &&
-        opensearch-benchmark execute-test --distribution-version=1.0.0 --target-host=https://captureproxy:9200 --workload=geonames --pipeline=benchmark-only --test-mode --kill-running-processes --workload-params "target_throughput:0.5,bulk_size:10,bulk_indexing_clients:1,search_clients:1"  --client-options="use_ssl:true,verify_certs:false" &&
-        echo "Running opensearch-benchmark w/ 'http_logs' workload..." &&
-        opensearch-benchmark execute-test --distribution-version=1.0.0 --target-host=https://captureproxy:9200 --workload=http_logs --pipeline=benchmark-only --test-mode --kill-running-processes --workload-params "target_throughput:0.5,bulk_size:10,bulk_indexing_clients:1,search_clients:1"  --client-options="use_ssl:true,verify_certs:false" &&
-        echo "Running opensearch-benchmark w/ 'nested' workload..." &&
-        opensearch-benchmark execute-test --distribution-version=1.0.0 --target-host=https://captureproxy:9200 --workload=nested --pipeline=benchmark-only --test-mode --kill-running-processes --workload-params "target_throughput:0.5,bulk_size:10,bulk_indexing_clients:1,search_clients:1"  --client-options="use_ssl:true,verify_certs:false" &&
-        echo "Running opensearch-benchmark w/ 'nyc_taxis' workload..." &&
-        opensearch-benchmark execute-test --distribution-version=1.0.0 --target-host=https://captureproxy:9200 --workload=nyc_taxis --pipeline=benchmark-only --test-mode --kill-running-processes --workload-params "target_throughput:0.5,bulk_size:10,bulk_indexing_clients:1,search_clients:1"  --client-options="use_ssl:true,verify_certs:false"
+    ports:
+      - "9220:9220"
+    healthcheck:
+      test: "lsof -i -P -n"
+    volumes:
+      - ${TRAFFIC_COMPARATOR_DIRECTORY}:/trafficComparator
+      - sharedComparatorSqlResults:/shared
+    command: /bin/sh -c "cd trafficComparator && pip3 install --editable . && nc -v -l -p 9220 | tee /dev/stderr | trafficcomparator -vv stream | trafficcomparator dump-to-sqlite --db /shared/comparisons.db"
+
+  jupyter_notebook:
+    image: 'migrations/jupyter_notebook:latest'
+    networks:
+      - migrations
+    ports:
+      - "8888:8888"
+    volumes:
+      - ${TRAFFIC_COMPARATOR_DIRECTORY}:/trafficComparator
+      - sharedComparatorSqlResults:/shared
+    environment:
+      # this needs to match the output db that traffic_comparator writes to
+      - COMPARISONS_DB_LOCATION=/shared/comparisons.db
+    command: /bin/sh -c 'cd trafficComparator && pip3 install --editable ".[data]" && jupyter notebook --ip=0.0.0.0 --port=8888 --no-browser --allow-root'
+
+#  opensearch-benchmarks:
+#    image: 'migrations/open_search_benchmark:latest'
+#    networks:
+#      - migrations
+#    depends_on:
+#      - captureproxy
+#    command:
+#      - /bin/sh
+#      - -c
+#      - >
+#        echo "Running opensearch-benchmark w/ 'geonames' workload..." &&
+#        opensearch-benchmark execute-test --distribution-version=1.0.0 --target-host=https://captureproxy:9200 --workload=geonames --pipeline=benchmark-only --test-mode --kill-running-processes --workload-params "target_throughput:0.5,bulk_size:10,bulk_indexing_clients:1,search_clients:1"  --client-options="use_ssl:true,verify_certs:false" &&
+#        echo "Running opensearch-benchmark w/ 'http_logs' workload..." &&
+#        opensearch-benchmark execute-test --distribution-version=1.0.0 --target-host=https://captureproxy:9200 --workload=http_logs --pipeline=benchmark-only --test-mode --kill-running-processes --workload-params "target_throughput:0.5,bulk_size:10,bulk_indexing_clients:1,search_clients:1"  --client-options="use_ssl:true,verify_certs:false" &&
+#        echo "Running opensearch-benchmark w/ 'nested' workload..." &&
+#        opensearch-benchmark execute-test --distribution-version=1.0.0 --target-host=https://captureproxy:9200 --workload=nested --pipeline=benchmark-only --test-mode --kill-running-processes --workload-params "target_throughput:0.5,bulk_size:10,bulk_indexing_clients:1,search_clients:1"  --client-options="use_ssl:true,verify_certs:false" &&
+#        echo "Running opensearch-benchmark w/ 'nyc_taxis' workload..." &&
+#        opensearch-benchmark execute-test --distribution-version=1.0.0 --target-host=https://captureproxy:9200 --workload=nyc_taxis --pipeline=benchmark-only --test-mode --kill-running-processes --workload-params "target_throughput:0.5,bulk_size:10,bulk_indexing_clients:1,search_clients:1"  --client-options="use_ssl:true,verify_certs:false"
 
 volumes:
   zookeeper_data:
     driver: local
   kafka_data:
     driver: local
-  traffic_comparator:
-
+  sharedComparatorSqlResults:
+    driver: local
 
 networks:
   migrations:


### PR DESCRIPTION
I've left OpenSearchBenchmark commented out at the moment so that developers opt-in rather than opting out of it.

### Description
`./gradlew :dockerSolution:composeUp` brings up the entire stack, including the jupyter notebooks.

### Issues Resolved
MIGRATIONS-1124

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
Manual testing

### Check List
- [ ] New functionality includes testing
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
