### PR TITLE
Add a global gradle file so that we can set the java version to use.

### DIFF
--- a/TrafficCapture/build.gradle
+++ b/TrafficCapture/build.gradle
@@ -1,0 +1,9 @@
+allprojects {
+    apply plugin: 'java'
+
+    java {
+        toolchain {
+            languageVersion = JavaLanguageVersion.of(11)
+        }
+    }
+}

--- a/TrafficCapture/settings.gradle
+++ b/TrafficCapture/settings.gradle
@@ -7,7 +7,7 @@
  * in the user manual at https://docs.gradle.org/8.0.2/userguide/multi_project_builds.html
  */
 
-rootProject.name = 'LoggingProxy'
+rootProject.name = 'TrafficCapture'
 include('captureKafkaOffloader',
         'captureOffloader',
         'captureProtobufs',


### PR DESCRIPTION
When the user doesn't have the specific version of java installed, they'll see the following...

* What went wrong: A problem occurred evaluating project ...
> Could not resolve all dependencies for configuration ...
   > Failed to calculate the value of task '...:compileJava' property 'javaCompiler'.
      > No matching toolchains found for requested specification: {languageVersion=11, vendor=any, implementation=vendor-specific}.
         > No locally installed toolchains match (see https://docs.gradle.org/8.0.2/userguide/toolchains.html#sec:auto_detection) and toolchain download repositories have not been configured (see https://docs.gradle.org/8.0.2/userguide/toolchains.html#sub:download_repositories).

This will apply for all of our java builds in projects under this directory.

### Issues Resolved
[MIGRATIONS-1112](https://opensearch.atlassian.net/browse/MIGRATIONS-1112)

### Testing
manual testing w/ different java versions, running gradle on different targets, and from within child project directories.

### Check List
- [ ] New functionality includes testing
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
