### PR TITLE
Migrations-1126 - Add documentation on compatibility and running one-click deployment locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,14 @@ This repo will contain code and documentation to assist in migrations and upgrad
 
 Developers must run the "install_githooks.sh" script in order to add the pre-commit hook.
 
+## Docker Solution
+
+The TrafficCapture directory hosts a set of projects designed to facilitate the proxying and capturing of HTTP
+traffic, which can then be offloaded and replayed to other HTTP server(s).
+
+More documentation on this solution can be found here:
+[TrafficCapture README](TrafficCapture/README.md)
+
 ## Security
 
 See [CONTRIBUTING](CONTRIBUTING.md#security-issue-notifications) for more information.

--- a/TrafficCapture/README.md
+++ b/TrafficCapture/README.md
@@ -1,3 +1,9 @@
+## Running the Docker Solution
+
+While in the TrafficCapture directory, run the following command:
+
+`./gradlew :dockerSolution:composeUp`
+
 ## Compatibility
 
 Must have Java version 11 installed.

--- a/TrafficCapture/README.md
+++ b/TrafficCapture/README.md
@@ -1,0 +1,22 @@
+## Compatibility
+
+Must have Java version 11 installed.
+
+The tools in this directory can only be built if you have Java version 11 installed.
+
+The version is specified in `TrafficCapture/build.gradle` using a Java toolchain, which allows us
+to decouple the Java version used by Gradle itself from Java version used by the tools here.
+
+Any attempt to use a different version will cause the build to fail and will result in the following error (or similar)
+depending on which tool/project is being built. The below example shows the error printed when running e.g `./gradlew 
+trafficCaptureProxyServer:build`
+
+```
+* What went wrong:
+A problem occurred evaluating project ':trafficCaptureProxyServer'.
+> Could not resolve all dependencies for configuration ':trafficCaptureProxyServer:opensearchSecurityPlugin'.
+   > Failed to calculate the value of task ':trafficCaptureProxyServer:compileJava' property 'javaCompiler'.
+      > No matching toolchains found for requested specification: {languageVersion=10, vendor=any, implementation=vendor-specific}.
+         > No locally installed toolchains match (see https://docs.gradle.org/8.0.2/userguide/toolchains.html#sec:auto_detection) and toolchain download repositories have not been configured (see https://docs.gradle.org/8.0.2/userguide/toolchains.html#sub:download_repositories).
+
+```


### PR DESCRIPTION
### Description
This PR adds a readme file to the TrafficCapture directory documenting how to run the solution and the compatibility of all the tools in that directory.

### Issues Resolved
[Migrations-1126](https://opensearch.atlassian.net/browse/MIGRATIONS-1126

### Check List
- [ ] New functionality includes testing
  - [ ] All tests pass, including unit test, integration test and doctest
- [X] New functionality has been documented
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
