### PR TITLE
[Spotbugs] Explicitly specify character set for PrintStream object in unit test code

### DIFF
--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/PruferTreeGeneratorTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/PruferTreeGeneratorTest.java
@@ -19,7 +19,10 @@ public class PruferTreeGeneratorTest {
         final int numNodes = 5;
         var edges = IntStream.range(0, numNodes-2).map(x->random.nextInt(numNodes)+1).toArray();
         var tree = ptg.makeTree(vn -> Integer.toString(vn), edges);
-        try (var baos = new ByteArrayOutputStream(); var printStream = new PrintStream(baos)) {
+        try (
+                var baos = new ByteArrayOutputStream();
+                var printStream = new PrintStream(baos, false, StandardCharsets.UTF_8)
+        ) {
             printTree(ptg, printStream, tree);
             printStream.flush();
             var expectedOutput = "5: { 3: {  1  2 } 4}";


### PR DESCRIPTION
### Description
[Test fix] Prior to this change, `:trafficReplayer:spotbugsTest` was failing with SpotBugs complaining about a reliance on default character sets. Explicitly specifying the character set for the `PrintStream` object resolves this.

### Issues Resolved
N/A

### Testing
`:trafficReplayer:spotbugsTest` was failing before. Now it passes.

### Check List
- [x] New functionality includes testing
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
