### PR TITLE
WIP: Remove Response Parsing from Capture

### DIFF
--- a/TrafficCapture/captureKafkaOffloader/src/main/java/org/opensearch/migrations/trafficcapture/kafkaoffloader/KafkaCaptureFactory.java
+++ b/TrafficCapture/captureKafkaOffloader/src/main/java/org/opensearch/migrations/trafficcapture/kafkaoffloader/KafkaCaptureFactory.java
@@ -21,12 +21,15 @@ public class KafkaCaptureFactory implements IConnectionCaptureFactory {
 
     private static final String DEFAULT_TOPIC_NAME_FOR_TRAFFIC = "logging-traffic-topic";
 
+    private final String nodeId;
     // Potential future optimization here to use a direct buffer (e.g. nio) instead of byte array
     private final Producer<String, byte[]> producer;
     private final String topicNameForTraffic;
     private final int bufferSize;
 
-    public KafkaCaptureFactory(Producer<String, byte[]> producer, String topicNameForTraffic, int bufferSize) {
+    public KafkaCaptureFactory(String nodeId, Producer<String, byte[]> producer,
+                               String topicNameForTraffic, int bufferSize) {
+        this.nodeId = nodeId;
         // There is likely some default timeout/retry settings we should configure here to reduce any potential blocking
         // i.e. the Kafka cluster is unavailable
         this.producer = producer;
@@ -34,8 +37,8 @@ public class KafkaCaptureFactory implements IConnectionCaptureFactory {
         this.bufferSize = bufferSize;
     }
 
-    public KafkaCaptureFactory(Producer<String, byte[]> producer, int bufferSize) {
-        this(producer, DEFAULT_TOPIC_NAME_FOR_TRAFFIC, bufferSize);
+    public KafkaCaptureFactory(String nodeId, Producer<String, byte[]> producer, int bufferSize) {
+        this(nodeId, producer, DEFAULT_TOPIC_NAME_FOR_TRAFFIC, bufferSize);
     }
 
     @Override
@@ -45,7 +48,7 @@ public class KafkaCaptureFactory implements IConnectionCaptureFactory {
         CompletableFuture[] singleAggregateCfRef = new CompletableFuture[1];
         singleAggregateCfRef[0] = CompletableFuture.completedFuture(null);
         WeakHashMap<CodedOutputStream, ByteBuffer> codedStreamToByteStreamMap = new WeakHashMap<>();
-        return new StreamChannelConnectionCaptureSerializer(connectionId,
+        return new StreamChannelConnectionCaptureSerializer(nodeId, connectionId,
             () -> {
                 ByteBuffer bb = ByteBuffer.allocate(bufferSize);
                 var cos = CodedOutputStream.newInstance(bb);

--- a/TrafficCapture/captureKafkaOffloader/src/test/java/org/opensearch/migrations/trafficcapture/kafkaoffloader/KafkaCaptureFactoryTest.java
+++ b/TrafficCapture/captureKafkaOffloader/src/test/java/org/opensearch/migrations/trafficcapture/kafkaoffloader/KafkaCaptureFactoryTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 public class KafkaCaptureFactoryTest {
 
+    public static final String TEST_NODE_ID_STRING = "test_node_id";
     @Mock
     private Producer<String, byte[]> mockProducer;
 
@@ -32,7 +33,8 @@ public class KafkaCaptureFactoryTest {
 
     @Test
     public void testLinearOffloadingIsSuccessful() throws IOException {
-        KafkaCaptureFactory kafkaCaptureFactory = new KafkaCaptureFactory(mockProducer, 1024*1024);
+        KafkaCaptureFactory kafkaCaptureFactory =
+                new KafkaCaptureFactory(TEST_NODE_ID_STRING, mockProducer, 1024*1024);
         IChannelConnectionCaptureSerializer offloader = kafkaCaptureFactory.createOffloader(connectionId);
 
         List<Callback> recordSentCallbacks = new ArrayList<>(3);
@@ -79,7 +81,8 @@ public class KafkaCaptureFactoryTest {
 
     @Test
     public void testOngoingFuturesAreAggregated() throws IOException {
-        KafkaCaptureFactory kafkaCaptureFactory = new KafkaCaptureFactory(mockProducer, 1024*1024);
+        KafkaCaptureFactory kafkaCaptureFactory =
+                new KafkaCaptureFactory(TEST_NODE_ID_STRING, mockProducer, 1024*1024);
         IChannelConnectionCaptureSerializer offloader = kafkaCaptureFactory.createOffloader(connectionId);
 
         List<Callback> recordSentCallbacks = new ArrayList<>(3);

--- a/TrafficCapture/captureOffloader/build.gradle
+++ b/TrafficCapture/captureOffloader/build.gradle
@@ -26,5 +26,9 @@ dependencies {
     implementation "com.google.protobuf:protobuf-java:3.22.2"
     implementation 'org.projectlombok:lombok:1.18.26'
     implementation group: 'org.slf4j', name: 'slf4j-api', version: '2.0.7'
+
+    testImplementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.20.0'
+    testImplementation group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.20.0'
+    testImplementation group: 'org.apache.logging.log4j', name: 'log4j-slf4j2-impl', version: '2.20.0'
     testImplementation group: 'org.slf4j', name: 'slf4j-api', version: '2.0.7'
 }

--- a/TrafficCapture/captureOffloader/src/test/resources/log4j2.properties
+++ b/TrafficCapture/captureOffloader/src/test/resources/log4j2.properties
@@ -1,0 +1,11 @@
+status = error 
+
+# Root logger options
+rootLogger.level = debug
+rootLogger.appenderRef.console.ref = Console
+
+# Console appender configuration
+appender.console.type = Console
+appender.console.name = Console
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = %d %p %c{1.} [%t] %m%n

--- a/TrafficCapture/captureProtobufs/src/main/proto/TrafficCaptureStream.proto
+++ b/TrafficCapture/captureProtobufs/src/main/proto/TrafficCaptureStream.proto
@@ -67,7 +67,8 @@ message TrafficObservation {
 }
 
 message TrafficStream {
-  string id = 1; // persistent identifier for all stream objects within a single connection
+  string connectionId = 1; // persistent identifier for all stream objects within a single connection
+  string nodeId = 5; // unique namespace such as a nodeId or computer mac address
   repeated TrafficObservation subStream = 2;
   oneof index {
     int32 number = 3;

--- a/TrafficCapture/kafkaPrinter/src/test/java/org/opensearch/migrations/KafkaPrinterTest.java
+++ b/TrafficCapture/kafkaPrinter/src/test/java/org/opensearch/migrations/KafkaPrinterTest.java
@@ -44,7 +44,8 @@ class KafkaPrinterTest {
                 .setNanos(t.getNano())
                 .build();
         var builder = TrafficStream.newBuilder()
-                .setId("testStreamId")
+                .setNodeId("testNode")
+                .setConnectionId("testStreamId")
                 .setNumberOfThisLastChunk(1);
         for (int i = 0; i < numReads; ++i) {
             builder = builder.addSubStream(TrafficObservation.newBuilder().setTs(fixedTimestamp)

--- a/TrafficCapture/nettyWireLogging/src/test/java/org/opensearch/migrations/trafficcapture/netty/ConditionallyReliableLoggingHttpRequestHandlerTest.java
+++ b/TrafficCapture/nettyWireLogging/src/test/java/org/opensearch/migrations/trafficcapture/netty/ConditionallyReliableLoggingHttpRequestHandlerTest.java
@@ -37,7 +37,7 @@ class ConditionallyReliableLoggingHttpRequestHandlerTest {
         AtomicReference<ByteBuffer> outputByteBuffer = new AtomicReference<>();
         byte[] scratchBytes = new byte[1024*1024];
         AtomicInteger flushCount = new AtomicInteger();
-        var offloader = new StreamChannelConnectionCaptureSerializer("Test",
+        var offloader = new StreamChannelConnectionCaptureSerializer("Test", "connection",
                 () -> CodedOutputStream.newInstance(scratchBytes),
                 cos -> {
                     outputByteBuffer.set(ByteBuffer.wrap(scratchBytes, 0, cos.getTotalBytesWritten()));

--- a/TrafficCapture/trafficCaptureProxyServer/src/test/java/org/opensearch/migrations/trafficcapture/InMemoryConnectionCaptureFactory.java
+++ b/TrafficCapture/trafficCaptureProxyServer/src/test/java/org/opensearch/migrations/trafficcapture/InMemoryConnectionCaptureFactory.java
@@ -13,6 +13,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 public class InMemoryConnectionCaptureFactory implements IConnectionCaptureFactory {
 
     private final int bufferSize;
+    private final String nodeId;
 
     @AllArgsConstructor
     public static class RecordedTrafficStream {
@@ -23,8 +24,9 @@ public class InMemoryConnectionCaptureFactory implements IConnectionCaptureFacto
     ConcurrentLinkedQueue<RecordedTrafficStream> recordedStreams = new ConcurrentLinkedQueue<>();
     Runnable onCaptureClosedCallback;
 
-    public InMemoryConnectionCaptureFactory(int bufferSize, Runnable onCaptureClosedCallback) {
+    public InMemoryConnectionCaptureFactory(String nodeId, int bufferSize, Runnable onCaptureClosedCallback) {
         this.bufferSize = bufferSize;
+        this.nodeId = nodeId;
         this.onCaptureClosedCallback = onCaptureClosedCallback;
     }
 
@@ -41,7 +43,7 @@ public class InMemoryConnectionCaptureFactory implements IConnectionCaptureFacto
         CompletableFuture[] singleAggregateCfRef = new CompletableFuture[1];
         singleAggregateCfRef[0] = CompletableFuture.completedFuture(null);
         WeakHashMap<CodedOutputStream, ByteBuffer> codedStreamToByteBufferMap = new WeakHashMap<>();
-        return new StreamChannelConnectionCaptureSerializer(connectionId, () -> {
+        return new StreamChannelConnectionCaptureSerializer(nodeId, connectionId, () -> {
             ByteBuffer bb = ByteBuffer.allocate(bufferSize);
             var cos = CodedOutputStream.newInstance(bb);
             codedStreamToByteBufferMap.put(cos, bb);

--- a/TrafficCapture/trafficCaptureProxyServer/src/test/java/org/opensearch/migrations/trafficcapture/proxyserver/netty/NettyScanningHttpProxyTest.java
+++ b/TrafficCapture/trafficCaptureProxyServer/src/test/java/org/opensearch/migrations/trafficcapture/proxyserver/netty/NettyScanningHttpProxyTest.java
@@ -81,6 +81,7 @@ class NettyScanningHttpProxyTest {
     private static final Random random = new Random();
     public static final String LOCALHOST = "localhost";
     public static final String UPSTREAM_SERVER_RESPONSE_BODY = "Hello tester!\n";
+    public static final String TEST_NODE_ID_STRING = "test_node_id";
 
     private static int retryWithNewPortUntilNoThrow(Consumer<Integer> r) {
         int numTries = 0;
@@ -102,7 +103,7 @@ class NettyScanningHttpProxyTest {
         final int NUM_EXPECTED_TRAFFIC_STREAMS = 1;
         final int NUM_INTERACTIONS = 3;
         CountDownLatch interactionsCapturedCountdown = new CountDownLatch(NUM_EXPECTED_TRAFFIC_STREAMS);
-        var captureFactory = new InMemoryConnectionCaptureFactory(1024*1024,
+        var captureFactory = new InMemoryConnectionCaptureFactory(TEST_NODE_ID_STRING, 1024*1024,
                 () -> interactionsCapturedCountdown.countDown());
         var servers = startServers(captureFactory);
 

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/Accumulation.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/Accumulation.java
@@ -1,0 +1,21 @@
+package org.opensearch.migrations.replay;
+
+public class Accumulation {
+    RequestResponsePacketPair rrPair = new RequestResponsePacketPair();
+    State state = State.NOTHING_SENT;
+
+    @Override
+    public String toString() {
+        final StringBuilder sb = new StringBuilder("Accumulation{");
+        sb.append("rrPair=").append(rrPair);
+        sb.append(", state=").append(state);
+        sb.append('}');
+        return sb.toString();
+    }
+
+    enum State {
+        NOTHING_SENT,
+        RESPONSE_SENT,
+        REQUEST_SENT
+    }
+}

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/RequestResponsePacketPair.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/RequestResponsePacketPair.java
@@ -3,6 +3,7 @@ package org.opensearch.migrations.replay;
 import lombok.extern.slf4j.Slf4j;
 
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -16,7 +17,7 @@ public class RequestResponsePacketPair {
 
     public void addRequestData(Instant packetTimeStamp, byte[] data) {
         if (log.isTraceEnabled()) {
-            log.trace(this + " Adding request data: " + new String(data, Charset.defaultCharset()));
+            log.trace(this + " Adding request data: " + new String(data, StandardCharsets.UTF_8));
         }
         if (requestData == null) {
             requestData = new HttpMessageAndTimestamp(packetTimeStamp);
@@ -27,21 +28,13 @@ public class RequestResponsePacketPair {
 
     public void addResponseData(Instant packetTimeStamp, byte[] data) {
         if (log.isTraceEnabled()) {
-            log.trace(this + " Adding response data: " + new String(data, Charset.defaultCharset()));
+            log.trace(this + " Adding response data: " + new String(data, StandardCharsets.UTF_8));
         }
         if (responseData == null) {
             responseData = new HttpMessageAndTimestamp(packetTimeStamp);
         }
         responseData.add(data);
         responseData.setLastPacketTimestamp(packetTimeStamp);
-    }
-
-    public Stream<byte[]> getRequestDataStream() {
-        return requestData.stream();
-    }
-
-    public Stream<byte[]> getResponseDataStream() {
-        return responseData.stream();
     }
 
     @Override

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/TrafficReplayer.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/TrafficReplayer.java
@@ -255,6 +255,7 @@ public class TrafficReplayer {
                           CapturedTrafficToHttpTransactionAccumulator trafficToHttpTransactionAccumulator) {
         trafficChunkStream
                 .forEach(ts->ts.getSubStreamList().stream()
-                        .forEach(o-> trafficToHttpTransactionAccumulator.accept(ts.getId(), o)));
+                        .forEach(o->
+                                trafficToHttpTransactionAccumulator.accept(ts.getNodeId(), ts.getConnectionId(), o)));
     }
 }

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/TrafficStreamMap.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/TrafficStreamMap.java
@@ -1,10 +1,44 @@
 package org.opensearch.migrations.replay;
 
-import java.util.Map;
+import java.time.Instant;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Stream;
 
 /**
- *
+ * This object manages the lifecycle of Accumulation objects, creating new ones and (eventually, once implemented)
+ * expiring old entries.  Callers are expected to modify the Accumulation values themselves, but to proxy every
+ * distinct interaction through this class along with the timestamp of the observed interaction.  That (will)
+ * allow this class to expunge outdated entries. Notice that a callback (or calling) mechanism still needs to
+ * be implemented so that the calling context is aware that items have been expired.
  */
 public class TrafficStreamMap {
-    Map<String, Accumulation> 
+    public TrafficStreamMap() {
+        this.connectionToAccumulationMap = new ConcurrentHashMap<>();
+    }
+
+    ConcurrentHashMap<String, Accumulation> connectionToAccumulationMap;
+
+    Accumulation get(String shardId, String id, Instant timestamp) {
+        return connectionToAccumulationMap.get(id);
+    }
+
+    Accumulation getOrCreate(String shardId, String id, Instant timestamp) {
+        return connectionToAccumulationMap.computeIfAbsent(id, k->new Accumulation());
+    }
+
+    Accumulation remove(String shardId, String id) {
+        return connectionToAccumulationMap.remove(id);
+    }
+
+    Accumulation reset(String shardId, String id, Instant timestamp) {
+        return connectionToAccumulationMap.put(id, new Accumulation());
+    }
+
+    Stream<Accumulation> values() {
+        return connectionToAccumulationMap.values().stream();
+    }
+
+    void clear() {
+        connectionToAccumulationMap.clear();
+    }
 }

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/TrafficStreamMap.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/TrafficStreamMap.java
@@ -1,0 +1,10 @@
+package org.opensearch.migrations.replay;
+
+import java.util.Map;
+
+/**
+ *
+ */
+public class TrafficStreamMap {
+    Map<String, Accumulation> 
+}

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/TrafficReplayerTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/TrafficReplayerTest.java
@@ -26,6 +26,7 @@ import java.util.stream.Collectors;
 
 class TrafficReplayerTest {
 
+    public static final String TEST_NODE_ID_STRING = "test_node_id";
     private static String TEST_TRAFFIC_STREAM_ID_STRING = "testId";
     private static String FAKE_READ_PACKET_DATA = "Useless packet data for test";
     private static String FAKE_EXCEPTION_DATA = "Mock Exception Message for testing";
@@ -36,7 +37,8 @@ class TrafficReplayerTest {
                 .setNanos(t.getNano())
                 .build();
         return TrafficStream.newBuilder()
-                .setId(TEST_TRAFFIC_STREAM_ID_STRING)
+                .setNodeId(TEST_NODE_ID_STRING)
+                .setConnectionId(TEST_TRAFFIC_STREAM_ID_STRING)
                 .setNumberOfThisLastChunk(1)
                 .addSubStream(TrafficObservation.newBuilder().setTs(fixedTimestamp)
                         .setRead(ReadObservation.newBuilder()


### PR DESCRIPTION
### Description
* **_Category_**: Bug fix/Enhancement
* **_Why these changes are required?_** See [MIGRATIONS-1114](https://opensearch.atlassian.net/browse/MIGRATIONS-1114)
* **_What is the old behavior before changes and new behavior after changes?_** Some (many) requests would be sent to the target cluster and responses would be received while their contents would accumulate (leak) until the input stream was severed.  Now, once connection ids are NOT observed in the source Traffic Stream for a configurable amount of time, they're cycled out and their responses will be considered to be complete.

Other related changes are also included in this PR.  These include
* Capturing a "nodeId" on each TrafficStream object so that we can dedup connectionIds (socket identifiers) and also to manage time horizons on a machine-by-machine basis.
* The proxy capture code no longer parses response messages at all.  At present, the capture code also isn't sending close/EOM messages even when the socket was disconnected.  Without that, all transactions should still be flushed by the timeout period.

### Issues Resolved
[MIGRATIONS-1114](https://opensearch.atlassian.net/browse/MIGRATIONS-1114)

### Testing
So far, making sure that unit tests succeed.

### Check List
- [ ] New functionality includes testing
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
