### PR TITLE
Add Support for Proxy to connect to HTTPS Servers

### DIFF
--- a/TrafficCapture/dockerSolution/src/main/docker/docker-compose.yml
+++ b/TrafficCapture/dockerSolution/src/main/docker/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - migrations
     ports:
       - "9200:9200"
-    command: /runJavaWithClasspath.sh org.opensearch.migrations.trafficcapture.proxyserver.Main  --kafkaConnection kafka:9092 --destinationHost  elasticsearch --destinationPort 9200 --listenPort 9200 --sslConfigFile /usr/share/elasticsearch/config/proxy_tls.yml
+    command: /runJavaWithClasspath.sh org.opensearch.migrations.trafficcapture.proxyserver.Main  --kafkaConnection kafka:9092 --destinationUri  http://elasticsearch:9200 --listenPort 9200 --sslConfigFile /usr/share/elasticsearch/config/proxy_tls.yml
     depends_on:
       - kafka
       - elasticsearch

--- a/TrafficCapture/trafficCaptureProxyServer/src/main/java/org/opensearch/migrations/trafficcapture/proxyserver/Main.java
+++ b/TrafficCapture/trafficCaptureProxyServer/src/main/java/org/opensearch/migrations/trafficcapture/proxyserver/Main.java
@@ -78,7 +78,7 @@ public class Main {
         @Parameter(required = false,
             names = {"--insecureDestination"},
             arity = 0,
-            description = "Do not check the backside server's certificate")
+            description = "Do not check the destination server's certificate")
         boolean allowInsecureConnectionsToBackside;
         @Parameter(required = true,
                 names = {"--destinationUri"},
@@ -174,6 +174,8 @@ public class Main {
         }
     }
 
+    // Utility method for converting uri string to an actual URI object. Similar logic is placed in the trafficReplayer
+    // module: TrafficReplayer.java
     private static URI convertStringToUri(String uriString) {
         URI serverUri;
         try {

--- a/TrafficCapture/trafficCaptureProxyServer/src/main/java/org/opensearch/migrations/trafficcapture/proxyserver/Main.java
+++ b/TrafficCapture/trafficCaptureProxyServer/src/main/java/org/opensearch/migrations/trafficcapture/proxyserver/Main.java
@@ -4,6 +4,9 @@ import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.ParameterException;
 import com.google.protobuf.CodedOutputStream;
+import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslContextBuilder;
+import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
 import lombok.NonNull;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
@@ -11,7 +14,6 @@ import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.logging.log4j.core.util.NullOutputStream;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.migrations.trafficcapture.FileConnectionCaptureFactory;
-import org.opensearch.migrations.trafficcapture.IChannelConnectionCaptureSerializer;
 import org.opensearch.migrations.trafficcapture.IConnectionCaptureFactory;
 import org.opensearch.migrations.trafficcapture.StreamChannelConnectionCaptureSerializer;
 import org.opensearch.migrations.trafficcapture.kafkaoffloader.KafkaCaptureFactory;
@@ -20,9 +22,10 @@ import org.opensearch.security.ssl.DefaultSecurityKeyStore;
 import org.opensearch.security.ssl.util.SSLConfigConstants;
 
 import javax.net.ssl.SSLEngine;
-import java.io.File;
+import javax.net.ssl.SSLException;
 import java.io.FileReader;
 import java.io.IOException;
+import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Optional;
@@ -73,15 +76,15 @@ public class Main {
                 description = "The maximum number of bytes that will be written to a single TrafficStream object.")
         int maximumTrafficStreamSize = 1024*1024;
         @Parameter(required = false,
-                names = {"--destinationHost"},
-                arity = 1,
-                description = "Hostname of the server that the proxy is capturing traffic for.")
-        String backsideHostname = "localhost";
+            names = {"--insecureDestination"},
+            arity = 0,
+            description = "Do not check the backside server's certificate")
+        boolean allowInsecureConnectionsToBackside;
         @Parameter(required = true,
-                names = {"--destinationPort"},
+                names = {"--destinationUri"},
                 arity = 1,
-                description = "Port of the server that the proxy connects to.")
-        int backsidePort = 0;
+                description = "URI of the server that the proxy is capturing traffic for.")
+        String backsideUriString;
         @Parameter(required = true,
                 names = {"--listenPort"},
                 arity = 1,
@@ -171,11 +174,46 @@ public class Main {
         }
     }
 
+    private static URI convertStringToUri(String uriString) {
+        URI serverUri;
+        try {
+            serverUri = new URI(uriString);
+        } catch (Exception e) {
+            System.err.println("Exception parsing URI string: " + uriString);
+            System.err.println(e.getMessage());
+            System.exit(3);
+            return null;
+        }
+        if (serverUri.getPort() < 0) {
+            throw new RuntimeException("Port not present for URI: " + serverUri);
+        }
+        if (serverUri.getHost() == null) {
+            throw new RuntimeException("Hostname not present for URI: " + serverUri);
+        }
+        if (serverUri.getScheme() == null) {
+            throw new RuntimeException("Scheme (http|https) is not present for URI: " + serverUri);
+        }
+        return serverUri;
+    }
+
+    private static SslContext loadBacksideSslContext(URI serverUri, boolean allowInsecureConnections) throws
+        SSLException {
+        if (serverUri.getScheme().equalsIgnoreCase("https")) {
+            var sslContextBuilder = SslContextBuilder.forClient();
+            if (allowInsecureConnections) {
+                sslContextBuilder.trustManager(InsecureTrustManagerFactory.INSTANCE);
+            }
+            return sslContextBuilder.build();
+        } else {
+            return null;
+        }
+    }
+
     public static void main(String[] args) throws InterruptedException, IOException {
 
         var params = parseArgs(args);
+        var backsideUri = convertStringToUri(params.backsideUriString);
 
-        // This should be added to the argument parser when added in
         var sksOp = Optional.ofNullable(params.sslConfigFilePath)
                 .map(sslConfigFile->new DefaultSecurityKeyStore(getSettings(sslConfigFile),
                         Paths.get(sslConfigFile).toAbsolutePath().getParent()));
@@ -184,7 +222,7 @@ public class Main {
         var proxy = new NettyScanningHttpProxy(params.frontsidePort);
 
         try {
-            proxy.start(params.backsideHostname, params.backsidePort,
+            proxy.start(backsideUri, loadBacksideSslContext(backsideUri, params.allowInsecureConnectionsToBackside),
                     sksOp.map(sks-> (Supplier<SSLEngine>) () -> {
                         try {
                             var sslEngine = sks.createHTTPSSLEngine();

--- a/TrafficCapture/trafficCaptureProxyServer/src/main/java/org/opensearch/migrations/trafficcapture/proxyserver/netty/NettyScanningHttpProxy.java
+++ b/TrafficCapture/trafficCaptureProxyServer/src/main/java/org/opensearch/migrations/trafficcapture/proxyserver/netty/NettyScanningHttpProxy.java
@@ -6,11 +6,13 @@ import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
+import io.netty.handler.ssl.SslContext;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 import io.netty.util.internal.logging.JdkLoggerFactory;
 import org.opensearch.migrations.trafficcapture.IConnectionCaptureFactory;
 
 import javax.net.ssl.SSLEngine;
+import java.net.URI;
 import java.util.function.Supplier;
 
 public class NettyScanningHttpProxy {
@@ -27,9 +29,8 @@ public class NettyScanningHttpProxy {
         return proxyPort;
     }
 
-    public void start(String backsideHost, int backsidePort, Supplier<SSLEngine> sslEngineSupplier,
-                      IConnectionCaptureFactory connectionCaptureFactory)
-            throws InterruptedException {
+    public void start(URI backsideUri, SslContext backsideSslContext, Supplier<SSLEngine> sslEngineSupplier,
+        IConnectionCaptureFactory connectionCaptureFactory) throws InterruptedException {
         InternalLoggerFactory.setDefaultFactory(JdkLoggerFactory.INSTANCE);
         bossGroup = new NioEventLoopGroup(1);
         workerGroup = new NioEventLoopGroup();
@@ -39,7 +40,7 @@ public class NettyScanningHttpProxy {
                     .channel(NioServerSocketChannel.class)
                     //.handler(new LoggingHandler(LogLevel.INFO))
                     //.childHandler(new HexDumpProxyInitializer(backsideHost, backsidePort))
-                    .childHandler(new ProxyChannelInitializer(backsideHost, backsidePort, sslEngineSupplier,
+                    .childHandler(new ProxyChannelInitializer(backsideUri, backsideSslContext, sslEngineSupplier,
                             connectionCaptureFactory))
                     .childOption(ChannelOption.AUTO_READ, false)
                     .bind(proxyPort).sync().channel();

--- a/TrafficCapture/trafficCaptureProxyServer/src/test/java/org/opensearch/migrations/trafficcapture/proxyserver/netty/NettyScanningHttpProxyTest.java
+++ b/TrafficCapture/trafficCaptureProxyServer/src/test/java/org/opensearch/migrations/trafficcapture/proxyserver/netty/NettyScanningHttpProxyTest.java
@@ -210,9 +210,9 @@ class NettyScanningHttpProxyTest {
         retryWithNewPortUntilNoThrow(port -> {
             nshp.set(new NettyScanningHttpProxy(port.intValue()));
             try {
-                URI testServer = new URI("http", null, LOCALHOST, upstreamTestServer.get().getAddress().getPort(),
+                URI testServerUri = new URI("http", null, LOCALHOST, upstreamTestServer.get().getAddress().getPort(),
                     null, null, null);
-                nshp.get().start(testServer,null, null, connectionCaptureFactory);
+                nshp.get().start(testServerUri,null, null, connectionCaptureFactory);
                 System.out.println("proxy port = "+port.intValue());
             } catch (InterruptedException | URISyntaxException e) {
                 throw new RuntimeException(e);

--- a/TrafficCapture/trafficCaptureProxyServer/src/test/java/org/opensearch/migrations/trafficcapture/proxyserver/netty/NettyScanningHttpProxyTest.java
+++ b/TrafficCapture/trafficCaptureProxyServer/src/test/java/org/opensearch/migrations/trafficcapture/proxyserver/netty/NettyScanningHttpProxyTest.java
@@ -22,6 +22,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
@@ -209,10 +210,11 @@ class NettyScanningHttpProxyTest {
         retryWithNewPortUntilNoThrow(port -> {
             nshp.set(new NettyScanningHttpProxy(port.intValue()));
             try {
-                nshp.get().start(LOCALHOST, upstreamTestServer.get().getAddress().getPort(), null,
-                        connectionCaptureFactory);
+                URI testServer = new URI("http", null, LOCALHOST, upstreamTestServer.get().getAddress().getPort(),
+                    null, null, null);
+                nshp.get().start(testServer,null, null, connectionCaptureFactory);
                 System.out.println("proxy port = "+port.intValue());
-            } catch (InterruptedException e) {
+            } catch (InterruptedException | URISyntaxException e) {
                 throw new RuntimeException(e);
             }
         });


### PR DESCRIPTION
### Description
This change, similar to what has been done in the Traffic-Replayer [here](https://github.com/opensearch-project/opensearch-migrations/commit/7bb1eef8ea1f2a438f609e8aa1c03fb5c57ade2e#diff-b8c531f1b8f2cf3948ca4249f59868e7181dbc734e5a9f531b1ea32ae75f7641), allows the Logging Proxy to connect to a backside HTTPS server by creating an SslContext and allowing insecure connections if specified.

### Issues Resolved
https://opensearch.atlassian.net/browse/MIGRATIONS-1105

### Testing
Docker compose local testing

### Check List
- [ ] New functionality includes testing
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
