### PR TITLE
Github Workflow for Gradle Build and Test

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,6 +1,13 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  [push, pull_request]:
+    paths:
+      - 'cluster_migration_core/**'
+      - 'cluster_traffic_capture/**'
+      - 'index_configuration_tool/**'
+      - 'test/**'
+      - 'upgrades/**'
 
 jobs:
   lint:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,13 +1,12 @@
 name: CI
 
 on:
-  [push, pull_request]:
+  push:
     paths:
-      - 'cluster_migration_core/**'
-      - 'cluster_traffic_capture/**'
-      - 'index_configuration_tool/**'
-      - 'test/**'
-      - 'upgrades/**'
+      - '**.py'
+  pull_request:
+    paths:
+      - '**.py'
 
 jobs:
   lint:

--- a/.github/workflows/gradle-build-and-test.yml
+++ b/.github/workflows/gradle-build-and-test.yml
@@ -3,7 +3,7 @@ name: Gradle Build and Test
 on: [push, pull_request]
 
 jobs:
-  build:
+  gradle-build-and-test:
 
     runs-on: ubuntu-latest
 
@@ -26,11 +26,6 @@ jobs:
       - name: Upload to Codecov
         uses: codecov/codecov-action@v3
         with:
-          files: TrafficCapture/captureKafkaOffloader/build/reports/jacoco/test/jacocoTestReport.xml,
-            TrafficCapture/captureOffloader/build/reports/jacoco/test/jacocoTestReport.xml,
-            TrafficCapture/KafkaPrinter/build/reports/jacoco/test/jacocoTestReport.xml,
-            TrafficCapture/nettyWireLogging/build/reports/jacoco/test/jacocoTestReport.xml,
-            TrafficCapture/trafficCaptureProxyServer/build/reports/jacoco/test/jacocoTestReport.xml,
-            TrafficCapture/trafficReplayer/build/reports/jacoco/test/jacocoTestReport.xml
+          files: "TrafficCapture/**/jacocoTestReport.xml"
           flags: unittests
           fail_ci_if_error: false

--- a/.github/workflows/gradle-build-and-test.yml
+++ b/.github/workflows/gradle-build-and-test.yml
@@ -16,11 +16,11 @@ jobs:
           distribution: 'adopt'
 
       - name: Run Gradle Build
-        run: ./gradlew build
+        run: ./gradlew build -x test
         working-directory: TrafficCapture
 
       - name: Run Tests with Coverage
-        run: ./gradlew test jacocoTestReport
+        run: ./gradlew test jacocoTestReport --info
         working-directory: TrafficCapture
 
       - name: Upload to Codecov

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -26,6 +26,11 @@ jobs:
       - name: Upload to Codecov
         uses: codecov/codecov-action@v3
         with:
-          file: ./TrafficCapture/*/build/reports/jacoco/test/jacocoTestReport.xml
+          files: TrafficCapture/captureKafkaOffloader/build/reports/jacoco/test/jacocoTestReport.xml,
+            TrafficCapture/captureOffloader/build/reports/jacoco/test/jacocoTestReport.xml,
+            TrafficCapture/KafkaPrinter/build/reports/jacoco/test/jacocoTestReport.xml,
+            TrafficCapture/nettyWireLogging/build/reports/jacoco/test/jacocoTestReport.xml,
+            TrafficCapture/trafficCaptureProxyServer/build/reports/jacoco/test/jacocoTestReport.xml,
+            TrafficCapture/trafficReplayer/build/reports/jacoco/test/jacocoTestReport.xml
           flags: unittests
-          fail_ci_if_error: true
+          fail_ci_if_error: false

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -24,9 +24,8 @@ jobs:
         working-directory: TrafficCapture
 
       - name: Upload to Codecov
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v3
         with:
           file: ./TrafficCapture/*/build/reports/jacoco/test/jacocoTestReport.xml
           flags: unittests
-          name: codecov-umbrella
           fail_ci_if_error: true

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,0 +1,32 @@
+name: Gradle Build and Test
+
+on: [push, pull_request]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          java-version: '11'
+          distribution: 'adopt'
+
+      - name: Run Gradle Build
+        run: ./gradlew assemble
+        working-directory: TrafficCapture
+
+      - name: Run Tests with Coverage
+        run: ./gradlew test jacocoTestReport
+        working-directory: TrafficCapture
+
+      - name: Upload to Codecov
+        uses: codecov/codecov-action@v1
+        with:
+          file: ./TrafficCapture/*/build/reports/jacoco/test/jacocoTestReport.xml
+          flags: unittests
+          name: codecov-umbrella
+          fail_ci_if_error: true

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -16,7 +16,7 @@ jobs:
           distribution: 'adopt'
 
       - name: Run Gradle Build
-        run: ./gradlew assemble
+        run: ./gradlew build
         working-directory: TrafficCapture
 
       - name: Run Tests with Coverage

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,6 +1,13 @@
 name: python-tests
 
-on: [push, pull_request]
+on:
+  [push, pull_request]:
+    paths:
+      - 'cluster_migration_core/**'
+      - 'cluster_traffic_capture/**'
+      - 'index_configuration_tool/**'
+      - 'test/**'
+      - 'upgrades/**'
 
 jobs:
   test-linux:

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,13 +1,12 @@
 name: python-tests
 
 on:
-  [push, pull_request]:
+  push:
     paths:
-      - 'cluster_migration_core/**'
-      - 'cluster_traffic_capture/**'
-      - 'index_configuration_tool/**'
-      - 'test/**'
-      - 'upgrades/**'
+      - 'cluster_migration_core/**.py'
+  pull_request:
+    paths:
+      - 'cluster_migration_core/**.py'
 
 jobs:
   test-linux:

--- a/TrafficCapture/build.gradle
+++ b/TrafficCapture/build.gradle
@@ -1,5 +1,6 @@
 allprojects {
     apply plugin: 'java'
+    apply plugin: 'jacoco'
 
     java {
         toolchain {
@@ -9,4 +10,15 @@ allprojects {
     test {
         jvmArgs '-ea'
     }
+
+    jacocoTestReport {
+        reports {
+            xml.required = true
+            xml.destination file("${buildDir}/reports/jacoco/test/jacocoTestReport.xml")
+        }
+    }
+}
+
+test {
+    finalizedBy 'jacocoTestReport'
 }

--- a/TrafficCapture/build.gradle
+++ b/TrafficCapture/build.gradle
@@ -18,4 +18,3 @@ allprojects {
         }
     }
 }
-TrafficCapture/*/build/reports/jacoco/test/jacocoTestReport.xml

--- a/TrafficCapture/build.gradle
+++ b/TrafficCapture/build.gradle
@@ -18,7 +18,4 @@ allprojects {
         }
     }
 }
-
-test {
-    finalizedBy 'jacocoTestReport'
-}
+TrafficCapture/*/build/reports/jacoco/test/jacocoTestReport.xml


### PR DESCRIPTION
### Description
This PR adds a github action for running `./gradlew build` and `./gradlew test` on the tools within the TrafficCapture directory. This will also add generating and uploading a coverage report for each tool (when applicable; has any tests)

This will also disable linting and pytest workflows for non-python directories.

### Issues Resolved
[Migrations-1152](https://opensearch.atlassian.net/browse/MIGRATIONS-1152)

### Testing
https://github.com/okhasawn/opensearch-migrations/actions/runs/5358402373/jobs/9720638919

### Check List
- [ ] New functionality includes testing
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
