### PR TITLE
Migrations-1150 - Enhance Setting Kafka Properties for Kafka Puller

### DIFF
--- a/TrafficCapture/kafkaPrinter/kafka.properties
+++ b/TrafficCapture/kafkaPrinter/kafka.properties
@@ -1,0 +1,4 @@
+# kafka properties
+key.deserializer=org.apache.kafka.common.serialization.StringDeserializer
+value.deserializer=org.apache.kafka.common.serialization.ByteArrayDeserializer
+auto.offset.reset=earliest

--- a/TrafficCapture/kafkaPrinter/kafka.properties
+++ b/TrafficCapture/kafkaPrinter/kafka.properties
@@ -1,4 +1,0 @@
-# kafka properties
-key.deserializer=org.apache.kafka.common.serialization.StringDeserializer
-value.deserializer=org.apache.kafka.common.serialization.ByteArrayDeserializer
-auto.offset.reset=earliest

--- a/TrafficCapture/kafkaPrinter/src/main/java/org/opensearch/migrations/KafkaPrinter.java
+++ b/TrafficCapture/kafkaPrinter/src/main/java/org/opensearch/migrations/KafkaPrinter.java
@@ -39,9 +39,9 @@ public class KafkaPrinter {
                 description = "Client id that should be used when communicating with the Kafka broker.")
         String clientGroupId;
         @Parameter(required = false,
-                names = {"-m", "--enable-msk-client"},
-                description = "Enables properties required for connecting to an MSK public endpoint.")
-        Boolean isMSKPublic = false;
+                names = {"--enableMSKAuth"},
+                description = "Enables SASL properties required for connecting to MSK with IAM auth.")
+        boolean mskAuthEnabled = false;
         @Parameter(required = false,
                 names = {"--kafkaConfigFile"},
                 arity = 1,
@@ -92,7 +92,7 @@ public class KafkaPrinter {
             properties.setProperty(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
         }
         // Required for using SASL auth with MSK public endpoint
-        if (params.isMSKPublic){
+        if (params.mskAuthEnabled){
             properties.setProperty("security.protocol", "SASL_SSL");
             properties.setProperty("sasl.mechanism", "AWS_MSK_IAM");
             properties.setProperty("sasl.jaas.config", "software.amazon.msk.auth.iam.IAMLoginModule required;");


### PR DESCRIPTION
### Description
This PR achieves the following:
- Adds ability to specify a Kafka properties file for the Kafka Puller using the `--kafkaConfigFile` argument, while reverting to our default Kafka properties when no properties file is provided.
- Adds ability to enable certain required properties for the MSK IAM client using the `--enable-msk-client` argument.


### Issues Resolved
[Migrations-1150](https://opensearch.atlassian.net/browse/MIGRATIONS-1150)


### Check List
- [ ] New functionality includes testing
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
