### PR TITLE
[Index configuration tool] Add support for insecure HTTPS endpoint

### DIFF
--- a/index_configuration_tool/index_operations.py
+++ b/index_configuration_tool/index_operations.py
@@ -11,9 +11,9 @@ __ALL_INDICES_ENDPOINT = "*"
 __INTERNAL_SETTINGS_KEYS = ["creation_date", "uuid", "provided_name", "version", "store"]
 
 
-def fetch_all_indices(endpoint: str, optional_auth: Optional[tuple] = None) -> dict:
+def fetch_all_indices(endpoint: str, optional_auth: Optional[tuple] = None, verify: bool = True) -> dict:
     actual_endpoint = endpoint + __ALL_INDICES_ENDPOINT
-    resp = requests.get(actual_endpoint, auth=optional_auth)
+    resp = requests.get(actual_endpoint, auth=optional_auth, verify=verify)
     # Remove internal settings
     result = dict(resp.json())
     for index in result:

--- a/index_configuration_tool/main.py
+++ b/index_configuration_tool/main.py
@@ -12,6 +12,18 @@ SINK_KEY = "sink"
 HOSTS_KEY = "hosts"
 USER_KEY = "username"
 PWD_KEY = "password"
+INSECURE_KEY = "insecure"
+CONNECTION_KEY = "connection"
+
+
+# This config key may be either directly in the main dict (for sink)
+# or inside a nested dict (for source). The default value is False.
+def is_insecure(config: dict) -> bool:
+    if INSECURE_KEY in config:
+        return bool(config[INSECURE_KEY])
+    elif CONNECTION_KEY in config and INSECURE_KEY in config[CONNECTION_KEY]:
+        return bool(config[CONNECTION_KEY][INSECURE_KEY])
+    return False
 
 
 # TODO Only supports basic auth for now
@@ -30,7 +42,9 @@ def get_endpoint_info(plugin_config: dict) -> tuple:
 
 def fetch_all_indices_by_plugin(plugin_config: dict) -> dict:
     endpoint, auth_tuple = get_endpoint_info(plugin_config)
-    return index_operations.fetch_all_indices(endpoint, auth_tuple)
+    # verify boolean will be the inverse of the insecure SSL key, if present
+    should_verify = not is_insecure(plugin_config)
+    return index_operations.fetch_all_indices(endpoint, auth_tuple, should_verify)
 
 
 def check_supported_endpoint(config: dict) -> Optional[tuple]:

--- a/index_configuration_tool/main.py
+++ b/index_configuration_tool/main.py
@@ -84,8 +84,10 @@ def validate_plugin_config(config: dict, key: str):
 
 
 def validate_pipeline_config(config: dict):
-    if SOURCE_KEY not in config or SINK_KEY not in config:
-        raise ValueError("Missing source or sink configuration in Data Prepper pipeline YAML")
+    if SOURCE_KEY not in config:
+        raise ValueError("Missing source configuration in Data Prepper pipeline YAML")
+    if SINK_KEY not in config:
+        raise ValueError("Missing sink configuration in Data Prepper pipeline YAML")
     validate_plugin_config(config, SOURCE_KEY)
     validate_plugin_config(config, SINK_KEY)
 

--- a/index_configuration_tool/main.py
+++ b/index_configuration_tool/main.py
@@ -20,9 +20,9 @@ CONNECTION_KEY = "connection"
 # or inside a nested dict (for source). The default value is False.
 def is_insecure(config: dict) -> bool:
     if INSECURE_KEY in config:
-        return bool(config[INSECURE_KEY])
+        return config[INSECURE_KEY]
     elif CONNECTION_KEY in config and INSECURE_KEY in config[CONNECTION_KEY]:
-        return bool(config[CONNECTION_KEY][INSECURE_KEY])
+        return config[CONNECTION_KEY][INSECURE_KEY]
     return False
 
 

--- a/index_configuration_tool/tests/test_main.py
+++ b/index_configuration_tool/tests/test_main.py
@@ -10,6 +10,8 @@ from tests import test_constants
 
 # Constants
 TEST_KEY = "test_key"
+INSECURE_KEY = "insecure"
+CONNECTION_KEY = "connection"
 BASE_CONFIG_SECTION = {
     TEST_KEY: [{"invalid_plugin1": {"key": "val"}}, {"invalid_plugin2": {}}]
 }
@@ -42,6 +44,21 @@ class TestMain(unittest.TestCase):
     def setUp(self) -> None:
         with open(test_constants.PIPELINE_CONFIG_PICKLE_FILE_PATH, "rb") as f:
             self.loaded_pipeline_config = pickle.load(f)
+
+    def test_is_insecure_default_value(self):
+        self.assertFalse(main.is_insecure({}))
+
+    def test_is_insecure_top_level_key(self):
+        test_input = {"key": 123, INSECURE_KEY: True}
+        self.assertTrue(main.is_insecure(test_input))
+
+    def test_is_insecure_nested_key(self):
+        test_input = {"key1": 123, CONNECTION_KEY: {"key2": "val", INSECURE_KEY: True}}
+        self.assertTrue(main.is_insecure(test_input))
+
+    def test_is_insecure_missing_nested(self):
+        test_input = {"key1": 123, CONNECTION_KEY: {"key2": "val"}}
+        self.assertFalse(main.is_insecure(test_input))
 
     def test_get_auth_returns_none(self):
         # The following inputs should not return an auth tuple:

--- a/index_configuration_tool/tests/test_main.py
+++ b/index_configuration_tool/tests/test_main.py
@@ -203,7 +203,7 @@ class TestMain(unittest.TestCase):
         # - Empty input
         # - missing output
         # - missing input
-        bad_configs = [{}, {"input": ()}, {"output": ()}]
+        bad_configs = [{}, {"source": {}}, {"sink": {}}]
         for config in bad_configs:
             self.assertRaises(ValueError, main.validate_pipeline_config, config)
 


### PR DESCRIPTION
### Description
This commit adds support for parsing the "insecure" flag from the Data Prepper YAML. This translates to a "verify" flag that is passed to the Python requests library. This commit also includes unit tests for this logic.
* Category: Enhancement

### Issues Resolved
N/A

### Testing
```
$ python -m coverage run -m unittest
.........................
----------------------------------------------------------------------
Ran 25 tests in 0.506s

OK

$ python -m coverage report --omit "*/tests/*"
Name                  Stmts   Miss  Cover
-----------------------------------------
index_operations.py      29      2    93%
main.py                  88      0   100%
utils.py                 13      0   100%
-----------------------------------------
TOTAL                   130      2    98%

```

### Check List
- [x] New functionality includes testing
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
