### PR TITLE
Enhance IaC Deployments with MSK Public Endpoints and Dev Deployment Script

### DIFF
--- a/TrafficCapture/captureKafkaOffloader/build.gradle
+++ b/TrafficCapture/captureKafkaOffloader/build.gradle
@@ -13,8 +13,8 @@ dependencies {
     implementation project(':captureOffloader')
     implementation 'org.projectlombok:lombok:1.18.26'
     implementation 'com.google.protobuf:protobuf-java:3.22.2'
-    implementation 'org.apache.kafka:kafka-clients:3.+'
-    implementation 'software.amazon.msk:aws-msk-iam-auth:1.+'
+    implementation 'org.apache.kafka:kafka-clients:3.5.0'
+    implementation 'software.amazon.msk:aws-msk-iam-auth:1.1.7'
     implementation 'org.slf4j:slf4j-api:2.0.7'
     testImplementation project(':captureProtobufs')
     testImplementation 'org.mockito:mockito-core:4.6.1'

--- a/TrafficCapture/captureKafkaOffloader/build.gradle
+++ b/TrafficCapture/captureKafkaOffloader/build.gradle
@@ -13,8 +13,8 @@ dependencies {
     implementation project(':captureOffloader')
     implementation 'org.projectlombok:lombok:1.18.26'
     implementation 'com.google.protobuf:protobuf-java:3.22.2'
-    implementation 'org.apache.kafka:kafka-clients:3.4.0'
-    implementation 'software.amazon.msk:aws-msk-iam-auth:1.1.6'
+    implementation 'org.apache.kafka:kafka-clients:3.+'
+    implementation 'software.amazon.msk:aws-msk-iam-auth:1.+'
     implementation 'org.slf4j:slf4j-api:2.0.7'
     testImplementation project(':captureProtobufs')
     testImplementation 'org.mockito:mockito-core:4.6.1'

--- a/TrafficCapture/kafkaPrinter/build.gradle
+++ b/TrafficCapture/kafkaPrinter/build.gradle
@@ -6,14 +6,14 @@ plugins {
 dependencies {
     implementation group: 'com.beust', name: 'jcommander', version: '1.82'
     implementation group: 'com.google.protobuf', name: 'protobuf-java', version: '3.22.2'
-    implementation group: 'org.apache.kafka', name: 'kafka-clients', version: '3.4.0'
+    implementation group: 'org.apache.kafka', name: 'kafka-clients', version: '3.+'
 
     implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.20.0'
     implementation group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.20.0'
     implementation group: 'org.apache.logging.log4j', name: 'log4j-slf4j2-impl', version: '2.20.0'
     implementation group: 'org.slf4j', name: 'slf4j-api', version: '2.0.7'
 
-    implementation group: 'software.amazon.msk', name: 'aws-msk-iam-auth', version: '1.1.6'
+    implementation group: 'software.amazon.msk', name: 'aws-msk-iam-auth', version: '1.+'
 
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.2'
     testImplementation project(":captureProtobufs")

--- a/TrafficCapture/kafkaPrinter/build.gradle
+++ b/TrafficCapture/kafkaPrinter/build.gradle
@@ -6,14 +6,14 @@ plugins {
 dependencies {
     implementation group: 'com.beust', name: 'jcommander', version: '1.82'
     implementation group: 'com.google.protobuf', name: 'protobuf-java', version: '3.22.2'
-    implementation group: 'org.apache.kafka', name: 'kafka-clients', version: '3.+'
+    implementation group: 'org.apache.kafka', name: 'kafka-clients', version: '3.5.0'
 
     implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.20.0'
     implementation group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.20.0'
     implementation group: 'org.apache.logging.log4j', name: 'log4j-slf4j2-impl', version: '2.20.0'
     implementation group: 'org.slf4j', name: 'slf4j-api', version: '2.0.7'
 
-    implementation group: 'software.amazon.msk', name: 'aws-msk-iam-auth', version: '1.+'
+    implementation group: 'software.amazon.msk', name: 'aws-msk-iam-auth', version: '1.1.7'
 
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.2'
     testImplementation project(":captureProtobufs")

--- a/deployment/cdk/opensearch-service-migration/README.md
+++ b/deployment/cdk/opensearch-service-migration/README.md
@@ -29,7 +29,10 @@ A `CDK_DEPLOYMENT_STAGE` environment variable must be set to assist in naming re
 ### Deploying your CDK
 Before deploying your CDK you should fill in any desired context parameters that will dictate the composition of your OpenSearch Service Domain
 
-This can be accomplished by providing these options in a `cdk.context.json` file
+This can be accomplished by providing these options in a `cdk.context.json` file and then deploying like so:
+```
+cdk deploy "*"
+```
 
 Or by passing the context options you want to change as options in the CDK CLI
 ```
@@ -100,10 +103,8 @@ Additional context on some of these options, can also be found in the Domain con
 | availabilityZoneCount                           | false    | number       | 1                                                                                                                                                                                                                              | The number of Availability Zones for the Domain to use. If not specified a single AZ is used. If specified the Domain CDK construct requires at least 2 AZs                                                                                                  |
 | openAccessPolicyEnabled                         | false    | boolean      | false                                                                                                                                                                                                                          | Applies an open access policy to the Domain. **NOTE**: This setting should only be used for Domains placed within a VPC, and is applicable to many use cases where access controlled by Security Groups on the VPC is sufficient.                            |
 | domainRemovalPolicy                             | false    | string       | "RETAIN"                                                                                                                                                                                                                       | Policy to apply when the domain is removed from the CloudFormation stack                                                                                                                                                                                     |
-| MSKARN                                          | false    | string       | `"arn:aws:kafka:us-east-2:123456789123:cluster/msk-cluster-test/81fbae45-5d25-44bb-aff0-108e71cc079b-7"`                                                                                                                       | Supply the Managed Streaming Apache Kafka Cluster ARN                                                                                                                                                                                                        |
-| MSKBrokers                                      | false    | object       | ["localhost"]                                                                                                                                                                                                                  | Supply the broker's addresses to be pulling from                                                                                                                                                                                                             |
-| MSKTopic                                        | fasle    | string       | "first_topic"                                                                                                                                                                                                                  | Supply the names of the topics to be pulling from                                                                                                                                                                                                            |
-
+| mskARN (Not currently available)                | false    | string       | `"arn:aws:kafka:us-east-2:123456789123:cluster/msk-cluster-test/81fbae45-5d25-44bb-aff0-108e71cc079b-7"`                                                                                                                       | Supply an existing MSK cluster ARN to use. **NOTE** As MSK is using an L1 construct this is not currently available for use                                                                                                                                  |
+| mskEnablePublicEndpoints                        | false    | boolean      | true                                                                                                                                                                                                                           | Specify if public endpoints should be enabled on the MSK cluster                                                                                                                                                                                             |
 
 A template `cdk.context.json` to be used to fill in these values is below:
 ```
@@ -138,7 +139,9 @@ A template `cdk.context.json` to be used to fill in these values is below:
   "vpcSecurityGroupIds": "",
   "availabilityZoneCount": "",
   "openAccessPolicyEnabled": "",
-  "domainRemovalPolicy": ""
+  "domainRemovalPolicy": "",
+  "mskARN": "",
+  "mskEnablePublicEndpoints": ""
 }
 
 ```

--- a/deployment/cdk/opensearch-service-migration/lib/lambda/msk-public-endpoint-handler.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/lambda/msk-public-endpoint-handler.ts
@@ -1,0 +1,172 @@
+import {Context} from 'aws-lambda';
+import {DescribeClusterV2Command, UpdateConnectivityCommand, GetBootstrapBrokersCommand, KafkaClient} from "@aws-sdk/client-kafka";
+import {InvokeCommand, LambdaClient} from "@aws-sdk/client-lambda"
+
+function delay(ms: number) {
+    return new Promise( resolve => setTimeout(resolve, ms) );
+}
+
+async function enablePublicEndpoint(mskVersion: string) {
+    const mskClient = new KafkaClient({})
+    const params = {
+        ClusterArn: process.env.MSK_ARN,
+        ConnectivityInfo: {
+            PublicAccess: {
+                Type: 'SERVICE_PROVIDED_EIPS'
+            }
+        },
+        CurrentVersion: mskVersion
+    }
+    const command = new UpdateConnectivityCommand(params)
+    try {
+        console.log("Starting update connectivity call")
+        await mskClient.send(command).then(
+            (data) => {
+                console.log("Update connectivity response: " + JSON.stringify(data))
+
+            },
+            (error) => {
+                console.log("Update connectivity error: " + JSON.stringify(error))
+            }
+        );
+    } catch (e) {
+        console.error(e);
+    }
+}
+
+async function describeClusterV2(): Promise<any> {
+    const mskClient = new KafkaClient({})
+    const params = {
+        ClusterArn: process.env.MSK_ARN
+    }
+    const command = new DescribeClusterV2Command(params)
+    let result
+    try {
+        console.log("Starting describe cluster call")
+        await mskClient.send(command).then(
+            (data) => {
+                console.log("Describe cluster response: " + JSON.stringify(data))
+                result = data
+            },
+            (error) => {
+                console.log("Describe cluster error: " + JSON.stringify(error))
+            }
+        );
+    } catch (e) {
+        console.error(e);
+    }
+    return result
+}
+
+async function getBootstrapBrokers(): Promise<any> {
+    const mskClient = new KafkaClient({})
+    const params = {
+        ClusterArn: process.env.MSK_ARN
+    }
+    const command = new GetBootstrapBrokersCommand(params)
+    let result
+    try {
+        console.log("Starting get brokers call")
+        await mskClient.send(command).then(
+            (data) => {
+                console.log("Get brokers response: " + JSON.stringify(data))
+                result = data
+            },
+            (error) => {
+                console.log("Get brokers error: " + JSON.stringify(error))
+            }
+        );
+    } catch (e) {
+        console.error(e);
+    }
+    return result
+}
+
+async function invokeNextLambda(payload: any, functionName: string) {
+    const lambdaClient = new LambdaClient({})
+    const params = {
+        FunctionName: functionName,
+        Payload: payload,
+        // Perform async request which does not wait on response
+        InvocationType: "Event"
+    }
+    const command = new InvokeCommand(params)
+    try {
+        console.log("Starting invoke lambda call")
+        await lambdaClient.send(command).then(
+            (data) => {
+                console.log("Invoke lambda response: " + JSON.stringify(data))
+                data.$metadata.httpStatusCode
+
+            },
+            (error) => {
+                console.log("Invoke lambda error: " + JSON.stringify(error))
+            }
+        );
+    } catch (e) {
+        console.error(e);
+    }
+}
+
+export const handler = async (event: any, context: Context): Promise<void> => {
+    console.log('Lambda is invoked with event:' + JSON.stringify(event));
+    console.log('Lambda is invoked with context:' + JSON.stringify(context));
+
+    let maxAttempts = process.env.MAX_ATTEMPTS ? parseInt(process.env.MAX_ATTEMPTS) : undefined
+    if (!maxAttempts) {
+        console.log('Max attempts not provided by environment or unable to be parsed, defaulting to 3 attempts')
+        maxAttempts = 3
+    }
+    if (!process.env.MSK_ARN) {
+        throw Error(`Missing at least one required environment variable [MSK_ARN: ${process.env.MSK_ARN}]`)
+    }
+
+    let attempt = 1;
+    let callback = "";
+    // Initial pass
+    if (event.Attempt == undefined) {
+        console.log("Starting initial attempt")
+        callback = event.ResourceProperties.CallbackUrl
+        attempt = attempt + 1
+        const clusterDetailsResponse = await describeClusterV2()
+        await enablePublicEndpoint(clusterDetailsResponse.ClusterInfo.CurrentVersion)
+        await delay(5000);
+    }
+    // Additional extended time passes
+    else {
+        console.log(`Starting attempt no. ${event.Attempt}`)
+        callback = event.CallbackUrl
+        if (event.Attempt > maxAttempts) {
+            console.log("Unable to conclude update has completed after max attempts... Stopping now")
+            return
+        }
+        attempt = event.Attempt + 1
+    }
+
+    const payloadData = {
+        Attempt: attempt,
+        CallbackUrl: callback
+    }
+    while(context.getRemainingTimeInMillis() > 25000) {
+        const clusterResponse = await describeClusterV2()
+        const state = clusterResponse.ClusterInfo.State
+        console.log("Current cluster state is: " + state)
+        if (state == "ACTIVE") {
+            console.log("MSK cluster is now 'Active', finishing Lambda")
+            const brokerResponse = await getBootstrapBrokers()
+            const responseBody = {
+                Status: "SUCCESS",
+                Reason: "Cluster connectivity update has successfully finished",
+                // Since our wait condition only needs one occurrence this value can be any static value
+                UniqueId: "updateConnectivityID",
+                Data: `export MIGRATION_KAFKA_BROKER_ENDPOINTS=${brokerResponse.BootstrapBrokerStringPublicSaslIam}`
+            }
+            // @ts-ignore
+            const waitConditionResponse = await fetch(payloadData.CallbackUrl, {method: 'PUT', body: JSON.stringify(responseBody)});
+            console.log("Wait condition completion response: " + JSON.stringify(waitConditionResponse))
+            return
+        }
+        await delay(20000);
+    }
+    await invokeNextLambda(JSON.stringify(payloadData), context.functionName)
+};

--- a/deployment/cdk/opensearch-service-migration/lib/migration-assistance-stack.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/migration-assistance-stack.ts
@@ -37,7 +37,7 @@ export class MigrationAssistanceStack extends Stack {
 
         // Create an MSK cluster
         const mskCluster = new CfnCluster(this, 'migrationMSKCluster', {
-            clusterName: 'migration-msk-cluster2',
+            clusterName: 'migration-msk-cluster',
             kafkaVersion: '2.8.1',
             numberOfBrokerNodes: 2,
             brokerNodeGroupInfo: {

--- a/deployment/cdk/opensearch-service-migration/lib/msk-utility-stack.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/msk-utility-stack.ts
@@ -1,0 +1,131 @@
+import {StackPropsExt} from "./stack-composer";
+import {IVpc} from "aws-cdk-lib/aws-ec2";
+import {CfnOutput, CfnWaitCondition, CfnWaitConditionHandle, CustomResource, Duration, Stack} from "aws-cdk-lib";
+import {Construct} from "constructs";
+import {Effect, ManagedPolicy, PolicyDocument, PolicyStatement, Role, ServicePrincipal} from "aws-cdk-lib/aws-iam";
+import {NodejsFunction} from "aws-cdk-lib/aws-lambda-nodejs";
+import {Runtime} from "aws-cdk-lib/aws-lambda";
+import {AwsCustomResource, AwsCustomResourcePolicy, PhysicalResourceId, Provider} from "aws-cdk-lib/custom-resources";
+import * as path from "path";
+
+export interface mskUtilityStackProps extends StackPropsExt {
+    readonly vpc: IVpc,
+    readonly mskARN: string,
+    readonly mskEnablePublicEndpoints?: boolean
+}
+
+
+export class MSKUtilityStack extends Stack {
+
+    constructor(scope: Construct, id: string, props: mskUtilityStackProps) {
+        super(scope, id, props);
+
+        let brokerEndpointsOutput
+        if (props.mskEnablePublicEndpoints) {
+            const lambdaInvokeStatement = new PolicyStatement({
+                effect: Effect.ALLOW,
+                actions: ["lambda:InvokeFunction"],
+                resources: ["*"]
+            })
+            const mskUpdateConnectivityStatement = new PolicyStatement({
+                effect: Effect.ALLOW,
+                actions: ["ec2:DescribeSubnets",
+                    "ec2:DescribeVpcs",
+                    "ec2:DescribeSecurityGroups",
+                    "ec2:DescribeRouteTables",
+                    "ec2:DescribeVpcEndpoints",
+                    "ec2:DescribeVpcAttribute",
+                    "ec2:DescribeNetworkAcls",
+                    "kafka:UpdateConnectivity",
+                    "kafka:DescribeClusterV2",
+                    "kafka:GetBootstrapBrokers"],
+                resources: ["*"]
+            })
+            const lambdaExecDocument = new PolicyDocument({
+                statements: [lambdaInvokeStatement, mskUpdateConnectivityStatement]
+            })
+
+            const lambdaExecRole = new Role(this, 'mskAccessLambda', {
+                assumedBy: new ServicePrincipal('lambda.amazonaws.com'),
+                description: 'Allow lambda to access MSK and invoke itself',
+                inlinePolicies: {
+                    mskAccessDoc: lambdaExecDocument,
+                },
+                // Required policies that the default Lambda exec role would add
+                managedPolicies: [
+                    ManagedPolicy.fromAwsManagedPolicyName("service-role/AWSLambdaVPCAccessExecutionRole"),
+                    ManagedPolicy.fromAwsManagedPolicyName("service-role/AWSLambdaBasicExecutionRole")
+                ]
+            });
+
+            const mskPublicLambda = new NodejsFunction(this, 'mskPublicLambdaFunction', {
+                runtime: Runtime.NODEJS_18_X,
+                vpc: props.vpc,
+                handler: 'handler',
+                timeout: Duration.minutes(15),
+                entry: path.join(__dirname, 'lambda/msk-public-endpoint-handler.ts'),
+                role: lambdaExecRole,
+                environment: {MSK_ARN: props.mskARN, MAX_ATTEMPTS: "3"}
+            });
+
+            const customResourceProvider = new Provider(this, 'customResourceProvider', {
+                onEventHandler: mskPublicLambda,
+            });
+
+            // WaitConditions will by default only run on create, the workaround here is to generate a unique id on each
+            // execution so that a new wait condition is created
+            const currentTime = Date.now().toString()
+            const wcHandle = new CfnWaitConditionHandle(this, 'WaitConditionHandle'.concat(currentTime));
+
+            const customResource = new CustomResource(this, "mskAccessLambdaCustomResource", {
+                serviceToken: customResourceProvider.serviceToken,
+                properties: {
+                    CallbackUrl: wcHandle.ref
+                }
+            })
+
+            // Note: AWS::CloudFormation::WaitCondition resource type does not support updates.
+            const waitCondition = new CfnWaitCondition(this, 'WaitCondition'.concat(currentTime), {
+                count: 1,
+                timeout: Duration.minutes(45).toSeconds().toString(),
+                handle: wcHandle.ref
+            })
+            waitCondition.node.addDependency(customResource);
+            brokerEndpointsOutput = waitCondition.attrData.toString()
+        }
+        else {
+            const mskGetBrokersCustomResource = getBrokersCR(this, props.vpc, props.mskARN)
+            brokerEndpointsOutput = mskGetBrokersCustomResource.getResponseField("BootstrapBrokerStringSaslIam")
+            //brokerEndpointsOutput = mskGetBrokersCustomResource.getResponseField("BootstrapBrokerStringPublicSaslIam")
+        }
+
+        const cfnOutput = new CfnOutput(this, 'CopilotBrokerEndpointsExport', {
+            value: brokerEndpointsOutput,
+            description: 'Exported MSK broker endpoint values created by CDK that are needed by Copilot container deployments',
+        });
+    }
+}
+
+export function getBrokersCR(scope: Construct, vpc: IVpc, clusterArn: string): AwsCustomResource {
+    const getBrokersCR = new AwsCustomResource(scope, 'migrationMSKGetBrokersCR', {
+        onCreate: {
+            service: 'Kafka',
+            action: 'getBootstrapBrokers',
+            parameters: {
+                ClusterArn: clusterArn,
+            },
+            physicalResourceId: PhysicalResourceId.of(Date.now().toString())
+        },
+        onUpdate: {
+            service: 'Kafka',
+            action: 'getBootstrapBrokers',
+            parameters: {
+                ClusterArn: clusterArn,
+            },
+            physicalResourceId: PhysicalResourceId.of(Date.now().toString())
+        },
+        policy: AwsCustomResourcePolicy.fromSdkCalls({resources: [clusterArn]}),
+        vpc: vpc
+    })
+    return getBrokersCR
+}

--- a/deployment/cdk/opensearch-service-migration/lib/msk-utility-stack.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/msk-utility-stack.ts
@@ -65,7 +65,7 @@ export class MSKUtilityStack extends Stack {
                 timeout: Duration.minutes(15),
                 entry: path.join(__dirname, 'lambda/msk-public-endpoint-handler.ts'),
                 role: lambdaExecRole,
-                environment: {MSK_ARN: props.mskARN, MAX_ATTEMPTS: "3"}
+                environment: {MSK_ARN: props.mskARN, MAX_ATTEMPTS: "4"}
             });
 
             const customResourceProvider = new Provider(this, 'customResourceProvider', {
@@ -94,7 +94,7 @@ export class MSKUtilityStack extends Stack {
             brokerEndpointsOutput = waitCondition.attrData.toString()
         }
         else {
-            const mskGetBrokersCustomResource = getBrokersCR(this, props.vpc, props.mskARN)
+            const mskGetBrokersCustomResource = getBrokersCustomResource(this, props.vpc, props.mskARN)
             brokerEndpointsOutput = mskGetBrokersCustomResource.getResponseField("BootstrapBrokerStringSaslIam")
             //brokerEndpointsOutput = mskGetBrokersCustomResource.getResponseField("BootstrapBrokerStringPublicSaslIam")
         }
@@ -106,7 +106,7 @@ export class MSKUtilityStack extends Stack {
     }
 }
 
-export function getBrokersCR(scope: Construct, vpc: IVpc, clusterArn: string): AwsCustomResource {
+export function getBrokersCustomResource(scope: Construct, vpc: IVpc, clusterArn: string): AwsCustomResource {
     const getBrokersCR = new AwsCustomResource(scope, 'migrationMSKGetBrokersCR', {
         onCreate: {
             service: 'Kafka',

--- a/deployment/cdk/opensearch-service-migration/package-lock.json
+++ b/deployment/cdk/opensearch-service-migration/package-lock.json
@@ -8,7 +8,11 @@
       "name": "opensearch-service-domain-cdk",
       "version": "0.1.0",
       "dependencies": {
-        "aws-cdk-lib": "2.80.0",
+        "@aws-sdk/client-kafka": "^3.354.0",
+        "@aws-sdk/client-lambda": "^3.359.0",
+        "@types/aws-lambda": "^8.10.117",
+        "aws-cdk-lib": "2.84.0",
+        "aws-lambda": "^1.0.7",
         "constructs": "^10.0.0",
         "source-map-support": "^0.5.21"
       },
@@ -39,9 +43,9 @@
       }
     },
     "node_modules/@aws-cdk/asset-awscli-v1": {
-      "version": "2.2.196",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.196.tgz",
-      "integrity": "sha512-F8hU1rEzYS7z5Dt2s+ttd0/jMvPuUE9BcXexgq+dIOLuZsRpDwNnkMBtjNaJXJS48ZGJ2X4b8VlklseepdtoSA=="
+      "version": "2.2.197",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.197.tgz",
+      "integrity": "sha512-gUM22fkas3lxVG5v1WW0I2CsnTLj2v7gRm/31fnAGTYnzP60BsYVWa0Vi99b2Qz3D3RXxOlGKaO+dQR7r2GqIg=="
     },
     "node_modules/@aws-cdk/asset-kubectl-v20": {
       "version": "2.1.1",
@@ -52,6 +56,2020 @@
       "version": "2.0.165",
       "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v5/-/asset-node-proxy-agent-v5-2.0.165.tgz",
       "integrity": "sha512-bsyLQD/vqXQcc9RDmlM1XqiFNO/yewgVFXmkMcQkndJbmE/jgYkzewwYGrBlfL725hGLQipXq19+jwWwdsXQqg=="
+    },
+    "node_modules/@aws-crypto/crc32": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-3.0.0.tgz",
+      "integrity": "sha512-IzSgsrxUcsrejQbPVilIKy16kAT52EwB6zSaI+M3xxIhKh5+aldEyvI+z6erM7TCLB2BJsFrtHjp6/4/sr+3dA==",
+      "dependencies": {
+        "@aws-crypto/util": "^3.0.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/crc32/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-crypto/ie11-detection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
+      "integrity": "sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==",
+      "dependencies": {
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/ie11-detection/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-crypto/sha256-browser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz",
+      "integrity": "sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==",
+      "dependencies": {
+        "@aws-crypto/ie11-detection": "^3.0.0",
+        "@aws-crypto/sha256-js": "^3.0.0",
+        "@aws-crypto/supports-web-crypto": "^3.0.0",
+        "@aws-crypto/util": "^3.0.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-crypto/sha256-js": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz",
+      "integrity": "sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==",
+      "dependencies": {
+        "@aws-crypto/util": "^3.0.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-js/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-3.0.0.tgz",
+      "integrity": "sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==",
+      "dependencies": {
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/supports-web-crypto/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
+      "integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-sdk/abort-controller": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.347.0.tgz",
+      "integrity": "sha512-P/2qE6ntYEmYG4Ez535nJWZbXqgbkJx8CMz7ChEuEg3Gp3dvVYEKg+iEUEvlqQ2U5dWP5J3ehw5po9t86IsVPQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-kafka": {
+      "version": "3.354.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-kafka/-/client-kafka-3.354.0.tgz",
+      "integrity": "sha512-iPSjqBsyrmQ8myO2FcNbd3w6zssdoer/n28xTBcwkykLveOf4PuQVurnEJaPOfdqFgpJ16+yfirdnzpVwUuXVw==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sts": "3.354.0",
+        "@aws-sdk/config-resolver": "3.354.0",
+        "@aws-sdk/credential-provider-node": "3.354.0",
+        "@aws-sdk/fetch-http-handler": "3.353.0",
+        "@aws-sdk/hash-node": "3.347.0",
+        "@aws-sdk/invalid-dependency": "3.347.0",
+        "@aws-sdk/middleware-content-length": "3.347.0",
+        "@aws-sdk/middleware-endpoint": "3.347.0",
+        "@aws-sdk/middleware-host-header": "3.347.0",
+        "@aws-sdk/middleware-logger": "3.347.0",
+        "@aws-sdk/middleware-recursion-detection": "3.347.0",
+        "@aws-sdk/middleware-retry": "3.354.0",
+        "@aws-sdk/middleware-serde": "3.347.0",
+        "@aws-sdk/middleware-signing": "3.354.0",
+        "@aws-sdk/middleware-stack": "3.347.0",
+        "@aws-sdk/middleware-user-agent": "3.352.0",
+        "@aws-sdk/node-config-provider": "3.354.0",
+        "@aws-sdk/node-http-handler": "3.350.0",
+        "@aws-sdk/smithy-client": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/url-parser": "3.347.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "@aws-sdk/util-body-length-browser": "3.310.0",
+        "@aws-sdk/util-body-length-node": "3.310.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.353.0",
+        "@aws-sdk/util-defaults-mode-node": "3.354.0",
+        "@aws-sdk/util-endpoints": "3.352.0",
+        "@aws-sdk/util-retry": "3.347.0",
+        "@aws-sdk/util-user-agent-browser": "3.347.0",
+        "@aws-sdk/util-user-agent-node": "3.354.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "@smithy/protocol-http": "^1.0.1",
+        "@smithy/types": "^1.0.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda": {
+      "version": "3.359.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-lambda/-/client-lambda-3.359.0.tgz",
+      "integrity": "sha512-o6A3x+R6Oi64+mmK+mbYO1BLr18z5U/NiBevqE+FqQFptAoA6vp8CQW7zpeuUeC1J0ZdSNZCHc3HqUAlv7l/bg==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sts": "3.359.0",
+        "@aws-sdk/config-resolver": "3.357.0",
+        "@aws-sdk/credential-provider-node": "3.358.0",
+        "@aws-sdk/eventstream-serde-browser": "3.357.0",
+        "@aws-sdk/eventstream-serde-config-resolver": "3.357.0",
+        "@aws-sdk/eventstream-serde-node": "3.357.0",
+        "@aws-sdk/fetch-http-handler": "3.357.0",
+        "@aws-sdk/hash-node": "3.357.0",
+        "@aws-sdk/invalid-dependency": "3.357.0",
+        "@aws-sdk/middleware-content-length": "3.357.0",
+        "@aws-sdk/middleware-endpoint": "3.357.0",
+        "@aws-sdk/middleware-host-header": "3.357.0",
+        "@aws-sdk/middleware-logger": "3.357.0",
+        "@aws-sdk/middleware-recursion-detection": "3.357.0",
+        "@aws-sdk/middleware-retry": "3.357.0",
+        "@aws-sdk/middleware-serde": "3.357.0",
+        "@aws-sdk/middleware-signing": "3.357.0",
+        "@aws-sdk/middleware-stack": "3.357.0",
+        "@aws-sdk/middleware-user-agent": "3.357.0",
+        "@aws-sdk/node-config-provider": "3.357.0",
+        "@aws-sdk/node-http-handler": "3.357.0",
+        "@aws-sdk/smithy-client": "3.358.0",
+        "@aws-sdk/types": "3.357.0",
+        "@aws-sdk/url-parser": "3.357.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "@aws-sdk/util-body-length-browser": "3.310.0",
+        "@aws-sdk/util-body-length-node": "3.310.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.358.0",
+        "@aws-sdk/util-defaults-mode-node": "3.358.0",
+        "@aws-sdk/util-endpoints": "3.357.0",
+        "@aws-sdk/util-retry": "3.357.0",
+        "@aws-sdk/util-stream": "3.358.0",
+        "@aws-sdk/util-user-agent-browser": "3.357.0",
+        "@aws-sdk/util-user-agent-node": "3.357.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "@aws-sdk/util-waiter": "3.357.0",
+        "@smithy/protocol-http": "^1.0.1",
+        "@smithy/types": "^1.0.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/abort-controller": {
+      "version": "3.357.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.357.0.tgz",
+      "integrity": "sha512-nQYDJon87quPwt2JZJwUN2GFKJnvE5kWb6tZP4xb5biSGUKBqDQo06oYed7yokatCuCMouIXV462aN0fWODtOw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.357.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/client-sso": {
+      "version": "3.358.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.358.0.tgz",
+      "integrity": "sha512-Kc9IsoPIHJfkjDuStyItwQAOpnxw/I9xfF3vvukeN9vkXcRiWeMDhEXACN4L1AYFlU9FHQSRdNwpYTIz7OrD2A==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/config-resolver": "3.357.0",
+        "@aws-sdk/fetch-http-handler": "3.357.0",
+        "@aws-sdk/hash-node": "3.357.0",
+        "@aws-sdk/invalid-dependency": "3.357.0",
+        "@aws-sdk/middleware-content-length": "3.357.0",
+        "@aws-sdk/middleware-endpoint": "3.357.0",
+        "@aws-sdk/middleware-host-header": "3.357.0",
+        "@aws-sdk/middleware-logger": "3.357.0",
+        "@aws-sdk/middleware-recursion-detection": "3.357.0",
+        "@aws-sdk/middleware-retry": "3.357.0",
+        "@aws-sdk/middleware-serde": "3.357.0",
+        "@aws-sdk/middleware-stack": "3.357.0",
+        "@aws-sdk/middleware-user-agent": "3.357.0",
+        "@aws-sdk/node-config-provider": "3.357.0",
+        "@aws-sdk/node-http-handler": "3.357.0",
+        "@aws-sdk/smithy-client": "3.358.0",
+        "@aws-sdk/types": "3.357.0",
+        "@aws-sdk/url-parser": "3.357.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "@aws-sdk/util-body-length-browser": "3.310.0",
+        "@aws-sdk/util-body-length-node": "3.310.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.358.0",
+        "@aws-sdk/util-defaults-mode-node": "3.358.0",
+        "@aws-sdk/util-endpoints": "3.357.0",
+        "@aws-sdk/util-retry": "3.357.0",
+        "@aws-sdk/util-user-agent-browser": "3.357.0",
+        "@aws-sdk/util-user-agent-node": "3.357.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "@smithy/protocol-http": "^1.0.1",
+        "@smithy/types": "^1.0.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/client-sso-oidc": {
+      "version": "3.358.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.358.0.tgz",
+      "integrity": "sha512-Gy09fSlhJdGbr8rNNR8EdLaUynB1B34nw8kN1aFT4CdAnjFKxTainqG6Aq4vx64TbMDMhvMYWpNAluvq7UHVhw==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/config-resolver": "3.357.0",
+        "@aws-sdk/fetch-http-handler": "3.357.0",
+        "@aws-sdk/hash-node": "3.357.0",
+        "@aws-sdk/invalid-dependency": "3.357.0",
+        "@aws-sdk/middleware-content-length": "3.357.0",
+        "@aws-sdk/middleware-endpoint": "3.357.0",
+        "@aws-sdk/middleware-host-header": "3.357.0",
+        "@aws-sdk/middleware-logger": "3.357.0",
+        "@aws-sdk/middleware-recursion-detection": "3.357.0",
+        "@aws-sdk/middleware-retry": "3.357.0",
+        "@aws-sdk/middleware-serde": "3.357.0",
+        "@aws-sdk/middleware-stack": "3.357.0",
+        "@aws-sdk/middleware-user-agent": "3.357.0",
+        "@aws-sdk/node-config-provider": "3.357.0",
+        "@aws-sdk/node-http-handler": "3.357.0",
+        "@aws-sdk/smithy-client": "3.358.0",
+        "@aws-sdk/types": "3.357.0",
+        "@aws-sdk/url-parser": "3.357.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "@aws-sdk/util-body-length-browser": "3.310.0",
+        "@aws-sdk/util-body-length-node": "3.310.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.358.0",
+        "@aws-sdk/util-defaults-mode-node": "3.358.0",
+        "@aws-sdk/util-endpoints": "3.357.0",
+        "@aws-sdk/util-retry": "3.357.0",
+        "@aws-sdk/util-user-agent-browser": "3.357.0",
+        "@aws-sdk/util-user-agent-node": "3.357.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "@smithy/protocol-http": "^1.0.1",
+        "@smithy/types": "^1.0.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/client-sts": {
+      "version": "3.359.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.359.0.tgz",
+      "integrity": "sha512-zpyui8hXvEUvq8MwzZsm51ni0intvPjtV8dgx10nVJnm605nqrLlAMGqQ1S/UxO7CVmhqWbh5dnGHEc//UJlsw==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/config-resolver": "3.357.0",
+        "@aws-sdk/credential-provider-node": "3.358.0",
+        "@aws-sdk/fetch-http-handler": "3.357.0",
+        "@aws-sdk/hash-node": "3.357.0",
+        "@aws-sdk/invalid-dependency": "3.357.0",
+        "@aws-sdk/middleware-content-length": "3.357.0",
+        "@aws-sdk/middleware-endpoint": "3.357.0",
+        "@aws-sdk/middleware-host-header": "3.357.0",
+        "@aws-sdk/middleware-logger": "3.357.0",
+        "@aws-sdk/middleware-recursion-detection": "3.357.0",
+        "@aws-sdk/middleware-retry": "3.357.0",
+        "@aws-sdk/middleware-sdk-sts": "3.357.0",
+        "@aws-sdk/middleware-serde": "3.357.0",
+        "@aws-sdk/middleware-signing": "3.357.0",
+        "@aws-sdk/middleware-stack": "3.357.0",
+        "@aws-sdk/middleware-user-agent": "3.357.0",
+        "@aws-sdk/node-config-provider": "3.357.0",
+        "@aws-sdk/node-http-handler": "3.357.0",
+        "@aws-sdk/smithy-client": "3.358.0",
+        "@aws-sdk/types": "3.357.0",
+        "@aws-sdk/url-parser": "3.357.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "@aws-sdk/util-body-length-browser": "3.310.0",
+        "@aws-sdk/util-body-length-node": "3.310.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.358.0",
+        "@aws-sdk/util-defaults-mode-node": "3.358.0",
+        "@aws-sdk/util-endpoints": "3.357.0",
+        "@aws-sdk/util-retry": "3.357.0",
+        "@aws-sdk/util-user-agent-browser": "3.357.0",
+        "@aws-sdk/util-user-agent-node": "3.357.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "@smithy/protocol-http": "^1.0.1",
+        "@smithy/types": "^1.0.0",
+        "fast-xml-parser": "4.2.5",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/config-resolver": {
+      "version": "3.357.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.357.0.tgz",
+      "integrity": "sha512-cukfg0nX7Tzx/xFyH5F4Eyb8DA1ITCGtSQv4vnEjgUop+bkzckuGLKEeBcBhyZY+aw+2C9CVwIHwIMhRm0ul5w==",
+      "dependencies": {
+        "@aws-sdk/types": "3.357.0",
+        "@aws-sdk/util-config-provider": "3.310.0",
+        "@aws-sdk/util-middleware": "3.357.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.357.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.357.0.tgz",
+      "integrity": "sha512-UOecwfqvXgJVqhfWSZ2S44v2Nq2oceW0PQVQp0JAa9opc2rxSVIfyOhPr0yMoPmpyNcP22rgeg6ce70KULYwiA==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.357.0",
+        "@aws-sdk/types": "3.357.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/credential-provider-imds": {
+      "version": "3.357.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.357.0.tgz",
+      "integrity": "sha512-upw/bfsl7/WydT6gM0lBuR4Ipp4fzYm/E3ObFr0Mg5OkgVPt5ZJE+eeFTvwCpDdBSTKs4JfrK6/iEK8A23Q1jQ==",
+      "dependencies": {
+        "@aws-sdk/node-config-provider": "3.357.0",
+        "@aws-sdk/property-provider": "3.357.0",
+        "@aws-sdk/types": "3.357.0",
+        "@aws-sdk/url-parser": "3.357.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.358.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.358.0.tgz",
+      "integrity": "sha512-Blmw4bhGxpaYvPmrbRKAltqnNDDSf6ZegNqJasc5OWvAlHJNvB/hYPmyQN0oFy79BXn7PbBip1QaLWaEhJvpAA==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.357.0",
+        "@aws-sdk/credential-provider-imds": "3.357.0",
+        "@aws-sdk/credential-provider-process": "3.357.0",
+        "@aws-sdk/credential-provider-sso": "3.358.0",
+        "@aws-sdk/credential-provider-web-identity": "3.357.0",
+        "@aws-sdk/property-provider": "3.357.0",
+        "@aws-sdk/shared-ini-file-loader": "3.357.0",
+        "@aws-sdk/types": "3.357.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.358.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.358.0.tgz",
+      "integrity": "sha512-iLjyRNOT0ycdLqkzXNW+V2zibVljkLjL8j45FpK6mNrAwc/Ynr7EYuRRp5OuRiiYDO3ZoneAxpBJQ5SqmK2Jfg==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.357.0",
+        "@aws-sdk/credential-provider-imds": "3.357.0",
+        "@aws-sdk/credential-provider-ini": "3.358.0",
+        "@aws-sdk/credential-provider-process": "3.357.0",
+        "@aws-sdk/credential-provider-sso": "3.358.0",
+        "@aws-sdk/credential-provider-web-identity": "3.357.0",
+        "@aws-sdk/property-provider": "3.357.0",
+        "@aws-sdk/shared-ini-file-loader": "3.357.0",
+        "@aws-sdk/types": "3.357.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.357.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.357.0.tgz",
+      "integrity": "sha512-qFWWilFPsc2hR7O0KIhwcE78w+pVIK+uQR6MQMfdRyxUndgiuCorJwVjedc3yZtmnoELHF34j+m8whTBXv9E7Q==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.357.0",
+        "@aws-sdk/shared-ini-file-loader": "3.357.0",
+        "@aws-sdk/types": "3.357.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.358.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.358.0.tgz",
+      "integrity": "sha512-hKu5NshKohSDoHaXKyeCW88J8dBt4TMljrL+WswTMifuThO9ptyMq4PCdl4z7CNjIq6zo3ftc/uNf8TY7Ga8+w==",
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.358.0",
+        "@aws-sdk/property-provider": "3.357.0",
+        "@aws-sdk/shared-ini-file-loader": "3.357.0",
+        "@aws-sdk/token-providers": "3.358.0",
+        "@aws-sdk/types": "3.357.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.357.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.357.0.tgz",
+      "integrity": "sha512-0KRRAFrXy5HJe2vqnCWCoCS+fQw7IoIj3KQsuURJMW4F+ifisxCgEsh3brJ2LQlN4ElWTRJhlrDHNZ/pd61D4w==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.357.0",
+        "@aws-sdk/types": "3.357.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/eventstream-codec": {
+      "version": "3.357.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-codec/-/eventstream-codec-3.357.0.tgz",
+      "integrity": "sha512-bqenTHG6GH6aCk/Il+ooWXVVAZuc8lOgVEy9bE2hI49oVqT8zSuXxQB+w1WWyZoAOPcelsjayB1wfPub8VDBxQ==",
+      "dependencies": {
+        "@aws-crypto/crc32": "3.0.0",
+        "@aws-sdk/types": "3.357.0",
+        "@aws-sdk/util-hex-encoding": "3.310.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/fetch-http-handler": {
+      "version": "3.357.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.357.0.tgz",
+      "integrity": "sha512-5sPloTO8y8fAnS/6/Sfp/aVoL9zuhzkLdWBORNzMazdynVNEzWKWCPZ27RQpgkaCDHiXjqUY4kfuFXAGkvFfDQ==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.357.0",
+        "@aws-sdk/querystring-builder": "3.357.0",
+        "@aws-sdk/types": "3.357.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/hash-node": {
+      "version": "3.357.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.357.0.tgz",
+      "integrity": "sha512-fq3LS9AxHKb7dTZkm6iM1TrGk6XOTZz96iEZPME1+vjiSEXGWuebHt87q92n+KozVGRypn9MId3lHOPBBjygNQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.357.0",
+        "@aws-sdk/util-buffer-from": "3.310.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/invalid-dependency": {
+      "version": "3.357.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.357.0.tgz",
+      "integrity": "sha512-HnCYZczf0VdyxMVMMxmA3QJAyyPSFbcMtZzgKbxVTWTG7GKpQe0psWZu/7O2Nk31mKg6vEUdiP1FylqLBsgMOA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.357.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/middleware-content-length": {
+      "version": "3.357.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.357.0.tgz",
+      "integrity": "sha512-zQOFEyzOXAgN4M54tYNWGxKxnyzY0WwYDTFzh9riJRmxN1hTEKHUKmze4nILIf5rkQmOG4kTf1qmfazjkvZAhw==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.357.0",
+        "@aws-sdk/types": "3.357.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/middleware-endpoint": {
+      "version": "3.357.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.357.0.tgz",
+      "integrity": "sha512-ScJi0SL8X/Lyi0Fp5blg0QN/Z6PoRwV/ZJXd8dQkXSznkbSvJHfqPP0xk/w3GcQ1TKsu5YEPfeYy8ejcq+7Pgg==",
+      "dependencies": {
+        "@aws-sdk/middleware-serde": "3.357.0",
+        "@aws-sdk/types": "3.357.0",
+        "@aws-sdk/url-parser": "3.357.0",
+        "@aws-sdk/util-middleware": "3.357.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.357.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.357.0.tgz",
+      "integrity": "sha512-HuGLcP7JP1qJ5wGT9GSlEknDaTSnOzHY4T6IPFuvFjAy3PvY5siQNm6+VRqdVS+n6/kzpL3JP5sAVM3aoxHT6Q==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.357.0",
+        "@aws-sdk/types": "3.357.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.357.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.357.0.tgz",
+      "integrity": "sha512-dncT3tr+lZ9+duZo52rASgO6AKVwRcsc2/T93gmaYVrJqI6WWAwQ7yML5s72l9ZjQ5LZ+4jjrgtlufavAS0eCg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.357.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.357.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.357.0.tgz",
+      "integrity": "sha512-AXC54IeDS3jC1dbbkYHML4STvBPcKZ4IJTWdjEK1RCOgqXd0Ze1cE1e21wyj1tM6prF03zLyvpBd+3TS++nqfA==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.357.0",
+        "@aws-sdk/types": "3.357.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/middleware-retry": {
+      "version": "3.357.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.357.0.tgz",
+      "integrity": "sha512-ZCbXCYv3nglQqwREYxxpclrnR9MYPAnHlLcC8e9PbApqxGnaZdhoywxoqbgqT3hf/RM7kput4vEHDl1fyymcRQ==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.357.0",
+        "@aws-sdk/service-error-classification": "3.357.0",
+        "@aws-sdk/types": "3.357.0",
+        "@aws-sdk/util-middleware": "3.357.0",
+        "@aws-sdk/util-retry": "3.357.0",
+        "tslib": "^2.5.0",
+        "uuid": "^8.3.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/middleware-sdk-sts": {
+      "version": "3.357.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.357.0.tgz",
+      "integrity": "sha512-Ng2VjLrPiL02QOcs1qs9jG2boO4Gn+v3VIbOJLG4zXcfbSq55iIWtlmr2ljfw9vP5aLhWtcODfmKHS5Bp+019Q==",
+      "dependencies": {
+        "@aws-sdk/middleware-signing": "3.357.0",
+        "@aws-sdk/types": "3.357.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/middleware-serde": {
+      "version": "3.357.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.357.0.tgz",
+      "integrity": "sha512-bGI4kYuuEsFjlANbyJLyy4AovETnyf/SukgLOG7Qjbua+ZGuzvRhMsk21mBKKGrnsTO4PmtieJo6xClThGAN8g==",
+      "dependencies": {
+        "@aws-sdk/types": "3.357.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/middleware-signing": {
+      "version": "3.357.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.357.0.tgz",
+      "integrity": "sha512-yB9ewEqI6Fw1OrmKFrUypbCqN5ijk06UGPochybamMuPxxkwMT3bnrm7eezsCA+TZbJyKhpffpyobwuv+xGNrA==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.357.0",
+        "@aws-sdk/protocol-http": "3.357.0",
+        "@aws-sdk/signature-v4": "3.357.0",
+        "@aws-sdk/types": "3.357.0",
+        "@aws-sdk/util-middleware": "3.357.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/middleware-stack": {
+      "version": "3.357.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.357.0.tgz",
+      "integrity": "sha512-nNV+jfwGwmbOGZujAY/U8AW3EbVlxa9DJDLz3TPp/39o6Vu5KEzHJyDDNreo2k9V/TMvV+nOzHafufgPdagv7w==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.357.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.357.0.tgz",
+      "integrity": "sha512-M/CsAXjGblZS4rEbMb0Dn9IXbfq4EjVaTHBfvuILU/dKRppWvjnm2lRtqCZ+LIT3ATbAjA3/dY7dWsjxQWwijA==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.357.0",
+        "@aws-sdk/types": "3.357.0",
+        "@aws-sdk/util-endpoints": "3.357.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/node-config-provider": {
+      "version": "3.357.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.357.0.tgz",
+      "integrity": "sha512-kwBIzKCaW3UWqLdELhy7TcN8itNMOjbzga530nalFILMvn2IxrkdKQhNgxGBXy6QK6kCOtH6OmcrG3/oZkLwig==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.357.0",
+        "@aws-sdk/shared-ini-file-loader": "3.357.0",
+        "@aws-sdk/types": "3.357.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/node-http-handler": {
+      "version": "3.357.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.357.0.tgz",
+      "integrity": "sha512-uoab4xIJux+Q9hQ9A/vWEAjojtBQ0U4K7xEQVa0BXEv7MHH5zv51H+VtrelU1Ed6hsHq4Sx0bxBMFpbbWhNyjA==",
+      "dependencies": {
+        "@aws-sdk/abort-controller": "3.357.0",
+        "@aws-sdk/protocol-http": "3.357.0",
+        "@aws-sdk/querystring-builder": "3.357.0",
+        "@aws-sdk/types": "3.357.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/property-provider": {
+      "version": "3.357.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.357.0.tgz",
+      "integrity": "sha512-im4W0u8WaYxG7J7ko4Xl3OEzK3Mrm1Rz6/txTGe6hTIHlyUISu1ekOQJXK6XYPqNMn8v1G3BiQREoRXUEJFbHg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.357.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/protocol-http": {
+      "version": "3.357.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.357.0.tgz",
+      "integrity": "sha512-w1JHiI50VEea7duDeAspUiKJmmdIQblvRyjVMOqWA6FIQAyDVuEiPX7/MdQr0ScxhtRQxHbP0I4MFyl7ctRQvA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.357.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/querystring-builder": {
+      "version": "3.357.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.357.0.tgz",
+      "integrity": "sha512-aQcicqB6Y2cNaXPPwunz612a01SMiQQPsdz632F/3Lzn0ua82BJKobHOtaiTUlmVJ5Q4/EAeNfwZgL7tTUNtDQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.357.0",
+        "@aws-sdk/util-uri-escape": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/querystring-parser": {
+      "version": "3.357.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.357.0.tgz",
+      "integrity": "sha512-Svvq+atRNP9s2VxiklcUNgCzmt3T5kfs7X2C+yjmxHvOQTPjLNaNGbfC/vhjOK7aoXw0h+lBac48r5ymx1PbQA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.357.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/service-error-classification": {
+      "version": "3.357.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.357.0.tgz",
+      "integrity": "sha512-VuXeL4g5vKO9HjgCZlxmH8Uv1FcqUSjmbPpQkbNtYIDck6u0qzM0rG+n0/1EjyQbPSr3MhW/pkWs5nx2Nljlyg==",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/shared-ini-file-loader": {
+      "version": "3.357.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.357.0.tgz",
+      "integrity": "sha512-ceyqM4XxQe0Plb/oQAD2t1UOV2Iy4PFe1oAGM8dfJzYrRKu7zvMwru7/WaB3NYq+/mIY6RU+jjhRmjQ3GySVqA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.357.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/signature-v4": {
+      "version": "3.357.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.357.0.tgz",
+      "integrity": "sha512-itt4/Jh9FqnzK30qIjXFBvM4J7zN4S/AAqsRMnaX7U4f/MV+1YxQHmzimpdMnsCXXs2jqFqKVRu6DewxJ3nbxg==",
+      "dependencies": {
+        "@aws-sdk/eventstream-codec": "3.357.0",
+        "@aws-sdk/is-array-buffer": "3.310.0",
+        "@aws-sdk/types": "3.357.0",
+        "@aws-sdk/util-hex-encoding": "3.310.0",
+        "@aws-sdk/util-middleware": "3.357.0",
+        "@aws-sdk/util-uri-escape": "3.310.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/smithy-client": {
+      "version": "3.358.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.358.0.tgz",
+      "integrity": "sha512-oqctxWb9yAqCh4ENwUkt9MC01l5uKoy+QCiSUUhQ76k7R3lyGOge9ycyRyoKl+oZWvEpnjZevXQFqEfGzkL7bA==",
+      "dependencies": {
+        "@aws-sdk/middleware-stack": "3.357.0",
+        "@aws-sdk/types": "3.357.0",
+        "@aws-sdk/util-stream": "3.358.0",
+        "@smithy/types": "^1.0.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/token-providers": {
+      "version": "3.358.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.358.0.tgz",
+      "integrity": "sha512-vATKNCwNhCSo2LzvtkIzW9Yp2/aKNR032VPtIWlDtWGGFhkzGi4FPS0VTdfefxz4rqPWfBz53mh54d9xylsWVw==",
+      "dependencies": {
+        "@aws-sdk/client-sso-oidc": "3.358.0",
+        "@aws-sdk/property-provider": "3.357.0",
+        "@aws-sdk/shared-ini-file-loader": "3.357.0",
+        "@aws-sdk/types": "3.357.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/types": {
+      "version": "3.357.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.357.0.tgz",
+      "integrity": "sha512-/riCRaXg3p71BeWnShrai0y0QTdXcouPSM0Cn1olZbzTf7s71aLEewrc96qFrL70XhY4XvnxMpqQh+r43XIL3g==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/url-parser": {
+      "version": "3.357.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.357.0.tgz",
+      "integrity": "sha512-fAaU6cFsaAba01lCRsRJiYR/LfXvX2wudyEyutBVglE4dWSoSeu3QJNxImIzTBULfbiFhz59++NQ1JUVx88IVg==",
+      "dependencies": {
+        "@aws-sdk/querystring-parser": "3.357.0",
+        "@aws-sdk/types": "3.357.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/util-defaults-mode-browser": {
+      "version": "3.358.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.358.0.tgz",
+      "integrity": "sha512-KGfw64wRL/gROLD4Gatda8cUsaNKNhSnx+yDDcG2WkFlFfLr6FHvTijpRxvIM2Jau2ZhcdGzbegLjsFxviTJAA==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.357.0",
+        "@aws-sdk/types": "3.357.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/util-defaults-mode-node": {
+      "version": "3.358.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.358.0.tgz",
+      "integrity": "sha512-2C5on0yppDS0xGpFkHRqfrG9TeTq6ive1hPX1V8UCkiI/TBQYl88XCKCKct8zTcejyK9klZUDGI8QQTan2UWkw==",
+      "dependencies": {
+        "@aws-sdk/config-resolver": "3.357.0",
+        "@aws-sdk/credential-provider-imds": "3.357.0",
+        "@aws-sdk/node-config-provider": "3.357.0",
+        "@aws-sdk/property-provider": "3.357.0",
+        "@aws-sdk/types": "3.357.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.357.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.357.0.tgz",
+      "integrity": "sha512-XHKyS5JClT9su9hDif715jpZiWHQF9gKZXER8tW0gOizU3R9cyWc9EsJ2BRhFNhi7nt/JF/CLUEc5qDx3ETbUw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.357.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/util-middleware": {
+      "version": "3.357.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.357.0.tgz",
+      "integrity": "sha512-pV1krjZs7BdahZBfsCJMatE8kcor7GFsBOWrQgQDm9T0We5b5xPpOO2vxAD0RytBpY8Ky2ELs/+qXMv7l5fWIA==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/util-retry": {
+      "version": "3.357.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.357.0.tgz",
+      "integrity": "sha512-SUqYJE9msbuOVq+vnUy+t0LH7XuYNFz66dSF8q6tedsbJK4j8tgya0I1Ct3m06ynGrXDJMaj39I7AXCyW9bjtw==",
+      "dependencies": {
+        "@aws-sdk/service-error-classification": "3.357.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.357.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.357.0.tgz",
+      "integrity": "sha512-JHaWlNIUkPNvXkqeDOrqFzAlAgdwZK5mZw7FQnCRvf8tdSogpGZSkuyb9Z6rLD9gC40Srbc2nepO1cFpeMsDkA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.357.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.357.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.357.0.tgz",
+      "integrity": "sha512-RdpQoaJWQvcS99TVgSbT451iGrlH4qpWUWFA9U1IRhxOSsmC1hz8ME7xc8nci9SREx/ZlfT3ai6LpoAzAtIEMA==",
+      "dependencies": {
+        "@aws-sdk/node-config-provider": "3.357.0",
+        "@aws-sdk/types": "3.357.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/fast-xml-parser": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.5.tgz",
+      "integrity": "sha512-B9/wizE4WngqQftFPmdaMYlXoJlJOYxGQOanC77fq9k8+Z0v5dDSVh+3glErdIROP//s/jgb7ZuxKfB8nVyo0g==",
+      "funding": [
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/naturalintelligence"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "dependencies": {
+        "strnum": "^1.0.5"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso": {
+      "version": "3.354.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.354.0.tgz",
+      "integrity": "sha512-4jmvjJYDaaPmm1n2TG4LYfTEnHLKcJmImgBqhgzhMgaypb4u/k1iw0INV2r/afYPL/FsrLFwc46RM3HYx3nc4A==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/config-resolver": "3.354.0",
+        "@aws-sdk/fetch-http-handler": "3.353.0",
+        "@aws-sdk/hash-node": "3.347.0",
+        "@aws-sdk/invalid-dependency": "3.347.0",
+        "@aws-sdk/middleware-content-length": "3.347.0",
+        "@aws-sdk/middleware-endpoint": "3.347.0",
+        "@aws-sdk/middleware-host-header": "3.347.0",
+        "@aws-sdk/middleware-logger": "3.347.0",
+        "@aws-sdk/middleware-recursion-detection": "3.347.0",
+        "@aws-sdk/middleware-retry": "3.354.0",
+        "@aws-sdk/middleware-serde": "3.347.0",
+        "@aws-sdk/middleware-stack": "3.347.0",
+        "@aws-sdk/middleware-user-agent": "3.352.0",
+        "@aws-sdk/node-config-provider": "3.354.0",
+        "@aws-sdk/node-http-handler": "3.350.0",
+        "@aws-sdk/smithy-client": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/url-parser": "3.347.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "@aws-sdk/util-body-length-browser": "3.310.0",
+        "@aws-sdk/util-body-length-node": "3.310.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.353.0",
+        "@aws-sdk/util-defaults-mode-node": "3.354.0",
+        "@aws-sdk/util-endpoints": "3.352.0",
+        "@aws-sdk/util-retry": "3.347.0",
+        "@aws-sdk/util-user-agent-browser": "3.347.0",
+        "@aws-sdk/util-user-agent-node": "3.354.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "@smithy/protocol-http": "^1.0.1",
+        "@smithy/types": "^1.0.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc": {
+      "version": "3.354.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.354.0.tgz",
+      "integrity": "sha512-XZcg4s2zKb4S8ltluiw5yxpm974uZqzo2HTECt1lbzUJgVgLsMAh/nPJ1fLqg4jadT+rf8Lq2FEFqOM/vxWT8A==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/config-resolver": "3.354.0",
+        "@aws-sdk/fetch-http-handler": "3.353.0",
+        "@aws-sdk/hash-node": "3.347.0",
+        "@aws-sdk/invalid-dependency": "3.347.0",
+        "@aws-sdk/middleware-content-length": "3.347.0",
+        "@aws-sdk/middleware-endpoint": "3.347.0",
+        "@aws-sdk/middleware-host-header": "3.347.0",
+        "@aws-sdk/middleware-logger": "3.347.0",
+        "@aws-sdk/middleware-recursion-detection": "3.347.0",
+        "@aws-sdk/middleware-retry": "3.354.0",
+        "@aws-sdk/middleware-serde": "3.347.0",
+        "@aws-sdk/middleware-stack": "3.347.0",
+        "@aws-sdk/middleware-user-agent": "3.352.0",
+        "@aws-sdk/node-config-provider": "3.354.0",
+        "@aws-sdk/node-http-handler": "3.350.0",
+        "@aws-sdk/smithy-client": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/url-parser": "3.347.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "@aws-sdk/util-body-length-browser": "3.310.0",
+        "@aws-sdk/util-body-length-node": "3.310.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.353.0",
+        "@aws-sdk/util-defaults-mode-node": "3.354.0",
+        "@aws-sdk/util-endpoints": "3.352.0",
+        "@aws-sdk/util-retry": "3.347.0",
+        "@aws-sdk/util-user-agent-browser": "3.347.0",
+        "@aws-sdk/util-user-agent-node": "3.354.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "@smithy/protocol-http": "^1.0.1",
+        "@smithy/types": "^1.0.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts": {
+      "version": "3.354.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.354.0.tgz",
+      "integrity": "sha512-l9Ar/C/3PNlToM1ukHVfBtp4plbRUxLMYY2DOTMI0nb3jzfcvETBcdEGCP51fX4uAfJ2vc4g5qBF/qXKX0LMWA==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/config-resolver": "3.354.0",
+        "@aws-sdk/credential-provider-node": "3.354.0",
+        "@aws-sdk/fetch-http-handler": "3.353.0",
+        "@aws-sdk/hash-node": "3.347.0",
+        "@aws-sdk/invalid-dependency": "3.347.0",
+        "@aws-sdk/middleware-content-length": "3.347.0",
+        "@aws-sdk/middleware-endpoint": "3.347.0",
+        "@aws-sdk/middleware-host-header": "3.347.0",
+        "@aws-sdk/middleware-logger": "3.347.0",
+        "@aws-sdk/middleware-recursion-detection": "3.347.0",
+        "@aws-sdk/middleware-retry": "3.354.0",
+        "@aws-sdk/middleware-sdk-sts": "3.354.0",
+        "@aws-sdk/middleware-serde": "3.347.0",
+        "@aws-sdk/middleware-signing": "3.354.0",
+        "@aws-sdk/middleware-stack": "3.347.0",
+        "@aws-sdk/middleware-user-agent": "3.352.0",
+        "@aws-sdk/node-config-provider": "3.354.0",
+        "@aws-sdk/node-http-handler": "3.350.0",
+        "@aws-sdk/smithy-client": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/url-parser": "3.347.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "@aws-sdk/util-body-length-browser": "3.310.0",
+        "@aws-sdk/util-body-length-node": "3.310.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.353.0",
+        "@aws-sdk/util-defaults-mode-node": "3.354.0",
+        "@aws-sdk/util-endpoints": "3.352.0",
+        "@aws-sdk/util-retry": "3.347.0",
+        "@aws-sdk/util-user-agent-browser": "3.347.0",
+        "@aws-sdk/util-user-agent-node": "3.354.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "@smithy/protocol-http": "^1.0.1",
+        "@smithy/types": "^1.0.0",
+        "fast-xml-parser": "4.2.4",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/config-resolver": {
+      "version": "3.354.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.354.0.tgz",
+      "integrity": "sha512-K4XWie8yJPT8bpYVX54VJMQhiJRTw8PrjEs9QrKqvwoCcZ3G4qEt40tIu33XksuokXxk8rrVH5d7odOPBsAtdg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/util-config-provider": "3.310.0",
+        "@aws-sdk/util-middleware": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.353.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.353.0.tgz",
+      "integrity": "sha512-Y4VsNS8O1FAD5J7S5itOhnOghQ5LIXlZ44t35nF8cbcF+JPvY3ToKzYpjYN1jM7DXKqU4shtqgYpzSqxlvEgKQ==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.353.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-imds": {
+      "version": "3.354.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.354.0.tgz",
+      "integrity": "sha512-AB+PuDd1jX6qgz+JYvIyOn8Kz9/lQ60KuY1TFb7g3S8zURw+DSeMJNR1jzEsorWICTzhxXmyasHVMa4Eo4Uq+Q==",
+      "dependencies": {
+        "@aws-sdk/node-config-provider": "3.354.0",
+        "@aws-sdk/property-provider": "3.353.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/url-parser": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.354.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.354.0.tgz",
+      "integrity": "sha512-bn2ifrRsxWpxzwXa25jRdUECQ1dC+NB3YlRYnGdIaIQLF559N2jnfCabYzqyfKI++WU7aQeMofPe2PxVGlbv9Q==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.353.0",
+        "@aws-sdk/credential-provider-imds": "3.354.0",
+        "@aws-sdk/credential-provider-process": "3.354.0",
+        "@aws-sdk/credential-provider-sso": "3.354.0",
+        "@aws-sdk/credential-provider-web-identity": "3.354.0",
+        "@aws-sdk/property-provider": "3.353.0",
+        "@aws-sdk/shared-ini-file-loader": "3.354.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.354.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.354.0.tgz",
+      "integrity": "sha512-ltKiRtHfqDaCcrb44DIoSHQ9MposFl/aDtNdu5OdQv/2Q1r7M/r2fQdq9DHOrxeQQjaUH4C6k6fGTsxALTHyNA==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.353.0",
+        "@aws-sdk/credential-provider-imds": "3.354.0",
+        "@aws-sdk/credential-provider-ini": "3.354.0",
+        "@aws-sdk/credential-provider-process": "3.354.0",
+        "@aws-sdk/credential-provider-sso": "3.354.0",
+        "@aws-sdk/credential-provider-web-identity": "3.354.0",
+        "@aws-sdk/property-provider": "3.353.0",
+        "@aws-sdk/shared-ini-file-loader": "3.354.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.354.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.354.0.tgz",
+      "integrity": "sha512-AxpASm+tS8V1PY4PLfG9dtqa96lzBJ3niTQb+RAm4uYCddW7gxNDkGB+jSCzVdUPVa3xA2ITBS/ka3C5yM8YWg==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.353.0",
+        "@aws-sdk/shared-ini-file-loader": "3.354.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.354.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.354.0.tgz",
+      "integrity": "sha512-ihiaUxh8V/nQgTOgQZxWQcbckXhM+J6Wdc4F0z9soi48iSOqzRpzPw5E14wSZScEZjNY/gKEDz8gCt8WkT/G0w==",
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.354.0",
+        "@aws-sdk/property-provider": "3.353.0",
+        "@aws-sdk/shared-ini-file-loader": "3.354.0",
+        "@aws-sdk/token-providers": "3.354.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.354.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.354.0.tgz",
+      "integrity": "sha512-scx9mAf4m3Hc3uMX2Vh8GciEcC/5GqeDI8qc0zBj+UF/5c/GtihZA4WoCV3Sg3jMPDUKY81DiFCtcKHhtUqKfg==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.353.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/eventstream-codec": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-codec/-/eventstream-codec-3.347.0.tgz",
+      "integrity": "sha512-61q+SyspjsaQ4sdgjizMyRgVph2CiW4aAtfpoH69EJFJfTxTR/OqnZ9Jx/3YiYi0ksrvDenJddYodfWWJqD8/w==",
+      "dependencies": {
+        "@aws-crypto/crc32": "3.0.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/util-hex-encoding": "3.310.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@aws-sdk/eventstream-serde-browser": {
+      "version": "3.357.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-browser/-/eventstream-serde-browser-3.357.0.tgz",
+      "integrity": "sha512-hBabtmwuspVHGSKnUccDiSIbg+IVoBThx6wYt6i4edbWAITHF3ADVKXy7icV400CAyG0XTZgxjE6FKpiDxj9rQ==",
+      "dependencies": {
+        "@aws-sdk/eventstream-serde-universal": "3.357.0",
+        "@aws-sdk/types": "3.357.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/eventstream-serde-browser/node_modules/@aws-sdk/types": {
+      "version": "3.357.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.357.0.tgz",
+      "integrity": "sha512-/riCRaXg3p71BeWnShrai0y0QTdXcouPSM0Cn1olZbzTf7s71aLEewrc96qFrL70XhY4XvnxMpqQh+r43XIL3g==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/eventstream-serde-config-resolver": {
+      "version": "3.357.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.357.0.tgz",
+      "integrity": "sha512-E6rwk+1KFXhKmJ+v7JW5Uyyda1yN5XRVupCnCrtFsHFmhVGQxFacoUZIee3bfuCpC58dLSyESggxGpUd3XOSsw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.357.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/eventstream-serde-config-resolver/node_modules/@aws-sdk/types": {
+      "version": "3.357.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.357.0.tgz",
+      "integrity": "sha512-/riCRaXg3p71BeWnShrai0y0QTdXcouPSM0Cn1olZbzTf7s71aLEewrc96qFrL70XhY4XvnxMpqQh+r43XIL3g==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/eventstream-serde-node": {
+      "version": "3.357.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-node/-/eventstream-serde-node-3.357.0.tgz",
+      "integrity": "sha512-boXDy+JWcPfHc9OIKV6I4Bh2XrLcg+eac+/LldNZFcDIB33/gHIM2CJw8u565Iebdz1NKEkP/QPPZbk2y+abPA==",
+      "dependencies": {
+        "@aws-sdk/eventstream-serde-universal": "3.357.0",
+        "@aws-sdk/types": "3.357.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/eventstream-serde-node/node_modules/@aws-sdk/types": {
+      "version": "3.357.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.357.0.tgz",
+      "integrity": "sha512-/riCRaXg3p71BeWnShrai0y0QTdXcouPSM0Cn1olZbzTf7s71aLEewrc96qFrL70XhY4XvnxMpqQh+r43XIL3g==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/eventstream-serde-universal": {
+      "version": "3.357.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-universal/-/eventstream-serde-universal-3.357.0.tgz",
+      "integrity": "sha512-9/Wcdxx38XQAturqOAGYNCaLOzFVnW+xwxd4af9eNOfZfZ5PP5PRKBIpvKDsN26e3l4f3GodHx7MS1WB7BBc2w==",
+      "dependencies": {
+        "@aws-sdk/eventstream-codec": "3.357.0",
+        "@aws-sdk/types": "3.357.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/eventstream-serde-universal/node_modules/@aws-sdk/eventstream-codec": {
+      "version": "3.357.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-codec/-/eventstream-codec-3.357.0.tgz",
+      "integrity": "sha512-bqenTHG6GH6aCk/Il+ooWXVVAZuc8lOgVEy9bE2hI49oVqT8zSuXxQB+w1WWyZoAOPcelsjayB1wfPub8VDBxQ==",
+      "dependencies": {
+        "@aws-crypto/crc32": "3.0.0",
+        "@aws-sdk/types": "3.357.0",
+        "@aws-sdk/util-hex-encoding": "3.310.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@aws-sdk/eventstream-serde-universal/node_modules/@aws-sdk/types": {
+      "version": "3.357.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.357.0.tgz",
+      "integrity": "sha512-/riCRaXg3p71BeWnShrai0y0QTdXcouPSM0Cn1olZbzTf7s71aLEewrc96qFrL70XhY4XvnxMpqQh+r43XIL3g==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/fetch-http-handler": {
+      "version": "3.353.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.353.0.tgz",
+      "integrity": "sha512-8ic2+4E6jzfDevd++QS1rOR05QFkAhEFbi5Ja3/Zzp7TkWIS8wv5wwMATjNkbbdsXYuB5Lhl/OsjfZmIv5aqRw==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.347.0",
+        "@aws-sdk/querystring-builder": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@aws-sdk/hash-node": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.347.0.tgz",
+      "integrity": "sha512-96+ml/4EaUaVpzBdOLGOxdoXOjkPgkoJp/0i1fxOJEvl8wdAQSwc3IugVK9wZkCxy2DlENtgOe6DfIOhfffm/g==",
+      "dependencies": {
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/util-buffer-from": "3.310.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/invalid-dependency": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.347.0.tgz",
+      "integrity": "sha512-8imQcwLwqZ/wTJXZqzXT9pGLIksTRckhGLZaXT60tiBOPKuerTsus2L59UstLs5LP8TKaVZKFFSsjRIn9dQdmQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@aws-sdk/is-array-buffer": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.310.0.tgz",
+      "integrity": "sha512-urnbcCR+h9NWUnmOtet/s4ghvzsidFmspfhYaHAmSRdy9yDjdjBJMFjjsn85A1ODUktztm+cVncXjQ38WCMjMQ==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-content-length": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.347.0.tgz",
+      "integrity": "sha512-i4qtWTDImMaDUtwKQPbaZpXsReiwiBomM1cWymCU4bhz81HL01oIxOxOBuiM+3NlDoCSPr3KI6txZSz/8cqXCQ==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-endpoint": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.347.0.tgz",
+      "integrity": "sha512-unF0c6dMaUL1ffU+37Ugty43DgMnzPWXr/Jup/8GbK5fzzWT5NQq6dj9KHPubMbWeEjQbmczvhv25JuJdK8gNQ==",
+      "dependencies": {
+        "@aws-sdk/middleware-serde": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/url-parser": "3.347.0",
+        "@aws-sdk/util-middleware": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.347.0.tgz",
+      "integrity": "sha512-kpKmR9OvMlnReqp5sKcJkozbj1wmlblbVSbnQAIkzeQj2xD5dnVR3Nn2ogQKxSmU1Fv7dEroBtrruJ1o3fY38A==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.347.0.tgz",
+      "integrity": "sha512-NYC+Id5UCkVn+3P1t/YtmHt75uED06vwaKyxDy0UmB2K66PZLVtwWbLpVWrhbroaw1bvUHYcRyQ9NIfnVcXQjA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.347.0.tgz",
+      "integrity": "sha512-qfnSvkFKCAMjMHR31NdsT0gv5Sq/ZHTUD4yQsSLpbVQ6iYAS834lrzXt41iyEHt57Y514uG7F/Xfvude3u4icQ==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-retry": {
+      "version": "3.354.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.354.0.tgz",
+      "integrity": "sha512-dnG5Nd/mobbhcWCM71DQWI9+f6b6fDSzALXftFIP/8lsXKRcWDSQuYjrnVST2wZzk/QmdF8TnVD0C1xL14K6CQ==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.347.0",
+        "@aws-sdk/service-error-classification": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/util-middleware": "3.347.0",
+        "@aws-sdk/util-retry": "3.347.0",
+        "tslib": "^2.5.0",
+        "uuid": "^8.3.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-sts": {
+      "version": "3.354.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.354.0.tgz",
+      "integrity": "sha512-L6vyAwYrdcOoB4YgCqNJNr+ZZtLHEF2Ym3CTfmFm2srXHqHuRB+mBu0NLV/grz77znIArK1H1ZL/ZaH2I5hclA==",
+      "dependencies": {
+        "@aws-sdk/middleware-signing": "3.354.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-serde": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.347.0.tgz",
+      "integrity": "sha512-x5Foi7jRbVJXDu9bHfyCbhYDH5pKK+31MmsSJ3k8rY8keXLBxm2XEEg/AIoV9/TUF9EeVvZ7F1/RmMpJnWQsEg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-signing": {
+      "version": "3.354.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.354.0.tgz",
+      "integrity": "sha512-Dd+vIhJL0VqqKWqlTKlKC5jkCaEIk73ZEXNfv44XbsI25a0vXbatHp1M8jB/cgkJC/Mri1TX9dmckP/C0FDEwA==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.353.0",
+        "@aws-sdk/protocol-http": "3.347.0",
+        "@aws-sdk/signature-v4": "3.354.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/util-middleware": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-stack": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.347.0.tgz",
+      "integrity": "sha512-Izidg4rqtYMcKuvn2UzgEpPLSmyd8ub9+LQ2oIzG3mpIzCBITq7wp40jN1iNkMg+X6KEnX9vdMJIYZsPYMCYuQ==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.352.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.352.0.tgz",
+      "integrity": "sha512-QGqblMTsVDqeomy22KPm9LUW8PHZXBA2Hjk9Hcw8U1uFS8IKYJrewInG3ae2+9FAcTyug4LFWDf8CRr9YH2B3Q==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/util-endpoints": "3.352.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/node-config-provider": {
+      "version": "3.354.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.354.0.tgz",
+      "integrity": "sha512-pF1ZGWWvmwbrloNHYF3EDqCb9hq5wfZwDqAwAPhWkYnUYKkR7E7MZVuTwUDU48io8k6Z5pM52l/54w8e8aedTw==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.353.0",
+        "@aws-sdk/shared-ini-file-loader": "3.354.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/node-http-handler": {
+      "version": "3.350.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.350.0.tgz",
+      "integrity": "sha512-oD96GAlmpzYilCdC8wwyURM5lNfNHZCjm/kxBkQulHKa2kRbIrnD9GfDqdCkWA5cTpjh1NzGLT4D6e6UFDjt9w==",
+      "dependencies": {
+        "@aws-sdk/abort-controller": "3.347.0",
+        "@aws-sdk/protocol-http": "3.347.0",
+        "@aws-sdk/querystring-builder": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/property-provider": {
+      "version": "3.353.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.353.0.tgz",
+      "integrity": "sha512-Iu6J59hncaew7eBKroTcLjZ8cgrom0IWyZZ09rsow3rZDHVtw7LQSrUyuqsSbKGY9eRtL7Wa6ZtYHnXFiAE2kg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/protocol-http": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.347.0.tgz",
+      "integrity": "sha512-2YdBhc02Wvy03YjhGwUxF0UQgrPWEy8Iq75pfS42N+/0B/+eWX1aQgfjFxIpLg7YSjT5eKtYOQGlYd4MFTgj9g==",
+      "dependencies": {
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/querystring-builder": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.347.0.tgz",
+      "integrity": "sha512-phtKTe6FXoV02MoPkIVV6owXI8Mwr5IBN3bPoxhcPvJG2AjEmnetSIrhb8kwc4oNhlwfZwH6Jo5ARW/VEWbZtg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/util-uri-escape": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/querystring-parser": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.347.0.tgz",
+      "integrity": "sha512-5VXOhfZz78T2W7SuXf2avfjKglx1VZgZgp9Zfhrt/Rq+MTu2D+PZc5zmJHhYigD7x83jLSLogpuInQpFMA9LgA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/service-error-classification": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.347.0.tgz",
+      "integrity": "sha512-xZ3MqSY81Oy2gh5g0fCtooAbahqh9VhsF8vcKjVX8+XPbGC8y+kej82+MsMg4gYL8gRFB9u4hgYbNgIS6JTAvg==",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/shared-ini-file-loader": {
+      "version": "3.354.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.354.0.tgz",
+      "integrity": "sha512-UL9loGEsdzpHBu/PtlwUvkl/yRdmWXkySp22jUaeeRtBhiGAnyeYhxJLIt+u+UkX7Mwz+810SaZJqA9ptOXNAg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4": {
+      "version": "3.354.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.354.0.tgz",
+      "integrity": "sha512-bDp43P5NkwwznpZqmsr78DuyqNcjtS4mriuajb8XPhFNo8DrMXUrdrKJ+5aNABW7YG8uK8PSKBpq88ado692/w==",
+      "dependencies": {
+        "@aws-sdk/eventstream-codec": "3.347.0",
+        "@aws-sdk/is-array-buffer": "3.310.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/util-hex-encoding": "3.310.0",
+        "@aws-sdk/util-middleware": "3.347.0",
+        "@aws-sdk/util-uri-escape": "3.310.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/smithy-client": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.347.0.tgz",
+      "integrity": "sha512-PaGTDsJLGK0sTjA6YdYQzILRlPRN3uVFyqeBUkfltXssvUzkm8z2t1lz2H4VyJLAhwnG5ZuZTNEV/2mcWrU7JQ==",
+      "dependencies": {
+        "@aws-sdk/middleware-stack": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.354.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.354.0.tgz",
+      "integrity": "sha512-KcijiySy0oIyafKQagcwgu0fo35mK+2K8pwxRU1WfXqe80Gn1qGceeWcG4iW+t/rUaxa/LVo857N0LcagxCrZA==",
+      "dependencies": {
+        "@aws-sdk/client-sso-oidc": "3.354.0",
+        "@aws-sdk/property-provider": "3.353.0",
+        "@aws-sdk/shared-ini-file-loader": "3.354.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
+      "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/url-parser": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.347.0.tgz",
+      "integrity": "sha512-lhrnVjxdV7hl+yCnJfDZOaVLSqKjxN20MIOiijRiqaWGLGEAiSqBreMhL89X1WKCifxAs4zZf9YB9SbdziRpAA==",
+      "dependencies": {
+        "@aws-sdk/querystring-parser": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-base64": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.310.0.tgz",
+      "integrity": "sha512-v3+HBKQvqgdzcbL+pFswlx5HQsd9L6ZTlyPVL2LS9nNXnCcR3XgGz9jRskikRUuUvUXtkSG1J88GAOnJ/apTPg==",
+      "dependencies": {
+        "@aws-sdk/util-buffer-from": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-body-length-browser": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.310.0.tgz",
+      "integrity": "sha512-sxsC3lPBGfpHtNTUoGXMQXLwjmR0zVpx0rSvzTPAuoVILVsp5AU/w5FphNPxD5OVIjNbZv9KsKTuvNTiZjDp9g==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-body-length-node": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.310.0.tgz",
+      "integrity": "sha512-2tqGXdyKhyA6w4zz7UPoS8Ip+7sayOg9BwHNidiGm2ikbDxm1YrCfYXvCBdwaJxa4hJfRVz+aL9e+d3GqPI9pQ==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-buffer-from": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.310.0.tgz",
+      "integrity": "sha512-i6LVeXFtGih5Zs8enLrt+ExXY92QV25jtEnTKHsmlFqFAuL3VBeod6boeMXkN2p9lbSVVQ1sAOOYZOHYbYkntw==",
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-config-provider": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.310.0.tgz",
+      "integrity": "sha512-xIBaYo8dwiojCw8vnUcIL4Z5tyfb1v3yjqyJKJWV/dqKUFOOS0U591plmXbM+M/QkXyML3ypon1f8+BoaDExrg==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-defaults-mode-browser": {
+      "version": "3.353.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.353.0.tgz",
+      "integrity": "sha512-ushvOQKJIH7S6E//xMDPyf2/Bbu0K2A0GJRB88qQV6VKRBo4PEbeHTb6BbzPhYVX0IbY3uR/X7+Xwk4FeEkMWg==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.353.0",
+        "@aws-sdk/types": "3.347.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-defaults-mode-node": {
+      "version": "3.354.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.354.0.tgz",
+      "integrity": "sha512-CaaRVBdOYX4wZadj+CDUxpO+4RjyYJcSv71A60jV6CZ/ya1+oYfmPbG5QZ4AlV6crdev2B+aUoR2LPIYqn/GnQ==",
+      "dependencies": {
+        "@aws-sdk/config-resolver": "3.354.0",
+        "@aws-sdk/credential-provider-imds": "3.354.0",
+        "@aws-sdk/node-config-provider": "3.354.0",
+        "@aws-sdk/property-provider": "3.353.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.352.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.352.0.tgz",
+      "integrity": "sha512-PjWMPdoIUWfBPgAWLyOrWFbdSS/3DJtc0OmFb/JrE8C8rKFYl+VGW5f1p0cVdRWiDR0xCGr0s67p8itAakVqjw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-hex-encoding": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.310.0.tgz",
+      "integrity": "sha512-sVN7mcCCDSJ67pI1ZMtk84SKGqyix6/0A1Ab163YKn+lFBQRMKexleZzpYzNGxYzmQS6VanP/cfU7NiLQOaSfA==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.310.0.tgz",
+      "integrity": "sha512-qo2t/vBTnoXpjKxlsC2e1gBrRm80M3bId27r0BRB2VniSSe7bL1mmzM+/HFtujm0iAxtPM+aLEflLJlJeDPg0w==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-middleware": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.347.0.tgz",
+      "integrity": "sha512-8owqUA3ePufeYTUvlzdJ7Z0miLorTwx+rNol5lourGQZ9JXsVMo23+yGA7nOlFuXSGkoKpMOtn6S0BT2bcfeiw==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-retry": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.347.0.tgz",
+      "integrity": "sha512-NxnQA0/FHFxriQAeEgBonA43Q9/VPFQa8cfJDuT2A1YZruMasgjcltoZszi1dvoIRWSZsFTW42eY2gdOd0nffQ==",
+      "dependencies": {
+        "@aws-sdk/service-error-classification": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-stream": {
+      "version": "3.358.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream/-/util-stream-3.358.0.tgz",
+      "integrity": "sha512-zUhpjxAXV2+0eALlTU6uXRYMs10XYpcYzl3NtLRe4wWgnrOOOZnF/t5LQDoKXOfaMdzwZ+i90+PYr+6JQ58+7g==",
+      "dependencies": {
+        "@aws-sdk/fetch-http-handler": "3.357.0",
+        "@aws-sdk/node-http-handler": "3.357.0",
+        "@aws-sdk/types": "3.357.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "@aws-sdk/util-buffer-from": "3.310.0",
+        "@aws-sdk/util-hex-encoding": "3.310.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-stream/node_modules/@aws-sdk/abort-controller": {
+      "version": "3.357.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.357.0.tgz",
+      "integrity": "sha512-nQYDJon87quPwt2JZJwUN2GFKJnvE5kWb6tZP4xb5biSGUKBqDQo06oYed7yokatCuCMouIXV462aN0fWODtOw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.357.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-stream/node_modules/@aws-sdk/fetch-http-handler": {
+      "version": "3.357.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.357.0.tgz",
+      "integrity": "sha512-5sPloTO8y8fAnS/6/Sfp/aVoL9zuhzkLdWBORNzMazdynVNEzWKWCPZ27RQpgkaCDHiXjqUY4kfuFXAGkvFfDQ==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.357.0",
+        "@aws-sdk/querystring-builder": "3.357.0",
+        "@aws-sdk/types": "3.357.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-stream/node_modules/@aws-sdk/node-http-handler": {
+      "version": "3.357.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.357.0.tgz",
+      "integrity": "sha512-uoab4xIJux+Q9hQ9A/vWEAjojtBQ0U4K7xEQVa0BXEv7MHH5zv51H+VtrelU1Ed6hsHq4Sx0bxBMFpbbWhNyjA==",
+      "dependencies": {
+        "@aws-sdk/abort-controller": "3.357.0",
+        "@aws-sdk/protocol-http": "3.357.0",
+        "@aws-sdk/querystring-builder": "3.357.0",
+        "@aws-sdk/types": "3.357.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-stream/node_modules/@aws-sdk/protocol-http": {
+      "version": "3.357.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.357.0.tgz",
+      "integrity": "sha512-w1JHiI50VEea7duDeAspUiKJmmdIQblvRyjVMOqWA6FIQAyDVuEiPX7/MdQr0ScxhtRQxHbP0I4MFyl7ctRQvA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.357.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-stream/node_modules/@aws-sdk/querystring-builder": {
+      "version": "3.357.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.357.0.tgz",
+      "integrity": "sha512-aQcicqB6Y2cNaXPPwunz612a01SMiQQPsdz632F/3Lzn0ua82BJKobHOtaiTUlmVJ5Q4/EAeNfwZgL7tTUNtDQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.357.0",
+        "@aws-sdk/util-uri-escape": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-stream/node_modules/@aws-sdk/types": {
+      "version": "3.357.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.357.0.tgz",
+      "integrity": "sha512-/riCRaXg3p71BeWnShrai0y0QTdXcouPSM0Cn1olZbzTf7s71aLEewrc96qFrL70XhY4XvnxMpqQh+r43XIL3g==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-uri-escape": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.310.0.tgz",
+      "integrity": "sha512-drzt+aB2qo2LgtDoiy/3sVG8w63cgLkqFIa2NFlGpUgHFWTXkqtbgf4L5QdjRGKWhmZsnqkbtL7vkSWEcYDJ4Q==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.347.0.tgz",
+      "integrity": "sha512-ydxtsKVtQefgbk1Dku1q7pMkjDYThauG9/8mQkZUAVik55OUZw71Zzr3XO8J8RKvQG8lmhPXuAQ0FKAyycc0RA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.347.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.354.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.354.0.tgz",
+      "integrity": "sha512-2xkblZS3PGxxh//0lgCwJw2gvh9ZBcI9H9xv05YP7hcwlz9BmkAlbei2i6Uew6agJMLO4unfgWoBTpzp3WLaKg==",
+      "dependencies": {
+        "@aws-sdk/node-config-provider": "3.354.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/util-utf8": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8/-/util-utf8-3.310.0.tgz",
+      "integrity": "sha512-DnLfFT8uCO22uOJc0pt0DsSNau1GTisngBCDw8jQuWT5CqogMJu4b/uXmwEqfj8B3GX6Xsz8zOd6JpRlPftQoA==",
+      "dependencies": {
+        "@aws-sdk/util-buffer-from": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-utf8-browser": {
+      "version": "3.259.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.259.0.tgz",
+      "integrity": "sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/util-waiter": {
+      "version": "3.357.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.357.0.tgz",
+      "integrity": "sha512-jQQGA5G8bm0JP5C4U85VzMpkFHdeeT7fOSUncXLG9Sh8Ambzi4XTud8m5/dA7aNJkvPwZeIF9QdgWCOzpkp1xA==",
+      "dependencies": {
+        "@aws-sdk/abort-controller": "3.357.0",
+        "@aws-sdk/types": "3.357.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-waiter/node_modules/@aws-sdk/abort-controller": {
+      "version": "3.357.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.357.0.tgz",
+      "integrity": "sha512-nQYDJon87quPwt2JZJwUN2GFKJnvE5kWb6tZP4xb5biSGUKBqDQo06oYed7yokatCuCMouIXV462aN0fWODtOw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.357.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-waiter/node_modules/@aws-sdk/types": {
+      "version": "3.357.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.357.0.tgz",
+      "integrity": "sha512-/riCRaXg3p71BeWnShrai0y0QTdXcouPSM0Cn1olZbzTf7s71aLEewrc96qFrL70XhY4XvnxMpqQh+r43XIL3g==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/@babel/code-frame": {
       "version": "7.18.6",
@@ -1012,6 +3030,29 @@
         "@sinonjs/commons": "^2.0.0"
       }
     },
+    "node_modules/@smithy/protocol-http": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-1.1.0.tgz",
+      "integrity": "sha512-H5y/kZOqfJSqRkwtcAoVbqONmhdXwSgYNJ1Glk5Ry8qlhVVy5qUzD9EklaCH8/XLnoCsLO/F/Giee8MIvaBRkg==",
+      "dependencies": {
+        "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.1.0.tgz",
+      "integrity": "sha512-KzmvisMmuwD2jZXuC9e65JrgsZM97y5NpDU7g347oB+Q+xQLU6hQZ5zFNNbEfwwOJHoOvEVTna+dk1h/lW7alw==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
@@ -1035,6 +3076,11 @@
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
       "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
       "dev": true
+    },
+    "node_modules/@types/aws-lambda": {
+      "version": "8.10.119",
+      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.119.tgz",
+      "integrity": "sha512-Vqm22aZrCvCd6I5g1SvpW151jfqwTzEZ7XJ3yZ6xaZG31nUEOEyzzVImjRcsN8Wi/QyPxId/x8GTtgIbsy8kEw=="
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.0",
@@ -1236,9 +3282,19 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
       "dependencies": {
         "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
+      "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/aws-cdk": {
@@ -1257,9 +3313,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.80.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.80.0.tgz",
-      "integrity": "sha512-PoqD3Yms5I0ajuTi071nTW/hpkH3XsdyZzn5gYsPv0qD7mqP3h6Qr+6RiGx+yQ1KcVFyxWdX15uK+DsC0KwvcQ==",
+      "version": "2.84.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.84.0.tgz",
+      "integrity": "sha512-4zLtCLCIs5Ia4WRGqiXRwxSkpGaNy3NxMexO9qYHSuIYpqf4sHObzZ0tDHZCFL5Wkui3sCu3OLQWrRHrr93HvA==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "case",
@@ -1596,6 +3652,48 @@
         "node": ">= 6"
       }
     },
+    "node_modules/aws-lambda": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/aws-lambda/-/aws-lambda-1.0.7.tgz",
+      "integrity": "sha512-9GNFMRrEMG5y3Jvv+V4azWvc+qNWdWLTjDdhf/zgMlz8haaaLWv0xeAIWxz9PuWUBawsVxy0zZotjCdR3Xq+2w==",
+      "dependencies": {
+        "aws-sdk": "^2.814.0",
+        "commander": "^3.0.2",
+        "js-yaml": "^3.14.1",
+        "watchpack": "^2.0.0-beta.10"
+      },
+      "bin": {
+        "lambda": "bin/lambda"
+      }
+    },
+    "node_modules/aws-sdk": {
+      "version": "2.1403.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1403.0.tgz",
+      "integrity": "sha512-qRhiE2iqfXhTEsGJ0unNY7mz5Y7YA4ljEh/1lU/HaUI8hPCQtmZjU3P2/w2YcHFaSzJsu9J9svzjkALfHpetoA==",
+      "dependencies": {
+        "buffer": "4.9.2",
+        "events": "1.1.1",
+        "ieee754": "1.1.13",
+        "jmespath": "0.16.0",
+        "querystring": "0.2.0",
+        "sax": "1.2.1",
+        "url": "0.10.3",
+        "util": "^0.12.4",
+        "uuid": "8.0.0",
+        "xml2js": "0.5.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/aws-sdk/node_modules/uuid": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.0.0.tgz",
+      "integrity": "sha512-jOXGuXZAWdsTH7eZLtyXMqUb9EcWMGZNbL9YcGBJl4MH4nrxHmZJhEHvyLFrkxo+28uLb/NYRcStH48fnD0Vzw==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/babel-jest": {
       "version": "29.4.1",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.4.1.tgz",
@@ -1693,6 +3791,30 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/bowser": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
+      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -1764,10 +3886,32 @@
         "node-int64": "^0.4.0"
       }
     },
+    "node_modules/buffer": {
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
+      "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
+      "dependencies": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
+      }
+    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "dependencies": {
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/callsites": {
       "version": "3.1.0",
@@ -1896,6 +4040,11 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
+    },
+    "node_modules/commander": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-3.0.2.tgz",
+      "integrity": "sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow=="
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -2051,13 +4200,20 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "dev": true,
       "bin": {
         "esparse": "bin/esparse.js",
         "esvalidate": "bin/esvalidate.js"
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/events": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+      "integrity": "sha512-kEcvvCBByWXGnZy6JUlgAp2gBIUjfCAV6P6TgT1/aaQKcmuAEC4OZTV1I4EWQLz2gxZw76atuVyvHhTxvi0Flw==",
+      "engines": {
+        "node": ">=0.4.x"
       }
     },
     "node_modules/execa": {
@@ -2114,6 +4270,27 @@
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "dev": true
     },
+    "node_modules/fast-xml-parser": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.4.tgz",
+      "integrity": "sha512-fbfMDvgBNIdDJLdLOwacjFAPYt67tr31H9ZhWSm45CDAxvd0I6WTlSOUo7K2P/K5sA5JgMKG64PI3DMcaFdWpQ==",
+      "funding": [
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/naturalintelligence"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "dependencies": {
+        "strnum": "^1.0.5"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
     "node_modules/fb-watchman": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.2.tgz",
@@ -2148,6 +4325,14 @@
         "node": ">=8"
       }
     },
+    "node_modules/for-each": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
+      "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+      "dependencies": {
+        "is-callable": "^1.1.3"
+      }
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -2171,8 +4356,7 @@
     "node_modules/function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
@@ -2190,6 +4374,20 @@
       "dev": true,
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.1.tgz",
+      "integrity": "sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==",
+      "dependencies": {
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-proto": "^1.0.1",
+        "has-symbols": "^1.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/get-package-type": {
@@ -2233,6 +4431,11 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/glob-to-regexp": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw=="
+    },
     "node_modules/globals": {
       "version": "11.12.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
@@ -2242,17 +4445,26 @@
         "node": ">=4"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
+      "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
+      "dependencies": {
+        "get-intrinsic": "^1.1.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.10",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
-      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
-      "dev": true
+      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
     },
     "node_modules/has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "dev": true,
       "dependencies": {
         "function-bind": "^1.1.1"
       },
@@ -2269,6 +4481,42 @@
         "node": ">=8"
       }
     },
+    "node_modules/has-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
+      "integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
+      "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
+      "dependencies": {
+        "has-symbols": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -2283,6 +4531,11 @@
       "engines": {
         "node": ">=10.17.0"
       }
+    },
+    "node_modules/ieee754": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
     },
     "node_modules/import-local": {
       "version": "3.1.0",
@@ -2325,14 +4578,39 @@
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "node_modules/is-arguments": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
+      "integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
       "dev": true
+    },
+    "node_modules/is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/is-core-module": {
       "version": "2.11.0",
@@ -2364,6 +4642,20 @@
         "node": ">=6"
       }
     },
+    "node_modules/is-generator-function": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
+      "integrity": "sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==",
+      "dependencies": {
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -2384,6 +4676,29 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/is-typed-array": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.10.tgz",
+      "integrity": "sha512-PJqgEHiWZvMpaFZ3uTc8kHPM4+4ADTlDniuQL7cU/UDA0Ql7F70yGfHph3cLNe+c9toaigv+DFzTJKhc2CtO6A==",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.5",
+        "call-bind": "^1.0.2",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -3137,6 +5452,14 @@
         }
       }
     },
+    "node_modules/jmespath": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.16.0.tgz",
+      "integrity": "sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw==",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -3147,7 +5470,6 @@
       "version": "3.14.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
       "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
-      "dev": true,
       "dependencies": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -3541,6 +5863,20 @@
         "node": ">= 6"
       }
     },
+    "node_modules/punycode": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+      "integrity": "sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw=="
+    },
+    "node_modules/querystring": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g==",
+      "deprecated": "The querystring API is considered Legacy. new code should use the URLSearchParams API instead.",
+      "engines": {
+        "node": ">=0.4.x"
+      }
+    },
     "node_modules/react-is": {
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
@@ -3602,6 +5938,11 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/sax": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+      "integrity": "sha512-8I2a3LovHTOpm7NV5yOyO8IHqgVsfK4+UuySrXU8YXkSRX7k6hCV9b3HrkKCr3nMpgj+0bmocaJJWpvp1oc7ZA=="
     },
     "node_modules/semver": {
       "version": "6.3.0",
@@ -3674,8 +6015,7 @@
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-      "dev": true
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
     },
     "node_modules/stack-utils": {
       "version": "2.0.6",
@@ -3766,6 +6106,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/strnum": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
+      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
     },
     "node_modules/supports-color": {
       "version": "7.2.0",
@@ -3951,6 +6296,11 @@
         }
       }
     },
+    "node_modules/tslib": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
+      "integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w=="
+    },
     "node_modules/type-detect": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
@@ -4011,6 +6361,35 @@
         "browserslist": ">= 4.21.0"
       }
     },
+    "node_modules/url": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+      "integrity": "sha512-hzSUW2q06EqL1gKM/a+obYHLIO6ct2hwPuviqTTOcfFVc61UbfJ2Q32+uGL/HCPxKqrdGB5QUwIe7UqlDgwsOQ==",
+      "dependencies": {
+        "punycode": "1.3.2",
+        "querystring": "0.2.0"
+      }
+    },
+    "node_modules/util": {
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
+      "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "is-arguments": "^1.0.4",
+        "is-generator-function": "^1.0.7",
+        "is-typed-array": "^1.1.3",
+        "which-typed-array": "^1.1.2"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
@@ -4046,6 +6425,18 @@
         "makeerror": "1.0.12"
       }
     },
+    "node_modules/watchpack": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.0.tgz",
+      "integrity": "sha512-Lcvm7MGST/4fup+ifyKi2hjyIAwcdI4HRgtvTpIUxBRhB+RFtUh8XtDOxUfctVCnhVi+QQj49i91OyvzkJl6cg==",
+      "dependencies": {
+        "glob-to-regexp": "^0.4.1",
+        "graceful-fs": "^4.1.2"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -4059,6 +6450,25 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/which-typed-array": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.9.tgz",
+      "integrity": "sha512-w9c4xkx6mPidwp7180ckYWfMmvxpjlZuIudNtDf4N/tTAUB8VJbX25qZoAsrtGuYNnGw3pa0AXgbGKRB8/EceA==",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.5",
+        "call-bind": "^1.0.2",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "has-tostringtag": "^1.0.0",
+        "is-typed-array": "^1.1.10"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/wrap-ansi": {
@@ -4095,6 +6505,26 @@
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/xml2js": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
+      "integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+      "engines": {
+        "node": ">=4.0"
       }
     },
     "node_modules/y18n": {
@@ -4173,9 +6603,9 @@
       }
     },
     "@aws-cdk/asset-awscli-v1": {
-      "version": "2.2.196",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.196.tgz",
-      "integrity": "sha512-F8hU1rEzYS7z5Dt2s+ttd0/jMvPuUE9BcXexgq+dIOLuZsRpDwNnkMBtjNaJXJS48ZGJ2X4b8VlklseepdtoSA=="
+      "version": "2.2.197",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.197.tgz",
+      "integrity": "sha512-gUM22fkas3lxVG5v1WW0I2CsnTLj2v7gRm/31fnAGTYnzP60BsYVWa0Vi99b2Qz3D3RXxOlGKaO+dQR7r2GqIg=="
     },
     "@aws-cdk/asset-kubectl-v20": {
       "version": "2.1.1",
@@ -4186,6 +6616,1681 @@
       "version": "2.0.165",
       "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v5/-/asset-node-proxy-agent-v5-2.0.165.tgz",
       "integrity": "sha512-bsyLQD/vqXQcc9RDmlM1XqiFNO/yewgVFXmkMcQkndJbmE/jgYkzewwYGrBlfL725hGLQipXq19+jwWwdsXQqg=="
+    },
+    "@aws-crypto/crc32": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-3.0.0.tgz",
+      "integrity": "sha512-IzSgsrxUcsrejQbPVilIKy16kAT52EwB6zSaI+M3xxIhKh5+aldEyvI+z6erM7TCLB2BJsFrtHjp6/4/sr+3dA==",
+      "requires": {
+        "@aws-crypto/util": "^3.0.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-crypto/ie11-detection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
+      "integrity": "sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==",
+      "requires": {
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-crypto/sha256-browser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz",
+      "integrity": "sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==",
+      "requires": {
+        "@aws-crypto/ie11-detection": "^3.0.0",
+        "@aws-crypto/sha256-js": "^3.0.0",
+        "@aws-crypto/supports-web-crypto": "^3.0.0",
+        "@aws-crypto/util": "^3.0.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-crypto/sha256-js": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz",
+      "integrity": "sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==",
+      "requires": {
+        "@aws-crypto/util": "^3.0.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-crypto/supports-web-crypto": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-3.0.0.tgz",
+      "integrity": "sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==",
+      "requires": {
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-crypto/util": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
+      "integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
+      "requires": {
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-sdk/abort-controller": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.347.0.tgz",
+      "integrity": "sha512-P/2qE6ntYEmYG4Ez535nJWZbXqgbkJx8CMz7ChEuEg3Gp3dvVYEKg+iEUEvlqQ2U5dWP5J3ehw5po9t86IsVPQ==",
+      "requires": {
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/client-kafka": {
+      "version": "3.354.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-kafka/-/client-kafka-3.354.0.tgz",
+      "integrity": "sha512-iPSjqBsyrmQ8myO2FcNbd3w6zssdoer/n28xTBcwkykLveOf4PuQVurnEJaPOfdqFgpJ16+yfirdnzpVwUuXVw==",
+      "requires": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sts": "3.354.0",
+        "@aws-sdk/config-resolver": "3.354.0",
+        "@aws-sdk/credential-provider-node": "3.354.0",
+        "@aws-sdk/fetch-http-handler": "3.353.0",
+        "@aws-sdk/hash-node": "3.347.0",
+        "@aws-sdk/invalid-dependency": "3.347.0",
+        "@aws-sdk/middleware-content-length": "3.347.0",
+        "@aws-sdk/middleware-endpoint": "3.347.0",
+        "@aws-sdk/middleware-host-header": "3.347.0",
+        "@aws-sdk/middleware-logger": "3.347.0",
+        "@aws-sdk/middleware-recursion-detection": "3.347.0",
+        "@aws-sdk/middleware-retry": "3.354.0",
+        "@aws-sdk/middleware-serde": "3.347.0",
+        "@aws-sdk/middleware-signing": "3.354.0",
+        "@aws-sdk/middleware-stack": "3.347.0",
+        "@aws-sdk/middleware-user-agent": "3.352.0",
+        "@aws-sdk/node-config-provider": "3.354.0",
+        "@aws-sdk/node-http-handler": "3.350.0",
+        "@aws-sdk/smithy-client": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/url-parser": "3.347.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "@aws-sdk/util-body-length-browser": "3.310.0",
+        "@aws-sdk/util-body-length-node": "3.310.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.353.0",
+        "@aws-sdk/util-defaults-mode-node": "3.354.0",
+        "@aws-sdk/util-endpoints": "3.352.0",
+        "@aws-sdk/util-retry": "3.347.0",
+        "@aws-sdk/util-user-agent-browser": "3.347.0",
+        "@aws-sdk/util-user-agent-node": "3.354.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "@smithy/protocol-http": "^1.0.1",
+        "@smithy/types": "^1.0.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/client-lambda": {
+      "version": "3.359.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-lambda/-/client-lambda-3.359.0.tgz",
+      "integrity": "sha512-o6A3x+R6Oi64+mmK+mbYO1BLr18z5U/NiBevqE+FqQFptAoA6vp8CQW7zpeuUeC1J0ZdSNZCHc3HqUAlv7l/bg==",
+      "requires": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sts": "3.359.0",
+        "@aws-sdk/config-resolver": "3.357.0",
+        "@aws-sdk/credential-provider-node": "3.358.0",
+        "@aws-sdk/eventstream-serde-browser": "3.357.0",
+        "@aws-sdk/eventstream-serde-config-resolver": "3.357.0",
+        "@aws-sdk/eventstream-serde-node": "3.357.0",
+        "@aws-sdk/fetch-http-handler": "3.357.0",
+        "@aws-sdk/hash-node": "3.357.0",
+        "@aws-sdk/invalid-dependency": "3.357.0",
+        "@aws-sdk/middleware-content-length": "3.357.0",
+        "@aws-sdk/middleware-endpoint": "3.357.0",
+        "@aws-sdk/middleware-host-header": "3.357.0",
+        "@aws-sdk/middleware-logger": "3.357.0",
+        "@aws-sdk/middleware-recursion-detection": "3.357.0",
+        "@aws-sdk/middleware-retry": "3.357.0",
+        "@aws-sdk/middleware-serde": "3.357.0",
+        "@aws-sdk/middleware-signing": "3.357.0",
+        "@aws-sdk/middleware-stack": "3.357.0",
+        "@aws-sdk/middleware-user-agent": "3.357.0",
+        "@aws-sdk/node-config-provider": "3.357.0",
+        "@aws-sdk/node-http-handler": "3.357.0",
+        "@aws-sdk/smithy-client": "3.358.0",
+        "@aws-sdk/types": "3.357.0",
+        "@aws-sdk/url-parser": "3.357.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "@aws-sdk/util-body-length-browser": "3.310.0",
+        "@aws-sdk/util-body-length-node": "3.310.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.358.0",
+        "@aws-sdk/util-defaults-mode-node": "3.358.0",
+        "@aws-sdk/util-endpoints": "3.357.0",
+        "@aws-sdk/util-retry": "3.357.0",
+        "@aws-sdk/util-stream": "3.358.0",
+        "@aws-sdk/util-user-agent-browser": "3.357.0",
+        "@aws-sdk/util-user-agent-node": "3.357.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "@aws-sdk/util-waiter": "3.357.0",
+        "@smithy/protocol-http": "^1.0.1",
+        "@smithy/types": "^1.0.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "@aws-sdk/abort-controller": {
+          "version": "3.357.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.357.0.tgz",
+          "integrity": "sha512-nQYDJon87quPwt2JZJwUN2GFKJnvE5kWb6tZP4xb5biSGUKBqDQo06oYed7yokatCuCMouIXV462aN0fWODtOw==",
+          "requires": {
+            "@aws-sdk/types": "3.357.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/client-sso": {
+          "version": "3.358.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.358.0.tgz",
+          "integrity": "sha512-Kc9IsoPIHJfkjDuStyItwQAOpnxw/I9xfF3vvukeN9vkXcRiWeMDhEXACN4L1AYFlU9FHQSRdNwpYTIz7OrD2A==",
+          "requires": {
+            "@aws-crypto/sha256-browser": "3.0.0",
+            "@aws-crypto/sha256-js": "3.0.0",
+            "@aws-sdk/config-resolver": "3.357.0",
+            "@aws-sdk/fetch-http-handler": "3.357.0",
+            "@aws-sdk/hash-node": "3.357.0",
+            "@aws-sdk/invalid-dependency": "3.357.0",
+            "@aws-sdk/middleware-content-length": "3.357.0",
+            "@aws-sdk/middleware-endpoint": "3.357.0",
+            "@aws-sdk/middleware-host-header": "3.357.0",
+            "@aws-sdk/middleware-logger": "3.357.0",
+            "@aws-sdk/middleware-recursion-detection": "3.357.0",
+            "@aws-sdk/middleware-retry": "3.357.0",
+            "@aws-sdk/middleware-serde": "3.357.0",
+            "@aws-sdk/middleware-stack": "3.357.0",
+            "@aws-sdk/middleware-user-agent": "3.357.0",
+            "@aws-sdk/node-config-provider": "3.357.0",
+            "@aws-sdk/node-http-handler": "3.357.0",
+            "@aws-sdk/smithy-client": "3.358.0",
+            "@aws-sdk/types": "3.357.0",
+            "@aws-sdk/url-parser": "3.357.0",
+            "@aws-sdk/util-base64": "3.310.0",
+            "@aws-sdk/util-body-length-browser": "3.310.0",
+            "@aws-sdk/util-body-length-node": "3.310.0",
+            "@aws-sdk/util-defaults-mode-browser": "3.358.0",
+            "@aws-sdk/util-defaults-mode-node": "3.358.0",
+            "@aws-sdk/util-endpoints": "3.357.0",
+            "@aws-sdk/util-retry": "3.357.0",
+            "@aws-sdk/util-user-agent-browser": "3.357.0",
+            "@aws-sdk/util-user-agent-node": "3.357.0",
+            "@aws-sdk/util-utf8": "3.310.0",
+            "@smithy/protocol-http": "^1.0.1",
+            "@smithy/types": "^1.0.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/client-sso-oidc": {
+          "version": "3.358.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.358.0.tgz",
+          "integrity": "sha512-Gy09fSlhJdGbr8rNNR8EdLaUynB1B34nw8kN1aFT4CdAnjFKxTainqG6Aq4vx64TbMDMhvMYWpNAluvq7UHVhw==",
+          "requires": {
+            "@aws-crypto/sha256-browser": "3.0.0",
+            "@aws-crypto/sha256-js": "3.0.0",
+            "@aws-sdk/config-resolver": "3.357.0",
+            "@aws-sdk/fetch-http-handler": "3.357.0",
+            "@aws-sdk/hash-node": "3.357.0",
+            "@aws-sdk/invalid-dependency": "3.357.0",
+            "@aws-sdk/middleware-content-length": "3.357.0",
+            "@aws-sdk/middleware-endpoint": "3.357.0",
+            "@aws-sdk/middleware-host-header": "3.357.0",
+            "@aws-sdk/middleware-logger": "3.357.0",
+            "@aws-sdk/middleware-recursion-detection": "3.357.0",
+            "@aws-sdk/middleware-retry": "3.357.0",
+            "@aws-sdk/middleware-serde": "3.357.0",
+            "@aws-sdk/middleware-stack": "3.357.0",
+            "@aws-sdk/middleware-user-agent": "3.357.0",
+            "@aws-sdk/node-config-provider": "3.357.0",
+            "@aws-sdk/node-http-handler": "3.357.0",
+            "@aws-sdk/smithy-client": "3.358.0",
+            "@aws-sdk/types": "3.357.0",
+            "@aws-sdk/url-parser": "3.357.0",
+            "@aws-sdk/util-base64": "3.310.0",
+            "@aws-sdk/util-body-length-browser": "3.310.0",
+            "@aws-sdk/util-body-length-node": "3.310.0",
+            "@aws-sdk/util-defaults-mode-browser": "3.358.0",
+            "@aws-sdk/util-defaults-mode-node": "3.358.0",
+            "@aws-sdk/util-endpoints": "3.357.0",
+            "@aws-sdk/util-retry": "3.357.0",
+            "@aws-sdk/util-user-agent-browser": "3.357.0",
+            "@aws-sdk/util-user-agent-node": "3.357.0",
+            "@aws-sdk/util-utf8": "3.310.0",
+            "@smithy/protocol-http": "^1.0.1",
+            "@smithy/types": "^1.0.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/client-sts": {
+          "version": "3.359.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.359.0.tgz",
+          "integrity": "sha512-zpyui8hXvEUvq8MwzZsm51ni0intvPjtV8dgx10nVJnm605nqrLlAMGqQ1S/UxO7CVmhqWbh5dnGHEc//UJlsw==",
+          "requires": {
+            "@aws-crypto/sha256-browser": "3.0.0",
+            "@aws-crypto/sha256-js": "3.0.0",
+            "@aws-sdk/config-resolver": "3.357.0",
+            "@aws-sdk/credential-provider-node": "3.358.0",
+            "@aws-sdk/fetch-http-handler": "3.357.0",
+            "@aws-sdk/hash-node": "3.357.0",
+            "@aws-sdk/invalid-dependency": "3.357.0",
+            "@aws-sdk/middleware-content-length": "3.357.0",
+            "@aws-sdk/middleware-endpoint": "3.357.0",
+            "@aws-sdk/middleware-host-header": "3.357.0",
+            "@aws-sdk/middleware-logger": "3.357.0",
+            "@aws-sdk/middleware-recursion-detection": "3.357.0",
+            "@aws-sdk/middleware-retry": "3.357.0",
+            "@aws-sdk/middleware-sdk-sts": "3.357.0",
+            "@aws-sdk/middleware-serde": "3.357.0",
+            "@aws-sdk/middleware-signing": "3.357.0",
+            "@aws-sdk/middleware-stack": "3.357.0",
+            "@aws-sdk/middleware-user-agent": "3.357.0",
+            "@aws-sdk/node-config-provider": "3.357.0",
+            "@aws-sdk/node-http-handler": "3.357.0",
+            "@aws-sdk/smithy-client": "3.358.0",
+            "@aws-sdk/types": "3.357.0",
+            "@aws-sdk/url-parser": "3.357.0",
+            "@aws-sdk/util-base64": "3.310.0",
+            "@aws-sdk/util-body-length-browser": "3.310.0",
+            "@aws-sdk/util-body-length-node": "3.310.0",
+            "@aws-sdk/util-defaults-mode-browser": "3.358.0",
+            "@aws-sdk/util-defaults-mode-node": "3.358.0",
+            "@aws-sdk/util-endpoints": "3.357.0",
+            "@aws-sdk/util-retry": "3.357.0",
+            "@aws-sdk/util-user-agent-browser": "3.357.0",
+            "@aws-sdk/util-user-agent-node": "3.357.0",
+            "@aws-sdk/util-utf8": "3.310.0",
+            "@smithy/protocol-http": "^1.0.1",
+            "@smithy/types": "^1.0.0",
+            "fast-xml-parser": "4.2.5",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/config-resolver": {
+          "version": "3.357.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.357.0.tgz",
+          "integrity": "sha512-cukfg0nX7Tzx/xFyH5F4Eyb8DA1ITCGtSQv4vnEjgUop+bkzckuGLKEeBcBhyZY+aw+2C9CVwIHwIMhRm0ul5w==",
+          "requires": {
+            "@aws-sdk/types": "3.357.0",
+            "@aws-sdk/util-config-provider": "3.310.0",
+            "@aws-sdk/util-middleware": "3.357.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/credential-provider-env": {
+          "version": "3.357.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.357.0.tgz",
+          "integrity": "sha512-UOecwfqvXgJVqhfWSZ2S44v2Nq2oceW0PQVQp0JAa9opc2rxSVIfyOhPr0yMoPmpyNcP22rgeg6ce70KULYwiA==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.357.0",
+            "@aws-sdk/types": "3.357.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/credential-provider-imds": {
+          "version": "3.357.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.357.0.tgz",
+          "integrity": "sha512-upw/bfsl7/WydT6gM0lBuR4Ipp4fzYm/E3ObFr0Mg5OkgVPt5ZJE+eeFTvwCpDdBSTKs4JfrK6/iEK8A23Q1jQ==",
+          "requires": {
+            "@aws-sdk/node-config-provider": "3.357.0",
+            "@aws-sdk/property-provider": "3.357.0",
+            "@aws-sdk/types": "3.357.0",
+            "@aws-sdk/url-parser": "3.357.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/credential-provider-ini": {
+          "version": "3.358.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.358.0.tgz",
+          "integrity": "sha512-Blmw4bhGxpaYvPmrbRKAltqnNDDSf6ZegNqJasc5OWvAlHJNvB/hYPmyQN0oFy79BXn7PbBip1QaLWaEhJvpAA==",
+          "requires": {
+            "@aws-sdk/credential-provider-env": "3.357.0",
+            "@aws-sdk/credential-provider-imds": "3.357.0",
+            "@aws-sdk/credential-provider-process": "3.357.0",
+            "@aws-sdk/credential-provider-sso": "3.358.0",
+            "@aws-sdk/credential-provider-web-identity": "3.357.0",
+            "@aws-sdk/property-provider": "3.357.0",
+            "@aws-sdk/shared-ini-file-loader": "3.357.0",
+            "@aws-sdk/types": "3.357.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/credential-provider-node": {
+          "version": "3.358.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.358.0.tgz",
+          "integrity": "sha512-iLjyRNOT0ycdLqkzXNW+V2zibVljkLjL8j45FpK6mNrAwc/Ynr7EYuRRp5OuRiiYDO3ZoneAxpBJQ5SqmK2Jfg==",
+          "requires": {
+            "@aws-sdk/credential-provider-env": "3.357.0",
+            "@aws-sdk/credential-provider-imds": "3.357.0",
+            "@aws-sdk/credential-provider-ini": "3.358.0",
+            "@aws-sdk/credential-provider-process": "3.357.0",
+            "@aws-sdk/credential-provider-sso": "3.358.0",
+            "@aws-sdk/credential-provider-web-identity": "3.357.0",
+            "@aws-sdk/property-provider": "3.357.0",
+            "@aws-sdk/shared-ini-file-loader": "3.357.0",
+            "@aws-sdk/types": "3.357.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/credential-provider-process": {
+          "version": "3.357.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.357.0.tgz",
+          "integrity": "sha512-qFWWilFPsc2hR7O0KIhwcE78w+pVIK+uQR6MQMfdRyxUndgiuCorJwVjedc3yZtmnoELHF34j+m8whTBXv9E7Q==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.357.0",
+            "@aws-sdk/shared-ini-file-loader": "3.357.0",
+            "@aws-sdk/types": "3.357.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/credential-provider-sso": {
+          "version": "3.358.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.358.0.tgz",
+          "integrity": "sha512-hKu5NshKohSDoHaXKyeCW88J8dBt4TMljrL+WswTMifuThO9ptyMq4PCdl4z7CNjIq6zo3ftc/uNf8TY7Ga8+w==",
+          "requires": {
+            "@aws-sdk/client-sso": "3.358.0",
+            "@aws-sdk/property-provider": "3.357.0",
+            "@aws-sdk/shared-ini-file-loader": "3.357.0",
+            "@aws-sdk/token-providers": "3.358.0",
+            "@aws-sdk/types": "3.357.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/credential-provider-web-identity": {
+          "version": "3.357.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.357.0.tgz",
+          "integrity": "sha512-0KRRAFrXy5HJe2vqnCWCoCS+fQw7IoIj3KQsuURJMW4F+ifisxCgEsh3brJ2LQlN4ElWTRJhlrDHNZ/pd61D4w==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.357.0",
+            "@aws-sdk/types": "3.357.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/eventstream-codec": {
+          "version": "3.357.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-codec/-/eventstream-codec-3.357.0.tgz",
+          "integrity": "sha512-bqenTHG6GH6aCk/Il+ooWXVVAZuc8lOgVEy9bE2hI49oVqT8zSuXxQB+w1WWyZoAOPcelsjayB1wfPub8VDBxQ==",
+          "requires": {
+            "@aws-crypto/crc32": "3.0.0",
+            "@aws-sdk/types": "3.357.0",
+            "@aws-sdk/util-hex-encoding": "3.310.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/fetch-http-handler": {
+          "version": "3.357.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.357.0.tgz",
+          "integrity": "sha512-5sPloTO8y8fAnS/6/Sfp/aVoL9zuhzkLdWBORNzMazdynVNEzWKWCPZ27RQpgkaCDHiXjqUY4kfuFXAGkvFfDQ==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.357.0",
+            "@aws-sdk/querystring-builder": "3.357.0",
+            "@aws-sdk/types": "3.357.0",
+            "@aws-sdk/util-base64": "3.310.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/hash-node": {
+          "version": "3.357.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.357.0.tgz",
+          "integrity": "sha512-fq3LS9AxHKb7dTZkm6iM1TrGk6XOTZz96iEZPME1+vjiSEXGWuebHt87q92n+KozVGRypn9MId3lHOPBBjygNQ==",
+          "requires": {
+            "@aws-sdk/types": "3.357.0",
+            "@aws-sdk/util-buffer-from": "3.310.0",
+            "@aws-sdk/util-utf8": "3.310.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/invalid-dependency": {
+          "version": "3.357.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.357.0.tgz",
+          "integrity": "sha512-HnCYZczf0VdyxMVMMxmA3QJAyyPSFbcMtZzgKbxVTWTG7GKpQe0psWZu/7O2Nk31mKg6vEUdiP1FylqLBsgMOA==",
+          "requires": {
+            "@aws-sdk/types": "3.357.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/middleware-content-length": {
+          "version": "3.357.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.357.0.tgz",
+          "integrity": "sha512-zQOFEyzOXAgN4M54tYNWGxKxnyzY0WwYDTFzh9riJRmxN1hTEKHUKmze4nILIf5rkQmOG4kTf1qmfazjkvZAhw==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.357.0",
+            "@aws-sdk/types": "3.357.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/middleware-endpoint": {
+          "version": "3.357.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.357.0.tgz",
+          "integrity": "sha512-ScJi0SL8X/Lyi0Fp5blg0QN/Z6PoRwV/ZJXd8dQkXSznkbSvJHfqPP0xk/w3GcQ1TKsu5YEPfeYy8ejcq+7Pgg==",
+          "requires": {
+            "@aws-sdk/middleware-serde": "3.357.0",
+            "@aws-sdk/types": "3.357.0",
+            "@aws-sdk/url-parser": "3.357.0",
+            "@aws-sdk/util-middleware": "3.357.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/middleware-host-header": {
+          "version": "3.357.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.357.0.tgz",
+          "integrity": "sha512-HuGLcP7JP1qJ5wGT9GSlEknDaTSnOzHY4T6IPFuvFjAy3PvY5siQNm6+VRqdVS+n6/kzpL3JP5sAVM3aoxHT6Q==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.357.0",
+            "@aws-sdk/types": "3.357.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/middleware-logger": {
+          "version": "3.357.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.357.0.tgz",
+          "integrity": "sha512-dncT3tr+lZ9+duZo52rASgO6AKVwRcsc2/T93gmaYVrJqI6WWAwQ7yML5s72l9ZjQ5LZ+4jjrgtlufavAS0eCg==",
+          "requires": {
+            "@aws-sdk/types": "3.357.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/middleware-recursion-detection": {
+          "version": "3.357.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.357.0.tgz",
+          "integrity": "sha512-AXC54IeDS3jC1dbbkYHML4STvBPcKZ4IJTWdjEK1RCOgqXd0Ze1cE1e21wyj1tM6prF03zLyvpBd+3TS++nqfA==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.357.0",
+            "@aws-sdk/types": "3.357.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/middleware-retry": {
+          "version": "3.357.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.357.0.tgz",
+          "integrity": "sha512-ZCbXCYv3nglQqwREYxxpclrnR9MYPAnHlLcC8e9PbApqxGnaZdhoywxoqbgqT3hf/RM7kput4vEHDl1fyymcRQ==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.357.0",
+            "@aws-sdk/service-error-classification": "3.357.0",
+            "@aws-sdk/types": "3.357.0",
+            "@aws-sdk/util-middleware": "3.357.0",
+            "@aws-sdk/util-retry": "3.357.0",
+            "tslib": "^2.5.0",
+            "uuid": "^8.3.2"
+          }
+        },
+        "@aws-sdk/middleware-sdk-sts": {
+          "version": "3.357.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.357.0.tgz",
+          "integrity": "sha512-Ng2VjLrPiL02QOcs1qs9jG2boO4Gn+v3VIbOJLG4zXcfbSq55iIWtlmr2ljfw9vP5aLhWtcODfmKHS5Bp+019Q==",
+          "requires": {
+            "@aws-sdk/middleware-signing": "3.357.0",
+            "@aws-sdk/types": "3.357.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/middleware-serde": {
+          "version": "3.357.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.357.0.tgz",
+          "integrity": "sha512-bGI4kYuuEsFjlANbyJLyy4AovETnyf/SukgLOG7Qjbua+ZGuzvRhMsk21mBKKGrnsTO4PmtieJo6xClThGAN8g==",
+          "requires": {
+            "@aws-sdk/types": "3.357.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/middleware-signing": {
+          "version": "3.357.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.357.0.tgz",
+          "integrity": "sha512-yB9ewEqI6Fw1OrmKFrUypbCqN5ijk06UGPochybamMuPxxkwMT3bnrm7eezsCA+TZbJyKhpffpyobwuv+xGNrA==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.357.0",
+            "@aws-sdk/protocol-http": "3.357.0",
+            "@aws-sdk/signature-v4": "3.357.0",
+            "@aws-sdk/types": "3.357.0",
+            "@aws-sdk/util-middleware": "3.357.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/middleware-stack": {
+          "version": "3.357.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.357.0.tgz",
+          "integrity": "sha512-nNV+jfwGwmbOGZujAY/U8AW3EbVlxa9DJDLz3TPp/39o6Vu5KEzHJyDDNreo2k9V/TMvV+nOzHafufgPdagv7w==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/middleware-user-agent": {
+          "version": "3.357.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.357.0.tgz",
+          "integrity": "sha512-M/CsAXjGblZS4rEbMb0Dn9IXbfq4EjVaTHBfvuILU/dKRppWvjnm2lRtqCZ+LIT3ATbAjA3/dY7dWsjxQWwijA==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.357.0",
+            "@aws-sdk/types": "3.357.0",
+            "@aws-sdk/util-endpoints": "3.357.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/node-config-provider": {
+          "version": "3.357.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.357.0.tgz",
+          "integrity": "sha512-kwBIzKCaW3UWqLdELhy7TcN8itNMOjbzga530nalFILMvn2IxrkdKQhNgxGBXy6QK6kCOtH6OmcrG3/oZkLwig==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.357.0",
+            "@aws-sdk/shared-ini-file-loader": "3.357.0",
+            "@aws-sdk/types": "3.357.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/node-http-handler": {
+          "version": "3.357.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.357.0.tgz",
+          "integrity": "sha512-uoab4xIJux+Q9hQ9A/vWEAjojtBQ0U4K7xEQVa0BXEv7MHH5zv51H+VtrelU1Ed6hsHq4Sx0bxBMFpbbWhNyjA==",
+          "requires": {
+            "@aws-sdk/abort-controller": "3.357.0",
+            "@aws-sdk/protocol-http": "3.357.0",
+            "@aws-sdk/querystring-builder": "3.357.0",
+            "@aws-sdk/types": "3.357.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/property-provider": {
+          "version": "3.357.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.357.0.tgz",
+          "integrity": "sha512-im4W0u8WaYxG7J7ko4Xl3OEzK3Mrm1Rz6/txTGe6hTIHlyUISu1ekOQJXK6XYPqNMn8v1G3BiQREoRXUEJFbHg==",
+          "requires": {
+            "@aws-sdk/types": "3.357.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/protocol-http": {
+          "version": "3.357.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.357.0.tgz",
+          "integrity": "sha512-w1JHiI50VEea7duDeAspUiKJmmdIQblvRyjVMOqWA6FIQAyDVuEiPX7/MdQr0ScxhtRQxHbP0I4MFyl7ctRQvA==",
+          "requires": {
+            "@aws-sdk/types": "3.357.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/querystring-builder": {
+          "version": "3.357.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.357.0.tgz",
+          "integrity": "sha512-aQcicqB6Y2cNaXPPwunz612a01SMiQQPsdz632F/3Lzn0ua82BJKobHOtaiTUlmVJ5Q4/EAeNfwZgL7tTUNtDQ==",
+          "requires": {
+            "@aws-sdk/types": "3.357.0",
+            "@aws-sdk/util-uri-escape": "3.310.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/querystring-parser": {
+          "version": "3.357.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.357.0.tgz",
+          "integrity": "sha512-Svvq+atRNP9s2VxiklcUNgCzmt3T5kfs7X2C+yjmxHvOQTPjLNaNGbfC/vhjOK7aoXw0h+lBac48r5ymx1PbQA==",
+          "requires": {
+            "@aws-sdk/types": "3.357.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/service-error-classification": {
+          "version": "3.357.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.357.0.tgz",
+          "integrity": "sha512-VuXeL4g5vKO9HjgCZlxmH8Uv1FcqUSjmbPpQkbNtYIDck6u0qzM0rG+n0/1EjyQbPSr3MhW/pkWs5nx2Nljlyg=="
+        },
+        "@aws-sdk/shared-ini-file-loader": {
+          "version": "3.357.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.357.0.tgz",
+          "integrity": "sha512-ceyqM4XxQe0Plb/oQAD2t1UOV2Iy4PFe1oAGM8dfJzYrRKu7zvMwru7/WaB3NYq+/mIY6RU+jjhRmjQ3GySVqA==",
+          "requires": {
+            "@aws-sdk/types": "3.357.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/signature-v4": {
+          "version": "3.357.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.357.0.tgz",
+          "integrity": "sha512-itt4/Jh9FqnzK30qIjXFBvM4J7zN4S/AAqsRMnaX7U4f/MV+1YxQHmzimpdMnsCXXs2jqFqKVRu6DewxJ3nbxg==",
+          "requires": {
+            "@aws-sdk/eventstream-codec": "3.357.0",
+            "@aws-sdk/is-array-buffer": "3.310.0",
+            "@aws-sdk/types": "3.357.0",
+            "@aws-sdk/util-hex-encoding": "3.310.0",
+            "@aws-sdk/util-middleware": "3.357.0",
+            "@aws-sdk/util-uri-escape": "3.310.0",
+            "@aws-sdk/util-utf8": "3.310.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/smithy-client": {
+          "version": "3.358.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.358.0.tgz",
+          "integrity": "sha512-oqctxWb9yAqCh4ENwUkt9MC01l5uKoy+QCiSUUhQ76k7R3lyGOge9ycyRyoKl+oZWvEpnjZevXQFqEfGzkL7bA==",
+          "requires": {
+            "@aws-sdk/middleware-stack": "3.357.0",
+            "@aws-sdk/types": "3.357.0",
+            "@aws-sdk/util-stream": "3.358.0",
+            "@smithy/types": "^1.0.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/token-providers": {
+          "version": "3.358.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.358.0.tgz",
+          "integrity": "sha512-vATKNCwNhCSo2LzvtkIzW9Yp2/aKNR032VPtIWlDtWGGFhkzGi4FPS0VTdfefxz4rqPWfBz53mh54d9xylsWVw==",
+          "requires": {
+            "@aws-sdk/client-sso-oidc": "3.358.0",
+            "@aws-sdk/property-provider": "3.357.0",
+            "@aws-sdk/shared-ini-file-loader": "3.357.0",
+            "@aws-sdk/types": "3.357.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.357.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.357.0.tgz",
+          "integrity": "sha512-/riCRaXg3p71BeWnShrai0y0QTdXcouPSM0Cn1olZbzTf7s71aLEewrc96qFrL70XhY4XvnxMpqQh+r43XIL3g==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/url-parser": {
+          "version": "3.357.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.357.0.tgz",
+          "integrity": "sha512-fAaU6cFsaAba01lCRsRJiYR/LfXvX2wudyEyutBVglE4dWSoSeu3QJNxImIzTBULfbiFhz59++NQ1JUVx88IVg==",
+          "requires": {
+            "@aws-sdk/querystring-parser": "3.357.0",
+            "@aws-sdk/types": "3.357.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/util-defaults-mode-browser": {
+          "version": "3.358.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.358.0.tgz",
+          "integrity": "sha512-KGfw64wRL/gROLD4Gatda8cUsaNKNhSnx+yDDcG2WkFlFfLr6FHvTijpRxvIM2Jau2ZhcdGzbegLjsFxviTJAA==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.357.0",
+            "@aws-sdk/types": "3.357.0",
+            "bowser": "^2.11.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/util-defaults-mode-node": {
+          "version": "3.358.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.358.0.tgz",
+          "integrity": "sha512-2C5on0yppDS0xGpFkHRqfrG9TeTq6ive1hPX1V8UCkiI/TBQYl88XCKCKct8zTcejyK9klZUDGI8QQTan2UWkw==",
+          "requires": {
+            "@aws-sdk/config-resolver": "3.357.0",
+            "@aws-sdk/credential-provider-imds": "3.357.0",
+            "@aws-sdk/node-config-provider": "3.357.0",
+            "@aws-sdk/property-provider": "3.357.0",
+            "@aws-sdk/types": "3.357.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/util-endpoints": {
+          "version": "3.357.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.357.0.tgz",
+          "integrity": "sha512-XHKyS5JClT9su9hDif715jpZiWHQF9gKZXER8tW0gOizU3R9cyWc9EsJ2BRhFNhi7nt/JF/CLUEc5qDx3ETbUw==",
+          "requires": {
+            "@aws-sdk/types": "3.357.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/util-middleware": {
+          "version": "3.357.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.357.0.tgz",
+          "integrity": "sha512-pV1krjZs7BdahZBfsCJMatE8kcor7GFsBOWrQgQDm9T0We5b5xPpOO2vxAD0RytBpY8Ky2ELs/+qXMv7l5fWIA==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/util-retry": {
+          "version": "3.357.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.357.0.tgz",
+          "integrity": "sha512-SUqYJE9msbuOVq+vnUy+t0LH7XuYNFz66dSF8q6tedsbJK4j8tgya0I1Ct3m06ynGrXDJMaj39I7AXCyW9bjtw==",
+          "requires": {
+            "@aws-sdk/service-error-classification": "3.357.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/util-user-agent-browser": {
+          "version": "3.357.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.357.0.tgz",
+          "integrity": "sha512-JHaWlNIUkPNvXkqeDOrqFzAlAgdwZK5mZw7FQnCRvf8tdSogpGZSkuyb9Z6rLD9gC40Srbc2nepO1cFpeMsDkA==",
+          "requires": {
+            "@aws-sdk/types": "3.357.0",
+            "bowser": "^2.11.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/util-user-agent-node": {
+          "version": "3.357.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.357.0.tgz",
+          "integrity": "sha512-RdpQoaJWQvcS99TVgSbT451iGrlH4qpWUWFA9U1IRhxOSsmC1hz8ME7xc8nci9SREx/ZlfT3ai6LpoAzAtIEMA==",
+          "requires": {
+            "@aws-sdk/node-config-provider": "3.357.0",
+            "@aws-sdk/types": "3.357.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "fast-xml-parser": {
+          "version": "4.2.5",
+          "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.5.tgz",
+          "integrity": "sha512-B9/wizE4WngqQftFPmdaMYlXoJlJOYxGQOanC77fq9k8+Z0v5dDSVh+3glErdIROP//s/jgb7ZuxKfB8nVyo0g==",
+          "requires": {
+            "strnum": "^1.0.5"
+          }
+        }
+      }
+    },
+    "@aws-sdk/client-sso": {
+      "version": "3.354.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.354.0.tgz",
+      "integrity": "sha512-4jmvjJYDaaPmm1n2TG4LYfTEnHLKcJmImgBqhgzhMgaypb4u/k1iw0INV2r/afYPL/FsrLFwc46RM3HYx3nc4A==",
+      "requires": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/config-resolver": "3.354.0",
+        "@aws-sdk/fetch-http-handler": "3.353.0",
+        "@aws-sdk/hash-node": "3.347.0",
+        "@aws-sdk/invalid-dependency": "3.347.0",
+        "@aws-sdk/middleware-content-length": "3.347.0",
+        "@aws-sdk/middleware-endpoint": "3.347.0",
+        "@aws-sdk/middleware-host-header": "3.347.0",
+        "@aws-sdk/middleware-logger": "3.347.0",
+        "@aws-sdk/middleware-recursion-detection": "3.347.0",
+        "@aws-sdk/middleware-retry": "3.354.0",
+        "@aws-sdk/middleware-serde": "3.347.0",
+        "@aws-sdk/middleware-stack": "3.347.0",
+        "@aws-sdk/middleware-user-agent": "3.352.0",
+        "@aws-sdk/node-config-provider": "3.354.0",
+        "@aws-sdk/node-http-handler": "3.350.0",
+        "@aws-sdk/smithy-client": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/url-parser": "3.347.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "@aws-sdk/util-body-length-browser": "3.310.0",
+        "@aws-sdk/util-body-length-node": "3.310.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.353.0",
+        "@aws-sdk/util-defaults-mode-node": "3.354.0",
+        "@aws-sdk/util-endpoints": "3.352.0",
+        "@aws-sdk/util-retry": "3.347.0",
+        "@aws-sdk/util-user-agent-browser": "3.347.0",
+        "@aws-sdk/util-user-agent-node": "3.354.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "@smithy/protocol-http": "^1.0.1",
+        "@smithy/types": "^1.0.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/client-sso-oidc": {
+      "version": "3.354.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.354.0.tgz",
+      "integrity": "sha512-XZcg4s2zKb4S8ltluiw5yxpm974uZqzo2HTECt1lbzUJgVgLsMAh/nPJ1fLqg4jadT+rf8Lq2FEFqOM/vxWT8A==",
+      "requires": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/config-resolver": "3.354.0",
+        "@aws-sdk/fetch-http-handler": "3.353.0",
+        "@aws-sdk/hash-node": "3.347.0",
+        "@aws-sdk/invalid-dependency": "3.347.0",
+        "@aws-sdk/middleware-content-length": "3.347.0",
+        "@aws-sdk/middleware-endpoint": "3.347.0",
+        "@aws-sdk/middleware-host-header": "3.347.0",
+        "@aws-sdk/middleware-logger": "3.347.0",
+        "@aws-sdk/middleware-recursion-detection": "3.347.0",
+        "@aws-sdk/middleware-retry": "3.354.0",
+        "@aws-sdk/middleware-serde": "3.347.0",
+        "@aws-sdk/middleware-stack": "3.347.0",
+        "@aws-sdk/middleware-user-agent": "3.352.0",
+        "@aws-sdk/node-config-provider": "3.354.0",
+        "@aws-sdk/node-http-handler": "3.350.0",
+        "@aws-sdk/smithy-client": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/url-parser": "3.347.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "@aws-sdk/util-body-length-browser": "3.310.0",
+        "@aws-sdk/util-body-length-node": "3.310.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.353.0",
+        "@aws-sdk/util-defaults-mode-node": "3.354.0",
+        "@aws-sdk/util-endpoints": "3.352.0",
+        "@aws-sdk/util-retry": "3.347.0",
+        "@aws-sdk/util-user-agent-browser": "3.347.0",
+        "@aws-sdk/util-user-agent-node": "3.354.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "@smithy/protocol-http": "^1.0.1",
+        "@smithy/types": "^1.0.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/client-sts": {
+      "version": "3.354.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.354.0.tgz",
+      "integrity": "sha512-l9Ar/C/3PNlToM1ukHVfBtp4plbRUxLMYY2DOTMI0nb3jzfcvETBcdEGCP51fX4uAfJ2vc4g5qBF/qXKX0LMWA==",
+      "requires": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/config-resolver": "3.354.0",
+        "@aws-sdk/credential-provider-node": "3.354.0",
+        "@aws-sdk/fetch-http-handler": "3.353.0",
+        "@aws-sdk/hash-node": "3.347.0",
+        "@aws-sdk/invalid-dependency": "3.347.0",
+        "@aws-sdk/middleware-content-length": "3.347.0",
+        "@aws-sdk/middleware-endpoint": "3.347.0",
+        "@aws-sdk/middleware-host-header": "3.347.0",
+        "@aws-sdk/middleware-logger": "3.347.0",
+        "@aws-sdk/middleware-recursion-detection": "3.347.0",
+        "@aws-sdk/middleware-retry": "3.354.0",
+        "@aws-sdk/middleware-sdk-sts": "3.354.0",
+        "@aws-sdk/middleware-serde": "3.347.0",
+        "@aws-sdk/middleware-signing": "3.354.0",
+        "@aws-sdk/middleware-stack": "3.347.0",
+        "@aws-sdk/middleware-user-agent": "3.352.0",
+        "@aws-sdk/node-config-provider": "3.354.0",
+        "@aws-sdk/node-http-handler": "3.350.0",
+        "@aws-sdk/smithy-client": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/url-parser": "3.347.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "@aws-sdk/util-body-length-browser": "3.310.0",
+        "@aws-sdk/util-body-length-node": "3.310.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.353.0",
+        "@aws-sdk/util-defaults-mode-node": "3.354.0",
+        "@aws-sdk/util-endpoints": "3.352.0",
+        "@aws-sdk/util-retry": "3.347.0",
+        "@aws-sdk/util-user-agent-browser": "3.347.0",
+        "@aws-sdk/util-user-agent-node": "3.354.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "@smithy/protocol-http": "^1.0.1",
+        "@smithy/types": "^1.0.0",
+        "fast-xml-parser": "4.2.4",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/config-resolver": {
+      "version": "3.354.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.354.0.tgz",
+      "integrity": "sha512-K4XWie8yJPT8bpYVX54VJMQhiJRTw8PrjEs9QrKqvwoCcZ3G4qEt40tIu33XksuokXxk8rrVH5d7odOPBsAtdg==",
+      "requires": {
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/util-config-provider": "3.310.0",
+        "@aws-sdk/util-middleware": "3.347.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/credential-provider-env": {
+      "version": "3.353.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.353.0.tgz",
+      "integrity": "sha512-Y4VsNS8O1FAD5J7S5itOhnOghQ5LIXlZ44t35nF8cbcF+JPvY3ToKzYpjYN1jM7DXKqU4shtqgYpzSqxlvEgKQ==",
+      "requires": {
+        "@aws-sdk/property-provider": "3.353.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/credential-provider-imds": {
+      "version": "3.354.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.354.0.tgz",
+      "integrity": "sha512-AB+PuDd1jX6qgz+JYvIyOn8Kz9/lQ60KuY1TFb7g3S8zURw+DSeMJNR1jzEsorWICTzhxXmyasHVMa4Eo4Uq+Q==",
+      "requires": {
+        "@aws-sdk/node-config-provider": "3.354.0",
+        "@aws-sdk/property-provider": "3.353.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/url-parser": "3.347.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/credential-provider-ini": {
+      "version": "3.354.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.354.0.tgz",
+      "integrity": "sha512-bn2ifrRsxWpxzwXa25jRdUECQ1dC+NB3YlRYnGdIaIQLF559N2jnfCabYzqyfKI++WU7aQeMofPe2PxVGlbv9Q==",
+      "requires": {
+        "@aws-sdk/credential-provider-env": "3.353.0",
+        "@aws-sdk/credential-provider-imds": "3.354.0",
+        "@aws-sdk/credential-provider-process": "3.354.0",
+        "@aws-sdk/credential-provider-sso": "3.354.0",
+        "@aws-sdk/credential-provider-web-identity": "3.354.0",
+        "@aws-sdk/property-provider": "3.353.0",
+        "@aws-sdk/shared-ini-file-loader": "3.354.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/credential-provider-node": {
+      "version": "3.354.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.354.0.tgz",
+      "integrity": "sha512-ltKiRtHfqDaCcrb44DIoSHQ9MposFl/aDtNdu5OdQv/2Q1r7M/r2fQdq9DHOrxeQQjaUH4C6k6fGTsxALTHyNA==",
+      "requires": {
+        "@aws-sdk/credential-provider-env": "3.353.0",
+        "@aws-sdk/credential-provider-imds": "3.354.0",
+        "@aws-sdk/credential-provider-ini": "3.354.0",
+        "@aws-sdk/credential-provider-process": "3.354.0",
+        "@aws-sdk/credential-provider-sso": "3.354.0",
+        "@aws-sdk/credential-provider-web-identity": "3.354.0",
+        "@aws-sdk/property-provider": "3.353.0",
+        "@aws-sdk/shared-ini-file-loader": "3.354.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/credential-provider-process": {
+      "version": "3.354.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.354.0.tgz",
+      "integrity": "sha512-AxpASm+tS8V1PY4PLfG9dtqa96lzBJ3niTQb+RAm4uYCddW7gxNDkGB+jSCzVdUPVa3xA2ITBS/ka3C5yM8YWg==",
+      "requires": {
+        "@aws-sdk/property-provider": "3.353.0",
+        "@aws-sdk/shared-ini-file-loader": "3.354.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/credential-provider-sso": {
+      "version": "3.354.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.354.0.tgz",
+      "integrity": "sha512-ihiaUxh8V/nQgTOgQZxWQcbckXhM+J6Wdc4F0z9soi48iSOqzRpzPw5E14wSZScEZjNY/gKEDz8gCt8WkT/G0w==",
+      "requires": {
+        "@aws-sdk/client-sso": "3.354.0",
+        "@aws-sdk/property-provider": "3.353.0",
+        "@aws-sdk/shared-ini-file-loader": "3.354.0",
+        "@aws-sdk/token-providers": "3.354.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/credential-provider-web-identity": {
+      "version": "3.354.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.354.0.tgz",
+      "integrity": "sha512-scx9mAf4m3Hc3uMX2Vh8GciEcC/5GqeDI8qc0zBj+UF/5c/GtihZA4WoCV3Sg3jMPDUKY81DiFCtcKHhtUqKfg==",
+      "requires": {
+        "@aws-sdk/property-provider": "3.353.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/eventstream-codec": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-codec/-/eventstream-codec-3.347.0.tgz",
+      "integrity": "sha512-61q+SyspjsaQ4sdgjizMyRgVph2CiW4aAtfpoH69EJFJfTxTR/OqnZ9Jx/3YiYi0ksrvDenJddYodfWWJqD8/w==",
+      "requires": {
+        "@aws-crypto/crc32": "3.0.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/util-hex-encoding": "3.310.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/eventstream-serde-browser": {
+      "version": "3.357.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-browser/-/eventstream-serde-browser-3.357.0.tgz",
+      "integrity": "sha512-hBabtmwuspVHGSKnUccDiSIbg+IVoBThx6wYt6i4edbWAITHF3ADVKXy7icV400CAyG0XTZgxjE6FKpiDxj9rQ==",
+      "requires": {
+        "@aws-sdk/eventstream-serde-universal": "3.357.0",
+        "@aws-sdk/types": "3.357.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.357.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.357.0.tgz",
+          "integrity": "sha512-/riCRaXg3p71BeWnShrai0y0QTdXcouPSM0Cn1olZbzTf7s71aLEewrc96qFrL70XhY4XvnxMpqQh+r43XIL3g==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        }
+      }
+    },
+    "@aws-sdk/eventstream-serde-config-resolver": {
+      "version": "3.357.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.357.0.tgz",
+      "integrity": "sha512-E6rwk+1KFXhKmJ+v7JW5Uyyda1yN5XRVupCnCrtFsHFmhVGQxFacoUZIee3bfuCpC58dLSyESggxGpUd3XOSsw==",
+      "requires": {
+        "@aws-sdk/types": "3.357.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.357.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.357.0.tgz",
+          "integrity": "sha512-/riCRaXg3p71BeWnShrai0y0QTdXcouPSM0Cn1olZbzTf7s71aLEewrc96qFrL70XhY4XvnxMpqQh+r43XIL3g==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        }
+      }
+    },
+    "@aws-sdk/eventstream-serde-node": {
+      "version": "3.357.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-node/-/eventstream-serde-node-3.357.0.tgz",
+      "integrity": "sha512-boXDy+JWcPfHc9OIKV6I4Bh2XrLcg+eac+/LldNZFcDIB33/gHIM2CJw8u565Iebdz1NKEkP/QPPZbk2y+abPA==",
+      "requires": {
+        "@aws-sdk/eventstream-serde-universal": "3.357.0",
+        "@aws-sdk/types": "3.357.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.357.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.357.0.tgz",
+          "integrity": "sha512-/riCRaXg3p71BeWnShrai0y0QTdXcouPSM0Cn1olZbzTf7s71aLEewrc96qFrL70XhY4XvnxMpqQh+r43XIL3g==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        }
+      }
+    },
+    "@aws-sdk/eventstream-serde-universal": {
+      "version": "3.357.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-universal/-/eventstream-serde-universal-3.357.0.tgz",
+      "integrity": "sha512-9/Wcdxx38XQAturqOAGYNCaLOzFVnW+xwxd4af9eNOfZfZ5PP5PRKBIpvKDsN26e3l4f3GodHx7MS1WB7BBc2w==",
+      "requires": {
+        "@aws-sdk/eventstream-codec": "3.357.0",
+        "@aws-sdk/types": "3.357.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "@aws-sdk/eventstream-codec": {
+          "version": "3.357.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-codec/-/eventstream-codec-3.357.0.tgz",
+          "integrity": "sha512-bqenTHG6GH6aCk/Il+ooWXVVAZuc8lOgVEy9bE2hI49oVqT8zSuXxQB+w1WWyZoAOPcelsjayB1wfPub8VDBxQ==",
+          "requires": {
+            "@aws-crypto/crc32": "3.0.0",
+            "@aws-sdk/types": "3.357.0",
+            "@aws-sdk/util-hex-encoding": "3.310.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.357.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.357.0.tgz",
+          "integrity": "sha512-/riCRaXg3p71BeWnShrai0y0QTdXcouPSM0Cn1olZbzTf7s71aLEewrc96qFrL70XhY4XvnxMpqQh+r43XIL3g==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        }
+      }
+    },
+    "@aws-sdk/fetch-http-handler": {
+      "version": "3.353.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.353.0.tgz",
+      "integrity": "sha512-8ic2+4E6jzfDevd++QS1rOR05QFkAhEFbi5Ja3/Zzp7TkWIS8wv5wwMATjNkbbdsXYuB5Lhl/OsjfZmIv5aqRw==",
+      "requires": {
+        "@aws-sdk/protocol-http": "3.347.0",
+        "@aws-sdk/querystring-builder": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/hash-node": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.347.0.tgz",
+      "integrity": "sha512-96+ml/4EaUaVpzBdOLGOxdoXOjkPgkoJp/0i1fxOJEvl8wdAQSwc3IugVK9wZkCxy2DlENtgOe6DfIOhfffm/g==",
+      "requires": {
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/util-buffer-from": "3.310.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/invalid-dependency": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.347.0.tgz",
+      "integrity": "sha512-8imQcwLwqZ/wTJXZqzXT9pGLIksTRckhGLZaXT60tiBOPKuerTsus2L59UstLs5LP8TKaVZKFFSsjRIn9dQdmQ==",
+      "requires": {
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/is-array-buffer": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.310.0.tgz",
+      "integrity": "sha512-urnbcCR+h9NWUnmOtet/s4ghvzsidFmspfhYaHAmSRdy9yDjdjBJMFjjsn85A1ODUktztm+cVncXjQ38WCMjMQ==",
+      "requires": {
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/middleware-content-length": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.347.0.tgz",
+      "integrity": "sha512-i4qtWTDImMaDUtwKQPbaZpXsReiwiBomM1cWymCU4bhz81HL01oIxOxOBuiM+3NlDoCSPr3KI6txZSz/8cqXCQ==",
+      "requires": {
+        "@aws-sdk/protocol-http": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/middleware-endpoint": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.347.0.tgz",
+      "integrity": "sha512-unF0c6dMaUL1ffU+37Ugty43DgMnzPWXr/Jup/8GbK5fzzWT5NQq6dj9KHPubMbWeEjQbmczvhv25JuJdK8gNQ==",
+      "requires": {
+        "@aws-sdk/middleware-serde": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/url-parser": "3.347.0",
+        "@aws-sdk/util-middleware": "3.347.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/middleware-host-header": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.347.0.tgz",
+      "integrity": "sha512-kpKmR9OvMlnReqp5sKcJkozbj1wmlblbVSbnQAIkzeQj2xD5dnVR3Nn2ogQKxSmU1Fv7dEroBtrruJ1o3fY38A==",
+      "requires": {
+        "@aws-sdk/protocol-http": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/middleware-logger": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.347.0.tgz",
+      "integrity": "sha512-NYC+Id5UCkVn+3P1t/YtmHt75uED06vwaKyxDy0UmB2K66PZLVtwWbLpVWrhbroaw1bvUHYcRyQ9NIfnVcXQjA==",
+      "requires": {
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/middleware-recursion-detection": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.347.0.tgz",
+      "integrity": "sha512-qfnSvkFKCAMjMHR31NdsT0gv5Sq/ZHTUD4yQsSLpbVQ6iYAS834lrzXt41iyEHt57Y514uG7F/Xfvude3u4icQ==",
+      "requires": {
+        "@aws-sdk/protocol-http": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/middleware-retry": {
+      "version": "3.354.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.354.0.tgz",
+      "integrity": "sha512-dnG5Nd/mobbhcWCM71DQWI9+f6b6fDSzALXftFIP/8lsXKRcWDSQuYjrnVST2wZzk/QmdF8TnVD0C1xL14K6CQ==",
+      "requires": {
+        "@aws-sdk/protocol-http": "3.347.0",
+        "@aws-sdk/service-error-classification": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/util-middleware": "3.347.0",
+        "@aws-sdk/util-retry": "3.347.0",
+        "tslib": "^2.5.0",
+        "uuid": "^8.3.2"
+      }
+    },
+    "@aws-sdk/middleware-sdk-sts": {
+      "version": "3.354.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.354.0.tgz",
+      "integrity": "sha512-L6vyAwYrdcOoB4YgCqNJNr+ZZtLHEF2Ym3CTfmFm2srXHqHuRB+mBu0NLV/grz77znIArK1H1ZL/ZaH2I5hclA==",
+      "requires": {
+        "@aws-sdk/middleware-signing": "3.354.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/middleware-serde": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.347.0.tgz",
+      "integrity": "sha512-x5Foi7jRbVJXDu9bHfyCbhYDH5pKK+31MmsSJ3k8rY8keXLBxm2XEEg/AIoV9/TUF9EeVvZ7F1/RmMpJnWQsEg==",
+      "requires": {
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/middleware-signing": {
+      "version": "3.354.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.354.0.tgz",
+      "integrity": "sha512-Dd+vIhJL0VqqKWqlTKlKC5jkCaEIk73ZEXNfv44XbsI25a0vXbatHp1M8jB/cgkJC/Mri1TX9dmckP/C0FDEwA==",
+      "requires": {
+        "@aws-sdk/property-provider": "3.353.0",
+        "@aws-sdk/protocol-http": "3.347.0",
+        "@aws-sdk/signature-v4": "3.354.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/util-middleware": "3.347.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/middleware-stack": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.347.0.tgz",
+      "integrity": "sha512-Izidg4rqtYMcKuvn2UzgEpPLSmyd8ub9+LQ2oIzG3mpIzCBITq7wp40jN1iNkMg+X6KEnX9vdMJIYZsPYMCYuQ==",
+      "requires": {
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/middleware-user-agent": {
+      "version": "3.352.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.352.0.tgz",
+      "integrity": "sha512-QGqblMTsVDqeomy22KPm9LUW8PHZXBA2Hjk9Hcw8U1uFS8IKYJrewInG3ae2+9FAcTyug4LFWDf8CRr9YH2B3Q==",
+      "requires": {
+        "@aws-sdk/protocol-http": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/util-endpoints": "3.352.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/node-config-provider": {
+      "version": "3.354.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.354.0.tgz",
+      "integrity": "sha512-pF1ZGWWvmwbrloNHYF3EDqCb9hq5wfZwDqAwAPhWkYnUYKkR7E7MZVuTwUDU48io8k6Z5pM52l/54w8e8aedTw==",
+      "requires": {
+        "@aws-sdk/property-provider": "3.353.0",
+        "@aws-sdk/shared-ini-file-loader": "3.354.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/node-http-handler": {
+      "version": "3.350.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.350.0.tgz",
+      "integrity": "sha512-oD96GAlmpzYilCdC8wwyURM5lNfNHZCjm/kxBkQulHKa2kRbIrnD9GfDqdCkWA5cTpjh1NzGLT4D6e6UFDjt9w==",
+      "requires": {
+        "@aws-sdk/abort-controller": "3.347.0",
+        "@aws-sdk/protocol-http": "3.347.0",
+        "@aws-sdk/querystring-builder": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/property-provider": {
+      "version": "3.353.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.353.0.tgz",
+      "integrity": "sha512-Iu6J59hncaew7eBKroTcLjZ8cgrom0IWyZZ09rsow3rZDHVtw7LQSrUyuqsSbKGY9eRtL7Wa6ZtYHnXFiAE2kg==",
+      "requires": {
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/protocol-http": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.347.0.tgz",
+      "integrity": "sha512-2YdBhc02Wvy03YjhGwUxF0UQgrPWEy8Iq75pfS42N+/0B/+eWX1aQgfjFxIpLg7YSjT5eKtYOQGlYd4MFTgj9g==",
+      "requires": {
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/querystring-builder": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.347.0.tgz",
+      "integrity": "sha512-phtKTe6FXoV02MoPkIVV6owXI8Mwr5IBN3bPoxhcPvJG2AjEmnetSIrhb8kwc4oNhlwfZwH6Jo5ARW/VEWbZtg==",
+      "requires": {
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/util-uri-escape": "3.310.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/querystring-parser": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.347.0.tgz",
+      "integrity": "sha512-5VXOhfZz78T2W7SuXf2avfjKglx1VZgZgp9Zfhrt/Rq+MTu2D+PZc5zmJHhYigD7x83jLSLogpuInQpFMA9LgA==",
+      "requires": {
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/service-error-classification": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.347.0.tgz",
+      "integrity": "sha512-xZ3MqSY81Oy2gh5g0fCtooAbahqh9VhsF8vcKjVX8+XPbGC8y+kej82+MsMg4gYL8gRFB9u4hgYbNgIS6JTAvg=="
+    },
+    "@aws-sdk/shared-ini-file-loader": {
+      "version": "3.354.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.354.0.tgz",
+      "integrity": "sha512-UL9loGEsdzpHBu/PtlwUvkl/yRdmWXkySp22jUaeeRtBhiGAnyeYhxJLIt+u+UkX7Mwz+810SaZJqA9ptOXNAg==",
+      "requires": {
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/signature-v4": {
+      "version": "3.354.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.354.0.tgz",
+      "integrity": "sha512-bDp43P5NkwwznpZqmsr78DuyqNcjtS4mriuajb8XPhFNo8DrMXUrdrKJ+5aNABW7YG8uK8PSKBpq88ado692/w==",
+      "requires": {
+        "@aws-sdk/eventstream-codec": "3.347.0",
+        "@aws-sdk/is-array-buffer": "3.310.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/util-hex-encoding": "3.310.0",
+        "@aws-sdk/util-middleware": "3.347.0",
+        "@aws-sdk/util-uri-escape": "3.310.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/smithy-client": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.347.0.tgz",
+      "integrity": "sha512-PaGTDsJLGK0sTjA6YdYQzILRlPRN3uVFyqeBUkfltXssvUzkm8z2t1lz2H4VyJLAhwnG5ZuZTNEV/2mcWrU7JQ==",
+      "requires": {
+        "@aws-sdk/middleware-stack": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/token-providers": {
+      "version": "3.354.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.354.0.tgz",
+      "integrity": "sha512-KcijiySy0oIyafKQagcwgu0fo35mK+2K8pwxRU1WfXqe80Gn1qGceeWcG4iW+t/rUaxa/LVo857N0LcagxCrZA==",
+      "requires": {
+        "@aws-sdk/client-sso-oidc": "3.354.0",
+        "@aws-sdk/property-provider": "3.353.0",
+        "@aws-sdk/shared-ini-file-loader": "3.354.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/types": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
+      "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
+      "requires": {
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/url-parser": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.347.0.tgz",
+      "integrity": "sha512-lhrnVjxdV7hl+yCnJfDZOaVLSqKjxN20MIOiijRiqaWGLGEAiSqBreMhL89X1WKCifxAs4zZf9YB9SbdziRpAA==",
+      "requires": {
+        "@aws-sdk/querystring-parser": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/util-base64": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.310.0.tgz",
+      "integrity": "sha512-v3+HBKQvqgdzcbL+pFswlx5HQsd9L6ZTlyPVL2LS9nNXnCcR3XgGz9jRskikRUuUvUXtkSG1J88GAOnJ/apTPg==",
+      "requires": {
+        "@aws-sdk/util-buffer-from": "3.310.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/util-body-length-browser": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.310.0.tgz",
+      "integrity": "sha512-sxsC3lPBGfpHtNTUoGXMQXLwjmR0zVpx0rSvzTPAuoVILVsp5AU/w5FphNPxD5OVIjNbZv9KsKTuvNTiZjDp9g==",
+      "requires": {
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/util-body-length-node": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.310.0.tgz",
+      "integrity": "sha512-2tqGXdyKhyA6w4zz7UPoS8Ip+7sayOg9BwHNidiGm2ikbDxm1YrCfYXvCBdwaJxa4hJfRVz+aL9e+d3GqPI9pQ==",
+      "requires": {
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/util-buffer-from": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.310.0.tgz",
+      "integrity": "sha512-i6LVeXFtGih5Zs8enLrt+ExXY92QV25jtEnTKHsmlFqFAuL3VBeod6boeMXkN2p9lbSVVQ1sAOOYZOHYbYkntw==",
+      "requires": {
+        "@aws-sdk/is-array-buffer": "3.310.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/util-config-provider": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.310.0.tgz",
+      "integrity": "sha512-xIBaYo8dwiojCw8vnUcIL4Z5tyfb1v3yjqyJKJWV/dqKUFOOS0U591plmXbM+M/QkXyML3ypon1f8+BoaDExrg==",
+      "requires": {
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/util-defaults-mode-browser": {
+      "version": "3.353.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.353.0.tgz",
+      "integrity": "sha512-ushvOQKJIH7S6E//xMDPyf2/Bbu0K2A0GJRB88qQV6VKRBo4PEbeHTb6BbzPhYVX0IbY3uR/X7+Xwk4FeEkMWg==",
+      "requires": {
+        "@aws-sdk/property-provider": "3.353.0",
+        "@aws-sdk/types": "3.347.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/util-defaults-mode-node": {
+      "version": "3.354.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.354.0.tgz",
+      "integrity": "sha512-CaaRVBdOYX4wZadj+CDUxpO+4RjyYJcSv71A60jV6CZ/ya1+oYfmPbG5QZ4AlV6crdev2B+aUoR2LPIYqn/GnQ==",
+      "requires": {
+        "@aws-sdk/config-resolver": "3.354.0",
+        "@aws-sdk/credential-provider-imds": "3.354.0",
+        "@aws-sdk/node-config-provider": "3.354.0",
+        "@aws-sdk/property-provider": "3.353.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/util-endpoints": {
+      "version": "3.352.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.352.0.tgz",
+      "integrity": "sha512-PjWMPdoIUWfBPgAWLyOrWFbdSS/3DJtc0OmFb/JrE8C8rKFYl+VGW5f1p0cVdRWiDR0xCGr0s67p8itAakVqjw==",
+      "requires": {
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/util-hex-encoding": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.310.0.tgz",
+      "integrity": "sha512-sVN7mcCCDSJ67pI1ZMtk84SKGqyix6/0A1Ab163YKn+lFBQRMKexleZzpYzNGxYzmQS6VanP/cfU7NiLQOaSfA==",
+      "requires": {
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/util-locate-window": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.310.0.tgz",
+      "integrity": "sha512-qo2t/vBTnoXpjKxlsC2e1gBrRm80M3bId27r0BRB2VniSSe7bL1mmzM+/HFtujm0iAxtPM+aLEflLJlJeDPg0w==",
+      "requires": {
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/util-middleware": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.347.0.tgz",
+      "integrity": "sha512-8owqUA3ePufeYTUvlzdJ7Z0miLorTwx+rNol5lourGQZ9JXsVMo23+yGA7nOlFuXSGkoKpMOtn6S0BT2bcfeiw==",
+      "requires": {
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/util-retry": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.347.0.tgz",
+      "integrity": "sha512-NxnQA0/FHFxriQAeEgBonA43Q9/VPFQa8cfJDuT2A1YZruMasgjcltoZszi1dvoIRWSZsFTW42eY2gdOd0nffQ==",
+      "requires": {
+        "@aws-sdk/service-error-classification": "3.347.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/util-stream": {
+      "version": "3.358.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream/-/util-stream-3.358.0.tgz",
+      "integrity": "sha512-zUhpjxAXV2+0eALlTU6uXRYMs10XYpcYzl3NtLRe4wWgnrOOOZnF/t5LQDoKXOfaMdzwZ+i90+PYr+6JQ58+7g==",
+      "requires": {
+        "@aws-sdk/fetch-http-handler": "3.357.0",
+        "@aws-sdk/node-http-handler": "3.357.0",
+        "@aws-sdk/types": "3.357.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "@aws-sdk/util-buffer-from": "3.310.0",
+        "@aws-sdk/util-hex-encoding": "3.310.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "@aws-sdk/abort-controller": {
+          "version": "3.357.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.357.0.tgz",
+          "integrity": "sha512-nQYDJon87quPwt2JZJwUN2GFKJnvE5kWb6tZP4xb5biSGUKBqDQo06oYed7yokatCuCMouIXV462aN0fWODtOw==",
+          "requires": {
+            "@aws-sdk/types": "3.357.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/fetch-http-handler": {
+          "version": "3.357.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.357.0.tgz",
+          "integrity": "sha512-5sPloTO8y8fAnS/6/Sfp/aVoL9zuhzkLdWBORNzMazdynVNEzWKWCPZ27RQpgkaCDHiXjqUY4kfuFXAGkvFfDQ==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.357.0",
+            "@aws-sdk/querystring-builder": "3.357.0",
+            "@aws-sdk/types": "3.357.0",
+            "@aws-sdk/util-base64": "3.310.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/node-http-handler": {
+          "version": "3.357.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.357.0.tgz",
+          "integrity": "sha512-uoab4xIJux+Q9hQ9A/vWEAjojtBQ0U4K7xEQVa0BXEv7MHH5zv51H+VtrelU1Ed6hsHq4Sx0bxBMFpbbWhNyjA==",
+          "requires": {
+            "@aws-sdk/abort-controller": "3.357.0",
+            "@aws-sdk/protocol-http": "3.357.0",
+            "@aws-sdk/querystring-builder": "3.357.0",
+            "@aws-sdk/types": "3.357.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/protocol-http": {
+          "version": "3.357.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.357.0.tgz",
+          "integrity": "sha512-w1JHiI50VEea7duDeAspUiKJmmdIQblvRyjVMOqWA6FIQAyDVuEiPX7/MdQr0ScxhtRQxHbP0I4MFyl7ctRQvA==",
+          "requires": {
+            "@aws-sdk/types": "3.357.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/querystring-builder": {
+          "version": "3.357.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.357.0.tgz",
+          "integrity": "sha512-aQcicqB6Y2cNaXPPwunz612a01SMiQQPsdz632F/3Lzn0ua82BJKobHOtaiTUlmVJ5Q4/EAeNfwZgL7tTUNtDQ==",
+          "requires": {
+            "@aws-sdk/types": "3.357.0",
+            "@aws-sdk/util-uri-escape": "3.310.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.357.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.357.0.tgz",
+          "integrity": "sha512-/riCRaXg3p71BeWnShrai0y0QTdXcouPSM0Cn1olZbzTf7s71aLEewrc96qFrL70XhY4XvnxMpqQh+r43XIL3g==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        }
+      }
+    },
+    "@aws-sdk/util-uri-escape": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.310.0.tgz",
+      "integrity": "sha512-drzt+aB2qo2LgtDoiy/3sVG8w63cgLkqFIa2NFlGpUgHFWTXkqtbgf4L5QdjRGKWhmZsnqkbtL7vkSWEcYDJ4Q==",
+      "requires": {
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/util-user-agent-browser": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.347.0.tgz",
+      "integrity": "sha512-ydxtsKVtQefgbk1Dku1q7pMkjDYThauG9/8mQkZUAVik55OUZw71Zzr3XO8J8RKvQG8lmhPXuAQ0FKAyycc0RA==",
+      "requires": {
+        "@aws-sdk/types": "3.347.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/util-user-agent-node": {
+      "version": "3.354.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.354.0.tgz",
+      "integrity": "sha512-2xkblZS3PGxxh//0lgCwJw2gvh9ZBcI9H9xv05YP7hcwlz9BmkAlbei2i6Uew6agJMLO4unfgWoBTpzp3WLaKg==",
+      "requires": {
+        "@aws-sdk/node-config-provider": "3.354.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/util-utf8": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8/-/util-utf8-3.310.0.tgz",
+      "integrity": "sha512-DnLfFT8uCO22uOJc0pt0DsSNau1GTisngBCDw8jQuWT5CqogMJu4b/uXmwEqfj8B3GX6Xsz8zOd6JpRlPftQoA==",
+      "requires": {
+        "@aws-sdk/util-buffer-from": "3.310.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/util-utf8-browser": {
+      "version": "3.259.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.259.0.tgz",
+      "integrity": "sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==",
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-waiter": {
+      "version": "3.357.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.357.0.tgz",
+      "integrity": "sha512-jQQGA5G8bm0JP5C4U85VzMpkFHdeeT7fOSUncXLG9Sh8Ambzi4XTud8m5/dA7aNJkvPwZeIF9QdgWCOzpkp1xA==",
+      "requires": {
+        "@aws-sdk/abort-controller": "3.357.0",
+        "@aws-sdk/types": "3.357.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "@aws-sdk/abort-controller": {
+          "version": "3.357.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.357.0.tgz",
+          "integrity": "sha512-nQYDJon87quPwt2JZJwUN2GFKJnvE5kWb6tZP4xb5biSGUKBqDQo06oYed7yokatCuCMouIXV462aN0fWODtOw==",
+          "requires": {
+            "@aws-sdk/types": "3.357.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.357.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.357.0.tgz",
+          "integrity": "sha512-/riCRaXg3p71BeWnShrai0y0QTdXcouPSM0Cn1olZbzTf7s71aLEewrc96qFrL70XhY4XvnxMpqQh+r43XIL3g==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        }
+      }
     },
     "@babel/code-frame": {
       "version": "7.18.6",
@@ -4936,6 +9041,23 @@
         "@sinonjs/commons": "^2.0.0"
       }
     },
+    "@smithy/protocol-http": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-1.1.0.tgz",
+      "integrity": "sha512-H5y/kZOqfJSqRkwtcAoVbqONmhdXwSgYNJ1Glk5Ry8qlhVVy5qUzD9EklaCH8/XLnoCsLO/F/Giee8MIvaBRkg==",
+      "requires": {
+        "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/types": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.1.0.tgz",
+      "integrity": "sha512-KzmvisMmuwD2jZXuC9e65JrgsZM97y5NpDU7g347oB+Q+xQLU6hQZ5zFNNbEfwwOJHoOvEVTna+dk1h/lW7alw==",
+      "requires": {
+        "tslib": "^2.5.0"
+      }
+    },
     "@tsconfig/node10": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
@@ -4959,6 +9081,11 @@
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
       "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
       "dev": true
+    },
+    "@types/aws-lambda": {
+      "version": "8.10.119",
+      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.119.tgz",
+      "integrity": "sha512-Vqm22aZrCvCd6I5g1SvpW151jfqwTzEZ7XJ3yZ6xaZG31nUEOEyzzVImjRcsN8Wi/QyPxId/x8GTtgIbsy8kEw=="
     },
     "@types/babel__core": {
       "version": "7.20.0",
@@ -5133,10 +9260,14 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
       "requires": {
         "sprintf-js": "~1.0.2"
       }
+    },
+    "available-typed-arrays": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
+      "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw=="
     },
     "aws-cdk": {
       "version": "2.62.2",
@@ -5148,9 +9279,9 @@
       }
     },
     "aws-cdk-lib": {
-      "version": "2.80.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.80.0.tgz",
-      "integrity": "sha512-PoqD3Yms5I0ajuTi071nTW/hpkH3XsdyZzn5gYsPv0qD7mqP3h6Qr+6RiGx+yQ1KcVFyxWdX15uK+DsC0KwvcQ==",
+      "version": "2.84.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.84.0.tgz",
+      "integrity": "sha512-4zLtCLCIs5Ia4WRGqiXRwxSkpGaNy3NxMexO9qYHSuIYpqf4sHObzZ0tDHZCFL5Wkui3sCu3OLQWrRHrr93HvA==",
       "requires": {
         "@aws-cdk/asset-awscli-v1": "^2.2.177",
         "@aws-cdk/asset-kubectl-v20": "^2.1.1",
@@ -5362,6 +9493,41 @@
         }
       }
     },
+    "aws-lambda": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/aws-lambda/-/aws-lambda-1.0.7.tgz",
+      "integrity": "sha512-9GNFMRrEMG5y3Jvv+V4azWvc+qNWdWLTjDdhf/zgMlz8haaaLWv0xeAIWxz9PuWUBawsVxy0zZotjCdR3Xq+2w==",
+      "requires": {
+        "aws-sdk": "^2.814.0",
+        "commander": "^3.0.2",
+        "js-yaml": "^3.14.1",
+        "watchpack": "^2.0.0-beta.10"
+      }
+    },
+    "aws-sdk": {
+      "version": "2.1403.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1403.0.tgz",
+      "integrity": "sha512-qRhiE2iqfXhTEsGJ0unNY7mz5Y7YA4ljEh/1lU/HaUI8hPCQtmZjU3P2/w2YcHFaSzJsu9J9svzjkALfHpetoA==",
+      "requires": {
+        "buffer": "4.9.2",
+        "events": "1.1.1",
+        "ieee754": "1.1.13",
+        "jmespath": "0.16.0",
+        "querystring": "0.2.0",
+        "sax": "1.2.1",
+        "url": "0.10.3",
+        "util": "^0.12.4",
+        "uuid": "8.0.0",
+        "xml2js": "0.5.0"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.0.0.tgz",
+          "integrity": "sha512-jOXGuXZAWdsTH7eZLtyXMqUb9EcWMGZNbL9YcGBJl4MH4nrxHmZJhEHvyLFrkxo+28uLb/NYRcStH48fnD0Vzw=="
+        }
+      }
+    },
     "babel-jest": {
       "version": "29.4.1",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.4.1.tgz",
@@ -5438,6 +9604,16 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
+    "base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+    },
+    "bowser": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
+      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -5487,10 +9663,29 @@
         "node-int64": "^0.4.0"
       }
     },
+    "buffer": {
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
+      "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
+      "requires": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
+      }
+    },
     "buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
+    },
+    "call-bind": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "requires": {
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.0.2"
+      }
     },
     "callsites": {
       "version": "3.1.0",
@@ -5575,6 +9770,11 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
+    },
+    "commander": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-3.0.2.tgz",
+      "integrity": "sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow=="
     },
     "concat-map": {
       "version": "0.0.1",
@@ -5691,8 +9891,12 @@
     "esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "dev": true
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+    },
+    "events": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+      "integrity": "sha512-kEcvvCBByWXGnZy6JUlgAp2gBIUjfCAV6P6TgT1/aaQKcmuAEC4OZTV1I4EWQLz2gxZw76atuVyvHhTxvi0Flw=="
     },
     "execa": {
       "version": "5.1.1",
@@ -5736,6 +9940,14 @@
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "dev": true
     },
+    "fast-xml-parser": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.4.tgz",
+      "integrity": "sha512-fbfMDvgBNIdDJLdLOwacjFAPYt67tr31H9ZhWSm45CDAxvd0I6WTlSOUo7K2P/K5sA5JgMKG64PI3DMcaFdWpQ==",
+      "requires": {
+        "strnum": "^1.0.5"
+      }
+    },
     "fb-watchman": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.2.tgz",
@@ -5764,6 +9976,14 @@
         "path-exists": "^4.0.0"
       }
     },
+    "for-each": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
+      "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+      "requires": {
+        "is-callable": "^1.1.3"
+      }
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -5780,8 +10000,7 @@
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
     "gensync": {
       "version": "1.0.0-beta.2",
@@ -5794,6 +10013,17 @@
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "dev": true
+    },
+    "get-intrinsic": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.1.tgz",
+      "integrity": "sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==",
+      "requires": {
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-proto": "^1.0.1",
+        "has-symbols": "^1.0.3"
+      }
     },
     "get-package-type": {
       "version": "0.1.0",
@@ -5821,23 +10051,34 @@
         "path-is-absolute": "^1.0.0"
       }
     },
+    "glob-to-regexp": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw=="
+    },
     "globals": {
       "version": "11.12.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
       "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
       "dev": true
     },
+    "gopd": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
+      "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
+      "requires": {
+        "get-intrinsic": "^1.1.3"
+      }
+    },
     "graceful-fs": {
       "version": "4.2.10",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
-      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
-      "dev": true
+      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
     },
     "has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "dev": true,
       "requires": {
         "function-bind": "^1.1.1"
       }
@@ -5847,6 +10088,24 @@
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true
+    },
+    "has-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
+      "integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg=="
+    },
+    "has-symbols": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A=="
+    },
+    "has-tostringtag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
+      "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
+      "requires": {
+        "has-symbols": "^1.0.2"
+      }
     },
     "html-escaper": {
       "version": "2.0.2",
@@ -5859,6 +10118,11 @@
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
       "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
       "dev": true
+    },
+    "ieee754": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
     },
     "import-local": {
       "version": "3.1.0",
@@ -5889,14 +10153,27 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "is-arguments": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
+      "integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
+      "requires": {
+        "call-bind": "^1.0.2",
+        "has-tostringtag": "^1.0.0"
+      }
     },
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
       "dev": true
+    },
+    "is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA=="
     },
     "is-core-module": {
       "version": "2.11.0",
@@ -5919,6 +10196,14 @@
       "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
       "dev": true
     },
+    "is-generator-function": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
+      "integrity": "sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==",
+      "requires": {
+        "has-tostringtag": "^1.0.0"
+      }
+    },
     "is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -5930,6 +10215,23 @@
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
       "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
       "dev": true
+    },
+    "is-typed-array": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.10.tgz",
+      "integrity": "sha512-PJqgEHiWZvMpaFZ3uTc8kHPM4+4ADTlDniuQL7cU/UDA0Ql7F70yGfHph3cLNe+c9toaigv+DFzTJKhc2CtO6A==",
+      "requires": {
+        "available-typed-arrays": "^1.0.5",
+        "call-bind": "^1.0.2",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "has-tostringtag": "^1.0.0"
+      }
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
     },
     "isexe": {
       "version": "2.0.0",
@@ -6515,6 +10817,11 @@
         }
       }
     },
+    "jmespath": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.16.0.tgz",
+      "integrity": "sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw=="
+    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -6525,7 +10832,6 @@
       "version": "3.14.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
       "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
-      "dev": true,
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -6819,6 +11125,16 @@
         "sisteransi": "^1.0.5"
       }
     },
+    "punycode": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+      "integrity": "sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw=="
+    },
+    "querystring": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g=="
+    },
     "react-is": {
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
@@ -6862,6 +11178,11 @@
       "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.0.tgz",
       "integrity": "sha512-6K/gDlqgQscOlg9fSRpWstA8sYe8rbELsSTNpx+3kTrsVCzvSl0zIvRErM7fdl9ERWDsKnrLnwB+Ne89918XOg==",
       "dev": true
+    },
+    "sax": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+      "integrity": "sha512-8I2a3LovHTOpm7NV5yOyO8IHqgVsfK4+UuySrXU8YXkSRX7k6hCV9b3HrkKCr3nMpgj+0bmocaJJWpvp1oc7ZA=="
     },
     "semver": {
       "version": "6.3.0",
@@ -6919,8 +11240,7 @@
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-      "dev": true
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
     },
     "stack-utils": {
       "version": "2.0.6",
@@ -6986,6 +11306,11 @@
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
       "dev": true
+    },
+    "strnum": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
+      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
     },
     "supports-color": {
       "version": "7.2.0",
@@ -7097,6 +11422,11 @@
         "yn": "3.1.1"
       }
     },
+    "tslib": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
+      "integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w=="
+    },
     "type-detect": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
@@ -7124,6 +11454,32 @@
         "escalade": "^3.1.1",
         "picocolors": "^1.0.0"
       }
+    },
+    "url": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+      "integrity": "sha512-hzSUW2q06EqL1gKM/a+obYHLIO6ct2hwPuviqTTOcfFVc61UbfJ2Q32+uGL/HCPxKqrdGB5QUwIe7UqlDgwsOQ==",
+      "requires": {
+        "punycode": "1.3.2",
+        "querystring": "0.2.0"
+      }
+    },
+    "util": {
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
+      "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
+      "requires": {
+        "inherits": "^2.0.3",
+        "is-arguments": "^1.0.4",
+        "is-generator-function": "^1.0.7",
+        "is-typed-array": "^1.1.3",
+        "which-typed-array": "^1.1.2"
+      }
+    },
+    "uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     },
     "v8-compile-cache-lib": {
       "version": "3.0.1",
@@ -7159,6 +11515,15 @@
         "makeerror": "1.0.12"
       }
     },
+    "watchpack": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.0.tgz",
+      "integrity": "sha512-Lcvm7MGST/4fup+ifyKi2hjyIAwcdI4HRgtvTpIUxBRhB+RFtUh8XtDOxUfctVCnhVi+QQj49i91OyvzkJl6cg==",
+      "requires": {
+        "glob-to-regexp": "^0.4.1",
+        "graceful-fs": "^4.1.2"
+      }
+    },
     "which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -7166,6 +11531,19 @@
       "dev": true,
       "requires": {
         "isexe": "^2.0.0"
+      }
+    },
+    "which-typed-array": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.9.tgz",
+      "integrity": "sha512-w9c4xkx6mPidwp7180ckYWfMmvxpjlZuIudNtDf4N/tTAUB8VJbX25qZoAsrtGuYNnGw3pa0AXgbGKRB8/EceA==",
+      "requires": {
+        "available-typed-arrays": "^1.0.5",
+        "call-bind": "^1.0.2",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "has-tostringtag": "^1.0.0",
+        "is-typed-array": "^1.1.10"
       }
     },
     "wrap-ansi": {
@@ -7194,6 +11572,20 @@
         "imurmurhash": "^0.1.4",
         "signal-exit": "^3.0.7"
       }
+    },
+    "xml2js": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
+      "integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
+      "requires": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      }
+    },
+    "xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
     },
     "y18n": {
       "version": "5.0.8",

--- a/deployment/cdk/opensearch-service-migration/package.json
+++ b/deployment/cdk/opensearch-service-migration/package.json
@@ -20,7 +20,11 @@
     "typescript": "~4.9.4"
   },
   "dependencies": {
-    "aws-cdk-lib": "2.80.0",
+    "@aws-sdk/client-kafka": "^3.354.0",
+    "@aws-sdk/client-lambda": "^3.359.0",
+    "@types/aws-lambda": "^8.10.117",
+    "aws-cdk-lib": "2.84.0",
+    "aws-lambda": "^1.0.7",
     "constructs": "^10.0.0",
     "source-map-support": "^0.5.21"
   }

--- a/deployment/cdk/opensearch-service-migration/package.json
+++ b/deployment/cdk/opensearch-service-migration/package.json
@@ -23,7 +23,7 @@
     "@aws-sdk/client-kafka": "^3.354.0",
     "@aws-sdk/client-lambda": "^3.359.0",
     "@types/aws-lambda": "^8.10.117",
-    "aws-cdk-lib": "2.84.0",
+    "aws-cdk-lib": "^2.84.0",
     "aws-lambda": "^1.0.7",
     "constructs": "^10.0.0",
     "source-map-support": "^0.5.21"

--- a/deployment/copilot/devDeploy.sh
+++ b/deployment/copilot/devDeploy.sh
@@ -24,6 +24,8 @@ fi
 export CDK_DEPLOYMENT_STAGE=dev
 # Will be used for CDK and Copilot
 export AWS_DEFAULT_REGION=us-east-1
+# Used to overcome error: "failed to solve with frontend dockerfile.v0: failed to create LLB definition: unexpected
+# status code [manifests latest]: 400 Bad Request" but may not be practical
 export DOCKER_BUILDKIT=0
 export COMPOSE_DOCKER_CLI_BUILD=0
 
@@ -43,6 +45,7 @@ found_exports=$(grep -o "export [a-zA-Z0-9_]*=[^\\;\"]*" cdkOutput.json)
 printf "The following exports were added from CDK:\n%s\n" "$found_exports"
 eval "$(grep -o "export [a-zA-Z0-9_]*=[^\\;\"]*" cdkOutput.json)"
 
+# Future enhancement needed here to make our Copilot deployment able to be reran without error even if no changes are deployed
 # === Copilot Deployment ===
 
 cd ../../copilot

--- a/deployment/copilot/devDeploy.sh
+++ b/deployment/copilot/devDeploy.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+
+# Stop script on command failures
+set -e
+
+skip_init=false
+if [[ $* == *--skip-init* ]]
+then
+  echo "Skipping initializations"
+  skip_init=true
+fi
+
+# === CDK Deployment ===
+export CDK_DEPLOYMENT_STAGE=dev
+
+# Pipe output to some place and grab the export commands and execute them :)
+cdk deploy "*" --c domainName="aos-domain" --c engineVersion="OS_1.3" --c --c dataNodeCount=2 --c vpcEnabled=true --c availabilityZoneCount=2 --c openAccessPolicyEnabled=true --c domainRemovalPolicy="DESTROY" --c migrationAssistanceEnabled=true --c mskEnablePublicEndpoints=true --require-approval never
+
+# === Copilot Deployment ===
+
+# Init app
+copilot app init
+
+# Init env
+copilot env init --name dev --profile default --default-config
+
+# Init services
+copilot svc init --name traffic-comparator-jupyter
+copilot svc init --name traffic-comparator
+copilot svc init --name traffic-replayer
+copilot svc init --name kafka-puller
+
+# Deploy env
+copilot env deploy --name dev
+
+# Deploy services
+copilot svc deploy --name traffic-comparator-jupyter --env dev
+copilot svc deploy --name traffic-comparator --env dev
+copilot svc deploy --name traffic-replayer --env dev
+copilot svc deploy --name kafka-puller --env dev

--- a/deployment/copilot/devDeploy.sh
+++ b/deployment/copilot/devDeploy.sh
@@ -1,42 +1,76 @@
 #!/bin/sh
 
+# Automation script to deploy the migration solution pipline to AWS for development use case. The current requirement
+# for use is having valid AWS credentials available to the environment
+
 # Stop script on command failures
 set -e
 
+# Allow executing this script from any dir
+script_abs_path=$(readlink -f "$0")
+script_dir_abs_path=$(dirname "$script_abs_path")
+cd $script_dir_abs_path
+
+SECONDS=0
+
+# Allow --skip-init flag to avoid one-time setups
 skip_init=false
 if [[ $* == *--skip-init* ]]
 then
-  echo "Skipping initializations"
   skip_init=true
 fi
 
 # === CDK Deployment ===
 export CDK_DEPLOYMENT_STAGE=dev
+# Will be used for CDK and Copilot
+export CDK_DEFAULT_REGION=us-east-1
+export DOCKER_BUILDKIT=0
+export COMPOSE_DOCKER_CLI_BUILD=0
 
-# Pipe output to some place and grab the export commands and execute them :)
-cd ../opensearch-service-migration
-cdk deploy "*" --c domainName="aos-domain" --c engineVersion="OS_1.3" --c --c dataNodeCount=2 --c vpcEnabled=true --c availabilityZoneCount=2 --c openAccessPolicyEnabled=true --c domainRemovalPolicy="DESTROY" --c migrationAssistanceEnabled=true --c mskEnablePublicEndpoints=true --require-approval never
+cd ../cdk/opensearch-service-migration
+if [ "$skip_init" = false ] ; then
+  cd ../../../TrafficCapture
+  ./gradlew :dockerSolution:buildDockerImages
+  cd ../deployment/cdk/opensearch-service-migration
+  npm install
+  cdk bootstrap
+fi
+
+cdk deploy "*" --c domainName="aos-domain" --c engineVersion="OS_1.3" --c  dataNodeCount=2 --c vpcEnabled=true --c availabilityZoneCount=2 --c openAccessPolicyEnabled=true --c domainRemovalPolicy="DESTROY" --c migrationAssistanceEnabled=true --c mskEnablePublicEndpoints=true -O cdkOutput.json --require-approval never
+
+# Gather CDK output which includes export commands needed by Copilot, and make them available to the environment
+found_exports=$(grep -o "export [a-zA-Z0-9_]*=[^\\;\"]*" cdkOutput.json)
+printf "The following exports were added from CDK:\n%s\n" "$found_exports"
+eval "$(grep -o "export [a-zA-Z0-9_]*=[^\\;\"]*" cdkOutput.json)"
 
 # === Copilot Deployment ===
 
-cd ../copilot
-# Init app
-copilot app init
+cd ../../copilot
 
-# Init env
-copilot env init --name dev --profile default --default-config
+if [ "$skip_init" = false ] ; then
+  # Init app
+  copilot app init migration-copilot
 
-# Init services
-copilot svc init --name traffic-comparator-jupyter
-copilot svc init --name traffic-comparator
-copilot svc init --name traffic-replayer
-copilot svc init --name kafka-puller
+  # Init env
+  copilot env init -a migration-copilot --name dev --default-config --aws-access-key-id $AWS_ACCESS_KEY_ID --aws-secret-access-key $AWS_SECRET_ACCESS_KEY --aws-session-token $AWS_SESSION_TOKEN --region $CDK_DEFAULT_REGION
+
+  # Init services
+  copilot svc init -a migration-copilot --name traffic-comparator-jupyter
+  copilot svc init -a migration-copilot --name traffic-comparator
+  copilot svc init -a migration-copilot --name traffic-replayer
+  copilot svc init -a migration-copilot --name kafka-puller
+fi
 
 # Deploy env
-copilot env deploy --name dev
+copilot env deploy -a migration-copilot --name dev
 
 # Deploy services
-copilot svc deploy --name traffic-comparator-jupyter --env dev
-copilot svc deploy --name traffic-comparator --env dev
-copilot svc deploy --name traffic-replayer --env dev
-copilot svc deploy --name kafka-puller --env dev
+copilot svc deploy -a migration-copilot --name traffic-comparator-jupyter --env dev
+copilot svc deploy -a migration-copilot --name traffic-comparator --env dev
+copilot svc deploy -a migration-copilot --name traffic-replayer --env dev
+copilot svc deploy -a migration-copilot --name kafka-puller --env dev
+
+
+# Output deployment time
+duration=$SECONDS
+echo "Total deployment time: $((duration / 3600)) hour(s), $(((duration / 60) % 60)) minute(s) and $((duration % 60)) second(s) elapsed."

--- a/deployment/copilot/devDeploy.sh
+++ b/deployment/copilot/devDeploy.sh
@@ -23,7 +23,7 @@ fi
 # === CDK Deployment ===
 export CDK_DEPLOYMENT_STAGE=dev
 # Will be used for CDK and Copilot
-export AWS_DEFAULT_REGION=us-east-2
+export AWS_DEFAULT_REGION=us-east-1
 export DOCKER_BUILDKIT=0
 export COMPOSE_DOCKER_CLI_BUILD=0
 

--- a/deployment/copilot/devDeploy.sh
+++ b/deployment/copilot/devDeploy.sh
@@ -14,10 +14,12 @@ fi
 export CDK_DEPLOYMENT_STAGE=dev
 
 # Pipe output to some place and grab the export commands and execute them :)
+cd ../opensearch-service-migration
 cdk deploy "*" --c domainName="aos-domain" --c engineVersion="OS_1.3" --c --c dataNodeCount=2 --c vpcEnabled=true --c availabilityZoneCount=2 --c openAccessPolicyEnabled=true --c domainRemovalPolicy="DESTROY" --c migrationAssistanceEnabled=true --c mskEnablePublicEndpoints=true --require-approval never
 
 # === Copilot Deployment ===
 
+cd ../copilot
 # Init app
 copilot app init
 

--- a/deployment/copilot/devDeploy.sh
+++ b/deployment/copilot/devDeploy.sh
@@ -23,7 +23,7 @@ fi
 # === CDK Deployment ===
 export CDK_DEPLOYMENT_STAGE=dev
 # Will be used for CDK and Copilot
-export CDK_DEFAULT_REGION=us-east-1
+export AWS_DEFAULT_REGION=us-east-2
 export DOCKER_BUILDKIT=0
 export COMPOSE_DOCKER_CLI_BUILD=0
 
@@ -52,7 +52,7 @@ if [ "$skip_init" = false ] ; then
   copilot app init migration-copilot
 
   # Init env
-  copilot env init -a migration-copilot --name dev --default-config --aws-access-key-id $AWS_ACCESS_KEY_ID --aws-secret-access-key $AWS_SECRET_ACCESS_KEY --aws-session-token $AWS_SESSION_TOKEN --region $CDK_DEFAULT_REGION
+  copilot env init -a migration-copilot --name dev --default-config --aws-access-key-id $AWS_ACCESS_KEY_ID --aws-secret-access-key $AWS_SECRET_ACCESS_KEY --aws-session-token $AWS_SESSION_TOKEN --region $AWS_DEFAULT_REGION
 
   # Init services
   copilot svc init -a migration-copilot --name traffic-comparator-jupyter

--- a/deployment/copilot/environments/dev/manifest.yml
+++ b/deployment/copilot/environments/dev/manifest.yml
@@ -3,7 +3,7 @@
 #  https://aws.github.io/copilot-cli/docs/manifest/environment/
 
 # Your environment name will be used in naming your resources like VPC, cluster, etc.
-name: test
+name: dev
 type: Environment
 
 # Import your own VPC and subnets or configure how they should be created.


### PR DESCRIPTION
### Description
This change introduces the following features/enhancements:

**Allows enabling MSK public endpoints with CDK**
A current limitation of the MSK L1 construct is the absence to enable public broker endpoints. To handle this in CDK the next logical step would be to use a Custom Resource. Unfortunately, updating a cluster to have broker endpoints with a basic Custom Resource does not give us the desired result. If we simply make the SDK call to enable this we get a response immediately, however, the actual update can take over 20 minutes and users would be left in the dark. Alternatively simply using the Lambda that the CR creates to query the cluster continually and wait for completion also faces the issue of the maximum Lambda timeout being 15 minutes. The solution used here is loosely based on the article [here](https://aws.amazon.com/blogs/devops/implementing-long-running-deployments-with-aws-cloudformation-custom-resources-using-aws-step-functions/) where we want to create a wait condition and have some resource notify that wait condition when processing is done and the CDK stack can proceed.  For our case we have a lambda that will perform the update and regularly check the cluster's status until it is ACTIVE again and will notify the wait condition. When the lambda nears the end of its allowed runtime it will spin up another lambda to continue where it left off, up to the maximum set number of times. There is probably an argument here to use a resource with a longer allowed runtime, which may be marginally better but would still require the created CR Lambda (or possibly SNS) to kick off.  I will agree that there are several enhancement that could be made to our Lambda logic and our MSK logic overall. The two items which make these enhancements seem less urgent are the eventual release of the MSK L2 constructs which would presumably replace a lot of logic here as well as unknowns with using MSK versus Kafka containers in this solution.

**Adds a dev deployment script to simplify deploying our migration pipeline**
This script should make deployments for devs much easier by taking away the manual work that was required to coordinate a deployment of CDK and Copilot and some of the necessary preliminary steps that had to be taken beforehand. There are still a few improvements around checking for install dependencies before starting a deployment as well as having this script be easily retryable without intervention as it currently is when issues are encountered with Copilot.

~~**Update some dependencies to pick up latest minor release**
To help combat Mend issues detected on some dependencies that aren't using the latest minor release, these dependencies have been updated to use latest minor release~~


### Issues Resolved
https://opensearch.atlassian.net/browse/MIGRATIONS-1151

### Testing
Manual deployment to AWS testing
<img width="1452" alt="image" src="https://github.com/opensearch-project/opensearch-migrations/assets/16884063/8fe9143a-ba4c-441b-ba1f-5bdeb8b89464">


### Check List
- [ ] New functionality includes testing
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
