### PR TITLE
[Index configuration tool] Support for disable_authentication key in Data Prepper YAML

### DIFF
--- a/index_configuration_tool/main.py
+++ b/index_configuration_tool/main.py
@@ -10,6 +10,7 @@ SUPPORTED_ENDPOINTS = ["opensearch", "elasticsearch"]
 SOURCE_KEY = "source"
 SINK_KEY = "sink"
 HOSTS_KEY = "hosts"
+DISABLE_AUTH_KEY = "disable_authentication"
 USER_KEY = "username"
 PWD_KEY = "password"
 INSECURE_KEY = "insecure"
@@ -28,7 +29,7 @@ def is_insecure(config: dict) -> bool:
 
 # TODO Only supports basic auth for now
 def get_auth(input_data: dict) -> Optional[tuple]:
-    if USER_KEY in input_data and PWD_KEY in input_data:
+    if not input_data.get(DISABLE_AUTH_KEY, False) and USER_KEY in input_data and PWD_KEY in input_data:
         return input_data[USER_KEY], input_data[PWD_KEY]
 
 
@@ -77,10 +78,13 @@ def validate_plugin_config(config: dict, key: str):
     plugin_config = supported_endpoint[1]
     if HOSTS_KEY not in plugin_config:
         raise ValueError("No hosts defined for endpoint: " + supported_endpoint[0])
-    if USER_KEY in plugin_config and PWD_KEY not in plugin_config:
-        raise ValueError("Invalid auth configuration (no password for user) for endpoint: " + supported_endpoint[0])
-    elif PWD_KEY in plugin_config and USER_KEY not in plugin_config:
-        raise ValueError("Invalid auth configuration (Password without user) for endpoint: " + supported_endpoint[0])
+    if not plugin_config.get(DISABLE_AUTH_KEY, False):
+        if USER_KEY in plugin_config and PWD_KEY not in plugin_config:
+            raise ValueError("Invalid auth configuration (no password for user) for endpoint: " +
+                             supported_endpoint[0])
+        elif PWD_KEY in plugin_config and USER_KEY not in plugin_config:
+            raise ValueError("Invalid auth configuration (Password without user) for endpoint: " +
+                             supported_endpoint[0])
 
 
 def validate_pipeline_config(config: dict):

--- a/index_configuration_tool/tests/test_main.py
+++ b/index_configuration_tool/tests/test_main.py
@@ -20,13 +20,16 @@ BASE_CONFIG_SECTION = {
 # Utility method to create a test plugin config
 def create_plugin_config(host_list: list[str],
                          user: Optional[str] = None,
-                         password: Optional[str] = None) -> dict:
+                         password: Optional[str] = None,
+                         disable_auth: Optional[bool] = None) -> dict:
     config = dict()
     config["hosts"] = host_list
     if user:
         config["username"] = user
     if password:
         config["password"] = password
+    if disable_auth is not None:
+        config["disable_authentication"] = disable_auth
     return config
 
 
@@ -185,12 +188,17 @@ class TestMain(unittest.TestCase):
         self.assertRaises(ValueError, main.validate_plugin_config, test_data, TEST_KEY)
 
     def test_validate_plugin_config_bad_auth_password(self):
-        test_data = create_config_section(create_plugin_config(["host"], user="test"))
+        test_data = create_config_section(create_plugin_config(["host"], user="test", disable_auth=False))
         self.assertRaises(ValueError, main.validate_plugin_config, test_data, TEST_KEY)
 
     def test_validate_plugin_config_bad_auth_user(self):
         test_data = create_config_section(create_plugin_config(["host"], password="test"))
         self.assertRaises(ValueError, main.validate_plugin_config, test_data, TEST_KEY)
+
+    def test_validate_plugin_config_auth_disabled(self):
+        test_data = create_config_section(create_plugin_config(["host"], user="test", disable_auth=True))
+        # Should complete without errors
+        main.validate_plugin_config(test_data, TEST_KEY)
 
     def test_validate_plugin_config_happy_case(self):
         plugin_config = create_plugin_config(["host"], "user", "password")


### PR DESCRIPTION
### Description
This change adds logic to read the "disable_authentication" key in the Data Prepper source and sink configuration. This flag was recently added to Data Prepper and removes the need to specify dummy username and password values in order to connect to an unauthenticated OpenSearch source/sink.
* Category: Enhancement

### Issues Resolved
N/A

### Testing
```
$ python -m coverage run -m unittest
..........................
----------------------------------------------------------------------
Ran 26 tests in 0.520s

OK
$ python -m coverage report --omit "*/tests/*"
Name                  Stmts   Miss  Cover
-----------------------------------------
index_operations.py      37      2    95%
main.py                  92      0   100%
utils.py                 13      0   100%
-----------------------------------------
TOTAL                   142      2    99%
```

### Check List
- [x] New functionality includes testing
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
