### PR TITLE
[Index configuration tool] Fix in validation logic for auth

### DIFF
--- a/index_configuration_tool/main.py
+++ b/index_configuration_tool/main.py
@@ -78,13 +78,14 @@ def validate_plugin_config(config: dict, key: str):
     plugin_config = supported_endpoint[1]
     if HOSTS_KEY not in plugin_config:
         raise ValueError("No hosts defined for endpoint: " + supported_endpoint[0])
-    if not plugin_config.get(DISABLE_AUTH_KEY, False):
-        if USER_KEY in plugin_config and PWD_KEY not in plugin_config:
-            raise ValueError("Invalid auth configuration (no password for user) for endpoint: " +
-                             supported_endpoint[0])
-        elif PWD_KEY in plugin_config and USER_KEY not in plugin_config:
-            raise ValueError("Invalid auth configuration (Password without user) for endpoint: " +
-                             supported_endpoint[0])
+    # Check if auth is disabled. If so, no further validation is required
+    if plugin_config.get(DISABLE_AUTH_KEY, False):
+        return
+    elif USER_KEY not in plugin_config:
+        raise ValueError("Invalid auth configuration (no username) for endpoint: " + supported_endpoint[0])
+    elif PWD_KEY not in plugin_config:
+        raise ValueError("Invalid auth configuration (no password for username) for endpoint: " +
+                         supported_endpoint[0])
 
 
 def validate_pipeline_config(config: dict):

--- a/index_configuration_tool/tests/test_main.py
+++ b/index_configuration_tool/tests/test_main.py
@@ -187,11 +187,15 @@ class TestMain(unittest.TestCase):
         test_data = create_config_section({})
         self.assertRaises(ValueError, main.validate_plugin_config, test_data, TEST_KEY)
 
-    def test_validate_plugin_config_bad_auth_password(self):
+    def test_validate_plugin_config_missing_auth(self):
+        test_data = create_config_section(create_plugin_config(["host"]))
+        self.assertRaises(ValueError, main.validate_plugin_config, test_data, TEST_KEY)
+
+    def test_validate_plugin_config_missing_password(self):
         test_data = create_config_section(create_plugin_config(["host"], user="test", disable_auth=False))
         self.assertRaises(ValueError, main.validate_plugin_config, test_data, TEST_KEY)
 
-    def test_validate_plugin_config_bad_auth_user(self):
+    def test_validate_plugin_config_missing_user(self):
         test_data = create_config_section(create_plugin_config(["host"], password="test"))
         self.assertRaises(ValueError, main.validate_plugin_config, test_data, TEST_KEY)
 


### PR DESCRIPTION
### Description
This change updates the validation logic to require both username and password unless the disable_auth key is present and set to True. If both username and password are missing, the tool now throws a ValueError.
* Category: Bug fix

### Issues Resolved
N/A

### Testing
```
$ python -m coverage run -m unittest
...........................
----------------------------------------------------------------------
Ran 27 tests in 0.031s

OK
$ python -m coverage report --omit "*/tests/*"
Name                  Stmts   Miss  Cover
-----------------------------------------
index_operations.py      37      2    95%
main.py                  93      0   100%
utils.py                 13      0   100%
-----------------------------------------
TOTAL                   143      2    99%

```

### Check List
- [x] New functionality includes testing
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
