### PR TITLE
[Index Configuration Tool] Adds support for writing to an output YAML file

### DIFF
--- a/index_configuration_tool/main.py
+++ b/index_configuration_tool/main.py
@@ -170,8 +170,7 @@ def run(args: argparse.Namespace) -> None:
     indices_to_create = diff[0]
     if indices_to_create:
         # Write output YAML
-        if not args.report:
-            write_output(dp_config, indices_to_create, args.output_file)
+        write_output(dp_config, indices_to_create, args.output_file)
         if not args.dryrun:
             index_data = dict()
             for index_name in indices_to_create:
@@ -189,8 +188,7 @@ if __name__ == '__main__':  # pragma no cover
         "of the pipeline YAML file is written. This version of the pipeline adds an index inclusion configuration " +
         "to the sink, specifying only those indices that were created by the index configuration tool.\nThis tool " +
         "can also print a report based on the indices in the source cluster, indicating which ones will be created, " +
-        "along with indices that are identical or have conflicting settings/mappings.\nIn case of the latter, no "
-        "action will be taken on the target cluster.",
+        "along with indices that are identical or have conflicting settings/mappings.",
         formatter_class=argparse.RawTextHelpFormatter
     )
     # Positional, required arguments
@@ -204,7 +202,7 @@ if __name__ == '__main__':  # pragma no cover
     )
     # Optional arguments
     arg_parser.add_argument("--report", "-r", action="store_true",
-                            help="Print a report of the index differences instead of generating a YAML file")
+                            help="Print a report of the index differences")
     arg_parser.add_argument("--dryrun", action="store_true",
                             help="Skips the actual creation of indices on the target cluster")
     print("\n##### Starting index configuration tool... #####\n")

--- a/index_configuration_tool/main.py
+++ b/index_configuration_tool/main.py
@@ -164,13 +164,14 @@ def run(args: argparse.Namespace) -> None:
     target_indices = index_operations.fetch_all_indices(target_endpoint, target_auth)
     # Compute index differences and print report
     diff = get_index_differences(source_indices, target_indices)
-    if args.report or args.dryrun:
+    if args.report:
         print_report(diff)
     # The first element in the tuple is the set of indices to create
     indices_to_create = diff[0]
     if indices_to_create:
         # Write output YAML
-        write_output(dp_config, indices_to_create, args.output_file)
+        if not args.report:
+            write_output(dp_config, indices_to_create, args.output_file)
         if not args.dryrun:
             index_data = dict()
             for index_name in indices_to_create:
@@ -183,10 +184,13 @@ if __name__ == '__main__':  # pragma no cover
     arg_parser = argparse.ArgumentParser(
         prog="python main.py",
         description="This tool creates indices on a target cluster based on the contents of a source cluster.\n" +
-        "The source and target endpoints are obtained by parsing a Data Prepper pipelines YAML file, which " +
-        "is the sole expected argument for this module.\nAlso prints a report of the indices to be created, " +
-        "along with indices that are identical or have conflicting settings/mappings.\nIn case of the " +
-        "latter, no action will be taken on the target cluster.",
+        "The first input to the tool is a path to a Data Prepper pipeline YAML file, which is parsed to obtain " +
+        "the source and target cluster endpoints.\nThe second input is an output path to which a modified version " +
+        "of the pipeline YAML file is written. This version of the pipeline adds an index inclusion configuration " +
+        "to the sink, specifying only those indices that were created by the index configuration tool.\nThis tool " +
+        "can also print a report based on the indices in the source cluster, indicating which ones will be created, " +
+        "along with indices that are identical or have conflicting settings/mappings.\nIn case of the latter, no "
+        "action will be taken on the target cluster.",
         formatter_class=argparse.RawTextHelpFormatter
     )
     # Positional, required arguments
@@ -202,7 +206,7 @@ if __name__ == '__main__':  # pragma no cover
     arg_parser.add_argument("--report", "-r", action="store_true",
                             help="Print a report of the index differences instead of generating a YAML file")
     arg_parser.add_argument("--dryrun", action="store_true",
-                            help="Print a report of the index differences but don't create any indices")
+                            help="Skips the actual creation of indices on the target cluster")
     print("\n##### Starting index configuration tool... #####\n")
     run(arg_parser.parse_args())
     print("\n##### Index configuration tool has completed! #####\n")

--- a/index_configuration_tool/main.py
+++ b/index_configuration_tool/main.py
@@ -15,6 +15,9 @@ USER_KEY = "username"
 PWD_KEY = "password"
 INSECURE_KEY = "insecure"
 CONNECTION_KEY = "connection"
+INDICES_KEY = "indices"
+INCLUDE_KEY = "include"
+INDEX_NAME_KEY = "index_name_regex"
 
 
 # This config key may be either directly in the main dict (for sink)
@@ -98,6 +101,15 @@ def validate_pipeline_config(config: dict):
 
 
 def write_output(yaml_data: dict, new_indices: set, output_path: str):
+    pipeline_config = next(iter(yaml_data.values()))
+    # Endpoint is a tuple of (type, config)
+    source_config = get_supported_endpoint(pipeline_config, SOURCE_KEY)[1]
+    source_indices = source_config.get(INDICES_KEY, dict())
+    included_indices = source_indices.get(INCLUDE_KEY, list())
+    for index in new_indices:
+        included_indices.append({INDEX_NAME_KEY: index})
+    source_indices[INCLUDE_KEY] = included_indices
+    source_config[INDICES_KEY] = source_indices
     with open(output_path, 'w') as out_file:
         yaml.dump(yaml_data, out_file)
     print("Wrote output YAML pipeline to: " + output_path)

--- a/index_configuration_tool/tests/test_main.py
+++ b/index_configuration_tool/tests/test_main.py
@@ -235,6 +235,7 @@ class TestMain(unittest.TestCase):
         index_to_create = test_constants.INDEX3_NAME
         index_with_conflict = test_constants.INDEX2_NAME
         index_exact_match = test_constants.INDEX1_NAME
+        expected_output_path = "dummy"
         # Set up expected arguments to mocks so we can verify
         expected_create_payload = {index_to_create: test_constants.BASE_INDICES_DATA[index_to_create]}
         # Print report accepts a tuple. The elements of the tuple
@@ -251,13 +252,13 @@ class TestMain(unittest.TestCase):
         # Set up test input
         test_input = argparse.Namespace()
         test_input.config_file_path = test_constants.PIPELINE_CONFIG_RAW_FILE_PATH
+        test_input.output_file = expected_output_path
         test_input.report = True
         test_input.dryrun = False
         main.run(test_input)
         mock_create_indices.assert_called_once_with(expected_create_payload, test_constants.TARGET_ENDPOINT, ANY)
         mock_print_report.assert_called_once_with(expected_diff)
-        # Write output should never be called when report is generated
-        mock_write_output.assert_not_called()
+        mock_write_output.assert_called_once_with(self.loaded_pipeline_config, {index_to_create}, expected_output_path)
 
     @patch('main.print_report')
     @patch('main.write_output')


### PR DESCRIPTION
### Description
The Index Configuration Tool has been updated to now produce a Data Prepper pipeline YAML file as an output. The tool now expects two positional arguments - the input pipeline YAML file like before, and an output path for the generated YAML file. The output YAML pipeline file is a modified version of the input that adds an index inclusion configuration for the sink, specifying only those indices that were created by the tool.

This change also adds two optional command line flags:
- "--report" prints a human-readable report to the command line in addition to generating an output YAML file
- "--dryrun" skips creation of indices on the target cluster
---
* Category: Enhancement

### Issues Resolved
N/A

### Testing
```
$ python -m coverage run -m unittest
.........................Wrote output YAML pipeline to: dummy
....
----------------------------------------------------------------------
Ran 29 tests in 0.041s

OK
$ python -m coverage report --omit "*/tests/*"
Name                  Stmts   Miss  Cover
-----------------------------------------
index_operations.py      37      2    95%
main.py                 112      0   100%
utils.py                 13      0   100%
-----------------------------------------
TOTAL                   162      2    99%
```

### Check List
- [x] New functionality includes testing
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
