### PR TITLE
[Index Configuration Tool] Unified Dockerfile for ICT and Data Prepper

### DIFF
--- a/index_configuration_tool/Dockerfile
+++ b/index_configuration_tool/Dockerfile
@@ -6,7 +6,8 @@ RUN apk update
 RUN apk add --no-cache python3 py-pip
 RUN pip install --user -r requirements.txt
 
-WORKDIR /code
+ENV ICT_CODE_PATH /code
+WORKDIR $ICT_CODE_PATH
 # Copy only source code
 COPY ./*.py .
 
@@ -14,4 +15,4 @@ COPY ./*.py .
 ENV PATH=/root/.local:$PATH
 
 # make sure you include the -u flag to have our stdout logged
-CMD python -u ./main.py -r $DATA_PREPPER_PATH/pipelines/pipelines.yaml $DATA_PREPPER_PATH/pipelines/pipelines.yaml; $DATA_PREPPER_PATH/bin/data-prepper
+ENTRYPOINT python -u ./main.py -r $ICT_CODE_PATH/input.yaml $DATA_PREPPER_PATH/pipelines/pipelines.yaml; $DATA_PREPPER_PATH/bin/data-prepper

--- a/index_configuration_tool/Dockerfile
+++ b/index_configuration_tool/Dockerfile
@@ -1,15 +1,12 @@
-# Multistage build - 1st stage
-FROM python:3.11 AS builder
+FROM opensearch-data-prepper:2.4.0-SNAPSHOT
 COPY requirements.txt .
 
 # Install dependencies to local user directory
+RUN apk update
+RUN apk add --no-cache python3 py-pip
 RUN pip install --user -r requirements.txt
 
-# Multistage build - 2nd stage
-FROM python:3.11-slim
 WORKDIR /code
-# Copy only required dependencies
-COPY --from=builder /root/.local /root/.local
 # Copy only source code
 COPY ./*.py .
 
@@ -17,4 +14,4 @@ COPY ./*.py .
 ENV PATH=/root/.local:$PATH
 
 # make sure you include the -u flag to have our stdout logged
-ENTRYPOINT [ "python", "-u", "./main.py" ]
+CMD python -u ./main.py -r $DATA_PREPPER_PATH/pipelines/pipelines.yaml $DATA_PREPPER_PATH/pipelines/pipelines.yaml; $DATA_PREPPER_PATH/bin/data-prepper


### PR DESCRIPTION
### Description

This change updates the Dockerfile definition for index_configuration_tool (ICT) to use Data Prepper as the base image. This will allow us to run (as a single Docker image) the index_configuration_tool Python logic to configure indices on the target cluster before kicking off Data Prepper execution to move data over. Note that since these steps must occur in sequence, the child Docker image overrides the parent's CMD definition and must manually invoke the data-prepper executable.

This is a POC implementation, so there are some limitations:

* The data migration pipeline does not shut down automatically once all data has been migrated. This is pending platform support in Data Prepper - https://github.com/opensearch-project/data-prepper/issues/2944
* If a `_bulk` call fails during data migration, the index-creation steps performed by ICT are not rolled back. These must be manually removed before running the Docker image again. This is necessary because ICT errs on the side of caution - the current logic does not validate `doc_count` for identical indices so we may end up incorrectly overwriting documents on the target cluster. Even if the `doc_count` is identical, it would require a much deeper check to verify if the contents of the index are identical.
* If there are no indices to migrate, the Docker container should ideally just shut down without running Data Prepper. Currently, Data Prepper is still kicked off but fails with an ugly stack-trace. This is because the Dockerfile simply defines two commands in sequence.
* There is scope to simplify the input mechanism for the unified Docker image. Today, it expects a Data Prepper YAML file, but this would require an understanding of the DP input format. Ideally, the input to the tool should be far simpler - possibly user-interactive and smartly deriving expected inputs based on endpoints. 
* Today, if an index is present on both source and target clusters but differs in settings/mappings, it is classified as a “conflict” and data is not migrated for it. However, it may be safe to migrate data that only differ in settings and not mappings, since these are unlikely to behave differently. We would still need to first incorporate a check for `doc_count` though (like with identical indices above)

### Issues Resolved
relates #165 and #163 

### Testing
```
$ python -m coverage run -m unittest
.........................Wrote output YAML pipeline to: dummy
....
----------------------------------------------------------------------
Ran 29 tests in 0.043s

OK
$ python -m coverage report --omit "*/tests/*"
Name                  Stmts   Miss  Cover
-----------------------------------------
index_operations.py      37      2    95%
main.py                 112      0   100%
utils.py                 13      0   100%
-----------------------------------------
TOTAL                   162      2    99%

```

### Check List
- [ ] New functionality includes testing
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
