### PR TITLE
Startup an OpenSearch Benchmark container, but put don't run tests up on startup

### DIFF
--- a/TrafficCapture/dockerSolution/src/main/docker/docker-compose.yml
+++ b/TrafficCapture/dockerSolution/src/main/docker/docker-compose.yml
@@ -78,26 +78,6 @@ services:
       - migrations
     ports:
       - "29200:9200"
-#  opensearch-benchmarks:
-#    image: 'migrations/open_search_benchmark:latest'
-#    networks:
-#      - migrations
-#    depends_on:
-#      - captureproxy
-#    command:
-#      - /bin/sh
-#      - -c
-#      - >
-#        echo "Running opensearch-benchmark w/ 'geonames' workload..." &&
-#        opensearch-benchmark execute-test --distribution-version=1.0.0 --target-host=https://captureproxy:9200 --workload=geonames --pipeline=benchmark-only --test-mode --kill-running-processes --workload-params "target_throughput:0.5,bulk_size:10,bulk_indexing_clients:1,search_clients:1"  --client-options="use_ssl:true,verify_certs:false,basic_auth_user:admin,basic_auth_password:admin" &&
-#        echo "Running opensearch-benchmark w/ 'http_logs' workload..." &&
-#        opensearch-benchmark execute-test --distribution-version=1.0.0 --target-host=https://captureproxy:9200 --workload=http_logs --pipeline=benchmark-only --test-mode --kill-running-processes --workload-params "target_throughput:0.5,bulk_size:10,bulk_indexing_clients:1,search_clients:1"  --client-options="use_ssl:true,verify_certs:false,basic_auth_user:admin,basic_auth_password:admin" &&
-#        echo "Running opensearch-benchmark w/ 'nested' workload..." &&
-#        opensearch-benchmark execute-test --distribution-version=1.0.0 --target-host=https://captureproxy:9200 --workload=nested --pipeline=benchmark-only --test-mode --kill-running-processes --workload-params "target_throughput:0.5,bulk_size:10,bulk_indexing_clients:1,search_clients:1"  --client-options="use_ssl:true,verify_certs:false,basic_auth_user:admin,basic_auth_password:admin" &&
-#        echo "Running opensearch-benchmark w/ 'nyc_taxis' workload..." &&
-#        opensearch-benchmark execute-test --distribution-version=1.0.0 --target-host=https://captureproxy:9200 --workload=nyc_taxis --pipeline=benchmark-only --test-mode --kill-running-processes --workload-params "target_throughput:0.5,bulk_size:10,bulk_indexing_clients:1,search_clients:1"  --client-options="use_ssl:true,verify_certs:false,basic_auth_user:admin,basic_auth_password:admin" &&
-#        sleep 30 &&
-#        curl --insecure https://captureproxy:9200/
 
   trafficcomparator:
     image: 'migrations/traffic_comparator:latest'
@@ -126,6 +106,12 @@ services:
       - COMPARISONS_DB_LOCATION=/shared/comparisons.db
     command: /bin/sh -c 'cd trafficComparator && pip3 install --editable ".[data]" && jupyter notebook --ip=0.0.0.0 --port=8888 --no-browser --allow-root'
 
+  opensearch-benchmarks:
+    image: 'migrations/open_search_benchmark:latest'
+    networks:
+      - migrations
+    depends_on:
+      - captureproxy
 
 volumes:
   zookeeper_data:

--- a/TrafficCapture/dockerSolution/src/main/docker/openSearchBenchmark/Dockerfile
+++ b/TrafficCapture/dockerSolution/src/main/docker/openSearchBenchmark/Dockerfile
@@ -6,4 +6,8 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends python3.9 python3-pip python3-dev gcc libc-dev git curl && \
     pip3 install opensearch-benchmark
 
+COPY runTestBenchmarks.sh /root/
+RUN chmod ugo+x /root/runTestBenchmarks.sh
+WORKDIR /root
+
 CMD tail -f /dev/null

--- a/TrafficCapture/dockerSolution/src/main/docker/openSearchBenchmark/runTestBenchmarks.sh
+++ b/TrafficCapture/dockerSolution/src/main/docker/openSearchBenchmark/runTestBenchmarks.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+echo "Running opensearch-benchmark w/ 'geonames' workload..." &&
+opensearch-benchmark execute-test --distribution-version=1.0.0 --target-host=https://captureproxy:9200 --workload=geonames --pipeline=benchmark-only --test-mode --kill-running-processes --workload-params "target_throughput:0.5,bulk_size:10,bulk_indexing_clients:1,search_clients:1"  --client-options="use_ssl:true,verify_certs:false,basic_auth_user:admin,basic_auth_password:admin" &&
+echo "Running opensearch-benchmark w/ 'http_logs' workload..." &&
+opensearch-benchmark execute-test --distribution-version=1.0.0 --target-host=https://captureproxy:9200 --workload=http_logs --pipeline=benchmark-only --test-mode --kill-running-processes --workload-params "target_throughput:0.5,bulk_size:10,bulk_indexing_clients:1,search_clients:1"  --client-options="use_ssl:true,verify_certs:false,basic_auth_user:admin,basic_auth_password:admin" &&
+echo "Running opensearch-benchmark w/ 'nested' workload..." &&
+opensearch-benchmark execute-test --distribution-version=1.0.0 --target-host=https://captureproxy:9200 --workload=nested --pipeline=benchmark-only --test-mode --kill-running-processes --workload-params "target_throughput:0.5,bulk_size:10,bulk_indexing_clients:1,search_clients:1"  --client-options="use_ssl:true,verify_certs:false,basic_auth_user:admin,basic_auth_password:admin" &&
+echo "Running opensearch-benchmark w/ 'nyc_taxis' workload..." &&
+opensearch-benchmark execute-test --distribution-version=1.0.0 --target-host=https://captureproxy:9200 --workload=nyc_taxis --pipeline=benchmark-only --test-mode --kill-running-processes --workload-params "target_throughput:0.5,bulk_size:10,bulk_indexing_clients:1,search_clients:1"  --client-options="use_ssl:true,verify_certs:false,basic_auth_user:admin,basic_auth_password:admin" &&
+sleep 30 &&
+curl --insecure https://captureproxy:9200/


### PR DESCRIPTION
### Description
Startup an OpenSearch Benchmark container, but put don't run tests up on startup.  Instead, put the tests into a shell script that can be invoked when the user wants to run it. That also lets the user run other tests too.

* **Category:** Enhancement, New feature, Refactoring
* **Why these changes are required?** Easier to control when a demo data load happens.  Also allows it to be run repeatedly, etc, etc.
* **What is the old behavior before changes and new behavior after changes?** The benchmark loaded with fixed tests, then the container completed.  Now, the container stays ready for a dev to run the tests when they're ready, however often they like, and with easier overrides.

### Issues Resolved
No jira

### Testing
Manual test.  To run - exec into the opensearch-benchmarks container and run `./runTestBenchmarks.sh `

### Check List
- [ ] New functionality includes testing
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
