### PR TITLE
[Index Configuration Tool] Remove filtering of "strict" mapping

### DIFF
--- a/index_configuration_tool/index_operations.py
+++ b/index_configuration_tool/index_operations.py
@@ -9,8 +9,6 @@ MAPPINGS_KEY = "mappings"
 __INDEX_KEY = "index"
 __ALL_INDICES_ENDPOINT = "*"
 __INTERNAL_SETTINGS_KEYS = ["creation_date", "uuid", "provided_name", "version", "store"]
-__DYNAMIC_KEY = "dynamic"
-__STRICT_VALUE = "strict"
 
 
 def fetch_all_indices(endpoint: str, optional_auth: Optional[tuple] = None, verify: bool = True) -> dict:
@@ -19,15 +17,6 @@ def fetch_all_indices(endpoint: str, optional_auth: Optional[tuple] = None, veri
     # Remove internal settings
     result = dict(resp.json())
     for index in result:
-        # TODO Remove after https://github.com/opensearch-project/data-prepper/issues/2864 is resolved
-        try:
-            dynamic_mapping_value = result[index][MAPPINGS_KEY][__DYNAMIC_KEY]
-            if dynamic_mapping_value == __STRICT_VALUE:
-                del result[index][MAPPINGS_KEY][__DYNAMIC_KEY]
-        except KeyError:
-            # One of the keys in the path above is not present, so we can
-            # ignore the deletion logic and execute the rest
-            pass
         for setting in __INTERNAL_SETTINGS_KEYS:
             index_settings = result[index][SETTINGS_KEY]
             if __INDEX_KEY in index_settings:

--- a/index_configuration_tool/tests/test_constants.py
+++ b/index_configuration_tool/tests/test_constants.py
@@ -38,7 +38,6 @@ BASE_INDICES_DATA = {
             }
         },
         MAPPINGS_KEY: {
-            # Strict mapping should be filtered out
             "dynamic": "strict"
         }
     },
@@ -50,7 +49,6 @@ BASE_INDICES_DATA = {
             }
         },
         MAPPINGS_KEY: {
-            "dynamic": "false",
             "id": {"type": "keyword"}
         }
     }

--- a/index_configuration_tool/tests/test_index_operations.py
+++ b/index_configuration_tool/tests/test_index_operations.py
@@ -20,11 +20,8 @@ class TestSearchEndpoint(unittest.TestCase):
         index_settings = index_data[test_constants.INDEX1_NAME][test_constants.SETTINGS_KEY]
         self.assertTrue(test_constants.INDEX_KEY in index_settings)
         self.assertEqual({"is_filtered": False}, index_settings[test_constants.INDEX_KEY])
-        # Test that only strict mapping is filtered out
         index_mappings = index_data[test_constants.INDEX2_NAME][test_constants.MAPPINGS_KEY]
-        self.assertEqual(0, len(index_mappings))
-        index_mappings = index_data[test_constants.INDEX3_NAME][test_constants.MAPPINGS_KEY]
-        self.assertEqual("false", index_mappings["dynamic"])
+        self.assertEqual("strict", index_mappings["dynamic"])
 
     @responses.activate
     def test_create_indices(self):


### PR DESCRIPTION
### Description
https://github.com/opensearch-project/data-prepper/issues/2864 has been fixed so that `index` and `document_id` fields are no longer injected into the resulting document that is pushed to the target cluster. Thus, we can remove this workaround and revert to enforcing "strict" mappings for indices that are configured as such.

* Category: Bug fix

### Issues Resolved
N/A

### Testing
```
$ python -m coverage run -m unittest
.........................Wrote output YAML pipeline to: dummy
....
----------------------------------------------------------------------
Ran 29 tests in 0.557s

OK
$ python -m coverage report --omit "*/tests/*"
Name                  Stmts   Miss  Cover
-----------------------------------------
index_operations.py      29      2    93%
main.py                 112      0   100%
utils.py                 13      0   100%
-----------------------------------------
TOTAL                   154      2    99%
```

### Check List
- [x] New functionality includes testing
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
