### PR TITLE
Fix MIGRATIONS-1268 (capturing encrypted, rather than plaintext data)

### DIFF
--- a/TrafficCapture/buildSrc/src/main/groovy/org.opensearch.migrations.java-common-conventions.gradle
+++ b/TrafficCapture/buildSrc/src/main/groovy/org.opensearch.migrations.java-common-conventions.gradle
@@ -19,7 +19,7 @@ dependencies {
     }
 
     // Use JUnit Jupiter for testing.
-    testImplementation 'org.junit.jupiter:junit-jupiter:5.9.1'
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.9.3'
 }
 
 tasks.named('test') {

--- a/TrafficCapture/settings.gradle
+++ b/TrafficCapture/settings.gradle
@@ -14,7 +14,7 @@ include('captureKafkaOffloader',
         'nettyWireLogging',
         'trafficCaptureProxyServer',
         'trafficReplayer',
-
+        'testUtilities',
         'dockerSolution',
         'trafficCaptureProxyServerTest'
 )

--- a/TrafficCapture/testUtilities/build.gradle
+++ b/TrafficCapture/testUtilities/build.gradle
@@ -52,8 +52,6 @@ dependencies {
     testImplementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.20.0'
     testImplementation group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.20.0'
     testImplementation group: 'org.apache.logging.log4j', name: 'log4j-slf4j2-impl', version: '2.20.0'
-
-    testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter', version: '5.9.2'
 }
 
 tasks.named('test') {

--- a/TrafficCapture/testUtilities/build.gradle
+++ b/TrafficCapture/testUtilities/build.gradle
@@ -1,0 +1,61 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+
+buildscript {
+    dependencies {
+        classpath 'org.junit.platform:junit-platform-gradle-plugin:1.0.1'
+    }
+}
+
+plugins {
+    id 'org.opensearch.migrations.java-library-conventions'
+    id "com.github.spotbugs" version "4.7.3"
+    id 'checkstyle'
+    id 'org.owasp.dependencycheck' version '8.2.1'
+    id "io.freefair.lombok" version "8.0.1"
+}
+
+spotbugs {
+    includeFilter = new File(rootDir, 'config/spotbugs/spotbugs-include.xml')
+}
+
+checkstyle {
+    toolVersion = '10.9.3'
+    configFile = new File(rootDir, 'config/checkstyle/checkstyle.xml')
+    System.setProperty('checkstyle.cache.file', String.format('%s/%s',
+            buildDir, 'checkstyle.cachefile'))
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.15.0'
+    implementation group: 'com.google.guava', name: 'guava', version: '31.1-jre'
+    implementation group: 'io.netty', name: 'netty-all', version: '4.1.89.Final'
+    implementation group: 'org.apache.httpcomponents.client5', name: 'httpclient5', version: '5.2.1'
+    implementation group: 'org.bouncycastle', name: 'bcprov-jdk15on', version: '1.68'
+    implementation group: 'org.bouncycastle', name: 'bcpkix-jdk15on', version: '1.68'
+    implementation group: 'org.projectlombok', name: 'lombok', version: '1.18.22'
+    implementation group: 'org.slf4j', name: 'slf4j-api', version: '2.0.7'
+
+    testImplementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.20.0'
+    testImplementation group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.20.0'
+    testImplementation group: 'org.apache.logging.log4j', name: 'log4j-slf4j2-impl', version: '2.20.0'
+
+    testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter', version: '5.9.2'
+}
+
+tasks.named('test') {
+    useJUnitPlatform()
+}

--- a/TrafficCapture/testUtilities/src/main/java/org/opensearch/migrations/testutils/PortFinder.java
+++ b/TrafficCapture/testUtilities/src/main/java/org/opensearch/migrations/testutils/PortFinder.java
@@ -1,0 +1,36 @@
+package org.opensearch.migrations.testutils;
+
+
+import java.util.Random;
+import java.util.function.Consumer;
+
+/**
+ * Helper class to keep retrying ports against a Consumer until the
+ * Consumer doesn't throw an exception.
+ */
+public class PortFinder {
+
+    private static final int MAX_PORT_TRIES = 100;
+    private static final Random random = new Random();
+
+    public static class ExceededMaxPortAssigmentAttemptException extends Exception {}
+
+    public static int retryWithNewPortUntilNoThrow(Consumer<Integer> r)
+            throws ExceededMaxPortAssigmentAttemptException {
+        int numTries = 0;
+        while (true) {
+            try {
+                int port = (Math.abs(random.nextInt()) % (2 ^ 16 - 1025)) + 1025;
+                r.accept(Integer.valueOf(port));
+                return port;
+            } catch (Exception e) {
+                System.err.println("Exception: "+e);
+                e.printStackTrace();
+                if (++numTries <= MAX_PORT_TRIES) {
+                    throw new ExceededMaxPortAssigmentAttemptException();
+                }
+            }
+        }
+    }
+
+}

--- a/TrafficCapture/testUtilities/src/main/java/org/opensearch/migrations/testutils/SimpleHttpClientForTesting.java
+++ b/TrafficCapture/testUtilities/src/main/java/org/opensearch/migrations/testutils/SimpleHttpClientForTesting.java
@@ -1,0 +1,76 @@
+package org.opensearch.migrations.testutils;
+
+import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.client5.http.impl.io.BasicHttpClientConnectionManager;
+import org.apache.hc.client5.http.socket.ConnectionSocketFactory;
+import org.apache.hc.client5.http.socket.PlainConnectionSocketFactory;
+import org.apache.hc.client5.http.ssl.NoopHostnameVerifier;
+import org.apache.hc.client5.http.ssl.SSLConnectionSocketFactory;
+import org.apache.hc.client5.http.ssl.TrustAllStrategy;
+import org.apache.hc.core5.http.config.RegistryBuilder;
+import org.apache.hc.core5.ssl.SSLContexts;
+
+import java.io.IOException;
+import java.net.URI;
+import java.security.KeyManagementException;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * This is an HTTP client that is capable of making GET requests (developers are
+ * encouraged to extend this) to either hosts that may be using TLS with a self=signed
+ * certificate.
+ */
+public class SimpleHttpClientForTesting implements AutoCloseable {
+
+    private final CloseableHttpClient httpClient;
+
+    private static BasicHttpClientConnectionManager getInsecureTlsConnectionManager()
+            throws NoSuchAlgorithmException, KeyStoreException, KeyManagementException {
+        final var sslContext = SSLContexts.custom()
+                .loadTrustMaterial(null, new TrustAllStrategy())
+                .build();
+
+        return new BasicHttpClientConnectionManager(
+                RegistryBuilder.<ConnectionSocketFactory>create()
+                        .register("https", new SSLConnectionSocketFactory(sslContext, NoopHostnameVerifier.INSTANCE))
+                        .register("http", new PlainConnectionSocketFactory())
+                        .build()
+        );
+    }
+
+    public SimpleHttpClientForTesting() {
+        this(new BasicHttpClientConnectionManager());
+    }
+
+    public SimpleHttpClientForTesting(boolean setupInsecureTls)
+            throws NoSuchAlgorithmException, KeyStoreException, KeyManagementException {
+        this(setupInsecureTls ? getInsecureTlsConnectionManager() : new BasicHttpClientConnectionManager());
+    }
+
+    private SimpleHttpClientForTesting(BasicHttpClientConnectionManager connectionManager) {
+        httpClient = HttpClients.custom().setConnectionManager(connectionManager).build();
+    }
+
+    public SimpleHttpResponse makeGetRequest(URI endpoint, Stream<Map.Entry<String,String>> requestHeaders)
+            throws IOException {
+        var request = new HttpGet(endpoint);
+        requestHeaders.forEach(kvp->request.setHeader(kvp.getKey(), kvp.getValue()));
+        var response = httpClient.execute(request);
+        var responseBodyBytes = response.getEntity().getContent().readAllBytes();
+        return new SimpleHttpResponse(
+                Arrays.stream(response.getHeaders()).collect(Collectors.toMap(h->h.getName(), h->h.getValue())),
+                responseBodyBytes, response.getReasonPhrase(), response.getCode());
+    }
+
+    @Override
+    public void close() throws IOException {
+        httpClient.close();
+    }
+}

--- a/TrafficCapture/testUtilities/src/main/java/org/opensearch/migrations/testutils/SimpleHttpResponse.java
+++ b/TrafficCapture/testUtilities/src/main/java/org/opensearch/migrations/testutils/SimpleHttpResponse.java
@@ -1,0 +1,19 @@
+package org.opensearch.migrations.testutils;
+
+import lombok.AllArgsConstructor;
+
+import java.util.Map;
+
+/**
+ * Basic components of an HTTP response.
+ */
+@AllArgsConstructor
+public class SimpleHttpResponse {
+    /**
+     * In cases where there are duplicate names, only one value will be chosen.
+     */
+    public final Map<String, String> headers;
+    public final byte[] payloadBytes;
+    public final String statusText;
+    public final int statusCode;
+}

--- a/TrafficCapture/testUtilities/src/main/java/org/opensearch/migrations/testutils/SimpleHttpServer.java
+++ b/TrafficCapture/testUtilities/src/main/java/org/opensearch/migrations/testutils/SimpleHttpServer.java
@@ -1,0 +1,174 @@
+package org.opensearch.migrations.testutils;
+
+import com.sun.net.httpserver.HttpServer;
+import com.sun.net.httpserver.HttpsConfigurator;
+import com.sun.net.httpserver.HttpsParameters;
+import com.sun.net.httpserver.HttpsServer;
+import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
+import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.operator.ContentSigner;
+import org.bouncycastle.operator.OperatorCreationException;
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
+
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.TrustManagerFactory;
+import java.math.BigInteger;
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.KeyStore;
+import java.security.SecureRandom;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Date;
+import java.util.function.Function;
+
+/**
+ * This class brings up an HTTP(s) server with its constructor that returns responses
+ * based upon a simple Function that is passed to the constructor.  This class can support
+ * TLS, but only with an auto-generated self-signed cert.
+ */
+public class SimpleHttpServer implements AutoCloseable {
+
+    public static final String LOCALHOST = "localhost";
+    public static final char[] KEYSTORE_PASSWORD = "".toCharArray();
+    protected final HttpServer httpServer;
+    private final boolean useTls;
+
+    public static class HttpFirstLine {
+        public final String verb;
+        public final URI path;
+        public final String version;
+
+        public HttpFirstLine(String verb, URI path, String version) {
+            this.verb = verb;
+            this.path = path;
+            this.version = version;
+        }
+    }
+
+    private static KeyStore buildKeyStoreForTesting() throws Exception {
+        var kpg = KeyPairGenerator.getInstance("RSA");
+        kpg.initialize(2048);
+        KeyPair keyPair = kpg.generateKeyPair();
+
+        KeyStore keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
+        keyStore.load(null, null); // don't load from file, load a new key on the next line
+        keyStore.setKeyEntry("selfsignedtestcert", keyPair.getPrivate(), KEYSTORE_PASSWORD,
+                new X509Certificate[]{generateSelfSignedCertificate(keyPair)});
+        return keyStore;
+    }
+
+    private static X509Certificate generateSelfSignedCertificate(KeyPair keyPair) throws OperatorCreationException, CertificateException {
+        var startValidityInstant = Instant.now();
+        var validityEndDate = Date.from(startValidityInstant.plus(Duration.ofHours(1)));
+        var validityStartDate = Date.from(startValidityInstant);
+
+        ContentSigner signer = new JcaContentSignerBuilder("SHA256WithRSA")
+                .setProvider(new BouncyCastleProvider())
+                .build(keyPair.getPrivate());
+        var certBuilder = new JcaX509v3CertificateBuilder(
+                new X500Name("CN=localhost"), // use your domain here
+                new BigInteger(64, new SecureRandom()),
+                validityStartDate,
+                validityEndDate,
+                new X500Name("CN=localhost"), // use your domain here
+                keyPair.getPublic()
+        );
+
+        return new JcaX509CertificateConverter().getCertificate(certBuilder.build(signer));
+    }
+
+    private static HttpsServer createSecureServer(InetSocketAddress address)
+            throws Exception {
+        var httpsServer = HttpsServer.create(address, 0);
+        SSLContext sslContext = SSLContext.getInstance("TLS");
+
+        KeyStore ks = buildKeyStoreForTesting();
+        //ks.load(fis, KEYSTORE_PASSWORD);
+
+        var kmf = KeyManagerFactory.getInstance("SunX509");
+        kmf.init(ks, KEYSTORE_PASSWORD);
+
+        var tmf = TrustManagerFactory.getInstance("SunX509");
+        tmf.init(ks);
+
+        sslContext.init(kmf.getKeyManagers(), tmf.getTrustManagers(), null);
+        httpsServer.setHttpsConfigurator(new HttpsConfigurator(sslContext) {
+            public void configure(HttpsParameters params) {
+                try {
+                    SSLContext c = getSSLContext();
+                    SSLEngine engine = c.createSSLEngine();
+                    params.setNeedClientAuth(false);
+                    params.setCipherSuites(engine.getEnabledCipherSuites());
+                    params.setProtocols(engine.getEnabledProtocols());
+
+                    var defaultSSLParameters = c.getDefaultSSLParameters();
+                    params.setSSLParameters(defaultSSLParameters);
+                } catch (Exception ex) {
+                    ex.printStackTrace();
+                    System.out.println("Failed to create HTTPS port");
+                }
+            }
+        });
+
+        return httpsServer;
+    }
+
+    /**
+     * @param port
+     * @return the port upon successfully binding the server
+     */
+    public SimpleHttpServer(
+            boolean useTls, int port,
+            Function<HttpFirstLine, SimpleHttpResponse> uriToContentMapper) throws Exception {
+        var addr = new InetSocketAddress(LOCALHOST, port);
+        this.useTls = useTls;
+        httpServer = useTls ? createSecureServer(addr) :
+                HttpServer.create(addr, 0);
+        httpServer.createContext("/", httpExchange -> {
+            var requestToMatch =
+                    new HttpFirstLine(httpExchange.getRequestMethod(),
+                            httpExchange.getRequestURI(),
+                            httpExchange.getProtocol());
+            var headersAndPayload = uriToContentMapper.apply(requestToMatch);
+            var responseHeaders = httpExchange.getResponseHeaders();
+            for (var kvp : headersAndPayload.headers.entrySet()) {
+                responseHeaders.set(kvp.getKey(), kvp.getValue());
+            }
+
+            httpExchange.sendResponseHeaders(200, 0);
+            httpExchange.getResponseBody().write(headersAndPayload.payloadBytes);
+            httpExchange.getResponseBody().flush();
+            httpExchange.getResponseBody().close();
+            httpExchange.close();
+        });
+        httpServer.start();
+    }
+
+    public int port() {
+        return httpServer.getAddress().getPort();
+    }
+
+    public URI localhostEndpoint() {
+        try {
+            return new URI((useTls ? "https" : "http"),
+                    null,LOCALHOST,port(),"/",null, null);
+        } catch (URISyntaxException e) {
+            throw new RuntimeException("Error building URI", e);
+        }
+    }
+
+    @Override
+    public void close() throws Exception {
+        httpServer.stop(0);
+    }
+}

--- a/TrafficCapture/trafficCaptureProxyServer/build.gradle
+++ b/TrafficCapture/trafficCaptureProxyServer/build.gradle
@@ -39,10 +39,8 @@ dependencies {
     implementation 'com.google.protobuf:protobuf-java:3.22.2'
 
     testImplementation project(':captureProtobufs')
-    testImplementation 'com.google.protobuf:protobuf-java:3.22.2'
-
+    testImplementation project(path: ':testUtilities')
     testImplementation 'org.junit.jupiter:junit-jupiter:5.9.2'
-    testImplementation "com.google.protobuf:protobuf-java:3.22.2"
 }
 
 tasks.withType(Tar){

--- a/TrafficCapture/trafficCaptureProxyServer/build.gradle
+++ b/TrafficCapture/trafficCaptureProxyServer/build.gradle
@@ -40,7 +40,6 @@ dependencies {
 
     testImplementation project(':captureProtobufs')
     testImplementation project(path: ':testUtilities')
-    testImplementation 'org.junit.jupiter:junit-jupiter:5.9.2'
 }
 
 tasks.withType(Tar){

--- a/TrafficCapture/trafficCaptureProxyServer/src/test/java/org/opensearch/migrations/trafficcapture/proxyserver/netty/NettyScanningHttpProxyTest.java
+++ b/TrafficCapture/trafficCaptureProxyServer/src/test/java/org/opensearch/migrations/trafficcapture/proxyserver/netty/NettyScanningHttpProxyTest.java
@@ -1,38 +1,32 @@
 package org.opensearch.migrations.trafficcapture.proxyserver.netty;
 
 import com.google.protobuf.InvalidProtocolBufferException;
-import com.sun.net.httpserver.HttpExchange;
-import com.sun.net.httpserver.HttpHandler;
-import com.sun.net.httpserver.HttpServer;
-import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.http.ProtocolVersion;
 import org.apache.http.client.methods.HttpGet;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClientBuilder;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 import org.opensearch.common.collect.Tuple;
+import org.opensearch.migrations.testutils.PortFinder;
+import org.opensearch.migrations.testutils.SimpleHttpClientForTesting;
+import org.opensearch.migrations.testutils.SimpleHttpResponse;
+import org.opensearch.migrations.testutils.SimpleHttpServer;
 import org.opensearch.migrations.trafficcapture.IConnectionCaptureFactory;
 import org.opensearch.migrations.trafficcapture.InMemoryConnectionCaptureFactory;
 import org.opensearch.migrations.trafficcapture.protos.TrafficStream;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.net.InetSocketAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Random;
+import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.Consumer;
 import java.util.stream.IntStream;
-
-import static java.lang.Math.abs;
 
 @Slf4j
 class NettyScanningHttpProxyTest {
@@ -61,8 +55,8 @@ class NettyScanningHttpProxyTest {
             "DumbAndLongHeaderValue-17: 17\r\n" +
             "DumbAndLongHeaderValue-18: 18\r\n" +
             "DumbAndLongHeaderValue-19: 19\r\n" +
-            "Connection: Keep-Alive\r\n" +
-            "Accept-Encoding: gzip,deflate\r\n" +
+            "Accept-Encoding: gzip, x-gzip, deflate\r\n" +
+            "Connection: keep-alive\r\n" +
             "\r\n";
     private final static String EXPECTED_RESPONSE_STRING =
             "HTTP/1.1 200 OK\r\n" +
@@ -78,29 +72,15 @@ class NettyScanningHttpProxyTest {
                     "0\r\n" +
                     "\r\n";
 
-    private static final int MAX_PORT_TRIES = 100;
-    private static final Random random = new Random();
-    public static final String LOCALHOST = "localhost";
     public static final String UPSTREAM_SERVER_RESPONSE_BODY = "Hello tester!\n";
     public static final String TEST_NODE_ID_STRING = "test_node_id";
 
-    private static int retryWithNewPortUntilNoThrow(Consumer<Integer> r) {
-        int numTries = 0;
-        while (true) {
-            try {
-                int port = (abs(random.nextInt()) % (2 ^ 16 - 1025)) + 1025;
-                r.accept(Integer.valueOf(port));
-                return port;
-            } catch (Exception e) {
-                System.err.println("Exception: "+e);
-                e.printStackTrace();
-                Assumptions.assumeTrue(++numTries <= MAX_PORT_TRIES);
-            }
-        }
-    }
-
     @Test
-    public void testRoundTrip() throws IOException, InterruptedException {
+    public void testRoundTrip() throws
+            IOException,
+            InterruptedException,
+            PortFinder.ExceededMaxPortAssigmentAttemptException
+    {
         final int NUM_EXPECTED_TRAFFIC_STREAMS = 1;
         final int NUM_INTERACTIONS = 3;
         CountDownLatch interactionsCapturedCountdown = new CountDownLatch(NUM_EXPECTED_TRAFFIC_STREAMS);
@@ -108,7 +88,7 @@ class NettyScanningHttpProxyTest {
                 () -> interactionsCapturedCountdown.countDown());
         var servers = startServers(captureFactory);
 
-        try (var client = HttpClientBuilder.create().build()) {
+        try (var client = new SimpleHttpClientForTesting()) {
             var nettyEndpoint = URI.create("http://localhost:" + servers.v1().getProxyPort() + "/");
             for (int i=0; i<NUM_INTERACTIONS; ++i) {
                 var responseBody = makeTestRequestViaClient(client, nettyEndpoint);
@@ -152,7 +132,7 @@ class NettyScanningHttpProxyTest {
             Assertions.assertTrue(observations.get(eomIndex+1).hasWrite());
             var eom = observations.get(eomIndex).getEndOfMessageIndicator();
             Assertions.assertEquals(14, eom.getFirstLineByteLength());
-            Assertions.assertEquals(646, eom.getHeadersByteLength());
+            Assertions.assertEquals(655, eom.getHeadersByteLength());
         }
     }
 
@@ -184,34 +164,38 @@ class NettyScanningHttpProxyTest {
         return rval;
     }
 
-    private static String makeTestRequestViaClient(CloseableHttpClient client, URI nettyEndpoint) throws IOException {
-        String responseBody;
-        var request = new HttpGet(nettyEndpoint);
-        request.setProtocolVersion(new ProtocolVersion("HTTP", 1, 1));
-        request.setHeader("Host", "localhost");
-        request.setHeader("User-Agent", "UnitTest");
+    private static String makeTestRequestViaClient(SimpleHttpClientForTesting client, URI endpoint) throws IOException {
+        var allHeaders = new LinkedHashMap<String,String>();
+        allHeaders.put("Host", "localhost");
+        allHeaders.put("User-Agent", "UnitTest");
         for (int i = 0; i < 20; i++) {
-            request.setHeader("DumbAndLongHeaderValue-" + i, "" + i);
+            allHeaders.put("DumbAndLongHeaderValue-" + i, "" + i);
         }
-        var response = client.execute(request);
-        responseBody = new String(response.getEntity().getContent().readAllBytes());
+        var response = client.makeGetRequest(endpoint, allHeaders.entrySet().stream());
+        var responseBody = new String(response.payloadBytes);
         return responseBody;
     }
 
-    private static Tuple<NettyScanningHttpProxy, HttpServer>
-    startServers(IConnectionCaptureFactory connectionCaptureFactory) throws InterruptedException {
-        AtomicReference<NettyScanningHttpProxy> nshp = new AtomicReference<>();
-        AtomicReference<HttpServer> upstreamTestServer = new AtomicReference<>();
-        retryWithNewPortUntilNoThrow(port -> {
-            upstreamTestServer.set(createAndStartTestServer(port.intValue()));
+    private static Tuple<NettyScanningHttpProxy, Integer>
+    startServers(IConnectionCaptureFactory connectionCaptureFactory) throws
+            PortFinder.ExceededMaxPortAssigmentAttemptException
+    {
+        var nshp = new AtomicReference<NettyScanningHttpProxy>();
+        var upstreamTestServer = new AtomicReference<SimpleHttpServer>();
+        PortFinder.retryWithNewPortUntilNoThrow(port -> {
+            try {
+                upstreamTestServer.set(new SimpleHttpServer(false, port.intValue(),
+                        NettyScanningHttpProxyTest::makeContext));
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
         });
-        var underlyingPort = upstreamTestServer.get().getAddress().getPort();
-        System.out.println("underlying port = "+underlyingPort);
+        var underlyingPort = upstreamTestServer.get().port();
 
-        retryWithNewPortUntilNoThrow(port -> {
+        PortFinder.retryWithNewPortUntilNoThrow(port -> {
             nshp.set(new NettyScanningHttpProxy(port.intValue()));
             try {
-                URI testServerUri = new URI("http", null, LOCALHOST, upstreamTestServer.get().getAddress().getPort(),
+                URI testServerUri = new URI("http", null, SimpleHttpServer.LOCALHOST, underlyingPort,
                     null, null, null);
                 nshp.get().start(testServerUri,null, null, connectionCaptureFactory);
                 System.out.println("proxy port = "+port.intValue());
@@ -219,30 +203,15 @@ class NettyScanningHttpProxyTest {
                 throw new RuntimeException(e);
             }
         });
-        return new Tuple<>(nshp.get(), upstreamTestServer.get());
+        return new Tuple<>(nshp.get(), underlyingPort);
     }
 
-    @SneakyThrows
-    private static HttpServer createAndStartTestServer(int port) {
-        HttpServer server = HttpServer.create(new InetSocketAddress(LOCALHOST, port), 0);
-        server.createContext("/", new HttpHandler() {
-            @Override
-            public void handle(HttpExchange httpExchange) throws IOException {
-                var headers = httpExchange.getResponseHeaders();
-                headers.set("Content-Type", "text/plain");
-                headers.set("Funtime", "checkIt!");
-                headers.set("Content-Transfer-Encoding", "chunked");
-                httpExchange.sendResponseHeaders(200, 0);
-                var response = UPSTREAM_SERVER_RESPONSE_BODY;
-                for (int i=0; i<1; ++i) {
-                    httpExchange.getResponseBody().write(response.getBytes());
-                    httpExchange.getResponseBody().flush();
-                }
-                httpExchange.getResponseBody().close();
-                httpExchange.close();
-            }
-        });
-        server.start();
-        return server;
+    private static SimpleHttpResponse makeContext(SimpleHttpServer.HttpFirstLine request) {
+        var headers = Map.of(
+        "Content-Type", "text/plain",
+        "Funtime", "checkIt!",
+        "Content-Transfer-Encoding", "chunked");
+        var payloadBytes = UPSTREAM_SERVER_RESPONSE_BODY.getBytes(StandardCharsets.UTF_8);
+        return new SimpleHttpResponse(headers, payloadBytes, "OK", 200);
     }
 }

--- a/TrafficCapture/trafficReplayer/build.gradle
+++ b/TrafficCapture/trafficReplayer/build.gradle
@@ -17,8 +17,7 @@ buildscript {
 }
 
 plugins {
-    id 'java'
-    id 'application'
+    id 'org.opensearch.migrations.java-application-conventions'
     id "com.github.spotbugs" version "4.7.3"
 //    id 'checkstyle'
     id 'org.owasp.dependencycheck' version '8.2.1'
@@ -61,7 +60,6 @@ dependencies {
 
     testImplementation project(':testUtilities')
     testImplementation group: 'org.apache.httpcomponents.client5', name: 'httpclient5', version: '5.2.1'
-    testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter', version: '5.9.2'
 }
 
 application {

--- a/TrafficCapture/trafficReplayer/build.gradle
+++ b/TrafficCapture/trafficReplayer/build.gradle
@@ -59,6 +59,8 @@ dependencies {
     implementation group: 'org.slf4j', name: 'slf4j-api', version: '2.0.7'
     implementation group: 'software.amazon.msk', name: 'aws-msk-iam-auth', version: '1.1.7'
 
+    testImplementation project(':testUtilities')
+    testImplementation group: 'org.apache.httpcomponents.client5', name: 'httpclient5', version: '5.2.1'
     testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter', version: '5.9.2'
 }
 

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/AggregatedRawResponse.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/AggregatedRawResponse.java
@@ -9,6 +9,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.AbstractMap;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.stream.Stream;
 
 @Slf4j
@@ -21,6 +22,13 @@ public class AggregatedRawResponse implements Serializable {
 
     public static Builder builder(Instant i) {
         return new Builder(i);
+    }
+
+    public byte[][] getCopyOfPackets() {
+            return responsePackets.stream()
+                    .map(kvp->kvp.getValue())
+                    .map(x->Arrays.copyOf(x,x.length))
+                    .toArray(byte[][]::new);
     }
 
     public static class Builder {

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/NettyPacketToHttpConsumer.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/NettyPacketToHttpConsumer.java
@@ -85,7 +85,7 @@ public class NettyPacketToHttpConsumer implements IPacketFinalizingConsumer<Aggr
         responseBuilder = AggregatedRawResponse.builder(Instant.now());
         b.group(eventLoopGroup)
                 .channel(NioSocketChannel.class)
-                .handler(new BacksideSnifferHandler(responseBuilder))
+                .handler(new ChannelDuplexHandler())
                 .option(ChannelOption.AUTO_READ, false);
         String host = serverUri.getHost();
         int port = serverUri.getPort();
@@ -133,6 +133,7 @@ public class NettyPacketToHttpConsumer implements IPacketFinalizingConsumer<Aggr
     }
 
     private void addHttpTransactionHandlersToPipeline(ChannelPipeline pipeline) {
+        pipeline.addLast(new BacksideSnifferHandler(responseBuilder));
         pipeline.addLast(new HttpResponseDecoder());
         // TODO - switch this out to use less memory.
         // We only need to know when the response has been fully received, not the contents

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/netty/BacksideSnifferHandler.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/netty/BacksideSnifferHandler.java
@@ -3,9 +3,10 @@ package org.opensearch.migrations.replay.netty;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelDuplexHandler;
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
 import org.opensearch.migrations.replay.AggregatedRawResponse;
 
-public class BacksideSnifferHandler extends ChannelDuplexHandler {
+public class BacksideSnifferHandler extends ChannelInboundHandlerAdapter {
 
     private final AggregatedRawResponse.Builder aggregatedRawResponseBuilder;
 

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/datahandlers/NettyPacketToHttpConsumerTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/datahandlers/NettyPacketToHttpConsumerTest.java
@@ -1,0 +1,123 @@
+package org.opensearch.migrations.replay.datahandlers;
+
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.handler.ssl.SslContextBuilder;
+import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.opensearch.migrations.testutils.PortFinder;
+import org.opensearch.migrations.testutils.SimpleHttpResponse;
+import org.opensearch.migrations.testutils.SimpleHttpClientForTesting;
+import org.opensearch.migrations.testutils.SimpleHttpServer;
+
+import javax.net.ssl.SSLException;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.security.KeyManagementException;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+
+class NettyPacketToHttpConsumerTest {
+    public static final String SERVER_RESPONSE_BODY = "I should be decrypted tester!\n";
+
+
+    private final static String EXPECTED_REQUEST_STRING =
+            "GET / HTTP/1.1\r\n" +
+                    "Host: localhost\r\n" +
+                    "User-Agent: UnitTest\r\n" +
+                    "Connection: Keep-Alive\r\n" +
+                    "\r\n";
+    private final static String EXPECTED_RESPONSE_STRING =
+            "HTTP/1.1 200 OK\r\n" +
+                    "Content-transfer-encoding: chunked\r\n" +
+                    "Date: Thu, 08 Jun 2023 23:06:23 GMT\r\n" + // This should be OK since it's always the same length
+                    "Transfer-encoding: chunked\r\n" +
+                    "Content-type: text/plain\r\n" +
+                    "Funtime: checkIt!\r\n" +
+                    "\r\n" +
+                    "1e\r\n" +
+                    "I should be decrypted tester!\n" +
+                    "\r\n" +
+                    "0\r\n" +
+                    "\r\n";
+
+
+    private static SimpleHttpServer testServer;
+
+    @BeforeAll
+    public static void setupTestServer() throws PortFinder.ExceededMaxPortAssigmentAttemptException {
+        var testServerRef = new AtomicReference<SimpleHttpServer>();
+        PortFinder.retryWithNewPortUntilNoThrow(port -> {
+            try {
+                testServerRef.set(new SimpleHttpServer(true, port.intValue(),
+                        NettyPacketToHttpConsumerTest::makeContext));
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        });
+        testServer = testServerRef.get();
+    }
+
+    @AfterAll
+    public static void tearDownTestServer() throws Exception {
+        testServer.close();
+    }
+
+    @Test
+    public void testThatTestSetupIsCorrect()
+            throws IOException, NoSuchAlgorithmException, KeyStoreException, KeyManagementException
+    {
+        //Thread.sleep(120000);
+        try (var client = new SimpleHttpClientForTesting(true)) {
+            var endpoint = URI.create("https://localhost:" + testServer.port() + "/");
+            var response = makeTestRequestViaClient(client, endpoint);
+            Assertions.assertEquals(SERVER_RESPONSE_BODY, new String(response.payloadBytes, StandardCharsets.UTF_8));
+        }
+    }
+
+    private SimpleHttpResponse makeTestRequestViaClient(SimpleHttpClientForTesting client, URI endpoint)
+            throws IOException {
+        return client.makeGetRequest(endpoint,
+                Map.of("Host", "localhost",
+        "User-Agent", "UnitTest").entrySet().stream());
+    }
+
+    private static SimpleHttpResponse makeContext(SimpleHttpServer.HttpFirstLine request) {
+        var headers = Map.of(
+                "Content-Type", "text/plain",
+                "Funtime", "checkIt!",
+                "Content-Transfer-Encoding", "chunked");
+        var payloadBytes = SERVER_RESPONSE_BODY.getBytes(StandardCharsets.UTF_8);
+        return new SimpleHttpResponse(headers, payloadBytes, "OK", 200);
+    }
+
+    @Test
+    public void testHttpResponseIsASuccessfullyCaptured()
+            throws SSLException, ExecutionException, InterruptedException
+    {
+        var sslContextBuilder = SslContextBuilder.forClient().trustManager(InsecureTrustManagerFactory.INSTANCE);
+        var nphc = new NettyPacketToHttpConsumer(new NioEventLoopGroup(),
+                testServer.localhostEndpoint(), sslContextBuilder.build(),"unitTest");
+        nphc.consumeBytes(EXPECTED_REQUEST_STRING.getBytes(StandardCharsets.UTF_8));
+        var aggregatedResponse = nphc.finalizeRequest().get();
+        var responseBytePackets = aggregatedResponse.getCopyOfPackets();
+        var responseAsString = Arrays.stream(responseBytePackets)
+                .map(bytes->new String(bytes,StandardCharsets.UTF_8))
+                .collect(Collectors.joining());
+        Assertions.assertEquals(normalizeMessage(EXPECTED_RESPONSE_STRING),
+                normalizeMessage(responseAsString));
+    }
+
+    private static String normalizeMessage(String s) {
+        return s.replaceAll("Date: .*", "Date: SOMETHING");
+    }
+
+}

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/datahandlers/NettyPacketToHttpConsumerTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/datahandlers/NettyPacketToHttpConsumerTest.java
@@ -100,7 +100,7 @@ class NettyPacketToHttpConsumerTest {
     }
 
     @Test
-    public void testHttpResponseIsASuccessfullyCaptured()
+    public void testHttpResponseIsSuccessfullyCaptured()
             throws SSLException, ExecutionException, InterruptedException
     {
         var sslContextBuilder = SslContextBuilder.forClient().trustManager(InsecureTrustManagerFactory.INSTANCE);


### PR DESCRIPTION
The fix itself to NettyPacketToHttpConsumer is trivial.  I've spent more efforts on getting a unit test setup to be able to do more live testing with TLS. I've intentionally used client and server implementations different from netty since the real world will have clients that aren't just netty.

### Description
* **Category**: Bug fix
* **Why these changes are required**?  We were capturing encrypted responses rather than plaintext ones, making it impossible to compare them or reason with them in any way.
* **What is the old behavior before changes and new behavior after changes?** 
 - Before: all response packets were encrypted when the target server was using TLS
 - Now: response pieces are first decrypted before being added to the packet responess.

### Issues Resolved
MIGRATIONS-1268

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
Unit test

### Check List
- [x] New functionality includes testing
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
