### PR TITLE
Fix misordered traffic streams

### DIFF
--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/Accumulation.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/Accumulation.java
@@ -1,13 +1,8 @@
 package org.opensearch.migrations.replay;
 
-import lombok.Getter;
-import org.opensearch.migrations.replay.util.OnlineRadixSorter;
 import org.opensearch.migrations.replay.util.OnlineRadixSorterForIntegratedKeys;
 import org.opensearch.migrations.trafficcapture.protos.TrafficStream;
 
-import java.util.ArrayDeque;
-import java.util.Deque;
-import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/Accumulation.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/Accumulation.java
@@ -1,7 +1,16 @@
 package org.opensearch.migrations.replay;
 
+import lombok.Getter;
+import org.opensearch.migrations.replay.util.OnlineRadixSorter;
+import org.opensearch.migrations.replay.util.OnlineRadixSorterForIntegratedKeys;
+import org.opensearch.migrations.trafficcapture.protos.TrafficStream;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Consumer;
 
 public class Accumulation {
 
@@ -11,6 +20,8 @@ public class Accumulation {
         RESPONSE_SENT
     }
 
+    OnlineRadixSorterForIntegratedKeys<TrafficStream> trafficStreamsSorter;
+
     RequestResponsePacketPair rrPair;
     AtomicLong newestPacketTimestampInMillis;
 
@@ -18,8 +29,14 @@ public class Accumulation {
     AtomicInteger numberOfResets;
 
     public Accumulation(String connectionId) {
+        trafficStreamsSorter = new OnlineRadixSorterForIntegratedKeys<>(1,
+                ts->ts.hasNumber() ? ts.getNumber() : ts.getNumberOfThisLastChunk());
         numberOfResets = new AtomicInteger();
         this.resetForRequest(new UniqueRequestKey(connectionId, 0));
+    }
+
+    void sequenceTrafficStream(TrafficStream ts, Consumer<TrafficStream> sortedVisitor) {
+        trafficStreamsSorter.add(ts, sortedVisitor);
     }
 
     public UniqueRequestKey getRequestId() {

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/CapturedTrafficToHttpTransactionAccumulator.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/CapturedTrafficToHttpTransactionAccumulator.java
@@ -89,7 +89,7 @@ public class CapturedTrafficToHttpTransactionAccumulator {
     }
 
     public void accept(TrafficStream yetToBeSequencedTrafficStream) {
-        log.warn("Got trafficStream: " + summarizeTrafficStream(yetToBeSequencedTrafficStream));
+        log.trace("Got trafficStream: " + summarizeTrafficStream(yetToBeSequencedTrafficStream));
         var accum = liveStreams.getOrCreateWithoutExpiration(
                 yetToBeSequencedTrafficStream.getNodeId(),
                 yetToBeSequencedTrafficStream.getConnectionId());
@@ -148,7 +148,6 @@ public class CapturedTrafficToHttpTransactionAccumulator {
                 throw new RuntimeException("Got an end of segment indicator, but no segments are in progress");
             }
         } else if (observation.hasConnectionException()) {
-            // the following line means that
             rotateAccumulationIfNecessary(connectionId, accum);
             closedConnectionCounter.incrementAndGet();
             accum.resetForNextRequest();

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/TrafficReplayer.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/TrafficReplayer.java
@@ -432,9 +432,6 @@ public class TrafficReplayer {
     public void runReplay(Stream<TrafficStream> trafficChunkStream,
                           CapturedTrafficToHttpTransactionAccumulator trafficToHttpTransactionAccumulator) {
         trafficChunkStream
-                .forEach(ts-> ts.getSubStreamList().stream()
-                        .forEach(o ->
-                                trafficToHttpTransactionAccumulator.accept(ts.getNodeId(), ts.getConnectionId(), o))
-                );
+                .forEach(ts-> trafficToHttpTransactionAccumulator.accept(ts));
     }
 }

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/util/OnlineRadixSorter.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/util/OnlineRadixSorter.java
@@ -1,0 +1,61 @@
+package org.opensearch.migrations.replay.util;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.ToIntFunction;
+import java.util.stream.Stream;
+
+/**
+ * This provides a simple implementation to sort incoming elements that are ordered by a sequence
+ * of unique and contiguous integers.  This implementation uses an ArrayList for staging out of order
+ * elements and the memory utilization will be O(total number of items to be sequenced).
+ *
+ * After the item has been added, all the next currently sequenced items are passed to the Consumer
+ * that was provided to add().  This allows the calling context to visit the items in the natural
+ * order as opposed to the order that items were added.  This class maintains a cursor of the last
+ * item that was sent so that items are only visited once and so that the class knows which item is
+ * the next item in the sequence.
+ *
+ * As items are visited, the object will drop its reference to the item, but no efforts are made to
+ * free its own storage.  The assumption is that this class will be used for small, short-lived
+ * data sets. or in cases where the worst-case performance (needing to hold space for all the items)
+ * would be common.
+ *
+ * @param <T>
+ */
+public class OnlineRadixSorter<T> {
+    ArrayList<T> items;
+    int currentOffset;
+
+    public OnlineRadixSorter(int startingOffset) {
+        items = new ArrayList<>();
+        currentOffset = startingOffset;
+    }
+
+    public void add(int index, T item, Consumer<T> sortedItemVisitor) {
+        if (currentOffset == index) {
+            ++currentOffset;
+            sortedItemVisitor.accept(item);
+            while (currentOffset < items.size()) {
+                var nextItem = items.get(currentOffset);
+                if (nextItem != null) {
+                    items.set(currentOffset, null);
+                    ++currentOffset;
+                    sortedItemVisitor.accept(nextItem);
+                } else {
+                    break;
+                }
+            }
+        } else {
+            while (index >= items.size()) {
+                items.add(null);
+            }
+            items.set(index, item);
+        }
+    }
+}

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/util/OnlineRadixSorterForIntegratedKeys.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/util/OnlineRadixSorterForIntegratedKeys.java
@@ -1,0 +1,32 @@
+package org.opensearch.migrations.replay.util;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.ToIntFunction;
+import java.util.stream.Stream;
+
+/**
+ * This class is a convenience wrapper for OnlineRadixSorter where the items will intrinsically
+ * contain their own sorting keys, which are resolved by a helper function that is passed to
+ * the constructor.
+ *
+ * @param <T>
+ */
+public class OnlineRadixSorterForIntegratedKeys<T> extends OnlineRadixSorter<T> {
+
+        ToIntFunction<T> radixResolver;
+
+        public OnlineRadixSorterForIntegratedKeys(int startingOffset, ToIntFunction<T> radixResolver) {
+            super(startingOffset);
+            this.radixResolver = radixResolver;
+        }
+
+        public void add(T item, Consumer<T> sortedItemVisitor) {
+            super.add(radixResolver.applyAsInt(item), item, sortedItemVisitor);
+        }
+    }

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/util/OnlineRadixSorterForIntegratedKeys.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/util/OnlineRadixSorterForIntegratedKeys.java
@@ -19,14 +19,14 @@ import java.util.stream.Stream;
  */
 public class OnlineRadixSorterForIntegratedKeys<T> extends OnlineRadixSorter<T> {
 
-        ToIntFunction<T> radixResolver;
+    ToIntFunction<T> radixResolver;
 
-        public OnlineRadixSorterForIntegratedKeys(int startingOffset, ToIntFunction<T> radixResolver) {
-            super(startingOffset);
-            this.radixResolver = radixResolver;
-        }
-
-        public void add(T item, Consumer<T> sortedItemVisitor) {
-            super.add(radixResolver.applyAsInt(item), item, sortedItemVisitor);
-        }
+    public OnlineRadixSorterForIntegratedKeys(int startingOffset, ToIntFunction<T> radixResolver) {
+        super(startingOffset);
+        this.radixResolver = radixResolver;
     }
+
+    public void add(T item, Consumer<T> sortedItemVisitor) {
+        super.add(radixResolver.applyAsInt(item), item, sortedItemVisitor);
+    }
+}

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/ExpiringTrafficStreamMapSequentialTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/ExpiringTrafficStreamMapSequentialTest.java
@@ -32,7 +32,10 @@ class ExpiringTrafficStreamMapSequentialTest {
         var expiredCountsPerLoop = new ArrayList<Integer>();
         for (int i=0; i<expectedExpirationCounts.length; ++i) {
             var ts = Instant.ofEpochSecond(i+1);
-            createdAccumulations.add(expiringMap.getOrCreate(TEST_NODE_ID_STRING, connectionGenerator.apply(i), ts));
+            var accumulation = expiringMap.getOrCreateWithoutExpiration(TEST_NODE_ID_STRING,
+                    connectionGenerator.apply(i));
+            createdAccumulations.add(accumulation);
+            expiringMap.expireOldEntries(TEST_NODE_ID_STRING, connectionGenerator.apply(i), accumulation, ts);
             createdAccumulations.get(i).rrPair.addResponseData(ts, ("Add"+i).getBytes(StandardCharsets.UTF_8));
             expiredCountsPerLoop.add(expiredAccumulations.size());
         }

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/ExpiringTrafficStreamMapUnorderedTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/ExpiringTrafficStreamMapUnorderedTest.java
@@ -34,7 +34,9 @@ class ExpiringTrafficStreamMapUnorderedTest {
         var expiredCountsPerLoop = new ArrayList<Integer>();
         for (int i=0; i<expectedExpirationCounts.length; ++i) {
             var ts = Instant.ofEpochSecond(timestamps[i]);
-            var accumulation = expiringMap.getOrCreate(TEST_NODE_ID_STRING, connectionGenerator.apply(i), ts);
+            var accumulation =
+                    expiringMap.getOrCreateWithoutExpiration(TEST_NODE_ID_STRING, connectionGenerator.apply(i));
+            expiringMap.expireOldEntries(TEST_NODE_ID_STRING, connectionGenerator.apply(i), accumulation, ts);
             createdAccumulations.add(accumulation);
             if (accumulation != null) {
                 accumulation.rrPair.addResponseData(ts, ("Add" + i).getBytes(StandardCharsets.UTF_8));

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/util/OnlineRadixSorterTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/util/OnlineRadixSorterTest.java
@@ -1,0 +1,42 @@
+package org.opensearch.migrations.replay.util;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class OnlineRadixSorterTest {
+
+    private static String stringify(Stream<Integer> stream) {
+        return stream.map(i->i.toString()).collect(Collectors.joining(","));
+    }
+
+    private static String add(OnlineRadixSorterForIntegratedKeys<Integer> sorter, int v) {
+        var sortedItems = new ArrayList<Integer>();
+        sorter.add(Integer.valueOf(v), i->sortedItems.add(i));
+        return sortedItems.stream().map(i->i.toString()).collect(Collectors.joining(","));
+    }
+
+    @Test
+    void testOnlineRadixSorter_inOrder() {
+        var radixSorter = new OnlineRadixSorterForIntegratedKeys(1, i -> (int) i);
+        Assertions.assertEquals("1", add(radixSorter,1));
+        Assertions.assertEquals("2", add(radixSorter, 2));
+        Assertions.assertEquals("3", add(radixSorter, 3));
+    }
+
+    @Test
+    void testOnlineRadixSorter_outOfOrder() {
+        var radixSorter = new OnlineRadixSorterForIntegratedKeys(1, i->(int) i);
+        Assertions.assertEquals("", add(radixSorter, 3));
+        Assertions.assertEquals("", add(radixSorter, 4));
+        Assertions.assertEquals("1", add(radixSorter, 1));
+        Assertions.assertEquals("2,3,4", add(radixSorter, 2));
+        Assertions.assertEquals("5", add(radixSorter, 5));
+        Assertions.assertEquals("", add(radixSorter, 7));
+    }
+}

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/util/OnlineRadixSorterTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/util/OnlineRadixSorterTest.java
@@ -7,8 +7,6 @@ import java.util.ArrayList;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static org.junit.jupiter.api.Assertions.*;
-
 class OnlineRadixSorterTest {
 
     private static String stringify(Stream<Integer> stream) {
@@ -17,8 +15,8 @@ class OnlineRadixSorterTest {
 
     private static String add(OnlineRadixSorterForIntegratedKeys<Integer> sorter, int v) {
         var sortedItems = new ArrayList<Integer>();
-        sorter.add(Integer.valueOf(v), i->sortedItems.add(i));
-        return sortedItems.stream().map(i->i.toString()).collect(Collectors.joining(","));
+        sorter.add(v, i->sortedItems.add(i));
+        return stringify(sortedItems.stream());
     }
 
     @Test


### PR DESCRIPTION
### Description

* **Category** Enhancement / Bug fix
* **Why these changes are required**? The capture proxy makes no guarantee that the Kafka Records containing TrafficStream objects will be sequenced correctly.
* **What is the old behavior before changes and new behavior after changes**?  Misordered TrafficStream objects would cause undefined behavior.  Now the system should be resilient to TrafficStream objects being reordered.

From the commit message:

Introduce a new class (OnlineRadixSorter) that takes a sequence of indexed objects and then visits the current contiguous monotonic sequence from the first item that had yet to be visited.  The javadoc has examples.  This is used because the TrafficStream sequences may arrive in the observed order.  

The CapturedTrafficToHttpTransactionAccumulator now accepts potentially unordered TrafficStream objects by first passing those objects through an OnlnieRadixSorter, which maps the index values of the TrafficStream to index values for the sorter.  Once the TrafficStreams are in order, they’re sent to the existing, but slightly modified code to add observations to the accumulation.  Changes in the accumulation logic to support this include adding an OnlineRadixSorter to the Accumulation object.  This was done because it’s the value within the ExpiringTrafficStreamMap that the CapturedTrafficToHttpTransactionAccumulator uses.  

However, the ExpiringTrafficStreamMap had coupled object addition (getOrCreate) with timestamp management and expiration.  Since a TrafficStream itself doesn’t have a timestamp (Observations within it do), the expiration logic has been pulled out of getOrCreate (which has been renamed getOrCreateWithoutExpiration).  The calling context is now responsible for calling expireOldEntries and get() still includes a timestamp argument that is updated each time an item is looked up.

Lastly, CapturedTrafficToHttpTransactionAccumulator was refactored so that the creation of an Accumulation was in the now outer-level accept() method for TrafficStreams rather than the inner-level one for Observations.  That necessitated changes in where edge conditions between writes and reads were handled.

### Issues Resolved
https://opensearch.atlassian.net/browse/MIGRATIONS-1263

### Testing
Unit testing

### Check List
- [x] New functionality includes testing
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
