### PR TITLE
Enhance devDeploy script and tighten down IAM polices and Security Groups

### DIFF
--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/KafkaPrinter.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/KafkaPrinter.java
@@ -29,7 +29,7 @@ import java.util.stream.StreamSupport;
  * 1. Capturing a particular set of Kafka traffic records to a file which can then be repeatedly passed as an input param
  * to the Replayer for testing.
  * 2. Printing records for a topic with a different group id then is used normally to compare
- * 3. Clearing records for a  topic with the same group id
+ * 3. Clearing records for a topic with the same group id
  */
 public class KafkaPrinter {
     private static final Logger log = LoggerFactory.getLogger(KafkaPrinter.class);

--- a/deployment/cdk/opensearch-service-migration/bin/app.ts
+++ b/deployment/cdk/opensearch-service-migration/bin/app.ts
@@ -7,11 +7,17 @@ const app = new App();
 const account = process.env.CDK_DEFAULT_ACCOUNT
 const region = process.env.CDK_DEFAULT_REGION
 const stage = process.env.CDK_DEPLOYMENT_STAGE
+let copilotAppName = process.env.COPILOT_APP_NAME
 if (!stage) {
     throw new Error("Required environment variable CDK_DEPLOYMENT_STAGE has not been set (i.e. dev, gamma, PROD)")
+}
+if (!copilotAppName) {
+    console.log("COPILOT_APP_NAME has not been set, defaulting to 'migration-copilot' for stack export identifier")
+    copilotAppName = "migration-copilot"
 }
 
 new StackComposer(app, {
     env: { account: account, region: region },
-    stage: stage
+    stage: stage,
+    copilotAppName: copilotAppName
 });

--- a/deployment/cdk/opensearch-service-migration/lib/msk-utility-stack.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/msk-utility-stack.ts
@@ -33,13 +33,13 @@ export class MSKUtilityStack extends Stack {
                     "ec2:DescribeVpcs",
                     "ec2:DescribeSecurityGroups",
                     "ec2:DescribeRouteTables",
-                    "ec2:DescribeVpcEndpoints",
-                    "ec2:DescribeVpcAttribute",
-                    "ec2:DescribeNetworkAcls",
+                    //"ec2:DescribeVpcEndpoints",
+                    //"ec2:DescribeVpcAttribute",
+                    //"ec2:DescribeNetworkAcls",
                     "kafka:UpdateConnectivity",
                     "kafka:DescribeClusterV2",
                     "kafka:GetBootstrapBrokers"],
-                resources: ["*"]
+                resources: [props.mskARN]
             })
             const lambdaExecDocument = new PolicyDocument({
                 statements: [lambdaInvokeStatement, mskUpdateConnectivityStatement]
@@ -95,7 +95,7 @@ export class MSKUtilityStack extends Stack {
         }
         else {
             const mskGetBrokersCustomResource = getBrokersCustomResource(this, props.vpc, props.mskARN)
-            brokerEndpointsOutput = mskGetBrokersCustomResource.getResponseField("BootstrapBrokerStringSaslIam")
+            brokerEndpointsOutput = `export MIGRATION_KAFKA_BROKER_ENDPOINTS=${mskGetBrokersCustomResource.getResponseField("BootstrapBrokerStringSaslIam")}`
             //brokerEndpointsOutput = mskGetBrokersCustomResource.getResponseField("BootstrapBrokerStringPublicSaslIam")
         }
 

--- a/deployment/cdk/opensearch-service-migration/lib/msk-utility-stack.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/msk-utility-stack.ts
@@ -27,22 +27,23 @@ export class MSKUtilityStack extends Stack {
                 actions: ["lambda:InvokeFunction"],
                 resources: ["*"]
             })
-            const mskUpdateConnectivityStatement = new PolicyStatement({
+            // Updating connectivity for an MSK cluster requires some VPC permissions
+            // (https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazonmanagedstreamingforapachekafka.html#amazonmanagedstreamingforapachekafka-cluster)
+            const describeVPCStatement = new PolicyStatement( {
                 effect: Effect.ALLOW,
                 actions: ["ec2:DescribeSubnets",
-                    "ec2:DescribeVpcs",
-                    "ec2:DescribeSecurityGroups",
-                    "ec2:DescribeRouteTables",
-                    //"ec2:DescribeVpcEndpoints",
-                    //"ec2:DescribeVpcAttribute",
-                    //"ec2:DescribeNetworkAcls",
-                    "kafka:UpdateConnectivity",
+                    "ec2:DescribeRouteTables"],
+                resources: ["*"]
+            })
+            const mskUpdateConnectivityStatement = new PolicyStatement({
+                effect: Effect.ALLOW,
+                actions: ["kafka:UpdateConnectivity",
                     "kafka:DescribeClusterV2",
                     "kafka:GetBootstrapBrokers"],
                 resources: [props.mskARN]
             })
             const lambdaExecDocument = new PolicyDocument({
-                statements: [lambdaInvokeStatement, mskUpdateConnectivityStatement]
+                statements: [lambdaInvokeStatement, describeVPCStatement, mskUpdateConnectivityStatement]
             })
 
             const lambdaExecRole = new Role(this, 'mskAccessLambda', {

--- a/deployment/cdk/opensearch-service-migration/lib/stack-composer.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/stack-composer.ts
@@ -11,7 +11,8 @@ import {HistoricalCaptureStack} from "./historical-capture-stack";
 import {MSKUtilityStack} from "./msk-utility-stack";
 
 export interface StackPropsExt extends StackProps {
-    readonly stage: string
+    readonly stage: string,
+    readonly copilotAppName: string
 }
 
 export class StackComposer {

--- a/deployment/cdk/opensearch-service-migration/test/domain-cdk-stack.test.ts
+++ b/deployment/cdk/opensearch-service-migration/test/domain-cdk-stack.test.ts
@@ -1,9 +1,9 @@
 import {App} from 'aws-cdk-lib';
 import {Template} from 'aws-cdk-lib/assertions';
-import {StackComposer} from "../lib/stack-composer";
 import * as testDefaultValues from "./default-values-test.json";
 import {OpensearchServiceDomainCdkStack} from "../lib/opensearch-service-domain-cdk-stack";
 import {NetworkStack} from "../lib/network-stack";
+import {createStackComposer} from "./test-utils";
 
 test('Test primary context options are mapped with standard data type', () => {
     // The cdk.context.json and default-values.json files allow multiple data types
@@ -47,9 +47,7 @@ test('Test primary context options are mapped with standard data type', () => {
         }
     })
 
-    const openSearchStacks = new StackComposer(app, {
-        env: {account: "test-account", region: "us-east-1"}, stage: "unittest"
-    })
+    const openSearchStacks = createStackComposer(app)
 
     const domainStack = openSearchStacks.stacks.filter((s) => s instanceof OpensearchServiceDomainCdkStack)[0]
     const domainTemplate = Template.fromStack(domainStack)
@@ -95,9 +93,7 @@ test('Test primary context options are mapped with only string data type', () =>
         }
     })
 
-    const openSearchStacks = new StackComposer(app, {
-        env: {account: "test-account", region: "us-east-1"}, stage: "unittest"
-    })
+    const openSearchStacks = createStackComposer(app)
 
     const domainStack = openSearchStacks.stacks.filter((s) => s instanceof OpensearchServiceDomainCdkStack)[0]
     const domainTemplate = Template.fromStack(domainStack)
@@ -123,9 +119,7 @@ test('Test alternate context options are mapped with standard data type', () => 
         }
     })
 
-    const openSearchStacks = new StackComposer(app, {
-        env: {account: "test-account", region: "us-east-1"}, stage: "unittest"
-    })
+    const openSearchStacks = createStackComposer(app)
 
     const domainStack = openSearchStacks.stacks.filter((s) => s instanceof OpensearchServiceDomainCdkStack)[0]
     const domainTemplate = Template.fromStack(domainStack)
@@ -146,9 +140,7 @@ test('Test alternate context options are mapped with only string data type', () 
         }
     })
 
-    const openSearchStacks = new StackComposer(app, {
-        env: {account: "test-account", region: "us-east-1"}, stage: "unittest"
-    })
+    const openSearchStacks = createStackComposer(app)
 
     const domainStack = openSearchStacks.stacks.filter((s) => s instanceof OpensearchServiceDomainCdkStack)[0]
     const domainTemplate = Template.fromStack(domainStack)
@@ -162,9 +154,7 @@ test('Test openAccessPolicy setting creates access policy when enabled', () => {
         }
     })
 
-    const openSearchStacks = new StackComposer(app, {
-        env: {account: "test-account", region: "us-east-1"}, stage: "unittest"
-    })
+    const openSearchStacks = createStackComposer(app)
 
     const domainStack = openSearchStacks.stacks.filter((s) => s instanceof OpensearchServiceDomainCdkStack)[0]
     const domainTemplate = Template.fromStack(domainStack)
@@ -180,9 +170,7 @@ test('Test openAccessPolicy setting does not create access policy when disabled'
         }
     })
 
-    const openSearchStacks = new StackComposer(app, {
-        env: {account: "test-account", region: "us-east-1"}, stage: "unittest"
-    })
+    const openSearchStacks = createStackComposer(app)
 
     const domainStack = openSearchStacks.stacks.filter((s) => s instanceof OpensearchServiceDomainCdkStack)[0]
     const domainTemplate = Template.fromStack(domainStack)
@@ -198,9 +186,7 @@ test('Test openAccessPolicy setting is mapped with string data type', () => {
         }
     })
 
-    const openSearchStacks = new StackComposer(app, {
-        env: {account: "test-account", region: "us-east-1"}, stage: "unittest"
-    })
+    const openSearchStacks = createStackComposer(app)
 
     const domainStack = openSearchStacks.stacks.filter((s) => s instanceof OpensearchServiceDomainCdkStack)[0]
     const domainTemplate = Template.fromStack(domainStack)
@@ -214,9 +200,7 @@ test( 'Test default stack is created with default values when no context options
         context: {}
     })
 
-    const openSearchStacks = new StackComposer(app, {
-        env: {account: "test-account", region: "us-east-1"}, stage: "unittest"
-    })
+    const openSearchStacks = createStackComposer(app)
 
     const defaultValues: { [x: string]: (string); } = testDefaultValues
     const domainStack = openSearchStacks.stacks.filter((s) => s instanceof OpensearchServiceDomainCdkStack)[0]
@@ -262,9 +246,7 @@ test( 'Test default stack is created when empty context options are provided for
         }
     })
 
-    const openSearchStacks = new StackComposer(app, {
-        env: {account: "test-account", region: "us-east-1"}, stage: "unittest"
-    })
+    const openSearchStacks = createStackComposer(app)
 
     const domainStack = openSearchStacks.stacks.filter((s) => s instanceof OpensearchServiceDomainCdkStack)[0]
     const domainTemplate = Template.fromStack(domainStack)

--- a/deployment/cdk/opensearch-service-migration/test/network-stack.test.ts
+++ b/deployment/cdk/opensearch-service-migration/test/network-stack.test.ts
@@ -2,6 +2,7 @@ import {App} from "aws-cdk-lib";
 import {StackComposer} from "../lib/stack-composer";
 import {NetworkStack} from "../lib/network-stack";
 import {Template} from "aws-cdk-lib/assertions";
+import {createStackComposer} from "./test-utils";
 
 test('Test vpcEnabled setting that is disabled does not create stack', () => {
     const app = new App({
@@ -10,9 +11,7 @@ test('Test vpcEnabled setting that is disabled does not create stack', () => {
         }
     })
 
-    const openSearchStacks = new StackComposer(app, {
-        env: {account: "test-account", region: "us-east-1"}, stage: "unittest"
-    })
+    const openSearchStacks = createStackComposer(app)
 
     openSearchStacks.stacks.forEach(function(stack) {
         expect(!(stack instanceof NetworkStack))
@@ -29,9 +28,7 @@ test('Test vpcEnabled setting that is enabled without existing resources creates
         }
     })
 
-    const openSearchStacks = new StackComposer(app, {
-        env: {account: "test-account", region: "us-east-1"}, stage: "unittest"
-    })
+    const openSearchStacks = createStackComposer(app)
 
     const networkStack: NetworkStack = (openSearchStacks.stacks.filter((s) => s instanceof NetworkStack)[0]) as NetworkStack
     const networkTemplate = Template.fromStack(networkStack)

--- a/deployment/cdk/opensearch-service-migration/test/stack-composer.test.ts
+++ b/deployment/cdk/opensearch-service-migration/test/stack-composer.test.ts
@@ -2,8 +2,9 @@ import {App} from "aws-cdk-lib";
 import {StackComposer} from "../lib/stack-composer";
 import {Template} from "aws-cdk-lib/assertions";
 import {OpensearchServiceDomainCdkStack} from "../lib/opensearch-service-domain-cdk-stack";
+import {createStackComposer} from "./test-utils";
 
-test('Test missing domain name throws error', () => {
+test('Test empty string provided for a parameter which has a default value, uses the default value', () => {
 
     const app = new App({
         context: {
@@ -11,27 +12,13 @@ test('Test missing domain name throws error', () => {
         }
     })
 
-    const createStackFunc = () => new StackComposer(app, {
-       env: {account: "test-account", region: "us-east-1"}, stage: "unittest"
-    })
+    const openSearchStacks =  createStackComposer(app)
 
-    expect(createStackFunc).toThrowError()
+    const domainStack = openSearchStacks.stacks.filter((s) => s instanceof OpensearchServiceDomainCdkStack)[0]
+    const domainTemplate = Template.fromStack(domainStack)
+    domainTemplate.resourceCountIs("AWS::OpenSearchService::Domain", 1)
 })
 
-test('Test missing engine version throws error', () => {
-
-    const app = new App({
-        context: {
-            engineVersion: ""
-        }
-    })
-
-    const createStackFunc = () => new StackComposer(app, {
-        env: {account: "test-account", region: "us-east-1"}, stage: "unittest"
-    })
-
-    expect(createStackFunc).toThrowError()
-})
 
 test('Test invalid engine version format throws error', () => {
 
@@ -42,9 +29,7 @@ test('Test invalid engine version format throws error', () => {
         }
     })
 
-    const createStackFunc = () => new StackComposer(app, {
-        env: {account: "test-account", region: "us-east-1"}, stage: "unittest"
-    })
+    const createStackFunc = () => createStackComposer(app)
 
     expect(createStackFunc).toThrowError()
 })
@@ -57,9 +42,7 @@ test('Test ES 7.10 engine version format is parsed', () => {
         }
     })
 
-    const openSearchStacks =  new StackComposer(app, {
-        env: {account: "test-account", region: "us-east-1"}, stage: "unittest"
-    })
+    const openSearchStacks = createStackComposer(app)
 
     const domainStack = openSearchStacks.stacks.filter((s) => s instanceof OpensearchServiceDomainCdkStack)[0]
     const domainTemplate = Template.fromStack(domainStack)
@@ -74,9 +57,7 @@ test('Test OS 1.3 engine version format is parsed', () => {
         }
     })
 
-    const openSearchStacks =  new StackComposer(app, {
-        env: {account: "test-account", region: "us-east-1"}, stage: "unittest"
-    })
+    const openSearchStacks = createStackComposer(app)
 
     const domainStack = openSearchStacks.stacks.filter((s) => s instanceof OpensearchServiceDomainCdkStack)[0]
     const domainTemplate = Template.fromStack(domainStack)
@@ -107,9 +88,7 @@ test('Test access policy is parsed for proper array format', () => {
         }
     })
 
-    const openSearchStacks =  new StackComposer(app, {
-        env: {account: "test-account", region: "us-east-1"}, stage: "unittest"
-    })
+    const openSearchStacks = createStackComposer(app)
 
     const domainStack = openSearchStacks.stacks.filter((s) => s instanceof OpensearchServiceDomainCdkStack)[0]
     const domainTemplate = Template.fromStack(domainStack)
@@ -134,9 +113,7 @@ test('Test access policy is parsed for proper block format', () => {
         }
     })
 
-    const openSearchStacks =  new StackComposer(app, {
-        env: {account: "test-account", region: "us-east-1"}, stage: "unittest"
-    })
+    const openSearchStacks = createStackComposer(app)
 
     const domainStack = openSearchStacks.stacks.filter((s) => s instanceof OpensearchServiceDomainCdkStack)[0]
     const domainTemplate = Template.fromStack(domainStack)
@@ -152,9 +129,7 @@ test('Test access policy missing Statement throws error', () => {
         }
     })
 
-    const createStackFunc = () => new StackComposer(app, {
-        env: {account: "test-account", region: "us-east-1"}, stage: "unittest"
-    })
+    const createStackFunc = () => createStackComposer(app)
 
     expect(createStackFunc).toThrowError()
 })
@@ -167,9 +142,7 @@ test('Test access policy with empty Statement array throws error', () => {
         }
     })
 
-    const createStackFunc = () => new StackComposer(app, {
-        env: {account: "test-account", region: "us-east-1"}, stage: "unittest"
-    })
+    const createStackFunc = () => createStackComposer(app)
 
     expect(createStackFunc).toThrowError()
 })
@@ -182,9 +155,7 @@ test('Test access policy with empty Statement block throws error', () => {
         }
     })
 
-    const createStackFunc = () => new StackComposer(app, {
-        env: {account: "test-account", region: "us-east-1"}, stage: "unittest"
-    })
+    const createStackFunc = () => createStackComposer(app)
 
     expect(createStackFunc).toThrowError()
 })
@@ -198,9 +169,7 @@ test('Test access policy with improper Statement throws error', () => {
         }
     })
 
-    const createStackFunc = () => new StackComposer(app, {
-        env: {account: "test-account", region: "us-east-1"}, stage: "unittest"
-    })
+    const createStackFunc = () => createStackComposer(app)
 
     expect(createStackFunc).toThrowError()
 })
@@ -213,9 +182,7 @@ test('Test invalid TLS security policy throws error', () => {
         }
     })
 
-    const createStackFunc = () => new StackComposer(app, {
-        env: {account: "test-account", region: "us-east-1"}, stage: "unittest"
-    })
+    const createStackFunc = () => createStackComposer(app)
 
     expect(createStackFunc).toThrowError()
 })
@@ -228,9 +195,7 @@ test('Test invalid EBS volume type throws error', () => {
         }
     })
 
-    const createStackFunc = () => new StackComposer(app, {
-        env: {account: "test-account", region: "us-east-1"}, stage: "unittest"
-    })
+    const createStackFunc = () => createStackComposer(app)
 
     expect(createStackFunc).toThrowError()
 })
@@ -243,9 +208,7 @@ test('Test invalid domain removal policy type throws error', () => {
         }
     })
 
-    const createStackFunc = () => new StackComposer(app, {
-        env: {account: "test-account", region: "us-east-1"}, stage: "unittest"
-    })
+    const createStackFunc = () => createStackComposer(app)
 
     expect(createStackFunc).toThrowError()
 })

--- a/deployment/cdk/opensearch-service-migration/test/test-utils.ts
+++ b/deployment/cdk/opensearch-service-migration/test/test-utils.ts
@@ -1,0 +1,8 @@
+import {Construct} from "constructs";
+import {StackComposer} from "../lib/stack-composer";
+
+export function createStackComposer(app: Construct) {
+    return new StackComposer(app, {
+        env: {account: "test-account", region: "us-east-1"}, stage: "unittest", copilotAppName: "test-app"
+    })
+}

--- a/deployment/copilot/README.md
+++ b/deployment/copilot/README.md
@@ -62,8 +62,9 @@ The typical use case for this Copilot app is to initially use the `opensearch-se
 
 The provided CDK will output export commands once deployed that can be ran on a given deployment machine to meet the required environment variables this Copilot app uses:
 ```
-export MIGRATION_VPC_ID=vpc-123;
+export MIGRATION_DOMAIN_SG_ID=sg-123;
 export MIGRATION_DOMAIN_ENDPOINT=vpc-aos-domain-123.us-east-1.es.amazonaws.com;
+export MIGRATION_VPC_ID=vpc-123;
 export MIGRATION_CAPTURE_MSK_SG_ID=sg-123;
 export MIGRATION_COMPARATOR_EFS_ID=fs-123;
 export MIGRATION_COMPARATOR_EFS_SG_ID=sg-123;

--- a/deployment/copilot/README.md
+++ b/deployment/copilot/README.md
@@ -34,9 +34,19 @@ The following script command can be executed to deploy both the CDK infrastructu
 ```
 Options:
 ```
---skip-bootstrap                Skips installing packages with npm for CDK, bootstrapping CDK, and building the docker images used by Copilot
---skip-copilot-init             Skips Copilot initialization of app, environments, and services
---destroy                       Cleans up all deployed resources from this script (CDK and Copilot)
+./devDeploy.sh -h
+
+Deploy migration solution infrastructure composed of resources deployed by CDK and Copilot
+
+Options:
+  --skip-bootstrap        Skip one-time setup of installing npm package, bootstrapping CDK, and building Docker images.
+  --skip-copilot-init     Skip one-time Copilot initialization of app, environments, and services
+  --copilot-app-name      [string, default: migration-copilot] Specify the Copilot application name to use for deployment
+  --destroy-region        Destroy all CDK and Copilot CloudFormation stacks deployed, excluding the Copilot app level stack, for the given region and return to a clean state.
+  --destroy-all-copilot   Destroy Copilot app and all Copilot CloudFormation stacks deployed for the given app across all regions.
+  -r, --region            [string, default: us-east-1] Specify the AWS region to deploy the CloudFormation stacks and resources.
+  -s, --stage             [string, default: dev] Specify the stage name to associate with the deployed resources
+
 ```
 
 Requirements:

--- a/deployment/copilot/capture-proxy/addons/taskRole.yml
+++ b/deployment/copilot/capture-proxy/addons/taskRole.yml
@@ -1,3 +1,5 @@
+AWSTemplateFormatVersion: "2010-09-09"
+
 # You can use any of these parameters to create conditions or mappings in your template.
 Parameters:
   App:
@@ -17,24 +19,24 @@ Resources:
       Description: Allow compute host to consume from MSK
       PolicyDocument:
         Version: '2012-10-17'
-        # We should enhance IAM policy here to further restrict the Resource
         Statement:
           - Action:
               - kafka-cluster:Connect
-              - kafka-cluster:DescribeCluster
             Effect: Allow
-            Resource: "*"
+            Resource:
+              - Fn::ImportValue: !Sub "${App}-${Env}-msk-cluster-arn"
           - Action:
-              - kafka-cluster:*Topic*
-              - kafka-cluster:ReadData
+              - kafka-cluster:CreateTopic
+              - kafka-cluster:DescribeTopic
               - kafka-cluster:WriteData
             Effect: Allow
-            Resource: "*"
-          - Action:
-              - kafka-cluster:AlterGroup
-              - kafka-cluster:DescribeGroup
-            Effect: Allow
-            Resource: "*"
+            Resource:
+              !Join
+              # Delimiter
+              - ''
+              # Values to join
+              - - { "Fn::Join" : [ ":topic", { "Fn::Split": [":cluster", {"Fn::ImportValue" : !Sub "${App}-${Env}-msk-cluster-arn"}]}] }
+                - "/*"
 
 Outputs:
   # 1. You need to output the IAM ManagedPolicy so that Copilot can add it as a managed policy to your ECS task role.

--- a/deployment/copilot/devDeploy.sh
+++ b/deployment/copilot/devDeploy.sh
@@ -91,7 +91,7 @@ export COMPOSE_DOCKER_CLI_BUILD=0
 
 if [ "$DESTROY_REGION" = true ] ; then
   set +e
-  # Reset AWS_DEFAULT_REGION as this will cause conflict with Copilot when interacting with multiple environments within the same AWS account
+  # Reset AWS_DEFAULT_REGION as the SDK used by Copilot will first check here for region to use to locate the Copilot app (https://github.com/aws/copilot-cli/issues/5138)
   export AWS_DEFAULT_REGION=""
   copilot svc delete -a $COPILOT_APP_NAME --name traffic-comparator-jupyter --env $COPILOT_DEPLOYMENT_STAGE --yes
   copilot svc delete -a $COPILOT_APP_NAME --name traffic-comparator --env $COPILOT_DEPLOYMENT_STAGE --yes
@@ -110,7 +110,7 @@ if [ "$DESTROY_REGION" = true ] ; then
 fi
 
 if [ "$DESTROY_ALL_COPILOT" = true ] ; then
-    # Reset AWS_DEFAULT_REGION as this will cause conflict with Copilot when interacting with multiple environments within the same AWS account
+    # Reset AWS_DEFAULT_REGION as the SDK used by Copilot will first check here for region to use to locate the Copilot app (https://github.com/aws/copilot-cli/issues/5138)
     export AWS_DEFAULT_REGION=""
     copilot app delete
     echo "Destroying a Copilot app will not remove generated manifest.yml files in the copilot/environments directory. These should be manually deleted before deploying again. "
@@ -143,7 +143,7 @@ printf "The following exports were added from CDK:\n%s\n" "$found_exports"
 
 cd ../../copilot
 
-# Reset AWS_DEFAULT_REGION as this will cause conflict with Copilot when interacting with multiple environments within the same AWS account
+# Reset AWS_DEFAULT_REGION as the SDK used by Copilot will first check here for region to use to locate the Copilot app (https://github.com/aws/copilot-cli/issues/5138)
 export AWS_DEFAULT_REGION=""
 
 # Allow script to continue on error for copilot services, as copilot will error when no changes are needed

--- a/deployment/copilot/devDeploy.sh
+++ b/deployment/copilot/devDeploy.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# Automation script to deploy the migration solution pipline to AWS for development use case. The current requirement
+# Automation script to deploy the migration solution pipeline to AWS for development use case. The current requirement
 # for use is having valid AWS credentials available to the environment
 
 # Stop script on command failures
@@ -13,47 +13,114 @@ cd $script_dir_abs_path
 
 SECONDS=0
 
-# Allow --skip-bootstrap flag to avoid one-time setups
-skip_bootstrap=false
-if [[ $* == *--skip-bootstrap* ]]
-then
-  skip_bootstrap=true
-fi
-# Allow --skip-copilot-init flag to avoid initializing Copilot components
-skip_copilot_init=false
-if [[ $* == *--skip-copilot-init* ]]
-then
-  skip_copilot_init=true
-fi
-# Allow --destroy flag to clean up existing resources
-destroy=false
-if [[ $* == *--destroy* ]]
-then
-  destroy=true
-fi
+usage() {
+  echo ""
+  echo "Deploy migration solution infrastructure composed of resources deployed by CDK and Copilot"
+  echo ""
+  echo "Options:"
+  echo "  --skip-bootstrap        Skip one-time setup of installing npm package, bootstrapping CDK, and building Docker images."
+  echo "  --skip-copilot-init     Skip one-time Copilot initialization of app, environments, and services"
+  echo "  --copilot-app-name      [string, default: migration-copilot] Specify the Copilot application name to use for deployment"
+  echo "  --destroy-region        Destroy all CDK and Copilot CloudFormation stacks deployed, excluding the Copilot app level stack, for the given region and return to a clean state."
+  echo "  --destroy-all-copilot   Destroy Copilot app and all Copilot CloudFormation stacks deployed for the given app across all regions."
+  echo "  -r, --region            [string, default: us-east-1] Specify the AWS region to deploy the CloudFormation stacks and resources."
+  echo "  -s, --stage             [string, default: dev] Specify the stage name to associate with the deployed resources"
+  exit 1
+}
 
-export CDK_DEPLOYMENT_STAGE=dev
-export COPILOT_DEPLOYMENT_STAGE=dev
-# Will be used for CDK and Copilot
-export AWS_DEFAULT_REGION=us-east-1
-export COPILOT_DEPLOYMENT_NAME=migration-copilot
+SKIP_BOOTSTRAP=false
+SKIP_COPILOT_INIT=false
+COPILOT_APP_NAME=migration-copilot
+DESTROY_REGION=false
+DESTROY_ALL_COPILOT=false
+REGION=us-east-1
+STAGE=dev
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --skip-bootstrap)
+      SKIP_BOOTSTRAP=true
+      shift # past argument
+      ;;
+    --skip-copilot-init)
+      SKIP_COPILOT_INIT=true
+      shift # past argument
+      ;;
+    --copilot-app-name)
+      COPILOT_APP_NAME="$2"
+      shift # past argument
+      shift # past value
+      ;;
+    --destroy-region)
+      DESTROY_REGION=true
+      shift # past argument
+      ;;
+    --destroy-all-copilot)
+      DESTROY_ALL_COPILOT=true
+      shift # past argument
+      ;;
+    -r|--region)
+      REGION="$2"
+      shift # past argument
+      shift # past value
+      ;;
+    -s|--stage)
+      STAGE="$2"
+      shift # past argument
+      shift # past value
+      ;;
+    -h|--h)
+      usage
+      ;;
+    -*)
+      echo "Unknown option $1"
+      usage
+      ;;
+    *)
+      shift # past argument
+      ;;
+  esac
+done
+
+COPILOT_DEPLOYMENT_STAGE=$STAGE
+export AWS_DEFAULT_REGION=$REGION
+export CDK_DEPLOYMENT_STAGE=$STAGE
 # Used to overcome error: "failed to solve with frontend dockerfile.v0: failed to create LLB definition: unexpected
 # status code [manifests latest]: 400 Bad Request" but may not be practical
 export DOCKER_BUILDKIT=0
 export COMPOSE_DOCKER_CLI_BUILD=0
 
-if [ "$destroy" = true ] ; then
+if [ "$DESTROY_REGION" = true ] ; then
   set +e
-  copilot app delete
+  # Reset AWS_DEFAULT_REGION as this will cause conflict with Copilot when interacting with multiple environments within the same AWS account
+  export AWS_DEFAULT_REGION=""
+  copilot svc delete -a $COPILOT_APP_NAME --name traffic-comparator-jupyter --env $COPILOT_DEPLOYMENT_STAGE --yes
+  copilot svc delete -a $COPILOT_APP_NAME --name traffic-comparator --env $COPILOT_DEPLOYMENT_STAGE --yes
+  copilot svc delete -a $COPILOT_APP_NAME --name traffic-replayer --env $COPILOT_DEPLOYMENT_STAGE --yes
+  copilot svc delete -a $COPILOT_APP_NAME --name elasticsearch --env $COPILOT_DEPLOYMENT_STAGE --yes
+  copilot svc delete -a $COPILOT_APP_NAME --name capture-proxy --env $COPILOT_DEPLOYMENT_STAGE --yes
+  copilot svc delete -a $COPILOT_APP_NAME --name opensearch-benchmark --env $COPILOT_DEPLOYMENT_STAGE --yes
+  copilot env delete -a $COPILOT_APP_NAME --name $COPILOT_DEPLOYMENT_STAGE --yes
+  rm ./environments/$COPILOT_DEPLOYMENT_STAGE/manifest.yml
+  echo "Destroying a region will not remove the Copilot app level stack that gets created in each region. This must be manually deleted from CloudFormation or automatically removed by deleting the Copilot app"
+
+  export AWS_DEFAULT_REGION=$REGION
   cd ../cdk/opensearch-service-migration
   cdk destroy "*" --c domainName="aos-domain" --c engineVersion="OS_1.3" --c  dataNodeCount=2 --c vpcEnabled=true --c availabilityZoneCount=2 --c openAccessPolicyEnabled=true --c domainRemovalPolicy="DESTROY" --c migrationAssistanceEnabled=true --c mskEnablePublicEndpoints=true --c enableDemoAdmin=true
   exit 1
 fi
 
+if [ "$DESTROY_ALL_COPILOT" = true ] ; then
+    # Reset AWS_DEFAULT_REGION as this will cause conflict with Copilot when interacting with multiple environments within the same AWS account
+    export AWS_DEFAULT_REGION=""
+    copilot app delete
+    echo "Destroying a Copilot app will not remove generated manifest.yml files in the copilot/environments directory. These should be manually deleted before deploying again. "
+    exit 1
+fi
+
 # === CDK Deployment ===
 
 cd ../cdk/opensearch-service-migration
-if [ "$skip_bootstrap" = false ] ; then
+if [ "$SKIP_BOOTSTRAP" = false ] ; then
   cd ../../../TrafficCapture
   ./gradlew :dockerSolution:buildDockerImages
   cd ../deployment/cdk/opensearch-service-migration
@@ -64,7 +131,7 @@ fi
 # This command deploys the required infrastructure for the migration solution with CDK that Copilot requires.
 # The options provided to `cdk deploy` here will cause a VPC, Opensearch Domain, and MSK(Kafka) resources to get created in AWS (among other resources)
 # More details on the CDK used here can be found at opensearch-migrations/deployment/cdk/opensearch-service-migration/README.md
-cdk deploy "*" --c domainName="aos-domain" --c engineVersion="OS_1.3" --c  dataNodeCount=2 --c vpcEnabled=true --c availabilityZoneCount=2 --c openAccessPolicyEnabled=true --c domainRemovalPolicy="DESTROY" --c migrationAssistanceEnabled=true --c mskEnablePublicEndpoints=true --c enableDemoAdmin=true -O cdkOutput.json --require-approval never
+cdk deploy "*" --c domainName="aos-domain" --c engineVersion="OS_1.3" --c  dataNodeCount=2 --c vpcEnabled=true --c availabilityZoneCount=2 --c openAccessPolicyEnabled=true --c domainRemovalPolicy="DESTROY" --c migrationAssistanceEnabled=true --c mskEnablePublicEndpoints=true --c enableDemoAdmin=true -O cdkOutput.json --require-approval never --concurrency 3
 
 # Gather CDK output which includes export commands needed by Copilot, and make them available to the environment
 found_exports=$(grep -o "export [a-zA-Z0-9_]*=[^\\;\"]*" cdkOutput.json)
@@ -76,39 +143,42 @@ printf "The following exports were added from CDK:\n%s\n" "$found_exports"
 
 cd ../../copilot
 
+# Reset AWS_DEFAULT_REGION as this will cause conflict with Copilot when interacting with multiple environments within the same AWS account
+export AWS_DEFAULT_REGION=""
+
 # Allow script to continue on error for copilot services, as copilot will error when no changes are needed
 set +e
 
-if [ "$skip_copilot_init" = false ] ; then
+if [ "$SKIP_COPILOT_INIT" = false ] ; then
   # Init app
-  copilot app init $COPILOT_DEPLOYMENT_NAME
+  copilot app init $COPILOT_APP_NAME
 
   # Init env, start state does not contain existing manifest but is created on the fly here to accommodate varying numbers of public and private subnets
-  copilot env init -a $COPILOT_DEPLOYMENT_NAME --name $COPILOT_DEPLOYMENT_STAGE --import-vpc-id $MIGRATION_VPC_ID --import-public-subnets $MIGRATION_PUBLIC_SUBNETS --import-private-subnets $MIGRATION_PRIVATE_SUBNETS --aws-access-key-id $AWS_ACCESS_KEY_ID --aws-secret-access-key $AWS_SECRET_ACCESS_KEY --aws-session-token $AWS_SESSION_TOKEN --region $AWS_DEFAULT_REGION
-  #copilot env init -a $COPILOT_DEPLOYMENT_NAME --name $COPILOT_DEPLOYMENT_STAGE --default-config --aws-access-key-id $AWS_ACCESS_KEY_ID --aws-secret-access-key $AWS_SECRET_ACCESS_KEY --aws-session-token $AWS_SESSION_TOKEN --region $AWS_DEFAULT_REGION
+  copilot env init -a $COPILOT_APP_NAME --name $COPILOT_DEPLOYMENT_STAGE --import-vpc-id $MIGRATION_VPC_ID --import-public-subnets $MIGRATION_PUBLIC_SUBNETS --import-private-subnets $MIGRATION_PRIVATE_SUBNETS --aws-access-key-id $AWS_ACCESS_KEY_ID --aws-secret-access-key $AWS_SECRET_ACCESS_KEY --aws-session-token $AWS_SESSION_TOKEN --region $REGION
+  #copilot env init -a $COPILOT_APP_NAME --name $COPILOT_DEPLOYMENT_STAGE --default-config --aws-access-key-id $AWS_ACCESS_KEY_ID --aws-secret-access-key $AWS_SECRET_ACCESS_KEY --aws-session-token $AWS_SESSION_TOKEN --region $REGION
 
   # Init services
-  copilot svc init -a $COPILOT_DEPLOYMENT_NAME --name traffic-comparator-jupyter
-  copilot svc init -a $COPILOT_DEPLOYMENT_NAME --name traffic-comparator
-  copilot svc init -a $COPILOT_DEPLOYMENT_NAME --name traffic-replayer
+  copilot svc init -a $COPILOT_APP_NAME --name traffic-comparator-jupyter
+  copilot svc init -a $COPILOT_APP_NAME --name traffic-comparator
+  copilot svc init -a $COPILOT_APP_NAME --name traffic-replayer
 
-  copilot svc init -a $COPILOT_DEPLOYMENT_NAME --name elasticsearch
-  copilot svc init -a $COPILOT_DEPLOYMENT_NAME --name capture-proxy
-  copilot svc init -a $COPILOT_DEPLOYMENT_NAME --name opensearch-benchmark
+  copilot svc init -a $COPILOT_APP_NAME --name elasticsearch
+  copilot svc init -a $COPILOT_APP_NAME --name capture-proxy
+  copilot svc init -a $COPILOT_APP_NAME --name opensearch-benchmark
 fi
 
 
 # Deploy env
-copilot env deploy -a $COPILOT_DEPLOYMENT_NAME --name $COPILOT_DEPLOYMENT_STAGE
+copilot env deploy -a $COPILOT_APP_NAME --name $COPILOT_DEPLOYMENT_STAGE
 
 # Deploy services
-copilot svc deploy -a $COPILOT_DEPLOYMENT_NAME --name traffic-comparator-jupyter --env $COPILOT_DEPLOYMENT_STAGE
-copilot svc deploy -a $COPILOT_DEPLOYMENT_NAME --name traffic-comparator --env $COPILOT_DEPLOYMENT_STAGE
-copilot svc deploy -a $COPILOT_DEPLOYMENT_NAME --name traffic-replayer --env $COPILOT_DEPLOYMENT_STAGE
+copilot svc deploy -a $COPILOT_APP_NAME --name traffic-comparator-jupyter --env $COPILOT_DEPLOYMENT_STAGE
+copilot svc deploy -a $COPILOT_APP_NAME --name traffic-comparator --env $COPILOT_DEPLOYMENT_STAGE
+copilot svc deploy -a $COPILOT_APP_NAME --name traffic-replayer --env $COPILOT_DEPLOYMENT_STAGE
 
-copilot svc deploy -a $COPILOT_DEPLOYMENT_NAME --name elasticsearch --env $COPILOT_DEPLOYMENT_STAGE
-copilot svc deploy -a $COPILOT_DEPLOYMENT_NAME --name capture-proxy --env $COPILOT_DEPLOYMENT_STAGE
-copilot svc deploy -a $COPILOT_DEPLOYMENT_NAME --name opensearch-benchmark --env $COPILOT_DEPLOYMENT_STAGE
+copilot svc deploy -a $COPILOT_APP_NAME --name elasticsearch --env $COPILOT_DEPLOYMENT_STAGE
+copilot svc deploy -a $COPILOT_APP_NAME --name capture-proxy --env $COPILOT_DEPLOYMENT_STAGE
+copilot svc deploy -a $COPILOT_APP_NAME --name opensearch-benchmark --env $COPILOT_DEPLOYMENT_STAGE
 
 
 # Output deployment time

--- a/deployment/copilot/opensearch-benchmark/manifest.yml
+++ b/deployment/copilot/opensearch-benchmark/manifest.yml
@@ -9,6 +9,8 @@ type: Backend Service
 # Allow service-to-service communication with ECS Service Connect
 network:
   connect: true
+  vpc:
+    security_groups: [ "${MIGRATION_DOMAIN_SG_ID}" ]
 
 # Configuration for your containers and service.
 image:

--- a/deployment/copilot/traffic-replayer/addons/taskRole.yml
+++ b/deployment/copilot/traffic-replayer/addons/taskRole.yml
@@ -1,3 +1,5 @@
+AWSTemplateFormatVersion: "2010-09-09"
+
 # You can use any of these parameters to create conditions or mappings in your template.
 Parameters:
   App:
@@ -17,23 +19,34 @@ Resources:
       Description: Allow compute host to consume from MSK
       PolicyDocument:
         Version: '2012-10-17'
-        # We should enhance IAM policy here to further restrict the Resource
         Statement:
           - Action:
               - kafka-cluster:Connect
-              - kafka-cluster:DescribeCluster
             Effect: Allow
-            Resource: "*"
+            Resource:
+              - Fn::ImportValue: !Sub "${App}-${Env}-msk-cluster-arn"
           - Action:
-              - kafka-cluster:*Topic*
+              - kafka-cluster:DescribeTopic
               - kafka-cluster:ReadData
             Effect: Allow
-            Resource: "*"
+            Resource:
+              !Join
+              # Delimiter
+              - ''
+              # Values to join
+              - - { "Fn::Join" : [ ":topic", { "Fn::Split": [":cluster", {"Fn::ImportValue" : !Sub "${App}-${Env}-msk-cluster-arn"}]}] }
+                - "/*"
           - Action:
               - kafka-cluster:AlterGroup
               - kafka-cluster:DescribeGroup
             Effect: Allow
-            Resource: "*"
+            Resource:
+              !Join
+              # Delimiter
+              - ''
+              # Values to join
+              - - { "Fn::Join" : [ ":group", { "Fn::Split": [":cluster", {"Fn::ImportValue" : !Sub "${App}-${Env}-msk-cluster-arn"}]}] }
+                - "/*"
 
 Outputs:
   # 1. You need to output the IAM ManagedPolicy so that Copilot can add it as a managed policy to your ECS task role.

--- a/deployment/copilot/traffic-replayer/manifest.yml
+++ b/deployment/copilot/traffic-replayer/manifest.yml
@@ -10,7 +10,7 @@ type: Backend Service
 network:
   connect: true
   vpc:
-    security_groups: [ "${MIGRATION_CAPTURE_MSK_SG_ID}" ]
+    security_groups: [ "${MIGRATION_CAPTURE_MSK_SG_ID}", "${MIGRATION_DOMAIN_SG_ID}" ]
 
 # Configuration for your containers and service.
 image:


### PR DESCRIPTION
### Description
This PR accomplishes a few different smaller tasks. These include:
* Fixing bug preventing devDeploy script from deploying to multiple regions
* Allowing additional options to devDeploy script for more flexibility i.e. region and stage
* Adding concurrency option to cdk deploy to speed up its stack deployment
* Tightening IAM permissions across the board

### Issues Resolved
https://opensearch.atlassian.net/browse/MIGRATIONS-1205

### Testing
Manual testing in progress to verify IaC has basic functionality and experimenting with tightening Custom Resource IAM actions

### Check List
- [ ] New functionality includes testing
  - [X] All tests pass, including unit test, integration test and doctest
- [X] New functionality has been documented
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
