### PR TITLE
Add JsonTransformer to remove SigV4 Artifacts

### DIFF
--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/TrafficReplayer.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/TrafficReplayer.java
@@ -14,6 +14,7 @@ import org.opensearch.migrations.trafficcapture.protos.TrafficStream;
 import org.opensearch.migrations.transform.CompositeJsonTransformer;
 import org.opensearch.migrations.transform.JoltJsonTransformer;
 import org.opensearch.migrations.transform.JsonTransformer;
+import org.opensearch.migrations.transform.SigV4ExcisionJsonTransformer;
 import org.opensearch.migrations.transform.TypeMappingJsonTransformer;
 import org.slf4j.event.Level;
 
@@ -49,7 +50,7 @@ public class TrafficReplayer {
             joltJsonTransformerBuilder = joltJsonTransformerBuilder.addAuthorizationOperation(authorizationHeader);
         }
         var joltJsonTransformer = joltJsonTransformerBuilder.build();
-        return new CompositeJsonTransformer(joltJsonTransformer, new TypeMappingJsonTransformer());
+        return new CompositeJsonTransformer(joltJsonTransformer, new TypeMappingJsonTransformer(), new SigV4ExcisionJsonTransformer());
     }
 
     public TrafficReplayer(URI serverUri, String authorizationHeader, boolean allowInsecureConnections)

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/transform/SigV4ExcisionJsonTransformer.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/transform/SigV4ExcisionJsonTransformer.java
@@ -1,0 +1,32 @@
+package org.opensearch.migrations.transform;
+
+import org.opensearch.migrations.replay.datahandlers.PayloadAccessFaultingMap;
+import org.opensearch.migrations.replay.datahandlers.http.HttpJsonMessageWithFaultingPayload;
+
+import java.util.Map;
+import java.util.regex.Pattern;
+
+/**
+ * This is a JsonTransformer that is meant to remove header fields related to a sigV4 signature.
+ */
+public class SigV4ExcisionJsonTransformer implements JsonTransformer {
+
+    public static final String AUTHORIZATION_KEYNAME = "Authorization";
+    public static final String SECURITY_TOKEN_KEYNAME = "X-Amz-Security-Token";
+
+    @Override
+    public Object transformJson(Object incomingJson) {
+        if (!(incomingJson instanceof Map)) {
+            return incomingJson;
+        } else {
+            return transformHttpMessage((Map) incomingJson);
+        }
+    }
+
+    private Object transformHttpMessage(Map<String, Object> httpMsg) {
+        var headers = (Map) httpMsg.get(HttpJsonMessageWithFaultingPayload.HEADERS);
+        headers.remove(AUTHORIZATION_KEYNAME);
+        headers.remove(SECURITY_TOKEN_KEYNAME);
+        return httpMsg;
+    }
+}

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/transform/SigV4AuthExcisionTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/transform/SigV4AuthExcisionTest.java
@@ -1,6 +1,5 @@
 package org.opensearch.migrations.transform;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.io.CharStreams;
 import org.junit.jupiter.api.Assertions;
@@ -54,6 +53,6 @@ public class SigV4AuthExcisionTest {
     }
 
     static JsonTransformer getJsonTransformer() {
-        return new TypeMappingJsonTransformer();
+        return new SigV4ExcisionJsonTransformer();
     }
 }

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/transform/SigV4AuthExcisionTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/transform/SigV4AuthExcisionTest.java
@@ -1,0 +1,59 @@
+package org.opensearch.migrations.transform;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.io.CharStreams;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.opensearch.migrations.replay.datahandlers.JsonAccumulator;
+
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+
+public class SigV4AuthExcisionTest {
+
+    static ObjectMapper objectMapper = new ObjectMapper();
+
+
+    static InputStream getInputStreamForTypeMappingResource(String resourceName) {
+        return SigV4AuthExcisionTest.class.getResourceAsStream("/sampleJsonDocuments/sigV4/" +
+                resourceName);
+    }
+
+    @Test
+    public void removesSigV4HeadersFromSignedRequest() throws Exception {
+        var json = parseJsonFromResourceName("signed_request_input.txt");
+        transformAndVerifyResult(json, "signed_request_output.txt");
+    }
+
+    @Test
+    public void doesntRemoveHeadersFromUnsignedRequest() throws Exception {
+        var json = parseJsonFromResourceName("unsigned_request.txt");
+        transformAndVerifyResult(json, "unsigned_request.txt");
+    }
+
+    private static Object parseJsonFromResourceName(String resourceName) throws Exception {
+        var jsonAccumulator = new JsonAccumulator();
+        try (var resourceStream = getInputStreamForTypeMappingResource(resourceName);
+             var isr = new InputStreamReader(resourceStream, StandardCharsets.UTF_8)) {
+            var expectedBytes = CharStreams.toString(isr).getBytes(StandardCharsets.UTF_8);
+            return jsonAccumulator.consumeByteBuffer(ByteBuffer.wrap(expectedBytes));
+        }
+    }
+
+    private static void transformAndVerifyResult(Object json, String expectedValueSource) throws Exception {
+        var jsonTransformer = getJsonTransformer();
+        json = jsonTransformer.transformJson(json);
+        var jsonAsStr = objectMapper.writeValueAsString(json);
+        Object expectedObject = parseJsonFromResourceName(expectedValueSource);
+        var expectedValue = objectMapper.writeValueAsString(expectedObject);
+        Assertions.assertEquals(expectedValue, jsonAsStr);
+    }
+
+    static JsonTransformer getJsonTransformer() {
+        return new TypeMappingJsonTransformer();
+    }
+}

--- a/TrafficCapture/trafficReplayer/src/test/resources/sampleJsonDocuments/sigV4/signed_request_input.txt
+++ b/TrafficCapture/trafficReplayer/src/test/resources/sampleJsonDocuments/sigV4/signed_request_input.txt
@@ -1,0 +1,18 @@
+{
+  "method": "POST",
+  "URI": "/_bulk",
+  "payload": "Content doesn't matter",
+  "headers": {
+      "Authorization": "AWS4-HMAC-SHA256 Credential=ASIAY4FG7SMAKOKG5ZH5/20230809/us-west-2/es/aws4_request, SignedHeaders=content-length;content-type;host;user-agent;x-amz-date;x-amz-security-token, Signature=2c50648275c42b7e7e10c2d3feadf5867d88728f89716565a33f3fa6816102a9",
+       "Content-Length": "17363",
+       "Content-Type": "application/json",
+       "Host": "opensearch.domain.goes.here.com",
+       "User-Agent": "Apache-HttpAsyncClient/4.1.5 (Java/1.8.0_372)",
+       "X-Amz-Date": "20230809T173309Z",
+       "X-Amz-Security-Token": "IQoJb3JpZ2luX2VjEAAaCXVzLXdlc3",
+       "X-Amzn-Trace-Id": "Root=1-64d3cdd5-4b46847b30c4448d7f7c9ad4",
+       "X-Forwarded-For": "10.0.127.233",
+       "X-Forwarded-Port": "443",
+       "X-Forwarded-Proto": "https"
+  }
+}

--- a/TrafficCapture/trafficReplayer/src/test/resources/sampleJsonDocuments/sigV4/signed_request_output.txt
+++ b/TrafficCapture/trafficReplayer/src/test/resources/sampleJsonDocuments/sigV4/signed_request_output.txt
@@ -1,0 +1,16 @@
+{
+  "method": "POST",
+  "URI": "/_bulk",
+  "payload": "Content doesn't matter",
+  "headers": {
+       "Content-Length": "17363",
+       "Content-Type": "application/json",
+       "Host": "opensearch.domain.goes.here.com",
+       "User-Agent": "Apache-HttpAsyncClient/4.1.5 (Java/1.8.0_372)",
+       "X-Amz-Date": "20230809T173309Z",
+       "X-Amzn-Trace-Id": "Root=1-64d3cdd5-4b46847b30c4448d7f7c9ad4",
+       "X-Forwarded-For": "10.0.127.233",
+       "X-Forwarded-Port": "443",
+       "X-Forwarded-Proto": "https"
+  }
+}

--- a/TrafficCapture/trafficReplayer/src/test/resources/sampleJsonDocuments/sigV4/unsigned_request.txt
+++ b/TrafficCapture/trafficReplayer/src/test/resources/sampleJsonDocuments/sigV4/unsigned_request.txt
@@ -1,0 +1,11 @@
+{
+  "method": "GET",
+  "URI": "/",
+  "payload": "Content doesn't matter",
+  "headers": {
+      "Accept-Encoding": "gzip, compressed",
+      "Connection": "close",
+      "Host": "10.0.124.241",
+      "User-Agent": "ELB-HealthChecker/2.0"
+  }
+}


### PR DESCRIPTION
Signed-off-by: Mikayla Thompson <thomika@amazon.com>
### Description
A task to add SigV4 signing to the replayer is underway.
In the meantime, testing against a cluster that does not require SigV4 revealed that if the original clients _are_ signing the requests, the signature-related headers will be passed along to the target cluster. This signature will almost certainly fail to be validated because it includes the `Host` header, which we modify.

This PR, as a pre-req, to full SigV4 signing, simply strips out the signature-related headers: `Authorization` and `X-Amz-Security-Token`.

### Issues Resolved

### Testing
Unit tests are included.

Additionally, evidence is available from deploying this in-situ for WhiteFir.
Pre-deployment, 100% of `_bulk` requests (which were signed by the client) failed with a 403 error. Requests to `/`, which came overwhelmingly from ALB health checks and were not signed, succeeded (200) 100% of the time.
Post-deployment, all requests--signed or not--received a 200 response.

### Check List
- [x] New functionality includes testing
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
