### PR TITLE
[Fetch Migration] Added total document count to report

### DIFF
--- a/FetchMigration/index_configuration_tool/endpoint_info.py
+++ b/FetchMigration/index_configuration_tool/endpoint_info.py
@@ -1,0 +1,8 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class EndpointInfo:
+    url: str
+    auth: tuple = None
+    verify_ssl: bool = True

--- a/FetchMigration/index_configuration_tool/index_operations.py
+++ b/FetchMigration/index_configuration_tool/index_operations.py
@@ -1,4 +1,3 @@
-import sys
 import requests
 
 from endpoint_info import EndpointInfo
@@ -36,7 +35,7 @@ def create_indices(indices_data: dict, endpoint: EndpointInfo):
             resp = requests.put(actual_endpoint, auth=endpoint.auth, verify=endpoint.verify_ssl, json=data_dict)
             resp.raise_for_status()
         except requests.exceptions.RequestException as e:
-            print(f"Failed to create index [{index}] - {e!s}", file=sys.stderr)
+            raise RuntimeError(f"Failed to create index [{index}] - {e!s}")
 
 
 def doc_count(indices: set, endpoint: EndpointInfo) -> int:

--- a/FetchMigration/index_configuration_tool/index_operations.py
+++ b/FetchMigration/index_configuration_tool/index_operations.py
@@ -6,8 +6,10 @@ import requests
 # Constants
 SETTINGS_KEY = "settings"
 MAPPINGS_KEY = "mappings"
+COUNT_KEY = "count"
 __INDEX_KEY = "index"
 __ALL_INDICES_ENDPOINT = "*"
+__COUNT_ENDPOINT = "/_count"
 __INTERNAL_SETTINGS_KEYS = ["creation_date", "uuid", "provided_name", "version", "store"]
 
 
@@ -35,3 +37,10 @@ def create_indices(indices_data: dict, endpoint: str, auth_tuple: Optional[tuple
             resp.raise_for_status()
         except requests.exceptions.RequestException as e:
             print(f"Failed to create index [{index}] - {e!s}", file=sys.stderr)
+
+
+def doc_count(indices: set, endpoint: str, optional_auth: Optional[tuple] = None, verify: bool = True) -> int:
+    actual_endpoint = endpoint + ','.join(indices) + __COUNT_ENDPOINT
+    resp = requests.get(actual_endpoint, auth=optional_auth, verify=verify)
+    result = dict(resp.json())
+    return int(result[COUNT_KEY])

--- a/FetchMigration/index_configuration_tool/index_operations.py
+++ b/FetchMigration/index_configuration_tool/index_operations.py
@@ -1,7 +1,7 @@
 import sys
-from typing import Optional
-
 import requests
+
+from endpoint_info import EndpointInfo
 
 # Constants
 SETTINGS_KEY = "settings"
@@ -13,9 +13,9 @@ __COUNT_ENDPOINT = "/_count"
 __INTERNAL_SETTINGS_KEYS = ["creation_date", "uuid", "provided_name", "version", "store"]
 
 
-def fetch_all_indices(endpoint: str, optional_auth: Optional[tuple] = None, verify: bool = True) -> dict:
-    actual_endpoint = endpoint + __ALL_INDICES_ENDPOINT
-    resp = requests.get(actual_endpoint, auth=optional_auth, verify=verify)
+def fetch_all_indices(endpoint: EndpointInfo) -> dict:
+    actual_endpoint = endpoint.url + __ALL_INDICES_ENDPOINT
+    resp = requests.get(actual_endpoint, auth=endpoint.auth, verify=endpoint.verify_ssl)
     # Remove internal settings
     result = dict(resp.json())
     for index in result:
@@ -26,21 +26,21 @@ def fetch_all_indices(endpoint: str, optional_auth: Optional[tuple] = None, veri
     return result
 
 
-def create_indices(indices_data: dict, endpoint: str, auth_tuple: Optional[tuple]):
+def create_indices(indices_data: dict, endpoint: EndpointInfo):
     for index in indices_data:
-        actual_endpoint = endpoint + index
+        actual_endpoint = endpoint.url + index
         data_dict = dict()
         data_dict[SETTINGS_KEY] = indices_data[index][SETTINGS_KEY]
         data_dict[MAPPINGS_KEY] = indices_data[index][MAPPINGS_KEY]
         try:
-            resp = requests.put(actual_endpoint, auth=auth_tuple, json=data_dict)
+            resp = requests.put(actual_endpoint, auth=endpoint.auth, verify=endpoint.verify_ssl, json=data_dict)
             resp.raise_for_status()
         except requests.exceptions.RequestException as e:
             print(f"Failed to create index [{index}] - {e!s}", file=sys.stderr)
 
 
-def doc_count(indices: set, endpoint: str, optional_auth: Optional[tuple] = None, verify: bool = True) -> int:
-    actual_endpoint = endpoint + ','.join(indices) + __COUNT_ENDPOINT
-    resp = requests.get(actual_endpoint, auth=optional_auth, verify=verify)
+def doc_count(indices: set, endpoint: EndpointInfo) -> int:
+    actual_endpoint = endpoint.url + ','.join(indices) + __COUNT_ENDPOINT
+    resp = requests.get(actual_endpoint, auth=endpoint.auth, verify=endpoint.verify_ssl)
     result = dict(resp.json())
     return int(result[COUNT_KEY])

--- a/FetchMigration/index_configuration_tool/main.py
+++ b/FetchMigration/index_configuration_tool/main.py
@@ -147,6 +147,9 @@ def print_report(index_differences: tuple[set, set, set]):  # pragma no cover
 
 
 def run(args: argparse.Namespace) -> None:
+    # Sanity check
+    if not args.report and len(args.output_file) == 0:
+        raise ValueError("No output file specified")
     # Parse and validate pipelines YAML file
     with open(args.config_file_path, 'r') as pipeline_file:
         dp_config = yaml.safe_load(pipeline_file)
@@ -170,7 +173,8 @@ def run(args: argparse.Namespace) -> None:
     indices_to_create = diff[0]
     if indices_to_create:
         # Write output YAML
-        write_output(dp_config, indices_to_create, args.output_file)
+        if len(args.output_file) > 0:
+            write_output(dp_config, indices_to_create, args.output_file)
         if not args.dryrun:
             index_data = dict()
             for index_name in indices_to_create:
@@ -191,16 +195,18 @@ if __name__ == '__main__':  # pragma no cover
         "along with indices that are identical or have conflicting settings/mappings.",
         formatter_class=argparse.RawTextHelpFormatter
     )
-    # Positional, required arguments
+    # Required positional argument
     arg_parser.add_argument(
         "config_file_path",
         help="Path to the Data Prepper pipeline YAML file to parse for source and target endpoint information"
     )
+    # Optional positional argument
     arg_parser.add_argument(
         "output_file",
+        nargs='?', default="",
         help="Output path for the Data Prepper pipeline YAML file that will be generated"
     )
-    # Optional arguments
+    # Flags
     arg_parser.add_argument("--report", "-r", action="store_true",
                             help="Print a report of the index differences")
     arg_parser.add_argument("--dryrun", action="store_true",

--- a/FetchMigration/index_configuration_tool/tests/test_index_operations.py
+++ b/FetchMigration/index_configuration_tool/tests/test_index_operations.py
@@ -6,6 +6,7 @@ import responses
 from responses import matchers
 
 import index_operations
+from endpoint_info import EndpointInfo
 from tests import test_constants
 
 
@@ -15,7 +16,7 @@ class TestSearchEndpoint(unittest.TestCase):
         # Set up GET response
         responses.get(test_constants.SOURCE_ENDPOINT + "*", json=test_constants.BASE_INDICES_DATA)
         # Now send request
-        index_data = index_operations.fetch_all_indices(test_constants.SOURCE_ENDPOINT)
+        index_data = index_operations.fetch_all_indices(EndpointInfo(test_constants.SOURCE_ENDPOINT))
         self.assertEqual(3, len(index_data.keys()))
         # Test that internal data has been filtered, but non-internal data is retained
         index_settings = index_data[test_constants.INDEX1_NAME][test_constants.SETTINGS_KEY]
@@ -33,7 +34,7 @@ class TestSearchEndpoint(unittest.TestCase):
                       match=[matchers.json_params_matcher(test_data[test_constants.INDEX2_NAME])])
         responses.put(test_constants.TARGET_ENDPOINT + test_constants.INDEX3_NAME,
                       match=[matchers.json_params_matcher(test_data[test_constants.INDEX3_NAME])])
-        index_operations.create_indices(test_data, test_constants.TARGET_ENDPOINT, None)
+        index_operations.create_indices(test_data, EndpointInfo(test_constants.TARGET_ENDPOINT))
 
     @responses.activate
     def test_create_indices_exception(self):
@@ -43,7 +44,7 @@ class TestSearchEndpoint(unittest.TestCase):
         del test_data[test_constants.INDEX3_NAME]
         responses.put(test_constants.TARGET_ENDPOINT + test_constants.INDEX1_NAME,
                       body=requests.Timeout())
-        index_operations.create_indices(test_data, test_constants.TARGET_ENDPOINT, None)
+        index_operations.create_indices(test_data, EndpointInfo(test_constants.TARGET_ENDPOINT))
 
     @responses.activate
     def test_doc_count(self):
@@ -52,7 +53,7 @@ class TestSearchEndpoint(unittest.TestCase):
         mock_count_response = {"count": "10"}
         responses.get(expected_count_endpoint, json=mock_count_response)
         # Now send request
-        count_value = index_operations.doc_count(test_indices, test_constants.SOURCE_ENDPOINT)
+        count_value = index_operations.doc_count(test_indices, EndpointInfo(test_constants.SOURCE_ENDPOINT))
         self.assertEqual(10, count_value)
 
 

--- a/FetchMigration/index_configuration_tool/tests/test_index_operations.py
+++ b/FetchMigration/index_configuration_tool/tests/test_index_operations.py
@@ -44,7 +44,8 @@ class TestSearchEndpoint(unittest.TestCase):
         del test_data[test_constants.INDEX3_NAME]
         responses.put(test_constants.TARGET_ENDPOINT + test_constants.INDEX1_NAME,
                       body=requests.Timeout())
-        index_operations.create_indices(test_data, EndpointInfo(test_constants.TARGET_ENDPOINT))
+        self.assertRaises(RuntimeError, index_operations.create_indices, test_data,
+                          EndpointInfo(test_constants.TARGET_ENDPOINT))
 
     @responses.activate
     def test_doc_count(self):

--- a/FetchMigration/index_configuration_tool/tests/test_index_operations.py
+++ b/FetchMigration/index_configuration_tool/tests/test_index_operations.py
@@ -45,6 +45,16 @@ class TestSearchEndpoint(unittest.TestCase):
                       body=requests.Timeout())
         index_operations.create_indices(test_data, test_constants.TARGET_ENDPOINT, None)
 
+    @responses.activate
+    def test_doc_count(self):
+        test_indices = {test_constants.INDEX1_NAME, test_constants.INDEX2_NAME}
+        expected_count_endpoint = test_constants.SOURCE_ENDPOINT + ",".join(test_indices) + "/_count"
+        mock_count_response = {"count": "10"}
+        responses.get(expected_count_endpoint, json=mock_count_response)
+        # Now send request
+        count_value = index_operations.doc_count(test_indices, test_constants.SOURCE_ENDPOINT)
+        self.assertEqual(10, count_value)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/FetchMigration/index_configuration_tool/tests/test_main.py
+++ b/FetchMigration/index_configuration_tool/tests/test_main.py
@@ -88,25 +88,26 @@ class TestMain(unittest.TestCase):
         # Simple base case
         test_config = create_plugin_config([host_input])
         result = main.get_endpoint_info(test_config)
-        self.assertEqual(expected_endpoint, result[0])
-        self.assertIsNone(result[1])
+        self.assertEqual(expected_endpoint, result.url)
+        self.assertIsNone(result.auth)
+        self.assertTrue(result.verify_ssl)
         # Invalid auth config
         test_config = create_plugin_config([host_input], test_user)
         result = main.get_endpoint_info(test_config)
-        self.assertEqual(expected_endpoint, result[0])
-        self.assertIsNone(result[1])
+        self.assertEqual(expected_endpoint, result.url)
+        self.assertIsNone(result.auth)
         # Valid auth config
         test_config = create_plugin_config([host_input], user=test_user, password=test_password)
         result = main.get_endpoint_info(test_config)
-        self.assertEqual(expected_endpoint, result[0])
-        self.assertEqual(test_user, result[1][0])
-        self.assertEqual(test_password, result[1][1])
+        self.assertEqual(expected_endpoint, result.url)
+        self.assertEqual(test_user, result.auth[0])
+        self.assertEqual(test_password, result.auth[1])
         # Array of hosts uses the first entry
         test_config = create_plugin_config([host_input, "other_host"], test_user, test_password)
         result = main.get_endpoint_info(test_config)
-        self.assertEqual(expected_endpoint, result[0])
-        self.assertEqual(test_user, result[1][0])
-        self.assertEqual(test_password, result[1][1])
+        self.assertEqual(expected_endpoint, result.url)
+        self.assertEqual(test_user, result.auth[0])
+        self.assertEqual(test_password, result.auth[1])
 
     def test_get_index_differences_empty(self):
         # Base case should return an empty list
@@ -258,7 +259,7 @@ class TestMain(unittest.TestCase):
         test_input.report = True
         test_input.dryrun = False
         main.run(test_input)
-        mock_create_indices.assert_called_once_with(expected_create_payload, test_constants.TARGET_ENDPOINT, ANY)
+        mock_create_indices.assert_called_once_with(expected_create_payload, ANY)
         mock_doc_count.assert_called()
         mock_print_report.assert_called_once_with(expected_diff, 1)
         mock_write_output.assert_not_called()

--- a/FetchMigration/index_configuration_tool/tests/test_main.py
+++ b/FetchMigration/index_configuration_tool/tests/test_main.py
@@ -265,13 +265,15 @@ class TestMain(unittest.TestCase):
         mock_write_output.assert_not_called()
 
     @patch('index_operations.doc_count')
+    @patch('main.dump_count_and_indices')
     @patch('main.print_report')
     @patch('main.write_output')
     @patch('index_operations.fetch_all_indices')
     # Note that mock objects are passed bottom-up from the patch order above
     def test_run_dryrun(self, mock_fetch_indices: MagicMock, mock_write_output: MagicMock,
-                        mock_print_report: MagicMock, mock_doc_count: MagicMock):
+                        mock_print_report: MagicMock, mock_dump: MagicMock, mock_doc_count: MagicMock):
         index_to_create = test_constants.INDEX1_NAME
+        mock_doc_count.return_value = 1
         expected_output_path = "dummy"
         # Create mock data for indices on target
         target_indices_data = copy.deepcopy(test_constants.BASE_INDICES_DATA)
@@ -287,8 +289,9 @@ class TestMain(unittest.TestCase):
         main.run(test_input)
         mock_write_output.assert_called_once_with(self.loaded_pipeline_config, {index_to_create}, expected_output_path)
         mock_doc_count.assert_called()
-        # Report should not be printed
+        # Report should not be printed, but dump should be invoked
         mock_print_report.assert_not_called()
+        mock_dump.assert_called_once_with(mock_doc_count.return_value, {index_to_create})
 
     @patch('yaml.dump')
     def test_write_output(self, mock_dump: MagicMock):

--- a/FetchMigration/index_configuration_tool/tests/test_main.py
+++ b/FetchMigration/index_configuration_tool/tests/test_main.py
@@ -235,7 +235,6 @@ class TestMain(unittest.TestCase):
         index_to_create = test_constants.INDEX3_NAME
         index_with_conflict = test_constants.INDEX2_NAME
         index_exact_match = test_constants.INDEX1_NAME
-        expected_output_path = "dummy"
         # Set up expected arguments to mocks so we can verify
         expected_create_payload = {index_to_create: test_constants.BASE_INDICES_DATA[index_to_create]}
         # Print report accepts a tuple. The elements of the tuple
@@ -252,13 +251,14 @@ class TestMain(unittest.TestCase):
         # Set up test input
         test_input = argparse.Namespace()
         test_input.config_file_path = test_constants.PIPELINE_CONFIG_RAW_FILE_PATH
-        test_input.output_file = expected_output_path
+        # Default value for missing output file
+        test_input.output_file = ""
         test_input.report = True
         test_input.dryrun = False
         main.run(test_input)
         mock_create_indices.assert_called_once_with(expected_create_payload, test_constants.TARGET_ENDPOINT, ANY)
         mock_print_report.assert_called_once_with(expected_diff)
-        mock_write_output.assert_called_once_with(self.loaded_pipeline_config, {index_to_create}, expected_output_path)
+        mock_write_output.assert_not_called()
 
     @patch('main.print_report')
     @patch('main.write_output')
@@ -310,6 +310,15 @@ class TestMain(unittest.TestCase):
             main.write_output(test_input, {index_to_create}, expected_output_path)
             mock_open.assert_called_once_with(expected_output_path, 'w')
             mock_dump.assert_called_once_with(expected_output_data, ANY)
+
+    def test_missing_output_file_non_report(self):
+        # Set up test input
+        test_input = argparse.Namespace()
+        test_input.config_file_path = test_constants.PIPELINE_CONFIG_RAW_FILE_PATH
+        # Default value for missing output file
+        test_input.output_file = ""
+        test_input.report = False
+        self.assertRaises(ValueError, main.run, test_input)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### Description
This change allows the Index Configuration Tool report to print the total number of documents that will be migrated, based on the indices identified for creation. The change includes a new API call under `index_operations.py` and updated unit tests. 
* Category: Enhancement

This PR also includes some other minor changes:
1. The output YAML file is now optional, allowing users to print a report without producing a YAML file. However, one of `--report` or an output YAML file path are required - omitting both will result in a `ValueError`
2. A new `EndpointInfo` [dataclass](https://docs.python.org/3/library/dataclasses.html) has been introduced to encapsulate endpoint information (URL, auth and SSL verification flag) for source and target
3. The default output of the tool has been changed to dump the total document count followed by the list of created indices. `-r / --report` should be specified to produce human-readable output. All other print statements have been removed.

### Testing
```
$ python -m coverage report --omit "*/tests/*"
Name                  Stmts   Miss  Cover
-----------------------------------------
endpoint_info.py          6      0   100%
index_operations.py      35      0   100%
main.py                 121      1    99%
utils.py                 13      0   100%
-----------------------------------------
TOTAL                   175      1    99%
```

### Check List
- [x] New functionality includes testing
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
