### PR TITLE
Add option to use AWS secret in auth header for Replayer requests

### DIFF
--- a/TrafficCapture/trafficReplayer/build.gradle
+++ b/TrafficCapture/trafficReplayer/build.gradle
@@ -61,6 +61,8 @@ dependencies {
 
     testImplementation project(':testUtilities')
     testImplementation group: 'org.apache.httpcomponents.client5', name: 'httpclient5', version: '5.2.1'
+    testImplementation 'org.mockito:mockito-core:4.6.1'
+    testImplementation 'org.mockito:mockito-junit-jupiter:4.6.1'
 }
 
 application {

--- a/TrafficCapture/trafficReplayer/build.gradle
+++ b/TrafficCapture/trafficReplayer/build.gradle
@@ -42,6 +42,7 @@ repositories {
 dependencies {
     implementation project(':captureProtobufs')
 
+    implementation group: 'com.amazonaws.secretsmanager', name: 'aws-secretsmanager-caching-java', version: '1.0.2'
     implementation group: 'com.beust', name: 'jcommander', version: '1.82'
     implementation group: 'com.bazaarvoice.jolt', name: 'jolt-core', version: '0.1.7'
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.15.0'
@@ -70,18 +71,6 @@ jar {
     manifest {
         attributes 'Main-Class': application.mainClass
     }
-}
-
-task uberJar(type: Jar) {
-    manifest {
-        attributes 'Main-Class': application.mainClass
-    }
-    from {
-        configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) }
-    }
-    archiveBaseName = project.name + "-uber"
-    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
-    with jar
 }
 
 tasks.named('test') {

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/AWSAuthService.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/AWSAuthService.java
@@ -1,0 +1,41 @@
+package org.opensearch.migrations.replay;
+
+import com.amazonaws.secretsmanager.caching.SecretCache;
+import lombok.extern.slf4j.Slf4j;
+
+import java.nio.charset.Charset;
+import java.util.Base64;
+
+@Slf4j
+public class AWSAuthService implements AutoCloseable {
+
+    private final SecretCache secretCache;
+
+    public AWSAuthService() {
+        secretCache = new SecretCache();
+    }
+
+    // SecretId here can be either the unique name of the secret or the secret ARN
+    public String getSecret(String secretId) {
+        return secretCache.getSecretString(secretId);
+    }
+
+    /**
+     * This method returns a Basic Auth header string, with the username:password Base64 encoded
+     * @param username The plaintext username
+     * @param secretId The unique name of the secret or the secret ARN from AWS Secrets Manager. Its retrieved value
+     *                 will fill the password part of the Basic Auth header
+     * @return Basic Auth header string
+     */
+    public String getBasicAuthHeaderFromSecret(String username, String secretId) {
+        String authHeaderString = username + ":" + getSecret(secretId);
+        String authHeaderBase64 = "Basic " + Base64.getEncoder().encodeToString(authHeaderString.getBytes(Charset.defaultCharset()));
+        log.error("Header: " + authHeaderBase64);
+        return authHeaderBase64;
+    }
+
+    @Override
+    public void close() {
+        secretCache.close();
+    }
+}

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/AWSAuthService.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/AWSAuthService.java
@@ -29,9 +29,7 @@ public class AWSAuthService implements AutoCloseable {
      */
     public String getBasicAuthHeaderFromSecret(String username, String secretId) {
         String authHeaderString = username + ":" + getSecret(secretId);
-        String authHeaderBase64 = "Basic " + Base64.getEncoder().encodeToString(authHeaderString.getBytes(Charset.defaultCharset()));
-        log.error("Header: " + authHeaderBase64);
-        return authHeaderBase64;
+        return "Basic " + Base64.getEncoder().encodeToString(authHeaderString.getBytes(Charset.defaultCharset()));
     }
 
     @Override

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/AWSAuthService.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/AWSAuthService.java
@@ -11,8 +11,12 @@ public class AWSAuthService implements AutoCloseable {
 
     private final SecretCache secretCache;
 
+    public AWSAuthService(SecretCache secretCache) {
+        this.secretCache = secretCache;
+    }
+
     public AWSAuthService() {
-        secretCache = new SecretCache();
+        this(new SecretCache());
     }
 
     // SecretId here can be either the unique name of the secret or the secret ARN

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/AWSAuthServiceTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/AWSAuthServiceTest.java
@@ -1,0 +1,32 @@
+package org.opensearch.migrations.replay;
+
+import com.amazonaws.secretsmanager.caching.SecretCache;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class AWSAuthServiceTest {
+
+    @Mock
+    private SecretCache secretCache;
+
+    @Test
+    public void testBasicAuthHeaderFromSecret() {
+        String testSecretId = "testSecretId";
+        String testUsername = "testAdmin";
+        String expectedResult = "Basic dGVzdEFkbWluOmFkbWluUGFzcw==";
+
+        when(secretCache.getSecretString(testSecretId)).thenReturn("adminPass");
+
+        AWSAuthService awsAuthService = new AWSAuthService(secretCache);
+        String header = awsAuthService.getBasicAuthHeaderFromSecret(testUsername, testSecretId);
+        Assertions.assertEquals(expectedResult, header);
+    }
+
+
+}

--- a/deployment/cdk/opensearch-service-migration/lib/opensearch-service-domain-cdk-stack.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/opensearch-service-domain-cdk-stack.ts
@@ -124,8 +124,13 @@ export class OpensearchServiceDomainCdkStack extends Stack {
     const exports = [
       `export MIGRATION_DOMAIN_ENDPOINT=${this.domainEndpoint}`
     ]
-    if (adminUserName) exports.push(`export MIGRATION_DOMAIN_USER_NAME=${adminUserName}`)
-    if (adminUserSecret) exports.push(`export MIGRATION_DOMAIN_USER_SECRET=${adminUserSecret.secretArn}`)
+    if (domain.masterUserPassword && !adminUserSecret) {
+      console.log("A master user was configured without an existing Secrets Manager secret, will not export MIGRATION_DOMAIN_USER_NAME and MIGRATION_DOMAIN_USER_SECRET_ARN for Copilot")
+    }
+    else if (domain.masterUserPassword && adminUserSecret) {
+      exports.push(`export MIGRATION_DOMAIN_USER_NAME=${adminUserName}`)
+      exports.push(`export MIGRATION_DOMAIN_USER_SECRET_ARN=${adminUserSecret.secretArn}`)
+    }
     new CfnOutput(this, 'CopilotDomainExports', {
       value: exports.join(";"),
       description: 'Exported Domain resource values created by CDK that are needed by Copilot container deployments',

--- a/deployment/cdk/opensearch-service-migration/lib/opensearch-service-domain-cdk-stack.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/opensearch-service-domain-cdk-stack.ts
@@ -5,7 +5,7 @@ import {CfnOutput, RemovalPolicy, SecretValue, Stack} from "aws-cdk-lib";
 import {IKey, Key} from "aws-cdk-lib/aws-kms";
 import {PolicyStatement} from "aws-cdk-lib/aws-iam";
 import {ILogGroup, LogGroup} from "aws-cdk-lib/aws-logs";
-import {Secret} from "aws-cdk-lib/aws-secretsmanager";
+import {ISecret, Secret} from "aws-cdk-lib/aws-secretsmanager";
 import {StackPropsExt} from "./stack-composer";
 
 
@@ -55,8 +55,9 @@ export class OpensearchServiceDomainCdkStack extends Stack {
     const earKmsKey: IKey|undefined = props.encryptionAtRestKmsKeyARN && props.encryptionAtRestEnabled ?
         Key.fromKeyArn(this, "earKey", props.encryptionAtRestKmsKeyARN) : undefined
 
-    let adminUserSecret: SecretValue|undefined = props.fineGrainedManagerUserSecretManagerKeyARN ?
-        Secret.fromSecretCompleteArn(this, "managerSecret", props.fineGrainedManagerUserSecretManagerKeyARN).secretValue : undefined
+    let adminUserSecret: ISecret|undefined = props.fineGrainedManagerUserSecretManagerKeyARN ?
+        Secret.fromSecretCompleteArn(this, "managerSecret", props.fineGrainedManagerUserSecretManagerKeyARN) : undefined
+
 
     const appLG: ILogGroup|undefined = props.appLogGroup && props.appLogEnabled ?
         LogGroup.fromLogGroupArn(this, "appLogGroup", props.appLogGroup) : undefined
@@ -67,12 +68,11 @@ export class OpensearchServiceDomainCdkStack extends Stack {
     // Enable demo mode setting
     if (props.enableDemoAdmin) {
       adminUserName = "admin"
-      const adminSecret = new Secret(this, "demoUserSecret", {
+      adminUserSecret = new Secret(this, "demoUserSecret", {
         secretName: "demo-user-secret",
         // This is unsafe and strictly for ease of use in a demo mode setup
         secretStringValue: SecretValue.unsafePlainText("Admin123!")
       })
-      adminUserSecret = adminSecret.secretValue;
     }
     const zoneAwarenessConfig: ZoneAwarenessConfig|undefined = props.availabilityZoneCount ?
         {enabled: true, availabilityZoneCount: props.availabilityZoneCount} : undefined
@@ -93,7 +93,7 @@ export class OpensearchServiceDomainCdkStack extends Stack {
       fineGrainedAccessControl: {
         masterUserArn: props.fineGrainedManagerUserARN,
         masterUserName: adminUserName,
-        masterUserPassword: adminUserSecret
+        masterUserPassword: adminUserSecret ? adminUserSecret.secretValue : undefined
       },
       nodeToNodeEncryption: props.nodeToNodeEncryptionEnabled,
       encryptionAtRest: {
@@ -125,7 +125,7 @@ export class OpensearchServiceDomainCdkStack extends Stack {
       `export MIGRATION_DOMAIN_ENDPOINT=${this.domainEndpoint}`
     ]
     if (adminUserName) exports.push(`export MIGRATION_DOMAIN_USER_NAME=${adminUserName}`)
-    if (adminUserSecret) exports.push(`export MIGRATION_DOMAIN_USER_SECRET=${adminUserSecret}`)
+    if (adminUserSecret) exports.push(`export MIGRATION_DOMAIN_USER_SECRET=${adminUserSecret.secretArn}`)
     new CfnOutput(this, 'CopilotDomainExports', {
       value: exports.join(";"),
       description: 'Exported Domain resource values created by CDK that are needed by Copilot container deployments',

--- a/deployment/copilot/README.md
+++ b/deployment/copilot/README.md
@@ -75,7 +75,7 @@ The provided CDK will output export commands once deployed that can be ran on a 
 export MIGRATION_DOMAIN_SG_ID=sg-123;
 export MIGRATION_DOMAIN_ENDPOINT=vpc-aos-domain-123.us-east-1.es.amazonaws.com;
 export MIGRATION_DOMAIN_USER_NAME=admin
-export MIGRATION_DOMAIN_USER_SECRET=arn:aws:secretsmanager:us-east-1:123456789123:secret:demo-user-secret-123abc
+export MIGRATION_DOMAIN_USER_SECRET_ARN=arn:aws:secretsmanager:us-east-1:123456789123:secret:demo-user-secret-123abc
 export MIGRATION_VPC_ID=vpc-123;
 export MIGRATION_CAPTURE_MSK_SG_ID=sg-123;
 export MIGRATION_COMPARATOR_EFS_ID=fs-123;
@@ -88,7 +88,7 @@ export MIGRATION_KAFKA_BROKER_ENDPOINTS=b-1-public.loggingmskcluster.123.45.kafk
 ```
 Additionally, if not using the deploy script, the following export is needed for the Replayer service:
 ```
-export MIGRATION_REPLAYER_COMMAND=/bin/sh -c "/runJavaWithClasspath.sh org.opensearch.migrations.replay.TrafficReplayer $MIGRATION_DOMAIN_ENDPOINT --insecure --kafka-traffic-brokers $MIGRATION_KAFKA_BROKER_ENDPOINTS --kafka-traffic-topic logging-traffic-topic --kafka-traffic-group-id default-logging-group --kafka-traffic-enable-msk-auth --aws-auth-header-user $MIGRATION_DOMAIN_USER_NAME --aws-auth-header-secret $MIGRATION_DOMAIN_USER_SECRET | nc traffic-comparator 9220"
+export MIGRATION_REPLAYER_COMMAND=/bin/sh -c "/runJavaWithClasspath.sh org.opensearch.migrations.replay.TrafficReplayer $MIGRATION_DOMAIN_ENDPOINT --insecure --kafka-traffic-brokers $MIGRATION_KAFKA_BROKER_ENDPOINTS --kafka-traffic-topic logging-traffic-topic --kafka-traffic-group-id default-logging-group --kafka-traffic-enable-msk-auth --aws-auth-header-user $MIGRATION_DOMAIN_USER_NAME --aws-auth-header-secret $MIGRATION_DOMAIN_USER_SECRET_ARN | nc traffic-comparator 9220"
 ```
 
 #### Setting up existing Copilot infrastructure

--- a/deployment/copilot/devDeploy.sh
+++ b/deployment/copilot/devDeploy.sh
@@ -181,7 +181,7 @@ elif [ -n "${REPLAY_AWS_AUTH_HEADER_USER}" ]; then
   auth_header_args="--aws-auth-header-user ${REPLAY_AWS_AUTH_HEADER_USER} --aws-auth-header-secret ${REPLAY_AWS_AUTH_HEADER_SECRET}"
 # Use CDK environment variables for a target cluster user if detected
 elif [ -n "${MIGRATION_DOMAIN_USER_NAME}" ]; then
-  auth_header_args="--aws-auth-header-user ${MIGRATION_DOMAIN_USER_NAME} --aws-auth-header-secret ${MIGRATION_DOMAIN_USER_SECRET}"
+  auth_header_args="--aws-auth-header-user ${MIGRATION_DOMAIN_USER_NAME} --aws-auth-header-secret ${MIGRATION_DOMAIN_USER_SECRET_ARN}"
 else
   echo "No auth header options detected for Replayer, defaulting to not specifying an explicit auth header"
 fi

--- a/deployment/copilot/devDeploy.sh
+++ b/deployment/copilot/devDeploy.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Automation script to deploy the migration solution pipeline to AWS for development use case. The current requirement
 # for use is having valid AWS credentials available to the environment
@@ -18,13 +18,16 @@ usage() {
   echo "Deploy migration solution infrastructure composed of resources deployed by CDK and Copilot"
   echo ""
   echo "Options:"
-  echo "  --skip-bootstrap        Skip one-time setup of installing npm package, bootstrapping CDK, and building Docker images."
-  echo "  --skip-copilot-init     Skip one-time Copilot initialization of app, environments, and services"
-  echo "  --copilot-app-name      [string, default: migration-copilot] Specify the Copilot application name to use for deployment"
-  echo "  --destroy-env           Destroy all CDK and Copilot CloudFormation stacks deployed, excluding the Copilot app level stack, for the given env/stage and return to a clean state."
-  echo "  --destroy-all-copilot   Destroy Copilot app and all Copilot CloudFormation stacks deployed for the given app across all regions."
-  echo "  -r, --region            [string, default: us-east-1] Specify the AWS region to deploy the CloudFormation stacks and resources."
-  echo "  -s, --stage             [string, default: dev] Specify the stage name to associate with the deployed resources"
+  echo "  --skip-bootstrap          Skip one-time setup of installing npm package, bootstrapping CDK, and building Docker images."
+  echo "  --skip-copilot-init       Skip one-time Copilot initialization of app, environments, and services"
+  echo "  --copilot-app-name        [string, default: migration-copilot] Specify the Copilot application name to use for deployment"
+  echo "  --destroy-env             Destroy all CDK and Copilot CloudFormation stacks deployed, excluding the Copilot app level stack, for the given env/stage and return to a clean state."
+  echo "  --destroy-all-copilot     Destroy Copilot app and all Copilot CloudFormation stacks deployed for the given app across all regions."
+  echo "  --auth-header-value       [string, default: null] Prepared \"authorization\" header to provide the Replayer, i.e. Basic YWRtaW46QWRtaW4xMjMh. This will override a CDK configured FGAC master user auth header if setup"
+  echo "  --aws-auth-header-user    [string, default: null] Plaintext username to provide the Replayer to construct an \"authorization\" header. Used in conjunction with --aws-auth-header-secret. This will override a CDK configured FGAC master user auth header if setup"
+  echo "  --aws-auth-header-secret  [string, default: null] Secret ARN or Secret name from AWS Secrets Manager to provide the Replayer to construct an \"authorization\" header. Used in conjunction with --aws-auth-header-user. This will override a CDK configured FGAC master user auth header if setup"
+  echo "  -r, --region              [string, default: us-east-1] Specify the AWS region to deploy the CloudFormation stacks and resources."
+  echo "  -s, --stage               [string, default: dev] Specify the stage name to associate with the deployed resources"
   exit 1
 }
 
@@ -35,6 +38,10 @@ DESTROY_ENV=false
 DESTROY_ALL_COPILOT=false
 REGION=us-east-1
 STAGE=dev
+
+REPLAY_AUTH_HEADER=""
+REPLAY_AWS_AUTH_HEADER_USER=""
+REPLAY_AWS_AUTH_HEADER_SECRET=""
 while [[ $# -gt 0 ]]; do
   case $1 in
     --skip-bootstrap)
@@ -58,6 +65,21 @@ while [[ $# -gt 0 ]]; do
       DESTROY_ALL_COPILOT=true
       shift # past argument
       ;;
+    --auth-header-value)
+      REPLAY_AUTH_HEADER="$2"
+      shift # past argument
+      shift # past value
+      ;;
+    --aws-auth-header-user)
+      REPLAY_AWS_AUTH_HEADER_USER="$2"
+      shift # past argument
+      shift # past value
+      ;;
+    --aws-auth-header-secret)
+      REPLAY_AWS_AUTH_HEADER_SECRET="$2"
+      shift # past argument
+      shift # past value
+      ;;
     -r|--region)
       REGION="$2"
       shift # past argument
@@ -80,6 +102,16 @@ while [[ $# -gt 0 ]]; do
       ;;
   esac
 done
+
+if [[ -n "${REPLAY_AUTH_HEADER}" && ( -n "${REPLAY_AWS_AUTH_HEADER_USER}" || -n "${REPLAY_AWS_AUTH_HEADER_SECRET}" ) ]]; then
+    echo "[--auth-header-value] and [--aws-auth-header-user, --aws-auth-header-secret] are mutually exclusive sets of authorization header parameters"
+    exit 1
+fi
+
+if [[ ( -n "${REPLAY_AWS_AUTH_HEADER_USER}" || -n "${REPLAY_AWS_AUTH_HEADER_SECRET}" ) && (  -z "${REPLAY_AWS_AUTH_HEADER_USER}" || -z "${REPLAY_AWS_AUTH_HEADER_SECRET}" ) ]]; then
+    echo "[--aws-auth-header-user, --aws-auth-header-secret] must both be provided if specified"
+    exit 1
+fi
 
 COPILOT_DEPLOYMENT_STAGE=$STAGE
 export AWS_DEFAULT_REGION=$REGION
@@ -133,12 +165,31 @@ fi
 cdk deploy "*" --c domainName="aos-domain" --c engineVersion="OS_1.3" --c  dataNodeCount=2 --c vpcEnabled=true --c availabilityZoneCount=2 --c openAccessPolicyEnabled=true --c domainRemovalPolicy="DESTROY" --c migrationAssistanceEnabled=true --c enableDemoAdmin=true -O cdkOutput.json --require-approval never --concurrency 3
 
 # Gather CDK output which includes export commands needed by Copilot, and make them available to the environment
-found_exports=$(grep -o "export [a-zA-Z0-9_]*=[^\\;\"]*" cdkOutput.json)
-eval "$(grep -o "export [a-zA-Z0-9_]*=[^\\;\"]*" cdkOutput.json)"
+found_exports=$(grep -o "export[^\"]" cdkOutput.json)
+eval "$(grep -o "export[^\"]" cdkOutput.json)"
 printf "The following exports were added from CDK:\n%s\n" "$found_exports"
 
 # Future enhancement needed here to make our Copilot deployment able to be reran without error even if no changes are deployed
 # === Copilot Deployment ===
+
+# Construct Replayer image docker command
+auth_header_args=""
+# Use arguments passed to script to override default auth header values
+if [ -n "${REPLAY_AUTH_HEADER}" ]; then
+  auth_header_args="--auth-header-value ${REPLAY_AUTH_HEADER}"
+elif [ -n "${REPLAY_AWS_AUTH_HEADER_USER}" ]; then
+  auth_header_args="--aws-auth-header-user ${REPLAY_AWS_AUTH_HEADER_USER} --aws-auth-header-secret ${REPLAY_AWS_AUTH_HEADER_SECRET}"
+# Use CDK environment variables for a target cluster user if detected
+elif [ -n "${MIGRATION_DOMAIN_USER_NAME}" ]; then
+  auth_header_args="--aws-auth-header-user ${MIGRATION_DOMAIN_USER_NAME} --aws-auth-header-secret ${MIGRATION_DOMAIN_USER_SECRET}"
+else
+  echo "No auth header options detected for Replayer, defaulting to not specifying an explicit auth header"
+fi
+replay_command_base="/bin/sh -c \"/runJavaWithClasspath.sh org.opensearch.migrations.replay.TrafficReplayer https://${MIGRATION_DOMAIN_ENDPOINT}:443 --insecure --kafka-traffic-brokers ${MIGRATION_KAFKA_BROKER_ENDPOINTS} --kafka-traffic-topic logging-traffic-topic --kafka-traffic-group-id default-logging-group --kafka-traffic-enable-msk-auth "
+replay_command_end="\" | nc traffic-comparator 9220"
+replay_command="${replay_command_base}${auth_header_args}${replay_command_end}"
+echo "Constructed replay command: ${replay_command}"
+export MIGRATION_REPLAYER_COMMAND="${replay_command}"
 
 cd ../../copilot
 

--- a/deployment/copilot/devDeploy.sh
+++ b/deployment/copilot/devDeploy.sh
@@ -165,8 +165,8 @@ fi
 cdk deploy "*" --c domainName="aos-domain" --c engineVersion="OS_1.3" --c  dataNodeCount=2 --c vpcEnabled=true --c availabilityZoneCount=2 --c openAccessPolicyEnabled=true --c domainRemovalPolicy="DESTROY" --c migrationAssistanceEnabled=true --c enableDemoAdmin=true -O cdkOutput.json --require-approval never --concurrency 3
 
 # Gather CDK output which includes export commands needed by Copilot, and make them available to the environment
-found_exports=$(grep -o "export[^\"]" cdkOutput.json)
-eval "$(grep -o "export[^\"]" cdkOutput.json)"
+found_exports=$(grep -o "export [a-zA-Z0-9_]*=[^\\;\"]*" cdkOutput.json)
+eval "$(grep -o "export [a-zA-Z0-9_]*=[^\\;\"]*" cdkOutput.json)"
 printf "The following exports were added from CDK:\n%s\n" "$found_exports"
 
 # Future enhancement needed here to make our Copilot deployment able to be reran without error even if no changes are deployed
@@ -186,7 +186,7 @@ else
   echo "No auth header options detected for Replayer, defaulting to not specifying an explicit auth header"
 fi
 replay_command_base="/bin/sh -c \"/runJavaWithClasspath.sh org.opensearch.migrations.replay.TrafficReplayer https://${MIGRATION_DOMAIN_ENDPOINT}:443 --insecure --kafka-traffic-brokers ${MIGRATION_KAFKA_BROKER_ENDPOINTS} --kafka-traffic-topic logging-traffic-topic --kafka-traffic-group-id default-logging-group --kafka-traffic-enable-msk-auth "
-replay_command_end="\" | nc traffic-comparator 9220"
+replay_command_end=" | nc traffic-comparator 9220\""
 replay_command="${replay_command_base}${auth_header_args}${replay_command_end}"
 echo "Constructed replay command: ${replay_command}"
 export MIGRATION_REPLAYER_COMMAND="${replay_command}"

--- a/deployment/copilot/traffic-replayer/addons/taskRole.yml
+++ b/deployment/copilot/traffic-replayer/addons/taskRole.yml
@@ -47,6 +47,11 @@ Resources:
               # Values to join
               - - { "Fn::Join" : [ ":group", { "Fn::Split": [":cluster", {"Fn::ImportValue" : !Sub "${App}-${Env}-msk-cluster-arn"}]}] }
                 - "/*"
+          - Action:
+              - secretsmanager:GetSecretValue
+              - secretsmanager:DescribeSecret
+            Effect: Allow
+            Resource: "*"
 
 Outputs:
   # 1. You need to output the IAM ManagedPolicy so that Copilot can add it as a managed policy to your ECS task role.

--- a/deployment/copilot/traffic-replayer/manifest.yml
+++ b/deployment/copilot/traffic-replayer/manifest.yml
@@ -18,7 +18,7 @@ image:
   build:
     dockerfile: ../TrafficCapture/dockerSolution/build/docker/trafficReplayer/Dockerfile
 
-command: /bin/sh -c "/runJavaWithClasspath.sh org.opensearch.migrations.replay.TrafficReplayer https://${MIGRATION_DOMAIN_ENDPOINT}:443 --insecure --auth-header-value Basic\\ YWRtaW46QWRtaW4xMjMh --kafka-traffic-brokers ${MIGRATION_KAFKA_BROKER_ENDPOINTS} --kafka-traffic-topic logging-traffic-topic --kafka-traffic-group-id default-logging-group --kafka-traffic-enable-msk-auth | nc traffic-comparator 9220"
+command: "${MIGRATION_REPLAYER_COMMAND}"
 
 storage:
   volumes:


### PR DESCRIPTION
### Description
This change adds two arguments to the Replayer to add support for adding an auth header from an AWS SecretsManager secret and users `--aws-auth-header-user admin --aws-auth-header-secret arn:123`

In the near future it is expected this structure will change as the Replayer is enhanced to support different users and providing a single user auth probably won't make sense. In the meantime this gives a structure to use a secret and construct an auth header with it for replayed requests. Another detail that presented itself is that the Jolt transformation library doesn't seem to easily support dynamic value transformations (i.e. we would want to access our SecretCache regularly and have it occasionally make requests to SecretsManager to get updated secrets). For now we are only fetching the secret once at app startup but this is a temporary measure until we have support for this.

More significant changes went into the IaC than originally estimated with trying to support a range of different auth-header options, and making it a bit easier from the Copilot side to override these options with cases where we didn't setup a target cluster initially (and don't want to make a CDK change) or we just want to use a different user altogether. These changes start to step in the territory of an orchestration layer which made me a little hesitant to add, but would rather strip them out later than to be in the case of wanting to change this and not easily being able to for the short term.

### Issues Resolved
https://opensearch.atlassian.net/browse/MIGRATIONS-1191

### Testing
Manual/Unit tests

### Check List
- [x] New functionality includes testing
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
