### PR TITLE
Update `runTestBenchmarks.sh` script with params and defaults for copilot vs docker

### DIFF
--- a/TrafficCapture/README.md
+++ b/TrafficCapture/README.md
@@ -73,6 +73,23 @@ Running check-cluster-health                                                   [
 Running index-append                                                           [100% done]
 ```
 
+The `runTestBenchmarks` tool has a few configurable options. It will attempt to guess the correct endpoint to send traffic to,
+and it will automatically attach the basic auth user/password `admin`/`admin`.
+
+To set a custom endpoint, specify it with `--endpoint`, for example `./runTestBenchmarks --endpoint https://capture-proxy-domain.com:9200`.
+
+To set custom basic auth params, use `--auth_user` and `--auth_pass`. To prevent the script from attaching _any_ auth params, use the `--no_auth` flag.
+This flag overrides any other auth params, so if you use both `--auth_user` and `--no_auth`, the end result will be no auth being applied.
+
+As an example of including multiple options:
+```sh
+./runTestBenchmarks --endpoint https://capture-proxy-domain.com:9200 --auth_pass Admin123!
+```
+
+will send requests to `capture-proxy-domain.com`, using the auth combo `admin`/`Admin123!`.
+
+Support for Sigv4 signing and other auth options may be a future option.
+
 ### Capture Kafka Offloader
 
 The Capture Kafka Offloader will act as a Kafka Producer for offloading captured traffic logs to the configured Kafka cluster.

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/runTestBenchmarks.sh
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/runTestBenchmarks.sh
@@ -1,10 +1,66 @@
-#!/bin/sh
+#!/bin/bash
 
+# Default values
+default_docker_endpoint="https://capture_proxy_es:9200"
+default_copilot_endpoint="https://capture-proxy-es:443"
+auth_user="admin"
+auth_pass="admin"
+no_auth=false
+
+# Check for the presence of COPILOT_SERVICE_NAME environment variable
+if [ -n "$COPILOT_SERVICE_NAME" ]; then
+    ENDPOINT="$default_copilot_endpoint"
+else
+    ENDPOINT="$default_docker_endpoint"
+fi
+
+# Override default values with optional command-line arguments
+while [[ $# -gt 0 ]]; do
+    key="$1"
+    case $key in
+        --endpoint)
+            ENDPOINT="$2"
+            shift
+            shift
+            ;;
+        --auth_user)
+            auth_user="$2"
+            shift
+            shift
+            ;;
+        --auth_pass)
+            auth_pass="$2"
+            shift
+            shift
+            ;;
+        --no-auth)
+            no_auth=true
+            shift
+            ;;
+        *)
+            shift
+            ;;
+    esac
+done
+
+# Populate auth string
+if [ "$no_auth" = true ]; then
+    auth_string=""
+else
+    auth_string=",basic_auth_user:${auth_user},basic_auth_password:${auth_pass}"
+fi
+
+# Construct the final client options string
+base_options_string="use_ssl:true,verify_certs:false"
+final_string="${base_options_string}${auth_string}"
+client_options="${base_options_string}${auth_string}"
+
+echo "Running opensearch-benchmark workloads against ${ENDPOINT}"
 echo "Running opensearch-benchmark w/ 'geonames' workload..." &&
-opensearch-benchmark execute-test --distribution-version=1.0.0 --target-host=https://capture_proxy_es:9200 --workload=geonames --pipeline=benchmark-only --test-mode --kill-running-processes --workload-params "target_throughput:0.5,bulk_size:10,bulk_indexing_clients:1,search_clients:1"  --client-options="use_ssl:true,verify_certs:false,basic_auth_user:admin,basic_auth_password:admin" &&
+opensearch-benchmark execute-test --distribution-version=1.0.0 --target-host=$ENDPOINT --workload=geonames --pipeline=benchmark-only --test-mode --kill-running-processes --workload-params "target_throughput:0.5,bulk_size:10,bulk_indexing_clients:1,search_clients:1"  --client-options=$client_options &&
 echo "Running opensearch-benchmark w/ 'http_logs' workload..." &&
-opensearch-benchmark execute-test --distribution-version=1.0.0 --target-host=https://capture_proxy_es:9200 --workload=http_logs --pipeline=benchmark-only --test-mode --kill-running-processes --workload-params "target_throughput:0.5,bulk_size:10,bulk_indexing_clients:1,search_clients:1"  --client-options="use_ssl:true,verify_certs:false,basic_auth_user:admin,basic_auth_password:admin" &&
+opensearch-benchmark execute-test --distribution-version=1.0.0 --target-host=$ENDPOINT --workload=http_logs --pipeline=benchmark-only --test-mode --kill-running-processes --workload-params "target_throughput:0.5,bulk_size:10,bulk_indexing_clients:1,search_clients:1" --client-options=$client_options &&
 echo "Running opensearch-benchmark w/ 'nested' workload..." &&
-opensearch-benchmark execute-test --distribution-version=1.0.0 --target-host=https://capture_proxy_es:9200 --workload=nested --pipeline=benchmark-only --test-mode --kill-running-processes --workload-params "target_throughput:0.5,bulk_size:10,bulk_indexing_clients:1,search_clients:1"  --client-options="use_ssl:true,verify_certs:false,basic_auth_user:admin,basic_auth_password:admin" &&
+opensearch-benchmark execute-test --distribution-version=1.0.0 --target-host=$ENDPOINT --workload=nested --pipeline=benchmark-only --test-mode --kill-running-processes --workload-params "target_throughput:0.5,bulk_size:10,bulk_indexing_clients:1,search_clients:1"  --client-options=$client_options &&
 echo "Running opensearch-benchmark w/ 'nyc_taxis' workload..." &&
-opensearch-benchmark execute-test --distribution-version=1.0.0 --target-host=https://capture_proxy_es:9200 --workload=nyc_taxis --pipeline=benchmark-only --test-mode --kill-running-processes --workload-params "target_throughput:0.5,bulk_size:10,bulk_indexing_clients:1,search_clients:1"  --client-options="use_ssl:true,verify_certs:false,basic_auth_user:admin,basic_auth_password:admin"
+opensearch-benchmark execute-test --distribution-version=1.0.0 --target-host=$ENDPOINT --workload=nyc_taxis --pipeline=benchmark-only --test-mode --kill-running-processes --workload-params "target_throughput:0.5,bulk_size:10,bulk_indexing_clients:1,search_clients:1"  --client-options=$client_options

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/runTestBenchmarks.sh
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/runTestBenchmarks.sh
@@ -52,7 +52,6 @@ fi
 
 # Construct the final client options string
 base_options_string="use_ssl:true,verify_certs:false"
-final_string="${base_options_string}${auth_string}"
 client_options="${base_options_string}${auth_string}"
 
 echo "Running opensearch-benchmark workloads against ${ENDPOINT}"


### PR DESCRIPTION
### Description
The current version of `runTestBenchmarks` has values in place that work for docker, but not for copilot, and the format of the script makes it challenging to update values quickly.

This version checks for a `COPILOT_SERVICE_NAME` env var. If it's present, it assumes we're in copilot and switches the default endpoint to the copilot-friendly one.

If the user is using a different endpoint or auth params (or no auth) on the source cluster, they can use a CL param to adjust those values. E.g.:

```
./runTestBenchmarks.sh --endpoint https://mycustomendpoint.com:9201 --auth_user admin123 --auth_pass admin123!
```

or
```
./runTestBenchmarks.sh --no_auth
```


### Issues Resolved
not created yet

### Testing
Manual testing. Documentation needs to be added!!

### Check List
- [ ] New functionality includes testing
  - [ ] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
