### PR TITLE
Add script to transform tuples to human readable format

### DIFF
--- a/TrafficCapture/README.md
+++ b/TrafficCapture/README.md
@@ -96,7 +96,7 @@ The Migration Console can be used to access and help interpret the data from the
 
 The data generated from the replayer is stored on an Elastic File System volume shared between the Replayer and Migration Console.
 It is mounted to the Migration Console at the path `/shared_replayer_output`. The Replayer generates files named `output_tuples.log`.
-These files are rolled over as they hit 10 Mb to a series of `output_tuples-%d{yyyy-MM-dd-HH:mm}.log` files.
+These files are rolled over as they hit 10 MB to a series of `output_tuples-%d{yyyy-MM-dd-HH:mm}.log` files.
 
 The data in these files is in the format of JSON lines, each of which is a log message containing a specific request-response-response tuple.
 The body of the messages is sometimes gzipped which makes it difficult to represent as text in a JSON. Therefore, the body field of all requests
@@ -117,7 +117,7 @@ options:
   -h, --help         show this help message and exit
   --outfile OUTFILE  Path for output human readable tuple file.
 
-# By default, the output file is the same path as the input file, but the file name is preface with `readable-`.
+# By default, the output file is the same path as the input file, but the file name is prefixed with `readable-`.
 $ ./humanReadableLogs.py /shared_replayer_output/tuples.log
 Input file: /shared_replayer_output/tuples.log; Output file: /shared_replayer_output/readable-tuples.log
 

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/Dockerfile
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/Dockerfile
@@ -8,8 +8,8 @@ RUN apt-get update && \
 
 COPY runTestBenchmarks.sh /root/
 COPY humanReadableLogs.py /root/
-RUN chmod ugo+x /root/runTestBenchmarks.sh
-RUN chmod ugo+x /root/humanReadableLogs.py
+RUN chmod ug+x /root/runTestBenchmarks.sh
+RUN chmod ug+x /root/humanReadableLogs.py
 WORKDIR /root
 
 CMD tail -f /dev/null

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/Dockerfile
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/Dockerfile
@@ -3,11 +3,13 @@ FROM ubuntu:focal
 ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends python3.11.4 python3-pip python3-dev gcc libc-dev git curl && \
-    pip3 install urllib3==1.25.11 opensearch-benchmark==1.1.0
+    apt-get install -y --no-install-recommends python3.9 python3-pip python3-dev gcc libc-dev git curl && \
+    pip3 install urllib3==1.25.11 opensearch-benchmark==1.1.0 tqdm
 
 COPY runTestBenchmarks.sh /root/
+COPY humanReadableLogs.py /root/
 RUN chmod ugo+x /root/runTestBenchmarks.sh
+RUN chmod ugo+x /root/humanReadableLogs.py
 WORKDIR /root
 
 CMD tail -f /dev/null

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/Dockerfile
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/Dockerfile
@@ -3,8 +3,8 @@ FROM ubuntu:focal
 ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends python3.9 python3-pip python3-dev gcc libc-dev git curl && \
-    pip3 install opensearch-benchmark
+    apt-get install -y --no-install-recommends python3.11.4 python3-pip python3-dev gcc libc-dev git curl && \
+    pip3 install urllib3==1.25.11 opensearch-benchmark==1.1.0
 
 COPY runTestBenchmarks.sh /root/
 RUN chmod ugo+x /root/runTestBenchmarks.sh

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/humanReadableLogs.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/humanReadableLogs.py
@@ -1,17 +1,10 @@
 #!/usr/bin/env python3
 
-# Find log files in /shared_replayer_output
-# User can select one or more files (down the line, specific time ranges?)
-# Load file, read each line as json.
-# Extract `message`, do the same un-base64 and possibly un-gzip as the comparator
-
-# ./humanReadableLogs /shared_replayer_output/output_tuple.log /shared_replayer_output/readable_tuples.json
-
 import argparse
-import pathlib
-import json
 import base64
 import gzip
+import json
+import pathlib
 from typing import Optional
 
 LOG_JSON_TUPLE_FIELD = "message"
@@ -92,13 +85,15 @@ def parse_tuple(line):
 
 if __name__ == "__main__":
     args = parse_args()
-    print(args.infile)
     if args.outfile:
         outfile = args.outfile
     else:
         outfile = args.infile.parent / f"readable-{args.infile.name}"
-    print(f"Will output to {outfile}")
+    print(f"Input file: {args.infile}; Output file: {outfile}")
     with open(args.infile, 'r') as in_f:
         with open(outfile, 'w') as out_f:
             for line in in_f:
                 print(parse_tuple(line), file=out_f)
+
+# TODO: add some try/catching
+# TODO: add a progress indicator for large files

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/humanReadableLogs.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/humanReadableLogs.py
@@ -107,7 +107,7 @@ def parse_body_value(raw_value: str, content_encoding: Optional[str],
     return decoded
 
 
-def parse_tuple(line: str, line_no: int):
+def parse_tuple(line: str, line_no: int) -> dict:
     item = json.loads(line)
     message = item[LOG_JSON_TUPLE_FIELD]
     tuple = json.loads(message)
@@ -143,4 +143,4 @@ if __name__ == "__main__":
         with open(args.infile, 'r') as in_f:
             with open(outfile, 'w') as out_f:
                 for i, line in tqdm(enumerate(in_f)):
-                    print(parse_tuple(line, i + 1), file=out_f)
+                    print(json.dumps(parse_tuple(line, i + 1)), file=out_f)

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/humanReadableLogs.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/humanReadableLogs.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+
+# Find log files in /shared_replayer_output
+# User can select one or more files (down the line, specific time ranges?)
+# Load file, read each line as json.
+# Extract `message`, do the same un-base64 and possibly un-gzip as the comparator
+
+# ./humanReadableLogs /shared_replayer_output/output_tuple.log /shared_replayer_output/readable_tuples.json
+
+import argparse
+import pathlib
+import json
+import base64
+import gzip
+from typing import Optional
+
+LOG_JSON_TUPLE_FIELD = "message"
+BASE64_ENCODED_TUPLE_PATHS = ["request.body", "primaryResponse.body", "shadowResponse.body"]
+# TODO: I'm not positive about the capitalization of the Content-Encoding and Content-Type headers.
+# This version worked on my test cases, but not guaranteed to work in all cases.
+CONTENT_ENCODING_PATH = {
+    BASE64_ENCODED_TUPLE_PATHS[0]: "request.content-encoding",
+    BASE64_ENCODED_TUPLE_PATHS[1]: "primaryResponse.content-encoding",
+    BASE64_ENCODED_TUPLE_PATHS[2]: "shadowResponse.content-encoding"
+}
+CONTENT_TYPE_PATH = {
+    BASE64_ENCODED_TUPLE_PATHS[0]: "request.content-type",
+    BASE64_ENCODED_TUPLE_PATHS[1]: "primaryResponse.content-type",
+    BASE64_ENCODED_TUPLE_PATHS[2]: "shadowResponse.content-type"
+}
+CONTENT_TYPE_JSON = "application/json"
+CONTENT_ENCODING_GZIP = "gzip"
+URI_PATH = "request.Request-URI"
+BULK_URI_PATH = "_bulk"
+
+
+def get_element(element: str, dict_: dict) -> Optional[any]:
+    keys = element.split('.')
+    rv = dict_
+    for key in keys:
+        try:
+            rv = rv[key]
+        except KeyError:
+            return None
+    return rv
+
+
+def set_element(element: str, dict_: dict, value: any) -> None:
+    keys = element.split('.')
+    rv = dict_
+    for key in keys[:-1]:
+        rv = rv[key]
+    rv[keys[-1]] = value
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("infile", type=pathlib.Path, help="Path to input logged tuple file.")
+    parser.add_argument("--outfile", type=pathlib.Path, help="Path for output human readable tuple file.")
+    return parser.parse_args()
+
+
+def parse_body_value(raw_value: str, content_encoding: Optional[str], content_type: Optional[str], is_bulk: bool):
+    b64decoded = base64.b64decode(raw_value)
+    is_gzipped = content_encoding is not None and content_encoding == CONTENT_ENCODING_GZIP
+    is_json = content_type is not None and CONTENT_TYPE_JSON in content_type
+    if is_gzipped:
+        unzipped = gzip.decompress(b64decoded)
+    else:
+        unzipped = b64decoded
+    decoded = unzipped.decode("utf-8")
+    if is_json and len(decoded) > 0:
+        if is_bulk:
+            return [json.loads(line) for line in decoded.splitlines()]
+        return json.loads(decoded)
+    return decoded
+
+
+def parse_tuple(line):
+    item = json.loads(line)
+    message = item[LOG_JSON_TUPLE_FIELD]
+    tuple = json.loads(message)
+    for path in BASE64_ENCODED_TUPLE_PATHS:
+        base64value = get_element(path, tuple)
+        content_encoding = get_element(CONTENT_ENCODING_PATH[path], tuple)
+        content_type = get_element(CONTENT_TYPE_PATH[path], tuple)
+        is_bulk_path = BULK_URI_PATH in get_element(URI_PATH, tuple)
+        value = parse_body_value(base64value, content_encoding, content_type, is_bulk_path)
+        set_element(path, tuple, value)
+    return tuple
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    print(args.infile)
+    if args.outfile:
+        outfile = args.outfile
+    else:
+        outfile = args.infile.parent / f"readable-{args.infile.name}"
+    print(f"Will output to {outfile}")
+    with open(args.infile, 'r') as in_f:
+        with open(outfile, 'w') as out_f:
+            for line in in_f:
+                print(parse_tuple(line), file=out_f)


### PR DESCRIPTION
Signed-off-by: Mikayla Thompson <thomika@amazon.com>

### Description
This adds a new feature as a follow up to #266 and #258 .
Those two PRs created a new EFS/shared volume attached to the replayer and migration console, and directed the replayer's output tuples to that volume.

The Replayer outputs base64 encoded message bodies in the tuples: this prevents issues where saving a gzipped message body in utf-8 in a json was corrupting them.

This PR adds a python script to the migration console that allows the user to specify a file of replayer-generated tuple logs. It loads each log line, extracts the tuple, and processes it:
- the message bodies are base64 decoded
- if the headers (Content-Encoding) indicate that the message is gzipped, it's unzipped
- if the headers (Content-Type) indicate that the message is a json, it's loaded as such
- if the uri indicates that the messages is a `_bulk` request, it's loaded as a bulk json (a list of jsons)

The processed tuples are then written to a new file. If an output file wasn't specified, it's the input file, but prefaced with `readable-`.

It takes a very tolerant approach to errors. If any errors are found (e.g. can't base64 decode, can't un-gzip, can't parse as json) it reports them (error & line number), but outputs the tuple to the final file in whatever most recent state it was able to generate (so if it can't be b64 decoded, the original tuple is written; if it can't be un-gzipped, the base64 decoded version is written). This is my best attempt to ensure that we tolerate weird data (which could be the OS cluster messing up its headers, for instance) and don't quietly hide it from a user's future analyses.

There are many ways this could be improved in the future:
- operating on an entire directory
- accepting/outputting streaming data
- more sophisticated and customizable parsing
- watching a directory and automatically running on each new file

but it is inherently a short-term tool, and I took a minimal but opinionated approach to giving the user a tool that allows them to make use of this data.

### Issues Resolved
https://opensearch.atlassian.net/browse/MIGRATIONS-1260

### Testing
Manual.

### Check List
- [ ] New functionality includes testing
  - [ ] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
