### PR TITLE
Migration Console small bugfixes

### DIFF
--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/Dockerfile
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/Dockerfile
@@ -4,12 +4,11 @@ ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends python3.9 python3-pip python3-dev gcc libc-dev git curl && \
-    pip3 install opensearch-benchmark
+    pip3 install urllib3==1.25.11 opensearch-benchmark==1.1.0 tqdm
 
 COPY runTestBenchmarks.sh /root/
 COPY humanReadableLogs.py /root/
-RUN chmod ug+x /root/runTestBenchmarks.sh
-RUN chmod ug+x /root/humanReadableLogs.py
+RUN chmod ug+x /root/runTestBenchmarks.sh && chmod ug+x /root/humanReadableLogs.py
 WORKDIR /root
 
 CMD tail -f /dev/null

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/runTestBenchmarks.sh
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/runTestBenchmarks.sh
@@ -55,8 +55,6 @@ base_options_string="use_ssl:true,verify_certs:false"
 client_options="${base_options_string}${auth_string}"
 
 echo "Running opensearch-benchmark workloads against ${ENDPOINT}"
-echo "Running opensearch-benchmark w/ 'geonames' workload..." &&
-opensearch-benchmark execute-test --distribution-version=1.0.0 --target-host=$ENDPOINT --workload=geonames --pipeline=benchmark-only --test-mode --kill-running-processes --workload-params "target_throughput:0.5,bulk_size:10,bulk_indexing_clients:1,search_clients:1"  --client-options=$client_options &&
 echo "Running opensearch-benchmark w/ 'http_logs' workload..." &&
 opensearch-benchmark execute-test --distribution-version=1.0.0 --target-host=$ENDPOINT --workload=http_logs --pipeline=benchmark-only --test-mode --kill-running-processes --workload-params "target_throughput:0.5,bulk_size:10,bulk_indexing_clients:1,search_clients:1" --client-options=$client_options &&
 echo "Running opensearch-benchmark w/ 'nested' workload..." &&


### PR DESCRIPTION
### Description
Small changes for the MIgration Console on the release branch.
1. Is re-adding the pip versioning locks that were added & explained [here](https://github.com/opensearch-project/opensearch-migrations/pull/274/files/928e55cae490ba84f5857b2a6a97f6ea600773bc#r1299298323). This breaks both `runTestBenchmarks` and `humanReadableLogs`
2. Remove geonames from the list opensearch-benchmark workloads that are run. Right now, we have an issue in the capture proxy/replayer that reacts particularly poorly to this dataset. After getting halfway through, there are one or more "poisonous" messages that break the replayer and make it difficult to revive, even with restarting. We're working on the real fix for this, but as a stopgap, this modifies `runTestBenchmarks` so that this workload isn't run immediately.

### Issues Resolved

### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]

### Check List
- [ ] New functionality includes testing
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
