### PR TITLE
Handle Chunked Transfer-Encoding for humanReadableLogs

### DIFF
--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/humanReadableLogs.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/humanReadableLogs.py
@@ -166,7 +166,7 @@ def parse_tuple(line: str, line_no: int) -> dict:
                                           tuple, try_lowercase_keys=True) == TRANSFER_ENCODING_CHUNKED
         value = parse_body_value(base64value, content_encoding, content_type, is_bulk_path,
                                  is_chunked_transfer, line_no)
-        if value and type(value) != bytes:
+        if value and type(value) is not bytes:
             set_element(body_path, tuple, value)
     return tuple
 


### PR DESCRIPTION
Signed-off-by: Mikayla Thompson <thomika@amazon.com>

### Description
We encountered several issues when running the humanReadableLogs on AWS:
1. It crashed on some gzipped messages. While it caught the error successfully, it output the in-progress byte string, and when that was written to JSON, JSON has no byte string type and it crashed.
2. When that was fixed, it became clear that the gzipped messages it was failing to unzip were both gzipped and had a "chunked" transfer encoding. This meant that they were split into several segments, with the length of those segments also written in, and generally were no longer gzip-compatible. By parsing through this data to extract the chunks, a continuous byte stream can be extracted, and that one is un-gzippable.

This also turned up an issue (hinted at in the last review) where the header keys used multiple capitalizations.  It would be better to have a fully case-insensitive lookup path, but for the short-term, I've made the lookup function check both the original capitalization and all lower case, which seems to cover the overwhelming majority of cases.

### Issues Resolved
No issue yet.

### Testing
Manual

### Check List
- [ ] New functionality includes testing
  - [ ] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
