### PR TITLE
Use CRLF in NettyJsonToByteBufHandler

### DIFF
--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/humanReadableLogs.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/humanReadableLogs.py
@@ -14,23 +14,23 @@ from tqdm.contrib.logging import logging_redirect_tqdm
 logger = logging.getLogger(__name__)
 
 LOG_JSON_TUPLE_FIELD = "message"
-BASE64_ENCODED_TUPLE_PATHS = ["request.body", "primaryResponse.body", "shadowResponse.body"]
+BASE64_ENCODED_TUPLE_PATHS = ["request.body", "sourceResponse.body", "targetResponse.body"]
 # TODO: I'm not positive about the capitalization of the Content-Encoding and Content-Type headers.
 # This version worked on my test cases, but not guaranteed to work in all cases.
 CONTENT_ENCODING_PATH = {
     BASE64_ENCODED_TUPLE_PATHS[0]: "request.Content-Encoding",
-    BASE64_ENCODED_TUPLE_PATHS[1]: "primaryResponse.Content-Encoding",
-    BASE64_ENCODED_TUPLE_PATHS[2]: "shadowResponse.Content-Encoding"
+    BASE64_ENCODED_TUPLE_PATHS[1]: "sourceResponse.Content-Encoding",
+    BASE64_ENCODED_TUPLE_PATHS[2]: "targetResponse.Content-Encoding"
 }
 CONTENT_TYPE_PATH = {
     BASE64_ENCODED_TUPLE_PATHS[0]: "request.Content-Type",
-    BASE64_ENCODED_TUPLE_PATHS[1]: "primaryResponse.Content-Type",
-    BASE64_ENCODED_TUPLE_PATHS[2]: "shadowResponse.Content-Type"
+    BASE64_ENCODED_TUPLE_PATHS[1]: "sourceResponse.Content-Type",
+    BASE64_ENCODED_TUPLE_PATHS[2]: "targetResponse.Content-Type"
 }
 TRANSFER_ENCODING_PATH = {
     BASE64_ENCODED_TUPLE_PATHS[0]: "request.Transfer-Encoding",
-    BASE64_ENCODED_TUPLE_PATHS[1]: "primaryResponse.Transfer-Encoding",
-    BASE64_ENCODED_TUPLE_PATHS[2]: "shadowResponse.Transfer-Encoding"
+    BASE64_ENCODED_TUPLE_PATHS[1]: "sourceResponse.Transfer-Encoding",
+    BASE64_ENCODED_TUPLE_PATHS[2]: "targetResponse.Transfer-Encoding"
 }
 
 CONTENT_TYPE_JSON = "application/json"

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/humanReadableLogs.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/humanReadableLogs.py
@@ -14,29 +14,32 @@ from tqdm.contrib.logging import logging_redirect_tqdm
 logger = logging.getLogger(__name__)
 
 LOG_JSON_TUPLE_FIELD = "message"
-BASE64_ENCODED_TUPLE_PATHS = ["request.body", "sourceResponse.body", "targetResponse.body"]
+BASE64_ENCODED_TUPLE_PATHS = ["sourceRequest.body", "targetRequest.body", "sourceResponse.body", "targetResponse.body"]
 # TODO: I'm not positive about the capitalization of the Content-Encoding and Content-Type headers.
 # This version worked on my test cases, but not guaranteed to work in all cases.
 CONTENT_ENCODING_PATH = {
-    BASE64_ENCODED_TUPLE_PATHS[0]: "request.Content-Encoding",
-    BASE64_ENCODED_TUPLE_PATHS[1]: "sourceResponse.Content-Encoding",
-    BASE64_ENCODED_TUPLE_PATHS[2]: "targetResponse.Content-Encoding"
+    BASE64_ENCODED_TUPLE_PATHS[0]: "sourceRequest.Content-Encoding",
+    BASE64_ENCODED_TUPLE_PATHS[1]: "targetRequest.Content-Encoding",
+    BASE64_ENCODED_TUPLE_PATHS[2]: "sourceResponse.Content-Encoding",
+    BASE64_ENCODED_TUPLE_PATHS[3]: "targetResponse.Content-Encoding"
 }
 CONTENT_TYPE_PATH = {
-    BASE64_ENCODED_TUPLE_PATHS[0]: "request.Content-Type",
-    BASE64_ENCODED_TUPLE_PATHS[1]: "sourceResponse.Content-Type",
-    BASE64_ENCODED_TUPLE_PATHS[2]: "targetResponse.Content-Type"
+    BASE64_ENCODED_TUPLE_PATHS[0]: "sourceRequest.Content-Type",
+    BASE64_ENCODED_TUPLE_PATHS[1]: "targetRequest.Content-Encoding",
+    BASE64_ENCODED_TUPLE_PATHS[2]: "sourceResponse.Content-Type",
+    BASE64_ENCODED_TUPLE_PATHS[3]: "targetResponse.Content-Type"
 }
 TRANSFER_ENCODING_PATH = {
-    BASE64_ENCODED_TUPLE_PATHS[0]: "request.Transfer-Encoding",
-    BASE64_ENCODED_TUPLE_PATHS[1]: "sourceResponse.Transfer-Encoding",
-    BASE64_ENCODED_TUPLE_PATHS[2]: "targetResponse.Transfer-Encoding"
+    BASE64_ENCODED_TUPLE_PATHS[0]: "sourceRequest.Transfer-Encoding",
+    BASE64_ENCODED_TUPLE_PATHS[1]: "targetRequest.Content-Encoding",
+    BASE64_ENCODED_TUPLE_PATHS[2]: "sourceResponse.Transfer-Encoding",
+    BASE64_ENCODED_TUPLE_PATHS[3]: "targetResponse.Transfer-Encoding"
 }
 
 CONTENT_TYPE_JSON = "application/json"
 CONTENT_ENCODING_GZIP = "gzip"
 TRANSFER_ENCODING_CHUNKED = "chunked"
-URI_PATH = "request.Request-URI"
+URI_PATH = "sourceRequest.Request-URI"
 BULK_URI_PATH = "_bulk"
 
 

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/SourceTargetCaptureTuple.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/SourceTargetCaptureTuple.java
@@ -48,7 +48,6 @@ public class SourceTargetCaptureTuple {
         }
 
         private JSONObject jsonFromHttpDataUnsafe(List<byte[]> data) throws IOException {
-
             SequenceInputStream collatedStream = ReplayUtils.byteArraysToInputStream(data);
             Scanner scanner = new Scanner(collatedStream, StandardCharsets.UTF_8);
             scanner.useDelimiter("\r\n\r\n");  // The headers are seperated from the body with two newlines.
@@ -88,12 +87,14 @@ public class SourceTargetCaptureTuple {
 
         private JSONObject toJSONObject(SourceTargetCaptureTuple triple) throws IOException {
             JSONObject meta = new JSONObject();
-            meta.put("request", jsonFromHttpData(triple.sourcePair.requestData.packetBytes));
+            meta.put("primaryRequest", jsonFromHttpData(triple.sourcePair.requestData.packetBytes));
+            meta.put("shadowRequest", jsonFromHttpData(triple.shadowRequestData));
             //log.warn("TODO: These durations are not measuring the same values!");
             meta.put("primaryResponse", jsonFromHttpData(triple.sourcePair.responseData.packetBytes,
                 Duration.between(triple.sourcePair.requestData.getLastPacketTimestamp(), triple.sourcePair.responseData.getLastPacketTimestamp())));
             meta.put("shadowResponse", jsonFromHttpData(triple.shadowResponseData,
                     triple.shadowResponseDuration));
+            meta.put("connectionId", triple.sourcePair.connectionId);
 
             return meta;
         }

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/TrafficReplayer.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/TrafficReplayer.java
@@ -491,7 +491,7 @@ public class TrafficReplayer {
         }
 
         try {
-            log.info("Source/Shadow Request/Response tuple: " + requestResponseTriple);
+            log.info("Source/Target Request/Response tuple: " + requestResponseTriple);
             tripleWriter.writeJSON(requestResponseTriple);
         } catch (IOException e) {
             log.error("Caught an IOException while writing triples output.");

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/http/NettyJsonToByteBufHandler.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/http/NettyJsonToByteBufHandler.java
@@ -185,7 +185,7 @@ public class NettyJsonToByteBufHandler extends ChannelInboundHandlerAdapter {
             osw.append(httpJson.path());
             osw.append(" ");
             osw.append(httpJson.protocol());
-            osw.append("\n");
+            osw.append("\r\n");
 
             for (var kvpList : httpJson.headers().asStrictMap().entrySet()) {
                 var key = kvpList.getKey();
@@ -193,10 +193,10 @@ public class NettyJsonToByteBufHandler extends ChannelInboundHandlerAdapter {
                     osw.append(key);
                     osw.append(": ");
                     osw.append(valueEntry);
-                    osw.append("\n");
+                    osw.append("\r\n");
                 }
             }
-            osw.append("\n");
+            osw.append("\r\n");
             osw.flush();
         }
     }

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/HeaderTransformerTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/HeaderTransformerTest.java
@@ -35,9 +35,9 @@ public class HeaderTransformerTest {
                 .build();
         var transformingHandler = new HttpJsonTransformingConsumer(jsonHandler, null, testPacketCapture, "TEST");
         runRandomPayloadWithTransformer(transformingHandler, dummyAggregatedResponse, testPacketCapture,
-                contentLength -> "GET / HTTP/1.1\n" +
-                        "HoSt: " + SOURCE_CLUSTER_NAME + "\n" +
-                        "content-length: " + contentLength + "\n");
+                contentLength -> "GET / HTTP/1.1\r\n" +
+                        "HoSt: " + SOURCE_CLUSTER_NAME + "\r\n" +
+                        "content-length: " + contentLength + "\r\n");
     }
 
     private void runRandomPayloadWithTransformer(HttpJsonTransformingConsumer transformingHandler,
@@ -88,11 +88,11 @@ public class HeaderTransformerTest {
                 httpBasicAuthTransformer, testPacketCapture, "TEST");
 
         runRandomPayloadWithTransformer(transformingHandler, dummyAggregatedResponse, testPacketCapture,
-                contentLength -> "GET / HTTP/1.1\n" +
-                        "HoSt: " + SOURCE_CLUSTER_NAME + "\n" +
-                        "content-type: application/json\n" +
-                        "content-length: " + contentLength + "\n" +
-                        "authorization: Basic YWRtaW46YWRtaW4=\n");
+                contentLength -> "GET / HTTP/1.1\r\n" +
+                        "HoSt: " + SOURCE_CLUSTER_NAME + "\r\n" +
+                        "content-type: application/json\r\n" +
+                        "content-length: " + contentLength + "\r\n" +
+                        "authorization: Basic YWRtaW46YWRtaW4=\r\n");
     }
 
     /**
@@ -119,10 +119,10 @@ public class HeaderTransformerTest {
                 TestUtils.chainedDualWriteHeaderAndPayloadParts(transformingHandler,
                         stringParts,
                         referenceStringBuilder,
-                        contentLength -> "PUT /foo HTTP/1.1\n" +
-                                "HoSt: " + SOURCE_CLUSTER_NAME + "\n" +
-                                "content-type: application/json\n" +
-                                "content-length: " + contentLength + "\n"
+                        contentLength -> "PUT /foo HTTP/1.1\r\n" +
+                                "HoSt: " + SOURCE_CLUSTER_NAME + "\r\n" +
+                                "content-type: application/json\r\n" +
+                                "content-length: " + contentLength + "\r\n"
                 );
 
         var finalizationFuture = allConsumesFuture.thenCompose(v->transformingHandler.finalizeRequest(),

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/TestUtils.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/TestUtils.java
@@ -78,7 +78,7 @@ public class TestUtils {
                                           StringBuilder referenceStringAccumulator,
                                           Function<Integer, String> headersGenerator) {
         var contentLength = stringParts.stream().mapToInt(s->s.length()).sum();
-        String headers = headersGenerator.apply(contentLength) + "\n";
+        String headers = headersGenerator.apply(contentLength) + "\r\n";
         referenceStringAccumulator.append(headers);
         return chainedWriteHeadersAndDualWritePayloadParts(packetConsumer, stringParts, referenceStringAccumulator, headers);
     }
@@ -134,10 +134,10 @@ public class TestUtils {
                 "TEST");
 
         var contentLength = stringParts.stream().mapToInt(s->s.length()).sum();
-        var headerString = "GET / HTTP/1.1\n" +
-                "host: localhost\n" +
+        var headerString = "GET / HTTP/1.1\r\n" +
+                "host: localhost\r\n" +
                 (extraHeaders == null ? "" : extraHeaders) +
-                "content-length: " + contentLength + "\n\n";
+                "content-length: " + contentLength + "\r\n\r\n";
         var referenceStringBuilder = new StringBuilder();
         var allConsumesFuture = chainedWriteHeadersAndDualWritePayloadParts(transformingHandler,
                         stringParts, referenceStringBuilder, headerString);


### PR DESCRIPTION
Signed-off-by: Mikayla Thompson <thomika@amazon.com>

### Description
This PR includes three (related) categories of changes:
1. It outputs the request that was replayed against the target cluster and the connection ID in the tuples that are logged as output.
2. It updates our terminology in the tuples & surrounding areas from primary/shadow to source/target, which matches what we're using in the rest of our code & documentation.
3. The NettyJsonToByteBufHandler was using line feeds (`\n`) when formatting HTTP messages, but [the spec is to use carriage return line feeds](https://www.ibm.com/docs/en/cics-ts/6.1?topic=protocol-http-requests#dfhtl21__title__3) (`\r\n`). This turned out to cause an issue in how we were parsing the HTTP message for the JSON, so rather than build in a workaround, I updated the code to use CRLFs.

These three categories are broken out quite neatly in the commits:
the first two commits are related to number 3, the next accomplishes 1, the third deals with 2, and then the final commit updates the humanReadableLogs script for 1 and 2.

### Issues Resolved
I haven't created an issue for this yet 😬 

### Testing
Manual, and updated the unit tests affected.

### Check List
- [x] New functionality includes testing
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
