### PR TITLE
MIGRATIONS-1294: Improve remaining space checks for Capture Proxy

### DIFF
--- a/TrafficCapture/captureOffloader/src/main/java/org/opensearch/migrations/trafficcapture/CodedOutputStreamSizeUtil.java
+++ b/TrafficCapture/captureOffloader/src/main/java/org/opensearch/migrations/trafficcapture/CodedOutputStreamSizeUtil.java
@@ -23,46 +23,38 @@ public class CodedOutputStreamSizeUtil {
     }
 
     /**
-     * This function calculates the maximum bytes needed to store a message ByteBuffer that needs to be segmented into
-     * different ReadSegmentObservation or WriteSegmentObservation and its associated Traffic Stream overhead into a
-     * CodedOutputStream. The actual required bytes could be marginally smaller.
+     * This function calculates the maximum bytes that would be needed to store a [Read/Write]SegmentObservation, if constructed
+     * from the given ByteBuffer and associated segment field numbers and values passed in. This estimate is essentially
+     * the max size needed in the CodedOutputStream to store the provided ByteBuffer data and its associated TrafficStream
+     * overhead. The actual required bytes could be marginally smaller.
      */
-    public static int maxBytesNeededForSegmentedMessage(Instant timestamp, int observationFieldNumber, int dataFieldNumber,
+    public static int maxBytesNeededForASegmentedObservation(Instant timestamp, int observationFieldNumber, int dataFieldNumber,
         int dataCountFieldNumber, int dataCount,  ByteBuffer buffer, int flushes) {
-        // Timestamp closure bytes
+        // Timestamp required bytes
         int tsContentSize = getSizeOfTimestamp(timestamp);
-        int tsClosureSize = CodedOutputStream.computeInt32Size(TrafficObservation.TS_FIELD_NUMBER, tsContentSize) + tsContentSize;
+        int tsTagAndContentSize = CodedOutputStream.computeInt32Size(TrafficObservation.TS_FIELD_NUMBER, tsContentSize) + tsContentSize;
 
-        // Capture closure bytes
+        // Capture required bytes
         int dataSize = CodedOutputStream.computeByteBufferSize(dataFieldNumber, buffer);
         int dataCountSize = dataCountFieldNumber > 0 ? CodedOutputStream.computeInt32Size(dataCountFieldNumber, dataCount) : 0;
         int captureContentSize = dataSize + dataCountSize;
-        int captureClosureSize = CodedOutputStream.computeInt32Size(observationFieldNumber, captureContentSize) + captureContentSize;
+        int captureTagAndContentSize = CodedOutputStream.computeInt32Size(observationFieldNumber, captureContentSize) + captureContentSize;
 
-        // Observation tag and closure size needed bytes
-        int observationTagAndClosureSize = CodedOutputStream.computeInt32Size(TrafficStream.SUBSTREAM_FIELD_NUMBER, tsClosureSize + captureClosureSize);
-
-        // Size for additional SegmentEndObservation to signify end of segments
-        int segmentEndBytes = bytesNeededForSegmentEndObservation(timestamp);
-
-        // Size for closing index, use arbitrary field to calculate
-        int indexSize = CodedOutputStream.computeInt32Size(TrafficStream.NUMBER_FIELD_NUMBER, flushes);
-
-        return observationTagAndClosureSize + tsClosureSize + captureClosureSize + segmentEndBytes + indexSize;
+        // Observation and closing index required bytes
+        return bytesNeededForObservationAndClosingIndex(tsTagAndContentSize + captureTagAndContentSize, flushes);
     }
 
-    public static int bytesNeededForSegmentEndObservation(Instant timestamp) {
-        // Timestamp closure bytes
-        int tsContentSize = getSizeOfTimestamp(timestamp);
-        int tsClosureSize = CodedOutputStream.computeInt32Size(TrafficObservation.TS_FIELD_NUMBER, tsContentSize) + tsContentSize;
+    /**
+     * This function determines the number of bytes needed to store a TrafficObservation and a closing index for a
+     * TrafficStream, from the provided input.
+     */
+    public static int bytesNeededForObservationAndClosingIndex(int observationContentSize, int flushes) {
+        int observationTagSize = CodedOutputStream.computeUInt32Size(TrafficStream.SUBSTREAM_FIELD_NUMBER, observationContentSize);
 
-        // Capture closure bytes
-        int captureClosureSize = CodedOutputStream.computeMessageSize(TrafficObservation.SEGMENTEND_FIELD_NUMBER, EndOfSegmentsIndication.getDefaultInstance());
+        // Size for TrafficStream index added when flushing, use arbitrary field to calculate
+        int indexSize = CodedOutputStream.computeInt32Size(TrafficStream.NUMBEROFTHISLASTCHUNK_FIELD_NUMBER, flushes);
 
-        // Observation tag and closure size needed bytes
-        int observationTagAndClosureSize = CodedOutputStream.computeInt32Size(TrafficStream.SUBSTREAM_FIELD_NUMBER, tsClosureSize + captureClosureSize);
-
-        return observationTagAndClosureSize + tsClosureSize + captureClosureSize;
+        return observationTagSize + observationContentSize + indexSize;
     }
 
 

--- a/TrafficCapture/captureOffloader/src/main/java/org/opensearch/migrations/trafficcapture/CodedOutputStreamSizeUtil.java
+++ b/TrafficCapture/captureOffloader/src/main/java/org/opensearch/migrations/trafficcapture/CodedOutputStreamSizeUtil.java
@@ -29,7 +29,7 @@ public class CodedOutputStreamSizeUtil {
      * overhead. The actual required bytes could be marginally smaller.
      */
     public static int maxBytesNeededForASegmentedObservation(Instant timestamp, int observationFieldNumber, int dataFieldNumber,
-        int dataCountFieldNumber, int dataCount,  ByteBuffer buffer, int flushes) {
+        int dataCountFieldNumber, int dataCount,  ByteBuffer buffer, int numberOfTrafficStreamsSoFar) {
         // Timestamp required bytes
         int tsContentSize = getSizeOfTimestamp(timestamp);
         int tsTagAndContentSize = CodedOutputStream.computeInt32Size(TrafficObservation.TS_FIELD_NUMBER, tsContentSize) + tsContentSize;
@@ -41,18 +41,18 @@ public class CodedOutputStreamSizeUtil {
         int captureTagAndContentSize = CodedOutputStream.computeInt32Size(observationFieldNumber, captureContentSize) + captureContentSize;
 
         // Observation and closing index required bytes
-        return bytesNeededForObservationAndClosingIndex(tsTagAndContentSize + captureTagAndContentSize, flushes);
+        return bytesNeededForObservationAndClosingIndex(tsTagAndContentSize + captureTagAndContentSize, numberOfTrafficStreamsSoFar);
     }
 
     /**
      * This function determines the number of bytes needed to store a TrafficObservation and a closing index for a
      * TrafficStream, from the provided input.
      */
-    public static int bytesNeededForObservationAndClosingIndex(int observationContentSize, int flushes) {
+    public static int bytesNeededForObservationAndClosingIndex(int observationContentSize, int numberOfTrafficStreamsSoFar) {
         int observationTagSize = CodedOutputStream.computeUInt32Size(TrafficStream.SUBSTREAM_FIELD_NUMBER, observationContentSize);
 
         // Size for TrafficStream index added when flushing, use arbitrary field to calculate
-        int indexSize = CodedOutputStream.computeInt32Size(TrafficStream.NUMBEROFTHISLASTCHUNK_FIELD_NUMBER, flushes);
+        int indexSize = CodedOutputStream.computeInt32Size(TrafficStream.NUMBEROFTHISLASTCHUNK_FIELD_NUMBER, numberOfTrafficStreamsSoFar);
 
         return observationTagSize + observationContentSize + indexSize;
     }

--- a/TrafficCapture/captureOffloader/src/main/java/org/opensearch/migrations/trafficcapture/StreamChannelConnectionCaptureSerializer.java
+++ b/TrafficCapture/captureOffloader/src/main/java/org/opensearch/migrations/trafficcapture/StreamChannelConnectionCaptureSerializer.java
@@ -125,8 +125,9 @@ public class StreamChannelConnectionCaptureSerializer implements IChannelConnect
         final var captureTagNoLengthSize = CodedOutputStream.computeTagSize(captureTagFieldNumber);
         final var observationContentSize = tsTagSize + tsContentSize + captureTagNoLengthSize + captureTagLengthAndContentSize;
         // Ensure space is available before starting an observation
-        if (getOrCreateCodedOutputStream().spaceLeft() < CodedOutputStreamSizeUtil.bytesNeededForObservationAndClosingIndex(
-            observationContentSize, numFlushesSoFar + 1)) {
+        if (getOrCreateCodedOutputStream().spaceLeft() <
+            CodedOutputStreamSizeUtil.bytesNeededForObservationAndClosingIndex(observationContentSize, numFlushesSoFar + 1))
+        {
             flushCommitAndResetStream(false);
         }
         // e.g. 2 {

--- a/TrafficCapture/captureOffloader/src/main/java/org/opensearch/migrations/trafficcapture/StreamChannelConnectionCaptureSerializer.java
+++ b/TrafficCapture/captureOffloader/src/main/java/org/opensearch/migrations/trafficcapture/StreamChannelConnectionCaptureSerializer.java
@@ -32,7 +32,7 @@ import java.util.function.Supplier;
  * into the defined Protobuf format {@link org.opensearch.migrations.trafficcapture.protos.TrafficStream}, and then write
  * this formatted data to the provided CodedOutputStream.
  *
- * Commented throughout the class are example markers such as (i.e. 1: "1234ABCD") which line up with the textual
+ * Commented throughout the class are example markers such as (e.g. 1: "1234ABCD") which line up with the textual
  * representation of this Protobuf format to be used as a guide as fields are written. An example TrafficStream can
  * also be visualized below for reference.
  *
@@ -94,9 +94,10 @@ public class StreamChannelConnectionCaptureSerializer implements IChannelConnect
             return currentCodedOutputStreamOrNull;
         } else {
             currentCodedOutputStreamOrNull = codedOutputStreamSupplier.get();
-            // i.e. 1: "1234ABCD"
+            // e.g. 1: "1234ABCD"
             currentCodedOutputStreamOrNull.writeString(TrafficStream.CONNECTIONID_FIELD_NUMBER, connectionIdString);
             if (nodeIdString != null) {
+                // e.g. 5: "5ae27fca-0ac4-11ee-be56-0242ac120002"
                 currentCodedOutputStreamOrNull.writeString(TrafficStream.NODEID_FIELD_NUMBER, nodeIdString);
             }
             return currentCodedOutputStreamOrNull;
@@ -113,18 +114,27 @@ public class StreamChannelConnectionCaptureSerializer implements IChannelConnect
                 getWireTypeForFieldIndex(TrafficObservation.getDescriptor(), fieldNumber));
     }
 
-    private void beginSubstreamObservation(Instant timestamp, int captureTag, int captureClosureSize) throws IOException {
-
-        // i.e. 2 {
+    /**
+     * Will write the beginning fields for a TrafficObservation after first checking if sufficient space exists in the
+     * CodedOutputStream and flushing if space does not exist. This should be called before writing any observation to
+     * the TrafficStream.
+     */
+    private void beginSubstreamObservation(Instant timestamp, int captureTagFieldNumber, int captureTagLengthAndContentSize) throws IOException {
+        final var tsContentSize = CodedOutputStreamSizeUtil.getSizeOfTimestamp(timestamp);
+        final var tsTagSize = CodedOutputStream.computeInt32Size(TrafficObservation.TS_FIELD_NUMBER, tsContentSize);
+        final var captureTagNoLengthSize = CodedOutputStream.computeTagSize(captureTagFieldNumber);
+        final var observationContentSize = tsTagSize + tsContentSize + captureTagNoLengthSize + captureTagLengthAndContentSize;
+        final var requiredBytes = CodedOutputStreamSizeUtil.bytesNeededForObservationAndClosingIndex(observationContentSize, numFlushesSoFar + 1);
+        // Ensure space is available before starting an observation
+        if (getOrCreateCodedOutputStream().spaceLeft() < CodedOutputStreamSizeUtil.bytesNeededForObservationAndClosingIndex(
+            observationContentSize, numFlushesSoFar + 1)) {
+            flushCommitAndResetStream(false);
+        }
+        // e.g. 2 {
         writeTrafficStreamTag(TrafficStream.SUBSTREAM_FIELD_NUMBER);
-        final var tsSize = CodedOutputStreamSizeUtil.getSizeOfTimestamp(timestamp);
-        final var captureTagSize = CodedOutputStream.computeTagSize(captureTag);
-        // Writing total size of substream closure [ts size + ts tag + capture tag + capture size]
-        getOrCreateCodedOutputStream().writeUInt32NoTag(tsSize +
-            CodedOutputStream.computeInt32Size(TrafficObservation.TS_FIELD_NUMBER, tsSize) +
-            captureTagSize +
-            captureClosureSize);
-        // i.e. 1 { 1: 1234 2: 1234 }
+        // Write observation content length
+        getOrCreateCodedOutputStream().writeUInt32NoTag(observationContentSize);
+        // e.g. 1 { 1: 1234 2: 1234 }
         writeTimestampForNowToCurrentStream(timestamp);
     }
 
@@ -162,8 +172,9 @@ public class StreamChannelConnectionCaptureSerializer implements IChannelConnect
         }
         CodedOutputStream currentStream = getOrCreateCodedOutputStream();
         var fieldNum = isFinal ? TrafficStream.NUMBEROFTHISLASTCHUNK_FIELD_NUMBER : TrafficStream.NUMBER_FIELD_NUMBER;
-        // i.e. 3: 1
+        // e.g. 3: 1
         currentStream.writeInt32(fieldNum, ++numFlushesSoFar);
+        log.debug("Flushing the current CodedOutputStream for {}.{}", connectionIdString, numFlushesSoFar);
         currentStream.flush();
         var future = closeHandler.apply(new CaptureSerializerResult(currentStream, numFlushesSoFar));
         //future.whenComplete((r,t)->{}); // do more cleanup stuff here once the future is complete
@@ -231,7 +242,7 @@ public class StreamChannelConnectionCaptureSerializer implements IChannelConnect
             lengthSize = getOrCreateCodedOutputStream().computeInt32SizeNoTag(dataSize);
         }
         beginSubstreamObservation(timestamp, captureFieldNumber, dataSize + lengthSize);
-        // i.e. 4 {
+        // e.g. 4 {
         writeObservationTag(captureFieldNumber);
         if (dataSize > 0) {
             getOrCreateCodedOutputStream().writeInt32NoTag(dataSize);
@@ -254,10 +265,10 @@ public class StreamChannelConnectionCaptureSerializer implements IChannelConnect
         }
 
         // The message bytes here are not optimizing for space and instead are calculated on the worst case estimate of
-        // the potentially required bytes for simplicity. This could leave ~25 bytes of unused space in the CodedOutputStream
-        // when considering the case of a message that does not need segments or ~5 for the case of a smaller segment created
+        // the potentially required bytes for simplicity. This could leave ~5 bytes of unused space in the CodedOutputStream
+        // when considering the case of a message that does not need segments or for the case of a smaller segment created
         // from a much larger message
-        int messageAndOverheadBytesLeft = CodedOutputStreamSizeUtil.maxBytesNeededForSegmentedMessage(timestamp,
+        int messageAndOverheadBytesLeft = CodedOutputStreamSizeUtil.maxBytesNeededForASegmentedObservation(timestamp,
             segmentFieldNumber, segmentDataFieldNumber, segmentCountFieldNumber, 2, byteBuffer, numFlushesSoFar + 1);
         int trafficStreamOverhead = messageAndOverheadBytesLeft - byteBuffer.capacity();
 
@@ -268,13 +279,9 @@ public class StreamChannelConnectionCaptureSerializer implements IChannelConnect
 
         // If our message is empty or can fit in the current CodedOutputStream no chunking is needed, and we can continue
         if (byteBuffer.limit() == 0 || messageAndOverheadBytesLeft <= getOrCreateCodedOutputStream().spaceLeft()) {
-            int calculatedMinSpaceAfterMessage = getOrCreateCodedOutputStream().spaceLeft() - messageAndOverheadBytesLeft;
+            int minExpectedSpaceAfterObservation = getOrCreateCodedOutputStream().spaceLeft() - messageAndOverheadBytesLeft;
             addSubstreamMessage(captureFieldNumber, dataFieldNumber, timestamp, byteBuffer);
-            if (getOrCreateCodedOutputStream().spaceLeft() < calculatedMinSpaceAfterMessage) {
-                log.warn("Writing a substream (capture type: {}) for Traffic Stream: {} left {} bytes in the CodedOutputStream but we calculated " +
-                    "at least {} bytes remaining, this should be investigated", captureFieldNumber, connectionIdString + "." + (numFlushesSoFar + 1),
-                    getOrCreateCodedOutputStream().spaceLeft(), calculatedMinSpaceAfterMessage);
-            }
+            observationSizeSanityCheck(minExpectedSpaceAfterObservation, captureFieldNumber);
             return;
         }
 
@@ -287,12 +294,8 @@ public class StreamChannelConnectionCaptureSerializer implements IChannelConnect
             bb = bb.slice();
             byteBuffer.position(byteBuffer.position() + chunkBytes);
             addSubstreamMessage(segmentFieldNumber, segmentDataFieldNumber, segmentCountFieldNumber, ++dataCount, timestamp, bb);
-            int calculatedMinSpaceAfterMessage = availableCOSSpace - chunkBytes - trafficStreamOverhead;
-            if (getOrCreateCodedOutputStream().spaceLeft() < calculatedMinSpaceAfterMessage) {
-                log.warn("Writing a substream (capture type: {}) for Traffic Stream: {} left {} bytes in the CodedOutputStream but we calculated " +
-                    "at least {} bytes remaining, this should be investigated", segmentFieldNumber, connectionIdString + "." + (numFlushesSoFar + 1),
-                    getOrCreateCodedOutputStream().spaceLeft(), calculatedMinSpaceAfterMessage);
-            }
+            int minExpectedSpaceAfterObservation = availableCOSSpace - chunkBytes - trafficStreamOverhead;
+            observationSizeSanityCheck(minExpectedSpaceAfterObservation, segmentFieldNumber);
             // 1 to N-1 chunked messages
             if (byteBuffer.position() < byteBuffer.limit()) {
                 flushCommitAndResetStream(false);
@@ -317,7 +320,7 @@ public class StreamChannelConnectionCaptureSerializer implements IChannelConnect
             captureClosureLength = CodedOutputStream.computeInt32SizeNoTag(dataSize + segmentCountSize);
         }
         beginSubstreamObservation(timestamp, captureFieldNumber, captureClosureLength + dataSize + segmentCountSize);
-        // i.e. 4 {
+        // e.g. 4 {
         writeObservationTag(captureFieldNumber);
         if (dataSize > 0) {
             // Write size of data after capture tag
@@ -421,7 +424,7 @@ public class StreamChannelConnectionCaptureSerializer implements IChannelConnect
                 CodedOutputStream.computeInt32Size(EndOfMessageIndication.HEADERSBYTELENGTH_FIELD_NUMBER, headersByteLength);
         int eomDataSize = eomPairSize + CodedOutputStream.computeInt32SizeNoTag(eomPairSize);
         beginSubstreamObservation(timestamp, TrafficObservation.ENDOFMESSAGEINDICATOR_FIELD_NUMBER, eomDataSize);
-        // i.e. 15 {
+        // e.g. 15 {
         writeObservationTag(TrafficObservation.ENDOFMESSAGEINDICATOR_FIELD_NUMBER);
         getOrCreateCodedOutputStream().writeUInt32NoTag(eomPairSize);
         getOrCreateCodedOutputStream().writeInt32(EndOfMessageIndication.FIRSTLINEBYTELENGTH_FIELD_NUMBER, firstLineByteLength);
@@ -431,5 +434,14 @@ public class StreamChannelConnectionCaptureSerializer implements IChannelConnect
     private void writeEndOfSegmentMessage(Instant timestamp) throws IOException {
         beginSubstreamObservation(timestamp, TrafficObservation.SEGMENTEND_FIELD_NUMBER, 1);
         getOrCreateCodedOutputStream().writeMessage(TrafficObservation.SEGMENTEND_FIELD_NUMBER, EndOfSegmentsIndication.getDefaultInstance());
+    }
+
+    private void observationSizeSanityCheck(int minExpectedSpaceAfterObservation, int fieldNumber) throws IOException {
+        int actualRemainingSpace = getOrCreateCodedOutputStream().spaceLeft();
+        if (actualRemainingSpace < minExpectedSpaceAfterObservation || minExpectedSpaceAfterObservation < 0) {
+            log.warn("Writing a substream (capture type: {}) for Traffic Stream: {} left {} bytes in the CodedOutputStream but we calculated " +
+                    "at least {} bytes remaining, this should be investigated", fieldNumber, connectionIdString + "." + (numFlushesSoFar + 1),
+                actualRemainingSpace, minExpectedSpaceAfterObservation);
+        }
     }
 }

--- a/TrafficCapture/captureOffloader/src/main/java/org/opensearch/migrations/trafficcapture/StreamChannelConnectionCaptureSerializer.java
+++ b/TrafficCapture/captureOffloader/src/main/java/org/opensearch/migrations/trafficcapture/StreamChannelConnectionCaptureSerializer.java
@@ -124,7 +124,6 @@ public class StreamChannelConnectionCaptureSerializer implements IChannelConnect
         final var tsTagSize = CodedOutputStream.computeInt32Size(TrafficObservation.TS_FIELD_NUMBER, tsContentSize);
         final var captureTagNoLengthSize = CodedOutputStream.computeTagSize(captureTagFieldNumber);
         final var observationContentSize = tsTagSize + tsContentSize + captureTagNoLengthSize + captureTagLengthAndContentSize;
-        final var requiredBytes = CodedOutputStreamSizeUtil.bytesNeededForObservationAndClosingIndex(observationContentSize, numFlushesSoFar + 1);
         // Ensure space is available before starting an observation
         if (getOrCreateCodedOutputStream().spaceLeft() < CodedOutputStreamSizeUtil.bytesNeededForObservationAndClosingIndex(
             observationContentSize, numFlushesSoFar + 1)) {

--- a/TrafficCapture/captureOffloader/src/test/java/org/opensearch/migrations/trafficcapture/StreamChannelConnectionCaptureSerializerTest.java
+++ b/TrafficCapture/captureOffloader/src/test/java/org/opensearch/migrations/trafficcapture/StreamChannelConnectionCaptureSerializerTest.java
@@ -14,6 +14,7 @@ import org.opensearch.migrations.trafficcapture.protos.EndOfSegmentsIndication;
 import org.opensearch.migrations.trafficcapture.protos.ReadObservation;
 import org.opensearch.migrations.trafficcapture.protos.TrafficObservation;
 import org.opensearch.migrations.trafficcapture.protos.TrafficStream;
+import org.opensearch.migrations.trafficcapture.protos.WriteObservation;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -130,7 +131,7 @@ class StreamChannelConnectionCaptureSerializerTest {
         var outputBuffersCreated = new ConcurrentLinkedQueue<ByteBuffer>();
         // Arbitrarily picking small buffer that can hold the overhead TrafficStream bytes as well as some
         // data bytes but not all the data bytes and require chunking
-        var serializer = createSerializerWithTestHandler(outputBuffersCreated, 85);
+        var serializer = createSerializerWithTestHandler(outputBuffersCreated, 55);
 
         var bb = Unpooled.wrappedBuffer(packetBytes);
         serializer.addWriteEvent(referenceTimestamp, bb);
@@ -156,13 +157,40 @@ class StreamChannelConnectionCaptureSerializerTest {
     }
 
     @Test
+    public void testCloseAfterWriteWillFlushWhenSpaceNeeded() throws IOException, ExecutionException, InterruptedException {
+        final var referenceTimestamp = Instant.ofEpochMilli(1686593191*1000);
+        String packetData = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+        byte[] packetBytes = packetData.getBytes(StandardCharsets.UTF_8);
+        var outputBuffersCreated = new ConcurrentLinkedQueue<ByteBuffer>();
+        // Arbitrarily picking small buffer that can only hold one write observation and no other observations
+        var serializer = createSerializerWithTestHandler(outputBuffersCreated, 85);
+
+        var bb = Unpooled.wrappedBuffer(packetBytes);
+        serializer.addWriteEvent(referenceTimestamp, bb);
+        serializer.addCloseEvent(referenceTimestamp);
+        CompletableFuture future = serializer.flushCommitAndResetStream(true);
+        future.get();
+        bb.release();
+
+        Assertions.assertEquals(2, outputBuffersCreated.size());
+        List<TrafficObservation> observations = new ArrayList<>();
+        for (ByteBuffer buffer : outputBuffersCreated) {
+            var trafficStream = TrafficStream.parseFrom(buffer);
+            observations.addAll(trafficStream.getSubStreamList());
+        }
+        Assertions.assertEquals(2, observations.size());
+        Assertions.assertTrue(observations.get(0).hasWrite());
+        Assertions.assertTrue(observations.get(1).hasClose());
+    }
+
+    @Test
     public void testEmptyPacketIsHandledForSmallCodedOutputStream()
         throws IOException, ExecutionException, InterruptedException {
         final var referenceTimestamp = Instant.now(Clock.systemUTC());
         var outputBuffersCreated = new ConcurrentLinkedQueue<ByteBuffer>();
         // Arbitrarily picking small buffer size that can only hold one empty message
         var serializer = createSerializerWithTestHandler(outputBuffersCreated,
-                TEST_NODE_ID_STRING.length() + 60);
+                TEST_NODE_ID_STRING.length() + 40);
         var bb = Unpooled.buffer(0);
         serializer.addWriteEvent(referenceTimestamp, bb);
         serializer.addWriteEvent(referenceTimestamp, bb);

--- a/TrafficCapture/captureOffloader/src/test/java/org/opensearch/migrations/trafficcapture/StreamChannelConnectionCaptureSerializerTest.java
+++ b/TrafficCapture/captureOffloader/src/test/java/org/opensearch/migrations/trafficcapture/StreamChannelConnectionCaptureSerializerTest.java
@@ -157,7 +157,7 @@ class StreamChannelConnectionCaptureSerializerTest {
     }
 
     @Test
-    public void testCloseAfterWriteWillFlushWhenSpaceNeeded() throws IOException, ExecutionException, InterruptedException {
+    public void testCloseObservationAfterWriteWillFlushWhenSpaceNeeded() throws IOException, ExecutionException, InterruptedException {
         final var referenceTimestamp = Instant.ofEpochMilli(1686593191*1000);
         String packetData = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
         byte[] packetBytes = packetData.getBytes(StandardCharsets.UTF_8);


### PR DESCRIPTION
### Description
This change primarily ensures that every observation we attempt to add to a TrafficStream performs a space check of the CodedOuputStream initially to ensure that there is ample space to store the observation and a closing index, or otherwise flush the stream so that space is available.

Beyond this, there is also some cleaning up of EndOfSegmentIndication size calculations as this will now be handled by the observation size check. As well as general naming and structuring to make things a bit cleaner and easier to follow.

### Issues Resolved
https://opensearch.atlassian.net/browse/MIGRATIONS-1294

### Testing
Unit testing and manual docker testing

### Check List
- [x] New functionality includes testing
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
