### PR TITLE
Adjusting logic for version comparison + fix CVE-42920

### DIFF
--- a/TrafficCapture/buildSrc/src/main/groovy/org/opensearch/migrations/common/CommonUtils.groovy
+++ b/TrafficCapture/buildSrc/src/main/groovy/org/opensearch/migrations/common/CommonUtils.groovy
@@ -69,6 +69,20 @@ class CommonUtils {
             //defaultCommand('/runJavaWithClasspath.sh', '...')
         }
     }
+
+    static def wasRequestedVersionReleasedBeforeTargetVersion(String requested, String target) {
+        def requestedParts = requested.split('\\.')*.toInteger()
+        def targetParts = target.split('\\.')*.toInteger()
+
+        for (int i = 0; i < 3; i++) {
+            if (requestedParts[i] < targetParts[i]) {
+                return true
+            } else if (requestedParts[i] > targetParts[i]) {
+                return false
+            }
+        }
+        return false // In this case, versions are equal
+    }
 }
 
 class CommonConfigurations {

--- a/TrafficCapture/testUtilities/build.gradle
+++ b/TrafficCapture/testUtilities/build.gradle
@@ -1,3 +1,5 @@
+import org.opensearch.migrations.common.CommonUtils
+
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -54,6 +56,17 @@ dependencies {
     testImplementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.20.0'
     testImplementation group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.20.0'
     testImplementation group: 'org.apache.logging.log4j', name: 'log4j-slf4j2-impl', version: '2.20.0'
+}
+
+configurations.all {
+    resolutionStrategy.eachDependency { DependencyResolveDetails details ->
+        if (details.requested.group == 'org.apache.bcel' && details.requested.name == 'bcel') {
+            def targetVersion = '6.7.0'
+            if (CommonUtils.wasRequestedVersionReleasedBeforeTargetVersion(details.requested.version, targetVersion)) {
+                details.useVersion targetVersion
+            }
+        }
+    }
 }
 
 tasks.named('test') {

--- a/TrafficCapture/trafficReplayer/build.gradle
+++ b/TrafficCapture/trafficReplayer/build.gradle
@@ -24,6 +24,8 @@ plugins {
     id "io.freefair.lombok" version "8.0.1"
 }
 
+import org.opensearch.migrations.common.CommonUtils
+
 spotbugs {
     includeFilter = new File(rootDir, 'config/spotbugs/spotbugs-include.xml')
 }
@@ -70,30 +72,19 @@ dependencies {
     testImplementation 'org.mockito:mockito-junit-jupiter:4.6.1'
 }
 
-def isRequestedVersionOlder(String requested, String target) {
-    def requestedParts = requested.split('\\.')*.toInteger()
-    def targetParts = target.split('\\.')*.toInteger()
 
-    for (int i = 0; i < 3; i++) {
-        if (requestedParts[i] < targetParts[i]) {
-            return false
-        } else if (requestedParts[i] > targetParts[i]) {
-            return true
-        }
-    }
-}
 
 configurations.all {
     resolutionStrategy.eachDependency { DependencyResolveDetails details ->
         if (details.requested.group == 'org.apache.commons' && details.requested.name == 'commons-text') {
             def targetVersion = '1.10.0'
-            if (isRequestedVersionOlder(details.requested.version, targetVersion) != true) {
+            if (CommonUtils.wasRequestedVersionReleasedBeforeTargetVersion(details.requested.version, targetVersion)) {
                 details.useVersion targetVersion
             }
         }
         if (details.requested.group == 'org.apache.bcel' && details.requested.name == 'bcel') {
             def targetVersion = '6.7.0'
-            if (isRequestedVersionOlder(details.requested.version, targetVersion) != true) {
+            if (CommonUtils.wasRequestedVersionReleasedBeforeTargetVersion(details.requested.version, targetVersion)) {
                 details.useVersion targetVersion
             }
         }


### PR DESCRIPTION
### Description
This PR brings one more critical mend fix.
Also adjusts the version comparison function and moves it to the common utilities build.gradle file since it's now needed in more than one file. (Addressing feedback gotten from @lewijacn here: `https://github.com/opensearch-project/opensearch-migrations/pull/293#discussion_r1316582995`)

### Issues Resolved

### Check List
- [ ] New functionality includes testing
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
