### PR TITLE
Add set of minor improvements to our IaC and Replayer story

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ coverage.xml
 __pycache__
 *.egg-info*
 .python-version
+logs

--- a/TrafficCapture/dockerSolution/src/main/docker/docker-compose.yml
+++ b/TrafficCapture/dockerSolution/src/main/docker/docker-compose.yml
@@ -72,7 +72,7 @@ services:
     volumes:
       - sharedReplayerOutput:/shared-replayer-output
     environment:
-      - TUPLE_DIR_NAME=traffic-replayer-default
+      - TUPLE_DIR_PATH=/shared-replayer-output/traffic-replayer-default
     depends_on:
       kafka:
         condition: service_started

--- a/TrafficCapture/dockerSolution/src/main/docker/docker-compose.yml
+++ b/TrafficCapture/dockerSolution/src/main/docker/docker-compose.yml
@@ -71,6 +71,8 @@ services:
       - migrations
     volumes:
       - sharedReplayerOutput:/shared-replayer-output
+    environment:
+      - TUPLE_DIR_NAME=traffic-replayer-default
     depends_on:
       kafka:
         condition: service_started

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/Dockerfile
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/Dockerfile
@@ -1,10 +1,10 @@
-FROM ubuntu:focal
+FROM ubuntu:jammy
 
 ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends python3.9 python3-pip python3-dev gcc libc-dev git curl && \
-    pip3 install urllib3==1.25.11 opensearch-benchmark==1.1.0 tqdm
+    apt-get install -y --no-install-recommends python3.9 python3-pip python3-dev gcc libc-dev git curl vim && \
+    pip3 install urllib3==1.25.11 opensearch-benchmark==1.1.0 awscurl tqdm
 
 COPY runTestBenchmarks.sh /root/
 COPY humanReadableLogs.py /root/

--- a/TrafficCapture/trafficReplayer/src/main/resources/log4j2.properties
+++ b/TrafficCapture/trafficReplayer/src/main/resources/log4j2.properties
@@ -1,5 +1,7 @@
 status = error
 
+property.tupleDir = /shared-replayer-output/${env:TUPLE_DIR_NAME}
+
 appender.console.type = Console
 appender.console.name = STDERR
 appender.console.target = SYSTEM_ERR
@@ -25,9 +27,8 @@ logger.HttpJsonTransformingConsumer.level = info
 appender.output_tuples.type = RollingFile
 appender.output_tuples.name = OUTPUT_TUPLES
 # This is the path to the shared volume configured by the deployment tools.
-# TODO: make this location configurable when the replayer is started
-appender.output_tuples.fileName = /shared-replayer-output/tuples.log
-appender.output_tuples.filePattern = /shared-replayer-output/tuples-%d{yyyy-MM-dd-HH:mm}.log
+appender.output_tuples.fileName = ${tupleDir}/tuples.log
+appender.output_tuples.filePattern = ${tupleDir}/tuples-%d{yyyy-MM-dd-HH:mm}.log
 appender.output_tuples.layout.type = JsonLayout
 appender.output_tuples.layout.properties = false
 appender.output_tuples.layout.complete = false

--- a/TrafficCapture/trafficReplayer/src/main/resources/log4j2.properties
+++ b/TrafficCapture/trafficReplayer/src/main/resources/log4j2.properties
@@ -1,6 +1,6 @@
 status = error
 
-property.tupleDir = ${env:TUPLE_DIR_PATH:-/logs/tuples}
+property.tupleDir = ${env:TUPLE_DIR_PATH:-./logs/tuples}
 
 appender.console.type = Console
 appender.console.name = STDERR

--- a/TrafficCapture/trafficReplayer/src/main/resources/log4j2.properties
+++ b/TrafficCapture/trafficReplayer/src/main/resources/log4j2.properties
@@ -1,6 +1,6 @@
 status = error
 
-property.tupleDir = /shared-replayer-output/${env:TUPLE_DIR_NAME}
+property.tupleDir = ${env:TUPLE_DIR_PATH:-/logs/tuples}
 
 appender.console.type = Console
 appender.console.name = STDERR

--- a/deployment/cdk/opensearch-service-migration/README.md
+++ b/deployment/cdk/opensearch-service-migration/README.md
@@ -106,6 +106,7 @@ Additional context on some of these options, can also be found in the Domain con
 | domainRemovalPolicy                             | false    | string       | "RETAIN"                                                                                                                                                                                                                       | Policy to apply when the domain is removed from the CloudFormation stack                                                                                                                                                                                     |
 | mskARN (Not currently available)                | false    | string       | `"arn:aws:kafka:us-east-2:123456789123:cluster/msk-cluster-test/81fbae45-5d25-44bb-aff0-108e71cc079b-7"`                                                                                                                       | Supply an existing MSK cluster ARN to use. **NOTE** As MSK is using an L1 construct this is not currently available for use                                                                                                                                  |
 | mskEnablePublicEndpoints                        | false    | boolean      | true                                                                                                                                                                                                                           | Specify if public endpoints should be enabled on the MSK cluster                                                                                                                                                                                             |
+| mskBrokerNodeCount                              | false    | number       | 2                                                                                                                                                                                                                              | The number of broker nodes to be used by the MSK cluster                                                                                                                                                                                                     |
 
 A template `cdk.context.json` to be used to fill in these values is below:
 ```
@@ -143,7 +144,8 @@ A template `cdk.context.json` to be used to fill in these values is below:
   "openAccessPolicyEnabled": "",
   "domainRemovalPolicy": "",
   "mskARN": "",
-  "mskEnablePublicEndpoints": ""
+  "mskEnablePublicEndpoints": "",
+  "mskBrokerNodeCount": ""
 }
 
 ```

--- a/deployment/cdk/opensearch-service-migration/default-values.json
+++ b/deployment/cdk/opensearch-service-migration/default-values.json
@@ -1,6 +1,7 @@
 {
-  "engineVersion": "OS_2.5",
+  "engineVersion": "OS_2.7",
   "domainName": "os-service-domain",
+  "tlsSecurityPolicy": "TLS_1_2",
   "enforceHTTPS": true,
   "nodeToNodeEncryptionEnabled": true,
   "encryptionAtRestEnabled": true

--- a/deployment/cdk/opensearch-service-migration/lib/migration-assistance-stack.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/migration-assistance-stack.ts
@@ -22,6 +22,7 @@ export interface migrationStackProps extends StackPropsExt {
     // Future support needed to allow importing an existing MSK cluster
     readonly mskARN?: string,
     readonly mskEnablePublicEndpoints?: boolean
+    readonly mskBrokerNodeCount?: number
 }
 
 
@@ -57,7 +58,7 @@ export class MigrationAssistanceStack extends Stack {
         const mskCluster = new CfnCluster(this, 'migrationMSKCluster', {
             clusterName: 'migration-msk-cluster',
             kafkaVersion: '2.8.1',
-            numberOfBrokerNodes: 2,
+            numberOfBrokerNodes: props.mskBrokerNodeCount ? props.mskBrokerNodeCount : 2,
             brokerNodeGroupInfo: {
                 instanceType: 'kafka.m5.large',
                 clientSubnets: props.vpc.selectSubnets({subnetType: SubnetType.PUBLIC}).subnetIds,

--- a/deployment/cdk/opensearch-service-migration/lib/opensearch-service-domain-cdk-stack.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/opensearch-service-domain-cdk-stack.ts
@@ -69,7 +69,7 @@ export class OpensearchServiceDomainCdkStack extends Stack {
     if (props.enableDemoAdmin) {
       adminUserName = "admin"
       adminUserSecret = new Secret(this, "demoUserSecret", {
-        secretName: "demo-user-secret",
+        secretName: `demo-user-secret-${props.stage}-${props.env?.region}`,
         // This is unsafe and strictly for ease of use in a demo mode setup
         secretStringValue: SecretValue.unsafePlainText("Admin123!")
       })

--- a/deployment/cdk/opensearch-service-migration/lib/stack-composer.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/stack-composer.ts
@@ -59,6 +59,7 @@ export class StackComposer {
         const migrationAssistanceEnabled = getContextForType('migrationAssistanceEnabled', 'boolean')
         const mskARN = getContextForType('mskARN', 'string')
         const mskEnablePublicEndpoints = getContextForType('mskEnablePublicEndpoints', 'boolean')
+        const mskBrokerNodeCount = getContextForType('mskBrokerNodeCount', 'number')
         const sourceClusterEndpoint = getContextForType('sourceClusterEndpoint', 'string')
         const historicalCaptureEnabled = getContextForType('historicalCaptureEnabled', 'boolean')
         const logstashConfigFilePath = getContextForType('logstashConfigFilePath', 'string')
@@ -169,6 +170,7 @@ export class StackComposer {
                 vpc: networkStack.vpc,
                 mskARN: mskARN,
                 mskEnablePublicEndpoints: mskEnablePublicEndpoints,
+                mskBrokerNodeCount: mskBrokerNodeCount,
                 stackName: `OSServiceMigrationCDKStack-${stage}-${region}`,
                 description: "This stack contains resources to assist migrating an OpenSearch Service domain",
                 ...props,

--- a/deployment/copilot/createReplayer.sh
+++ b/deployment/copilot/createReplayer.sh
@@ -100,7 +100,7 @@ done
 
 # Remove service from Copilot and delete created service directory
 if [[ -n "${ID_TO_DELETE}" ]]; then
-  copilot svc delete -a $COPILOT_APP_NAME --name traffic-replayer-$ID_TO_DELETE --env $STAGE --yes
+  copilot svc delete -a $COPILOT_APP_NAME --name traffic-replayer-$ID_TO_DELETE --yes
   rm -r traffic-replayer-$ID_TO_DELETE
   exit 1
 fi

--- a/deployment/copilot/devDeploy.sh
+++ b/deployment/copilot/devDeploy.sh
@@ -104,7 +104,7 @@ if [ "$DESTROY_ENV" = true ] ; then
 
   export AWS_DEFAULT_REGION=$REGION
   cd ../cdk/opensearch-service-migration
-  cdk destroy "*" --c domainName="aos-domain" --c engineVersion="OS_1.3" --c  dataNodeCount=2 --c vpcEnabled=true --c availabilityZoneCount=2 --c openAccessPolicyEnabled=true --c domainRemovalPolicy="DESTROY" --c migrationAssistanceEnabled=true --c enableDemoAdmin=true
+  cdk destroy "*" --c domainName="aos-domain" --c engineVersion="OS_2.7" --c  dataNodeCount=2 --c vpcEnabled=true --c availabilityZoneCount=2 --c openAccessPolicyEnabled=true --c domainRemovalPolicy="DESTROY" --c migrationAssistanceEnabled=true --c enableDemoAdmin=true
   exit 1
 fi
 
@@ -130,7 +130,7 @@ fi
 # This command deploys the required infrastructure for the migration solution with CDK that Copilot requires.
 # The options provided to `cdk deploy` here will cause a VPC, Opensearch Domain, and MSK(Kafka) resources to get created in AWS (among other resources)
 # More details on the CDK used here can be found at opensearch-migrations/deployment/cdk/opensearch-service-migration/README.md
-cdk deploy "*" --c domainName="aos-domain" --c engineVersion="OS_1.3" --c  dataNodeCount=2 --c vpcEnabled=true --c availabilityZoneCount=2 --c openAccessPolicyEnabled=true --c domainRemovalPolicy="DESTROY" --c migrationAssistanceEnabled=true --c enableDemoAdmin=true -O cdk.out/cdkOutput.json --require-approval never --concurrency 3
+cdk deploy "*" --c domainName="aos-domain" --c engineVersion="OS_2.7" --c  dataNodeCount=2 --c vpcEnabled=true --c availabilityZoneCount=2 --c openAccessPolicyEnabled=true --c domainRemovalPolicy="DESTROY" --c migrationAssistanceEnabled=true --c enableDemoAdmin=true -O cdk.out/cdkOutput.json --require-approval never --concurrency 3
 
 # Collect export commands from CDK output, which are needed by Copilot, wrap the commands in double quotes and store them within the "environment" dir
 export_file_path=../../copilot/environments/$COPILOT_DEPLOYMENT_STAGE/envExports.sh

--- a/deployment/copilot/templates/traffic-replayer/manifest.yml
+++ b/deployment/copilot/templates/traffic-replayer/manifest.yml
@@ -35,7 +35,7 @@ exec: true     # Enable getting a shell to your container (https://docs.aws.amaz
 
 # Pass environment variables as key value pairs.
 variables:
-  TUPLE_DIR_NAME: SERVICE_NAME_PLACEHOLDER
+  TUPLE_DIR_PATH: /shared-replayer-output/SERVICE_NAME_PLACEHOLDER
 
 environments:
   dev:

--- a/deployment/copilot/templates/traffic-replayer/manifest.yml
+++ b/deployment/copilot/templates/traffic-replayer/manifest.yml
@@ -33,6 +33,10 @@ memory: 4096    # Amount of memory in MiB used by the task.
 count: 1       # Number of tasks that should be running in your service.
 exec: true     # Enable getting a shell to your container (https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-exec.html).
 
+# Pass environment variables as key value pairs.
+variables:
+  TUPLE_DIR_NAME: SERVICE_NAME_PLACEHOLDER
+
 environments:
   dev:
     count: 1               # Number of tasks to run for the "dev" environment.


### PR DESCRIPTION
### Description
This includes several minor improvements to our IaC story for deploying multiple replayers that I have come across while deploying and testing our solution.

One additional point I want to make is that setting our log4j2.properties for the tuple directory at program startup before logging gets initialized was more involved than I originally thought. I am still open to going that direction but didn't want to get hung up here. This instead uses an env variable that seems to work well for the near term

### Issues Resolved
None

### Testing
E2E Cloud Testing

### Check List
- [ ] New functionality includes testing
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
