### PR TITLE
Use an example keypair (with the string "EXAMPLE" rather than a fabricated one) to satisfy scanners.

### DIFF
--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/SigV4SigningTransformationTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/SigV4SigningTransformationTest.java
@@ -19,16 +19,13 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 public class SigV4SigningTransformationTest {
-    private static String decodeString(String s) {
-        var decodedByteBuf = Base64.decode(Unpooled.wrappedBuffer(s.getBytes(StandardCharsets.UTF_8)));
-        return decodedByteBuf.toString(StandardCharsets.UTF_8);
-    }
 
     private static class MockCredentialsProvider implements AwsCredentialsProvider {
         @Override
         public AwsCredentials resolveCredentials() {
-            return AwsBasicCredentials.create(decodeString("QUtJQUlPU0ZPRE5ON0VYQU1QTEUK"),
-                    decodeString("d0phbHJYVXRuRkVNSS9LN01ERU5HL2JQeFJmaUNZRVhBTVBMRUtFWQo="));
+            // Notice that these are example keys
+            return AwsBasicCredentials.create("AKIAIOSFODNN7EXAMPLE",
+                    "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY");
         }
     }
 

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/TestUtils.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/TestUtils.java
@@ -92,11 +92,8 @@ public class TestUtils {
 
         AtomicReference<FullHttpRequest> fullHttpRequestAtomicReference = new AtomicReference<>();
         EmbeddedChannel unpackVerifier = new EmbeddedChannel(
-                new LoggingHandler(LogLevel.ERROR),
                 new HttpRequestDecoder(),
-                new LoggingHandler(LogLevel.WARN),
                 new HttpContentDecompressor(),
-                new LoggingHandler(LogLevel.INFO),
                 new HttpObjectAggregator(bytesCaptured.length*2),
                 new SimpleChannelInboundHandler<FullHttpRequest>() {
                     @Override


### PR DESCRIPTION
### Testing
Reran the unit test with example creds and it works as expected.

### Check List
- [ ] New functionality includes testing
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
