### PR TITLE
Fix for CVE-2022-42969

### DIFF
--- a/experimental/cluster_migration_core/setup.py
+++ b/experimental/cluster_migration_core/setup.py
@@ -11,8 +11,7 @@ setuptools.setup(
         "coloredlogs",
         "docker",
         "pexpect",
-        "py",
-        "pytest",
+        "pytest>=7.4.2",
         "requests",
         "robotframework"
     ],


### PR DESCRIPTION
### Description
Testing if this fixes CVE-2022-42969.
I tested running the UTF again without the `py` library and also upgrading `pytest` to latest, and it worked as it previously was.

This is the reason I updated `pytest` to 7.4.2: https://github.com/advisories/GHSA-w596-4wvx-j9j6


### Check List
- [ ] New functionality includes testing
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
