### PR TITLE
Add MetricsLogger to Traffic Replayer

### DIFF
--- a/TrafficCapture/captureKafkaOffloader/src/main/java/org/opensearch/migrations/trafficcapture/kafkaoffloader/KafkaCaptureFactory.java
+++ b/TrafficCapture/captureKafkaOffloader/src/main/java/org/opensearch/migrations/trafficcapture/kafkaoffloader/KafkaCaptureFactory.java
@@ -74,7 +74,7 @@ public class KafkaCaptureFactory implements IConnectionCaptureFactory {
                     producer.send(record, handleProducerRecordSent(cf, recordId));
                     metricsLogger.atSuccess()
                             .addKeyValue("channelId", connectionId)
-                            .addKeyValue("topic-name", topicNameForTraffic)
+                            .addKeyValue("topicName", topicNameForTraffic)
                             .addKeyValue("sizeInBytes", record.value().length)
                             .addKeyValue("diagnosticId", recordId)
                             .setMessage("Sent message to Kafka").log();
@@ -85,7 +85,7 @@ public class KafkaCaptureFactory implements IConnectionCaptureFactory {
                 } catch (Exception e) {
                     metricsLogger.atError(e)
                             .addKeyValue("channelId", connectionId)
-                            .addKeyValue("topic-name", topicNameForTraffic)
+                            .addKeyValue("topicName", topicNameForTraffic)
                             .setMessage("Sending message to Kafka failed.").log();
                     throw new RuntimeException(e);
                 }

--- a/TrafficCapture/captureKafkaOffloader/src/main/java/org/opensearch/migrations/trafficcapture/kafkaoffloader/KafkaCaptureFactory.java
+++ b/TrafficCapture/captureKafkaOffloader/src/main/java/org/opensearch/migrations/trafficcapture/kafkaoffloader/KafkaCaptureFactory.java
@@ -75,7 +75,7 @@ public class KafkaCaptureFactory implements IConnectionCaptureFactory {
                     metricsLogger.atSuccess()
                             .addKeyValue("channelId", connectionId)
                             .addKeyValue("topic-name", topicNameForTraffic)
-                            .addKeyValue("size", record.value().length)
+                            .addKeyValue("sizeInBytes", record.value().length)
                             .addKeyValue("diagnosticId", recordId)
                             .setMessage("Sent message to Kafka").log();
                     // Note that ordering is not guaranteed to be preserved here

--- a/TrafficCapture/coreUtilities/src/main/java/org/opensearch/migrations/coreutils/MetricsLogger.java
+++ b/TrafficCapture/coreUtilities/src/main/java/org/opensearch/migrations/coreutils/MetricsLogger.java
@@ -50,4 +50,8 @@ class MetricsLogger {
     public LoggingEventBuilder atError() {
         return logger.makeLoggingEventBuilder(Level.ERROR);
     }
+
+    public LoggingEventBuilder atTrace() {
+        return logger.makeLoggingEventBuilder(Level.TRACE);
+    }
 }

--- a/TrafficCapture/trafficReplayer/build.gradle
+++ b/TrafficCapture/trafficReplayer/build.gradle
@@ -45,6 +45,7 @@ dependencies {
     def resilience4jVersion = "1.7.0";
 
     implementation project(':captureProtobufs')
+    implementation project(':coreUtilities')
 
     implementation group: 'com.beust', name: 'jcommander', version: '1.82'
     implementation group: 'com.bazaarvoice.jolt', name: 'jolt-core', version: '0.1.7'

--- a/TrafficCapture/trafficReplayer/build.gradle
+++ b/TrafficCapture/trafficReplayer/build.gradle
@@ -23,8 +23,6 @@ plugins {
     id "io.freefair.lombok" version "8.0.1"
 }
 
-import org.opensearch.migrations.common.CommonUtils
-
 //spotbugs {
 //    includeFilter = new File(rootDir, 'config/spotbugs/spotbugs-include.xml')
 //}

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/CapturedTrafficToHttpTransactionAccumulator.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/CapturedTrafficToHttpTransactionAccumulator.java
@@ -243,8 +243,8 @@ public class CapturedTrafficToHttpTransactionAccumulator {
         assert accumulation.state == Accumulation.State.NOTHING_SENT : "state == " + accumulation.state;
         var requestPacketBytes = accumulation.rrPair.requestData;
         metricsLogger.atSuccess()
-                .addKeyValue("diagnosticLabel", accumulation.getRequestId())
-                .setMessage("Full captured request was accumulated").log();
+                .addKeyValue("requestId", accumulation.getRequestId())
+                .setMessage("Full captured source request was accumulated").log();
         if (requestPacketBytes != null) {
             requestHandler.accept(accumulation.getRequestId(), requestPacketBytes);
             accumulation.state = Accumulation.State.REQUEST_SENT;
@@ -260,8 +260,8 @@ public class CapturedTrafficToHttpTransactionAccumulator {
     private void handleEndOfResponse(Accumulation accumulation) {
         assert accumulation.state == Accumulation.State.REQUEST_SENT;
         metricsLogger.atSuccess()
-                .addKeyValue("diagnosticLabel", accumulation.getRequestId())
-                .setMessage("Full captured response was accumulated").log();
+                .addKeyValue("requestId", accumulation.getRequestId())
+                .setMessage("Full captured source response was accumulated").log();
         fullDataHandler.accept(accumulation.rrPair);
         accumulation.resetForNextRequest();
     }

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/CapturedTrafficToHttpTransactionAccumulator.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/CapturedTrafficToHttpTransactionAccumulator.java
@@ -244,6 +244,7 @@ public class CapturedTrafficToHttpTransactionAccumulator {
         var requestPacketBytes = accumulation.rrPair.requestData;
         metricsLogger.atSuccess()
                 .addKeyValue("requestId", accumulation.getRequestId())
+                .addKeyValue("connectionId", accumulation.getRequestId().connectionId)
                 .setMessage("Full captured source request was accumulated").log();
         if (requestPacketBytes != null) {
             requestHandler.accept(accumulation.getRequestId(), requestPacketBytes);
@@ -261,6 +262,7 @@ public class CapturedTrafficToHttpTransactionAccumulator {
         assert accumulation.state == Accumulation.State.REQUEST_SENT;
         metricsLogger.atSuccess()
                 .addKeyValue("requestId", accumulation.getRequestId())
+                .addKeyValue("connectionId", accumulation.getRequestId().connectionId)
                 .setMessage("Full captured source response was accumulated").log();
         fullDataHandler.accept(accumulation.rrPair);
         accumulation.resetForNextRequest();

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/CapturedTrafficToHttpTransactionAccumulator.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/CapturedTrafficToHttpTransactionAccumulator.java
@@ -1,6 +1,7 @@
 package org.opensearch.migrations.replay;
 
 import lombok.extern.slf4j.Slf4j;
+import org.opensearch.migrations.coreutils.MetricsLogger;
 import org.opensearch.migrations.replay.datatypes.UniqueRequestKey;
 import org.opensearch.migrations.replay.traffic.expiration.BehavioralPolicy;
 import org.opensearch.migrations.replay.traffic.expiration.ExpiringTrafficStreamMap;
@@ -56,6 +57,8 @@ public class CapturedTrafficToHttpTransactionAccumulator {
     private final AtomicInteger exceptionConnectionCounter = new AtomicInteger();
     private final AtomicInteger connectionsExpiredCounter = new AtomicInteger();
     private final AtomicInteger requestsTerminatedUponAccumulatorCloseCounter = new AtomicInteger();
+
+    private final static MetricsLogger metricsLogger = new MetricsLogger("CapturedTrafficToHttpTransactionAccumulator");
 
     public CapturedTrafficToHttpTransactionAccumulator(Duration minTimeout,
                                                        BiConsumer<UniqueRequestKey,HttpMessageAndTimestamp> requestReceivedHandler,
@@ -239,6 +242,9 @@ public class CapturedTrafficToHttpTransactionAccumulator {
     private boolean handleEndOfRequest(Accumulation accumulation) {
         assert accumulation.state == Accumulation.State.NOTHING_SENT : "state == " + accumulation.state;
         var requestPacketBytes = accumulation.rrPair.requestData;
+        metricsLogger.atSuccess()
+                .addKeyValue("diagnosticLabel", accumulation.getRequestId())
+                .setMessage("Full captured request was accumulated").log();
         if (requestPacketBytes != null) {
             requestHandler.accept(accumulation.getRequestId(), requestPacketBytes);
             accumulation.state = Accumulation.State.REQUEST_SENT;
@@ -253,6 +259,9 @@ public class CapturedTrafficToHttpTransactionAccumulator {
 
     private void handleEndOfResponse(Accumulation accumulation) {
         assert accumulation.state == Accumulation.State.REQUEST_SENT;
+        metricsLogger.atSuccess()
+                .addKeyValue("diagnosticLabel", accumulation.getRequestId())
+                .setMessage("Full captured response was accumulated").log();
         fullDataHandler.accept(accumulation.rrPair);
         accumulation.resetForNextRequest();
     }

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/PacketToTransformingHttpHandlerFactory.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/PacketToTransformingHttpHandlerFactory.java
@@ -36,6 +36,6 @@ public class PacketToTransformingHttpHandlerFactory implements
     create(UniqueRequestKey requestKey) {
         log.trace("creating HttpJsonTransformingConsumer");
         return new HttpJsonTransformingConsumer(jsonTransformer, authTransformerFactory,
-                new TransformedPacketReceiver(), requestKey.toString());
+                new TransformedPacketReceiver(), requestKey.toString(), requestKey);
     }
 }

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/ReplayEngine.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/ReplayEngine.java
@@ -133,6 +133,7 @@ public class ReplayEngine {
         var interval = numPackets > 1 ? Duration.between(start, end).dividedBy(numPackets-1) : Duration.ZERO;
         metricsLogger.atSuccess()
                 .addKeyValue("requestId", requestKey.toString())
+                .addKeyValue("connectionId", requestKey.connectionId)
                 .addKeyValue("delayFromOriginalToScheduledStartInMs", Duration.between(originalStart, start).toMillis())
                 .addKeyValue("scheduledStartTime", start.toString())
                 .setMessage("Request scheduled to be sent").log();

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/ReplayEngine.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/ReplayEngine.java
@@ -132,8 +132,8 @@ public class ReplayEngine {
         var end = timeShifter.transformSourceTimeToRealTime(originalEnd);
         var interval = numPackets > 1 ? Duration.between(start, end).dividedBy(numPackets-1) : Duration.ZERO;
         metricsLogger.atSuccess()
-                .addKeyValue("requestKey", requestKey.toString())
-                .addKeyValue("delayFromOriginalToScheduledStart", Duration.between(originalStart, start).toString())
+                .addKeyValue("requestId", requestKey.toString())
+                .addKeyValue("delayFromOriginalToScheduledStartInMs", Duration.between(originalStart, start).toMillis())
                 .addKeyValue("scheduledStartTime", start.toString())
                 .setMessage("Request scheduled to be sent").log();
         var sendResult = networkSendOrchestrator.scheduleRequest(requestKey, start, interval, packets);

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/ReplayEngine.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/ReplayEngine.java
@@ -3,6 +3,7 @@ package org.opensearch.migrations.replay;
 import io.netty.buffer.ByteBuf;
 import io.netty.util.concurrent.ScheduledFuture;
 import lombok.extern.slf4j.Slf4j;
+import org.opensearch.migrations.coreutils.MetricsLogger;
 import org.opensearch.migrations.replay.datatypes.UniqueRequestKey;
 import org.opensearch.migrations.replay.util.DiagnosticTrackableCompletableFuture;
 
@@ -25,6 +26,7 @@ public class ReplayEngine {
     private final AtomicLong lastIdleUpdatedTimestampEpochMs;
     private final TimeShifter timeShifter;
     private final double maxSpeedupFactor;
+    private static final MetricsLogger metricsLogger = new MetricsLogger("ReplayEngine");
     /**
      * If this proves to be a contention bottleneck, we can move to a scheme with ThreadLocals
      * and on a scheduled basis, submit work to each thread to find out if they're idle or not.
@@ -129,6 +131,11 @@ public class ReplayEngine {
         var start = timeShifter.transformSourceTimeToRealTime(originalStart);
         var end = timeShifter.transformSourceTimeToRealTime(originalEnd);
         var interval = numPackets > 1 ? Duration.between(start, end).dividedBy(numPackets-1) : Duration.ZERO;
+        metricsLogger.atSuccess()
+                .addKeyValue("requestKey", requestKey.toString())
+                .addKeyValue("delayFromOriginalToScheduledStart", Duration.between(originalStart, start).toString())
+                .addKeyValue("scheduledStartTime", start.toString())
+                .setMessage("Request scheduled to be sent").log();
         var sendResult = networkSendOrchestrator.scheduleRequest(requestKey, start, interval, packets);
         return hookWorkFinishingUpdates(sendResult, originalStart);
     }

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/RequestSenderOrchestrator.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/RequestSenderOrchestrator.java
@@ -206,7 +206,7 @@ public class RequestSenderOrchestrator {
     getPacketReceiver(UniqueRequestKey requestKey, ChannelFuture channelFuture,
                       AtomicReference<NettyPacketToHttpConsumer> packetReceiver) {
         if (packetReceiver.get() == null) {
-            packetReceiver.set(new NettyPacketToHttpConsumer(channelFuture, requestKey.toString()));
+            packetReceiver.set(new NettyPacketToHttpConsumer(channelFuture, requestKey.toString(), requestKey));
         }
         return packetReceiver.get();
     }

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/NettyPacketToHttpConsumer.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/NettyPacketToHttpConsumer.java
@@ -224,8 +224,9 @@ public class NettyPacketToHttpConsumer implements IPacketFinalizingConsumer<Aggr
                                 + packetData + " hash=" + System.identityHashCode(packetData)).log();
                         metricsLogger.atError(cause)
                                 .addKeyValue("channelId", channel.id().asLongText())
-                                .addKeyValue("requestId", diagnosticLabel)
-                                .setMessage("Failed to write request packet").log();
+                                .addKeyValue("requestId", diagnosticLabel) // TODO: this should be a requestKey, not diagnosticLabel
+                                .addKeyValue("connectionId", 0) // TODO
+                                .setMessage("Failed to write component of request").log();
                         completableFuture.future.completeExceptionally(cause);
                         channel.close();
                     }
@@ -234,9 +235,10 @@ public class NettyPacketToHttpConsumer implements IPacketFinalizingConsumer<Aggr
                 ".  Created future for writing data="+completableFuture).log();
         metricsLogger.atSuccess()
                 .addKeyValue("channelId", channel.id().asLongText())
-                .addKeyValue("requestId", diagnosticLabel)
+                .addKeyValue("requestId", diagnosticLabel) // TODO: this should be a requestKey, not diagnosticLabel
+                .addKeyValue("connectionId", 0) // TODO
                 .addKeyValue("sizeInBytes", readableBytes)
-                .setMessage("Request packet written to target").log();
+                .setMessage("Component of request written to target").log();
         return completableFuture;
     }
 

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/NettyPacketToHttpConsumer.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/NettyPacketToHttpConsumer.java
@@ -224,7 +224,7 @@ public class NettyPacketToHttpConsumer implements IPacketFinalizingConsumer<Aggr
                                 + packetData + " hash=" + System.identityHashCode(packetData)).log();
                         metricsLogger.atError(cause)
                                 .addKeyValue("channelId", channel.id().asLongText())
-                                .addKeyValue("diagnosticLabel", diagnosticLabel)
+                                .addKeyValue("requestId", diagnosticLabel)
                                 .setMessage("Failed to write request packet").log();
                         completableFuture.future.completeExceptionally(cause);
                         channel.close();
@@ -234,9 +234,9 @@ public class NettyPacketToHttpConsumer implements IPacketFinalizingConsumer<Aggr
                 ".  Created future for writing data="+completableFuture).log();
         metricsLogger.atSuccess()
                 .addKeyValue("channelId", channel.id().asLongText())
-                .addKeyValue("diagnosticLabel", diagnosticLabel)
-                .addKeyValue("size", readableBytes)
-                .setMessage("Request packet written").log();
+                .addKeyValue("requestId", diagnosticLabel)
+                .addKeyValue("sizeInBytes", readableBytes)
+                .setMessage("Request packet written to target").log();
         return completableFuture;
     }
 

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/http/HttpJsonTransformingConsumer.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/http/HttpJsonTransformingConsumer.java
@@ -133,14 +133,14 @@ public class HttpJsonTransformingConsumer<R> implements IPacketFinalizingConsume
                             return redriveWithoutTransformation(offloadingHandler.packetReceiver, t);
                         } else {
                             metricsLogger.atError(t)
-                                    .addKeyValue("diagnosticLabel", diagnosticLabel)
+                                    .addKeyValue("requestId", diagnosticLabel)
                                     .addKeyValue("channelId", channel.id().asLongText())
                                     .setMessage("Request failed to be transformed").log();
                             throw new CompletionException(t);
                         }
                     } else {
                         metricsLogger.atSuccess()
-                                .addKeyValue("diagnosticLabel", diagnosticLabel)
+                                .addKeyValue("requestId", diagnosticLabel)
                                 .addKeyValue("channelId", channel.id().asLongText())
                                 .setMessage("Request was transformed").log();
                         return StringTrackableCompletableFuture.completedFuture(v, ()->"transformedHttpMessageValue");
@@ -171,7 +171,7 @@ public class HttpJsonTransformingConsumer<R> implements IPacketFinalizingConsume
                 consumptionChainedFuture.thenCompose(v -> packetConsumer.finalizeRequest(),
                         ()->"HttpJsonTransformingConsumer.redriveWithoutTransformation.compose()");
         metricsLogger.atSuccess()
-                .addKeyValue("diagnosticLabel", diagnosticLabel)
+                .addKeyValue("requestId", diagnosticLabel)
                 .addKeyValue("channelId", channel.id().asLongText())
                 .setMessage("Request was redriven without transformation").log();
         return finalizedFuture.map(f->f.thenApply(r->reason == null ?

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/http/HttpJsonTransformingConsumer.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/http/HttpJsonTransformingConsumer.java
@@ -133,14 +133,16 @@ public class HttpJsonTransformingConsumer<R> implements IPacketFinalizingConsume
                             return redriveWithoutTransformation(offloadingHandler.packetReceiver, t);
                         } else {
                             metricsLogger.atError(t)
-                                    .addKeyValue("requestId", diagnosticLabel)
+                                    .addKeyValue("requestId", diagnosticLabel) // TODO: this should be a requestKey, not diagnosticLabel
+                                    .addKeyValue("connectionId", 0) // TODO
                                     .addKeyValue("channelId", channel.id().asLongText())
                                     .setMessage("Request failed to be transformed").log();
                             throw new CompletionException(t);
                         }
                     } else {
                         metricsLogger.atSuccess()
-                                .addKeyValue("requestId", diagnosticLabel)
+                                .addKeyValue("requestId", diagnosticLabel) // TODO: this should be a requestKey, not diagnosticLabel
+                                .addKeyValue("connectionId", 0) // TODO
                                 .addKeyValue("channelId", channel.id().asLongText())
                                 .setMessage("Request was transformed").log();
                         return StringTrackableCompletableFuture.completedFuture(v, ()->"transformedHttpMessageValue");
@@ -170,8 +172,9 @@ public class HttpJsonTransformingConsumer<R> implements IPacketFinalizingConsume
         DiagnosticTrackableCompletableFuture<String,R> finalizedFuture =
                 consumptionChainedFuture.thenCompose(v -> packetConsumer.finalizeRequest(),
                         ()->"HttpJsonTransformingConsumer.redriveWithoutTransformation.compose()");
-        metricsLogger.atSuccess()
-                .addKeyValue("requestId", diagnosticLabel)
+        metricsLogger.atError(reason)
+                .addKeyValue("requestId", diagnosticLabel) // TODO: this should be a requestKey, not diagnosticLabel
+                .addKeyValue("connectionId", 0) // TODO
                 .addKeyValue("channelId", channel.id().asLongText())
                 .setMessage("Request was redriven without transformation").log();
         return finalizedFuture.map(f->f.thenApply(r->reason == null ?

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/http/NettyDecodedHttpRequestPreliminaryConvertHandler.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/http/NettyDecodedHttpRequestPreliminaryConvertHandler.java
@@ -5,6 +5,7 @@ import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.handler.codec.http.HttpContent;
 import io.netty.handler.codec.http.HttpRequest;
 import lombok.extern.slf4j.Slf4j;
+import org.opensearch.migrations.coreutils.MetricsLogger;
 import org.opensearch.migrations.replay.datahandlers.PayloadAccessFaultingMap;
 import org.opensearch.migrations.replay.datahandlers.PayloadNotLoadedException;
 import org.opensearch.migrations.transform.IAuthTransformer;
@@ -23,6 +24,7 @@ public class NettyDecodedHttpRequestPreliminaryConvertHandler extends ChannelInb
     final IJsonTransformer transformer;
     final List<List<Integer>> chunkSizes;
     final String diagnosticLabel;
+    final static MetricsLogger metricsLogger = new MetricsLogger("NettyDecodedHttpRequestPreliminaryConvertHandler");
 
     public NettyDecodedHttpRequestPreliminaryConvertHandler(IJsonTransformer transformer,
                                                             List<List<Integer>> chunkSizes,
@@ -46,6 +48,11 @@ public class NettyDecodedHttpRequestPreliminaryConvertHandler extends ChannelInb
                     .append(" ")
                     .append(request.protocolVersion().text())
                     .toString());
+            metricsLogger.atSuccess()
+                    .addKeyValue("requestId", diagnosticLabel)
+                    .addKeyValue("httpMethod", request.method())
+                    .addKeyValue("httpEndpoint", request.uri())
+                    .setMessage("Captured request parsed to HTTP").log();
 
             // TODO - this is super ugly and sloppy - this has to be improved
             chunkSizes.add(new ArrayList<>(EXPECTED_PACKET_COUNT_GUESS_FOR_PAYLOAD));

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/http/NettyDecodedHttpRequestPreliminaryConvertHandler.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/http/NettyDecodedHttpRequestPreliminaryConvertHandler.java
@@ -49,7 +49,8 @@ public class NettyDecodedHttpRequestPreliminaryConvertHandler extends ChannelInb
                     .append(request.protocolVersion().text())
                     .toString());
             metricsLogger.atSuccess()
-                    .addKeyValue("requestId", diagnosticLabel)
+                    .addKeyValue("requestId", diagnosticLabel) // TODO: this should be a requestKey, not diagnosticLabel
+                    .addKeyValue("connectionId", 0) // TODO
                     .addKeyValue("httpMethod", request.method())
                     .addKeyValue("httpEndpoint", request.uri())
                     .setMessage("Captured request parsed to HTTP").log();

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/kafka/KafkaProtobufConsumer.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/kafka/KafkaProtobufConsumer.java
@@ -108,14 +108,14 @@ public class KafkaProtobufConsumer implements ITrafficCaptureSource {
                     log.trace("Parsed traffic stream #{}: {}", trafficStreamsRead.incrementAndGet(), ts);
                     metricsLogger.atSuccess()
                             .addKeyValue("connectionId", ts.getConnectionId())
-                            .addKeyValue("topic-name", this.topic)
+                            .addKeyValue("topicName", this.topic)
                             .addKeyValue("sizeInBytes", ts.getSerializedSize())
                             .setMessage("Parsed traffic stream from Kafka").log();
                     return ts;
                 } catch (InvalidProtocolBufferException e) {
                     RuntimeException recordError = behavioralPolicy.onInvalidKafkaRecord(record, e);
                     metricsLogger.atError(recordError)
-                            .addKeyValue("topic-name", this.topic)
+                            .addKeyValue("topicName", this.topic)
                             .setMessage("Failed to parse traffic stream from Kafka.").log();
                     if (recordError != null) {
                         throw recordError;

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/kafka/KafkaProtobufConsumer.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/kafka/KafkaProtobufConsumer.java
@@ -109,7 +109,7 @@ public class KafkaProtobufConsumer implements ITrafficCaptureSource {
                     metricsLogger.atSuccess()
                             .addKeyValue("connectionId", ts.getConnectionId())
                             .addKeyValue("topic-name", this.topic)
-                            .addKeyValue("size", ts.getSerializedSize())
+                            .addKeyValue("sizeInBytes", ts.getSerializedSize())
                             .setMessage("Parsed traffic stream from Kafka").log();
                     return ts;
                 } catch (InvalidProtocolBufferException e) {

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/netty/BacksideHttpWatcherHandler.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/netty/BacksideHttpWatcherHandler.java
@@ -27,6 +27,7 @@ public class BacksideHttpWatcherHandler extends SimpleChannelInboundHandler<Full
     protected void channelRead0(ChannelHandlerContext ctx, FullHttpResponse msg) throws Exception {
         doneReadingRequest = true;
         triggerResponseCallbackAndRemoveCallback();
+//      TODO: Add requestId to this metrics log entry
         metricsLogger.atSuccess()
                 .addKeyValue("channelId", ctx.channel().id().asLongText())
                 .addKeyValue("httpStatus", msg.status().toString())
@@ -43,6 +44,7 @@ public class BacksideHttpWatcherHandler extends SimpleChannelInboundHandler<Full
     @Override
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
         aggregatedRawResponseBuilder.addErrorCause(cause);
+//      TODO: Add requestId to this metrics log entry
         metricsLogger.atError(cause)
                 .addKeyValue("channelId", ctx.channel().id().asLongText())
                 .setMessage("Failed to receive full response").log();

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/netty/BacksideSnifferHandler.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/netty/BacksideSnifferHandler.java
@@ -33,7 +33,7 @@ public class BacksideSnifferHandler extends ChannelInboundHandlerAdapter {
         ctx.fireChannelRead(msg);
         metricsLogger.atSuccess()
                 .addKeyValue("channelId", ctx.channel().id().asLongText())
-                .addKeyValue("size", output.length)
+                .addKeyValue("sizeInBytes", output.length)
                 .setMessage("Component of response received").log();
     }
 

--- a/TrafficCapture/trafficReplayer/src/main/resources/log4j2.properties
+++ b/TrafficCapture/trafficReplayer/src/main/resources/log4j2.properties
@@ -12,6 +12,21 @@ rootLogger.level = info
 rootLogger.appenderRefs = stderr
 rootLogger.appenderRef.stderr.ref = STDERR
 
+appender.metrics.type = Console
+appender.metrics.name = METRICS
+appender.metrics.target = SYSTEM_ERR
+appender.metrics.layout.type = JsonLayout
+appender.metrics.layout.properties = true
+appender.metrics.layout.complete = false
+appender.metrics.layout.eventEol = true
+appender.metrics.layout.compact = true
+
+logger.MetricsLogger.name = MetricsLogger
+logger.MetricsLogger.level = info
+logger.MetricsLogger.additivity = false
+logger.MetricsLogger.appenderRefs = metrics
+logger.MetricsLogger.appenderRef.metrics.ref = METRICS
+
 logger.HttpJsonTransformingConsumer.name = org.opensearch.migrations.replay.TrafficReplayer
 logger.HttpJsonTransformingConsumer.level = info
 

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/AddCompressionEncodingTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/AddCompressionEncodingTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.opensearch.migrations.replay.datahandlers.http.HttpJsonTransformingConsumer;
 import org.opensearch.migrations.replay.datatypes.HttpRequestTransformationStatus;
+import org.opensearch.migrations.replay.datatypes.UniqueRequestKey;
 import org.opensearch.migrations.replay.util.DiagnosticTrackableCompletableFuture;
 import org.opensearch.migrations.transform.JsonJoltTransformBuilder;
 import org.opensearch.migrations.transform.JsonJoltTransformer;
@@ -36,7 +37,8 @@ public class AddCompressionEncodingTest {
         var compressingTransformer = new HttpJsonTransformingConsumer(
                 JsonJoltTransformer.newBuilder()
                         .addCannedOperation(JsonJoltTransformBuilder.CANNED_OPERATION.ADD_GZIP)
-                        .build(), null, testPacketCapture, "TEST");
+                        .build(), null, testPacketCapture, "TEST",
+                new UniqueRequestKey("testConnectionId", 0));
 
         final var payloadPartSize = 511;
         final var numParts = 1025;

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/HeaderTransformerTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/HeaderTransformerTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.opensearch.migrations.replay.datahandlers.http.HttpJsonTransformingConsumer;
 import org.opensearch.migrations.replay.datatypes.HttpRequestTransformationStatus;
+import org.opensearch.migrations.replay.datatypes.UniqueRequestKey;
 import org.opensearch.migrations.replay.util.DiagnosticTrackableCompletableFuture;
 import org.opensearch.migrations.transform.JsonJoltTransformer;
 import org.opensearch.migrations.transform.StaticAuthTransformerFactory;
@@ -34,7 +35,8 @@ public class HeaderTransformerTest {
         var jsonHandler = JsonJoltTransformer.newBuilder()
                 .addHostSwitchOperation(SILLY_TARGET_CLUSTER_NAME)
                 .build();
-        var transformingHandler = new HttpJsonTransformingConsumer(jsonHandler, null, testPacketCapture, "TEST");
+        var transformingHandler = new HttpJsonTransformingConsumer(jsonHandler, null, testPacketCapture,
+                "TEST", new UniqueRequestKey("testConnectionId", 0));
         runRandomPayloadWithTransformer(transformingHandler, dummyAggregatedResponse, testPacketCapture,
                 contentLength -> "GET / HTTP/1.1\r\n" +
                         "HoSt: " + SOURCE_CLUSTER_NAME + "\r\n" +
@@ -86,7 +88,7 @@ public class HeaderTransformerTest {
         var httpBasicAuthTransformer = new StaticAuthTransformerFactory("Basic YWRtaW46YWRtaW4=");
         var transformingHandler = new HttpJsonTransformingConsumer(
                 TrafficReplayer.buildDefaultJsonTransformer(SILLY_TARGET_CLUSTER_NAME),
-                httpBasicAuthTransformer, testPacketCapture, "TEST");
+                httpBasicAuthTransformer, testPacketCapture, "TEST", new UniqueRequestKey("testConnectionId", 0));
 
         runRandomPayloadWithTransformer(transformingHandler, dummyAggregatedResponse, testPacketCapture,
                 contentLength -> "GET / HTTP/1.1\r\n" +
@@ -110,7 +112,7 @@ public class HeaderTransformerTest {
         var testPacketCapture = new TestCapturePacketToHttpHandler(Duration.ofMillis(100), dummyAggregatedResponse);
         var transformingHandler = new HttpJsonTransformingConsumer(
                 TrafficReplayer.buildDefaultJsonTransformer(SILLY_TARGET_CLUSTER_NAME),
-                null, testPacketCapture, "TEST");
+                null, testPacketCapture, "TEST", new UniqueRequestKey("testConnectionId", 0));
 
         Random r = new Random(2);
         var stringParts = IntStream.range(0, 1).mapToObj(i-> TestUtils.makeRandomString(r, 10)).map(o->(String)o)

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/TestUtils.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/TestUtils.java
@@ -15,6 +15,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Assertions;
 import org.opensearch.migrations.replay.datahandlers.IPacketConsumer;
 import org.opensearch.migrations.replay.datahandlers.http.HttpJsonTransformingConsumer;
+import org.opensearch.migrations.replay.datatypes.UniqueRequestKey;
 import org.opensearch.migrations.replay.util.DiagnosticTrackableCompletableFuture;
 import org.opensearch.migrations.transform.IAuthTransformerFactory;
 import org.opensearch.migrations.transform.IJsonTransformer;
@@ -128,7 +129,7 @@ public class TestUtils {
         var testPacketCapture = new TestCapturePacketToHttpHandler(Duration.ofMillis(100),
                 new AggregatedRawResponse(-1, Duration.ZERO, new ArrayList<>(), null));
         var transformingHandler = new HttpJsonTransformingConsumer(transformer, authTransformer, testPacketCapture,
-                "TEST");
+                "TEST", new UniqueRequestKey("testConnectionId", 0));
 
         var contentLength = stringParts.stream().mapToInt(s->s.length()).sum();
         var headerString = "GET / HTTP/1.1\r\n" +

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/datahandlers/NettyPacketToHttpConsumerTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/datahandlers/NettyPacketToHttpConsumerTest.java
@@ -124,7 +124,8 @@ class NettyPacketToHttpConsumerTest {
             var sslContext = !testServer.localhostEndpoint().getScheme().toLowerCase().equals("https") ? null :
                     SslContextBuilder.forClient().trustManager(InsecureTrustManagerFactory.INSTANCE).build();
             var nphc = new NettyPacketToHttpConsumer(new NioEventLoopGroup(4),
-                    testServer.localhostEndpoint(), sslContext, "unitTest"+i);
+                    testServer.localhostEndpoint(), sslContext, "unitTest"+i,
+                    new UniqueRequestKey("testConnectionId", 0));
             nphc.consumeBytes((EXPECTED_REQUEST_STRING).getBytes(StandardCharsets.UTF_8));
             var aggregatedResponse = nphc.finalizeRequest().get();
             var responseBytePackets = aggregatedResponse.getCopyOfPackets();

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/datahandlers/http/HttpJsonTransformingConsumerTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/datahandlers/http/HttpJsonTransformingConsumerTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 import org.opensearch.migrations.replay.AggregatedRawResponse;
 import org.opensearch.migrations.replay.TestCapturePacketToHttpHandler;
 import org.opensearch.migrations.replay.datatypes.HttpRequestTransformationStatus;
+import org.opensearch.migrations.replay.datatypes.UniqueRequestKey;
 import org.opensearch.migrations.transform.JsonCompositeTransformer;
 import org.opensearch.migrations.transform.JsonJoltTransformer;
 import org.opensearch.migrations.transform.IJsonTransformer;
@@ -22,7 +23,7 @@ class HttpJsonTransformingConsumerTest {
         var testPacketCapture = new TestCapturePacketToHttpHandler(Duration.ofMillis(100), dummyAggregatedResponse);
         var transformingHandler =
                 new HttpJsonTransformingConsumer<AggregatedRawResponse>(JsonJoltTransformer.newBuilder().build(),
-                        null, testPacketCapture, "TEST");
+                        null, testPacketCapture, "TEST", new UniqueRequestKey("testConnectionId", 0));
         byte[] testBytes;
         try (var sampleStream = HttpJsonTransformingConsumer.class.getResourceAsStream(
                 "/requests/raw/post_formUrlEncoded_withFixedLength.txt")) {
@@ -44,7 +45,7 @@ class HttpJsonTransformingConsumerTest {
                         JsonJoltTransformer.newBuilder()
                                 .addHostSwitchOperation("test.domain")
                                 .build(),
-                        null, testPacketCapture, "TEST");
+                        null, testPacketCapture, "TEST", new UniqueRequestKey("testConnectionId", 0));
         byte[] testBytes;
         try (var sampleStream = HttpJsonTransformingConsumer.class.getResourceAsStream(
                 "/requests/raw/post_formUrlEncoded_withFixedLength.txt")) {
@@ -82,7 +83,7 @@ class HttpJsonTransformingConsumerTest {
         });
         var transformingHandler =
                 new HttpJsonTransformingConsumer<AggregatedRawResponse>(complexTransformer, null,
-                        testPacketCapture, "TEST");
+                        testPacketCapture, "TEST", new UniqueRequestKey("testConnectionId", 0));
         byte[] testBytes;
         try (var sampleStream = HttpJsonTransformingConsumer.class.getResourceAsStream(
                 "/requests/raw/post_formUrlEncoded_withFixedLength.txt")) {


### PR DESCRIPTION
### Description
Based on PR #297, which establishes a MetricsLogger convention and inserts metrics logging in various places in the capture proxy, this PR inserts metric logging in the Replayer.

In a fully successful replay of a given request, the events seen, with their contextual information are:
- Parsed traffic stream from Kafka (connectionId, sizeInBytes, topic name)
- Full captured source request was accumulated (requestId)
- Full captured source response was accumulated (requestId)
- Captured request parsed to HTTP (requestId, httpEndpoint, httpMethod)
- Request was transformed (channelId, requestId)
- Request scheduled to be sent (requestId, delayFromOriginalToScheduledStartInMs, scheduledStartTime)
- Request packet written to target (requestId, size, channelId)
- Component of response received (channelId, size)
- Full response received (channelId, httpStatus)

There are also a number of "something went wrong" events:
- Failed to write request packet (channelId, requestId)
- Request failed to be transformed (channelId, requestId)
- Failed to parse traffic stream from Kafka (topic-name)
- Failed to receive full response (channelId)
- Failed to receive component of response (channelId)

There's a _lot_ of room for improvement here, but this should give us many of the basics for being able to track the overall flow of events.

**Note about requestId:**
This is the connectionId + index of request that's used throughout the code as a label/identifier for captured requests/responses. It's also called the requestKey & diagnosticLabel. I decided to standardize on requestId so that it's easier for users to track a given piece of data through their system, and a little more descriptive than "diagnosticLabel". I'm open to switching this if there are strong opinions.

### Issues Resolved
https://opensearch.atlassian.net/browse/MIGRATIONS-1299

### Testing
Manual. 

### Check List
- [ ] New functionality includes testing
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
