### PR TITLE
Fixing at least one cause of test failures in ExpiringSubstitutableItemPool

### DIFF
--- a/TrafficCapture/trafficCaptureProxyServer/src/test/java/org/opensearch/migrations/trafficcapture/proxyserver/netty/ExpiringSubstitutableItemPoolTest.java
+++ b/TrafficCapture/trafficCaptureProxyServer/src/test/java/org/opensearch/migrations/trafficcapture/proxyserver/netty/ExpiringSubstitutableItemPoolTest.java
@@ -117,11 +117,14 @@ class ExpiringSubstitutableItemPoolTest {
         Assertions.assertTrue(pool.getStats().getNItemsExpired() >= 4);
 
         for (int i=1; i<=NUM_POOLED_ITEMS*2; ++i) {
-            log.info("Pool=" + pool);
-            Assertions.assertEquals(NUM_POOLED_ITEMS+i, getNextItem(pool));
+            var nextItemGrabbed = getNextItem(pool);
+            log.debug("Pool=" + pool + " nextItem="+nextItemGrabbed);
+            Assertions.assertEquals(NUM_POOLED_ITEMS+i, nextItemGrabbed);
         }
 
-        Assertions.assertTrue(pool.getStats().getNItemsCreated() >= 15);
+        var numItemsCreated = pool.getStats().getNItemsCreated();
+        log.debug("numItemsCreated="+numItemsCreated);
+        Assertions.assertTrue(numItemsCreated >= 15);
         Assertions.assertEquals(11, pool.getStats().getNHotGets()+pool.getStats().getNColdGets());
         Assertions.assertTrue(pool.getStats().getNItemsExpired() >= 4);
 
@@ -139,7 +142,7 @@ class ExpiringSubstitutableItemPoolTest {
     private static Integer getIntegerItem(AtomicInteger builtItemCursor,
                                           AtomicReference<Instant> lastCreation,
                                           CountDownLatch countdownLatchToUse) {
-        log.info("Building item (" +builtItemCursor.hashCode() + ") " + (builtItemCursor.get()+1));
+        log.debug("Building item (" +builtItemCursor.hashCode() + ") " + (builtItemCursor.get()+1));
         countdownLatchToUse.countDown();
         lastCreation.set(Instant.now());
         return Integer.valueOf(builtItemCursor.incrementAndGet());


### PR DESCRIPTION

### Description
* Category Bug fix/Test fix
* Why these changes are required? Fix a test
* What is the old behavior before changes and new behavior after changes? getStats() objects returned by the Expiring Pool will be immutable, but will be up-to-date and consistent at the time that getStats() was called.

### Issues Resolved
The stats that were returned by the Lombok @Getter annotation weren't thread-safe.  The Pool itself isn't threadsafe.  The expectation is that all of the calls will be conducted on the event loop that the object is bound to.  Stats are also updated from that same event loop thread and the stats are implemented with plain old non-concurrent primitives and objects. The unit test, however, queried the stats object after various calls were made and got the same stats object that may have previously been present within its CPU memory cache. To prevent this race condition from happening, getStats() now returns. a COPY of the Stats object AND runs the copy on the eventLoop of the Pool, guaranteeing that we read up-to-date values and that they're copied into what is effectively an immutable object for any other thread to consume.

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
Unit testing

### Check List
- [ ] New functionality includes testing
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
