### PR TITLE
Add time based file output that rotates and compresses every hour for up to 72 hours.

### DIFF
--- a/TrafficCapture/coreUtilities/build.gradle
+++ b/TrafficCapture/coreUtilities/build.gradle
@@ -18,22 +18,22 @@ buildscript {
 
 plugins {
     id 'org.opensearch.migrations.java-library-conventions'
-    id "com.github.spotbugs" version "4.7.3"
-    id 'checkstyle'
+//    id "com.github.spotbugs" version "4.7.3"
+//    id 'checkstyle'
     id 'org.owasp.dependencycheck' version '8.2.1'
     id "io.freefair.lombok" version "8.0.1"
 }
 
-spotbugs {
-    includeFilter = new File(rootDir, 'config/spotbugs/spotbugs-include.xml')
-}
+//spotbugs {
+//    includeFilter = new File(rootDir, 'config/spotbugs/spotbugs-include.xml')
+//}
 
-checkstyle {
-    toolVersion = '10.12.3'
-    configFile = new File(rootDir, 'config/checkstyle/checkstyle.xml')
-    System.setProperty('checkstyle.cache.file', String.format('%s/%s',
-            buildDir, 'checkstyle.cachefile'))
-}
+//checkstyle {
+//    toolVersion = '10.12.3'
+//    configFile = new File(rootDir, 'config/checkstyle/checkstyle.xml')
+//    System.setProperty('checkstyle.cache.file', String.format('%s/%s',
+//            buildDir, 'checkstyle.cachefile'))
+//}
 
 repositories {
     mavenCentral()

--- a/TrafficCapture/dockerSolution/build.gradle
+++ b/TrafficCapture/dockerSolution/build.gradle
@@ -77,7 +77,7 @@ trafficComparatorServices.forEach {projectName, dockerImageName ->
         dependsOn "copyArtifact_${projectName}"
         destFile = project.file("${dockerBuildDir}/Dockerfile")
         from 'python:3.10.10'
-        runCommand("apt-get update && apt-get install -y netcat lsof jq")
+        runCommand("apt-get update && apt-get install -y netcat lsof")
         copyFile("setup.py", "/setup.py")
         copyFile(".", "/containerTC/")
         runCommand("pip3 install --editable \".[data]\"")

--- a/TrafficCapture/dockerSolution/build.gradle
+++ b/TrafficCapture/dockerSolution/build.gradle
@@ -77,7 +77,7 @@ trafficComparatorServices.forEach {projectName, dockerImageName ->
         dependsOn "copyArtifact_${projectName}"
         destFile = project.file("${dockerBuildDir}/Dockerfile")
         from 'python:3.10.10'
-        runCommand("apt-get update && apt-get install -y netcat lsof")
+        runCommand("apt-get update && apt-get install -y netcat lsof jq")
         copyFile("setup.py", "/setup.py")
         copyFile(".", "/containerTC/")
         runCommand("pip3 install --editable \".[data]\"")

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/Dockerfile
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:jammy
 ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends python3.9 python3-pip python3-dev gcc libc-dev git curl vim && \
+    apt-get install -y --no-install-recommends python3.9 python3-pip python3-dev gcc libc-dev git curl vim jq && \
     pip3 install urllib3==1.25.11 opensearch-benchmark==1.1.0 awscurl tqdm
 
 COPY runTestBenchmarks.sh /root/

--- a/TrafficCapture/testUtilities/build.gradle
+++ b/TrafficCapture/testUtilities/build.gradle
@@ -20,29 +20,29 @@ buildscript {
 
 plugins {
     id 'org.opensearch.migrations.java-library-conventions'
-    id "com.github.spotbugs" version "4.7.3"
-    id 'checkstyle'
+//    id "com.github.spotbugs" version "4.7.3"
+//    id 'checkstyle'
     id 'org.owasp.dependencycheck' version '8.2.1'
     id "io.freefair.lombok" version "8.0.1"
 }
 
-spotbugs {
-    includeFilter = new File(rootDir, 'config/spotbugs/spotbugs-include.xml')
-}
+//spotbugs {
+//    includeFilter = new File(rootDir, 'config/spotbugs/spotbugs-include.xml')
+//}
 
-checkstyle {
-    toolVersion = '10.12.3'
-    configFile = new File(rootDir, 'config/checkstyle/checkstyle.xml')
-    System.setProperty('checkstyle.cache.file', String.format('%s/%s',
-            buildDir, 'checkstyle.cachefile'))
-}
+//checkstyle {
+//    toolVersion = '10.12.3'
+//    configFile = new File(rootDir, 'config/checkstyle/checkstyle.xml')
+//    System.setProperty('checkstyle.cache.file', String.format('%s/%s',
+//            buildDir, 'checkstyle.cachefile'))
+//}
 
 repositories {
     mavenCentral()
 }
 
 dependencies {
-    spotbugs 'com.github.spotbugs:spotbugs:4.7.3'
+//    spotbugs 'com.github.spotbugs:spotbugs:4.7.3'
 
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.15.0'
     implementation group: 'com.google.guava', name: 'guava', version: '32.0.1-jre'

--- a/TrafficCapture/trafficReplayer/src/main/resources/log4j2.properties
+++ b/TrafficCapture/trafficReplayer/src/main/resources/log4j2.properties
@@ -2,27 +2,32 @@ status = error
 
 property.tupleDir = ${env:TUPLE_DIR_PATH:-./logs/tuples}
 
+rootLogger.level = info
+
 appender.console.type = Console
 appender.console.name = STDERR
 appender.console.target = SYSTEM_ERR
 appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = [%-5level] %d{yyyy-MM-dd HH:mm:ss.SSS} [%t] %c{1} - %msg%n
 
-rootLogger.level = info
-rootLogger.appenderRefs = stderr
 rootLogger.appenderRef.stderr.ref = STDERR
 
-logger.HttpJsonTransformingConsumer.name = org.opensearch.migrations.replay.TrafficReplayer
-logger.HttpJsonTransformingConsumer.level = info
 
-#logger.HttpJsonTransformingConsumer.name = org.opensearch.migrations.replay.CapturedTrafficToHttpTransactionAccumulator
-#logger.HttpJsonTransformingConsumer.level = trace
+appender.debug_out.type = RollingFile
+appender.debug_out.name = ReplayerLogFile
+appender.debug_out.fileName = logs/replayer.log
+appender.debug_out.filePattern = logs/$${date:yyyy-MM}/replayer-%d{MM-dd-yyyy}-%i.log.gz
+appender.debug_out.layout.type = PatternLayout
+appender.debug_out.layout.pattern = [%-5level] %d{yyyy-MM-dd HH:mm:ss.SSS} [%t] %c{1} - %msg%n
+appender.debug_out.policies.type = Policies
+appender.debug_out.policies.time.type = TimeBasedTriggeringPolicy
+appender.debug_out.policies.time.interval = 1
+appender.debug_out.policies.time.modulate = true
+appender.debug_out.strategy.type = DefaultRolloverStrategy
+appender.debug_out.strategy.max = 72
 
-#logger.HttpJsonTransformingConsumer.name = org.opensearch.migrations.replay.datahandlers.http.HttpJsonTransformingConsumer
-#logger.HttpJsonTransformingConsumer.level = trace
+rootLogger.appenderRef.logfile.ref = ReplayerLogFile
 
-#logger.NettySendByteBufsToPacketHandlerHandler.name = org.opensearch.migrations.replay.datahandlers.http.NettySendByteBufsToPacketHandlerHandler
-#logger.NettySendByteBufsToPacketHandlerHandler.level = trace
 
 appender.output_tuples.type = RollingFile
 appender.output_tuples.name = OUTPUT_TUPLES


### PR DESCRIPTION
By default, this is currently on, though the block could be commented out to disable that logging.  Personally, I find having logs console logging to be a major impediment. I've also commented out checkstyle or findbugs since they are respectively too verbose and don't work.

### Description
* Category Enhancements
* Why these changes are required? To make debugging and building better.
* What is the old behavior before changes and new behavior after changes?  No durable logs for docker or the replayer/migration console and lots of useless spew in the builds.  Now it's better.

### Issues Resolved
No Issue

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
Manual testing.

### Check List
- [ ] New functionality includes testing
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
