### PR TITLE
Fix memory leaks in NettyWireLogging and improve leak tracking abilities in tests

### DIFF
--- a/TrafficCapture/nettyWireLogging/build.gradle
+++ b/TrafficCapture/nettyWireLogging/build.gradle
@@ -15,8 +15,13 @@ dependencies {
     implementation group: 'org.slf4j', name: 'slf4j-api', version: '2.0.7'
 
     testImplementation project(':captureProtobufs')
+    testImplementation project(':testUtilities')
     testImplementation group: 'org.apache.httpcomponents.client5', name: 'httpclient5', version: '5.2.1'
     testImplementation group: 'org.slf4j', name: 'slf4j-api', version: '2.0.7'
     testImplementation group: 'com.google.guava', name: 'guava', version: '32.0.1-jre'
     testImplementation group: 'com.google.protobuf', name: 'protobuf-java', version:'3.22.2'
+
+    testImplementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.20.0'
+    testImplementation group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.20.0'
+    testImplementation group: 'org.apache.logging.log4j', name: 'log4j-slf4j2-impl', version: '2.20.0'
 }

--- a/TrafficCapture/nettyWireLogging/src/main/java/org/opensearch/migrations/trafficcapture/netty/ConditionallyReliableLoggingHttpRequestHandler.java
+++ b/TrafficCapture/nettyWireLogging/src/main/java/org/opensearch/migrations/trafficcapture/netty/ConditionallyReliableLoggingHttpRequestHandler.java
@@ -2,6 +2,7 @@ package org.opensearch.migrations.trafficcapture.netty;
 
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http.HttpRequest;
+import io.netty.util.ReferenceCountUtil;
 import lombok.extern.slf4j.Slf4j;
 import org.opensearch.migrations.trafficcapture.IChannelConnectionCaptureSerializer;
 
@@ -18,7 +19,8 @@ public class ConditionallyReliableLoggingHttpRequestHandler extends LoggingHttpR
     }
 
     @Override
-    protected void channelFinishedReadingAnHttpMessage(ChannelHandlerContext ctx, Object msg, HttpRequest httpRequest) throws Exception {
+    protected void channelFinishedReadingAnHttpMessage(ChannelHandlerContext ctx, Object msg, HttpRequest httpRequest)
+            throws Exception {
         if (shouldBlockPredicate.test(httpRequest)) {
             trafficOffloader.flushCommitAndResetStream(false).whenComplete((result, t) -> {
                 if (t != null) {
@@ -26,11 +28,13 @@ public class ConditionallyReliableLoggingHttpRequestHandler extends LoggingHttpR
                     // could set as needed. Some users may be fine with just logging a failed offloading of a request
                     // where other users may want to stop entirely. JIRA here: https://opensearch.atlassian.net/browse/MIGRATIONS-1276
                     log.warn("Got error: " + t.getMessage());
-                }
-                try {
-                    super.channelFinishedReadingAnHttpMessage(ctx, msg, httpRequest);
-                } catch (Exception e) {
-                    throw new RuntimeException(e);
+                    ReferenceCountUtil.release(msg);
+                } else {
+                    try {
+                        super.channelFinishedReadingAnHttpMessage(ctx, msg, httpRequest);
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
+                    }
                 }
             });
         } else {

--- a/TrafficCapture/nettyWireLogging/src/main/java/org/opensearch/migrations/trafficcapture/netty/LoggingHttpRequestHandler.java
+++ b/TrafficCapture/nettyWireLogging/src/main/java/org/opensearch/migrations/trafficcapture/netty/LoggingHttpRequestHandler.java
@@ -1,10 +1,12 @@
 package org.opensearch.migrations.trafficcapture.netty;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.http.DefaultHttpRequest;
+import io.netty.handler.codec.http.HttpContent;
 import io.netty.handler.codec.http.HttpMessage;
 import io.netty.handler.codec.http.HttpMessageDecoderResult;
 import io.netty.handler.codec.http.HttpMethod;
@@ -46,10 +48,14 @@ public class LoggingHttpRequestHandler extends ChannelInboundHandlerAdapter {
         public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
             if (msg instanceof HttpRequest) {
                 currentRequest = (HttpRequest) msg;
-            } else if (msg instanceof LastHttpContent) {
-                isDone = true;
+            } else if (msg instanceof HttpContent) {
+                ((HttpContent)msg).release();
+                if (msg instanceof LastHttpContent) {
+                    isDone = true;
+                }
+            } else {
+                super.channelRead(ctx, msg);
             }
-            super.channelRead(ctx, msg);
         }
 
         public HttpRequest resetCurrentRequest() {
@@ -76,15 +82,7 @@ public class LoggingHttpRequestHandler extends ChannelInboundHandlerAdapter {
     }
 
     private HttpCaptureSerializerUtil.HttpProcessedState parseHttpMessageParts(ByteBuf msg) throws Exception {
-        var bb = msg;
-        // Preserve ownership of this ByteBuf because the HttpRequestDecoder will take ownership of the
-        // ByteBuf, releasing it once the data has been copied into its cumulation buffer.  However,
-        // this handler still fires ByteBufs through the pipeline.  It's up to a future handler to perform
-        // the release, as it would have been if this method was implemented any other way.
-        bb.retain();
-        bb.markReaderIndex();
-        httpDecoderChannel.writeInbound(bb);
-        bb.resetReaderIndex();
+        httpDecoderChannel.writeInbound(msg); // Consume this outright, up to the caller to know what else to do
         return getHandlerThatHoldsParsedHttpRequest().isDone ?
                 HttpCaptureSerializerUtil.HttpProcessedState.FULL_MESSAGE :
                 HttpCaptureSerializerUtil.HttpProcessedState.ONGOING;
@@ -138,13 +136,16 @@ public class LoggingHttpRequestHandler extends ChannelInboundHandlerAdapter {
     @Override
     public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
         var timestamp = Instant.now();
-        var bb = (ByteBuf) msg;
-        trafficOffloader.addReadEvent(timestamp, bb);
-        metricsLogger.atSuccess()
-                .addKeyValue("channelId", ctx.channel().id().asLongText())
-                .setMessage("Component of request received").log();
+        HttpCaptureSerializerUtil.HttpProcessedState httpProcessedState;
+        {
+            var bb = ((ByteBuf) msg).retainedDuplicate();
+            trafficOffloader.addReadEvent(timestamp, bb);
+            metricsLogger.atSuccess()
+                    .addKeyValue("channelId", ctx.channel().id().asLongText())
+                    .setMessage("Component of request received").log();
 
-        var httpProcessedState = parseHttpMessageParts(bb);
+            httpProcessedState = parseHttpMessageParts(bb); // bb is consumed/release by this method
+        }
         if (httpProcessedState == HttpCaptureSerializerUtil.HttpProcessedState.FULL_MESSAGE) {
             var httpRequest = getHandlerThatHoldsParsedHttpRequest().resetCurrentRequest();
             var decoderResultLoose = httpRequest.decoderResult();

--- a/TrafficCapture/nettyWireLogging/src/test/java/org/opensearch/migrations/trafficcapture/netty/ConditionallyReliableLoggingHttpRequestHandlerTest.java
+++ b/TrafficCapture/nettyWireLogging/src/test/java/org/opensearch/migrations/trafficcapture/netty/ConditionallyReliableLoggingHttpRequestHandlerTest.java
@@ -1,11 +1,19 @@
 package org.opensearch.migrations.trafficcapture.netty;
 
 import com.google.protobuf.CodedOutputStream;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.util.ResourceLeakDetector;
+import io.netty.util.ResourceLeakDetectorFactory;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.opensearch.migrations.testutils.CountingNettyResourceLeakDetector;
 import org.opensearch.migrations.trafficcapture.StreamChannelConnectionCaptureSerializer;
 import org.opensearch.migrations.trafficcapture.protos.TrafficStream;
 
@@ -14,6 +22,7 @@ import java.io.IOException;
 import java.io.SequenceInputStream;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -21,15 +30,13 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
+@Slf4j
 class ConditionallyReliableLoggingHttpRequestHandlerTest {
 
-    @Test
-    public void testThatSinglePacketPostBlocks() throws IOException {
-        byte[] fullTrafficBytes = SimpleRequests.SMALL_POST.getBytes(StandardCharsets.UTF_8);
-        var bigBuff = Unpooled.wrappedBuffer(fullTrafficBytes);
-        writeMessageAndVerify(fullTrafficBytes, w -> {
-            w.writeInbound(bigBuff);
-        });
+    @BeforeAll
+    public static void setup() {
+        ResourceLeakDetectorFactory.setResourceLeakDetectorFactory(new CountingNettyResourceLeakDetector.MyResourceLeakDetectorFactory());
+        CountingNettyResourceLeakDetector.setLevel(ResourceLeakDetector.Level.PARANOID);
     }
 
     private static void writeMessageAndVerify(byte[] fullTrafficBytes, Consumer<EmbeddedChannel> channelWriter)
@@ -50,10 +57,20 @@ class ConditionallyReliableLoggingHttpRequestHandlerTest {
                     return CompletableFuture.completedFuture(flushCount.incrementAndGet());
                 });
 
-        EmbeddedChannel channel = new EmbeddedChannel(new ConditionallyReliableLoggingHttpRequestHandler(offloader,
-                x->true));
+        EmbeddedChannel channel = new EmbeddedChannel(
+                new ConditionallyReliableLoggingHttpRequestHandler(offloader, x->true)); // true: block every request
         channelWriter.accept(channel);
 
+        // we wrote the correct data to the downstream handler/channel
+        var outputData = new SequenceInputStream(Collections.enumeration(channel.inboundMessages().stream()
+                .map(m->new ByteArrayInputStream(consumeIntoArray((ByteBuf)m)))
+                .collect(Collectors.toList())))
+                .readAllBytes();
+        Assertions.assertArrayEquals(fullTrafficBytes, outputData);
+
+        Assertions.assertNotNull(outputByteBuffer,
+                "This would be null if the handler didn't block until the output was written");
+        // we wrote the correct data to the offloaded stream
         var trafficStream = TrafficStream.parseFrom(outputByteBuffer.get());
         Assertions.assertTrue(trafficStream.getSubStreamCount() > 0 &&
                 trafficStream.getSubStream(0).hasRead());
@@ -66,14 +83,75 @@ class ConditionallyReliableLoggingHttpRequestHandlerTest {
         Assertions.assertEquals(1, flushCount.get());
     }
 
-    @Test
-    public void testThatTinyPacketsPostBlocks() throws IOException {
+    private static byte[] consumeIntoArray(ByteBuf m) {
+        var bArr = new byte[m.readableBytes()];
+        m.readBytes(bArr);
+        m.release();
+        return bArr;
+    }
+
+    private ByteBuf getByteBuf(byte[] src, boolean usePool) {
+        var unpooled = Unpooled.wrappedBuffer(src);
+        if (usePool) {
+            var pooled = ByteBufAllocator.DEFAULT.buffer(src.length);
+            pooled.writeBytes(unpooled);
+            unpooled.release();
+            return pooled;
+        } else {
+            return unpooled;
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void testThatAPostInASinglePacketBlocksFutureActivity(boolean usePool) throws IOException {
+        byte[] fullTrafficBytes = SimpleRequests.SMALL_POST.getBytes(StandardCharsets.UTF_8);
+        var bb = getByteBuf(fullTrafficBytes, usePool);
+        writeMessageAndVerify(fullTrafficBytes, w -> {
+            w.writeInbound(bb);
+        });
+        log.info("buf.refCnt="+bb.refCnt());
+        //Assertions.assertEquals(0, bigBuff.refCnt());
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void testThatAPostInTinyPacketsBlocksFutureActivity(boolean usePool) throws IOException {
         byte[] fullTrafficBytes = SimpleRequests.SMALL_POST.getBytes(StandardCharsets.UTF_8);
         writeMessageAndVerify(fullTrafficBytes, w -> {
             for (int i=0; i<fullTrafficBytes.length; ++i) {
-                var singleByte = Unpooled.wrappedBuffer(fullTrafficBytes, i, 1);
+                var singleByte = getByteBuf(Arrays.copyOfRange(fullTrafficBytes, i, i+1), usePool);
                 w.writeInbound(singleByte);
             }
         });
     }
+
+    @Test
+    public void testThatAPostInTinyPacketsBlocksFutureActivity_withLeakDetection() throws Exception {
+        CountingNettyResourceLeakDetector.activate();
+
+        var COUNT = 32;
+        for (int i=0; i<COUNT; ++i) {
+            testThatAPostInTinyPacketsBlocksFutureActivity((i%2)==0);
+            System.gc();
+            System.runFinalization();
+        }
+        Assertions.assertEquals(0, CountingNettyResourceLeakDetector.getNumLeaks());
+        //MyResourceLeakDetector.dumpHeap("nettyWireLogging_"+COUNT+"_"+ Instant.now() +".hprof", true);
+    }
+
+    @Test
+    public void testThatAPostInASinglePacketBlocksFutureActivity_withLeakDetection() throws Exception {
+        CountingNettyResourceLeakDetector.activate();
+
+        var COUNT = 64;
+        for (int i=0; i<COUNT; ++i) {
+            testThatAPostInASinglePacketBlocksFutureActivity((i%2)==0);
+            System.gc();
+            System.runFinalization();
+            Assertions.assertEquals(0, CountingNettyResourceLeakDetector.getNumLeaks());
+        }
+        //MyResourceLeakDetector.dumpHeap("nettyWireLogging_"+COUNT+"_"+ Instant.now() +".hprof", true);
+    }
+
 }

--- a/TrafficCapture/nettyWireLogging/src/test/java/org/opensearch/migrations/trafficcapture/netty/ConditionallyReliableLoggingHttpRequestHandlerTest.java
+++ b/TrafficCapture/nettyWireLogging/src/test/java/org/opensearch/migrations/trafficcapture/netty/ConditionallyReliableLoggingHttpRequestHandlerTest.java
@@ -111,7 +111,6 @@ class ConditionallyReliableLoggingHttpRequestHandlerTest {
             w.writeInbound(bb);
         });
         log.info("buf.refCnt="+bb.refCnt());
-        //Assertions.assertEquals(0, bigBuff.refCnt());
     }
 
     @ParameterizedTest

--- a/TrafficCapture/nettyWireLogging/src/test/resources/log4j2.properties
+++ b/TrafficCapture/nettyWireLogging/src/test/resources/log4j2.properties
@@ -1,0 +1,11 @@
+status = error
+
+rootLogger.level = debug
+
+appender.console.type = Console
+appender.console.name = STDERR
+appender.console.target = SYSTEM_ERR
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = [%-5level] %d{yyyy-MM-dd HH:mm:ss.SSS} [%t] %c{1} - %msg%n
+
+rootLogger.appenderRef.stderr.ref = STDERR

--- a/TrafficCapture/testUtilities/src/main/java/org/opensearch/migrations/testutils/CountingNettyResourceLeakDetector.java
+++ b/TrafficCapture/testUtilities/src/main/java/org/opensearch/migrations/testutils/CountingNettyResourceLeakDetector.java
@@ -1,0 +1,92 @@
+package org.opensearch.migrations.testutils;
+
+import com.sun.management.HotSpotDiagnosticMXBean;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.util.ResourceLeakDetector;
+import io.netty.util.ResourceLeakDetectorFactory;
+import lombok.extern.slf4j.Slf4j;
+
+import javax.management.MBeanServer;
+import java.lang.management.ManagementFactory;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * This class doesn't do too much over the stock ResourceLeakDetector, but it does help
+ * to provide a counter on the number of leaks detected, which can then be checked within
+ * automated tests.
+ */
+@Slf4j
+public class CountingNettyResourceLeakDetector<T> extends ResourceLeakDetector<T> {
+
+    private static AtomicInteger numLeaksFoundAtomic = new AtomicInteger();
+
+    /**
+     * Utility method to create an hmap file to show all of the objects within the JVM.
+     * @param fileName
+     * @param live only include live objects
+     * @throws Exception
+     */
+    public static void dumpHeap(String fileName, boolean live) throws Exception {
+        MBeanServer server = ManagementFactory.getPlatformMBeanServer();
+        var mxBean = ManagementFactory.newPlatformMXBeanProxy(
+                server, "com.sun.management:type=HotSpotDiagnostic", HotSpotDiagnosticMXBean.class);
+        mxBean.dumpHeap(fileName, live);
+    }
+
+    /**
+     * Do everything necessary to turn leak detection on with the highest sensitivity.
+     */
+    public static void activate() {
+        ResourceLeakDetectorFactory.setResourceLeakDetectorFactory(new CountingNettyResourceLeakDetector.MyResourceLeakDetectorFactory());
+        CountingNettyResourceLeakDetector.setLevel(ResourceLeakDetector.Level.PARANOID);
+    }
+
+    public static class MyResourceLeakDetectorFactory extends ResourceLeakDetectorFactory {
+        static {
+            System.setProperty("io.netty.leakDetection.targetRecords", "32");
+            System.setProperty("io.netty.leakDetection.samplingInterval", "1");
+            System.setProperty("io.netty.leakDetection.level", "paranoid");
+        }
+
+        @Override
+        public <T> ResourceLeakDetector<T> newResourceLeakDetector(Class<T> resource, int samplingInterval, long maxActive) {
+            return new CountingNettyResourceLeakDetector<>(resource, samplingInterval);
+        }
+    }
+
+    public CountingNettyResourceLeakDetector(Class<?> resourceType, int samplingInterval) {
+        super(resourceType, 1);
+    }
+
+    @Override
+    protected void reportTracedLeak(String resourceType, String records) {
+        incrementLeakCount();
+        super.reportTracedLeak(resourceType, records);
+    }
+
+    @Override
+    protected void reportUntracedLeak(String resourceType) {
+        incrementLeakCount();
+        super.reportUntracedLeak(resourceType);
+    }
+
+    public static int getNumLeaks() {
+        return numLeaksFoundAtomic.get();
+    }
+
+    private static void incrementLeakCount() {
+        if (numLeaksFoundAtomic.incrementAndGet() == 1) {
+            setupMonitoringLogger();
+        }
+    }
+
+    private static void setupMonitoringLogger() {
+        var eventExecutor = new NioEventLoopGroup(1);
+        eventExecutor.scheduleAtFixedRate(()->{
+            System.gc();
+            System.runFinalization();
+            log.warn("numLeaks="+ CountingNettyResourceLeakDetector.getNumLeaks());
+        }, 0, 10, TimeUnit.MILLISECONDS);
+    }
+}

--- a/TrafficCapture/trafficCaptureProxyServer/src/main/java/org/opensearch/migrations/trafficcapture/proxyserver/netty/FrontsideHandler.java
+++ b/TrafficCapture/trafficCaptureProxyServer/src/main/java/org/opensearch/migrations/trafficcapture/proxyserver/netty/FrontsideHandler.java
@@ -5,6 +5,7 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.util.ReferenceCountUtil;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -58,6 +59,7 @@ public class FrontsideHandler extends ChannelInboundHandlerAdapter {
             outboundChannel.config().setAutoRead(true);
         } else { // if the outbound channel has died, so be it... let this frontside finish with it's caller naturally
             log.warn("Output channel (" + outboundChannel + ") is NOT active");
+            ReferenceCountUtil.release(msg);
         }
     }
 

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/TrafficReplayer.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/TrafficReplayer.java
@@ -8,6 +8,8 @@ import io.netty.buffer.Unpooled;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
+import io.netty.util.ResourceLeakDetector;
+import io.netty.util.ResourceLeakDetectorFactory;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.opensearch.migrations.replay.datahandlers.IPacketFinalizingConsumer;
@@ -228,6 +230,7 @@ public class TrafficReplayer {
             return null;
         }
     }
+
 
     public static void main(String[] args) throws IOException, InterruptedException, ExecutionException {
         var params = parseArgs(args);


### PR DESCRIPTION
### Description
Fixes two bugs in the NettyWireLogging, which the CaptureProxyServer uses.  This should make the memory consumption of the capture proxy more stable.  

* Category Bug fix
* Why these changes are required? So that the proxy can run for longer without running out of memory
* What is the old behavior before changes and new behavior after changes? Now it doesn't leak memory as fast

### Issues Resolved
https://github.com/opensearch-project/opensearch-migrations/pull/316

TODO: Is this a backport? If so, please add backport PR # and/or commits #

### Testing
Unit tests.
Plus, I’ve been running it for about 30 minutes (looping the 4 test cases from OpenSearch Benchmark) with PARANOID leak awareness.  I’m seeing a pretty stable 260 MB of Resident Memory usage in the docker solution.

### Check List
- [x] New functionality includes testing
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
