### PR TITLE
Two bugfixes to facilitate "--remove-auth-headers" (MIGRATIONS-1309).

### DIFF
--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/http/ListKeyAdaptingCaseInsensitiveHeadersMap.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/http/ListKeyAdaptingCaseInsensitiveHeadersMap.java
@@ -50,6 +50,12 @@ public class ListKeyAdaptingCaseInsensitiveHeadersMap extends AbstractMap<String
         return strictHeadersMap.put(key, strList);
     }
 
+    @Override
+    public List<String> remove(Object key) {
+        return strictHeadersMap.remove(key);
+    }
+
+
     /**
      * This is just casting the underlying object's entrySet.  An old git commit will show this unrolled,
      * but this should be significantly more efficient.

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/http/NettyDecodedHttpRequestPreliminaryConvertHandler.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/http/NettyDecodedHttpRequestPreliminaryConvertHandler.java
@@ -150,7 +150,8 @@ public class NettyDecodedHttpRequestPreliminaryConvertHandler extends ChannelInb
 
     private boolean headerFieldsAreIdentical(HttpRequest request, HttpJsonMessageWithFaultingPayload httpJsonMessage) {
         if (!request.uri().equals(httpJsonMessage.path()) ||
-                !request.method().toString().equals(httpJsonMessage.method())) {
+                !request.method().toString().equals(httpJsonMessage.method()) ||
+                request.headers().size() != httpJsonMessage.headers().strictHeadersMap.size()) {
             return false;
         }
         for (var headerName : httpJsonMessage.headers().keySet()) {

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/datahandlers/http/HttpJsonTransformingConsumerTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/datahandlers/http/HttpJsonTransformingConsumerTest.java
@@ -9,6 +9,7 @@ import org.opensearch.migrations.replay.datatypes.UniqueRequestKey;
 import org.opensearch.migrations.transform.JsonCompositeTransformer;
 import org.opensearch.migrations.transform.JsonJoltTransformer;
 import org.opensearch.migrations.transform.IJsonTransformer;
+import org.opensearch.migrations.transform.RemovingAuthTransformerFactory;
 
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
@@ -48,10 +49,38 @@ class HttpJsonTransformingConsumerTest {
                         null, testPacketCapture, "TEST", new UniqueRequestKey("testConnectionId", 0));
         byte[] testBytes;
         try (var sampleStream = HttpJsonTransformingConsumer.class.getResourceAsStream(
-                "/requests/raw/post_formUrlEncoded_withFixedLength.txt")) {
+                "/requests/raw/get_withAuthHeader.txt")) {
             testBytes = sampleStream.readAllBytes();
             testBytes = new String(testBytes, StandardCharsets.UTF_8)
                     .replace("foo.example", "test.domain")
+                    .getBytes(StandardCharsets.UTF_8);
+        }
+        transformingHandler.consumeBytes(testBytes);
+        var returnedResponse = transformingHandler.finalizeRequest().get();
+        Assertions.assertEquals(new String(testBytes, StandardCharsets.UTF_8),
+                testPacketCapture.getCapturedAsString());
+        Assertions.assertArrayEquals(testBytes, testPacketCapture.getBytesCaptured());
+        Assertions.assertEquals(HttpRequestTransformationStatus.SKIPPED, returnedResponse.transformationStatus);
+    }
+
+    @Test
+    public void testRemoveAuthHeadersWorks() throws Exception {
+        final var dummyAggregatedResponse = new AggregatedRawResponse(17, null, null, null);
+        var testPacketCapture = new TestCapturePacketToHttpHandler(Duration.ofMillis(100), dummyAggregatedResponse);
+        var transformingHandler =
+                new HttpJsonTransformingConsumer<AggregatedRawResponse>(
+                        JsonJoltTransformer.newBuilder()
+                                .addHostSwitchOperation("test.domain")
+                                .build(),
+                        RemovingAuthTransformerFactory.instance,
+                        testPacketCapture, "TEST", new UniqueRequestKey("testConnectionId", 0));
+        byte[] testBytes;
+        try (var sampleStream = HttpJsonTransformingConsumer.class.getResourceAsStream(
+                "/requests/raw/get_withAuthHeader.txt")) {
+            testBytes = sampleStream.readAllBytes();
+            testBytes = new String(testBytes, StandardCharsets.UTF_8)
+                    .replace("foo.example", "test.domain")
+                    .replace("auTHorization: Basic YWRtaW46YWRtaW4=\n", "")
                     .getBytes(StandardCharsets.UTF_8);
         }
         transformingHandler.consumeBytes(testBytes);
@@ -100,4 +129,6 @@ class HttpJsonTransformingConsumerTest {
         Assertions.assertInstanceOf(NettyJsonBodyAccumulateHandler.IncompleteJsonBodyException.class,
                 returnedResponse.error);
     }
+
+
 }

--- a/TrafficCapture/trafficReplayer/src/test/resources/requests/raw/get_withAuthHeader.txt
+++ b/TrafficCapture/trafficReplayer/src/test/resources/requests/raw/get_withAuthHeader.txt
@@ -1,0 +1,5 @@
+GET /test HTTP/1.1
+Host: foo.example
+auTHorization: Basic YWRtaW46YWRtaW4=
+Content-Type: application/json
+


### PR DESCRIPTION
### Description

First, wire up the remove method for the wrapper (list adapting) map of the case insensitive map implementation so that remove() is actually called on the underlying map, rather than calling an UnsupportedOperationException.  The second issue was that the original request headers and the newly transformed headers were deemed to be identical, even though an item was missing within the transformed map.  We only iterated through the transformed map and we didn't make sure that we were going to hit all of the elements.  Now we check that the lengths are the same too.

* Category Bug fix
* Why these changes are required? to make --remove-auth-header work
* What is the old behavior before changes and new behavior after changes? --remove-auth-header should now remove any authorization header in the requests.

### Issues Resolved
MIGRATIONS-1309

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
Unit tests, plus a manual test

Here's what happened when I passed an auth header through the source cluster and then what came out for the target
```
requestData=HttpMessageAndTimestamp{firstPacketTimestamp=2023-09-13T21:14:25.470398714Z, lastPacketTimestamp=2023-09-13T21:14:25.470398714Z, message=[[GET /_cat/indices HTTP/1.1
2023-09-13 17:14:25 Host: localhost:9200
2023-09-13 17:14:25 Authorization: Basic YWRtaW46YWRtaW4=
2023-09-13 17:14:25 User-Agent: curl/8.1.2
2023-09-13 17:14:25 Accept: */*

targetRequestData=[GET /_cat/indices HTTP/1.1
2023-09-13 17:14:25 Host: opensearchtarget
2023-09-13 17:14:25 User-Agent: curl/8.1.2
2023-09-13 17:14:25 Accept: */*
2023-09-13 17:14:25 
2023-09-13 17:14:25 ],[]
```

### Check List
- [x] New functionality includes testing
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
