### PR TITLE
Script to create Metric Filters

### DIFF
--- a/deployment/copilot/README.md
+++ b/deployment/copilot/README.md
@@ -208,3 +208,13 @@ To remove the resources installed from the steps above, follow these instruction
 1.  `./devDeploy.sh --destroy-env` - Destroy all CDK and Copilot CloudFormation stacks deployed, excluding the Copilot app level stack, for the given env/stage and return to a clean state.
 2.  `./devDeploy.sh --destroy-all-copilot` - Destroy Copilot app and all Copilot CloudFormation stacks deployed for the given app across all regions
 3. After execution of the above steps, a CDK bootstrap stack remains. To remove this stack, begin by deleting the S3 objects and the associated bucket. After that, you can delete the stack using the AWS Console or CLI.
+
+## Metric Filters
+The services emit a number of logs, some of which are designed to be easily parsed for Cloudwatch metric filters. Setting up the appropriate metric filters will create Cloudwatch Metrics for each event, which can be incorporated into graphs and dashboard, as well as alarms.
+The `setMetricFilters.sh` script will set up 17 metrics that span the path of a request from being captured, written to Kafka, pulled by the replayer and played against the target cluster. While this script may be fully sufficient in a simple use case with a single replayer, it will likely not suffice in a more complex environment and you should consider it a model rather than a full solution.
+To use it, install the AWS CLI (installation instructions: https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html) and configure it (`aws configure`) with the account credentials and region for your deployment, and then:
+```
+./setMetricFilters.sh
+```
+
+The metrics will not exist until they are triggered by a matching log line. Once data is flowing through the system and log lines are matching, you can find the metrics under the metricNamespaces `capture-proxy` and `traffic-replayer`.

--- a/deployment/copilot/setMetricFilters.sh
+++ b/deployment/copilot/setMetricFilters.sh
@@ -1,0 +1,124 @@
+#!/bin/bash
+
+# A note on the implementation method:
+# This would be better implemented as a script using `boto` in python, or using
+# the `--cli-input-json` option. However, both of those seem to have a bug that prevents dimensions
+# and units from being provided.
+# There also seems to be a bug in this CLI interface that prevents multiple dimensions from being provided,
+# so for the time being all metrics are provided with 0 or 1 dimensions, and any additional ones need to be
+# added in the console UI.
+
+CAPUTRE_PROXY_LOG_GROUP="/copilot/migration-copilot-dev-capture-proxy-es"
+TRAFFIC_REPLAYER_LOG_GROUP="/copilot/migration-copilot-dev-traffic-replayer-default"
+# TODO: Both of the values above may change. The capture proxy could be running as a standalone and
+# therefore not have `-es` as part of the name. If multiple traffic replayers are deployed,
+# only the first would use `-default`. For now, the path to resolving this is for the user to
+# edit this file and change the values. Down the line, we should incorporate this with `devDeploy`
+# to automatically set these values. Additionally, this is currently untested with multiple
+# replayers. I believe the correct solution would be to add a dimension for which replayer is
+# being instrumented.
+
+
+# CAPTURE PROXY
+aws logs put-metric-filter \
+    --log-group-name $CAPUTRE_PROXY_LOG_GROUP \
+    --filter-name "CaptureProxy-FullRequestReceived" \
+    --filter-pattern "{ ($.message  = \"Sent message to Kafka\") && ($.loggerName = \"MetricsLogger.*\") }" \
+    --metric-transformations metricName="FullRequestReceived",metricNamespace="capture-proxy",metricValue=1,dimensions={"Method"="$.contextMap.httpMethod"},unit="Count"
+
+aws logs put-metric-filter \
+    --log-group-name $CAPUTRE_PROXY_LOG_GROUP \
+    --filter-name "CaptureProxy-SentMessageToKafka" \
+    --filter-pattern "{ ($.message  = \"Sent message to Kafka\") && ($.loggerName = \"MetricsLogger.*\") }" \
+    --metric-transformations metricName="SentMessageToKafka",metricNamespace="capture-proxy",metricValue=1,dimensions={"topic-name"="$.contextMap.topicName"},unit="Count"
+
+aws logs put-metric-filter  \
+    --log-group-name $CAPUTRE_PROXY_LOG_GROUP \
+    --filter-name "CaptureProxy-SentMessageToKafkaBytes" \
+    --filter-pattern "{ ($.message  = \"Sent message to Kafka\") && ($.loggerName = \"MetricsLogger.*\") }" \
+    --metric-transformations metricName="SentMessageToKafkaBytes",metricNamespace="capture-proxy",metricValue="$.contextMap.sizeInBytes",dimensions={"topic-name"="$.contextMap.topicName"},unit="Bytes"
+
+aws logs put-metric-filter \
+    --log-group-name $CAPUTRE_PROXY_LOG_GROUP \
+    --filter-name "CaptureProxy-FailedMessageToKafka" \
+    --filter-pattern "{ ($.message  = \"Sending message to Kafka failed.\") && ($.loggerName = \"MetricsLogger.*\") }" \
+    --metric-transformations metricName="FailedMessageToKafka",metricNamespace="capture-proxy",metricValue=1,defaultValue=0,unit="Count"
+
+# REPLAYER
+aws logs put-metric-filter \
+    --log-group-name $TRAFFIC_REPLAYER_LOG_GROUP \
+    --filter-name "TrafficReplayer-ParsedKafkaTrafficStream" \
+    --filter-pattern "{ ($.message  = \"Parsed traffic stream from Kafka\") && ($.loggerName = \"MetricsLogger.*\") }" \
+    --metric-transformations metricName="ParsedKafkaTrafficStream",metricNamespace="traffic-replayer",metricValue=1,dimensions={"topic-name"="$.contextMap.topicName"},unit="Count"
+
+aws logs put-metric-filter \
+    --log-group-name $TRAFFIC_REPLAYER_LOG_GROUP \
+    --filter-name "TrafficReplayer-FailedToParseKafkaTrafficStream" \
+    --filter-pattern "{ ($.message  = \"Failed to parse traffic stream from Kafka.\") && ($.loggerName = \"MetricsLogger.*\") }" \
+    --metric-transformations metricName="FailedToParseKafkaTrafficStream",metricNamespace="traffic-replayer",metricValue=1,defaultValue=0,unit="Count"
+
+aws logs put-metric-filter \
+    --log-group-name $TRAFFIC_REPLAYER_LOG_GROUP \
+    --filter-name "TrafficReplayer-ParsedKafkaTrafficStreamBytes" \
+    --filter-pattern "{ ($.message  = \"Parsed traffic stream from Kafka\") && ($.loggerName = \"MetricsLogger.*\") }" \
+    --metric-transformations metricName="ParsedKafkaTrafficStreamBytes",metricNamespace="traffic-replayer",metricValue="$.contextMap.sizeInBytes",dimensions={"topic-name"="$.contextMap.topicName"},unit="Bytes"
+
+aws logs put-metric-filter \
+    --log-group-name $TRAFFIC_REPLAYER_LOG_GROUP \
+    --filter-name "TrafficReplayer-CapturedRequestParsed" \
+    --filter-pattern "{ ($.message  = \"Captured request parsed to HTTP\") && ($.loggerName = \"MetricsLogger.*\") }" \
+    --metric-transformations metricName="CapturedRequestParsed",metricNamespace="traffic-replayer",metricValue=1,dimensions={"Method"="$.contextMap.httpMethod"},unit="Count"
+
+aws logs put-metric-filter \
+    --log-group-name $TRAFFIC_REPLAYER_LOG_GROUP \
+    --filter-name "TrafficReplayer-RequestTransformed" \
+    --filter-pattern "{ ($.message  = \"Request was transformed\") && ($.loggerName = \"MetricsLogger.*\") }" \
+    --metric-transformations metricName="RequestTransformed",metricNamespace="traffic-replayer",metricValue=1,unit="Count"
+
+aws logs put-metric-filter \
+    --log-group-name $TRAFFIC_REPLAYER_LOG_GROUP \
+    --filter-name "TrafficReplayer-FailedToTransformRequest" \
+    --filter-pattern "{ ($.message  = \"Request failed to be transformed\") && ($.loggerName = \"MetricsLogger.*\") }" \
+    --metric-transformations metricName="FailedToTransformRequest",metricNamespace="traffic-replayer",metricValue=1,defaultValue=0,unit="Count"
+
+aws logs put-metric-filter \
+    --log-group-name $TRAFFIC_REPLAYER_LOG_GROUP \
+    --filter-name "TrafficReplayer-RequestScheduledToBeSent" \
+    --filter-pattern "{ ($.message  = \"Request scheduled to be sent\") && ($.loggerName = \"MetricsLogger.*\") }" \
+    --metric-transformations metricName="RequestScheduledToBeSent",metricNamespace="traffic-replayer",metricValue=1,unit="Count"
+
+aws logs put-metric-filter \
+    --log-group-name $TRAFFIC_REPLAYER_LOG_GROUP \
+    --filter-name "TrafficReplayer-RequestScheduledToBeSentDelay" \
+    --filter-pattern "{ ($.message  = \"Request scheduled to be sent\") && ($.loggerName = \"MetricsLogger.*\") }" \
+    --metric-transformations metricName="RequestScheduledToBeSentDelay",metricNamespace="traffic-replayer",metricValue="$.contextMap.delayFromOriginalToScheduledStartInMs",unit="Milliseconds"
+
+aws logs put-metric-filter \
+    --log-group-name $TRAFFIC_REPLAYER_LOG_GROUP \
+    --filter-name "TrafficReplayer-FailedRequestComponent" \
+    --filter-pattern "{ ($.message  = \"Failed to write component of request\") && ($.loggerName = \"MetricsLogger.*\") }" \
+    --metric-transformations metricName="FailedRequestComponent",metricNamespace="traffic-replayer",metricValue=1,defaultValue=0,unit="Count"
+
+aws logs put-metric-filter \
+    --log-group-name $TRAFFIC_REPLAYER_LOG_GROUP \
+    --filter-name "TrafficReplayer-RequestComponentWritten" \
+    --filter-pattern "{ ($.message  = \"Component of request written to target\") && ($.loggerName = \"MetricsLogger.*\") }" \
+    --metric-transformations metricName="RequestComponentWritten",metricNamespace="traffic-replayer",metricValue=1,unit="Count"
+
+aws logs put-metric-filter \
+    --log-group-name $TRAFFIC_REPLAYER_LOG_GROUP \
+    --filter-name "TrafficReplayer-RequestComponentWrittenBytes" \
+    --filter-pattern "{ ($.message  = \"Component of request written to target\") && ($.loggerName = \"MetricsLogger.*\") }" \
+    --metric-transformations metricName="RequestComponentWrittenBytes",metricNamespace="traffic-replayer",metricValue="$.contextMap.sizeInBytes",unit="Bytes"
+
+aws logs put-metric-filter \
+    --log-group-name $TRAFFIC_REPLAYER_LOG_GROUP \
+    --filter-name "TrafficReplayer-FullResponseReceived" \
+    --filter-pattern "{ ($.message  = \"Full response received\") && ($.loggerName = \"MetricsLogger.*\") }" \
+    --metric-transformations metricName="FullResponseReceived",metricNamespace="traffic-replayer",metricValue=1,dimensions={"Status"="$.contextMap.httpStatus"},unit="Count"
+
+aws logs put-metric-filter \
+    --log-group-name $TRAFFIC_REPLAYER_LOG_GROUP \
+    --filter-name "TrafficReplayer-FailedToReceiveResponse" \
+    --filter-pattern "{ ($.message  = \"Failed to receive full response\") && ($.loggerName = \"MetricsLogger.*\") }" \
+    --metric-transformations metricName="FailedToReceiveResponse",metricNamespace="traffic-replayer",metricValue=1,defaultValue=0,unit="Count"


### PR DESCRIPTION
### Description
This sets up about 17 metric filters in the user's AWS account that match the metrics logging lines.

There are a couple lines of caveats in the README and the beginning of the file. This could _definitely_ be improved moving forward in both simple and more complex ways.

One of the areas for big improvement in the future is linking this to the source code to ensure that the filters stay up to date with the code. This serves more as a reference implementation so is out of scope at the moment. It would also be much easier if the JSON options worked to configure the filters.

### Issues Resolved
n/a

### Testing
Manual, on several accounts.

### Check List
- [ ] New functionality includes testing
  - [ ] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
