### PR TITLE
Fix some bugs and improve some log messages.

### DIFF
--- a/TrafficCapture/coreUtilities/build.gradle
+++ b/TrafficCapture/coreUtilities/build.gradle
@@ -40,6 +40,9 @@ repositories {
 }
 
 dependencies {
+    implementation project(':captureProtobufs')
+
+    implementation "com.google.protobuf:protobuf-java:3.22.2"
     implementation group: 'org.slf4j', name: 'slf4j-api', version: '2.0.7'
 
     testImplementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.20.0'

--- a/TrafficCapture/coreUtilities/src/main/java/org/opensearch/migrations/trafficcapture/protos/TrafficStreamUtils.java
+++ b/TrafficCapture/coreUtilities/src/main/java/org/opensearch/migrations/trafficcapture/protos/TrafficStreamUtils.java
@@ -1,0 +1,33 @@
+package org.opensearch.migrations.trafficcapture.protos;
+
+import com.google.protobuf.Timestamp;
+import java.time.Instant;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+public class TrafficStreamUtils {
+    public static Instant instantFromProtoTimestamp(Timestamp timestampProto) {
+        return Instant.ofEpochSecond(timestampProto.getSeconds(), timestampProto.getNanos());
+    }
+
+    public static Optional<Instant> getFirstTimestamp(TrafficStream ts) {
+        var substream = ts.getSubStreamList();
+        return substream != null && substream.size() > 0 ?
+                Optional.of(instantFromProtoTimestamp(substream.get(0).getTs())) :
+                Optional.empty();
+    }
+
+    public static Optional<Instant> getLastTimestamp(TrafficStream ts) {
+        var substream = ts.getSubStreamList();
+        return substream != null && substream.size() > 0 ?
+                Optional.of(instantFromProtoTimestamp(substream.get(substream.size()-1).getTs())) :
+                Optional.empty();
+    }
+
+    public static String summarizeTrafficStream(TrafficStream ts) {
+        var listSummaryStr = ts.getSubStreamList().stream()
+                .map(tso->instantFromProtoTimestamp(tso.getTs()) + ": " + tso.getCaptureCase())
+                .collect(Collectors.joining(";  "));
+        return ts.getConnectionId() + " [" + listSummaryStr + "]";
+    }
+}

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/InputStreamOfTraffic.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/InputStreamOfTraffic.java
@@ -2,6 +2,7 @@ package org.opensearch.migrations.replay;
 
 import lombok.extern.slf4j.Slf4j;
 import org.opensearch.migrations.trafficcapture.protos.TrafficStream;
+import org.opensearch.migrations.trafficcapture.protos.TrafficStreamUtils;
 
 import java.io.EOFException;
 import java.io.IOException;

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/TimeShifter.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/TimeShifter.java
@@ -1,30 +1,25 @@
 package org.opensearch.migrations.replay;
 
 import lombok.extern.slf4j.Slf4j;
+import org.opensearch.migrations.trafficcapture.protos.TrafficStream;
+import org.slf4j.event.Level;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 
+
+// TODO - Reconsider how time shifting is done
 @Slf4j
-public
-class TimeShifter {
+public class TimeShifter {
 
-    private static class TimeAdjustData {
-        public final Instant sourceTimeStart;
-        public final Instant systemTimeStart;
-
-        public TimeAdjustData(Instant sourceTimeStart) {
-            this.sourceTimeStart = sourceTimeStart;
-            this.systemTimeStart = Instant.now();
-        }
-    }
+    private final AtomicReference<Instant> sourceTimeStart = new AtomicReference<>();
+    private AtomicReference<Instant> systemTimeStart = new AtomicReference<>();
 
     private final double rateMultiplier;
 
-    // TODO - Reconsider how time shifting is done
-    private final AtomicReference<TimeAdjustData> firstTimestampRef = new AtomicReference<>();
 
     public TimeShifter() {
         this(1.0);
@@ -34,27 +29,46 @@ class TimeShifter {
         this.rateMultiplier = rateMultiplier;
     }
 
+    public void setFirstTimestamp(Instant sourceTime) {
+        var didSet = sourceTimeStart.compareAndSet(null, sourceTime);
+        if (didSet) {
+            var didSetSystemStart = systemTimeStart.compareAndSet(null, Instant.now());
+            assert didSetSystemStart : "expected to always start systemTimeStart immediately after sourceTimeStart ";
+        }
+        log.atLevel(didSet ? Level.INFO : Level.TRACE).setMessage("Set first source timestamp to {}")
+                .addArgument(sourceTime).log();
+    }
+
+    public boolean hasFirstTimestamp() {
+        return sourceTimeStart.get() != null;
+    }
+
     Instant transformSourceTimeToRealTime(Instant sourceTime) {
-        firstTimestampRef.compareAndSet(null, new TimeAdjustData(sourceTime));
-        var tad = firstTimestampRef.get();
         // realtime = systemTimeStart + rateMultiplier * (sourceTime-sourceTimeStart)
-        var rval = tad.systemTimeStart
+        if (sourceTimeStart.get() == null) {
+            throw new RuntimeException("setFirstTimestamp has not yet been called");
+        }
+        var rval = systemTimeStart.get()
                 .plus(Duration.ofMillis((long)
-                        (Duration.between(firstTimestampRef.get().sourceTimeStart, sourceTime).toMillis() / rateMultiplier)));
-        log.trace("Transformed real time=" + rval + " <- " + sourceTime);
+                        (Duration.between(sourceTimeStart.get(), sourceTime).toMillis() / rateMultiplier)));
+        //log.trace("Transformed real time=" + rval + " <- " + sourceTime);
         return rval;
     }
 
     Optional<Instant> transformRealTimeToSourceTime(Instant realTime) {
-        return Optional.ofNullable(firstTimestampRef.get())
-                .map(tad->{
+        return Optional.ofNullable(sourceTimeStart.get())
+                .map(sourceTimeStart->{
                     // sourceTime = realTime - systemTimeStart + sourceTimeStart
                     // sourceTime = sourceTimeStart + (realTime-systemTimeStart) / rateMultiplier
-                    var rval = tad.sourceTimeStart
+                    var rval = sourceTimeStart
                             .plus(Duration.ofMillis((long)
-                                    (Duration.between(tad.systemTimeStart, realTime).toMillis() * rateMultiplier)));
-                    log.trace("Transformed source time=" + rval + " <- " + realTime);
+                                    (Duration.between(systemTimeStart.get(), realTime).toMillis() * rateMultiplier)));
+                    //log.trace("Transformed source time=" + rval + " <- " + realTime);
                     return rval;
                 });
+    }
+
+    public double maxRateMultiplier() {
+        return rateMultiplier;
     }
 }

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/http/HttpJsonTransformingConsumer.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/http/HttpJsonTransformingConsumer.java
@@ -122,7 +122,8 @@ public class HttpJsonTransformingConsumer<R> implements IPacketFinalizingConsume
             }
             return redriveWithoutTransformation(pipelineOrchestrator.packetReceiver, e);
         } finally {
-            channel.close();
+            var cf = channel.close();
+            log.atInfo().setCause(cf.cause()).log();
         }
         if (offloadingHandler == null) {
             // the NettyDecodedHttpRequestHandler gave up and didn't bother installing the baseline handlers -

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/traffic/expiration/BehavioralPolicy.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/traffic/expiration/BehavioralPolicy.java
@@ -12,37 +12,44 @@ import java.time.Instant;
  */
 @Slf4j
 public class BehavioralPolicy {
+    private static String formatPartitionAndConnectionIds(String partitionId, String connectionId) {
+        return connectionId + "[" + partitionId + "]";
+    }
+
+    public String appendageToDescribeHowToSetMinimumGuaranteedLifetime() {
+        return null;
+    }
+
     public void onDataArrivingBeforeTheStartOfTheCurrentProcessingWindow(
             String partitionId, String connectionId, Instant timestamp, Instant endOfWindow) {
+        var hintString = appendageToDescribeHowToSetMinimumGuaranteedLifetime();
         log.error("Could not update the expiration of an object whose timestamp is before the " +
                 "oldest point in time that packets are still being processed for this partition.  " +
                 "This means that there was larger than expected temporal jitter in packets.  " +
-                "That means that traffic for this connection may have already been reported as expired " +
-                "and processed as such and that this data will not be properly handled due to other data " +
+                "The traffic for this connection may have already been reported as expired and processed " +
+                "(potentially partially). This data may not be properly handled due to other data " +
                 "within the connection being prematurely expired.  Trying to send the data through a new " +
                 "instance of this object with a minimumGuaranteedLifetime of " +
                 Duration.between(timestamp, endOfWindow) + " will allow for this packet to be properly " +
-                "accumulated for (" + partitionId + "," + connectionId + ")");
+                "accumulated for (" + formatPartitionAndConnectionIds(partitionId, connectionId) + ")." +
+                (hintString == null ? "" : "  " + hintString));
     }
 
     public void onNewDataArrivingAfterItsAccumulationHasBeenExpired(
-            String partitionId, String connectionId, Instant lastPacketTimestamp, Instant endOfWindow) {
-        log.error("New data has arrived, but during the processing of this Accumulation object, " +
-                "the Accumulation was expired.  This indicates that the minimumGuaranteedLifetime " +
-                "must be set to at least " + Duration.between(lastPacketTimestamp, endOfWindow) +
-                ".  The beginning of the valid time window is currently " + endOfWindow +
-                " for (" + partitionId + "," + connectionId + ") and the last timestamp of the " +
-                "Accumulation object that was being assembled was");
-    }
-
-    public void onNewDataArrivingWithATimestampThatIsAlreadyExpired(
-            String partitionId, String connectionId, Instant timestamp, Instant endOfWindow) {
-        log.error("New data has arrived, but during the processing of this Accumulation object, " +
-                "the Accumulation was expired.  This indicates that the minimumGuaranteedLifetime " +
-                "must be set to at least " + Duration.between(timestamp, endOfWindow) +
-                ".  The beginning of the valid time window is currently " + endOfWindow +
-                " for (" + partitionId + "," + connectionId + ") and the last timestamp of the " +
-                "Accumulation object that was being assembled was");
+            String partitionId, String connectionId, Instant packetTimestamp,
+            long lastPacketTimestampMs, Instant endOfLastWindow, Duration minimumGuaranteedLifetime) {
+        var extraGap = Duration.between(Instant.ofEpochMilli(lastPacketTimestampMs), packetTimestamp);
+        var hintString = appendageToDescribeHowToSetMinimumGuaranteedLifetime();
+        log.error("New data has arrived outside of the expiration window.  Data may be prematurely expired.  " +
+                "The minimumGuaranteedLifetime for the ExpiringQueue should be increased from " +
+                minimumGuaranteedLifetime + " to at least " + extraGap +
+                (hintString == null ? "" : "  " + hintString));
+        log.atInfo().setMessage(()->
+                "New data has arrived for " + formatPartitionAndConnectionIds(partitionId, connectionId) +
+                ", but during the processing of this Accumulation object, the Accumulation was expired.  " +
+                "The maximum timestamp that would NOT have triggered expirations of previously observed data is " +
+                endOfLastWindow + " and the last timestamp of the reference packet was " + packetTimestamp +
+                ".  To remedy this, set the minimumGuaranteedLifetime to at least " + extraGap).log();
     }
 
     public boolean shouldRetryAfterAccumulationTimestampRaceDetected(String partitionId, String connectionId,
@@ -51,12 +58,20 @@ public class BehavioralPolicy {
         if (attempts > ExpiringTrafficStreamMap.DEFAULT_NUM_TIMESTAMP_UPDATE_ATTEMPTS) {
             log.error("A race condition was detected while trying to update the most recent timestamp " +
                     "(" + timestamp + ") of " + "accumulation (" + accumulation + ") for " +
-                    partitionId + "/" + connectionId + ".  Giving up after " + attempts + " attempts.  " +
-                    "Data for this connection may be corrupted.");
+                    formatPartitionAndConnectionIds(partitionId, connectionId) +
+                    ".  Giving up after " + attempts + " attempts.  Data for this connection may be corrupted.");
             return false;
         } else {
             return true;
         }
+    }
+
+    public void onNewDataArrivingAfterItsAccumulationHadBeenRemoved(String partitionId, String connectionId) {
+        log.error("A race condition was detected that shows that while trying to add additional captured data for " +
+                formatPartitionAndConnectionIds(partitionId, connectionId) +
+                ", the accumulation was previously deleted.  Typically, the accumulation value will be purged from " +
+                "the map before any such warning could even be detected.  However, there could still be a defect in " +
+                "some of the caller's logic where remove() is being called prematurely.");
     }
 
     public void onExpireAccumulation(String partitionId, Accumulation accumulation) {

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/RequestSenderOrchestratorTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/RequestSenderOrchestratorTest.java
@@ -32,7 +32,8 @@ class RequestSenderOrchestratorTest {
 
     @Test
     public void testThatSchedulingWorks() throws Exception {
-        var httpServer = SimpleHttpServer.makeServer(false, TestHttpServerContext::makeResponse);
+        var httpServer = SimpleHttpServer.makeServer(false,
+                r -> TestHttpServerContext.makeResponse(r, Duration.ofMillis(100)));
         var testServerUri = httpServer.localhostEndpoint();
         var clientConnectionPool = new ClientConnectionPool(testServerUri, null, 1);
         var senderOrchestrator = new RequestSenderOrchestrator(clientConnectionPool);

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/TestHttpServerContext.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/TestHttpServerContext.java
@@ -27,8 +27,12 @@ public class TestHttpServerContext {
     public static Duration SERVER_RESPONSE_LATENCY = Duration.ofMillis(100);
 
     public static SimpleHttpResponse makeResponse(HttpFirstLine r) {
+        return makeResponse(r, SERVER_RESPONSE_LATENCY);
+    }
+
+    public static SimpleHttpResponse makeResponse(HttpFirstLine r, Duration responseWaitTime) {
         try {
-            Thread.sleep(SERVER_RESPONSE_LATENCY.toMillis());
+            Thread.sleep(responseWaitTime.toMillis());
         } catch (InterruptedException e) {
             throw new RuntimeException(e);
         }

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/TimeShifterTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/TimeShifterTest.java
@@ -22,6 +22,9 @@ class TimeShifterTest {
         var sourceTime = nowTime.minus(Duration.ofHours(1));
 
         Assertions.assertEquals(Optional.empty(), shifter.transformRealTimeToSourceTime(nowTime));
+        Assertions.assertThrows(Exception.class, ()->shifter.transformRealTimeToSourceTime(
+                shifter.transformSourceTimeToRealTime(sourceTime)).get());
+        shifter.setFirstTimestamp(sourceTime);
         Assertions.assertEquals(sourceTime, shifter.transformRealTimeToSourceTime(
                 shifter.transformSourceTimeToRealTime(sourceTime)).get());
 

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/datahandlers/NettyPacketToHttpConsumerTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/datahandlers/NettyPacketToHttpConsumerTest.java
@@ -149,10 +149,12 @@ class NettyPacketToHttpConsumerTest {
                 SslContextBuilder.forClient().trustManager(InsecureTrustManagerFactory.INSTANCE).build();
         var transformingHttpHandlerFactory = new PacketToTransformingHttpHandlerFactory(
                 new JsonJoltTransformBuilder().build(), null);
+        var timeShifter = new TimeShifter();
+        timeShifter.setFirstTimestamp(Instant.now());
         var sendingFactory = new ReplayEngine(
                 new RequestSenderOrchestrator(
                         new ClientConnectionPool(testServer.localhostEndpoint(), sslContext, 1)),
-                new TestTimeController(), new TimeShifter(), 2.0);
+                new TestTimeController(), timeShifter);
         for (int j=0; j<2; ++j) {
             for (int i = 0; i < 2; ++i) {
                 String connId = "TEST_" + j;


### PR DESCRIPTION
This code fixes a major bug that was triggered when a TrafficStream's first set of records was missing its first (0) index.  That caused the BlockingTrafficSource to wait for the first TrafficStream to complete, but it never would.  How we manage bumping time at the beginning of the application has been significantly rethought.  We should still test that expirations are carrying through to bump all of the other cases.

The logging messages for when the expiration timeout window weren't big enough weren't helpful.  I've reworked those to provide the correct values and to provide stronger guidance to the user.

Other refactoring in a number of spots to try to improve out logging stories, including making the coreUtilities project dependent upon the captureProtobuf project so that it can add some common, handy code.

### Description
* Category Bug fixes and logging improvements

### Issues Resolved
https://opensearch.atlassian.net/browse/MIGRATIONS-1293

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
Unit testing

### Check List
- [ ] New functionality includes testing
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
