### PR TITLE
Fix classpath for capture proxy after renaming

### DIFF
--- a/TrafficCapture/dockerSolution/src/main/docker/docker-compose.yml
+++ b/TrafficCapture/dockerSolution/src/main/docker/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     environment:
       - http.port=19200
     # Run processes for elasticsearch and capture proxy, and exit if either one ends
-    command: /bin/sh -c '/usr/local/bin/docker-entrypoint.sh eswrapper & /runJavaWithClasspath.sh org.opensearch.migrations.trafficcapture.proxyserver.Main  --kafkaConnection kafka:9092 --destinationUri  https://localhost:19200  --insecureDestination --listenPort 9200 --sslConfigFile /usr/share/elasticsearch/config/proxy_tls.yml & wait -n 1'
+    command: /bin/sh -c '/usr/local/bin/docker-entrypoint.sh eswrapper & /runJavaWithClasspath.sh org.opensearch.migrations.trafficcapture.proxyserver.CaptureProxy  --kafkaConnection kafka:9092 --destinationUri  https://localhost:19200  --insecureDestination --listenPort 9200 --sslConfigFile /usr/share/elasticsearch/config/proxy_tls.yml & wait -n 1'
     depends_on:
       - kafka
 
@@ -24,7 +24,7 @@ services:
 #      - migrations
 #    ports:
 #      - "9200:9200"
-#    command: /runJavaWithClasspath.sh org.opensearch.migrations.trafficcapture.proxyserver.Main  --kafkaConnection kafka:9092 --destinationUri  https://elasticsearch:9200  --insecureDestination --listenPort 9200 --sslConfigFile /usr/share/elasticsearch/config/proxy_tls.yml
+#    command: /runJavaWithClasspath.sh org.opensearch.migrations.trafficcapture.proxyserver.CaptureProxy  --kafkaConnection kafka:9092 --destinationUri  https://elasticsearch:9200  --insecureDestination --listenPort 9200 --sslConfigFile /usr/share/elasticsearch/config/proxy_tls.yml
 #    depends_on:
 #      - kafka
 #      - elasticsearch

--- a/TrafficCapture/trafficCaptureProxyServer/build.gradle
+++ b/TrafficCapture/trafficCaptureProxyServer/build.gradle
@@ -53,5 +53,5 @@ tasks.withType(Zip){
 
 application {
     // Define the main class for the application.
-    mainClass = 'org.opensearch.migrations.trafficcapture.proxyserver.Main'
+    mainClass = 'org.opensearch.migrations.trafficcapture.proxyserver.CaptureProxy'
 }

--- a/TrafficCapture/trafficCaptureProxyServerTest/src/main/docker/docker-compose.yml
+++ b/TrafficCapture/trafficCaptureProxyServerTest/src/main/docker/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - testing
     ports:
       - "9201:9201"
-    command: /runJavaWithClasspath.sh org.opensearch.migrations.trafficcapture.proxyserver.Main --destinationUri  http://webserver:80 --listenPort 9201 --noCapture --destinationConnectionPoolSize 0 --numThreads 1
+    command: /runJavaWithClasspath.sh org.opensearch.migrations.trafficcapture.proxyserver.CaptureProxy --destinationUri  http://webserver:80 --listenPort 9201 --noCapture --destinationConnectionPoolSize 0 --numThreads 1
     depends_on:
       - webserver
 

--- a/deployment/copilot/capture-proxy-es/manifest.yml
+++ b/deployment/copilot/capture-proxy-es/manifest.yml
@@ -28,7 +28,7 @@ image:
   # Port exposed through your container to route traffic to it.
   port: 9200
 
-command: /bin/sh -c '/usr/local/bin/docker-entrypoint.sh eswrapper & /runJavaWithClasspath.sh org.opensearch.migrations.trafficcapture.proxyserver.Main  --kafkaConnection ${MIGRATION_KAFKA_BROKER_ENDPOINTS} --enableMSKAuth --destinationUri https://localhost:19200 --insecureDestination --listenPort 9200 --sslConfigFile /usr/share/elasticsearch/config/proxy_tls.yml & wait -n 1'
+command: /bin/sh -c '/usr/local/bin/docker-entrypoint.sh eswrapper & /runJavaWithClasspath.sh org.opensearch.migrations.trafficcapture.proxyserver.CaptureProxy  --kafkaConnection ${MIGRATION_KAFKA_BROKER_ENDPOINTS} --enableMSKAuth --destinationUri https://localhost:19200 --insecureDestination --listenPort 9200 --sslConfigFile /usr/share/elasticsearch/config/proxy_tls.yml & wait -n 1'
 
 cpu: 1024       # Number of CPU units for the task.
 memory: 4096    # Amount of memory in MiB used by the task.

--- a/deployment/copilot/capture-proxy/manifest.yml
+++ b/deployment/copilot/capture-proxy/manifest.yml
@@ -20,7 +20,7 @@ image:
   # Port exposed through your container to route traffic to it.
   port: 9200
 
-command: /runJavaWithClasspath.sh org.opensearch.migrations.trafficcapture.proxyserver.Main  --kafkaConnection ${MIGRATION_KAFKA_BROKER_ENDPOINTS} --enableMSKAuth --destinationUri https://elasticsearch:9200 --insecureDestination --listenPort 9200 --sslConfigFile /usr/share/elasticsearch/config/proxy_tls.yml
+command: /runJavaWithClasspath.sh org.opensearch.migrations.trafficcapture.proxyserver.CaptureProxy  --kafkaConnection ${MIGRATION_KAFKA_BROKER_ENDPOINTS} --enableMSKAuth --destinationUri https://elasticsearch:9200 --insecureDestination --listenPort 9200 --sslConfigFile /usr/share/elasticsearch/config/proxy_tls.yml
 
 cpu: 512       # Number of CPU units for the task.
 memory: 2048    # Amount of memory in MiB used by the task.


### PR DESCRIPTION
### Description
The capture proxy class name was change recently, this PR will fix the instances where the classpath for the Capture Proxy was used.

### Check List
- [ ] New functionality includes testing
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
