### PR TITLE
Add invalid and incorrect URI tests to E2E script

### DIFF
--- a/test/tests.py
+++ b/test/tests.py
@@ -164,8 +164,9 @@ class E2ETests(unittest.TestCase):
         self.assertEqual(response.status_code, HTTPStatus.OK)
 
     def test_004_negativeAuth(self):
+        # This sends negative credentials to the clusters to validate that unauthorized access is prevented.
         alphabet = string.ascii_letters + string.digits
-        for _ in range(10):  # Adjust the range as needed
+        for _ in range(10):
             username = ''.join(secrets.choice(alphabet) for _ in range(8))
             password = ''.join(secrets.choice(alphabet) for _ in range(8))
 

--- a/test/tests.py
+++ b/test/tests.py
@@ -71,7 +71,7 @@ class E2ETests(unittest.TestCase):
         delete_index(self.proxy_endpoint, self.index, self.auth)
         delete_document(self.proxy_endpoint, self.index, self.doc_id, self.auth)
 
-    def test_001_index(self):
+    def test_0001_index(self):
         # This test will verify that an index will be created (then deleted) on the target cluster when one is created
         # on the source cluster by going through the proxy first. It will verify that the traffic is captured by the
         # proxy and that the traffic reaches the source cluster, replays said traffic to the target cluster by the
@@ -100,7 +100,7 @@ class E2ETests(unittest.TestCase):
                                         expected_status_code=HTTPStatus.NOT_FOUND)
         self.assertEqual(source_response.status_code, HTTPStatus.NOT_FOUND)
 
-    def test_002_document(self):
+    def test_0002_document(self):
         # This test will verify that a document will be created (then deleted) on the target cluster when one is created
         # on the source cluster by going through the proxy first. It will verify that the traffic is captured by the
         # proxy and that the traffic reaches the source cluster, replays said traffic to the target cluster by the
@@ -158,13 +158,13 @@ class E2ETests(unittest.TestCase):
                                         expected_status_code=HTTPStatus.NOT_FOUND)
         self.assertEqual(source_response.status_code, HTTPStatus.NOT_FOUND)
 
-    def test_003_jupyterAwake(self):
+    def test_0003_jupyterAwake(self):
         # Making sure that the Jupyter notebook is up and can be reached.
         response = requests.get(self.jupyter_endpoint)
         self.assertEqual(response.status_code, HTTPStatus.OK)
 
-    def test_004_negativeAuth(self):
-        # This sends negative credentials to the clusters to validate that unauthorized access is prevented.
+    def test_0004_negativeAuth_invalidCreds(self):
+        # This test sends negative credentials to the clusters to validate that unauthorized access is prevented.
         alphabet = string.ascii_letters + string.digits
         for _ in range(10):
             username = ''.join(secrets.choice(alphabet) for _ in range(8))
@@ -179,3 +179,13 @@ class E2ETests(unittest.TestCase):
             for user, pw in credentials:
                 response = requests.get(self.proxy_endpoint, auth=(user, pw), verify=False)
                 self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
+
+    def test_0005_negativeAuth_missingCreds(self):
+        # This test will use no credentials at all
+        # With an empty authorization header
+        response = requests.get(self.proxy_endpoint, auth=('', ''), verify=False)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
+
+        # Without an authorization header.
+        response = requests.get(self.proxy_endpoint, verify=False)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)

--- a/test/tests.py
+++ b/test/tests.py
@@ -163,7 +163,6 @@ class E2ETests(unittest.TestCase):
         response = requests.get(self.jupyter_endpoint)
         self.assertEqual(response.status_code, HTTPStatus.OK)
 
-
     def test_004_negativeAuth(self):
         alphabet = string.ascii_letters + string.digits
         for _ in range(10):  # Adjust the range as needed
@@ -179,5 +178,3 @@ class E2ETests(unittest.TestCase):
             for user, pw in credentials:
                 response = requests.get(self.proxy_endpoint, auth=(user, pw), verify=False)
                 self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
-
-

--- a/test/tests.py
+++ b/test/tests.py
@@ -8,6 +8,8 @@ import logging
 import time
 import requests
 import uuid
+import string
+import secrets
 from requests.exceptions import ConnectionError, SSLError
 
 logger = logging.getLogger(__name__)
@@ -160,3 +162,22 @@ class E2ETests(unittest.TestCase):
         # Making sure that the Jupyter notebook is up and can be reached.
         response = requests.get(self.jupyter_endpoint)
         self.assertEqual(response.status_code, HTTPStatus.OK)
+
+
+    def test_004_negativeAuth(self):
+        alphabet = string.ascii_letters + string.digits
+        for _ in range(10):  # Adjust the range as needed
+            username = ''.join(secrets.choice(alphabet) for _ in range(8))
+            password = ''.join(secrets.choice(alphabet) for _ in range(8))
+
+            credentials = [
+                (username, password),
+                (self.username, password),
+                (username, self.password)
+            ]
+
+            for user, pw in credentials:
+                response = requests.get(self.proxy_endpoint, auth=(user, pw), verify=False)
+                self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
+
+

--- a/test/tests.py
+++ b/test/tests.py
@@ -189,3 +189,14 @@ class E2ETests(unittest.TestCase):
         # Without an authorization header.
         response = requests.get(self.proxy_endpoint, verify=False)
         self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
+
+    def test_0006_invalidIncorrectUri(self):
+        # This test will send an invalid URI
+        invalidUri = "/invalidURI"
+        response = requests.get(f'{self.proxy_endpoint}{invalidUri}', auth=self.auth, verify=False)
+        self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND)
+
+        # This test will send an incorrect URI
+        incorrectUri = "/_cluster/incorrectUri"
+        response = requests.get(f'{self.proxy_endpoint}{incorrectUri}', auth=self.auth, verify=False)
+        self.assertEqual(response.status_code, HTTPStatus.METHOD_NOT_ALLOWED)


### PR DESCRIPTION
### Description
This PR adds a test to the E2E script that uses invalid and incorrect URIs. This PR is built on #362.

### Issues Resolved
[MIGRATIONS-1153](https://opensearch.atlassian.net/browse/MIGRATIONS-1153)


### Check List
- [ ] New functionality includes testing
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
