### PR TITLE
Bugfixes and better shutdowns

### DIFF
--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/Accumulation.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/Accumulation.java
@@ -2,13 +2,11 @@ package org.opensearch.migrations.replay;
 
 import lombok.NonNull;
 import org.opensearch.migrations.replay.datatypes.ITrafficStreamKey;
-import org.opensearch.migrations.replay.datatypes.UniqueRequestKey;
+import org.opensearch.migrations.replay.datatypes.UniqueReplayerRequestKey;
 
 import java.time.Instant;
-import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.atomic.AtomicReference;
 
 public class Accumulation {
 
@@ -50,8 +48,8 @@ public class Accumulation {
         return rrPair = new RequestResponsePacketPair();
     }
 
-    public UniqueRequestKey getRequestKey() {
-        return new UniqueRequestKey(trafficStreamKey, startingSourceRequestIndex, getIndexOfCurrentRequest());
+    public UniqueReplayerRequestKey getRequestKey() {
+        return new UniqueReplayerRequestKey(trafficStreamKey, startingSourceRequestIndex, getIndexOfCurrentRequest());
     }
 
     public boolean hasSignaledRequests() {

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/AccumulationCallbacks.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/AccumulationCallbacks.java
@@ -1,0 +1,14 @@
+package org.opensearch.migrations.replay;
+
+import org.opensearch.migrations.replay.datatypes.ITrafficStreamKey;
+import org.opensearch.migrations.replay.datatypes.UniqueRequestKey;
+
+import java.time.Instant;
+import java.util.List;
+
+public interface AccumulationCallbacks {
+    void onRequestReceived(UniqueRequestKey key, HttpMessageAndTimestamp request);
+    void onFullDataReceived(UniqueRequestKey key, RequestResponsePacketPair rrpp);
+    void onTrafficStreamsExpired(RequestResponsePacketPair.ReconstructionStatus status, List<ITrafficStreamKey> trafficStreamKeysBeingHeld);
+    void onConnectionClose(UniqueRequestKey key, Instant when);
+}

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/AccumulationCallbacks.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/AccumulationCallbacks.java
@@ -1,14 +1,14 @@
 package org.opensearch.migrations.replay;
 
 import org.opensearch.migrations.replay.datatypes.ITrafficStreamKey;
-import org.opensearch.migrations.replay.datatypes.UniqueRequestKey;
+import org.opensearch.migrations.replay.datatypes.UniqueReplayerRequestKey;
 
 import java.time.Instant;
 import java.util.List;
 
 public interface AccumulationCallbacks {
-    void onRequestReceived(UniqueRequestKey key, HttpMessageAndTimestamp request);
-    void onFullDataReceived(UniqueRequestKey key, RequestResponsePacketPair rrpp);
+    void onRequestReceived(UniqueReplayerRequestKey key, HttpMessageAndTimestamp request);
+    void onFullDataReceived(UniqueReplayerRequestKey key, RequestResponsePacketPair rrpp);
     void onTrafficStreamsExpired(RequestResponsePacketPair.ReconstructionStatus status, List<ITrafficStreamKey> trafficStreamKeysBeingHeld);
-    void onConnectionClose(UniqueRequestKey key, Instant when);
+    void onConnectionClose(UniqueReplayerRequestKey key, Instant when);
 }

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/ClientConnectionPool.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/ClientConnectionPool.java
@@ -15,7 +15,7 @@ import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.opensearch.migrations.replay.datahandlers.NettyPacketToHttpConsumer;
 import org.opensearch.migrations.replay.datatypes.ConnectionReplaySession;
-import org.opensearch.migrations.replay.datatypes.UniqueRequestKey;
+import org.opensearch.migrations.replay.datatypes.UniqueReplayerRequestKey;
 import org.opensearch.migrations.replay.util.DiagnosticTrackableCompletableFuture;
 import org.opensearch.migrations.replay.util.StringTrackableCompletableFuture;
 
@@ -132,7 +132,7 @@ public class ClientConnectionPool {
     }
 
     public Future<ConnectionReplaySession>
-    submitEventualChannelGet(UniqueRequestKey requestKey, boolean ignoreIfNotPresent) {
+    submitEventualChannelGet(UniqueReplayerRequestKey requestKey, boolean ignoreIfNotPresent) {
         ConnectionReplaySession channelFutureAndSchedule =
                 getCachedSession(requestKey, ignoreIfNotPresent);
         if (channelFutureAndSchedule == null) {
@@ -151,7 +151,7 @@ public class ClientConnectionPool {
     }
 
     @SneakyThrows
-    public ConnectionReplaySession getCachedSession(UniqueRequestKey requestKey, boolean dontCreate) {
+    public ConnectionReplaySession getCachedSession(UniqueReplayerRequestKey requestKey, boolean dontCreate) {
         var crs = dontCreate ? connectionId2ChannelCache.getIfPresent(requestKey.getTrafficStreamKey().getConnectionId()) :
                 connectionId2ChannelCache.get(requestKey.getTrafficStreamKey().getConnectionId());
         if (crs != null) {

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/PacketConsumerFactory.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/PacketConsumerFactory.java
@@ -1,8 +1,8 @@
 package org.opensearch.migrations.replay;
 
 import org.opensearch.migrations.replay.datahandlers.IPacketFinalizingConsumer;
-import org.opensearch.migrations.replay.datatypes.UniqueRequestKey;
+import org.opensearch.migrations.replay.datatypes.UniqueReplayerRequestKey;
 
 public interface PacketConsumerFactory<R> {
-    IPacketFinalizingConsumer<R> create(UniqueRequestKey requestKey);
+    IPacketFinalizingConsumer<R> create(UniqueReplayerRequestKey requestKey);
 }

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/PacketToTransformingHttpHandlerFactory.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/PacketToTransformingHttpHandlerFactory.java
@@ -1,22 +1,14 @@
 package org.opensearch.migrations.replay;
 
-import io.netty.channel.Channel;
-import io.netty.channel.ChannelFuture;
 import lombok.extern.slf4j.Slf4j;
 import org.opensearch.migrations.replay.datahandlers.IPacketFinalizingConsumer;
 import org.opensearch.migrations.replay.datahandlers.TransformedPacketReceiver;
 import org.opensearch.migrations.replay.datahandlers.http.HttpJsonTransformingConsumer;
 import org.opensearch.migrations.replay.datatypes.TransformedOutputAndResult;
 import org.opensearch.migrations.replay.datatypes.TransformedPackets;
-import org.opensearch.migrations.replay.datatypes.UniqueRequestKey;
+import org.opensearch.migrations.replay.datatypes.UniqueReplayerRequestKey;
 import org.opensearch.migrations.transform.IAuthTransformerFactory;
 import org.opensearch.migrations.transform.IJsonTransformer;
-import org.opensearch.migrations.replay.util.DiagnosticTrackableCompletableFuture;
-import org.opensearch.migrations.replay.util.StringTrackableCompletableFuture;
-
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
-import java.util.stream.Collectors;
 
 @Slf4j
 public class PacketToTransformingHttpHandlerFactory implements
@@ -33,7 +25,7 @@ public class PacketToTransformingHttpHandlerFactory implements
 
     @Override
     public IPacketFinalizingConsumer<TransformedOutputAndResult<TransformedPackets>>
-    create(UniqueRequestKey requestKey) {
+    create(UniqueReplayerRequestKey requestKey) {
         log.trace("creating HttpJsonTransformingConsumer");
         return new HttpJsonTransformingConsumer(jsonTransformer, authTransformerFactory,
                 new TransformedPacketReceiver(), requestKey.toString(), requestKey);

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/ReplayEngine.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/ReplayEngine.java
@@ -1,6 +1,7 @@
 package org.opensearch.migrations.replay;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.ScheduledFuture;
 import lombok.extern.slf4j.Slf4j;
 import org.opensearch.migrations.coreutils.MetricsLogger;
@@ -156,8 +157,12 @@ public class ReplayEngine {
         hookWorkFinishingUpdates(future, timestamp, requestKey, label);
     }
 
-    public DiagnosticTrackableCompletableFuture<String, Void> close() {
-        return networkSendOrchestrator.clientConnectionPool.stopGroup();
+    public DiagnosticTrackableCompletableFuture<String, Void> closeConnectionsAndShutdown() {
+        return networkSendOrchestrator.clientConnectionPool.closeConnectionsAndShutdown();
+    }
+
+    public Future shutdownNow() {
+        return networkSendOrchestrator.clientConnectionPool.shutdownNow();
     }
 
     public int getNumConnectionsCreated() {

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/ReplayEngine.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/ReplayEngine.java
@@ -5,7 +5,7 @@ import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.ScheduledFuture;
 import lombok.extern.slf4j.Slf4j;
 import org.opensearch.migrations.coreutils.MetricsLogger;
-import org.opensearch.migrations.replay.datatypes.UniqueRequestKey;
+import org.opensearch.migrations.replay.datatypes.UniqueReplayerRequestKey;
 import org.opensearch.migrations.replay.traffic.source.BufferedFlowController;
 import org.opensearch.migrations.replay.util.DiagnosticTrackableCompletableFuture;
 
@@ -97,7 +97,7 @@ public class ReplayEngine {
 
     private <T> DiagnosticTrackableCompletableFuture<String, T>
     hookWorkFinishingUpdates(DiagnosticTrackableCompletableFuture<String, T> future, Instant timestamp,
-                             UniqueRequestKey requestKey, String taskDescription) {
+                             UniqueReplayerRequestKey requestKey, String taskDescription) {
         return future.map(f->f
                         .whenComplete((v,t)->Utils.setIfLater(lastCompletedSourceTimeEpochMs, timestamp.toEpochMilli()))
                         .whenComplete((v,t)->{
@@ -113,13 +113,13 @@ public class ReplayEngine {
                 ()->"Updating fields for callers to poll progress and updating backpressure");
     }
 
-    private static void logStartOfWork(UniqueRequestKey requestKey, long newCount, Instant start, String label) {
+    private static void logStartOfWork(UniqueReplayerRequestKey requestKey, long newCount, Instant start, String label) {
         log.atInfo().setMessage(()->"Scheduling '" + label + "' (" + requestKey +
                 ") to run at " + start + " incremented tasksOutstanding to "+ newCount).log();
     }
 
     public <T> DiagnosticTrackableCompletableFuture<String, T>
-    scheduleTransformationWork(UniqueRequestKey requestKey, Instant originalStart,
+    scheduleTransformationWork(UniqueReplayerRequestKey requestKey, Instant originalStart,
                                Supplier<DiagnosticTrackableCompletableFuture<String,T>> task) {
         var newCount = totalCountOfScheduledTasksOutstanding.incrementAndGet();
         final String label = "processing";
@@ -130,7 +130,7 @@ public class ReplayEngine {
     }
 
     public DiagnosticTrackableCompletableFuture<String, AggregatedRawResponse>
-    scheduleRequest(UniqueRequestKey requestKey, Instant originalStart, Instant originalEnd,
+    scheduleRequest(UniqueReplayerRequestKey requestKey, Instant originalStart, Instant originalEnd,
                     int numPackets, Stream<ByteBuf> packets) {
         var newCount = totalCountOfScheduledTasksOutstanding.incrementAndGet();
         final String label = "request";
@@ -148,7 +148,7 @@ public class ReplayEngine {
         return hookWorkFinishingUpdates(sendResult, originalStart, requestKey, label);
     }
 
-    public void closeConnection(UniqueRequestKey requestKey, Instant timestamp) {
+    public void closeConnection(UniqueReplayerRequestKey requestKey, Instant timestamp) {
         var newCount = totalCountOfScheduledTasksOutstanding.incrementAndGet();
         final String label = "close";
         var atTime = timeShifter.transformSourceTimeToRealTime(timestamp);

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/RequestResponsePacketPair.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/RequestResponsePacketPair.java
@@ -16,7 +16,7 @@ import java.util.Optional;
 @Slf4j
 public class RequestResponsePacketPair {
 
-    enum ReconstructionStatus {
+    public enum ReconstructionStatus {
         Complete,
         ExpiredPrematurely,
         ClosedPrematurely
@@ -25,12 +25,7 @@ public class RequestResponsePacketPair {
     HttpMessageAndTimestamp requestData;
     HttpMessageAndTimestamp responseData;
     List<ITrafficStreamKey> trafficStreamKeysBeingHeld;
-    public final UniqueRequestKey requestKey;
     ReconstructionStatus completionStatus;
-
-    public RequestResponsePacketPair(UniqueRequestKey requestKey) {
-        this.requestKey = requestKey;
-    }
 
     public void addRequestData(Instant packetTimeStamp, byte[] data) {
         if (log.isTraceEnabled()) {
@@ -80,13 +75,12 @@ public class RequestResponsePacketPair {
         RequestResponsePacketPair that = (RequestResponsePacketPair) o;
         return Objects.equal(requestData, that.requestData)
                 && Objects.equal(responseData, that.responseData)
-                && Objects.equal(requestKey, that.requestKey)
                 && Objects.equal(trafficStreamKeysBeingHeld, that.trafficStreamKeysBeingHeld);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(requestData, responseData, requestKey, trafficStreamKeysBeingHeld);
+        return Objects.hashCode(requestData, responseData, trafficStreamKeysBeingHeld);
     }
 
     @Override

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/RequestResponsePacketPair.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/RequestResponsePacketPair.java
@@ -3,12 +3,10 @@ package org.opensearch.migrations.replay;
 import com.google.common.base.Objects;
 import lombok.extern.slf4j.Slf4j;
 import org.opensearch.migrations.replay.datatypes.ITrafficStreamKey;
-import org.opensearch.migrations.replay.datatypes.UniqueRequestKey;
 
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/TrafficReplayer.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/TrafficReplayer.java
@@ -7,14 +7,17 @@ import io.netty.buffer.Unpooled;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
+import lombok.AllArgsConstructor;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.opensearch.migrations.replay.datahandlers.IPacketFinalizingConsumer;
 import org.opensearch.migrations.replay.datatypes.HttpRequestTransformationStatus;
+import org.opensearch.migrations.replay.datatypes.ITrafficStreamKey;
 import org.opensearch.migrations.replay.datatypes.TransformedPackets;
 import org.opensearch.migrations.replay.datatypes.UniqueRequestKey;
 import org.opensearch.migrations.replay.traffic.source.BlockingTrafficSource;
 import org.opensearch.migrations.replay.traffic.source.ITrafficCaptureSource;
+import org.opensearch.migrations.replay.traffic.source.ITrafficStreamWithKey;
 import org.opensearch.migrations.replay.traffic.source.TrafficStreamLimiter;
 import org.opensearch.migrations.replay.util.DiagnosticTrackableCompletableFuture;
 import org.opensearch.migrations.replay.util.StringTrackableCompletableFuture;
@@ -36,6 +39,7 @@ import java.io.EOFException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.lang.ref.WeakReference;
 import java.net.URI;
 import java.time.Duration;
 import java.time.Instant;
@@ -44,12 +48,15 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.BiConsumer;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -73,6 +80,12 @@ public class TrafficReplayer {
             DiagnosticTrackableCompletableFuture<String, TransformedTargetRequestAndResponse>> requestFutureMap;
     private ConcurrentHashMap<UniqueRequestKey,
             DiagnosticTrackableCompletableFuture<String, TransformedTargetRequestAndResponse>> requestToFinalWorkFuturesMap;
+
+    private AtomicBoolean stopReadingRef;
+    private AtomicReference<StringTrackableCompletableFuture<Void>> allRemainingWorkFutureRef;
+    private AtomicReference<Error> shutdownReasonRef;
+    private AtomicReference<CompletableFuture<Void>> shutdownFutureRef;
+    private AtomicReference<CompletableFuture<List<ITrafficStreamWithKey>>> nextChunkFutureRef;
 
     public static IJsonTransformer buildDefaultJsonTransformer(String newHostName) {
         var joltJsonTransformerBuilder = JsonJoltTransformer.newBuilder()
@@ -124,6 +137,11 @@ public class TrafficReplayer {
         successCount = new AtomicInteger();
         exceptionCount = new AtomicInteger();
         liveTrafficStreamLimiter = new TrafficStreamLimiter(maxConcurrentOutstandingRequests);
+        allRemainingWorkFutureRef = new AtomicReference<>();
+        shutdownReasonRef = new AtomicReference<>();
+        shutdownFutureRef = new AtomicReference<>();
+        nextChunkFutureRef = new AtomicReference<>();
+        stopReadingRef = new AtomicBoolean();
     }
 
     private static SslContext loadSslContext(URI serverUri, boolean allowInsecureConnections) throws SSLException {
@@ -296,14 +314,38 @@ public class TrafficReplayer {
                         Duration.ofSeconds(params.lookaheadTimeSeconds))) {
                     var tr = new TrafficReplayer(uri, buildAuthTransformerFactory(params),
                             params.allowInsecureConnections, params.numClientThreads,  params.maxConcurrentRequests);
+                    setupShutdownHookForReplayer(tr);
                     var tupleWriter = new SourceTargetCaptureTuple.TupleToFileWriter(bufferedOutputStream);
                     var timeShifter = new TimeShifter(params.speedupFactor);
                     tr.runReplayWithIOStreams(Duration.ofSeconds(params.observedPacketConnectionTimeout),
                             blockingTrafficStream, bufferedOutputStream, timeShifter, tupleWriter);
-                    log.info("reached the end of the ingestion output stream");
+                    log.info("Done processing TrafficStreams");
                 }
             }
         }
+    }
+
+    private static void setupShutdownHookForReplayer(TrafficReplayer tr) {
+        var weakTrafficReplayer = new WeakReference<>(tr);
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            // both Log4J and the java builtin loggers add shutdown hooks.
+            // The API for addShutdownHook says that those hooks registered will run in an undetermined order.
+            // Hence, the reason that this code logs via slf4j logging AND stderr.
+            {
+                var beforeMsg = "Running TrafficReplayer Shutdown.  " +
+                        "The logging facilities may also be shutting down concurrently, " +
+                        "resulting in missing logs messages.";
+                log.atWarn().setMessage(beforeMsg).log();
+                System.err.println(beforeMsg);
+            }
+            Optional.ofNullable(weakTrafficReplayer.get()).ifPresent(o->o.shutdown(null));
+            {
+                var afterMsg = "Done shutting down TrafficReplayer (due to Runtime shutdown).  " +
+                        "Logs may be missing for events that have happened after the Shutdown event was received.";
+                log.atWarn().setMessage(afterMsg).log();
+                System.err.println(afterMsg);
+            }
+        }));
     }
 
     /**
@@ -373,12 +415,7 @@ public class TrafficReplayer {
         CapturedTrafficToHttpTransactionAccumulator trafficToHttpTransactionAccumulator =
                 new CapturedTrafficToHttpTransactionAccumulator(observedPacketConnectionTimeout,
                         "(see " + PACKET_TIMEOUT_SECONDS_PARAMETER_NAME + ")",
-                        getRecordedRequestReconstructCompleteHandler(replayEngine),
-                        getRecordedRequestAndResponseReconstructCompleteHandler(resultTupleConsumer),
-                        (requestKey, timestamp) -> {
-                            replayEngine.setFirstTimestamp(timestamp);
-                            replayEngine.closeConnection(requestKey, timestamp);
-                        });
+                        new TrafficReplayerAccumulationCallbacks(replayEngine, resultTupleConsumer));
         try {
             pullCaptureFromSourceToAccumulator(trafficChunkStream, trafficToHttpTransactionAccumulator);
         } catch (Exception e) {
@@ -397,6 +434,9 @@ public class TrafficReplayer {
                     log.atLevel(logLevel).log("Timed out while waiting for the remaining " +
                             "requests to be finalized...");
                     logLevel = SECONDARY_LOG_LEVEL;
+                } finally {
+                    shutdown(null).get();
+                    log.error("Done waiting for TrafficReplayer (" + this + ") to shut down");
                 }
             }
             if (exceptionCount.get() > 0) {
@@ -421,9 +461,14 @@ public class TrafficReplayer {
 
     ConcurrentHashMap<UniqueRequestKey, Boolean> liveRequests = new ConcurrentHashMap<>();
 
-    private BiConsumer<UniqueRequestKey, HttpMessageAndTimestamp>
-    getRecordedRequestReconstructCompleteHandler(ReplayEngine replayEngine) {
-        return (requestKey, request) -> {
+
+    @AllArgsConstructor
+    class TrafficReplayerAccumulationCallbacks implements AccumulationCallbacks {
+        private final ReplayEngine replayEngine;
+        private Consumer<SourceTargetCaptureTuple> resultTupleConsumer;
+
+        @Override
+        public void onRequestReceived(UniqueRequestKey requestKey, HttpMessageAndTimestamp request) {
             replayEngine.setFirstTimestamp(request.getFirstPacketTimestamp());
 
             liveTrafficStreamLimiter.addWork(1);
@@ -432,48 +477,59 @@ public class TrafficReplayer {
             liveRequests.put(requestKey, true);
             requestPushFuture.map(f->f.whenComplete((v,t)->{
                         liveRequests.remove(requestKey);
-                liveTrafficStreamLimiter.doneProcessing(1);
+                        liveTrafficStreamLimiter.doneProcessing(1);
                         log.atTrace()
                                 .setMessage(()->"Summary response value for " + requestKey + " returned=" + v).log();
                     }),
                     ()->"logging summary");
-        };
-    }
+        }
 
-    private final static Instant startTime = Instant.now();
 
-    private Consumer<RequestResponsePacketPair>
-    getRecordedRequestAndResponseReconstructCompleteHandler(Consumer<SourceTargetCaptureTuple> resultTupleConsumer) {
-        return rrPair -> {
+        @Override
+        public void onFullDataReceived(UniqueRequestKey requestKey, RequestResponsePacketPair rrPair) {
             log.atTrace().setMessage(()->"Done receiving captured stream for this " + rrPair.requestData).log();
-            var resultantCf = requestFutureMap.remove(rrPair.requestKey)
+            var resultantCf = requestFutureMap.remove(requestKey)
                     .map(f ->
                             f.handle((summary, t) -> {
                                 TransformedTargetRequestAndResponse rval = null;
                                 try {
-                                    rval = packageAndWriteResponse(resultTupleConsumer, rrPair, summary, t);
-                                    successCount.incrementAndGet();
-                                    return rval;
-                                } catch (Exception e) {
-                                    log.atInfo().setCause(e).setMessage("Exception for request {}: ")
-                                            .addArgument(rrPair.requestKey).log();
-                                    exceptionCount.incrementAndGet();
-                                    throw e;
+                                    return packageAndWriteResponse(resultTupleConsumer, requestKey, rrPair, summary, t);
+                                } catch (Error error) {
+                                    log.atError()
+                                            .setCause(error)
+                                            .setMessage(()->"Caught error and initiating TrafficReplayer shutdown")
+                                            .log();
+                                    shutdown(error);
+                                    throw error;
                                 } finally {
-                                    requestToFinalWorkFuturesMap.remove(rrPair.requestKey);
+                                    requestToFinalWorkFuturesMap.remove(requestKey);
                                     log.trace("removed rrPair.requestData to " +
                                             "targetTransactionInProgressMap for " +
-                                            rrPair.requestKey);
+                                            requestKey);
                                 }
                             }), () -> "TrafficReplayer.runReplayWithIOStreams.progressTracker");
             if (!resultantCf.future.isDone()) {
-                log.trace("Adding " + rrPair.requestKey + " to targetTransactionInProgressMap");
-                requestToFinalWorkFuturesMap.put(rrPair.requestKey, resultantCf);
+                log.trace("Adding " + requestKey + " to targetTransactionInProgressMap");
+                requestToFinalWorkFuturesMap.put(requestKey, resultantCf);
                 if (resultantCf.future.isDone()) {
-                    requestToFinalWorkFuturesMap.remove(rrPair.requestKey);
+                    requestToFinalWorkFuturesMap.remove(requestKey);
                 }
             }
-        };
+        }
+
+        @Override
+        public void onTrafficStreamsExpired(RequestResponsePacketPair.ReconstructionStatus status,
+                                            List<ITrafficStreamKey> trafficStreamKeysBeingHeld) {
+            if (status == RequestResponsePacketPair.ReconstructionStatus.ExpiredPrematurely) {
+
+            }
+        }
+
+        @Override
+        public void onConnectionClose(UniqueRequestKey requestKey, Instant timestamp) {
+            replayEngine.setFirstTimestamp(timestamp);
+            replayEngine.closeConnection(requestKey, timestamp);
+        }
     }
 
     private void waitForRemainingWork(Level logLevel,
@@ -503,7 +559,23 @@ public class TrafficReplayer {
         var allWorkFuture = StringTrackableCompletableFuture.allOf(allCompletableFuturesArray,
                 () -> "TrafficReplayer.AllWorkFinished");
         try {
-            allWorkFuture.get(timeout);
+            if (allRemainingWorkFutureRef.compareAndSet(null, allWorkFuture)) {
+                allWorkFuture.get(timeout);
+            } else {
+                try {
+                    allRemainingWorkFutureRef.get().future.get();
+                } catch (ExecutionException e) {
+                    var c = e.getCause();
+                    if (c instanceof Error) { throw (Error) c; }
+                    else throw e;
+                } catch (Error t) {
+                    log.atError().setCause(t).setMessage(() -> "Not waiting for all work to finish.  " +
+                            "The TrafficReplayer is shutting down").log();
+                    throw t;
+                }
+            }
+        } catch (CancellationException e) {
+            throw shutdownReasonRef.get();
         } catch (TimeoutException e) {
             var didCancel = allWorkFuture.future.cancel(true);
             if (!didCancel) {
@@ -512,10 +584,12 @@ public class TrafficReplayer {
             } else {
                 throw e;
             }
+        } finally {
+            allRemainingWorkFutureRef.set(null);
         }
         allWorkFuture.getDeferredFutureThroughHandle((t, v) -> {
                     log.info("stopping packetHandlerFactory's group");
-                    replayEngine.close();
+                    replayEngine.closeConnectionsAndShutdown();
                     // squash exceptions for individual requests
                     return StringTrackableCompletableFuture.completedFuture(null, () -> "finished all work");
                 }, () -> "TrafficReplayer.PacketHandlerFactory->stopGroup")
@@ -535,37 +609,46 @@ public class TrafficReplayer {
         }
     }
 
-    private static TransformedTargetRequestAndResponse
+    private TransformedTargetRequestAndResponse
     packageAndWriteResponse(Consumer<SourceTargetCaptureTuple> tupleWriter,
+                            UniqueRequestKey requestKey,
                             RequestResponsePacketPair rrPair,
                             TransformedTargetRequestAndResponse summary,
                             Throwable t) {
         log.trace("done sending and finalizing data to the packet handler");
 
-        try (var requestResponseTuple = getSourceTargetCaptureTuple(rrPair, summary, t)) {
+        try (var requestResponseTuple = getSourceTargetCaptureTuple(requestKey, rrPair, summary, t)) {
             log.atInfo().setMessage(()->"Source/Target Request/Response tuple: " + requestResponseTuple).log();
             tupleWriter.accept(requestResponseTuple);
         }
 
         if (t != null) { throw new CompletionException(t); }
-        if (summary.getError() != null) { throw new CompletionException(summary.getError()); }
-        if (summary.getTransformationStatus() == HttpRequestTransformationStatus.ERROR) {
-            throw new CompletionException(new RuntimeException("Unknown error transforming the request"));
+        if (summary.getError() != null) {
+            log.atInfo().setCause(summary.getError()).setMessage("Exception for request {}: ")
+                .addArgument(requestKey).log();
+            exceptionCount.incrementAndGet();
+        } else if (summary.getTransformationStatus() == HttpRequestTransformationStatus.ERROR) {
+            log.atInfo().setCause(summary.getError()).setMessage("Unknown error transforming the request {}: ")
+                    .addArgument(requestKey).log();
+            exceptionCount.incrementAndGet();
+        } else {
+            successCount.incrementAndGet();
         }
         return summary;
     }
 
-    private static SourceTargetCaptureTuple getSourceTargetCaptureTuple(RequestResponsePacketPair rrPair,
+    private static SourceTargetCaptureTuple getSourceTargetCaptureTuple(UniqueRequestKey uniqueRequestKey,
+                                                                        RequestResponsePacketPair rrPair,
                                                                         TransformedTargetRequestAndResponse summary,
                                                                         Throwable t) {
         SourceTargetCaptureTuple requestResponseTriple;
         if (t != null) {
             log.error("Got exception in CompletableFuture callback: ", t);
-            requestResponseTriple = new SourceTargetCaptureTuple(rrPair,
+            requestResponseTriple = new SourceTargetCaptureTuple(uniqueRequestKey, rrPair,
                     new TransformedPackets(), new ArrayList<>(),
                     HttpRequestTransformationStatus.ERROR, t, Duration.ZERO);
         } else {
-            requestResponseTriple = new SourceTargetCaptureTuple(rrPair,
+            requestResponseTriple = new SourceTargetCaptureTuple(uniqueRequestKey, rrPair,
                     summary.requestPackets,
                     summary.getReceiptTimeAndResponsePackets()
                             .map(entry -> entry.getValue()).collect(Collectors.toList()),
@@ -587,7 +670,7 @@ public class TrafficReplayer {
     public static DiagnosticTrackableCompletableFuture<String, TransformedTargetRequestAndResponse>
     transformAndSendRequest(PacketToTransformingHttpHandlerFactory inputRequestTransformerFactory,
                             ReplayEngine replayEngine,
-                            Instant start, Instant end,
+                            @NonNull Instant start, @NonNull Instant end,
                             UniqueRequestKey requestKey,
                             Supplier<Stream<byte[]>> packetsSupplier)
     {
@@ -642,33 +725,80 @@ public class TrafficReplayer {
         }
     }
 
+    public void stopReadingAsync() {
+        log.warn("TrafficReplayer is being signalled to stop reading new TrafficStraem objects");
+        stopReadingRef.set(true);
+        var nextChunkFutureRef = this.nextChunkFutureRef.get();
+        if (nextChunkFutureRef != null) {
+            nextChunkFutureRef.cancel(true);
+        }
+    }
+
+    public @NonNull CompletableFuture<Void> shutdown(Error error) {
+        log.warn("Shutting down "+this+" because of "+error);
+        if (!shutdownFutureRef.compareAndSet(null, new CompletableFuture<>())) {
+            log.atError().setMessage(()->"Shutdown was already signaled by {}.  " +
+                    "Ignoring this shutdown request due to {}.")
+                    .addArgument(shutdownReasonRef.get())
+                    .addArgument(error)
+                    .log();
+            return shutdownFutureRef.get();
+        }
+        stopReadingAsync();
+        shutdownReasonRef.compareAndSet(null, error);
+        clientConnectionPool.shutdownNow()
+                .addListener(f->{
+                    if (f.isSuccess()) {
+                        shutdownFutureRef.get().complete(null);
+                    } else {
+                        shutdownFutureRef.get().completeExceptionally(f.cause());
+                    }
+                });
+        var signalFuture = error == null ?
+                StringTrackableCompletableFuture.<Void>completedFuture(null, ()->"TrafficReplayer shutdown") :
+                StringTrackableCompletableFuture.<Void>failedFuture(error, ()->"TrafficReplayer shutdown");
+        while (!allRemainingWorkFutureRef.compareAndSet(null, signalFuture)) {
+            var otherRemainingWorkObj = allRemainingWorkFutureRef.get();
+            if (otherRemainingWorkObj != null) {
+                otherRemainingWorkObj.future.cancel(true);
+                break;
+            }
+        }
+        var rval = shutdownFutureRef.get();
+        log.atWarn().setMessage(()->"Shutdown procedure has finished").log();
+        return rval;
+    }
+
     public void pullCaptureFromSourceToAccumulator(
             ITrafficCaptureSource trafficChunkStream,
             CapturedTrafficToHttpTransactionAccumulator trafficToHttpTransactionAccumulator) {
-        try {
-            while (true) {
-                log.trace("Reading next chunk from TrafficStream supplier");
-                var trafficStreams = trafficChunkStream.readNextTrafficStreamChunk().get();
-                if (log.isInfoEnabled()) {
-                    Optional.of(trafficStreams.stream()
-                                    .map(ts->TrafficStreamUtils.summarizeTrafficStream(ts.getStream()))
-                                    .collect(Collectors.joining(";")))
-                            .filter(s->!s.isEmpty())
-                            .ifPresent(s->log.atInfo().log("TrafficStream Summary: {" + s + "}"));
+        while (true) {
+            log.trace("Reading next chunk from TrafficStream supplier");
+            this.nextChunkFutureRef.set(trafficChunkStream.readNextTrafficStreamChunk());
+            List<ITrafficStreamWithKey> trafficStreams = null;
+            if (stopReadingRef.get()) {
+                break;
+            }
+            try {
+                trafficStreams = this.nextChunkFutureRef.get().get();
+            } catch (InterruptedException | ExecutionException | CancellationException ex) {
+                if (ex.getCause() instanceof EOFException) {
+                    log.atWarn().setCause(ex.getCause()).setMessage("Got an EOF on the stream.  " +
+                            "Done reading traffic streams.").log();
+                    break;
+                } else {
+                    log.atWarn().setCause(ex).setMessage("Interrupted.  Done reading traffic streams.").log();
+                    throw new RuntimeException(ex);
                 }
-                trafficStreams.forEach(ts->trafficToHttpTransactionAccumulator.accept(ts));
             }
-        } catch (ExecutionException ee) {
-            if (ee.getCause() instanceof EOFException) {
-                log.atWarn().setCause(ee.getCause()).setMessage("Got an EOF on the stream.  " +
-                        "Done reading traffic streams.").log();
-            } else {
-                throw new RuntimeException(ee.getCause());
+            if (log.isInfoEnabled()) {
+                Optional.of(trafficStreams.stream()
+                                .map(ts -> TrafficStreamUtils.summarizeTrafficStream(ts.getStream()))
+                                .collect(Collectors.joining(";")))
+                        .filter(s -> !s.isEmpty())
+                        .ifPresent(s -> log.atInfo().log("TrafficStream Summary: {" + s + "}"));
             }
-        } catch (InterruptedException ex) {
-            log.atInfo().setCause(ex).setMessage("Interrupted.  Done reading traffic streams.").log();
-        } catch (Exception e) {
-            log.atError().setCause(e).log();
+            trafficStreams.forEach(ts->trafficToHttpTransactionAccumulator.accept(ts));
         }
     }
 }

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/NettyPacketToHttpConsumer.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/NettyPacketToHttpConsumer.java
@@ -21,7 +21,7 @@ import io.netty.handler.ssl.SslHandler;
 import lombok.extern.slf4j.Slf4j;
 import org.opensearch.migrations.coreutils.MetricsLogger;
 import org.opensearch.migrations.replay.AggregatedRawResponse;
-import org.opensearch.migrations.replay.datatypes.UniqueRequestKey;
+import org.opensearch.migrations.replay.datatypes.UniqueReplayerRequestKey;
 import org.opensearch.migrations.replay.netty.BacksideHttpWatcherHandler;
 import org.opensearch.migrations.replay.netty.BacksideSnifferHandler;
 import org.opensearch.migrations.replay.util.DiagnosticTrackableCompletableFuture;
@@ -51,15 +51,15 @@ public class NettyPacketToHttpConsumer implements IPacketFinalizingConsumer<Aggr
     private final Channel channel;
     AggregatedRawResponse.Builder responseBuilder;
     final String diagnosticLabel;
-    private UniqueRequestKey uniqueRequestKeyForMetricsLogging;
+    private UniqueReplayerRequestKey uniqueRequestKeyForMetricsLogging;
 
     public NettyPacketToHttpConsumer(NioEventLoopGroup eventLoopGroup, URI serverUri, SslContext sslContext,
-                                     String diagnosticLabel, UniqueRequestKey uniqueRequestKeyForMetricsLogging) {
+                                     String diagnosticLabel, UniqueReplayerRequestKey uniqueRequestKeyForMetricsLogging) {
         this(createClientConnection(eventLoopGroup, sslContext, serverUri, diagnosticLabel),
                 diagnosticLabel, uniqueRequestKeyForMetricsLogging);
     }
 
-    public NettyPacketToHttpConsumer(ChannelFuture clientConnection, String diagnosticLabel, UniqueRequestKey uniqueRequestKeyForMetricsLogging) {
+    public NettyPacketToHttpConsumer(ChannelFuture clientConnection, String diagnosticLabel, UniqueReplayerRequestKey uniqueRequestKeyForMetricsLogging) {
         this.diagnosticLabel = "[" + diagnosticLabel + "] ";
         this.uniqueRequestKeyForMetricsLogging = uniqueRequestKeyForMetricsLogging;
         responseBuilder = AggregatedRawResponse.builder(Instant.now());

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/http/HttpJsonTransformingConsumer.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/http/HttpJsonTransformingConsumer.java
@@ -9,7 +9,7 @@ import org.opensearch.migrations.replay.datatypes.HttpRequestTransformationStatu
 import org.opensearch.migrations.replay.datatypes.TransformedOutputAndResult;
 import org.opensearch.migrations.replay.Utils;
 import org.opensearch.migrations.replay.datahandlers.IPacketFinalizingConsumer;
-import org.opensearch.migrations.replay.datatypes.UniqueRequestKey;
+import org.opensearch.migrations.replay.datatypes.UniqueReplayerRequestKey;
 import org.opensearch.migrations.replay.util.DiagnosticTrackableCompletableFuture;
 import org.opensearch.migrations.replay.util.StringTrackableCompletableFuture;
 import org.opensearch.migrations.transform.IAuthTransformerFactory;
@@ -48,7 +48,7 @@ public class HttpJsonTransformingConsumer<R> implements IPacketFinalizingConsume
     private final EmbeddedChannel channel;
     private static final MetricsLogger metricsLogger = new MetricsLogger("HttpJsonTransformingConsumer");
     private String diagnosticLabel;
-    private UniqueRequestKey requestKeyForMetricsLogging;
+    private UniqueReplayerRequestKey requestKeyForMetricsLogging;
 
     /**
      * Roughly try to keep track of how big each data chunk was that came into the transformer.  These values
@@ -66,7 +66,7 @@ public class HttpJsonTransformingConsumer<R> implements IPacketFinalizingConsume
                                         IAuthTransformerFactory authTransformerFactory,
                                         IPacketFinalizingConsumer<R> transformedPacketReceiver,
                                         String diagnosticLabel,
-                                        UniqueRequestKey requestKeyForMetricsLogging) {
+                                        UniqueReplayerRequestKey requestKeyForMetricsLogging) {
         chunkSizes = new ArrayList<>(HTTP_MESSAGE_NUM_SEGMENTS);
         chunkSizes.add(new ArrayList<>(EXPECTED_PACKET_COUNT_GUESS_FOR_HEADERS));
         chunks = new ArrayList<>(HTTP_MESSAGE_NUM_SEGMENTS + EXPECTED_PACKET_COUNT_GUESS_FOR_HEADERS);

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/http/NettyDecodedHttpRequestPreliminaryConvertHandler.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/http/NettyDecodedHttpRequestPreliminaryConvertHandler.java
@@ -8,7 +8,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.opensearch.migrations.coreutils.MetricsLogger;
 import org.opensearch.migrations.replay.datahandlers.PayloadAccessFaultingMap;
 import org.opensearch.migrations.replay.datahandlers.PayloadNotLoadedException;
-import org.opensearch.migrations.replay.datatypes.UniqueRequestKey;
+import org.opensearch.migrations.replay.datatypes.UniqueReplayerRequestKey;
 import org.opensearch.migrations.transform.IAuthTransformer;
 import org.opensearch.migrations.transform.IJsonTransformer;
 
@@ -25,14 +25,14 @@ public class NettyDecodedHttpRequestPreliminaryConvertHandler extends ChannelInb
     final IJsonTransformer transformer;
     final List<List<Integer>> chunkSizes;
     final String diagnosticLabel;
-    private UniqueRequestKey requestKeyForMetricsLogging;
+    private UniqueReplayerRequestKey requestKeyForMetricsLogging;
     final static MetricsLogger metricsLogger = new MetricsLogger("NettyDecodedHttpRequestPreliminaryConvertHandler");
 
     public NettyDecodedHttpRequestPreliminaryConvertHandler(IJsonTransformer transformer,
                                                             List<List<Integer>> chunkSizes,
                                                             RequestPipelineOrchestrator requestPipelineOrchestrator,
                                                             String diagnosticLabel,
-                                                            UniqueRequestKey requestKeyForMetricsLogging) {
+                                                            UniqueReplayerRequestKey requestKeyForMetricsLogging) {
         this.transformer = transformer;
         this.chunkSizes = chunkSizes;
         this.requestPipelineOrchestrator = requestPipelineOrchestrator;

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/http/RequestPipelineOrchestrator.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/http/RequestPipelineOrchestrator.java
@@ -10,7 +10,7 @@ import io.netty.handler.logging.LoggingHandler;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.opensearch.migrations.replay.datahandlers.IPacketFinalizingConsumer;
-import org.opensearch.migrations.replay.datatypes.UniqueRequestKey;
+import org.opensearch.migrations.replay.datatypes.UniqueReplayerRequestKey;
 import org.opensearch.migrations.transform.IAuthTransformer;
 import org.opensearch.migrations.transform.IAuthTransformerFactory;
 import org.opensearch.migrations.transform.IJsonTransformer;
@@ -43,7 +43,7 @@ public class RequestPipelineOrchestrator<R> {
     private final List<List<Integer>> chunkSizes;
     final IPacketFinalizingConsumer<R> packetReceiver;
     final String diagnosticLabel;
-    private UniqueRequestKey requestKeyForMetricsLogging;
+    private UniqueReplayerRequestKey requestKeyForMetricsLogging;
     @Getter
     final IAuthTransformerFactory authTransfomerFactory;
 
@@ -51,7 +51,7 @@ public class RequestPipelineOrchestrator<R> {
                                        IPacketFinalizingConsumer<R> packetReceiver,
                                        IAuthTransformerFactory incomingAuthTransformerFactory,
                                        String diagnosticLabel,
-                                       UniqueRequestKey requestKeyForMetricsLogging) {
+                                       UniqueReplayerRequestKey requestKeyForMetricsLogging) {
         this.chunkSizes = chunkSizes;
         this.packetReceiver = packetReceiver;
         this.authTransfomerFactory = incomingAuthTransformerFactory != null ? incomingAuthTransformerFactory :

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datatypes/ConnectionReplaySession.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datatypes/ConnectionReplaySession.java
@@ -31,7 +31,7 @@ public class ConnectionReplaySession {
 
     @Getter
     @Setter
-    private UniqueRequestKey currentConnectionId;
+    private UniqueReplayerRequestKey currentConnectionId;
 
     public ConnectionReplaySession(EventLoop eventLoop) {
         this.eventLoop = eventLoop;

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datatypes/UniqueReplayerRequestKey.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datatypes/UniqueReplayerRequestKey.java
@@ -1,11 +1,11 @@
 package org.opensearch.migrations.replay.datatypes;
 
-public class UniqueRequestKey extends UniqueSourceRequestKey {
+public class UniqueReplayerRequestKey extends UniqueSourceRequestKey {
     public final ITrafficStreamKey trafficStreamKey;
     public final int sourceRequestIndexOffsetAtFirstObservation;
     public final int replayerRequestIndex;
 
-    public UniqueRequestKey(ITrafficStreamKey streamKey, int sourceOffset, int replayerIndex) {
+    public UniqueReplayerRequestKey(ITrafficStreamKey streamKey, int sourceOffset, int replayerIndex) {
         this.trafficStreamKey = streamKey;
         this.sourceRequestIndexOffsetAtFirstObservation = sourceOffset;
         this.replayerRequestIndex = replayerIndex;

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datatypes/UniqueRequestKey.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datatypes/UniqueRequestKey.java
@@ -1,6 +1,6 @@
 package org.opensearch.migrations.replay.datatypes;
 
-public class UniqueRequestKey {
+public class UniqueRequestKey extends UniqueSourceRequestKey {
     public final ITrafficStreamKey trafficStreamKey;
     public final int sourceRequestIndexOffsetAtFirstObservation;
     public final int replayerRequestIndex;
@@ -11,6 +11,12 @@ public class UniqueRequestKey {
         this.replayerRequestIndex = replayerIndex;
     }
 
+    @Override
+    public ITrafficStreamKey getTrafficStreamKey() {
+        return trafficStreamKey;
+    }
+
+    @Override
     public int getSourceRequestIndex() {
         return replayerRequestIndex + sourceRequestIndexOffsetAtFirstObservation;
     }
@@ -21,12 +27,21 @@ public class UniqueRequestKey {
 
     @Override
     public String toString() {
+        // The offset that is shown is a mouthful to describe.
+        // The thing that’s tricky is that these indices are stateful across different TrafficStreams.
+        // One part is stateful from the capture and the other part is stateful from the replayer.
+        // We’re piecing things back into sequence in the replayer, so each Observation (and request)
+        // may be from different TrafficStreams and therefore might have had a different starting index.
+        //
+        // So the idea with showing that index is to just give a hint about how far back the history of
+        // the current TrafficStreams go for this stretch of Observations.  This offset value is the
+        // value from the very first TrafficStream that was calculated when the very first Accumulation
+        // was being initialized.  The value itself is derived on that first observed TrafficStream as
+        // `stream.getPriorRequestsReceived()+(stream.hasLastObservationWasUnterminatedRead()?1:0)`
+        //
+        // That code currently resides in CapturedTrafficToHttpTransactionAccumulator.
         return trafficStreamKey + "." + getSourceRequestIndex() +
                 (sourceRequestIndexOffsetAtFirstObservation == 0 ? "" :
                         "(offset: "+sourceRequestIndexOffsetAtFirstObservation+")");
-    }
-
-    public ITrafficStreamKey getTrafficStreamKey() {
-        return trafficStreamKey;
     }
 }

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datatypes/UniqueSourceRequestKey.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datatypes/UniqueSourceRequestKey.java
@@ -1,0 +1,23 @@
+package org.opensearch.migrations.replay.datatypes;
+
+import com.google.common.base.Objects;
+
+public abstract class UniqueSourceRequestKey {
+    public abstract ITrafficStreamKey getTrafficStreamKey();
+
+    public abstract int getSourceRequestIndex();
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        UniqueSourceRequestKey that = (UniqueSourceRequestKey) o;
+        return getSourceRequestIndex() == that.getSourceRequestIndex() &&
+                Objects.equal(getTrafficStreamKey(), that.getTrafficStreamKey());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(getTrafficStreamKey(), getSourceRequestIndex());
+    }
+}

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/traffic/source/ISimpleTrafficCaptureSource.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/traffic/source/ISimpleTrafficCaptureSource.java
@@ -5,5 +5,4 @@ import org.opensearch.migrations.replay.datatypes.ITrafficStreamKey;
 import java.io.IOException;
 
 public interface ISimpleTrafficCaptureSource extends ITrafficCaptureSource {
-    void commitTrafficStream(ITrafficStreamKey trafficStreamKey) throws IOException;
 }

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/traffic/source/ITrafficCaptureSource.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/traffic/source/ITrafficCaptureSource.java
@@ -1,10 +1,17 @@
 package org.opensearch.migrations.replay.traffic.source;
 
+import org.opensearch.migrations.replay.datatypes.ITrafficStreamKey;
+
 import java.io.Closeable;
+import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 public interface ITrafficCaptureSource extends Closeable {
 
     CompletableFuture<List<ITrafficStreamWithKey>> readNextTrafficStreamChunk();
+
+    default void commitTrafficStream(ITrafficStreamKey trafficStreamKey) throws IOException {}
+
+    default void close() throws IOException {}
 }

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/ExhaustiveCapturedTrafficToHttpTransactionAccumulatorTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/ExhaustiveCapturedTrafficToHttpTransactionAccumulatorTest.java
@@ -33,7 +33,7 @@ public class ExhaustiveCapturedTrafficToHttpTransactionAccumulatorTest {
         var possibilitiesLeftToTest = TrafficStreamGenerator.getPossibleTests();
         var numTries = new AtomicInteger();
         StringJoiner seedsThatOfferUniqueTestCases = new StringJoiner(",");
-        var argsArray = TrafficStreamGenerator.generateAllIndicativeRandomTrafficStreamsAndSizes(seedStream)
+        var argsArray = TrafficStreamGenerator.generateRandomTrafficStreamsAndSizes(seedStream)
                 .takeWhile(c->!possibilitiesLeftToTest.isEmpty())
                 .filter(c->TrafficStreamGenerator.classifyTrafficStream(possibilitiesLeftToTest, c.trafficStreams) > 0)
                 .flatMap(c-> {

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/ExpiringTrafficStreamMapSequentialTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/ExpiringTrafficStreamMapSequentialTest.java
@@ -3,7 +3,6 @@ package org.opensearch.migrations.replay;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.opensearch.migrations.replay.datatypes.PojoTrafficStreamKey;
-import org.opensearch.migrations.replay.datatypes.UniqueRequestKey;
 import org.opensearch.migrations.replay.traffic.expiration.BehavioralPolicy;
 import org.opensearch.migrations.replay.traffic.expiration.ExpiringTrafficStreamMap;
 

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/ExpiringTrafficStreamMapSequentialTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/ExpiringTrafficStreamMapSequentialTest.java
@@ -35,11 +35,11 @@ class ExpiringTrafficStreamMapSequentialTest {
         for (int i=0; i<expectedExpirationCounts.length; ++i) {
             var ts = Instant.ofEpochSecond(i+1);
             var tsk = new PojoTrafficStreamKey(TEST_NODE_ID_STRING, connectionGenerator.apply(i), 0);
-            var accumulation = expiringMap.getOrCreateWithoutExpiration(tsk, k->new Accumulation(0));
+            var accumulation = expiringMap.getOrCreateWithoutExpiration(tsk, k->new Accumulation(tsk, 0));
             createdAccumulations.add(accumulation);
             expiringMap.expireOldEntries(new PojoTrafficStreamKey(TEST_NODE_ID_STRING, connectionGenerator.apply(i), 0),
                     accumulation, ts);
-            var rrPair = createdAccumulations.get(i).getOrCreateTransactionPair(tsk);
+            var rrPair = createdAccumulations.get(i).getOrCreateTransactionPair();
             rrPair.addResponseData(ts, ("Add"+i).getBytes(StandardCharsets.UTF_8));
             expiredCountsPerLoop.add(expiredAccumulations.size());
         }

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/ExpiringTrafficStreamMapUnorderedTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/ExpiringTrafficStreamMapUnorderedTest.java
@@ -38,11 +38,11 @@ class ExpiringTrafficStreamMapUnorderedTest {
         for (int i=0; i<expectedExpirationCounts.length; ++i) {
             var ts = Instant.ofEpochSecond(timestamps[i]);
             var tsk = new PojoTrafficStreamKey(TEST_NODE_ID_STRING, connectionGenerator.apply(i), 0);
-            var accumulation = expiringMap.getOrCreateWithoutExpiration(tsk, k->new Accumulation(0));
+            var accumulation = expiringMap.getOrCreateWithoutExpiration(tsk, k->new Accumulation(tsk, 0));
             expiringMap.expireOldEntries(new PojoTrafficStreamKey(TEST_NODE_ID_STRING, connectionGenerator.apply(i), 0), accumulation, ts);
             createdAccumulations.add(accumulation);
             if (accumulation != null) {
-                var rrPair = accumulation.getOrCreateTransactionPair(tsk);
+                var rrPair = accumulation.getOrCreateTransactionPair();
                 rrPair.addResponseData(ts, ("Add" + i).getBytes(StandardCharsets.UTF_8));
             }
             expiredCountsPerLoop.add(expiredAccumulations.size());

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/ExpiringTrafficStreamMapUnorderedTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/ExpiringTrafficStreamMapUnorderedTest.java
@@ -3,7 +3,6 @@ package org.opensearch.migrations.replay;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.opensearch.migrations.replay.datatypes.PojoTrafficStreamKey;
-import org.opensearch.migrations.replay.datatypes.UniqueRequestKey;
 import org.opensearch.migrations.replay.traffic.expiration.BehavioralPolicy;
 import org.opensearch.migrations.replay.traffic.expiration.ExpiringTrafficStreamMap;
 import org.opensearch.migrations.testutils.WrapWithNettyLeakDetection;

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/FullTrafficReplayerTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/FullTrafficReplayerTest.java
@@ -1,6 +1,9 @@
 package org.opensearch.migrations.replay;
 
 import com.google.common.collect.Streams;
+import io.vavr.Tuple2;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
@@ -11,12 +14,15 @@ import org.apache.kafka.clients.producer.ProducerRecord;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.opensearch.migrations.replay.datatypes.ITrafficStreamKey;
 import org.opensearch.migrations.replay.kafka.KafkaProtobufConsumer;
 import org.opensearch.migrations.replay.traffic.source.BlockingTrafficSource;
+import org.opensearch.migrations.replay.traffic.source.ISimpleTrafficCaptureSource;
 import org.opensearch.migrations.replay.traffic.source.ITrafficStreamWithKey;
 import org.opensearch.migrations.replay.traffic.source.TrafficStreamWithEmbeddedKey;
 import org.opensearch.migrations.testutils.SimpleNettyHttpServer;
 import org.opensearch.migrations.trafficcapture.protos.TrafficStream;
+import org.opensearch.migrations.trafficcapture.protos.TrafficStreamUtils;
 import org.opensearch.migrations.transform.StaticAuthTransformerFactory;
 import org.testcontainers.containers.KafkaContainer;
 import org.testcontainers.junit.jupiter.Container;
@@ -25,22 +31,29 @@ import org.testcontainers.shaded.org.apache.commons.io.output.NullOutputStream;
 import org.testcontainers.utility.DockerImageName;
 
 import java.io.BufferedOutputStream;
+import java.io.EOFException;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Optional;
+import java.util.PriorityQueue;
 import java.util.Properties;
 import java.util.Random;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
+import java.util.function.ToIntFunction;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 @Slf4j
-@Testcontainers
+//@Testcontainers
 //@WrapWithNettyLeakDetection(repetitions = 1)
 public class FullTrafficReplayerTest {
 
@@ -52,38 +65,89 @@ public class FullTrafficReplayerTest {
     public static final String TEST_TRAFFIC_STREAM_ID_STRING = "TEST_TRAFFIC_STREAM_ID_STRING";
     public static final int PRODUCER_SLEEP_INTERVAL_MS = 100;
     public static final Duration MAX_WAIT_TIME_FOR_TOPIC = Duration.ofMillis(PRODUCER_SLEEP_INTERVAL_MS*2);
+    public static final int INITIAL_STOP_REPLAYER_REQUEST_COUNT = 1;
 
+    @AllArgsConstructor
+    private static class FabricatedErrorToKillTheReplayer extends Error {
+        public final boolean doneWithTest;
+    }
 
     @Container
     // see https://docs.confluent.io/platform/current/installation/versions-interoperability.html#cp-and-apache-kafka-compatibility
-    private KafkaContainer embeddedKafkaBroker =
-            new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.5.0"));;
+    private KafkaContainer embeddedKafkaBroker;
+//             = new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.5.0"));;
 
-    //@Test
+    @Test
     @Tag("longTest")
     public void fullTest() throws Exception {
         Random r = new Random(1);
-        var kafkaConsumerProps = KafkaProtobufConsumer.buildKafkaProperties(embeddedKafkaBroker.getBootstrapServers(),
-                TEST_GROUP_CONSUMER_ID, false,  null);
-        kafkaConsumerProps.setProperty("max.poll.interval.ms", "300000");
-        var kafkaConsumer = new KafkaConsumer<String,byte[]>(kafkaConsumerProps);
+        var nextStopPointRef = new AtomicInteger(INITIAL_STOP_REPLAYER_REQUEST_COUNT);
 
-        var previouslyCompletelyHandledItems = new ConcurrentHashMap<String, SourceTargetCaptureTuple>();
         var httpServer = SimpleNettyHttpServer.makeServer(false, Duration.ofMillis(2),
                 TestHttpServerContext::makeResponse);
+        var streamAndConsumer = generateStreamAndTupleConsumerWithSomeChecks();
+        var onNewTupleReceived = streamAndConsumer._2;
+        var trafficSourceSupplier = loadStreamsToCursorArraySource(streamAndConsumer._1.collect(Collectors.toList()));
+
         Consumer<SourceTargetCaptureTuple> tupleReceiver = t -> {
-            var key = t.sourcePair.requestKey;
-            var keyString = key.trafficStreamKey + "_" + key.getSourceRequestIndex();
-            previouslyCompletelyHandledItems.put(keyString, t);
+            var stopPoint = nextStopPointRef.get();
+            if (onNewTupleReceived.applyAsInt(t) > stopPoint) {
+                var roughlyDoubled = stopPoint + new Random(stopPoint).nextInt(stopPoint+1);
+                if (nextStopPointRef.compareAndSet(stopPoint, roughlyDoubled)) {
+                    throw new FabricatedErrorToKillTheReplayer(false);
+                } else {
+                    // somebody else got to this, don't worry about it
+                }
+            }
         };
 
-        var testCases = TrafficStreamGenerator.generateAllIndicativeRandomTrafficStreamsAndSizes()
-                .toArray(TrafficStreamGenerator.RandomTrafficStreamAndTransactionSizes[]::new);
-        loadStreamsToKafka(kafkaConsumer,
-                randomlyIterleaveStreams(r, Arrays.stream(testCases).map(c-> Arrays.stream(c.trafficStreams))));
-        runTrafficReplayer(kafkaConsumer, httpServer, tupleReceiver);
+        for (AtomicInteger runNumberRef = new AtomicInteger(); true; runNumberRef.incrementAndGet()) {
+            int runNumber = runNumberRef.get();
+            try {
+                runTrafficReplayer(trafficSourceSupplier, httpServer, (t) -> {
+                    Assertions.assertEquals(runNumber, runNumberRef.get());
+                    tupleReceiver.accept(t);
+                });
+            } catch (FabricatedErrorToKillTheReplayer e) {
+                if (e.doneWithTest) {
+                    break;
+                } else {
+                    log.error("broke out of the replayer, but the doneWithTest flag was false");
+                }
+            }
+        }
+
         //Assertions.assertEquals();
         log.error("done");
+    }
+
+    private Tuple2<Stream<TrafficStream>, ToIntFunction<SourceTargetCaptureTuple>>
+    generateStreamAndTupleConsumerWithSomeChecks() {
+        return generateStreamAndTupleConsumerWithSomeChecks(-1);
+    }
+
+    private Tuple2<Stream<TrafficStream>, ToIntFunction<SourceTargetCaptureTuple>>
+    generateStreamAndTupleConsumerWithSomeChecks(int count) {
+        Random r = new Random(1);
+        var generatedCases = count > 0 ?
+                TrafficStreamGenerator.generateRandomTrafficStreamsAndSizes(IntStream.range(0,count)) :
+                TrafficStreamGenerator.generateAllIndicativeRandomTrafficStreamsAndSizes();
+        var testCaseArr = generatedCases.toArray(TrafficStreamGenerator.RandomTrafficStreamAndTransactionSizes[]::new);
+        var shuffledStreams =
+                randomlyInterleaveStreams(r, Arrays.stream(testCaseArr).map(c->Arrays.stream(c.trafficStreams)));
+        var numExpectedRequests = Arrays.stream(testCaseArr).mapToInt(c->c.requestByteSizes.length).sum();
+
+        var previouslyCompletelyHandledItems = new ConcurrentHashMap<String, SourceTargetCaptureTuple>();
+        return new Tuple2<>(shuffledStreams, t -> {
+            var key = t.uniqueRequestKey;
+            var keyString = key.getTrafficStreamKey() + "_" + key.getSourceRequestIndex();
+            previouslyCompletelyHandledItems.put(keyString, t);
+            var newSize = previouslyCompletelyHandledItems.size();
+            if (newSize >= numExpectedRequests) {
+                throw new FabricatedErrorToKillTheReplayer(true);
+            }
+            return newSize;
+        });
     }
 
     private <R extends AutoCloseable> void
@@ -101,7 +165,7 @@ public class FullTrafficReplayerTest {
         }
     }
 
-    public static <T> Stream<T> randomlyIterleaveStreams(Random r, Stream<Stream<T>> orderedItemStreams) {
+    public static <T> Stream<T> randomlyInterleaveStreams(Random r, Stream<Stream<T>> orderedItemStreams) {
         List<Iterator<T>> iteratorList = orderedItemStreams
                 .map(Stream::iterator)
                 .filter(it->it.hasNext())
@@ -145,17 +209,87 @@ public class FullTrafficReplayerTest {
         }
     }
 
-    private void loadStreamsToKafka(KafkaConsumer<String, byte[]> kafkaConsumer,
-                                    Stream<TrafficStream> streams) throws Exception {
+    @Getter
+    private static class TrafficStreamCursorKey implements ITrafficStreamKey, Comparable<TrafficStreamCursorKey> {
+        public final String connectionId;
+        public final String nodeId;
+        public final int trafficStreamIndex;
+
+        public final int sourceListIndex;
+
+        public TrafficStreamCursorKey(TrafficStream stream, int sourceListIndex) {
+            connectionId = stream.getConnectionId();
+            nodeId = stream.getNodeId();
+            trafficStreamIndex = TrafficStreamUtils.getTrafficStreamIndex(stream);
+            this.sourceListIndex = this.getSourceListIndex();
+        }
+
+        @Override
+        public int compareTo(TrafficStreamCursorKey other) {
+            return Integer.compare(sourceListIndex, other.sourceListIndex);
+        }
+    }
+
+    @AllArgsConstructor
+    @Getter
+    private static class PojoTrafficStreamWithKey implements ITrafficStreamWithKey {
+        TrafficStream stream;
+        ITrafficStreamKey key;
+    }
+
+    private Supplier<ISimpleTrafficCaptureSource> loadStreamsToCursorArraySource(List<TrafficStream> streams) {
+        var commitCursor = new AtomicInteger(-1);
+
+        return () -> new ISimpleTrafficCaptureSource() {
+            AtomicInteger readCursor = new AtomicInteger(commitCursor.get()+1);
+            PriorityQueue<TrafficStreamCursorKey> pQueue = new PriorityQueue<>();
+
+            @Override
+            public CompletableFuture<List<ITrafficStreamWithKey>> readNextTrafficStreamChunk() {
+                var idx = readCursor.getAndIncrement();
+                if (streams.size() <= idx) {
+                    return CompletableFuture.failedFuture(new EOFException());
+                }
+                var stream = streams.get(idx);
+                var key = new TrafficStreamCursorKey(stream, idx);
+                pQueue.add(key);
+                return CompletableFuture.supplyAsync(()->List.of(new PojoTrafficStreamWithKey(stream, key)));
+            }
+
+            @Override
+            public void commitTrafficStream(ITrafficStreamKey trafficStreamKey) {
+                synchronized (readCursor) { // figure out if I need to do something faster later
+                    int topCursor = pQueue.peek().sourceListIndex;
+                    var didRemove = pQueue.remove(trafficStreamKey);
+                    assert didRemove;
+                    var incomingCursor = trafficStreamKey.getTrafficStreamIndex();
+                    if (topCursor == incomingCursor) {
+                        topCursor = Optional.ofNullable(pQueue.peek()).map(k->k.getSourceListIndex()).orElse(topCursor);
+                        commitCursor.set(topCursor);
+                    }
+                }
+            }
+        };
+    }
+
+    private Supplier<ISimpleTrafficCaptureSource> loadStreamsToKafka(Stream<TrafficStream> streams) throws Exception {
+        var kafkaConsumerProps = KafkaProtobufConsumer.buildKafkaProperties(embeddedKafkaBroker.getBootstrapServers(),
+                TEST_GROUP_CONSUMER_ID, false,  null);
+        kafkaConsumerProps.setProperty("max.poll.interval.ms", "300000");
+        var kafkaConsumer = new KafkaConsumer<String,byte[]>(kafkaConsumerProps);
+
         var kafkaProducer = buildKafkaProducer();
         var counter = new AtomicInteger();
         loadStreamsAsynchronouslyWithResource(kafkaConsumer, streams, s->s.forEach(trafficStream ->
             writeTrafficStreamRecord(kafkaProducer, new TrafficStreamWithEmbeddedKey(trafficStream),
                     "KEY_" + counter.incrementAndGet())));
+
+        return () -> new KafkaProtobufConsumer(kafkaConsumer, TEST_TOPIC_NAME, null);
     }
 
-    private void loadStreamsToKafkaFromCompressedFile(KafkaConsumer<String, byte[]> kafkaConsumer,
-                                                     String filename, int recordCount) throws Exception {
+    private Supplier<ISimpleTrafficCaptureSource>
+    loadStreamsToKafkaFromCompressedFile(KafkaConsumer<String, byte[]> kafkaConsumer,
+                                         String filename, int recordCount) throws Exception {
         var kafkaProducer = buildKafkaProducer();
         loadStreamsAsynchronouslyWithResource(kafkaConsumer, new V0_1TrafficCaptureSource(filename),
                 originalTrafficSource -> {
@@ -171,6 +305,7 @@ public class FullTrafficReplayerTest {
                         throw new RuntimeException(e);
                     }
                 });
+        return () -> new KafkaProtobufConsumer(kafkaConsumer, TEST_TOPIC_NAME, null);
     }
 
     @SneakyThrows
@@ -183,9 +318,10 @@ public class FullTrafficReplayerTest {
         Thread.sleep(PRODUCER_SLEEP_INTERVAL_MS);
     }
 
-    private static void runTrafficReplayer(KafkaConsumer<String, byte[]> kafkaConsumer,
+    private static void runTrafficReplayer(Supplier<ISimpleTrafficCaptureSource> captureSourceSupplier,
                                            SimpleNettyHttpServer httpServer,
                                            Consumer<SourceTargetCaptureTuple> tupleReceiver) throws Exception {
+        log.info("Starting a new replayer and running it");
         var tr = new TrafficReplayer(httpServer.localhostEndpoint(),
                 new StaticAuthTransformerFactory("TEST"),
                 true, 10, 10*1024,
@@ -193,13 +329,13 @@ public class FullTrafficReplayerTest {
 
         try (var os = new NullOutputStream();
              var bos = new BufferedOutputStream(os);
-             var trafficSource = new KafkaProtobufConsumer(kafkaConsumer, TEST_TOPIC_NAME, null);
+             var trafficSource = captureSourceSupplier.get();
              var blockingTrafficSource = new BlockingTrafficSource(trafficSource, Duration.ofMinutes(2))) {
             tr.runReplayWithIOStreams(Duration.ofSeconds(70), blockingTrafficSource, bos,
                     new TimeShifter(10 * 1000), tupleReceiver);
         } catch (Exception e) {
             log.atError().setCause(e).setMessage(() -> "eating exception to check for memory leaks.").log();
-            throw e;
+            throw new RuntimeException(e);
         }
     }
 }

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/SimpleCapturedTrafficToHttpTransactionAccumulatorTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/SimpleCapturedTrafficToHttpTransactionAccumulatorTest.java
@@ -11,7 +11,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.opensearch.migrations.replay.datatypes.ITrafficStreamKey;
 import org.opensearch.migrations.replay.datatypes.RawPackets;
-import org.opensearch.migrations.replay.datatypes.UniqueRequestKey;
+import org.opensearch.migrations.replay.datatypes.UniqueReplayerRequestKey;
 import org.opensearch.migrations.replay.traffic.source.TrafficStreamWithEmbeddedKey;
 import org.opensearch.migrations.trafficcapture.IChannelConnectionCaptureSerializer;
 import org.opensearch.migrations.trafficcapture.InMemoryConnectionCaptureFactory;
@@ -188,12 +188,12 @@ public class SimpleCapturedTrafficToHttpTransactionAccumulatorTest {
                 new CapturedTrafficToHttpTransactionAccumulator(Duration.ofSeconds(30), null,
                         new AccumulationCallbacks() {
                             @Override
-                            public void onRequestReceived(UniqueRequestKey key, HttpMessageAndTimestamp request) {
+                            public void onRequestReceived(UniqueReplayerRequestKey key, HttpMessageAndTimestamp request) {
                                 requestsReceived.incrementAndGet();
                             }
 
                             @Override
-                            public void onFullDataReceived(UniqueRequestKey requestKey, RequestResponsePacketPair fullPair) {
+                            public void onFullDataReceived(UniqueReplayerRequestKey requestKey, RequestResponsePacketPair fullPair) {
                                 var sourceIdx = requestKey.getSourceRequestIndex();
                                 if (fullPair.completionStatus ==
                                         RequestResponsePacketPair.ReconstructionStatus.ClosedPrematurely) {
@@ -216,7 +216,7 @@ public class SimpleCapturedTrafficToHttpTransactionAccumulatorTest {
                                                                 List<ITrafficStreamKey> trafficStreamKeysBeingHeld) {}
 
                             @Override
-                            public void onConnectionClose(UniqueRequestKey key, Instant when) {}
+                            public void onConnectionClose(UniqueReplayerRequestKey key, Instant when) {}
                         });
         var tsList = trafficStreams.collect(Collectors.toList());
         trafficStreams = tsList.stream();

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/SimpleCapturedTrafficToHttpTransactionAccumulatorTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/SimpleCapturedTrafficToHttpTransactionAccumulatorTest.java
@@ -9,12 +9,12 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.opensearch.migrations.replay.datatypes.ITrafficStreamKey;
 import org.opensearch.migrations.replay.datatypes.RawPackets;
 import org.opensearch.migrations.replay.datatypes.UniqueRequestKey;
 import org.opensearch.migrations.replay.traffic.source.TrafficStreamWithEmbeddedKey;
 import org.opensearch.migrations.trafficcapture.IChannelConnectionCaptureSerializer;
 import org.opensearch.migrations.trafficcapture.InMemoryConnectionCaptureFactory;
-import org.opensearch.migrations.trafficcapture.protos.TrafficObservation;
 import org.opensearch.migrations.trafficcapture.protos.TrafficStream;
 
 import java.io.IOException;
@@ -22,16 +22,10 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Random;
-import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
@@ -95,10 +89,11 @@ public class SimpleCapturedTrafficToHttpTransactionAccumulatorTest {
         return bb;
     }
 
+    static AtomicInteger uniqueIdCounter = new AtomicInteger();
     static TrafficStream[] makeTrafficStreams(int bufferSize, int interactionOffset,
                                              List<ObservationDirective> directives) throws Exception {
         var connectionFactory = buildSerializerFactory(bufferSize, ()->{});
-        var offloader = connectionFactory.createOffloader("TEST_CONNECTION_ID");
+        var offloader = connectionFactory.createOffloader("TEST_"+uniqueIdCounter.incrementAndGet());
         for (var directive : directives) {
             serializeEvent(offloader, interactionOffset++, directive);
         }
@@ -191,26 +186,38 @@ public class SimpleCapturedTrafficToHttpTransactionAccumulatorTest {
         var tsIndicesReceived = new TreeSet<Integer>();
         CapturedTrafficToHttpTransactionAccumulator trafficAccumulator =
                 new CapturedTrafficToHttpTransactionAccumulator(Duration.ofSeconds(30), null,
-                        (id,request) -> requestsReceived.incrementAndGet(),
-                        fullPair -> {
-                            var sourceIdx = fullPair.requestKey.getSourceRequestIndex();
-                            if (fullPair.completionStatus ==
-                                    RequestResponsePacketPair.ReconstructionStatus.ClosedPrematurely) {
-                                return;
+                        new AccumulationCallbacks() {
+                            @Override
+                            public void onRequestReceived(UniqueRequestKey key, HttpMessageAndTimestamp request) {
+                                requestsReceived.incrementAndGet();
                             }
-                            fullPair.getTrafficStreamsHeld().stream()
-                                    .forEach(tsk -> tsIndicesReceived.add(tsk.getTrafficStreamIndex()));
-                            if (aggregations.size() > sourceIdx) {
-                                var oldVal = aggregations.set(sourceIdx, fullPair);
-                                if (oldVal != null) {
-                                    Assertions.assertEquals(oldVal, fullPair);
+
+                            @Override
+                            public void onFullDataReceived(UniqueRequestKey requestKey, RequestResponsePacketPair fullPair) {
+                                var sourceIdx = requestKey.getSourceRequestIndex();
+                                if (fullPair.completionStatus ==
+                                        RequestResponsePacketPair.ReconstructionStatus.ClosedPrematurely) {
+                                    return;
                                 }
-                            } else{
-                                aggregations.add(fullPair);
+                                fullPair.getTrafficStreamsHeld().stream()
+                                        .forEach(tsk -> tsIndicesReceived.add(tsk.getTrafficStreamIndex()));
+                                if (aggregations.size() > sourceIdx) {
+                                    var oldVal = aggregations.set(sourceIdx, fullPair);
+                                    if (oldVal != null) {
+                                        Assertions.assertEquals(oldVal, fullPair);
+                                    }
+                                } else{
+                                    aggregations.add(fullPair);
+                                }
                             }
-                        },
-                        (rk,timestamp) -> {}
-                );
+
+                            @Override
+                            public void onTrafficStreamsExpired(RequestResponsePacketPair.ReconstructionStatus status,
+                                                                List<ITrafficStreamKey> trafficStreamKeysBeingHeld) {}
+
+                            @Override
+                            public void onConnectionClose(UniqueRequestKey key, Instant when) {}
+                        });
         var tsList = trafficStreams.collect(Collectors.toList());
         trafficStreams = tsList.stream();
         trafficStreams.forEach(ts->trafficAccumulator.accept(new TrafficStreamWithEmbeddedKey(ts)));

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/TestRequestKey.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/TestRequestKey.java
@@ -1,11 +1,11 @@
 package org.opensearch.migrations.replay;
 
 import org.opensearch.migrations.replay.datatypes.PojoTrafficStreamKey;
-import org.opensearch.migrations.replay.datatypes.UniqueRequestKey;
+import org.opensearch.migrations.replay.datatypes.UniqueReplayerRequestKey;
 
 public class TestRequestKey {
-    public final static UniqueRequestKey getTestConnectionRequestId(int replayerIdx) {
-        return new UniqueRequestKey(
+    public final static UniqueReplayerRequestKey getTestConnectionRequestId(int replayerIdx) {
+        return new UniqueReplayerRequestKey(
                 new PojoTrafficStreamKey("testNodeId", "testConnectionId", 0),
                 0, replayerIdx);
     }

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/TrafficReplayerTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/TrafficReplayerTest.java
@@ -6,7 +6,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.opensearch.migrations.replay.datatypes.ITrafficStreamKey;
-import org.opensearch.migrations.replay.datatypes.UniqueRequestKey;
+import org.opensearch.migrations.replay.datatypes.UniqueReplayerRequestKey;
 import org.opensearch.migrations.replay.traffic.source.InputStreamOfTraffic;
 import org.opensearch.migrations.testutils.WrapWithNettyLeakDetection;
 import org.opensearch.migrations.trafficcapture.protos.CloseObservation;
@@ -153,14 +153,14 @@ class TrafficReplayerTest {
                 new CapturedTrafficToHttpTransactionAccumulator(Duration.ofSeconds(30), null,
                         new AccumulationCallbacks() {
                             @Override
-                            public void onRequestReceived(UniqueRequestKey id, HttpMessageAndTimestamp request) {
+                            public void onRequestReceived(UniqueReplayerRequestKey id, HttpMessageAndTimestamp request) {
                                 var bytesList = request.stream().collect(Collectors.toList());
                                 byteArrays.add(bytesList);
                                 Assertions.assertEquals(FAKE_READ_PACKET_DATA, collectBytesToUtf8String(bytesList));
                             }
 
                             @Override
-                            public void onFullDataReceived(UniqueRequestKey key, RequestResponsePacketPair fullPair) {
+                            public void onFullDataReceived(UniqueReplayerRequestKey key, RequestResponsePacketPair fullPair) {
                                 var responseBytes = fullPair.responseData.packetBytes.stream().collect(Collectors.toList());
                                 Assertions.assertEquals(FAKE_READ_PACKET_DATA, collectBytesToUtf8String(responseBytes));
                             }
@@ -170,7 +170,7 @@ class TrafficReplayerTest {
                                                                 List<ITrafficStreamKey> trafficStreamKeysBeingHeld) {}
 
                             @Override
-                            public void onConnectionClose(UniqueRequestKey key, Instant when) {}
+                            public void onConnectionClose(UniqueReplayerRequestKey key, Instant when) {}
                         });
         var bytes = synthesizeTrafficStreamsIntoByteArray(Instant.now(), 1);
 
@@ -194,14 +194,14 @@ class TrafficReplayerTest {
                                 "CapturedTrafficToHttpTransactionAccumulator that's being used in this unit test!",
                         new AccumulationCallbacks() {
                             @Override
-                            public void onRequestReceived(UniqueRequestKey id, HttpMessageAndTimestamp request) {
+                            public void onRequestReceived(UniqueReplayerRequestKey id, HttpMessageAndTimestamp request) {
                                 var bytesList = request.stream().collect(Collectors.toList());
                                 byteArrays.add(bytesList);
                                 Assertions.assertEquals(FAKE_READ_PACKET_DATA, collectBytesToUtf8String(bytesList));
                             }
 
                             @Override
-                            public void onFullDataReceived(UniqueRequestKey key, RequestResponsePacketPair fullPair) {
+                            public void onFullDataReceived(UniqueReplayerRequestKey key, RequestResponsePacketPair fullPair) {
                                 var responseBytes = fullPair.responseData.packetBytes.stream().collect(Collectors.toList());
                                 Assertions.assertEquals(FAKE_READ_PACKET_DATA, collectBytesToUtf8String(responseBytes));
                             }
@@ -211,7 +211,7 @@ class TrafficReplayerTest {
                                                                 List<ITrafficStreamKey> trafficStreamKeysBeingHeld) {}
 
                             @Override
-                            public void onConnectionClose(UniqueRequestKey key, Instant when) {}
+                            public void onConnectionClose(UniqueReplayerRequestKey key, Instant when) {}
                         }
                 );
         byte[] serializedChunks;

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/TrafficReplayerTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/TrafficReplayerTest.java
@@ -5,6 +5,8 @@ import com.google.protobuf.Timestamp;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.opensearch.migrations.replay.datatypes.ITrafficStreamKey;
+import org.opensearch.migrations.replay.datatypes.UniqueRequestKey;
 import org.opensearch.migrations.replay.traffic.source.InputStreamOfTraffic;
 import org.opensearch.migrations.testutils.WrapWithNettyLeakDetection;
 import org.opensearch.migrations.trafficcapture.protos.CloseObservation;
@@ -149,17 +151,27 @@ class TrafficReplayerTest {
         List<List<byte[]>> byteArrays = new ArrayList<>();
         CapturedTrafficToHttpTransactionAccumulator trafficAccumulator =
                 new CapturedTrafficToHttpTransactionAccumulator(Duration.ofSeconds(30), null,
-                        (id,request) -> {
-                            var bytesList = request.stream().collect(Collectors.toList());
-                            byteArrays.add(bytesList);
-                            Assertions.assertEquals(FAKE_READ_PACKET_DATA, collectBytesToUtf8String(bytesList));
-                        },
-                        fullPair -> {
-                            var responseBytes = fullPair.responseData.packetBytes.stream().collect(Collectors.toList());
-                            Assertions.assertEquals(FAKE_READ_PACKET_DATA, collectBytesToUtf8String(responseBytes));
-                        },
-                        (rk,ts) -> {}
-                );
+                        new AccumulationCallbacks() {
+                            @Override
+                            public void onRequestReceived(UniqueRequestKey id, HttpMessageAndTimestamp request) {
+                                var bytesList = request.stream().collect(Collectors.toList());
+                                byteArrays.add(bytesList);
+                                Assertions.assertEquals(FAKE_READ_PACKET_DATA, collectBytesToUtf8String(bytesList));
+                            }
+
+                            @Override
+                            public void onFullDataReceived(UniqueRequestKey key, RequestResponsePacketPair fullPair) {
+                                var responseBytes = fullPair.responseData.packetBytes.stream().collect(Collectors.toList());
+                                Assertions.assertEquals(FAKE_READ_PACKET_DATA, collectBytesToUtf8String(responseBytes));
+                            }
+
+                            @Override
+                            public void onTrafficStreamsExpired(RequestResponsePacketPair.ReconstructionStatus status,
+                                                                List<ITrafficStreamKey> trafficStreamKeysBeingHeld) {}
+
+                            @Override
+                            public void onConnectionClose(UniqueRequestKey key, Instant when) {}
+                        });
         var bytes = synthesizeTrafficStreamsIntoByteArray(Instant.now(), 1);
 
         try (var bais = new ByteArrayInputStream(bytes)) {
@@ -180,16 +192,27 @@ class TrafficReplayerTest {
                 new CapturedTrafficToHttpTransactionAccumulator(Duration.ofSeconds(30),
                         "change the minTimeout argument to the c'tor of " +
                                 "CapturedTrafficToHttpTransactionAccumulator that's being used in this unit test!",
-                        (id,request) -> {
-                            var bytesList = request.stream().collect(Collectors.toList());
-                            byteArrays.add(bytesList);
-                            Assertions.assertEquals(FAKE_READ_PACKET_DATA, collectBytesToUtf8String(bytesList));
-                        },
-                        fullPair -> {
-                            var responseBytes = fullPair.responseData.packetBytes.stream().collect(Collectors.toList());
-                            Assertions.assertEquals(FAKE_READ_PACKET_DATA, collectBytesToUtf8String(responseBytes));
-                        },
-                        (rk,ts) -> {}
+                        new AccumulationCallbacks() {
+                            @Override
+                            public void onRequestReceived(UniqueRequestKey id, HttpMessageAndTimestamp request) {
+                                var bytesList = request.stream().collect(Collectors.toList());
+                                byteArrays.add(bytesList);
+                                Assertions.assertEquals(FAKE_READ_PACKET_DATA, collectBytesToUtf8String(bytesList));
+                            }
+
+                            @Override
+                            public void onFullDataReceived(UniqueRequestKey key, RequestResponsePacketPair fullPair) {
+                                var responseBytes = fullPair.responseData.packetBytes.stream().collect(Collectors.toList());
+                                Assertions.assertEquals(FAKE_READ_PACKET_DATA, collectBytesToUtf8String(responseBytes));
+                            }
+
+                            @Override
+                            public void onTrafficStreamsExpired(RequestResponsePacketPair.ReconstructionStatus status,
+                                                                List<ITrafficStreamKey> trafficStreamKeysBeingHeld) {}
+
+                            @Override
+                            public void onConnectionClose(UniqueRequestKey key, Instant when) {}
+                        }
                 );
         byte[] serializedChunks;
         try (var baos = new ByteArrayOutputStream()) {

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/TrafficStreamGenerator.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/TrafficStreamGenerator.java
@@ -239,7 +239,7 @@ public class TrafficStreamGenerator {
     }
 
     public static Stream<RandomTrafficStreamAndTransactionSizes>
-    generateAllIndicativeRandomTrafficStreamsAndSizes(IntStream seedStream) {
+    generateRandomTrafficStreamsAndSizes(IntStream seedStream) {
         return seedStream.mapToObj(rSeed->{
             var commands = new ArrayList<SimpleCapturedTrafficToHttpTransactionAccumulatorTest.ObservationDirective>();
             var sizes = new ArrayList<Integer>();
@@ -252,7 +252,7 @@ public class TrafficStreamGenerator {
     }
 
     public static Stream<RandomTrafficStreamAndTransactionSizes> generateAllIndicativeRandomTrafficStreamsAndSizes() {
-        return generateAllIndicativeRandomTrafficStreamsAndSizes(
+        return generateRandomTrafficStreamsAndSizes(
                 RANDOM_GENERATOR_SEEDS_FOR_SUFFICIENT_TRAFFIC_VARIANCE.stream().mapToInt(i->i));
     }
 }

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/datahandlers/NettyPacketToHttpConsumerTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/datahandlers/NettyPacketToHttpConsumerTest.java
@@ -19,7 +19,7 @@ import org.opensearch.migrations.replay.TestRequestKey;
 import org.opensearch.migrations.replay.TimeShifter;
 import org.opensearch.migrations.replay.TrafficReplayer;
 import org.opensearch.migrations.replay.datatypes.PojoTrafficStreamKey;
-import org.opensearch.migrations.replay.datatypes.UniqueRequestKey;
+import org.opensearch.migrations.replay.datatypes.UniqueReplayerRequestKey;
 import org.opensearch.migrations.replay.traffic.source.BufferedFlowController;
 import org.opensearch.migrations.testutils.HttpFirstLine;
 import org.opensearch.migrations.testutils.PortFinder;
@@ -163,7 +163,7 @@ class NettyPacketToHttpConsumerTest {
                 var trafficStreamKey = new PojoTrafficStreamKey("testNodeId", connId, 0);
                 var requestFinishFuture = TrafficReplayer.transformAndSendRequest(transformingHttpHandlerFactory,
                         sendingFactory, Instant.now(), Instant.now(),
-                        new UniqueRequestKey(trafficStreamKey, 0, i),
+                        new UniqueReplayerRequestKey(trafficStreamKey, 0, i),
                         ()->Stream.of(EXPECTED_REQUEST_STRING.getBytes(StandardCharsets.UTF_8)));
                 log.info("requestFinishFuture="+requestFinishFuture);
                 var aggregatedResponse = requestFinishFuture.get();

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/datahandlers/NettyPacketToHttpConsumerTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/datahandlers/NettyPacketToHttpConsumerTest.java
@@ -177,7 +177,7 @@ class NettyPacketToHttpConsumerTest {
                         normalizeMessage(responseAsString));
             }
         }
-        var stopFuture = sendingFactory.close();
+        var stopFuture = sendingFactory.closeConnectionsAndShutdown();
         log.info("waiting for factory to shutdown: " + stopFuture);
         stopFuture.get();
         Assertions.assertEquals(2, sendingFactory.getNumConnectionsCreated());


### PR DESCRIPTION
### Description

From the commit message:

Continue work on making the replayer more reliable to the point where each TrafficStream is being committed after it's been fully processed.
Along the way, partially to build up the tools for testing that behavior, partially because other bugs were discovered along the way, a number of bugfixes, enhancements, and refactorings continue to pile up.

Accumulations now track the TrafficKey instead of the RequestResponsePair. There are moments (since the past couple commits) where the rrPair field may be null and we might not have access to the trafficStreamKey. This change was made a bit easier since I've also refactored the CapturedTrafficToHttpTransactionAccumulator to take in a help object of callbacks rather than 3 callbacks. It's actually now 4 callbacks because of a new one that will be required for commits of TrafficStreams that are expired that won't be flushed. Accumulations no longer reset the last timestamp that came in. Doing that means that we can use the same value within fireAccumulationsCallbacksAndClose, which was using a value from rrPair, but as mentioned, that could be null under the newer processing model.

In addition to that, there's a notion of shutdown within the TrafficReplayer. A number of additional Atomic fields were added. These are most valuable at the moment from test code so that I can tear a TrafficReplayer down and bring a subsequent one up with a totally fresh state EXCEPT for my tupleReceiver callback (which has also been newly refactored). That structure will allow me to verify that the commit points that we've reached were accurate and that the flow of "at least once" message delivery is present for all requests. That last part isn't being verified yet, but the test should complete after shutting down a series of TrafficReplayers. There ARE assertions in place to make sure that old replayer signals (calls to the callback) aren't happening after we've torn down an old TrafficReplayer and created a new one.

To support shutdowns, a number of minor changes were made. The policy is to basically shed work as fast/abruptly as possible, with the idea being that we'll just rerun requests a second time through. Also to support the new unit test, Error (as in Throwable) handling is cleaner now. OOMErrors and other Errors should now trigger a shutdown of the replayer and cause a quick exit. This is being tested by the FullReplayerTest as it shuts down TrafficReplayers by throwing an Error, so I get to test two features in one test.


* Category Enhancement, New feature, Bug fix, Refactoring
* Why these changes are required? To make the replayer more reliable
* What is the old behavior before changes and new behavior after changes? More messages were dropped, more deadlock in the case of throw Errors.

### Issues Resolved
https://opensearch.atlassian.net/browse/MIGRATIONS-1384
https://opensearch.atlassian.net/browse/MIGRATIONS-1388
https://opensearch.atlassian.net/browse/MIGRATIONS-1392

### Testing
`./gradlew allTests` and `./gradlew :dockerSolution:composeUp`... + an OSB 4 dataset test run from the console container (all docs migrated)

### Check List
- [x] New functionality includes testing
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
