### PR TITLE
Linting Round 2 - Flip the interrupt status back on in many places where InterruptedExceptions are handled

### DIFF
--- a/TrafficCapture/trafficCaptureProxyServer/src/main/java/org/opensearch/migrations/trafficcapture/proxyserver/CaptureProxy.java
+++ b/TrafficCapture/trafficCaptureProxyServer/src/main/java/org/opensearch/migrations/trafficcapture/proxyserver/CaptureProxy.java
@@ -303,8 +303,8 @@ public class CaptureProxy {
                 proxy.stop();
                 System.err.println("Done stopping the proxy.");
             } catch (InterruptedException e) {
-                System.err.println("Caught exception while shutting down: "+e);
-                throw new RuntimeException(e);
+                System.err.println("Caught InterruptedException while shutting down, resetting interrupt status: "+e);
+                Thread.currentThread().interrupt();
             }
         }));
         // This loop just gives the main() function something to do while the netty event loops

--- a/TrafficCapture/trafficCaptureProxyServer/src/test/java/org/opensearch/migrations/trafficcapture/proxyserver/netty/ExpiringSubstitutableItemPoolTest.java
+++ b/TrafficCapture/trafficCaptureProxyServer/src/test/java/org/opensearch/migrations/trafficcapture/proxyserver/netty/ExpiringSubstitutableItemPoolTest.java
@@ -73,6 +73,7 @@ class ExpiringSubstitutableItemPoolTest {
                     try {
                         expiredItems.add(item.get());
                     } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
                         throw new RuntimeException(e);
                     } catch (ExecutionException e) {
                         throw new RuntimeException(e);

--- a/TrafficCapture/trafficCaptureProxyServer/src/test/java/org/opensearch/migrations/trafficcapture/proxyserver/netty/NettyScanningHttpProxyTest.java
+++ b/TrafficCapture/trafficCaptureProxyServer/src/test/java/org/opensearch/migrations/trafficcapture/proxyserver/netty/NettyScanningHttpProxyTest.java
@@ -187,12 +187,15 @@ class NettyScanningHttpProxyTest {
             nshp.set(new NettyScanningHttpProxy(port.intValue()));
             try {
                 URI testServerUri = new URI("http", null, SimpleHttpServer.LOCALHOST, underlyingPort,
-                    null, null, null);
+                        null, null, null);
                 var connectionPool = new BacksideConnectionPool(testServerUri, null,
                         10, Duration.ofSeconds(10));
-                nshp.get().start(connectionPool,1, null, connectionCaptureFactory);
-                System.out.println("proxy port = "+port.intValue());
-            } catch (InterruptedException | URISyntaxException e) {
+                nshp.get().start(connectionPool, 1, null, connectionCaptureFactory);
+                System.out.println("proxy port = " + port.intValue());
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException(e);
+            } catch (URISyntaxException e) {
                 throw new RuntimeException(e);
             }
         });

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/traffic/source/BlockingTrafficSource.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/traffic/source/BlockingTrafficSource.java
@@ -101,7 +101,8 @@ public class BlockingTrafficSource implements ITrafficCaptureSource, BufferedFlo
                                             readGate.acquire();
                                         } catch (InterruptedException e) {
                                             log.atWarn().setCause(e).log("Interrupted while waiting to read more data");
-                                            throw new RuntimeException(e);
+                                            Thread.currentThread().interrupt();
+                                            break;
                                         }
                                     }
                                     return null;

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/traffic/source/TrafficStreamLimiter.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/traffic/source/TrafficStreamLimiter.java
@@ -23,6 +23,7 @@ public class TrafficStreamLimiter {
             log.atDebug().setMessage(()->"Acquired liveTrafficStreamCostGate (available=" +
                     liveTrafficStreamCostGate.availablePermits()+")").log();
         } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
             throw new RuntimeException(e);
         }
     }

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/TestCapturePacketToHttpHandler.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/TestCapturePacketToHttpHandler.java
@@ -43,6 +43,7 @@ public class TestCapturePacketToHttpHandler implements IPacketFinalizingConsumer
                 Thread.sleep(consumeDuration.toMillis());
                 log.info("woke up from sleeping for " + nextRequestPacket);
             } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
                 throw new RuntimeException(e);
             }
             try {

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/TestHttpServerContext.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/TestHttpServerContext.java
@@ -35,6 +35,7 @@ public class TestHttpServerContext {
         try {
             Thread.sleep(responseWaitTime.toMillis());
         } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
             throw new RuntimeException(e);
         }
         String body = SERVER_RESPONSE_BODY_PREFIX + r.path();

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/TrafficReplayerTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/TrafficReplayerTest.java
@@ -146,7 +146,7 @@ class TrafficReplayerTest {
     }
 
     @Test
-    public void testReader() throws IOException, URISyntaxException {
+    public void testReader() throws Exception {
         var tr = new TrafficReplayer(new URI("http://localhost:9200"), null,false);
         List<List<byte[]>> byteArrays = new ArrayList<>();
         CapturedTrafficToHttpTransactionAccumulator trafficAccumulator =
@@ -184,7 +184,7 @@ class TrafficReplayerTest {
     }
 
     @Test
-    public void testCapturedReadsAfterCloseAreHandledAsNew() throws IOException, URISyntaxException {
+    public void testCapturedReadsAfterCloseAreHandledAsNew() throws Exception {
         var tr = new TrafficReplayer(new URI("http://localhost:9200"), null,false);
         List<List<byte[]>> byteArrays = new ArrayList<>();
         var remainingAccumulations = new AtomicInteger();

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/util/StringTrackableCompletableFutureTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/util/StringTrackableCompletableFutureTest.java
@@ -73,7 +73,10 @@ class StringTrackableCompletableFutureTest {
     public static String formatCompletableFuture(DiagnosticTrackableCompletableFuture<String,?> cf) {
         try {
             return "" + cf.get();
-        } catch (ExecutionException | InterruptedException e) {
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return "EXCEPTION";
+        } catch (ExecutionException e) {
             return "EXCEPTION";
         }
     }


### PR DESCRIPTION
### Description
Fix lint issues around IntteruptedExceptions.  See SonarQube rule: S2142.

### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]

### Check List
- [ ] New functionality includes testing
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
