### PR TITLE
Build fixes

### DIFF
--- a/TrafficCapture/testUtilities/src/testFixtures/java/org/opensearch/migrations/testutils/CountingNettyResourceLeakDetector.java
+++ b/TrafficCapture/testUtilities/src/testFixtures/java/org/opensearch/migrations/testutils/CountingNettyResourceLeakDetector.java
@@ -28,6 +28,14 @@ public class CountingNettyResourceLeakDetector<T> extends ResourceLeakDetector<T
         numLeaksFoundAtomic.set(0);
     }
 
+    /**
+     * Do everything necessary to turn leak detection on with the highest sensitivity.
+     */
+    public static void deactivate() {
+        CountingNettyResourceLeakDetector.setLevel(Level.DISABLED);
+        numLeaksFoundAtomic.set(0);
+    }
+
     public static class MyResourceLeakDetectorFactory extends ResourceLeakDetectorFactory {
         static {
             System.setProperty("io.netty.leakDetection.targetRecords", "32");

--- a/TrafficCapture/testUtilities/src/testFixtures/java/org/opensearch/migrations/testutils/NettyLeakCheckTestExtension.java
+++ b/TrafficCapture/testUtilities/src/testFixtures/java/org/opensearch/migrations/testutils/NettyLeakCheckTestExtension.java
@@ -20,6 +20,7 @@ public class NettyLeakCheckTestExtension implements InvocationInterceptor {
             throws Throwable {
         if (allLeakChecksAreDisabled ||
                 getAnnotation(extensionContext).map(a -> a.disableLeakChecks()).orElse(false)) {
+            CountingNettyResourceLeakDetector.deactivate();
             finalCall.call();
             return;
         } else {

--- a/TrafficCapture/testUtilities/src/testFixtures/java/org/opensearch/migrations/testutils/PortFinder.java
+++ b/TrafficCapture/testUtilities/src/testFixtures/java/org/opensearch/migrations/testutils/PortFinder.java
@@ -3,6 +3,7 @@ package org.opensearch.migrations.testutils;
 
 import java.util.Random;
 import java.util.function.Consumer;
+import java.util.function.IntConsumer;
 
 /**
  * Helper class to keep retrying ports against a Consumer until the
@@ -10,17 +11,19 @@ import java.util.function.Consumer;
  */
 public class PortFinder {
 
+    private PortFinder() {}
+
     private static final int MAX_PORT_TRIES = 100;
     private static final Random random = new Random();
 
     public static class ExceededMaxPortAssigmentAttemptException extends Exception {}
 
-    public static int retryWithNewPortUntilNoThrow(Consumer<Integer> r)
+    public static int retryWithNewPortUntilNoThrow(IntConsumer r)
             throws ExceededMaxPortAssigmentAttemptException {
         int numTries = 0;
         while (true) {
             try {
-                int port = (Math.abs(random.nextInt()) % (2 ^ 16 - 1025)) + 1025;
+                int port = random.nextInt((2 << 15) - 1025) + 1025;
                 r.accept(Integer.valueOf(port));
                 return port;
             } catch (Exception e) {

--- a/TrafficCapture/testUtilities/src/testFixtures/java/org/opensearch/migrations/testutils/SimpleHttpServer.java
+++ b/TrafficCapture/testUtilities/src/testFixtures/java/org/opensearch/migrations/testutils/SimpleHttpServer.java
@@ -28,7 +28,7 @@ public class SimpleHttpServer implements AutoCloseable {
         var testServerRef = new AtomicReference<SimpleHttpServer>();
         PortFinder.retryWithNewPortUntilNoThrow(port -> {
             try {
-                testServerRef.set(new SimpleHttpServer(useTls, port.intValue(), makeContext));
+                testServerRef.set(new SimpleHttpServer(useTls, port, makeContext));
             } catch (Exception e) {
                 throw new RuntimeException(e);
             }

--- a/TrafficCapture/testUtilities/src/testFixtures/java/org/opensearch/migrations/testutils/SimpleNettyHttpServer.java
+++ b/TrafficCapture/testUtilities/src/testFixtures/java/org/opensearch/migrations/testutils/SimpleNettyHttpServer.java
@@ -69,7 +69,7 @@ public class SimpleNettyHttpServer implements AutoCloseable {
         var testServerRef = new AtomicReference<SimpleNettyHttpServer>();
         PortFinder.retryWithNewPortUntilNoThrow(port -> {
             try {
-                testServerRef.set(new SimpleNettyHttpServer(useTls, port.intValue(), readTimeout, makeContext));
+                testServerRef.set(new SimpleNettyHttpServer(useTls, port, readTimeout, makeContext));
             } catch (Exception e) {
                 throw new RuntimeException(e);
             }

--- a/TrafficCapture/trafficCaptureProxyServer/src/main/java/org/opensearch/migrations/trafficcapture/proxyserver/CaptureProxy.java
+++ b/TrafficCapture/trafficCaptureProxyServer/src/main/java/org/opensearch/migrations/trafficcapture/proxyserver/CaptureProxy.java
@@ -303,8 +303,8 @@ public class CaptureProxy {
                 proxy.stop();
                 System.err.println("Done stopping the proxy.");
             } catch (InterruptedException e) {
-                System.err.println("Caught exception while shutting down: "+e);
-                throw new RuntimeException(e);
+                System.err.println("Caught InterruptedException while shutting down, resetting interrupt status: "+e);
+                Thread.currentThread().interrupt();
             }
         }));
         // This loop just gives the main() function something to do while the netty event loops

--- a/TrafficCapture/trafficCaptureProxyServer/src/main/java/org/opensearch/migrations/trafficcapture/proxyserver/CaptureProxy.java
+++ b/TrafficCapture/trafficCaptureProxyServer/src/main/java/org/opensearch/migrations/trafficcapture/proxyserver/CaptureProxy.java
@@ -125,7 +125,7 @@ public class CaptureProxy {
         String destinationConnectionPoolTimeout = "PT30S";
     }
 
-    public static Parameters parseArgs(String[] args) {
+    public static @NonNull Parameters parseArgs(String[] args) {
         Parameters p = new Parameters();
         JCommander jCommander = new JCommander(p);
         try {

--- a/TrafficCapture/trafficCaptureProxyServer/src/test/java/org/opensearch/migrations/trafficcapture/proxyserver/netty/ExpiringSubstitutableItemPoolTest.java
+++ b/TrafficCapture/trafficCaptureProxyServer/src/test/java/org/opensearch/migrations/trafficcapture/proxyserver/netty/ExpiringSubstitutableItemPoolTest.java
@@ -73,6 +73,7 @@ class ExpiringSubstitutableItemPoolTest {
                     try {
                         expiredItems.add(item.get());
                     } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
                         throw new RuntimeException(e);
                     } catch (ExecutionException e) {
                         throw new RuntimeException(e);

--- a/TrafficCapture/trafficCaptureProxyServer/src/test/java/org/opensearch/migrations/trafficcapture/proxyserver/netty/NettyScanningHttpProxyTest.java
+++ b/TrafficCapture/trafficCaptureProxyServer/src/test/java/org/opensearch/migrations/trafficcapture/proxyserver/netty/NettyScanningHttpProxyTest.java
@@ -187,12 +187,15 @@ class NettyScanningHttpProxyTest {
             nshp.set(new NettyScanningHttpProxy(port.intValue()));
             try {
                 URI testServerUri = new URI("http", null, SimpleHttpServer.LOCALHOST, underlyingPort,
-                    null, null, null);
+                        null, null, null);
                 var connectionPool = new BacksideConnectionPool(testServerUri, null,
                         10, Duration.ofSeconds(10));
-                nshp.get().start(connectionPool,1, null, connectionCaptureFactory);
-                System.out.println("proxy port = "+port.intValue());
-            } catch (InterruptedException | URISyntaxException e) {
+                nshp.get().start(connectionPool, 1, null, connectionCaptureFactory);
+                System.out.println("proxy port = " + port.intValue());
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException(e);
+            } catch (URISyntaxException e) {
                 throw new RuntimeException(e);
             }
         });

--- a/TrafficCapture/trafficCaptureProxyServer/src/test/java/org/opensearch/migrations/trafficcapture/proxyserver/netty/NettyScanningHttpProxyTest.java
+++ b/TrafficCapture/trafficCaptureProxyServer/src/test/java/org/opensearch/migrations/trafficcapture/proxyserver/netty/NettyScanningHttpProxyTest.java
@@ -175,7 +175,7 @@ class NettyScanningHttpProxyTest {
         var upstreamTestServer = new AtomicReference<SimpleHttpServer>();
         PortFinder.retryWithNewPortUntilNoThrow(port -> {
             try {
-                upstreamTestServer.set(new SimpleHttpServer(false, port.intValue(),
+                upstreamTestServer.set(new SimpleHttpServer(false, port,
                         NettyScanningHttpProxyTest::makeContext));
             } catch (Exception e) {
                 throw new RuntimeException(e);
@@ -184,14 +184,14 @@ class NettyScanningHttpProxyTest {
         var underlyingPort = upstreamTestServer.get().port();
 
         PortFinder.retryWithNewPortUntilNoThrow(port -> {
-            nshp.set(new NettyScanningHttpProxy(port.intValue()));
+            nshp.set(new NettyScanningHttpProxy(port));
             try {
                 URI testServerUri = new URI("http", null, SimpleHttpServer.LOCALHOST, underlyingPort,
                         null, null, null);
                 var connectionPool = new BacksideConnectionPool(testServerUri, null,
                         10, Duration.ofSeconds(10));
                 nshp.get().start(connectionPool, 1, null, connectionCaptureFactory);
-                System.out.println("proxy port = " + port.intValue());
+                System.out.println("proxy port = " + port);
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
                 throw new RuntimeException(e);

--- a/TrafficCapture/trafficReplayer/build.gradle
+++ b/TrafficCapture/trafficReplayer/build.gradle
@@ -53,10 +53,11 @@ dependencies {
     implementation group: 'org.apache.logging.log4j', name: 'log4j-slf4j2-impl', version: '2.20.0'
     implementation group: 'org.json', name: 'json', version: '20230227'
     implementation group: 'org.slf4j', name: 'slf4j-api', version: '2.0.7'
-    implementation group: 'software.amazon.msk', name: 'aws-msk-iam-auth', version: '1.1.9'
-    implementation group: 'software.amazon.awssdk', name: 'sdk-core', version: '2.20.102'
+    implementation group: 'software.amazon.awssdk', name: 'arns', version: '2.20.102'
     implementation group: 'software.amazon.awssdk', name: 'auth', version: '2.20.102'
+    implementation group: 'software.amazon.awssdk', name: 'sdk-core', version: '2.20.102'
     implementation group: 'software.amazon.awssdk', name: 'secretsmanager', version: '2.20.127'
+    implementation group: 'software.amazon.msk', name: 'aws-msk-iam-auth', version: '1.1.9'
 
 
     testImplementation project(':captureOffloader')

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/AWSAuthService.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/AWSAuthService.java
@@ -1,6 +1,8 @@
 package org.opensearch.migrations.replay;
 
 import lombok.extern.slf4j.Slf4j;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
 
 import java.nio.charset.Charset;
@@ -15,8 +17,8 @@ public class AWSAuthService implements AutoCloseable {
         this.secretsManagerClient = secretsManagerClient;
     }
 
-    public AWSAuthService() {
-        this(SecretsManagerClient.builder().build());
+    public AWSAuthService(AwsCredentialsProvider credentialsProvider, Region region) {
+        this(SecretsManagerClient.builder().credentialsProvider(credentialsProvider).region(region).build());
     }
 
     // SecretId here can be either the unique name of the secret or the secret ARN

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/Accumulation.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/Accumulation.java
@@ -45,7 +45,8 @@ public class Accumulation {
         if (rrPair != null) {
             return rrPair;
         }
-        return rrPair = new RequestResponsePacketPair();
+        rrPair = new RequestResponsePacketPair();
+        return rrPair;
     }
 
     public UniqueReplayerRequestKey getRequestKey() {

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/AdaptiveRateLimiter.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/AdaptiveRateLimiter.java
@@ -5,12 +5,9 @@ import io.github.resilience4j.ratelimiter.RateLimiter;
 import io.github.resilience4j.ratelimiter.RateLimiterConfig;
 import io.github.resilience4j.retry.Retry;
 import io.github.resilience4j.retry.RetryConfig;
-import io.netty.channel.ChannelFuture;
 import org.opensearch.migrations.replay.util.DiagnosticTrackableCompletableFuture;
 
 import java.time.Duration;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
 import java.util.function.Supplier;
 
 /**

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/AggregatedRawResponse.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/AggregatedRawResponse.java
@@ -1,7 +1,5 @@
 package org.opensearch.migrations.replay;
 
-
-import io.netty.buffer.ByteBuf;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
@@ -11,12 +9,14 @@ import java.time.Instant;
 import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
 
 @Slf4j
 public class AggregatedRawResponse implements Serializable {
 
+    @Getter
     protected final int responseSizeInBytes;
     @Getter
     protected final Duration responseDuration;
@@ -30,7 +30,7 @@ public class AggregatedRawResponse implements Serializable {
 
     public byte[][] getCopyOfPackets() {
             return responsePackets.stream()
-                    .map(kvp->kvp.getValue())
+                    .map(Map.Entry::getValue)
                     .map(x->Arrays.copyOf(x,x.length))
                     .toArray(byte[][]::new);
     }
@@ -75,12 +75,6 @@ public class AggregatedRawResponse implements Serializable {
         this.error = error;
     }
 
-    int getResponseSizeInBytes() {
-        return this.responseSizeInBytes;
-    }
-    Duration getResponseDuration() {
-        return this.responseDuration;
-    }
     Stream<AbstractMap.SimpleEntry<Instant, byte[]>> getReceiptTimeAndResponsePackets() {
         return Optional.ofNullable(this.responsePackets).map(rp->rp.stream()).orElse(Stream.empty());
     }
@@ -97,5 +91,7 @@ public class AggregatedRawResponse implements Serializable {
         return sb.toString();
     }
 
-    protected void addSubclassInfoForToString(StringBuilder sb) {}
+    protected void addSubclassInfoForToString(StringBuilder sb) {
+        // do nothing by default, let subclasses fill this in
+    }
 }

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/ClientConnectionPool.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/ClientConnectionPool.java
@@ -141,10 +141,10 @@ public class ClientConnectionPool {
             return rval;
         }
         return channelFutureAndSchedule.eventLoop.submit(() -> {
-            if (channelFutureAndSchedule.channelFutureFuture == null) {
-                channelFutureAndSchedule.channelFutureFuture =
+            if (channelFutureAndSchedule.getChannelFutureFuture() == null) {
+                channelFutureAndSchedule.setChannelFutureFuture(
                         getResilientClientChannelProducer(channelFutureAndSchedule.eventLoop,
-                                requestKey.getTrafficStreamKey().getConnectionId());
+                                requestKey.getTrafficStreamKey().getConnectionId()));
             }
             return channelFutureAndSchedule;
         });
@@ -167,7 +167,7 @@ public class ClientConnectionPool {
                         ()->"Waiting for closeFuture() on channel");
 
         numConnectionsClosed.incrementAndGet();
-        channelAndFutureWork.channelFutureFuture.map(cff->cff
+        channelAndFutureWork.getChannelFutureFuture().map(cff->cff
                         .thenAccept(cf-> {
                             cf.channel().close()
                                     .addListener(closeFuture -> {

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/HttpMessageAndTimestamp.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/HttpMessageAndTimestamp.java
@@ -2,6 +2,7 @@ package org.opensearch.migrations.replay;
 
 import com.google.common.base.Objects;
 import io.netty.buffer.Unpooled;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
@@ -14,6 +15,7 @@ import java.util.Optional;
 import java.util.stream.Stream;
 
 @Slf4j
+@EqualsAndHashCode(exclude = "currentSegmentBytes")
 public class HttpMessageAndTimestamp {
 
     public static class Request extends HttpMessageAndTimestamp {
@@ -89,19 +91,6 @@ public class HttpMessageAndTimestamp {
         packetBytes.add(currentSegmentBytes.toByteArray());
         this.lastPacketTimestamp = timestamp;
         currentSegmentBytes = null;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        HttpMessageAndTimestamp that = (HttpMessageAndTimestamp) o;
-        return Objects.equal(firstPacketTimestamp, that.firstPacketTimestamp) && Objects.equal(lastPacketTimestamp, that.lastPacketTimestamp) && Objects.equal(packetBytes, that.packetBytes);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hashCode(firstPacketTimestamp, lastPacketTimestamp, packetBytes);
     }
 
     @Override

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/RequestSenderOrchestrator.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/RequestSenderOrchestrator.java
@@ -99,13 +99,13 @@ public class RequestSenderOrchestrator {
                     finalTunneledResponse.future.complete(null);
                     return;
                 }
-                channelFutureAndRequestSchedule.channelFutureFuture
+                channelFutureAndRequestSchedule.getChannelFutureFuture()
                         .map(channelFutureGetAttemptFuture->channelFutureGetAttemptFuture
                                         .thenAccept(v->{
                                             log.atTrace().setMessage(()->requestKey.toString() +
                                                     " ChannelFuture was created with "+v).log();
                                             assert v.channel() ==
-                                                    channelFutureAndRequestSchedule.channelFutureFuture.future
+                                                    channelFutureAndRequestSchedule.getChannelFutureFuture().future
                                                             .getNow(null).channel();
                                             runAfterChannelSetup(channelFutureAndRequestSchedule,
                                                     finalTunneledResponse,

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/NettyPacketToHttpConsumer.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/NettyPacketToHttpConsumer.java
@@ -191,7 +191,7 @@ public class NettyPacketToHttpConsumer implements IPacketFinalizingConsumer<Aggr
                 log.atWarn().setMessage(()->diagnosticLabel + "outbound channel was not set up successfully, " +
                         "NOT writing bytes hash=" + System.identityHashCode(packetData)).log();
                 channel.close();
-                return StringTrackableCompletableFuture.factory.failedFuture(channelInitException, ()->"");
+                return DiagnosticTrackableCompletableFuture.Factory.failedFuture(channelInitException, ()->"");
             }
         }, ()->"consumeBytes - after channel is fully initialized (potentially waiting on TLS handshake)");
         log.atTrace().setMessage(()->"Setting up write of packetData["+packetData+"] hash=" +

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/PayloadAccessFaultingMap.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/PayloadAccessFaultingMap.java
@@ -1,5 +1,6 @@
 package org.opensearch.migrations.replay.datahandlers;
 
+import lombok.EqualsAndHashCode;
 import lombok.extern.slf4j.Slf4j;
 import org.opensearch.migrations.replay.datahandlers.http.IHttpMessage;
 import org.opensearch.migrations.replay.datahandlers.http.StrictCaseInsensitiveHttpHeadersMap;
@@ -18,6 +19,7 @@ import java.util.Set;
  * the paylaod (unzip, parse, etc).  If a transform DOES require the payload to be present, get()
  *
  */
+@EqualsAndHashCode
 @Slf4j
 public class PayloadAccessFaultingMap extends AbstractMap<String, Object> {
 

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/TransformedPacketReceiver.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/TransformedPacketReceiver.java
@@ -3,7 +3,6 @@ package org.opensearch.migrations.replay.datahandlers;
 import io.netty.buffer.ByteBuf;
 import org.opensearch.migrations.replay.datatypes.TransformedPackets;
 import org.opensearch.migrations.replay.util.DiagnosticTrackableCompletableFuture;
-import org.opensearch.migrations.replay.util.StringTrackableCompletableFuture;
 
 public class TransformedPacketReceiver implements IPacketFinalizingConsumer<TransformedPackets> {
 

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/TransformedPacketReceiver.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/TransformedPacketReceiver.java
@@ -11,13 +11,13 @@ public class TransformedPacketReceiver implements IPacketFinalizingConsumer<Tran
     @Override
     public DiagnosticTrackableCompletableFuture<String, Void> consumeBytes(ByteBuf nextRequestPacket) {
         packets.add(nextRequestPacket);
-        return DiagnosticTrackableCompletableFuture.factory.completedFuture(null,
+        return DiagnosticTrackableCompletableFuture.Factory.completedFuture(null,
                 ()->"TransformedPacketReceiver.consume...");
     }
 
     @Override
     public DiagnosticTrackableCompletableFuture<String, TransformedPackets> finalizeRequest() {
-        return DiagnosticTrackableCompletableFuture.factory.completedFuture(packets,
+        return DiagnosticTrackableCompletableFuture.Factory.completedFuture(packets,
                 ()->"TransformedPacketReceiver.finalize...");
     }
 }

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/http/HttpJsonMessageWithFaultingPayload.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/http/HttpJsonMessageWithFaultingPayload.java
@@ -7,16 +7,16 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 public class HttpJsonMessageWithFaultingPayload extends LinkedHashMap<String, Object> implements IHttpMessage {
-    public final static String METHOD_KEY = "method";
-    public final static String URI_KEY = "URI";
-    public final static String PROTOCOL_KEY = "protocol";
-    public final static String HEADERS_KEY = "headers";
-    public final static String PAYLOAD_KEY = "payload";
+    public static final String METHOD_KEY = "method";
+    public static final String URI_KEY = "URI";
+    public static final String PROTOCOL_KEY = "protocol";
+    public static final String HEADERS_KEY = "headers";
+    public static final String PAYLOAD_KEY = "payload";
 
     public HttpJsonMessageWithFaultingPayload() {
     }
 
-    public HttpJsonMessageWithFaultingPayload(Map<? extends String, ?> m) {
+    public HttpJsonMessageWithFaultingPayload(Map<String, ?> m) {
         super(m);
     }
 

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/http/HttpJsonTransformingConsumer.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/http/HttpJsonTransformingConsumer.java
@@ -168,7 +168,7 @@ public class HttpJsonTransformingConsumer<R> implements IPacketFinalizingConsume
     redriveWithoutTransformation(IPacketFinalizingConsumer<R> packetConsumer, Throwable reason) {
         DiagnosticTrackableCompletableFuture<String,Void> consumptionChainedFuture =
                 chunks.stream().collect(
-                        Utils.foldLeft(DiagnosticTrackableCompletableFuture.factory.
+                        Utils.foldLeft(DiagnosticTrackableCompletableFuture.Factory.
                                         completedFuture(null, ()->"Initial value"),
                                 (dcf, bb) -> dcf.thenCompose(v -> {
                                     var rval = packetConsumer.consumeBytes(bb);

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/http/HttpJsonTransformingConsumer.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/http/HttpJsonTransformingConsumer.java
@@ -14,6 +14,7 @@ import org.opensearch.migrations.replay.util.DiagnosticTrackableCompletableFutur
 import org.opensearch.migrations.replay.util.StringTrackableCompletableFuture;
 import org.opensearch.migrations.transform.IAuthTransformerFactory;
 import org.opensearch.migrations.transform.IJsonTransformer;
+import org.slf4j.event.Level;
 
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -44,10 +45,9 @@ import java.util.concurrent.CompletionException;
 public class HttpJsonTransformingConsumer<R> implements IPacketFinalizingConsumer<TransformedOutputAndResult<R>> {
     public static final int HTTP_MESSAGE_NUM_SEGMENTS = 2;
     public static final int EXPECTED_PACKET_COUNT_GUESS_FOR_HEADERS = 4;
-    private final RequestPipelineOrchestrator pipelineOrchestrator;
+    private final RequestPipelineOrchestrator<R> pipelineOrchestrator;
     private final EmbeddedChannel channel;
     private static final MetricsLogger metricsLogger = new MetricsLogger("HttpJsonTransformingConsumer");
-    private String diagnosticLabel;
     private UniqueReplayerRequestKey requestKeyForMetricsLogging;
 
     /**
@@ -71,10 +71,9 @@ public class HttpJsonTransformingConsumer<R> implements IPacketFinalizingConsume
         chunkSizes.add(new ArrayList<>(EXPECTED_PACKET_COUNT_GUESS_FOR_HEADERS));
         chunks = new ArrayList<>(HTTP_MESSAGE_NUM_SEGMENTS + EXPECTED_PACKET_COUNT_GUESS_FOR_HEADERS);
         channel = new EmbeddedChannel();
-        pipelineOrchestrator = new RequestPipelineOrchestrator(chunkSizes, transformedPacketReceiver,
+        pipelineOrchestrator = new RequestPipelineOrchestrator<>(chunkSizes, transformedPacketReceiver,
                 authTransformerFactory, diagnosticLabel, requestKeyForMetricsLogging);
         pipelineOrchestrator.addInitialHandlers(channel.pipeline(), transformer);
-        this.diagnosticLabel = diagnosticLabel;
         this.requestKeyForMetricsLogging = requestKeyForMetricsLogging;
     }
 
@@ -115,11 +114,11 @@ public class HttpJsonTransformingConsumer<R> implements IPacketFinalizingConsume
                 channel.writeInbound(new EndOfInput());   // so send our own version of 'EOF'
             }
         } catch (Exception e) {
-            if (e instanceof NettyJsonBodyAccumulateHandler.IncompleteJsonBodyException) {
-                log.debug("Caught IncompleteJsonBodyException when sending the end of content", e);
-            } else {
-                log.warn("Caught exception when sending the end of content", e);
-            }
+            log.atLevel(e instanceof NettyJsonBodyAccumulateHandler.IncompleteJsonBodyException ?
+                            Level.DEBUG : Level.WARN)
+                    .setMessage("Caught IncompleteJsonBodyException when sending the end of content")
+                    .setCause(e)
+                    .log();
             return redriveWithoutTransformation(pipelineOrchestrator.packetReceiver, e);
         } finally {
             var cf = channel.close();
@@ -186,8 +185,8 @@ public class HttpJsonTransformingConsumer<R> implements IPacketFinalizingConsume
                 .addKeyValue("channelId", channel.id().asLongText())
                 .setMessage("Request was redriven without transformation").log();
         return finalizedFuture.map(f->f.thenApply(r->reason == null ?
-                                new TransformedOutputAndResult(r, HttpRequestTransformationStatus.SKIPPED, null) :
-                                new TransformedOutputAndResult(r, HttpRequestTransformationStatus.ERROR, reason)),
-                        ()->"HttpJsonTransformingConsumer.redriveWithoutTransformation().map()");
+                        new TransformedOutputAndResult<R>(r, HttpRequestTransformationStatus.SKIPPED, null) :
+                        new TransformedOutputAndResult<R>(r, HttpRequestTransformationStatus.ERROR, reason)),
+                ()->"HttpJsonTransformingConsumer.redriveWithoutTransformation().map()");
     }
 }

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/http/ListKeyAdaptingCaseInsensitiveHeadersMap.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/http/ListKeyAdaptingCaseInsensitiveHeadersMap.java
@@ -1,9 +1,10 @@
 package org.opensearch.migrations.replay.datahandlers.http;
 
+import com.google.common.base.Objects;
+import lombok.EqualsAndHashCode;
+
 import java.util.AbstractMap;
-import java.util.AbstractSet;
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -16,6 +17,7 @@ import java.util.stream.Collectors;
  * This is a kludge to provide that.  Note that this code doesn't do conversions such as joining
  * or splitting.  If more control is required, callers should use the multimap interfaces.
  */
+@EqualsAndHashCode
 public class ListKeyAdaptingCaseInsensitiveHeadersMap extends AbstractMap<String,Object> {
     protected final StrictCaseInsensitiveHttpHeadersMap strictHeadersMap;
 
@@ -36,11 +38,11 @@ public class ListKeyAdaptingCaseInsensitiveHeadersMap extends AbstractMap<String
     public List<String> put(String key, Object value) {
         List<String> strList;
         if (value instanceof List) {
-            if (((List) value).stream().allMatch(item -> item instanceof String)) {
+            if (((List) value).stream().allMatch(String.class::isInstance)) {
                 strList = (List) value;
             } else {
                 strList = (List) ((List) value).stream()
-                        .map(item -> item.toString())
+                        .map(Object::toString)
                         .collect(Collectors.toCollection(ArrayList::new));
             }
         } else {

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/http/NettyJsonBodySerializeHandler.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/http/NettyJsonBodySerializeHandler.java
@@ -15,9 +15,6 @@ import java.util.Map;
 public class NettyJsonBodySerializeHandler extends ChannelInboundHandlerAdapter {
     public static final int NUM_BYTES_TO_ACCUMULATE_BEFORE_FIRING = 1024;
 
-    public NettyJsonBodySerializeHandler() {
-    }
-
     @Override
     public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
         if (msg instanceof HttpJsonMessageWithFaultingPayload) {
@@ -26,7 +23,7 @@ public class NettyJsonBodySerializeHandler extends ChannelInboundHandlerAdapter 
             jsonMessage.setPayloadFaultMap(null);
             var payloadContents = (Map<String, Object>) payload.get(PayloadAccessFaultingMap.INLINED_JSON_BODY_DOCUMENT_KEY);
             ctx.fireChannelRead(msg);
-            if (payload != null && payloadContents != null) {
+            if (payloadContents != null) {
                 serializePayload(ctx, payloadContents);
             }
         } else {

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/http/NettyJsonContentCompressor.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/http/NettyJsonContentCompressor.java
@@ -1,11 +1,8 @@
 package org.opensearch.migrations.replay.datahandlers.http;
 
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufAllocator;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.handler.codec.http.DefaultHttpContent;
-import io.netty.handler.codec.http.DefaultLastHttpContent;
 import io.netty.handler.codec.http.HttpContent;
 import io.netty.handler.codec.http.LastHttpContent;
 import lombok.extern.slf4j.Slf4j;
@@ -64,7 +61,7 @@ public class NettyJsonContentCompressor extends ChannelInboundHandlerAdapter {
                 contentBuf.readBytes(compressorStream, contentBuf.readableBytes());
                 if (msg instanceof LastHttpContent) {
                     closeStream();
-                    ctx.fireChannelRead(DefaultLastHttpContent.EMPTY_LAST_CONTENT);
+                    ctx.fireChannelRead(LastHttpContent.EMPTY_LAST_CONTENT);
                 }
                 return; // fireChannelRead will be fired on the compressed contents via the compressorStream.
            } else {

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/http/NettyJsonContentStreamToByteBufHandler.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/http/NettyJsonContentStreamToByteBufHandler.java
@@ -1,12 +1,10 @@
 package org.opensearch.migrations.replay.datahandlers.http;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.CompositeByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
-import io.netty.handler.codec.http.DefaultLastHttpContent;
 import io.netty.handler.codec.http.HttpContent;
 import io.netty.handler.codec.http.LastHttpContent;
 
@@ -50,41 +48,49 @@ public class NettyJsonContentStreamToByteBufHandler extends ChannelInboundHandle
     @Override
     public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
         if (msg instanceof HttpJsonMessageWithFaultingPayload) {
-            bufferedJsonMessage = (HttpJsonMessageWithFaultingPayload) msg;
-            var transferEncoding =
-                    bufferedJsonMessage.headers().asStrictMap().get("transfer-encoding");
-            streamMode = (transferEncoding != null && transferEncoding.contains(TRANSFER_ENCODING_CHUNKED_VALUE)) ?
-                    MODE.CHUNKED : MODE.FIXED;
-            if (streamMode == MODE.CHUNKED) {
-                bufferedJsonMessage.headers().asStrictMap().remove(CONTENT_LENGTH_HEADER_NAME);
-                ctx.fireChannelRead(bufferedJsonMessage);
-            } else {
-                bufferedContents = ctx.alloc().compositeHeapBuffer();
-            }
+            handleReadJsonMessageObject(ctx, (HttpJsonMessageWithFaultingPayload) msg);
         } else if (msg instanceof HttpContent) {
-            boolean lastContent = (msg instanceof LastHttpContent);
-            var dataByteBuf = ((HttpContent) msg).content();
-            contentBytesReceived += dataByteBuf.readableBytes();
-            switch (streamMode) {
-                case CHUNKED:
-                    if (dataByteBuf.readableBytes() > 0) {
-                        handleAsChunked(ctx, dataByteBuf);
-                    }
-                    if (lastContent) {
-                        sendEndChunk(ctx);
-                    }
-                    break;
-                case FIXED:
-                    bufferedContents.addComponents(true, dataByteBuf);
-                    if (lastContent) {
-                        finalizeFixedContentStream(ctx);
-                    }
-                    break;
-                default:
-                    throw new RuntimeException("Unknown transfer encoding mode " + streamMode);
-            }
+            handleReadBody(ctx, (HttpContent) msg);
         } else {
             super.channelRead(ctx, msg);
+        }
+    }
+
+    private void handleReadBody(ChannelHandlerContext ctx, HttpContent msg) {
+        boolean lastContent = (msg instanceof LastHttpContent);
+        var dataByteBuf = msg.content();
+        contentBytesReceived += dataByteBuf.readableBytes();
+        switch (streamMode) {
+            case CHUNKED:
+                if (dataByteBuf.readableBytes() > 0) {
+                    handleAsChunked(ctx, dataByteBuf);
+                }
+                if (lastContent) {
+                    sendEndChunk(ctx);
+                }
+                break;
+            case FIXED:
+                bufferedContents.addComponents(true, dataByteBuf);
+                if (lastContent) {
+                    finalizeFixedContentStream(ctx);
+                }
+                break;
+            default:
+                throw new RuntimeException("Unknown transfer encoding mode " + streamMode);
+        }
+    }
+
+    private void handleReadJsonMessageObject(ChannelHandlerContext ctx, HttpJsonMessageWithFaultingPayload msg) {
+        bufferedJsonMessage = msg;
+        var transferEncoding =
+                bufferedJsonMessage.headers().asStrictMap().get("transfer-encoding");
+        streamMode = (transferEncoding != null && transferEncoding.contains(TRANSFER_ENCODING_CHUNKED_VALUE)) ?
+                MODE.CHUNKED : MODE.FIXED;
+        if (streamMode == MODE.CHUNKED) {
+            bufferedJsonMessage.headers().asStrictMap().remove(CONTENT_LENGTH_HEADER_NAME);
+            ctx.fireChannelRead(bufferedJsonMessage);
+        } else {
+            bufferedContents = ctx.alloc().compositeHeapBuffer();
         }
     }
 
@@ -102,7 +108,7 @@ public class NettyJsonContentStreamToByteBufHandler extends ChannelInboundHandle
         // make this a singleton
         var lastChunkByteBuf = Unpooled.wrappedBuffer("0\r\n\r\n".getBytes(StandardCharsets.UTF_8));
         ctx.fireChannelRead(lastChunkByteBuf);
-        ctx.fireChannelRead(DefaultLastHttpContent.EMPTY_LAST_CONTENT);
+        ctx.fireChannelRead(LastHttpContent.EMPTY_LAST_CONTENT);
     }
 
     private void finalizeFixedContentStream(ChannelHandlerContext ctx) {
@@ -110,6 +116,6 @@ public class NettyJsonContentStreamToByteBufHandler extends ChannelInboundHandle
         ctx.fireChannelRead(bufferedJsonMessage);
         bufferedJsonMessage = null;
         ctx.fireChannelRead(bufferedContents);
-        ctx.fireChannelRead(DefaultLastHttpContent.EMPTY_LAST_CONTENT);
+        ctx.fireChannelRead(LastHttpContent.EMPTY_LAST_CONTENT);
     }
 }

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/http/NettyJsonToByteBufHandler.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/http/NettyJsonToByteBufHandler.java
@@ -52,7 +52,7 @@ public class NettyJsonToByteBufHandler extends ChannelInboundHandlerAdapter {
         if (msg instanceof HttpJsonMessageWithFaultingPayload) {
             writeHeadersIntoByteBufs(ctx, (HttpJsonMessageWithFaultingPayload) msg);
         } else if (msg instanceof ByteBuf) {
-            ctx.fireChannelRead((ByteBuf) msg);
+            ctx.fireChannelRead(msg);
         } else if (msg instanceof HttpContent) {
             writeContentsIntoByteBufs(ctx, (HttpContent) msg);
             if (msg instanceof LastHttpContent) {

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/http/NettySendByteBufsToPacketHandlerHandler.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/http/NettySendByteBufsToPacketHandlerHandler.java
@@ -25,13 +25,13 @@ import java.util.concurrent.atomic.AtomicReference;
 public class NettySendByteBufsToPacketHandlerHandler<R> extends ChannelInboundHandlerAdapter {
     final IPacketFinalizingConsumer<R> packetReceiver;
     // final Boolean value indicates if the handler received a LastHttpContent or EndOfInput message
-    // TODO - make this threadsafe.  calls may come in on different threads
     DiagnosticTrackableCompletableFuture<String, Boolean> currentFuture;
     private AtomicReference<DiagnosticTrackableCompletableFuture<String, TransformedOutputAndResult<R>>>
             packetReceiverCompletionFutureRef;
     String diagnosticLabel;
 
-    public NettySendByteBufsToPacketHandlerHandler(IPacketFinalizingConsumer packetReceiver, String diagnosticLabel) {
+    public NettySendByteBufsToPacketHandlerHandler(IPacketFinalizingConsumer<R> packetReceiver,
+                                                   String diagnosticLabel) {
         this.packetReceiver = packetReceiver;
         this.packetReceiverCompletionFutureRef = new AtomicReference<>();
         this.diagnosticLabel = diagnosticLabel;
@@ -75,7 +75,8 @@ public class NettySendByteBufsToPacketHandlerHandler<R> extends ChannelInboundHa
                                             ()->"fixed failure from packetReceiver.finalizeRequest()");
                                 } else {
                                     return StringTrackableCompletableFuture.completedFuture(Optional.ofNullable(v2)
-                                                    .map(r->new TransformedOutputAndResult(r,  transformationStatus, null))
+                                                    .map(r-> new TransformedOutputAndResult<R>(r,  transformationStatus,
+                                                            null))
                                                     .orElse(null),
                                             ()->"fixed value from packetReceiver.finalizeRequest()"
                                             );
@@ -121,24 +122,26 @@ public class NettySendByteBufsToPacketHandlerHandler<R> extends ChannelInboundHa
             final var preexistingFutureForCapture = currentFuture;
             var numBytesToSend = bb.readableBytes();
             currentFuture = currentFuture.getDeferredFutureThroughHandle((v,t)-> {
-                if (t != null) {
-                    bb.release();
-                    log.atInfo().setCause(t).setMessage(()->"got exception from a previous future that will prohibit " +
-                            "sending any more data to the packetReceiver").log();
-                    return StringTrackableCompletableFuture.failedFuture(t, ()->"failed previous future");
-                } else {
-                    log.atTrace().setMessage(()->"chaining consumingBytes with " + msg +
-                            " lastFuture=" + preexistingFutureForCapture).log();
-                    var rval = packetReceiver.consumeBytes(bb);
-                    bb.release();
-                    log.atTrace().setMessage(()->"packetReceiver.consumeBytes()=" + rval + " bb.refCnt=" + bb.refCnt())
-                            .log();
-                    return rval.map(cf -> cf.thenApply(ignore -> false),
-                            () -> "NettySendByteBufsToPacketHandlerHandler.channelRead()'s future is going " +
-                                    "to return a completedValue of false to indicate that more packets may " +
-                                    "need to be sent");
-                }
-            },
+                        try {
+                            if (t != null) {
+                                log.atInfo().setCause(t).setMessage(() -> "got exception from a previous future that " +
+                                        "will prohibit sending any more data to the packetReceiver").log();
+                                return StringTrackableCompletableFuture.failedFuture(t, () -> "failed previous future");
+                            } else {
+                                log.atTrace().setMessage(() -> "chaining consumingBytes with " + msg +
+                                        " lastFuture=" + preexistingFutureForCapture).log();
+                                var rval = packetReceiver.consumeBytes(bb);
+                                log.atTrace().setMessage(() -> "packetReceiver.consumeBytes()=" + rval +
+                                        " bb.refCnt=" + bb.refCnt()).log();
+                                return rval.map(cf -> cf.thenApply(ignore -> false),
+                                        () -> "NettySendByteBufsToPacketHandlerHandler.channelRead()'s future is " +
+                                                "going to return a completedValue of false to indicate that more " +
+                                                "packets may need to be sent");
+                            }
+                        } finally {
+                            bb.release();
+                        }
+                    },
                     ()->"NettySendByteBufsToPacketHandlerHandler.channelRead waits for the previous future " +
                             "to finish before writing the next set of " + numBytesToSend + " bytes ");
             log.trace("CR: new currentFuture="+currentFuture);

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/http/NettySendByteBufsToPacketHandlerHandler.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/http/NettySendByteBufsToPacketHandlerHandler.java
@@ -35,7 +35,7 @@ public class NettySendByteBufsToPacketHandlerHandler<R> extends ChannelInboundHa
         this.packetReceiver = packetReceiver;
         this.packetReceiverCompletionFutureRef = new AtomicReference<>();
         this.diagnosticLabel = diagnosticLabel;
-        currentFuture = DiagnosticTrackableCompletableFuture.factory.completedFuture(null,
+        currentFuture = DiagnosticTrackableCompletableFuture.Factory.completedFuture(null,
                 ()->"currentFuture for NettySendByteBufsToPacketHandlerHandler initialized to the base case for " + diagnosticLabel);
     }
 
@@ -105,7 +105,7 @@ public class NettySendByteBufsToPacketHandlerHandler<R> extends ChannelInboundHa
 
     @Override
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
-        currentFuture = DiagnosticTrackableCompletableFuture.factory.failedFuture(cause,
+        currentFuture = DiagnosticTrackableCompletableFuture.Factory.failedFuture(cause,
                 () -> "NettySendByteBufsToPacketHandlerHandler got an exception");
         super.exceptionCaught(ctx, cause);
     }

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/http/RequestPipelineOrchestrator.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/http/RequestPipelineOrchestrator.java
@@ -37,7 +37,7 @@ public class RequestPipelineOrchestrator<R> {
      * Set this to of(LogLevel.ERROR) or whatever level you'd like to get logging between each handler.
      * Set this to Optional.empty() to disable intra-handler logging.
      */
-    private final static Optional<LogLevel> PIPELINE_LOGGING_OPTIONAL = Optional.empty();
+    private static final Optional<LogLevel> PIPELINE_LOGGING_OPTIONAL = Optional.empty();
     public static final String OFFLOADING_HANDLER_NAME = "OFFLOADING_HANDLER";
     public static final String HTTP_REQUEST_DECODER_NAME = "HTTP_REQUEST_DECODER";
     private final List<List<Integer>> chunkSizes;
@@ -99,7 +99,7 @@ public class RequestPipelineOrchestrator<R> {
         // Note3: ByteBufs will be sent through when there were pending bytes left to be parsed by the
         //        HttpRequestDecoder when the HttpRequestDecoder is removed from the pipeline BEFORE the
         //        NettyDecodedHttpRequestHandler is removed.
-        pipeline.addLast(new NettyDecodedHttpRequestPreliminaryConvertHandler(transformer, chunkSizes, this,
+        pipeline.addLast(new NettyDecodedHttpRequestPreliminaryConvertHandler<R>(transformer, chunkSizes, this,
                 diagnosticLabel, requestKeyForMetricsLogging));
         addLoggingHandler(pipeline, "B");
     }
@@ -150,7 +150,7 @@ public class RequestPipelineOrchestrator<R> {
         // OUT: nothing - terminal!  ByteBufs are routed to the packet handler!
         addLoggingHandler(pipeline, "K");
         pipeline.addLast(OFFLOADING_HANDLER_NAME,
-                new NettySendByteBufsToPacketHandlerHandler(packetReceiver, diagnosticLabel));
+                new NettySendByteBufsToPacketHandlerHandler<R>(packetReceiver, diagnosticLabel));
     }
 
     private void addLoggingHandler(ChannelPipeline pipeline, String name) {

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/http/StrictCaseInsensitiveHttpHeadersMap.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/http/StrictCaseInsensitiveHttpHeadersMap.java
@@ -1,5 +1,8 @@
 package org.opensearch.migrations.replay.datahandlers.http;
 
+import com.google.common.base.Objects;
+import lombok.EqualsAndHashCode;
+
 import java.util.AbstractMap;
 import java.util.AbstractSet;
 import java.util.Iterator;
@@ -13,6 +16,7 @@ import java.util.Set;
  * so that we can maintain that original order.  However, we add an extra ability to keep key values
  * (or header names) case insensitive.
  */
+@EqualsAndHashCode
 public class StrictCaseInsensitiveHttpHeadersMap extends AbstractMap<String,List<String>> {
     protected LinkedHashMap<String, SimpleEntry<String, List<String>>> lowerCaseToUpperCaseAndValueMap;
 
@@ -32,7 +36,7 @@ public class StrictCaseInsensitiveHttpHeadersMap extends AbstractMap<String,List
         var normalizedKey = incomingKey.toLowerCase();
         SimpleEntry<String,List<String>> oldEntry =
                 lowerCaseToUpperCaseAndValueMap.get(normalizedKey);
-        var newValue = new SimpleEntry(oldEntry == null ? incomingKey : oldEntry.getKey(), value);
+        var newValue = new SimpleEntry<>(oldEntry == null ? incomingKey : oldEntry.getKey(), value);
         lowerCaseToUpperCaseAndValueMap.put(normalizedKey, newValue);
         return oldEntry == null ? null : oldEntry.getValue();
     }
@@ -45,7 +49,7 @@ public class StrictCaseInsensitiveHttpHeadersMap extends AbstractMap<String,List
 
     @Override
     public Set<Entry<String, List<String>>> entrySet() {
-        return new AbstractSet() {
+        return new AbstractSet<>() {
             @Override
             public Iterator<Entry<String, List<String>>> iterator() {
                 return new Iterator<Entry<String, List<String>>>() {

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datatypes/ConnectionReplaySession.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datatypes/ConnectionReplaySession.java
@@ -25,8 +25,9 @@ public class ConnectionReplaySession {
      * EventLoop so that we can route all calls for this object into that loop/thread.
      */
     public final EventLoop eventLoop;
-    public DiagnosticTrackableCompletableFuture<String,ChannelFuture> channelFutureFuture;
-    public OnlineRadixSorter<Runnable> scheduleSequencer;
+    @Getter @Setter
+    private DiagnosticTrackableCompletableFuture<String,ChannelFuture> channelFutureFuture;
+    public final OnlineRadixSorter<Runnable> scheduleSequencer;
     public final TimeToResponseFulfillmentFutureMap schedule;
 
     @Getter
@@ -35,7 +36,7 @@ public class ConnectionReplaySession {
 
     public ConnectionReplaySession(EventLoop eventLoop) {
         this.eventLoop = eventLoop;
-        this.scheduleSequencer = new OnlineRadixSorter(0);
+        this.scheduleSequencer = new OnlineRadixSorter<>(0);
         this.schedule = new TimeToResponseFulfillmentFutureMap();
     }
 

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datatypes/TimeToResponseFulfillmentFutureMap.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datatypes/TimeToResponseFulfillmentFutureMap.java
@@ -12,17 +12,13 @@ public class TimeToResponseFulfillmentFutureMap {
 
     public void appendTask(Instant start, Runnable packetSender) {
         assert timeToRunnableMap.keySet().stream().allMatch(t->!t.isAfter(start));
-        var existing = timeToRunnableMap.get(start);
-        if (existing == null) {
-            existing = new ArrayDeque<>();
-            timeToRunnableMap.put(start, existing);
-        }
+        var existing = timeToRunnableMap.computeIfAbsent(start, k->new ArrayDeque<>());
         existing.offer(packetSender);
     }
 
     public Map.Entry<Instant, Runnable> peekFirstItem() {
         var e = timeToRunnableMap.firstEntry();
-        return e == null ? null : new AbstractMap.SimpleEntry(e.getKey(), e.getValue().peek());
+        return e == null ? null : new AbstractMap.SimpleEntry<>(e.getKey(), e.getValue().peek());
     }
 
     public Instant removeFirstItem() {
@@ -44,7 +40,7 @@ public class TimeToResponseFulfillmentFutureMap {
     }
 
     public long calculateSizeSlowly() {
-        return timeToRunnableMap.values().stream().map(q->q.size()).mapToInt(x->x).sum();
+        return timeToRunnableMap.values().stream().map(ArrayDeque::size).mapToInt(x->x).sum();
     }
 
     @Override

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datatypes/TransformedPackets.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datatypes/TransformedPackets.java
@@ -16,11 +16,11 @@ public class TransformedPackets implements AutoCloseable {
     public int size() { return data.size(); }
 
     public Stream<ByteBuf> streamUnretained() {
-        return data.stream().map(bb->bb.duplicate());
+        return data.stream().map(ByteBuf::duplicate);
     }
 
     public Stream<ByteBuf> streamRetained() {
-        return data.stream().map(bb->bb.retainedDuplicate());
+        return data.stream().map(ByteBuf::retainedDuplicate);
     }
 
     public Stream<byte[]> asByteArrayStream() {

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datatypes/UniqueReplayerRequestKey.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datatypes/UniqueReplayerRequestKey.java
@@ -1,5 +1,8 @@
 package org.opensearch.migrations.replay.datatypes;
 
+import lombok.EqualsAndHashCode;
+
+@EqualsAndHashCode
 public class UniqueReplayerRequestKey extends UniqueSourceRequestKey {
     public final ITrafficStreamKey trafficStreamKey;
     public final int sourceRequestIndexOffsetAtFirstObservation;

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/kafka/KafkaBehavioralPolicy.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/kafka/KafkaBehavioralPolicy.java
@@ -12,12 +12,13 @@ public class KafkaBehavioralPolicy {
      * TrafficStream protobuf object. The default implementation here simply returns null(which the caller will ignore)
      * instead of returning an Exception for the caller to throw.
      *
-     * @param record The record unable to be parsed
+     * @param kafkaRecord The record unable to be parsed
      * @param e The exception encountered when parsing the record
      * @return Null if no exception should be thrown, otherwise provide the exception that will be thrown by the calling class
      */
-    public RuntimeException onInvalidKafkaRecord(ConsumerRecord<String, byte[]> record, InvalidProtocolBufferException e) {
-        log.error("Unable to parse incoming traffic stream with record id: {} from error: ", record.key(), e);
+    public RuntimeException onInvalidKafkaRecord(ConsumerRecord<String, byte[]> kafkaRecord,
+                                                 InvalidProtocolBufferException e) {
+        log.error("Unable to parse incoming traffic stream with record id: {} from error: ", kafkaRecord.key(), e);
         return null;
     }
 }

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/netty/BacksideHttpWatcherHandler.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/netty/BacksideHttpWatcherHandler.java
@@ -56,9 +56,9 @@ public class BacksideHttpWatcherHandler extends SimpleChannelInboundHandler<Full
         log.atTrace().setMessage(()->"triggerResponseCallbackAndRemoveCallback, callback="+this.responseCallback).log();
         if (this.responseCallback != null) {
             // this method may be re-entrant upon calling the callback, so make sure that we don't loop
-            var responseCallback = this.responseCallback;
+            var originalResponseCallback = this.responseCallback;
             this.responseCallback = null;
-            responseCallback.accept(aggregatedRawResponseBuilder.build());
+            originalResponseCallback.accept(aggregatedRawResponseBuilder.build());
             aggregatedRawResponseBuilder = null;
         }
     }

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/traffic/expiration/EpochMillis.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/traffic/expiration/EpochMillis.java
@@ -36,6 +36,6 @@ class EpochMillis implements Comparable<EpochMillis> {
 
     @Override
     public int compareTo(EpochMillis o) {
-        return Long.valueOf(this.millis).compareTo(o.millis);
+        return Long.compare(this.millis, o.millis);
     }
 }

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/traffic/expiration/ExpiringKeyQueue.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/traffic/expiration/ExpiringKeyQueue.java
@@ -1,5 +1,6 @@
 package org.opensearch.migrations.replay.traffic.expiration;
 
+import lombok.EqualsAndHashCode;
 import lombok.extern.slf4j.Slf4j;
 
 import java.time.Duration;
@@ -14,6 +15,7 @@ import java.util.concurrent.ConcurrentSkipListMap;
  * than all items within all maps that preceded it.
  */
 @Slf4j
+@EqualsAndHashCode(callSuper = true)
 class ExpiringKeyQueue extends
         ConcurrentSkipListMap<EpochMillis, ConcurrentHashMap<String, Boolean>> {
     private final Duration granularity;

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/traffic/source/BlockingTrafficSource.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/traffic/source/BlockingTrafficSource.java
@@ -101,7 +101,8 @@ public class BlockingTrafficSource implements ITrafficCaptureSource, BufferedFlo
                                             readGate.acquire();
                                         } catch (InterruptedException e) {
                                             log.atWarn().setCause(e).log("Interrupted while waiting to read more data");
-                                            throw new RuntimeException(e);
+                                            Thread.currentThread().interrupt();
+                                            break;
                                         }
                                     }
                                     return null;

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/traffic/source/ISimpleTrafficCaptureSource.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/traffic/source/ISimpleTrafficCaptureSource.java
@@ -1,8 +1,4 @@
 package org.opensearch.migrations.replay.traffic.source;
 
-import org.opensearch.migrations.replay.datatypes.ITrafficStreamKey;
-
-import java.io.IOException;
-
 public interface ISimpleTrafficCaptureSource extends ITrafficCaptureSource {
 }

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/traffic/source/TrafficStreamLimiter.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/traffic/source/TrafficStreamLimiter.java
@@ -23,6 +23,7 @@ public class TrafficStreamLimiter {
             log.atDebug().setMessage(()->"Acquired liveTrafficStreamCostGate (available=" +
                     liveTrafficStreamCostGate.availablePermits()+")").log();
         } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
             throw new RuntimeException(e);
         }
     }

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/util/DiagnosticTrackableCompletableFuture.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/util/DiagnosticTrackableCompletableFuture.java
@@ -7,6 +7,7 @@ import lombok.extern.slf4j.Slf4j;
 import java.time.Duration;
 import java.util.AbstractMap;
 import java.util.Arrays;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -18,7 +19,6 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-import java.util.stream.Stream;
 
 /**
  * This class wraps CompletableFutures into traceable and identifiable pieces so that when
@@ -38,11 +38,16 @@ public class DiagnosticTrackableCompletableFuture<D, T> {
     protected final Supplier<D> diagnosticSupplier;
     protected final DiagnosticTrackableCompletableFuture<D, ?> dependencyDiagnosticFuture;
 
+    private DiagnosticTrackableCompletableFuture() {
+        throw new IllegalCallerException();
+    }
+
     /**
      * This factory class is here so that subclasses can write their own versions that return objects
      * of their own subclass.
      */
-    public static class factory {
+    public static class Factory {
+        private Factory() {}
         public static <T, D> DiagnosticTrackableCompletableFuture<D, T>
         failedFuture(@NonNull Throwable e, @NonNull Supplier<D> diagnosticSupplier) {
             return new DiagnosticTrackableCompletableFuture<>(CompletableFuture.failedFuture(e),
@@ -68,7 +73,7 @@ public class DiagnosticTrackableCompletableFuture<D, T> {
     private DiagnosticTrackableCompletableFuture(
             @NonNull CompletableFuture<T> future,
             @NonNull Supplier<D> diagnosticSupplier,
-            DiagnosticTrackableCompletableFuture parentFuture) {
+            DiagnosticTrackableCompletableFuture<D,?> parentFuture) {
         this.future = future;
         this.diagnosticSupplier = diagnosticSupplier;
         this.dependencyDiagnosticFuture = parentFuture;
@@ -137,7 +142,7 @@ public class DiagnosticTrackableCompletableFuture<D, T> {
     public <U> DiagnosticTrackableCompletableFuture<D, U>
     handle(@NonNull BiFunction<? super T, Throwable, ? extends U> fn,
                              @NonNull  Supplier<D> diagnosticSupplier) {
-        CompletableFuture<U> newCf = this.future.handle((v, t)->fn.apply(v,t));
+        CompletableFuture<U> newCf = this.future.handle(fn::apply);
         return new DiagnosticTrackableCompletableFuture<>(newCf, diagnosticSupplier, this);
     }
 
@@ -151,17 +156,6 @@ public class DiagnosticTrackableCompletableFuture<D, T> {
         return future.get(millis, TimeUnit.MILLISECONDS);
     }
 
-    public Stream<AbstractMap.SimpleEntry<DiagnosticTrackableCompletableFuture,Supplier<D>>> diagnosticStream() {
-        var chainHeadReference = new AtomicReference<>((DiagnosticTrackableCompletableFuture)this);
-        return IntStream.generate(()->chainHeadReference.get()!=null?1:0)
-                .takeWhile(x->x==1)
-                .mapToObj(i->{
-                    var dcf = chainHeadReference.get();
-                    chainHeadReference.set(dcf.dependencyDiagnosticFuture);
-                    return new AbstractMap.SimpleEntry(dcf, dcf.diagnosticSupplier);
-                });
-    }
-
     public boolean isDone() { return future.isDone(); }
 
     @Override
@@ -169,16 +163,24 @@ public class DiagnosticTrackableCompletableFuture<D, T> {
         return formatAsString(x->null);
     }
 
-    public String formatAsString(@NonNull Function<DiagnosticTrackableCompletableFuture,String> resultFormatter) {
-        var strList = diagnosticStream().map(kvp->formatFutureWithDiagnostics(kvp, resultFormatter))
+    public String formatAsString(@NonNull Function<DiagnosticTrackableCompletableFuture<D,?>,String> resultFormatter) {
+        AtomicReference<DiagnosticTrackableCompletableFuture<D,?>> chainHeadReference =
+                new AtomicReference<>(this);
+        var strList = IntStream.generate(() -> chainHeadReference.get() != null ? 1 : 0)
+                .takeWhile(x -> x == 1)
+                .<AbstractMap.SimpleEntry<DiagnosticTrackableCompletableFuture<D, ?>, Supplier<D>>>mapToObj(i -> {
+                    var dcf = chainHeadReference.get();
+                    chainHeadReference.set(dcf.dependencyDiagnosticFuture);
+                    return new AbstractMap.SimpleEntry<>(dcf, dcf.diagnosticSupplier);
+                }).map(kvp->formatFutureWithDiagnostics(kvp, resultFormatter))
                 .collect(Collectors.toList());
         return strList.stream().collect(Collectors.joining("<-"));
     }
 
     @SneakyThrows
     protected String formatFutureWithDiagnostics(
-            @NonNull AbstractMap.SimpleEntry<DiagnosticTrackableCompletableFuture, Supplier<D>> kvp,
-            @NonNull Function<DiagnosticTrackableCompletableFuture,String> resultFormatter) {
+            @NonNull AbstractMap.SimpleEntry<DiagnosticTrackableCompletableFuture<D,?>, Supplier<D>> kvp,
+            @NonNull Function<DiagnosticTrackableCompletableFuture<D,?>,String> resultFormatter) {
         var diagnosticInfo = kvp.getValue().get();
         var isDone = kvp.getKey().isDone();
         return "[" + System.identityHashCode(kvp.getKey()) + "] " + diagnosticInfo +
@@ -187,18 +189,18 @@ public class DiagnosticTrackableCompletableFuture<D, T> {
     }
 
     private static <D> String
-    getPendingString(AbstractMap.SimpleEntry<DiagnosticTrackableCompletableFuture, Supplier<D>> kvp,
-                     Function<DiagnosticTrackableCompletableFuture, String> resultFormatter) {
+    getPendingString(AbstractMap.SimpleEntry<DiagnosticTrackableCompletableFuture<D,?>, Supplier<D>> kvp,
+                     Function<DiagnosticTrackableCompletableFuture<D,?>, String> resultFormatter) {
         return Optional.ofNullable(kvp.getKey().innerComposedPendingCompletableFutureReference)
                 .map(r -> (DiagnosticTrackableCompletableFuture<D, ?>) r.get())
-                .filter(df -> df != null)
+                .filter(Objects::nonNull)
                 .map(df -> " --[[" + df.formatAsString(resultFormatter) + " ]] ")
                 .orElse("[…]");
     }
 
     private static <D> String formatWithDefault(
-            @NonNull Function<DiagnosticTrackableCompletableFuture,String> formatter,
-            DiagnosticTrackableCompletableFuture df) {
+            @NonNull Function<DiagnosticTrackableCompletableFuture<D,?>,String> formatter,
+            DiagnosticTrackableCompletableFuture<D,?> df) {
         var str = formatter.apply(df);
         return "[" + (str == null ? "^" : str) + "]";
     }

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/util/OnlineRadixSorter.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/util/OnlineRadixSorter.java
@@ -1,14 +1,7 @@
 package org.opensearch.migrations.replay.util;
 
-import java.util.ArrayDeque;
 import java.util.ArrayList;
-import java.util.Deque;
-import java.util.Optional;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
-import java.util.function.Function;
-import java.util.function.ToIntFunction;
-import java.util.stream.Stream;
 
 /**
  * This provides a simple implementation to sort incoming elements that are ordered by a sequence
@@ -73,6 +66,6 @@ public class OnlineRadixSorter<T> {
     }
 
     public long numPending() {
-        return items.size() - currentOffset;
+        return items.size() - (long) currentOffset;
     }
 }

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/util/OnlineRadixSorterForIntegratedKeys.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/util/OnlineRadixSorterForIntegratedKeys.java
@@ -1,14 +1,7 @@
 package org.opensearch.migrations.replay.util;
 
-import java.util.ArrayDeque;
-import java.util.ArrayList;
-import java.util.Deque;
-import java.util.Optional;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
-import java.util.function.Function;
 import java.util.function.ToIntFunction;
-import java.util.stream.Stream;
 
 /**
  * This class is a convenience wrapper for OnlineRadixSorter where the items will intrinsically

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/transform/IAuthTransformerFactory.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/transform/IAuthTransformerFactory.java
@@ -3,8 +3,11 @@ package org.opensearch.migrations.transform;
 import org.opensearch.migrations.replay.datahandlers.http.HttpJsonMessageWithFaultingPayload;
 import org.opensearch.migrations.replay.datahandlers.http.IHttpMessage;
 
-public interface IAuthTransformerFactory {
+import java.io.IOException;
+
+public interface IAuthTransformerFactory extends AutoCloseable {
     IAuthTransformer getAuthTransformer(IHttpMessage httpMessage);
+    default void close() throws IOException {}
 
     class NullAuthTransformerFactory implements IAuthTransformerFactory {
         public final static NullAuthTransformerFactory instance = new NullAuthTransformerFactory();

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/FullTrafficReplayerTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/FullTrafficReplayerTest.java
@@ -54,8 +54,14 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 @Slf4j
+// Turn this on to test with a live Kafka broker.  Other code changes will need to be activated too
 //@Testcontainers
-@WrapWithNettyLeakDetection(repetitions = 1)
+// It would be great to test with leak detection here, but right now this test relies upon TrafficReplayer.shutdown()
+// to recycle the TrafficReplayers.  Since that shutdown process optimizes for speed of teardown, rather than tidying
+// everything up as it closes the door, some leaks may be inevitable.  E.g. when work is outstanding and being sent
+// to the test server, a shutdown will stop those work threads without letting them flush through all of their work
+// (since that could take a very long time) and some of the work might have been followed by resource releases.
+@WrapWithNettyLeakDetection(disableLeakChecks = true)
 public class FullTrafficReplayerTest {
 
     public static final String TEST_GROUP_CONSUMER_ID = "TEST_GROUP_CONSUMER_ID";

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/FullTrafficReplayerTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/FullTrafficReplayerTest.java
@@ -21,6 +21,7 @@ import org.opensearch.migrations.replay.traffic.source.ISimpleTrafficCaptureSour
 import org.opensearch.migrations.replay.traffic.source.ITrafficStreamWithKey;
 import org.opensearch.migrations.replay.traffic.source.TrafficStreamWithEmbeddedKey;
 import org.opensearch.migrations.testutils.SimpleNettyHttpServer;
+import org.opensearch.migrations.testutils.WrapWithNettyLeakDetection;
 import org.opensearch.migrations.trafficcapture.protos.TrafficStream;
 import org.opensearch.migrations.trafficcapture.protos.TrafficStreamUtils;
 import org.opensearch.migrations.transform.StaticAuthTransformerFactory;
@@ -54,7 +55,7 @@ import java.util.stream.Stream;
 
 @Slf4j
 //@Testcontainers
-//@WrapWithNettyLeakDetection(repetitions = 1)
+@WrapWithNettyLeakDetection(repetitions = 1)
 public class FullTrafficReplayerTest {
 
     public static final String TEST_GROUP_CONSUMER_ID = "TEST_GROUP_CONSUMER_ID";

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/TestCapturePacketToHttpHandler.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/TestCapturePacketToHttpHandler.java
@@ -43,6 +43,7 @@ public class TestCapturePacketToHttpHandler implements IPacketFinalizingConsumer
                 Thread.sleep(consumeDuration.toMillis());
                 log.info("woke up from sleeping for " + nextRequestPacket);
             } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
                 throw new RuntimeException(e);
             }
             try {

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/TestHttpServerContext.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/TestHttpServerContext.java
@@ -35,6 +35,7 @@ public class TestHttpServerContext {
         try {
             Thread.sleep(responseWaitTime.toMillis());
         } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
             throw new RuntimeException(e);
         }
         String body = SERVER_RESPONSE_BODY_PREFIX + r.path();

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/TrafficReplayerTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/TrafficReplayerTest.java
@@ -146,7 +146,7 @@ class TrafficReplayerTest {
     }
 
     @Test
-    public void testReader() throws IOException, URISyntaxException {
+    public void testReader() throws Exception {
         var tr = new TrafficReplayer(new URI("http://localhost:9200"), null,false);
         List<List<byte[]>> byteArrays = new ArrayList<>();
         CapturedTrafficToHttpTransactionAccumulator trafficAccumulator =
@@ -184,7 +184,7 @@ class TrafficReplayerTest {
     }
 
     @Test
-    public void testCapturedReadsAfterCloseAreHandledAsNew() throws IOException, URISyntaxException {
+    public void testCapturedReadsAfterCloseAreHandledAsNew() throws Exception {
         var tr = new TrafficReplayer(new URI("http://localhost:9200"), null,false);
         List<List<byte[]>> byteArrays = new ArrayList<>();
         var remainingAccumulations = new AtomicInteger();

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/util/StringTrackableCompletableFutureTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/util/StringTrackableCompletableFutureTest.java
@@ -73,7 +73,10 @@ class StringTrackableCompletableFutureTest {
     public static String formatCompletableFuture(DiagnosticTrackableCompletableFuture<String,?> cf) {
         try {
             return "" + cf.get();
-        } catch (ExecutionException | InterruptedException e) {
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return "EXCEPTION";
+        } catch (ExecutionException e) {
             return "EXCEPTION";
         }
     }


### PR DESCRIPTION
### Description
Fix a bug in the serializer created by a de-linting change... 

Also fixed some other flaky tests too...
Comment in FullTrafficReplayerTest.java ...
// It would be great to test with leak detection here, but right now this test relies upon TrafficReplayer.shutdown()
// to recycle the TrafficReplayers.  Since that shutdown process optimizes for speed of teardown, rather than tidying
// everything up as it closes the door, some leaks may be inevitable.  E.g. when work is outstanding and being sent
// to the test server, a shutdown will stop those work threads without letting them flush through all of their work
// (since that could take a very long time) and some of the work might have been followed by resource releases.

Commit message...
...JUnit wrapping code now explicitly makes a call to DEACTIVATE the NettyResourceLeakDetector when those test tags are NOT present. That should eliminate the FullTrafficReplayerTest from continuously generating leaks that are detected and charged to other tests. The inaccurate accounting stems from the leak count detection not being done until the end of the test. AND... even though the counter is reset at the beginning of each test, the leaked objects may not get picked up immediately by the test that had created them, ESPECIALLY when that test isn't forcing GCs.

* Category Bugfix, Test fix
* Why these changes are required? Flaky test
* What is the old behavior before changes and new behavior after changes? Tests should be more reliable

### Issues Resolved
No Jiras

### Testing
./gradlew ...

### Check List
- [ ] New functionality includes testing
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
