### PR TITLE
Fixing Multi-Proxy build

### DIFF
--- a/TrafficCapture/dockerSolution/src/main/docker/docker-compose-multi.yml
+++ b/TrafficCapture/dockerSolution/src/main/docker/docker-compose-multi.yml
@@ -14,6 +14,7 @@ services:
       - cluster.name=es-cluster
       - discovery.seed_hosts=capture-proxy-es2
       - cluster.initial_master_nodes=capture-proxy-es1,capture-proxy-es2
+      # "multi-node" didn't yet exist as a discovery.type in ES 7.10.2, "zen" was used instead to discover additional nodes. This can be updated depending on ES version being used.
       - discovery.type=zen
       # Run processes for elasticsearch and capture proxy, and exit if either one ends
      command: /bin/sh -c '/usr/local/bin/docker-entrypoint.sh eswrapper & /runJavaWithClasspath.sh org.opensearch.migrations.trafficcapture.proxyserver.CaptureProxy --kafkaConnection kafka:9092 --destinationUri https://localhost:19200 --insecureDestination --listenPort 9200 --sslConfigFile /usr/share/elasticsearch/config/proxy_tls.yml & wait -n 1'
@@ -33,6 +34,7 @@ services:
       - cluster.name=es-cluster
       - discovery.seed_hosts=capture-proxy-es1
       - cluster.initial_master_nodes=capture-proxy-es1,capture-proxy-es2
+      # "multi-node" didn't yet exist as a discovery.type in ES 7.10.2, "zen" was used instead to discover additional nodes. This can be updated depending on ES version being used.
       - discovery.type=zen
       # Run processes for elasticsearch and capture proxy, and exit if either one ends
     command: /bin/sh -c '/usr/local/bin/docker-entrypoint.sh eswrapper & /runJavaWithClasspath.sh org.opensearch.migrations.trafficcapture.proxyserver.CaptureProxy --kafkaConnection kafka:9092 --destinationUri https://localhost:19201 --insecureDestination --listenPort 9201 --sslConfigFile /usr/share/elasticsearch/config/proxy_tls.yml & wait -n 1'

--- a/TrafficCapture/dockerSolution/src/main/docker/docker-compose-multi.yml
+++ b/TrafficCapture/dockerSolution/src/main/docker/docker-compose-multi.yml
@@ -14,8 +14,9 @@ services:
       - cluster.name=es-cluster
       - discovery.seed_hosts=capture-proxy-es2
       - cluster.initial_master_nodes=capture-proxy-es1,capture-proxy-es2
+      - discovery.type=zen
       # Run processes for elasticsearch and capture proxy, and exit if either one ends
-     command: /bin/sh -c '/usr/local/bin/docker-entrypoint.sh eswrapper & /runJavaWithClasspath.sh org.opensearch.migrations.trafficcapture.proxyserver.Main --kafkaConnection kafka:9092 --destinationUri https://localhost:19200 --insecureDestination --listenPort 9200 --sslConfigFile /usr/share/elasticsearch/config/proxy_tls.yml & wait -n 1'
+     command: /bin/sh -c '/usr/local/bin/docker-entrypoint.sh eswrapper & /runJavaWithClasspath.sh org.opensearch.migrations.trafficcapture.proxyserver.CaptureProxy --kafkaConnection kafka:9092 --destinationUri https://localhost:19200 --insecureDestination --listenPort 9200 --sslConfigFile /usr/share/elasticsearch/config/proxy_tls.yml & wait -n 1'
      depends_on:
       - kafka
 
@@ -32,7 +33,8 @@ services:
       - cluster.name=es-cluster
       - discovery.seed_hosts=capture-proxy-es1
       - cluster.initial_master_nodes=capture-proxy-es1,capture-proxy-es2
+      - discovery.type=zen
       # Run processes for elasticsearch and capture proxy, and exit if either one ends
-    command: /bin/sh -c '/usr/local/bin/docker-entrypoint.sh eswrapper & /runJavaWithClasspath.sh org.opensearch.migrations.trafficcapture.proxyserver.Main --kafkaConnection kafka:9092 --destinationUri https://localhost:19201 --insecureDestination --listenPort 9201 --sslConfigFile /usr/share/elasticsearch/config/proxy_tls.yml & wait -n 1'
+    command: /bin/sh -c '/usr/local/bin/docker-entrypoint.sh eswrapper & /runJavaWithClasspath.sh org.opensearch.migrations.trafficcapture.proxyserver.CaptureProxy --kafkaConnection kafka:9092 --destinationUri https://localhost:19201 --insecureDestination --listenPort 9201 --sslConfigFile /usr/share/elasticsearch/config/proxy_tls.yml & wait -n 1'
     depends_on:
       - kafka

--- a/TrafficCapture/dockerSolution/src/main/docker/docker-compose-multi.yml
+++ b/TrafficCapture/dockerSolution/src/main/docker/docker-compose-multi.yml
@@ -14,7 +14,7 @@ services:
       - cluster.name=es-cluster
       - discovery.seed_hosts=capture-proxy-es2
       - cluster.initial_master_nodes=capture-proxy-es1,capture-proxy-es2
-      # "multi-node" didn't yet exist as a discovery.type in ES 7.10.2, "zen" was used instead to discover additional nodes. This can be updated depending on ES version being used.
+      # Some versions of ES might use "multi-node" instead of "zen" as discovery.type for discovery additional nodes. Update this value accordingly.
       - discovery.type=zen
       # Run processes for elasticsearch and capture proxy, and exit if either one ends
      command: /bin/sh -c '/usr/local/bin/docker-entrypoint.sh eswrapper & /runJavaWithClasspath.sh org.opensearch.migrations.trafficcapture.proxyserver.CaptureProxy --kafkaConnection kafka:9092 --destinationUri https://localhost:19200 --insecureDestination --listenPort 9200 --sslConfigFile /usr/share/elasticsearch/config/proxy_tls.yml & wait -n 1'
@@ -34,7 +34,7 @@ services:
       - cluster.name=es-cluster
       - discovery.seed_hosts=capture-proxy-es1
       - cluster.initial_master_nodes=capture-proxy-es1,capture-proxy-es2
-      # "multi-node" didn't yet exist as a discovery.type in ES 7.10.2, "zen" was used instead to discover additional nodes. This can be updated depending on ES version being used.
+      # Some versions of ES might use "multi-node" instead of "zen" as discovery.type for discovery additional nodes. Update this value accordingly.
       - discovery.type=zen
       # Run processes for elasticsearch and capture proxy, and exit if either one ends
     command: /bin/sh -c '/usr/local/bin/docker-entrypoint.sh eswrapper & /runJavaWithClasspath.sh org.opensearch.migrations.trafficcapture.proxyserver.CaptureProxy --kafkaConnection kafka:9092 --destinationUri https://localhost:19201 --insecureDestination --listenPort 9201 --sslConfigFile /usr/share/elasticsearch/config/proxy_tls.yml & wait -n 1'


### PR DESCRIPTION
### Description
This PR restores the ability to create a setup that has 2 coordinator nodes with a Capture Proxy on each node.
This is needed after a change to the Dockerfile that creates the ES image was made, along with renaming the Capture Proxy.

### Check List
- [ ] New functionality includes testing
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
