### PR TITLE
[Fetch Migration] CDK bugfix and other minor updates

### DIFF
--- a/deployment/cdk/opensearch-service-migration/dp_pipeline_template.yaml
+++ b/deployment/cdk/opensearch-service-migration/dp_pipeline_template.yaml
@@ -1,18 +1,36 @@
+# Name of the Data Prepper pipeline
 historical-data-migration:
+  # Source cluster configuration
   source:
     opensearch:
+      # DO NOT CHANGE the hosts value - this will be updated by the CDK
       hosts:
       - <SOURCE_CLUSTER_HOST>
+      # Uncomment the following line to disable TLS
+      #insecure: true
+      # Example configuration on how to disable authentication (default: false)
       disable_authentication: true
       indices:
+        # Indices to exclude - exclude system indices by default
         exclude:
         - index_name_regex: \.*
+  # Target cluster configuration
   sink:
   - opensearch:
-      bulk_size: 10
+      # DO NOT CHANGE the hosts value - this will be updated by the CDK
+      # But adjust the protocol (http or https) as appropriate
       hosts:
       - https://<TARGET_CLUSTER_HOST>
+      # Derive index name from record metadata
       index: ${getMetadata("opensearch-index")}
+      # Use the same document ID as the source cluster document
       document_id: ${getMetadata("opensearch-document_id")}
+      # Example configuration for basic auth
       username: user
       password: pass
+      #disable_authentication: true
+  # Additional pipeline options/optimizations
+  # For maximum throughput, match workers to number of vCPUs (default: 1)
+  workers: 1
+  # delay is how often the worker threads should process data (default: 3000 ms)
+  delay: 0

--- a/deployment/cdk/opensearch-service-migration/lib/fetch-migration-stack.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/fetch-migration-stack.ts
@@ -26,7 +26,7 @@ export class FetchMigrationStack extends Stack {
         super(scope, id, props);
 
         // Import required values
-        const targetClusterEndpoint = StringParameter.valueForStringParameter(this, `/migration/${props.stage}/${props.defaultDeployId}/osClusterEndpoint`)
+        const targetClusterEndpoint = StringParameter.valueFromLookup(this, `/migration/${props.stage}/${props.defaultDeployId}/osClusterEndpoint`)
         const domainAccessGroupId = StringParameter.valueForStringParameter(this, `/migration/${props.stage}/${props.defaultDeployId}/osAccessSecurityGroupId`)
         // This SG allows outbound access for ECR access as well as communication with other services in the cluster
         const serviceConnectGroupId = StringParameter.valueForStringParameter(this, `/migration/${props.stage}/${props.defaultDeployId}/serviceConnectSecurityGroupId`)

--- a/deployment/cdk/opensearch-service-migration/lib/fetch-migration-stack.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/fetch-migration-stack.ts
@@ -38,8 +38,8 @@ export class FetchMigrationStack extends Stack {
 
         // ECS Task Definition
         const fetchMigrationFargateTask = new FargateTaskDefinition(this, "fetchMigrationFargateTask", {
-            memoryLimitMiB: 2048,
-            cpu: 512
+            memoryLimitMiB: 4096,
+            cpu: 1024
         });
 
         new StringParameter(this, 'SSMParameterFetchMigrationTaskDefArn', {


### PR DESCRIPTION
### Description
* Category: Bug fix
> Why these changes are required?

The Fetch Migration stack now uses `StringParameter.valueFromLookup` to resolve the target cluster endpoint from Parameter Store. This is required instead of the `StringParameter.valueForStringParameter` that was previously used because _valueForStringParameter_ returns a `Token` that is only resolved at deployment time. 

This PR also includes two other minor updates:
* Bumping the Fetch Migration task definition to 1 CPU and 4 GB of memory
* Additional documentation in the pipeline template file to aid readability

> What is the old behavior before changes and new behavior after changes?

Since the value of the target cluster endpoint is substituted into the pipeline template file prior to deployment time, a string representation of the Token object (eg. `${Token[TOKEN.123]}`) was being written instead of the actual endpoint URI. Using _valueFromLookup_ looks up the value immediately, so the substitution occurs correctly with the bugfix.

### Issues Resolved
N/A

### Testing
Bug identified while using CDK. Bugfix verified by re-deploying CDK and verifying that the correct value is now used.

### Check List
- [ ] New functionality includes testing
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
