### PR TITLE
[Fetch Migration] Enable migration for identical, empty target cluster index

### DIFF
--- a/FetchMigration/python/fetch_orchestrator.py
+++ b/FetchMigration/python/fetch_orchestrator.py
@@ -59,7 +59,7 @@ def write_inline_pipeline(pipeline_file_path: str, inline_pipeline: str, inline_
 
 
 def write_inline_target_host(pipeline_file_path: str, inline_target_host: str):
-    with open(pipeline_file_path, 'rw') as pipeline_file:
+    with open(pipeline_file_path, 'r+') as pipeline_file:
         pipeline_yaml = yaml.safe_load(pipeline_file)
         update_target_host(pipeline_yaml, inline_target_host)
         # Note - this does not preserve comments

--- a/FetchMigration/python/fetch_orchestrator.py
+++ b/FetchMigration/python/fetch_orchestrator.py
@@ -84,7 +84,7 @@ def run(params: FetchOrchestratorParams) -> Optional[int]:
                                                         report=True, dryrun=params.is_dry_run)
     logging.info("Running metadata migration...\n")
     metadata_migration_result = metadata_migration.run(metadata_migration_params)
-    if len(metadata_migration_result.created_indices) > 0 and not params.is_only_metadata_migration():
+    if len(metadata_migration_result.migration_indices) > 0 and not params.is_only_metadata_migration():
         # Kick off a subprocess for Data Prepper
         logging.info("Running Data Prepper...\n")
         proc = subprocess.Popen(dp_exec_path)

--- a/FetchMigration/python/index_diff.py
+++ b/FetchMigration/python/index_diff.py
@@ -1,0 +1,31 @@
+import utils
+from index_operations import SETTINGS_KEY, MAPPINGS_KEY
+
+
+# Computes and captures differences in indices between a "source" cluster
+# and a "target" cluster. Indices that exist on the source cluster but not
+# on the target cluster are considered "to-create". "Conflicting" indices
+# are present on both source and target clusters, but differ in their index
+# settings or mappings.
+class IndexDiff:
+    indices_to_create: set
+    identical_indices: set
+    identical_empty_indices: set
+    conflicting_indices: set
+
+    def __init__(self, source: dict, target: dict):
+        self.identical_empty_indices = set()
+        self.conflicting_indices = set()
+        indices_in_target = set(source.keys()) & set(target.keys())
+        for index in indices_in_target:
+            # Check settings
+            if utils.has_differences(SETTINGS_KEY, source[index], target[index]):
+                self.conflicting_indices.add(index)
+            # Check mappings
+            if utils.has_differences(MAPPINGS_KEY, source[index], target[index]):
+                self.conflicting_indices.add(index)
+        self.identical_indices = set(indices_in_target) - set(self.conflicting_indices)
+        self.indices_to_create = set(source.keys()) - set(indices_in_target)
+
+    def set_identical_empty_indices(self, indices: set):
+        self.identical_empty_indices = indices

--- a/FetchMigration/python/index_diff.py
+++ b/FetchMigration/python/index_diff.py
@@ -16,16 +16,20 @@ class IndexDiff:
     def __init__(self, source: dict, target: dict):
         self.identical_empty_indices = set()
         self.conflicting_indices = set()
-        indices_in_target = set(source.keys()) & set(target.keys())
-        for index in indices_in_target:
+        # Compute index names that are present in both the source and target
+        indices_intersection = set(source.keys()) & set(target.keys())
+        # Check if these "common" indices are identical or have metadata conflicts
+        for index in indices_intersection:
             # Check settings
             if utils.has_differences(SETTINGS_KEY, source[index], target[index]):
                 self.conflicting_indices.add(index)
             # Check mappings
             if utils.has_differences(MAPPINGS_KEY, source[index], target[index]):
                 self.conflicting_indices.add(index)
-        self.identical_indices = set(indices_in_target) - set(self.conflicting_indices)
-        self.indices_to_create = set(source.keys()) - set(indices_in_target)
+        # Identical indices are the subset that do not have metadata conflicts
+        self.identical_indices = set(indices_intersection) - set(self.conflicting_indices)
+        # Indices that are not already on the target need to be created
+        self.indices_to_create = set(source.keys()) - set(indices_intersection)
 
     def set_identical_empty_indices(self, indices: set):
         self.identical_empty_indices = indices

--- a/FetchMigration/python/index_doc_count.py
+++ b/FetchMigration/python/index_doc_count.py
@@ -1,0 +1,8 @@
+from dataclasses import dataclass
+
+
+# Captures the doc_count for indices in a cluster, and also computes a total
+@dataclass
+class IndexDocCount:
+    total: int
+    index_doc_count_map: dict

--- a/FetchMigration/python/index_operations.py
+++ b/FetchMigration/python/index_operations.py
@@ -1,14 +1,22 @@
+import jsonpath_ng
 import requests
 
 from endpoint_info import EndpointInfo
 
 # Constants
+from index_doc_count import IndexDocCount
+
 SETTINGS_KEY = "settings"
 MAPPINGS_KEY = "mappings"
 COUNT_KEY = "count"
 __INDEX_KEY = "index"
 __ALL_INDICES_ENDPOINT = "*"
-__COUNT_ENDPOINT = "/_count"
+__SEARCH_COUNT_PATH = "/_search?size=0"
+__SEARCH_COUNT_PAYLOAD = {"aggs": {"count": {"terms": {"field": "_index"}}}}
+__TOTAL_COUNT_JSONPATH = jsonpath_ng.parse("$.hits.total.value")
+__INDEX_COUNT_JSONPATH = jsonpath_ng.parse("$.aggregations.count.buckets")
+__BUCKET_INDEX_NAME_KEY = "key"
+__BUCKET_DOC_COUNT_KEY = "doc_count"
 __INTERNAL_SETTINGS_KEYS = ["creation_date", "uuid", "provided_name", "version", "store"]
 
 
@@ -43,9 +51,16 @@ def create_indices(indices_data: dict, endpoint: EndpointInfo):
             raise RuntimeError(f"Failed to create index [{index}] - {e!s}")
 
 
-def doc_count(indices: set, endpoint: EndpointInfo) -> int:
-    count_endpoint_suffix: str = ','.join(indices) + __COUNT_ENDPOINT
+def doc_count(indices: set, endpoint: EndpointInfo) -> IndexDocCount:
+    count_endpoint_suffix: str = ','.join(indices) + __SEARCH_COUNT_PATH
     doc_count_endpoint: str = endpoint.add_path(count_endpoint_suffix)
-    resp = requests.get(doc_count_endpoint, auth=endpoint.get_auth(), verify=endpoint.is_verify_ssl())
+    resp = requests.get(doc_count_endpoint, auth=endpoint.get_auth(), verify=endpoint.is_verify_ssl(),
+                        json=__SEARCH_COUNT_PAYLOAD)
+    # TODO Handle resp.status_code for non successful requests
     result = dict(resp.json())
-    return int(result[COUNT_KEY])
+    total: int = __TOTAL_COUNT_JSONPATH.find(result)[0].value
+    counts_list: list = __INDEX_COUNT_JSONPATH.find(result)[0].value
+    count_map = dict()
+    for entry in counts_list:
+        count_map[entry[__BUCKET_INDEX_NAME_KEY]] = entry[__BUCKET_DOC_COUNT_KEY]
+    return IndexDocCount(total, count_map)

--- a/FetchMigration/python/metadata_migration.py
+++ b/FetchMigration/python/metadata_migration.py
@@ -1,4 +1,5 @@
 import argparse
+import logging
 
 import yaml
 
@@ -30,15 +31,14 @@ def write_output(yaml_data: dict, indices_to_migrate: set, output_path: str):
 
 
 def print_report(diff: IndexDiff, total_doc_count: int):  # pragma no cover
-    print("Identical indices in the target cluster: " +
-          utils.string_from_set(diff.identical_indices))
-    print("Identical empty indices in the target cluster (data will be migrated): " +
-          utils.string_from_set(diff.identical_empty_indices))
-    print("Indices present in both clusters with conflicting settings/mappings (data will not be migrated): " +
-          utils.string_from_set(diff.conflicting_indices))
-    print("Indices to be created in the target cluster (data will be migrated): " +
-          utils.string_from_set(diff.indices_to_create))
-    print("Total number of documents to be moved: " + str(total_doc_count))
+    logging.info("Identical indices in the target cluster: " + utils.string_from_set(diff.identical_indices))
+    logging.info("Identical empty indices in the target cluster (data will be migrated): " +
+                 utils.string_from_set(diff.identical_empty_indices))
+    logging.info("Indices present in both clusters with conflicting settings/mappings (data will not be migrated): " +
+                 utils.string_from_set(diff.conflicting_indices))
+    logging.info("Indices to be created in the target cluster (data will be migrated): " +
+                 utils.string_from_set(diff.indices_to_create))
+    logging.info("Total number of documents to be moved: " + str(total_doc_count))
 
 
 def run(args: MetadataMigrationParams) -> MetadataMigrationResult:
@@ -83,8 +83,7 @@ def run(args: MetadataMigrationParams) -> MetadataMigrationResult:
         # Write output YAML
         if len(args.output_file) > 0:
             write_output(dp_config, result.migration_indices, args.output_file)
-            if args.report:  # pragma no cover
-                print("Wrote output YAML pipeline to: " + args.output_file)
+            logging.debug("Wrote output YAML pipeline to: " + args.output_file)
         if not args.dryrun:
             index_data = dict()
             for index_name in diff.indices_to_create:

--- a/FetchMigration/python/metadata_migration.py
+++ b/FetchMigration/python/metadata_migration.py
@@ -5,6 +5,7 @@ import yaml
 import endpoint_utils
 import index_operations
 import utils
+from index_diff import IndexDiff
 from metadata_migration_params import MetadataMigrationParams
 from metadata_migration_result import MetadataMigrationResult
 
@@ -14,13 +15,13 @@ INCLUDE_KEY = "include"
 INDEX_NAME_KEY = "index_name_regex"
 
 
-def write_output(yaml_data: dict, new_indices: set, output_path: str):
+def write_output(yaml_data: dict, indices_to_migrate: set, output_path: str):
     pipeline_config = next(iter(yaml_data.values()))
     # Result is a tuple of (type, config)
     source_config = endpoint_utils.get_supported_endpoint_config(pipeline_config, endpoint_utils.SOURCE_KEY)[1]
     source_indices = source_config.get(INDICES_KEY, dict())
     included_indices = source_indices.get(INCLUDE_KEY, list())
-    for index in new_indices:
+    for index in indices_to_migrate:
         included_indices.append({INDEX_NAME_KEY: index})
     source_indices[INCLUDE_KEY] = included_indices
     source_config[INDICES_KEY] = source_indices
@@ -28,36 +29,16 @@ def write_output(yaml_data: dict, new_indices: set, output_path: str):
         yaml.dump(yaml_data, out_file)
 
 
-# Computes differences in indices between source and target.
-# Returns a tuple with 3 elements:
-# - The 1st element is the set of indices to create on the target
-# - The 2nd element is a set of indices that are identical on source and target
-# - The 3rd element is a set of indices that are present on both source and target,
-# but differ in their settings or mappings.
-def get_index_differences(source: dict, target: dict) -> tuple[set, set, set]:
-    index_conflicts = set()
-    indices_in_target = set(source.keys()) & set(target.keys())
-    for index in indices_in_target:
-        # Check settings
-        if utils.has_differences(index_operations.SETTINGS_KEY, source[index], target[index]):
-            index_conflicts.add(index)
-        # Check mappings
-        if utils.has_differences(index_operations.MAPPINGS_KEY, source[index], target[index]):
-            index_conflicts.add(index)
-    identical_indices = set(indices_in_target) - set(index_conflicts)
-    indices_to_create = set(source.keys()) - set(indices_in_target)
-    return indices_to_create, identical_indices, index_conflicts
-
-
-# The order of data in the tuple is:
-# (indices to create), (identical indices), (indices with conflicts)
-def print_report(index_differences: tuple[set, set, set], count: int):  # pragma no cover
-    print("Identical indices in the target cluster (no changes will be made): " +
-          utils.string_from_set(index_differences[1]))
-    print("Indices in target cluster with conflicting settings/mappings: " +
-          utils.string_from_set(index_differences[2]))
-    print("Indices to create: " + utils.string_from_set(index_differences[0]))
-    print("Total documents to be moved: " + str(count))
+def print_report(diff: IndexDiff, total_doc_count: int):  # pragma no cover
+    print("Identical indices in the target cluster: " +
+          utils.string_from_set(diff.identical_indices))
+    print("Identical empty indices in the target cluster (data will be migrated): " +
+          utils.string_from_set(diff.identical_empty_indices))
+    print("Indices present in both clusters with conflicting settings/mappings (data will not be migrated): " +
+          utils.string_from_set(diff.conflicting_indices))
+    print("Indices to be created in the target cluster (data will be migrated): " +
+          utils.string_from_set(diff.indices_to_create))
+    print("Total number of documents to be moved: " + str(total_doc_count))
 
 
 def run(args: MetadataMigrationParams) -> MetadataMigrationResult:
@@ -83,24 +64,30 @@ def run(args: MetadataMigrationParams) -> MetadataMigrationResult:
         return result
     target_indices = index_operations.fetch_all_indices(target_endpoint_info)
     # Compute index differences and print report
-    diff = get_index_differences(source_indices, target_indices)
-    # The first element in the tuple is the set of indices to create
-    indices_to_create = diff[0]
-    if indices_to_create:
-        result.created_indices = indices_to_create
-        doc_count_result = index_operations.doc_count(indices_to_create, source_endpoint_info)
+    diff = IndexDiff(source_indices, target_indices)
+    if diff.identical_indices:
+        # Identical indices with zero documents on the target are eligible for migration
+        target_doc_count = index_operations.doc_count(diff.identical_indices, target_endpoint_info)
+        # doc_count only returns indices that have non-zero counts, so the difference in responses
+        # gives us the set of identical, empty indices
+        result.migration_indices = diff.identical_indices.difference(target_doc_count.index_doc_count_map.keys())
+        diff.set_identical_empty_indices(result.migration_indices)
+    if diff.indices_to_create:
+        result.migration_indices.update(diff.indices_to_create)
+    if result.migration_indices:
+        doc_count_result = index_operations.doc_count(result.migration_indices, source_endpoint_info)
         result.target_doc_count = doc_count_result.total
     if args.report:
-        print_report(diff, doc_count_result.total)
-    if indices_to_create:
+        print_report(diff, result.target_doc_count)
+    if result.migration_indices:
         # Write output YAML
         if len(args.output_file) > 0:
-            write_output(dp_config, indices_to_create, args.output_file)
+            write_output(dp_config, result.migration_indices, args.output_file)
             if args.report:  # pragma no cover
                 print("Wrote output YAML pipeline to: " + args.output_file)
         if not args.dryrun:
             index_data = dict()
-            for index_name in indices_to_create:
+            for index_name in diff.indices_to_create:
                 index_data[index_name] = source_indices[index_name]
             index_operations.create_indices(index_data, target_endpoint_info)
     return result

--- a/FetchMigration/python/metadata_migration.py
+++ b/FetchMigration/python/metadata_migration.py
@@ -88,9 +88,10 @@ def run(args: MetadataMigrationParams) -> MetadataMigrationResult:
     indices_to_create = diff[0]
     if indices_to_create:
         result.created_indices = indices_to_create
-        result.target_doc_count = index_operations.doc_count(indices_to_create, source_endpoint_info)
+        doc_count_result = index_operations.doc_count(indices_to_create, source_endpoint_info)
+        result.target_doc_count = doc_count_result.total
     if args.report:
-        print_report(diff, result.target_doc_count)
+        print_report(diff, doc_count_result.total)
     if indices_to_create:
         # Write output YAML
         if len(args.output_file) > 0:

--- a/FetchMigration/python/metadata_migration_result.py
+++ b/FetchMigration/python/metadata_migration_result.py
@@ -4,4 +4,5 @@ from dataclasses import dataclass, field
 @dataclass
 class MetadataMigrationResult:
     target_doc_count: int = 0
-    created_indices: set = field(default_factory=set)
+    # Set of indices for which data needs to be migrated
+    migration_indices: set = field(default_factory=set)

--- a/FetchMigration/python/migration_monitor.py
+++ b/FetchMigration/python/migration_monitor.py
@@ -162,6 +162,6 @@ if __name__ == '__main__':  # pragma no cover
         help="Target doc_count to reach, after which the Data Prepper pipeline will be terminated"
     )
     namespace = arg_parser.parse_args()
-    print("\n##### Starting monitor tool... #####\n")
+    logging.info("\n##### Starting monitor tool... #####\n")
     run(MigrationMonitorParams(namespace.target_count, namespace.data_prepper_endpoint))
-    print("\n##### Ending monitor tool... #####\n")
+    logging.info("\n##### Ending monitor tool... #####\n")

--- a/FetchMigration/python/requirements.txt
+++ b/FetchMigration/python/requirements.txt
@@ -1,5 +1,6 @@
 botocore>=1.31.70
 jsondiff>=2.0.0
+jsonpath>=1.6.0
 prometheus-client>=0.17.1
 pyyaml>=6.0.1
 requests>=2.31.0

--- a/FetchMigration/python/requirements.txt
+++ b/FetchMigration/python/requirements.txt
@@ -1,6 +1,6 @@
 botocore>=1.31.70
 jsondiff>=2.0.0
-jsonpath>=1.6.0
+jsonpath-ng>=1.6.0
 prometheus-client>=0.17.1
 pyyaml>=6.0.1
 requests>=2.31.0

--- a/FetchMigration/python/tests/test_endpoint_utils.py
+++ b/FetchMigration/python/tests/test_endpoint_utils.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock, patch
 from moto import mock_iam
 
 import endpoint_utils
+from endpoint_info import EndpointInfo
 from tests import test_constants
 
 # Constants
@@ -70,6 +71,10 @@ class TestEndpointUtils(unittest.TestCase):
     def test_is_insecure_missing_nested(self):
         test_input = {"key1": 123, CONNECTION_KEY: {"key2": "val"}}
         self.assertFalse(endpoint_utils.is_insecure(test_input))
+
+    def test_auth_normalized_url(self):
+        val = EndpointInfo("test")
+        self.assertEqual("test/", val.get_url())
 
     def test_get_auth_returns_none(self):
         # The following inputs should not return an auth tuple:

--- a/FetchMigration/python/tests/test_fetch_orchestrator.py
+++ b/FetchMigration/python/tests/test_fetch_orchestrator.py
@@ -157,7 +157,7 @@ class TestFetchOrchestrator(unittest.TestCase):
             mock_file_open.reset_mock()
             mock_yaml_dump.reset_mock()
             orchestrator.write_inline_target_host("test", val)
-            mock_file_open.assert_called_once_with("test", "rw")
+            mock_file_open.assert_called_once_with("test", "r+")
             mock_yaml_dump.assert_called_once_with(expected_pipeline, ANY)
 
     def test_update_target_host_bad_config(self):

--- a/FetchMigration/python/tests/test_index_diff.py
+++ b/FetchMigration/python/tests/test_index_diff.py
@@ -1,0 +1,73 @@
+import copy
+import unittest
+
+from index_diff import IndexDiff
+from tests import test_constants
+
+
+class TestIndexDiff(unittest.TestCase):
+    def test_index_diff_empty(self):
+        # Base case should return an empty list
+        diff = IndexDiff(dict(), dict())
+        # All members should be empty
+        self.assertEqual(set(), diff.indices_to_create)
+        self.assertEqual(set(), diff.identical_indices)
+        self.assertEqual(set(), diff.conflicting_indices)
+
+    def test_index_diff_empty_target(self):
+        diff = IndexDiff(test_constants.BASE_INDICES_DATA, dict())
+        # No conflicts or identical indices
+        self.assertEqual(set(), diff.conflicting_indices)
+        self.assertEqual(set(), diff.identical_indices)
+        # Indices-to-create
+        self.assertEqual(3, len(diff.indices_to_create))
+        self.assertTrue(test_constants.INDEX1_NAME in diff.indices_to_create)
+        self.assertTrue(test_constants.INDEX2_NAME in diff.indices_to_create)
+        self.assertTrue(test_constants.INDEX3_NAME in diff.indices_to_create)
+
+    def test_index_diff_identical_index(self):
+        test_data = copy.deepcopy(test_constants.BASE_INDICES_DATA)
+        del test_data[test_constants.INDEX2_NAME]
+        del test_data[test_constants.INDEX3_NAME]
+        diff = IndexDiff(test_data, test_data)
+        # No indices to move, or conflicts
+        self.assertEqual(set(), diff.indices_to_create)
+        self.assertEqual(set(), diff.conflicting_indices)
+        # Identical indices
+        self.assertEqual(1, len(diff.identical_indices))
+        self.assertTrue(test_constants.INDEX1_NAME in diff.identical_indices)
+
+    def test_index_diff_settings_conflict(self):
+        test_data = copy.deepcopy(test_constants.BASE_INDICES_DATA)
+        # Set up conflict in settings
+        index_settings = test_data[test_constants.INDEX2_NAME][test_constants.SETTINGS_KEY]
+        index_settings[test_constants.INDEX_KEY][test_constants.NUM_REPLICAS_SETTING] += 1
+        diff = IndexDiff(test_constants.BASE_INDICES_DATA, test_data)
+        # No indices to move
+        self.assertEqual(set(), diff.indices_to_create)
+        # Identical indices
+        self.assertEqual(2, len(diff.identical_indices))
+        self.assertTrue(test_constants.INDEX1_NAME in diff.identical_indices)
+        self.assertTrue(test_constants.INDEX3_NAME in diff.identical_indices)
+        # Conflicting indices
+        self.assertEqual(1, len(diff.conflicting_indices))
+        self.assertTrue(test_constants.INDEX2_NAME in diff.conflicting_indices)
+
+    def test_index_diff_mappings_conflict(self):
+        test_data = copy.deepcopy(test_constants.BASE_INDICES_DATA)
+        # Set up conflict in mappings
+        test_data[test_constants.INDEX3_NAME][test_constants.MAPPINGS_KEY] = {}
+        diff = IndexDiff(test_constants.BASE_INDICES_DATA, test_data)
+        # No indices to move
+        self.assertEqual(set(), diff.indices_to_create)
+        # Identical indices
+        self.assertEqual(2, len(diff.identical_indices))
+        self.assertTrue(test_constants.INDEX1_NAME in diff.identical_indices)
+        self.assertTrue(test_constants.INDEX2_NAME in diff.identical_indices)
+        # Conflicting indices
+        self.assertEqual(1, len(diff.conflicting_indices))
+        self.assertTrue(test_constants.INDEX3_NAME in diff.conflicting_indices)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/FetchMigration/python/tests/test_index_operations.py
+++ b/FetchMigration/python/tests/test_index_operations.py
@@ -60,12 +60,18 @@ class TestIndexOperations(unittest.TestCase):
     @responses.activate
     def test_doc_count(self):
         test_indices = {test_constants.INDEX1_NAME, test_constants.INDEX2_NAME}
-        expected_count_endpoint = test_constants.SOURCE_ENDPOINT + ",".join(test_indices) + "/_count"
-        mock_count_response = {"count": "10"}
+        index_doc_count: int = 5
+        test_buckets = list()
+        for index_name in test_indices:
+            test_buckets.append({"key": index_name, "doc_count": index_doc_count})
+        total_docs: int = index_doc_count * len(test_buckets)
+        expected_count_endpoint = test_constants.SOURCE_ENDPOINT + ",".join(test_indices) + "/_search?size=0"
+        mock_count_response = {"hits": {"total": {"value": total_docs}},
+                               "aggregations": {"count": {"buckets": test_buckets}}}
         responses.get(expected_count_endpoint, json=mock_count_response)
         # Now send request
-        count_value = index_operations.doc_count(test_indices, EndpointInfo(test_constants.SOURCE_ENDPOINT))
-        self.assertEqual(10, count_value)
+        doc_count_result = index_operations.doc_count(test_indices, EndpointInfo(test_constants.SOURCE_ENDPOINT))
+        self.assertEqual(total_docs, doc_count_result.total)
 
 
 if __name__ == '__main__':

--- a/FetchMigration/python/tests/test_metadata_migration.py
+++ b/FetchMigration/python/tests/test_metadata_migration.py
@@ -4,6 +4,7 @@ import unittest
 from unittest.mock import patch, MagicMock, ANY
 
 import metadata_migration
+from index_doc_count import IndexDocCount
 from metadata_migration_params import MetadataMigrationParams
 from tests import test_constants
 
@@ -94,7 +95,7 @@ class TestMetadataMigration(unittest.TestCase):
     # Note that mock objects are passed bottom-up from the patch order above
     def test_run_report(self, mock_fetch_indices: MagicMock, mock_create_indices: MagicMock,
                         mock_print_report: MagicMock, mock_write_output: MagicMock, mock_doc_count: MagicMock):
-        mock_doc_count.return_value = 1
+        mock_doc_count.return_value = IndexDocCount(1, dict())
         index_to_create = test_constants.INDEX3_NAME
         index_with_conflict = test_constants.INDEX2_NAME
         index_exact_match = test_constants.INDEX1_NAME
@@ -126,7 +127,7 @@ class TestMetadataMigration(unittest.TestCase):
     def test_run_dryrun(self, mock_fetch_indices: MagicMock, mock_write_output: MagicMock,
                         mock_print_report: MagicMock, mock_doc_count: MagicMock):
         index_to_create = test_constants.INDEX1_NAME
-        mock_doc_count.return_value = 1
+        mock_doc_count.return_value = IndexDocCount(1, dict())
         expected_output_path = "dummy"
         # Create mock data for indices on target
         target_indices_data = copy.deepcopy(test_constants.BASE_INDICES_DATA)
@@ -136,7 +137,7 @@ class TestMetadataMigration(unittest.TestCase):
         test_input = MetadataMigrationParams(test_constants.PIPELINE_CONFIG_RAW_FILE_PATH, expected_output_path,
                                              dryrun=True)
         test_result = metadata_migration.run(test_input)
-        self.assertEqual(mock_doc_count.return_value, test_result.target_doc_count)
+        self.assertEqual(mock_doc_count.return_value.total, test_result.target_doc_count)
         self.assertEqual({index_to_create}, test_result.created_indices)
         mock_write_output.assert_called_once_with(self.loaded_pipeline_config, {index_to_create}, expected_output_path)
         mock_doc_count.assert_called()

--- a/deployment/cdk/opensearch-service-migration/dp_pipeline_template.yaml
+++ b/deployment/cdk/opensearch-service-migration/dp_pipeline_template.yaml
@@ -1,18 +1,36 @@
+# Name of the Data Prepper pipeline
 historical-data-migration:
+  # Source cluster configuration
   source:
     opensearch:
+      # DO NOT CHANGE the hosts value - this will be updated by the CDK
       hosts:
       - <SOURCE_CLUSTER_HOST>
+      # Uncomment the following line to disable TLS
+      #insecure: true
+      # Example configuration on how to disable authentication (default: false)
       disable_authentication: true
       indices:
+        # Indices to exclude - exclude system indices by default
         exclude:
         - index_name_regex: \.*
+  # Target cluster configuration
   sink:
   - opensearch:
-      bulk_size: 10
+      # DO NOT CHANGE the hosts value - this will be updated by the CDK
+      # But adjust the protocol (http or https) as appropriate
       hosts:
       - https://<TARGET_CLUSTER_HOST>
+      # Derive index name from record metadata
       index: ${getMetadata("opensearch-index")}
+      # Use the same document ID as the source cluster document
       document_id: ${getMetadata("opensearch-document_id")}
+      # Example configuration for basic auth
       username: user
       password: pass
+      #disable_authentication: true
+  # Additional pipeline options/optimizations
+  # For maximum throughput, match workers to number of vCPUs (default: 1)
+  workers: 1
+  # delay is how often the worker threads should process data (default: 3000 ms)
+  delay: 0

--- a/deployment/cdk/opensearch-service-migration/dp_pipeline_template.yaml
+++ b/deployment/cdk/opensearch-service-migration/dp_pipeline_template.yaml
@@ -3,7 +3,8 @@ historical-data-migration:
   # Source cluster configuration
   source:
     opensearch:
-      # DO NOT CHANGE the hosts value - this will be updated by the CDK
+      # CDK code will replace this value, so DO NOT CHANGE this
+      # unless the file is being used outside of the CDK
       hosts:
       - <SOURCE_CLUSTER_HOST>
       # Uncomment the following line to disable TLS
@@ -17,10 +18,9 @@ historical-data-migration:
   # Target cluster configuration
   sink:
   - opensearch:
-      # DO NOT CHANGE the hosts value - this will be updated by the CDK
-      # But adjust the protocol (http or https) as appropriate
+      # Note - CDK code will replace this value with the target cluster endpoint
       hosts:
-      - https://<TARGET_CLUSTER_HOST>
+      - <TARGET_CLUSTER_ENDPOINT_PLACEHOLDER>
       # Derive index name from record metadata
       index: ${getMetadata("opensearch-index")}
       # Use the same document ID as the source cluster document

--- a/deployment/cdk/opensearch-service-migration/lib/fetch-migration-stack.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/fetch-migration-stack.ts
@@ -38,8 +38,8 @@ export class FetchMigrationStack extends Stack {
 
         // ECS Task Definition
         const fetchMigrationFargateTask = new FargateTaskDefinition(this, "fetchMigrationFargateTask", {
-            memoryLimitMiB: 2048,
-            cpu: 512
+            memoryLimitMiB: 4096,
+            cpu: 1024
         });
 
         new StringParameter(this, 'SSMParameterFetchMigrationTaskDefArn', {


### PR DESCRIPTION
### Description
* Category: Enhancement
>  Why these changes are required?

This change enables Fetch Migration to migrate data for indices that are identical between the source and target cluster, _and_ the document count on the target cluster is zero. Such behavior allow users to execute Fetch Migration in an idempotent manner without having to manually remove empty indices on the target cluster (that were created by a previous run of Fetch Migration that did not complete successfully)

> What is the old behavior before changes and new behavior after changes?

Prior to this change, all indices that were identical between the source and target clusters were ineligible for data migration. Now, we check the doc_count for identical indices on the target cluster and only exclude identical indices with a non-zero document count.

### Testing
```
$ python -m coverage report --omit "*/tests/*"
Name                           Stmts   Miss  Cover
--------------------------------------------------
endpoint_info.py                   6      0   100%
fetch_orchestrator.py             25      0   100%
index_diff.py                     20      0   100%
index_doc_count.py                 5      0   100%
index_operations.py               49      0   100%
metadata_migration.py            118      0   100%
metadata_migration_params.py       7      0   100%
metadata_migration_result.py       5      0   100%
migration_monitor.py              94      4    96%
migration_monitor_params.py        6      0   100%
progress_metrics.py               89      0   100%
utils.py                          13      0   100%
--------------------------------------------------
TOTAL                            437      4    99%

```

Also tested end-to-end via the CDK. Log output from a test run:

```
INFO:root:Running pre-migration steps...

Identical indices in the target cluster: [logs-241998, sonested, logs-181998, logs-221998, reindexed-logs, nyc_taxis, geonames, logs-191998, logs-201998, logs-231998, logs-211998]

Identical empty indices in the target cluster (data will be migrated): [sonested, reindexed-logs, nyc_taxis, geonames]

Indices present in both clusters with conflicting settings/mappings (data will not be migrated): []

Indices to be created in the target cluster (data will be migrated): []

Total number of documents to be moved: 3000

...
```

### Check List
- [x] New functionality includes testing
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
