### PR TITLE
Allow Existing App Registry for CDK

### DIFF
--- a/deployment/cdk/opensearch-service-migration/bin/app.ts
+++ b/deployment/cdk/opensearch-service-migration/bin/app.ts
@@ -9,7 +9,14 @@ const version = readFileSync('../../../VERSION', 'utf-8')
 Tags.of(app).add("migration_deployment", version)
 const account = process.env.CDK_DEFAULT_ACCOUNT
 const region = process.env.CDK_DEFAULT_REGION
+// Environment setting to allow providing an existing AWS AppRegistry application ARN which each created CDK stack
+// from this CDK app will be added to.
+const migrationsAppRegistryARN = process.env.MIGRATIONS_APP_REGISTRY_ARN
+if (migrationsAppRegistryARN) {
+    console.info(`App Registry mode is enabled for CFN stack tracking. Will attempt to import the App Registry application from the MIGRATIONS_APP_REGISTRY_ARN env variable of ${migrationsAppRegistryARN} and looking in the configured region of ${region}`)
+}
 
 new StackComposer(app, {
+    migrationsAppRegistryARN: migrationsAppRegistryARN,
     env: { account: account, region: region }
 });

--- a/deployment/cdk/opensearch-service-migration/buildDockerImages.sh
+++ b/deployment/cdk/opensearch-service-migration/buildDockerImages.sh
@@ -6,4 +6,4 @@ script_dir_abs_path=$(dirname "$script_abs_path")
 cd $script_dir_abs_path || exit
 
 cd ../../../TrafficCapture || exit
-./gradlew :dockerSolution:buildDockerImages
+./gradlew :dockerSolution:buildDockerImages -x test

--- a/deployment/cdk/opensearch-service-migration/lib/stack-composer.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/stack-composer.ts
@@ -30,15 +30,15 @@ export interface StackComposerProps extends StackProps {
     readonly migrationsAppRegistryARN?: string
 }
 
-export function addStacksToAppRegistry(scope: Construct, appRegistryAppARN: string, allStacks: Stack[]) {
-    for (let stack of allStacks) {
-        const appRegistryApp = Application.fromApplicationArn(stack, 'AppRegistryApplicationImport', appRegistryAppARN)
-        appRegistryApp.associateApplicationWithStack(stack)
-    }
-}
-
 export class StackComposer {
     public stacks: Stack[] = [];
+
+    private addStacksToAppRegistry(scope: Construct, appRegistryAppARN: string, allStacks: Stack[]) {
+        for (let stack of allStacks) {
+            const appRegistryApp = Application.fromApplicationArn(stack, 'AppRegistryApplicationImport', appRegistryAppARN)
+            appRegistryApp.associateApplicationWithStack(stack)
+        }
+    }
 
     constructor(scope: Construct, props: StackComposerProps) {
 
@@ -433,7 +433,7 @@ export class StackComposer {
         }
 
         if (props.migrationsAppRegistryARN) {
-            addStacksToAppRegistry(scope, props.migrationsAppRegistryARN, this.stacks)
+            this.addStacksToAppRegistry(scope, props.migrationsAppRegistryARN, this.stacks)
         }
 
         function getContextForType(optionName: string, expectedType: string): any {

--- a/deployment/cdk/opensearch-service-migration/lib/stack-composer.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/stack-composer.ts
@@ -18,6 +18,7 @@ import {CaptureProxyStack} from "./service-stacks/capture-proxy-stack";
 import {ElasticsearchStack} from "./service-stacks/elasticsearch-stack";
 import {KafkaBrokerStack} from "./service-stacks/kafka-broker-stack";
 import {KafkaZookeeperStack} from "./service-stacks/kafka-zookeeper-stack";
+import {Application} from "@aws-cdk/aws-servicecatalogappregistry-alpha";
 
 export interface StackPropsExt extends StackProps {
     readonly stage: string,
@@ -25,10 +26,21 @@ export interface StackPropsExt extends StackProps {
     readonly addOnMigrationDeployId?: string
 }
 
+export interface StackComposerProps extends StackProps {
+    readonly migrationsAppRegistryARN?: string
+}
+
+export function addStacksToAppRegistry(scope: Construct, appRegistryAppARN: string, allStacks: Stack[]) {
+    for (let stack of allStacks) {
+        const appRegistryApp = Application.fromApplicationArn(stack, 'AppRegistryApplicationImport', appRegistryAppARN)
+        appRegistryApp.associateApplicationWithStack(stack)
+    }
+}
+
 export class StackComposer {
     public stacks: Stack[] = [];
 
-    constructor(scope: Construct, props: StackProps) {
+    constructor(scope: Construct, props: StackComposerProps) {
 
         const defaultValues: { [x: string]: (any); } = defaultValuesJson
         const account = props.env?.account
@@ -418,6 +430,10 @@ export class StackComposer {
             migrationConsoleStack.addDependency(mskUtilityStack)
             migrationConsoleStack.addDependency(openSearchStack)
             this.stacks.push(migrationConsoleStack)
+        }
+
+        if (props.migrationsAppRegistryARN) {
+            addStacksToAppRegistry(scope, props.migrationsAppRegistryARN, this.stacks)
         }
 
         function getContextForType(optionName: string, expectedType: string): any {

--- a/deployment/cdk/opensearch-service-migration/package-lock.json
+++ b/deployment/cdk/opensearch-service-migration/package-lock.json
@@ -8,6 +8,7 @@
       "name": "opensearch-service-domain-cdk",
       "version": "0.1.0",
       "dependencies": {
+        "@aws-cdk/aws-servicecatalogappregistry-alpha": "2.100.0-alpha.0",
         "@aws-sdk/client-kafka": "^3.410.0",
         "@aws-sdk/client-lambda": "^3.359.0",
         "@types/aws-lambda": "^8.10.117",
@@ -54,6 +55,18 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.0.1.tgz",
       "integrity": "sha512-DDt4SLdLOwWCjGtltH4VCST7hpOI5DzieuhGZsBpZ+AgJdSI2GCjklCXm0GCTwJG/SolkL5dtQXyUKgg9luBDg=="
+    },
+    "node_modules/@aws-cdk/aws-servicecatalogappregistry-alpha": {
+      "version": "2.100.0-alpha.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-servicecatalogappregistry-alpha/-/aws-servicecatalogappregistry-alpha-2.100.0-alpha.0.tgz",
+      "integrity": "sha512-+CVSZ9KVspdXENqD8TV3inD1TNybvgdBwq00t0b9xbFCZpsRHKeD3bkU9ZTd/0+zXhxDDkJyAr09TJ3iJUrKFw==",
+      "engines": {
+        "node": ">= 14.15.0"
+      },
+      "peerDependencies": {
+        "aws-cdk-lib": "^2.100.0",
+        "constructs": "^10.0.0"
+      }
     },
     "node_modules/@aws-crypto/crc32": {
       "version": "3.0.0",

--- a/deployment/cdk/opensearch-service-migration/package.json
+++ b/deployment/cdk/opensearch-service-migration/package.json
@@ -17,6 +17,7 @@
     "typescript": "~4.9.4"
   },
   "dependencies": {
+    "@aws-cdk/aws-servicecatalogappregistry-alpha": "2.100.0-alpha.0",
     "@aws-sdk/client-kafka": "^3.410.0",
     "@aws-sdk/client-lambda": "^3.359.0",
     "@types/aws-lambda": "^8.10.117",


### PR DESCRIPTION
### Description
This is a small change to allow an existing AppRegistry application to be imported into our CDK, such that all stacks that get created are associated with the AppRegistry application. It is an optional setting this is enabled through the MIGRATIONS_APP_REGISTRY_ARN environment variable. 

### Issues Resolved
https://opensearch.atlassian.net/browse/MIGRATIONS-1411

### Testing
Manual deployment testing

### Check List
- [ ] New functionality includes testing
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
