### PR TITLE
Cleaning up some code and fixed some NPEs in outputting tuples.

### DIFF
--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/AccumulationCallbacks.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/AccumulationCallbacks.java
@@ -9,6 +9,7 @@ import java.util.List;
 public interface AccumulationCallbacks {
     void onRequestReceived(UniqueReplayerRequestKey key, HttpMessageAndTimestamp request);
     void onFullDataReceived(UniqueReplayerRequestKey key, RequestResponsePacketPair rrpp);
-    void onTrafficStreamsExpired(RequestResponsePacketPair.ReconstructionStatus status, List<ITrafficStreamKey> trafficStreamKeysBeingHeld);
+    void onTrafficStreamsExpired(RequestResponsePacketPair.ReconstructionStatus status,
+                                 List<ITrafficStreamKey> trafficStreamKeysBeingHeld);
     void onConnectionClose(UniqueReplayerRequestKey key, Instant when);
 }

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/AggregatedRawResponse.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/AggregatedRawResponse.java
@@ -83,8 +83,8 @@ public class AggregatedRawResponse {
         final StringBuilder sb = new StringBuilder("IResponseSummary{");
         sb.append("responseSizeInBytes=").append(responseSizeInBytes);
         sb.append(", responseDuration=").append(responseDuration);
-        sb.append(", # of responsePackets=").append(""+
-                (this.responsePackets==null ? "-1" : "" + this.responsePackets.size()));
+        sb.append(", # of responsePackets=").append("" +
+                (this.responsePackets == null ? "-1" : "" + this.responsePackets.size()));
         addSubclassInfoForToString(sb);
         sb.append('}');
         return sb.toString();

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/SourceTargetCaptureTuple.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/SourceTargetCaptureTuple.java
@@ -19,7 +19,9 @@ import java.time.Duration;
 import java.util.Base64;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Scanner;
+import java.util.StringJoiner;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
@@ -33,7 +35,7 @@ public class SourceTargetCaptureTuple implements AutoCloseable {
     final Throwable errorCause;
     Duration targetResponseDuration;
 
-    public SourceTargetCaptureTuple(UniqueSourceRequestKey uniqueRequestKey,
+    public SourceTargetCaptureTuple(@NonNull UniqueSourceRequestKey uniqueRequestKey,
                                     RequestResponsePacketPair sourcePair,
                                     TransformedPackets targetRequestData,
                                     List<byte[]> targetResponseData,
@@ -51,14 +53,14 @@ public class SourceTargetCaptureTuple implements AutoCloseable {
 
     @Override
     public void close() {
-        targetRequestData.close();
+        Optional.ofNullable(targetRequestData).ifPresent(d->d.close());
     }
 
-    public static class TupleToFileWriter implements Consumer<SourceTargetCaptureTuple> {
+    public static class TupleToStreamConsumer implements Consumer<SourceTargetCaptureTuple> {
         OutputStream outputStream;
         Logger tupleLogger = LogManager.getLogger("OutputTupleJsonLogger");
 
-        public TupleToFileWriter(OutputStream outputStream){
+        public TupleToStreamConsumer(OutputStream outputStream){
             this.outputStream = outputStream;
         }
 
@@ -100,22 +102,28 @@ public class SourceTargetCaptureTuple implements AutoCloseable {
             return message;
         }
 
-        private JSONObject toJSONObject(SourceTargetCaptureTuple triple) {
+        private JSONObject toJSONObject(SourceTargetCaptureTuple tuple) {
             // TODO: Use Netty to parse the packets as HTTP rather than json.org (we can also remove it as a dependency)
             JSONObject meta = new JSONObject();
-            meta.put("sourceRequest", jsonFromHttpData(triple.sourcePair.requestData.packetBytes));
-            meta.put("targetRequest", jsonFromHttpData(triple.targetRequestData.asByteArrayStream()
-                    .collect(Collectors.toList())));
-            //log.warn("TODO: These durations are not measuring the same values!");
-            if (triple.sourcePair.responseData != null) {
-                meta.put("sourceResponse", jsonFromHttpData(triple.sourcePair.responseData.packetBytes,
-                        Duration.between(triple.sourcePair.requestData.getLastPacketTimestamp(),
-                                triple.sourcePair.responseData.getLastPacketTimestamp())));
-            }
-            if (triple.targetResponseData != null && !triple.targetResponseData.isEmpty()) {
-                meta.put("targetResponse", jsonFromHttpData(triple.targetResponseData, triple.targetResponseDuration));
-            }
-            meta.put("connectionId", triple.uniqueRequestKey);
+            Optional.ofNullable(tuple.sourcePair).ifPresent(p-> {
+                Optional.ofNullable(p.requestData).flatMap(d -> Optional.ofNullable(d.packetBytes))
+                        .ifPresent(d -> meta.put("sourceRequest", jsonFromHttpData(d)));
+                Optional.ofNullable(p.responseData).flatMap(d -> Optional.ofNullable(d.packetBytes))
+                        .ifPresent(d -> meta.put("sourceResponse", jsonFromHttpData(d,
+                                //log.warn("TODO: These durations are not measuring the same values!");
+                                Duration.between(tuple.sourcePair.requestData.getLastPacketTimestamp(),
+                                        tuple.sourcePair.responseData.getLastPacketTimestamp()))));
+            });
+
+            Optional.ofNullable(tuple.targetRequestData)
+                    .map(d->d.asByteArrayStream())
+                    .ifPresent(d->meta.put("targetRequest", jsonFromHttpData(d.collect(Collectors.toList()))));
+
+            Optional.ofNullable(tuple.targetResponseData)
+                    .filter(r->!r.isEmpty())
+                    .ifPresent(d-> meta.put("targetResponse", jsonFromHttpData(d, tuple.targetResponseDuration)));
+            meta.put("connectionId", tuple.uniqueRequestKey);
+            Optional.ofNullable(tuple.errorCause).ifPresent(e->meta.put("error", e));
             return meta;
         }
 
@@ -177,18 +185,18 @@ public class SourceTargetCaptureTuple implements AutoCloseable {
     @Override
     public String toString() {
         return PrettyPrinter.setPrintStyleFor(PrettyPrinter.PacketPrintFormat.TRUNCATED, () -> {
-            final StringBuilder sb = new StringBuilder("SourceTargetCaptureTuple{");
-            sb.append("\n diagnosticLabel=").append(uniqueRequestKey);
-            sb.append("\n sourcePair=").append(sourcePair);
-            sb.append("\n targetResponseDuration=").append(targetResponseDuration);
-            sb.append("\n targetRequestData=")
-                    .append(PrettyPrinter.httpPacketBufsToString(PrettyPrinter.HttpMessageType.REQUEST, targetRequestData.streamUnretained()));
-            sb.append("\n targetResponseData=")
-                    .append(PrettyPrinter.httpPacketBytesToString(PrettyPrinter.HttpMessageType.RESPONSE, targetResponseData));
-            sb.append("\n transformStatus=").append(transformationStatus);
-            sb.append("\n errorCause=").append(errorCause == null ? "null" : errorCause.toString());
-            sb.append('}');
-            return sb.toString();
+            final StringJoiner sj = new StringJoiner("\n ", "SourceTargetCaptureTuple{","}");
+            sj.add("diagnosticLabel=").add(uniqueRequestKey.toString());
+            if (sourcePair != null) { sj.add("sourcePair=").add(sourcePair.toString()); }
+            if (targetResponseDuration != null) { sj.add("targetResponseDuration=").add(targetResponseDuration+""); }
+            Optional.ofNullable(targetRequestData).filter(d->!d.isEmpty()).ifPresent(d-> sj.add("targetRequestData=")
+                    .add(PrettyPrinter.httpPacketBufsToString(PrettyPrinter.HttpMessageType.REQUEST,
+                            d.streamUnretained())));
+            Optional.ofNullable(targetResponseData).filter(d->!d.isEmpty()).ifPresent(d -> sj.add("targetResponseData=")
+                    .add(PrettyPrinter.httpPacketBytesToString(PrettyPrinter.HttpMessageType.RESPONSE, d)));
+            sj.add("transformStatus=").add(transformationStatus+"");
+            sj.add("errorCause=").add(errorCause == null ? "none" : errorCause.toString());
+            return sj.toString();
         });
     }
 }

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datatypes/PojoTrafficStreamKey.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datatypes/PojoTrafficStreamKey.java
@@ -7,6 +7,10 @@ public class PojoTrafficStreamKey implements ITrafficStreamKey {
     private final String connectionId;
     private final int trafficStreamIndex;
 
+    public PojoTrafficStreamKey(ITrafficStreamKey orig) {
+        this(orig.getNodeId(), orig.getConnectionId(), orig.getTrafficStreamIndex());
+    }
+
     public PojoTrafficStreamKey(String nodeId, String connectionId, int index) {
         this.nodeId = nodeId;
         this.connectionId = connectionId;

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datatypes/TransformedPackets.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datatypes/TransformedPackets.java
@@ -13,6 +13,7 @@ public class TransformedPackets implements AutoCloseable {
         return data.add(nextRequestPacket.retainedDuplicate());
     }
 
+    public boolean isEmpty() { return data.isEmpty(); }
     public int size() { return data.size(); }
 
     public Stream<ByteBuf> streamUnretained() {

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datatypes/UniqueSourceRequestKey.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datatypes/UniqueSourceRequestKey.java
@@ -2,6 +2,8 @@ package org.opensearch.migrations.replay.datatypes;
 
 import com.google.common.base.Objects;
 
+import java.util.StringJoiner;
+
 public abstract class UniqueSourceRequestKey {
     public abstract ITrafficStreamKey getTrafficStreamKey();
 
@@ -14,6 +16,11 @@ public abstract class UniqueSourceRequestKey {
         UniqueSourceRequestKey that = (UniqueSourceRequestKey) o;
         return getSourceRequestIndex() == that.getSourceRequestIndex() &&
                 Objects.equal(getTrafficStreamKey(), that.getTrafficStreamKey());
+    }
+
+    @Override
+    public String toString() {
+        return getTrafficStreamKey() + "." + getSourceRequestIndex();
     }
 
     @Override

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/SourceTargetCaptureTupleTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/SourceTargetCaptureTupleTest.java
@@ -1,0 +1,59 @@
+package org.opensearch.migrations.replay;
+
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.opensearch.migrations.replay.datatypes.PojoTrafficStreamKey;
+import org.opensearch.migrations.replay.datatypes.UniqueReplayerRequestKey;
+import org.opensearch.migrations.replay.datatypes.UniqueSourceRequestKey;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Slf4j
+class SourceTargetCaptureTupleTest {
+    private static final String NODE_ID = "n";
+    public static final String TEST_EXCEPTION_MESSAGE = "TEST_EXCEPTION";
+
+    @Test
+    public void testTupleNewWithNullKeyThrows() {
+        Assertions.assertThrows(Exception.class,
+                ()->new SourceTargetCaptureTuple(null, null, null,
+                        null, null, null, null));
+    }
+
+    @Test
+    public void testOutputterWithNulls() throws IOException {
+        var emptyTuple = new SourceTargetCaptureTuple(
+                new UniqueReplayerRequestKey(new PojoTrafficStreamKey(NODE_ID,"c",0), 0, 0),
+                null, null, null, null, null, null);
+        String contents;
+        try (var byteArrayOutputStream = new ByteArrayOutputStream()) {
+            var consumer = new SourceTargetCaptureTuple.TupleToStreamConsumer(byteArrayOutputStream);
+            consumer.accept(emptyTuple);
+            contents = new String(byteArrayOutputStream.toByteArray(), StandardCharsets.UTF_8);
+        }
+        log.info("Output="+contents);
+        Assertions.assertTrue(contents.contains(NODE_ID));
+    }
+
+    @Test
+    public void testOutputterWithNullsShowsException() throws IOException {
+        var exception = new Exception(TEST_EXCEPTION_MESSAGE);
+        var emptyTuple = new SourceTargetCaptureTuple(
+                new UniqueReplayerRequestKey(new PojoTrafficStreamKey(NODE_ID,"c",0), 0, 0),
+                null, null, null, null, exception, null);
+        String contents;
+        try (var byteArrayOutputStream = new ByteArrayOutputStream()) {
+            var consumer = new SourceTargetCaptureTuple.TupleToStreamConsumer(byteArrayOutputStream);
+            consumer.accept(emptyTuple);
+            contents = new String(byteArrayOutputStream.toByteArray(), StandardCharsets.UTF_8);
+        }
+        log.info("Output="+contents);
+        Assertions.assertTrue(contents.contains(NODE_ID));
+        Assertions.assertTrue(contents.contains(TEST_EXCEPTION_MESSAGE));
+    }
+}

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/TrafficStreamGenerator.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/TrafficStreamGenerator.java
@@ -145,7 +145,8 @@ public class TrafficStreamGenerator {
     }
 
     private static void addCommands(Random r, double flushLikelihood, int numPacketCommands,
-                                    List<SimpleCapturedTrafficToHttpTransactionAccumulatorTest.ObservationDirective> outgoingCommands, List<Integer> outgoingSizes,
+                                    List<SimpleCapturedTrafficToHttpTransactionAccumulatorTest.ObservationDirective> outgoingCommands,
+                                    List<Integer> outgoingSizes,
                                     Supplier<SimpleCapturedTrafficToHttpTransactionAccumulatorTest.ObservationDirective> directiveSupplier) {
         int aggregateBufferSize = 0;
         for (var cmdCount = new AtomicInteger(numPacketCommands); cmdCount.get()>0;) {
@@ -172,7 +173,8 @@ public class TrafficStreamGenerator {
     }
 
     private static void fillCommandsAndSizes(int bufferSize, Random r, double flushLikelihood, int bufferBound,
-                                             List<SimpleCapturedTrafficToHttpTransactionAccumulatorTest.ObservationDirective> commands, List<Integer> sizes) {
+                                             List<SimpleCapturedTrafficToHttpTransactionAccumulatorTest.ObservationDirective> commands,
+                                             List<Integer> sizes) {
         var numTransactions = r.nextInt(MAX_COMMANDS_IN_CONNECTION);
         for (int i=numTransactions; i>0; --i) {
             addCommands(r, flushLikelihood, r.nextInt(MAX_READS_IN_REQUEST)+1, commands, sizes,


### PR DESCRIPTION
I'm still preparing to commit messages.  There's some minor refactoring to make that easier.  The FullTrafficReplayerTest continues to undergo changes. In making those changes, I also realized that during shutdown, some rare exceptions fire & tickle code that's otherwise tough to reach.  One spot caught an exception before almost anything other than a UniqueResponseRequestKey was parsed.  That left most of the tuple fields as null, except for the error.  Unfortunately, we weren't outputting the error at all and would throw an exception on the null fields.  Now we output the error and don't emit each specific field when the data to serialize was null.  Unit tests are included.  The contract stipulates that ONLY the request key must not be null.

### Description
[Describe what this change achieves]
* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)
* Why these changes are required?
* What is the old behavior before changes and new behavior after changes?

### Issues Resolved
[List any issues this PR will resolve]

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]

### Check List
- [x] New functionality includes testing
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
