### PR TITLE
Bump Kafka version on Docker

### DIFF
--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/Dockerfile
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/Dockerfile
@@ -19,7 +19,7 @@ RUN chmod ug+x /root/humanReadableLogs.py
 RUN chmod ug+x /root/catIndices.sh
 WORKDIR /root/kafka-tools
 # Get kafka distribution and unpack to 'kafka'
-RUN wget -qO- https://archive.apache.org/dist/kafka/3.5.0/kafka_2.13-3.5.0.tgz | tar --transform 's!^[^/]*!kafka!' -xvz
+RUN wget -qO- https://archive.apache.org/dist/kafka/3.6.0/kafka_2.13-3.6.0.tgz | tar --transform 's!^[^/]*!kafka!' -xvz
 RUN wget -O kafka/libs/msk-iam-auth.jar https://github.com/aws/aws-msk-iam-auth/releases/download/v1.1.9/aws-msk-iam-auth-1.1.9-all.jar
 WORKDIR /root
 


### PR DESCRIPTION
### Description
Changed the version of kafka on the Kafka Docker image to match the version we are updating to after applying this security fix:

https://github.com/opensearch-project/opensearch-migrations/pull/340

### Issues Resolved
https://github.com/opensearch-project/opensearch-migrations/pull/340


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
