### PR TITLE
[Fetch Migration] Support for dynamic target host substitution via environment variable, and fetch_orchestrator updates

### DIFF
--- a/FetchMigration/Dockerfile
+++ b/FetchMigration/Dockerfile
@@ -18,5 +18,6 @@ ENV PATH=/root/.local:$PATH
 RUN echo "ssl: false" > $DATA_PREPPER_PATH/config/data-prepper-config.yaml
 RUN echo "metricRegistries: [Prometheus]" >> $DATA_PREPPER_PATH/config/data-prepper-config.yaml
 
-# Include the -u flag to have stdout logged
-ENTRYPOINT python3 -u ./fetch_orchestrator.py --insecure $DATA_PREPPER_PATH $FM_CODE_PATH/input.yaml
+# Include the -u flag to have unbuffered stdout (for detached mode)
+# "$0" "$@" allows passing extra args/flags to the entrypoint when the image is run
+ENTRYPOINT python3 -u ./fetch_orchestrator.py --insecure $DATA_PREPPER_PATH $FM_CODE_PATH/input.yaml "$0" "$@"

--- a/FetchMigration/Dockerfile
+++ b/FetchMigration/Dockerfile
@@ -19,5 +19,5 @@ RUN echo "ssl: false" > $DATA_PREPPER_PATH/config/data-prepper-config.yaml
 RUN echo "metricRegistries: [Prometheus]" >> $DATA_PREPPER_PATH/config/data-prepper-config.yaml
 
 # Include the -u flag to have unbuffered stdout (for detached mode)
-# "$0" "$@" allows passing extra args/flags to the entrypoint when the image is run
-ENTRYPOINT python3 -u ./fetch_orchestrator.py --insecure $DATA_PREPPER_PATH $FM_CODE_PATH/input.yaml "$0" "$@"
+# "$@" allows passing extra args/flags to the entrypoint when the image is run
+ENTRYPOINT python3 -u ./fetch_orchestrator.py --insecure $DATA_PREPPER_PATH $FM_CODE_PATH/input.yaml "$@"

--- a/FetchMigration/Dockerfile
+++ b/FetchMigration/Dockerfile
@@ -19,4 +19,4 @@ RUN echo "ssl: false" > $DATA_PREPPER_PATH/config/data-prepper-config.yaml
 RUN echo "metricRegistries: [Prometheus]" >> $DATA_PREPPER_PATH/config/data-prepper-config.yaml
 
 # Include the -u flag to have stdout logged
-ENTRYPOINT python3 -u ./fetch_orchestrator.py $DATA_PREPPER_PATH $FM_CODE_PATH/input.yaml http://localhost:4900
+ENTRYPOINT python3 -u ./fetch_orchestrator.py --insecure $DATA_PREPPER_PATH $FM_CODE_PATH/input.yaml

--- a/FetchMigration/python/fetch_orchestrator.py
+++ b/FetchMigration/python/fetch_orchestrator.py
@@ -2,20 +2,79 @@ import argparse
 import base64
 import logging
 import os
+import re
 import subprocess
 import sys
 from typing import Optional
+
+import yaml
 
 import metadata_migration
 import migration_monitor
 from metadata_migration_params import MetadataMigrationParams
 from migration_monitor_params import MigrationMonitorParams
 
+__PROTOCOL_PREFIX_PATTERN = re.compile(r"^https?://")
+__HTTPS_PREFIX = "https://"
 __DP_EXECUTABLE_SUFFIX = "/bin/data-prepper"
 __PIPELINE_OUTPUT_FILE_SUFFIX = "/pipelines/pipeline.yaml"
 
 
+def __get_env_string(name: str) -> Optional[str]:
+    val: str = os.environ.get(name, "")
+    if len(val) > 0:
+        return val
+    else:
+        return None
+
+
+def update_target_host(dp_config: dict, target_host: str):
+    # Inline target host only supports HTTPS, so force it
+    target_with_protocol = target_host
+    match = __PROTOCOL_PREFIX_PATTERN.match(target_with_protocol)
+    if match:
+        target_with_protocol = target_host[match.end():]
+    target_with_protocol = __HTTPS_PREFIX + target_with_protocol
+    if len(dp_config) > 0:
+        # We expect the Data Prepper pipeline to only have a single top-level value
+        pipeline_config = next(iter(dp_config.values()))
+        # The entire pipeline will be validated later
+        if metadata_migration.SINK_KEY in pipeline_config:
+            # throws ValueError if no supported endpoints are found
+            plugin_name, plugin_config = metadata_migration.get_supported_endpoint(pipeline_config,
+                                                                                   metadata_migration.SINK_KEY)
+            plugin_config[metadata_migration.HOSTS_KEY] = [target_with_protocol]
+            pipeline_config[metadata_migration.SINK_KEY] = {plugin_name: plugin_config}
+
+
+def write_inline_pipeline(pipeline_file_path: str):
+    # This is expected to be a base64 encoded string
+    inline_pipeline = __get_env_string("INLINE_PIPELINE")
+    pipeline_yaml = yaml.safe_load(base64.b64decode(inline_pipeline))
+    inline_target_host = __get_env_string("INLINE_TARGET_HOST")
+    if inline_target_host is not None:
+        update_target_host(pipeline_yaml, inline_target_host)
+    with open(pipeline_file_path, 'w') as out_file:
+        # Note - this does not preserve comments
+        yaml.safe_dump(pipeline_yaml, out_file)
+
+
+def write_inline_target_host(pipeline_file_path: str, inline_target_host: str):
+    with open(pipeline_file_path, 'rw') as pipeline_file:
+        pipeline_yaml = yaml.safe_load(pipeline_file)
+        update_target_host(pipeline_yaml, inline_target_host)
+        # Note - this does not preserve comments
+        yaml.safe_dump(pipeline_yaml, pipeline_file)
+
+
 def run(dp_base_path: str, dp_config_file: str, dp_endpoint: str) -> Optional[int]:
+    # This is expected to be a base64 encoded string
+    inline_pipeline = __get_env_string("INLINE_PIPELINE")
+    inline_target_host = __get_env_string("INLINE_TARGET_HOST")
+    if inline_pipeline is not None:
+        write_inline_pipeline(dp_config_file)
+    elif inline_target_host is not None:
+        write_inline_target_host(dp_config_file, inline_target_host)
     dp_exec_path = dp_base_path + __DP_EXECUTABLE_SUFFIX
     output_file = dp_base_path + __PIPELINE_OUTPUT_FILE_SUFFIX
     metadata_migration_params = MetadataMigrationParams(dp_config_file, output_file, report=True)
@@ -46,7 +105,7 @@ if __name__ == '__main__':  # pragma no cover
         help="Path to the base directory where Data Prepper is installed "
     )
     arg_parser.add_argument(
-        "config_file_path",
+        "pipeline_file_path",
         help="Path to the Data Prepper pipeline YAML file to parse for source and target endpoint information"
     )
     arg_parser.add_argument(
@@ -55,13 +114,7 @@ if __name__ == '__main__':  # pragma no cover
     )
     cli_args = arg_parser.parse_args()
     base_path = os.path.expandvars(cli_args.data_prepper_path)
-
-    inline_pipeline = os.environ.get("INLINE_PIPELINE", None)
-    if inline_pipeline is not None:
-        decoded_bytes = base64.b64decode(inline_pipeline)
-        with open(cli_args.config_file_path, 'wb') as config_file:
-            config_file.write(decoded_bytes)
-    return_code = run(base_path, cli_args.config_file_path, cli_args.data_prepper_endpoint)
+    return_code = run(base_path, os.path.expandvars(cli_args.pipeline_file_path), cli_args.data_prepper_endpoint)
     if return_code == 0:
         sys.exit(0)
     else:

--- a/FetchMigration/python/fetch_orchestrator.py
+++ b/FetchMigration/python/fetch_orchestrator.py
@@ -45,7 +45,7 @@ def update_target_host(dp_config: dict, target_host: str):
             plugin_name, plugin_config = metadata_migration.get_supported_endpoint(pipeline_config,
                                                                                    metadata_migration.SINK_KEY)
             plugin_config[metadata_migration.HOSTS_KEY] = [target_with_protocol]
-            pipeline_config[metadata_migration.SINK_KEY] = {plugin_name: plugin_config}
+            pipeline_config[metadata_migration.SINK_KEY] = [{plugin_name: plugin_config}]
 
 
 def write_inline_pipeline(pipeline_file_path: str, inline_pipeline: str, inline_target_host: Optional[str]):

--- a/FetchMigration/python/fetch_orchestrator.py
+++ b/FetchMigration/python/fetch_orchestrator.py
@@ -48,11 +48,8 @@ def update_target_host(dp_config: dict, target_host: str):
             pipeline_config[metadata_migration.SINK_KEY] = {plugin_name: plugin_config}
 
 
-def write_inline_pipeline(pipeline_file_path: str):
-    # This is expected to be a base64 encoded string
-    inline_pipeline = __get_env_string("INLINE_PIPELINE")
+def write_inline_pipeline(pipeline_file_path: str, inline_pipeline: str, inline_target_host: Optional[str]):
     pipeline_yaml = yaml.safe_load(base64.b64decode(inline_pipeline))
-    inline_target_host = __get_env_string("INLINE_TARGET_HOST")
     if inline_target_host is not None:
         update_target_host(pipeline_yaml, inline_target_host)
     with open(pipeline_file_path, 'w') as out_file:
@@ -73,7 +70,7 @@ def run(params: FetchOrchestratorParams) -> Optional[int]:
     inline_pipeline = __get_env_string("INLINE_PIPELINE")
     inline_target_host = __get_env_string("INLINE_TARGET_HOST")
     if inline_pipeline is not None:
-        write_inline_pipeline(params.pipeline_file_path)
+        write_inline_pipeline(params.pipeline_file_path, inline_pipeline, inline_target_host)
     elif inline_target_host is not None:
         write_inline_target_host(params.pipeline_file_path, inline_target_host)
     dp_exec_path = params.data_prepper_path + __DP_EXECUTABLE_SUFFIX

--- a/FetchMigration/python/fetch_orchestrator_params.py
+++ b/FetchMigration/python/fetch_orchestrator_params.py
@@ -1,0 +1,29 @@
+LOCAL_ENDPOINT_HTTP: str = "http://localhost:"
+LOCAL_ENDPOINT_HTTPS: str = "https://localhost:"
+
+
+class FetchOrchestratorParams:
+    data_prepper_path: str
+    pipeline_file_path: str
+    local_port: int
+    is_insecure: bool
+    is_dry_run: bool
+    is_create_only: bool
+
+    def __init__(self, dp_path: str, config_path: str, port: int = 4900, insecure: bool = False, dryrun: bool = False,
+                 create_only: bool = False):
+        self.data_prepper_path = dp_path
+        self.pipeline_file_path = config_path
+        self.local_port = port
+        self.is_insecure = insecure
+        self.is_dry_run = dryrun
+        self.is_create_only = create_only
+
+    def get_local_endpoint(self) -> str:
+        if self.is_insecure:
+            return LOCAL_ENDPOINT_HTTP + str(self.local_port)
+        else:
+            return LOCAL_ENDPOINT_HTTPS + str(self.local_port)
+
+    def is_only_metadata_migration(self) -> bool:
+        return self.is_dry_run or self.is_create_only

--- a/FetchMigration/python/tests/resources/test_pipeline_input.yaml
+++ b/FetchMigration/python/tests/resources/test_pipeline_input.yaml
@@ -16,6 +16,7 @@ test-pipeline-input:
         - sink1:
             num_array: [0]
         - opensearch:
-            hosts: ["https://os_host"]
+            hosts:
+              - "https://os_host"
             username: "test_user"
             password: "test"

--- a/FetchMigration/python/tests/test_fetch_orchestrator.py
+++ b/FetchMigration/python/tests/test_fetch_orchestrator.py
@@ -124,8 +124,14 @@ class TestFetchOrchestrator(unittest.TestCase):
         for config in bad_configs:
             original = copy.deepcopy(config)
             orchestrator.update_target_host(config, "host")
-            # Bad configs shoudl result in no change
+            # Bad configs should result in no change
             self.assertEqual(config, original)
+
+    def test_get_local_endpoint(self):
+        # Default value for insecure flag (secure endpoint)
+        self.assertEqual("https://localhost:123", orchestrator.get_local_endpoint(123))
+        # insecure endpoint
+        self.assertEqual("http://localhost:123", orchestrator.get_local_endpoint(123, True))
 
 
 if __name__ == '__main__':

--- a/FetchMigration/python/tests/test_fetch_orchestrator.py
+++ b/FetchMigration/python/tests/test_fetch_orchestrator.py
@@ -143,7 +143,7 @@ class TestFetchOrchestrator(unittest.TestCase):
     # Note that mock objects are passed bottom-up from the patch order above
     def test_write_inline_target_host(self, mock_file_open: MagicMock, mock_yaml_load: MagicMock,
                                       mock_yaml_dump: MagicMock):
-        mock_yaml_load.return_value = {"root": {"sink": {"opensearch": {"hosts": ["val"]}}}}
+        mock_yaml_load.return_value = {"root": {"sink": [{"opensearch": {"hosts": ["val"]}}]}}
         inline_target = "host"
         expected_target_url = "https://" + inline_target
         test_values = [
@@ -152,7 +152,7 @@ class TestFetchOrchestrator(unittest.TestCase):
         ]
         expected_pipeline = copy.deepcopy(mock_yaml_load.return_value)
         # TODO - replace with jsonpath
-        expected_pipeline["root"]["sink"]["opensearch"]["hosts"] = [expected_target_url]
+        expected_pipeline["root"]["sink"][0]["opensearch"]["hosts"] = [expected_target_url]
         for val in test_values:
             mock_file_open.reset_mock()
             mock_yaml_dump.reset_mock()

--- a/FetchMigration/python/tests/test_fetch_orchestrator.py
+++ b/FetchMigration/python/tests/test_fetch_orchestrator.py
@@ -1,10 +1,13 @@
+import copy
+import os
 import unittest
-from unittest.mock import patch, MagicMock, ANY
+from unittest import mock
+from unittest.mock import patch, MagicMock, ANY, mock_open
 
 import fetch_orchestrator as orchestrator
-from migration_monitor_params import MigrationMonitorParams
 from metadata_migration_params import MetadataMigrationParams
 from metadata_migration_result import MetadataMigrationResult
+from migration_monitor_params import MigrationMonitorParams
 
 
 class TestFetchOrchestrator(unittest.TestCase):
@@ -13,6 +16,7 @@ class TestFetchOrchestrator(unittest.TestCase):
     @patch('subprocess.Popen')
     @patch('metadata_migration.run')
     # Note that mock objects are passed bottom-up from the patch order above
+    @mock.patch.dict(os.environ, {}, clear=True)
     def test_orchestrator_run(self, mock_metadata_migration: MagicMock, mock_subprocess: MagicMock,
                               mock_monitor: MagicMock):
         test_path = "test_path"
@@ -37,6 +41,7 @@ class TestFetchOrchestrator(unittest.TestCase):
     @patch('subprocess.Popen')
     @patch('metadata_migration.run')
     # Note that mock objects are passed bottom-up from the patch order above
+    @mock.patch.dict(os.environ, {}, clear=True)
     def test_orchestrator_no_migration(self, mock_metadata_migration: MagicMock, mock_subprocess: MagicMock,
                                        mock_monitor: MagicMock):
         # Setup empty result from pre-migration
@@ -46,6 +51,81 @@ class TestFetchOrchestrator(unittest.TestCase):
         # Subsequent steps should not be called
         mock_subprocess.assert_not_called()
         mock_monitor.assert_not_called()
+
+    @patch('fetch_orchestrator.write_inline_target_host')
+    @patch('metadata_migration.run')
+    # Note that mock objects are passed bottom-up from the patch order above
+    @mock.patch.dict(os.environ, {"INLINE_TARGET_HOST": "host"}, clear=True)
+    def test_orchestrator_inline_target_host(self, mock_metadata_migration: MagicMock, mock_write_host: MagicMock):
+        # For testing, return no indices to migrate
+        mock_metadata_migration.return_value = MetadataMigrationResult()
+        orchestrator.run("test", "test", "test")
+        mock_metadata_migration.assert_called_once_with(ANY)
+        mock_write_host.assert_called_once_with(ANY, "host")
+
+    @patch('fetch_orchestrator.update_target_host')
+    @patch('fetch_orchestrator.write_inline_pipeline')
+    @patch('metadata_migration.run')
+    # Note that mock objects are passed bottom-up from the patch order above
+    @mock.patch.dict(os.environ, {"INLINE_PIPELINE": "test"}, clear=True)
+    def test_orchestrator_inline_pipeline(self, mock_metadata_migration: MagicMock, mock_write_pipeline: MagicMock,
+                                          mock_update_host: MagicMock):
+        # For testing, return no indices to migrate
+        mock_metadata_migration.return_value = MetadataMigrationResult()
+        orchestrator.run("test", "test", "test")
+        mock_metadata_migration.assert_called_once_with(ANY)
+        mock_write_pipeline.assert_called_once_with("test")
+        mock_update_host.assert_not_called()
+
+    @patch('builtins.open', new_callable=mock_open())
+    @patch('fetch_orchestrator.update_target_host')
+    @patch('metadata_migration.run')
+    # INLINE_PIPELINE value is base64 encoded version of {}
+    @mock.patch.dict(os.environ, {"INLINE_PIPELINE": "e30K", "INLINE_TARGET_HOST": "host"}, clear=True)
+    def test_orchestrator_inline_pipeline_and_host(self, mock_metadata_migration: MagicMock,
+                                                   mock_update_host: MagicMock, mock_file_open: MagicMock):
+        # For testing, return no indices to migrate
+        mock_metadata_migration.return_value = MetadataMigrationResult()
+        test_config_file = "config_file"
+        orchestrator.run("test", test_config_file, "test")
+        mock_metadata_migration.assert_called_once_with(ANY)
+        mock_update_host.assert_called_once_with(ANY, "host")
+        mock_file_open.assert_called_once_with(test_config_file, 'w')
+
+    @patch('yaml.safe_dump')
+    @patch('yaml.safe_load')
+    @patch('builtins.open', new_callable=mock_open())
+    # Note that mock objects are passed bottom-up from the patch order above
+    def test_write_inline_target_host(self, mock_file_open: MagicMock, mock_yaml_load: MagicMock,
+                                      mock_yaml_dump: MagicMock):
+        mock_yaml_load.return_value = {"root": {"sink": {"opensearch": {"hosts": ["val"]}}}}
+        inline_target = "host"
+        expected_target_url = "https://" + inline_target
+        test_values = [
+            inline_target,  # base case test
+            "http://" + inline_target  # tests forcing of HTTPS
+        ]
+        expected_pipeline = copy.deepcopy(mock_yaml_load.return_value)
+        # TODO - replace with jsonpath
+        expected_pipeline["root"]["sink"]["opensearch"]["hosts"] = [expected_target_url]
+        for val in test_values:
+            mock_file_open.reset_mock()
+            mock_yaml_dump.reset_mock()
+            orchestrator.write_inline_target_host("test", val)
+            mock_file_open.assert_called_once_with("test", "rw")
+            mock_yaml_dump.assert_called_once_with(expected_pipeline, ANY)
+
+    def test_update_target_host_bad_config(self):
+        bad_configs = [
+            {},  # empty config
+            {"root": {}},  # only root element
+            {"root": {"source": True}},  # no sink
+        ]
+        for config in bad_configs:
+            original = copy.deepcopy(config)
+            orchestrator.update_target_host(config, "host")
+            # Bad configs shoudl result in no change
+            self.assertEqual(config, original)
 
 
 if __name__ == '__main__':

--- a/FetchMigration/python/tests/test_fetch_orchestrator.py
+++ b/FetchMigration/python/tests/test_fetch_orchestrator.py
@@ -5,9 +5,12 @@ from unittest import mock
 from unittest.mock import patch, MagicMock, ANY, mock_open
 
 import fetch_orchestrator as orchestrator
+from fetch_orchestrator_params import FetchOrchestratorParams
 from metadata_migration_params import MetadataMigrationParams
 from metadata_migration_result import MetadataMigrationResult
 from migration_monitor_params import MigrationMonitorParams
+
+EXPECTED_LOCAL_ENDPOINT = "https://localhost:4900"
 
 
 class TestFetchOrchestrator(unittest.TestCase):
@@ -19,21 +22,21 @@ class TestFetchOrchestrator(unittest.TestCase):
     @mock.patch.dict(os.environ, {}, clear=True)
     def test_orchestrator_run(self, mock_metadata_migration: MagicMock, mock_subprocess: MagicMock,
                               mock_monitor: MagicMock):
-        test_path = "test_path"
-        test_file = "test_file"
-        test_host = "test_host"
+        fetch_params = FetchOrchestratorParams("test_dp_path", "test_pipeline_file")
         # Setup mock pre-migration
-        expected_metadata_migration_input = MetadataMigrationParams(test_file, test_path + "/pipelines/pipeline.yaml",
-                                                                    report=True)
+        expected_metadata_migration_input = \
+            MetadataMigrationParams(fetch_params.pipeline_file_path,
+                                    fetch_params.data_prepper_path + "/pipelines/pipeline.yaml",
+                                    report=True)
         test_result = MetadataMigrationResult(10, {"index1", "index2"})
-        expected_monitor_input = MigrationMonitorParams(test_result.target_doc_count, test_host)
+        expected_monitor_input = MigrationMonitorParams(test_result.target_doc_count, EXPECTED_LOCAL_ENDPOINT)
         mock_metadata_migration.return_value = test_result
         # setup subprocess return value
         mock_subprocess.return_value.returncode = 0
         # Run test
-        orchestrator.run(test_path, test_file, test_host)
+        orchestrator.run(fetch_params)
         mock_metadata_migration.assert_called_once_with(expected_metadata_migration_input)
-        expected_dp_runnable = test_path + "/bin/data-prepper"
+        expected_dp_runnable = fetch_params.data_prepper_path + "/bin/data-prepper"
         mock_subprocess.assert_called_once_with(expected_dp_runnable)
         mock_monitor.assert_called_once_with(expected_monitor_input, mock_subprocess.return_value)
 
@@ -46,9 +49,51 @@ class TestFetchOrchestrator(unittest.TestCase):
                                        mock_monitor: MagicMock):
         # Setup empty result from pre-migration
         mock_metadata_migration.return_value = MetadataMigrationResult()
-        orchestrator.run("test", "test", "test")
+        orchestrator.run(FetchOrchestratorParams("test", "test"))
         mock_metadata_migration.assert_called_once_with(ANY)
         # Subsequent steps should not be called
+        mock_subprocess.assert_not_called()
+        mock_monitor.assert_not_called()
+
+    @patch('migration_monitor.run')
+    @patch('subprocess.Popen')
+    @patch('metadata_migration.run')
+    # Note that mock objects are passed bottom-up from the patch order above
+    @mock.patch.dict(os.environ, {}, clear=True)
+    def test_orchestrator_run_create_only(self, mock_metadata_migration: MagicMock, mock_subprocess: MagicMock,
+                                          mock_monitor: MagicMock):
+        fetch_params = FetchOrchestratorParams("test_dp_path", "test_pipeline_file", create_only=True)
+        # Setup mock pre-migration
+        expected_metadata_migration_input = \
+            MetadataMigrationParams(fetch_params.pipeline_file_path,
+                                    fetch_params.data_prepper_path + "/pipelines/pipeline.yaml",
+                                    report=True)
+        test_result = MetadataMigrationResult(10, {"index1", "index2"})
+        mock_metadata_migration.return_value = test_result
+        # Run test
+        orchestrator.run(fetch_params)
+        mock_metadata_migration.assert_called_once_with(expected_metadata_migration_input)
+        mock_subprocess.assert_not_called()
+        mock_monitor.assert_not_called()
+
+    @patch('migration_monitor.run')
+    @patch('subprocess.Popen')
+    @patch('metadata_migration.run')
+    # Note that mock objects are passed bottom-up from the patch order above
+    @mock.patch.dict(os.environ, {}, clear=True)
+    def test_orchestrator_dryrun(self, mock_metadata_migration: MagicMock, mock_subprocess: MagicMock,
+                                 mock_monitor: MagicMock):
+        fetch_params = FetchOrchestratorParams("test_dp_path", "test_pipeline_file", dryrun=True)
+        # Setup mock pre-migration
+        expected_metadata_migration_input = \
+            MetadataMigrationParams(fetch_params.pipeline_file_path,
+                                    fetch_params.data_prepper_path + "/pipelines/pipeline.yaml",
+                                    report=True, dryrun=True)
+        test_result = MetadataMigrationResult(10, {"index1", "index2"})
+        mock_metadata_migration.return_value = test_result
+        # Run test
+        orchestrator.run(fetch_params)
+        mock_metadata_migration.assert_called_once_with(expected_metadata_migration_input)
         mock_subprocess.assert_not_called()
         mock_monitor.assert_not_called()
 
@@ -59,7 +104,7 @@ class TestFetchOrchestrator(unittest.TestCase):
     def test_orchestrator_inline_target_host(self, mock_metadata_migration: MagicMock, mock_write_host: MagicMock):
         # For testing, return no indices to migrate
         mock_metadata_migration.return_value = MetadataMigrationResult()
-        orchestrator.run("test", "test", "test")
+        orchestrator.run(FetchOrchestratorParams("test", "test"))
         mock_metadata_migration.assert_called_once_with(ANY)
         mock_write_host.assert_called_once_with(ANY, "host")
 
@@ -72,7 +117,7 @@ class TestFetchOrchestrator(unittest.TestCase):
                                           mock_update_host: MagicMock):
         # For testing, return no indices to migrate
         mock_metadata_migration.return_value = MetadataMigrationResult()
-        orchestrator.run("test", "test", "test")
+        orchestrator.run(FetchOrchestratorParams("test", "test"))
         mock_metadata_migration.assert_called_once_with(ANY)
         mock_write_pipeline.assert_called_once_with("test")
         mock_update_host.assert_not_called()
@@ -86,11 +131,11 @@ class TestFetchOrchestrator(unittest.TestCase):
                                                    mock_update_host: MagicMock, mock_file_open: MagicMock):
         # For testing, return no indices to migrate
         mock_metadata_migration.return_value = MetadataMigrationResult()
-        test_config_file = "config_file"
-        orchestrator.run("test", test_config_file, "test")
+        params = FetchOrchestratorParams("test", "config_file")
+        orchestrator.run(params)
         mock_metadata_migration.assert_called_once_with(ANY)
         mock_update_host.assert_called_once_with(ANY, "host")
-        mock_file_open.assert_called_once_with(test_config_file, 'w')
+        mock_file_open.assert_called_once_with(params.pipeline_file_path, 'w')
 
     @patch('yaml.safe_dump')
     @patch('yaml.safe_load')
@@ -126,12 +171,6 @@ class TestFetchOrchestrator(unittest.TestCase):
             orchestrator.update_target_host(config, "host")
             # Bad configs should result in no change
             self.assertEqual(config, original)
-
-    def test_get_local_endpoint(self):
-        # Default value for insecure flag (secure endpoint)
-        self.assertEqual("https://localhost:123", orchestrator.get_local_endpoint(123))
-        # insecure endpoint
-        self.assertEqual("http://localhost:123", orchestrator.get_local_endpoint(123, True))
 
 
 if __name__ == '__main__':

--- a/FetchMigration/python/tests/test_fetch_orchestrator.py
+++ b/FetchMigration/python/tests/test_fetch_orchestrator.py
@@ -119,7 +119,7 @@ class TestFetchOrchestrator(unittest.TestCase):
         mock_metadata_migration.return_value = MetadataMigrationResult()
         orchestrator.run(FetchOrchestratorParams("test", "test"))
         mock_metadata_migration.assert_called_once_with(ANY)
-        mock_write_pipeline.assert_called_once_with("test")
+        mock_write_pipeline.assert_called_once_with("test", "test", None)
         mock_update_host.assert_not_called()
 
     @patch('builtins.open', new_callable=mock_open())

--- a/FetchMigration/python/tests/test_fetch_orchestrator_params.py
+++ b/FetchMigration/python/tests/test_fetch_orchestrator_params.py
@@ -1,0 +1,17 @@
+import unittest
+
+from fetch_orchestrator_params import FetchOrchestratorParams
+
+
+class TestFetchOrchestratorParams(unittest.TestCase):
+    def test_get_local_endpoint(self):
+        # Default value for insecure flag (secure endpoint)
+        params = FetchOrchestratorParams("test", "test", port=123)
+        self.assertEqual("https://localhost:123", params.get_local_endpoint())
+        # insecure endpoint
+        params = FetchOrchestratorParams("test", "test", port=123, insecure=True)
+        self.assertEqual("http://localhost:123", params.get_local_endpoint())
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/deployment/cdk/opensearch-service-migration/lib/fetch-migration-stack.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/fetch-migration-stack.ts
@@ -26,7 +26,7 @@ export class FetchMigrationStack extends Stack {
         super(scope, id, props);
 
         // Import required values
-        const targetClusterEndpoint = StringParameter.valueForStringParameter(this, `/migration/${props.stage}/${props.defaultDeployId}/osClusterEndpoint`)
+        const targetClusterEndpoint = StringParameter.fromStringParameterName(this, "targetClusterEndpoint", `/migration/${props.stage}/${props.defaultDeployId}/osClusterEndpoint`)
         const domainAccessGroupId = StringParameter.valueForStringParameter(this, `/migration/${props.stage}/${props.defaultDeployId}/osAccessSecurityGroupId`)
         // This SG allows outbound access for ECR access as well as communication with other services in the cluster
         const serviceConnectGroupId = StringParameter.valueForStringParameter(this, `/migration/${props.stage}/${props.defaultDeployId}/serviceConnectSecurityGroupId`)


### PR DESCRIPTION
### Description

This PR includes a few changes:

1 - Fetch Migration now supports supplying the target cluster endpoint via environment variable (`INLINE_TARGET_HOST`) similar to `INLINE_PIPELINE` behavior. If present, the value of this env variable is written as the hostname for the Data Prepper sink in the Data Prepper pipeline configuration file _before_ kicking off any steps in the Fetch Migration workflow.

2 - The CDK has been changed to utilize the above environment variable. This mitigates the [bug described here](https://github.com/opensearch-project/opensearch-migrations/pull/387)

3 - `fetch_orchestrator` has been updated to assume a local Data Prepper process, so it no longer accepts a Data Prepper "endpoint" URL but constructs this based on input parameters (port value and SSL flag). This incorporates [PR feedback from a previous change](https://github.com/opensearch-project/opensearch-migrations/pull/372#discussion_r1375003829)

3 - `fetch_orchestrator` now accepts additional flags that let it only execute metadata migration (and skip data migration). This is useful to run index setup prior to performing a Capture & Replay migration.

### Testing
CDK synth snippet:

```
...
      "Name": "fetch-migration",
      "Secrets": [
       {
        "Name": "INLINE_PIPELINE",
        "ValueFrom": {
         "Ref": "<pipeline-config-secret>"
        }
       },
       {
        "Name": "INLINE_TARGET_HOST",
        "ValueFrom": "<os-cluster-endpoint-arn>"
       }
      ]
     }
    ],
...
```

Code coverage:

```
$ python -m coverage report --omit "*/tests/*"
Name                           Stmts   Miss  Cover
--------------------------------------------------
endpoint_info.py                   6      0   100%
fetch_orchestrator.py             71      0   100%
fetch_orchestrator_params.py      22      0   100%
index_operations.py               37      0   100%
metadata_migration.py            123      0   100%
metadata_migration_params.py       7      0   100%
metadata_migration_result.py       5      0   100%
migration_monitor.py              94      4    96%
migration_monitor_params.py        6      0   100%
progress_metrics.py               89      0   100%
utils.py                          13      0   100%
--------------------------------------------------
TOTAL                            473      4    99%
```

### Check List
- [x] New functionality includes testing
  - [] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
