### PR TITLE
Bugfix - Use typing.Union in Fetch Migration rather than "|" operator

### DIFF
--- a/FetchMigration/python/endpoint_info.py
+++ b/FetchMigration/python/endpoint_info.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Union
 
 from requests_aws4auth import AWS4Auth
 
@@ -7,10 +7,11 @@ from requests_aws4auth import AWS4Auth
 class EndpointInfo:
     # Private member variables
     __url: str
-    __auth: Optional[tuple] | AWS4Auth
+    # "|" operator is only supported in 3.10+
+    __auth: Union[AWS4Auth, tuple, None]
     __verify_ssl: bool
 
-    def __init__(self, url: str, auth: tuple | AWS4Auth = None, verify_ssl: bool = True):
+    def __init__(self, url: str, auth: Union[AWS4Auth, tuple, None] = None, verify_ssl: bool = True):
         self.__url = url
         # Normalize url value to have trailing slash
         if not url.endswith("/"):
@@ -33,7 +34,7 @@ class EndpointInfo:
     def get_url(self) -> str:
         return self.__url
 
-    def get_auth(self) -> Optional[tuple] | AWS4Auth:
+    def get_auth(self) -> Union[AWS4Auth, tuple, None]:
         return self.__auth
 
     def is_verify_ssl(self) -> bool:

--- a/FetchMigration/python/endpoint_utils.py
+++ b/FetchMigration/python/endpoint_utils.py
@@ -1,5 +1,5 @@
 import re
-from typing import Optional
+from typing import Optional, Union
 
 from requests_aws4auth import AWS4Auth
 from botocore.session import Session
@@ -124,7 +124,7 @@ def get_aws_sigv4_auth(region: str, is_serverless: bool = False) -> AWS4Auth:
         return AWS4Auth(region=region, service=ES_SERVICE_NAME, refreshable_credentials=credentials)
 
 
-def get_auth(plugin_config: dict) -> Optional[tuple] | AWS4Auth:
+def get_auth(plugin_config: dict) -> Union[AWS4Auth, tuple, None]:
     # Basic auth
     if USER_KEY in plugin_config and PWD_KEY in plugin_config:
         return plugin_config[USER_KEY], plugin_config[PWD_KEY]

--- a/FetchMigration/python/tests/test_index_operations.py
+++ b/FetchMigration/python/tests/test_index_operations.py
@@ -10,7 +10,7 @@ from endpoint_info import EndpointInfo
 from tests import test_constants
 
 
-class TestSearchEndpoint(unittest.TestCase):
+class TestIndexOperations(unittest.TestCase):
     @responses.activate
     def test_fetch_all_indices(self):
         # Set up GET response


### PR DESCRIPTION
### Description
This change swaps out the use of the `|` operator for `typing.Union` since `|` is only available in Python 3.10+ . Hence, `typing.Union` provides broader compatibility. Also included in this change is a name correction for the index_operations unit test class.
* Category:  Bug fix

### Testing
```
$ python -m coverage report --omit "*/tests/*"
Name                           Stmts   Miss  Cover
--------------------------------------------------
endpoint_info.py                  24      1    96%
endpoint_utils.py                107      1    99%
fetch_orchestrator.py             70      0   100%
fetch_orchestrator_params.py      22      0   100%
index_operations.py               38      0   100%
metadata_migration.py             62      0   100%
metadata_migration_params.py       7      0   100%
metadata_migration_result.py       5      0   100%
migration_monitor.py              89      0   100%
migration_monitor_params.py        6      0   100%
progress_metrics.py               91      0   100%
utils.py                          13      0   100%
--------------------------------------------------
TOTAL                            534      2    99%
```

### Check List
- [x] New functionality includes testing
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
