### PR TITLE
Update all netty dependencies to wire up to be 4.1.100.Final

### DIFF
--- a/TrafficCapture/captureKafkaOffloader/build.gradle
+++ b/TrafficCapture/captureKafkaOffloader/build.gradle
@@ -25,3 +25,12 @@ dependencies {
     testImplementation group: 'org.apache.logging.log4j', name: 'log4j-slf4j2-impl', version: '2.20.0'
     testImplementation group: 'org.slf4j', name: 'slf4j-api', version: '2.0.7'
 }
+
+
+configurations.all {
+    resolutionStrategy.eachDependency { DependencyResolveDetails details ->
+        if (details.requested.group == 'io.netty') {
+            details.useVersion '4.1.100.Final'
+        }
+    }
+}

--- a/TrafficCapture/trafficReplayer/build.gradle
+++ b/TrafficCapture/trafficReplayer/build.gradle
@@ -98,6 +98,9 @@ configurations.all {
                 details.useVersion targetVersion
             }
         }
+        if (details.requested.group == 'io.netty') {
+            details.useVersion '4.1.100.Final'
+        }
     }
 }
 


### PR DESCRIPTION
### Description

Upgrade all transitive dependencies to use netty 4.1.100.

### Issues Resolved
https://github.com/opensearch-project/opensearch-migrations/issues/397


### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]

### Check List
- [ ] New functionality includes testing
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
