### PR TITLE
Fix logging regressions

### DIFF
--- a/TrafficCapture/trafficReplayer/src/main/resources/log4j2.properties
+++ b/TrafficCapture/trafficReplayer/src/main/resources/log4j2.properties
@@ -1,7 +1,7 @@
 status = error
 packages = io.opentelemetry.instrumentation.log4j.appender.v2_17
 
-property.tupleDir = ${sys:TUPLE_DIR_PATH:-./logs/tuples}
+property.tupleDir = ${env:TUPLE_DIR_PATH:-./logs/tuples}
 
 appenders = console, ReplayerLogFile, OUTPUT_TUPLES, METRICS
 
@@ -9,14 +9,14 @@ appender.console.type = Console
 appender.console.name = STDERR
 appender.console.target = SYSTEM_ERR
 appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = [%-5level] %d{yyyy-MM-dd HH:mm:ss,SSS}{UTC} [%t] %c{1} - %msg%equals{ ctx=%mdc}{ ctx={}}{}
+appender.console.layout.pattern = [%-5level] %d{yyyy-MM-dd HH:mm:ss,SSS}{UTC} [%t] %c{1} - %msg%equals{ ctx=%mdc}{ ctx={}}{}%n
 
 appender.ReplayerLogFile.type = RollingFile
 appender.ReplayerLogFile.name = ReplayerLogFile
 appender.ReplayerLogFile.fileName = logs/replayer.log
 appender.ReplayerLogFile.filePattern = logs/$${date:yyyy-MM}{UTC}/replayer-%d{yyyy-MM-dd-HH-mm}-%i.log.gz
 appender.ReplayerLogFile.layout.type = PatternLayout
-appender.ReplayerLogFile.layout.pattern = [%-5level] %d{yyyy-MM-dd HH:mm:ss,SSS}{UTC} [%t] %c{1} - %msg%equals{ ctx=%mdc}{ ctx={}}{}
+appender.ReplayerLogFile.layout.pattern = [%-5level] %d{yyyy-MM-dd HH:mm:ss,SSS}{UTC} [%t] %c{1} - %msg%equals{ ctx=%mdc}{ ctx={}}{}%n
 appender.ReplayerLogFile.policies.type = Policies
 appender.ReplayerLogFile.policies.time.type = TimeBasedTriggeringPolicy
 appender.ReplayerLogFile.policies.time.interval = 15
@@ -44,7 +44,7 @@ appender.METRICS.captureMapMessageAttributes = true
 appender.METRICS.captureExperimentalAttributes = true
 appender.METRICS.captureContextDataAttributes = *
 
-rootLogger.level = trace
+rootLogger.level = info
 rootLogger.appenderRef.STDERR.ref = STDERR
 rootLogger.appenderRef.ReplayerLogFile.ref = ReplayerLogFile
 


### PR DESCRIPTION
### Description
Put log entries on separate lines, reduce verbosity & use an env variable, not a system property to pickup changes to WHERE the replayer logs should go.

### Testing
Manual testing of the trafficReplayer and observed the output.

### Check List
- [ ] New functionality includes testing
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
