### PR TITLE
[Fetch Migration] Improved request error handling

### DIFF
--- a/FetchMigration/python/endpoint_utils.py
+++ b/FetchMigration/python/endpoint_utils.py
@@ -98,7 +98,6 @@ def validate_auth(plugin_name: str, plugin_config: dict):
     if plugin_config.get(AWS_SIGV4_KEY, False) or AWS_CONFIG_KEY in plugin_config:
         # Raises a ValueError if region cannot be derived
         get_aws_region(plugin_config)
-        return
     # Validate basic auth
     elif USER_KEY not in plugin_config:
         raise ValueError("Invalid auth configuration (no username) for plugin: " + plugin_name)

--- a/FetchMigration/python/fetch_orchestrator.py
+++ b/FetchMigration/python/fetch_orchestrator.py
@@ -137,9 +137,15 @@ if __name__ == '__main__':  # pragma no cover
     arg_parser.add_argument("--createonly", "-c", action="store_true",
                             help="Skips data migration and only creates indices on the target cluster")
     cli_args = arg_parser.parse_args()
-    params = FetchOrchestratorParams(os.path.expandvars(cli_args.data_prepper_path),
-                                     os.path.expandvars(cli_args.pipeline_file_path),
-                                     port=cli_args.port, insecure=cli_args.insecure,
+    dp_path = os.path.expandvars(cli_args.data_prepper_path)
+    if not os.path.isdir(dp_path):
+        raise ValueError("Path to Data Prepper installation is not a directory")
+    elif not os.path.exists(dp_path + __DP_EXECUTABLE_SUFFIX):
+        raise ValueError(f"Could not find {__DP_EXECUTABLE_SUFFIX} executable under Data Prepper install location")
+    pipeline_file = os.path.expandvars(cli_args.pipeline_file_path)
+    if not os.path.exists(pipeline_file):
+        raise ValueError("Data Prepper pipeline file does not exist")
+    params = FetchOrchestratorParams(dp_path, pipeline_file, port=cli_args.port, insecure=cli_args.insecure,
                                      dryrun=cli_args.dryrun, create_only=cli_args.createonly)
     return_code = run(params)
     if return_code == 0:

--- a/FetchMigration/python/index_operations.py
+++ b/FetchMigration/python/index_operations.py
@@ -13,10 +13,9 @@ import jsonpath_ng
 import requests
 
 from endpoint_info import EndpointInfo
-
-# Constants
 from index_doc_count import IndexDocCount
 
+# Constants
 SETTINGS_KEY = "settings"
 MAPPINGS_KEY = "mappings"
 ALIASES_KEY = "aliases"

--- a/FetchMigration/python/metadata_migration.py
+++ b/FetchMigration/python/metadata_migration.py
@@ -97,7 +97,13 @@ def run(args: MetadataMigrationParams) -> MetadataMigrationResult:
             index_data = dict()
             for index_name in diff.indices_to_create:
                 index_data[index_name] = source_indices[index_name]
-            index_operations.create_indices(index_data, target_endpoint_info)
+            failed_indices = index_operations.create_indices(index_data, target_endpoint_info)
+            fail_count = len(failed_indices)
+            if fail_count > 0:
+                logging.error(f"Failed to create {fail_count} of {len(index_data)} indices")
+                for failed_index_name, error in failed_indices.items():
+                    logging.error(f"Index name {failed_index_name} failed: {error!s}")
+                raise RuntimeError("Metadata migration failed, index creation unsuccessful")
     return result
 
 

--- a/FetchMigration/python/migration_monitor.py
+++ b/FetchMigration/python/migration_monitor.py
@@ -30,6 +30,7 @@ __DOC_SUCCESS_METRIC: str = "_opensearch_documentsSuccess"
 __RECORDS_IN_FLIGHT_METRIC: str = "_BlockingBuffer_recordsInFlight"
 __NO_PARTITIONS_METRIC: str = "_noPartitionsAcquired"
 __IDLE_THRESHOLD: int = 5
+__TIMEOUT_SECONDS: int = 5
 
 
 def is_process_alive(proc: Popen) -> bool:
@@ -51,13 +52,15 @@ def shutdown_process(proc: Popen) -> Optional[int]:
 
 def shutdown_pipeline(endpoint: EndpointInfo):
     shutdown_endpoint = endpoint.add_path(__SHUTDOWN_API_PATH)
-    requests.post(shutdown_endpoint, auth=endpoint.get_auth(), verify=endpoint.is_verify_ssl())
+    requests.post(shutdown_endpoint, auth=endpoint.get_auth(), verify=endpoint.is_verify_ssl(),
+                  timeout=__TIMEOUT_SECONDS)
 
 
 def fetch_prometheus_metrics(endpoint: EndpointInfo) -> Optional[List[Metric]]:
     metrics_endpoint = endpoint.add_path(__METRICS_API_PATH)
     try:
-        response = requests.get(metrics_endpoint, auth=endpoint.get_auth(), verify=endpoint.is_verify_ssl())
+        response = requests.get(metrics_endpoint, auth=endpoint.get_auth(), verify=endpoint.is_verify_ssl(),
+                                timeout=__TIMEOUT_SECONDS)
         response.raise_for_status()
     except requests.exceptions.RequestException:
         return None

--- a/FetchMigration/python/tests/test_index_operations.py
+++ b/FetchMigration/python/tests/test_index_operations.py
@@ -53,7 +53,8 @@ class TestIndexOperations(unittest.TestCase):
                       match=[matchers.json_params_matcher(test_data[test_constants.INDEX2_NAME])])
         responses.put(test_constants.TARGET_ENDPOINT + test_constants.INDEX3_NAME,
                       match=[matchers.json_params_matcher(test_data[test_constants.INDEX3_NAME])])
-        index_operations.create_indices(test_data, EndpointInfo(test_constants.TARGET_ENDPOINT))
+        failed = index_operations.create_indices(test_data, EndpointInfo(test_constants.TARGET_ENDPOINT))
+        self.assertEqual(0, len(failed))
 
     @responses.activate
     def test_create_indices_empty_alias(self):
@@ -67,21 +68,28 @@ class TestIndexOperations(unittest.TestCase):
         responses.put(test_constants.TARGET_ENDPOINT + test_constants.INDEX1_NAME,
                       match=[matchers.json_params_matcher(expected_payload)])
         # Empty "aliases" should be stripped
-        index_operations.create_indices(test_data, EndpointInfo(test_constants.TARGET_ENDPOINT))
+        failed = index_operations.create_indices(test_data, EndpointInfo(test_constants.TARGET_ENDPOINT))
+        self.assertEqual(0, len(failed))
         # Index without "aliases" should not fail
         del test_data[test_constants.INDEX1_NAME][aliases_key]
-        index_operations.create_indices(test_data, EndpointInfo(test_constants.TARGET_ENDPOINT))
+        failed = index_operations.create_indices(test_data, EndpointInfo(test_constants.TARGET_ENDPOINT))
+        self.assertEqual(0, len(failed))
 
     @responses.activate
-    def test_create_indices_exception(self):
-        # Set up expected PUT calls with a mock response status
-        test_data = copy.deepcopy(test_constants.BASE_INDICES_DATA)
-        del test_data[test_constants.INDEX2_NAME]
-        del test_data[test_constants.INDEX3_NAME]
-        responses.put(test_constants.TARGET_ENDPOINT + test_constants.INDEX1_NAME,
+    def test_create_indices_exceptions(self):
+        # Set up second index to hit an exception
+        responses.put(test_constants.TARGET_ENDPOINT + test_constants.INDEX2_NAME,
                       body=requests.Timeout())
-        self.assertRaises(RuntimeError, index_operations.create_indices, test_data,
-                          EndpointInfo(test_constants.TARGET_ENDPOINT))
+        responses.put(test_constants.TARGET_ENDPOINT + test_constants.INDEX1_NAME,
+                      json={})
+        responses.put(test_constants.TARGET_ENDPOINT + test_constants.INDEX3_NAME,
+                      json={})
+        failed_indices = index_operations.create_indices(test_constants.BASE_INDICES_DATA,
+                                                         EndpointInfo(test_constants.TARGET_ENDPOINT))
+        # Verify that failed indices are returned with their respective errors
+        self.assertEqual(1, len(failed_indices))
+        self.assertTrue(test_constants.INDEX2_NAME in failed_indices)
+        self.assertTrue(isinstance(failed_indices[test_constants.INDEX2_NAME], requests.Timeout))
 
     @responses.activate
     def test_doc_count(self):

--- a/FetchMigration/python/tests/test_metadata_migration.py
+++ b/FetchMigration/python/tests/test_metadata_migration.py
@@ -8,9 +8,12 @@
 #
 
 import copy
+import logging
 import pickle
 import unittest
 from unittest.mock import patch, MagicMock, ANY
+
+import requests
 
 import metadata_migration
 from index_doc_count import IndexDocCount
@@ -21,8 +24,12 @@ from tests import test_constants
 class TestMetadataMigration(unittest.TestCase):
     # Run before each test
     def setUp(self) -> None:
+        logging.disable(logging.CRITICAL)
         with open(test_constants.PIPELINE_CONFIG_PICKLE_FILE_PATH, "rb") as f:
             self.loaded_pipeline_config = pickle.load(f)
+
+    def tearDown(self) -> None:
+        logging.disable(logging.NOTSET)
 
     @patch('index_operations.doc_count')
     @patch('metadata_migration.write_output')
@@ -144,6 +151,27 @@ class TestMetadataMigration(unittest.TestCase):
         mock_fetch_indices.assert_called_once()
         self.assertEqual(0, test_result.target_doc_count)
         self.assertEqual(0, len(test_result.migration_indices))
+
+    @patch('metadata_migration.write_output')
+    @patch('index_operations.doc_count')
+    @patch('index_operations.create_indices')
+    @patch('index_operations.fetch_all_indices')
+    # Note that mock objects are passed bottom-up from the patch order above
+    def test_failed_indices(self, mock_fetch_indices: MagicMock, mock_create_indices: MagicMock,
+                            mock_doc_count: MagicMock, mock_write_output: MagicMock):
+        mock_doc_count.return_value = IndexDocCount(1, dict())
+        # Setup failed indices
+        test_failed_indices_result = {
+            test_constants.INDEX1_NAME: requests.Timeout(),
+            test_constants.INDEX2_NAME: requests.ConnectionError(),
+            test_constants.INDEX3_NAME: requests.Timeout()
+        }
+        mock_create_indices.return_value = test_failed_indices_result
+        # Fetch indices is called first for source, then for target
+        mock_fetch_indices.side_effect = [test_constants.BASE_INDICES_DATA, {}]
+        test_input = MetadataMigrationParams(test_constants.PIPELINE_CONFIG_RAW_FILE_PATH, "dummy")
+        self.assertRaises(RuntimeError, metadata_migration.run, test_input)
+        mock_create_indices.assert_called_once_with(test_constants.BASE_INDICES_DATA, ANY)
 
 
 if __name__ == '__main__':

--- a/FetchMigration/python/tests/test_migration_monitor.py
+++ b/FetchMigration/python/tests/test_migration_monitor.py
@@ -44,7 +44,7 @@ class TestMigrationMonitor(unittest.TestCase):
         expected_shutdown_url = TEST_ENDPOINT + "/shutdown"
         test_endpoint = EndpointInfo(TEST_ENDPOINT, TEST_AUTH, TEST_FLAG)
         migration_monitor.shutdown_pipeline(test_endpoint)
-        mock_post.assert_called_once_with(expected_shutdown_url, auth=TEST_AUTH, verify=TEST_FLAG)
+        mock_post.assert_called_once_with(expected_shutdown_url, auth=TEST_AUTH, verify=TEST_FLAG, timeout=ANY)
 
     @patch('requests.get')
     def test_fetch_prometheus_metrics(self, mock_get: MagicMock):
@@ -57,7 +57,7 @@ class TestMigrationMonitor(unittest.TestCase):
         mock_get.return_value = mock_response
         # Test fetch
         raw_metrics_list = migration_monitor.fetch_prometheus_metrics(EndpointInfo(TEST_ENDPOINT))
-        mock_get.assert_called_once_with(expected_url, auth=None, verify=True)
+        mock_get.assert_called_once_with(expected_url, auth=None, verify=True, timeout=ANY)
         self.assertEqual(1, len(raw_metrics_list))
         test_metric = raw_metrics_list[0]
         self.assertEqual(TEST_METRIC_NAME, test_metric.name)


### PR DESCRIPTION
### Description
This change adds more robust request error handling to network calls in Fetch Migration.
* The `GET` calls in metadata migration have been refactored into a helper method that executes the request and handles request errors by wrapping them in a `RuntimeError` and raising this.
* The `create_indices` logic to no longer throw on the first failure. Instead, the function attempts to create as many indices as possible and collects any failures into a `dict` that is then returned to the caller. Correspondingly, the metadata migration logic now handles raising a `RuntimeError` and also logs all failed index names along with their respective errors.
* All `requests` API calls also include a `timeout` value now to prevent an indefinite network wait
* Unit tests have been added and updated to maintain code coverage for the new code paths

* Category: Enhancement, Bug fix, Refactoring

### Testing
```
$ python -m coverage report --omit "*/tests/*"
Name                           Stmts   Miss  Cover
--------------------------------------------------
endpoint_info.py                  24      0   100%
endpoint_utils.py                107      1    99%
fetch_orchestrator.py             70      0   100%
fetch_orchestrator_params.py      22      0   100%
index_diff.py                     20      0   100%
index_doc_count.py                 5      0   100%
index_operations.py               76      0   100%
metadata_migration.py             65      0   100%
metadata_migration_params.py       7      0   100%
metadata_migration_result.py       5      0   100%
migration_monitor.py              90      0   100%
migration_monitor_params.py        6      0   100%
progress_metrics.py               91      0   100%
utils.py                          13      0   100%
--------------------------------------------------
TOTAL                            601      1    99%

```

### Check List
- [x] New functionality includes testing
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
