### PR TITLE
Allow custom user agent to be specified from environment

### DIFF
--- a/deployment/cdk/opensearch-service-migration/bin/app.ts
+++ b/deployment/cdk/opensearch-service-migration/bin/app.ts
@@ -15,8 +15,10 @@ const migrationsAppRegistryARN = process.env.MIGRATIONS_APP_REGISTRY_ARN
 if (migrationsAppRegistryARN) {
     console.info(`App Registry mode is enabled for CFN stack tracking. Will attempt to import the App Registry application from the MIGRATIONS_APP_REGISTRY_ARN env variable of ${migrationsAppRegistryARN} and looking in the configured region of ${region}`)
 }
+const customReplayerUserAgent = process.env.CUSTOM_REPLAYER_USER_AGENT
 
 new StackComposer(app, {
     migrationsAppRegistryARN: migrationsAppRegistryARN,
+    customReplayerUserAgent: customReplayerUserAgent,
     env: { account: account, region: region }
 });

--- a/deployment/cdk/opensearch-service-migration/lib/stack-composer.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/stack-composer.ts
@@ -19,12 +19,13 @@ import {Application} from "@aws-cdk/aws-servicecatalogappregistry-alpha";
 
 export interface StackPropsExt extends StackProps {
     readonly stage: string,
-    readonly defaultDeployId: string
+    readonly defaultDeployId: string,
     readonly addOnMigrationDeployId?: string
 }
 
 export interface StackComposerProps extends StackProps {
-    readonly migrationsAppRegistryARN?: string
+    readonly migrationsAppRegistryARN?: string,
+    readonly customReplayerUserAgent?: string
 }
 
 export class StackComposer {
@@ -190,6 +191,14 @@ export class StackComposer {
         const domainRemovalPolicy = domainRemovalPolicyName ? RemovalPolicy[domainRemovalPolicyName as keyof typeof RemovalPolicy] : undefined
         if (domainRemovalPolicyName && !domainRemovalPolicy) {
             throw new Error("Provided domainRemovalPolicy does not match a selectable option, for reference https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.RemovalPolicy.html")
+        }
+
+        let trafficReplayerCustomUserAgent
+        if (props.customReplayerUserAgent && trafficReplayerUserAgentSuffix) {
+            trafficReplayerCustomUserAgent = `${props.customReplayerUserAgent};${trafficReplayerUserAgentSuffix}`
+        }
+        else {
+            trafficReplayerCustomUserAgent = trafficReplayerUserAgentSuffix ? trafficReplayerUserAgentSuffix : props.customReplayerUserAgent
         }
 
         const deployId = addOnMigrationDeployId ? addOnMigrationDeployId : defaultDeployId
@@ -398,7 +407,7 @@ export class StackComposer {
                 enableClusterFGACAuth: trafficReplayerEnableClusterFGACAuth,
                 addOnMigrationDeployId: addOnMigrationDeployId,
                 customKafkaGroupId: trafficReplayerGroupId,
-                userAgentSuffix: trafficReplayerUserAgentSuffix,
+                userAgentSuffix: trafficReplayerCustomUserAgent,
                 extraArgs: trafficReplayerExtraArgs,
                 analyticsServiceEnabled: migrationAnalyticsServiceEnabled,
                 stackName: `OSMigrations-${stage}-${region}-${deployId}-TrafficReplayer`,


### PR DESCRIPTION
### Description
Minor change to allow a custom user agent for the Traffic Replayer to be specified from environment. If a user agent is also specified from a context option these users agents are joined and passed to the replayer.

### Issues Resolved
N/A

### Testing
Manual testing

### Check List
- [ ] New functionality includes testing
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
