### PR TITLE
Use a name to look up transformers rather than the classname.

### DIFF
--- a/TrafficCapture/replayerPlugins/jsonMessageTransformers/jsonMessageTransformerInterface/src/main/java/org/opensearch/migrations/transform/IJsonTransformerProvider.java
+++ b/TrafficCapture/replayerPlugins/jsonMessageTransformers/jsonMessageTransformerInterface/src/main/java/org/opensearch/migrations/transform/IJsonTransformerProvider.java
@@ -1,5 +1,7 @@
 package org.opensearch.migrations.transform;
 
+import lombok.NonNull;
+
 public interface IJsonTransformerProvider {
     /**
      * Create a new transformer from the given configuration.  This transformer
@@ -10,4 +12,10 @@ public interface IJsonTransformerProvider {
      * @return
      */
     IJsonTransformer createTransformer(Object jsonConfig);
+
+    /**
+     * Friendly name that can be used as a key to identify transformer providers.
+     * @return
+     */
+    default @NonNull String getName() { return this.getClass().getSimpleName(); }
 }

--- a/TrafficCapture/trafficReplayer/README.md
+++ b/TrafficCapture/trafficReplayer/README.md
@@ -97,14 +97,16 @@ to supply a _provider-configuration_ file (`META-INF/services/org.opensearch.mig
 with the fully qualified class name of the IJsonTransformerProvider implementation that should be loaded.  The contents
 of that file must be in plain text with a single class on a line.
 
-If multiple IJsonTransformerProviders are loaded, or if the provider/transformer require additional configuration 
-parameters, the user must specify additional configuration to the TrafficReplayer via the "--transformer-config" 
-argument.  This argument must be a json formatted list of maps.  The order of the list will define the order that
-the transformations are run.  Within each map is a single key-value pair whose name is the fully-qualified classname
-of the IJsonTransformerProvider.  The value of that key is then passed to the provider to fully instantiate an 
-IJsonTransformer object.  If only one IJsonTransformerProvider was loaded, configuration may be excluded.  Note that
-when the transformer-config is specified, it will control which of the loaded IJsonTransformerProviders will be 
-created, how they'll be created, and what order they will run in.
+The user must specify transformers to use and their configuration to the TrafficReplayer via the `--transformer-config` 
+argument.  If only one transformer is to be used and it doesn't require additional configuration, specifying JUST the
+classname will cause that single transformer to be used.  Otherwise, the user must specify `--transformer-config` as
+a json formatted list of maps.  The contents may also be specified in a file that can be read from 
+`--transformer-config-file` (which is mutually exclusive with `--transformer-config`).  The order of the list of 
+transformers and configs will define the order that the transformations are run.  Within each map is a single 
+key-value pair whose name must match the getName() of the IJsonTransformerProvider that the user is attempting to use.
+The name is defined by the `IJsonTransformerProvider::getName()`, which unless overridden is the classname 
+(e.g. 'JsonJoltTransformerProvider').  The value corresponding to that key is then passed to instantiate an 
+IJsonTransformer object.
 
 The base [jsonJoltMessageTransformerProvider](../replayerPlugins/jsonMessageTransformers/jsonJoltMessageTransformerProvider) 
 package includes [JsonCompositeTransformer.java]
@@ -135,7 +137,7 @@ transform to add GZIP encoding and another to apply a new header would be config
 ```
 
 To run only one transformer without any configuration, the `--transformer-config` argument can simply 
-be set to the classname of the transformer (e.g. 'JsonTransformerForOpenSearch23PlusTargetTransformerProvider', 
+be set to the name of the transformer (e.g. 'JsonTransformerForOpenSearch23PlusTargetTransformerProvider', 
 without quotes or any json surrounding it).
 
 The user can also specify a file to read the transformations from using the `--transformer-config-file`, but can't use

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/TransformationLoader.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/TransformationLoader.java
@@ -25,7 +25,7 @@ import java.util.stream.Stream;
 public class TransformationLoader {
     public static final String WRONG_JSON_STRUCTURE_MESSAGE = "Must specify the top-level configuration list with a sequence of " +
             "maps that have only one key each, where the key is the name of the transformer to be configured.";
-    public static final Pattern CLASS_NAME_PATTERN = Pattern.compile("^[a-zA-Z_$][a-zA-Z\\d_$]*$");
+    public static final Pattern CLASS_NAME_PATTERN = Pattern.compile("^[^{}]*$");
     private final List<IJsonTransformerProvider> providers;
     ObjectMapper objMapper = new ObjectMapper();
 

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/TransformationLoader.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/TransformationLoader.java
@@ -71,10 +71,11 @@ public class TransformationLoader {
         var key = keys.stream().findFirst()
                 .orElseThrow(()->new IllegalArgumentException(WRONG_JSON_STRUCTURE_MESSAGE));
         for (var p : providers) {
-            var className = p.getClass().getSimpleName();
-            if (className.equals(key)) {
+            var transformerName = p.getName();
+            if (transformerName.equals(key)) {
                 var configuration = c.get(key);
-                log.atInfo().setMessage(()->"Creating a transformer with configuration="+configuration).log();
+                log.atInfo().setMessage(()->"Creating a transformer through provider=" + p +
+                        " with configuration="+configuration).log();
                 return p.createTransformer(configuration);
             }
         }


### PR DESCRIPTION
By default, we'll still use classname, but this now gives us flexibility to use characters that cannot be in classnames. It will be up to the overall package and end-users bringing their own to NOT put conflicting transformers in place (as it always has been)

### Description

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)
* Why these changes are required? Usability
* What is the old behavior before changes and new behavior after changes? No change, but this supports future changes

### Issues Resolved
https://opensearch.atlassian.net/browse/MIGRATIONS-1439

### Testing
gradle build

### Check List
- [x] New functionality includes testing
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
