### PR TITLE
[Bugfix] Strip newlines from VERSION file before using it as AWS tag value

### DIFF
--- a/deployment/cdk/opensearch-service-migration/bin/app.ts
+++ b/deployment/cdk/opensearch-service-migration/bin/app.ts
@@ -5,7 +5,9 @@ import {App, Tags} from 'aws-cdk-lib';
 import {StackComposer} from "../lib/stack-composer";
 
 const app = new App();
-const version = readFileSync('../../../VERSION', 'utf-8')
+const versionFile = readFileSync('../../../VERSION', 'utf-8')
+// Remove any blank newlines because this would be an invalid tag value
+const version = versionFile.replace(/\n/g, '');
 Tags.of(app).add("migration_deployment", version)
 const account = process.env.CDK_DEFAULT_ACCOUNT
 const region = process.env.CDK_DEFAULT_REGION


### PR DESCRIPTION
### Description

This protects against CDK failures when the `VERSION` file has [extra newlines in it](https://github.com/opensearch-project/opensearch-migrations/commit/3c4b9c7f9fd9c9ce27b0b75d13cd6793bfcbaf81), which would cause the tag value to be `1.0.0\n` which is invalid.

### Testing
Tested manually and verified using `cdk synth`

### Check List
- [ ] New functionality includes testing
  - [ ] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
