### PR TITLE
[Fetch Migration] Usability updates and bugfixes

### DIFF
--- a/FetchMigration/Dockerfile
+++ b/FetchMigration/Dockerfile
@@ -19,5 +19,4 @@ RUN echo "ssl: false" > $DATA_PREPPER_PATH/config/data-prepper-config.yaml
 RUN echo "metricRegistries: [Prometheus]" >> $DATA_PREPPER_PATH/config/data-prepper-config.yaml
 
 # Include the -u flag to have unbuffered stdout (for detached mode)
-# "$@" allows passing extra args/flags to the entrypoint when the image is run
-ENTRYPOINT python3 -u ./fetch_orchestrator.py --insecure $DATA_PREPPER_PATH $FM_CODE_PATH/input.yaml "$@"
+ENTRYPOINT ["python3", "-u", "./fetch_orchestrator.py", "--insecure", "$DATA_PREPPER_PATH", "$FM_CODE_PATH/input.yaml"]

--- a/FetchMigration/python/fetch_orchestrator.py
+++ b/FetchMigration/python/fetch_orchestrator.py
@@ -93,7 +93,9 @@ def run(params: FetchOrchestratorParams) -> Optional[int]:
                                                         report=True, dryrun=params.is_dry_run)
     logging.info("Running metadata migration...\n")
     metadata_migration_result = metadata_migration.run(metadata_migration_params)
-    if len(metadata_migration_result.migration_indices) > 0 and not params.is_only_metadata_migration():
+    if metadata_migration_result.target_doc_count == 0:
+        logging.warning("Target document count is zero, skipping data migration...")
+    elif len(metadata_migration_result.migration_indices) > 0 and not params.is_only_metadata_migration():
         # Kick off a subprocess for Data Prepper
         logging.info("Running Data Prepper...\n")
         proc = subprocess.Popen(dp_exec_path)

--- a/FetchMigration/python/fetch_orchestrator.py
+++ b/FetchMigration/python/fetch_orchestrator.py
@@ -143,7 +143,8 @@ if __name__ == '__main__':  # pragma no cover
     elif not os.path.exists(dp_path + __DP_EXECUTABLE_SUFFIX):
         raise ValueError(f"Could not find {__DP_EXECUTABLE_SUFFIX} executable under Data Prepper install location")
     pipeline_file = os.path.expandvars(cli_args.pipeline_file_path)
-    if not os.path.exists(pipeline_file):
+    # Raise error if pipeline file is neither on disk nor provided inline
+    if __get_env_string("INLINE_PIPELINE") is None and not os.path.exists(pipeline_file):
         raise ValueError("Data Prepper pipeline file does not exist")
     params = FetchOrchestratorParams(dp_path, pipeline_file, port=cli_args.port, insecure=cli_args.insecure,
                                      dryrun=cli_args.dryrun, create_only=cli_args.createonly)

--- a/FetchMigration/python/metadata_migration.py
+++ b/FetchMigration/python/metadata_migration.py
@@ -41,13 +41,13 @@ def write_output(yaml_data: dict, indices_to_migrate: set, output_path: str):
 
 def print_report(diff: IndexDiff, total_doc_count: int):  # pragma no cover
     logging.info("Identical indices in the target cluster: " + utils.string_from_set(diff.identical_indices))
-    logging.info("Identical empty indices in the target cluster (data will be migrated): " +
+    logging.info("Identical empty indices in the target cluster (will be migrated): " +
                  utils.string_from_set(diff.identical_empty_indices))
-    logging.info("Indices present in both clusters with conflicting settings/mappings (data will not be migrated): " +
+    logging.info("Indices present in both clusters with conflicting settings/mappings (will NOT be migrated): " +
                  utils.string_from_set(diff.conflicting_indices))
-    logging.info("Indices to be created in the target cluster (data will be migrated): " +
+    logging.info("Indices to be created in the target cluster (will be migrated): " +
                  utils.string_from_set(diff.indices_to_create))
-    logging.info("Total number of documents to be moved: " + str(total_doc_count))
+    logging.info("Target document count: " + str(total_doc_count))
 
 
 def run(args: MetadataMigrationParams) -> MetadataMigrationResult:

--- a/FetchMigration/python/tests/test_fetch_orchestrator.py
+++ b/FetchMigration/python/tests/test_fetch_orchestrator.py
@@ -8,6 +8,7 @@
 #
 
 import copy
+import logging
 import os
 import unittest
 from unittest import mock
@@ -23,6 +24,12 @@ EXPECTED_LOCAL_ENDPOINT = "https://localhost:4900"
 
 
 class TestFetchOrchestrator(unittest.TestCase):
+    # Run before each test
+    def setUp(self) -> None:
+        logging.disable(logging.CRITICAL)
+
+    def tearDown(self) -> None:
+        logging.disable(logging.NOTSET)
 
     @patch('migration_monitor.run')
     @patch('subprocess.Popen')

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/Dockerfile
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/Dockerfile
@@ -12,11 +12,13 @@ RUN mkdir /root/kafka-tools/aws
 COPY runTestBenchmarks.sh /root/
 COPY humanReadableLogs.py /root/
 COPY catIndices.sh /root/
+COPY showFetchMigrationCommand.sh /root/
 COPY msk-iam-auth.properties /root/kafka-tools/aws
 COPY kafkaCmdRef.md /root/kafka-tools
 RUN chmod ug+x /root/runTestBenchmarks.sh
 RUN chmod ug+x /root/humanReadableLogs.py
 RUN chmod ug+x /root/catIndices.sh
+RUN chmod ug+x /root/showFetchMigrationCommand.sh
 WORKDIR /root/kafka-tools
 # Get kafka distribution and unpack to 'kafka'
 RUN wget -qO- https://archive.apache.org/dist/kafka/3.6.0/kafka_2.13-3.6.0.tgz | tar --transform 's!^[^/]*!kafka!' -xvz

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/showFetchMigrationCommand.sh
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/showFetchMigrationCommand.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+# Ensure Fetch Migration command is available before proceeding
+if [ -z "$FETCH_MIGRATION_COMMAND" ]; then
+    echo "Fetch Migration unavailable or not deployed, exiting..."
+    exit 1
+fi
+
+# ECS command overrides argument with placeholder for flags
+OVERRIDES_ARG="--overrides '{ \"containerOverrides\": [ { \"name\": \"fetch-migration\", \"command\": <FLAGS> }]}'"
+
+# Default values
+create_only=false
+dry_run=false
+
+while [[ $# -gt 0 ]]; do
+    key="$1"
+    case $key in
+        --create-only)
+            create_only=true
+            shift
+            ;;
+        --dryrun)
+            dry_run=true
+            shift
+            ;;
+        *)
+            shift
+            ;;
+    esac
+done
+
+# Build flags string
+flags=""
+if [ "$dry_run" = true ]; then
+    flags="--dryrun,${flags}"
+fi
+if [ "$create_only" = true ]; then
+    flags="--createonly,${flags}"
+fi
+
+command_to_run="$FETCH_MIGRATION_COMMAND"
+# Only add overrides suffix if any flags were specified
+if [ -n  "$flags" ]; then
+    # Remove trailing ,
+    flags=${flags%?}
+    # Convert to JSON array string
+    flags=$(echo -n $flags | jq -cRs 'split("\n")')
+    # Replace placeholder value in overrides string with actual flags
+    command_to_run="$command_to_run ${OVERRIDES_ARG/<FLAGS>/$flags}"
+fi
+
+echo $command_to_run


### PR DESCRIPTION
### Description

This change includes a few usability improvements and some bugfixes:

1. (Bugfix) `fetch_orchestrator.py` skips the check for a Data Prepper pipeline file if an `INLINE_PIPELINE` value is present
2. The Fetch Migration Dockerfile entrypoint has been updated to use the exec form. This allows command line arguments (such as flags) to be passed to it
3. A wrapper script (`showFetchMigrationCommand.sh`) has been added which provides an easy way to supply flags (such as `--create-only` or `--dryrun`) to the ECS task. The script does not run the AWS command - it only prints it for the user to copy and run themselves
4. The messaging in the metadata migration report has been tweaked to decrease confusion when performing a run where data isn't migrated
5. Added handling for scenarios where the target document count is zero

### Testing
Functionality has been tested via CDK. Unit test coverage report:

```
$ python -m coverage report --omit "*/tests/*"
Name                           Stmts   Miss  Cover
--------------------------------------------------
endpoint_info.py                  24      0   100%
endpoint_utils.py                106      1    99%
fetch_orchestrator.py             72      0   100%
fetch_orchestrator_params.py      22      0   100%
index_diff.py                     20      0   100%
index_doc_count.py                 5      0   100%
index_operations.py               76      0   100%
metadata_migration.py             65      0   100%
metadata_migration_params.py       7      0   100%
metadata_migration_result.py       5      0   100%
migration_monitor.py              90      0   100%
migration_monitor_params.py        6      0   100%
progress_metrics.py               91      0   100%
utils.py                          13      0   100%
--------------------------------------------------
TOTAL                            602      1    99%

```

### Check List
- [x] New functionality includes testing
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
