### PR TITLE
Update tuple output directory location

### DIFF
--- a/TrafficCapture/trafficReplayer/src/main/resources/log4j2.properties
+++ b/TrafficCapture/trafficReplayer/src/main/resources/log4j2.properties
@@ -32,8 +32,8 @@ appender.ReplayerLogFile.strategy.max = 288
 
 appender.OUTPUT_TUPLES.type = RollingFile
 appender.OUTPUT_TUPLES.name = OUTPUT_TUPLES
-appender.OUTPUT_TUPLES.fileName = ${bundle:bundle.base}/${bundle:bundle.version}/${bundle:bundle.name}/logs/${bundle:bundle.name}_app.log
-appender.OUTPUT_TUPLES.filePattern = ${bundle:bundle.base}/${bundle:bundle.version}/${bundle:bundle.name}/logs/${bundle:bundle.name}_app-%d{yyyy-MM-dd_HH-mm}.log.gz
+appender.OUTPUT_TUPLES.fileName = ${tupleDir}/tuples.log
+appender.OUTPUT_TUPLES.filePattern = ${tupleDir}/tuples-%d{yyyy-MM-dd-HH:mm}{UTC}.log
 appender.OUTPUT_TUPLES.layout.type = JsonLayout
 appender.OUTPUT_TUPLES.layout.properties = false
 appender.OUTPUT_TUPLES.layout.complete = false


### PR DESCRIPTION
### Description
Send Replayer tuple output to location specified by TUPLE_DIR_PATH (if defined).

### Testing
Verified tuple files are available in specified output directory.

<img width="726" alt="image" src="https://github.com/opensearch-project/opensearch-migrations/assets/42596015/75f0459c-9cc8-40d4-9df4-5b776678428a">


### Check List
- [x] New functionality includes testing
  - [ ] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
