### PR TITLE
Drop user agent matches and a bugfix for over-committing KafkaRecords too early

### DIFF
--- a/TrafficCapture/captureOffloader/src/main/java/org/opensearch/migrations/trafficcapture/IChannelConnectionCaptureListener.java
+++ b/TrafficCapture/captureOffloader/src/main/java/org/opensearch/migrations/trafficcapture/IChannelConnectionCaptureListener.java
@@ -78,4 +78,6 @@ public interface IChannelConnectionCaptureListener<T> {
     default CompletableFuture<T> flushCommitAndResetStream(boolean isFinal) throws IOException {
         return CompletableFuture.completedFuture(null);
     }
+
+    default void cancelCaptureForCurrentRequest(Instant timestamp) throws IOException {}
 }

--- a/TrafficCapture/captureOffloader/src/main/java/org/opensearch/migrations/trafficcapture/StreamChannelConnectionCaptureSerializer.java
+++ b/TrafficCapture/captureOffloader/src/main/java/org/opensearch/migrations/trafficcapture/StreamChannelConnectionCaptureSerializer.java
@@ -13,6 +13,7 @@ import org.opensearch.migrations.trafficcapture.protos.EndOfMessageIndication;
 import org.opensearch.migrations.trafficcapture.protos.EndOfSegmentsIndication;
 import org.opensearch.migrations.trafficcapture.protos.ReadObservation;
 import org.opensearch.migrations.trafficcapture.protos.ReadSegmentObservation;
+import org.opensearch.migrations.trafficcapture.protos.RequestIntentionallyDropped;
 import org.opensearch.migrations.trafficcapture.protos.TrafficObservation;
 import org.opensearch.migrations.trafficcapture.protos.TrafficStream;
 import org.opensearch.migrations.trafficcapture.protos.WriteObservation;
@@ -202,6 +203,16 @@ public class StreamChannelConnectionCaptureSerializer<T> implements IChannelConn
             streamHasBeenClosed = true;
         }
         return future;
+    }
+
+    @Override
+    public void cancelCaptureForCurrentRequest(Instant timestamp) throws IOException {
+        beginSubstreamObservation(timestamp, TrafficObservation.REQUESTDROPPED_FIELD_NUMBER, 1);
+        getOrCreateCodedOutputStream().writeMessage(TrafficObservation.REQUESTDROPPED_FIELD_NUMBER,
+                RequestIntentionallyDropped.getDefaultInstance());
+        this.readObservationsAreWaitingForEom = false;
+        this.firstLineByteLength = -1;
+        this.headersByteLength = -1;
     }
 
     @Override

--- a/TrafficCapture/captureProtobufs/src/main/proto/TrafficCaptureStream.proto
+++ b/TrafficCapture/captureProtobufs/src/main/proto/TrafficCaptureStream.proto
@@ -41,6 +41,7 @@ message EndOfMessageIndication {
   optional int32 firstLineByteLength = 1;
   optional int32 headersByteLength = 2;
 }
+message RequestIntentionallyDropped {}
 
 message TrafficObservation {
   google.protobuf.Timestamp ts = 1;
@@ -61,6 +62,8 @@ message TrafficObservation {
     // having been committed to the stream.
     EndOfSegmentsIndication segmentEnd = 14;
     EndOfMessageIndication endOfMessageIndicator = 15;
+
+    RequestIntentionallyDropped requestDropped = 16;
   }
 }
 

--- a/TrafficCapture/coreUtilities/src/main/java/org/opensearch/migrations/trafficcapture/protos/TrafficStreamUtils.java
+++ b/TrafficCapture/coreUtilities/src/main/java/org/opensearch/migrations/trafficcapture/protos/TrafficStreamUtils.java
@@ -1,6 +1,8 @@
 package org.opensearch.migrations.trafficcapture.protos;
 
 import com.google.protobuf.Timestamp;
+
+import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -22,9 +24,30 @@ public class TrafficStreamUtils {
 
     public static String summarizeTrafficStream(TrafficStream ts) {
         var listSummaryStr = ts.getSubStreamList().stream()
-                .map(tso->instantFromProtoTimestamp(tso.getTs()) + ": " + captureCaseToString(tso.getCaptureCase()))
+                .map(tso->instantFromProtoTimestamp(tso.getTs()) + ": " + captureCaseToString(tso.getCaptureCase())
+                        + getOptionalContext(tso))
                 .collect(Collectors.joining(", "));
         return ts.getConnectionId() + " (#" + getTrafficStreamIndex(ts) + ")[" + listSummaryStr + "]";
+    }
+
+    private static Object getOptionalContext(TrafficObservation tso) {
+        return Optional.ofNullable(getByteArrayForDataOf(tso))
+                .map(b->" " + new String(b, 0, Math.min(3, b.length), StandardCharsets.UTF_8))
+                .orElse("");
+    }
+    
+    private static byte[] getByteArrayForDataOf(TrafficObservation tso) {
+        if (tso.hasRead()) {
+            return tso.getRead().getData().toByteArray();
+        } else if (tso.hasReadSegment()) {
+            return tso.getReadSegment().getData().toByteArray();
+        } else if (tso.hasWrite()) {
+            return tso.getWrite().getData().toByteArray();
+        } else if (tso.hasWriteSegment()) {
+            return tso.getWriteSegment().getData().toByteArray();
+        } else {
+            return null;
+        }
     }
 
     public static int getTrafficStreamIndex(TrafficStream ts) {

--- a/TrafficCapture/nettyWireLogging/src/main/java/org/opensearch/migrations/trafficcapture/netty/ConditionallyReliableLoggingHttpRequestHandler.java
+++ b/TrafficCapture/nettyWireLogging/src/main/java/org/opensearch/migrations/trafficcapture/netty/ConditionallyReliableLoggingHttpRequestHandler.java
@@ -4,6 +4,7 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.util.ReferenceCountUtil;
 import lombok.Lombok;
+import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.opensearch.migrations.trafficcapture.IChannelConnectionCaptureSerializer;
 
@@ -13,16 +14,18 @@ import java.util.function.Predicate;
 public class ConditionallyReliableLoggingHttpRequestHandler<T> extends LoggingHttpRequestHandler<T> {
     private final Predicate<HttpRequest> shouldBlockPredicate;
 
-    public ConditionallyReliableLoggingHttpRequestHandler(IChannelConnectionCaptureSerializer<T> trafficOffloader,
-                                                          Predicate<HttpRequest> headerPredicateForWhenToBlock) {
-        super(trafficOffloader);
+    public ConditionallyReliableLoggingHttpRequestHandler(@NonNull IChannelConnectionCaptureSerializer<T> trafficOffloader,
+                                                          @NonNull RequestCapturePredicate requestCapturePredicate,
+                                                          @NonNull Predicate<HttpRequest> headerPredicateForWhenToBlock) {
+        super(trafficOffloader, requestCapturePredicate);
         this.shouldBlockPredicate = headerPredicateForWhenToBlock;
     }
 
     @Override
-    protected void channelFinishedReadingAnHttpMessage(ChannelHandlerContext ctx, Object msg, HttpRequest httpRequest)
+    protected void channelFinishedReadingAnHttpMessage(ChannelHandlerContext ctx, Object msg,
+                                                       boolean shouldCapture, HttpRequest httpRequest)
             throws Exception {
-        if (shouldBlockPredicate.test(httpRequest)) {
+        if (shouldCapture && shouldBlockPredicate.test(httpRequest)) {
             trafficOffloader.flushCommitAndResetStream(false).whenComplete((result, t) -> {
                 if (t != null) {
                     // This is a spot where we would benefit from having a behavioral policy that different users
@@ -32,14 +35,14 @@ public class ConditionallyReliableLoggingHttpRequestHandler<T> extends LoggingHt
                     ReferenceCountUtil.release(msg);
                 } else {
                     try {
-                        super.channelFinishedReadingAnHttpMessage(ctx, msg, httpRequest);
+                        super.channelFinishedReadingAnHttpMessage(ctx, msg, shouldCapture, httpRequest);
                     } catch (Exception e) {
                         throw Lombok.sneakyThrow(e);
                     }
                 }
             });
         } else {
-            super.channelFinishedReadingAnHttpMessage(ctx, msg, httpRequest);
+            super.channelFinishedReadingAnHttpMessage(ctx, msg, shouldCapture, httpRequest);
         }
     }
 }

--- a/TrafficCapture/nettyWireLogging/src/main/java/org/opensearch/migrations/trafficcapture/netty/HeaderValueFilteringCapturePredicate.java
+++ b/TrafficCapture/nettyWireLogging/src/main/java/org/opensearch/migrations/trafficcapture/netty/HeaderValueFilteringCapturePredicate.java
@@ -1,0 +1,29 @@
+package org.opensearch.migrations.trafficcapture.netty;
+
+
+import io.netty.handler.codec.http.HttpRequest;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+public class HeaderValueFilteringCapturePredicate extends RequestCapturePredicate {
+    private final Map<String, Pattern> headerToPredicateRegexMap;
+
+    public HeaderValueFilteringCapturePredicate(Map<String, String> suppressCaptureHeaderPairs) {
+        super(new PassThruHttpHeaders.HttpHeadersToPreserve(suppressCaptureHeaderPairs.keySet()
+                .toArray(String[]::new)));
+        headerToPredicateRegexMap = suppressCaptureHeaderPairs.entrySet().stream()
+                .collect(Collectors.toMap(Map.Entry::getKey, kvp->Pattern.compile(kvp.getValue())));
+    }
+
+    @Override
+    public CaptureDirective apply(HttpRequest request) {
+        return headerToPredicateRegexMap.entrySet().stream().anyMatch(kvp->
+                Optional.ofNullable(request.headers().get(kvp.getKey()))
+                        .map(v->kvp.getValue().matcher(v).matches())
+                        .orElse(false)
+        ) ? CaptureDirective.DROP : CaptureDirective.CAPTURE;
+    }
+}

--- a/TrafficCapture/nettyWireLogging/src/main/java/org/opensearch/migrations/trafficcapture/netty/RequestCapturePredicate.java
+++ b/TrafficCapture/nettyWireLogging/src/main/java/org/opensearch/migrations/trafficcapture/netty/RequestCapturePredicate.java
@@ -1,0 +1,30 @@
+package org.opensearch.migrations.trafficcapture.netty;
+
+import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpRequest;
+import lombok.Getter;
+
+import java.util.function.Function;
+
+public class RequestCapturePredicate implements Function<HttpRequest, RequestCapturePredicate.CaptureDirective> {
+
+    public enum CaptureDirective {
+        CAPTURE, DROP
+    }
+
+    @Getter
+    protected final PassThruHttpHeaders.HttpHeadersToPreserve headersRequiredForMatcher;
+
+    public RequestCapturePredicate() {
+        this(new PassThruHttpHeaders.HttpHeadersToPreserve());
+    }
+
+    public RequestCapturePredicate(PassThruHttpHeaders.HttpHeadersToPreserve incoming) {
+        this.headersRequiredForMatcher = incoming;
+    }
+
+    @Override
+    public CaptureDirective apply(HttpRequest request) {
+        return CaptureDirective.CAPTURE;
+    }
+}

--- a/TrafficCapture/nettyWireLogging/src/test/java/org/opensearch/migrations/trafficcapture/netty/ConditionallyReliableLoggingHttpRequestHandlerTest.java
+++ b/TrafficCapture/nettyWireLogging/src/test/java/org/opensearch/migrations/trafficcapture/netty/ConditionallyReliableLoggingHttpRequestHandlerTest.java
@@ -2,6 +2,7 @@ package org.opensearch.migrations.trafficcapture.netty;
 
 import com.google.protobuf.CodedOutputStream;
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
 import lombok.AllArgsConstructor;
 import lombok.SneakyThrows;
@@ -18,14 +19,16 @@ import org.opensearch.migrations.trafficcapture.StreamChannelConnectionCaptureSe
 import org.opensearch.migrations.trafficcapture.protos.TrafficStream;
 
 import java.io.ByteArrayInputStream;
-import java.io.FileOutputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.SequenceInputStream;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
@@ -34,14 +37,19 @@ import java.util.stream.Collectors;
 @Slf4j
 public class ConditionallyReliableLoggingHttpRequestHandlerTest {
 
-    @AllArgsConstructor
-    static class StreamManager extends OrderedStreamLifecyleManager {
-        AtomicReference<ByteBuffer> byteBufferAtomicReference;
+    static class TestStreamManager extends OrderedStreamLifecyleManager implements AutoCloseable {
+        AtomicReference<ByteBuffer> byteBufferAtomicReference = new AtomicReference<>();
         AtomicInteger flushCount = new AtomicInteger();
+        ByteArrayOutputStream collectedSerializedTrafficStream = new ByteArrayOutputStream();
 
         @Override
         public CodedOutputStreamAndByteBufferWrapper createStream() {
             return new CodedOutputStreamAndByteBufferWrapper(1024*1024);
+        }
+
+        @Override
+        public void close() throws Exception {
+            collectedSerializedTrafficStream.close();
         }
 
         @SneakyThrows
@@ -58,6 +66,7 @@ public class ConditionallyReliableLoggingHttpRequestHandlerTest {
             cos.flush();
             byteBufferAtomicReference.set(osh.getByteBuffer().flip().asReadOnlyBuffer());
             log.trace("byteBufferAtomicReference.get="+byteBufferAtomicReference.get());
+            //collectedSerializedTrafficStream.write(byteBufferAtomicReference.get().array());
 
             return CompletableFuture.completedFuture(flushCount.incrementAndGet());
         }
@@ -66,13 +75,11 @@ public class ConditionallyReliableLoggingHttpRequestHandlerTest {
 
     private static void writeMessageAndVerify(byte[] fullTrafficBytes, Consumer<EmbeddedChannel> channelWriter)
             throws IOException {
-        AtomicReference<ByteBuffer> outputByteBuffer = new AtomicReference<>();
-        AtomicInteger flushCount = new AtomicInteger();
-        var offloader = new StreamChannelConnectionCaptureSerializer("Test", "connection",
-                new StreamManager(outputByteBuffer, flushCount));
+        var streamManager = new TestStreamManager();
+        var offloader = new StreamChannelConnectionCaptureSerializer("Test", "c", streamManager);
 
         EmbeddedChannel channel = new EmbeddedChannel(
-                new ConditionallyReliableLoggingHttpRequestHandler(offloader, x->true)); // true: block every request
+                new ConditionallyReliableLoggingHttpRequestHandler(offloader, new RequestCapturePredicate(), x->true)); // true: block every request
         channelWriter.accept(channel);
 
         // we wrote the correct data to the downstream handler/channel
@@ -82,10 +89,10 @@ public class ConditionallyReliableLoggingHttpRequestHandlerTest {
                 .readAllBytes();
         Assertions.assertArrayEquals(fullTrafficBytes, outputData);
 
-        Assertions.assertNotNull(outputByteBuffer,
+        Assertions.assertNotNull(streamManager.byteBufferAtomicReference,
                 "This would be null if the handler didn't block until the output was written");
         // we wrote the correct data to the offloaded stream
-        var trafficStream = TrafficStream.parseFrom(outputByteBuffer.get());
+        var trafficStream = TrafficStream.parseFrom(streamManager.byteBufferAtomicReference.get());
         Assertions.assertTrue(trafficStream.getSubStreamCount() > 0 &&
                 trafficStream.getSubStream(0).hasRead());
         var combinedTrafficPacketsSteam =
@@ -94,7 +101,7 @@ public class ConditionallyReliableLoggingHttpRequestHandlerTest {
                 .map(to->new ByteArrayInputStream(to.getRead().getData().toByteArray()))
                 .collect(Collectors.toList())));
         Assertions.assertArrayEquals(fullTrafficBytes, combinedTrafficPacketsSteam.readAllBytes());
-        Assertions.assertEquals(1, flushCount.get());
+        Assertions.assertEquals(1, streamManager.flushCount.get());
     }
 
     private static byte[] consumeIntoArray(ByteBuf m) {
@@ -109,9 +116,7 @@ public class ConditionallyReliableLoggingHttpRequestHandlerTest {
     public void testThatAPostInASinglePacketBlocksFutureActivity(boolean usePool) throws IOException {
         byte[] fullTrafficBytes = SimpleRequests.SMALL_POST.getBytes(StandardCharsets.UTF_8);
         var bb = TestUtilities.getByteBuf(fullTrafficBytes, usePool);
-        writeMessageAndVerify(fullTrafficBytes, w -> {
-            w.writeInbound(bb);
-        });
+        writeMessageAndVerify(fullTrafficBytes, w -> w.writeInbound(bb));
         log.info("buf.refCnt="+bb.refCnt());
     }
 
@@ -119,12 +124,81 @@ public class ConditionallyReliableLoggingHttpRequestHandlerTest {
     @ValueSource(booleans = {true, false})
     public void testThatAPostInTinyPacketsBlocksFutureActivity(boolean usePool) throws IOException {
         byte[] fullTrafficBytes = SimpleRequests.SMALL_POST.getBytes(StandardCharsets.UTF_8);
-        writeMessageAndVerify(fullTrafficBytes, w -> {
-            for (int i=0; i<fullTrafficBytes.length; ++i) {
+        writeMessageAndVerify(fullTrafficBytes, getSingleByteAtATimeWriter(usePool, fullTrafficBytes));
+    }
+
+    private static Consumer<EmbeddedChannel> getSingleByteAtATimeWriter(boolean usePool, byte[] fullTrafficBytes) {
+        return w -> {
+            for (int i = 0; i< fullTrafficBytes.length; ++i) {
                 var singleByte = TestUtilities.getByteBuf(Arrays.copyOfRange(fullTrafficBytes, i, i+1), usePool);
                 w.writeInbound(singleByte);
             }
-        });
+        };
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testThatHealthCheckCaptureCanBeSuppressed(boolean singleBytes) throws Exception {
+        var streamMgr = new TestStreamManager();
+        var offloader = new StreamChannelConnectionCaptureSerializer("Test", "connection", streamMgr);
+
+        var headerCapturePredicate = new HeaderValueFilteringCapturePredicate(Map.of("user-Agent", ".*uploader.*"));
+        EmbeddedChannel channel = new EmbeddedChannel(
+                new ConditionallyReliableLoggingHttpRequestHandler(offloader, headerCapturePredicate, x->true));
+        getWriter(singleBytes, true, SimpleRequests.HEALTH_CHECK.getBytes(StandardCharsets.UTF_8)).accept(channel);
+        getWriter(singleBytes, true, SimpleRequests.SMALL_POST.getBytes(StandardCharsets.UTF_8)).accept(channel);
+        var requestBytes = (SimpleRequests.HEALTH_CHECK + SimpleRequests.SMALL_POST).getBytes(StandardCharsets.UTF_8);
+
+        // we wrote the correct data to the downstream handler/channel
+        var outputData = new SequenceInputStream(Collections.enumeration(channel.inboundMessages().stream()
+                .map(m->new ByteArrayInputStream(consumeIntoArray((ByteBuf)m)))
+                .collect(Collectors.toList())))
+                .readAllBytes();
+        log.info("outputdata = " + new String(outputData, StandardCharsets.UTF_8));
+        Assertions.assertArrayEquals(requestBytes, outputData);
+
+        Assertions.assertNotNull(streamMgr.byteBufferAtomicReference,
+                "This would be null if the handler didn't block until the output was written");
+        // we wrote the correct data to the offloaded stream
+        var trafficStream = TrafficStream.parseFrom(streamMgr.byteBufferAtomicReference.get());
+        Assertions.assertTrue(trafficStream.getSubStreamCount() > 0 &&
+                trafficStream.getSubStream(0).hasRead());
+        Assertions.assertEquals(1, streamMgr.flushCount.get());
+        var observations = trafficStream.getSubStreamList();
+        if (singleBytes) {
+            var sawRequestDropped = new AtomicBoolean(false);
+            var observationsAfterDrop = observations.stream().dropWhile(o->{
+                var wasDrop = o.hasRequestDropped();
+                sawRequestDropped.compareAndSet(false, wasDrop);
+                return !sawRequestDropped.get() || wasDrop;
+            }).collect(Collectors.toList());
+            var combinedTrafficPacketsSteam =
+                    new SequenceInputStream(Collections.enumeration(observationsAfterDrop.stream()
+                            .filter(to->to.hasRead())
+                            .map(to->new ByteArrayInputStream(to.getRead().getData().toByteArray()))
+                            .collect(Collectors.toList())));
+            Assertions.assertArrayEquals(SimpleRequests.SMALL_POST.getBytes(StandardCharsets.UTF_8),
+                    combinedTrafficPacketsSteam.readAllBytes());
+        } else {
+            var combinedTrafficPacketsSteam =
+                    new SequenceInputStream(Collections.enumeration(observations.stream()
+                            .filter(to->to.hasRead())
+                            .map(to->new ByteArrayInputStream(to.getRead().getData().toByteArray()))
+                            .collect(Collectors.toList())));
+            var reconstitutedTrafficStreamReads = combinedTrafficPacketsSteam.readAllBytes();
+            log.info("reconstitutedTrafficStreamReads="+
+                    new String(reconstitutedTrafficStreamReads, StandardCharsets.UTF_8));
+            Assertions.assertArrayEquals(SimpleRequests.SMALL_POST.getBytes(StandardCharsets.UTF_8),
+                    reconstitutedTrafficStreamReads);
+        }
+    }
+
+    private Consumer<EmbeddedChannel> getWriter(boolean singleBytes, boolean usePool, byte[] bytes) {
+        if (singleBytes) {
+            return getSingleByteAtATimeWriter(usePool, bytes);
+        } else {
+            return w -> w.writeInbound(Unpooled.wrappedBuffer(bytes));
+        }
     }
 
     @ParameterizedTest

--- a/TrafficCapture/nettyWireLogging/src/test/java/org/opensearch/migrations/trafficcapture/netty/SimpleRequests.java
+++ b/TrafficCapture/nettyWireLogging/src/test/java/org/opensearch/migrations/trafficcapture/netty/SimpleRequests.java
@@ -1,10 +1,17 @@
 package org.opensearch.migrations.trafficcapture.netty;
 
 public class SimpleRequests {
-    public static String SMALL_POST = "POST / HTTP/1.1\n" +
-            "Host: localhost\n" +
-            "Content-Type: application/x-www-form-urlencoded\n" +
-            "Content-Length: 27\n" +
-            "\n" +
+    public static String SMALL_POST = "POST / HTTP/1.1\r\n" +
+            "Host: localhost\r\n" +
+            "Content-Type: application/x-www-form-urlencoded\r\n" +
+            "Content-Length: 16\r\n" +
+            "\r\n" +
+            "FAKE_UPLOAD_DATA";
+
+    public static String HEALTH_CHECK = "POST / HTTP/1.1\r\n" +
+            "Host: localhost\r\n" +
+            "User-Agent: uploader\r\n" +
+            "Content-Length: 27\r\n" +
+            "\r\n" +
             "field1=value1&field2=value2";
 }

--- a/TrafficCapture/trafficCaptureProxyServer/src/main/java/org/opensearch/migrations/trafficcapture/proxyserver/netty/ProxyChannelInitializer.java
+++ b/TrafficCapture/trafficCaptureProxyServer/src/main/java/org/opensearch/migrations/trafficcapture/proxyserver/netty/ProxyChannelInitializer.java
@@ -5,8 +5,10 @@ import io.netty.channel.socket.SocketChannel;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.ssl.SslHandler;
+import lombok.NonNull;
 import org.opensearch.migrations.trafficcapture.IConnectionCaptureFactory;
 import org.opensearch.migrations.trafficcapture.netty.ConditionallyReliableLoggingHttpRequestHandler;
+import org.opensearch.migrations.trafficcapture.netty.RequestCapturePredicate;
 import org.opensearch.migrations.trafficcapture.netty.LoggingHttpResponseHandler;
 
 import javax.net.ssl.SSLEngine;
@@ -18,12 +20,15 @@ public class ProxyChannelInitializer<T> extends ChannelInitializer<SocketChannel
     private final IConnectionCaptureFactory<T> connectionCaptureFactory;
     private final Supplier<SSLEngine> sslEngineProvider;
     private final BacksideConnectionPool backsideConnectionPool;
+    private final RequestCapturePredicate requestCapturePredicate;
 
     public ProxyChannelInitializer(BacksideConnectionPool backsideConnectionPool, Supplier<SSLEngine> sslEngineSupplier,
-                                   IConnectionCaptureFactory<T> connectionCaptureFactory) {
+                                   IConnectionCaptureFactory<T> connectionCaptureFactory,
+                                   @NonNull RequestCapturePredicate requestCapturePredicate) {
         this.backsideConnectionPool = backsideConnectionPool;
         this.sslEngineProvider = sslEngineSupplier;
         this.connectionCaptureFactory = connectionCaptureFactory;
+        this.requestCapturePredicate = requestCapturePredicate;
     }
 
     public boolean shouldGuaranteeMessageOffloading(HttpRequest httpRequest) {
@@ -44,7 +49,7 @@ public class ProxyChannelInitializer<T> extends ChannelInitializer<SocketChannel
         var offloader = connectionCaptureFactory.createOffloader(ch.id().asLongText());
         ch.pipeline().addLast(new LoggingHttpResponseHandler(offloader));
         ch.pipeline().addLast(new ConditionallyReliableLoggingHttpRequestHandler<T>(offloader,
-                this::shouldGuaranteeMessageOffloading));
+                requestCapturePredicate, this::shouldGuaranteeMessageOffloading));
         ch.pipeline().addLast(new FrontsideHandler(backsideConnectionPool));
     }
 }

--- a/TrafficCapture/trafficCaptureProxyServer/src/test/java/org/opensearch/migrations/trafficcapture/proxyserver/netty/NettyScanningHttpProxyTest.java
+++ b/TrafficCapture/trafficCaptureProxyServer/src/test/java/org/opensearch/migrations/trafficcapture/proxyserver/netty/NettyScanningHttpProxyTest.java
@@ -12,6 +12,7 @@ import org.opensearch.migrations.testutils.SimpleHttpResponse;
 import org.opensearch.migrations.testutils.SimpleHttpServer;
 import org.opensearch.migrations.trafficcapture.IConnectionCaptureFactory;
 import org.opensearch.migrations.trafficcapture.InMemoryConnectionCaptureFactory;
+import org.opensearch.migrations.trafficcapture.netty.RequestCapturePredicate;
 import org.opensearch.migrations.trafficcapture.protos.TrafficStream;
 
 import java.io.ByteArrayOutputStream;
@@ -197,7 +198,8 @@ class NettyScanningHttpProxyTest {
             try {
                 var connectionPool = new BacksideConnectionPool(testServerUri, null,
                         10, Duration.ofSeconds(10));
-                nshp.get().start(connectionPool, 1, null, connectionCaptureFactory);
+                nshp.get().start(connectionPool, 1, null, connectionCaptureFactory,
+                        new RequestCapturePredicate());
                 System.out.println("proxy port = " + port);
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/Accumulation.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/Accumulation.java
@@ -106,4 +106,9 @@ public class Accumulation {
         this.state = State.ACCUMULATING_READS;
         this.rrPair = null;
     }
+
+    public void resetToIgnoreAndForgetCurrentRequest() {
+        this.state = State.WAITING_FOR_NEXT_READ_CHUNK;
+        this.rrPair = null;
+    }
 }

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/Accumulation.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/Accumulation.java
@@ -4,6 +4,7 @@ import lombok.NonNull;
 import org.opensearch.migrations.replay.datatypes.ISourceTrafficChannelKey;
 import org.opensearch.migrations.replay.datatypes.ITrafficStreamKey;
 import org.opensearch.migrations.replay.datatypes.UniqueReplayerRequestKey;
+import org.opensearch.migrations.trafficcapture.protos.TrafficStream;
 
 import java.time.Instant;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -26,7 +27,12 @@ public class Accumulation {
     AtomicLong newestPacketTimestampInMillis;
     State state;
     AtomicInteger numberOfResets;
-    final int startingSourceRequestIndex;
+    int startingSourceRequestIndex;
+
+    public Accumulation(ITrafficStreamKey key, TrafficStream ts) {
+        this(key, ts.getPriorRequestsReceived()+(ts.hasLastObservationWasUnterminatedRead()?1:0),
+                ts.getLastObservationWasUnterminatedRead());
+    }
 
     public Accumulation(@NonNull ITrafficStreamKey trafficChannelKey, int startingSourceRequestIndex) {
         this(trafficChannelKey, startingSourceRequestIndex, false);
@@ -108,6 +114,9 @@ public class Accumulation {
     }
 
     public void resetToIgnoreAndForgetCurrentRequest() {
+        if (state == State.IGNORING_LAST_REQUEST) {
+            --startingSourceRequestIndex;
+        }
         this.state = State.WAITING_FOR_NEXT_READ_CHUNK;
         this.rrPair = null;
     }

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/RequestResponsePacketPair.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/RequestResponsePacketPair.java
@@ -23,17 +23,17 @@ public class RequestResponsePacketPair {
 
     HttpMessageAndTimestamp requestData;
     HttpMessageAndTimestamp responseData;
+    final ITrafficStreamKey trafficStreamKey;
     List<ITrafficStreamKey> trafficStreamKeysBeingHeld;
     ReconstructionStatus completionStatus;
 
-    public RequestResponsePacketPair(ITrafficStreamKey startingAtTrafficStreamKey) {
+    public RequestResponsePacketPair(@NonNull ITrafficStreamKey startingAtTrafficStreamKey) {
         this.trafficStreamKeysBeingHeld = new ArrayList<>();
-        this.trafficStreamKeysBeingHeld.add(startingAtTrafficStreamKey);
+        trafficStreamKey = startingAtTrafficStreamKey;
     }
 
     @NonNull ITrafficStreamKey getBeginningTrafficStreamKey() {
-        assert trafficStreamKeysBeingHeld != null && !trafficStreamKeysBeingHeld.isEmpty();
-        return trafficStreamKeysBeingHeld.get(0);
+        return trafficStreamKey;
     }
 
     public void addRequestData(Instant packetTimeStamp, byte[] data) {

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/RequestResponsePacketPair.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/RequestResponsePacketPair.java
@@ -10,7 +10,6 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 
 @Slf4j
 public class RequestResponsePacketPair {
@@ -23,17 +22,17 @@ public class RequestResponsePacketPair {
 
     HttpMessageAndTimestamp requestData;
     HttpMessageAndTimestamp responseData;
-    final ITrafficStreamKey trafficStreamKey;
+    final ITrafficStreamKey firstTrafficStreamKeyForRequest;
     List<ITrafficStreamKey> trafficStreamKeysBeingHeld;
     ReconstructionStatus completionStatus;
 
     public RequestResponsePacketPair(@NonNull ITrafficStreamKey startingAtTrafficStreamKey) {
         this.trafficStreamKeysBeingHeld = new ArrayList<>();
-        trafficStreamKey = startingAtTrafficStreamKey;
+        firstTrafficStreamKeyForRequest = startingAtTrafficStreamKey;
     }
 
     @NonNull ITrafficStreamKey getBeginningTrafficStreamKey() {
-        return trafficStreamKey;
+        return firstTrafficStreamKeyForRequest;
     }
 
     public void addRequestData(Instant packetTimeStamp, byte[] data) {

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/RequestSenderOrchestrator.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/RequestSenderOrchestrator.java
@@ -5,9 +5,11 @@ import io.netty.channel.ChannelFuture;
 import io.netty.channel.EventLoop;
 import lombok.extern.slf4j.Slf4j;
 import org.opensearch.migrations.replay.datahandlers.NettyPacketToHttpConsumer;
+import org.opensearch.migrations.replay.datatypes.ChannelTaskType;
 import org.opensearch.migrations.replay.datatypes.ConnectionReplaySession;
 import org.opensearch.migrations.replay.datatypes.ISourceTrafficChannelKey;
 import org.opensearch.migrations.replay.datatypes.IndexedChannelInteraction;
+import org.opensearch.migrations.replay.datatypes.ChannelTask;
 import org.opensearch.migrations.replay.datatypes.UniqueReplayerRequestKey;
 import org.opensearch.migrations.replay.util.DiagnosticTrackableCompletableFuture;
 import org.opensearch.migrations.replay.util.StringTrackableCompletableFuture;
@@ -41,6 +43,11 @@ public class RequestSenderOrchestrator {
                 new StringTrackableCompletableFuture<T>(new CompletableFuture<>(),
                         ()->"waiting for final signal to confirm processing work has finished");
         log.atDebug().setMessage(()->"Scheduling work for "+channelKey+" at time "+timestamp).log();
+        // this method doesn't use the scheduling that scheduleRequest and scheduleClose use because
+        // doing work associated with a connection is considered to be preprocessing work independent
+        // of the underlying network connection itself, so it's fair to be able to do this without
+        // first needing to wait for a connection to succeed.  In fact, making them more independent
+        // means that the work item being enqueued is less likely to cause a connection timeout.
         connectionSession.eventLoop.schedule(()->
                         task.get().map(f->f.whenComplete((v,t) -> {
                                     if (t!=null) {
@@ -78,12 +85,12 @@ public class RequestSenderOrchestrator {
                 finalTunneledResponse,
                 channelFutureAndRequestSchedule->
                     scheduleOnConnectionReplaySession(channelKey, channelInteractionNum, channelFutureAndRequestSchedule,
-                            finalTunneledResponse, timestamp, "close", () -> {
+                            finalTunneledResponse, timestamp,
+                            new ChannelTask(ChannelTaskType.CLOSE, () -> {
                                 log.trace("Closing client connection " + channelInteraction);
                                 clientConnectionPool.closeConnection(channelKey.getConnectionId());
                                 finalTunneledResponse.future.complete(null);
-                            })
-                );
+                            })));
         return finalTunneledResponse;
     }
 
@@ -118,13 +125,13 @@ public class RequestSenderOrchestrator {
                                                             .getNow(null).channel();
                                             runAfterChannelSetup(channelFutureAndRequestSchedule,
                                                     finalTunneledResponse,
-                                                    cffr -> {
-                                                        cffr.scheduleSequencer.add(channelInteractionNumber,
+                                                    replaySession -> {
+                                                        replaySession.scheduleSequencer.add(channelInteractionNumber,
                                                                 () -> successFn.accept(channelFutureAndRequestSchedule),
                                                                 x -> x.run());
-                                                        if (cffr.scheduleSequencer.hasPending()) {
+                                                        if (replaySession.scheduleSequencer.hasPending()) {
                                                             log.atDebug().setMessage(()->"Sequencer for "+channelKey+
-                                                                    " = "+cffr.scheduleSequencer).log();
+                                                                    " = "+replaySession.scheduleSequencer).log();
                                                         }
                                                     });
                                         })
@@ -143,32 +150,16 @@ public class RequestSenderOrchestrator {
     private <T> void scheduleOnConnectionReplaySession(ISourceTrafficChannelKey channelKey, int channelInteractionIdx,
                                                        ConnectionReplaySession channelFutureAndRequestSchedule,
                                                        StringTrackableCompletableFuture<T> futureToBeCompletedByTask,
-                                                       Instant atTime, String activityNameForLogging, Runnable task) {
+                                                       Instant atTime, ChannelTask task) {
         var channelInteraction = new IndexedChannelInteraction(channelKey, channelInteractionIdx);
-        log.atInfo().setMessage(()->channelInteraction + " scheduling " + activityNameForLogging + " at " + atTime).log();
+        log.atInfo().setMessage(()->channelInteraction + " scheduling " + task.kind + " at " + atTime).log();
 
         var schedule = channelFutureAndRequestSchedule.schedule;
         var eventLoop = channelFutureAndRequestSchedule.getInnerChannelFuture().channel().eventLoop();
 
-        futureToBeCompletedByTask.map(f->f.whenComplete((v,t)-> {
-            var itemStartTimeOfPopped = schedule.removeFirstItem();
-            assert atTime.equals(itemStartTimeOfPopped):
-                    "Expected to have popped the item to match the start time for the responseFuture that finished";
-            log.atDebug().setMessage(()->channelInteraction.toString() + " responseFuture completed - checking "
-                    + schedule + " for the next item to schedule").log();
-            Optional.ofNullable(schedule.peekFirstItem()).ifPresent(kvp-> {
-                var sf = eventLoop.schedule(kvp.getValue(), getDelayFromNowMs(kvp.getKey()), TimeUnit.MILLISECONDS);
-                sf.addListener(sfp->{
-                    if (!sfp.isSuccess()) {
-                        log.atWarn().setCause(sfp.cause()).setMessage(()->"Scheduled future was not successful").log();
-                    }
-                });
-            });
-        }), ()->"");
-
         if (schedule.isEmpty()) {
             var scheduledFuture =
-                    eventLoop.schedule(task, getDelayFromNowMs(atTime), TimeUnit.MILLISECONDS);
+                    eventLoop.schedule(task.runnable, getDelayFromNowMs(atTime), TimeUnit.MILLISECONDS);
             scheduledFuture.addListener(f->{
                 if (!f.isSuccess()) {
                     log.atError().setCause(f.cause()).setMessage(()->"Error scheduling task").log();
@@ -184,6 +175,23 @@ public class RequestSenderOrchestrator {
         schedule.appendTask(atTime, task);
         log.atTrace().setMessage(()->channelInteraction + " added a scheduled event at " + atTime +
                 "... " + schedule).log();
+
+        futureToBeCompletedByTask.map(f->f.whenComplete((v,t)-> {
+            var itemStartTimeOfPopped = schedule.removeFirstItem();
+            assert atTime.equals(itemStartTimeOfPopped):
+                    "Expected to have popped the item to match the start time for the responseFuture that finished";
+            log.atDebug().setMessage(()->channelInteraction.toString() + " responseFuture completed - checking "
+                    + schedule + " for the next item to schedule").log();
+            Optional.ofNullable(schedule.peekFirstItem()).ifPresent(kvp-> {
+                var runnable = kvp.getValue().runnable;
+                var sf = eventLoop.schedule(runnable, getDelayFromNowMs(kvp.getKey()), TimeUnit.MILLISECONDS);
+                sf.addListener(sfp->{
+                    if (!sfp.isSuccess()) {
+                        log.atWarn().setCause(sfp.cause()).setMessage(()->"Scheduled future was not successful").log();
+                    }
+                });
+            });
+        }), ()->"");
     }
 
     private void scheduleSendOnConnectionReplaySession(UniqueReplayerRequestKey requestKey,
@@ -197,7 +205,8 @@ public class RequestSenderOrchestrator {
                                 packetReceiverRef),
                 eventLoop, packets.iterator(), start, interval, new AtomicInteger(), responseFuture);
         scheduleOnConnectionReplaySession(requestKey.trafficStreamKey, requestKey.getSourceRequestIndex(),
-                channelFutureAndRequestSchedule, responseFuture, start, "send", packetSender);
+                channelFutureAndRequestSchedule, responseFuture, start,
+                new ChannelTask(ChannelTaskType.TRANSMIT, packetSender));
     }
 
     private <T> void runAfterChannelSetup(ConnectionReplaySession channelFutureAndItsFutureRequests,

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datatypes/ChannelTask.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datatypes/ChannelTask.java
@@ -1,0 +1,11 @@
+package org.opensearch.migrations.replay.datatypes;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class ChannelTask {
+    public final ChannelTaskType kind;
+    public final Runnable runnable;
+}

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datatypes/ChannelTaskType.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datatypes/ChannelTaskType.java
@@ -1,0 +1,5 @@
+package org.opensearch.migrations.replay.datatypes;
+
+public enum ChannelTaskType {
+    TRANSMIT, CLOSE
+}

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datatypes/ConnectionReplaySession.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datatypes/ConnectionReplaySession.java
@@ -46,7 +46,7 @@ public class ConnectionReplaySession {
     }
 
     public boolean hasWorkRemaining() {
-        return !schedule.isEmpty() || scheduleSequencer.hasPending();
+        return scheduleSequencer.hasPending() || schedule.hasPendingTransmissions();
     }
 
     public long calculateSizeSlowly() {

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datatypes/RawPackets.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datatypes/RawPackets.java
@@ -3,7 +3,22 @@ package org.opensearch.migrations.replay.datatypes;
 import lombok.EqualsAndHashCode;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 
-@EqualsAndHashCode(callSuper = true)
+
 public class RawPackets extends ArrayList<byte[]> {
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof RawPackets)) { return false; }
+        RawPackets that = (RawPackets) o;
+        if (size() != that.size()) { return false; }
+
+        for (int i = 0; i < size(); i++) {
+            if (!Arrays.equals(get(i), that.get(i))) {
+                return false;
+            }
+        }
+        return true;
+    }
 }

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/ExhaustiveCapturedTrafficToHttpTransactionAccumulatorTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/ExhaustiveCapturedTrafficToHttpTransactionAccumulatorTest.java
@@ -60,7 +60,7 @@ public class ExhaustiveCapturedTrafficToHttpTransactionAccumulatorTest {
         return generateAllTestsAndConfirmComplete(
 //                IntStream.generate(()->rand.nextInt())
                 TrafficStreamGenerator.RANDOM_GENERATOR_SEEDS_FOR_SUFFICIENT_TRAFFIC_VARIANCE
-//                List.of(1705850753)
+//                List.of(2110766901)
                         .stream().mapToInt(i->i)
         );
     }

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/KafkaRestartingTrafficReplayerTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/KafkaRestartingTrafficReplayerTest.java
@@ -11,6 +11,7 @@ import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.opensearch.migrations.replay.kafka.KafkaTrafficCaptureSource;
 import org.opensearch.migrations.replay.traffic.source.ISimpleTrafficCaptureSource;

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/SimpleCapturedTrafficToHttpTransactionAccumulatorTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/SimpleCapturedTrafficToHttpTransactionAccumulatorTest.java
@@ -92,11 +92,19 @@ public class SimpleCapturedTrafficToHttpTransactionAccumulatorTest {
         return new InMemoryConnectionCaptureFactory("TEST_NODE_ID", bufferSize, onClosedCallback);
     }
 
+    private static byte nextPrintable(int i) {
+        final char firstChar = ' ';
+        final byte lastChar = '~';
+        var r = (byte) (i%(lastChar-firstChar));
+        return (byte) ((r < 0) ? (lastChar + r) : (byte) (r + firstChar));
+    }
+
     static ByteBuf makeSequentialByteBuf(int offset, int size) {
         var bb = Unpooled.buffer(size);
+        final var b = nextPrintable(offset);
         for (int i=0; i<size; ++i) {
             //bb.writeByte((i+offset)%255);
-            bb.writeByte('A'+offset);
+            bb.writeByte(b);
         }
         return bb;
     }

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/SimpleCapturedTrafficToHttpTransactionAccumulatorTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/SimpleCapturedTrafficToHttpTransactionAccumulatorTest.java
@@ -26,6 +26,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.SortedSet;
+import java.util.StringJoiner;
 import java.util.TreeSet;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
@@ -79,6 +80,11 @@ public class SimpleCapturedTrafficToHttpTransactionAccumulatorTest {
         }
         public static ObservationDirective flush() {
             return new ObservationDirective(OffloaderCommandType.Flush, 0);
+        }
+
+        @Override
+        public String toString() {
+            return "(" + offloaderCommandType + ":" + size + ")";
         }
     }
 
@@ -231,7 +237,9 @@ public class SimpleCapturedTrafficToHttpTransactionAccumulatorTest {
                                                           List<ITrafficStreamKey> trafficStreamKeysBeingHeld) {
                             }
 
-                            @Override public void onTrafficStreamIgnored(@NonNull ITrafficStreamKey tsk) {}
+                            @Override public void onTrafficStreamIgnored(@NonNull ITrafficStreamKey tsk) {
+                                tsIndicesReceived.add(tsk.getTrafficStreamIndex());
+                            }
                         });
         var tsList = trafficStreams.collect(Collectors.toList());
         trafficStreams = tsList.stream();

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/SimpleCapturedTrafficToHttpTransactionAccumulatorTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/SimpleCapturedTrafficToHttpTransactionAccumulatorTest.java
@@ -55,6 +55,7 @@ public class SimpleCapturedTrafficToHttpTransactionAccumulatorTest {
     enum OffloaderCommandType {
         Read,
         EndOfMessage,
+        DropRequest,
         Write,
         Flush
     }
@@ -69,6 +70,9 @@ public class SimpleCapturedTrafficToHttpTransactionAccumulatorTest {
         }
         public static ObservationDirective eom() {
             return new ObservationDirective(OffloaderCommandType.EndOfMessage, 0);
+        }
+        public static ObservationDirective cancelOffload() {
+            return new ObservationDirective(OffloaderCommandType.DropRequest, 0);
         }
         public static ObservationDirective write(int i) {
             return new ObservationDirective(OffloaderCommandType.Write, i);
@@ -118,6 +122,9 @@ public class SimpleCapturedTrafficToHttpTransactionAccumulatorTest {
                 return;
             case Flush:
                 offloader.flushCommitAndResetStream(false);
+                return;
+            case DropRequest:
+                 offloader.cancelCaptureForCurrentRequest(Instant.EPOCH);
                 return;
             default:
                 throw new IllegalStateException("Unknown directive type: " + directive.offloaderCommandType);

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/TrafficReplayerRunner.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/TrafficReplayerRunner.java
@@ -17,6 +17,7 @@ import java.net.URI;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Optional;
 import java.util.Random;
 import java.util.StringJoiner;
 import java.util.concurrent.ConcurrentHashMap;
@@ -62,7 +63,10 @@ public class TrafficReplayerRunner {
                     var key = t.uniqueRequestKey;
                     ISourceTrafficChannelKey tsk = key.getTrafficStreamKey();
                     var keyString = tsk.getConnectionId() + "_" + key.getSourceRequestIndex();
+                    var prevKeyString = tsk.getConnectionId() + "_" + (key.getSourceRequestIndex()-1);
                     tupleReceiver.accept(t);
+                    Assertions.assertFalse(Optional.ofNullable(completelyHandledItems.get(prevKeyString))
+                            .map(prevT->t.sourcePair.equals(prevT.sourcePair)).orElse(false));
                     var totalUnique = null != completelyHandledItems.put(keyString, t) ?
                             totalUniqueEverReceived.get() :
                             totalUniqueEverReceived.incrementAndGet();

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/TrafficStreamGenerator.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/TrafficStreamGenerator.java
@@ -6,6 +6,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.opensearch.migrations.testutils.StreamInterleaver;
 import org.opensearch.migrations.trafficcapture.protos.TrafficObservation;
 import org.opensearch.migrations.trafficcapture.protos.TrafficStream;
+import org.opensearch.migrations.trafficcapture.protos.TrafficStreamUtils;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -270,6 +271,11 @@ public class TrafficStreamGenerator {
                 generateRandomTrafficStreamsAndSizes(IntStream.range(0,count)) :
                 generateAllIndicativeRandomTrafficStreamsAndSizes();
         var testCaseArr = generatedCases.toArray(RandomTrafficStreamAndTransactionSizes[]::new);
+        log.atInfo().setMessage(()->
+                Arrays.stream(testCaseArr)
+                        .flatMap(tc->Arrays.stream(tc.trafficStreams).map(TrafficStreamUtils::summarizeTrafficStream))
+                        .collect(Collectors.joining("\n")))
+                .log();
         var aggregatedStreams = randomize ?
                 StreamInterleaver.randomlyInterleaveStreams(new Random(count),
                         Arrays.stream(testCaseArr).map(c->Arrays.stream(c.trafficStreams))) :

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/TrafficStreamGenerator.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/TrafficStreamGenerator.java
@@ -32,11 +32,11 @@ public class TrafficStreamGenerator {
     public static final int MAX_READS_IN_REQUEST = 5;
     public static final int MAX_WRITES_IN_RESPONSE = 5;
     public static final List<Integer> RANDOM_GENERATOR_SEEDS_FOR_SUFFICIENT_TRAFFIC_VARIANCE = List.of(
-            -1155869325, 892128508, 155629808, 1429008869, -138487339, 26273138, 685382526,
-            -226796111, -270230103, 1705850753, -1978864692, -836540342, 1181244667,-193570837,
-            -1617640095, -1359243304, -1973979577, -67333094, -2129721489, -2114584541, -1121163101,
-            866345822, 1302951949, 30280569, -1199907813, 34574822, 2109003795, -1349584475, -2050877083,
-            160359681, -1345969040, -20026097, 793184536, 834861033
+            -1155869325, 892128508, 155629808, 1429008869, 26273138, 685382526, 1705850753, -1978864692,
+            -836540342, -193570837, -1617640095, -1359243304, -1973979577, -67333094, -2129721489,
+            2110766901, -1121163101, 866345822, -297497515, -736375570, 30280569, -1199907813,
+            1887084032, 519330814, -2050877083, 174127839, 1712524135, -861378278, 793184536, 174500816,
+            237039773, 944491332
     );
 
     public enum ObservationType {
@@ -191,6 +191,9 @@ public class TrafficStreamGenerator {
                     ()-> SimpleCapturedTrafficToHttpTransactionAccumulatorTest.ObservationDirective.read(r.nextInt(bufferBound)));
             if (r.nextDouble() <= cancelRequestLikelihood) {
                 commands.add(SimpleCapturedTrafficToHttpTransactionAccumulatorTest.ObservationDirective.cancelOffload());
+                ++i; // compensate to get the right number of requests in the loop
+                sizes.remove(sizes.size()-1); // This won't show up as a request, so don't propagate it
+                continue;
             }
             if (r.nextDouble() <= flushLikelihood) {
                 commands.add(SimpleCapturedTrafficToHttpTransactionAccumulatorTest.ObservationDirective.flush());

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/TrafficStreamGenerator.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/TrafficStreamGenerator.java
@@ -1,6 +1,5 @@
 package org.opensearch.migrations.replay;
 
-import io.vavr.Tuple2;
 import lombok.AllArgsConstructor;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
@@ -33,9 +32,12 @@ public class TrafficStreamGenerator {
     public static final int MAX_READS_IN_REQUEST = 5;
     public static final int MAX_WRITES_IN_RESPONSE = 5;
     public static final List<Integer> RANDOM_GENERATOR_SEEDS_FOR_SUFFICIENT_TRAFFIC_VARIANCE = List.of(
-            -1155869325, 892128508, 155629808, 1429008869, -1465154083, -1242363800, 26273138,
-            1705850753, -1956122223, -193570837, 1558626465, 1248685248, -1292756720, -3507139, 929459541,
-            474550272, -957816454, -1418261474, 431108934, 1601212083, 1788602357, 1722788072, 1421653156);
+            -1155869325, 892128508, 155629808, 1429008869, -138487339, 26273138, 685382526,
+            -226796111, -270230103, 1705850753, -1978864692, -836540342, 1181244667,-193570837,
+            -1617640095, -1359243304, -1973979577, -67333094, -2129721489, -2114584541, -1121163101,
+            866345822, 1302951949, 30280569, -1199907813, 34574822, 2109003795, -1349584475, -2050877083,
+            160359681, -1345969040, -20026097, 793184536, 834861033
+    );
 
     public enum ObservationType {
         Read(0),
@@ -45,7 +47,8 @@ public class TrafficStreamGenerator {
         Write(4),
         WriteSegment(5),
         EndOfWriteSegment(6),
-        Close(7);
+        RequestDropped(7),
+        Close(8);
 
         private final int intValue;
 
@@ -72,7 +75,7 @@ public class TrafficStreamGenerator {
      * a bit more work to fully implement.  For now, the count parameter is ignored.
      */
     private static int makeClassificationValue(ObservationType ot1, ObservationType ot2, Integer count) {
-        return (((0 * CLASSIFY_COMPONENT_INT_SHIFT) + ot1.intValue) * CLASSIFY_COMPONENT_INT_SHIFT) + ot2.intValue;
+        return ((ot1.intValue) * CLASSIFY_COMPONENT_INT_SHIFT) + ot2.intValue;
     }
 
     static String classificationToString(int c) {
@@ -100,6 +103,8 @@ public class TrafficStreamGenerator {
             return Optional.empty();
         } else if (trafficObservation.hasClose()) {
             return Optional.of(ObservationType.Close);
+        } else if (trafficObservation.hasRequestDropped()) {
+            return Optional.of(ObservationType.RequestDropped);
         } else {
             throw new IllegalStateException("unknown traffic observation: " + trafficObservation);
         }
@@ -117,6 +122,8 @@ public class TrafficStreamGenerator {
                 case Write:
                 case WriteSegment:
                     return ObservationType.EndOfWriteSegment;
+                case RequestDropped:
+                    return ObservationType.RequestDropped;
                 default:
                     throw new IllegalStateException("previous observation type doesn't match expected possibilities: " +
                             lastObservationType);
@@ -174,13 +181,17 @@ public class TrafficStreamGenerator {
         return (r.nextDouble() <= p1) ? supplier1.get() : supplier2.get();
     }
 
-    private static void fillCommandsAndSizes(int bufferSize, Random r, double flushLikelihood, int bufferBound,
+    private static void fillCommandsAndSizes(Random r, double cancelRequestLikelihood, double flushLikelihood,
+                                             int bufferBound,
                                              List<SimpleCapturedTrafficToHttpTransactionAccumulatorTest.ObservationDirective> commands,
                                              List<Integer> sizes) {
         var numTransactions = r.nextInt(MAX_COMMANDS_IN_CONNECTION);
         for (int i=numTransactions; i>0; --i) {
             addCommands(r, flushLikelihood, r.nextInt(MAX_READS_IN_REQUEST)+1, commands, sizes,
                     ()-> SimpleCapturedTrafficToHttpTransactionAccumulatorTest.ObservationDirective.read(r.nextInt(bufferBound)));
+            if (r.nextDouble() <= cancelRequestLikelihood) {
+                commands.add(SimpleCapturedTrafficToHttpTransactionAccumulatorTest.ObservationDirective.cancelOffload());
+            }
             if (r.nextDouble() <= flushLikelihood) {
                 commands.add(SimpleCapturedTrafficToHttpTransactionAccumulatorTest.ObservationDirective.flush());
             }
@@ -204,7 +215,8 @@ public class TrafficStreamGenerator {
                 .setMessage(()->String.format("bufferSize=%d bufferBound=%d maxPossibleReads=%d maxPossibleWrites=%d",
                         bufferSize, bufferBound, MAX_READS_IN_REQUEST, MAX_WRITES_IN_RESPONSE))
                 .log();
-        fillCommandsAndSizes(bufferSize, r2, Math.pow(r2.nextDouble(),2.0), bufferBound, commands, sizes);
+        var flushLikelihood = Math.pow(r2.nextDouble(),2.0);
+        fillCommandsAndSizes(r2, flushLikelihood/4, flushLikelihood, bufferBound, commands, sizes);
         return SimpleCapturedTrafficToHttpTransactionAccumulatorTest.makeTrafficStreams(bufferSize, (int) rSeed, commands);
     }
 
@@ -222,7 +234,8 @@ public class TrafficStreamGenerator {
                         ObservationType.EOM, List.of(ObservationType.EndOfReadSegment, ObservationType.EndOfWriteSegment),
                         ObservationType.Write, List.of(ObservationType.EndOfReadSegment, ObservationType.EndOfWriteSegment),
                         ObservationType.WriteSegment, List.of(ObservationType.EndOfReadSegment),
-                        ObservationType.EndOfWriteSegment, List.of(ObservationType.EndOfReadSegment))
+                        ObservationType.EndOfWriteSegment, List.of(ObservationType.EndOfReadSegment),
+                        ObservationType.RequestDropped, List.of(ObservationType.EndOfReadSegment, ObservationType.EndOfWriteSegment))
                 .entrySet().stream()
                 .flatMap(kvp->kvp.getValue().stream().map(v->makeClassificationValue(kvp.getKey(), v,0)))
                 .collect(Collectors.toSet());
@@ -230,7 +243,7 @@ public class TrafficStreamGenerator {
         ObservationType.valueStream()
                 .flatMap(ot1->ObservationType.valueStream().map(ot2->makeClassificationValue(ot1, ot2, 0)))
                 .filter(i->!impossibleTransitions.contains(i))
-                .forEach(i->possibilities.add(i));
+                .forEach(possibilities::add);
         return possibilities;
     }
 

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/datatypes/TimeToResponseFulfillmentFutureMapTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/datatypes/TimeToResponseFulfillmentFutureMapTest.java
@@ -13,16 +13,16 @@ class TimeToResponseFulfillmentFutureMapTest {
     public void testAddsAndPopsAreOrdered() {
         var timeMap = new TimeToResponseFulfillmentFutureMap();
         StringBuilder log = new StringBuilder();
-        timeMap.appendTask(Instant.EPOCH, ()->log.append('A'));
-        timeMap.appendTask(Instant.EPOCH, ()->log.append('B'));
-        timeMap.appendTask(Instant.EPOCH.plus(Duration.ofMillis(1)), ()->log.append('C'));
-        timeMap.appendTask(Instant.EPOCH.plus(Duration.ofMillis(1)), ()->log.append('D'));
+        timeMap.appendTask(Instant.EPOCH, new ChannelTask(ChannelTaskType.TRANSMIT, ()->log.append('A')));
+        timeMap.appendTask(Instant.EPOCH, new ChannelTask(ChannelTaskType.TRANSMIT, ()->log.append('B')));
+        timeMap.appendTask(Instant.EPOCH.plus(Duration.ofMillis(1)), new ChannelTask(ChannelTaskType.TRANSMIT, ()->log.append('C')));
+        timeMap.appendTask(Instant.EPOCH.plus(Duration.ofMillis(1)), new ChannelTask(ChannelTaskType.TRANSMIT, ()->log.append('D')));
         while (true) {
             var t = timeMap.peekFirstItem();
             if (t == null) {
                 break;
             }
-            t.getValue().run();
+            t.getValue().runnable.run();
             timeMap.removeFirstItem();
         }
         Assertions.assertEquals("ABCD", log.toString());


### PR DESCRIPTION
### Description

Add the ability to drop captures, while still forwarding the contents, for requests when a specific header matches some regex.

Since captures are really on a connection (socket) basis and not a request one, there are additional complications.
Data is captured as it is received.  We may not know that we want to drop packets early enough.  To compensate and to give the traffic stream enough details to differentiate this occurrence from a bug where packets were dropped, a new "RequestIntentionallyDropped" TrafficObservation has been introduced.  This observation will only be used when data for a request has been included.  That means that if we get a packet that has the entire HTTP preamble (first line + headers) that matches the drop filter, we won't capture anything at all.
The --suppressCaptureForHeaderMatch argument has been added to the CaptureProxy.  It expects two elements for a header name and a regex to match that header's value.  When a request matches, it will be passed to the HTTP server, but will NOT be captured as per the above.  Because the capture proxy only captures a handful of headers so that it can understand request boundaries, the predicate to scan additional headers must tweak the set of headers that the LoggingHttpRequestHandler's internal classes will preserve.

There was also a bugfix for over-committing KafkaRecords too early and a spurious log message has been disabled.

* Category New feature, Bug fix, Test fix
* Why these changes are required? To stop the capture proxy from capturing data that is being pulled by the fetch migration.
* What is the old behavior before changes and new behavior after changes?  Now users can suppress some captures with additional command line flags.  Otherwise, behavior is identical.

### Issues Resolved
https://opensearch.atlassian.net/browse/MIGRATIONS-1444

### Testing
`./gradlew :dockerSolution:composeUp` ... OSB --test script and doc count check

### Check List
- [x] New functionality includes testing
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
