### PR TITLE
[Fetch Migration] Add track_total_hits parameter to doc-count operation

### DIFF
--- a/FetchMigration/python/index_operations.py
+++ b/FetchMigration/python/index_operations.py
@@ -22,8 +22,10 @@ ALIASES_KEY = "aliases"
 COUNT_KEY = "count"
 __INDEX_KEY = "index"
 __ALL_INDICES_ENDPOINT = "*"
-__SEARCH_COUNT_PATH = "/_search?size=0"
-__SEARCH_COUNT_PAYLOAD = {"aggs": {"count": {"terms": {"field": "_index"}}}}
+# (ES 7+) size=0 avoids the "hits" payload to reduce the response size since we're only interested in the aggregation,
+# and track_total_hits forces an accurate doc-count
+__SEARCH_COUNT_PATH = "/_search"
+__SEARCH_COUNT_PAYLOAD = {"size": 0, "track_total_hits": True, "aggs": {"count": {"terms": {"field": "_index"}}}}
 __TOTAL_COUNT_JSONPATH = jsonpath_ng.parse("$.hits.total.value")
 __INDEX_COUNT_JSONPATH = jsonpath_ng.parse("$.aggregations.count.buckets")
 __BUCKET_INDEX_NAME_KEY = "key"

--- a/FetchMigration/python/tests/test_index_operations.py
+++ b/FetchMigration/python/tests/test_index_operations.py
@@ -99,7 +99,7 @@ class TestIndexOperations(unittest.TestCase):
         for index_name in test_indices:
             test_buckets.append({"key": index_name, "doc_count": index_doc_count})
         total_docs: int = index_doc_count * len(test_buckets)
-        expected_count_endpoint = test_constants.SOURCE_ENDPOINT + ",".join(test_indices) + "/_search?size=0"
+        expected_count_endpoint = test_constants.SOURCE_ENDPOINT + ",".join(test_indices) + "/_search"
         mock_count_response = {"hits": {"total": {"value": total_docs}},
                                "aggregations": {"count": {"buckets": test_buckets}}}
         responses.get(expected_count_endpoint, json=mock_count_response)
@@ -110,7 +110,7 @@ class TestIndexOperations(unittest.TestCase):
     @responses.activate
     def test_doc_count_error(self):
         test_indices = {test_constants.INDEX1_NAME, test_constants.INDEX2_NAME}
-        expected_count_endpoint = test_constants.SOURCE_ENDPOINT + ",".join(test_indices) + "/_search?size=0"
+        expected_count_endpoint = test_constants.SOURCE_ENDPOINT + ",".join(test_indices) + "/_search"
         responses.get(expected_count_endpoint, body=requests.Timeout())
         self.assertRaises(RuntimeError, index_operations.doc_count, test_indices,
                           EndpointInfo(test_constants.SOURCE_ENDPOINT))


### PR DESCRIPTION
### Description
The [track_total_hits](https://www.elastic.co/guide/en/elasticsearch/reference/7.10/search-your-data.html#track-total-hits) parameter forces an accurate doc-count even when the hit count for `_search` is above the default 10K limit. This resolves a bug where the total doc count was not being computed properly. Unit tests have also been updated to match the new path.
* Category: Bug fix

### Testing
Tested emperically by performing a Fetch Migration between clusters, including an index with nested documents.
Unit tests:
```
$ python -m coverage report --omit "*/tests/*"
Name                           Stmts   Miss  Cover
--------------------------------------------------
endpoint_info.py                  24      0   100%
endpoint_utils.py                106      1    99%
fetch_orchestrator.py             72      0   100%
fetch_orchestrator_params.py      22      0   100%
index_diff.py                     20      0   100%
index_doc_count.py                 5      0   100%
index_operations.py               76      0   100%
metadata_migration.py             65      0   100%
metadata_migration_params.py       7      0   100%
metadata_migration_result.py       5      0   100%
migration_monitor.py              90      0   100%
migration_monitor_params.py        6      0   100%
progress_metrics.py               91      0   100%
utils.py                          13      0   100%
--------------------------------------------------
TOTAL                            602      1    99%

```

### Check List
- [x] New functionality includes testing
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
