### PR TITLE
[Fetch Migration] Migrate index templates and component templates as a part of metadata migration

### DIFF
--- a/FetchMigration/python/component_template_info.py
+++ b/FetchMigration/python/component_template_info.py
@@ -1,0 +1,34 @@
+#
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+#
+
+
+# Constants
+from typing import Optional
+
+NAME_KEY = "name"
+DEFAULT_TEMPLATE_KEY = "component_template"
+
+
+# Class that encapsulates component template information
+class ComponentTemplateInfo:
+    # Private member variables
+    __name: str
+    __template_def: Optional[dict]
+
+    def __init__(self, template_payload: dict, template_key: str = DEFAULT_TEMPLATE_KEY):
+        self.__name = template_payload[NAME_KEY]
+        self.__template_def = None
+        if template_key in template_payload:
+            self.__template_def = template_payload[template_key]
+
+    def get_name(self) -> str:
+        return self.__name
+
+    def get_template_definition(self) -> dict:
+        return self.__template_def

--- a/FetchMigration/python/index_template_info.py
+++ b/FetchMigration/python/index_template_info.py
@@ -1,0 +1,23 @@
+#
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+#
+
+from component_template_info import ComponentTemplateInfo
+
+# Constants
+INDEX_TEMPLATE_KEY = "index_template"
+
+
+# Class that encapsulates index template information from a cluster.
+# Subclass of ComponentTemplateInfo because the structure of an index
+# template is identical to a component template, except that it uses
+# a different template key. Also, index templates can be "composed" of
+# one or more component templates.
+class IndexTemplateInfo(ComponentTemplateInfo):
+    def __init__(self, template_payload: dict):
+        super().__init__(template_payload, INDEX_TEMPLATE_KEY)

--- a/FetchMigration/python/tests/test_index_operations.py
+++ b/FetchMigration/python/tests/test_index_operations.py
@@ -212,10 +212,16 @@ class TestIndexOperations(unittest.TestCase):
         # Set up error responses
         responses.get(test_constants.SOURCE_ENDPOINT + "_component_template", body=requests.Timeout())
         responses.get(test_constants.SOURCE_ENDPOINT + "_index_template", body=requests.HTTPError())
-        self.assertRaises(RuntimeError, index_operations.fetch_all_component_templates,
-                          EndpointInfo(test_constants.SOURCE_ENDPOINT))
-        self.assertRaises(RuntimeError, index_operations.fetch_all_index_templates,
-                          EndpointInfo(test_constants.SOURCE_ENDPOINT))
+        try:
+            self.assertRaises(RuntimeError, index_operations.fetch_all_component_templates,
+                              EndpointInfo(test_constants.SOURCE_ENDPOINT))
+        except RuntimeError as e:
+            self.assertIsNotNone(e.__cause__)
+        try:
+            self.assertRaises(RuntimeError, index_operations.fetch_all_index_templates,
+                              EndpointInfo(test_constants.SOURCE_ENDPOINT))
+        except RuntimeError as e:
+            self.assertIsNotNone(e.__cause__)
 
     @responses.activate
     def test_create_templates(self):

--- a/FetchMigration/python/tests/test_index_operations.py
+++ b/FetchMigration/python/tests/test_index_operations.py
@@ -15,8 +15,18 @@ import responses
 from responses import matchers
 
 import index_operations
+from component_template_info import ComponentTemplateInfo
 from endpoint_info import EndpointInfo
+from index_template_info import IndexTemplateInfo
 from tests import test_constants
+
+
+# Helper method to create a template API response
+def create_base_template_response(list_name: str, body: dict) -> dict:
+    return {list_name: [{"name": "test", list_name[:-1]: {"template": {
+        test_constants.SETTINGS_KEY: body.get(test_constants.SETTINGS_KEY, {}),
+        test_constants.MAPPINGS_KEY: body.get(test_constants.MAPPINGS_KEY, {})
+    }}}]}
 
 
 class TestIndexOperations(unittest.TestCase):
@@ -125,6 +135,137 @@ class TestIndexOperations(unittest.TestCase):
             responses.get(test_constants.SOURCE_ENDPOINT + "*", body=e)
             self.assertRaises(RuntimeError, index_operations.fetch_all_indices,
                               EndpointInfo(test_constants.SOURCE_ENDPOINT))
+
+    @responses.activate
+    def test_fetch_all_component_templates_empty(self):
+        # 1 - Empty response
+        responses.get(test_constants.SOURCE_ENDPOINT + "_component_template", json={})
+        result = index_operations.fetch_all_component_templates(EndpointInfo(test_constants.SOURCE_ENDPOINT))
+        # Missing key returns empty result
+        self.assertEqual(0, len(result))
+        # 2 - Valid response structure but no templates
+        responses.get(test_constants.SOURCE_ENDPOINT + "_component_template", json={"component_templates": []})
+        result = index_operations.fetch_all_component_templates(EndpointInfo(test_constants.SOURCE_ENDPOINT))
+        self.assertEqual(0, len(result))
+        # 2 - Invalid response structure
+        responses.get(test_constants.SOURCE_ENDPOINT + "_component_template", json={"templates": []})
+        result = index_operations.fetch_all_component_templates(EndpointInfo(test_constants.SOURCE_ENDPOINT))
+        self.assertEqual(0, len(result))
+
+    @responses.activate
+    def test_fetch_all_component_templates(self):
+        # Set up response
+        test_index = test_constants.BASE_INDICES_DATA[test_constants.INDEX3_NAME]
+        test_resp = create_base_template_response("component_templates", test_index)
+        responses.get(test_constants.SOURCE_ENDPOINT + "_component_template", json=test_resp)
+        result = index_operations.fetch_all_component_templates(EndpointInfo(test_constants.SOURCE_ENDPOINT))
+        # Result should contain one template
+        self.assertEqual(1, len(result))
+        template = result.pop()
+        self.assertTrue(isinstance(template, ComponentTemplateInfo))
+        self.assertEqual("test", template.get_name())
+        template_def = template.get_template_definition()["template"]
+        self.assertEqual(test_index[test_constants.SETTINGS_KEY], template_def[test_constants.SETTINGS_KEY])
+        self.assertEqual(test_index[test_constants.MAPPINGS_KEY], template_def[test_constants.MAPPINGS_KEY])
+
+    @responses.activate
+    def test_fetch_all_index_templates_empty(self):
+        # 1 - Empty response
+        responses.get(test_constants.SOURCE_ENDPOINT + "_index_template", json={})
+        result = index_operations.fetch_all_index_templates(EndpointInfo(test_constants.SOURCE_ENDPOINT))
+        # Missing key returns empty result
+        self.assertEqual(0, len(result))
+        # 2 - Valid response structure but no templates
+        responses.get(test_constants.SOURCE_ENDPOINT + "_index_template", json={"index_templates": []})
+        result = index_operations.fetch_all_index_templates(EndpointInfo(test_constants.SOURCE_ENDPOINT))
+        self.assertEqual(0, len(result))
+        # 2 - Invalid response structure
+        responses.get(test_constants.SOURCE_ENDPOINT + "_index_template", json={"templates": []})
+        result = index_operations.fetch_all_index_templates(EndpointInfo(test_constants.SOURCE_ENDPOINT))
+        self.assertEqual(0, len(result))
+
+    @responses.activate
+    def test_fetch_all_index_templates(self):
+        # Set up base response
+        key = "index_templates"
+        test_index_pattern = "test-*"
+        test_component_template_name = "test_component_template"
+        test_index = test_constants.BASE_INDICES_DATA[test_constants.INDEX2_NAME]
+        test_resp = create_base_template_response(key, test_index)
+        # Add fields specific to index templates
+        template_body = test_resp[key][0][key[:-1]]
+        template_body["index_patterns"] = [test_index_pattern]
+        template_body["composed_of"] = [test_component_template_name]
+        responses.get(test_constants.SOURCE_ENDPOINT + "_index_template", json=test_resp)
+        result = index_operations.fetch_all_index_templates(EndpointInfo(test_constants.SOURCE_ENDPOINT))
+        # Result should contain one template
+        self.assertEqual(1, len(result))
+        template = result.pop()
+        self.assertTrue(isinstance(template, IndexTemplateInfo))
+        self.assertEqual("test", template.get_name())
+        template_def = template.get_template_definition()["template"]
+        self.assertEqual(test_index[test_constants.SETTINGS_KEY], template_def[test_constants.SETTINGS_KEY])
+        self.assertEqual(test_index[test_constants.MAPPINGS_KEY], template_def[test_constants.MAPPINGS_KEY])
+
+    @responses.activate
+    def test_fetch_all_templates_errors(self):
+        # Set up error responses
+        responses.get(test_constants.SOURCE_ENDPOINT + "_component_template", body=requests.Timeout())
+        responses.get(test_constants.SOURCE_ENDPOINT + "_index_template", body=requests.HTTPError())
+        self.assertRaises(RuntimeError, index_operations.fetch_all_component_templates,
+                          EndpointInfo(test_constants.SOURCE_ENDPOINT))
+        self.assertRaises(RuntimeError, index_operations.fetch_all_index_templates,
+                          EndpointInfo(test_constants.SOURCE_ENDPOINT))
+
+    @responses.activate
+    def test_create_templates(self):
+        # Set up test input
+        test1_template_def = copy.deepcopy(test_constants.BASE_INDICES_DATA[test_constants.INDEX2_NAME])
+        test2_template_def = copy.deepcopy(test_constants.BASE_INDICES_DATA[test_constants.INDEX3_NAME])
+        # Remove "aliases" since that's not a valid component template entry
+        del test1_template_def[test_constants.ALIASES_KEY]
+        del test2_template_def[test_constants.ALIASES_KEY]
+        # Test component templates first
+        test_templates = set()
+        test_templates.add(ComponentTemplateInfo({"name": "test1", "component_template": test1_template_def}))
+        test_templates.add(ComponentTemplateInfo({"name": "test2", "component_template": test2_template_def}))
+        # Set up expected PUT calls with a mock response status
+        responses.put(test_constants.TARGET_ENDPOINT + "_component_template/test1",
+                      match=[matchers.json_params_matcher(test1_template_def)])
+        responses.put(test_constants.TARGET_ENDPOINT + "_component_template/test2",
+                      match=[matchers.json_params_matcher(test2_template_def)])
+        failed = index_operations.create_component_templates(test_templates,
+                                                             EndpointInfo(test_constants.TARGET_ENDPOINT))
+        self.assertEqual(0, len(failed))
+        # Also test index templates
+        test_templates.clear()
+        test_templates.add(IndexTemplateInfo({"name": "test1", "index_template": test1_template_def}))
+        test_templates.add(IndexTemplateInfo({"name": "test2", "index_template": test2_template_def}))
+        # Set up expected PUT calls with a mock response status
+        responses.put(test_constants.TARGET_ENDPOINT + "_index_template/test1",
+                      match=[matchers.json_params_matcher(test1_template_def)])
+        responses.put(test_constants.TARGET_ENDPOINT + "_index_template/test2",
+                      match=[matchers.json_params_matcher(test2_template_def)])
+        failed = index_operations.create_index_templates(test_templates, EndpointInfo(test_constants.TARGET_ENDPOINT))
+        self.assertEqual(0, len(failed))
+
+    @responses.activate
+    def test_create_templates_failure(self):
+        # Set up failures
+        responses.put(test_constants.TARGET_ENDPOINT + "_component_template/test1", body=requests.Timeout())
+        responses.put(test_constants.TARGET_ENDPOINT + "_index_template/test2", body=requests.HTTPError())
+        test_input = ComponentTemplateInfo({"name": "test1", "component_template": {}})
+        failed = index_operations.create_component_templates({test_input}, EndpointInfo(test_constants.TARGET_ENDPOINT))
+        # Verify that failures return their respective errors
+        self.assertEqual(1, len(failed))
+        self.assertTrue("test1" in failed)
+        self.assertTrue(isinstance(failed["test1"], requests.Timeout))
+        test_input = IndexTemplateInfo({"name": "test2", "index_template": {}})
+        failed = index_operations.create_index_templates({test_input}, EndpointInfo(test_constants.TARGET_ENDPOINT))
+        # Verify that failures return their respective errors
+        self.assertEqual(1, len(failed))
+        self.assertTrue("test2" in failed)
+        self.assertTrue(isinstance(failed["test2"], requests.HTTPError))
 
 
 if __name__ == '__main__':

--- a/FetchMigration/python/tests/test_template_info.py
+++ b/FetchMigration/python/tests/test_template_info.py
@@ -1,0 +1,52 @@
+#
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+#
+import unittest
+
+from component_template_info import ComponentTemplateInfo
+from index_template_info import IndexTemplateInfo
+
+
+class TestTemplateInfo(unittest.TestCase):
+    # Template info expects at least a NAME key
+    def test_bad_template_info(self):
+        with self.assertRaises(KeyError):
+            ComponentTemplateInfo({})
+            IndexTemplateInfo({})
+
+    def test_empty_template_info(self):
+        template_payload: dict = {"name": "test", "template": "dontcare"}
+        info = ComponentTemplateInfo(template_payload)
+        self.assertEqual("test", info.get_name())
+        self.assertIsNone(info.get_template_definition())
+
+    def test_component_template_info(self):
+        test_template = {"test": 1}
+        template_payload: dict = {"name": "test", "component_template": test_template}
+        info = ComponentTemplateInfo(template_payload)
+        self.assertEqual("test", info.get_name())
+        self.assertEqual(test_template, info.get_template_definition())
+        info = IndexTemplateInfo(template_payload)
+        self.assertEqual("test", info.get_name())
+        # Index template uses a different key, so this should be None
+        self.assertIsNone(info.get_template_definition())
+
+    def test_index_template_info(self):
+        test_template = {"test": 1}
+        template_payload: dict = {"name": "test", "index_template": test_template}
+        info = IndexTemplateInfo(template_payload)
+        self.assertEqual("test", info.get_name())
+        self.assertEqual(test_template, info.get_template_definition())
+        info = ComponentTemplateInfo(template_payload)
+        self.assertEqual("test", info.get_name())
+        # Component template uses a different key, so this should be None
+        self.assertIsNone(info.get_template_definition())
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
### Description

This change enables index template and component template migration from source to target cluster as a part of the metadata migration step of Fetch Migration. Now that metadata migration performs multiple distinct steps, these have been refactored into encapsulated functions rather than being inline in the `run` entrypoint.

New functions have been added to `index_operations.py` to fetch and create component templates and index templates. The `IndexTemplateInfo` class derives from the `ComponentTemplateInfo` class since the former can include a "template" definition that overrides its components, and it includes additional fields (such as "composed_of", "priority" and "index_patterns")

Unit tests have been added to maintain high test coverage.
* Category: Enhancement, New feature, Refactoring

### Testing
Tested emperically by running Fetch Migration from a source cluster that had index templates and component templates defined, to a target cluster. The templates were correctly copied over (verified by diff-ing their structures)
Unit test coverage:
```
$ python -m coverage run -m unittest
............................................................................................
----------------------------------------------------------------------
Ran 92 tests in 0.869s

OK

$ python -m coverage report --omit "*/tests/*"
Name                           Stmts   Miss  Cover
--------------------------------------------------
component_template_info.py        15      0   100%
endpoint_info.py                  24      0   100%
endpoint_utils.py                106      1    99%
fetch_orchestrator.py             76      0   100%
fetch_orchestrator_params.py      22      0   100%
index_diff.py                     20      0   100%
index_doc_count.py                 5      0   100%
index_operations.py              117      0   100%
index_template_info.py             5      0   100%
metadata_migration.py             87      0   100%
metadata_migration_params.py       7      0   100%
metadata_migration_result.py       5      0   100%
migration_monitor.py              90      0   100%
migration_monitor_params.py        6      0   100%
progress_metrics.py               91      0   100%
utils.py                          13      0   100%
--------------------------------------------------
TOTAL                            689      1    99%

```

### Check List
- [x] New functionality includes testing
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
