### PR TITLE
Python Integ Test Updates

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,6 +1,6 @@
 # conftest.py
 import pytest
-
+import uuid
 import logging
 
 
@@ -27,7 +27,7 @@ def pytest_addoption(parser):
     parser.addoption("--source_password", action="store", default="admin")
     parser.addoption("--target_username", action="store", default="admin")
     parser.addoption("--target_password", action="store", default="admin")
-    parser.addoption("--unique_id", action="store", default="")
+    parser.addoption("--unique_id", action="store", default=uuid.uuid4().hex)
 
 
 @pytest.fixture

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -6,7 +6,7 @@ packaging==23.1
 pluggy==1.0.0
 pytest==7.3.1
 pytest-xdist==3.3.1
-requests==2.31.0
-urllib3==2.0.7
+requests>==2.31.0
+urllib3>==2.0.7
 requests_aws4auth
 boto3

--- a/test/tests.py
+++ b/test/tests.py
@@ -266,11 +266,11 @@ class E2ETests(unittest.TestCase):
         if self.deployment_type == "cloud":
             cmd_exec = f"/root/runTestBenchmarks.sh --unique-id {self.unique_id} --endpoint {self.proxy_endpoint}"
             if self.source_auth_type is None:
-                cmd_exec = cmd_exec.join(" --no-auth")
+                cmd_exec = cmd_exec + " --no-auth"
             elif self.source_auth_type == "basic":
-                cmd_exec = cmd_exec.join(f" --auth_user {self.source_username} --auth_pass {self.source_password}")
-            if not self.source_verify_ssl :
-                cmd_exec = cmd_exec.join(" --no-ssl")
+                cmd_exec = cmd_exec + f" --auth_user {self.source_username} --auth_pass {self.source_password}"
+            if not self.source_verify_ssl:
+                cmd_exec = cmd_exec + " --no-ssl"
             logger.warning(f"Running local command: {cmd_exec}")
             subprocess.run(cmd_exec, shell=True)
             # TODO: Enhance our waiting logic for determining when all OSB records have been processed by Replayer

--- a/test/tests.py
+++ b/test/tests.py
@@ -265,7 +265,7 @@ class E2ETests(unittest.TestCase):
     def test_0006_OSB(self):
         if self.deployment_type == "cloud":
             cmd_exec = f"/root/runTestBenchmarks.sh --unique-id {self.unique_id} --endpoint {self.proxy_endpoint}"
-            if self.source_auth_type is None:
+            if self.source_auth_type == "none":
                 cmd_exec = cmd_exec + " --no-auth"
             elif self.source_auth_type == "basic":
                 cmd_exec = cmd_exec + f" --auth_user {self.source_username} --auth_pass {self.source_password}"

--- a/test/tests.py
+++ b/test/tests.py
@@ -278,6 +278,7 @@ class E2ETests(unittest.TestCase):
             cmd_exec = f"/root/runTestBenchmarks.sh --unique-id {self.unique_id} --endpoint {self.proxy_endpoint} --no-auth --no-ssl"
             logger.warning(f"Running local command: {cmd_exec}")
             subprocess.run(cmd_exec, shell=True)
+            time.sleep(60)
         else:
             cmd = ['docker', 'ps', '--format="{{.ID}}"', '--filter', 'name=migration']
             container_id = subprocess.run(cmd, stdout=subprocess.PIPE, text=True).stdout.strip().replace('"', '')

--- a/test/tests.py
+++ b/test/tests.py
@@ -290,9 +290,11 @@ class E2ETests(unittest.TestCase):
                 self.assert_(False)
 
         source_indices = get_indices(self.source_endpoint, self.source_auth, self.source_verify_ssl)
-        valid_source_indices = set([index for index in source_indices if not self.does_index_match_ignored_index(index)])
+        valid_source_indices = set([index for index in source_indices
+                                    if not self.does_index_match_ignored_index(index)])
         target_indices = get_indices(self.target_endpoint, self.target_auth, self.target_verify_ssl)
-        valid_target_indices = set([index for index in target_indices if not self.does_index_match_ignored_index(index)])
+        valid_target_indices = set([index for index in target_indices
+                                    if not self.does_index_match_ignored_index(index)])
 
         self.assertTrue(valid_source_indices, "No valid indices found on source after running OpenSearch Benchmark")
         self.assertEqual(valid_source_indices, valid_target_indices,
@@ -303,4 +305,5 @@ class E2ETests(unittest.TestCase):
             source_count = get_doc_count(self.source_endpoint, index, self.source_auth, self.source_verify_ssl)
             target_count = get_doc_count(self.target_endpoint, index, self.target_auth, self.target_verify_ssl)
             if source_count != target_count:
-                self.assertEqual(source_count, target_count, f'{index}: doc counts do not match - Source = {source_count}, Target = {target_count}')
+                self.assertEqual(source_count, target_count, f'{index}: doc counts do not match - '
+                                                             f'Source = {source_count}, Target = {target_count}')

--- a/test/tests.py
+++ b/test/tests.py
@@ -278,7 +278,7 @@ class E2ETests(unittest.TestCase):
             cmd_exec = f"/root/runTestBenchmarks.sh --unique-id {self.unique_id} --endpoint {self.proxy_endpoint} --no-auth --no-ssl"
             logger.warning(f"Running local command: {cmd_exec}")
             subprocess.run(cmd_exec, shell=True)
-            time.sleep(300)
+            time.sleep(240)
         else:
             cmd = ['docker', 'ps', '--format="{{.ID}}"', '--filter', 'name=migration']
             container_id = subprocess.run(cmd, stdout=subprocess.PIPE, text=True).stdout.strip().replace('"', '')

--- a/test/tests.py
+++ b/test/tests.py
@@ -278,7 +278,7 @@ class E2ETests(unittest.TestCase):
             cmd_exec = f"/root/runTestBenchmarks.sh --unique-id {self.unique_id} --endpoint {self.proxy_endpoint} --no-auth --no-ssl"
             logger.warning(f"Running local command: {cmd_exec}")
             subprocess.run(cmd_exec, shell=True)
-            time.sleep(60)
+            time.sleep(300)
         else:
             cmd = ['docker', 'ps', '--format="{{.ID}}"', '--filter', 'name=migration']
             container_id = subprocess.run(cmd, stdout=subprocess.PIPE, text=True).stdout.strip().replace('"', '')

--- a/test/tests.py
+++ b/test/tests.py
@@ -110,15 +110,23 @@ class E2ETests(unittest.TestCase):
 
     def setUp(self):
         self.set_common_values()
-        retry_request(delete_index, args=(self.proxy_endpoint, self.index, self.source_auth, self.source_verify_ssl),
+        retry_request(delete_index, args=(self.source_endpoint, self.index, self.source_auth, self.source_verify_ssl),
                       expected_status_code=HTTPStatus.NOT_FOUND)
-        retry_request(delete_document, args=(self.proxy_endpoint, self.index, self.doc_id, self.source_auth,
+        retry_request(delete_document, args=(self.source_endpoint, self.index, self.doc_id, self.source_auth,
                                              self.source_verify_ssl),
+                      expected_status_code=HTTPStatus.NOT_FOUND)
+        retry_request(delete_index, args=(self.target_endpoint, self.index, self.target_auth, self.target_verify_ssl),
+                      expected_status_code=HTTPStatus.NOT_FOUND)
+        retry_request(delete_document, args=(self.target_endpoint, self.index, self.doc_id, self.target_auth,
+                                         self.target_verify_ssl),
                       expected_status_code=HTTPStatus.NOT_FOUND)
 
     def tearDown(self):
-        delete_index(self.proxy_endpoint, self.index, self.source_auth, self.source_verify_ssl)
-        delete_document(self.proxy_endpoint, self.index, self.doc_id, self.source_auth, self.source_verify_ssl)
+        # TODO can't I just delete the index?
+        delete_index(self.source_endpoint, self.index, self.source_auth, self.source_verify_ssl)
+        delete_document(self.source_endpoint, self.index, self.doc_id, self.source_auth, self.source_verify_ssl)
+        delete_index(self.target_endpoint, self.index, self.target_auth, self.target_verify_ssl)
+        delete_document(self.target_endpoint, self.index, self.doc_id, self.target_auth, self.target_verify_ssl)
 
     def test_0001_index(self):
         # This test will verify that an index will be created (then deleted) on the target cluster when one is created

--- a/test/tests.py
+++ b/test/tests.py
@@ -274,7 +274,8 @@ class E2ETests(unittest.TestCase):
 
     def test_0006_OSB(self):
         if self.deployment_type == "cloud":
-            cmd_exec = f"/root/runTestBenchmarks.sh --unique-id {self.unique_id}"
+            # TODO: Enhancement needed to support different auth patterns
+            cmd_exec = f"/root/runTestBenchmarks.sh --unique-id {self.unique_id} --endpoint {self.proxy_endpoint} --no-auth --no-ssl"
             logger.warning(f"Running local command: {cmd_exec}")
             subprocess.run(cmd_exec, shell=True)
         else:

--- a/test/tests.py
+++ b/test/tests.py
@@ -278,7 +278,7 @@ class E2ETests(unittest.TestCase):
             cmd_exec = f"/root/runTestBenchmarks.sh --unique-id {self.unique_id} --endpoint {self.proxy_endpoint} --no-auth --no-ssl"
             logger.warning(f"Running local command: {cmd_exec}")
             subprocess.run(cmd_exec, shell=True)
-            time.sleep(240)
+            time.sleep(300)
         else:
             cmd = ['docker', 'ps', '--format="{{.ID}}"', '--filter', 'name=migration']
             container_id = subprocess.run(cmd, stdout=subprocess.PIPE, text=True).stdout.strip().replace('"', '')


### PR DESCRIPTION
### Description
This change contains improvements and refactors to the integration test script we have currently. It fixes some indentation errors that occurred at some point with the OSB test which was causing some indexes to not get checked. It also adds additional logic for the OSB test to add proper parameters for the `./runTestBenchmarks` script. Also included is a refactoring to not try and delete a given index after every test which can cause some flakiness between tests if using the proxy endpoint. Instead we use a unique index for each test now, and let the test delete the index if it chooses.

### Issues Resolved
[List any issues this PR will resolve]

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]

### Check List
- [ ] New functionality includes testing
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
