### PR TITLE
Enhancements in StreamChannelConnectionCaptureSerializer

### DIFF
--- a/TrafficCapture/captureOffloader/src/test/java/org/opensearch/migrations/trafficcapture/StreamChannelConnectionCaptureSerializerTest.java
+++ b/TrafficCapture/captureOffloader/src/test/java/org/opensearch/migrations/trafficcapture/StreamChannelConnectionCaptureSerializerTest.java
@@ -31,7 +31,8 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ExecutionException;
-import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @Slf4j
 class StreamChannelConnectionCaptureSerializerTest {
@@ -313,6 +314,28 @@ class StreamChannelConnectionCaptureSerializerTest {
             }
         }
         Assertions.assertEquals(0, foundEndOfSegments);
+    }
+
+    @Test
+    public void testAssertionErrorDuringInitializationWhenInitializeWithTooLargeId() {
+        final String realNodeId = "b671d2f2-577b-414e-9eb4-8bc3e89ee182";
+        final String realKafkaConnectionId = "9a25a4fffe620014-00034cfa-00000001-d208faac76346d02-864e38e2";
+
+        var outputBuffersCreated = new ConcurrentLinkedQueue<ByteBuffer>();
+        assertThrows(AssertionError.class, () ->
+                new StreamChannelConnectionCaptureSerializer<>("a" + realNodeId, realKafkaConnectionId,
+                        new StreamManager(getEstimatedTrafficStreamByteSize(0, 0), outputBuffersCreated))
+        );
+    }
+
+    @Test
+    public void testInitializationWithRealIds() {
+        final String realNodeId = "b671d2f2-577b-414e-9eb4-8bc3e89ee182";
+        final String realKafkaConnectionId = "9a25a4fffe620014-00034cfa-00000001-d208faac76346d02-864e38e2";
+
+        var outputBuffersCreated = new ConcurrentLinkedQueue<ByteBuffer>();
+        new StreamChannelConnectionCaptureSerializer<>(realNodeId, realKafkaConnectionId,
+                new StreamManager(getEstimatedTrafficStreamByteSize(0, 0), outputBuffersCreated));
     }
 
     @AllArgsConstructor


### PR DESCRIPTION
### Description
This pull request introduces two key enhancements to the StreamChannelConnectionCaptureSerializer:
- Refactoring the StreamChannelConnectionCaptureSerializerTest with a calculated bufferSize.
- Increasing the StreamChannelConnectionCaptureSerializer's max ID size.

* Category: Bug fix, Refactoring
* These changes are required to fix max id size assertion in StreamChannelConnectionCaptureSerializer which currently is not large enough to allow for kafka connectionIds when executed with assertions enabled.
* Old behavior: Threw assertion error when starting up with `-ea` jdk flag.
* New behavior: No StreamChannelConnectionCaptureSerializer assertion error during startup with `-ea`.

### Issues Resolved
- [MIGRATIONS-1490](https://opensearch.atlassian.net/browse/MIGRATIONS-1490)

Is this a backport? If so, please add backport PR # and/or commits #
  - N/A

### Testing
- Unit testing have been conducted to ensure functionality with new tests added to verify behavior
- Manual testing has been performed to verify the changes via starting up dockerSolution with `-enableassertions` with OSB --test script and doc count check

### Check List
- [x] New functionality includes testing
  - [x] All tests pass, including unit test, integration test and doctest
- [N/A] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).