### PR TITLE
Slow test fixup

### DIFF
--- a/TrafficCapture/build.gradle
+++ b/TrafficCapture/build.gradle
@@ -48,6 +48,11 @@ allprojects {
     }
 
     task slowTest(type: Test) {
+        useJUnitPlatform {
+            // SlowTests currently use additional resource overhead, so halving core based parallelism
+            systemProperty 'junit.jupiter.execution.parallel.config.strategy', 'dynamic'
+            systemProperty 'junit.jupiter.execution.parallel.config.dynamic.factor', '0.5'
+        }
         systemProperty 'disableMemoryLeakTests', 'false'
         jacoco {
             enabled = true
@@ -85,3 +90,4 @@ jacocoTestReport {
         html.destination file("${buildDir}/reports/jacoco/test/html")
     }
 }
+

--- a/TrafficCapture/trafficCaptureProxyServer/src/test/java/org/opensearch/migrations/trafficcapture/proxyserver/testcontainers/annotations/HttpdContainerTest.java
+++ b/TrafficCapture/trafficCaptureProxyServer/src/test/java/org/opensearch/migrations/trafficcapture/proxyserver/testcontainers/annotations/HttpdContainerTest.java
@@ -1,10 +1,16 @@
 package org.opensearch.migrations.trafficcapture.proxyserver.testcontainers.annotations;
 
+import java.lang.annotation.ElementType;
 import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 import org.junit.jupiter.api.parallel.ResourceLock;
 
 @Inherited
 @ResourceLock("HttpdContainer")
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE})
 @TestContainerTest
 public @interface HttpdContainerTest {
 

--- a/TrafficCapture/trafficCaptureProxyServer/src/test/java/org/opensearch/migrations/trafficcapture/proxyserver/testcontainers/annotations/KafkaContainerTest.java
+++ b/TrafficCapture/trafficCaptureProxyServer/src/test/java/org/opensearch/migrations/trafficcapture/proxyserver/testcontainers/annotations/KafkaContainerTest.java
@@ -1,10 +1,16 @@
 package org.opensearch.migrations.trafficcapture.proxyserver.testcontainers.annotations;
 
+import java.lang.annotation.ElementType;
 import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 import org.junit.jupiter.api.parallel.ResourceLock;
 
 @Inherited
 @ResourceLock("KafkaContainer")
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE})
 @TestContainerTest
 public @interface KafkaContainerTest {
 

--- a/TrafficCapture/trafficCaptureProxyServer/src/test/java/org/opensearch/migrations/trafficcapture/proxyserver/testcontainers/annotations/TestContainerTest.java
+++ b/TrafficCapture/trafficCaptureProxyServer/src/test/java/org/opensearch/migrations/trafficcapture/proxyserver/testcontainers/annotations/TestContainerTest.java
@@ -1,10 +1,16 @@
 package org.opensearch.migrations.trafficcapture.proxyserver.testcontainers.annotations;
 
+import java.lang.annotation.ElementType;
 import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 import org.junit.jupiter.api.Tag;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 @Inherited
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE})
 @Tag("longTest")
 @Testcontainers(disabledWithoutDocker = true, parallel = true)
 public @interface TestContainerTest {

--- a/TrafficCapture/trafficCaptureProxyServer/src/test/java/org/opensearch/migrations/trafficcapture/proxyserver/testcontainers/annotations/ToxiproxyContainerTest.java
+++ b/TrafficCapture/trafficCaptureProxyServer/src/test/java/org/opensearch/migrations/trafficcapture/proxyserver/testcontainers/annotations/ToxiproxyContainerTest.java
@@ -1,10 +1,16 @@
 package org.opensearch.migrations.trafficcapture.proxyserver.testcontainers.annotations;
 
+import java.lang.annotation.ElementType;
 import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 import org.junit.jupiter.api.parallel.ResourceLock;
 
 @Inherited
 @ResourceLock("ToxiproxyContainerTestBase")
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE})
 @TestContainerTest
 public @interface ToxiproxyContainerTest {
 }


### PR DESCRIPTION
### Description
Increase reliability of capture proxy tests by correctly passing longTest tag and lowering concurrency to numberOfCores/2
* Category: Test Fix
* Why these changes are required? Currently, proxy tests are running for both slow test 
* What is the old behavior before changes and new behavior after changes? Current, KafkaConfigurationCaptureProxyTest tests run for both test and slowTest tasks which is not desired, new behavior is that KafkaConfigurationCaptureProxyTest only runs with SlowTest with dynamic parallelization in half.

### Issues Resolved
N/A

Is this a backport? If so, please add backport PR # and/or commits #
N/A

### Testing
Tested with gradle test to ensure tests are not being run

### Check List
- [x] New functionality includes testing
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
