### PR TITLE
Make globally unique default bucket name

### DIFF
--- a/deployment/cdk/opensearch-service-migration/lib/migration-assistance-stack.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/migration-assistance-stack.ts
@@ -183,7 +183,7 @@ export class MigrationAssistanceStack extends Stack {
         });
 
         const artifactBucket = new Bucket(this, 'migrationArtifactsS3', {
-            bucketName: `migration-artifacts-${props.stage}-${this.region}`,
+            bucketName: `migration-artifacts-${this.account}-${props.stage}-${this.region}`,
             encryption: BucketEncryption.S3_MANAGED,
             enforceSSL: true
         });


### PR DESCRIPTION
### Description
Changing default S3 bucket name to be globally unique given S3 naming constraints via adding in account name.
* Category  - Bug Fix
* Why these changes are required? S3 buckets will fail to be created if not globally unique.
* What is the old behavior before changes and new behavior after changes? Before, no account name in bucket name, collisions can occur if multiple deployments happen with same stage name and region across any customer.

### Issues Resolved
N/A

Is this a backport? If so, please add backport PR # and/or commits #
N/A

### Testing
Ran CDK Diff on a stack where this was already deployed previously.

```
Stack migrationInfraStack (OSMigrations-dev-us-west-2-MigrationInfra)
Creating a change set, this may take a while...
Resources
[~] AWS::S3::Bucket migrationArtifactsS3 migrationArtifactsS35D99BC6A replace
 └─ [~] BucketName (requires replacement)
     ├─ [-] migration-artifacts-dev-us-west-2
     └─ [+] migration-artifacts-905418235891-dev-us-west-2
[~] AWS::S3::BucketPolicy migrationArtifactsS3/Policy migrationArtifactsS3PolicyBD77C90F replace
 └─ [~] Bucket (requires replacement)
     └─ [~] .Ref:
         ├─ [-] migrationArtifactsS35D99BC6A
         └─ [+] migrationArtifactsS35D99BC6A (replaced)
```

### Check List
- [x] New functionality includes testing
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
