### PR TITLE
Improvements to Fetch Migration stability

### DIFF
--- a/FetchMigration/python/progress_metrics.py
+++ b/FetchMigration/python/progress_metrics.py
@@ -95,7 +95,8 @@ class ProgressMetrics:
         self.__record_value(self._REC_IN_FLIGHT_KEY, rec_in_flight)
 
     def update_no_partitions_count(self, no_part_count: Optional[int]):
-        self.__record_value(self._NO_PART_KEY, no_part_count)
+        if no_part_count and no_part_count > 0:
+            self.__record_value(self._NO_PART_KEY, no_part_count)
 
     def get_doc_completion_percentage(self) -> int:
         success_doc_count = self.__get_current_value(self._SUCCESS_DOCS_KEY)

--- a/deployment/cdk/opensearch-service-migration/dp_pipeline_template.yaml
+++ b/deployment/cdk/opensearch-service-migration/dp_pipeline_template.yaml
@@ -34,7 +34,11 @@ historical-data-migration:
       connection:
         insecure: true
   # Additional pipeline options/optimizations
+  buffer:
+    bounded_blocking: # Values recommended by an expert
+      buffer_size: 1000000
+      batch_size: 12500
   # For maximum throughput, match workers to number of vCPUs (default: 1)
-  workers: 1
+  workers: 2
   # delay is how often the worker threads should process data (default: 3000 ms)
   delay: 0

--- a/deployment/cdk/opensearch-service-migration/lib/fetch-migration-stack.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/fetch-migration-stack.ts
@@ -50,8 +50,8 @@ export class FetchMigrationStack extends Stack {
         // ECS Task Definition
         const fetchMigrationFargateTask = new FargateTaskDefinition(this, "fetchMigrationFargateTask", {
             family: `migration-${props.stage}-${serviceName}`,
-            memoryLimitMiB: 4096,
-            cpu: 1024,
+            memoryLimitMiB: 8192,
+            cpu: 2048,
             taskRole: ecsTaskRole
         });
 

--- a/deployment/cdk/opensearch-service-migration/lib/service-stacks/migration-service-core.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/service-stacks/migration-service-core.ts
@@ -86,6 +86,7 @@ export class MigrationServiceCore extends Stack {
         props.taskRolePolicies?.forEach(policy => serviceTaskRole.addToPolicy(policy))
 
         const serviceTaskDef = new FargateTaskDefinition(this, "ServiceTaskDef", {
+            ephemeralStorageGiB: 75,
             family: `migration-${props.stage}-${props.serviceName}`,
             memoryLimitMiB: props.taskMemoryLimitMiB ? props.taskMemoryLimitMiB : 1024,
             cpu: props.taskCpuUnits ? props.taskCpuUnits : 256,


### PR DESCRIPTION
### Description
* Updated default disk size for the Migration Console so larger OpenSearch Benchmark data sets can be run on it
* Updated Data Prepper container resources (vCPU, mem) per expert recommendation.
* Updated Data Prepper Pipeline parameters per expert recommendation
* Fixed a bug in how Fetch assesses idle Pipelines

### Issues Resolved
https://opensearch.atlassian.net/browse/MIGRATIONS-1497

### Testing
Manually tested the migration using the `awsE2ESolutionSetup.sh` test setup, running the Fetch Migration process from the Migration Console against my source which contains the `geonames` and `http_logs` indices from the OpenSearch Benchmark tool.  More details/logs in the linked JIRA.

### Check List
- [ ] New functionality includes testing
  - [ ] All tests pass, including unit test, integration test and doctest
- [X] New functionality has been documented
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
