### PR TITLE
Fix some flaky tests that were checking if metrics were being emitted.

### DIFF
--- a/TrafficCapture/coreUtilities/src/testFixtures/java/org/opensearch/migrations/tracing/InMemoryInstrumentationBundle.java
+++ b/TrafficCapture/coreUtilities/src/testFixtures/java/org/opensearch/migrations/tracing/InMemoryInstrumentationBundle.java
@@ -1,112 +1,50 @@
 package org.opensearch.migrations.tracing;
 
 import io.opentelemetry.sdk.OpenTelemetrySdk;
-import io.opentelemetry.sdk.common.CompletableResultCode;
-import io.opentelemetry.sdk.metrics.InstrumentType;
 import io.opentelemetry.sdk.metrics.SdkMeterProvider;
-import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
 import io.opentelemetry.sdk.metrics.data.MetricData;
-import io.opentelemetry.sdk.metrics.export.MetricExporter;
-import io.opentelemetry.sdk.metrics.export.PeriodicMetricReader;
+import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
 import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
 import lombok.Getter;
 import lombok.Lombok;
-import lombok.NonNull;
 import lombok.SneakyThrows;
 
 import java.io.IOException;
 import java.time.Duration;
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import java.util.Queue;
-import java.util.concurrent.ConcurrentLinkedQueue;
 
 public class InMemoryInstrumentationBundle implements AutoCloseable {
-
-    public static final Duration DEFAULT_COLLECTION_PERIOD = Duration.ofMillis(1);
-    private static final int MIN_MILLIS_TO_WAIT_FOR_FINISH = 10;
-
-    public static class LastMetricsExporter implements MetricExporter {
-        private final Queue<MetricData> finishedMetricItems = new ConcurrentLinkedQueue<>();
-        boolean isStopped;
-
-        public List<MetricData> getFinishedMetricItems() {
-            return Collections.unmodifiableList(new ArrayList<>(finishedMetricItems));
-        }
-
-        @Override
-        public CompletableResultCode export(@NonNull Collection<MetricData> metrics) {
-            if (isStopped) {
-                return CompletableResultCode.ofFailure();
-            }
-            finishedMetricItems.clear();
-            finishedMetricItems.addAll(metrics);
-            return CompletableResultCode.ofSuccess();
-        }
-
-        @Override
-        public CompletableResultCode flush() {
-            return CompletableResultCode.ofSuccess();
-        }
-
-        @Override
-        public CompletableResultCode shutdown() {
-            isStopped = true;
-            return CompletableResultCode.ofSuccess();
-        }
-
-        @Override
-        public AggregationTemporality getAggregationTemporality(@NonNull InstrumentType instrumentType) {
-            return AggregationTemporality.CUMULATIVE;
-        }
-    }
 
     @Getter
     public final OpenTelemetrySdk openTelemetrySdk;
     private final InMemorySpanExporter testSpanExporter;
-    private final LastMetricsExporter testMetricExporter;
-    private final PeriodicMetricReader periodicMetricReader;
-    private final Duration collectionPeriod;
-    private boolean alreadyWaitedForMetrics;
+    private final InMemoryMetricReader testMetricReader;
 
     public InMemoryInstrumentationBundle(boolean collectTraces,
                                          boolean collectMetrics) {
         this(collectTraces ? InMemorySpanExporter.create() : null,
-                collectMetrics ? new LastMetricsExporter() : null);
+                collectMetrics ? InMemoryMetricReader.create() : null);
     }
 
     public InMemoryInstrumentationBundle(InMemorySpanExporter testSpanExporter,
-                                         LastMetricsExporter testMetricExporter) {
-        this(testSpanExporter, testMetricExporter, DEFAULT_COLLECTION_PERIOD);
-    }
-
-    public InMemoryInstrumentationBundle(InMemorySpanExporter testSpanExporter,
-                                         LastMetricsExporter testMetricExporter,
-                                         Duration collectionPeriod) {
+                                         InMemoryMetricReader testMetricReader) {
         this.testSpanExporter = testSpanExporter;
-        this.testMetricExporter = testMetricExporter;
-        this.collectionPeriod = collectionPeriod;
+        this.testMetricReader = testMetricReader;
 
         var otelBuilder = OpenTelemetrySdk.builder();
         if (testSpanExporter != null) {
             otelBuilder = otelBuilder.setTracerProvider(SdkTracerProvider.builder()
                     .addSpanProcessor(SimpleSpanProcessor.create(testSpanExporter)).build());
         }
-        if (testMetricExporter != null) {
-            this.periodicMetricReader = PeriodicMetricReader.builder(testMetricExporter)
-                    .setInterval(Duration.ofMillis(collectionPeriod.toMillis()))
-                    .build();
+        if (testMetricReader != null) {
             otelBuilder = otelBuilder.setMeterProvider(SdkMeterProvider.builder()
-                    .registerMetricReader(periodicMetricReader)
+                    .registerMetricReader(testMetricReader)
                     .build());
-        } else {
-            this.periodicMetricReader = null;
         }
         openTelemetrySdk = otelBuilder.build();
     }
@@ -124,25 +62,20 @@ public class InMemoryInstrumentationBundle implements AutoCloseable {
      */
     @SneakyThrows
     public Collection<MetricData> getFinishedMetrics() {
-        if (testMetricExporter == null) {
+        if (testMetricReader == null) {
             throw new IllegalStateException("Metrics collector was not configured");
         }
-        if (!alreadyWaitedForMetrics) {
-            Thread.sleep(Math.max(collectionPeriod.toMillis() * 2, MIN_MILLIS_TO_WAIT_FOR_FINISH));
-            alreadyWaitedForMetrics = true;
-        }
-        return testMetricExporter.getFinishedMetricItems();
+        return testMetricReader.collectAllMetrics();
     }
 
     @Override
     public void close() {
-        Optional.ofNullable(testMetricExporter).ifPresent(me -> {
+        Optional.ofNullable(testMetricReader).ifPresent(me -> {
             try {
-                periodicMetricReader.close();
+                me.close();
             } catch (IOException e) {
                 throw Lombok.sneakyThrow(e);
             }
-            me.close();
         });
         Optional.ofNullable(testSpanExporter).ifPresent(te -> {
             te.close();

--- a/TrafficCapture/nettyWireLogging/build.gradle
+++ b/TrafficCapture/nettyWireLogging/build.gradle
@@ -29,4 +29,5 @@ dependencies {
     testImplementation group: 'org.slf4j', name: 'slf4j-api', version: '2.0.7'
 
     testImplementation testFixtures(project(path: ':testUtilities'))
+    testImplementation testFixtures(project(path: ':coreUtilities'))
 }

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/ParsedHttpMessagesAsDictsTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/ParsedHttpMessagesAsDictsTest.java
@@ -8,10 +8,6 @@ import java.util.Optional;
 
 class ParsedHttpMessagesAsDictsTest extends InstrumentationTest {
 
-    ParsedHttpMessagesAsDicts makeTestData() {
-        return makeTestData(null, null);
-    }
-
     @Override
     protected TestContext makeInstrumentationContext() {
         return TestContext.withTracking(false, true);

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/ResultsToLogsConsumerTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/ResultsToLogsConsumerTest.java
@@ -280,7 +280,7 @@ class ResultsToLogsConsumerTest extends InstrumentationTest {
         } catch (InterruptedException e) {
             throw new RuntimeException(e);
         }
-        var allMetricData = rootContext.inMemoryInstrumentationBundle.testMetricExporter.getFinishedMetricItems();
+        var allMetricData = rootContext.inMemoryInstrumentationBundle.getFinishedMetrics();
         var filteredMetrics = allMetricData.stream().filter(md->md.getName().startsWith("tupleResult"))
                 .collect(Collectors.toList());
         // TODO - find out how to verify these metrics

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/datahandlers/NettyPacketToHttpConsumerTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/datahandlers/NettyPacketToHttpConsumerTest.java
@@ -194,8 +194,7 @@ public class NettyPacketToHttpConsumerTest extends InstrumentationTest {
     @WrapWithNettyLeakDetection(repetitions = 1)
     public void testMetricCountsFor_testThatConnectionsAreKeptAliveAndShared(boolean useTls) throws Exception {
         testThatConnectionsAreKeptAliveAndShared(useTls);
-        Thread.sleep(200); // let metrics settle down
-        var allMetricData = rootContext.inMemoryInstrumentationBundle.testMetricExporter.getFinishedMetricItems();
+        var allMetricData = rootContext.inMemoryInstrumentationBundle.getFinishedMetrics();
         long tcpOpenConnectionCount = allMetricData.stream().filter(md->md.getName().startsWith("tcpConnectionCount"))
                 .reduce((a,b)->b).get().getLongSumData().getPoints().stream().reduce((a,b)->b).get().getValue();
         long connectionsOpenedCount = allMetricData.stream().filter(md->md.getName().startsWith("connectionsOpened"))

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/datahandlers/NettyPacketToHttpConsumerTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/datahandlers/NettyPacketToHttpConsumerTest.java
@@ -194,6 +194,7 @@ public class NettyPacketToHttpConsumerTest extends InstrumentationTest {
     @WrapWithNettyLeakDetection(repetitions = 1)
     public void testMetricCountsFor_testThatConnectionsAreKeptAliveAndShared(boolean useTls) throws Exception {
         testThatConnectionsAreKeptAliveAndShared(useTls);
+        Thread.sleep(200); // let metrics settle down
         var allMetricData = rootContext.inMemoryInstrumentationBundle.getFinishedMetrics();
         long tcpOpenConnectionCount = allMetricData.stream().filter(md->md.getName().startsWith("tcpConnectionCount"))
                 .reduce((a,b)->b).get().getLongSumData().getPoints().stream().reduce((a,b)->b).get().getValue();

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/tracing/TracingTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/tracing/TracingTest.java
@@ -14,6 +14,7 @@ import org.opensearch.migrations.tracing.TestContext;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -59,8 +60,8 @@ public class TracingTest extends InstrumentationTest {
             }
         }
 
-        var recordedSpans = rootContext.inMemoryInstrumentationBundle.testSpanExporter.getFinishedSpanItems();
-        var recordedMetrics = rootContext.inMemoryInstrumentationBundle.testMetricExporter.getFinishedMetricItems();
+        var recordedSpans = rootContext.inMemoryInstrumentationBundle.getFinishedSpans();
+        var recordedMetrics = rootContext.inMemoryInstrumentationBundle.getFinishedMetrics();
 
         checkSpans(recordedSpans);
         checkMetrics(recordedMetrics);
@@ -68,7 +69,7 @@ public class TracingTest extends InstrumentationTest {
         Assertions.assertTrue(rootContext.contextTracker.getAllRemainingActiveScopes().isEmpty());
     }
 
-    private void checkMetrics(List<MetricData> recordedMetrics) {
+    private void checkMetrics(Collection<MetricData> recordedMetrics) {
     }
 
     private void checkSpans(List<SpanData> recordedSpans) {


### PR DESCRIPTION
Fix some flaky tests that were checking if metrics were being emitted.

They had a resource lock around them because they were using some static constructs provided by the Otel SDK. Now the resource locks on tests are gone for the ConditionallyReliableLoggingHttpHandlerTest and each test constructs its own non-static otel sdk. I've also tried to make tests that confirm otel instrumentation a bit safer.  They properly shut down metric exporter threads now.  They also wait a couple cycles before returning the in-memory exported metrics. I really wish that there were an exporter that didn't have to wait, but at least for now, this seems like the only option. At some point, it might be worth implementing a different MeterProvider which would in turn build out a different implementation hierarchy to return instruments that have getters.  Using mock classes to spy on calls could work too.

### Description

* Category: Test fixes
* Why these changes are required? Make builds more reliable
* What is the old behavior before changes and new behavior after changes? Tests should be more stable and use less resources (threads)

### Issues Resolved
No Jira

### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]

### Check List
- [ ] New functionality includes testing
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
