### PR TITLE
Local maven publish

### DIFF
--- a/TrafficCapture/README.md
+++ b/TrafficCapture/README.md
@@ -10,6 +10,7 @@
         - [Traffic Capture Proxy Server](#traffic-capture-proxy-server)
         - [Traffic Replayer](#traffic-replayer)
         - [Capture Kafka Offloader](#capture-kafka-offloader)
+    - [Publishing](#publishing)
 
 ## Overview
 
@@ -136,3 +137,22 @@ The Capture Kafka Offloader will act as a Kafka Producer for offloading captured
 
 Learn more about its functionality and setup here: [Capture Kafka Offloader](captureKafkaOffloader/README.md)
 
+## Publishing
+
+This project can be published to a local maven repository with:
+```sh
+./gradlew publishToMavenLocal
+```
+
+And subsequently imported into a separate gradle project with (replacing name with any subProject name) 
+```groovy
+repositories {
+    mavenCentral()
+    mavenLocal()
+}
+
+dependencies {
+    implementation group: "org.opensearch.migrations.trafficcapture", name: "captureKafkaOffloader", version: "0.1.0-SNAPSHOT"
+    //... other dependencies
+}
+```

--- a/TrafficCapture/README.md
+++ b/TrafficCapture/README.md
@@ -156,3 +156,23 @@ dependencies {
     //... other dependencies
 }
 ```
+
+The entire list of published subprojects is
+```text
+captureKafkaOffloader
+captureOffloader
+captureProtobufs
+coreUtilities
+jsonJMESPathMessageTransformer
+jsonJMESPathMessageTransformerProvider
+jsonJoltMessageTransformer
+jsonJoltMessageTransformerProvider
+jsonMessageTransformerInterface
+jsonMessageTransformers
+nettyWireLogging
+openSearch23PlusTargetTransformerProvider
+replayerPlugins
+trafficCaptureProxyServer
+trafficCaptureProxyServerTest
+trafficReplayer
+```

--- a/TrafficCapture/build.gradle
+++ b/TrafficCapture/build.gradle
@@ -9,6 +9,35 @@ allprojects {
     }
 }
 
+subprojects {
+    apply plugin: 'java'
+    apply plugin: 'maven-publish'
+    def excludedProjects = [
+            'buildSrc',
+            'dockerSolution',
+            // TODO: Get testFixtures exported to Maven
+            'testUtilities',
+    ]
+    if (!(project.name in excludedProjects)) {
+        publishing {
+            publications {
+                mavenJava(MavenPublication) {
+                    artifactId = project.name
+
+                    from components.java
+
+                    groupId = 'org.opensearch.migrations.trafficcapture'
+                    version = '0.1.0-SNAPSHOT'
+
+                    // Suppress POM metadata warnings for test fixtures
+                    suppressPomMetadataWarningsFor('testFixturesApiElements')
+                    suppressPomMetadataWarningsFor('testFixturesRuntimeElements')
+                }
+            }
+        }
+    }
+}
+
 allprojects {
     apply plugin: 'java'
     apply plugin: 'jacoco'

--- a/TrafficCapture/nettyWireLogging/build.gradle
+++ b/TrafficCapture/nettyWireLogging/build.gradle
@@ -12,9 +12,9 @@ dependencies {
 
     implementation project(':captureOffloader')
     implementation project(':coreUtilities')
-    api            group: 'io.netty', name: 'netty-buffer'
-    api            group: 'io.netty', name: 'netty-codec-http'
-    api            group: 'io.netty', name: 'netty-handler'
+    api            group: 'io.netty', name: 'netty-buffer', version: '4.1.100.Final'
+    api            group: 'io.netty', name: 'netty-codec-http', version: '4.1.100.Final'
+    api            group: 'io.netty', name: 'netty-handler', version: '4.1.100.Final'
 
     implementation group: 'org.slf4j', name: 'slf4j-api', version: '2.0.7'
 

--- a/TrafficCapture/settings.gradle
+++ b/TrafficCapture/settings.gradle
@@ -37,6 +37,3 @@ include('captureKafkaOffloader',
 )
 
 addSubProjects('', new File(rootProject.projectDir,'replayerPlugins'))
-include 'replayerPlugins:jsonMessageTransformers:jsonJoltMessageTransformerProvider:untitled'
-findProject(':replayerPlugins:jsonMessageTransformers:jsonJoltMessageTransformerProvider:untitled')?.name = 'untitled'
-


### PR DESCRIPTION
### Description
Adds support for local maven repo publish

* Category: New Feature
* Why these changes are required? Current projects wishing to import code from this project need a way to develop locally and import jars from local builds.
* What is the old behavior before changes and new behavior after changes? Did not support publishing, now support publishing.

### Issues Resolved
[MIGRATIONS-1508](https://opensearch.atlassian.net/browse/MIGRATIONS-1508)

Is this a backport? If so, please add backport PR # and/or commits #
No

### Testing
Created a sample external gradle project and imported all projects and attempted to build with some class imports.

Extract from test project build.gradle:
```groovy
repositories {
    mavenCentral()
    mavenLocal()
}

dependencies {
    // This dependency is used by the application.
    implementation libs.guava

    String trafficCaptureGroup = 'org.opensearch.migrations.trafficcapture'
    String trafficCaptureVersion = '0.1.0-SNAPSHOT'

    // Define a list of projects
    def projects = [
            'captureKafkaOffloader',
            'captureOffloader',
            'captureProtobufs',
            'coreUtilities',
            'jsonJMESPathMessageTransformer',
            'jsonJMESPathMessageTransformerProvider',
            'jsonJoltMessageTransformer',
            'jsonJoltMessageTransformerProvider',
            'jsonMessageTransformerInterface',
            'jsonMessageTransformers',
            'nettyWireLogging',
            'openSearch23PlusTargetTransformerProvider',
            'replayerPlugins',
            'trafficCaptureProxyServer',
            'trafficCaptureProxyServerTest',
            'trafficReplayer',
    ]

    projects.each { projectName ->
        implementation group: "$trafficCaptureGroup", name: "$projectName", version: "$trafficCaptureVersion"
    }
}

```

### Check List
- [x] New functionality includes testing
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
