### PR TITLE
CDK Extensibility Improvments

### DIFF
--- a/deployment/cdk/opensearch-service-migration/.gitignore
+++ b/deployment/cdk/opensearch-service-migration/.gitignore
@@ -4,7 +4,7 @@
 node_modules
 cdk.context.json
 coverage
-
+dist
 # CDK asset staging directory
 .cdk.staging
 cdk.out

--- a/deployment/cdk/opensearch-service-migration/lib/service-stacks/capture-proxy-es-stack.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/service-stacks/capture-proxy-es-stack.ts
@@ -1,10 +1,9 @@
 import {StackPropsExt} from "../stack-composer";
 import {IVpc, SecurityGroup} from "aws-cdk-lib/aws-ec2";
-import {PortMapping, Protocol} from "aws-cdk-lib/aws-ecs";
+import {PortMapping, Protocol, ServiceConnectService} from "aws-cdk-lib/aws-ecs";
 import {Construct} from "constructs";
 import {join} from "path";
 import {MigrationServiceCore} from "./migration-service-core";
-import {ServiceConnectService} from "aws-cdk-lib/aws-ecs/lib/base/base-service";
 import {StringParameter} from "aws-cdk-lib/aws-ssm";
 import {StreamingSourceType} from "../streaming-source-type";
 import {createMSKProducerIAMPolicies} from "../common-utilities";

--- a/deployment/cdk/opensearch-service-migration/lib/service-stacks/capture-proxy-stack.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/service-stacks/capture-proxy-stack.ts
@@ -1,10 +1,9 @@
 import {StackPropsExt} from "../stack-composer";
 import {IVpc, SecurityGroup} from "aws-cdk-lib/aws-ec2";
-import {PortMapping, Protocol} from "aws-cdk-lib/aws-ecs";
+import {PortMapping, Protocol, ServiceConnectService} from "aws-cdk-lib/aws-ecs";
 import {Construct} from "constructs";
 import {join} from "path";
 import {MigrationServiceCore} from "./migration-service-core";
-import {ServiceConnectService} from "aws-cdk-lib/aws-ecs/lib/base/base-service";
 import {StringParameter} from "aws-cdk-lib/aws-ssm";
 import {StreamingSourceType} from "../streaming-source-type";
 import {createMSKProducerIAMPolicies} from "../common-utilities";

--- a/deployment/cdk/opensearch-service-migration/lib/service-stacks/elasticsearch-stack.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/service-stacks/elasticsearch-stack.ts
@@ -1,10 +1,9 @@
 import {StackPropsExt} from "../stack-composer";
 import {IVpc, SecurityGroup} from "aws-cdk-lib/aws-ec2";
-import {PortMapping, Protocol} from "aws-cdk-lib/aws-ecs";
+import {PortMapping, Protocol, ServiceConnectService} from "aws-cdk-lib/aws-ecs";
 import {Construct} from "constructs";
 import {join} from "path";
 import {MigrationServiceCore} from "./migration-service-core";
-import {ServiceConnectService} from "aws-cdk-lib/aws-ecs/lib/base/base-service";
 import {StringParameter} from "aws-cdk-lib/aws-ssm";
 
 

--- a/deployment/cdk/opensearch-service-migration/lib/service-stacks/kafka-broker-stack.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/service-stacks/kafka-broker-stack.ts
@@ -1,12 +1,11 @@
 import {StackPropsExt} from "../stack-composer";
 import {IVpc, SecurityGroup} from "aws-cdk-lib/aws-ec2";
 import {
-    PortMapping, Protocol
+    PortMapping, Protocol, ServiceConnectService
 } from "aws-cdk-lib/aws-ecs";
 import {Construct} from "constructs";
 import {MigrationServiceCore} from "./migration-service-core";
 import {StringParameter} from "aws-cdk-lib/aws-ssm";
-import {ServiceConnectService} from "aws-cdk-lib/aws-ecs/lib/base/base-service";
 
 export interface KafkaBrokerProps extends StackPropsExt {
     readonly vpc: IVpc

--- a/deployment/cdk/opensearch-service-migration/lib/service-stacks/kafka-zookeeper-stack.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/service-stacks/kafka-zookeeper-stack.ts
@@ -1,12 +1,11 @@
 import {StackPropsExt} from "../stack-composer";
 import {IVpc, SecurityGroup} from "aws-cdk-lib/aws-ec2";
 import {
-    PortMapping, Protocol,
+    PortMapping, Protocol, ServiceConnectService,
 } from "aws-cdk-lib/aws-ecs";
 import {Construct} from "constructs";
 import {MigrationServiceCore} from "./migration-service-core";
 import {StringParameter} from "aws-cdk-lib/aws-ssm";
-import {ServiceConnectService} from "aws-cdk-lib/aws-ecs/lib/base/base-service";
 
 export interface KafkaZookeeperProps extends StackPropsExt {
     readonly vpc: IVpc

--- a/deployment/cdk/opensearch-service-migration/lib/service-stacks/migration-service-core.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/service-stacks/migration-service-core.ts
@@ -1,21 +1,20 @@
 import {StackPropsExt} from "../stack-composer";
 import {ISecurityGroup, IVpc, SubnetType} from "aws-cdk-lib/aws-ec2";
 import {
-    CfnService as FargateCfnService,
+    CfnService as FargateCfnService, CloudMapOptions,
     Cluster,
     ContainerImage,
     FargateService,
     FargateTaskDefinition,
     LogDrivers,
     MountPoint,
-    PortMapping, Ulimit,
+    PortMapping, ServiceConnectService, Ulimit,
     Volume
 } from "aws-cdk-lib/aws-ecs";
 import {DockerImageAsset} from "aws-cdk-lib/aws-ecr-assets";
 import {RemovalPolicy, Stack} from "aws-cdk-lib";
 import {LogGroup, RetentionDays} from "aws-cdk-lib/aws-logs";
 import {PolicyStatement} from "aws-cdk-lib/aws-iam";
-import {CloudMapOptions, ServiceConnectService} from "aws-cdk-lib/aws-ecs/lib/base/base-service";
 import {CfnService as DiscoveryCfnService, PrivateDnsNamespace} from "aws-cdk-lib/aws-servicediscovery";
 import {StringParameter} from "aws-cdk-lib/aws-ssm";
 import {createDefaultECSTaskRole} from "../common-utilities";

--- a/deployment/cdk/opensearch-service-migration/lib/service-stacks/opensearch-container-stack.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/service-stacks/opensearch-container-stack.ts
@@ -1,10 +1,9 @@
 import {StackPropsExt} from "../stack-composer";
 import {IVpc, SecurityGroup} from "aws-cdk-lib/aws-ec2";
-import {PortMapping, Protocol, Ulimit, UlimitName} from "aws-cdk-lib/aws-ecs";
+import {PortMapping, Protocol, ServiceConnectService, Ulimit, UlimitName} from "aws-cdk-lib/aws-ecs";
 import {Construct} from "constructs";
 import {MigrationServiceCore} from "./migration-service-core";
 import {StringParameter} from "aws-cdk-lib/aws-ssm";
-import {ServiceConnectService} from "aws-cdk-lib/aws-ecs/lib/base/base-service";
 
 export interface OpenSearchContainerProps extends StackPropsExt {
     readonly vpc: IVpc

--- a/deployment/cdk/opensearch-service-migration/package-lock.json
+++ b/deployment/cdk/opensearch-service-migration/package-lock.json
@@ -9,25 +9,30 @@
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-cdk/aws-servicecatalogappregistry-alpha": "2.100.0-alpha.0",
         "@aws-sdk/client-kafka": "^3.410.0",
         "@aws-sdk/client-lambda": "^3.359.0",
         "@types/aws-lambda": "^8.10.117",
-        "aws-cdk-lib": "2.100.0",
         "aws-lambda": "^1.0.7",
-        "constructs": "^10.0.0",
         "esbuild": "^0.19.5",
         "semver": "^7.5.4",
         "source-map-support": "^0.5.21"
       },
       "devDependencies": {
+        "@aws-cdk/aws-servicecatalogappregistry-alpha": "2.100.0-alpha.0",
         "@types/jest": "^29.2.5",
         "@types/node": "18.11.18",
-        "aws-cdk": "2.62.2",
+        "aws-cdk": "2.100.0",
+        "aws-cdk-lib": "2.100.0",
+        "constructs": "^10.0.0",
         "jest": "^29.3.1",
         "ts-jest": "^29.0.3",
         "ts-node": "^10.9.1",
         "typescript": "~4.9.4"
+      },
+      "peerDependencies": {
+        "@aws-cdk/aws-servicecatalogappregistry-alpha": "^2.100.0-alpha.0",
+        "aws-cdk-lib": "^2.100.0",
+        "constructs": "^10.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -46,22 +51,26 @@
     "node_modules/@aws-cdk/asset-awscli-v1": {
       "version": "2.2.200",
       "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.200.tgz",
-      "integrity": "sha512-Kf5J8DfJK4wZFWT2Myca0lhwke7LwHcHBo+4TvWOGJrFVVKVuuiLCkzPPRBQQVDj0Vtn2NBokZAz8pfMpAqAKg=="
+      "integrity": "sha512-Kf5J8DfJK4wZFWT2Myca0lhwke7LwHcHBo+4TvWOGJrFVVKVuuiLCkzPPRBQQVDj0Vtn2NBokZAz8pfMpAqAKg==",
+      "dev": true
     },
     "node_modules/@aws-cdk/asset-kubectl-v20": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/@aws-cdk/asset-kubectl-v20/-/asset-kubectl-v20-2.1.2.tgz",
-      "integrity": "sha512-3M2tELJOxQv0apCIiuKQ4pAbncz9GuLwnKFqxifWfe77wuMxyTRPmxssYHs42ePqzap1LT6GDcPygGs+hHstLg=="
+      "integrity": "sha512-3M2tELJOxQv0apCIiuKQ4pAbncz9GuLwnKFqxifWfe77wuMxyTRPmxssYHs42ePqzap1LT6GDcPygGs+hHstLg==",
+      "dev": true
     },
     "node_modules/@aws-cdk/asset-node-proxy-agent-v6": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.0.1.tgz",
-      "integrity": "sha512-DDt4SLdLOwWCjGtltH4VCST7hpOI5DzieuhGZsBpZ+AgJdSI2GCjklCXm0GCTwJG/SolkL5dtQXyUKgg9luBDg=="
+      "integrity": "sha512-DDt4SLdLOwWCjGtltH4VCST7hpOI5DzieuhGZsBpZ+AgJdSI2GCjklCXm0GCTwJG/SolkL5dtQXyUKgg9luBDg==",
+      "dev": true
     },
     "node_modules/@aws-cdk/aws-servicecatalogappregistry-alpha": {
       "version": "2.100.0-alpha.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-servicecatalogappregistry-alpha/-/aws-servicecatalogappregistry-alpha-2.100.0-alpha.0.tgz",
       "integrity": "sha512-+CVSZ9KVspdXENqD8TV3inD1TNybvgdBwq00t0b9xbFCZpsRHKeD3bkU9ZTd/0+zXhxDDkJyAr09TJ3iJUrKFw==",
+      "dev": true,
       "engines": {
         "node": ">= 14.15.0"
       },
@@ -1325,51 +1334,6 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
-    "node_modules/@esbuild/android-arm": {
-      "version": "0.19.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.19.5.tgz",
-      "integrity": "sha512-bhvbzWFF3CwMs5tbjf3ObfGqbl/17ict2/uwOSfr3wmxDE6VdS2GqY/FuzIPe0q0bdhj65zQsvqfArI9MY6+AA==",
-      "cpu": [
-        "arm"
-      ],
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/android-arm64": {
-      "version": "0.19.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.19.5.tgz",
-      "integrity": "sha512-5d1OkoJxnYQfmC+Zd8NBFjkhyCNYwM4n9ODrycTFY6Jk1IGiZ+tjVJDDSwDt77nK+tfpGP4T50iMtVi4dEGzhQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/android-x64": {
-      "version": "0.19.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.19.5.tgz",
-      "integrity": "sha512-9t+28jHGL7uBdkBjL90QFxe7DVA+KGqWlHCF8ChTKyaKO//VLuoBricQCgwhOjA1/qOczsw843Fy4cbs4H3DVA==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/@esbuild/darwin-arm64": {
       "version": "0.19.5",
       "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.19.5.tgz",
@@ -1380,276 +1344,6 @@
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/darwin-x64": {
-      "version": "0.19.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.19.5.tgz",
-      "integrity": "sha512-Ly8cn6fGLNet19s0X4unjcniX24I0RqjPv+kurpXabZYSXGM4Pwpmf85WHJN3lAgB8GSth7s5A0r856S+4DyiA==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.19.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.19.5.tgz",
-      "integrity": "sha512-GGDNnPWTmWE+DMchq1W8Sd0mUkL+APvJg3b11klSGUDvRXh70JqLAO56tubmq1s2cgpVCSKYywEiKBfju8JztQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.19.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.19.5.tgz",
-      "integrity": "sha512-1CCwDHnSSoA0HNwdfoNY0jLfJpd7ygaLAp5EHFos3VWJCRX9DMwWODf96s9TSse39Br7oOTLryRVmBoFwXbuuQ==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-arm": {
-      "version": "0.19.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.19.5.tgz",
-      "integrity": "sha512-lrWXLY/vJBzCPC51QN0HM71uWgIEpGSjSZZADQhq7DKhPcI6NH1IdzjfHkDQws2oNpJKpR13kv7/pFHBbDQDwQ==",
-      "cpu": [
-        "arm"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-arm64": {
-      "version": "0.19.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.19.5.tgz",
-      "integrity": "sha512-o3vYippBmSrjjQUCEEiTZ2l+4yC0pVJD/Dl57WfPwwlvFkrxoSO7rmBZFii6kQB3Wrn/6GwJUPLU5t52eq2meA==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-ia32": {
-      "version": "0.19.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.19.5.tgz",
-      "integrity": "sha512-MkjHXS03AXAkNp1KKkhSKPOCYztRtK+KXDNkBa6P78F8Bw0ynknCSClO/ztGszILZtyO/lVKpa7MolbBZ6oJtQ==",
-      "cpu": [
-        "ia32"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-loong64": {
-      "version": "0.19.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.19.5.tgz",
-      "integrity": "sha512-42GwZMm5oYOD/JHqHska3Jg0r+XFb/fdZRX+WjADm3nLWLcIsN27YKtqxzQmGNJgu0AyXg4HtcSK9HuOk3v1Dw==",
-      "cpu": [
-        "loong64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.19.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.19.5.tgz",
-      "integrity": "sha512-kcjndCSMitUuPJobWCnwQ9lLjiLZUR3QLQmlgaBfMX23UEa7ZOrtufnRds+6WZtIS9HdTXqND4yH8NLoVVIkcg==",
-      "cpu": [
-        "mips64el"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.19.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.19.5.tgz",
-      "integrity": "sha512-yJAxJfHVm0ZbsiljbtFFP1BQKLc8kUF6+17tjQ78QjqjAQDnhULWiTA6u0FCDmYT1oOKS9PzZ2z0aBI+Mcyj7Q==",
-      "cpu": [
-        "ppc64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.19.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.19.5.tgz",
-      "integrity": "sha512-5u8cIR/t3gaD6ad3wNt1MNRstAZO+aNyBxu2We8X31bA8XUNyamTVQwLDA1SLoPCUehNCymhBhK3Qim1433Zag==",
-      "cpu": [
-        "riscv64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-s390x": {
-      "version": "0.19.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.19.5.tgz",
-      "integrity": "sha512-Z6JrMyEw/EmZBD/OFEFpb+gao9xJ59ATsoTNlj39jVBbXqoZm4Xntu6wVmGPB/OATi1uk/DB+yeDPv2E8PqZGw==",
-      "cpu": [
-        "s390x"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-x64": {
-      "version": "0.19.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.19.5.tgz",
-      "integrity": "sha512-psagl+2RlK1z8zWZOmVdImisMtrUxvwereIdyJTmtmHahJTKb64pAcqoPlx6CewPdvGvUKe2Jw+0Z/0qhSbG1A==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.19.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.19.5.tgz",
-      "integrity": "sha512-kL2l+xScnAy/E/3119OggX8SrWyBEcqAh8aOY1gr4gPvw76la2GlD4Ymf832UCVbmuWeTf2adkZDK+h0Z/fB4g==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.19.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.19.5.tgz",
-      "integrity": "sha512-sPOfhtzFufQfTBgRnE1DIJjzsXukKSvZxloZbkJDG383q0awVAq600pc1nfqBcl0ice/WN9p4qLc39WhBShRTA==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/sunos-x64": {
-      "version": "0.19.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.19.5.tgz",
-      "integrity": "sha512-dGZkBXaafuKLpDSjKcB0ax0FL36YXCvJNnztjKV+6CO82tTYVDSH2lifitJ29jxRMoUhgkg9a+VA/B03WK5lcg==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/win32-arm64": {
-      "version": "0.19.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.19.5.tgz",
-      "integrity": "sha512-dWVjD9y03ilhdRQ6Xig1NWNgfLtf2o/STKTS+eZuF90fI2BhbwD6WlaiCGKptlqXlURVB5AUOxUj09LuwKGDTg==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/win32-ia32": {
-      "version": "0.19.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.19.5.tgz",
-      "integrity": "sha512-4liggWIA4oDgUxqpZwrDhmEfAH4d0iljanDOK7AnVU89T6CzHon/ony8C5LeOdfgx60x5cnQJFZwEydVlYx4iw==",
-      "cpu": [
-        "ia32"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/win32-x64": {
-      "version": "0.19.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.19.5.tgz",
-      "integrity": "sha512-czTrygUsB/jlM8qEW5MD8bgYU2Xg14lo6kBDXW6HdxKjh8M5PzETGiSHaz9MtbXBYDloHNUAUW2tMiKW4KM9Mw==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
       ],
       "engines": {
         "node": ">=12"
@@ -2811,9 +2505,9 @@
       }
     },
     "node_modules/aws-cdk": {
-      "version": "2.62.2",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.62.2.tgz",
-      "integrity": "sha512-fACUQEdc43AfiqKKXUZLuHB2VADLU965hl50Fn6BhMemFmUsc+iS/GFfOwvfCUO3/iaRtsn/gk+dQ3zZ+snKRw==",
+      "version": "2.100.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.100.0.tgz",
+      "integrity": "sha512-Gt/4wPuEiBYw2tl0+cN0EbLxxJEvltcJxSQAcVHgNbqvDj49KUJ/oCbZ335dF0gK/hrVVb70xfNiYbBSPOsmvg==",
       "dev": true,
       "bin": {
         "cdk": "bin/cdk"
@@ -2841,6 +2535,7 @@
         "table",
         "yaml"
       ],
+      "dev": true,
       "dependencies": {
         "@aws-cdk/asset-awscli-v1": "^2.2.200",
         "@aws-cdk/asset-kubectl-v20": "^2.1.2",
@@ -2865,11 +2560,13 @@
     },
     "node_modules/aws-cdk-lib/node_modules/@balena/dockerignore": {
       "version": "1.0.2",
+      "dev": true,
       "inBundle": true,
       "license": "Apache-2.0"
     },
     "node_modules/aws-cdk-lib/node_modules/ajv": {
       "version": "8.12.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -2885,6 +2582,7 @@
     },
     "node_modules/aws-cdk-lib/node_modules/ansi-regex": {
       "version": "5.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -2893,6 +2591,7 @@
     },
     "node_modules/aws-cdk-lib/node_modules/ansi-styles": {
       "version": "4.3.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -2907,6 +2606,7 @@
     },
     "node_modules/aws-cdk-lib/node_modules/astral-regex": {
       "version": "2.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -2915,11 +2615,13 @@
     },
     "node_modules/aws-cdk-lib/node_modules/balanced-match": {
       "version": "1.0.2",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/brace-expansion": {
       "version": "1.1.11",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -2929,6 +2631,7 @@
     },
     "node_modules/aws-cdk-lib/node_modules/case": {
       "version": "1.6.3",
+      "dev": true,
       "inBundle": true,
       "license": "(MIT OR GPL-3.0-or-later)",
       "engines": {
@@ -2937,6 +2640,7 @@
     },
     "node_modules/aws-cdk-lib/node_modules/color-convert": {
       "version": "2.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -2948,26 +2652,31 @@
     },
     "node_modules/aws-cdk-lib/node_modules/color-name": {
       "version": "1.1.4",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/concat-map": {
       "version": "0.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/emoji-regex": {
       "version": "8.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/fast-deep-equal": {
       "version": "3.1.3",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/fs-extra": {
       "version": "11.1.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -2981,11 +2690,13 @@
     },
     "node_modules/aws-cdk-lib/node_modules/graceful-fs": {
       "version": "4.2.11",
+      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/aws-cdk-lib/node_modules/ignore": {
       "version": "5.2.4",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -2994,6 +2705,7 @@
     },
     "node_modules/aws-cdk-lib/node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -3002,11 +2714,13 @@
     },
     "node_modules/aws-cdk-lib/node_modules/json-schema-traverse": {
       "version": "1.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/jsonfile": {
       "version": "6.1.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -3018,6 +2732,7 @@
     },
     "node_modules/aws-cdk-lib/node_modules/jsonschema": {
       "version": "1.4.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -3026,11 +2741,13 @@
     },
     "node_modules/aws-cdk-lib/node_modules/lodash.truncate": {
       "version": "4.4.2",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/lru-cache": {
       "version": "6.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -3042,6 +2759,7 @@
     },
     "node_modules/aws-cdk-lib/node_modules/minimatch": {
       "version": "3.1.2",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -3053,6 +2771,7 @@
     },
     "node_modules/aws-cdk-lib/node_modules/punycode": {
       "version": "2.3.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -3061,6 +2780,7 @@
     },
     "node_modules/aws-cdk-lib/node_modules/require-from-string": {
       "version": "2.0.2",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -3069,6 +2789,7 @@
     },
     "node_modules/aws-cdk-lib/node_modules/semver": {
       "version": "7.5.4",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -3083,6 +2804,7 @@
     },
     "node_modules/aws-cdk-lib/node_modules/slice-ansi": {
       "version": "4.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -3099,6 +2821,7 @@
     },
     "node_modules/aws-cdk-lib/node_modules/string-width": {
       "version": "4.2.3",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -3112,6 +2835,7 @@
     },
     "node_modules/aws-cdk-lib/node_modules/strip-ansi": {
       "version": "6.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -3123,6 +2847,7 @@
     },
     "node_modules/aws-cdk-lib/node_modules/table": {
       "version": "6.8.1",
+      "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -3138,6 +2863,7 @@
     },
     "node_modules/aws-cdk-lib/node_modules/universalify": {
       "version": "2.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -3146,6 +2872,7 @@
     },
     "node_modules/aws-cdk-lib/node_modules/uri-js": {
       "version": "4.4.1",
+      "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -3154,11 +2881,13 @@
     },
     "node_modules/aws-cdk-lib/node_modules/yallist": {
       "version": "4.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/aws-cdk-lib/node_modules/yaml": {
       "version": "1.10.2",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -3602,6 +3331,7 @@
       "version": "10.2.70",
       "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.2.70.tgz",
       "integrity": "sha512-z6zr1E8K/9tzJbCQzY0UGX0/oVKPFKu9C/mzEnghCG6TAJINnvlq0CMKm63XqqeMleadZYm5T3sZGJKcxJS/Pg==",
+      "dev": true,
       "engines": {
         "node": ">= 16.14.0"
       }

--- a/deployment/cdk/opensearch-service-migration/package.json
+++ b/deployment/cdk/opensearch-service-migration/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "author": {
     "name": "Amazon Web Services",
-    "url": "https://github.com/opensearch-project"
+    "url": "https://github.com/opensearch-project/opensearch-migrations"
   },
   "scripts": {
     "build": "tsc",
@@ -14,25 +14,30 @@
     "cdk": "cdk"
   },
   "devDependencies": {
+    "@aws-cdk/aws-servicecatalogappregistry-alpha": "2.100.0-alpha.0",
     "@types/jest": "^29.2.5",
     "@types/node": "18.11.18",
-    "aws-cdk": "2.62.2",
+    "aws-cdk": "2.100.0",
+    "aws-cdk-lib": "2.100.0",
+    "constructs": "^10.0.0",
     "jest": "^29.3.1",
     "ts-jest": "^29.0.3",
     "ts-node": "^10.9.1",
     "typescript": "~4.9.4"
   },
   "dependencies": {
-    "@aws-cdk/aws-servicecatalogappregistry-alpha": "2.100.0-alpha.0",
     "@aws-sdk/client-kafka": "^3.410.0",
     "@aws-sdk/client-lambda": "^3.359.0",
     "@types/aws-lambda": "^8.10.117",
-    "aws-cdk-lib": "2.100.0",
     "aws-lambda": "^1.0.7",
-    "constructs": "^10.0.0",
     "esbuild": "^0.19.5",
     "semver": "^7.5.4",
     "source-map-support": "^0.5.21"
+  },
+  "peerDependencies": {
+    "@aws-cdk/aws-servicecatalogappregistry-alpha": "^2.100.0-alpha.0",
+    "aws-cdk-lib": "^2.100.0",
+    "constructs": "^10.0.0"
   },
   "overrides": {
     "semver": "^7.5.4"

--- a/deployment/cdk/opensearch-service-migration/tsconfig.json
+++ b/deployment/cdk/opensearch-service-migration/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "outDir": "dist",
     "target": "ES2020",
     "module": "commonjs",
     "lib": [


### PR DESCRIPTION
### Description
This change makes the existing CDK more extensible into other CDK projects by streamlining package imports, moving cdk dependencies to peerDependencies. This change also makes it so build artifacts to be published in library are exported in dist directory. 
This is a requirement to expose the cdk code as a library to other cdk apps.
* Category: Enhancement
* Why these changes are required? Extensibility of the deployment artifacts.
* What is the old behavior before changes and new behavior after changes? CDK would be difficult to integrate into other packages requiring overrides or changes in cdk version.

### Issues Resolved
[MIGRATIONS-1520](https://opensearch.atlassian.net/browse/MIGRATIONS-1520)

Is this a backport? If so, please add backport PR # and/or commits #
No

### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]

### Check List
- [x] New functionality includes testing
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
