### PR TITLE
Update default docker OS version to 2.11

### DIFF
--- a/TrafficCapture/dockerSolution/src/main/docker/docker-compose.yml
+++ b/TrafficCapture/dockerSolution/src/main/docker/docker-compose.yml
@@ -85,7 +85,7 @@ services:
     command: /bin/sh -c "/runJavaWithClasspath.sh org.opensearch.migrations.replay.TrafficReplayer https://opensearchtarget:9200 --auth-header-value Basic\\ YWRtaW46YWRtaW4= --insecure --kafka-traffic-brokers kafka:9092 --kafka-traffic-topic logging-traffic-topic --kafka-traffic-group-id default-logging-group --otelCollectorEndpoint http://otel-collector:4317"
 
   opensearchtarget:
-    image: 'opensearchproject/opensearch:latest'
+    image: 'opensearchproject/opensearch:2.11.0'
     environment:
       - discovery.type=single-node
     networks:

--- a/TrafficCapture/dockerSolution/src/main/docker/docker-compose.yml
+++ b/TrafficCapture/dockerSolution/src/main/docker/docker-compose.yml
@@ -94,7 +94,7 @@ services:
       - "29200:9200"
 
   opensearchanalytics:
-    image: 'opensearchproject/opensearch:latest'
+    image: 'opensearchproject/opensearch:2.11.0'
     environment:
       - discovery.type=single-node
     networks:
@@ -103,7 +103,7 @@ services:
       - "39200:9200"
 
   opensearch-dashboards:
-    image: migrations/opensearch_dashboards:latest # Make sure the version of opensearch-dashboards matches the version of opensearch installed on other nodes
+    image: migrations/opensearch_dashboards:2.11.0 # Make sure the version of opensearch-dashboards matches the version of opensearch installed on other nodes
     container_name: opensearch-dashboards
     ports:
       - "5601:5601" # Map host port 5601 to container port 5601

--- a/TrafficCapture/dockerSolution/src/main/docker/docker-compose.yml
+++ b/TrafficCapture/dockerSolution/src/main/docker/docker-compose.yml
@@ -103,7 +103,7 @@ services:
       - "39200:9200"
 
   opensearch-dashboards:
-    image: migrations/opensearch_dashboards:2.11.0 # Make sure the version of opensearch-dashboards matches the version of opensearch installed on other nodes
+    image: migrations/opensearch_dashboards:latest # Make sure the version of opensearch-dashboards matches the version of opensearch installed on other nodes
     container_name: opensearch-dashboards
     ports:
       - "5601:5601" # Map host port 5601 to container port 5601


### PR DESCRIPTION
### Description
This is a temporary change to unblock PR testing github actions until the needed fix for 2.12 is released here: https://github.com/opensearch-project/opensearch-migrations/pull/480

### Issues Resolved
N/A

### Testing
Local docker testing

### Check List
- [ ] New functionality includes testing
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
