### PR TITLE
Rename cdk to follow opensearch-project standards

### DIFF
--- a/deployment/cdk/opensearch-service-migration/package-lock.json
+++ b/deployment/cdk/opensearch-service-migration/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "opensearch-service-domain-cdk",
+  "name": "@opensearch-project/opensearch-service-migration-cdk",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "opensearch-service-domain-cdk",
+      "name": "@opensearch-project/opensearch-service-migration-cdk",
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
@@ -28,6 +28,9 @@
         "ts-jest": "^29.0.3",
         "ts-node": "^10.9.1",
         "typescript": "~4.9.4"
+      },
+      "engines": {
+        "node": ">=18"
       },
       "peerDependencies": {
         "@aws-cdk/aws-servicecatalogappregistry-alpha": "^2.100.0-alpha.0",

--- a/deployment/cdk/opensearch-service-migration/package.json
+++ b/deployment/cdk/opensearch-service-migration/package.json
@@ -1,13 +1,21 @@
 {
-  "name": "opensearch-service-domain-cdk",
+  "name": "@opensearch-project/opensearch-service-migration-cdk",
   "version": "1.0.0",
   "description": "CDK infrastructure for migrating to AWS OpenSearch",
   "license": "Apache-2.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "author": {
-    "name": "Amazon Web Services",
-    "url": "https://github.com/opensearch-project/opensearch-migrations"
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/opensearch-project/opensearch-migrations.git",
+    "directory": "deployment/cdk/opensearch-service-migration"
+  },
+  "bugs": {
+    "url": "https://github.com/opensearch-project/opensearch-migrations/issues"
+  },
+  "homepage": "https://github.com/opensearch-project/opensearch-migrations#readme",
+  "engines": {
+    "node": ">=18"
   },
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
### Description
Rename cdk to follow opensearch-project standards, a prereq to npmjs publishing.
* Category: Enhancement
* Why these changes are required? to publish to the opensearch-project npmjs org
* What is the old behavior before changes and new behavior after changes? name changes to package

### Issues Resolved
N/A

Is this a backport? If so, please add backport PR # and/or commits #
N/A

### Testing
`npm run test`

### Check List
- [x ] New functionality includes testing
  - [ x] All tests pass, including unit test, integration test and doctest
- [x ] New functionality has been documented
- [ x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
