### PR TITLE
Minor E2E edits from Jenkins testing

### DIFF
--- a/test/awsRunIntegTests.sh
+++ b/test/awsRunIntegTests.sh
@@ -76,7 +76,7 @@ echo "Clearing non-system target indices"
 unbuffer aws ecs execute-command --cluster "migration-${STAGE}-ecs-cluster" --task "${task_arn}" --container "migration-console" --interactive --command "curl -XDELETE ${target_endpoint}/*,-.*"
 
 echo "Print initial source and target indices after clearing indices: "
-unbuffer aws ecs execute-command --cluster "migration-${STAGE}-ecs-cluster" --task "${task_arn}" --container "migration-console" --interactive --command "./catIndices.sh --source_endpoint ${source_endpoint} --source_no_auth --target_no_auth"
+unbuffer aws ecs execute-command --cluster "migration-${STAGE}-ecs-cluster" --task "${task_arn}" --container "migration-console" --interactive --command "./catIndices.sh --source-endpoint ${source_endpoint} --source-no-auth --target-no-auth"
 
 # Spin up Replayer container and wait for service to be stable
 aws ecs update-service --cluster "migration-${STAGE}-ecs-cluster" --service "migration-${STAGE}-traffic-replayer-default" --desired-count 1 > /dev/null 2>&1

--- a/test/tests.py
+++ b/test/tests.py
@@ -269,8 +269,6 @@ class E2ETests(unittest.TestCase):
                 cmd_exec = cmd_exec + " --no-auth"
             elif self.source_auth_type == "basic":
                 cmd_exec = cmd_exec + f" --auth-user {self.source_username} --auth-pass {self.source_password}"
-            if not self.source_verify_ssl:
-                cmd_exec = cmd_exec + " --no-ssl"
             logger.warning(f"Running local command: {cmd_exec}")
             subprocess.run(cmd_exec, shell=True)
             # TODO: Enhance our waiting logic for determining when all OSB records have been processed by Replayer

--- a/test/tests.py
+++ b/test/tests.py
@@ -264,7 +264,7 @@ class E2ETests(unittest.TestCase):
 
     def test_0006_OSB(self):
         if self.deployment_type == "cloud":
-            cmd_exec = f"/root/runTestBenchmarks.sh --unique-id {self.unique_id} --endpoint {self.proxy_endpoint}"
+            cmd_exec = f"/root/runTestBenchmarks.sh --endpoint {self.proxy_endpoint}"
             if self.source_auth_type == "none":
                 cmd_exec = cmd_exec + " --no-auth"
             elif self.source_auth_type == "basic":


### PR DESCRIPTION
### Description
Minor fixes around console script calls that have recently changed, as well as adding specific dependencies between SSM parameters for the OpenSearch Domain stack and the resources they are for. This dependency link has not been an issue before but have noticed a case recently where the SSM parameter for an OpenSearch Domain endpoint tries to create before the Domain is finished deploying which results in an error as the Domain endpoint is not available yet.

### Issues Resolved
https://opensearch.atlassian.net/browse/MIGRATIONS-1523

### Testing
Deployment testing

### Check List
- [ ] New functionality includes testing
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
