### PR TITLE
Fix logging and metrics for TrackingKafkaConsumer with partition assignment

### DIFF
--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/kafka/TrackingKafkaConsumer.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/kafka/TrackingKafkaConsumer.java
@@ -126,6 +126,11 @@ public class TrackingKafkaConsumer implements ConsumerRebalanceListener {
 
     @Override
     public void onPartitionsRevoked(Collection<TopicPartition> partitions) {
+        if (partitions.isEmpty()) {
+            log.atInfo().setMessage(() -> this + " revoked no partitions.").log();
+            return;
+        }
+
         new KafkaConsumerContexts.AsyncListeningContext(globalContext).onPartitionsRevoked(partitions);
         synchronized (commitDataLock) {
             safeCommit(globalContext::createCommitContext);
@@ -138,19 +143,24 @@ public class TrackingKafkaConsumer implements ConsumerRebalanceListener {
             kafkaRecordsLeftToCommitEventually.set(partitionToOffsetLifecycleTrackerMap.values().stream()
                     .mapToInt(OffsetLifecycleTracker::size).sum());
             kafkaRecordsReadyToCommit.set(!nextSetOfCommitsMap.values().isEmpty());
-            log.atWarn().setMessage(() -> this + "partitions revoked for " + partitions.stream()
-                    .map(p -> p + "").collect(Collectors.joining(","))).log();
+            log.atInfo().setMessage(() -> this + " partitions revoked for " + partitions.stream()
+                    .map(String::valueOf).collect(Collectors.joining(","))).log();
         }
     }
 
     @Override public void onPartitionsAssigned(Collection<TopicPartition> newPartitions) {
+        if (newPartitions.isEmpty()) {
+            log.atInfo().setMessage(() -> this + " assigned no new partitions.").log();
+            return;
+        }
+
         new KafkaConsumerContexts.AsyncListeningContext(globalContext).onPartitionsAssigned(newPartitions);
         synchronized (commitDataLock) {
             consumerConnectionGeneration.incrementAndGet();
             newPartitions.forEach(p -> partitionToOffsetLifecycleTrackerMap.computeIfAbsent(p.partition(),
                     x -> new OffsetLifecycleTracker(consumerConnectionGeneration.get())));
-            log.atWarn().setMessage(() -> this + "partitions added for " + newPartitions.stream()
-                    .map(p -> p + "").collect(Collectors.joining(","))).log();
+            log.atInfo().setMessage(() -> this + " partitions added for " + newPartitions.stream()
+                    .map(String::valueOf).collect(Collectors.joining(","))).log();
         }
     }
 
@@ -199,11 +209,11 @@ public class TrackingKafkaConsumer implements ConsumerRebalanceListener {
         } catch (IllegalStateException e) {
             log.atError().setCause(e).setMessage(()->"Unable to pause the topic partitions: " + topic + ".  " +
                     "The active partitions passed here : " + activePartitions.stream()
-                            .map(x->""+x).collect(Collectors.joining(",")) + ".  " +
+                            .map(String::valueOf).collect(Collectors.joining(",")) + ".  " +
                     "The active partitions as tracked here are: " + getActivePartitions().stream()
-                            .map(x->""+x).collect(Collectors.joining(",")) + ".  " +
+                            .map(String::valueOf).collect(Collectors.joining(",")) + ".  " +
                     "The active partitions according to the consumer:  " + kafkaConsumer.assignment().stream()
-                            .map(x->""+x).collect(Collectors.joining(","))
+                            .map(String::valueOf).collect(Collectors.joining(","))
                     ).log();
         }
     }
@@ -217,11 +227,11 @@ public class TrackingKafkaConsumer implements ConsumerRebalanceListener {
                     "This may not be a fatal error for the entire process as the consumer should eventually"
                     + " rejoin and rebalance.  " +
                     "The active partitions passed here : " + activePartitions.stream()
-                    .map(x->""+x).collect(Collectors.joining(",")) + ".  " +
+                    .map(String::valueOf).collect(Collectors.joining(",")) + ".  " +
                     "The active partitions as tracked here are: " + getActivePartitions().stream()
-                    .map(x->""+x).collect(Collectors.joining(",")) + ".  " +
+                    .map(String::valueOf).collect(Collectors.joining(",")) + ".  " +
                     "The active partitions according to the consumer:  " + kafkaConsumer.assignment().stream()
-                    .map(x->""+x).collect(Collectors.joining(","))
+                    .map(String::valueOf).collect(Collectors.joining(","))
             ).log();
         }
     }
@@ -389,5 +399,18 @@ public class TrackingKafkaConsumer implements ConsumerRebalanceListener {
     String nextCommitsToString() {
         return "nextCommits="+nextSetOfCommitsMap.entrySet().stream()
                 .map(kvp->kvp.getKey()+"->"+kvp.getValue()).collect(Collectors.joining(","));
+    }
+
+    @Override
+    public String toString() {
+        synchronized (commitDataLock) {
+            int partitionCount = partitionToOffsetLifecycleTrackerMap.size();
+            int commitsPending = nextSetOfCommitsMap.size();
+            int recordsLeftToCommit = kafkaRecordsLeftToCommitEventually.get();
+            boolean recordsReadyToCommit = kafkaRecordsReadyToCommit.get();
+            return String.format("TrackingKafkaConsumer{topic='%s', partitionCount=%d, commitsPending=%d, " +
+                                 "recordsLeftToCommit=%d, recordsReadyToCommit=%b}",
+                topic, partitionCount, commitsPending, recordsLeftToCommit, recordsReadyToCommit);
+        }
     }
 }

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/kafka/TrackingKafkaConsumer.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/kafka/TrackingKafkaConsumer.java
@@ -127,7 +127,7 @@ public class TrackingKafkaConsumer implements ConsumerRebalanceListener {
     @Override
     public void onPartitionsRevoked(Collection<TopicPartition> partitions) {
         if (partitions.isEmpty()) {
-            log.atInfo().setMessage(() -> this + " revoked no partitions.").log();
+            log.atDebug().setMessage(() -> this + " revoked no partitions.").log();
             return;
         }
 
@@ -143,7 +143,7 @@ public class TrackingKafkaConsumer implements ConsumerRebalanceListener {
             kafkaRecordsLeftToCommitEventually.set(partitionToOffsetLifecycleTrackerMap.values().stream()
                     .mapToInt(OffsetLifecycleTracker::size).sum());
             kafkaRecordsReadyToCommit.set(!nextSetOfCommitsMap.values().isEmpty());
-            log.atInfo().setMessage(() -> this + " partitions revoked for " + partitions.stream()
+            log.atWarn().setMessage(() -> this + " partitions revoked for " + partitions.stream()
                     .map(String::valueOf).collect(Collectors.joining(","))).log();
         }
     }

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/tracing/KafkaConsumerContexts.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/tracing/KafkaConsumerContexts.java
@@ -59,7 +59,7 @@ public class KafkaConsumerContexts {
 
         public void onPartitionsRevoked(Collection<TopicPartition> partitions) {
             meterIncrementEvent(getMetrics().kafkaPartitionsRevokedCounter);
-            onParitionsAssignedChanged(partitions.size());
+            onParitionsAssignedChanged(-1 * partitions.size());
         }
 
         public void onPartitionsAssigned(Collection<TopicPartition> partitions) {

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/tracing/KafkaConsumerContexts.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/tracing/KafkaConsumerContexts.java
@@ -11,7 +11,6 @@ import org.opensearch.migrations.tracing.BaseNestedSpanContext;
 import org.opensearch.migrations.tracing.CommonMetricInstruments;
 import org.opensearch.migrations.tracing.CommonScopedMetricInstruments;
 import org.opensearch.migrations.tracing.DirectNestedSpanContext;
-import org.opensearch.migrations.tracing.IInstrumentationAttributes;
 import org.opensearch.migrations.tracing.IScopedInstrumentationAttributes;
 
 import java.util.Collection;
@@ -59,15 +58,15 @@ public class KafkaConsumerContexts {
 
         public void onPartitionsRevoked(Collection<TopicPartition> partitions) {
             meterIncrementEvent(getMetrics().kafkaPartitionsRevokedCounter);
-            onParitionsAssignedChanged(-1 * partitions.size());
+            onPartitionsAssignedChanged(-1 * partitions.size());
         }
 
         public void onPartitionsAssigned(Collection<TopicPartition> partitions) {
             meterIncrementEvent(getMetrics().kafkaPartitionsAssignedCounter);
-            onParitionsAssignedChanged(partitions.size());
+            onPartitionsAssignedChanged(partitions.size());
         }
 
-        private void onParitionsAssignedChanged(int delta) {
+        private void onPartitionsAssignedChanged(int delta) {
             meterDeltaEvent(getMetrics().kafkaActivePartitionsCounter, delta);
         }
     }


### PR DESCRIPTION
### Description
Improves logging in TrackingKafkaConsumer by improving clarity when an empty partition collection is assigned/revoked and correcting the behavior with `this` is logged by adding a toString method. Fixes metrics by only emitting metrics when a nonEmpty partition collection is modified and corrected for negative delta when partitions are revoked. Also moved a couple Warn Messages to Info for partition assginment/revocation.
* Category: Bug Fix
* Why these changes are required? Improving correctness of observability in the replayer
* What is the old behavior before changes and new behavior after changes? Old Behavior, partition assignment increased during revocations and some logs were unintelligible, e.g.: 
```
[WARN ] 2024-03-08 17:42:18,263 [kafkaConsumerThread-1-1] TrackingKafkaConsumer - org.opensearch.migrations.replay.kafka.TrackingKafkaConsumer@597f4cadpartitions added for
```
Now metrics are corrected and log messages are meaningful. 


### Issues Resolved
N/A

Is this a backport? If so, please add backport PR # and/or commits #
No

### Testing
Unit Testing and PR Auto Tests

### Check List
- [x ] New functionality includes testing
  - [ x] All tests pass, including unit test, integration test and doctest
- [ x] New functionality has been documented
- [ x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
