### PR TITLE
Allow Larger Responses

### DIFF
--- a/TrafficCapture/testUtilities/src/testFixtures/java/org/opensearch/migrations/testutils/SimpleHttpServer.java
+++ b/TrafficCapture/testUtilities/src/testFixtures/java/org/opensearch/migrations/testutils/SimpleHttpServer.java
@@ -133,7 +133,7 @@ public class SimpleHttpServer implements AutoCloseable {
     }
 
     @Override
-    public void close() throws Exception {
+    public void close() {
         httpServer.stop(0);
     }
 }

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/NettyPacketToHttpConsumer.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/NettyPacketToHttpConsumer.java
@@ -13,7 +13,6 @@ import io.netty.channel.ChannelPipeline;
 import io.netty.channel.DefaultChannelPromise;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.socket.nio.NioSocketChannel;
-import io.netty.handler.codec.http.HttpObjectAggregator;
 import io.netty.handler.codec.http.HttpResponseDecoder;
 import io.netty.handler.logging.LogLevel;
 import io.netty.handler.logging.LoggingHandler;
@@ -231,11 +230,6 @@ public class NettyPacketToHttpConsumer implements IPacketFinalizingConsumer<Aggr
         pipeline.addLast(new BacksideSnifferHandler(responseBuilder));
         addLoggingHandlerLast(pipeline, "C");
         pipeline.addLast(new HttpResponseDecoder());
-        addLoggingHandlerLast(pipeline, "D");
-        // TODO - switch this out to use less memory.
-        // We only need to know when the response has been fully received, not the contents
-        // since we're already logging those in the sniffer earlier in the pipeline.
-        pipeline.addLast(new HttpObjectAggregator(1024 * 1024));
         addLoggingHandlerLast(pipeline, "D");
         pipeline.addLast(BACKSIDE_HTTP_WATCHER_HANDLER_NAME, new BacksideHttpWatcherHandler(responseBuilder));
         addLoggingHandlerLast(pipeline, "E");

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/datahandlers/NettyPacketToHttpConsumerTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/datahandlers/NettyPacketToHttpConsumerTest.java
@@ -4,13 +4,12 @@ import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
 import io.netty.util.concurrent.DefaultThreadFactory;
-import lombok.Lombok;
+import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.opensearch.migrations.replay.ClientConnectionPool;
 import org.opensearch.migrations.replay.PacketToTransformingHttpHandlerFactory;
@@ -22,7 +21,6 @@ import org.opensearch.migrations.replay.TransformationLoader;
 import org.opensearch.migrations.replay.datatypes.ConnectionReplaySession;
 import org.opensearch.migrations.replay.traffic.source.BufferedFlowController;
 import org.opensearch.migrations.testutils.HttpRequestFirstLine;
-import org.opensearch.migrations.testutils.PortFinder;
 import org.opensearch.migrations.testutils.SimpleHttpResponse;
 import org.opensearch.migrations.testutils.SimpleHttpClientForTesting;
 import org.opensearch.migrations.testutils.SimpleHttpServer;
@@ -30,7 +28,6 @@ import org.opensearch.migrations.testutils.WrapWithNettyLeakDetection;
 import org.opensearch.migrations.tracing.InstrumentationTest;
 import org.opensearch.migrations.tracing.TestContext;
 
-import javax.net.ssl.SSLException;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
@@ -41,7 +38,6 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.Map;
-import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -50,6 +46,8 @@ import java.util.stream.Stream;
 public class NettyPacketToHttpConsumerTest extends InstrumentationTest {
 
     public static final String SERVER_RESPONSE_BODY = "I should be decrypted tester!\n";
+    public static final int LARGE_RESPONSE_CONTENT_LENGTH = 2 * 1024 * 1024;
+    public static final int LARGE_RESPONSE_LENGTH = LARGE_RESPONSE_CONTENT_LENGTH + 4246;
 
     final static String EXPECTED_REQUEST_STRING =
             "GET / HTTP/1.1\r\n" +
@@ -72,29 +70,37 @@ public class NettyPacketToHttpConsumerTest extends InstrumentationTest {
                     "0\r\n" +
                     "\r\n";
 
-    private static Map<Boolean, SimpleHttpServer> testServers;
-
-    @BeforeAll
-    public static void setupTestServer() throws PortFinder.ExceededMaxPortAssigmentAttemptException {
-        testServers = Map.of(
-                false, SimpleHttpServer.makeServer(false, NettyPacketToHttpConsumerTest::makeResponseContext),
-                true, SimpleHttpServer.makeServer(true, NettyPacketToHttpConsumerTest::makeResponseContext));
-    }
-
-    @AfterAll
-    public static void tearDownTestServer() throws Exception {
-        testServers.values().stream().forEach(s-> {
-            try {
-                s.close();
-            } catch (Exception e) {
-                throw Lombok.sneakyThrow(e);
-            }
-        });
-    }
-
     @Override
     protected TestContext makeInstrumentationContext() {
         return TestContext.withTracking(false, true);
+    }
+
+    private static SimpleHttpResponse makeResponseContext(HttpRequestFirstLine request) {
+        var headers = Map.of(
+            "Content-Type", "text/plain",
+            "Funtime", "checkIt!",
+            "Content-Transfer-Encoding", "chunked");
+        var payloadBytes = SERVER_RESPONSE_BODY.getBytes(StandardCharsets.UTF_8);
+        return new SimpleHttpResponse(headers, payloadBytes, "OK", 200);
+    }
+
+    private static SimpleHttpResponse makeResponseContextLarge(HttpRequestFirstLine request) {
+        var headers = Map.of(
+            "Content-Type", "text/plain",
+            "Funtime", "checkIt!",
+            "Content-Transfer-Encoding", "chunked");
+
+        int size = 2 * 1024 * 1024;
+        byte[] payloadBytes = new byte[size];
+        Arrays.fill(payloadBytes, (byte) 'A');
+        return new SimpleHttpResponse(headers, payloadBytes, "OK", 200);
+    }
+
+    @SneakyThrows
+    private static SimpleHttpServer createTestServer(boolean useTls, boolean largeResponse) {
+        return SimpleHttpServer.makeServer(useTls,
+            largeResponse ? NettyPacketToHttpConsumerTest::makeResponseContextLarge
+                : NettyPacketToHttpConsumerTest::makeResponseContext);
     }
 
     @Test
@@ -103,10 +109,12 @@ public class NettyPacketToHttpConsumerTest extends InstrumentationTest {
     {
         for (var useTls : new boolean[]{false, true}) {
             try (var client = new SimpleHttpClientForTesting(useTls)) {
-                var endpoint = testServers.get(useTls).localhostEndpoint();
-                var response = makeTestRequestViaClient(client, endpoint);
-                Assertions.assertEquals(SERVER_RESPONSE_BODY,
+                try (var testServer = createTestServer(useTls, false)) {
+                    var endpoint = testServer.localhostEndpoint();
+                    var response = makeTestRequestViaClient(client, endpoint);
+                    Assertions.assertEquals(SERVER_RESPONSE_BODY,
                         new String(response.payloadBytes, StandardCharsets.UTF_8));
+                }
             }
         }
     }
@@ -117,86 +125,103 @@ public class NettyPacketToHttpConsumerTest extends InstrumentationTest {
         "User-Agent", "UnitTest").entrySet().stream());
     }
 
-    private static SimpleHttpResponse makeResponseContext(HttpRequestFirstLine request) {
-        var headers = Map.of(
-                "Content-Type", "text/plain",
-                "Funtime", "checkIt!",
-                "Content-Transfer-Encoding", "chunked");
-        var payloadBytes = SERVER_RESPONSE_BODY.getBytes(StandardCharsets.UTF_8);
-        return new SimpleHttpResponse(headers, payloadBytes, "OK", 200);
-    }
+
 
     @ParameterizedTest
-    @ValueSource(booleans = {false, true})
-    public void testHttpResponseIsSuccessfullyCaptured(boolean useTls) throws Exception {
-        for (int i = 0; i < 1; ++i) {
-            var testServer = testServers.get(useTls);
-            var sslContext = !testServer.localhostEndpoint().getScheme().toLowerCase().equals("https") ? null :
+    @CsvSource({
+        "false, false",
+        "false, true",
+        "true, false",
+        "true, true"
+    })
+    public void testHttpResponseIsSuccessfullyCaptured(boolean useTls, boolean largeResponse) throws Exception {
+        try (var testServer = createTestServer(useTls, largeResponse)) {
+            for (int i = 0; i < 1; ++i) {
+                var sslContext = !testServer.localhostEndpoint().getScheme().toLowerCase().equals("https") ? null :
                     SslContextBuilder.forClient().trustManager(InsecureTrustManagerFactory.INSTANCE).build();
-            var httpContext = rootContext.getTestConnectionRequestContext(0);
-            var channelContext = httpContext.getChannelKeyContext();
-            var eventLoop = new NioEventLoopGroup(1, new DefaultThreadFactory("test")).next();
-            var replaySession = new ConnectionReplaySession(eventLoop, channelContext,
+                var httpContext = rootContext.getTestConnectionRequestContext(0);
+                var channelContext = httpContext.getChannelKeyContext();
+                var eventLoop = new NioEventLoopGroup(1, new DefaultThreadFactory("test")).next();
+                var replaySession = new ConnectionReplaySession(eventLoop, channelContext,
                     () -> ClientConnectionPool.getCompletedChannelFutureAsCompletableFuture(
-                            httpContext.getChannelKeyContext(),
-                            NettyPacketToHttpConsumer.createClientConnection(eventLoop, sslContext,
-                                    testServer.localhostEndpoint(), channelContext)));
-            var nphc = new NettyPacketToHttpConsumer(replaySession, httpContext);
-            nphc.consumeBytes((EXPECTED_REQUEST_STRING).getBytes(StandardCharsets.UTF_8));
-            var aggregatedResponse = nphc.finalizeRequest().get();
-            var responseBytePackets = aggregatedResponse.getCopyOfPackets();
-            var responseAsString = Arrays.stream(responseBytePackets)
+                        httpContext.getChannelKeyContext(),
+                        NettyPacketToHttpConsumer.createClientConnection(eventLoop, sslContext,
+                            testServer.localhostEndpoint(), channelContext)));
+                var nphc = new NettyPacketToHttpConsumer(replaySession, httpContext);
+                nphc.consumeBytes((EXPECTED_REQUEST_STRING).getBytes(StandardCharsets.UTF_8));
+                var aggregatedResponse = nphc.finalizeRequest().get();
+                var responseBytePackets = aggregatedResponse.getCopyOfPackets();
+                var responseAsString = Arrays.stream(responseBytePackets)
                     .map(bytes -> new String(bytes, StandardCharsets.UTF_8))
                     .collect(Collectors.joining());
-            Assertions.assertEquals(normalizeMessage(EXPECTED_RESPONSE_STRING),
-                    normalizeMessage(responseAsString));
+                if (!largeResponse) {
+                    Assertions.assertEquals(normalizeMessage(EXPECTED_RESPONSE_STRING),
+                        normalizeMessage(responseAsString));
+                } else {
+                    Assertions.assertEquals(LARGE_RESPONSE_LENGTH,
+                        normalizeMessage(responseAsString).getBytes(StandardCharsets.UTF_8).length);
+
+                }            }
         }
     }
 
     @ParameterizedTest
-    @ValueSource(booleans = {false, true})
-    public void testThatConnectionsAreKeptAliveAndShared(boolean useTls)
-            throws SSLException, ExecutionException, InterruptedException {
-        var testServer = testServers.get(useTls);
-        var sslContext = !testServer.localhostEndpoint().getScheme().equalsIgnoreCase("https") ? null :
+    @CsvSource({
+        "false, false",
+        "false, true",
+        "true, false",
+        "true, true"
+    })
+    public void testThatConnectionsAreKeptAliveAndShared(boolean useTls, boolean largeResponse)
+            throws Exception {
+        try (var testServer = SimpleHttpServer.makeServer(useTls,
+            largeResponse ? NettyPacketToHttpConsumerTest::makeResponseContextLarge : NettyPacketToHttpConsumerTest::makeResponseContext)) {
+            var sslContext = !testServer.localhostEndpoint().getScheme().equalsIgnoreCase("https") ? null :
                 SslContextBuilder.forClient().trustManager(InsecureTrustManagerFactory.INSTANCE).build();
-        var transformingHttpHandlerFactory = new PacketToTransformingHttpHandlerFactory(
+            var transformingHttpHandlerFactory = new PacketToTransformingHttpHandlerFactory(
                 new TransformationLoader().getTransformerFactoryLoader(null), null);
-        var timeShifter = new TimeShifter();
-        timeShifter.setFirstTimestamp(Instant.now());
-        var sendingFactory = new ReplayEngine(
+            var timeShifter = new TimeShifter();
+            timeShifter.setFirstTimestamp(Instant.now());
+            var sendingFactory = new ReplayEngine(
                 new RequestSenderOrchestrator(
                         new ClientConnectionPool(testServer.localhostEndpoint(), sslContext,
                                 "targetPool for testThatConnectionsAreKeptAliveAndShared", 1)),
                 new TestFlowController(), timeShifter);
-        for (int j = 0; j < 2; ++j) {
-            for (int i = 0; i < 2; ++i) {
-                var ctx = rootContext.getTestConnectionRequestContext("TEST_" + i, j);
-                var requestFinishFuture = TrafficReplayer.transformAndSendRequest(transformingHttpHandlerFactory,
+            for (int j = 0; j < 2; ++j) {
+                for (int i = 0; i < 2; ++i) {
+                    var ctx = rootContext.getTestConnectionRequestContext("TEST_" + i, j);
+                    var requestFinishFuture = TrafficReplayer.transformAndSendRequest(transformingHttpHandlerFactory,
                         sendingFactory, ctx, Instant.now(), Instant.now(),
                         () -> Stream.of(EXPECTED_REQUEST_STRING.getBytes(StandardCharsets.UTF_8)));
-                log.info("requestFinishFuture=" + requestFinishFuture);
-                var aggregatedResponse = requestFinishFuture.get();
-                log.debug("Got aggregated response=" + aggregatedResponse);
-                Assertions.assertNull(aggregatedResponse.getError());
-                var responseBytePackets = aggregatedResponse.getCopyOfPackets();
-                var responseAsString = Arrays.stream(responseBytePackets)
+                    log.info("requestFinishFuture=" + requestFinishFuture);
+                    var aggregatedResponse = requestFinishFuture.get();
+                    log.debug("Got aggregated response=" + aggregatedResponse);
+                    Assertions.assertNull(aggregatedResponse.getError());
+                    var responseBytePackets = aggregatedResponse.getCopyOfPackets();
+                    var responseAsString = Arrays.stream(responseBytePackets)
                         .map(bytes -> new String(bytes, StandardCharsets.UTF_8))
                         .collect(Collectors.joining());
-                Assertions.assertEquals(normalizeMessage(EXPECTED_RESPONSE_STRING),
-                        normalizeMessage(responseAsString));
+                    if (!largeResponse) {
+                        Assertions.assertEquals(normalizeMessage(EXPECTED_RESPONSE_STRING),
+                            normalizeMessage(responseAsString));
+                    } else {
+                        Assertions.assertEquals(LARGE_RESPONSE_LENGTH,
+                            normalizeMessage(responseAsString).getBytes(StandardCharsets.UTF_8).length);
+
+                    }
+                }
             }
+            var stopFuture = sendingFactory.closeConnectionsAndShutdown();
+            log.info("waiting for factory to shutdown: " + stopFuture);
+            stopFuture.get();
         }
-        var stopFuture = sendingFactory.closeConnectionsAndShutdown();
-        log.info("waiting for factory to shutdown: " + stopFuture);
-        stopFuture.get();
     }
 
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     @WrapWithNettyLeakDetection(repetitions = 1)
     public void testMetricCountsFor_testThatConnectionsAreKeptAliveAndShared(boolean useTls) throws Exception {
-        testThatConnectionsAreKeptAliveAndShared(useTls);
+        testThatConnectionsAreKeptAliveAndShared(useTls, false);
         Thread.sleep(200); // let metrics settle down
         var allMetricData = rootContext.inMemoryInstrumentationBundle.getFinishedMetrics();
         long tcpOpenConnectionCount = allMetricData.stream().filter(md->md.getName().startsWith("tcpConnectionCount"))

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/datahandlers/NettyPacketToHttpConsumerTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/datahandlers/NettyPacketToHttpConsumerTest.java
@@ -108,13 +108,12 @@ public class NettyPacketToHttpConsumerTest extends InstrumentationTest {
             throws IOException, NoSuchAlgorithmException, KeyStoreException, KeyManagementException
     {
         for (var useTls : new boolean[]{false, true}) {
-            try (var client = new SimpleHttpClientForTesting(useTls)) {
-                try (var testServer = createTestServer(useTls, false)) {
+            try (var client = new SimpleHttpClientForTesting(useTls);
+                var testServer = createTestServer(useTls, false)) {
                     var endpoint = testServer.localhostEndpoint();
                     var response = makeTestRequestViaClient(client, endpoint);
                     Assertions.assertEquals(SERVER_RESPONSE_BODY,
                         new String(response.payloadBytes, StandardCharsets.UTF_8));
-                }
             }
         }
     }


### PR DESCRIPTION
### Description
Currently, our replayer netty pipeline can only handle responses < 1MB due to configuration in HttpObjectAggregator. This change removes that restriction by enabling the BacksideHttpWatcherHandler to stream in content until HttpLastContent is received.
* Category: Enhancement
* Why these changes are required? Allow > 1 MB Responses
* What is the old behavior before changes and new behavior after changes? Old Behavior was an error after > 1 MB Responses with full content being buffered, this removes that failure mode and reduces memory footprint.

### Issues Resolved
[MIGRATIONS-1605](https://opensearch.atlassian.net/browse/MIGRATIONS-1605)

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
Unit Tests

### Check List
- [x] New functionality includes testing
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
