### PR TITLE
Fix connection leaks

### DIFF
--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/ClientConnectionPool.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/ClientConnectionPool.java
@@ -132,12 +132,12 @@ public class ClientConnectionPool {
                 () -> "Final shutdown for " + this.getClass().getSimpleName());
     }
 
-    public void closeConnection(IReplayContexts.IChannelKeyContext ctx) {
+    public void closeConnection(IReplayContexts.IChannelKeyContext ctx, int sessionNumber) {
         var connId = ctx.getConnectionId();
         log.atInfo().setMessage(() -> "closing connection for " + connId).log();
-        var channelsFuture = connectionId2ChannelCache.getIfPresent(connId);
-        if (channelsFuture != null) {
-            closeClientConnectionChannel(channelsFuture);
+        var connectionReplaySession = connectionId2ChannelCache.getIfPresent(getKey(connId, sessionNumber));
+        if (connectionReplaySession != null) {
+            closeClientConnectionChannel(connectionReplaySession);
             connectionId2ChannelCache.invalidate(connId);
         } else {
             log.atTrace().setMessage(()->"No ChannelFuture for " + ctx +

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/RequestSenderOrchestrator.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/RequestSenderOrchestrator.java
@@ -100,7 +100,7 @@ public class RequestSenderOrchestrator {
                             channelFutureAndRequestSchedule, finalTunneledResponse, timestamp,
                             new ChannelTask(ChannelTaskType.CLOSE, () -> {
                                 log.trace("Closing client connection " + channelInteraction);
-                                clientConnectionPool.closeConnection(ctx);
+                                clientConnectionPool.closeConnection(ctx, sessionNumber);
                                 finalTunneledResponse.future.complete(null);
                             })));
         return finalTunneledResponse;


### PR DESCRIPTION
When closing connections in the ClientConnectionPool, the right key was never used to grab the connection from the cache to close it down.

I'll add tighter tests in a subsequent commit.

### Description
[Describe what this change achieves]
* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)
* Why these changes are required?
* What is the old behavior before changes and new behavior after changes?

### Issues Resolved
https://opensearch.atlassian.net/browse/MIGRATIONS-1579

### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]

### Check List
- [ ] New functionality includes testing
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
