### PR TITLE
Support Limitless CodedOutputStreams

### DIFF
--- a/TrafficCapture/captureKafkaOffloader/src/main/java/org/opensearch/migrations/trafficcapture/kafkaoffloader/KafkaCaptureFactory.java
+++ b/TrafficCapture/captureKafkaOffloader/src/main/java/org/opensearch/migrations/trafficcapture/kafkaoffloader/KafkaCaptureFactory.java
@@ -61,6 +61,11 @@ public class KafkaCaptureFactory implements IConnectionCaptureFactory<RecordMeta
         private final CodedOutputStream codedOutputStream;
         private final ByteBuffer byteBuffer;
         @Override
+        public int getOutputStreamBytesLimit() {
+            return byteBuffer.limit();
+        }
+
+        @Override
         public @NonNull CodedOutputStream getOutputStream() {
             return codedOutputStream;
         }

--- a/TrafficCapture/captureOffloader/src/main/java/org/opensearch/migrations/trafficcapture/CodedOutputStreamAndByteBufferWrapper.java
+++ b/TrafficCapture/captureOffloader/src/main/java/org/opensearch/migrations/trafficcapture/CodedOutputStreamAndByteBufferWrapper.java
@@ -6,16 +6,19 @@ import lombok.NonNull;
 
 import java.nio.ByteBuffer;
 
+@Getter
 public class CodedOutputStreamAndByteBufferWrapper implements CodedOutputStreamHolder {
     @NonNull
-    @Getter
     private final CodedOutputStream outputStream;
     @NonNull
-    @Getter
     private final ByteBuffer byteBuffer;
 
     public CodedOutputStreamAndByteBufferWrapper(int bufferSize) {
         this.byteBuffer = ByteBuffer.allocate(bufferSize);
         outputStream = CodedOutputStream.newInstance(byteBuffer);
+    }
+
+    public int getOutputStreamBytesLimit() {
+        return byteBuffer.limit();
     }
 }

--- a/TrafficCapture/captureOffloader/src/main/java/org/opensearch/migrations/trafficcapture/CodedOutputStreamHolder.java
+++ b/TrafficCapture/captureOffloader/src/main/java/org/opensearch/migrations/trafficcapture/CodedOutputStreamHolder.java
@@ -4,5 +4,28 @@ import com.google.protobuf.CodedOutputStream;
 import lombok.NonNull;
 
 public interface CodedOutputStreamHolder {
+
+    /**
+     * Returns the maximum number of bytes that can be written to the output stream before exceeding
+     * its limit, or -1 if the stream has no defined limit.
+     *
+     * @return the byte limit of the output stream, or -1 if no limit exists.
+     */
+    int getOutputStreamBytesLimit();
+
+    /**
+     * Calculates the remaining space in the output stream based on the limit set by
+     * {@link #getOutputStreamBytesLimit()}. If the limit is defined, this method returns
+     * the difference between that limit and the number of bytes already written. If no
+     * limit is defined, returns -1, indicating unbounded space.
+     *
+     * @return the number of remaining bytes that can be written before reaching the limit,
+     * or -1 if the stream is unbounded.
+     */
+    default int getOutputStreamSpaceLeft() {
+        var limit = getOutputStreamBytesLimit();
+        return (limit != -1) ? limit - getOutputStream().getTotalBytesWritten() : -1;
+    }
+
     @NonNull CodedOutputStream getOutputStream();
 }

--- a/TrafficCapture/captureOffloader/src/test/java/org/opensearch/migrations/trafficcapture/StreamChannelConnectionCaptureSerializerTest.java
+++ b/TrafficCapture/captureOffloader/src/test/java/org/opensearch/migrations/trafficcapture/StreamChannelConnectionCaptureSerializerTest.java
@@ -3,9 +3,11 @@ package org.opensearch.migrations.trafficcapture;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.google.protobuf.ByteString;
+import com.google.protobuf.CodedOutputStream;
 import com.google.protobuf.Timestamp;
 import io.netty.buffer.Unpooled;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
@@ -18,9 +20,11 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ExecutionException;
 import lombok.AllArgsConstructor;
 import lombok.Lombok;
+import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.opensearch.migrations.trafficcapture.StreamChannelConnectionCaptureSerializerTest.StreamManager.NullStreamManager;
 import org.opensearch.migrations.trafficcapture.protos.CloseObservation;
 import org.opensearch.migrations.trafficcapture.protos.ConnectionExceptionObservation;
 import org.opensearch.migrations.trafficcapture.protos.EndOfMessageIndication;
@@ -28,7 +32,6 @@ import org.opensearch.migrations.trafficcapture.protos.EndOfSegmentsIndication;
 import org.opensearch.migrations.trafficcapture.protos.ReadObservation;
 import org.opensearch.migrations.trafficcapture.protos.TrafficObservation;
 import org.opensearch.migrations.trafficcapture.protos.TrafficStream;
-
 import org.opensearch.migrations.trafficcapture.protos.WriteObservation;
 
 @Slf4j
@@ -185,6 +188,22 @@ class StreamChannelConnectionCaptureSerializerTest {
         TrafficStream reconstitutedTrafficStream = TrafficStream.parseFrom(outputBuffersList.get(0));
         Assertions.assertEquals(0, reconstitutedTrafficStream.getSubStream(0).getWrite().getData().size());
         Assertions.assertEquals(0, reconstitutedTrafficStream.getSubStream(1).getWrite().getData().size());
+    }
+
+    @Test
+    public void testWithLimitlessCodedOutputStreamHolder()
+        throws IOException, ExecutionException, InterruptedException {
+
+        var serializer = new StreamChannelConnectionCaptureSerializer<>(TEST_NODE_ID_STRING,
+            TEST_TRAFFIC_STREAM_ID_STRING,
+            new NullStreamManager());
+
+        var bb = Unpooled.buffer(0);
+        serializer.addWriteEvent(REFERENCE_TIMESTAMP, bb);
+        serializer.addWriteEvent(REFERENCE_TIMESTAMP, bb);
+        var future = serializer.flushCommitAndResetStream(true);
+        future.get();
+        bb.release();
     }
 
     @Test
@@ -359,6 +378,34 @@ class StreamChannelConnectionCaptureSerializerTest {
                     throw Lombok.sneakyThrow(e);
                 }
             }).thenApply(x -> null);
+        }
+
+        static class NullStreamManager implements StreamLifecycleManager<CodedOutputStreamHolder> {
+
+            @Override
+            public CodedOutputStreamHolder createStream() {
+                return new CodedOutputStreamHolder() {
+                    final CodedOutputStream nullOutputStream = CodedOutputStream.newInstance(
+                        OutputStream.nullOutputStream());
+
+                    @Override
+                    public int getOutputStreamBytesLimit() {
+                        return -1;
+                    }
+
+                    @Override
+                    public @NonNull CodedOutputStream getOutputStream() {
+                        return nullOutputStream;
+                    }
+                };
+            }
+
+            @Override
+            public CompletableFuture<CodedOutputStreamHolder> closeStream(CodedOutputStreamHolder outputStreamHolder,
+                int index) {
+                return CompletableFuture.completedFuture(null);
+            }
+
         }
     }
 }

--- a/TrafficCapture/trafficCaptureProxyServer/src/test/java/org/opensearch/migrations/trafficcapture/proxyserver/CaptureProxyConfigurationTest.java
+++ b/TrafficCapture/trafficCaptureProxyServer/src/test/java/org/opensearch/migrations/trafficcapture/proxyserver/CaptureProxyConfigurationTest.java
@@ -1,0 +1,78 @@
+package org.opensearch.migrations.trafficcapture.proxyserver;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.IOException;
+import java.net.URI;
+import java.time.Duration;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.opensearch.migrations.testutils.SimpleHttpClientForTesting;
+import org.opensearch.migrations.trafficcapture.proxyserver.testcontainers.CaptureProxyContainer;
+import org.opensearch.migrations.trafficcapture.proxyserver.testcontainers.HttpdContainerTestBase;
+import org.opensearch.migrations.trafficcapture.proxyserver.testcontainers.annotations.HttpdContainerTest;
+
+@Slf4j
+@HttpdContainerTest
+public class CaptureProxyConfigurationTest {
+
+    private static final HttpdContainerTestBase httpdTestBase = new HttpdContainerTestBase();
+    private static final String HTTPD_GET_EXPECTED_RESPONSE = "<html><body><h1>It works!</h1></body></html>\n";
+    private static final int DEFAULT_NUMBER_OF_CALLS = 3;
+    private static final long PROXY_EXPECTED_MAX_LATENCY_MS = Duration.ofSeconds(1).toMillis();
+
+    @BeforeAll
+    public static void setUp() {
+        httpdTestBase.start();
+    }
+
+    @AfterAll
+    public static void tearDown() {
+        httpdTestBase.stop();
+    }
+
+    private static void assertLessThan(long ceiling, long actual) {
+        Assertions.assertTrue(actual < ceiling,
+            () -> "Expected actual value to be less than " + ceiling + " but was " + actual + ".");
+    }
+
+    @Test
+    public void testCaptureProxyWithNoCapturePassesRequest() {
+        try (var captureProxy = new CaptureProxyContainer(httpdTestBase.getContainer())) {
+            captureProxy.start();
+
+            var latency = assertBasicCalls(captureProxy, DEFAULT_NUMBER_OF_CALLS);
+
+            assertLessThan(PROXY_EXPECTED_MAX_LATENCY_MS, latency.toMillis());
+        }
+    }
+
+    private Duration assertBasicCalls(CaptureProxyContainer proxy, int numberOfCalls) {
+        return assertBasicCalls(CaptureProxyContainer.getUriFromContainer(proxy), numberOfCalls);
+    }
+
+    private Duration assertBasicCalls(String endpoint, int numberOfCalls) {
+        return IntStream.range(0, numberOfCalls).mapToObj(i -> assertBasicCall(endpoint))
+            .reduce(Duration.ZERO, Duration::plus).dividedBy(numberOfCalls);
+    }
+
+
+    private Duration assertBasicCall(String endpoint) {
+        try (var client = new SimpleHttpClientForTesting()) {
+            long startTimeNanos = System.nanoTime();
+            var response = client.makeGetRequest(URI.create(endpoint), Stream.empty());
+            long endTimeNanos = System.nanoTime();
+
+            var responseBody = new String(response.payloadBytes);
+            assertEquals(HTTPD_GET_EXPECTED_RESPONSE, responseBody);
+            return Duration.ofNanos(endTimeNanos - startTimeNanos);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
### Description
This change adds functionality within the CodedOutputStreamHolder and refactors the StreamChannelConnectionCaptureSerializer to support limitless CodedOutputStreams through new interface method `getOutputStreamBytesLimit` which can be set to the limit of an underlying byte buffer or `-1` for a limitless CodedOutputStreams. 
* Category: Bug Fix
* Why these changes are required? Currently, the CaptureProxy `--noCapture` parameter is broken and prevents proxy functionality.
* What is the old behavior before changes and new behavior after changes? Without this change `--noCapture` prevents proxy from forwarding requests to the destination, with this change the proxy behaves as expected

### Issues Resolved
[Issues#540](https://github.com/opensearch-project/opensearch-migrations/issues/540)
[MIGRATIONS-1616](https://opensearch.atlassian.net/browse/MIGRATIONS-1616)

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
Unit Tests

### Check List
- [x] New functionality includes testing
  - [x] All tests pass, including unit test, integration test and doctest
- [N/A] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
