### PR TITLE
Assorted bugfixes and improvements 

### DIFF
--- a/TrafficCapture/testUtilities/src/testFixtures/java/org/opensearch/migrations/testutils/SimpleNettyHttpServer.java
+++ b/TrafficCapture/testUtilities/src/testFixtures/java/org/opensearch/migrations/testutils/SimpleNettyHttpServer.java
@@ -167,9 +167,7 @@ public class SimpleNettyHttpServer implements AutoCloseable {
                         }
                         pipeline.addLast(new HttpRequestDecoder());
                         pipeline.addLast(new HttpObjectAggregator(16*1024));
-                        pipeline.addLast(new LoggingHandler(LogLevel.INFO));
                         pipeline.addLast(new HttpResponseEncoder());
-                        pipeline.addLast(new LoggingHandler(LogLevel.WARN));
                         pipeline.addLast(makeHandlerFromResponseContext(responseBuilder));
                     }
                 });

--- a/TrafficCapture/testUtilities/src/testFixtures/java/org/opensearch/migrations/testutils/SimpleNettyHttpServer.java
+++ b/TrafficCapture/testUtilities/src/testFixtures/java/org/opensearch/migrations/testutils/SimpleNettyHttpServer.java
@@ -15,9 +15,14 @@ import io.netty.handler.codec.http.DefaultHttpHeaders;
 import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpObjectAggregator;
+import io.netty.handler.codec.http.HttpRequestDecoder;
+import io.netty.handler.codec.http.HttpResponseDecoder;
+import io.netty.handler.codec.http.HttpResponseEncoder;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpServerCodec;
 import io.netty.handler.codec.http.HttpVersion;
+import io.netty.handler.logging.LogLevel;
+import io.netty.handler.logging.LoggingHandler;
 import io.netty.handler.ssl.SslHandler;
 import io.netty.handler.timeout.ReadTimeoutHandler;
 import io.netty.util.concurrent.DefaultThreadFactory;
@@ -112,6 +117,10 @@ public class SimpleNettyHttpServer implements AutoCloseable {
             @Override
             protected void channelRead0(ChannelHandlerContext ctx, FullHttpRequest req) {
                 try {
+                    if (req.decoderResult().isFailure()) {
+                        ctx.close();
+                        return;
+                    }
                     var specifiedResponse = responseBuilder.apply(new RequestToFirstLineAdapter(req));
                     var fullResponse = new DefaultFullHttpResponse(
                             HttpVersion.HTTP_1_1,
@@ -156,8 +165,11 @@ public class SimpleNettyHttpServer implements AutoCloseable {
                         if (timeout != null) {
                             pipeline.addLast(new ReadTimeoutHandler(timeout.toMillis(), TimeUnit.MILLISECONDS));
                         }
-                        pipeline.addLast(new HttpServerCodec());
+                        pipeline.addLast(new HttpRequestDecoder());
                         pipeline.addLast(new HttpObjectAggregator(16*1024));
+                        pipeline.addLast(new LoggingHandler(LogLevel.INFO));
+                        pipeline.addLast(new HttpResponseEncoder());
+                        pipeline.addLast(new LoggingHandler(LogLevel.WARN));
                         pipeline.addLast(makeHandlerFromResponseContext(responseBuilder));
                     }
                 });

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/Accumulation.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/Accumulation.java
@@ -2,6 +2,7 @@ package org.opensearch.migrations.replay;
 
 import lombok.AllArgsConstructor;
 import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
 import org.opensearch.migrations.replay.datatypes.ITrafficStreamKey;
 import org.opensearch.migrations.trafficcapture.protos.TrafficStream;
 
@@ -10,6 +11,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 
+@Slf4j
 public class Accumulation {
 
     enum State {
@@ -73,7 +75,7 @@ public class Accumulation {
     }
 
     public RequestResponsePacketPair getOrCreateTransactionPair(ITrafficStreamKey forTrafficStreamKey,
-                                                                            Instant originTimestamp) {
+                                                                Instant originTimestamp) {
         if (rrPairWithCallback != null) {
             return rrPairWithCallback.pair;
         }

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/HttpByteBufFormatter.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/HttpByteBufFormatter.java
@@ -143,10 +143,8 @@ public class HttpByteBufFormatter {
                 new HttpObjectAggregator(Utils.MAX_PAYLOAD_SIZE_TO_PRINT)  // Set max content length if needed
         );
 
-        //log.warn("Beginning to parse bytes for parseHttpMessageFromBufs");
         byteBufStream.forEach(b -> {
             try {
-                //log.warn("processing bytes: " + b.toString(StandardCharsets.UTF_8));
                 channel.writeInbound(b.retainedDuplicate());
             } finally {
                 if (releaseByteBufs) {

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/ReplayEngine.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/ReplayEngine.java
@@ -148,6 +148,8 @@ public class ReplayEngine {
         var requestKey = ctx.getReplayerRequestKey();
         logStartOfWork(requestKey, newCount, start, label);
 
+        log.atDebug().setMessage(()->"Scheduling request for " + ctx + " to run from [" + start + ", " + end +
+                " with an interval of " + interval + " for " + numPackets + " packets").log();
         var sendResult = networkSendOrchestrator.scheduleRequest(requestKey, ctx, start, interval, packets);
         return hookWorkFinishingUpdates(sendResult, originalStart, requestKey, label);
     }

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/RequestSenderOrchestrator.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/RequestSenderOrchestrator.java
@@ -71,7 +71,6 @@ public class RequestSenderOrchestrator {
         var finalTunneledResponse =
                 new StringTrackableCompletableFuture<AggregatedRawResponse>(new CompletableFuture<>(),
                         ()->"waiting for final aggregated response");
-        log.atDebug().setMessage(()->"Scheduling request for "+requestKey+" at start time "+start).log();
         // When a socket connection is attempted could be more precise.
         // Ideally, we would match the relative timestamps of when connections were being initiated
         // as well as the period between connection and the first bytes sent.  However, this code is a

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/ResultsToLogsConsumer.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/ResultsToLogsConsumer.java
@@ -1,6 +1,7 @@
 package org.opensearch.migrations.replay;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.netty.buffer.ByteBuf;
 import lombok.Lombok;
 import lombok.extern.slf4j.Slf4j;
 import org.opensearch.migrations.replay.datatypes.UniqueSourceRequestKey;
@@ -11,6 +12,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.StringJoiner;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiConsumer;
 
 @Slf4j
@@ -21,6 +23,7 @@ public class ResultsToLogsConsumer implements BiConsumer<SourceTargetCaptureTupl
 
     private final Logger tupleLogger;
     private final Logger progressLogger;
+    private final AtomicInteger tupleCounter;
 
     public ResultsToLogsConsumer() {
         this(null, null);
@@ -29,6 +32,7 @@ public class ResultsToLogsConsumer implements BiConsumer<SourceTargetCaptureTupl
     public ResultsToLogsConsumer(Logger tupleLogger, Logger progressLogger) {
         this.tupleLogger = tupleLogger != null ? tupleLogger : LoggerFactory.getLogger(OUTPUT_TUPLE_JSON_LOGGER);
         this.progressLogger = progressLogger != null ? progressLogger : makeTransactionSummaryLogger();
+        tupleCounter = new AtomicInteger();
     }
 
     // set this up so that the preamble prints out once, right after we have a logger
@@ -102,7 +106,8 @@ public class ResultsToLogsConsumer implements BiConsumer<SourceTargetCaptureTupl
      * @param tuple the RequestResponseResponseTriple object to be converted into json and written to the stream.
      */
     public void accept(SourceTargetCaptureTuple tuple, ParsedHttpMessagesAsDicts parsedMessages) {
-        progressLogger.atInfo().setMessage(()->toTransactionSummaryString(tuple, parsedMessages)).log();
+        final var index = tupleCounter.getAndIncrement();
+        progressLogger.atInfo().setMessage(()->toTransactionSummaryString(index, tuple, parsedMessages)).log();
         tupleLogger.atInfo().setMessage(() -> {
             try {
                 return PLAIN_MAPPER.writeValueAsString(toJSONObject(tuple, parsedMessages));
@@ -114,32 +119,46 @@ public class ResultsToLogsConsumer implements BiConsumer<SourceTargetCaptureTupl
 
     public static String getTransactionSummaryStringPreamble() {
         return new StringJoiner(", ")
-                .add("SOURCE_STATUS_CODE")
-                .add("TARGET_STATUS_CODE")
-                .add("SOURCE_LATENCY")
-                .add("TARGET_LATENCY")
+                .add("#")
                 .add("REQUEST_ID")
                 .add("ORIGINAL_TIMESTAMP")
+                .add("SOURCE_STATUS_CODE/TARGET_STATUS_CODE")
+                .add("SOURCE_REQUEST_SIZE_BYTES/TARGET_REQUEST_SIZE_BYTES")
+                .add("SOURCE_RESPONSE_SIZE_BYTES/TARGET_RESPONSE_SIZE_BYTES")
+                .add("SOURCE_LATENCY_MS/TARGET_LATENCY_MS")
                 .toString();
     }
 
-    public static String toTransactionSummaryString(SourceTargetCaptureTuple tuple, ParsedHttpMessagesAsDicts parsed) {
+    public static String toTransactionSummaryString(int index, SourceTargetCaptureTuple tuple, ParsedHttpMessagesAsDicts parsed) {
         final String MISSING_STR = "-";
         var s = parsed.sourceResponseOp;
         var t = parsed.targetResponseOp;
         return new StringJoiner(", ")
-                // SOURCE_STATUS_CODE
-                .add(s.map(r->""+r.get(ParsedHttpMessagesAsDicts.STATUS_CODE_KEY)).orElse(MISSING_STR))
-                // TARGET_STATUS_CODE
-                .add(t.map(r->""+r.get(ParsedHttpMessagesAsDicts.STATUS_CODE_KEY)).orElse(MISSING_STR))
-                // SOURCE_LATENCY
-                .add(s.map(r->""+r.get(ParsedHttpMessagesAsDicts.RESPONSE_TIME_MS_KEY)).orElse(MISSING_STR))
-                // TARGET_LATENCY
-                .add(t.map(r->""+r.get(ParsedHttpMessagesAsDicts.RESPONSE_TIME_MS_KEY)).orElse(MISSING_STR))
+                .add(Integer.toString(index))
                 // REQUEST_ID
                 .add(formatUniqueRequestKey(tuple.getRequestKey()))
+                // Original request timestamp
                 .add(Optional.ofNullable(tuple.sourcePair).map(sp->sp.requestData.getLastPacketTimestamp().toString())
                         .orElse(MISSING_STR))
+                // SOURCE/TARGET STATUS_CODE
+                .add(s.map(r->""+r.get(ParsedHttpMessagesAsDicts.STATUS_CODE_KEY)).orElse(MISSING_STR) + "/" +
+                        t.map(r->""+r.get(ParsedHttpMessagesAsDicts.STATUS_CODE_KEY)).orElse(MISSING_STR))
+                // SOURCE/TARGET REQUEST_SIZE_BYTES
+                .add(Optional.ofNullable(tuple.sourcePair).map(sp->sp.requestData.stream().mapToInt(bArr->bArr.length)
+                                .sum()+"")
+                        .orElse(MISSING_STR) + "/" +
+                        Optional.ofNullable(tuple.targetRequestData)
+                                .map(transformedPackets->transformedPackets.streamUnretained()
+                                        .mapToInt(ByteBuf::readableBytes)
+                                        .sum()+"").orElse(MISSING_STR))
+                // SOURCE/TARGET RESPONSE_SIZE_BYTES
+                .add(Optional.ofNullable(tuple.sourcePair).flatMap(sp->Optional.ofNullable(sp.responseData))
+                        .map(rd->rd.stream().mapToInt(bArr->bArr.length).sum()+"").orElse(MISSING_STR) + "/" +
+                        Optional.ofNullable(tuple.targetResponseData)
+                                .map(rd->rd.stream().mapToInt(bArr->bArr.length).sum()+"").orElse(MISSING_STR))
+                // SOURCE/TARGET LATENCY
+                .add(s.map(r->""+r.get(ParsedHttpMessagesAsDicts.RESPONSE_TIME_MS_KEY)).orElse(MISSING_STR) + "/" +
+                        t.map(r->""+r.get(ParsedHttpMessagesAsDicts.RESPONSE_TIME_MS_KEY)).orElse(MISSING_STR))
                 .toString();
     }
 

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/TrafficReplayer.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/TrafficReplayer.java
@@ -275,7 +275,7 @@ public class TrafficReplayer implements AutoCloseable {
                 names = {"--max-concurrent-requests"},
                 arity = 1,
                 description = "Maximum number of requests at a time that can be outstanding")
-        int maxConcurrentRequests = 1;
+        int maxConcurrentRequests = 1024;
         @Parameter(required = false,
                 names = {"--num-client-threads"},
                 arity = 1,

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/NettyPacketToHttpConsumer.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/NettyPacketToHttpConsumer.java
@@ -47,7 +47,7 @@ public class NettyPacketToHttpConsumer implements IPacketFinalizingConsumer<Aggr
      * Set this to of(LogLevel.ERROR) or whatever level you'd like to get logging between each handler.
      * Set this to Optional.empty() to disable intra-handler logging.
      */
-    private static final Optional<LogLevel> PIPELINE_LOGGING_OPTIONAL = Optional.of(LogLevel.INFO);
+    private static final Optional<LogLevel> PIPELINE_LOGGING_OPTIONAL = Optional.empty();
 
     public static final String BACKSIDE_HTTP_WATCHER_HANDLER_NAME = "BACKSIDE_HTTP_WATCHER_HANDLER";
     public static final String CONNECTION_CLOSE_HANDLER_NAME = "CONNECTION_CLOSE_HANDLER";
@@ -281,7 +281,7 @@ public class NettyPacketToHttpConsumer implements IPacketFinalizingConsumer<Aggr
                         System.identityHashCode(packetData) + "): " + httpContext() + ": " +
                         packetData.toString(StandardCharsets.UTF_8)).log();
                 return writePacketAndUpdateFuture(packetData).whenComplete((v2,t2)->{
-                    log.atInfo().setMessage(()->"finished writing " + httpContext() + " t=" + t2).log();
+                    log.atDebug().setMessage(()->"finished writing " + httpContext() + " t=" + t2).log();
                 }, ()->"");
             } else {
                 log.atWarn().setMessage(()-> httpContext().getReplayerRequestKey() +

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/netty/BacksideHttpWatcherHandler.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/netty/BacksideHttpWatcherHandler.java
@@ -1,18 +1,23 @@
 package org.opensearch.migrations.replay.netty;
 
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpObject;
+import io.netty.handler.codec.http.LastHttpContent;
+import io.netty.util.ReferenceCountUtil;
+import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.opensearch.migrations.replay.AggregatedRawResponse;
 
 import java.util.function.Consumer;
 
 @Slf4j
-public class BacksideHttpWatcherHandler extends SimpleChannelInboundHandler<FullHttpResponse> {
+public class BacksideHttpWatcherHandler extends SimpleChannelInboundHandler<HttpObject> {
 
     private AggregatedRawResponse.Builder aggregatedRawResponseBuilder;
-    private boolean doneReadingRequest; // later, when connections are reused, switch this to a counter?
+    private boolean doneReadingRequest;
     Consumer<AggregatedRawResponse> responseCallback;
 
     public BacksideHttpWatcherHandler(AggregatedRawResponse.Builder aggregatedRawResponseBuilder) {
@@ -21,16 +26,28 @@ public class BacksideHttpWatcherHandler extends SimpleChannelInboundHandler<Full
     }
 
     @Override
-    protected void channelRead0(ChannelHandlerContext ctx, FullHttpResponse msg) throws Exception {
-        doneReadingRequest = true;
-        triggerResponseCallbackAndRemoveCallback();
-        super.channelReadComplete(ctx);
+    protected void channelRead0(ChannelHandlerContext ctx, HttpObject msg) throws Exception {
+        if (msg instanceof LastHttpContent) {
+            triggerResponseCallbackAndRemoveCallback();
+        }
     }
 
     @Override
     public void handlerRemoved(ChannelHandlerContext ctx) throws Exception {
         triggerResponseCallbackAndRemoveCallback();
         super.handlerRemoved(ctx);
+    }
+
+    @Override
+    public void channelInactive(@NonNull ChannelHandlerContext ctx) throws Exception {
+        triggerResponseCallbackAndRemoveCallback();
+        super.channelInactive(ctx);
+    }
+
+    @Override
+    public void channelUnregistered(ChannelHandlerContext ctx) throws Exception {
+        triggerResponseCallbackAndRemoveCallback();
+        super.channelUnregistered(ctx);
     }
 
     @Override
@@ -42,6 +59,7 @@ public class BacksideHttpWatcherHandler extends SimpleChannelInboundHandler<Full
 
     private void triggerResponseCallbackAndRemoveCallback() {
         log.atTrace().setMessage(()->"triggerResponseCallbackAndRemoveCallback, callback="+this.responseCallback).log();
+        doneReadingRequest = true;
         if (this.responseCallback != null) {
             // this method may be re-entrant upon calling the callback, so make sure that we don't loop
             var originalResponseCallback = this.responseCallback;
@@ -63,13 +81,4 @@ public class BacksideHttpWatcherHandler extends SimpleChannelInboundHandler<Full
             this.responseCallback = callback;
         }
     }
-
-    @Override
-    public void channelInactive(ChannelHandlerContext ctx) throws Exception {
-        doneReadingRequest = true;
-        log.trace("inactive channel - closing");
-        triggerResponseCallbackAndRemoveCallback();
-        super.channelInactive(ctx);
-    }
-
 }

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/traffic/expiration/AccumulatorMap.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/traffic/expiration/AccumulatorMap.java
@@ -4,5 +4,5 @@ import org.opensearch.migrations.replay.Accumulation;
 
 import java.util.concurrent.ConcurrentHashMap;
 
-class AccumulatorMap extends ConcurrentHashMap<ScopedConnectionIdKey, Accumulation> {
+public class AccumulatorMap extends ConcurrentHashMap<ScopedConnectionIdKey, Accumulation> {
 }

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/traffic/source/TrafficStreamLimiter.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/traffic/source/TrafficStreamLimiter.java
@@ -2,9 +2,12 @@ package org.opensearch.migrations.replay.traffic.source;
 
 import lombok.AllArgsConstructor;
 import lombok.Lombok;
+import lombok.NonNull;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
+import org.opensearch.migrations.tracing.commoncontexts.IHttpTransactionContext;
 
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.LinkedTransferQueue;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -13,18 +16,17 @@ import java.util.function.Consumer;
 @Slf4j
 public class TrafficStreamLimiter implements AutoCloseable {
 
-
     @AllArgsConstructor
     public static class WorkItem {
-        private final Consumer<WorkItem> task;
+        private final @NonNull Consumer<WorkItem> task;
+        private final IHttpTransactionContext context;
         private final int cost;
     }
-
 
     public final Semaphore liveTrafficStreamCostGate;
     private final LinkedTransferQueue<WorkItem> workQueue;
     private final Thread consumerThread;
-    private AtomicBoolean stopped;
+    private final AtomicBoolean stopped;
 
     public TrafficStreamLimiter(int maxConcurrentCost) {
         this.liveTrafficStreamCostGate = new Semaphore(maxConcurrentCost);
@@ -32,6 +34,10 @@ public class TrafficStreamLimiter implements AutoCloseable {
         this.stopped = new AtomicBoolean();
         this.consumerThread = new Thread(this::consumeFromQueue, "requestFeederThread");
         this.consumerThread.start();
+    }
+
+    public boolean isStopped() {
+        return stopped.get();
     }
 
     @SneakyThrows
@@ -44,22 +50,23 @@ public class TrafficStreamLimiter implements AutoCloseable {
                     .log();
             liveTrafficStreamCostGate.acquire(workItem.cost);
             log.atDebug().setMessage(()->"Acquired liveTrafficStreamCostGate (available=" +
-                    liveTrafficStreamCostGate.availablePermits()+")").log();
+                    liveTrafficStreamCostGate.availablePermits()+") to process " + workItem.context).log();
             workItem.task.accept(workItem);
         }
     }
 
-    public WorkItem queueWork(int cost, Consumer<WorkItem> task) {
-        var workItem = new WorkItem(task, cost);
+    public WorkItem queueWork(int cost, IHttpTransactionContext context, @NonNull Consumer<WorkItem> task) {
+        var workItem = new WorkItem(task, context, cost);
         var rval = workQueue.offer(workItem);
         assert rval;
         return workItem;
     }
 
-    public void doneProcessing(WorkItem workItem) {
+    public void doneProcessing(@NonNull WorkItem workItem) {
         liveTrafficStreamCostGate.release(workItem.cost);
-        log.atDebug().setMessage(()->"released "+workItem.cost+
-                " liveTrafficStreamCostGate.availablePermits="+liveTrafficStreamCostGate.availablePermits()).log();
+        log.atDebug().setMessage(()->"released " + workItem.cost +
+                " liveTrafficStreamCostGate.availablePermits=" + liveTrafficStreamCostGate.availablePermits() +
+                " for " + workItem.context).log();
     }
 
     @Override

--- a/TrafficCapture/trafficReplayer/src/main/resources/log4j2.properties
+++ b/TrafficCapture/trafficReplayer/src/main/resources/log4j2.properties
@@ -2,7 +2,7 @@ status = error
 
 property.tupleDir = ${env:TUPLE_DIR_PATH:-./logs/tuples}
 
-appenders = console, ReplayerLogFile, OUTPUT_TUPLES, TRANSACTION_SUMMARIES
+appenders = console, ReplayerLogFile, OUTPUT_TUPLES, TRANSACTION_SUMMARIES, TRANSACTION_SUMMARIES_LOGFILE
 
 appender.console.type = Console
 appender.console.name = STDERR
@@ -10,21 +10,15 @@ appender.console.target = SYSTEM_ERR
 appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = [%-5level] %d{yyyy-MM-dd HH:mm:ss,SSS}{UTC} [%t] %c{1} - %msg%equals{ ctx=%mdc}{ ctx={}}{}%n
 
-appender.TRANSACTION_SUMMARIES.type = Console
-appender.TRANSACTION_SUMMARIES.name = TRANSACTION_SUMMARIES
-appender.TRANSACTION_SUMMARIES.target = SYSTEM_OUT
-appender.TRANSACTION_SUMMARIES.layout.type = PatternLayout
-appender.TRANSACTION_SUMMARIES.layout.pattern = %d{yyyy-MM-dd HH:mm:ss,SSS}{UTC}: %msg%n
-
 appender.ReplayerLogFile.type = RollingFile
 appender.ReplayerLogFile.name = ReplayerLogFile
 appender.ReplayerLogFile.fileName = logs/replayer.log
-appender.ReplayerLogFile.filePattern = logs/$${date:yyyy-MM}{UTC}/replayer-%d{yyyy-MM-dd-HH-mm}-%i.log.gz
+appender.ReplayerLogFile.filePattern = logs/%d{yyyy-MM}{UTC}/replayer-%d{yyyy-MM-dd-HH-mm}{UTC}-%i.log
 appender.ReplayerLogFile.layout.type = PatternLayout
 appender.ReplayerLogFile.layout.pattern = [%-5level] %d{yyyy-MM-dd HH:mm:ss,SSS}{UTC} [%t] %c{1} - %msg%equals{ ctx=%mdc}{ ctx={}}{}%n
 appender.ReplayerLogFile.policies.type = Policies
 appender.ReplayerLogFile.policies.time.type = TimeBasedTriggeringPolicy
-appender.ReplayerLogFile.policies.time.interval = 15
+appender.ReplayerLogFile.policies.time.interval = 60
 appender.ReplayerLogFile.policies.time.modulate = true
 appender.ReplayerLogFile.strategy.type = DefaultRolloverStrategy
 appender.ReplayerLogFile.strategy.max = 288
@@ -40,7 +34,26 @@ appender.OUTPUT_TUPLES.policies.size.type = SizeBasedTriggeringPolicy
 appender.OUTPUT_TUPLES.policies.size.size = 10 MB
 appender.OUTPUT_TUPLES.strategy.type = DefaultRolloverStrategy
 
-rootLogger.level = info
+appender.TRANSACTION_SUMMARIES.type = Console
+appender.TRANSACTION_SUMMARIES.name = TransactionSummariesConsole
+appender.TRANSACTION_SUMMARIES.target = SYSTEM_OUT
+appender.TRANSACTION_SUMMARIES.layout.type = PatternLayout
+appender.TRANSACTION_SUMMARIES.layout.pattern = %d{yyyy-MM-dd HH:mm:ss,SSS}{UTC}: %msg%n
+
+appender.TRANSACTION_SUMMARIES_LOGFILE.type = RollingFile
+appender.TRANSACTION_SUMMARIES_LOGFILE.name = TransactionSummariesFile
+appender.TRANSACTION_SUMMARIES_LOGFILE.fileName = logs/progress.log
+appender.TRANSACTION_SUMMARIES_LOGFILE.filePattern = logs/%d{yyyy-MM}{UTC}/progress-%d{yyyy-MM-dd-HH-mm}{UTC}-%i.log.gz
+appender.TRANSACTION_SUMMARIES_LOGFILE.layout.type = PatternLayout
+appender.TRANSACTION_SUMMARIES_LOGFILE.layout.pattern = %d{yyyy-MM-dd HH:mm:ss,SSS}{UTC}: %msg%n
+appender.TRANSACTION_SUMMARIES_LOGFILE.policies.type = Policies
+appender.TRANSACTION_SUMMARIES_LOGFILE.policies.time.type = TimeBasedTriggeringPolicy
+appender.TRANSACTION_SUMMARIES_LOGFILE.policies.time.interval = 60
+appender.TRANSACTION_SUMMARIES_LOGFILE.policies.time.modulate = true
+appender.TRANSACTION_SUMMARIES_LOGFILE.strategy.type = DefaultRolloverStrategy
+appender.TRANSACTION_SUMMARIES_LOGFILE.strategy.max = 720
+
+rootLogger.level = trace
 rootLogger.appenderRef.STDERR.ref = STDERR
 rootLogger.appenderRef.ReplayerLogFile.ref = ReplayerLogFile
 
@@ -51,4 +64,5 @@ logger.OutputTupleJsonLogger.appenderRef.OUTPUT_TUPLES.ref = OUTPUT_TUPLES
 
 logger.TransactionSummaryLogger.name = TransactionSummaryLogger
 logger.TransactionSummaryLogger.level = info
-logger.TransactionSummaryLogger.appenderRef.TRANSACTION_SUMMARIES.ref = TRANSACTION_SUMMARIES
+logger.TransactionSummaryLogger.appenderRef.TRANSACTION_SUMMARIES.ref = TransactionSummariesConsole
+logger.TransactionSummaryLogger.appenderRef.TRANSACTION_SUMMARIES_LOGFILE.ref = TransactionSummariesFile

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/ExhaustiveCapturedTrafficToHttpTransactionAccumulatorTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/ExhaustiveCapturedTrafficToHttpTransactionAccumulatorTest.java
@@ -62,13 +62,6 @@ public class ExhaustiveCapturedTrafficToHttpTransactionAccumulatorTest extends I
         );
     }
 
-    private static String renderLeftToTest(HashSet<Integer> possibilitiesLeftToTest) {
-        return possibilitiesLeftToTest.size() + ": " +
-                possibilitiesLeftToTest.stream().map(c-> ExhaustiveTrafficStreamGenerator.classificationToString(c))
-                        .sorted()
-                        .collect(Collectors.joining("\n"));
-    }
-
     @ParameterizedTest(name="{0}.{1}")
     @MethodSource("generateTestCombinations")
     public void testAccumulatedSplit(String testName, int cutPoint,

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/HttpByteBufFormatterTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/HttpByteBufFormatterTest.java
@@ -27,23 +27,31 @@ public class HttpByteBufFormatterTest {
 
     final static String SAMPLE_REQUEST_STRING =
             "GET / HTTP/1.1\r\n" +
-                    "Connection: Keep-Alive\r\n" +
                     "Host: localhost\r\n" +
+                    "Connection: Keep-Alive\r\n" +
                     "User-Agent: UnitTest\r\n" +
                     "\r\n";
 
     final static String SAMPLE_REQUEST_AS_BLOCKS = "[G],[E],[T],[ ],[/],[ ],[H],[T],[T],[P],[/],[1],[.],[1],[\r" +
             "],[\n" +
-            "],[C],[o],[n],[n],[e],[c],[t],[i],[o],[n],[:],[ ],[K],[e],[e],[p],[-],[A],[l],[i],[v],[e],[\r" +
-            "],[\n" +
             "],[H],[o],[s],[t],[:],[ ],[l],[o],[c],[a],[l],[h],[o],[s],[t],[\r" +
+            "],[\n" +
+            "],[C],[o],[n],[n],[e],[c],[t],[i],[o],[n],[:],[ ],[K],[e],[e],[p],[-],[A],[l],[i],[v],[e],[\r" +
             "],[\n" +
             "],[U],[s],[e],[r],[-],[A],[g],[e],[n],[t],[:],[ ],[U],[n],[i],[t],[T],[e],[s],[t],[\r" +
             "],[\n" +
             "],[\r" +
             "],[\n" +
             "]";
+
     final static String SAMPLE_REQUEST_AS_PARSED_HTTP = "GET / HTTP/1.1\n" +
+            "Host: localhost\n" +
+            "Connection: Keep-Alive\n" +
+            "User-Agent: UnitTest\n" +
+            "content-length: 0\n" +
+            "\n";
+
+    final static String SAMPLE_REQUEST_AS_PARSED_HTTP_SORTED = "GET / HTTP/1.1\n" +
             "Connection: Keep-Alive\n" +
             "Host: localhost\n" +
             "User-Agent: UnitTest\n" +
@@ -147,11 +155,17 @@ public class HttpByteBufFormatterTest {
                         throw new IllegalStateException("Unknown BufferContent value: " + content);
                 }
             case PARSED_HTTP:
+            case PARSED_HTTP_SORTED_HEADERS:
                 switch (content) {
                     case Empty:
                         return "[NULL]";
                     case SimpleGetRequest:
-                        return SAMPLE_REQUEST_AS_PARSED_HTTP;
+                    switch (format) {
+                        case PARSED_HTTP:
+                            return SAMPLE_REQUEST_AS_PARSED_HTTP;
+                        case PARSED_HTTP_SORTED_HEADERS:
+                            return SAMPLE_REQUEST_AS_PARSED_HTTP_SORTED;
+                    }
                     default:
                         throw new IllegalStateException("Unknown BufferContent value: " + content);
                 }

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/ResultsToLogsConsumerTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/ResultsToLogsConsumerTest.java
@@ -20,7 +20,6 @@ import org.apache.logging.log4j.core.appender.AbstractAppender;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.ResourceLock;
-import org.opensearch.migrations.replay.datahandlers.NettyPacketToHttpConsumerTest;
 import org.opensearch.migrations.replay.datatypes.HttpRequestTransformationStatus;
 import org.opensearch.migrations.replay.datatypes.PojoTrafficStreamKeyAndContext;
 import org.opensearch.migrations.replay.datatypes.TransformedPackets;
@@ -36,6 +35,20 @@ class ResultsToLogsConsumerTest extends InstrumentationTest {
     private static final String NODE_ID = "n";
     private static final ObjectMapper mapper = new ObjectMapper();
     public static final String TEST_EXCEPTION_MESSAGE = "TEST_EXCEPTION";
+
+    public final static String EXPECTED_RESPONSE_STRING =
+            "HTTP/1.1 200 OK\r\n" +
+                    "Content-transfer-encoding: chunked\r\n" +
+                    "Date: Thu, 08 Jun 2023 23:06:23 GMT\r\n" + // This should be OK since it's always the same length
+                    "Transfer-encoding: chunked\r\n" +
+                    "Content-type: text/plain\r\n" +
+                    "Funtime: checkIt!\r\n" +
+                    "\r\n" +
+                    "1e\r\n" +
+                    "I should be decrypted tester!\n" +
+                    "\r\n" +
+                    "0\r\n" +
+                    "\r\n";
 
     @Override
     protected TestContext makeInstrumentationContext() {
@@ -252,7 +265,7 @@ class ResultsToLogsConsumerTest extends InstrumentationTest {
                 0, 0);
         var rawRequestData = loadResourceAsBytes("/requests/raw/" + requestResourceName);
         sourcePair.addRequestData(Instant.EPOCH, rawRequestData);
-        var rawResponseData = NettyPacketToHttpConsumerTest.EXPECTED_RESPONSE_STRING.getBytes(StandardCharsets.UTF_8);
+        var rawResponseData = EXPECTED_RESPONSE_STRING.getBytes(StandardCharsets.UTF_8);
         sourcePair.addResponseData(Instant.EPOCH, rawResponseData);
 
         var targetRequest = new TransformedPackets();

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/SimpleCapturedTrafficToHttpTransactionAccumulatorTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/SimpleCapturedTrafficToHttpTransactionAccumulatorTest.java
@@ -83,8 +83,9 @@ public class SimpleCapturedTrafficToHttpTransactionAccumulatorTest extends Instr
     @MethodSource("loadSimpleCombinations")
     void generateAndTest(String testName, int bufferSize, int skipCount,
                          List<ObservationDirective> directives, List<Integer> expectedSizes) throws Exception {
-        var trafficStreams = Arrays.stream(TrafficStreamGenerator.makeTrafficStream(bufferSize, 0, new AtomicInteger(),
-                directives, rootContext)).skip(skipCount);
+        final var trafficStreamsArray = TrafficStreamGenerator.makeTrafficStream(bufferSize, 0, new AtomicInteger(),
+                directives, rootContext);
+        var trafficStreams = Arrays.stream(trafficStreamsArray).skip(skipCount);
         List<RequestResponsePacketPair> reconstructedTransactions = new ArrayList<>();
         AtomicInteger requestsReceived = new AtomicInteger(0);
         accumulateTrafficStreamsWithNewAccumulator(rootContext, trafficStreams, reconstructedTransactions,

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/TrafficReplayerTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/TrafficReplayerTest.java
@@ -2,6 +2,7 @@ package org.opensearch.migrations.replay;
 
 import com.google.protobuf.ByteString;
 import com.google.protobuf.Timestamp;
+import io.netty.handler.logging.LogLevel;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Assertions;
@@ -18,6 +19,7 @@ import org.opensearch.migrations.trafficcapture.protos.ReadObservation;
 import org.opensearch.migrations.trafficcapture.protos.TrafficObservation;
 import org.opensearch.migrations.trafficcapture.protos.TrafficStream;
 import org.opensearch.migrations.trafficcapture.protos.WriteObservation;
+import org.slf4j.event.Level;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -195,6 +197,9 @@ class TrafficReplayerTest extends InstrumentationTest {
                 try (var trafficSource = new InputStreamOfTraffic(rootContext, bais)) {
                     tr.pullCaptureFromSourceToAccumulator(trafficSource, trafficAccumulator);
                 }
+                trafficAccumulator.close();
+                tr.waitForRemainingWork(Level.INFO, Duration.ofSeconds(10));
+                log.info("done waiting");
             }
             Assertions.assertEquals(1, byteArrays.size());
             Assertions.assertTrue(byteArrays.stream().allMatch(ba -> ba.size() == 2));

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/datahandlers/NettyPacketToHttpConsumerTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/datahandlers/NettyPacketToHttpConsumerTest.java
@@ -195,7 +195,6 @@ public class NettyPacketToHttpConsumerTest extends InstrumentationTest {
             var reqCtx = rootContext.getTestConnectionRequestContext(1);
             var nphc = new NettyPacketToHttpConsumer(clientConnectionPool
                     .buildConnectionReplaySession(reqCtx.getChannelKeyContext()), reqCtx);
-            //nphc.consumeBytes("\r\n{\"\": \"\"}\r\n".getBytes(StandardCharsets.UTF_8));
             nphc.consumeBytes("\r\nbadrequest\r\n".getBytes(StandardCharsets.UTF_8));
             var result = nphc.finalizeRequest().get(Duration.ofSeconds(4));
 

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/e2etests/KafkaRestartingTrafficReplayerTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/e2etests/KafkaRestartingTrafficReplayerTest.java
@@ -22,6 +22,7 @@ import org.opensearch.migrations.replay.kafka.KafkaTrafficCaptureSource;
 import org.opensearch.migrations.replay.traffic.source.ISimpleTrafficCaptureSource;
 import org.opensearch.migrations.replay.traffic.source.ITrafficStreamWithKey;
 import org.opensearch.migrations.testutils.SimpleNettyHttpServer;
+import org.opensearch.migrations.testutils.WrapWithNettyLeakDetection;
 import org.opensearch.migrations.tracing.InstrumentationTest;
 import org.opensearch.migrations.tracing.TestContext;
 import org.opensearch.migrations.trafficcapture.protos.TrafficStream;
@@ -44,6 +45,7 @@ import java.util.stream.Stream;
 
 @Slf4j
 @Testcontainers(disabledWithoutDocker = true)
+@WrapWithNettyLeakDetection(disableLeakChecks = true)
 @Tag("requiresDocker")
 public class KafkaRestartingTrafficReplayerTest extends InstrumentationTest {
     public static final int INITIAL_STOP_REPLAYER_REQUEST_COUNT = 1;

--- a/TrafficCapture/trafficReplayer/src/testFixtures/java/org/opensearch/migrations/replay/TestHttpServerContext.java
+++ b/TrafficCapture/trafficReplayer/src/testFixtures/java/org/opensearch/migrations/replay/TestHttpServerContext.java
@@ -50,5 +50,4 @@ public class TestHttpServerContext {
                 "Content-Length", ""+payloadBytes.length);
         return new SimpleHttpResponse(headers, payloadBytes, "OK", 200);
     }
-
 }


### PR DESCRIPTION
### Description

* Put some protections around time windows.  The default lookahead timeout is now 300 seconds.  That value must be > the packet timeout value.  If the lookahead was < the packet timeout, we could be waiting for streams to be expired but never get to the end of those streams, holding work remaining to be completed, resulting in a deadlock.  Warnings are printed out to the user and exit is called if configured incorrectly.
* Be more careful about when the trafficStreamLimiter should consider work to have been completed.  Now that work is marked as done once the response is returned by the target.  That may put more memory pressure on the system by processing many tuples, some of which may be outstatnding/buffered while more traffic is accumulated from the buffered stream.  However, this allows work to continue which will also have a trickle-down effect to keep drawing messages from the stream so that connections will be closed or expired, preventing deadlock.
* TrafficReplayer::waitForRemainingWork() now waits for all of the queued work to complete before checking the TrafficReplayer's maps of all remaining work.  That gives the replayer's pending work a chance to gracefull finish after it was was backed up for concurrency/backpressure control to not swamp the targets.  Otherwise, the limiter would be terminated harshly and a number of requests would never be run.
* BacksideHttpWatcherHandler is a bit safer.  Now it will run the callback in cases that the Http message wasn't received due to an error.  The handler now extends SimpleChannelInboundHandler so that release will be called automatically after channelRead0 is called.
* Make the progress that's normally printed to stdout also print to a file that only contains those lines (progress.log).  Enhance those lines to print out a few more fields (the requests index, starting from 0 for the beginning of the process), the request and response sizes, and those values for both the source and target.  Now source/target values are emitted next to each other, delimited by '/'.  That makes for much less cognitive load when tailing the output.
* Dates on log directories shouldn't include "{UTC}" any more.  I'm not positive that they're right on edge conditions, but it's better than what was there before.
* Squash an obscure pair of netty memory leaks when a header field wasn't present in the parsed HTTP message that would result in the message not being properly released.
* Add the full requestId to a few more log messages.  This required me to rotate some messages from one class to a calling class, but it should accomplish the same effect.
* Tweak the behavior of the SimpleNettyHttpServer so that it can close connections when there was a failure.  
* Convert the NettyPacketToHttpConsumerTest to use the SimpleNettyHttpServer over the Sun backed one.  That's to better support the new test `testThatPeerResetTriggersFinalizeFuture`.  If doesn't send a malformed request in yet that will hang the server, but adjusting the body of the request to use 2 words rather than one word "badrequest" (yes, really, the HTTP state models for parsing can be really complex and specific).
* That same test, now that it's using the Netty server variant, no longer needs to worry about Date headers, which simplifies some of the logic... though it did require more careful handling to keep the headers in the correct order.
* Allow sorting headers in HttpByteBufFormatter.  Though nobody is using this today, in one incarnation of tests, it was being used & it seems that it could be a useful feature for other tests too.
* Explicitly disable memory leak checks for KafkaRestartingTrafficReplayerTest.  That was implicit before.


* Category: Operational Code Improvements
* Why these changes are required? To make it easier to diagnose bugs
* What is the old behavior before changes and new behavior after changes? It should be a little bit easier to find out where issues are happening in the system.  Some errors shouldn't be likely any more.

### Issues Resolved
https://opensearch.atlassian.net/browse/MIGRATIONS-1643

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]

### Check List
- [x] New functionality includes testing
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
