### PR TITLE
RFS can now take the source snapshot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,31 @@ __pycache__
 *.egg-info*
 .python-version
 logs
-test/opensearch-cluster-cdk/
+.vscode/
+
+# Build files
+plugins/opensearch/loggable-transport-netty4/.gradle/
+
 RFS/.gradle/
+RFS/bin/
 RFS/build/
+
+TrafficCapture/captureKafkaOffloader/bin/
+TrafficCapture/captureOffloader/bin/
+TrafficCapture/captureProtobufs/bin/
+TrafficCapture/coreUtilities/bin/
+TrafficCapture/nettyWireLogging/bin/
+TrafficCapture/replayerPlugins/jsonMessageTransformers/jsonJMESPathMessageTransformer/bin/
+TrafficCapture/replayerPlugins/jsonMessageTransformers/jsonJMESPathMessageTransformerProvider/bin/
+TrafficCapture/replayerPlugins/jsonMessageTransformers/jsonJoltMessageTransformer/bin/
+TrafficCapture/replayerPlugins/jsonMessageTransformers/jsonJoltMessageTransformerProvider/bin/
+TrafficCapture/replayerPlugins/jsonMessageTransformers/jsonMessageTransformerInterface/bin/
+TrafficCapture/replayerPlugins/jsonMessageTransformers/openSearch23PlusTargetTransformerProvider/bin/
+TrafficCapture/testUtilities/bin/
+TrafficCapture/trafficCaptureProxyServer/bin/
+TrafficCapture/trafficCaptureProxyServerTest/bin/
+TrafficCapture/trafficReplayer/bin/
+
+# CDK files from end-to-end testing
 opensearch-cluster-cdk/
+test/opensearch-cluster-cdk/

--- a/.gitignore
+++ b/.gitignore
@@ -16,21 +16,7 @@ RFS/.gradle/
 RFS/bin/
 RFS/build/
 
-TrafficCapture/captureKafkaOffloader/bin/
-TrafficCapture/captureOffloader/bin/
-TrafficCapture/captureProtobufs/bin/
-TrafficCapture/coreUtilities/bin/
-TrafficCapture/nettyWireLogging/bin/
-TrafficCapture/replayerPlugins/jsonMessageTransformers/jsonJMESPathMessageTransformer/bin/
-TrafficCapture/replayerPlugins/jsonMessageTransformers/jsonJMESPathMessageTransformerProvider/bin/
-TrafficCapture/replayerPlugins/jsonMessageTransformers/jsonJoltMessageTransformer/bin/
-TrafficCapture/replayerPlugins/jsonMessageTransformers/jsonJoltMessageTransformerProvider/bin/
-TrafficCapture/replayerPlugins/jsonMessageTransformers/jsonMessageTransformerInterface/bin/
-TrafficCapture/replayerPlugins/jsonMessageTransformers/openSearch23PlusTargetTransformerProvider/bin/
-TrafficCapture/testUtilities/bin/
-TrafficCapture/trafficCaptureProxyServer/bin/
-TrafficCapture/trafficCaptureProxyServerTest/bin/
-TrafficCapture/trafficReplayer/bin/
+TrafficCapture/**/bin/
 
 # CDK files from end-to-end testing
 opensearch-cluster-cdk/

--- a/RFS/README.md
+++ b/RFS/README.md
@@ -288,5 +288,5 @@ curl -X POST "localhost:9200/another_alias/_doc" -H "Content-Type: application/j
 
 ## How to set up an OS 2.11 Target Cluster
 
-I've only tested the scripts going from ES 6.8 to OS 2.11.  For my test target, I just spun up an Amazon OpenSearch Service 2.11 cluster with a master user/password combo and otherwise default settings.
+The only target cluster version this has been tested agains is OpenSearch 2.11.  For my test target, I just spun up an Amazon OpenSearch Service 2.11 cluster with a master user/password combo and otherwise default settings.
 

--- a/RFS/README.md
+++ b/RFS/README.md
@@ -2,7 +2,65 @@
 
 ## How to run
 
-### Set up your ES 6.8 Source Cluster
+RFS provides a number of different options for running it.  We'll look at some of them below.  
+
+### Using a local snapshot directory
+
+In this scenario, you have a local directory on disk containing the snapshot you want to migrate.  You'll supply the `--snapshot-dir` arg, but not the ones related to a source cluster (`--source-host`, `--source-username`, `--source-password`) or S3 (`--s3-local-dir`, `--s3-repo-uri`, `--s3-region`)
+
+```
+TARGET_HOST=<source cluster URL>
+TARGET_USERNAME=<master user name>
+TARGET_PASSWORD=<master password>
+
+gradle build
+
+gradle run --args='-n global_state_snapshot --snapshot-dir ./test-resources/snapshots/ES_6_8_Single -l /tmp/lucene_files --target-host $TARGET_HOST --target-username $TARGET_USERNAME --target-password $TARGET_PASSWORD -s es_6_8 -t os_2_11 --movement-type everything'
+```
+
+### Using an existing S3 snapshot
+
+In this scenario, you have an existing snapshot in S3 you want to migrate.  You'll supply the S3-related args (`--s3-local-dir`, `--s3-repo-uri`, `--s3-region`), but not the `--snapshot-dir` one or the ones related to a source cluster (`--source-host`, `--source-username`, `--source-password`).
+
+```
+S3_REPO_URI=<something like "s3://my-test-bucket/ES_6_8_Single/">
+S3_REGION=us-east-1
+
+TARGET_HOST=<source cluster URL>
+TARGET_USERNAME=<master user name>
+TARGET_PASSWORD=<master password>
+
+gradle build
+
+gradle run --args='-n global_state_snapshot --s3-local-dir /tmp/s3_files --s3-repo-uri $S3_REPO_URI --s3-region $S3_REGION -l /tmp/lucene_files --target-host $TARGET_HOST --target-username $TARGET_USERNAME --target-password $TARGET_PASSWORD -s es_6_8 -t os_2_11 --movement-type everything'
+```
+
+### Using an source cluster
+
+In this scenario, you have a source cluster, and don't yet have a snapshot.  RFS will need to first make a snapshot of your source cluster, send it to S3, and then begin reindexing.  In this scenario, you'll supply the source cluster-related args (`--source-host`, `--source-username`, `--source-password`) and the S3-related args (`--s3-local-dir`, `--s3-repo-uri`, `--s3-region`), but not the `--snapshot-dir` one.
+
+```
+SOURCE_HOST=<source cluster URL>
+SOURCE_USERNAME=<master user name>
+SOURCE_PASSWORD=<master password>
+
+S3_REPO_URI=<something like "s3://my-test-bucket/ES_6_8_Single/">
+S3_REGION=us-east-1
+
+TARGET_HOST=<source cluster URL>
+TARGET_USERNAME=<master user name>
+TARGET_PASSWORD=<master password>
+
+gradle build
+
+gradle run --args='-n global_state_snapshot --source-host $SOURCE_HOST --source-username $SOURCE_USERNAME --source-password $SOURCE_PASSWORD --s3-local-dir /tmp/s3_files --s3-repo-uri $S3_REPO_URI --s3-region $S3_REGION -l /tmp/lucene_files --target-host $TARGET_HOST --target-username $TARGET_USERNAME --target-password $TARGET_PASSWORD -s es_6_8 -t os_2_11 --movement-type everything'
+```
+
+### Handling auth
+
+RFS currently supports both basic auth (username/password) and no auth for both the source and target clusters.  To use the no-auth approach, just neglect the username/password arguments.
+
+## How to set up an ES 6.8 Source Cluster w/ an attached debugger
 
 ```
 git clone git@github.com:elastic/elasticsearch.git
@@ -93,24 +151,142 @@ curl -X PUT "localhost:9200/_snapshot/fs_repository/global_state_snapshot?wait_f
   "ignore_unavailable": true,
   "include_global_state": true
 }'
-``` 
+```
 
-### Set up your OS 2.11 Target Cluster
+## How to set up an ES 7.10 Source Cluster running in Docker
+
+The `./docker` directory contains a Dockerfile for an ES 7.10 cluster, which you can use for testing.  You can run it like so:
+
+```
+(cd ./docker/TestSource_ES_7_10; docker build . -t es-w-s3)
+
+docker run -d \
+-p 9200:9200 \
+-e discovery.type=single-node \
+--name elastic-source \
+es-w-s3 \
+/bin/sh -c '/usr/local/bin/docker-entrypoint.sh eswrapper & wait -n'
+
+curl http://localhost:9200
+```
+
+### Providing AWS permissions for S3 snapshot creation
+
+While the container will have the `repository-s3` plugin installed out-of-the-box, to use it you'll need to provide AWS Credentials.  This plugin will either accept credential [from the Elasticsearch Keystore](https://www.elastic.co/guide/en/elasticsearch/plugins/7.10/repository-s3-client.html) or via the standard ENV variables (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and `AWS_SESSION_TOKEN`).  The issue w/ either approach in local testing is renewal of the timeboxed creds.  One possible solution is to use an IAM User, but that is generally frowned upon.  The approach we'll take here is to accept that the test cluster is temporary, so the creds can be as well.  Therefore, we can make an AWS IAM Role in our AWS Account with the creds it needs, assume it locally to generate the credential triple, and pipe that into the container using ENV variables.
+
+Start by making an AWS IAM Role (e.g. `arn:aws:iam::XXXXXXXXXXXX:role/testing-es-source-cluster-s3-access`) with S3 Full Access permissions in your AWS Account.  You can then get credentials with that identity good for up to one hour:
+
+```
+unset access_key && unset secret_key && unset session_token
+
+output=$(aws sts assume-role --role-arn "arn:aws:iam::XXXXXXXXXXXX:role/testing-es-source-cluster-s3-access" --role-session-name "ES-Source-Cluster")
+
+access_key=$(echo $output | jq -r .Credentials.AccessKeyId)
+secret_key=$(echo $output | jq -r .Credentials.SecretAccessKey)
+session_token=$(echo $output | jq -r .Credentials.SessionToken)
+```
+
+The one hour limit is annoying but workable, given the only thing it's needed for is creating the snapshot at the very start of the RFS process.  This is primarily driven by the fact that IAM limits session durations to one hour when the role is assumed via another role (e.g. role chaining).  If your original creds in the AWS keyring are from an IAM User, etc, then this might not be a restriction for you and you can have up to 12 hours with the assumed creds.  Ideas on how to improve this would be greatly appreciated.
+
+Anyways, you can then launch the container with those temporary credentials like so, using the :
+
+```
+docker run -d \
+-p 9200:9200 \
+-e discovery.type=single-node \
+-e AWS_ACCESS_KEY_ID=$access_key \
+-e AWS_SECRET_ACCESS_KEY=$secret_key \
+-e AWS_SESSION_TOKEN=$session_token \
+-v ~/.aws:/root/.aws:ro \
+--name elastic-source \
+es-w-s3
+```
+
+If you need to renew the creds, you can just kill the existing source container, renew the creds, and spin up a new container.
+
+```
+docker stop elastic-source; docker rm elastic-source
+```
+
+### Setting up the Cluster w/ some sample docs
+
+You can set up the cluster w/ some sample docs like so:
+
+```
+curl -X PUT "localhost:9200/_component_template/posts_template" -H "Content-Type: application/json" -d'
+{
+  "template": {
+    "mappings": {
+      "properties": {
+        "contents": { "type": "text" },
+        "author": { "type": "keyword" },
+        "tags": { "type": "keyword" }
+      }
+    }
+  }
+}'
+
+curl -X PUT "localhost:9200/_index_template/posts_index_template" -H "Content-Type: application/json" -d'
+{
+  "index_patterns": ["posts_*"],
+  "template": {
+    "settings": {
+      "number_of_shards": 1,
+      "number_of_replicas": 1
+    },
+    "aliases": {
+      "current_posts": {}
+    }
+  },
+  "composed_of": ["posts_template"]
+}'
+
+curl -X PUT "localhost:9200/posts_2023_02_25"
+
+curl -X POST "localhost:9200/current_posts/_doc" -H "Content-Type: application/json" -d'
+{
+  "contents": "This is a sample blog post content.",
+  "author": "Author Name",
+  "tags": ["Elasticsearch", "Tutorial"]
+}'
+
+curl -X PUT "localhost:9200/posts_2024_01_01" -H "Content-Type: application/json" -d'
+{
+  "aliases": {
+    "another_alias": {
+      "routing": "user123",
+      "filter": {
+        "term": {
+          "author": "Tobias Funke"
+        }
+      }
+    }
+  }
+}'
+
+curl -X POST "localhost:9200/another_alias/_doc" -H "Content-Type: application/json" -d'
+{
+  "contents": "How Elasticsearch helped my patients",
+  "author": "Tobias Funke",
+  "tags": ["Elasticsearch", "Tutorial"]
+}'
+
+curl -X POST "localhost:9200/another_alias/_doc" -H "Content-Type: application/json" -d'
+{
+  "contents": "My Time in the Blue Man Group",
+  "author": "Tobias Funke",
+  "tags": ["Lifestyle"]
+}'
+
+curl -X POST "localhost:9200/another_alias/_doc" -H "Content-Type: application/json" -d'
+{
+  "contents": "On the Importance of Word Choice",
+  "author": "Tobias Funke",
+  "tags": ["Lifestyle"]
+}'
+```
+
+## How to set up an OS 2.11 Target Cluster
 
 I've only tested the scripts going from ES 6.8 to OS 2.11.  For my test target, I just spun up an Amazon OpenSearch Service 2.11 cluster with a master user/password combo and otherwise default settings.
 
-### Run the scripts
-
-I've been running them VS Code integration, but you should be able to do it using their dedicated gradle commands as well.  That would look something like:
-
-```
-SNAPSHOT_DIR=/Users/chelma/workspace/ElasticSearch/elasticsearch/distribution/build/cluster/shared/repo
-LUCENE_DIR=/tmp/lucene_files
-HOSTNAME=<Amazon OpenSearch Domain URL>
-USERNAME=<Amazon OpenSearch Domain master user name>
-PASSWORD=<Amazon OpenSearch Domain master password>
-
-gradle build
-
-gradle run --args='-n global_state_snapshot --snapshot-dir $SNAPSHOT_DIR -l $LUCENE_DIR -h $HOSTNAME  -u $USERNAME -p $PASSWORD -s es_6_8 -t os_2_11 --movement-type everything'
-```

--- a/RFS/build.gradle
+++ b/RFS/build.gradle
@@ -12,17 +12,17 @@ repositories {
 
 dependencies {
     implementation 'com.beust:jcommander:1.81'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.16.2'
+    implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.16.2'
+    implementation 'com.fasterxml.jackson.core:jackson-annotations:2.16.2'
+    implementation 'com.fasterxml.jackson.core:jackson-core:2.16.2'
+    implementation 'io.netty:netty-codec-http:4.1.108.Final'
     implementation 'org.apache.logging.log4j:log4j-api:2.23.1'
     implementation 'org.apache.logging.log4j:log4j-core:2.23.1'
     implementation 'org.apache.lucene:lucene-core:8.11.3'
     implementation 'org.apache.lucene:lucene-analyzers-common:8.11.3'
     implementation 'org.apache.lucene:lucene-backward-codecs:8.11.3'
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.16.2'
-    implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.16.2'
-    implementation 'com.fasterxml.jackson.core:jackson-annotations:2.16.2'
-    implementation 'com.fasterxml.jackson.core:jackson-core:2.16.2'
     implementation 'software.amazon.awssdk:s3:2.25.16'
-    implementation 'io.netty:netty-codec-http:4.1.108.Final'
 }
 
 application {

--- a/RFS/docker/TestSource_ES_7_10/Dockerfile
+++ b/RFS/docker/TestSource_ES_7_10/Dockerfile
@@ -1,0 +1,20 @@
+FROM docker.elastic.co/elasticsearch/elasticsearch-oss:7.10.2
+
+# Install the S3 Repo Plugin
+RUN echo y | /usr/share/elasticsearch/bin/elasticsearch-plugin install repository-s3
+
+# Install the AWS CLI for testing purposes
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
+    unzip awscliv2.zip && \
+    ./aws/install
+
+# Install our custom entrypoint script
+COPY ./container-start.sh .
+
+# Configure Elastic
+ENV ELASTIC_SEARCH_CONFIG_FILE=/usr/share/elasticsearch/config/elasticsearch.yml
+# Prevents ES from complaining about nodes coun
+RUN echo "discovery.type: single-node" >> $ELASTIC_SEARCH_CONFIG_FILE
+ENV PATH=${PATH}:/usr/share/elasticsearch/jdk/bin/
+
+CMD /usr/share/elasticsearch/container-start.sh

--- a/RFS/docker/TestSource_ES_7_10/Dockerfile
+++ b/RFS/docker/TestSource_ES_7_10/Dockerfile
@@ -9,7 +9,7 @@ RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2
     ./aws/install
 
 # Install our custom entrypoint script
-COPY ./container-start.sh .
+COPY ./container-start.sh /usr/share/elasticsearch/container-start.sh
 
 # Configure Elastic
 ENV ELASTIC_SEARCH_CONFIG_FILE=/usr/share/elasticsearch/config/elasticsearch.yml

--- a/RFS/docker/TestSource_ES_7_10/container-start.sh
+++ b/RFS/docker/TestSource_ES_7_10/container-start.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+echo "Setting AWS Creds from ENV Variables"
+bin/elasticsearch-keystore create
+echo $AWS_ACCESS_KEY_ID | bin/elasticsearch-keystore add s3.client.default.access_key --stdin
+echo $AWS_SECRET_ACCESS_KEY | bin/elasticsearch-keystore add s3.client.default.secret_key --stdin
+
+if [ -n "$AWS_SESSION_TOKEN" ]; then
+    echo $AWS_SESSION_TOKEN | bin/elasticsearch-keystore add s3.client.default.session_token --stdin
+fi
+
+echo "Starting Elasticsearch"
+/usr/local/bin/docker-entrypoint.sh eswrapper

--- a/RFS/src/main/java/com/rfs/ReindexFromSnapshot.java
+++ b/RFS/src/main/java/com/rfs/ReindexFromSnapshot.java
@@ -23,7 +23,7 @@ public class ReindexFromSnapshot {
     private static final Logger logger = LogManager.getLogger(ReindexFromSnapshot.class);
 
     public static class Args {
-        @Parameter(names = {"-n", "--snapshot-name"}, description = "The name of the snapshot migrate", required = true)
+        @Parameter(names = {"-n", "--snapshot-name"}, description = "The name of the snapshot to migrate", required = true)
         public String snapshotName;
 
         @Parameter(names = {"--snapshot-dir"}, description = "The absolute path to the source snapshot directory on local disk", required = false)

--- a/RFS/src/main/java/com/rfs/ReindexFromSnapshot.java
+++ b/RFS/src/main/java/com/rfs/ReindexFromSnapshot.java
@@ -23,7 +23,7 @@ public class ReindexFromSnapshot {
     private static final Logger logger = LogManager.getLogger(ReindexFromSnapshot.class);
 
     public static class Args {
-        @Parameter(names = {"-n", "--snapshot-name"}, description = "The name of the snapshot to read", required = true)
+        @Parameter(names = {"-n", "--snapshot-name"}, description = "The name of the snapshot migrate", required = true)
         public String snapshotName;
 
         @Parameter(names = {"--snapshot-dir"}, description = "The absolute path to the source snapshot directory on local disk", required = false)
@@ -41,14 +41,23 @@ public class ReindexFromSnapshot {
         @Parameter(names = {"-l", "--lucene-dir"}, description = "The absolute path to the directory where we'll put the Lucene docs", required = true)
         public String luceneDirPath;
 
-        @Parameter(names = {"-h", "--target-host"}, description = "The target host and port (e.g. http://localhost:9200)", required = true)
+        @Parameter(names = {"--source-host"}, description = "The source host and port (e.g. http://localhost:9200)", required = false)
+        public String sourceHost = null;
+
+        @Parameter(names = {"--source-username"}, description = "The source username; if not provided, will assume no auth on source", required = false)
+        public String sourceUser = null;
+
+        @Parameter(names = {"--source-password"}, description = "The source password; if not provided, will assume no auth on source", required = false)
+        public String sourcePass = null;
+
+        @Parameter(names = {"--target-host"}, description = "The target host and port (e.g. http://localhost:9200)", required = true)
         public String targetHost;
 
-        @Parameter(names = {"-u", "--target-username"}, description = "The target username", required = true)
-        public String targetUser;
+        @Parameter(names = {"--target-username"}, description = "The target username; if not provided, will assume no auth on target", required = false)
+        public String targetUser = null;
 
-        @Parameter(names = {"-p", "--target-password"}, description = "The target password", required = true)
-        public String targetPass;
+        @Parameter(names = {"--target-password"}, description = "The target password; if not provided, will assume no auth on target", required = false)
+        public String targetPass = null;
 
         @Parameter(names = {"-s", "--source-version"}, description = "The source cluster's version (e.g. 'es_6_8')", required = true, converter = ClusterVersion.ArgsConverter.class)
         public ClusterVersion sourceVersion;
@@ -77,6 +86,9 @@ public class ReindexFromSnapshot {
         String s3RepoUri = arguments.s3RepoUri;
         String s3Region = arguments.s3Region;
         Path luceneDirPath = Paths.get(arguments.luceneDirPath);
+        String sourceHost = arguments.sourceHost;
+        String sourceUser = arguments.sourceUser;
+        String sourcePass = arguments.sourcePass;
         String targetHost = arguments.targetHost;
         String targetUser = arguments.targetUser;
         String targetPass = arguments.targetPass;
@@ -87,6 +99,7 @@ public class ReindexFromSnapshot {
 
         Logging.setLevel(logLevel);
 
+        ConnectionDetails sourceConnection = new ConnectionDetails(sourceHost, sourceUser, sourcePass);
         ConnectionDetails targetConnection = new ConnectionDetails(targetHost, targetUser, targetPass);
 
         // Should probably be passed in as an arguments
@@ -103,19 +116,50 @@ public class ReindexFromSnapshot {
             throw new IllegalArgumentException("Unsupported target version: " + sourceVersion);
         }
 
+        /*
+         * You have three options for providing the snapshot data
+         * 1. A local snapshot directory
+         * 2. A source host we'll take the snapshot from
+         * 3. An S3 URI of an existing snapshot in S3
+         * 
+         * If you provide the source host, you still need to provide the S3 URI, etc to write the snapshot to.
+         */
+        if (snapshotDirPath != null && (sourceHost != null || s3RepoUri != null)) {
+            throw new IllegalArgumentException("If you specify a local directory to take the snapshot from, you cannot specify a source host or S3 URI");
+        } else if (sourceHost != null && (s3RepoUri == null || s3Region == null || s3LocalDirPath == null)) {
+            throw new IllegalArgumentException("If you specify a source host, you must also specify the S3 details as well");
+        }
+
         SourceRepo repo;
         if (snapshotDirPath != null) {
             repo = new FilesystemRepo(snapshotDirPath);
         } else if (s3RepoUri != null && s3Region != null && s3LocalDirPath != null) {
             repo = new S3Repo(s3LocalDirPath, s3RepoUri, s3Region);
         } else {
-            throw new IllegalArgumentException("You must specify either a local snapshot directory or an S3 URI");
+            throw new IllegalArgumentException("Could not construct a source repo from the available, user-supplied arguments");
         }
 
         // Set the transformer
         Transformer transformer = TransformFunctions.getTransformer(sourceVersion, targetVersion, awarenessAttributeDimensionality);
 
         try {
+
+            if (sourceHost != null) {
+                // ==========================================================================================================
+                // Create the snapshot if necessary
+                // ==========================================================================================================            
+                logger.info("==================================================================");
+                logger.info("Attempting to create the snapshot...");
+                S3SnapshotCreator snapshotCreator = new S3SnapshotCreator(snapshotName, sourceConnection, s3RepoUri, s3Region);
+                snapshotCreator.registerRepo();
+                snapshotCreator.createSnapshot();
+                while (!snapshotCreator.isSnapshotFinished()) {
+                    logger.info("Snapshot not finished yet; sleeping for 5 seconds...");
+                    Thread.sleep(5000);
+                }
+                logger.info("Snapshot created successfully");
+            }
+
             // ==========================================================================================================
             // Read the Repo data file
             // ==========================================================================================================

--- a/RFS/src/main/java/com/rfs/common/ConnectionDetails.java
+++ b/RFS/src/main/java/com/rfs/common/ConnectionDetails.java
@@ -4,12 +4,28 @@ package com.rfs.common;
  * Stores the connection details (assuming basic auth) for an Elasticsearch/OpenSearch cluster
  */
 public class ConnectionDetails {
+    public static enum AuthType {
+        BASIC,
+        NONE
+    }
+
     public final String host;
     public final String username;
     public final String password;
+    public final AuthType authType;
 
     public ConnectionDetails(String host, String username, String password) {
         this.host = host; // http://localhost:9200
+
+        // If the username is provided, the password must be as well, and vice versa
+        if ((username == null && password != null) || (username != null && password == null)) {
+            throw new IllegalArgumentException("Both username and password must be provided, or neither");
+        } else if (username != null){
+            this.authType = AuthType.BASIC;
+        } else {
+            this.authType = AuthType.NONE;
+        }        
+
         this.username = username;
         this.password = password;
     }

--- a/RFS/src/main/java/com/rfs/common/S3SnapshotCreator.java
+++ b/RFS/src/main/java/com/rfs/common/S3SnapshotCreator.java
@@ -1,0 +1,152 @@
+package com.rfs.common;
+
+import java.net.HttpURLConnection;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+public class S3SnapshotCreator {
+    private static final Logger logger = LogManager.getLogger(S3SnapshotCreator.class);
+    private static final ObjectMapper mapper = new ObjectMapper();
+
+    private final ConnectionDetails connectionDetails;
+    private final String snapshotName;
+    private final String s3Uri;
+    private final String s3Region;
+
+    public S3SnapshotCreator(String snapshotName, ConnectionDetails connectionDetails, String s3Uri, String s3Region) {
+        this.snapshotName = snapshotName;
+        this.connectionDetails = connectionDetails;
+        this.s3Uri = s3Uri;
+        this.s3Region = s3Region;
+    }
+
+    public String getSnapshotName() {
+        return snapshotName;
+    }
+
+    /*
+     * Extracts the bucket name from the S3 URI
+     * s3://my-bucket-name/my-folder/my-nested-folder => my-bucket-name
+     */
+    public String getBucketName() {
+        return s3Uri.split("/")[2];
+    }
+
+    /*
+     * Extracts the base path from the S3 URI; could be nested arbitrarily deep
+     * s3://my-bucket-name/my-folder/my-nested-folder => my-folder/my-nested-folder
+     */
+    public String getBasePath() {
+        int thirdSlashIndex = s3Uri.indexOf('/', 5);
+        if (thirdSlashIndex == -1) {
+            // Nothing after the bucket name
+            return null;
+        }
+
+        // Extract everything after the third "/", excluding any final "/"
+        String rawBasePath = s3Uri.substring(thirdSlashIndex + 1);
+        if (rawBasePath.endsWith("/")) {
+            return rawBasePath.substring(0, rawBasePath.length() - 1);
+        } else {
+            return rawBasePath;
+        }
+    }
+
+    public void registerRepo() throws Exception {
+        // Assemble the REST path
+        String targetName = "_snapshot/s3_repo";
+
+        // Assemble the request body
+        ObjectNode settings = mapper.createObjectNode();
+        settings.put("bucket", getBucketName());
+        settings.put("region", s3Region);
+        settings.put("base_path", getBasePath());
+
+        ObjectNode body = mapper.createObjectNode();
+        body.put("type", "s3");
+        body.set("settings", settings);
+
+        // Register the repo; it's fine if it already exists
+        RestClient client = new RestClient(connectionDetails);
+        String bodyString = body.toString();
+        RestClient.Response response = client.put(targetName, bodyString, false);
+        if (response.code == HttpURLConnection.HTTP_OK) {
+            logger.info("S3 Repo registration successful");
+        } else {
+            logger.error("S3 Repo registration failed");
+            throw new RepoRegistrationFailed("s3_repo");
+        }
+    }
+
+    public void createSnapshot() throws Exception {
+        // Assemble the REST path
+        String targetName = "_snapshot/s3_repo/" + getSnapshotName();
+
+        // Assemble the request body
+        ObjectNode body = mapper.createObjectNode();
+        body.put("indices", "_all");
+        body.put("ignore_unavailable", true);
+        body.put("include_global_state", true);
+
+        // Register the repo; it's fine if it already exists
+        RestClient client = new RestClient(connectionDetails);
+        String bodyString = body.toString();
+        RestClient.Response response = client.put(targetName, bodyString, false);
+        if (response.code == HttpURLConnection.HTTP_OK) {
+            logger.info("Snapshot " + getSnapshotName() + " creation successful");
+        } else {
+            logger.error("Snapshot " + getSnapshotName() + " creation failed");
+            throw new SnapshotCreationFailed(getSnapshotName());
+        }
+    }
+
+    public boolean isSnapshotFinished() throws Exception {
+        // Assemble the REST path
+        String targetName = "_snapshot/s3_repo/" + getSnapshotName();
+
+        // Check if the snapshot has finished
+        RestClient client = new RestClient(connectionDetails);
+        RestClient.Response response = client.get(targetName, false);
+        if (response.code == HttpURLConnection.HTTP_NOT_FOUND) {
+            logger.error("Snapshot " + getSnapshotName() + " does not exist");
+            throw new SnapshotDoesNotExist(getSnapshotName());
+        }
+        JsonNode responseJson = mapper.readTree(response.body);
+        JsonNode firstSnapshot = responseJson.path("snapshots").get(0);
+        JsonNode stateNode = firstSnapshot.path("state");
+        String state = stateNode.asText();
+
+        if (state.equals("SUCCESS")) {
+            return true;
+        } else if (state.equals("IN_PROGRESS")) {
+            return false;
+        } else {
+            logger.error("Snapshot " + getSnapshotName() + " has failed");
+            throw new SnapshotCreationFailed(getSnapshotName());
+        }
+    }
+
+    public class RepoRegistrationFailed extends Exception {
+        public RepoRegistrationFailed(String repoName) {
+            super("Failed to register S3 repo " + repoName);
+        }
+    }
+
+    public class SnapshotCreationFailed extends Exception {
+        public SnapshotCreationFailed(String snapshotName) {
+            super("Failed to create snapshot " + snapshotName);
+        }
+    }
+
+    public class SnapshotDoesNotExist extends Exception {
+        public SnapshotDoesNotExist(String snapshotName) {
+            super("Snapshot " + snapshotName + " does not exist");
+        }
+    }
+    
+}

--- a/RFS/src/main/java/com/rfs/version_os_2_11/GlobalMetadataCreator_OS_2_11.java
+++ b/RFS/src/main/java/com/rfs/version_os_2_11/GlobalMetadataCreator_OS_2_11.java
@@ -137,11 +137,11 @@ public class GlobalMetadataCreator_OS_2_11 {
 
         // Confirm the index doesn't already exist, then create it
         RestClient client = new RestClient(connectionDetails);
-        int getResponseCode = client.get(path, true);
-        if (getResponseCode == HttpURLConnection.HTTP_NOT_FOUND) {
+        RestClient.Response response = client.get(path, true);
+        if (response.code == HttpURLConnection.HTTP_NOT_FOUND) {
             String bodyString = body.toString();
             client.put(path, bodyString, false);
-        } else if (getResponseCode == HttpURLConnection.HTTP_OK) {
+        } else if (response.code == HttpURLConnection.HTTP_OK) {
             logger.warn(entityName + " already exists. Skipping creation.");
         } else {
             logger.warn("Could not confirm that " + entityName + " does not already exist. Skipping creation.");

--- a/RFS/src/main/java/com/rfs/version_os_2_11/IndexCreator_OS_2_11.java
+++ b/RFS/src/main/java/com/rfs/version_os_2_11/IndexCreator_OS_2_11.java
@@ -32,11 +32,11 @@ public class IndexCreator_OS_2_11 {
 
         // Confirm the index doesn't already exist, then create it
         RestClient client = new RestClient(connectionDetails);
-        int getResponseCode = client.get(targetName, true);
-        if (getResponseCode == HttpURLConnection.HTTP_NOT_FOUND) {
+        RestClient.Response response = client.get(targetName, true);
+        if (response.code == HttpURLConnection.HTTP_NOT_FOUND) {
             String bodyString = body.toString();
             client.put(targetName, bodyString, false);
-        } else if (getResponseCode == HttpURLConnection.HTTP_OK) {
+        } else if (response.code == HttpURLConnection.HTTP_OK) {
             logger.warn("Index " + targetName + " already exists. Skipping creation.");
         } else {
             logger.warn("Could not confirm that index " + targetName + " does not already exist. Skipping creation.");


### PR DESCRIPTION
### Description
* Updated README with better instructions on how to set up and run, test
* Added the ability for the RFS script to take the source snapshot from an existing cluster
* Added a Dockerfile to use as a source cluster in local testing

### Issues Resolved
* https://opensearch.atlassian.net/browse/MIGRATIONS-1621

### Testing
* Tested manually snapshotting w/ the new Dockerfile as a source against an AOS 2.11 Domain target in own AWS Account
* Also manually confirmed that using a local directory or existing snapshot in S3 still works

### Check List
- [ ] New functionality includes testing
  - [ ] All tests pass, including unit test, integration test and doctest
- [X] New functionality has been documented
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
