### PR TITLE
Kafka printer improvements

### DIFF
--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/kafkaExport.sh
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/kafkaExport.sh
@@ -4,6 +4,8 @@ broker_endpoints="${MIGRATION_KAFKA_BROKER_ENDPOINTS}"
 msk_auth_settings=""
 kafka_command_settings=""
 s3_bucket_name=""
+partition_offsets=""
+partition_limits=""
 if [ -n "$ECS_AGENT_URI" ]; then
     msk_auth_settings="--kafka-traffic-enable-msk-auth"
     kafka_command_settings="--command-config aws/msk-iam-auth.properties"
@@ -25,7 +27,9 @@ usage() {
   echo "Options:"
   echo "  --timeout-seconds                           Timeout for how long process will try to collect the Kafka records. Default is 60 seconds."
   echo "  --enable-s3                                 Option to store created archive on S3."
-  echo "  --s3-bucket-name                            Option to specify a given S3 bucket to store archive on".
+  echo "  --s3-bucket-name                            Option to specify a given S3 bucket to store archive on."
+  echo "  --partition-offsets                         Option to specify partition offsets in the format 'partition_id:offset,partition_id:offset'."
+  echo "  --partition-limits                          Option to specify partition limits in the format 'partition_id:num_records,partition_id:num_records'."
   echo ""
   exit 1
 }
@@ -47,6 +51,16 @@ while [[ $# -gt 0 ]]; do
             shift
             shift
             ;;
+        --partition-offsets)
+            partition_offsets="$2"
+            shift
+            shift
+            ;;
+        --partition-limits)
+            partition_limits="$2"
+            shift
+            shift
+            ;;
         -h|--h|--help)
             usage
             ;;
@@ -60,6 +74,20 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
+if [ -n "$partition_offsets" ]; then
+    # Prepend the topic name to each partition offset
+    partition_offsets_with_topic=$(echo "$partition_offsets" | awk -v topic="$topic" 'BEGIN{RS=",";ORS=","}{print topic ":" $0}' | sed 's/,$//')
+else
+    partition_offsets_with_topic=""
+fi
+
+if [ -n "$partition_limits" ]; then
+    # Prepend the topic name to each partition limit
+    partition_limits_with_topic=$(echo "$partition_limits" | awk -v topic="$topic" 'BEGIN{RS=",";ORS=","}{print topic ":" $0}' | sed 's/,$//')
+else
+    partition_limits_with_topic=""
+fi
+
 partition_offsets=$(./kafka/bin/kafka-run-class.sh kafka.tools.GetOffsetShell --broker-list "$broker_endpoints" --topic "$topic" --time -1 $(echo "$kafka_command_settings"))
 comma_sep_partition_offsets=$(echo $partition_offsets | sed 's/ /,/g')
 echo "Collected offsets from current Kafka topic: "
@@ -68,17 +96,25 @@ echo $comma_sep_partition_offsets
 epoch_ts=$(date +%s)
 dir_name="kafka_export_$epoch_ts"
 mkdir -p $dir_name
-archive_name="kafka_export_from_migration_console_$epoch_ts.tar.gz"
+archive_name="kafka_export_from_migration_console_$epoch_ts.proto.gz"
 group="exportFromMigrationConsole_$(hostname -s)_$$_$epoch_ts"
 echo "Group name: $group"
 
-set -o xtrace
-./runJavaWithClasspath.sh org.opensearch.migrations.replay.KafkaPrinter --kafka-traffic-brokers "$broker_endpoints" --kafka-traffic-topic "$topic" --kafka-traffic-group-id "$group" $(echo "$msk_auth_settings") --timeout-seconds "$timeout_seconds" --partition-limits "$comma_sep_partition_offsets" --output-directory "./$dir_name"
-set +o xtrace
+# Construct the command dynamically
+runJavaCmd="./runJavaWithClasspath.sh org.opensearch.migrations.replay.KafkaPrinter --kafka-traffic-brokers \"$broker_endpoints\" --kafka-traffic-topic \"$topic\" --kafka-traffic-group-id \"$group\" $msk_auth_settings --timeout-seconds \"$timeout_seconds\""
 
-cd $dir_name
-tar -czvf "$archive_name" *.proto && rm *.proto
-cd ..
+if [ -n "$partition_offsets_with_topic" ]; then
+    runJavaCmd+=" --partition-offsets \"$partition_offsets_with_topic\""
+fi
+
+if [ -n "$partition_limits_with_topic" ]; then
+    runJavaCmd+=" --partition-limits \"$partition_limits_with_topic\""
+fi
+
+# Execute the command
+set -o xtrace
+eval $runJavaCmd | gzip -c -9 > "dir_name/$archive_name"
+set +o xtrace
 
 # Remove created consumer group
 ./kafka/bin/kafka-consumer-groups.sh --bootstrap-server "$broker_endpoints" --timeout 100000 --delete --group "$group" $(echo "$kafka_command_settings")

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/kafkaExport.sh
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/kafkaExport.sh
@@ -29,7 +29,7 @@ usage() {
   echo "  --enable-s3                                 Option to store created archive on S3."
   echo "  --s3-bucket-name                            Option to specify a given S3 bucket to store archive on."
   echo "  --partition-offsets                         Option to specify partition offsets in the format 'partition_id:offset,partition_id:offset'. Behavior defaults to using first offset in partition."
-  echo "  --partition-limits                          Option to specify number of records to print per partition in the format 'partition_id:num_records,partition_id:num_records'. Acts as a lower bound on records and will stop polling once all limits are hit."
+  echo "  --partition-limits                          Option to specify number of records to print per partition in the format 'partition_id:num_records,partition_id:num_records'."
   echo ""
   exit 1
 }
@@ -113,7 +113,7 @@ fi
 
 # Execute the command
 set -o xtrace
-eval $runJavaCmd | gzip -c -9 > "dir_name/$archive_name"
+eval "$runJavaCmd" | gzip -c -9 > "$dir_name/$archive_name"
 set +o xtrace
 
 # Remove created consumer group

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/kafkaExport.sh
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/kafkaExport.sh
@@ -28,8 +28,8 @@ usage() {
   echo "  --timeout-seconds                           Timeout for how long process will try to collect the Kafka records. Default is 60 seconds."
   echo "  --enable-s3                                 Option to store created archive on S3."
   echo "  --s3-bucket-name                            Option to specify a given S3 bucket to store archive on."
-  echo "  --partition-offsets                         Option to specify partition offsets in the format 'partition_id:offset,partition_id:offset'."
-  echo "  --partition-limits                          Option to specify partition limits in the format 'partition_id:num_records,partition_id:num_records'."
+  echo "  --partition-offsets                         Option to specify partition offsets in the format 'partition_id:offset,partition_id:offset'. Behavior defaults to using first offset in partition."
+  echo "  --partition-limits                          Option to specify number of records to print per partition in the format 'partition_id:num_records,partition_id:num_records'. Acts as a lower bound on records and will stop polling once all limits are hit."
   echo ""
   exit 1
 }
@@ -88,10 +88,10 @@ else
     partition_limits_with_topic=""
 fi
 
-partition_offsets=$(./kafka/bin/kafka-run-class.sh kafka.tools.GetOffsetShell --broker-list "$broker_endpoints" --topic "$topic" --time -1 $(echo "$kafka_command_settings"))
-comma_sep_partition_offsets=$(echo $partition_offsets | sed 's/ /,/g')
-echo "Collected offsets from current Kafka topic: "
-echo $comma_sep_partition_offsets
+all_consumers_partition_offsets=$(./kafka/bin/kafka-run-class.sh kafka.tools.GetOffsetShell --broker-list "$broker_endpoints" --topic "$topic" --time -1 $(echo "$kafka_command_settings"))
+comma_sep_all_consumers_partition_offsets="${all_consumers_partition_offsets// /,}"
+echo "Existing offsets from current Kafka topic across all consumer groups: "
+echo "$comma_sep_all_consumers_partition_offsets"
 
 epoch_ts=$(date +%s)
 dir_name="kafka_export_$epoch_ts"

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/kafkaExport.sh
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/kafkaExport.sh
@@ -88,6 +88,7 @@ else
     partition_limits_with_topic=""
 fi
 
+# Printing existing offsets in topic
 all_consumers_partition_offsets=$(./kafka/bin/kafka-run-class.sh kafka.tools.GetOffsetShell --broker-list "$broker_endpoints" --topic "$topic" --time -1 $(echo "$kafka_command_settings"))
 comma_sep_all_consumers_partition_offsets="${all_consumers_partition_offsets// /,}"
 echo "Existing offsets from current Kafka topic across all consumer groups: "


### PR DESCRIPTION
### Description
Updates the KafkaPrinter with the ability to take in a commit offset to start printing from per partition.
Updates the KafkaExport script to be able to provide the commit offsets and record limits per partition.
Updates the KafkaExport script to directly compress the kafkaPrinter output script instead of first writing the uncompressed output to disc.

Note: Unit tests are currently lacking for the kafkaPrinter. Will focus on usability enhancements first then add testing once we know what we need.

* Category: Enhancement
* Why these changes are required? Improved usability of the KafkaExport script.
* What is the old behavior before changes and new behavior after changes? KafkaExport script now can process more data with less disk space and has increased functionality with commit offsets and partition limits

### Issues Resolved
https://opensearch.atlassian.net/browse/MIGRATIONS-1642

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
Ran the script with various configurations in an ECS container and verified correct publishing through s3

### Check List
- [ ] New functionality includes testing
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [ x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
