### PR TITLE
Update release-drafter.yml to use subshell for traffic capture building

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -27,8 +27,7 @@ jobs:
       - name: Download Repo Tar
         run: |
           wget https://github.com/opensearch-project/opensearch-migrations/archive/refs/tags/${{ steps.get_data.outputs.version }}.tar.gz -O artifacts.tar.gz
-          cd TrafficCapture
-          ./gradlew publishMavenJavaPublicationToMavenRepository && tar -C build -cvf traffic-capture-artifacts.tar.gz repository
+          (cd TrafficCapture && ./gradlew publishMavenJavaPublicationToMavenRepository && tar -C build -cvf traffic-capture-artifacts.tar.gz repository)
       - name: Draft a release
         uses: softprops/action-gh-release@v1
         with:


### PR DESCRIPTION
### Description
Update release-drafter.yml to use subshell for traffic capture building
* Category: Bug Fix
* Why these changes are required? Fix release drafter action
* What is the old behavior before changes and new behavior after changes? Action would remain in TrafficCapture directory and not find the artifacts

### Issues Resolved
N/A

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
Tested build commands locally

### Check List
- [ ] New functionality includes testing
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
