### PR TITLE
Update release-drafter.yml artifact path

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -29,10 +29,10 @@ jobs:
           wget https://github.com/opensearch-project/opensearch-migrations/archive/refs/tags/${{ steps.get_data.outputs.version }}.tar.gz -O artifacts.tar.gz
           (cd TrafficCapture && ./gradlew publishMavenJavaPublicationToMavenRepository && tar -C build -cvf traffic-capture-artifacts.tar.gz repository)
       - name: Draft a release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           draft: true
           generate_release_notes: true
           files: |
-            - artifacts.tar.gz
-            - TrafficCapture/traffic-capture-artifacts.tar.gz
+            artifacts.tar.gz
+            TrafficCapture/traffic-capture-artifacts.tar.gz


### PR DESCRIPTION
### Description
Update release-drafter.yml artifact path to correctly include both source code and traffic capture jars.

Also updates softprops/action-gh-release to version 2 to comply with Node 16 EOL

* Category: New Feature
* Why these changes are required? Maven publishing
* What is the old behavior before changes and new behavior after changes? release workflow did not publish artifacts

### Issues Resolved

Is this a backport? If so, please add backport PR # and/or commits #

### Testing

### Check List
- [ ] New functionality includes testing
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
