### PR TITLE
Add snapshot publish and snapshot version property

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Download Repo Tar
         run: |
           wget https://github.com/opensearch-project/opensearch-migrations/archive/refs/tags/${{ steps.get_data.outputs.version }}.tar.gz -O artifacts.tar.gz
-          (cd TrafficCapture && ./gradlew publishMavenJavaPublicationToMavenRepository && tar -C build -cvf traffic-capture-artifacts.tar.gz repository)
+          (cd TrafficCapture && ./gradlew publishMavenJavaPublicationToMavenRepository -Dbuild.snapshot=false && tar -C build -cvf traffic-capture-artifacts.tar.gz repository)
       - name: Draft a release
         uses: softprops/action-gh-release@v2
         with:

--- a/TrafficCapture/build.gradle
+++ b/TrafficCapture/build.gradle
@@ -23,7 +23,33 @@ subprojects {
                     from components.java
 
                     group = 'org.opensearch.migrations.trafficcapture'
-                    version = '0.1.0-SNAPSHOT'
+                    version = '0.1.0'
+
+                    // support -Dbuild.snapshot=false, but default to true
+                    if (System.getProperty("build.snapshot", "true") == "true") {
+                        println "Add Snapshot"
+                        version += "-SNAPSHOT"
+                    }
+
+
+                    pom {
+                        name = project.name
+                        description = 'Everything opensearch migrations'
+                        url = 'http://github.com/opensearch-project/opensearch-migrations'
+
+                        licenses {
+                            license {
+                                name = 'The Apache License, Version 2.0'
+                                url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                            }
+                        }
+                        developers {
+                            developer {
+                                name = "OpenSearch"
+                                url = "https://github.com/opensearch-project/opensearch-migrations"
+                            }
+                        }
+                    }
 
                     // Suppress POM metadata warnings for test fixtures
                     suppressPomMetadataWarningsFor('testFixturesApiElements')
@@ -31,8 +57,10 @@ subprojects {
                 }
             }
             repositories {
+                maven { url = "${rootProject.buildDir}/repository"}
                 maven {
-                    url = "${rootProject.buildDir}/repository"
+                    url "https://aws.oss.sonatype.org/content/repositories/snapshots"
+                    name = 'staging'
                 }
             }
         }

--- a/TrafficCapture/build.gradle
+++ b/TrafficCapture/build.gradle
@@ -27,7 +27,6 @@ subprojects {
 
                     // support -Dbuild.snapshot=false, but default to true
                     if (System.getProperty("build.snapshot", "true") == "true") {
-                        println "Add Snapshot"
                         version += "-SNAPSHOT"
                     }
 


### PR DESCRIPTION
### Description
Add snapshot publish and snapshot version property
* Category: Enhancement
* Why these changes are required? Prereq for maven publishing
* What is the old behavior before changes and new behavior after changes? When `-Dbuild.snapshot=false` is provided, snapshot will not be included in the version tag.

### Issues Resolved
https://opensearch.atlassian.net/browse/MIGRATIONS-1606

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
Ran publish commands locally with and without `-Dbuild.snapshot=false` 

### Check List
- [ x] New functionality includes testing
  - [ x] All tests pass, including unit test, integration test and doctest
- [x ] New functionality has been documented
- [ x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
