### PR TITLE
Update Release Drafter and Traffic Capture to define a variable for publishing version based on tag

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -22,12 +22,13 @@ jobs:
           approvers: ${{ steps.get_data.outputs.approvers }}
           minimum-approvals: 2
           issue-title: 'Release opensearch-migrations version ${{ steps.get_data.outputs.version }}'
-          issue-body: "Please approve or deny the release of opensearch-migrations **TAG**: ${{ github.ref_name }}  **COMMIT**: ${{ github.sha }} **VERSION** : ${{ steps.get_data.outputs.version }} "
+          issue-body: "This release requires approval from at least two reviewers. Please approve or deny the release of opensearch-migrations **TAG**: ${{ github.ref_name }}  **COMMIT**: ${{ github.sha }} **VERSION**: ${{ steps.get_data.outputs.version }}. The published TrafficCapture version will be 0.${{ steps.get_data.outputs.version }}."
           exclude-workflow-initiator-as-approver: true
       - name: Download Repo Tar
+        # Preface Traffic Capture version with 0. to signal interface immaturity
         run: |
           wget https://github.com/opensearch-project/opensearch-migrations/archive/refs/tags/${{ steps.get_data.outputs.version }}.tar.gz -O artifacts.tar.gz
-          (cd TrafficCapture && ./gradlew publishMavenJavaPublicationToMavenRepository -Dbuild.snapshot=false && tar -C build -cvf traffic-capture-artifacts.tar.gz repository)
+          (cd TrafficCapture && ./gradlew publishMavenJavaPublicationToMavenRepository -Dbuild.snapshot=false -Dbuild.version=0.${{ steps.get_data.outputs.version }} && tar -C build -cvf traffic-capture-artifacts.tar.gz repository)
       - name: Draft a release
         uses: softprops/action-gh-release@v2
         with:

--- a/TrafficCapture/build.gradle
+++ b/TrafficCapture/build.gradle
@@ -35,7 +35,9 @@ subprojects {
 
 
                     group = 'org.opensearch.migrations.trafficcapture'
-                    version = '0.1.0'
+
+                    // support -Dbuild.version, but include default
+                    version = System.getProperty("build.version", "0.1.0")
 
                     // support -Dbuild.snapshot=false, but default to true
                     if (System.getProperty("build.snapshot", "true") == "true") {


### PR DESCRIPTION
### Description

Previously, the Traffic Capture maven artifacts were always published under version 0.1.0. Now, the version will be based on the cut tag with the preface of `0.` signaling the potential for class interface changes.
* Category: Enhancement
* Why these changes are required? In order to publish subsequent releases and release candidates, the version needs to be based on the tag
* What is the old behavior before changes and new behavior after changes? Version was hardcoded at 0.1.0, now it is configurable based on tag

### Issues Resolved
https://opensearch.atlassian.net/browse/MIGRATIONS-1606

Is this a backport? If so, please add backport PR # and/or commits #

### Testing

### Check List
- [ N/A ] New functionality includes testing
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
