### PR TITLE
Add ExitOnOutOfMemoryError to Docker JVM Options

### DIFF
--- a/TrafficCapture/buildSrc/src/main/groovy/org/opensearch/migrations/common/CommonUtils.groovy
+++ b/TrafficCapture/buildSrc/src/main/groovy/org/opensearch/migrations/common/CommonUtils.groovy
@@ -60,11 +60,12 @@ class CommonUtils {
             }
 
             copyFile("jars", "/jars")
+            def jvmParams = "-XX:MaxRAMPercentage=80.0 -XX:+ExitOnOutOfMemoryError"
             // can't set the environment variable from the runtimeClasspath because the Dockerfile is
             // constructed in the configuration phase and the classpath won't be realized until the
             // execution phase.  Therefore, we need to have docker run the command to resolve the classpath
             // and it's simplest to pack that up into a helper script.
-            runCommand("printf \"#!/bin/sh\\njava -XX:MaxRAMPercentage=80.0 -cp `echo /jars/*.jar | tr \\   :` \\\"\\\$@\\\" \" > /runJavaWithClasspath.sh");
+            runCommand("printf \"#!/bin/sh\\njava ${jvmParams} -cp `echo /jars/*.jar | tr \\   :` \\\"\\\$@\\\" \" > /runJavaWithClasspath.sh");
             runCommand("chmod +x /runJavaWithClasspath.sh")
             // container stay-alive
             defaultCommand('tail', '-f', '/dev/null')


### PR DESCRIPTION
### Description
Add ExitOnOutOfMemoryError flag to JVM Start
* Category: Bug Fix
* Why these changes are required? Currently, various code paths squash observed exceptions. This can cause unexpected behavior with OutOfMemoryError as threads may die in unexpected state and leave the system unrecoverable but running. This was the observed behavior in [MIGRATIONS-1626](https://opensearch.atlassian.net/browse/MIGRATIONS-1626). This change sets the JVM flag to kill the jvm on out of memory which will allow better visibility and recovery at the container level.
* What is the old behavior before changes and new behavior after changes? Replayer may continue running incorrectly after OutOfMemoryError, now replayer jvm will die. 

### Issues Resolved
[MIGRATIONS-1626](https://opensearch.atlassian.net/browse/MIGRATIONS-1626)

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
N/A, Adding common JVM Parameter

### Check List
- [ ] New functionality includes testing
  - [x ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [x ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
