### PR TITLE
Remove parallel test execution and mark long tests

### DIFF
--- a/TrafficCapture/build.gradle
+++ b/TrafficCapture/build.gradle
@@ -107,9 +107,8 @@ allprojects {
             exclude project.property('excludeTests')
         }
         useJUnitPlatform {
-            systemProperty 'junit.jupiter.execution.parallel.enabled', 'true'
-            systemProperty 'junit.jupiter.execution.parallel.mode.default', "concurrent"
-            systemProperty 'junit.jupiter.execution.parallel.mode.classes.default', 'concurrent'
+            //  Disable parallel test execution, see MIGRATIONS-1666
+            systemProperty 'junit.jupiter.execution.parallel.enabled', 'false'
         }
     }
 
@@ -124,11 +123,6 @@ allprojects {
     }
 
     task slowTest(type: Test) {
-        useJUnitPlatform {
-            // SlowTests currently use additional resource overhead, so halving core based parallelism
-            systemProperty 'junit.jupiter.execution.parallel.config.strategy', 'dynamic'
-            systemProperty 'junit.jupiter.execution.parallel.config.dynamic.factor', '0.5'
-        }
         systemProperty 'disableMemoryLeakTests', 'false'
         jacoco {
             enabled = true

--- a/TrafficCapture/trafficReplayer/build.gradle
+++ b/TrafficCapture/trafficReplayer/build.gradle
@@ -120,10 +120,3 @@ jar {
         attributes 'Main-Class': application.mainClass
     }
 }
-
-// TODO: Fix Parallel Execution for junit trafficReplayer tests
-//  with resourceSharing of TrafficReplayerRunner to eliminate forking and rely on threads
-slowTest {
-    forkEvery(1)
-    maxParallelForks = Runtime.runtime.availableProcessors()
-}

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/TrafficReplayerTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/TrafficReplayerTest.java
@@ -5,6 +5,7 @@ import com.google.protobuf.Timestamp;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.opensearch.migrations.replay.datatypes.ITrafficStreamKey;
 import org.opensearch.migrations.replay.tracing.IReplayContexts;
@@ -208,6 +209,7 @@ class TrafficReplayerTest extends InstrumentationTest {
     }
 
     @Test
+    @Tag("longTest")
     public void testCapturedReadsAfterCloseAreHandledAsNew() throws Exception {
     var uri = new URI("http://localhost:9200");
         try (var tr = new RootReplayerConstructorExtensions(rootContext,

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/datahandlers/NettyPacketToHttpConsumerTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/datahandlers/NettyPacketToHttpConsumerTest.java
@@ -139,6 +139,7 @@ public class NettyPacketToHttpConsumerTest extends InstrumentationTest {
         "true, false",
         "true, true"
     })
+    @Tag("longTest")
     public void testHttpResponseIsSuccessfullyCaptured(boolean useTls, boolean largeResponse) throws Exception {
         try (var testServer = createTestServer(useTls, largeResponse)) {
             for (int i = 0; i < 1; ++i) {
@@ -177,6 +178,7 @@ public class NettyPacketToHttpConsumerTest extends InstrumentationTest {
             "true, true"})
     @Tag("longTest")
     @WrapWithNettyLeakDetection(repetitions = 1)
+    @Tag("longTest")
     public void testThatPeerResetTriggersFinalizeFuture(boolean useTls, boolean withServerReadTimeout) throws Exception {
         final var RESPONSE_TIMEOUT_FOR_HUNG_TEST = Duration.ofMillis(500);
         testPeerResets(useTls, withServerReadTimeout, RESPONSE_TIMEOUT_FOR_HUNG_TEST,
@@ -248,6 +250,7 @@ public class NettyPacketToHttpConsumerTest extends InstrumentationTest {
         "true, false",
         "true, true"
     })
+    @Tag("longTest")
     public void testThatConnectionsAreKeptAliveAndShared(boolean useTls, boolean largeResponse)
             throws Exception {
         try (var testServer = SimpleNettyHttpServer.makeServer(useTls,
@@ -297,6 +300,7 @@ public class NettyPacketToHttpConsumerTest extends InstrumentationTest {
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     @WrapWithNettyLeakDetection(repetitions = 1)
+    @Tag("longTest")
     public void testMetricCountsFor_testThatConnectionsAreKeptAliveAndShared(boolean useTls) throws Exception {
         testThatConnectionsAreKeptAliveAndShared(useTls, false);
         Thread.sleep(200); // let metrics settle down

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/e2etests/FullReplayerWithTracingChecksTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/e2etests/FullReplayerWithTracingChecksTest.java
@@ -5,6 +5,7 @@ import com.google.protobuf.Timestamp;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.parallel.ResourceLock;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -50,6 +51,7 @@ public class FullReplayerWithTracingChecksTest extends FullTrafficReplayerTest {
     @ParameterizedTest
     @ValueSource(ints = {1, 2})
     @ResourceLock("TrafficReplayerRunner")
+    @Tag("longTest")
     public void testStreamWithRequestsWithCloseIsCommittedOnce(int numRequests) throws Throwable {
         var random = new Random(1);
         try (var httpServer = SimpleNettyHttpServer.makeServer(false, Duration.ofMinutes(10),

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/e2etests/FullTrafficReplayerTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/e2etests/FullTrafficReplayerTest.java
@@ -166,6 +166,7 @@ public class FullTrafficReplayerTest extends InstrumentationTest {
 
     @Test
     @ResourceLock("TrafficReplayerRunner")
+    @Tag("longTest")
     public void testSingleStreamWithCloseIsCommitted() throws Throwable {
         var random = new Random(1);
         try (var httpServer = SimpleNettyHttpServer.makeServer(false, Duration.ofMillis(2),

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/e2etests/SlowAndExpiredTrafficStreamBecomesTwoTargetChannelsTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/e2etests/SlowAndExpiredTrafficStreamBecomesTwoTargetChannelsTest.java
@@ -6,6 +6,7 @@ import io.opentelemetry.sdk.metrics.data.LongPointData;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.opensearch.migrations.replay.TimeShifter;
 import org.opensearch.migrations.replay.RootReplayerConstructorExtensions;
@@ -84,6 +85,7 @@ public class SlowAndExpiredTrafficStreamBecomesTwoTargetChannelsTest {
     }
 
     @Test
+    @Tag("longTest")
     public void test() throws Exception {
         TestContext rc = TestContext.withTracking(false, true);
         var responseTracker = new TrackingResponseBuilder(3);


### PR DESCRIPTION
### Description
We're seeing some intermittent test failures during parallel execution due. While we would like to make the tests robust to these timing differences, for the maturity of the project and for the meantime, seeking to disable parallel test execution. 

Also, marked some long running tests (> 2s per run) as longTest

* Category: Enhancement
* Why these changes are required? Test Reliablity
* What is the old behavior before changes and new behavior after changes? Tests would intermittently fail, now tests take ~30 seconds and run reliably

### Issues Resolved

[MIGRATIONS-1666](https://opensearch.atlassian.net/browse/MIGRATIONS-1666)

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
Ran on M1 Pro macbook, got build and test execution down to 29s https://gradle.com/s/6sybg3hsa6lry

### Check List
- [x ] New functionality includes testing
  - [x ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [ x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
