### PR TITLE
Simplify Netty RefCounting and ByteBuf Consumption

### DIFF
--- a/TrafficCapture/build.gradle
+++ b/TrafficCapture/build.gradle
@@ -12,6 +12,22 @@ allprojects {
 subprojects {
     apply plugin: 'java'
     apply plugin: 'maven-publish'
+
+    // TODO: Expand to do more static checking in more projects
+    if (project.name == "trafficReplayer" || project.name == "trafficCaptureProxyServer") {
+        dependencies {
+            annotationProcessor group: 'com.google.errorprone', name: 'error_prone_core', version: '2.26.1'
+        }
+        tasks.named('compileJava', JavaCompile) {
+            if (project.name == "trafficReplayer" || project.name == "trafficCaptureProxyServer") {
+                options.compilerArgs += [
+                        "-XDcompilePolicy=simple",
+                        "-Xplugin:ErrorProne -XepDisableAllChecks -Xep:MustBeClosed:ERROR -XepDisableWarningsInGeneratedCode",
+                ]
+            }
+        }
+    }
+
     task javadocJar(type: Jar, dependsOn: javadoc) {
         archiveClassifier.set('javadoc')
         from javadoc.destinationDir

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/HttpByteBufFormatter.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/HttpByteBufFormatter.java
@@ -95,9 +95,8 @@ public class HttpByteBufFormatter {
     public static String httpPacketsToPrettyPrintedString(HttpMessageType msgType, Stream<ByteBuf> byteBufStream,
         boolean sortHeaders, String lineDelimiter) {
         try(var messageHolder = RefSafeHolder.create(parseHttpMessageFromBufs(msgType, byteBufStream))) {
-            final Optional<HttpMessage> httpMessageOp = messageHolder.get();
-            if (httpMessageOp.isPresent()) {
-                var httpMessage = httpMessageOp.get();
+            final HttpMessage httpMessage = messageHolder.get();
+            if (httpMessage != null) {
                 if (httpMessage instanceof FullHttpRequest) {
                     return prettyPrintNettyRequest((FullHttpRequest) httpMessage, sortHeaders, lineDelimiter);
                 } else if (httpMessage instanceof FullHttpResponse) {

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/HttpByteBufFormatter.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/HttpByteBufFormatter.java
@@ -21,7 +21,7 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
-import org.opensearch.migrations.replay.util.ByteBufUtils;
+import org.opensearch.migrations.replay.util.NettyUtils;
 import org.opensearch.migrations.replay.util.RefSafeHolder;
 
 @Slf4j
@@ -70,7 +70,7 @@ public class HttpByteBufFormatter {
     public static String httpPacketBytesToString(HttpMessageType msgType, List<byte[]> byteArrs, String lineDelimiter) {
         // This isn't memory efficient,
         // but stringifying byte bufs through a full parse and reserializing them was already really slow!
-        try (var stream = ByteBufUtils.createCloseableByteBufStream(byteArrs)) {
+        try (var stream = NettyUtils.createCloseableByteBufStream(byteArrs)) {
             return httpPacketBufsToString(msgType, stream, lineDelimiter);
         }
     }

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/HttpByteBufFormatter.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/HttpByteBufFormatter.java
@@ -70,7 +70,7 @@ public class HttpByteBufFormatter {
     public static String httpPacketBytesToString(HttpMessageType msgType, List<byte[]> byteArrs, String lineDelimiter) {
         // This isn't memory efficient,
         // but stringifying byte bufs through a full parse and reserializing them was already really slow!
-        try (var stream = NettyUtils.createCloseableByteBufStream(byteArrs)) {
+        try (var stream = NettyUtils.createRefCntNeutralCloseableByteBufStream(byteArrs)) {
             return httpPacketBufsToString(msgType, stream, lineDelimiter);
         }
     }

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/HttpMessageAndTimestamp.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/HttpMessageAndTimestamp.java
@@ -1,6 +1,6 @@
 package org.opensearch.migrations.replay;
 
-import static org.opensearch.migrations.replay.util.ByteBufUtils.createCloseableByteBufStream;
+import static org.opensearch.migrations.replay.util.NettyUtils.createCloseableByteBufStream;
 
 import lombok.EqualsAndHashCode;
 import lombok.Getter;

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/HttpMessageAndTimestamp.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/HttpMessageAndTimestamp.java
@@ -1,7 +1,5 @@
 package org.opensearch.migrations.replay;
 
-import static org.opensearch.migrations.replay.util.NettyUtils.createCloseableByteBufStream;
-
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Lombok;
@@ -14,6 +12,7 @@ import java.io.IOException;
 import java.time.Instant;
 import java.util.Optional;
 import java.util.stream.Stream;
+import org.opensearch.migrations.replay.util.NettyUtils;
 
 @Slf4j
 @EqualsAndHashCode(exclude = "currentSegmentBytes")
@@ -66,7 +65,7 @@ public class HttpMessageAndTimestamp {
     }
 
     public String format(Optional<HttpByteBufFormatter.HttpMessageType> messageTypeOp) {
-        try (var bufStream = createCloseableByteBufStream(packetBytes)) {
+        try (var bufStream = NettyUtils.createRefCntNeutralCloseableByteBufStream(packetBytes)) {
             var packetBytesAsStr = messageTypeOp.map(mt-> HttpByteBufFormatter.httpPacketBytesToString(mt, packetBytes,
                     HttpByteBufFormatter.LF_LINE_DELIMITER))
                 .orElseGet(()-> HttpByteBufFormatter.httpPacketBufsToString(bufStream, Utils.MAX_PAYLOAD_SIZE_TO_PRINT));

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/ParsedHttpMessagesAsDicts.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/ParsedHttpMessagesAsDicts.java
@@ -16,7 +16,6 @@ import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.opensearch.migrations.replay.datatypes.TransformedPackets;
 import org.opensearch.migrations.replay.tracing.IReplayContexts;
-import org.opensearch.migrations.replay.tracing.IReplayContexts.ITupleHandlingContext;
 import org.opensearch.migrations.replay.util.RefSafeHolder;
 
 /**
@@ -82,7 +81,7 @@ public class ParsedHttpMessagesAsDicts {
                         .map(d -> convertRequest(context, d)));
     }
 
-    public ParsedHttpMessagesAsDicts(ITupleHandlingContext context,
+    public ParsedHttpMessagesAsDicts(IReplayContexts.ITupleHandlingContext context,
                                      Optional<Map<String, Object>> sourceRequestOp1,
                                      Optional<Map<String, Object>> sourceResponseOp2,
                                      Optional<Map<String, Object>> targetRequestOp3,

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/ParsedHttpMessagesAsDicts.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/ParsedHttpMessagesAsDicts.java
@@ -1,6 +1,6 @@
 package org.opensearch.migrations.replay;
 
-import static org.opensearch.migrations.replay.util.ByteBufUtils.createCloseableByteBufStream;
+import static org.opensearch.migrations.replay.util.NettyUtils.createCloseableByteBufStream;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.handler.codec.http.HttpHeaders;

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/ParsedHttpMessagesAsDicts.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/ParsedHttpMessagesAsDicts.java
@@ -134,9 +134,8 @@ public class ParsedHttpMessagesAsDicts {
             var map = new LinkedHashMap<String, Object>();
             try (var bufStream = createCloseableByteBufStream(data);
                 var messageHolder = RefSafeHolder.create(HttpByteBufFormatter.parseHttpRequestFromBufs(bufStream))) {
-                var messageOp = messageHolder.get();
-                if (messageOp.isPresent()) {
-                    var message = messageOp.get();
+                var message = messageHolder.get();
+                if (message != null) {
                     map.put("Request-URI", message.uri());
                     map.put("Method", message.method().toString());
                     map.put("HTTP-Version", message.protocolVersion().toString());
@@ -157,9 +156,8 @@ public class ParsedHttpMessagesAsDicts {
             var map = new LinkedHashMap<String, Object>();
             try (var bufStream = createCloseableByteBufStream(data);
                 var messageHolder = RefSafeHolder.create(HttpByteBufFormatter.parseHttpResponseFromBufs(bufStream))) {
-                var messageOp = messageHolder.get();
-                if (messageOp.isPresent()) {
-                    var message = messageOp.get();
+                var message = messageHolder.get();
+                if (message != null) {
                     map.put("HTTP-Version", message.protocolVersion());
                     map.put(STATUS_CODE_KEY, message.status().code());
                     map.put("Reason-Phrase", message.status().reasonPhrase());

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/ParsedHttpMessagesAsDicts.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/ParsedHttpMessagesAsDicts.java
@@ -1,7 +1,5 @@
 package org.opensearch.migrations.replay;
 
-import static org.opensearch.migrations.replay.util.NettyUtils.createCloseableByteBufStream;
-
 import io.netty.buffer.ByteBuf;
 import io.netty.handler.codec.http.HttpHeaders;
 import java.time.Duration;
@@ -16,6 +14,7 @@ import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.opensearch.migrations.replay.datatypes.TransformedPackets;
 import org.opensearch.migrations.replay.tracing.IReplayContexts;
+import org.opensearch.migrations.replay.util.NettyUtils;
 import org.opensearch.migrations.replay.util.RefSafeHolder;
 
 /**
@@ -132,7 +131,7 @@ public class ParsedHttpMessagesAsDicts {
                                                       @NonNull List<byte[]> data) {
         return makeSafeMap(context, () -> {
             var map = new LinkedHashMap<String, Object>();
-            try (var bufStream = createCloseableByteBufStream(data);
+            try (var bufStream = NettyUtils.createRefCntNeutralCloseableByteBufStream(data);
                 var messageHolder = RefSafeHolder.create(HttpByteBufFormatter.parseHttpRequestFromBufs(bufStream))) {
                 var message = messageHolder.get();
                 if (message != null) {
@@ -154,7 +153,7 @@ public class ParsedHttpMessagesAsDicts {
                                                        @NonNull List<byte[]> data, Duration latency) {
         return makeSafeMap(context, () -> {
             var map = new LinkedHashMap<String, Object>();
-            try (var bufStream = createCloseableByteBufStream(data);
+            try (var bufStream = NettyUtils.createRefCntNeutralCloseableByteBufStream(data);
                 var messageHolder = RefSafeHolder.create(HttpByteBufFormatter.parseHttpResponseFromBufs(bufStream))) {
                 var message = messageHolder.get();
                 if (message != null) {

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/SourceTargetCaptureTuple.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/SourceTargetCaptureTuple.java
@@ -54,7 +54,7 @@ public class SourceTargetCaptureTuple implements AutoCloseable {
             if (targetResponseDuration != null) { sj.add("targetResponseDuration=").add(targetResponseDuration+""); }
             Optional.ofNullable(targetRequestData).ifPresent(d-> sj.add("targetRequestData=")
                     .add(d.isClosed() ? "CLOSED" : HttpByteBufFormatter.httpPacketBufsToString(
-                            HttpByteBufFormatter.HttpMessageType.REQUEST, d.streamUnretained(), false, LF_LINE_DELIMITER)));
+                            HttpByteBufFormatter.HttpMessageType.REQUEST, d.streamUnretained(), LF_LINE_DELIMITER)));
             Optional.ofNullable(targetResponseData).filter(d->!d.isEmpty()).ifPresent(d -> sj.add("targetResponseData=")
                     .add(HttpByteBufFormatter.httpPacketBytesToString(HttpByteBufFormatter.HttpMessageType.RESPONSE, d, LF_LINE_DELIMITER)));
             sj.add("transformStatus=").add(transformationStatus+"");

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/util/ByteBufUtils.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/util/ByteBufUtils.java
@@ -1,0 +1,17 @@
+package org.opensearch.migrations.replay.util;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import java.util.Collection;
+
+import java.util.stream.Stream;
+
+public interface ByteBufUtils {
+    static Stream<ByteBuf> createCloseableByteBufStream(Stream<byte[]> byteArrStream) {
+        return RefSafeStreamUtils.refSafeMap(byteArrStream, Unpooled::wrappedBuffer);
+    }
+
+    static Stream<ByteBuf> createCloseableByteBufStream(Collection<byte[]> byteArrCollection) {
+        return createCloseableByteBufStream(byteArrCollection.stream());
+    }
+}

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/util/NettyUtils.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/util/NettyUtils.java
@@ -6,12 +6,14 @@ import java.util.Collection;
 
 import java.util.stream.Stream;
 
-public interface ByteBufUtils {
-    static Stream<ByteBuf> createCloseableByteBufStream(Stream<byte[]> byteArrStream) {
+public final class NettyUtils {
+    public static Stream<ByteBuf> createCloseableByteBufStream(Stream<byte[]> byteArrStream) {
         return RefSafeStreamUtils.refSafeMap(byteArrStream, Unpooled::wrappedBuffer);
     }
 
-    static Stream<ByteBuf> createCloseableByteBufStream(Collection<byte[]> byteArrCollection) {
+    public static Stream<ByteBuf> createCloseableByteBufStream(Collection<byte[]> byteArrCollection) {
         return createCloseableByteBufStream(byteArrCollection.stream());
     }
+
+    private NettyUtils() {}
 }

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/util/NettyUtils.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/util/NettyUtils.java
@@ -1,5 +1,6 @@
 package org.opensearch.migrations.replay.util;
 
+import com.google.errorprone.annotations.MustBeClosed;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import java.util.Collection;
@@ -7,10 +8,12 @@ import java.util.Collection;
 import java.util.stream.Stream;
 
 public final class NettyUtils {
+    @MustBeClosed
     public static Stream<ByteBuf> createCloseableByteBufStream(Stream<byte[]> byteArrStream) {
         return RefSafeStreamUtils.refSafeMap(byteArrStream, Unpooled::wrappedBuffer);
     }
 
+    @MustBeClosed
     public static Stream<ByteBuf> createCloseableByteBufStream(Collection<byte[]> byteArrCollection) {
         return createCloseableByteBufStream(byteArrCollection.stream());
     }

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/util/NettyUtils.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/util/NettyUtils.java
@@ -9,13 +9,13 @@ import java.util.stream.Stream;
 
 public final class NettyUtils {
     @MustBeClosed
-    public static Stream<ByteBuf> createCloseableByteBufStream(Stream<byte[]> byteArrStream) {
+    public static Stream<ByteBuf> createRefCntNeutralCloseableByteBufStream(Stream<byte[]> byteArrStream) {
         return RefSafeStreamUtils.refSafeMap(byteArrStream, Unpooled::wrappedBuffer);
     }
 
     @MustBeClosed
-    public static Stream<ByteBuf> createCloseableByteBufStream(Collection<byte[]> byteArrCollection) {
-        return createCloseableByteBufStream(byteArrCollection.stream());
+    public static Stream<ByteBuf> createRefCntNeutralCloseableByteBufStream(Collection<byte[]> byteArrCollection) {
+        return createRefCntNeutralCloseableByteBufStream(byteArrCollection.stream());
     }
 
     private NettyUtils() {}

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/util/RefSafeHolder.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/util/RefSafeHolder.java
@@ -1,5 +1,6 @@
 package org.opensearch.migrations.replay.util;
 
+import com.google.errorprone.annotations.MustBeClosed;
 import io.netty.util.ReferenceCountUtil;
 import javax.annotation.Nullable;
 
@@ -10,6 +11,7 @@ public class RefSafeHolder<T> implements AutoCloseable {
         this.resource = resource;
     }
 
+    @MustBeClosed
     static public <T> RefSafeHolder<T> create(@Nullable T resource) {
         return new RefSafeHolder<>(resource);
     }

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/util/RefSafeHolder.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/util/RefSafeHolder.java
@@ -1,7 +1,6 @@
 package org.opensearch.migrations.replay.util;
 
 import io.netty.util.ReferenceCountUtil;
-import java.util.Optional;
 import javax.annotation.Nullable;
 
 public class RefSafeHolder<T> implements AutoCloseable {
@@ -15,8 +14,8 @@ public class RefSafeHolder<T> implements AutoCloseable {
         return new RefSafeHolder<>(resource);
     }
 
-    public Optional<T> get() {
-        return Optional.ofNullable(resource);
+    public @Nullable T get() {
+        return resource;
     }
 
     @Override

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/util/RefSafeHolder.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/util/RefSafeHolder.java
@@ -1,0 +1,26 @@
+package org.opensearch.migrations.replay.util;
+
+import io.netty.util.ReferenceCountUtil;
+import java.util.Optional;
+import javax.annotation.Nullable;
+
+public class RefSafeHolder<T> implements AutoCloseable {
+    private final T resource;
+
+    private RefSafeHolder(@Nullable T resource) {
+        this.resource = resource;
+    }
+
+    static public <T> RefSafeHolder<T> create(@Nullable T resource) {
+        return new RefSafeHolder<>(resource);
+    }
+
+    public Optional<T> get() {
+        return Optional.ofNullable(resource);
+    }
+
+    @Override
+    public void close() {
+        ReferenceCountUtil.release(resource);
+    }
+}

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/util/RefSafeStreamUtils.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/util/RefSafeStreamUtils.java
@@ -17,5 +17,13 @@ public final class RefSafeStreamUtils {
         }).onClose(() -> refCountedTracker.forEach(ReferenceCounted::release));
     }
 
+    public static <T, R extends ReferenceCounted, U> U refSafeTransform(Stream<T> inputStream,
+        Function<T, R> transformCreatingReferenceTrackedObjects,
+        Function<Stream<R>, U> streamApplication) {
+        try (var mappedStream = refSafeMap(inputStream, transformCreatingReferenceTrackedObjects)) {
+            return streamApplication.apply(mappedStream);
+        }
+    }
+
     private RefSafeStreamUtils() {}
 }

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/util/RefSafeStreamUtils.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/util/RefSafeStreamUtils.java
@@ -1,0 +1,19 @@
+package org.opensearch.migrations.replay.util;
+
+import io.netty.util.ReferenceCounted;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+public interface RefSafeStreamUtils {
+    static <T, R extends ReferenceCounted> Stream<R> refSafeMap(Stream<T> inputStream,
+        Function<T, R> referenceTrackedMappingFunction) {
+        final Deque<R> refCountedTracker = new ArrayDeque<>();
+        return inputStream.map(t -> {
+            var resource = referenceTrackedMappingFunction.apply(t);
+            refCountedTracker.add(resource);
+            return resource;
+        }).onClose(() -> refCountedTracker.forEach(ReferenceCounted::release));
+    }
+}

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/util/RefSafeStreamUtils.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/util/RefSafeStreamUtils.java
@@ -1,5 +1,6 @@
 package org.opensearch.migrations.replay.util;
 
+import com.google.errorprone.annotations.MustBeClosed;
 import io.netty.util.ReferenceCounted;
 import java.util.ArrayDeque;
 import java.util.Deque;
@@ -7,6 +8,7 @@ import java.util.function.Function;
 import java.util.stream.Stream;
 
 public final class RefSafeStreamUtils {
+    @MustBeClosed
     public static <T, R extends ReferenceCounted> Stream<R> refSafeMap(Stream<T> inputStream,
         Function<T, R> referenceTrackedMappingFunction) {
         final Deque<R> refCountedTracker = new ArrayDeque<>();

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/util/RefSafeStreamUtils.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/util/RefSafeStreamUtils.java
@@ -6,8 +6,8 @@ import java.util.Deque;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
-public interface RefSafeStreamUtils {
-    static <T, R extends ReferenceCounted> Stream<R> refSafeMap(Stream<T> inputStream,
+public final class RefSafeStreamUtils {
+    public static <T, R extends ReferenceCounted> Stream<R> refSafeMap(Stream<T> inputStream,
         Function<T, R> referenceTrackedMappingFunction) {
         final Deque<R> refCountedTracker = new ArrayDeque<>();
         return inputStream.map(t -> {
@@ -16,4 +16,6 @@ public interface RefSafeStreamUtils {
             return resource;
         }).onClose(() -> refCountedTracker.forEach(ReferenceCounted::release));
     }
+
+    private RefSafeStreamUtils() {}
 }

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/HttpByteBufFormatterTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/HttpByteBufFormatterTest.java
@@ -146,7 +146,7 @@ public class HttpByteBufFormatterTest {
                                        HttpByteBufFormatter.HttpMessageType messageType,
                                        boolean usePooled) {
         var bbList = byteArrays.stream().map(b->TestUtilities.getByteBuf(b,usePooled)).collect(Collectors.toList());
-        var formattedString = HttpByteBufFormatter.httpPacketBufsToString(messageType, bbList.stream(), false);
+        var formattedString = HttpByteBufFormatter.httpPacketBufsToString(messageType, bbList.stream());
         bbList.forEach(bb->bb.release());
         return formattedString;
     }

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/HttpByteBufFormatterTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/HttpByteBufFormatterTest.java
@@ -1,6 +1,5 @@
 package org.opensearch.migrations.replay;
 
-import static org.opensearch.migrations.replay.util.RefSafeStreamUtils.refSafeTransform;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
@@ -8,6 +7,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.opensearch.migrations.replay.util.RefSafeStreamUtils;
 import org.opensearch.migrations.testutils.CountingNettyResourceLeakDetector;
 import org.opensearch.migrations.testutils.TestUtilities;
 import org.opensearch.migrations.testutils.WrapWithNettyLeakDetection;
@@ -146,7 +146,7 @@ public class HttpByteBufFormatterTest {
     private static String prettyPrintByteBufs(List<byte[]> byteArrays,
                                        HttpByteBufFormatter.HttpMessageType messageType,
                                        boolean usePooled) {
-        return refSafeTransform(byteArrays.stream(),
+        return RefSafeStreamUtils.refSafeTransform(byteArrays.stream(),
             b->TestUtilities.getByteBuf(b,usePooled),
             bbs -> HttpByteBufFormatter.httpPacketBufsToString(messageType, bbs));
 

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/RequestSenderOrchestratorTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/RequestSenderOrchestratorTest.java
@@ -1,5 +1,7 @@
 package org.opensearch.migrations.replay;
 
+import static org.opensearch.migrations.replay.util.NettyUtils.createCloseableByteBufStream;
+
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.handler.codec.http.FullHttpResponse;
@@ -16,7 +18,6 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
-import org.opensearch.migrations.replay.util.ByteBufUtils;
 import org.opensearch.migrations.replay.util.DiagnosticTrackableCompletableFuture;
 import org.opensearch.migrations.replay.util.RefSafeHolder;
 import org.opensearch.migrations.testutils.SimpleHttpServer;
@@ -68,7 +69,7 @@ class RequestSenderOrchestratorTest extends InstrumentationTest {
                 Assertions.assertNull(arr.error);
                 Assertions.assertTrue(arr.responseSizeInBytes > 0);
                 var packetBytesArr = arr.responsePackets.stream().map(SimpleEntry::getValue).collect(Collectors.toList());
-                try (var bufStream = ByteBufUtils.createCloseableByteBufStream(packetBytesArr);
+                try (var bufStream = createCloseableByteBufStream(packetBytesArr);
                     var messageHolder = RefSafeHolder.create(
                         HttpByteBufFormatter.parseHttpMessageFromBufs(HttpByteBufFormatter.HttpMessageType.RESPONSE,
                             bufStream))) {

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/RequestSenderOrchestratorTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/RequestSenderOrchestratorTest.java
@@ -1,7 +1,5 @@
 package org.opensearch.migrations.replay;
 
-import static org.opensearch.migrations.replay.util.NettyUtils.createCloseableByteBufStream;
-
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.handler.codec.http.FullHttpResponse;
@@ -19,6 +17,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.opensearch.migrations.replay.util.DiagnosticTrackableCompletableFuture;
+import org.opensearch.migrations.replay.util.NettyUtils;
 import org.opensearch.migrations.replay.util.RefSafeHolder;
 import org.opensearch.migrations.testutils.SimpleHttpServer;
 import org.opensearch.migrations.testutils.WrapWithNettyLeakDetection;
@@ -69,7 +68,7 @@ class RequestSenderOrchestratorTest extends InstrumentationTest {
                 Assertions.assertNull(arr.error);
                 Assertions.assertTrue(arr.responseSizeInBytes > 0);
                 var packetBytesArr = arr.responsePackets.stream().map(SimpleEntry::getValue).collect(Collectors.toList());
-                try (var bufStream = createCloseableByteBufStream(packetBytesArr);
+                try (var bufStream = NettyUtils.createRefCntNeutralCloseableByteBufStream(packetBytesArr);
                     var messageHolder = RefSafeHolder.create(
                         HttpByteBufFormatter.parseHttpMessageFromBufs(HttpByteBufFormatter.HttpMessageType.RESPONSE,
                             bufStream))) {

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/RequestSenderOrchestratorTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/RequestSenderOrchestratorTest.java
@@ -73,8 +73,9 @@ class RequestSenderOrchestratorTest extends InstrumentationTest {
                     var messageHolder = RefSafeHolder.create(
                         HttpByteBufFormatter.parseHttpMessageFromBufs(HttpByteBufFormatter.HttpMessageType.RESPONSE,
                             bufStream))) {
-                    Assertions.assertTrue(messageHolder.get().isPresent());
-                    var response = (FullHttpResponse) messageHolder.get().get();
+                    var message = messageHolder.get();
+                    Assertions.assertNotNull(message);
+                    var response = (FullHttpResponse) message;
                     Assertions.assertEquals(200, response.status().code());
                     var body = response.content();
                     Assertions.assertEquals(TestHttpServerContext.SERVER_RESPONSE_BODY_PREFIX +

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/RequestSenderOrchestratorTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/RequestSenderOrchestratorTest.java
@@ -1,27 +1,27 @@
 package org.opensearch.migrations.replay;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufHolder;
 import io.netty.buffer.Unpooled;
 import io.netty.handler.codec.http.FullHttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.AbstractMap.SimpleEntry;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.opensearch.migrations.replay.util.ByteBufUtils;
 import org.opensearch.migrations.replay.util.DiagnosticTrackableCompletableFuture;
+import org.opensearch.migrations.replay.util.RefSafeHolder;
 import org.opensearch.migrations.testutils.SimpleHttpServer;
 import org.opensearch.migrations.testutils.WrapWithNettyLeakDetection;
 import org.opensearch.migrations.tracing.InstrumentationTest;
-
-import java.nio.charset.StandardCharsets;
-import java.time.Duration;
-import java.time.Instant;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
 
 @Slf4j
 @WrapWithNettyLeakDetection(repetitions = 1)
@@ -67,18 +67,18 @@ class RequestSenderOrchestratorTest extends InstrumentationTest {
                 var arr = cf.get();
                 Assertions.assertNull(arr.error);
                 Assertions.assertTrue(arr.responseSizeInBytes > 0);
-                var httpMessage = HttpByteBufFormatter.parseHttpMessageFromBufs(HttpByteBufFormatter.HttpMessageType.RESPONSE,
-                        arr.responsePackets.stream().map(kvp -> Unpooled.wrappedBuffer(kvp.getValue())), false);
-                try {
-                    var response = (FullHttpResponse) httpMessage;
+                var packetBytesArr = arr.responsePackets.stream().map(SimpleEntry::getValue).collect(Collectors.toList());
+                try (var bufStream = ByteBufUtils.createCloseableByteBufStream(packetBytesArr);
+                    var messageHolder = RefSafeHolder.create(
+                        HttpByteBufFormatter.parseHttpMessageFromBufs(HttpByteBufFormatter.HttpMessageType.RESPONSE,
+                            bufStream))) {
+                    Assertions.assertTrue(messageHolder.get().isPresent());
+                    var response = (FullHttpResponse) messageHolder.get().get();
                     Assertions.assertEquals(200, response.status().code());
                     var body = response.content();
                     Assertions.assertEquals(TestHttpServerContext.SERVER_RESPONSE_BODY_PREFIX +
                                     TestHttpServerContext.getUriForIthRequest(i / NUM_REPEATS),
-                            new String(body.duplicate().toString(StandardCharsets.UTF_8)));
-                } finally {
-                    Optional.ofNullable((httpMessage instanceof ByteBufHolder) ? (ByteBufHolder) httpMessage : null)
-                            .ifPresent(bbh -> bbh.content().release());
+                        body.duplicate().toString(StandardCharsets.UTF_8));
                 }
             }
             closeFuture.get();

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/util/RefSafeStreamUtilsTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/util/RefSafeStreamUtilsTest.java
@@ -1,0 +1,119 @@
+package org.opensearch.migrations.replay.util;
+
+import io.netty.util.AbstractReferenceCounted;
+import io.netty.util.ReferenceCounted;
+
+import java.util.function.Predicate;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class RefSafeStreamUtilsTest {
+
+    @Test
+    void refSafeMap_shouldMapAndReleaseResources() {
+        Stream<String> inputStream = Stream.of("a", "b", "c");
+        
+        List<TestReferenceCounted> result;
+        try (Stream<TestReferenceCounted> mappedStream = RefSafeStreamUtils.refSafeMap(inputStream, TestReferenceCounted::new)) {
+            result = mappedStream.collect(Collectors.toList());
+        }
+        
+        assertEquals(3, result.size());
+        assertTrue(result.stream().allMatch(TestReferenceCounted::isReleased));
+    }
+
+    @Test
+    void refSafeTransform_shouldTransformAndReleaseResources() {
+        Stream<String> inputStream = Stream.of("a", "b", "c");
+
+        List<TestReferenceCounted> refCountedObjects = new ArrayList<>();
+        List<String> result = RefSafeStreamUtils.refSafeTransform(
+                inputStream,
+                value -> {
+                    TestReferenceCounted refCounted = new TestReferenceCounted(value);
+                    refCountedObjects.add(refCounted);
+                    return refCounted;
+                },
+                stream -> stream.map(TestReferenceCounted::getValue).collect(Collectors.toList())
+        );
+
+        assertEquals(List.of("a", "b", "c"), result);
+        assertTrue(refCountedObjects.stream().allMatch(TestReferenceCounted::isReleased));
+    }
+
+    @Test
+    void refSafeMap_shouldHandleExceptionDuringMapping() {
+        List<String> inputStreamConsumedObjects = new ArrayList<>();
+        Stream<String> inputStream = Stream.of("a", "b", "c", "d", "e")
+            .peek(inputStreamConsumedObjects::add);
+
+        List<TestReferenceCounted> refCountedObjects = new ArrayList<>();
+        assertThrows(RuntimeException.class, () -> {
+            try (Stream<TestReferenceCounted> mappedStream = RefSafeStreamUtils.refSafeMap(inputStream,
+                value -> {
+                    if (value.equals("d")) {
+                        throw new RuntimeException("Simulated exception");
+                    }
+                    TestReferenceCounted refCounted = new TestReferenceCounted(value);
+                    refCountedObjects.add(refCounted);
+                    return refCounted;
+                })) {
+                try {
+                    mappedStream.collect(Collectors.toList());
+                } finally {
+                    // Expect no release until try-with-resources close
+                    assertEquals(3, refCountedObjects.size());
+                    assertTrue(refCountedObjects.stream().allMatch(Predicate.not(TestReferenceCounted::isReleased)));
+                }
+            }
+        });
+        assertEquals(4, inputStreamConsumedObjects.size());
+        assertEquals(3, refCountedObjects.size());
+        assertTrue(refCountedObjects.stream().allMatch(TestReferenceCounted::isReleased));
+    }
+
+    private static class TestReferenceCounted extends AbstractReferenceCounted {
+        private final String value;
+        private boolean released;
+
+        TestReferenceCounted(String value) {
+            this.value = value;
+        }
+
+        String getValue() {
+            return value;
+        }
+
+        boolean isReleased() {
+            return released;
+        }
+
+        @Override
+        public boolean release() {
+            if (released) {
+                throw new AssertionError("TestReferenceCounted object released twice");
+            }
+            try {
+                return super.release();
+            } finally {
+                released = true;
+            }
+        }
+
+        @Override
+        protected void deallocate() {
+            // No-op
+        }
+
+        @Override
+        public ReferenceCounted touch(Object hint) {
+            return this;
+        }
+    }
+}


### PR DESCRIPTION
### Description
Previously, we relied on stream mapping to create the byte buffs with an assumption that no exception would occur in the stream mapping. There was some uncertainty regarding lazy processing of the stream, and overall it was difficult to reason with. 

This change seeks to simplify this behavior by introducing a helper method `ByteBufUtils::createCloseableByteBufStream` which constructs a byte buf stream from a collection of byte arrays that keeps track of the reference counted objects it creates and releases them upon the Stream:close which can be leveraged by try-with-resources constructs.

This change also adds in static semantic analysis with google checkerror `MustBeClosed`

* Category: Bug fix/Enhancement
* Why these changes are required? Simplifies tracking of RefCount bugs by streamlining management.
* What is the old behavior before changes and new behavior after changes? The new behavior is that the HttpByteBufFormatter is much more resilient to RefCount issues.

### Issues Resolved
[MIGRATIONS-1665](https://opensearch.atlassian.net/browse/MIGRATIONS-1665)

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
Unit Testing, deployed to AWS and tested with high throughput to verify no regressions in leaks or ref count issues. (Still seeing some with high load, but not seeing regressions due to this)

### Check List
- [x ] New functionality includes testing
  - [ x] All tests pass, including unit test, integration test and doctest
- [ x] New functionality has been documented
- [ x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
