### PR TITLE
[RFS] Make indexSuffix a parameter

### DIFF
--- a/RFS/src/main/java/com/rfs/ReindexFromSnapshot.java
+++ b/RFS/src/main/java/com/rfs/ReindexFromSnapshot.java
@@ -88,6 +88,9 @@ public class ReindexFromSnapshot {
 
         @Parameter(names = {"--log-level"}, description = "What log level you want.  Default: 'info'", required = false, converter = Logging.ArgsConverter.class)
         public Level logLevel = Level.INFO;
+
+        @Parameter(names = {"--index_suffix"}, description = "An optional suffix to add to index names as they're transfered. Default: none", required = false)
+        public String indexSuffix = "";
     }
 
     public static void main(String[] args) throws InterruptedException {
@@ -118,6 +121,7 @@ public class ReindexFromSnapshot {
         List<String> componentTemplateWhitelist = arguments.componentTemplateWhitelist;
         MovementType movementType = arguments.movementType;
         Level logLevel = arguments.logLevel;
+        String indexSuffix = arguments.indexSuffix;
 
         Logging.setLevel(logLevel);
 
@@ -297,7 +301,7 @@ public class ReindexFromSnapshot {
                 logger.info("==================================================================");
                 logger.info("Attempting to recreate the indices...");
                 for (IndexMetadata.Data indexMetadata : indexMetadatas) {
-                    String reindexName = indexMetadata.getName() + "_reindexed";
+                    String reindexName = indexMetadata.getName() + indexSuffix;
                     logger.info("Recreating index " + indexMetadata.getName() + " as " + reindexName + " on target...");
 
                     ObjectNode root = indexMetadata.toObjectNode();
@@ -355,7 +359,7 @@ public class ReindexFromSnapshot {
                         logger.info("Documents read successfully");
 
                         for (Document document : documents) {
-                            String targetIndex = indexMetadata.getName() + "_reindexed";
+                            String targetIndex = indexMetadata.getName() + indexSuffix;
                             DocumentReindexer.reindex(targetIndex, document, targetConnection);
                         }
                     }


### PR DESCRIPTION
### Description

* Category : Enhancement
* Why these changes are required?
* What is the old behavior before changes and new behavior after changes?
	* Previously all indices were suffixed with `_reindexed`. Now, they are 

### Issues Resolved
https://opensearch.atlassian.net/browse/MIGRATIONS-1672

### Testing
Manual testing

### Check List
- [ ] New functionality includes testing
  - [ ] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
