### PR TITLE
Updated RFS Docker Compose to handle AWS Creds; fix S3Repo bug

### DIFF
--- a/RFS/build.gradle
+++ b/RFS/build.gradle
@@ -38,6 +38,12 @@ dependencies {
     implementation 'org.apache.lucene:lucene-analyzers-common:8.11.3'
     implementation 'org.apache.lucene:lucene-backward-codecs:8.11.3'
     implementation 'software.amazon.awssdk:s3:2.25.16'
+
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.10.2'
+    testImplementation 'org.junit.jupiter:junit-jupiter-params:5.10.2'
+    testImplementation 'org.mockito:mockito-core:5.11.0'
+    testImplementation 'org.mockito:mockito-junit-jupiter:5.11.0'
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.10.2'
 }
 
 application {
@@ -111,3 +117,7 @@ task buildDockerImages {
 
 tasks.getByName('composeUp')
         .dependsOn(tasks.getByName('buildDockerImages'))
+
+test {
+    useJUnitPlatform()
+}

--- a/RFS/docker/docker-compose.yml
+++ b/RFS/docker/docker-compose.yml
@@ -8,6 +8,9 @@ services:
     environment:
       - discovery.type=single-node
       - path.repo=/snapshots
+      - AWS_ACCESS_KEY_ID=${access_key}
+      - AWS_SECRET_ACCESS_KEY=${secret_key}
+      - AWS_SESSION_TOKEN=${session_token}
     ports:
       - '19200:9200'
     volumes:

--- a/RFS/docker/docker-compose.yml
+++ b/RFS/docker/docker-compose.yml
@@ -26,6 +26,10 @@ services:
         condition: service_started
     networks:
       - migrations
+    environment:
+      - AWS_ACCESS_KEY_ID=${access_key}
+      - AWS_SECRET_ACCESS_KEY=${secret_key}
+      - AWS_SESSION_TOKEN=${session_token}
     volumes:
       - snapshotStorage:/snapshots
 

--- a/RFS/src/main/java/com/rfs/ReindexFromSnapshot.java
+++ b/RFS/src/main/java/com/rfs/ReindexFromSnapshot.java
@@ -159,7 +159,7 @@ public class ReindexFromSnapshot {
         if (snapshotDirPath != null) {
             repo = new FilesystemRepo(snapshotDirPath);
         } else if (s3RepoUri != null && s3Region != null && s3LocalDirPath != null) {
-            repo = new S3Repo(s3LocalDirPath, s3RepoUri, s3Region);
+            repo = S3Repo.create(s3LocalDirPath, s3RepoUri, s3Region);
         } else if (snapshotLocalRepoDirPath != null) {
             repo = new FilesystemRepo(snapshotLocalRepoDirPath);
         } else {

--- a/RFS/src/test/java/com/rfs/common/S3RepoTest.java
+++ b/RFS/src/test/java/com/rfs/common/S3RepoTest.java
@@ -1,0 +1,270 @@
+package com.rfs.common;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.api.Test;
+
+import org.mockito.Mockito;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import software.amazon.awssdk.core.sync.ResponseTransformer;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+
+@ExtendWith(MockitoExtension.class)
+public class S3RepoTest {
+    @Mock
+    private S3Client mockS3Client;
+    private TestableS3Repo testRepo;
+    private Path testDir = Paths.get("/fake/path");
+    private String testRegion = "us-fake-1";
+    private String testUri = "s3://bucket-name/directory";
+    private String testRepoFileName = "index-2";
+    private String testRepoFileUri = testUri + "/" + testRepoFileName;
+    
+
+    class TestableS3Repo extends S3Repo {
+        public TestableS3Repo(Path s3LocalDir, String s3RepoUri, String s3Region, S3Client s3Client) {
+            super(s3LocalDir, s3RepoUri, s3Region, s3Client);
+        }
+
+        @Override
+        protected void ensureS3LocalDirectoryExists(Path path) {
+            // Do nothing
+        }
+
+        @Override
+        protected String findRepoFileUri() {
+            return testRepoFileUri;
+        }
+    }
+
+    @BeforeEach
+    void setUp() {
+        testRepo = Mockito.spy(new TestableS3Repo(testDir, testUri, testRegion, mockS3Client));
+    }
+
+    @Test
+    void GetRepoRootDir_AsExpected() throws IOException {
+        // Run the test
+        Path filePath = testRepo.getRepoRootDir();
+
+        // Check the results
+        assertEquals(testDir, filePath);
+    }
+
+    @Test
+    void GetSnapshotRepoDataFilePath_AsExpected() throws IOException {
+        // Set up the test
+        Path expectedPath = testDir.resolve(testRepoFileName);
+        String expectedBucketName = testRepo.getS3BucketName();
+        String expectedKey = testRepo.getS3ObjectsPrefix() + "/" + testRepoFileName;
+
+        // Run the test
+        Path filePath = testRepo.getSnapshotRepoDataFilePath();
+
+        // Check the results
+        assertEquals(expectedPath, filePath);
+
+        Mockito.verify(testRepo, times(1)).ensureS3LocalDirectoryExists(expectedPath.getParent());
+
+        GetObjectRequest expectedRequest = GetObjectRequest.builder()
+            .bucket(expectedBucketName)
+            .key(expectedKey)
+            .build();
+
+        verify(mockS3Client).getObject(eq(expectedRequest), any(ResponseTransformer.class));
+    }
+
+
+    @Test
+    void GetGlobalMetadataFilePath_AsExpected() throws IOException {
+        // Set up the test
+        String snapshotId = "snapshot1";
+        String snapshotFileName = "meta-" + snapshotId + ".dat";
+        Path expectedPath = testDir.resolve(snapshotFileName);
+        String expectedBucketName = testRepo.getS3BucketName();
+        String expectedKey = testRepo.getS3ObjectsPrefix() + "/" + snapshotFileName;
+
+        // Run the test
+        Path filePath = testRepo.getGlobalMetadataFilePath(snapshotId);
+
+        // Check the results
+        assertEquals(expectedPath, filePath);
+
+        Mockito.verify(testRepo, times(1)).ensureS3LocalDirectoryExists(expectedPath.getParent());
+
+        GetObjectRequest expectedRequest = GetObjectRequest.builder()
+            .bucket(expectedBucketName)
+            .key(expectedKey)
+            .build();
+
+        verify(mockS3Client).getObject(eq(expectedRequest), any(ResponseTransformer.class));
+    }
+
+    @Test
+    void GetSnapshotMetadataFilePath_AsExpected() throws IOException {
+        // Set up the test
+        String snapshotId = "snapshot1";
+        String snapshotFileName = "snap-" + snapshotId + ".dat";
+        Path expectedPath = testDir.resolve(snapshotFileName);
+        String expectedBucketName = testRepo.getS3BucketName();
+        String expectedKey = testRepo.getS3ObjectsPrefix() + "/" + snapshotFileName;
+
+        // Run the test
+        Path filePath = testRepo.getSnapshotMetadataFilePath(snapshotId);
+
+        // Check the results
+        assertEquals(expectedPath, filePath);
+
+        Mockito.verify(testRepo, times(1)).ensureS3LocalDirectoryExists(expectedPath.getParent());
+
+        GetObjectRequest expectedRequest = GetObjectRequest.builder()
+            .bucket(expectedBucketName)
+            .key(expectedKey)
+            .build();
+
+        verify(mockS3Client).getObject(eq(expectedRequest), any(ResponseTransformer.class));
+    }
+
+    @Test
+    void GetIndexMetadataFilePath_AsExpected() throws IOException {
+        // Set up the test
+        String indexId = "123abc";
+        String indexFileId = "234bcd";
+        String indexFileName = "indices/" + indexId + "/meta-" + indexFileId + ".dat";
+        Path expectedPath = testDir.resolve(indexFileName);
+        String expectedBucketName = testRepo.getS3BucketName();
+        String expectedKey = testRepo.getS3ObjectsPrefix() + "/" + indexFileName;
+
+        // Run the test
+        Path filePath = testRepo.getIndexMetadataFilePath(indexId, indexFileId);
+
+        // Check the results
+        assertEquals(expectedPath, filePath);
+
+        Mockito.verify(testRepo, times(1)).ensureS3LocalDirectoryExists(expectedPath.getParent());
+
+        GetObjectRequest expectedRequest = GetObjectRequest.builder()
+            .bucket(expectedBucketName)
+            .key(expectedKey)
+            .build();
+
+        verify(mockS3Client).getObject(eq(expectedRequest), any(ResponseTransformer.class));
+    }
+
+    @Test
+    void GetShardDirPath_AsExpected() throws IOException {
+        // Set up the test
+        String indexId = "123abc";
+        int shardId = 7;
+        String shardDirName = "indices/" + indexId + "/" + shardId;
+        Path expectedPath = testDir.resolve(shardDirName);
+
+        // Run the test
+        Path filePath = testRepo.getShardDirPath(indexId, shardId);
+
+        // Check the results
+        assertEquals(expectedPath, filePath);
+    }
+
+    @Test
+    void GetShardMetadataFilePath_AsExpected() throws IOException {
+        // Set up the test
+        String snapshotId = "snapshot1";
+        String indexId = "123abc";
+        int shardId = 7;
+        String shardFileName = "indices/" + indexId + "/" + shardId + "/snap-" + snapshotId + ".dat";
+        Path expectedPath = testDir.resolve(shardFileName);
+        String expectedBucketName = testRepo.getS3BucketName();
+        String expectedKey = testRepo.getS3ObjectsPrefix() + "/" + shardFileName;
+
+        // Run the test
+        Path filePath = testRepo.getShardMetadataFilePath(snapshotId, indexId, shardId);
+
+        // Check the results
+        assertEquals(expectedPath, filePath);
+
+        Mockito.verify(testRepo, times(1)).ensureS3LocalDirectoryExists(expectedPath.getParent());
+
+        GetObjectRequest expectedRequest = GetObjectRequest.builder()
+            .bucket(expectedBucketName)
+            .key(expectedKey)
+            .build();
+
+        verify(mockS3Client).getObject(eq(expectedRequest), any(ResponseTransformer.class));
+    }
+
+    @Test
+    void GetBlobFilePath_AsExpected() throws IOException {
+        // Set up the test
+        String blobName = "bobloblaw";
+        String indexId = "123abc";
+        int shardId = 7;
+        String shardFileName = "indices/" + indexId + "/" + shardId + "/" + blobName;
+        Path expectedPath = testDir.resolve(shardFileName);
+        String expectedBucketName = testRepo.getS3BucketName();
+        String expectedKey = testRepo.getS3ObjectsPrefix() + "/" + shardFileName;
+
+        // Run the test
+        Path filePath = testRepo.getBlobFilePath(indexId, shardId, blobName);
+
+        // Check the results
+        assertEquals(expectedPath, filePath);
+
+        Mockito.verify(testRepo, times(1)).ensureS3LocalDirectoryExists(expectedPath.getParent());
+
+        GetObjectRequest expectedRequest = GetObjectRequest.builder()
+            .bucket(expectedBucketName)
+            .key(expectedKey)
+            .build();
+
+        verify(mockS3Client).getObject(eq(expectedRequest), any(ResponseTransformer.class));
+    }
+
+    static Stream<Arguments> provideUrisForBucketNames() {
+        return Stream.of(
+            Arguments.of("s3://bucket-name", "bucket-name"),
+            Arguments.of("s3://bucket-name/", "bucket-name"),
+            Arguments.of("s3://bucket-name/with/suffix", "bucket-name")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideUrisForBucketNames")
+    void getS3BucketName_AsExpected(String uri, String expectedBucketName) {
+        TestableS3Repo repo = new TestableS3Repo(testDir, uri, testRegion, mock(S3Client.class));
+        assertEquals(expectedBucketName, repo.getS3BucketName());
+    }
+
+    static Stream<Arguments> provideUrisForPrefixes() {
+        return Stream.of(
+            Arguments.of("s3://bucket-name", ""),
+            Arguments.of("s3://bucket-name/", ""),
+            Arguments.of("s3://bucket-name/with/suffix", "with/suffix"),
+            Arguments.of("s3://bucket-name/with/suffix/", "with/suffix")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideUrisForPrefixes")
+    void getS3ObjectsPrefix_AsExpected(String uri, String expectedPrefix) {
+        TestableS3Repo repo = new TestableS3Repo(testDir, uri, testRegion, mock(S3Client.class));
+        assertEquals(expectedPrefix, repo.getS3ObjectsPrefix());
+    }
+}


### PR DESCRIPTION
### Description
* Updated the DockerCompose file for RFS to accept AWS Creds for the containers
* Updated RFS README to explain how to leverage the new behavior
* Fixed a bug in the S3Repo class' handling of S3 URI's (it was failing to handle passing in the bucket root path as an acceptable repo location)
* Unit tested the S3Repo class

### Issues Resolved
Done while working on https://opensearch.atlassian.net/browse/MIGRATIONS-1600

### Testing
* Ran the new unit tests (`./gradlew tests`)
* Ran the RFS process from snapshot through reindexing using the docker compose setup

### Check List
- [X] New functionality includes testing
  - [X] All tests pass, including unit test, integration test and doctest
- [X] New functionality has been documented
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
