### PR TITLE
Downgrade aws-msk-iam-auth to latest good version (2.0.3)

### DIFF
--- a/TrafficCapture/captureKafkaOffloader/build.gradle
+++ b/TrafficCapture/captureKafkaOffloader/build.gradle
@@ -16,7 +16,7 @@ dependencies {
     implementation group: 'org.projectlombok', name:'lombok', version:'1.18.26'
     implementation group: 'org.apache.kafka', name:'kafka-clients', version:'3.6.0'
     implementation group: 'org.slf4j', name:'slf4j-api', version:'2.0.7'
-    implementation group: 'software.amazon.msk', name:'aws-msk-iam-auth', version:'1.1.9'
+    implementation group: 'software.amazon.msk', name:'aws-msk-iam-auth', version:'2.0.3'
 
     testImplementation project(':captureProtobufs')
     testImplementation testFixtures(project(path: ':coreUtilities'))

--- a/TrafficCapture/captureKafkaOffloader/build.gradle
+++ b/TrafficCapture/captureKafkaOffloader/build.gradle
@@ -16,7 +16,7 @@ dependencies {
     implementation group: 'org.projectlombok', name:'lombok', version:'1.18.26'
     implementation group: 'org.apache.kafka', name:'kafka-clients', version:'3.6.0'
     implementation group: 'org.slf4j', name:'slf4j-api', version:'2.0.7'
-    implementation group: 'software.amazon.msk', name:'aws-msk-iam-auth', version:'2.1.0'
+    implementation group: 'software.amazon.msk', name:'aws-msk-iam-auth', version:'1.1.9'
 
     testImplementation project(':captureProtobufs')
     testImplementation testFixtures(project(path: ':coreUtilities'))

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/Dockerfile
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/Dockerfile
@@ -11,7 +11,7 @@ RUN mkdir /root/kafka-tools/aws
 WORKDIR /root/kafka-tools
 # Get kafka distribution and unpack to 'kafka'
 RUN wget -qO- https://archive.apache.org/dist/kafka/3.6.0/kafka_2.13-3.6.0.tgz | tar --transform 's!^[^/]*!kafka!' -xvz
-RUN wget -O kafka/libs/msk-iam-auth.jar https://github.com/aws/aws-msk-iam-auth/releases/download/v1.1.9/aws-msk-iam-auth-1.1.9-all.jar
+RUN wget -O kafka/libs/msk-iam-auth.jar https://github.com/aws/aws-msk-iam-auth/releases/download/v2.0.3/aws-msk-iam-auth-2.0.3-all.jar
 WORKDIR /root
 
 # Add Traffic Replayer jars for running KafkaPrinter from this container

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/Dockerfile
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/Dockerfile
@@ -11,7 +11,7 @@ RUN mkdir /root/kafka-tools/aws
 WORKDIR /root/kafka-tools
 # Get kafka distribution and unpack to 'kafka'
 RUN wget -qO- https://archive.apache.org/dist/kafka/3.6.0/kafka_2.13-3.6.0.tgz | tar --transform 's!^[^/]*!kafka!' -xvz
-RUN wget -O kafka/libs/msk-iam-auth.jar https://github.com/aws/aws-msk-iam-auth/releases/download/v2.1.0/aws-msk-iam-auth-2.1.0-all.jar
+RUN wget -O kafka/libs/msk-iam-auth.jar https://github.com/aws/aws-msk-iam-auth/releases/download/v1.1.9/aws-msk-iam-auth-1.1.9-all.jar
 WORKDIR /root
 
 # Add Traffic Replayer jars for running KafkaPrinter from this container

--- a/TrafficCapture/trafficReplayer/build.gradle
+++ b/TrafficCapture/trafficReplayer/build.gradle
@@ -59,7 +59,7 @@ dependencies {
     implementation group: 'software.amazon.awssdk', name: 'auth', version: '2.20.102'
     implementation group: 'software.amazon.awssdk', name: 'sdk-core', version: '2.20.102'
     implementation group: 'software.amazon.awssdk', name: 'secretsmanager', version: '2.20.127'
-    implementation group: 'software.amazon.msk', name: 'aws-msk-iam-auth', version: '2.1.0'
+    implementation group: 'software.amazon.msk', name: 'aws-msk-iam-auth', version: '1.1.9'
     implementation 'org.apache.commons:commons-compress:1.26.0'
 
     testFixturesImplementation project(':replayerPlugins:jsonMessageTransformers:jsonMessageTransformerInterface')

--- a/TrafficCapture/trafficReplayer/build.gradle
+++ b/TrafficCapture/trafficReplayer/build.gradle
@@ -59,7 +59,7 @@ dependencies {
     implementation group: 'software.amazon.awssdk', name: 'auth', version: '2.20.102'
     implementation group: 'software.amazon.awssdk', name: 'sdk-core', version: '2.20.102'
     implementation group: 'software.amazon.awssdk', name: 'secretsmanager', version: '2.20.127'
-    implementation group: 'software.amazon.msk', name: 'aws-msk-iam-auth', version: '1.1.9'
+    implementation group: 'software.amazon.msk', name: 'aws-msk-iam-auth', version: '2.0.3'
     implementation 'org.apache.commons:commons-compress:1.26.0'
 
     testFixturesImplementation project(':replayerPlugins:jsonMessageTransformers:jsonMessageTransformerInterface')


### PR DESCRIPTION
### Description

The latest version of aws-msk-iam-auth has a bug that prevents it from correctly acquiring IAM credentials on an EC2 instance. This bug is documented in their GH (https://github.com/aws/aws-msk-iam-auth/issues/168) and a PR has been merged, but no release with this fix has been cut.

We are downgrading our version of this library to the latest without this bug (2.0.3), which has been tested and verified on one of our EC2 instances.

### Issues Resolved
n/a (but it's breaking the build on main)

### Testing
Manual testing

### Check List
- [ ] New functionality includes testing
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
