### PR TITLE
Fix final netty-codec-http 4.1.108 spot for Mend

### DIFF
--- a/TrafficCapture/dockerSolution/build.gradle
+++ b/TrafficCapture/dockerSolution/build.gradle
@@ -14,6 +14,11 @@ def calculateDockerHash = { projectName ->
 dependencies {
     implementation project(':trafficCaptureProxyServer')
     implementation project(':trafficReplayer')
+    constraints {
+        implementation('software.amazon.awssdk:secretsmanager:2.25.19') {
+            because 'mend security issue'
+        }
+    }
 }
 
 def dockerFilesForExternalServices = [

--- a/TrafficCapture/trafficCaptureProxyServer/build.gradle
+++ b/TrafficCapture/trafficCaptureProxyServer/build.gradle
@@ -46,6 +46,11 @@ dependencies {
     testImplementation group: 'org.testcontainers', name: 'kafka', version: '1.19.7'
     testImplementation group: 'org.testcontainers', name: 'testcontainers', version: '1.19.7'
     testImplementation group: 'org.testcontainers', name: 'toxiproxy', version: '1.19.7'
+    constraints {
+        testImplementation('org.apache.commons:commons-compress:1.26.0') {
+            because 'mend security issue'
+        }
+    }
 }
 
 tasks.withType(Tar){

--- a/TrafficCapture/trafficCaptureProxyServerTest/build.gradle
+++ b/TrafficCapture/trafficCaptureProxyServerTest/build.gradle
@@ -54,6 +54,9 @@ dependencies {
         implementation('org.apache.tika:tika-core:1.28.4') {
             because 'mend security issue'
         }
+        implementation('com.jayway.jsonpath:json-path:2.9.0') {
+            because 'mend security issue'
+        }
     }
 }
 

--- a/TrafficCapture/trafficReplayer/build.gradle
+++ b/TrafficCapture/trafficReplayer/build.gradle
@@ -116,7 +116,11 @@ configurations.all {
             }
         }
         if (details.requested.group == 'io.netty') {
-            details.useVersion '4.1.100.Final'
+            if (details.requested.name == 'netty-codec-http') {
+                details.useVersion '4.1.108.Final'
+            } else {
+                details.useVersion '4.1.100.Final'
+            }
         }
     }
 }

--- a/TrafficCapture/trafficReplayer/build.gradle
+++ b/TrafficCapture/trafficReplayer/build.gradle
@@ -86,6 +86,12 @@ dependencies {
     testImplementation group: 'org.testcontainers', name: 'junit-jupiter', version: '1.19.7'
     testImplementation group: 'org.testcontainers', name: 'kafka', version: '1.19.7'
     testImplementation group: 'org.testcontainers', name: 'testcontainers', version: '1.19.7'
+    constraints {
+        testImplementation('org.apache.commons:commons-compress:1.26.0') {
+            because 'mend security issue'
+        }
+    }
+
     testImplementation group: 'org.mockito', name:'mockito-core', version:'4.6.1'
     testImplementation group: 'org.mockito', name:'mockito-junit-jupiter', version:'4.6.1'
     testRuntimeOnly group:'org.junit.jupiter', name:'junit-jupiter-engine', version:'5.x.x'

--- a/TrafficCapture/trafficReplayer/build.gradle
+++ b/TrafficCapture/trafficReplayer/build.gradle
@@ -58,7 +58,7 @@ dependencies {
     implementation group: 'software.amazon.awssdk', name: 'arns', version: '2.20.102'
     implementation group: 'software.amazon.awssdk', name: 'auth', version: '2.20.102'
     implementation group: 'software.amazon.awssdk', name: 'sdk-core', version: '2.20.102'
-    implementation group: 'software.amazon.awssdk', name: 'secretsmanager', version: '2.20.127'
+    implementation group: 'software.amazon.awssdk', name: 'secretsmanager', version: '2.25.19'
     implementation group: 'software.amazon.msk', name: 'aws-msk-iam-auth', version: '2.0.3'
     implementation 'org.apache.commons:commons-compress:1.26.0'
 
@@ -86,15 +86,19 @@ dependencies {
     testImplementation group: 'org.testcontainers', name: 'junit-jupiter', version: '1.19.7'
     testImplementation group: 'org.testcontainers', name: 'kafka', version: '1.19.7'
     testImplementation group: 'org.testcontainers', name: 'testcontainers', version: '1.19.7'
-    constraints {
-        testImplementation('org.apache.commons:commons-compress:1.26.0') {
-            because 'mend security issue'
-        }
-    }
 
     testImplementation group: 'org.mockito', name:'mockito-core', version:'4.6.1'
     testImplementation group: 'org.mockito', name:'mockito-junit-jupiter', version:'4.6.1'
     testRuntimeOnly group:'org.junit.jupiter', name:'junit-jupiter-engine', version:'5.x.x'
+
+    constraints {
+        testImplementation('org.apache.commons:commons-compress:1.26.0') {
+            because 'mend security issue'
+        }
+        implementation('io.netty:netty-codec-http:4.1.108.Final') {
+            because 'mend security issue'
+        }
+    }
 }
 
 configurations.all {


### PR DESCRIPTION
Signed-off-by: Mikayla Thompson <thomika@amazon.com>

### Description

This is an extension of #600 with one final fix.

### Check List
- [ ] New functionality includes testing
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
