### PR TITLE
Enhance logging with Async and high performance appenders

### DIFF
--- a/TrafficCapture/build.gradle
+++ b/TrafficCapture/build.gradle
@@ -110,6 +110,8 @@ allprojects {
             //  Disable parallel test execution, see MIGRATIONS-1666
             systemProperty 'junit.jupiter.execution.parallel.enabled', 'false'
         }
+        systemProperty 'log4j2.contextSelector', 'org.apache.logging.log4j.core.selector.BasicContextSelector'
+        jvmArgs '-ea'
     }
 
     test {

--- a/TrafficCapture/trafficCaptureProxyServer/build.gradle
+++ b/TrafficCapture/trafficCaptureProxyServer/build.gradle
@@ -29,10 +29,12 @@ dependencies {
     implementation project(':coreUtilities')
 
     implementation group: 'io.netty', name: 'netty-all', version: '4.1.100.Final'
-    implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.20.0'
-    implementation group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.20.0'
-    implementation group: 'org.apache.logging.log4j', name: 'log4j-slf4j2-impl', version: '2.20.0'
-    implementation group: 'org.slf4j', name: 'slf4j-api', version: '2.0.7'
+
+    implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.23.1'
+    implementation group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.23.1'
+    implementation group: 'org.apache.logging.log4j', name: 'log4j-slf4j2-impl', version: '2.23.1'
+    implementation group: 'org.slf4j', name: 'slf4j-api', version: '2.0.13'
+    implementation group: 'com.lmax', name: 'disruptor', version: '4.0.0'
 
     implementation group: 'com.beust', name: 'jcommander', version: '1.82'
     implementation 'com.google.protobuf:protobuf-java:3.22.2'

--- a/TrafficCapture/trafficCaptureProxyServer/src/main/resources/log4j2.component.properties
+++ b/TrafficCapture/trafficCaptureProxyServer/src/main/resources/log4j2.component.properties
@@ -1,0 +1,2 @@
+Log4jContextSelector=org.apache.logging.log4j.core.async.AsyncLoggerContextSelector
+AsyncLogger.WaitStrategy=Yield

--- a/TrafficCapture/trafficCaptureProxyServer/src/main/resources/log4j2.properties
+++ b/TrafficCapture/trafficCaptureProxyServer/src/main/resources/log4j2.properties
@@ -8,6 +8,7 @@ appender.console.target = SYSTEM_ERR
 appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = [%-5level] %d{DEFAULT_MICROS}{UTC} [%t] %c{1} - %msg%equals{ ctx=%mdc}{ ctx=\{\}}{}%n
 appender.console.direct = true
+appender.console.includeLocation = true
 
 rootLogger.level = info
 rootLogger.appenderRefs = stderr

--- a/TrafficCapture/trafficCaptureProxyServer/src/main/resources/log4j2.properties
+++ b/TrafficCapture/trafficCaptureProxyServer/src/main/resources/log4j2.properties
@@ -8,7 +8,6 @@ appender.console.target = SYSTEM_ERR
 appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = [%-5level] %d{DEFAULT_MICROS}{UTC} [%t] %c{1} - %msg%equals{ ctx=%mdc}{ ctx=\{\}}{}%n
 appender.console.direct = true
-appender.console.includeLocation = true
 
 rootLogger.level = info
 rootLogger.appenderRefs = stderr

--- a/TrafficCapture/trafficCaptureProxyServer/src/main/resources/log4j2.properties
+++ b/TrafficCapture/trafficCaptureProxyServer/src/main/resources/log4j2.properties
@@ -6,7 +6,8 @@ appender.console.type = Console
 appender.console.name = STDERR
 appender.console.target = SYSTEM_ERR
 appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = [%-5level] %d{yyyy-MM-dd HH:mm:ss,SSS}{UTC} [%t] %c{1} - %msg%equals{ ctx=%mdc}{ ctx=\{\}}{}%n
+appender.console.layout.pattern = [%-5level] %d{DEFAULT_MICROS}{UTC} [%t] %c{1} - %msg%equals{ ctx=%mdc}{ ctx=\{\}}{}%n
+appender.console.direct = true
 
 rootLogger.level = info
 rootLogger.appenderRefs = stderr

--- a/TrafficCapture/trafficReplayer/build.gradle
+++ b/TrafficCapture/trafficReplayer/build.gradle
@@ -50,11 +50,14 @@ dependencies {
     implementation group: 'io.github.resilience4j', name: 'resilience4j-ratelimiter', version:"${resilience4jVersion}"
     implementation group: 'io.github.resilience4j', name: 'resilience4j-retry', version:"${resilience4jVersion}"
     implementation group: 'io.netty', name: 'netty-all', version: '4.1.100.Final'
+
     implementation group: 'org.apache.kafka', name: 'kafka-clients', version: '3.6.0'
-    implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.20.0'
-    implementation group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.20.0'
-    implementation group: 'org.apache.logging.log4j', name: 'log4j-slf4j2-impl', version: '2.20.0'
-    implementation group: 'org.slf4j', name: 'slf4j-api', version: '2.0.7'
+    implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.23.1'
+    implementation group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.23.1'
+    implementation group: 'org.apache.logging.log4j', name: 'log4j-slf4j2-impl', version: '2.23.1'
+    implementation group: 'org.slf4j', name: 'slf4j-api', version: '2.0.13'
+    implementation group: 'com.lmax', name: 'disruptor', version: '4.0.0'
+
     implementation group: 'software.amazon.awssdk', name: 'arns', version: '2.20.102'
     implementation group: 'software.amazon.awssdk', name: 'auth', version: '2.20.102'
     implementation group: 'software.amazon.awssdk', name: 'sdk-core', version: '2.20.102'

--- a/TrafficCapture/trafficReplayer/src/main/resources/log4j2.component.properties
+++ b/TrafficCapture/trafficReplayer/src/main/resources/log4j2.component.properties
@@ -1,0 +1,2 @@
+Log4jContextSelector=org.apache.logging.log4j.core.async.AsyncLoggerContextSelector
+AsyncLogger.WaitStrategy=Yield

--- a/TrafficCapture/trafficReplayer/src/main/resources/log4j2.properties
+++ b/TrafficCapture/trafficReplayer/src/main/resources/log4j2.properties
@@ -1,4 +1,4 @@
-status = error
+status = warn
 
 property.tupleDir = ${env:TUPLE_DIR_PATH:-./logs/tuples}
 
@@ -8,14 +8,15 @@ appender.console.type = Console
 appender.console.name = STDERR
 appender.console.target = SYSTEM_ERR
 appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = [%-5level] %d{yyyy-MM-dd HH:mm:ss,SSS}{UTC} [%t] %c{1} - %msg%equals{ ctx=%mdc}{ ctx={}}{}%n
+appender.console.layout.pattern = [%-5level] %d{DEFAULT_MICROS}{UTC} [%t] %c{1} - %msg%equals{ ctx=%mdc}{ ctx={}}{}%n
+appender.console.direct = true
 
-appender.ReplayerLogFile.type = RollingFile
+appender.ReplayerLogFile.type = RollingRandomAccessFile
 appender.ReplayerLogFile.name = ReplayerLogFile
 appender.ReplayerLogFile.fileName = logs/replayer.log
 appender.ReplayerLogFile.filePattern = logs/%d{yyyy-MM}{UTC}/replayer-%d{yyyy-MM-dd-HH-mm}{UTC}-%i.log.gz
 appender.ReplayerLogFile.layout.type = PatternLayout
-appender.ReplayerLogFile.layout.pattern = [%-5level] %d{yyyy-MM-dd HH:mm:ss,SSS}{UTC} [%t] %c{1} - %msg%equals{ ctx=%mdc}{ ctx={}}{}%n
+appender.ReplayerLogFile.layout.pattern = [%-5level] %d{DEFAULT_MICROS}{UTC} [%t] %c{1} - %msg%equals{ ctx=%mdc}{ ctx={}}{}%n
 appender.ReplayerLogFile.policies.type = Policies
 appender.ReplayerLogFile.policies.time.type = TimeBasedTriggeringPolicy
 appender.ReplayerLogFile.policies.time.interval = 60
@@ -23,10 +24,10 @@ appender.ReplayerLogFile.policies.time.modulate = true
 appender.ReplayerLogFile.strategy.type = DefaultRolloverStrategy
 appender.ReplayerLogFile.strategy.max = 288
 
-appender.OUTPUT_TUPLES.type = RollingFile
+appender.OUTPUT_TUPLES.type = RollingRandomAccessFile
 appender.OUTPUT_TUPLES.name = OUTPUT_TUPLES
 appender.OUTPUT_TUPLES.fileName = ${tupleDir}/tuples.log
-appender.OUTPUT_TUPLES.filePattern = ${tupleDir}/tuples-%d{yyyy-MM-dd-HH:mm}{UTC}.log
+appender.OUTPUT_TUPLES.filePattern = ${tupleDir}/tuples-%d{yyyy-MM-dd-HH:mm}{UTC}-%i.log.gz
 appender.OUTPUT_TUPLES.layout.type = PatternLayout
 appender.OUTPUT_TUPLES.layout.pattern = %m%n
 appender.OUTPUT_TUPLES.policies.type = Policies
@@ -38,9 +39,10 @@ appender.TRANSACTION_SUMMARIES.type = Console
 appender.TRANSACTION_SUMMARIES.name = TransactionSummariesConsole
 appender.TRANSACTION_SUMMARIES.target = SYSTEM_OUT
 appender.TRANSACTION_SUMMARIES.layout.type = PatternLayout
-appender.TRANSACTION_SUMMARIES.layout.pattern = %d{yyyy-MM-dd HH:mm:ss,SSS}{UTC}: %msg%n
+appender.TRANSACTION_SUMMARIES.layout.pattern = %d{DEFAULT_MICROS}{UTC}: %msg%n
+appender.TRANSACTION_SUMMARIES.direct = true
 
-appender.TRANSACTION_SUMMARIES_LOGFILE.type = RollingFile
+appender.TRANSACTION_SUMMARIES_LOGFILE.type = RollingRandomAccessFile
 appender.TRANSACTION_SUMMARIES_LOGFILE.name = TransactionSummariesFile
 appender.TRANSACTION_SUMMARIES_LOGFILE.fileName = logs/progress.log
 appender.TRANSACTION_SUMMARIES_LOGFILE.filePattern = logs/%d{yyyy-MM}{UTC}/progress-%d{yyyy-MM-dd-HH-mm}{UTC}-%i.log.gz
@@ -53,10 +55,10 @@ appender.TRANSACTION_SUMMARIES_LOGFILE.policies.time.modulate = true
 appender.TRANSACTION_SUMMARIES_LOGFILE.strategy.type = DefaultRolloverStrategy
 appender.TRANSACTION_SUMMARIES_LOGFILE.strategy.max = 720
 
-appender.ALL_ACTIVE_WORK_MONITOR_LOGFILE.type = RollingFile
+appender.ALL_ACTIVE_WORK_MONITOR_LOGFILE.type = RollingRandomAccessFile
 appender.ALL_ACTIVE_WORK_MONITOR_LOGFILE.name = AllActiveWorkMonitorFile
 appender.ALL_ACTIVE_WORK_MONITOR_LOGFILE.fileName = logs/longRunningActivity.log
-appender.ALL_ACTIVE_WORK_MONITOR_LOGFILE.filePattern = logs/%d{yyyy-MM}{UTC}/longRunningActivity-%d{yyyy-MM-dd-HH-mm}{UTC}-%i.log
+appender.ALL_ACTIVE_WORK_MONITOR_LOGFILE.filePattern = logs/%d{yyyy-MM}{UTC}/longRunningActivity-%d{yyyy-MM-dd-HH-mm}{UTC}-%i.log.gz
 appender.ALL_ACTIVE_WORK_MONITOR_LOGFILE.layout.type = PatternLayout
 appender.ALL_ACTIVE_WORK_MONITOR_LOGFILE.layout.pattern = %msg ([%-5level] %d{yyyy-MM-dd HH:mm:ss,SSS}{UTC})%n
 appender.ALL_ACTIVE_WORK_MONITOR_LOGFILE.policies.type = Policies

--- a/TrafficCapture/trafficReplayer/src/main/resources/log4j2.properties
+++ b/TrafficCapture/trafficReplayer/src/main/resources/log4j2.properties
@@ -9,6 +9,7 @@ appender.console.name = STDERR
 appender.console.target = SYSTEM_ERR
 appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = [%-5level] %d{DEFAULT_MICROS}{UTC} [%t] %c{1} - %msg%equals{ ctx=%mdc}{ ctx={}}{}%n
+appender.console.includeLocation = true
 appender.console.direct = true
 
 appender.ReplayerLogFile.type = RollingRandomAccessFile
@@ -23,6 +24,8 @@ appender.ReplayerLogFile.policies.time.interval = 60
 appender.ReplayerLogFile.policies.time.modulate = true
 appender.ReplayerLogFile.strategy.type = DefaultRolloverStrategy
 appender.ReplayerLogFile.strategy.max = 288
+appender.ReplayerLogFile.includeLocation = true
+appender.ReplayerLogFile.immediateFlush = false
 
 appender.OUTPUT_TUPLES.type = RollingRandomAccessFile
 appender.OUTPUT_TUPLES.name = OUTPUT_TUPLES
@@ -34,6 +37,7 @@ appender.OUTPUT_TUPLES.policies.type = Policies
 appender.OUTPUT_TUPLES.policies.size.type = SizeBasedTriggeringPolicy
 appender.OUTPUT_TUPLES.policies.size.size = 10 MB
 appender.OUTPUT_TUPLES.strategy.type = DefaultRolloverStrategy
+appender.OUTPUT_TUPLES.immediateFlush = false
 
 appender.TRANSACTION_SUMMARIES.type = Console
 appender.TRANSACTION_SUMMARIES.name = TransactionSummariesConsole
@@ -54,6 +58,7 @@ appender.TRANSACTION_SUMMARIES_LOGFILE.policies.time.interval = 60
 appender.TRANSACTION_SUMMARIES_LOGFILE.policies.time.modulate = true
 appender.TRANSACTION_SUMMARIES_LOGFILE.strategy.type = DefaultRolloverStrategy
 appender.TRANSACTION_SUMMARIES_LOGFILE.strategy.max = 720
+appender.TRANSACTION_SUMMARIES_LOGFILE.immediateFlush = false
 
 appender.ALL_ACTIVE_WORK_MONITOR_LOGFILE.type = RollingRandomAccessFile
 appender.ALL_ACTIVE_WORK_MONITOR_LOGFILE.name = AllActiveWorkMonitorFile
@@ -67,6 +72,7 @@ appender.ALL_ACTIVE_WORK_MONITOR_LOGFILE.policies.time.interval = 60
 appender.ALL_ACTIVE_WORK_MONITOR_LOGFILE.policies.time.modulate = true
 appender.ALL_ACTIVE_WORK_MONITOR_LOGFILE.strategy.type = DefaultRolloverStrategy
 appender.ALL_ACTIVE_WORK_MONITOR_LOGFILE.strategy.max = 4
+appender.ALL_ACTIVE_WORK_MONITOR_LOGFILE.immediateFlush = false
 
 rootLogger.level = info
 rootLogger.appenderRef.STDERR.ref = STDERR

--- a/TrafficCapture/trafficReplayer/src/main/resources/log4j2.properties
+++ b/TrafficCapture/trafficReplayer/src/main/resources/log4j2.properties
@@ -9,7 +9,6 @@ appender.console.name = STDERR
 appender.console.target = SYSTEM_ERR
 appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = [%-5level] %d{DEFAULT_MICROS}{UTC} [%t] %c{1} - %msg%equals{ ctx=%mdc}{ ctx={}}{}%n
-appender.console.includeLocation = true
 appender.console.direct = true
 
 appender.ReplayerLogFile.type = RollingRandomAccessFile
@@ -24,7 +23,6 @@ appender.ReplayerLogFile.policies.time.interval = 60
 appender.ReplayerLogFile.policies.time.modulate = true
 appender.ReplayerLogFile.strategy.type = DefaultRolloverStrategy
 appender.ReplayerLogFile.strategy.max = 288
-appender.ReplayerLogFile.includeLocation = true
 appender.ReplayerLogFile.immediateFlush = false
 
 appender.OUTPUT_TUPLES.type = RollingRandomAccessFile

--- a/TrafficCapture/trafficReplayer/src/test/resources/log4j2.properties
+++ b/TrafficCapture/trafficReplayer/src/test/resources/log4j2.properties
@@ -1,4 +1,4 @@
-status = error 
+status = error
 
 # Root logger options
 rootLogger.level = info

--- a/deployment/cdk/opensearch-service-migration/lib/service-stacks/migration-service-core.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/service-stacks/migration-service-core.ts
@@ -136,7 +136,7 @@ export class MigrationServiceCore extends Stack {
                 // and  "[ERROR] 2024-12-31 23:59:59..."
                 // and  "2024-12-31 23:59:59..."
                 multilinePattern: "^(\\[[A-Z ]{1,5}\\] )?\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}",
-                // Log appenders are non-blocking so defer async behavior to them
+                // Defer buffering behavior to log4j2 for greater flexibility
                 mode: AwsLogDriverMode.BLOCKING,
             }),
             ulimits: props.ulimits

--- a/deployment/cdk/opensearch-service-migration/lib/service-stacks/migration-service-core.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/service-stacks/migration-service-core.ts
@@ -12,7 +12,8 @@ import {
     ServiceConnectService,
     Ulimit,
     OperatingSystemFamily,
-    Volume
+    Volume,
+    AwsLogDriverMode
 } from "aws-cdk-lib/aws-ecs";
 import {DockerImageAsset} from "aws-cdk-lib/aws-ecr-assets";
 import {RemovalPolicy, Stack} from "aws-cdk-lib";
@@ -130,7 +131,13 @@ export class MigrationServiceCore extends Stack {
             portMappings: props.portMappings,
             logging: LogDrivers.awsLogs({
                 streamPrefix: `${props.serviceName}-logs`,
-                logGroup: serviceLogGroup
+                logGroup: serviceLogGroup,
+                // E.g. "[INFO ] 2024-12-31 23:59:59..."
+                // and  "[ERROR] 2024-12-31 23:59:59..."
+                // and  "2024-12-31 23:59:59..."
+                multilinePattern: "^(\\[[A-Z ]{1,5}\\] )?\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}",
+                // Log appenders are non-blocking so defer async behavior to them
+                mode: AwsLogDriverMode.BLOCKING,
             }),
             ulimits: props.ulimits
         });


### PR DESCRIPTION
### Description

Move log4j2 appenders to high performance async loggers:
   * Existing logging was performed synchronous and blocking based on appender behavior. Moves this logic to be async with higher performance appender configuration.
   * Note: This will still eventually block on flushing out the appenders, but there will be a buffer between logging and io streams.
   * Existing Data Flow (All Blocking Calls):
            Application → Log4j2 Appender → Standard Out → ECSLogDriver → Cloudwatch Logs
   * New Data Flow (Blocking unless specified):
            Application → [AsyncLogger](https://github.com/apache/logging-log4j2/blob/f0bd87818d43efa8337f56526ced2020c308d9bf/log4j-core/src/main/java/org/apache/logging/log4j/core/async/AsyncLogger.java#L66) (async)→ Log4j2 Appender → ECSLogDriver → Cloudwatch Logs

The AsyncLogger internally buffers so the rest can be "blocking" and still not block the application flow until it's internal queue is full

Enhance logging with microsecond clock and enhanced performance options
    * Added precision on logging and moved console appender to direct reference instead of through standard output stream.

Add multilinePattern to log driver

Fixed some logging unreliable unit tests with specifying a synchronous logger.

Documentation on Proxy Behavior added in [PR#595](https://github.com/opensearch-project/opensearch-migrations/pull/595)

* Category: Enhancement/Bug Fix
* Why these changes are required?
* What is the old behavior before changes and new behavior after changes? In AWS, logs were one line per line, now combined (e.g. stack trace together). Now microsecond instead of millisecond timing. Higher throughput replayer when debug/trace logging is enabled.

### Issues Resolved
[MIGRATIONS-1663](https://opensearch.atlassian.net/browse/MIGRATIONS-1663)

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
Deployed to AWS and tested in high performance scenarios with high logging (Debug/Trace). Verified multiline behavior in AWS.

### Check List
- [x] New functionality includes testing
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
