### PR TITLE
RFS now uses reactor-netty for bulk indexing

### DIFF
--- a/RFS/build.gradle
+++ b/RFS/build.gradle
@@ -37,6 +37,11 @@ dependencies {
     implementation 'org.apache.lucene:lucene-core:8.11.3'
     implementation 'org.apache.lucene:lucene-analyzers-common:8.11.3'
     implementation 'org.apache.lucene:lucene-backward-codecs:8.11.3'
+
+    implementation platform('io.projectreactor:reactor-bom:2023.0.5') 
+    implementation 'io.projectreactor.netty:reactor-netty-core' 
+    implementation 'io.projectreactor.netty:reactor-netty-http'
+}
     implementation 'software.amazon.awssdk:s3:2.25.16'
 
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.10.2'

--- a/RFS/build.gradle
+++ b/RFS/build.gradle
@@ -41,7 +41,6 @@ dependencies {
     implementation platform('io.projectreactor:reactor-bom:2023.0.5') 
     implementation 'io.projectreactor.netty:reactor-netty-core' 
     implementation 'io.projectreactor.netty:reactor-netty-http'
-}
     implementation 'software.amazon.awssdk:s3:2.25.16'
 
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.10.2'

--- a/RFS/build.gradle
+++ b/RFS/build.gradle
@@ -43,6 +43,8 @@ dependencies {
     implementation 'io.projectreactor.netty:reactor-netty-http'
     implementation 'software.amazon.awssdk:s3:2.25.16'
 
+    testImplementation 'io.projectreactor:reactor-test:3.6.5'
+    testImplementation 'org.apache.logging.log4j:log4j-core:2.23.1'
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.10.2'
     testImplementation 'org.junit.jupiter:junit-jupiter-params:5.10.2'
     testImplementation 'org.mockito:mockito-core:5.11.0'
@@ -124,4 +126,13 @@ tasks.getByName('composeUp')
 
 test {
     useJUnitPlatform()
+
+    testLogging {
+        exceptionFormat = 'full'
+        events "failed"
+        showExceptions true
+        showCauses true
+        showStackTraces true
+        showStandardStreams = true
+    }
 }

--- a/RFS/src/main/java/com/rfs/ReindexFromSnapshot.java
+++ b/RFS/src/main/java/com/rfs/ReindexFromSnapshot.java
@@ -356,10 +356,10 @@ public class ReindexFromSnapshot {
                     for (int shardId = 0; shardId < indexMetadata.getNumberOfShards(); shardId++) {
                         logger.info("=== Index Id: " + indexMetadata.getName() + ", Shard ID: " + shardId + " ===");
 
-                        Flux<Document> documents = LuceneDocumentsReader.readDocuments(luceneDirPath, indexMetadata.getName(), shardId);
+                        Flux<Document> documents = new LuceneDocumentsReader().readDocuments(luceneDirPath, indexMetadata.getName(), shardId);
                         String targetIndex = indexMetadata.getName() + indexSuffix;
                         DocumentReindexer.reindex(targetIndex, documents, targetConnection);
-                        
+
                         logger.info("Shard reindexing completed");
                     }
                 }

--- a/RFS/src/main/java/com/rfs/ReindexFromSnapshot.java
+++ b/RFS/src/main/java/com/rfs/ReindexFromSnapshot.java
@@ -125,7 +125,7 @@ public class ReindexFromSnapshot {
 
         Logging.setLevel(logLevel);
 
-        ConnectionDetails sourceConnection = new ConnectionDetails(sourceHost, sourceUser, sourcePass);
+        ConnectionDetails sourceConnection = new ConnectionDetails(sourceHost, sourceUser, sourcePass);        
         ConnectionDetails targetConnection = new ConnectionDetails(targetHost, targetUser, targetPass);
 
         // Sanity checks

--- a/RFS/src/main/java/com/rfs/common/ConnectionDetails.java
+++ b/RFS/src/main/java/com/rfs/common/ConnectionDetails.java
@@ -17,7 +17,7 @@ public class ConnectionDetails {
     public final String url;
     public final Protocol protocol;
     public final String hostName;
-    public final String port;
+    public final int port;
     public final String username;
     public final String password;
     public final AuthType authType;
@@ -39,7 +39,7 @@ public class ConnectionDetails {
 
         if (url == null) {
             hostName = null;
-            port = null;
+            port = -1;
             protocol = null;
         } else {
             // Parse the URL to get the protocol, host name, and port
@@ -50,8 +50,8 @@ public class ConnectionDetails {
 
             hostName = urlParts[1].split(":")[0];
 
-            String [] portParts = urlParts[1].split(":");
-            port = portParts.length == 1 ? null : portParts[1].split("/")[0];
+            String[] portParts = urlParts[1].split(":");
+            port = portParts.length == 1 ? -1 : Integer.parseInt(portParts[1].split("/")[0]);
 
             if (urlParts[0].equals("http")) {
                 protocol = Protocol.HTTP;

--- a/RFS/src/main/java/com/rfs/common/ConnectionDetails.java
+++ b/RFS/src/main/java/com/rfs/common/ConnectionDetails.java
@@ -1,5 +1,8 @@
 package com.rfs.common;
 
+import java.net.URI;
+import java.net.URISyntaxException;
+
 /**
  * Stores the connection details (assuming basic auth) for an Elasticsearch/OpenSearch cluster
  */
@@ -42,20 +45,19 @@ public class ConnectionDetails {
             port = -1;
             protocol = null;
         } else {
-            // Parse the URL to get the protocol, host name, and port
-            String[] urlParts = url.split("://");
-            if (urlParts.length != 2) {
-                throw new IllegalArgumentException("Invalid URL format");
+            URI uri;
+            try {
+                uri = new URI(url);
+            } catch (URISyntaxException e) {
+                throw new IllegalArgumentException("Invalid URL format", e);
             }
 
-            hostName = urlParts[1].split(":")[0];
+            hostName = uri.getHost();
+            port = uri.getPort(); // Default port can be set here if -1
 
-            String[] portParts = urlParts[1].split(":");
-            port = portParts.length == 1 ? -1 : Integer.parseInt(portParts[1].split("/")[0]);
-
-            if (urlParts[0].equals("http")) {
+            if (uri.getScheme().equals("http")) {
                 protocol = Protocol.HTTP;
-            } else if (urlParts[0].equals("https")) {
+            } else if (uri.getScheme().equals("https")) {
                 protocol = Protocol.HTTPS;
             } else {
                 throw new IllegalArgumentException("Invalid protocol");

--- a/RFS/src/main/java/com/rfs/common/ConnectionDetails.java
+++ b/RFS/src/main/java/com/rfs/common/ConnectionDetails.java
@@ -9,13 +9,21 @@ public class ConnectionDetails {
         NONE
     }
 
-    public final String host;
+    public static enum Protocol {
+        HTTP,
+        HTTPS
+    }
+
+    public final String url;
+    public final Protocol protocol;
+    public final String hostName;
+    public final String port;
     public final String username;
     public final String password;
     public final AuthType authType;
 
-    public ConnectionDetails(String host, String username, String password) {
-        this.host = host; // http://localhost:9200
+    public ConnectionDetails(String url, String username, String password) {
+        this.url = url; // http://localhost:9200
 
         // If the username is provided, the password must be as well, and vice versa
         if ((username == null && password != null) || (username != null && password == null)) {
@@ -28,5 +36,30 @@ public class ConnectionDetails {
 
         this.username = username;
         this.password = password;
+
+        if (url == null) {
+            hostName = null;
+            port = null;
+            protocol = null;
+        } else {
+            // Parse the URL to get the protocol, host name, and port
+            String[] urlParts = url.split("://");
+            if (urlParts.length != 2) {
+                throw new IllegalArgumentException("Invalid URL format");
+            }
+
+            hostName = urlParts[1].split(":")[0];
+
+            String [] portParts = urlParts[1].split(":");
+            port = portParts.length == 1 ? null : portParts[1].split("/")[0];
+
+            if (urlParts[0].equals("http")) {
+                protocol = Protocol.HTTP;
+            } else if (urlParts[0].equals("https")) {
+                protocol = Protocol.HTTPS;
+            } else {
+                throw new IllegalArgumentException("Invalid protocol");
+            }
+        }        
     }
 }

--- a/RFS/src/main/java/com/rfs/common/DocumentReindexer.java
+++ b/RFS/src/main/java/com/rfs/common/DocumentReindexer.java
@@ -1,32 +1,124 @@
 package com.rfs.common;
 
+import java.time.Duration;
+import java.util.Base64;
+import java.util.List;
+
+import io.netty.buffer.Unpooled;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.document.Document;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.netty.http.client.HttpClient;
+import reactor.util.retry.Retry;
 
 
 public class DocumentReindexer {
     private static final Logger logger = LogManager.getLogger(DocumentReindexer.class);
+    private static final int MAX_BATCH_SIZE = 1000; // Arbitrarily chosen
 
-    public static void reindex(String indexName, Document document, ConnectionDetails targetConnection) throws Exception {        
-        // Get the document details
+    public static void reindex(String indexName, Flux<Document> documentStream, ConnectionDetails targetConnection) throws Exception {
+        String targetUrl = "/" + indexName + "/_bulk";
+        HttpClient client = HttpClient.create()
+            .host(targetConnection.hostName)
+            .port(targetConnection.port)
+            .headers(h -> {
+                h.set("Content-Type", "application/json");
+                if (targetConnection.authType == ConnectionDetails.AuthType.BASIC) {
+                    String credentials = targetConnection.username + ":" + targetConnection.password;
+                    String encodedCredentials = Base64.getEncoder().encodeToString(credentials.getBytes());
+                    h.set("Authorization", "Basic " + encodedCredentials);
+                }
+            });
+
+        documentStream
+            .map(DocumentReindexer::convertDocumentToBulkSection)  // Convert each Document to part of a bulk operation
+            .buffer(MAX_BATCH_SIZE) // Collect until you hit the batch size
+            .map(DocumentReindexer::convertToBulkJson)  // Assemble the bulk request body from the parts
+            .flatMap(bulkJson -> sendBulkRequest(client, targetUrl, bulkJson)) // Send the request
+            .retryWhen(Retry.backoff(3, Duration.ofSeconds(1)).maxBackoff(Duration.ofSeconds(5)))
+            .subscribe(
+                response -> logger.info("Batch uploaded successfully"),
+                error -> logger.error("Failed to upload batch", error)
+            );
+    }
+
+    private static String convertDocumentToBulkSection(Document document) {
         String id = Uid.decodeId(document.getBinaryValue("_id").bytes);
         String source = document.getBinaryValue("_source").utf8ToString();
+        String action = "{\"index\": {\"_id\": \"" + id + "\"}}";
 
-        logger.info("Reindexing document - Index: " + indexName + ", Document ID: " + id);
+        return action + "\n" + source;
+    }
 
-        // Assemble the request details
-        String path = indexName + "/_doc/" + id;
-        String body = source;
+    private static String convertToBulkJson(List<String> bulkSections) {
+        logger.info(bulkSections.size() + " documents in current bulk request");
+        StringBuilder builder = new StringBuilder();
+        for (String section : bulkSections) {
+            builder.append(section).append("\n");
+        }
+        return builder.toString();
+    }
 
-        // Send the request
-        RestClient client = new RestClient(targetConnection);
-        client.put(path, body, false);
+    private static Mono<Void> sendBulkRequest(HttpClient client, String url, String bulkJson) {
+        return client.post()
+                .uri(url)
+                .send(Flux.just(Unpooled.wrappedBuffer(bulkJson.getBytes())))
+                .responseSingle((res, content) -> 
+                    content.asString()  // Convert the response content to a string
+                    .map(body -> new BulkResponseDetails(res.status().code(), body))  // Map both status code and body into a response details object
+                )
+                .flatMap(responseDetails -> {
+                    // Something bad happened with our request, log it
+                    if (responseDetails.hasBadStatusCode()) {
+                        logger.error(responseDetails.getFailureMessage());
+                    }
+                    // Some of the bulk operations failed, log it
+                    else if (responseDetails.hasFailedOperations()) {
+                        logger.error(responseDetails.getFailureMessage());
+                    }
+                    return Mono.just(responseDetails);
+                })
+                .doOnError(err -> {
+                    // We weren't even able to complete the request, log it
+                    logger.error("Bulk request failed", err);
+                })
+                .then();
     }
 
     public static void refreshAllDocuments(ConnectionDetails targetConnection) throws Exception {
         // Send the request
         RestClient client = new RestClient(targetConnection);
         client.get("_refresh", false);
+    }
+
+    static class BulkResponseDetails {
+        public final int statusCode;
+        public final String body;
+    
+        BulkResponseDetails(int statusCode, String body) {
+            this.statusCode = statusCode;
+            this.body = body;
+        }
+
+        public boolean hasBadStatusCode() {
+            return !(statusCode == 200 || statusCode == 201);
+        }
+
+        public boolean hasFailedOperations() {
+            return body.contains("\"errors\":true");
+        }
+
+        public String getFailureMessage() {
+            String failureMessage;
+            if (hasBadStatusCode()) {
+                failureMessage = "Bulk request failed.  Status code: " + statusCode + ", Response body: " + body;
+            } else {
+                failureMessage = "Bulk request succeeded, but some operations failed.  Response body: " + body;
+            }
+
+            return failureMessage;
+        }
     }
 }

--- a/RFS/src/main/java/com/rfs/common/DocumentReindexer.java
+++ b/RFS/src/main/java/com/rfs/common/DocumentReindexer.java
@@ -35,7 +35,7 @@ public class DocumentReindexer {
         documentStream
             .map(DocumentReindexer::convertDocumentToBulkSection)  // Convert each Document to part of a bulk operation
             .buffer(MAX_BATCH_SIZE) // Collect until you hit the batch size
-            .map(DocumentReindexer::convertToBulkJson)  // Assemble the bulk request body from the parts
+            .map(DocumentReindexer::convertToBulkRequestBody)  // Assemble the bulk request body from the parts
             .flatMap(bulkJson -> sendBulkRequest(client, targetUrl, bulkJson)) // Send the request
             .retryWhen(Retry.backoff(3, Duration.ofSeconds(1)).maxBackoff(Duration.ofSeconds(5)))
             .subscribe(
@@ -52,7 +52,7 @@ public class DocumentReindexer {
         return action + "\n" + source;
     }
 
-    private static String convertToBulkJson(List<String> bulkSections) {
+    private static String convertToBulkRequestBody(List<String> bulkSections) {
         logger.info(bulkSections.size() + " documents in current bulk request");
         StringBuilder builder = new StringBuilder();
         for (String section : bulkSections) {

--- a/RFS/src/main/java/com/rfs/common/LuceneDocumentsReader.java
+++ b/RFS/src/main/java/com/rfs/common/LuceneDocumentsReader.java
@@ -1,8 +1,7 @@
 package com.rfs.common;
 
+import java.io.IOException;
 import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.List;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -11,40 +10,57 @@ import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.store.FSDirectory;
 import org.apache.lucene.util.BytesRef;
+import reactor.core.publisher.Flux;
 
 public class LuceneDocumentsReader {
     private static final Logger logger = LogManager.getLogger(LuceneDocumentsReader.class);
 
-    public static List<Document> readDocuments(Path luceneFilesBasePath, String indexName, int shardId) throws Exception {
+    public static Flux<Document> readDocuments(Path luceneFilesBasePath, String indexName, int shardId) {
         Path indexDirectoryPath = luceneFilesBasePath.resolve(indexName).resolve(String.valueOf(shardId));
 
-        List<Document> documents = new ArrayList<>();
+        return Flux.using(
+            () -> DirectoryReader.open(FSDirectory.open(indexDirectoryPath)),
+            reader -> {
+                logger.info(reader.maxDoc() + " documents found in the current Lucene index");
 
-        try (FSDirectory directory = FSDirectory.open(indexDirectoryPath);
-             IndexReader reader = DirectoryReader.open(directory)) {
-
-            // Add all documents to our output that have the _source field set and filled in
-            for (int i = 0; i < reader.maxDoc(); i++) {
-                Document document = reader.document(i);
-                BytesRef source_bytes = document.getBinaryValue("_source");
-                String id;
-                // TODO Improve handling of missing document id (https://opensearch.atlassian.net/browse/MIGRATIONS-1649)
+                return Flux.range(0, reader.maxDoc()) // Extract all the Documents in the IndexReader
+                           .map(i -> getDocument(reader, i))
+                           .cast(Document.class);
+            },
+            reader -> { // Close the IndexReader when done
                 try {
-                    id = Uid.decodeId(reader.document(i).getBinaryValue("_id").bytes);
-                } catch (Exception e) {
-                    logger.warn("Unable to parse Document id from Document");
-                    id = "unknown-id";
+                    reader.close();
+                } catch (IOException e) {
+                    logger.error("Failed to close IndexReader", e);
                 }
-                if (source_bytes == null || source_bytes.bytes.length == 0) { // Skip deleted documents
-                    logger.info("Document " + id + " is deleted or doesn't have the _source field enabled");
-                    continue;
-                }
-
-                documents.add(document);
-                logger.info("Document " + id + " read successfully");
             }
-        }
+        ).filter(doc -> doc != null); // Skip docs that failed to read
+    }
 
-        return documents;
+    private static Document getDocument(IndexReader reader, int docId) {
+        try {
+            Document document = reader.document(docId);
+            BytesRef source_bytes = document.getBinaryValue("_source");
+            String id;
+            try {
+                id = Uid.decodeId(reader.document(docId).getBinaryValue("_id").bytes);
+            } catch (Exception e) {
+                StringBuilder errorMessage = new StringBuilder();
+                errorMessage.append("Unable to parse Document id from Document.  The Document's Fields: ");
+                document.getFields().forEach(f -> errorMessage.append(f.name()).append(", "));
+                logger.error(errorMessage.toString());
+                return null; // Skip documents with missing id
+            }
+            if (source_bytes == null || source_bytes.bytes.length == 0) {
+                logger.warn("Document " + id + " is deleted or doesn't have the _source field enabled");
+                return null;  // Skip deleted documents or those without the _source field
+            }
+
+            logger.debug("Document " + id + " read successfully");
+            return document;
+        } catch (Exception e) {
+            logger.error("Failed to read document at Lucene index location " + docId, e);
+            return null;
+        }
     }
 }

--- a/RFS/src/main/java/com/rfs/common/RestClient.java
+++ b/RFS/src/main/java/com/rfs/common/RestClient.java
@@ -34,7 +34,7 @@ public class RestClient {
     }
 
     public Response get(String path, boolean quietLogging) throws Exception {
-        String urlString = connectionDetails.host + "/" + path;
+        String urlString = connectionDetails.url + "/" + path;
         
         URL url = new URL(urlString);
         HttpURLConnection conn = (HttpURLConnection) url.openConnection();
@@ -76,7 +76,7 @@ public class RestClient {
     }
     
     public Response put(String path, String body, boolean quietLogging) throws Exception {
-        String urlString = connectionDetails.host + "/" + path;
+        String urlString = connectionDetails.url + "/" + path;
         
         URL url = new URL(urlString);
         HttpURLConnection conn = (HttpURLConnection) url.openConnection();

--- a/RFS/src/main/java/com/rfs/common/Uid.java
+++ b/RFS/src/main/java/com/rfs/common/Uid.java
@@ -10,9 +10,9 @@ import org.apache.lucene.util.BytesRef;
  * See: https://github.com/elastic/elasticsearch/blob/6.8/server/src/main/java/org/elasticsearch/index/mapper/Uid.java#L32
  */
 public class Uid {
-    private static final int UTF8 = 0xff;
-    private static final int NUMERIC = 0xfe;
-    private static final int BASE64_ESCAPE = 0xfd;
+    public static final int UTF8 = 0xff;
+    public static final int NUMERIC = 0xfe;
+    public static final int BASE64_ESCAPE = 0xfd;
 
     private static String decodeNumericId(byte[] idBytes, int offset, int len) {
         assert Byte.toUnsignedInt(idBytes[offset]) == NUMERIC;

--- a/RFS/src/test/java/com/rfs/common/ConnectionDetailsTest.java
+++ b/RFS/src/test/java/com/rfs/common/ConnectionDetailsTest.java
@@ -16,9 +16,9 @@ public class ConnectionDetailsTest {
             Arguments.of("https://localhost:9200", "username", "pass", "https://localhost:9200", "username", "pass", ConnectionDetails.Protocol.HTTPS, "localhost", 9200),
             Arguments.of("http://localhost:9200", "username", "pass", "http://localhost:9200", "username", "pass", ConnectionDetails.Protocol.HTTP, "localhost", 9200),
             Arguments.of("http://localhost:9200", null, null, "http://localhost:9200", null, null, ConnectionDetails.Protocol.HTTP, "localhost", 9200),
-            Arguments.of("http://localhost", "username", "pass", "http://localhost", "username", "pass", ConnectionDetails.Protocol.HTTP, "localhost", null),
+            Arguments.of("http://localhost", "username", "pass", "http://localhost", "username", "pass", ConnectionDetails.Protocol.HTTP, "localhost", -1),
             Arguments.of("http://localhost:9200/longer/path", "username", "pass", "http://localhost:9200/longer/path", "username", "pass", ConnectionDetails.Protocol.HTTP, "localhost", 9200),
-            Arguments.of(null, "username", "pass", null, "username", "pass", null, null, null)
+            Arguments.of(null, "username", "pass", null, "username", "pass", null, null, -1)
         );
     }
 
@@ -26,7 +26,7 @@ public class ConnectionDetailsTest {
     @MethodSource("happyPathArgs")
     void ConnectionDetails_HappyPath_AsExpected(String url, String username, String password,
             String expectedUrl, String expectedUsername, String expectedPassword,
-            ConnectionDetails.Protocol expectedProtocal, String expectedHostName, String expectedPort) {
+            ConnectionDetails.Protocol expectedProtocal, String expectedHostName, int expectedPort) {
         ConnectionDetails details = new ConnectionDetails(url, username, password);
         assertEquals(expectedUrl, details.url);
         assertEquals(expectedUsername, details.username);

--- a/RFS/src/test/java/com/rfs/common/ConnectionDetailsTest.java
+++ b/RFS/src/test/java/com/rfs/common/ConnectionDetailsTest.java
@@ -1,0 +1,54 @@
+package com.rfs.common;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.stream.Stream;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+
+public class ConnectionDetailsTest {
+    static Stream<Arguments> happyPathArgs() {
+        return Stream.of(
+            Arguments.of("https://localhost:9200", "username", "pass", "https://localhost:9200", "username", "pass", ConnectionDetails.Protocol.HTTPS, "localhost", "9200"),
+            Arguments.of("http://localhost:9200", "username", "pass", "http://localhost:9200", "username", "pass", ConnectionDetails.Protocol.HTTP, "localhost", "9200"),
+            Arguments.of("http://localhost:9200", null, null, "http://localhost:9200", null, null, ConnectionDetails.Protocol.HTTP, "localhost", "9200"),
+            Arguments.of("http://localhost", "username", "pass", "http://localhost", "username", "pass", ConnectionDetails.Protocol.HTTP, "localhost", null),
+            Arguments.of("http://localhost:9200/longer/path", "username", "pass", "http://localhost:9200/longer/path", "username", "pass", ConnectionDetails.Protocol.HTTP, "localhost", "9200"),
+            Arguments.of(null, "username", "pass", null, "username", "pass", null, null, null)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("happyPathArgs")
+    void ConnectionDetails_HappyPath_AsExpected(String url, String username, String password,
+            String expectedUrl, String expectedUsername, String expectedPassword,
+            ConnectionDetails.Protocol expectedProtocal, String expectedHostName, String expectedPort) {
+        ConnectionDetails details = new ConnectionDetails(url, username, password);
+        assertEquals(expectedUrl, details.url);
+        assertEquals(expectedUsername, details.username);
+        assertEquals(expectedPassword, details.password);
+        assertEquals(expectedProtocal, details.protocol);
+        assertEquals(expectedHostName, details.hostName);
+        assertEquals(expectedPort, details.port);
+    }
+
+    static Stream<Arguments> unhappyPathArgs() {
+        return Stream.of(
+            Arguments.of("localhost:9200", "username", "pass", IllegalArgumentException.class),
+            Arguments.of("http://localhost:9200", "username", null, IllegalArgumentException.class),
+            Arguments.of("http://localhost:9200", null, "pass", IllegalArgumentException.class),
+            Arguments.of("ftp://localhost:9200", null, "pass", IllegalArgumentException.class)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("unhappyPathArgs")
+    void ConnectionDetails_UnhappyPath_AsExpected(String url, String username, String password,
+            Class<Exception> expectedException) {
+        assertThrows(expectedException, () -> new ConnectionDetails(url, username, password));
+    }
+}

--- a/RFS/src/test/java/com/rfs/common/ConnectionDetailsTest.java
+++ b/RFS/src/test/java/com/rfs/common/ConnectionDetailsTest.java
@@ -13,11 +13,11 @@ import org.junit.jupiter.params.provider.MethodSource;
 public class ConnectionDetailsTest {
     static Stream<Arguments> happyPathArgs() {
         return Stream.of(
-            Arguments.of("https://localhost:9200", "username", "pass", "https://localhost:9200", "username", "pass", ConnectionDetails.Protocol.HTTPS, "localhost", "9200"),
-            Arguments.of("http://localhost:9200", "username", "pass", "http://localhost:9200", "username", "pass", ConnectionDetails.Protocol.HTTP, "localhost", "9200"),
-            Arguments.of("http://localhost:9200", null, null, "http://localhost:9200", null, null, ConnectionDetails.Protocol.HTTP, "localhost", "9200"),
+            Arguments.of("https://localhost:9200", "username", "pass", "https://localhost:9200", "username", "pass", ConnectionDetails.Protocol.HTTPS, "localhost", 9200),
+            Arguments.of("http://localhost:9200", "username", "pass", "http://localhost:9200", "username", "pass", ConnectionDetails.Protocol.HTTP, "localhost", 9200),
+            Arguments.of("http://localhost:9200", null, null, "http://localhost:9200", null, null, ConnectionDetails.Protocol.HTTP, "localhost", 9200),
             Arguments.of("http://localhost", "username", "pass", "http://localhost", "username", "pass", ConnectionDetails.Protocol.HTTP, "localhost", null),
-            Arguments.of("http://localhost:9200/longer/path", "username", "pass", "http://localhost:9200/longer/path", "username", "pass", ConnectionDetails.Protocol.HTTP, "localhost", "9200"),
+            Arguments.of("http://localhost:9200/longer/path", "username", "pass", "http://localhost:9200/longer/path", "username", "pass", ConnectionDetails.Protocol.HTTP, "localhost", 9200),
             Arguments.of(null, "username", "pass", null, "username", "pass", null, null, null)
         );
     }

--- a/RFS/src/test/java/com/rfs/common/LuceneDocumentsReaderTest.java
+++ b/RFS/src/test/java/com/rfs/common/LuceneDocumentsReaderTest.java
@@ -1,0 +1,95 @@
+package com.rfs.common;
+
+import static org.mockito.Mockito.*;
+
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.StoredField;
+import org.apache.lucene.document.StringField;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.util.BytesRef;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+import reactor.test.StepVerifier;
+
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+
+class TestLuceneDocumentsReader extends LuceneDocumentsReader {
+    // Helper method to correctly encode the Document IDs for test
+    public static byte[] encodeUtf8Id(String id) {
+        byte[] idBytes = id.getBytes(StandardCharsets.UTF_8);
+        byte[] encoded = new byte[idBytes.length + 1];
+        encoded[0] = (byte) Uid.UTF8;
+        System.arraycopy(idBytes, 0, encoded, 1, idBytes.length);
+        return encoded;
+    }
+
+    // Override to return a mocked IndexReader
+    @Override
+    protected IndexReader openIndexReader(Path indexDirectoryPath) throws IOException {
+        // Set up our test docs
+        Document doc1 = new Document();
+        doc1.add(new StringField("_id", new BytesRef(encodeUtf8Id("id1")), Field.Store.YES));
+        doc1.add(new StoredField("_source", new BytesRef("source1")));
+
+        Document doc2 = new Document();
+        doc2.add(new StringField("_id", new BytesRef(encodeUtf8Id("id2")), Field.Store.YES));
+        doc2.add(new StoredField("_source", new BytesRef("source2")));
+
+        Document doc3 = new Document();
+        doc3.add(new StringField("_id", new BytesRef(encodeUtf8Id("id3")), Field.Store.YES));
+        doc3.add(new StoredField("_source", new BytesRef("source3")));
+
+        Document doc4 = new Document(); // Doc w/ no fields
+        
+        Document doc5 = new Document(); // Doc w/ missing _source
+        doc5.add(new StringField("_id", new BytesRef(encodeUtf8Id("id5")), Field.Store.YES));
+
+        // Set up our mock reader
+        IndexReader mockReader = mock(IndexReader.class);
+        when(mockReader.maxDoc()).thenReturn(5);
+        when(mockReader.document(0)).thenReturn(doc1);
+        when(mockReader.document(1)).thenReturn(doc2);
+        when(mockReader.document(2)).thenReturn(doc3);
+        when(mockReader.document(3)).thenReturn(doc4);
+        when(mockReader.document(4)).thenReturn(doc5);
+
+        return mockReader;
+    }
+}
+
+public class LuceneDocumentsReaderTest {
+    @Test
+    void testReadDocuments() {
+        // Use the TestLuceneDocumentsReader to get the mocked documents
+        Flux<Document> documents = new TestLuceneDocumentsReader().readDocuments(Paths.get("/fake/path"), "testIndex", 1);
+
+        // Verify that the results are as expected
+        StepVerifier.create(documents)
+            .expectNextMatches(doc -> {
+                String testId = Uid.decodeId(doc.getBinaryValue("_id").bytes);
+                String testSource = doc.getBinaryValue("_source").utf8ToString();
+                return "id1".equals(testId) && "source1".equals(testSource);
+            })
+            .expectNextMatches(doc -> {
+                String testId = Uid.decodeId(doc.getBinaryValue("_id").bytes);
+                String testSource = doc.getBinaryValue("_source").utf8ToString();
+                return "id2".equals(testId) && "source2".equals(testSource);
+            })
+            .expectNextMatches(doc -> {
+                String testId = Uid.decodeId(doc.getBinaryValue("_id").bytes);
+                String testSource = doc.getBinaryValue("_source").utf8ToString();
+                return "id3".equals(testId) && "source3".equals(testSource);
+            })
+            .expectComplete()
+            .verify();
+    }
+}
+
+
+
+
+

--- a/RFS/src/test/java/com/rfs/common/LuceneDocumentsReaderTest.java
+++ b/RFS/src/test/java/com/rfs/common/LuceneDocumentsReaderTest.java
@@ -63,7 +63,7 @@ class TestLuceneDocumentsReader extends LuceneDocumentsReader {
 
 public class LuceneDocumentsReaderTest {
     @Test
-    void testReadDocuments() {
+    void ReadDocuments_AsExpected() {
         // Use the TestLuceneDocumentsReader to get the mocked documents
         Flux<Document> documents = new TestLuceneDocumentsReader().readDocuments(Paths.get("/fake/path"), "testIndex", 1);
 

--- a/RFS/src/test/resources/log4j2-test.xml
+++ b/RFS/src/test/resources/log4j2-test.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN">
+    <Appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} %-5level %msg%n"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Root level="info">
+            <AppenderRef ref="Console"/>
+        </Root>
+    </Loggers>
+</Configuration>


### PR DESCRIPTION
### Description
* Updated RFS to use the reactor-netty library to perform asynchronous HTTP operations
* Updated RFS to perform indexing against the target cluster w/ bulk operations
* Added logging to capture when there's a wacky Lucene document we can't parse correctly (such as not having an `_id`)

### Issues Resolved
* https://opensearch.atlassian.net/browse/MIGRATIONS-1600
* https://opensearch.atlassian.net/browse/MIGRATIONS-1651
* https://opensearch.atlassian.net/browse/MIGRATIONS-1671
* https://opensearch.atlassian.net/browse/MIGRATIONS-1649

### Testing
* Added unit tests for the changes to the ConnectionDetails class
* Manually tested the changes to the reindexing behavior.  Example output below:

```
16:31:59.167 INFO  Blob files unpacked successfully
16:31:59.167 INFO  ==================================================================
16:31:59.167 INFO  Reindexing the documents...
16:31:59.171 INFO  === Index Id: logs-241998, Shard ID: 0 ===
16:31:59.586 INFO  199 documents found in the current Lucene index
16:31:59.627 INFO  199 documents in current bulk request
16:31:59.999 INFO  Shard reindexing completed
16:31:59.999 INFO  === Index Id: logs-241998, Shard ID: 1 ===
16:32:00.008 INFO  203 documents found in the current Lucene index
16:32:00.028 INFO  203 documents in current bulk request
16:32:00.030 INFO  Shard reindexing completed
16:32:00.030 INFO  === Index Id: logs-241998, Shard ID: 2 ===
16:32:00.037 INFO  201 documents found in the current Lucene index
16:32:00.048 INFO  201 documents in current bulk request
16:32:00.049 INFO  Shard reindexing completed
16:32:00.049 INFO  === Index Id: logs-241998, Shard ID: 3 ===
16:32:00.057 INFO  201 documents found in the current Lucene index
16:32:00.062 INFO  201 documents in current bulk request
16:32:00.063 INFO  Shard reindexing completed
16:32:00.063 INFO  === Index Id: logs-241998, Shard ID: 4 ===
16:32:00.070 INFO  196 documents found in the current Lucene index
16:32:00.076 INFO  196 documents in current bulk request
16:32:00.078 INFO  Shard reindexing completed
16:32:00.079 INFO  === Index Id: logs-191998, Shard ID: 0 ===
16:32:00.082 INFO  206 documents found in the current Lucene index
16:32:00.090 INFO  206 documents in current bulk request
16:32:00.091 INFO  Shard reindexing completed
16:32:00.092 INFO  === Index Id: logs-191998, Shard ID: 1 ===
16:32:00.101 INFO  204 documents found in the current Lucene index
16:32:00.117 INFO  204 documents in current bulk request
16:32:00.118 INFO  Shard reindexing completed
16:32:00.118 INFO  === Index Id: logs-191998, Shard ID: 2 ===
16:32:00.124 INFO  192 documents found in the current Lucene index
16:32:00.129 INFO  192 documents in current bulk request
16:32:00.131 INFO  Shard reindexing completed
16:32:00.131 INFO  === Index Id: logs-191998, Shard ID: 3 ===
16:32:00.135 INFO  196 documents found in the current Lucene index
16:32:00.141 INFO  196 documents in current bulk request
16:32:00.142 INFO  Shard reindexing completed
16:32:00.143 INFO  === Index Id: logs-191998, Shard ID: 4 ===
16:32:00.148 INFO  202 documents found in the current Lucene index
16:32:00.156 INFO  202 documents in current bulk request
16:32:00.157 INFO  Shard reindexing completed
16:32:00.158 INFO  === Index Id: logs-221998, Shard ID: 0 ===
16:32:00.177 INFO  190 documents found in the current Lucene index
16:32:00.184 INFO  190 documents in current bulk request
16:32:00.185 INFO  Shard reindexing completed
16:32:00.185 INFO  === Index Id: logs-221998, Shard ID: 1 ===
16:32:00.218 INFO  207 documents found in the current Lucene index
16:32:00.235 INFO  207 documents in current bulk request
16:32:00.236 INFO  Shard reindexing completed
16:32:00.237 INFO  === Index Id: logs-221998, Shard ID: 2 ===
16:32:00.255 INFO  188 documents found in the current Lucene index
16:32:00.281 INFO  188 documents in current bulk request
16:32:00.283 INFO  Shard reindexing completed
16:32:00.283 INFO  === Index Id: logs-221998, Shard ID: 3 ===
16:32:00.373 INFO  215 documents found in the current Lucene index
16:32:00.483 INFO  215 documents in current bulk request
16:32:00.484 INFO  Shard reindexing completed
16:32:00.484 INFO  === Index Id: logs-221998, Shard ID: 4 ===
16:32:00.535 INFO  200 documents found in the current Lucene index
16:32:00.553 INFO  200 documents in current bulk request
16:32:00.554 INFO  Shard reindexing completed
16:32:00.554 INFO  === Index Id: logs-231998, Shard ID: 0 ===
16:32:00.587 INFO  208 documents found in the current Lucene index
16:32:00.594 INFO  208 documents in current bulk request
16:32:00.595 INFO  Shard reindexing completed
16:32:00.595 INFO  === Index Id: logs-231998, Shard ID: 1 ===
16:32:00.603 INFO  192 documents found in the current Lucene index
16:32:00.610 INFO  192 documents in current bulk request
16:32:00.611 INFO  Shard reindexing completed
16:32:00.611 INFO  === Index Id: logs-231998, Shard ID: 2 ===
16:32:00.614 INFO  190 documents found in the current Lucene index
16:32:00.629 INFO  190 documents in current bulk request
16:32:00.630 INFO  Shard reindexing completed
16:32:00.630 INFO  === Index Id: logs-231998, Shard ID: 3 ===
16:32:00.637 INFO  224 documents found in the current Lucene index
16:32:00.655 INFO  224 documents in current bulk request
16:32:00.656 INFO  Shard reindexing completed
16:32:00.656 INFO  === Index Id: logs-231998, Shard ID: 4 ===
16:32:00.662 INFO  186 documents found in the current Lucene index
16:32:00.665 INFO  186 documents in current bulk request
16:32:00.666 INFO  Shard reindexing completed
16:32:00.666 INFO  === Index Id: reindexed-logs, Shard ID: 0 ===
16:32:00.669 INFO  0 documents found in the current Lucene index
16:32:00.672 INFO  Shard reindexing completed
16:32:00.672 INFO  === Index Id: reindexed-logs, Shard ID: 1 ===
16:32:00.676 INFO  0 documents found in the current Lucene index
16:32:00.676 INFO  Shard reindexing completed
16:32:00.676 INFO  === Index Id: reindexed-logs, Shard ID: 2 ===
16:32:00.679 INFO  0 documents found in the current Lucene index
16:32:00.680 INFO  Shard reindexing completed
16:32:00.680 INFO  === Index Id: reindexed-logs, Shard ID: 3 ===
16:32:00.682 INFO  0 documents found in the current Lucene index
16:32:00.682 INFO  Shard reindexing completed
16:32:00.682 INFO  === Index Id: reindexed-logs, Shard ID: 4 ===
16:32:00.685 INFO  0 documents found in the current Lucene index
16:32:00.685 INFO  Shard reindexing completed
16:32:00.685 INFO  === Index Id: logs-201998, Shard ID: 0 ===
16:32:00.715 INFO  222 documents found in the current Lucene index
16:32:00.723 INFO  222 documents in current bulk request
16:32:00.723 INFO  Shard reindexing completed
16:32:00.724 INFO  === Index Id: logs-201998, Shard ID: 1 ===
16:32:00.760 INFO  193 documents found in the current Lucene index
16:32:00.765 INFO  193 documents in current bulk request
16:32:00.765 INFO  Shard reindexing completed
16:32:00.766 INFO  === Index Id: logs-201998, Shard ID: 2 ===
16:32:00.783 INFO  188 documents found in the current Lucene index
16:32:00.786 INFO  188 documents in current bulk request
16:32:00.787 INFO  Shard reindexing completed
16:32:00.787 INFO  === Index Id: logs-201998, Shard ID: 3 ===
16:32:00.800 INFO  191 documents found in the current Lucene index
16:32:00.811 INFO  191 documents in current bulk request
16:32:00.812 INFO  Shard reindexing completed
16:32:00.812 INFO  === Index Id: logs-201998, Shard ID: 4 ===
16:32:00.831 INFO  206 documents found in the current Lucene index
16:32:00.841 INFO  206 documents in current bulk request
16:32:00.843 INFO  Shard reindexing completed
16:32:00.843 INFO  === Index Id: sonested, Shard ID: 0 ===
16:32:00.854 INFO  2977 documents found in the current Lucene index
16:32:00.856 ERROR Unable to parse Document id from Document.  The Document's Fields: 
16:32:00.877 INFO  Shard reindexing completed
16:32:00.877 INFO  === Index Id: nyc_taxis, Shard ID: 0 ===
16:32:00.882 INFO  1000 documents found in the current Lucene index
16:32:01.179 INFO  1000 documents in current bulk request
16:32:01.181 INFO  Shard reindexing completed
16:32:01.181 INFO  === Index Id: logs-211998, Shard ID: 0 ===
16:32:01.187 INFO  206 documents found in the current Lucene index
16:32:01.190 INFO  206 documents in current bulk request
16:32:01.191 INFO  Shard reindexing completed
16:32:01.191 INFO  === Index Id: logs-211998, Shard ID: 1 ===
16:32:01.199 INFO  189 documents found in the current Lucene index
16:32:01.201 INFO  189 documents in current bulk request
16:32:01.202 INFO  Shard reindexing completed
16:32:01.202 INFO  === Index Id: logs-211998, Shard ID: 2 ===
16:32:01.211 INFO  190 documents found in the current Lucene index
16:32:01.213 INFO  190 documents in current bulk request
16:32:01.214 INFO  Shard reindexing completed
16:32:01.214 INFO  === Index Id: logs-211998, Shard ID: 3 ===
16:32:01.230 INFO  223 documents found in the current Lucene index
16:32:01.233 INFO  223 documents in current bulk request
16:32:01.233 INFO  Shard reindexing completed
16:32:01.234 INFO  === Index Id: logs-211998, Shard ID: 4 ===
16:32:01.271 INFO  192 documents found in the current Lucene index
16:32:01.279 INFO  192 documents in current bulk request
16:32:01.280 INFO  Shard reindexing completed
16:32:01.280 INFO  === Index Id: logs-181998, Shard ID: 0 ===
16:32:01.313 INFO  214 documents found in the current Lucene index
16:32:01.317 INFO  214 documents in current bulk request
16:32:01.318 INFO  Shard reindexing completed
16:32:01.318 INFO  === Index Id: logs-181998, Shard ID: 1 ===
16:32:01.331 INFO  192 documents found in the current Lucene index
16:32:01.338 INFO  192 documents in current bulk request
16:32:01.339 INFO  Shard reindexing completed
16:32:01.340 INFO  === Index Id: logs-181998, Shard ID: 2 ===
16:32:01.364 INFO  183 documents found in the current Lucene index
16:32:01.369 INFO  183 documents in current bulk request
16:32:01.370 INFO  Shard reindexing completed
16:32:01.370 INFO  === Index Id: logs-181998, Shard ID: 3 ===
16:32:01.384 INFO  193 documents found in the current Lucene index
16:32:01.388 INFO  193 documents in current bulk request
16:32:01.388 INFO  Shard reindexing completed
16:32:01.388 INFO  === Index Id: logs-181998, Shard ID: 4 ===
16:32:01.405 INFO  218 documents found in the current Lucene index
16:32:01.410 INFO  218 documents in current bulk request
16:32:01.411 INFO  Shard reindexing completed
16:32:01.411 INFO  === Index Id: geonames, Shard ID: 0 ===
16:32:01.438 INFO  206 documents found in the current Lucene index
16:32:01.453 INFO  206 documents in current bulk request
16:32:01.464 INFO  Shard reindexing completed
16:32:01.464 INFO  === Index Id: geonames, Shard ID: 1 ===
16:32:01.473 INFO  210 documents found in the current Lucene index
16:32:01.479 INFO  210 documents in current bulk request
16:32:01.495 INFO  Shard reindexing completed
16:32:01.495 INFO  === Index Id: geonames, Shard ID: 2 ===
16:32:01.506 INFO  201 documents found in the current Lucene index
16:32:01.515 INFO  201 documents in current bulk request
16:32:01.521 INFO  Shard reindexing completed
16:32:01.521 INFO  === Index Id: geonames, Shard ID: 3 ===
16:32:01.531 INFO  188 documents found in the current Lucene index
16:32:01.535 INFO  188 documents in current bulk request
16:32:01.543 INFO  Shard reindexing completed
16:32:01.543 INFO  === Index Id: geonames, Shard ID: 4 ===
16:32:01.550 INFO  195 documents found in the current Lucene index
16:32:01.555 INFO  195 documents in current bulk request
16:32:01.564 INFO  Shard reindexing completed
```

### Check List
- [x] New functionality includes testing
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
