### PR TITLE
Change gradle copy to sync to clear old jars

### DIFF
--- a/RFS/build.gradle
+++ b/RFS/build.gradle
@@ -70,7 +70,7 @@ task demoPrintOutSnapshot (type: JavaExec) {
     mainClass = 'com.rfs.DemoPrintOutSnapshot'
 }
 
-task copyDockerRuntimeJars (type: Copy) {
+task copyDockerRuntimeJars (type: Sync) {
     description = 'Copy runtime JARs and app jar to docker build directory'
 
     // Define the destination directory

--- a/TrafficCapture/buildSrc/src/main/groovy/org/opensearch/migrations/common/CommonUtils.groovy
+++ b/TrafficCapture/buildSrc/src/main/groovy/org/opensearch/migrations/common/CommonUtils.groovy
@@ -1,6 +1,6 @@
 package org.opensearch.migrations.common
 
-import org.gradle.api.tasks.Copy
+import org.gradle.api.tasks.Sync
 import org.gradle.api.Project
 import com.bmuschko.gradle.docker.tasks.image.Dockerfile
 
@@ -27,7 +27,9 @@ class CommonUtils {
         copyArtifact(project, projectName, projectName, destDir)
     }
     static def copyArtifact(Project project, String artifactProjectName, String destProjectName, String destDir) {
-        project.task("copyArtifact_${destProjectName}", type: Copy) {
+        // Sync performs a copy, while also deleting items from the destination directory that are not in the source directory
+        // In our case, jars of old versions were getting "stuck" and causing conflicts when the program was run
+        project.task("copyArtifact_${destProjectName}", type: Sync) {
             dependsOn ":${artifactProjectName}:build"
             dependsOn ":${artifactProjectName}:jar"
             if (destProjectName == "trafficCaptureProxyServerTest") {


### PR DESCRIPTION
### Description
There is a step in our gradle build that copies jar files from the project (e.g. Replayer) build artifacts directory into a `dockerSolution` build directory, which is where the generated Dockerfile expects them to be to copy them into the image.

However, this `dockerSolution` build directory is only "emptied" on a `gradle clean`, which means that as versions of our dependencies are updated, that build directory is effectively append-only and continues collecting old versions of jars, which are then copied into our images.

This causes issues. In this specific case, conflicting versions of log4j2 were causing the replayer to crash on startup, when the image was being built in a non-clean environment.
We're also probably making our images larger than they need to be.

The same pattern was being used in TrafficCapture and RFS gradle build scripts, so both have been updated.


### Issues Resolved
n/a

### Testing
Local testing.
Along with functional testing, I did:
```shell
# after running with Copy
-> ls ~/code/opensearch-migrations/TrafficCapture/dockerSolution/build/docker/trafficReplayer/jars > copied_jars.txt
-> cat copied_jars.txt | grep 'log4j-'
log4j-api-2.21.1.jar
log4j-api-2.23.1.jar # note the conflicting versions here
log4j-core-2.21.1.jar
log4j-core-2.23.1.jar
log4j-slf4j2-impl-2.21.1.jar
log4j-slf4j2-impl-2.23.1.jar
# after running with Sync
-> ls ~/code/opensearch-migrations/TrafficCapture/dockerSolution/build/docker/trafficReplayer/jars > synced_jars.txt
# compare (output is truncated to the relevant changes in this case)
-> diff copied_jars.txt synced_jars.txt
74d59
< log4j-api-2.21.1.jar
76d60
< log4j-core-2.21.1.jar
78d61
< log4j-slf4j2-impl-2.21.1.jar
81d63
```


### Check List
- [ ] New functionality includes testing
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
