### PR TITLE
Enhance matching in multilinePattern

### DIFF
--- a/deployment/cdk/opensearch-service-migration/lib/service-stacks/migration-service-core.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/service-stacks/migration-service-core.ts
@@ -135,7 +135,8 @@ export class MigrationServiceCore extends Stack {
                 // E.g. "[INFO ] 2024-12-31 23:59:59..."
                 // and  "[ERROR] 2024-12-31 23:59:59..."
                 // and  "2024-12-31 23:59:59..."
-                multilinePattern: "^(\\[[A-Z ]{1,5}\\] )?\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}",
+                // and  "2024-12-31T23:59:59..."
+                multilinePattern: "^(\\[[A-Z ]{1,5}\\] )?\\d{4}-\\d{2}-\\d{2}[ T]\\d{2}:\\d{2}:\\d{2}",
                 // Defer buffering behavior to log4j2 for greater flexibility
                 mode: AwsLogDriverMode.BLOCKING,
             }),


### PR DESCRIPTION
### Description
Encountered some commingled logs based on log4j error messages with start pattern

```
2024-04-24T20:14:52.298694Z activeWorkMonitorThread-1-1 ERROR Unable to format msg:   age=PT22M33.253339957S, start=2024-04-24T19:52:19.045091Z id=<<1213618629>> backPressureBlock: attribs={}

    age=PT22M33.253607907S, start=2024-04-24T19:52:19.044828Z id=<<1199419919>> readNextTrafficStreamChunk: attribs={} java.lang.IllegalArgumentException: found 2 argument placeholders, but provided 0 for pattern `  age=PT22M33.253339957S, start=2024-04-24T19:52:19.045091Z id=<<1213618629>> backPressureBlock: attribs={}
``` 

* Category: Bug fix
* Why these changes are required? all unique lines start patterns should be specified in our multiline pattern
* What is the old behavior before changes and new behavior after changes? this log may have been joined with another one.

### Issues Resolved
N/A

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]

### Check List
- [ ] New functionality includes testing
  - [ ] All tests pass, including unit test, integration test and doctest
- [ x] New functionality has been documented
- [ x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
