### PR TITLE
S3Repo now uses Async client and TransferManager

### DIFF
--- a/RFS/build.gradle
+++ b/RFS/build.gradle
@@ -25,6 +25,11 @@ repositories {
     mavenCentral()
 }
 
+ext {
+    awsSdkVersion = '2.25.16'
+    dataset = findProperty('dataset') ?: 'skip_dataset'
+}
+
 dependencies {
     implementation 'com.beust:jcommander:1.81'
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.16.2'
@@ -41,7 +46,11 @@ dependencies {
     implementation platform('io.projectreactor:reactor-bom:2023.0.5') 
     implementation 'io.projectreactor.netty:reactor-netty-core' 
     implementation 'io.projectreactor.netty:reactor-netty-http'
-    implementation 'software.amazon.awssdk:s3:2.25.16'
+
+    implementation platform("software.amazon.awssdk:bom:$awsSdkVersion")
+    implementation 'software.amazon.awssdk:s3'
+    implementation 'software.amazon.awssdk:s3-transfer-manager'
+    implementation 'software.amazon.awssdk.crt:aws-crt:0.29.18'
 
     testImplementation 'io.projectreactor:reactor-test:3.6.5'
     testImplementation 'org.apache.logging.log4j:log4j-core:2.23.1'
@@ -59,10 +68,6 @@ application {
 // Cleanup additional docker build directory
 clean.doFirst {
     delete project.file("./docker/build")
-}
-
-ext {
-    dataset = findProperty('dataset') ?: 'skip_dataset'
 }
 
 task demoPrintOutSnapshot (type: JavaExec) {

--- a/RFS/src/main/java/com/rfs/ReindexFromSnapshot.java
+++ b/RFS/src/main/java/com/rfs/ReindexFromSnapshot.java
@@ -164,7 +164,7 @@ public class ReindexFromSnapshot {
         if (snapshotDirPath != null) {
             repo = new FilesystemRepo(snapshotDirPath);
         } else if (s3RepoUri != null && s3Region != null && s3LocalDirPath != null) {
-            repo = S3Repo.create(s3LocalDirPath, s3RepoUri, s3Region);
+            repo = S3Repo.create(s3LocalDirPath, new S3Uri(s3RepoUri), s3Region);
         } else if (snapshotLocalRepoDirPath != null) {
             repo = new FilesystemRepo(snapshotLocalRepoDirPath);
         } else {

--- a/RFS/src/main/java/com/rfs/common/FilesystemRepo.java
+++ b/RFS/src/main/java/com/rfs/common/FilesystemRepo.java
@@ -38,46 +38,55 @@ public class FilesystemRepo implements SourceRepo {
         this.repoRootDir = repoRootDir;
     }
 
+    @Override
     public Path getRepoRootDir() {
         return repoRootDir;
     }
 
+    @Override
     public Path getSnapshotRepoDataFilePath() throws IOException {
         return findRepoFile();
     }
 
+    @Override
     public Path getGlobalMetadataFilePath(String snapshotId) throws IOException {
         String filePath = getRepoRootDir().toString() + "/meta-" + snapshotId + ".dat";
         return Path.of(filePath);
     }
 
+    @Override
     public Path getSnapshotMetadataFilePath(String snapshotId) throws IOException {
         String filePath = getRepoRootDir().toString() + "/snap-" + snapshotId + ".dat";
         return Path.of(filePath);
     }
 
+    @Override
     public Path getIndexMetadataFilePath(String indexId, String indexFileId) throws IOException {
         String filePath = getRepoRootDir().toString() + "/indices/" + indexId + "/meta-" + indexFileId + ".dat";
         return Path.of(filePath);
     }
 
+    @Override
     public Path getShardDirPath(String indexId, int shardId) throws IOException {
         String shardDirPath = getRepoRootDir().toString() + "/indices/" + indexId + "/" + shardId;
         return Path.of(shardDirPath);
     }
 
+    @Override
     public Path getShardMetadataFilePath(String snapshotId, String indexId, int shardId) throws IOException {
         Path shardDirPath = getShardDirPath(indexId, shardId);
         Path filePath = shardDirPath.resolve("snap-" + snapshotId + ".dat");
         return filePath;
     }
 
+    @Override
     public Path getBlobFilePath(String indexId, int shardId, String blobName) throws IOException {
         Path shardDirPath = getShardDirPath(indexId, shardId);
         Path filePath = shardDirPath.resolve(blobName);
         return filePath;
     }
 
+    @Override
     public void prepBlobFiles(ShardMetadata.Data shardMetadata) throws IOException {
         // No work necessary for local filesystem
     }

--- a/RFS/src/main/java/com/rfs/common/FilesystemRepo.java
+++ b/RFS/src/main/java/com/rfs/common/FilesystemRepo.java
@@ -77,4 +77,8 @@ public class FilesystemRepo implements SourceRepo {
         Path filePath = shardDirPath.resolve(blobName);
         return filePath;
     }
+
+    public void prepBlobFiles(ShardMetadata.Data shardMetadata) throws IOException {
+        // No work necessary for local filesystem
+    }
 }

--- a/RFS/src/main/java/com/rfs/common/S3Repo.java
+++ b/RFS/src/main/java/com/rfs/common/S3Repo.java
@@ -3,29 +3,36 @@ package com.rfs.common;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
-import software.amazon.awssdk.core.sync.ResponseTransformer;
+import software.amazon.awssdk.core.async.AsyncResponseTransformer;
 import software.amazon.awssdk.regions.Region;
-import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
 import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
 import software.amazon.awssdk.services.s3.model.S3Object;
+import software.amazon.awssdk.transfer.s3.S3TransferManager;
+import software.amazon.awssdk.transfer.s3.model.CompletedDirectoryDownload;
+import software.amazon.awssdk.transfer.s3.model.DirectoryDownload;
+import software.amazon.awssdk.transfer.s3.model.DownloadDirectoryRequest;
 
 import java.util.Comparator;
 import java.util.Optional;
 
 public class S3Repo implements SourceRepo {
     private static final Logger logger = LogManager.getLogger(S3Repo.class);
+    private static final double S3_TARGET_THROUGHPUT_GIBPS = 10.0; // Arbitrarily chosen
+    private static final long S3_MINIMUM_PART_SIZE_BYTES = 8L * 1024 * 1024; // Default, but be explicit
 
     private final Path s3LocalDir;
-    private final String s3RepoUri;
+    private final S3Uri s3RepoUri;
     private final String s3Region;
-    private final S3Client s3Client;
+    private final S3AsyncClient s3Client;
 
     private static int extractVersion(String key) {
         try {
@@ -35,55 +42,61 @@ public class S3Repo implements SourceRepo {
         }
     }
 
-    protected String findRepoFileUri() {
-        String bucketName = getS3BucketName();
-        String prefix = getS3ObjectsPrefix();
-
+    protected S3Uri findRepoFileUri() {
         ListObjectsV2Request listRequest = ListObjectsV2Request.builder()
-                .bucket(bucketName)
-                .prefix(prefix)
+                .bucket(s3RepoUri.bucketName)
+                .prefix(s3RepoUri.key)
                 .build();
 
-        ListObjectsV2Response listResponse = s3Client.listObjectsV2(listRequest);
+        ListObjectsV2Response listResponse = s3Client.listObjectsV2(listRequest).join();
 
         Optional<S3Object> highestVersionedIndexFile = listResponse.contents().stream()
                 .filter(s3Object -> s3Object.key().matches(".*index-\\d+$")) // Regex to match index files
                 .max(Comparator.comparingInt(s3Object -> extractVersion(s3Object.key())));
 
-        return highestVersionedIndexFile
-                .map(s3Object -> "s3://" + bucketName + "/" + s3Object.key())
-                .orElse(null);
+        String rawUri = highestVersionedIndexFile
+                .map(s3Object -> "s3://" + s3RepoUri.bucketName + "/" + s3Object.key())
+                .orElse("");
+        return new S3Uri(rawUri);
     }
 
     protected void ensureS3LocalDirectoryExists(Path localPath) throws IOException {
         Files.createDirectories(localPath);
     }
 
-    private void downloadFile(String s3Uri, Path localPath) throws IOException {
-        logger.info("Downloading file from S3: " + s3Uri + " to " + localPath);
-        ensureS3LocalDirectoryExists(localPath.getParent());
-
-        String bucketName = s3Uri.split("/")[2];
-        String key = s3Uri.split(bucketName + "/")[1];
-
-        GetObjectRequest getObjectRequest = GetObjectRequest.builder()
-                .bucket(bucketName)
-                .key(key)
-                .build();
-
-        s3Client.getObject(getObjectRequest, ResponseTransformer.toFile(localPath));
+    protected boolean doesFileExistLocally(Path localPath) {
+        return Files.exists(localPath);
     }
 
-    public static S3Repo create(Path s3LocalDir, String s3Uri, String s3Region) {
-        S3Client s3Client = S3Client.builder()
-                .region(Region.of(s3Region))
-                .credentialsProvider(DefaultCredentialsProvider.create())
+    private void ensureFileExistsLocally(S3Uri s3Uri, Path localPath) throws IOException {
+        ensureS3LocalDirectoryExists(localPath.getParent());
+
+        if (doesFileExistLocally(localPath)) {
+            logger.debug("File already exists locally: " + localPath);
+            return;
+        }
+
+        logger.info("Downloading file from S3: " + s3Uri.uri + " to " + localPath);
+        GetObjectRequest getObjectRequest = GetObjectRequest.builder()
+                .bucket(s3Uri.bucketName)
+                .key(s3Uri.key)
                 .build();
+
+        s3Client.getObject(getObjectRequest, AsyncResponseTransformer.toFile(localPath)).join();
+    }
+
+    public static S3Repo create(Path s3LocalDir, S3Uri s3Uri, String s3Region) {
+        S3AsyncClient s3Client = S3AsyncClient.crtBuilder()
+                                                   .credentialsProvider(DefaultCredentialsProvider.create())
+                                                   .region(Region.of(s3Region))
+                                                   .targetThroughputInGbps(S3_TARGET_THROUGHPUT_GIBPS)
+                                                   .minimumPartSizeInBytes(S3_MINIMUM_PART_SIZE_BYTES)
+                                                   .build();
 
         return new S3Repo(s3LocalDir, s3Uri, s3Region, s3Client);
     }
 
-    public S3Repo(Path s3LocalDir, String s3Uri, String s3Region, S3Client s3Client) {
+    public S3Repo(Path s3LocalDir, S3Uri s3Uri, String s3Region, S3AsyncClient s3Client) {
         this.s3LocalDir = s3LocalDir;
         this.s3RepoUri = s3Uri;        
         this.s3Region = s3Region;
@@ -95,12 +108,12 @@ public class S3Repo implements SourceRepo {
     }
 
     public Path getSnapshotRepoDataFilePath() throws IOException {
-        String repoFileS3Uri = findRepoFileUri();
+        S3Uri repoFileS3Uri = findRepoFileUri();
         
-        String relativeFileS3Uri = repoFileS3Uri.substring(s3RepoUri.length() + 1);
+        String relativeFileS3Uri = repoFileS3Uri.uri.substring(s3RepoUri.uri.length() + 1);
 
         Path localFilePath = s3LocalDir.resolve(relativeFileS3Uri);
-        downloadFile(repoFileS3Uri, localFilePath);
+        ensureFileExistsLocally(repoFileS3Uri, localFilePath);
         
         return localFilePath;
     }
@@ -108,21 +121,24 @@ public class S3Repo implements SourceRepo {
     public Path getGlobalMetadataFilePath(String snapshotId) throws IOException {
         String suffix = "meta-" + snapshotId + ".dat";
         Path filePath = s3LocalDir.resolve(suffix);
-        downloadFile(s3RepoUri + "/" + suffix, filePath);
+        S3Uri fileUri = new S3Uri(s3RepoUri.uri + "/" + suffix);
+        ensureFileExistsLocally(fileUri, filePath);
         return filePath;
     }
 
     public Path getSnapshotMetadataFilePath(String snapshotId) throws IOException {
         String suffix = "snap-" + snapshotId + ".dat";
         Path filePath = s3LocalDir.resolve(suffix);
-        downloadFile(s3RepoUri + "/" + suffix, filePath);
+        S3Uri fileUri = new S3Uri(s3RepoUri.uri + "/" + suffix);
+        ensureFileExistsLocally(fileUri, filePath);
         return filePath;
     }
 
     public Path getIndexMetadataFilePath(String indexId, String indexFileId) throws IOException {
         String suffix = "indices/" + indexId + "/meta-" + indexFileId + ".dat";
         Path filePath = s3LocalDir.resolve(suffix);
-        downloadFile(s3RepoUri + "/" + suffix, filePath);
+        S3Uri fileUri = new S3Uri(s3RepoUri.uri + "/" + suffix);
+        ensureFileExistsLocally(fileUri, filePath);
         return filePath;
     }
 
@@ -135,30 +151,39 @@ public class S3Repo implements SourceRepo {
     public Path getShardMetadataFilePath(String snapshotId, String indexId, int shardId) throws IOException {
         String suffix = "indices/" + indexId + "/" + shardId + "/snap-" + snapshotId + ".dat";
         Path filePath = s3LocalDir.resolve(suffix);
-        downloadFile(s3RepoUri + "/" + suffix, filePath);
+        S3Uri fileUri = new S3Uri(s3RepoUri.uri + "/" + suffix);
+        ensureFileExistsLocally(fileUri, filePath);
         return filePath;
     }
 
     public Path getBlobFilePath(String indexId, int shardId, String blobName) throws IOException {
         String suffix = "indices/" + indexId + "/" + shardId + "/" + blobName;
         Path filePath = s3LocalDir.resolve(suffix);
-        downloadFile(s3RepoUri + "/" + suffix, filePath);
+        S3Uri fileUri = new S3Uri(s3RepoUri.uri + "/" + suffix);
+        ensureFileExistsLocally(fileUri, filePath);
         return filePath;
     }
 
-    public String getS3BucketName() {
-         String[] parts = s3RepoUri.substring(5).split("/", 2);
-         return parts[0];
-    }
+    public void prepBlobFiles(ShardMetadata.Data shardMetadata) throws IOException {
+        S3TransferManager transferManager = S3TransferManager.builder().s3Client(s3Client).build();
+        
+        Path shardDirPath = getShardDirPath(shardMetadata.getIndexId(), shardMetadata.getShardId());
+        ensureS3LocalDirectoryExists(shardDirPath);        
 
-    public String getS3ObjectsPrefix() {
-        String[] parts = s3RepoUri.substring(5).split("/", 2);
-        String prefix = parts.length > 1 ? parts[1] : "";
+        String blobFilesS3Prefix = s3RepoUri.key + "indices/" + shardMetadata.getIndexId() + "/" + shardMetadata.getShardId() + "/";
 
-        if (!prefix.isEmpty() && prefix.endsWith("/")) {
-            prefix = prefix.substring(0, prefix.length() - 1);
-        }
+        DirectoryDownload directoryDownload = transferManager.downloadDirectory(
+            DownloadDirectoryRequest.builder()
+                .destination(shardDirPath)
+                .bucket(s3RepoUri.bucketName)
+                .listObjectsV2RequestTransformer(l -> l.prefix(blobFilesS3Prefix))
+                .build()
+        );
 
-        return prefix;
+        // Wait for the transfer to complete
+        CompletedDirectoryDownload completedDirectoryDownload = directoryDownload.completionFuture().join();
+
+        // Print out any failed downloads
+        completedDirectoryDownload.failedTransfers().forEach(logger::warn);
     }
 }

--- a/RFS/src/main/java/com/rfs/common/S3Repo.java
+++ b/RFS/src/main/java/com/rfs/common/S3Repo.java
@@ -172,6 +172,7 @@ public class S3Repo implements SourceRepo {
 
         String blobFilesS3Prefix = s3RepoUri.key + "indices/" + shardMetadata.getIndexId() + "/" + shardMetadata.getShardId() + "/";
 
+        logger.info("Downloading blob files from S3: s3://" + s3RepoUri.bucketName + "/" + blobFilesS3Prefix + " to " + shardDirPath);
         DirectoryDownload directoryDownload = transferManager.downloadDirectory(
             DownloadDirectoryRequest.builder()
                 .destination(shardDirPath)
@@ -183,7 +184,9 @@ public class S3Repo implements SourceRepo {
         // Wait for the transfer to complete
         CompletedDirectoryDownload completedDirectoryDownload = directoryDownload.completionFuture().join();
 
+        logger.info("Blob file download(s) complete");
+
         // Print out any failed downloads
-        completedDirectoryDownload.failedTransfers().forEach(logger::warn);
+        completedDirectoryDownload.failedTransfers().forEach(logger::error);
     }
 }

--- a/RFS/src/main/java/com/rfs/common/S3Uri.java
+++ b/RFS/src/main/java/com/rfs/common/S3Uri.java
@@ -1,0 +1,20 @@
+package com.rfs.common;
+
+public class S3Uri {
+    public final String bucketName;
+    public final String key;
+    public final String uri;
+
+    public S3Uri(String rawUri) {
+        String[] parts = rawUri.substring(5).split("/", 2);
+        bucketName = parts[0];
+
+        String keyRaw = parts.length > 1 ? parts[1] : "";
+        if (!keyRaw.isEmpty() && keyRaw.endsWith("/")) {
+            keyRaw = keyRaw.substring(0, keyRaw.length() - 1);
+        }
+        key = keyRaw;
+
+        uri = rawUri.endsWith("/") ? rawUri.substring(0, rawUri.length() - 1) : rawUri;
+    }
+}

--- a/RFS/src/main/java/com/rfs/common/SnapshotShardUnpacker.java
+++ b/RFS/src/main/java/com/rfs/common/SnapshotShardUnpacker.java
@@ -21,6 +21,9 @@ public class SnapshotShardUnpacker {
         // Some constants
         NativeFSLockFactory lockFactory = NativeFSLockFactory.INSTANCE;
 
+        // Ensure the blob files are prepped, if they need to be
+        repo.prepBlobFiles(shardMetadata);
+
         // Create the directory for the shard's lucene files
         Path luceneIndexDir = Paths.get(luceneFilesBasePath + "/" + shardMetadata.getIndexName() + "/" + shardMetadata.getShardId());
         Files.createDirectories(luceneIndexDir);

--- a/RFS/src/main/java/com/rfs/common/SourceRepo.java
+++ b/RFS/src/main/java/com/rfs/common/SourceRepo.java
@@ -12,4 +12,10 @@ public interface SourceRepo {
     public Path getShardDirPath(String indexId, int shardId) throws IOException;
     public Path getShardMetadataFilePath(String snapshotId, String indexId, int shardId) throws IOException;
     public Path getBlobFilePath(String indexId, int shardId, String blobName) throws IOException;
+
+    /*
+    * Performs any work necessary to facilitate access to a given shard's blob files.  Depending on the implementation,
+    * may involve no work at all, bulk downloading objects from a remote source, or any other operations.
+    */
+    public void prepBlobFiles(ShardMetadata.Data shardMetadata) throws IOException;
 }

--- a/RFS/src/main/java/com/rfs/transformers/Transformer_ES_6_8_to_OS_2_11.java
+++ b/RFS/src/main/java/com/rfs/transformers/Transformer_ES_6_8_to_OS_2_11.java
@@ -15,6 +15,7 @@ public class Transformer_ES_6_8_to_OS_2_11 implements Transformer {
         this.awarenessAttributeDimensionality = awarenessAttributeDimensionality;
     }
 
+    @Override
     public ObjectNode transformGlobalMetadata(ObjectNode root) {
         ObjectNode newRoot = mapper.createObjectNode();
 
@@ -49,6 +50,7 @@ public class Transformer_ES_6_8_to_OS_2_11 implements Transformer {
         return newRoot;
     }
 
+    @Override
     public ObjectNode transformIndexMetadata(ObjectNode root){
         ObjectNode newRoot = root.deepCopy();
 

--- a/RFS/src/main/java/com/rfs/transformers/Transformer_ES_7_10_OS_2_11.java
+++ b/RFS/src/main/java/com/rfs/transformers/Transformer_ES_7_10_OS_2_11.java
@@ -15,6 +15,7 @@ public class Transformer_ES_7_10_OS_2_11 implements Transformer {
         this.awarenessAttributeDimensionality = awarenessAttributeDimensionality;
     }
 
+    @Override
     public ObjectNode transformGlobalMetadata(ObjectNode root){
         ObjectNode newRoot = mapper.createObjectNode();
 
@@ -64,6 +65,7 @@ public class Transformer_ES_7_10_OS_2_11 implements Transformer {
         return newRoot;
     }
 
+    @Override
     public ObjectNode transformIndexMetadata(ObjectNode root){
         ObjectNode newRoot = root.deepCopy();
 

--- a/RFS/src/main/java/com/rfs/version_es_6_8/GlobalMetadataData_ES_6_8.java
+++ b/RFS/src/main/java/com/rfs/version_es_6_8/GlobalMetadataData_ES_6_8.java
@@ -9,6 +9,7 @@ public class GlobalMetadataData_ES_6_8 implements com.rfs.common.GlobalMetadata.
         this.root = root;
     }
 
+    @Override
     public ObjectNode toObjectNode() throws Exception {
         return root;
     }

--- a/RFS/src/main/java/com/rfs/version_es_6_8/GlobalMetadataFactory_ES_6_8.java
+++ b/RFS/src/main/java/com/rfs/version_es_6_8/GlobalMetadataFactory_ES_6_8.java
@@ -7,11 +7,13 @@ import com.rfs.common.GlobalMetadata;
 
 public class GlobalMetadataFactory_ES_6_8 implements com.rfs.common.GlobalMetadata.Factory{
     
+    @Override
     public GlobalMetadata.Data fromJsonNode(JsonNode root) throws Exception {
         ObjectNode metadataRoot = (ObjectNode) root.get("meta-data");
         return new GlobalMetadataData_ES_6_8(metadataRoot);
     }
 
+    @Override
     public SmileFactory getSmileFactory() {
         return ElasticsearchConstants_ES_6_8.SMILE_FACTORY;
     }

--- a/RFS/src/main/java/com/rfs/version_es_6_8/IndexMetadataData_ES_6_8.java
+++ b/RFS/src/main/java/com/rfs/version_es_6_8/IndexMetadataData_ES_6_8.java
@@ -19,14 +19,17 @@ public class IndexMetadataData_ES_6_8 implements com.rfs.common.IndexMetadata.Da
         this.indexName = indexName;
     }
 
+    @Override
     public ObjectNode getAliases() {
         return (ObjectNode) root.get("aliases");
     }
 
+    @Override
     public String getId() {
         return indexId;
     }
 
+    @Override
     public ObjectNode getMappings() {
         if (mappings != null) {
             return mappings;
@@ -39,14 +42,17 @@ public class IndexMetadataData_ES_6_8 implements com.rfs.common.IndexMetadata.Da
         return mappings;
     }
 
+    @Override
     public String getName() {
         return indexName;
     }
 
+    @Override
     public int getNumberOfShards() {
         return this.getSettings().get("index").get("number_of_shards").asInt();
     }   
 
+    @Override
     public ObjectNode getSettings() {
         if (settings != null) {
             return settings;
@@ -61,6 +67,7 @@ public class IndexMetadataData_ES_6_8 implements com.rfs.common.IndexMetadata.Da
         return settings;
     }
 
+    @Override
     public ObjectNode toObjectNode() {
         return root;
     }

--- a/RFS/src/main/java/com/rfs/version_es_6_8/IndexMetadataFactory_ES_6_8.java
+++ b/RFS/src/main/java/com/rfs/version_es_6_8/IndexMetadataFactory_ES_6_8.java
@@ -8,15 +8,18 @@ import com.rfs.common.SnapshotRepo;
 
 public class IndexMetadataFactory_ES_6_8 implements com.rfs.common.IndexMetadata.Factory {
     
+    @Override
     public IndexMetadata.Data fromJsonNode(JsonNode root, String indexId, String indexName) throws Exception {
         ObjectNode objectNodeRoot = (ObjectNode) root.get(indexName);
         return new IndexMetadataData_ES_6_8(objectNodeRoot, indexId, indexName);
     }
 
+    @Override
     public SmileFactory getSmileFactory() {
         return ElasticsearchConstants_ES_6_8.SMILE_FACTORY;
     }
 
+    @Override
     public String getIndexFileId(SnapshotRepo.Provider repoDataProvider, String snapshotName, String indexName) {
         return repoDataProvider.getSnapshotId(snapshotName);
     }

--- a/RFS/src/main/java/com/rfs/version_es_6_8/ShardMetadataData_ES_6_8.java
+++ b/RFS/src/main/java/com/rfs/version_es_6_8/ShardMetadataData_ES_6_8.java
@@ -60,42 +60,52 @@ public class ShardMetadataData_ES_6_8 implements com.rfs.common.ShardMetadata.Da
         this.files = convertedFiles;
     }
 
+    @Override
     public String getSnapshotName() {
         return snapshotName;
     }
 
+    @Override
     public String getIndexName() {
         return indexName;
     }
 
+    @Override
     public String getIndexId() {
         return indexId;
     }
 
+    @Override
     public int getShardId() {
         return shardId;
     }
 
+    @Override
     public int getIndexVersion() {
         return indexVersion;
     }
 
+    @Override
     public long getStartTime() {
         return startTime;
     }
 
+    @Override
     public long getTime() {
         return time;
     }
 
+    @Override
     public int getNumberOfFiles() {
         return numberOfFiles;
     }
 
+    @Override
     public long getTotalSize() {
         return totalSize;
     }
 
+    @Override
     public List<ShardMetadata.FileInfo> getFiles() {
         List<ShardMetadata.FileInfo> convertedFiles = new ArrayList<>(files);
         return convertedFiles;
@@ -194,39 +204,48 @@ public class ShardMetadataData_ES_6_8 implements com.rfs.common.ShardMetadata.Da
             this.numberOfParts = numberOfParts;
         }
 
+        @Override
         public String getName() {
             return name;
         }
 
+        @Override
         public String getPhysicalName() {
             return physicalName;
         }
 
+        @Override
         public long getLength() {
             return length;
         }
 
+        @Override
         public String getChecksum() {
             return checksum;
         }
 
+        @Override
         public long getPartSize() {
             return partSize;
         }
 
+        @Override
         public String getWrittenBy() {
             return writtenBy;
         }
 
+        @Override
         public BytesRef getMetaHash() {
             return metaHash;
         }
 
+        @Override
         public long getNumberOfParts() {
             return numberOfParts;
         }
 
         // The Snapshot file may be split into multiple blobs; use this to find the correct file name
+        @Override
         public String partName(long part) {
             if (numberOfParts > 1) {
                 return name + ".part" + part;

--- a/RFS/src/main/java/com/rfs/version_es_6_8/ShardMetadataFactory_ES_6_8.java
+++ b/RFS/src/main/java/com/rfs/version_es_6_8/ShardMetadataFactory_ES_6_8.java
@@ -9,6 +9,7 @@ import com.rfs.common.ShardMetadata;
 
 public class ShardMetadataFactory_ES_6_8 implements ShardMetadata.Factory {
 
+    @Override
     public ShardMetadata.Data fromJsonNode(JsonNode root, String indexId, String indexName, int shardId) throws Exception {
         ObjectMapper objectMapper = new ObjectMapper();
         SimpleModule module = new SimpleModule();
@@ -31,6 +32,7 @@ public class ShardMetadataFactory_ES_6_8 implements ShardMetadata.Factory {
         );
     }
 
+    @Override
     public SmileFactory getSmileFactory() {
         return ElasticsearchConstants_ES_6_8.SMILE_FACTORY;
     }

--- a/RFS/src/main/java/com/rfs/version_es_6_8/SnapshotMetadataData_ES_6_8.java
+++ b/RFS/src/main/java/com/rfs/version_es_6_8/SnapshotMetadataData_ES_6_8.java
@@ -4,8 +4,10 @@ import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import com.rfs.common.SnapshotMetadata;
 
-public class SnapshotMetadataData_ES_6_8 implements com.rfs.common.SnapshotMetadata.Data{
+
+public class SnapshotMetadataData_ES_6_8 implements SnapshotMetadata.Data{
 
     private String name;
     private String uuid;
@@ -26,50 +28,62 @@ public class SnapshotMetadataData_ES_6_8 implements com.rfs.common.SnapshotMetad
     private int successfulShards;
     private List<?> failures; // Haven't looked at this yet
 
+    @Override
     public String getName() {
         return name;
     }
 
+    @Override
     public String getUuid() {
         return uuid;
     }
 
+    @Override
     public int getVersionId() {
         return versionId;
     }
 
+    @Override
     public List<String> getIndices() {
         return indices;
     }
 
+    @Override
     public String getState() {
         return state;
     }
 
+    @Override
     public String getReason() {
         return reason;
     }
 
+    @Override
     public boolean isIncludeGlobalState() {
         return includeGlobalState;
     }
 
+    @Override
     public long getStartTime() {
         return startTime;
     }
 
+    @Override
     public long getEndTime() {
         return endTime;
     }
 
+    @Override
     public int getTotalShards() {
         return totalShards;
     }
 
+    @Override
     public int getSuccessfulShards() {
         return successfulShards;
     }
 
+    @Override
     public List<?> getFailures() {
         return failures;
     }

--- a/RFS/src/main/java/com/rfs/version_es_6_8/SnapshotMetadataFactory_ES_6_8.java
+++ b/RFS/src/main/java/com/rfs/version_es_6_8/SnapshotMetadataFactory_ES_6_8.java
@@ -13,6 +13,7 @@ public class SnapshotMetadataFactory_ES_6_8 implements com.rfs.common.SnapshotMe
      * 
      * [1] https://github.com/elastic/elasticsearch/blob/6.8/server/src/main/java/org/elasticsearch/snapshots/SnapshotInfo.java#L583
      */
+    @Override
     public SnapshotMetadata.Data fromJsonNode(JsonNode root) throws Exception {
         ObjectMapper mapper = new ObjectMapper();
         ObjectNode objectNodeRoot = (ObjectNode) root;
@@ -20,6 +21,7 @@ public class SnapshotMetadataFactory_ES_6_8 implements com.rfs.common.SnapshotMe
         return snapshotMetadata;
     }
 
+    @Override
     public SmileFactory getSmileFactory() {
         return ElasticsearchConstants_ES_6_8.SMILE_FACTORY;
     }

--- a/RFS/src/main/java/com/rfs/version_es_6_8/SnapshotRepoData_ES_6_8.java
+++ b/RFS/src/main/java/com/rfs/version_es_6_8/SnapshotRepoData_ES_6_8.java
@@ -37,10 +37,12 @@ public class SnapshotRepoData_ES_6_8 {
         public String uuid;
         public int state;
 
+        @Override
         public String getName() {
             return name;
         }
 
+        @Override
         public String getId() {
             return uuid;
         }
@@ -64,14 +66,17 @@ public class SnapshotRepoData_ES_6_8 {
         public String id;
         public List<String> snapshots;
 
+        @Override
         public String getName() {
             return name;
         }
 
+        @Override
         public String getId() {
             return id;
         }
 
+        @Override
         public List<String> getSnapshots() {
             return snapshots;
         }

--- a/RFS/src/main/java/com/rfs/version_es_6_8/SnapshotRepoProvider_ES_6_8.java
+++ b/RFS/src/main/java/com/rfs/version_es_6_8/SnapshotRepoProvider_ES_6_8.java
@@ -21,6 +21,7 @@ public class SnapshotRepoProvider_ES_6_8 implements SnapshotRepo.Provider {
                 .collect(Collectors.toList());
     }
 
+    @Override
     public List<SnapshotRepo.Index> getIndicesInSnapshot(String snapshotName) {
         List<SnapshotRepo.Index> matchedIndices = new ArrayList<>();
         SnapshotRepoData_ES_6_8.Snapshot targetSnapshot = repoData.snapshots.stream()
@@ -38,11 +39,13 @@ public class SnapshotRepoProvider_ES_6_8 implements SnapshotRepo.Provider {
         return matchedIndices;
     }
 
+    @Override
     public List<SnapshotRepo.Snapshot> getSnapshots() {
         List<SnapshotRepo.Snapshot> convertedList = new ArrayList<>(repoData.snapshots);
         return convertedList;
     }
     
+    @Override
     public String getSnapshotId(String snapshotName) {
         for (SnapshotRepoData_ES_6_8.Snapshot snapshot : repoData.snapshots) {
             if (snapshot.name.equals(snapshotName)) {
@@ -52,6 +55,7 @@ public class SnapshotRepoProvider_ES_6_8 implements SnapshotRepo.Provider {
         return null;
     }
 
+    @Override
     public String getIndexId(String indexName) {
         return repoData.indices.get(indexName).id;
     }

--- a/RFS/src/main/java/com/rfs/version_es_7_10/GlobalMetadataData_ES_7_10.java
+++ b/RFS/src/main/java/com/rfs/version_es_7_10/GlobalMetadataData_ES_7_10.java
@@ -9,6 +9,7 @@ public class GlobalMetadataData_ES_7_10 implements com.rfs.common.GlobalMetadata
         this.root = root;
     }
 
+    @Override
     public ObjectNode toObjectNode() throws Exception {
         return root;
     }

--- a/RFS/src/main/java/com/rfs/version_es_7_10/GlobalMetadataFactory_ES_7_10.java
+++ b/RFS/src/main/java/com/rfs/version_es_7_10/GlobalMetadataFactory_ES_7_10.java
@@ -7,11 +7,13 @@ import com.rfs.common.GlobalMetadata;
 
 public class GlobalMetadataFactory_ES_7_10 implements com.rfs.common.GlobalMetadata.Factory{
 
+    @Override
     public GlobalMetadata.Data fromJsonNode(JsonNode root) throws Exception {
         ObjectNode metadataRoot = (ObjectNode) root.get("meta-data");
         return new GlobalMetadataData_ES_7_10(metadataRoot);
     }
 
+    @Override
     public SmileFactory getSmileFactory() {
         return ElasticsearchConstants_ES_7_10.SMILE_FACTORY;
     }

--- a/RFS/src/main/java/com/rfs/version_es_7_10/IndexMetadataData_ES_7_10.java
+++ b/RFS/src/main/java/com/rfs/version_es_7_10/IndexMetadataData_ES_7_10.java
@@ -19,14 +19,17 @@ public class IndexMetadataData_ES_7_10 implements com.rfs.common.IndexMetadata.D
         this.indexName = indexName;
     }
 
+    @Override
     public ObjectNode getAliases() {
         return (ObjectNode) root.get("aliases");
     }
 
+    @Override
     public String getId() {
         return indexId;
     }
 
+    @Override
     public ObjectNode getMappings() {
         if (mappings != null) {
             return mappings;
@@ -39,14 +42,17 @@ public class IndexMetadataData_ES_7_10 implements com.rfs.common.IndexMetadata.D
         return mappings;
     }
 
+    @Override
     public String getName() {
         return indexName;
     }
 
+    @Override
     public int getNumberOfShards() {
         return this.getSettings().get("index").get("number_of_shards").asInt();
     }   
 
+    @Override
     public ObjectNode getSettings() {
         if (settings != null) {
             return settings;
@@ -61,6 +67,7 @@ public class IndexMetadataData_ES_7_10 implements com.rfs.common.IndexMetadata.D
         return settings;
     }
 
+    @Override
     public ObjectNode toObjectNode() {
         return root;
     }

--- a/RFS/src/main/java/com/rfs/version_es_7_10/IndexMetadataFactory_ES_7_10.java
+++ b/RFS/src/main/java/com/rfs/version_es_7_10/IndexMetadataFactory_ES_7_10.java
@@ -8,15 +8,18 @@ import com.rfs.common.SnapshotRepo;
 
 public class IndexMetadataFactory_ES_7_10 implements com.rfs.common.IndexMetadata.Factory {
     
+    @Override
     public IndexMetadata.Data fromJsonNode(JsonNode root, String indexId, String indexName) throws Exception {
         ObjectNode objectNodeRoot = (ObjectNode) root.get(indexName);
         return new IndexMetadataData_ES_7_10(objectNodeRoot, indexId, indexName);
     }
 
+    @Override
     public SmileFactory getSmileFactory() {
         return ElasticsearchConstants_ES_7_10.SMILE_FACTORY;
     }
 
+    @Override
     public String getIndexFileId(SnapshotRepo.Provider repoDataProvider, String snapshotName, String indexName) {
         SnapshotRepoProvider_ES_7_10 providerES710 = (SnapshotRepoProvider_ES_7_10) repoDataProvider;
         return providerES710.getIndexMetadataId(snapshotName, indexName);

--- a/RFS/src/main/java/com/rfs/version_es_7_10/ShardMetadataData_ES_7_10.java
+++ b/RFS/src/main/java/com/rfs/version_es_7_10/ShardMetadataData_ES_7_10.java
@@ -59,42 +59,52 @@ public class ShardMetadataData_ES_7_10 implements ShardMetadata.Data {
         this.files = convertedFiles;
     }
 
+    @Override
     public String getSnapshotName() {
         return snapshotName;
     }
 
+    @Override
     public String getIndexName() {
         return indexName;
     }
 
+    @Override
     public String getIndexId() {
         return indexId;
     }
 
+    @Override
     public int getShardId() {
         return shardId;
     }
 
+    @Override
     public int getIndexVersion() {
         return indexVersion;
     }
 
+    @Override
     public long getStartTime() {
         return startTime;
     }
 
+    @Override
     public long getTime() {
         return time;
     }
 
+    @Override
     public int getNumberOfFiles() {
         return numberOfFiles;
     }
 
+    @Override
     public long getTotalSize() {
         return totalSize;
     }
 
+    @Override
     public List<ShardMetadata.FileInfo> getFiles() {
         List<ShardMetadata.FileInfo> convertedFiles = new ArrayList<>(files);
         return convertedFiles;
@@ -193,39 +203,48 @@ public class ShardMetadataData_ES_7_10 implements ShardMetadata.Data {
             this.numberOfParts = numberOfParts;
         }
 
+        @Override
         public String getName() {
             return name;
         }
 
+        @Override
         public String getPhysicalName() {
             return physicalName;
         }
 
+        @Override
         public long getLength() {
             return length;
         }
 
+        @Override
         public String getChecksum() {
             return checksum;
         }
 
+        @Override
         public long getPartSize() {
             return partSize;
         }
 
+        @Override
         public String getWrittenBy() {
             return writtenBy;
         }
 
+        @Override
         public BytesRef getMetaHash() {
             return metaHash;
         }
 
+        @Override
         public long getNumberOfParts() {
             return numberOfParts;
         }
 
         // The Snapshot file may be split into multiple blobs; use this to find the correct file name
+        @Override
         public String partName(long part) {
             if (numberOfParts > 1) {
                 return name + ".part" + part;

--- a/RFS/src/main/java/com/rfs/version_es_7_10/ShardMetadataFactory_ES_7_10.java
+++ b/RFS/src/main/java/com/rfs/version_es_7_10/ShardMetadataFactory_ES_7_10.java
@@ -9,7 +9,7 @@ import com.rfs.common.ShardMetadata;
 
 public class ShardMetadataFactory_ES_7_10 implements ShardMetadata.Factory {
     
-
+    @Override
     public ShardMetadata.Data fromJsonNode(JsonNode root, String indexId, String indexName, int shardId) throws Exception {
         ObjectMapper objectMapper = new ObjectMapper();
         SimpleModule module = new SimpleModule();
@@ -32,6 +32,7 @@ public class ShardMetadataFactory_ES_7_10 implements ShardMetadata.Factory {
         );
     }
 
+    @Override
     public SmileFactory getSmileFactory() {
         return ElasticsearchConstants_ES_7_10.SMILE_FACTORY;
     }

--- a/RFS/src/main/java/com/rfs/version_es_7_10/SnapshotMetadataData_ES_7_10.java
+++ b/RFS/src/main/java/com/rfs/version_es_7_10/SnapshotMetadataData_ES_7_10.java
@@ -4,8 +4,10 @@ import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import com.rfs.common.SnapshotMetadata;
 
-public class SnapshotMetadataData_ES_7_10 implements com.rfs.common.SnapshotMetadata.Data{
+
+public class SnapshotMetadataData_ES_7_10 implements SnapshotMetadata.Data{
 
     private String name;
     private String uuid;
@@ -30,50 +32,62 @@ public class SnapshotMetadataData_ES_7_10 implements com.rfs.common.SnapshotMeta
     @JsonProperty("metadata")
     private Object metaData; // Haven't looked into this yet
 
+    @Override
     public String getName() {
         return name;
     }
 
+    @Override
     public String getUuid() {
         return uuid;
     }
 
+    @Override
     public int getVersionId() {
         return versionId;
     }
 
+    @Override
     public List<String> getIndices() {
         return indices;
     }
 
+    @Override
     public String getState() {
         return state;
     }
 
+    @Override
     public String getReason() {
         return reason;
     }
 
+    @Override
     public boolean isIncludeGlobalState() {
         return includeGlobalState;
     }
 
+    @Override
     public long getStartTime() {
         return startTime;
     }
 
+    @Override
     public long getEndTime() {
         return endTime;
     }
 
+    @Override
     public int getTotalShards() {
         return totalShards;
     }
 
+    @Override
     public int getSuccessfulShards() {
         return successfulShards;
     }
 
+    @Override
     public List<?> getFailures() {
         return failures;
     }

--- a/RFS/src/main/java/com/rfs/version_es_7_10/SnapshotMetadataFactory_ES_7_10.java
+++ b/RFS/src/main/java/com/rfs/version_es_7_10/SnapshotMetadataFactory_ES_7_10.java
@@ -13,6 +13,7 @@ public class SnapshotMetadataFactory_ES_7_10 implements com.rfs.common.SnapshotM
      * 
      * [1] https://github.com/elastic/elasticsearch/blob/6.8/server/src/main/java/org/elasticsearch/snapshots/SnapshotInfo.java#L583
      */
+    @Override
     public SnapshotMetadata.Data fromJsonNode(JsonNode root) throws Exception {
         ObjectMapper mapper = new ObjectMapper();
         ObjectNode objectNodeRoot = (ObjectNode) root;
@@ -20,6 +21,7 @@ public class SnapshotMetadataFactory_ES_7_10 implements com.rfs.common.SnapshotM
         return snapshotMetadata;
     }
 
+    @Override
     public SmileFactory getSmileFactory() {
         return ElasticsearchConstants_ES_7_10.SMILE_FACTORY;
     }

--- a/RFS/src/main/java/com/rfs/version_es_7_10/SnapshotRepoData_ES_7_10.java
+++ b/RFS/src/main/java/com/rfs/version_es_7_10/SnapshotRepoData_ES_7_10.java
@@ -44,10 +44,12 @@ public class SnapshotRepoData_ES_7_10 {
         public Map<String, String> indexMetadataLookup;
         public String version;
 
+        @Override
         public String getName() {
             return name;
         }
 
+        @Override
         public String getId() {
             return uuid;
         }
@@ -75,14 +77,17 @@ public class SnapshotRepoData_ES_7_10 {
         public List<String> snapshots;
         public List<String> shardGenerations;
 
+        @Override
         public String getName() {
             return name;
         }
 
+        @Override
         public String getId() {
             return id;
         }
 
+        @Override
         public List<String> getSnapshots() {
             return snapshots;
         }

--- a/RFS/src/main/java/com/rfs/version_es_7_10/SnapshotRepoProvider_ES_7_10.java
+++ b/RFS/src/main/java/com/rfs/version_es_7_10/SnapshotRepoProvider_ES_7_10.java
@@ -21,6 +21,7 @@ public class SnapshotRepoProvider_ES_7_10 implements SnapshotRepo.Provider {
                 .collect(Collectors.toList());
     }
 
+    @Override
     public List<SnapshotRepo.Index> getIndicesInSnapshot(String snapshotName) {
         List<SnapshotRepo.Index> matchedIndices = new ArrayList<>();
         SnapshotRepoData_ES_7_10.Snapshot targetSnapshot = repoData.snapshots.stream()
@@ -40,6 +41,7 @@ public class SnapshotRepoProvider_ES_7_10 implements SnapshotRepo.Provider {
         return matchedIndices;
     }
 
+    @Override
     public List<SnapshotRepo.Snapshot> getSnapshots() {
         List<SnapshotRepo.Snapshot> convertedList = new ArrayList<>(repoData.snapshots);
         return convertedList;
@@ -54,6 +56,7 @@ public class SnapshotRepoProvider_ES_7_10 implements SnapshotRepo.Provider {
         return null;
     }
 
+    @Override
     public String getIndexId(String indexName) {
         return repoData.indices.get(indexName).id;
     }

--- a/RFS/src/main/java/com/rfs/version_os_2_11/GlobalMetadataData_OS_2_11.java
+++ b/RFS/src/main/java/com/rfs/version_os_2_11/GlobalMetadataData_OS_2_11.java
@@ -9,6 +9,7 @@ public class GlobalMetadataData_OS_2_11 implements com.rfs.common.GlobalMetadata
         this.root = root;
     }
 
+    @Override
     public ObjectNode toObjectNode() throws Exception {
         return root;
     }

--- a/RFS/src/main/java/com/rfs/version_os_2_11/IndexMetadataData_OS_2_11.java
+++ b/RFS/src/main/java/com/rfs/version_os_2_11/IndexMetadataData_OS_2_11.java
@@ -2,7 +2,9 @@ package com.rfs.version_os_2_11;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
-public class IndexMetadataData_OS_2_11 implements com.rfs.common.IndexMetadata.Data {
+import com.rfs.common.IndexMetadata;
+
+public class IndexMetadataData_OS_2_11 implements IndexMetadata.Data {
     private ObjectNode root;
     private String indexId;
     private String indexName;
@@ -13,30 +15,37 @@ public class IndexMetadataData_OS_2_11 implements com.rfs.common.IndexMetadata.D
         this.indexName = indexName;
     }
 
+    @Override
     public ObjectNode getAliases() {
         return (ObjectNode) root.get("aliases");
     }
 
+    @Override
     public String getId() {
         return indexId;
     }
 
+    @Override
     public ObjectNode getMappings() {
         return (ObjectNode) root.get("mappings");
     }
 
+    @Override
     public String getName() {
         return indexName;
     }
 
+    @Override
     public int getNumberOfShards() {
         return this.getSettings().get("number_of_shards").asInt();
     }   
 
+    @Override
     public ObjectNode getSettings() {
         return (ObjectNode) root.get("settings");
     }
 
+    @Override
     public ObjectNode toObjectNode() {
         return root;
     }

--- a/RFS/src/test/java/com/rfs/common/S3UriTest.java
+++ b/RFS/src/test/java/com/rfs/common/S3UriTest.java
@@ -1,0 +1,29 @@
+package com.rfs.common;
+
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+
+public class S3UriTest {
+    static Stream<Arguments> provideUris() {
+        return Stream.of(
+            Arguments.of("s3://bucket-name", "bucket-name", "", "s3://bucket-name"),
+            Arguments.of("s3://bucket-name/", "bucket-name", "", "s3://bucket-name"),
+            Arguments.of("s3://bucket-name/with/suffix", "bucket-name", "with/suffix", "s3://bucket-name/with/suffix"),
+            Arguments.of("s3://bucket-name/with/suffix/", "bucket-name", "with/suffix", "s3://bucket-name/with/suffix")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideUris")
+    void S3Uri_AsExpected(String uri, String expectedBucketName, String expectedPrefix, String expectedUri) {
+        S3Uri s3Uri = new S3Uri(uri);
+        assertEquals(expectedBucketName, s3Uri.bucketName);
+        assertEquals(expectedPrefix, s3Uri.key);
+        assertEquals(expectedUri, s3Uri.uri);
+    }
+}


### PR DESCRIPTION
### Description
* Updated the S3Repo to use the S3AsyncClient instead of the synchronous client
* Updated S3Repo to download the shard blob files more efficiently using the S3 TransferManager

### Issues Resolved
* https://opensearch.atlassian.net/browse/MIGRATIONS-1688

### Testing
* Updated unit tests
* Ran a test migration locally, you can see the new behavior below:

```
14:45:31.384 INFO  Unpacking blob files to disk...
14:45:31.384 INFO  Processing index: logs-241998
14:45:31.386 INFO  === Shard ID: 0 ===
14:45:31.396 INFO  Downloading file from S3: s3://chelma-iad-rfs-local-testing/indices/gCmLQ2WOTOyaKAUF2xSdcg/0/snap-a49xLBn1TqyxcjyKiWgtpA.dat to /tmp/s3_files/indices/gCmLQ2WOTOyaKAUF2xSdcg/0/snap-a49xLBn1TqyxcjyKiWgtpA.dat
14:45:31.865 INFO  Downloading blob files from S3: s3://chelma-iad-rfs-local-testing/indices/gCmLQ2WOTOyaKAUF2xSdcg/0/ to /tmp/s3_files/indices/gCmLQ2WOTOyaKAUF2xSdcg/0
14:45:32.435 INFO  Blob file download(s) complete
14:45:32.449 INFO  Unpacking - Blob Name: __eUUGlyLIT9-NLqru0m367Q, Lucene Name: _2_Lucene84_0.doc
14:45:32.455 INFO  Unpacking - Blob Name: __iydNTkHZRJqvfZwbdlaJYA, Lucene Name: _2_Lucene84_0.tim
14:45:32.456 INFO  Unpacking - Blob Name: __PsRSXgBYRSWxKELAkEbcpw, Lucene Name: _2.kdd
14:45:32.456 INFO  Unpacking - Blob Name: v__aZ1RTOxzSX-PdX-dRbBz8A, Lucene Name: _2.si
14:45:32.457 INFO  Unpacking - Blob Name: __LVamudogTvGCpgJnb3BxNA, Lucene Name: _2.kdi
14:45:32.457 INFO  Unpacking - Blob Name: __gzYq-jl6TSSCD7w0S17AJw, Lucene Name: _2.fdm
14:45:32.458 INFO  Unpacking - Blob Name: __D7j2BRqiRKOe83Ht0869PA, Lucene Name: _2_Lucene84_0.pos
14:45:32.459 INFO  Unpacking - Blob Name: __IaW8fFBTS7aoQ7-EdYSd4g, Lucene Name: _2.fdt
14:45:32.460 INFO  Unpacking - Blob Name: ___1JaSLAJTHCk-TdYG_6JYg, Lucene Name: _2_Lucene80_0.dvm
14:45:32.461 INFO  Unpacking - Blob Name: __Xpi9vJHESKSPqxGvxDa1RA, Lucene Name: _2.kdm
14:45:32.461 INFO  Unpacking - Blob Name: __o6l-K0YpQ2K695c8tiL7JA, Lucene Name: _2.fdx
14:45:32.462 INFO  Unpacking - Blob Name: v__3VZW6cZNSwqlVaTn0SsIFA, Lucene Name: segments_4
14:45:32.462 INFO  Unpacking - Blob Name: ___8lqMrY7QWiWMoUFMADo1g, Lucene Name: _2_Lucene84_0.tip
14:45:32.463 INFO  Unpacking - Blob Name: __HOR0nDIEQhOu3a-dwtRvKg, Lucene Name: _2.nvd
14:45:32.463 INFO  Unpacking - Blob Name: __tgnM14uTRf-B18lFuxBxPQ, Lucene Name: _2_Lucene80_0.dvd
14:45:32.464 INFO  Unpacking - Blob Name: __gMHUg1-3Ql26o8E3wtH1HQ, Lucene Name: _2.nvm
14:45:32.465 INFO  Unpacking - Blob Name: __3_oFHwvnSZaKCh1pNMbtjA, Lucene Name: _2.fnm
14:45:32.466 INFO  Unpacking - Blob Name: __0Uj5U7guRlO1FVqwar5j4g, Lucene Name: _2_Lucene84_0.tmd
```

Compare that to:

```
11:27:45.963 INFO  Unpacking blob files to disk...
11:27:45.963 INFO  Processing index: logs-241998
11:27:45.965 INFO  === Shard ID: 0 ===
11:27:45.976 INFO  Downloading file from S3: s3://chelma-iad-rfs-local-testing/indices/gCmLQ2WOTOyaKAUF2xSdcg/0/snap-a49xLBn1TqyxcjyKiWgtpA.dat to /tmp/s3_files/indices/gCmLQ2WOTOyaKAUF2xSdcg/0/snap-a49xLBn1TqyxcjyKiWgtpA.dat
11:27:46.710 INFO  Unpacking - Blob Name: __eUUGlyLIT9-NLqru0m367Q, Lucene Name: _2_Lucene84_0.doc
11:27:46.714 INFO  Downloading file from S3: s3://chelma-iad-rfs-local-testing/indices/gCmLQ2WOTOyaKAUF2xSdcg/0/__eUUGlyLIT9-NLqru0m367Q to /tmp/s3_files/indices/gCmLQ2WOTOyaKAUF2xSdcg/0/__eUUGlyLIT9-NLqru0m367Q
11:27:46.976 INFO  Unpacking - Blob Name: __iydNTkHZRJqvfZwbdlaJYA, Lucene Name: _2_Lucene84_0.tim
11:27:46.976 INFO  Downloading file from S3: s3://chelma-iad-rfs-local-testing/indices/gCmLQ2WOTOyaKAUF2xSdcg/0/__iydNTkHZRJqvfZwbdlaJYA to /tmp/s3_files/indices/gCmLQ2WOTOyaKAUF2xSdcg/0/__iydNTkHZRJqvfZwbdlaJYA
11:27:47.154 INFO  Unpacking - Blob Name: __PsRSXgBYRSWxKELAkEbcpw, Lucene Name: _2.kdd
11:27:47.155 INFO  Downloading file from S3: s3://chelma-iad-rfs-local-testing/indices/gCmLQ2WOTOyaKAUF2xSdcg/0/__PsRSXgBYRSWxKELAkEbcpw to /tmp/s3_files/indices/gCmLQ2WOTOyaKAUF2xSdcg/0/__PsRSXgBYRSWxKELAkEbcpw
11:27:47.347 INFO  Unpacking - Blob Name: v__aZ1RTOxzSX-PdX-dRbBz8A, Lucene Name: _2.si
11:27:47.348 INFO  Unpacking - Blob Name: __LVamudogTvGCpgJnb3BxNA, Lucene Name: _2.kdi
11:27:47.348 INFO  Downloading file from S3: s3://chelma-iad-rfs-local-testing/indices/gCmLQ2WOTOyaKAUF2xSdcg/0/__LVamudogTvGCpgJnb3BxNA to /tmp/s3_files/indices/gCmLQ2WOTOyaKAUF2xSdcg/0/__LVamudogTvGCpgJnb3BxNA
11:27:47.496 INFO  Unpacking - Blob Name: __gzYq-jl6TSSCD7w0S17AJw, Lucene Name: _2.fdm
11:27:47.496 INFO  Downloading file from S3: s3://chelma-iad-rfs-local-testing/indices/gCmLQ2WOTOyaKAUF2xSdcg/0/__gzYq-jl6TSSCD7w0S17AJw to /tmp/s3_files/indices/gCmLQ2WOTOyaKAUF2xSdcg/0/__gzYq-jl6TSSCD7w0S17AJw
11:27:47.644 INFO  Unpacking - Blob Name: __D7j2BRqiRKOe83Ht0869PA, Lucene Name: _2_Lucene84_0.pos
11:27:47.645 INFO  Downloading file from S3: s3://chelma-iad-rfs-local-testing/indices/gCmLQ2WOTOyaKAUF2xSdcg/0/__D7j2BRqiRKOe83Ht0869PA to /tmp/s3_files/indices/gCmLQ2WOTOyaKAUF2xSdcg/0/__D7j2BRqiRKOe83Ht0869PA
11:27:47.828 INFO  Unpacking - Blob Name: __IaW8fFBTS7aoQ7-EdYSd4g, Lucene Name: _2.fdt
11:27:47.829 INFO  Downloading file from S3: s3://chelma-iad-rfs-local-testing/indices/gCmLQ2WOTOyaKAUF2xSdcg/0/__IaW8fFBTS7aoQ7-EdYSd4g to /tmp/s3_files/indices/gCmLQ2WOTOyaKAUF2xSdcg/0/__IaW8fFBTS7aoQ7-EdYSd4g
11:27:47.981 INFO  Unpacking - Blob Name: ___1JaSLAJTHCk-TdYG_6JYg, Lucene Name: _2_Lucene80_0.dvm
11:27:47.982 INFO  Downloading file from S3: s3://chelma-iad-rfs-local-testing/indices/gCmLQ2WOTOyaKAUF2xSdcg/0/___1JaSLAJTHCk-TdYG_6JYg to /tmp/s3_files/indices/gCmLQ2WOTOyaKAUF2xSdcg/0/___1JaSLAJTHCk-TdYG_6JYg
11:27:48.147 INFO  Unpacking - Blob Name: __Xpi9vJHESKSPqxGvxDa1RA, Lucene Name: _2.kdm
11:27:48.148 INFO  Downloading file from S3: s3://chelma-iad-rfs-local-testing/indices/gCmLQ2WOTOyaKAUF2xSdcg/0/__Xpi9vJHESKSPqxGvxDa1RA to /tmp/s3_files/indices/gCmLQ2WOTOyaKAUF2xSdcg/0/__Xpi9vJHESKSPqxGvxDa1RA
11:27:48.375 INFO  Unpacking - Blob Name: __o6l-K0YpQ2K695c8tiL7JA, Lucene Name: _2.fdx
11:27:48.376 INFO  Downloading file from S3: s3://chelma-iad-rfs-local-testing/indices/gCmLQ2WOTOyaKAUF2xSdcg/0/__o6l-K0YpQ2K695c8tiL7JA to /tmp/s3_files/indices/gCmLQ2WOTOyaKAUF2xSdcg/0/__o6l-K0YpQ2K695c8tiL7JA
11:27:48.525 INFO  Unpacking - Blob Name: v__3VZW6cZNSwqlVaTn0SsIFA, Lucene Name: segments_4
11:27:48.526 INFO  Unpacking - Blob Name: ___8lqMrY7QWiWMoUFMADo1g, Lucene Name: _2_Lucene84_0.tip
11:27:48.526 INFO  Downloading file from S3: s3://chelma-iad-rfs-local-testing/indices/gCmLQ2WOTOyaKAUF2xSdcg/0/___8lqMrY7QWiWMoUFMADo1g to /tmp/s3_files/indices/gCmLQ2WOTOyaKAUF2xSdcg/0/___8lqMrY7QWiWMoUFMADo1g
11:27:48.674 INFO  Unpacking - Blob Name: __HOR0nDIEQhOu3a-dwtRvKg, Lucene Name: _2.nvd
11:27:48.675 INFO  Downloading file from S3: s3://chelma-iad-rfs-local-testing/indices/gCmLQ2WOTOyaKAUF2xSdcg/0/__HOR0nDIEQhOu3a-dwtRvKg to /tmp/s3_files/indices/gCmLQ2WOTOyaKAUF2xSdcg/0/__HOR0nDIEQhOu3a-dwtRvKg
11:27:48.837 INFO  Unpacking - Blob Name: __tgnM14uTRf-B18lFuxBxPQ, Lucene Name: _2_Lucene80_0.dvd
11:27:48.838 INFO  Downloading file from S3: s3://chelma-iad-rfs-local-testing/indices/gCmLQ2WOTOyaKAUF2xSdcg/0/__tgnM14uTRf-B18lFuxBxPQ to /tmp/s3_files/indices/gCmLQ2WOTOyaKAUF2xSdcg/0/__tgnM14uTRf-B18lFuxBxPQ
11:27:49.035 INFO  Unpacking - Blob Name: __gMHUg1-3Ql26o8E3wtH1HQ, Lucene Name: _2.nvm
11:27:49.036 INFO  Downloading file from S3: s3://chelma-iad-rfs-local-testing/indices/gCmLQ2WOTOyaKAUF2xSdcg/0/__gMHUg1-3Ql26o8E3wtH1HQ to /tmp/s3_files/indices/gCmLQ2WOTOyaKAUF2xSdcg/0/__gMHUg1-3Ql26o8E3wtH1HQ
11:27:49.340 INFO  Unpacking - Blob Name: __3_oFHwvnSZaKCh1pNMbtjA, Lucene Name: _2.fnm
11:27:49.341 INFO  Downloading file from S3: s3://chelma-iad-rfs-local-testing/indices/gCmLQ2WOTOyaKAUF2xSdcg/0/__3_oFHwvnSZaKCh1pNMbtjA to /tmp/s3_files/indices/gCmLQ2WOTOyaKAUF2xSdcg/0/__3_oFHwvnSZaKCh1pNMbtjA
11:27:49.524 INFO  Unpacking - Blob Name: __0Uj5U7guRlO1FVqwar5j4g, Lucene Name: _2_Lucene84_0.tmd
11:27:49.524 INFO  Downloading file from S3: s3://chelma-iad-rfs-local-testing/indices/gCmLQ2WOTOyaKAUF2xSdcg/0/__0Uj5U7guRlO1FVqwar5j4g to /tmp/s3_files/indices/gCmLQ2WOTOyaKAUF2xSdcg/0/__0Uj5U7guRlO1FVqwar5j4g
```

### Check List
- [X] New functionality includes testing
  - [X] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
