### PR TITLE
Favor ByteBuf Duplicates, NettyJsonContentAuthSigner and StreamChannelConnectionCaptureSerializer Refactoring

### DIFF
--- a/TrafficCapture/captureOffloader/build.gradle
+++ b/TrafficCapture/captureOffloader/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     implementation group: 'org.projectlombok', name: 'lombok', version: '1.18.26'
     implementation group: 'org.slf4j', name: 'slf4j-api', version: '2.0.7'
 
+    testImplementation testFixtures(project(path: ':testUtilities'))
     testImplementation project(':coreUtilities')
     testImplementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.20.0'
     testImplementation group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.20.0'

--- a/TrafficCapture/captureOffloader/src/main/java/org/opensearch/migrations/trafficcapture/CodedOutputStreamSizeUtil.java
+++ b/TrafficCapture/captureOffloader/src/main/java/org/opensearch/migrations/trafficcapture/CodedOutputStreamSizeUtil.java
@@ -39,13 +39,33 @@ public class CodedOutputStreamSizeUtil {
         int tsTagAndContentSize = CodedOutputStream.computeInt32Size(TrafficObservation.TS_FIELD_NUMBER, tsContentSize) + tsContentSize;
 
         // Capture required bytes
-        int dataSize = CodedOutputStream.computeByteBufferSize(dataFieldNumber, buffer);
+        int dataSize = computeByteBufferRemainingSize(dataFieldNumber, buffer);
         int captureTagAndContentSize = CodedOutputStream.computeInt32Size(observationFieldNumber, dataSize) + dataSize;
 
         // Observation and closing index required bytes
         return bytesNeededForObservationAndClosingIndex(tsTagAndContentSize + captureTagAndContentSize,
                 Integer.MAX_VALUE);
     }
+
+    /**
+     * This function determines the number of bytes needed to write the remaining bytes in a byteBuffer and its tag.
+     * Use this over CodeOutputStream.computeByteBufferSize(int fieldNumber, ByteBuffer buffer) due to the latter
+     * relying on the ByteBuffer capacity instead of limit in size calculation.
+     */
+    public static int computeByteBufferRemainingSize(int fieldNumber, ByteBuffer buffer) {
+        return CodedOutputStream.computeTagSize(fieldNumber) + computeByteBufferRemainingSizeNoTag(buffer);
+    }
+
+    /**
+     * This function determines the number of bytes needed to write the remaining bytes in a byteBuffer. Use this over
+     * CodeOutputStream.computeByteBufferSizeNoTag(ByteBuffer buffer) due to the latter relying on the
+     * ByteBuffer capacity instead of limit in size calculation.
+     */
+    public static int computeByteBufferRemainingSizeNoTag(ByteBuffer buffer) {
+        int bufferSize = buffer.remaining();
+        return CodedOutputStream.computeUInt32SizeNoTag(bufferSize) + bufferSize;
+    }
+
 
     /**
      * This function determines the number of bytes needed to store a TrafficObservation and a closing index for a

--- a/TrafficCapture/captureOffloader/src/main/java/org/opensearch/migrations/trafficcapture/CodedOutputStreamSizeUtil.java
+++ b/TrafficCapture/captureOffloader/src/main/java/org/opensearch/migrations/trafficcapture/CodedOutputStreamSizeUtil.java
@@ -50,16 +50,16 @@ public class CodedOutputStreamSizeUtil {
     /**
      * This function determines the number of bytes needed to write the readable bytes in a byteBuf and its tag.
      */
-    public static int computeByteBufRemainingSize(int fieldNumber, ByteBuf buffer) {
-        return CodedOutputStream.computeTagSize(fieldNumber) + computeByteBufRemainingSizeNoTag(buffer);
+    public static int computeByteBufRemainingSize(int fieldNumber, ByteBuf buf) {
+        return CodedOutputStream.computeTagSize(fieldNumber) + computeByteBufRemainingSizeNoTag(buf);
     }
 
     /**
      * This function determines the number of bytes needed to write the readable bytes in a byteBuf.
      */
-    public static int computeByteBufRemainingSizeNoTag(ByteBuf buffer) {
-        int bufferSize = buffer.readableBytes();
-        return CodedOutputStream.computeUInt32SizeNoTag(bufferSize) + bufferSize;
+    public static int computeByteBufRemainingSizeNoTag(ByteBuf buf) {
+        int bufSize = buf.readableBytes();
+        return CodedOutputStream.computeUInt32SizeNoTag(bufSize) + bufSize;
     }
 
 

--- a/TrafficCapture/captureOffloader/src/main/java/org/opensearch/migrations/trafficcapture/StreamChannelConnectionCaptureSerializer.java
+++ b/TrafficCapture/captureOffloader/src/main/java/org/opensearch/migrations/trafficcapture/StreamChannelConnectionCaptureSerializer.java
@@ -313,9 +313,9 @@ public class StreamChannelConnectionCaptureSerializer<T> implements IChannelConn
             // COS checked for unbounded limit above
             int availableCOSSpace = getOrCreateCodedOutputStreamHolder().getOutputStreamSpaceLeft();
             int chunkBytes = messageAndOverheadBytesLeft > availableCOSSpace ? availableCOSSpace - trafficStreamOverhead : byteBuffer.limit() - byteBuffer.position();
-            ByteBuffer bb = byteBuffer.slice();
+            ByteBuffer bb = byteBuffer.duplicate();
             bb.limit(chunkBytes);
-            bb = bb.slice();
+            bb = bb.duplicate();
             byteBuffer.position(byteBuffer.position() + chunkBytes);
             addSubstreamMessage(segmentFieldNumber, segmentDataFieldNumber, timestamp, bb);
             int minExpectedSpaceAfterObservation = availableCOSSpace - chunkBytes - trafficStreamOverhead;

--- a/TrafficCapture/captureOffloader/src/test/java/org/opensearch/migrations/trafficcapture/CodedOutputStreamSizeUtilTest.java
+++ b/TrafficCapture/captureOffloader/src/test/java/org/opensearch/migrations/trafficcapture/CodedOutputStreamSizeUtilTest.java
@@ -1,0 +1,85 @@
+package org.opensearch.migrations.trafficcapture;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+import java.nio.ByteBuffer;
+import java.time.Instant;
+
+class CodedOutputStreamSizeUtilTest {
+
+    @Test
+    void testGetSizeOfTimestamp() {
+        // Timestamp with only seconds (no explicit nanoseconds)
+        Instant timestampSecondsOnly = Instant.parse("2024-01-01T00:00:00Z");
+        int sizeSecondsOnly = CodedOutputStreamSizeUtil.getSizeOfTimestamp(timestampSecondsOnly);
+        assertEquals( 6, sizeSecondsOnly);
+
+        // Timestamp with both seconds and nanoseconds
+        Instant timestampWithNanos = Instant.parse("2024-12-31T23:59:59.123456789Z");
+        int sizeWithNanos = CodedOutputStreamSizeUtil.getSizeOfTimestamp(timestampWithNanos);
+        assertEquals( 11, sizeWithNanos);
+    }
+
+    @Test
+    void testMaxBytesNeededForASegmentedObservation() {
+        Instant timestamp = Instant.parse("2024-01-01T00:00:00Z");
+        ByteBuffer buffer = ByteBuffer.allocate(100).limit(50);
+        buffer.position(25);
+        int result = CodedOutputStreamSizeUtil.maxBytesNeededForASegmentedObservation(timestamp, 1, 2, buffer);
+        assertEquals(45, result);
+    }
+
+    @Test
+    void test_computeByteBufferRemainingSize() {
+        ByteBuffer buffer = ByteBuffer.allocate(100).limit(50);
+        int result = CodedOutputStreamSizeUtil.computeByteBufferRemainingSize(2, buffer);
+        assertEquals(52, result);
+    }
+
+    @Test
+    void test_computeByteBufferRemainingSize_ByteBufferAtCapacity() {
+        ByteBuffer buffer = ByteBuffer.allocate(200);
+        int result = CodedOutputStreamSizeUtil.computeByteBufferRemainingSize(2, buffer);
+        assertEquals(203, result);
+    }
+
+    @Test
+    void test_computeByteBufferRemainingSize_EmptyByteBuffer() {
+        ByteBuffer buffer = ByteBuffer.allocate(0);
+        int result = CodedOutputStreamSizeUtil.computeByteBufferRemainingSize(2, buffer);
+        assertEquals(2, result);
+    }
+
+    @Test
+    void testBytesNeededForObservationAndClosingIndex() {
+        int observationContentSize = 50;
+        int numberOfTrafficStreamsSoFar = 10;
+
+        int result = CodedOutputStreamSizeUtil.bytesNeededForObservationAndClosingIndex(observationContentSize, numberOfTrafficStreamsSoFar);
+        assertEquals(54, result);
+    }
+
+    @Test
+    void testBytesNeededForObservationAndClosingIndex_WithZeroContent() {
+        int observationContentSize = 0;
+        int numberOfTrafficStreamsSoFar = 0;
+
+        int result = CodedOutputStreamSizeUtil.bytesNeededForObservationAndClosingIndex(observationContentSize, numberOfTrafficStreamsSoFar);
+        assertEquals(4, result);
+    }
+
+    @Test
+    void testBytesNeededForObservationAndClosingIndex_VariousIndices() {
+        int observationContentSize = 20;
+
+        // Test with increasing indices to verify scaling of index size
+        int[] indices = new int[]{1, 1000, 100000};
+        int[] expectedResults = new int[]{24, 25, 26};
+
+        for (int i = 0; i < indices.length; i++) {
+            int result = CodedOutputStreamSizeUtil.bytesNeededForObservationAndClosingIndex(observationContentSize, indices[i]);
+            assertEquals(expectedResults[i], result);
+        }
+    }
+
+}

--- a/TrafficCapture/captureOffloader/src/test/java/org/opensearch/migrations/trafficcapture/CodedOutputStreamSizeUtilTest.java
+++ b/TrafficCapture/captureOffloader/src/test/java/org/opensearch/migrations/trafficcapture/CodedOutputStreamSizeUtilTest.java
@@ -1,8 +1,10 @@
 package org.opensearch.migrations.trafficcapture;
 
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import static org.junit.jupiter.api.Assertions.*;
-import java.nio.ByteBuffer;
 import java.time.Instant;
 
 class CodedOutputStreamSizeUtilTest {
@@ -12,42 +14,60 @@ class CodedOutputStreamSizeUtilTest {
         // Timestamp with only seconds (no explicit nanoseconds)
         Instant timestampSecondsOnly = Instant.parse("2024-01-01T00:00:00Z");
         int sizeSecondsOnly = CodedOutputStreamSizeUtil.getSizeOfTimestamp(timestampSecondsOnly);
-        assertEquals( 6, sizeSecondsOnly);
+        Assertions.assertEquals( 6, sizeSecondsOnly);
 
         // Timestamp with both seconds and nanoseconds
         Instant timestampWithNanos = Instant.parse("2024-12-31T23:59:59.123456789Z");
         int sizeWithNanos = CodedOutputStreamSizeUtil.getSizeOfTimestamp(timestampWithNanos);
-        assertEquals( 11, sizeWithNanos);
+        Assertions.assertEquals( 11, sizeWithNanos);
     }
 
     @Test
     void testMaxBytesNeededForASegmentedObservation() {
         Instant timestamp = Instant.parse("2024-01-01T00:00:00Z");
-        ByteBuffer buffer = ByteBuffer.allocate(100).limit(50);
-        buffer.position(25);
-        int result = CodedOutputStreamSizeUtil.maxBytesNeededForASegmentedObservation(timestamp, 1, 2, buffer);
-        assertEquals(45, result);
+        ByteBuf buf = Unpooled.buffer(100);
+        buf.writeCharSequence("Test", StandardCharsets.UTF_8);
+        int result = CodedOutputStreamSizeUtil.maxBytesNeededForASegmentedObservation(timestamp, 1, 2, buf);
+        Assertions.assertEquals(24, result);
     }
 
     @Test
-    void test_computeByteBufferRemainingSize() {
-        ByteBuffer buffer = ByteBuffer.allocate(100).limit(50);
-        int result = CodedOutputStreamSizeUtil.computeByteBufferRemainingSize(2, buffer);
-        assertEquals(52, result);
+    void test_computeByteBufRemainingSize_emptyBufWithCapacity() {
+        var buf = Unpooled.directBuffer(100);
+        int result = CodedOutputStreamSizeUtil.computeByteBufRemainingSize(2, buf);
+        Assertions.assertEquals(2, result);
     }
 
     @Test
-    void test_computeByteBufferRemainingSize_ByteBufferAtCapacity() {
-        ByteBuffer buffer = ByteBuffer.allocate(200);
-        int result = CodedOutputStreamSizeUtil.computeByteBufferRemainingSize(2, buffer);
-        assertEquals(203, result);
+    void test_computeByteBufRemainingSize() {
+        var buf = Unpooled.directBuffer();
+        buf.writeCharSequence("hello_test", StandardCharsets.UTF_8);
+        int result = CodedOutputStreamSizeUtil.computeByteBufRemainingSize(2, buf);
+        Assertions.assertEquals(12, result);
     }
 
     @Test
-    void test_computeByteBufferRemainingSize_EmptyByteBuffer() {
-        ByteBuffer buffer = ByteBuffer.allocate(0);
-        int result = CodedOutputStreamSizeUtil.computeByteBufferRemainingSize(2, buffer);
-        assertEquals(2, result);
+    void test_computeByteBufRemainingSize_largeBuf() {
+        var buf = Unpooled.directBuffer();
+        buf.writeCharSequence("1234567890".repeat(100000), StandardCharsets.UTF_8);
+        int result = CodedOutputStreamSizeUtil.computeByteBufRemainingSize(2, buf);
+        Assertions.assertEquals(1000004, result);
+    }
+
+
+    @Test
+    void test_computeByteBufRemainingSize_ByteBufAtCapacity() {
+        ByteBuf buf = Unpooled.buffer(4);
+        buf.writeCharSequence("Test", StandardCharsets.UTF_8);
+        int result = CodedOutputStreamSizeUtil.computeByteBufRemainingSize(2, buf);
+        Assertions.assertEquals(6, result);
+    }
+
+    @Test
+    void test_computeByteBufRemainingSize_EmptyByteBuf() {
+        ByteBuf buf = Unpooled.buffer(0, 0);
+        int result = CodedOutputStreamSizeUtil.computeByteBufRemainingSize(2, buf);
+        Assertions.assertEquals(2, result);
     }
 
     @Test
@@ -56,7 +76,7 @@ class CodedOutputStreamSizeUtilTest {
         int numberOfTrafficStreamsSoFar = 10;
 
         int result = CodedOutputStreamSizeUtil.bytesNeededForObservationAndClosingIndex(observationContentSize, numberOfTrafficStreamsSoFar);
-        assertEquals(54, result);
+        Assertions.assertEquals(54, result);
     }
 
     @Test
@@ -65,7 +85,7 @@ class CodedOutputStreamSizeUtilTest {
         int numberOfTrafficStreamsSoFar = 0;
 
         int result = CodedOutputStreamSizeUtil.bytesNeededForObservationAndClosingIndex(observationContentSize, numberOfTrafficStreamsSoFar);
-        assertEquals(4, result);
+        Assertions.assertEquals(4, result);
     }
 
     @Test
@@ -78,7 +98,7 @@ class CodedOutputStreamSizeUtilTest {
 
         for (int i = 0; i < indices.length; i++) {
             int result = CodedOutputStreamSizeUtil.bytesNeededForObservationAndClosingIndex(observationContentSize, indices[i]);
-            assertEquals(expectedResults[i], result);
+            Assertions.assertEquals(expectedResults[i], result);
         }
     }
 

--- a/TrafficCapture/captureOffloader/src/test/java/org/opensearch/migrations/trafficcapture/StreamChannelConnectionCaptureSerializerTest.java
+++ b/TrafficCapture/captureOffloader/src/test/java/org/opensearch/migrations/trafficcapture/StreamChannelConnectionCaptureSerializerTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.opensearch.migrations.testutils.WrapWithNettyLeakDetection;
 import org.opensearch.migrations.trafficcapture.StreamChannelConnectionCaptureSerializerTest.StreamManager.NullStreamManager;
 import org.opensearch.migrations.trafficcapture.protos.CloseObservation;
 import org.opensearch.migrations.trafficcapture.protos.ConnectionExceptionObservation;
@@ -37,6 +38,7 @@ import org.opensearch.migrations.trafficcapture.protos.WriteObservation;
 import org.opensearch.migrations.trafficcapture.protos.WriteSegmentObservation;
 
 @Slf4j
+@WrapWithNettyLeakDetection(repetitions = 4)
 class StreamChannelConnectionCaptureSerializerTest {
 
     public static final String TEST_TRAFFIC_STREAM_ID_STRING = "Test";

--- a/TrafficCapture/captureOffloader/src/test/java/org/opensearch/migrations/trafficcapture/StreamChannelConnectionCaptureSerializerTest.java
+++ b/TrafficCapture/captureOffloader/src/test/java/org/opensearch/migrations/trafficcapture/StreamChannelConnectionCaptureSerializerTest.java
@@ -538,6 +538,15 @@ class StreamChannelConnectionCaptureSerializerTest {
                                                                 - (calculatedMaxWritableSpace + 1);
             Assertions.assertTrue(expectedSpaceLeftAfterWriteIfOneMoreByteWrote < 0, "expected no space to write one more byte");
         }
+
+        // Test that when PessimisticallyCalculateMaxWritableSpace != calculatedMaxWritableSpace, then
+        // it is positive and equal to calculateMaxWritableSpace - 1
+        var pessimisticWriteableSpace = StreamChannelConnectionCaptureSerializer.pessimisticallyCalculateMaxWritableSpace(totalAvailableSpace,
+            requestedWriteableSpace);
+        if (pessimisticWriteableSpace != calculatedMaxWritableSpace) {
+            Assertions.assertTrue(pessimisticWriteableSpace > 0);
+            Assertions.assertEquals(calculatedMaxWritableSpace - 1, pessimisticWriteableSpace);
+        }
     }
 
     @Test

--- a/TrafficCapture/captureOffloader/src/test/java/org/opensearch/migrations/trafficcapture/StreamChannelConnectionCaptureSerializerTest.java
+++ b/TrafficCapture/captureOffloader/src/test/java/org/opensearch/migrations/trafficcapture/StreamChannelConnectionCaptureSerializerTest.java
@@ -370,18 +370,18 @@ class StreamChannelConnectionCaptureSerializerTest {
                     "Unknown outputStreamHolder sent back to StreamManager: " + outputStreamHolder);
             }
             var osh = (CodedOutputStreamAndByteBufferWrapper) outputStreamHolder;
-            log.trace("Getting ready to flush for " + osh);
-            log.trace("Bytes written so far... " + StandardCharsets.UTF_8.decode(osh.getByteBuffer().duplicate()));
+            log.atTrace().log(() -> "Getting ready to flush for " + osh);
+            log.atTrace().log(() -> "Bytes written so far... " + StandardCharsets.UTF_8.decode(osh.getByteBuffer().duplicate()));
 
             return CompletableFuture.runAsync(() -> {
                 try {
                     osh.getOutputStream().flush();
-                    log.trace("Just flushed for " + osh.getOutputStream());
+                    log.atTrace().log(() -> "Just flushed for " + osh.getOutputStream());
                     var bb = osh.getByteBuffer();
                     bb.position(0);
                     var bytesWritten = osh.getOutputStream().getTotalBytesWritten();
                     bb.limit(bytesWritten);
-                    log.trace("Adding " + StandardCharsets.UTF_8.decode(bb.duplicate()));
+                    log.atTrace().log(() -> "Adding " + StandardCharsets.UTF_8.decode(bb.duplicate()));
                     outputBuffers.add(bb);
                 } catch (IOException e) {
                     throw Lombok.sneakyThrow(e);

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/ParsedHttpMessagesAsDicts.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/ParsedHttpMessagesAsDicts.java
@@ -1,9 +1,11 @@
 package org.opensearch.migrations.replay;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.handler.codec.base64.Base64;
+import io.netty.handler.codec.base64.Base64Dialect;
 import io.netty.handler.codec.http.HttpHeaders;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
-import java.util.Base64;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -100,18 +102,16 @@ public class ParsedHttpMessagesAsDicts {
         targetResponseOp.ifPresent(r -> context.setTargetStatus((Integer) r.get(STATUS_CODE_KEY)));
     }
 
-    private static byte[] getBytesFromByteBuf(ByteBuf buf) {
-        var bytes = new byte[buf.readableBytes()];
-        buf.getBytes(buf.readerIndex(), bytes);
-        return bytes;
-    }
-
     private static Map<String, Object> fillMap(LinkedHashMap<String, Object> map,
                                                HttpHeaders headers, ByteBuf content) {
-        String base64body = Base64.getEncoder().encodeToString(getBytesFromByteBuf(content));
-        map.put("body", base64body);
-        headers.entries().stream().forEach(kvp -> map.put(kvp.getKey(), kvp.getValue()));
-        return map;
+        try (var encodedBufHolder = RefSafeHolder.create(Base64.encode(content, false, Base64Dialect.STANDARD))) {
+            var encodedBuf = encodedBufHolder.get();
+            assert encodedBuf != null : "Base64.encode should not return null";
+            String base64body = encodedBuf.toString(StandardCharsets.UTF_8);
+            map.put("body", base64body);
+            headers.entries().forEach(kvp -> map.put(kvp.getKey(), kvp.getValue()));
+            return map;
+        }
     }
 
     private static Map<String, Object> makeSafeMap(@NonNull IReplayContexts.ITupleHandlingContext context,

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/ParsedHttpMessagesAsDicts.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/ParsedHttpMessagesAsDicts.java
@@ -107,9 +107,8 @@ public class ParsedHttpMessagesAsDicts {
         try (var encodedBufHolder = RefSafeHolder.create(Base64.encode(content, false, Base64Dialect.STANDARD))) {
             var encodedBuf = encodedBufHolder.get();
             assert encodedBuf != null : "Base64.encode should not return null";
-            String base64body = encodedBuf.toString(StandardCharsets.UTF_8);
-            map.put("body", base64body);
             headers.entries().forEach(kvp -> map.put(kvp.getKey(), kvp.getValue()));
+            map.put("body", encodedBuf.toString(StandardCharsets.UTF_8));
             return map;
         }
     }

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/http/HttpJsonTransformingConsumer.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/http/HttpJsonTransformingConsumer.java
@@ -90,7 +90,7 @@ public class HttpJsonTransformingConsumer<R> implements IPacketFinalizingConsume
 
     @Override
     public TrackedFuture<String, Void> consumeBytes(ByteBuf nextRequestPacket) {
-        chunks.add(nextRequestPacket.duplicate().readerIndex(0).retain());
+        chunks.add(nextRequestPacket.retainedDuplicate());
         chunkSizes.get(chunkSizes.size() - 1).add(nextRequestPacket.readableBytes());
         log.atTrace().log(() -> "HttpJsonTransformingConsumer[" + this + "]: writing into embedded channel: "
                    + nextRequestPacket.toString(StandardCharsets.UTF_8));

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/http/HttpJsonTransformingConsumer.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/http/HttpJsonTransformingConsumer.java
@@ -92,15 +92,11 @@ public class HttpJsonTransformingConsumer<R> implements IPacketFinalizingConsume
     public TrackedFuture<String, Void> consumeBytes(ByteBuf nextRequestPacket) {
         chunks.add(nextRequestPacket.duplicate().readerIndex(0).retain());
         chunkSizes.get(chunkSizes.size() - 1).add(nextRequestPacket.readableBytes());
-        if (log.isTraceEnabled()) {
-            byte[] copy = new byte[nextRequestPacket.readableBytes()];
-            nextRequestPacket.duplicate().readBytes(copy);
-            log.trace("HttpJsonTransformingConsumer[" + this + "]: writing into embedded channel: "
-                    + new String(copy, StandardCharsets.UTF_8));
-        }
+        log.atTrace().log(() -> "HttpJsonTransformingConsumer[" + this + "]: writing into embedded channel: "
+                   + nextRequestPacket.toString(StandardCharsets.UTF_8));
         return TextTrackedFuture.completedFuture(null, ()->"initialValue")
-                .map(cf->cf.thenAccept(x -> channel.writeInbound(nextRequestPacket)),
-                        ()->"HttpJsonTransformingConsumer sending bytes to its EmbeddedChannel");
+            .map(cf->cf.thenAccept(x -> channel.writeInbound(nextRequestPacket)),
+                ()->"HttpJsonTransformingConsumer sending bytes to its EmbeddedChannel");
     }
 
     public TrackedFuture<String, TransformedOutputAndResult<R>> finalizeRequest() {

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/http/NettyJsonContentAuthSigner.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/http/NettyJsonContentAuthSigner.java
@@ -54,7 +54,8 @@ public class NettyJsonContentAuthSigner extends ChannelInboundHandlerAdapter {
     public void handlerRemoved(ChannelHandlerContext ctx) throws Exception {
         boolean messageFlushed = flushDownstream(ctx);
         if (messageFlushed) {
-            log.atWarn().setMessage(() -> "Failed to sign message due to handler removed").log();
+            log.atWarn().setMessage(() -> "Failed to sign message due to handler removed"
+                                          + " before the end of the http contents were received").log();
         }
         super.handlerRemoved(ctx);
     }
@@ -63,7 +64,8 @@ public class NettyJsonContentAuthSigner extends ChannelInboundHandlerAdapter {
     public void channelUnregistered(ChannelHandlerContext ctx) throws Exception {
         boolean messageFlushed = flushDownstream(ctx);
         if (messageFlushed) {
-            log.atWarn().setMessage(() -> "Failed to sign message due to channel unregistered").log();
+            log.atWarn().setMessage(() -> "Failed to sign message due to channel unregistered"
+                                          + " before the end of the http contents were received").log();
         }
         super.channelUnregistered(ctx);
     }

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datatypes/TransformedPackets.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datatypes/TransformedPackets.java
@@ -20,11 +20,11 @@ public class TransformedPackets implements AutoCloseable {
     public int size() { return data.size(); }
 
     public Stream<ByteBuf> streamUnretained() {
-        return data.stream().map(ByteBuf::slice);
+        return data.stream().map(ByteBuf::duplicate);
     }
 
     public Stream<ByteBuf> streamRetained() {
-        return data.stream().map(ByteBuf::retainedSlice);
+        return data.stream().map(ByteBuf::retainedDuplicate);
     }
 
     public Stream<byte[]> asByteArrayStream() {

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datatypes/TransformedPackets.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datatypes/TransformedPackets.java
@@ -2,6 +2,7 @@ package org.opensearch.migrations.replay.datatypes;
 
 import io.netty.buffer.ByteBuf;
 
+import io.netty.util.ReferenceCounted;
 import java.util.ArrayList;
 import java.util.StringJoiner;
 import java.util.stream.Stream;
@@ -19,11 +20,11 @@ public class TransformedPackets implements AutoCloseable {
     public int size() { return data.size(); }
 
     public Stream<ByteBuf> streamUnretained() {
-        return data.stream().map(ByteBuf::duplicate);
+        return data.stream().map(ByteBuf::slice);
     }
 
     public Stream<ByteBuf> streamRetained() {
-        return data.stream().map(ByteBuf::retainedDuplicate);
+        return data.stream().map(ByteBuf::retainedSlice);
     }
 
     public Stream<byte[]> asByteArrayStream() {
@@ -36,7 +37,7 @@ public class TransformedPackets implements AutoCloseable {
 
     @Override
     public void close() {
-        data.stream().forEach(bb->bb.release());
+        data.forEach(ReferenceCounted::release);
         // Once we're closed, I'd rather see an NPE rather than refCnt errors from netty, which
         // could cause us to look in many places before finding out that it was just localize
         // to how callers were handling this object

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/netty/BacksideSnifferHandler.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/netty/BacksideSnifferHandler.java
@@ -25,9 +25,8 @@ public class BacksideSnifferHandler extends ChannelInboundHandlerAdapter {
     public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
         var bb = (ByteBuf) msg;
         byte[] output = new byte[bb.readableBytes()];
-        bb.readBytes(output);
+        bb.duplicate().readBytes(output);
         aggregatedRawResponseBuilder.addResponsePacket(output);
-        bb.resetReaderIndex();
         ctx.fireChannelRead(msg);
     }
 }

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/RequestSenderOrchestratorTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/RequestSenderOrchestratorTest.java
@@ -210,7 +210,7 @@ class RequestSenderOrchestratorTest extends InstrumentationTest {
                     var body = response.content();
                     Assertions.assertEquals(TestHttpServerContext.SERVER_RESPONSE_BODY_PREFIX +
                                     TestHttpServerContext.getUriForIthRequest(i / NUM_REPEATS),
-                        body.duplicate().toString(StandardCharsets.UTF_8));
+                        body.toString(StandardCharsets.UTF_8));
                 }
             }
             closeFuture.get();

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/ResultsToLogsConsumerTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/ResultsToLogsConsumerTest.java
@@ -17,13 +17,14 @@ import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.impl.Log4jContextFactory;
+import org.apache.logging.log4j.core.selector.ClassLoaderContextSelector;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.ResourceLock;
 import org.opensearch.migrations.replay.datatypes.HttpRequestTransformationStatus;
 import org.opensearch.migrations.replay.datatypes.PojoTrafficStreamKeyAndContext;
 import org.opensearch.migrations.replay.datatypes.TransformedPackets;
-import org.opensearch.migrations.replay.datatypes.UniqueReplayerRequestKey;
 import org.opensearch.migrations.testutils.WrapWithNettyLeakDetection;
 import org.opensearch.migrations.tracing.InstrumentationTest;
 import org.opensearch.migrations.tracing.TestContext;
@@ -32,6 +33,10 @@ import org.slf4j.LoggerFactory;
 @Slf4j
 @WrapWithNettyLeakDetection(repetitions = 4)
 class ResultsToLogsConsumerTest extends InstrumentationTest {
+    static {
+        // Synchronize logging to for assertions
+        LogManager.setFactory(new Log4jContextFactory(new ClassLoaderContextSelector()));
+    }
     private static final String NODE_ID = "n";
     private static final ObjectMapper mapper = new ObjectMapper();
     public static final String TEST_EXCEPTION_MESSAGE = "TEST_EXCEPTION";
@@ -153,11 +158,11 @@ class ResultsToLogsConsumerTest extends InstrumentationTest {
                         "        \"Request-URI\": \"/test\",\r\n" +
                         "        \"Method\": \"GET\",\r\n" +
                         "        \"HTTP-Version\": \"HTTP/1.1\",\r\n" +
-                        "        \"body\": \"\",\r\n" +
                         "        \"Host\": \"foo.example\",\r\n" +
                         "        \"auTHorization\": \"Basic YWRtaW46YWRtaW4=\",\r\n" +
                         "        \"Content-Type\": \"application/json\",\r\n" +
-                        "        \"content-length\": \"0\"\r\n" +
+                        "        \"content-length\": \"0\",\r\n" +
+                        "        \"body\": \"\"\r\n" +
                         "    },\r\n" +
                         "    \"sourceResponse\": {\r\n" +
                         "        \"HTTP-Version\": {\r\n" +
@@ -166,22 +171,22 @@ class ResultsToLogsConsumerTest extends InstrumentationTest {
                         "        \"Status-Code\": 200,\r\n" +
                         "        \"Reason-Phrase\": \"OK\",\r\n" +
                         "        \"response_time_ms\": 0,\r\n" +
-                        "        \"body\": \"SSBzaG91bGQgYmUgZGVjcnlwdGVkIHRlc3RlciEN\",\r\n" +
                         "        \"Content-transfer-encoding\": \"chunked\",\r\n" +
                         "        \"Date\": \"Thu, 08 Jun 2023 23:06:23 GMT\",\r\n" +
                         "        \"Content-type\": \"text/plain\",\r\n" +
                         "        \"Funtime\": \"checkIt!\",\r\n" +
-                        "        \"content-length\": \"30\"\r\n" +
+                        "        \"content-length\": \"30\",\r\n" +
+                        "        \"body\": \"SSBzaG91bGQgYmUgZGVjcnlwdGVkIHRlc3RlciEN\"\r\n" +
                         "    },\r\n" +
                         "    \"targetRequest\": {\r\n" +
                         "        \"Request-URI\": \"/test\",\r\n" +
                         "        \"Method\": \"GET\",\r\n" +
                         "        \"HTTP-Version\": \"HTTP/1.1\",\r\n" +
-                        "        \"body\": \"\",\r\n" +
                         "        \"Host\": \"foo.example\",\r\n" +
                         "        \"auTHorization\": \"Basic YWRtaW46YWRtaW4=\",\r\n" +
                         "        \"Content-Type\": \"application/json\",\r\n" +
-                        "        \"content-length\": \"0\"\r\n" +
+                        "        \"content-length\": \"0\",\r\n" +
+                        "        \"body\": \"\"\r\n" +
                         "    },\r\n" +
                         "    \"targetResponse\": {\r\n" +
                         "        \"HTTP-Version\": {\r\n" +
@@ -190,12 +195,12 @@ class ResultsToLogsConsumerTest extends InstrumentationTest {
                         "        \"Status-Code\": 200,\r\n" +
                         "        \"Reason-Phrase\": \"OK\",\r\n" +
                         "        \"response_time_ms\": 267,\r\n" +
-                        "        \"body\": \"SSBzaG91bGQgYmUgZGVjcnlwdGVkIHRlc3RlciEN\",\r\n" +
                         "        \"Content-transfer-encoding\": \"chunked\",\r\n" +
                         "        \"Date\": \"Thu, 08 Jun 2023 23:06:23 GMT\",\r\n" +
                         "        \"Content-type\": \"text/plain\",\r\n" +
                         "        \"Funtime\": \"checkIt!\",\r\n" +
-                        "        \"content-length\": \"30\"\r\n" +
+                        "        \"content-length\": \"30\",\r\n" +
+                        "        \"body\": \"SSBzaG91bGQgYmUgZGVjcnlwdGVkIHRlc3RlciEN\"\r\n" +
                         "    },\r\n" +
                         "    \"connectionId\": \"testConnection.1\"\r\n" +
                         "}";
@@ -211,10 +216,10 @@ class ResultsToLogsConsumerTest extends InstrumentationTest {
                 "        \"Request-URI\": \"/test\",\r\n" +
                 "        \"Method\": \"POST\",\r\n" +
                 "        \"HTTP-Version\": \"HTTP/1.1\",\r\n" +
-                "        \"body\": \"ew0KICAic2V0dGluZ3MiOiB7DQogICAgImluZGV4Ijogew0KICAgICAgIm51bWJlcl9vZl9zaGFyZHMiOiA3LA0KICAgICAgIm51bWJlcl9vZl9yZXBsaWNhcyI6IDMNCiAgICB9LA0KICAgICJhbmFseXNpcyI6IHsNCiAgICAgICJhbmFseXplciI6IHsNCiAgICAgICAgIm5hbWVBbmFseXplciI6IHsNCiAgICAgICAgICAidHlwZSI6ICJjdXN0b20iLA0KICAgICAgICAgICJ0b2tlbml6ZXIiOiAia2V5d29yZCIsDQogICAgICAgICAgImZpbHRlciI6ICJ1cHBlcmNhc2UiDQogICAgICAgIH0NCiAgICAgIH0NCiAgICB9DQogIH0sDQogICJtYXBwaW5ncyI6IHsNCiAgICAiZW1wbG95ZWUiOiB7DQogICAgICAicHJvcGVydGllcyI6IHsNCiAgICAgICAgImFnZSI6IHsNCiAgICAgICAgICAidHlwZSI6ICJsb25nIg0KICAgICAgICB9LA0KICAgICAgICAibGV2ZWwiOiB7DQogICAgICAgICAgInR5cGUiOiAibG9uZyINCiAgICAgICAgfSwNCiAgICAgICAgInRpdGxlIjogew0KICAgICAgICAgICJ0eXBlIjogInRleHQiDQogICAgICAgIH0sDQogICAgICAgICJuYW1lIjogew0KICAgICAgICAgICJ0eXBlIjogInRleHQiLA0KICAgICAgICAgICJhbmFseXplciI6ICJuYW1lQW5hbHl6ZXIiDQogICAgICAgIH0NCiAgICAgIH0NCiAgICB9DQogIH0NCn0NCg==\",\r\n" +
                 "        \"Host\": \"foo.example\",\r\n" +
                 "        \"Content-Type\": \"application/json\",\r\n" +
-                "        \"Content-Length\": \"652\"\r\n" +
+                "        \"Content-Length\": \"652\",\r\n" +
+                "        \"body\": \"ew0KICAic2V0dGluZ3MiOiB7DQogICAgImluZGV4Ijogew0KICAgICAgIm51bWJlcl9vZl9zaGFyZHMiOiA3LA0KICAgICAgIm51bWJlcl9vZl9yZXBsaWNhcyI6IDMNCiAgICB9LA0KICAgICJhbmFseXNpcyI6IHsNCiAgICAgICJhbmFseXplciI6IHsNCiAgICAgICAgIm5hbWVBbmFseXplciI6IHsNCiAgICAgICAgICAidHlwZSI6ICJjdXN0b20iLA0KICAgICAgICAgICJ0b2tlbml6ZXIiOiAia2V5d29yZCIsDQogICAgICAgICAgImZpbHRlciI6ICJ1cHBlcmNhc2UiDQogICAgICAgIH0NCiAgICAgIH0NCiAgICB9DQogIH0sDQogICJtYXBwaW5ncyI6IHsNCiAgICAiZW1wbG95ZWUiOiB7DQogICAgICAicHJvcGVydGllcyI6IHsNCiAgICAgICAgImFnZSI6IHsNCiAgICAgICAgICAidHlwZSI6ICJsb25nIg0KICAgICAgICB9LA0KICAgICAgICAibGV2ZWwiOiB7DQogICAgICAgICAgInR5cGUiOiAibG9uZyINCiAgICAgICAgfSwNCiAgICAgICAgInRpdGxlIjogew0KICAgICAgICAgICJ0eXBlIjogInRleHQiDQogICAgICAgIH0sDQogICAgICAgICJuYW1lIjogew0KICAgICAgICAgICJ0eXBlIjogInRleHQiLA0KICAgICAgICAgICJhbmFseXplciI6ICJuYW1lQW5hbHl6ZXIiDQogICAgICAgIH0NCiAgICAgIH0NCiAgICB9DQogIH0NCn0NCg==\"\r\n" +
                 "    },\r\n" +
                 "    \"sourceResponse\": {\r\n" +
                 "        \"HTTP-Version\": {\r\n" +
@@ -223,21 +228,21 @@ class ResultsToLogsConsumerTest extends InstrumentationTest {
                 "        \"Status-Code\": 200,\r\n" +
                 "        \"Reason-Phrase\": \"OK\",\r\n" +
                 "        \"response_time_ms\": 0,\r\n" +
-                "        \"body\": \"SSBzaG91bGQgYmUgZGVjcnlwdGVkIHRlc3RlciEN\",\r\n" +
                 "        \"Content-transfer-encoding\": \"chunked\",\r\n" +
                 "        \"Date\": \"Thu, 08 Jun 2023 23:06:23 GMT\",\r\n" +
                 "        \"Content-type\": \"text/plain\",\r\n" +
                 "        \"Funtime\": \"checkIt!\",\r\n" +
-                "        \"content-length\": \"30\"\r\n" +
+                "        \"content-length\": \"30\",\r\n" +
+                "        \"body\": \"SSBzaG91bGQgYmUgZGVjcnlwdGVkIHRlc3RlciEN\"\r\n" +
                 "    },\r\n" +
                 "    \"targetRequest\": {\r\n" +
                 "        \"Request-URI\": \"/test\",\r\n" +
                 "        \"Method\": \"POST\",\r\n" +
                 "        \"HTTP-Version\": \"HTTP/1.1\",\r\n" +
-                "        \"body\": \"ew0KICAic2V0dGluZ3MiOiB7DQogICAgImluZGV4Ijogew0KICAgICAgIm51bWJlcl9vZl9zaGFyZHMiOiA3LA0KICAgICAgIm51bWJlcl9vZl9yZXBsaWNhcyI6IDMNCiAgICB9LA0KICAgICJhbmFseXNpcyI6IHsNCiAgICAgICJhbmFseXplciI6IHsNCiAgICAgICAgIm5hbWVBbmFseXplciI6IHsNCiAgICAgICAgICAidHlwZSI6ICJjdXN0b20iLA0KICAgICAgICAgICJ0b2tlbml6ZXIiOiAia2V5d29yZCIsDQogICAgICAgICAgImZpbHRlciI6ICJ1cHBlcmNhc2UiDQogICAgICAgIH0NCiAgICAgIH0NCiAgICB9DQogIH0sDQogICJtYXBwaW5ncyI6IHsNCiAgICAiZW1wbG95ZWUiOiB7DQogICAgICAicHJvcGVydGllcyI6IHsNCiAgICAgICAgImFnZSI6IHsNCiAgICAgICAgICAidHlwZSI6ICJsb25nIg0KICAgICAgICB9LA0KICAgICAgICAibGV2ZWwiOiB7DQogICAgICAgICAgInR5cGUiOiAibG9uZyINCiAgICAgICAgfSwNCiAgICAgICAgInRpdGxlIjogew0KICAgICAgICAgICJ0eXBlIjogInRleHQiDQogICAgICAgIH0sDQogICAgICAgICJuYW1lIjogew0KICAgICAgICAgICJ0eXBlIjogInRleHQiLA0KICAgICAgICAgICJhbmFseXplciI6ICJuYW1lQW5hbHl6ZXIiDQogICAgICAgIH0NCiAgICAgIH0NCiAgICB9DQogIH0NCn0NCg==\",\r\n" +
                 "        \"Host\": \"foo.example\",\r\n" +
                 "        \"Content-Type\": \"application/json\",\r\n" +
-                "        \"Content-Length\": \"652\"\r\n" +
+                "        \"Content-Length\": \"652\",\r\n" +
+                "        \"body\": \"ew0KICAic2V0dGluZ3MiOiB7DQogICAgImluZGV4Ijogew0KICAgICAgIm51bWJlcl9vZl9zaGFyZHMiOiA3LA0KICAgICAgIm51bWJlcl9vZl9yZXBsaWNhcyI6IDMNCiAgICB9LA0KICAgICJhbmFseXNpcyI6IHsNCiAgICAgICJhbmFseXplciI6IHsNCiAgICAgICAgIm5hbWVBbmFseXplciI6IHsNCiAgICAgICAgICAidHlwZSI6ICJjdXN0b20iLA0KICAgICAgICAgICJ0b2tlbml6ZXIiOiAia2V5d29yZCIsDQogICAgICAgICAgImZpbHRlciI6ICJ1cHBlcmNhc2UiDQogICAgICAgIH0NCiAgICAgIH0NCiAgICB9DQogIH0sDQogICJtYXBwaW5ncyI6IHsNCiAgICAiZW1wbG95ZWUiOiB7DQogICAgICAicHJvcGVydGllcyI6IHsNCiAgICAgICAgImFnZSI6IHsNCiAgICAgICAgICAidHlwZSI6ICJsb25nIg0KICAgICAgICB9LA0KICAgICAgICAibGV2ZWwiOiB7DQogICAgICAgICAgInR5cGUiOiAibG9uZyINCiAgICAgICAgfSwNCiAgICAgICAgInRpdGxlIjogew0KICAgICAgICAgICJ0eXBlIjogInRleHQiDQogICAgICAgIH0sDQogICAgICAgICJuYW1lIjogew0KICAgICAgICAgICJ0eXBlIjogInRleHQiLA0KICAgICAgICAgICJhbmFseXplciI6ICJuYW1lQW5hbHl6ZXIiDQogICAgICAgIH0NCiAgICAgIH0NCiAgICB9DQogIH0NCn0NCg==\"\r\n" +
                 "    },\r\n" +
                 "    \"targetResponse\": {\r\n" +
                 "        \"HTTP-Version\": {\r\n" +
@@ -246,12 +251,12 @@ class ResultsToLogsConsumerTest extends InstrumentationTest {
                 "        \"Status-Code\": 200,\r\n" +
                 "        \"Reason-Phrase\": \"OK\",\r\n" +
                 "        \"response_time_ms\": 267,\r\n" +
-                "        \"body\": \"SSBzaG91bGQgYmUgZGVjcnlwdGVkIHRlc3RlciEN\",\r\n" +
                 "        \"Content-transfer-encoding\": \"chunked\",\r\n" +
                 "        \"Date\": \"Thu, 08 Jun 2023 23:06:23 GMT\",\r\n" +
                 "        \"Content-type\": \"text/plain\",\r\n" +
                 "        \"Funtime\": \"checkIt!\",\r\n" +
-                "        \"content-length\": \"30\"\r\n" +
+                "        \"content-length\": \"30\",\r\n" +
+                "        \"body\": \"SSBzaG91bGQgYmUgZGVjcnlwdGVkIHRlc3RlciEN\"\r\n" +
                 "    },\r\n" +
                 "    \"connectionId\": \"testConnection.1\"\r\n" +
                 "}";

--- a/TrafficCapture/trafficReplayer/src/testFixtures/java/org/opensearch/migrations/replay/TestCapturePacketToHttpHandler.java
+++ b/TrafficCapture/trafficReplayer/src/testFixtures/java/org/opensearch/migrations/replay/TestCapturePacketToHttpHandler.java
@@ -42,7 +42,7 @@ public class TestCapturePacketToHttpHandler implements IPacketFinalizingConsumer
     public TrackedFuture<String, Void> consumeBytes(ByteBuf nextRequestPacket) {
         numConsumes.incrementAndGet();
         log.info("incoming buffer refcnt="+nextRequestPacket.refCnt());
-        var duplicatedPacket = nextRequestPacket.duplicate().retain();
+        var duplicatedPacket = nextRequestPacket.retainedDuplicate();
         return new TrackedFuture<>(CompletableFuture.runAsync(() -> {
             try {
                 log.info("Running async future for " + nextRequestPacket);

--- a/TrafficCapture/trafficReplayer/src/testFixtures/java/org/opensearch/migrations/replay/TestUtils.java
+++ b/TrafficCapture/trafficReplayer/src/testFixtures/java/org/opensearch/migrations/replay/TestUtils.java
@@ -115,13 +115,10 @@ public class TestUtils {
         fullRequest.release();
     }
 
-    private static String getStringFromContent(FullHttpRequest fullRequest) throws IOException {
-        try (var baos = new ByteArrayOutputStream()) {
-            var bb = fullRequest.content();
-            bb.duplicate().readBytes(baos, bb.readableBytes());
-            return baos.toString(StandardCharsets.UTF_8);
-        }
+    private static String getStringFromContent(FullHttpRequest fullRequest) {
+        return fullRequest.content().toString(StandardCharsets.UTF_8);
     }
+
     static void runPipelineAndValidate(TestContext rootContext,
                                        IAuthTransformerFactory authTransformer,
                                        String extraHeaders,

--- a/TrafficCapture/trafficReplayer/src/testFixtures/java/org/opensearch/migrations/replay/TestUtils.java
+++ b/TrafficCapture/trafficReplayer/src/testFixtures/java/org/opensearch/migrations/replay/TestUtils.java
@@ -118,7 +118,7 @@ public class TestUtils {
     private static String getStringFromContent(FullHttpRequest fullRequest) throws IOException {
         try (var baos = new ByteArrayOutputStream()) {
             var bb = fullRequest.content();
-            bb.readBytes(baos, bb.readableBytes());
+            bb.duplicate().readBytes(baos, bb.readableBytes());
             return baos.toString(StandardCharsets.UTF_8);
         }
     }


### PR DESCRIPTION
### Description
This change seeks to simplify the complexity ByteBuf reading and duplicating indexes through use of `.duplicate` over `.slice` and being more intentional about side effects to the buffer after reading.

This change also seeks to harden NettyJsonContentAuthSigner by flushing the buffer in error cases and removing unnecessary release/retains.

Furthermore, moved to the Netty Base64 Encoder in ParsedHttpMessagesAsDicts to directly decode from ByteBufs.

Also, fixed up some trace logging that previously wasn't using a supplier to reduce unnecessary cycles.

This change also refactors StreamChannelConnectionCaptureSerializer to clean up the interfaces, improve performance, and remove bugs around chunking and serializing data.

* Category: Refactoring
* Why these changes are required? Simplify logic and make it easier to understand
* What is the old behavior before changes and new behavior after changes? NettyJsonContentAuthSigner was less defensible around exceptions or handler being removed or channel closed scenarios and now will flush out buffer in those cases. ByteBufs are less likely to have their reader index modified unintentionally due to use of slicing.

### Issues Resolved
[MIGRATIONS-1696](https://opensearch.atlassian.net/browse/MIGRATIONS-1696)

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
Unit testing

### Check List
- [x] New functionality includes testing
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
