### PR TITLE
Fix missing gatheringRequest trace for non-blocking requests

### DIFF
--- a/TrafficCapture/nettyWireLogging/src/main/java/org/opensearch/migrations/trafficcapture/netty/tracing/WireCaptureContexts.java
+++ b/TrafficCapture/nettyWireLogging/src/main/java/org/opensearch/migrations/trafficcapture/netty/tracing/WireCaptureContexts.java
@@ -121,12 +121,6 @@ public class WireCaptureContexts extends IWireCaptureContexts {
             super(rootWireLoggingContext, enclosingScope, sourceRequestIndex);
         }
 
-        @Override
-        public IWireCaptureContexts.IWaitingForResponseContext createWaitingForResponseContext() {
-            return new WaitingForResponseContext(getRootInstrumentationScope(), getImmediateEnclosingScope(),
-                    sourceRequestIndex);
-        }
-
         public static class MetricInstruments extends CommonScopedMetricInstruments {
             public final LongCounter blockingRequestCounter;
             public final LongCounter requestsNotOffloadedCounter;

--- a/TrafficCapture/nettyWireLogging/src/test/java/org/opensearch/migrations/trafficcapture/netty/ConditionallyReliableLoggingHttpHandlerTest.java
+++ b/TrafficCapture/nettyWireLogging/src/test/java/org/opensearch/migrations/trafficcapture/netty/ConditionallyReliableLoggingHttpHandlerTest.java
@@ -1,6 +1,7 @@
 package org.opensearch.migrations.trafficcapture.netty;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufInputStream;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
 import lombok.extern.slf4j.Slf4j;
@@ -28,8 +29,6 @@ import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static org.opensearch.migrations.trafficcapture.netty.TestStreamManager.consumeIntoArray;
-
 @Slf4j
 public class ConditionallyReliableLoggingHttpHandlerTest {
 
@@ -48,7 +47,7 @@ public class ConditionallyReliableLoggingHttpHandlerTest {
 
             // we wrote the correct data to the downstream handler/channel
             var outputData = new SequenceInputStream(Collections.enumeration(channel.inboundMessages().stream()
-                    .map(m -> new ByteArrayInputStream(consumeIntoArray((ByteBuf) m)))
+                    .map(m -> new ByteBufInputStream((ByteBuf) m, true))
                     .collect(Collectors.toList())))
                     .readAllBytes();
             Assertions.assertArrayEquals(fullTrafficBytes, outputData);
@@ -132,7 +131,7 @@ public class ConditionallyReliableLoggingHttpHandlerTest {
             Assertions.assertEquals(0, streamMgr.flushCount.get());
             // we wrote the correct data to the downstream handler/channel
             var outputData = new SequenceInputStream(Collections.enumeration(channel.inboundMessages().stream()
-                    .map(m -> new ByteArrayInputStream(consumeIntoArray((ByteBuf) m)))
+                    .map(m -> new ByteBufInputStream((ByteBuf) m, true))
                     .collect(Collectors.toList())))
                     .readAllBytes();
             log.info("outputdata = " + new String(outputData, StandardCharsets.UTF_8));
@@ -161,7 +160,7 @@ public class ConditionallyReliableLoggingHttpHandlerTest {
 
             // we wrote the correct data to the downstream handler/channel
             var consumedData = new SequenceInputStream(Collections.enumeration(channel.inboundMessages().stream()
-                    .map(m -> new ByteArrayInputStream(consumeIntoArray((ByteBuf) m)))
+                    .map(m -> new ByteBufInputStream((ByteBuf) m))
                     .collect(Collectors.toList())))
                     .readAllBytes();
             log.info("captureddata = " + new String(consumedData, StandardCharsets.UTF_8));

--- a/TrafficCapture/nettyWireLogging/src/test/java/org/opensearch/migrations/trafficcapture/netty/ConditionallyReliableLoggingHttpHandlerTest.java
+++ b/TrafficCapture/nettyWireLogging/src/test/java/org/opensearch/migrations/trafficcapture/netty/ConditionallyReliableLoggingHttpHandlerTest.java
@@ -1,12 +1,8 @@
 package org.opensearch.migrations.trafficcapture.netty;
 
-import com.google.protobuf.CodedOutputStream;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
-import lombok.Getter;
-import lombok.NonNull;
-import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Disabled;
@@ -15,92 +11,27 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.opensearch.migrations.testutils.TestUtilities;
 import org.opensearch.migrations.testutils.WrapWithNettyLeakDetection;
-import org.opensearch.migrations.tracing.IContextTracker;
-import org.opensearch.migrations.tracing.InMemoryInstrumentationBundle;
-import org.opensearch.migrations.trafficcapture.CodedOutputStreamAndByteBufferWrapper;
-import org.opensearch.migrations.trafficcapture.CodedOutputStreamHolder;
-import org.opensearch.migrations.trafficcapture.OrderedStreamLifecyleManager;
 import org.opensearch.migrations.trafficcapture.StreamChannelConnectionCaptureSerializer;
-import org.opensearch.migrations.trafficcapture.netty.tracing.RootWireLoggingContext;
 import org.opensearch.migrations.trafficcapture.protos.TrafficObservation;
 import org.opensearch.migrations.trafficcapture.protos.TrafficStream;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.SequenceInputStream;
-import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static org.opensearch.migrations.trafficcapture.netty.TestStreamManager.consumeIntoArray;
+
 @Slf4j
 public class ConditionallyReliableLoggingHttpHandlerTest {
-
-    private static class TestRootContext extends RootWireLoggingContext implements AutoCloseable {
-        @Getter
-        InMemoryInstrumentationBundle instrumentationBundle;
-
-        public TestRootContext() {
-            this(false, false);
-        }
-        public TestRootContext(boolean trackMetrics, boolean trackTraces) {
-            this(trackMetrics, trackTraces, DO_NOTHING_TRACKER);
-        }
-        public TestRootContext(boolean trackMetrics, boolean trackTraces, @NonNull IContextTracker contextTracker) {
-            this(new InMemoryInstrumentationBundle(trackMetrics, trackTraces), contextTracker);
-        }
-
-        public TestRootContext(InMemoryInstrumentationBundle inMemoryInstrumentationBundle,
-                               IContextTracker contextTracker) {
-            super(inMemoryInstrumentationBundle.openTelemetrySdk, contextTracker);
-            this.instrumentationBundle = inMemoryInstrumentationBundle;
-        }
-
-        @Override
-        public void close() {
-            instrumentationBundle.close();
-        }
-    }
-
-    static class TestStreamManager extends OrderedStreamLifecyleManager implements AutoCloseable {
-        AtomicReference<ByteBuffer> byteBufferAtomicReference = new AtomicReference<>();
-        AtomicInteger flushCount = new AtomicInteger();
-
-        @Override
-        public void close() {}
-
-        @Override
-        public CodedOutputStreamAndByteBufferWrapper createStream() {
-            return new CodedOutputStreamAndByteBufferWrapper(1024*1024);
-        }
-
-        @SneakyThrows
-        @Override
-        public CompletableFuture<Object>
-        kickoffCloseStream(CodedOutputStreamHolder outputStreamHolder, int index) {
-            if (!(outputStreamHolder instanceof CodedOutputStreamAndByteBufferWrapper)) {
-                throw new IllegalStateException("Unknown outputStreamHolder sent back to StreamManager: " +
-                        outputStreamHolder);
-            }
-            var osh = (CodedOutputStreamAndByteBufferWrapper) outputStreamHolder;
-            CodedOutputStream cos = osh.getOutputStream();
-
-            cos.flush();
-            byteBufferAtomicReference.set(osh.getByteBuffer().flip().asReadOnlyBuffer());
-            log.trace("byteBufferAtomicReference.get="+byteBufferAtomicReference.get());
-
-            return CompletableFuture.completedFuture(flushCount.incrementAndGet());
-        }
-    }
 
     private static void writeMessageAndVerify(byte[] fullTrafficBytes, Consumer<EmbeddedChannel> channelWriter,
                                               boolean checkInstrumentation)
@@ -122,18 +53,18 @@ public class ConditionallyReliableLoggingHttpHandlerTest {
                     .readAllBytes();
             Assertions.assertArrayEquals(fullTrafficBytes, outputData);
 
-            Assertions.assertNotNull(streamManager.byteBufferAtomicReference,
+            Assertions.assertNotNull(streamManager.byteBufferAtomicReference.get(),
                     "This would be null if the handler didn't block until the output was written");
             // we wrote the correct data to the offloaded stream
             var trafficStream = TrafficStream.parseFrom(streamManager.byteBufferAtomicReference.get());
             Assertions.assertTrue(trafficStream.getSubStreamCount() > 0 &&
                     trafficStream.getSubStream(0).hasRead());
-            var combinedTrafficPacketsSteam =
+            var combinedTrafficPacketsStream =
                     new SequenceInputStream(Collections.enumeration(trafficStream.getSubStreamList().stream()
                             .filter(TrafficObservation::hasRead)
                             .map(to -> new ByteArrayInputStream(to.getRead().getData().toByteArray()))
                             .collect(Collectors.toList())));
-            Assertions.assertArrayEquals(fullTrafficBytes, combinedTrafficPacketsSteam.readAllBytes());
+            Assertions.assertArrayEquals(fullTrafficBytes, combinedTrafficPacketsStream.readAllBytes());
             Assertions.assertEquals(1, streamManager.flushCount.get());
 
             if (checkInstrumentation) {
@@ -141,13 +72,6 @@ public class ConditionallyReliableLoggingHttpHandlerTest {
                 Assertions.assertTrue(!rootContext.instrumentationBundle.getFinishedMetrics().isEmpty());
             }
         }
-    }
-
-    private static byte[] consumeIntoArray(ByteBuf m) {
-        var bArr = new byte[m.readableBytes()];
-        m.readBytes(bArr);
-        m.release();
-        return bArr;
     }
 
     @ParameterizedTest

--- a/TrafficCapture/nettyWireLogging/src/test/java/org/opensearch/migrations/trafficcapture/netty/RootWireLoggingContextTest.java
+++ b/TrafficCapture/nettyWireLogging/src/test/java/org/opensearch/migrations/trafficcapture/netty/RootWireLoggingContextTest.java
@@ -1,0 +1,103 @@
+package org.opensearch.migrations.trafficcapture.netty;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.opensearch.migrations.testutils.TestUtilities;
+import org.opensearch.migrations.tracing.IContextTracker;
+import org.opensearch.migrations.tracing.InMemoryInstrumentationBundle;
+import org.opensearch.migrations.trafficcapture.StreamChannelConnectionCaptureSerializer;
+import org.opensearch.migrations.trafficcapture.netty.tracing.RootWireLoggingContext;
+import org.opensearch.migrations.trafficcapture.protos.TrafficObservation;
+import org.opensearch.migrations.trafficcapture.protos.TrafficStream;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.SequenceInputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+import static org.opensearch.migrations.trafficcapture.netty.TestStreamManager.consumeIntoArray;
+
+@Slf4j
+public class RootWireLoggingContextTest {
+
+  private static void writeMessageAndVerifyTraces(byte[] fullTrafficBytes, Consumer<EmbeddedChannel> channelWriter, boolean shouldBlock,
+                                                  List<String> expectedTraces) throws IOException {
+    try (var rootContext = new TestRootContext(true, true)) {
+      var streamManager = new TestStreamManager();
+      var offloader = new StreamChannelConnectionCaptureSerializer("Test", "c", streamManager);
+
+      EmbeddedChannel channel = new EmbeddedChannel(
+          new ConditionallyReliableLoggingHttpHandler(rootContext,
+              "n", "c", ctx -> offloader,
+              new RequestCapturePredicate(), x -> shouldBlock));
+      channelWriter.accept(channel);
+
+      // we wrote the correct data to the downstream handler/channel
+      var outputData = new SequenceInputStream(Collections.enumeration(channel.inboundMessages().stream()
+          .map(m -> new ByteArrayInputStream(consumeIntoArray((ByteBuf) m)))
+          .collect(Collectors.toList())))
+          .readAllBytes();
+      Assertions.assertArrayEquals(fullTrafficBytes, outputData);
+
+      // For a non-blocking write, close the channel to force it to flush
+      if (!shouldBlock) {
+        channel.close().awaitUninterruptibly();
+      }
+
+      Assertions.assertNotNull(streamManager.byteBufferAtomicReference.get(),
+          "This would be null if the handler didn't block until the output was written");
+
+      var trafficStream = TrafficStream.parseFrom(streamManager.byteBufferAtomicReference.get());
+      Assertions.assertTrue(trafficStream.getSubStreamCount() > 0 &&
+          trafficStream.getSubStream(0).hasRead());
+      var combinedTrafficPacketsStream =
+          new SequenceInputStream(Collections.enumeration(trafficStream.getSubStreamList().stream()
+              .filter(TrafficObservation::hasRead)
+              .map(to -> new ByteArrayInputStream(to.getRead().getData().toByteArray()))
+              .collect(Collectors.toList())));
+      Assertions.assertArrayEquals(fullTrafficBytes, combinedTrafficPacketsStream.readAllBytes());
+      Assertions.assertEquals(1, streamManager.flushCount.get());
+
+      List<SpanData> finishedSpans = rootContext.instrumentationBundle.getFinishedSpans();
+      Assertions.assertTrue(!finishedSpans.isEmpty());
+      Assertions.assertTrue(!rootContext.instrumentationBundle.getFinishedMetrics().isEmpty());
+
+      List<String> finishedSpanNames = finishedSpans.stream().map(x -> x.getName()).collect(Collectors.toList());
+      expectedTraces.forEach(trace ->
+          Assertions.assertTrue(finishedSpanNames.contains(trace), "finishedSpans does not contain " + trace)
+      );
+      if (shouldBlock) {
+        Assertions.assertTrue(finishedSpanNames.contains("blocked"), "finishedSpans does not contain 'blocked' on a blocking request");
+      }
+    }
+
+  }
+
+
+  @Test
+  public void testThatAGetProducesGatheringRequestTrace()
+      throws IOException {
+    byte[] fullTrafficBytes = SimpleRequests.HEALTH_CHECK.getBytes(StandardCharsets.UTF_8);
+    var bb = TestUtilities.getByteBuf(fullTrafficBytes, false);
+    writeMessageAndVerifyTraces(fullTrafficBytes, w -> w.writeInbound(bb), false, List.of("gatheringRequest"));
+  }
+
+  @Test
+  public void testThatAPostProducesGatheringRequestTrace()
+      throws IOException {
+    byte[] fullTrafficBytes = SimpleRequests.SMALL_POST.getBytes(StandardCharsets.UTF_8);
+    var bb = TestUtilities.getByteBuf(fullTrafficBytes, false);
+    writeMessageAndVerifyTraces(fullTrafficBytes, w -> w.writeInbound(bb), true, List.of("gatheringRequest"));
+  }
+
+
+}

--- a/TrafficCapture/nettyWireLogging/src/test/java/org/opensearch/migrations/trafficcapture/netty/RootWireLoggingContextTest.java
+++ b/TrafficCapture/nettyWireLogging/src/test/java/org/opensearch/migrations/trafficcapture/netty/RootWireLoggingContextTest.java
@@ -1,6 +1,7 @@
 package org.opensearch.migrations.trafficcapture.netty;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufInputStream;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import lombok.Getter;
@@ -21,17 +22,17 @@ import java.io.SequenceInputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
-
-import static org.opensearch.migrations.trafficcapture.netty.TestStreamManager.consumeIntoArray;
 
 @Slf4j
 public class RootWireLoggingContextTest {
 
-  private static void writeMessageAndVerifyTraces(byte[] fullTrafficBytes, Consumer<EmbeddedChannel> channelWriter, boolean shouldBlock,
-                                                  List<String> expectedTraces) throws IOException {
+  private static void writeMessageAndVerifyTraces(byte[] fullTrafficBytes, boolean shouldBlock, boolean shouldCloseChannel,
+                                                  Set<String> expectedTraces) throws IOException {
     try (var rootContext = new TestRootContext(true, true)) {
+      Consumer<EmbeddedChannel> channelWriter = w -> w.writeInbound(TestUtilities.getByteBuf(fullTrafficBytes, false));
       var streamManager = new TestStreamManager();
       var offloader = new StreamChannelConnectionCaptureSerializer("Test", "c", streamManager);
 
@@ -43,18 +44,28 @@ public class RootWireLoggingContextTest {
 
       // we wrote the correct data to the downstream handler/channel
       var outputData = new SequenceInputStream(Collections.enumeration(channel.inboundMessages().stream()
-          .map(m -> new ByteArrayInputStream(consumeIntoArray((ByteBuf) m)))
+          .map(m -> new ByteBufInputStream((ByteBuf) m, true))
           .collect(Collectors.toList())))
           .readAllBytes();
       Assertions.assertArrayEquals(fullTrafficBytes, outputData);
 
-      // For a non-blocking write, close the channel to force it to flush
+      // For a non-blocking write, we need to force it to flush
       if (!shouldBlock) {
+        // We should not have flushed at this point
+        Assertions.assertEquals(0, streamManager.flushCount.get());
+        if (!shouldCloseChannel) {
+          // Force a manual flush without closing the channel
+          offloader.flushCommitAndResetStream(true).join();
+        }
+      }
+      if (shouldCloseChannel) {
+        // Fully close the channel, which should prompt a flush
         channel.close().awaitUninterruptibly();
       }
 
       Assertions.assertNotNull(streamManager.byteBufferAtomicReference.get(),
           "This would be null if the handler didn't block until the output was written");
+      Assertions.assertEquals(1, streamManager.flushCount.get());
 
       var trafficStream = TrafficStream.parseFrom(streamManager.byteBufferAtomicReference.get());
       Assertions.assertTrue(trafficStream.getSubStreamCount() > 0 &&
@@ -65,39 +76,37 @@ public class RootWireLoggingContextTest {
               .map(to -> new ByteArrayInputStream(to.getRead().getData().toByteArray()))
               .collect(Collectors.toList())));
       Assertions.assertArrayEquals(fullTrafficBytes, combinedTrafficPacketsStream.readAllBytes());
-      Assertions.assertEquals(1, streamManager.flushCount.get());
 
-      List<SpanData> finishedSpans = rootContext.instrumentationBundle.getFinishedSpans();
+      var finishedSpans = rootContext.instrumentationBundle.getFinishedSpans();
       Assertions.assertTrue(!finishedSpans.isEmpty());
       Assertions.assertTrue(!rootContext.instrumentationBundle.getFinishedMetrics().isEmpty());
 
-      List<String> finishedSpanNames = finishedSpans.stream().map(x -> x.getName()).collect(Collectors.toList());
-      expectedTraces.forEach(trace ->
-          Assertions.assertTrue(finishedSpanNames.contains(trace), "finishedSpans does not contain " + trace)
+      Assertions.assertEquals(expectedTraces.stream().sorted().collect(Collectors.joining("\n")),
+          finishedSpans.stream().map(SpanData::getName).sorted().collect(Collectors.joining("\n"))
       );
-      if (shouldBlock) {
-        Assertions.assertTrue(finishedSpanNames.contains("blocked"), "finishedSpans does not contain 'blocked' on a blocking request");
-      }
     }
-
   }
 
 
   @Test
-  public void testThatAGetProducesGatheringRequestTrace()
-      throws IOException {
+  public void testThatAGetProducesGatheringRequestTrace_WithoutClosingChannel() throws IOException {
     byte[] fullTrafficBytes = SimpleRequests.HEALTH_CHECK.getBytes(StandardCharsets.UTF_8);
-    var bb = TestUtilities.getByteBuf(fullTrafficBytes, false);
-    writeMessageAndVerifyTraces(fullTrafficBytes, w -> w.writeInbound(bb), false, List.of("gatheringRequest"));
+    writeMessageAndVerifyTraces(fullTrafficBytes, false, false,
+          Set.of("gatheringRequest"));
   }
 
   @Test
-  public void testThatAPostProducesGatheringRequestTrace()
-      throws IOException {
-    byte[] fullTrafficBytes = SimpleRequests.SMALL_POST.getBytes(StandardCharsets.UTF_8);
-    var bb = TestUtilities.getByteBuf(fullTrafficBytes, false);
-    writeMessageAndVerifyTraces(fullTrafficBytes, w -> w.writeInbound(bb), true, List.of("gatheringRequest"));
+  public void testThatAGetProducesGatheringRequestTrace_WithClosingChannel() throws IOException {
+    byte[] fullTrafficBytes = SimpleRequests.HEALTH_CHECK.getBytes(StandardCharsets.UTF_8);
+    writeMessageAndVerifyTraces(fullTrafficBytes, false, true,
+        Set.of("captureConnection", "gatheringRequest", "waitingForResponse"));
   }
 
+  @Test
+  public void testThatAPostProducesGatheringRequestTrace_WithoutClosingChannel() throws IOException {
+    byte[] fullTrafficBytes = SimpleRequests.SMALL_POST.getBytes(StandardCharsets.UTF_8);
+    writeMessageAndVerifyTraces(fullTrafficBytes, true, false,
+        Set.of("gatheringRequest", "blocked"));
+  }
 
 }

--- a/TrafficCapture/nettyWireLogging/src/test/java/org/opensearch/migrations/trafficcapture/netty/TestRootContext.java
+++ b/TrafficCapture/nettyWireLogging/src/test/java/org/opensearch/migrations/trafficcapture/netty/TestRootContext.java
@@ -1,0 +1,35 @@
+package org.opensearch.migrations.trafficcapture.netty;
+
+import lombok.Getter;
+import lombok.NonNull;
+import org.opensearch.migrations.tracing.IContextTracker;
+import org.opensearch.migrations.tracing.InMemoryInstrumentationBundle;
+import org.opensearch.migrations.trafficcapture.netty.tracing.RootWireLoggingContext;
+
+public class TestRootContext extends RootWireLoggingContext implements AutoCloseable {
+  @Getter
+  InMemoryInstrumentationBundle instrumentationBundle;
+
+  public TestRootContext() {
+    this(false, false);
+  }
+
+  public TestRootContext(boolean trackMetrics, boolean trackTraces) {
+    this(trackMetrics, trackTraces, DO_NOTHING_TRACKER);
+  }
+
+  public TestRootContext(boolean trackMetrics, boolean trackTraces, @NonNull IContextTracker contextTracker) {
+    this(new InMemoryInstrumentationBundle(trackMetrics, trackTraces), contextTracker);
+  }
+
+  public TestRootContext(InMemoryInstrumentationBundle inMemoryInstrumentationBundle,
+                         IContextTracker contextTracker) {
+    super(inMemoryInstrumentationBundle.openTelemetrySdk, contextTracker);
+    this.instrumentationBundle = inMemoryInstrumentationBundle;
+  }
+
+  @Override
+  public void close() {
+    instrumentationBundle.close();
+  }
+}

--- a/TrafficCapture/nettyWireLogging/src/test/java/org/opensearch/migrations/trafficcapture/netty/TestStreamManager.java
+++ b/TrafficCapture/nettyWireLogging/src/test/java/org/opensearch/migrations/trafficcapture/netty/TestStreamManager.java
@@ -1,0 +1,54 @@
+package org.opensearch.migrations.trafficcapture.netty;
+
+import com.google.protobuf.CodedOutputStream;
+import io.netty.buffer.ByteBuf;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import org.opensearch.migrations.trafficcapture.CodedOutputStreamAndByteBufferWrapper;
+import org.opensearch.migrations.trafficcapture.CodedOutputStreamHolder;
+import org.opensearch.migrations.trafficcapture.OrderedStreamLifecyleManager;
+
+import java.nio.ByteBuffer;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+@Slf4j
+class TestStreamManager extends OrderedStreamLifecyleManager implements AutoCloseable {
+  AtomicReference<ByteBuffer> byteBufferAtomicReference = new AtomicReference<>();
+  AtomicInteger flushCount = new AtomicInteger();
+
+  static byte[] consumeIntoArray(ByteBuf m) {
+      var bArr = new byte[m.readableBytes()];
+      m.readBytes(bArr);
+      m.release();
+      return bArr;
+  }
+
+  @Override
+  public void close() {
+  }
+
+  @Override
+  public CodedOutputStreamAndByteBufferWrapper createStream() {
+    return new CodedOutputStreamAndByteBufferWrapper(1024 * 1024);
+  }
+
+  @SneakyThrows
+  @Override
+  public CompletableFuture<Object>
+  kickoffCloseStream(CodedOutputStreamHolder outputStreamHolder, int index) {
+    if (!(outputStreamHolder instanceof CodedOutputStreamAndByteBufferWrapper)) {
+      throw new IllegalStateException("Unknown outputStreamHolder sent back to StreamManager: " +
+          outputStreamHolder);
+    }
+    var osh = (CodedOutputStreamAndByteBufferWrapper) outputStreamHolder;
+    CodedOutputStream cos = osh.getOutputStream();
+
+    cos.flush();
+    byteBufferAtomicReference.set(osh.getByteBuffer().flip().asReadOnlyBuffer());
+    log.trace("byteBufferAtomicReference.get=" + byteBufferAtomicReference.get());
+
+    return CompletableFuture.completedFuture(flushCount.incrementAndGet());
+  }
+}

--- a/TrafficCapture/nettyWireLogging/src/test/java/org/opensearch/migrations/trafficcapture/netty/TestStreamManager.java
+++ b/TrafficCapture/nettyWireLogging/src/test/java/org/opensearch/migrations/trafficcapture/netty/TestStreamManager.java
@@ -18,13 +18,6 @@ class TestStreamManager extends OrderedStreamLifecyleManager implements AutoClos
   AtomicReference<ByteBuffer> byteBufferAtomicReference = new AtomicReference<>();
   AtomicInteger flushCount = new AtomicInteger();
 
-  static byte[] consumeIntoArray(ByteBuf m) {
-      var bArr = new byte[m.readableBytes()];
-      m.readBytes(bArr);
-      m.release();
-      return bArr;
-  }
-
   @Override
   public void close() {
   }


### PR DESCRIPTION
Signed-off-by: Mikayla Thompson <thomika@amazon.com>
### Description

The `gatheringRequest` span was missing from `GET` requests, but present for mutating requests. There was an unnecessary overridden method specifically for non-blocking requests, which wasn't closing that request.

The override is now removed, and tests are added to demonstrate the fixed behavior. The testing in this section was refactored a bit to prepare for additional trace-related testing. 

### Issues Resolved
https://opensearch.atlassian.net/browse/MIGRATIONS-1658


### Testing
Unit tests & manual testing

### Check List
- [x] New functionality includes testing
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
