### PR TITLE
Use public.ecr.aws images

### DIFF
--- a/FetchMigration/Dockerfile
+++ b/FetchMigration/Dockerfile
@@ -1,4 +1,4 @@
-FROM opensearchproject/data-prepper:2.5.0
+FROM public.ecr.aws/opensearchproject/data-prepper:2.5.0
 COPY python/requirements.txt .
 
 # Install dependencies to local user directory

--- a/RFS/docker/Dockerfile
+++ b/RFS/docker/Dockerfile
@@ -1,5 +1,6 @@
 # Using same base image as other Java containers in this repo
-FROM openjdk:11-jre
+FROM public.ecr.aws/amazoncorretto/amazoncorretto:11-al2023-headless
+
 # Requires Gradle to genearte runtime jars initially
 COPY ./build/runtimeJars /rfs-app/jars
 WORKDIR /rfs-app

--- a/TrafficCapture/buildSrc/src/main/groovy/org/opensearch/migrations/common/CommonUtils.groovy
+++ b/TrafficCapture/buildSrc/src/main/groovy/org/opensearch/migrations/common/CommonUtils.groovy
@@ -57,8 +57,8 @@ class CommonUtils {
                 runCommand("sed -i -e \"s|mirrorlist=|#mirrorlist=|g\" /etc/yum.repos.d/CentOS-* ;  sed -i -e \"s|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g\" /etc/yum.repos.d/CentOS-*")
                 runCommand("yum -y install nmap-ncat")
             } else {
-                from 'openjdk:11-jre'
-                runCommand("apt-get update && apt-get install -y netcat")
+                from 'public.ecr.aws/amazoncorretto/amazoncorretto:11-al2023-headless'
+                runCommand("dnf update && dnf install -y nmap-ncat")
             }
 
             copyFile("jars", "/jars")

--- a/TrafficCapture/dockerSolution/src/main/docker/grafana/Dockerfile
+++ b/TrafficCapture/dockerSolution/src/main/docker/grafana/Dockerfile
@@ -1,3 +1,3 @@
-FROM grafana/grafana:latest
+FROM public.ecr.aws/bitnami/grafana:latest
 
 COPY datasources.yaml /usr/share/grafana/conf/provisioning/datasources/

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/Dockerfile
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/Dockerfile
@@ -1,13 +1,15 @@
-FROM ubuntu:jammy
+FROM public.ecr.aws/amazonlinux/amazonlinux:2023
 
-ENV DEBIAN_FRONTEND noninteractive
+RUN dnf update -y
+RUN dnf install -y python3.9 python3-pip python3-devel \
+        java-11-amazon-corretto-devel java-11-amazon-corretto \
+        wget gcc glibc-devel git vim jq unzip less curl-minimal
+RUN pip3 install setuptools
+RUN pip3 install urllib3 opensearch-benchmark==1.2.0 awscurl tqdm awscli
 
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends python3.9 python3-pip python3-dev openjdk-11-jre-headless wget gcc libc-dev git curl vim jq unzip less && \
-    pip3 install urllib3 opensearch-benchmark==1.2.0 awscurl tqdm awscli
-RUN mkdir /root/kafka-tools
-RUN mkdir /root/kafka-tools/aws
+RUN mkdir -p /root/kafka-tools/aws
 
+# Set working directory
 WORKDIR /root/kafka-tools
 # Get kafka distribution and unpack to 'kafka'
 RUN wget -qO- https://archive.apache.org/dist/kafka/3.6.0/kafka_2.13-3.6.0.tgz | tar --transform 's!^[^/]*!kafka!' -xvz

--- a/TrafficCapture/trafficCaptureProxyServerTest/src/main/docker/nginx/Dockerfile
+++ b/TrafficCapture/trafficCaptureProxyServerTest/src/main/docker/nginx/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:1.25.1
+FROM public.ecr.aws/nginx/nginx:1.25-bookworm
 
 # Installing VIM for the sake of users who would like to exec shells in the webserver container.
 RUN apt-get update


### PR DESCRIPTION
### Description
Currently we are getting throttling from docker and ecr within github actions. To resolve this, we should 

### TODO: before this change is merged, we should include adding credentials for authenticated ecr pulling to extend our limits.

* Category: Bug Fix
* Why these changes are required? Fix throttling for github actions
* What is the old behavior before changes and new behavior after changes? Some test runs failed and need to be retried.

### Issues Resolved

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
Tested locally

### Check List
- [ ] New functionality includes testing
  - [x ] All tests pass, including unit test, integration test and doctest
- [x ] New functionality has been documented
- [x ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
