### PR TITLE
Increase default MAX_PAYLOAD_BYTES_TO_PRINT to 100MiB

### DIFF
--- a/TrafficCapture/replayerPlugins/jsonMessageTransformers/jsonJoltMessageTransformerProvider/src/test/java/org/opensearch/migrations/replay/AddCompressionEncodingTest.java
+++ b/TrafficCapture/replayerPlugins/jsonMessageTransformers/jsonJoltMessageTransformerProvider/src/test/java/org/opensearch/migrations/replay/AddCompressionEncodingTest.java
@@ -67,7 +67,7 @@ public class AddCompressionEncodingTest extends InstrumentationTest {
 
         EmbeddedChannel channel = new EmbeddedChannel(
             new HttpServerCodec(),
-            new HttpObjectAggregator(Utils.MAX_PAYLOAD_SIZE_TO_PRINT)  // Set max content length if needed
+            new HttpObjectAggregator(Utils.MAX_PAYLOAD_BYTES_TO_PRINT)  // Set max content length if needed
         );
 
         channel.writeInbound(Unpooled.wrappedBuffer(testPacketCapture.getBytesCaptured()));

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/HttpByteBufFormatter.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/HttpByteBufFormatter.java
@@ -146,7 +146,7 @@ public class HttpByteBufFormatter {
         EmbeddedChannel channel = new EmbeddedChannel(
                 msgType == HttpMessageType.REQUEST ? new HttpServerCodec() : new HttpClientCodec(),
                 new HttpContentDecompressor(),
-                new HttpObjectAggregator(Utils.MAX_PAYLOAD_SIZE_TO_PRINT)  // Set max content length if needed
+                new HttpObjectAggregator(Utils.MAX_PAYLOAD_BYTES_TO_PRINT)  // Set max content length if needed
         );
         try {
             byteBufStream.forEachOrdered(b -> channel.writeInbound(b.retainedDuplicate()));

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/HttpMessageAndTimestamp.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/HttpMessageAndTimestamp.java
@@ -68,7 +68,7 @@ public class HttpMessageAndTimestamp {
         try (var bufStream = NettyUtils.createRefCntNeutralCloseableByteBufStream(packetBytes)) {
             var packetBytesAsStr = messageTypeOp.map(mt-> HttpByteBufFormatter.httpPacketBytesToString(mt, packetBytes,
                     HttpByteBufFormatter.LF_LINE_DELIMITER))
-                .orElseGet(()-> HttpByteBufFormatter.httpPacketBufsToString(bufStream, Utils.MAX_PAYLOAD_SIZE_TO_PRINT));
+                .orElseGet(()-> HttpByteBufFormatter.httpPacketBufsToString(bufStream, Utils.MAX_PAYLOAD_BYTES_TO_PRINT));
             final StringBuilder sb = new StringBuilder("HttpMessageAndTimestamp{");
             sb.append("firstPacketTimestamp=").append(firstPacketTimestamp);
             sb.append(", lastPacketTimestamp=").append(lastPacketTimestamp);

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/Utils.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/Utils.java
@@ -21,7 +21,7 @@ import java.util.zip.GZIPOutputStream;
 @Slf4j
 public class Utils {
     public static final int MAX_BYTES_SHOWN_FOR_TO_STRING = 128;
-    public static final int MAX_PAYLOAD_SIZE_TO_PRINT = 1024 * 1024; // 1MB
+    public static final int MAX_PAYLOAD_BYTES_TO_PRINT = 100 * 1024 * 1024; // 100MiB based on https://docs.aws.amazon.com/opensearch-service/latest/developerguide/limits.html#network-limits
 
     public static Instant setIfLater(AtomicReference<Instant> referenceValue, Instant pointInTime) {
         return referenceValue.updateAndGet(existingInstant -> existingInstant.isBefore(pointInTime) ?


### PR DESCRIPTION
### Description
Increases MAX_PAYLOAD_BYTES_TO_PRINT to 100 MiB to keep in line with [AWS Opensearch Support](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/limits.html#network-limits)
* Category: Bug Fix
* Why these changes are required? The default configuration should work with aws opensearch 
* What is the old behavior before changes and new behavior after changes? Large requests over 1MB would not be included in the tuple output. Now by default all requests that are supported within AWS Managed Opensearch will work.

### Issues Resolved
[MIGRATIONS-1715](https://opensearch.atlassian.net/browse/MIGRATIONS-1715)

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
Unit Testing

### Check List
- [x ] New functionality includes testing
  - [ x] All tests pass, including unit test, integration test and doctest
- [x ] New functionality has been documented
- [x ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
