### PR TITLE
[RFS] Refactored DocumentReindexer, HTTP client usage, added a OpenSearchClient

### DIFF
--- a/RFS/src/main/java/com/rfs/common/DocumentReindexer.java
+++ b/RFS/src/main/java/com/rfs/common/DocumentReindexer.java
@@ -16,16 +16,14 @@ public class DocumentReindexer {
     private static final int MAX_BATCH_SIZE = 1000; // Arbitrarily chosen
 
     public static Mono<Void> reindex(String indexName, Flux<Document> documentStream, ConnectionDetails targetConnection) throws Exception {   
-        RestClient client = new RestClient(targetConnection);
-
-        String targetPath = indexName + "/_bulk";
+        OpenSearchClient client = new OpenSearchClient(targetConnection);
 
         return documentStream
             .map(DocumentReindexer::convertDocumentToBulkSection)  // Convert each Document to part of a bulk operation
             .buffer(MAX_BATCH_SIZE) // Collect until you hit the batch size
             .doOnNext(bulk -> logger.info(bulk.size() + " documents in current bulk request"))
             .map(DocumentReindexer::convertToBulkRequestBody)  // Assemble the bulk request body from the parts
-            .flatMap(bulkJson -> client.postBulkAsync(targetPath, bulkJson) // Send the request
+            .flatMap(bulkJson -> client.sendBulkRequest(indexName, bulkJson) // Send the request
                 .doOnSuccess(unused -> logger.debug("Batch succeeded"))
                 .doOnError(error -> logger.error("Batch failed", error))
                 .onErrorResume(e -> Mono.empty()) // Prevent the error from stopping the entire stream
@@ -53,7 +51,7 @@ public class DocumentReindexer {
 
     public static void refreshAllDocuments(ConnectionDetails targetConnection) throws Exception {
         // Send the request
-        RestClient client = new RestClient(targetConnection);
-        client.get("_refresh", false);
+        OpenSearchClient client = new OpenSearchClient(targetConnection);
+        client.refresh();
     }
 }

--- a/RFS/src/main/java/com/rfs/common/DocumentReindexer.java
+++ b/RFS/src/main/java/com/rfs/common/DocumentReindexer.java
@@ -1,16 +1,13 @@
 package com.rfs.common;
 
 import java.time.Duration;
-import java.util.Base64;
 import java.util.List;
 
-import io.netty.buffer.Unpooled;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.document.Document;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
-import reactor.netty.http.client.HttpClient;
 import reactor.util.retry.Retry;
 
 
@@ -18,26 +15,17 @@ public class DocumentReindexer {
     private static final Logger logger = LogManager.getLogger(DocumentReindexer.class);
     private static final int MAX_BATCH_SIZE = 1000; // Arbitrarily chosen
 
-    public static Mono<Void> reindex(String indexName, Flux<Document> documentStream, ConnectionDetails targetConnection) throws Exception {
-        String targetUrl = "/" + indexName + "/_bulk";
-        HttpClient client = HttpClient.create()
-            .host(targetConnection.hostName)
-            .port(targetConnection.port)
-            .headers(h -> {
-                h.set("Content-Type", "application/json");
-                if (targetConnection.authType == ConnectionDetails.AuthType.BASIC) {
-                    String credentials = targetConnection.username + ":" + targetConnection.password;
-                    String encodedCredentials = Base64.getEncoder().encodeToString(credentials.getBytes());
-                    h.set("Authorization", "Basic " + encodedCredentials);
-                }
-            });
+    public static Mono<Void> reindex(String indexName, Flux<Document> documentStream, ConnectionDetails targetConnection) throws Exception {   
+        RestClient client = new RestClient(targetConnection);
+
+        String targetPath = indexName + "/_bulk";
 
         return documentStream
             .map(DocumentReindexer::convertDocumentToBulkSection)  // Convert each Document to part of a bulk operation
             .buffer(MAX_BATCH_SIZE) // Collect until you hit the batch size
             .doOnNext(bulk -> logger.info(bulk.size() + " documents in current bulk request"))
             .map(DocumentReindexer::convertToBulkRequestBody)  // Assemble the bulk request body from the parts
-            .flatMap(bulkJson -> sendBulkRequest(client, targetUrl, bulkJson) // Send the request
+            .flatMap(bulkJson -> client.postBulkAsync(targetPath, bulkJson) // Send the request
                 .doOnSuccess(unused -> logger.debug("Batch succeeded"))
                 .doOnError(error -> logger.error("Batch failed", error))
                 .onErrorResume(e -> Mono.empty()) // Prevent the error from stopping the entire stream
@@ -63,51 +51,9 @@ public class DocumentReindexer {
         return builder.toString();
     }
 
-    private static Mono<Void> sendBulkRequest(HttpClient client, String url, String bulkJson) {
-        return client.post()
-                .uri(url)
-                .send(Flux.just(Unpooled.wrappedBuffer(bulkJson.getBytes())))
-                .responseSingle((res, content) -> content.asString().map(body -> new BulkResponseDetails(res.status().code(), body)))
-                .flatMap(responseDetails -> {
-                    if (responseDetails.hasBadStatusCode() || responseDetails.hasFailedOperations()) {
-                        return Mono.error(new RuntimeException(responseDetails.getFailureMessage()));
-                    }
-                    return Mono.empty();
-                });
-    }
-
     public static void refreshAllDocuments(ConnectionDetails targetConnection) throws Exception {
         // Send the request
         RestClient client = new RestClient(targetConnection);
         client.get("_refresh", false);
-    }
-
-    static class BulkResponseDetails {
-        public final int statusCode;
-        public final String body;
-    
-        BulkResponseDetails(int statusCode, String body) {
-            this.statusCode = statusCode;
-            this.body = body;
-        }
-
-        public boolean hasBadStatusCode() {
-            return !(statusCode == 200 || statusCode == 201);
-        }
-
-        public boolean hasFailedOperations() {
-            return body.contains("\"errors\":true");
-        }
-
-        public String getFailureMessage() {
-            String failureMessage;
-            if (hasBadStatusCode()) {
-                failureMessage = "Bulk request failed.  Status code: " + statusCode + ", Response body: " + body;
-            } else {
-                failureMessage = "Bulk request succeeded, but some operations failed.  Response body: " + body;
-            }
-
-            return failureMessage;
-        }
     }
 }

--- a/RFS/src/main/java/com/rfs/common/FileSystemSnapshotCreator.java
+++ b/RFS/src/main/java/com/rfs/common/FileSystemSnapshotCreator.java
@@ -9,14 +9,14 @@ public class FileSystemSnapshotCreator extends SnapshotCreator {
     private static final Logger logger = LogManager.getLogger(FileSystemSnapshotCreator.class);
     private static final ObjectMapper mapper = new ObjectMapper();
 
-    private final ConnectionDetails connectionDetails;
+    private final OpenSearchClient client;
     private final String snapshotName;
     private final String snapshotRepoDirectoryPath;
 
-    public FileSystemSnapshotCreator(String snapshotName, ConnectionDetails connectionDetails, String snapshotRepoDirectoryPath) {
-        super(snapshotName, connectionDetails);
+    public FileSystemSnapshotCreator(String snapshotName, OpenSearchClient client, String snapshotRepoDirectoryPath) {
+        super(snapshotName, client);
         this.snapshotName = snapshotName;
-        this.connectionDetails = connectionDetails;
+        this.client = client;
         this.snapshotRepoDirectoryPath = snapshotRepoDirectoryPath;
     }
 

--- a/RFS/src/main/java/com/rfs/common/LuceneDocumentsReader.java
+++ b/RFS/src/main/java/com/rfs/common/LuceneDocumentsReader.java
@@ -35,7 +35,7 @@ public class LuceneDocumentsReader {
                 try {
                     reader.close();
                 } catch (IOException e) {
-                    logger.error("Failed to close IndexReader", e);
+                    throw new RuntimeException("Failed to close IndexReader", e);
                 }
             }
         );
@@ -61,7 +61,7 @@ public class LuceneDocumentsReader {
             }
             if (source_bytes == null || source_bytes.bytes.length == 0) {
                 logger.warn("Document " + id + " is deleted or doesn't have the _source field enabled");
-                return null;  // Skip deleted documents or those without the _source field
+                return null;  // Skip these too
             }
 
             logger.debug("Document " + id + " read successfully");

--- a/RFS/src/main/java/com/rfs/common/OpenSearchClient.java
+++ b/RFS/src/main/java/com/rfs/common/OpenSearchClient.java
@@ -1,0 +1,127 @@
+package com.rfs.common;
+
+import java.net.HttpURLConnection;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import reactor.core.publisher.Mono;
+
+public class OpenSearchClient {
+    private static final Logger logger = LogManager.getLogger(OpenSearchClient.class);
+
+    public static class BulkResponse extends RestClient.Response {
+        public BulkResponse(int responseCode, String responseBody, String responseMessage) {
+            super(responseCode, responseBody, responseMessage);
+        }
+
+        public boolean hasBadStatusCode() {
+            return !(code == HttpURLConnection.HTTP_OK || code == HttpURLConnection.HTTP_CREATED);
+        }
+
+        public boolean hasFailedOperations() {
+            return body.contains("\"errors\":true");
+        }
+
+        public String getFailureMessage() {
+            String failureMessage;
+            if (hasBadStatusCode()) {
+                failureMessage = "Bulk request failed.  Status code: " + code + ", Response body: " + body;
+            } else {
+                failureMessage = "Bulk request succeeded, but some operations failed.  Response body: " + body;
+            }
+
+            return failureMessage;
+        }
+    }
+
+    public final ConnectionDetails connectionDetails;
+    private final RestClient client;
+
+    public OpenSearchClient(ConnectionDetails connectionDetails) {
+        this.connectionDetails = connectionDetails;
+        this.client = new RestClient(connectionDetails);
+    }
+
+    /*
+     * Create a legacy template if it does not already exist; return true if created, false otherwise.
+     */
+    public boolean createLegacyTemplateIdempotent(String templateName, ObjectNode settings){
+        String targetPath = "_template/" + templateName;
+        return createObjectIdempotent(targetPath, settings);
+    }
+
+    /*
+     * Create a component template if it does not already exist; return true if created, false otherwise.
+     */
+    public boolean createComponentTemplateIdempotent(String templateName, ObjectNode settings){
+        String targetPath = "_component_template/" + templateName;
+        return createObjectIdempotent(targetPath, settings);
+    }
+
+    /*
+     * Create an index template if it does not already exist; return true if created, false otherwise.
+     */
+    public boolean createIndexTemplateIdempotent(String templateName, ObjectNode settings){
+        String targetPath = "_index_template/" + templateName;
+        return createObjectIdempotent(targetPath, settings);
+    }
+
+    /*
+     * Create an index if it does not already exist; return true if created, false otherwise.
+     */
+    public boolean createIndexIdempotent(String indexName, ObjectNode settings){
+        String targetPath = indexName;
+        return createObjectIdempotent(targetPath, settings);
+    }
+
+    private boolean createObjectIdempotent(String objectPath, ObjectNode settings){
+        RestClient.Response response = client.get(objectPath, true);
+        if (response.code == HttpURLConnection.HTTP_NOT_FOUND) {
+            client.put(objectPath, settings.toString(), false);
+            return true;
+        } else if (response.code == HttpURLConnection.HTTP_OK) {
+            logger.warn(objectPath + " already exists. Skipping creation.");
+        } else {
+            logger.warn("Could not confirm that " + objectPath + " does not already exist. Skipping creation.");
+        }
+        return false;
+    }
+
+    public RestClient.Response registerSnapshotRepo(String repoName, ObjectNode settings){
+        String targetPath = "_snapshot/" + repoName;
+        return client.put(targetPath, settings.toString(), false);
+    }
+
+    public RestClient.Response createSnapshot(String repoName, String snapshotName, ObjectNode settings){
+        String targetPath = "_snapshot/" + repoName + "/" + snapshotName;
+        return client.put(targetPath, settings.toString(), false);
+    }
+
+    public RestClient.Response getSnapshotStatus(String repoName, String snapshotName){
+        String targetPath = "_snapshot/" + repoName + "/" + snapshotName;
+        return client.get(targetPath, false);
+    }
+
+    public Mono<BulkResponse> sendBulkRequest(String indexName, String body) {
+        String targetPath = indexName + "/_bulk";
+
+        return client.postAsync(targetPath, body)
+            .map(response -> new BulkResponse(response.code, response.body, response.message))
+            .flatMap(responseDetails -> {
+                if (responseDetails.hasBadStatusCode() || responseDetails.hasFailedOperations()) {
+                    logger.error(responseDetails.getFailureMessage());
+                    return Mono.error(new RuntimeException(responseDetails.getFailureMessage()));
+                }
+                return Mono.just(responseDetails);
+            });
+    }
+
+    public RestClient.Response refresh() {
+        String targetPath = "_refresh";
+
+        return client.get(targetPath, false);
+    }
+}

--- a/RFS/src/main/java/com/rfs/common/RestClient.java
+++ b/RFS/src/main/java/com/rfs/common/RestClient.java
@@ -1,21 +1,18 @@
 package com.rfs.common;
 
-import java.io.BufferedReader;
-import java.io.InputStreamReader;
-import java.io.OutputStream;
-import java.net.HttpURLConnection;
-import java.net.URL;
-import java.nio.charset.StandardCharsets;
 import java.util.Base64;
-import java.util.stream.Collectors;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import reactor.core.publisher.Mono;
+import reactor.netty.http.client.HttpClient;
+import reactor.netty.ByteBufMono;
+
 public class RestClient {
     private static final Logger logger = LogManager.getLogger(RestClient.class);
 
-    public class Response {
+    public static class Response {
         public final int code;
         public final String body;
         public final String message;
@@ -27,109 +24,94 @@ public class RestClient {
         }
     }
 
+    public static class BulkResponse extends Response {
+        public BulkResponse(int responseCode, String responseBody, String responseMessage) {
+            super(responseCode, responseBody, responseMessage);
+        }
+
+        public boolean hasBadStatusCode() {
+            return !(code == 200 || code == 201);
+        }
+
+        public boolean hasFailedOperations() {
+            return body.contains("\"errors\":true");
+        }
+
+        public String getFailureMessage() {
+            String failureMessage;
+            if (hasBadStatusCode()) {
+                failureMessage = "Bulk request failed.  Status code: " + code + ", Response body: " + body;
+            } else {
+                failureMessage = "Bulk request succeeded, but some operations failed.  Response body: " + body;
+            }
+
+            return failureMessage;
+        }
+    }
+
     public final ConnectionDetails connectionDetails;
+    private final HttpClient client;
 
     public RestClient(ConnectionDetails connectionDetails) {
         this.connectionDetails = connectionDetails;
+
+        this.client = HttpClient.create()
+            .baseUrl(connectionDetails.url)
+            .headers(h -> {
+                h.add("Content-Type", "application/json");
+                if (connectionDetails.authType == ConnectionDetails.AuthType.BASIC) {
+                    String credentials = connectionDetails.username + ":" + connectionDetails.password;
+                    String encodedCredentials = Base64.getEncoder().encodeToString(credentials.getBytes());
+                    h.add("Authorization", "Basic " + encodedCredentials);
+                }
+            });
     }
 
-    public Response get(String path, boolean quietLogging) throws Exception {
-        String urlString = connectionDetails.url + "/" + path;
-        
-        URL url = new URL(urlString);
-        HttpURLConnection conn = (HttpURLConnection) url.openConnection();
-
-        // Set the request method
-        conn.setRequestMethod("GET");
-        
-        // Set the necessary headers
-        setAuthHeader(conn);
-
-        // Enable input and output streams
-        conn.setDoOutput(true);
-
-        // Report the results
-        int responseCode = conn.getResponseCode();
-
-        String responseBody;
-        if (responseCode >= HttpURLConnection.HTTP_BAD_REQUEST) {
-            // Read error stream if present
-            try (BufferedReader br = new BufferedReader(new InputStreamReader(conn.getErrorStream(), StandardCharsets.UTF_8))) {
-                responseBody = br.lines().collect(Collectors.joining(System.lineSeparator()));
-            }
-        } else {
-            // Read input stream for successful requests
-            try (BufferedReader br = new BufferedReader(new InputStreamReader(conn.getInputStream(), StandardCharsets.UTF_8))) {
-                responseBody = br.lines().collect(Collectors.joining(System.lineSeparator()));
-            }
-        }
-
-        if (quietLogging || (responseCode == HttpURLConnection.HTTP_CREATED || responseCode == HttpURLConnection.HTTP_OK)) {
-            logger.debug("Response Code: " + responseCode + ", Response Message: " + conn.getResponseMessage() + ", Response Body: " + responseBody);
-        } else {
-            logger.error("Response Code: " + responseCode + ", Response Message: " + conn.getResponseMessage() + ", Response Body: " + responseBody);
-        }
-
-        conn.disconnect();
-
-        return new Response(responseCode, responseBody, conn.getResponseMessage());
-    }
-    
-    public Response put(String path, String body, boolean quietLogging) throws Exception {
-        String urlString = connectionDetails.url + "/" + path;
-        
-        URL url = new URL(urlString);
-        HttpURLConnection conn = (HttpURLConnection) url.openConnection();
-
-        // Set the request method
-        conn.setRequestMethod("PUT");
-
-        // Set the necessary headers
-        conn.setRequestProperty("Content-Type", "application/json");
-        setAuthHeader(conn);
-
-        // Enable input and output streams
-        conn.setDoOutput(true);
-
-        // Write the request body
-        try(OutputStream os = conn.getOutputStream()) {
-            byte[] input = body.getBytes("utf-8");
-            os.write(input, 0, input.length);           
-        }        
-
-        // Report the results
-        int responseCode = conn.getResponseCode();
-
-        String responseBody;
-        if (responseCode >= HttpURLConnection.HTTP_BAD_REQUEST) {
-            // Read error stream if present
-            try (BufferedReader br = new BufferedReader(new InputStreamReader(conn.getErrorStream(), StandardCharsets.UTF_8))) {
-                responseBody = br.lines().collect(Collectors.joining(System.lineSeparator()));
-            }
-        } else {
-            // Read input stream for successful requests
-            try (BufferedReader br = new BufferedReader(new InputStreamReader(conn.getInputStream(), StandardCharsets.UTF_8))) {
-                responseBody = br.lines().collect(Collectors.joining(System.lineSeparator()));
-            }
-        }
-
-        if (quietLogging || (responseCode == HttpURLConnection.HTTP_CREATED || responseCode == HttpURLConnection.HTTP_OK)) {
-            logger.debug("Response Code: " + responseCode + ", Response Message: " + conn.getResponseMessage() + ", Response Body: " + responseBody);
-        } else {
-            logger.error("Response Code: " + responseCode + ", Response Message: " + conn.getResponseMessage() + ", Response Body: " + responseBody);
-        }
-
-        conn.disconnect();
-        
-        return new Response(responseCode, responseBody, conn.getResponseMessage());
+    public Mono<Response> getAsync(String path, boolean quietLogging) {
+        return client.get()
+            .uri("/" + path)
+            .responseSingle((response, bytes) -> bytes.asString()
+                .map(body -> new Response(response.status().code(), body, response.status().reasonPhrase()))
+                .doOnNext(resp -> logResponse(resp, quietLogging)));
     }
 
-    private void setAuthHeader(HttpURLConnection conn) {
-        if (connectionDetails.authType == ConnectionDetails.AuthType.BASIC) {
-            String auth = connectionDetails.username + ":" + connectionDetails.password;
-            byte[] encodedAuth = Base64.getEncoder().encode(auth.getBytes(StandardCharsets.UTF_8));
-            String authHeaderValue = "Basic " + new String(encodedAuth);
-            conn.setRequestProperty("Authorization", authHeaderValue);
+    public Response get(String path, boolean quietLogging) {
+        return getAsync(path, quietLogging).block();
+    }
+
+    public Mono<BulkResponse> postBulkAsync(String path, String body) {
+        return client.post()
+            .uri("/" + path)
+            .send(ByteBufMono.fromString(Mono.just(body)))
+            .responseSingle((response, bytes) -> bytes.asString()
+                .map(b -> new BulkResponse(response.status().code(), b, response.status().reasonPhrase()))
+                .flatMap(responseDetails -> {
+                    if (responseDetails.hasBadStatusCode() || responseDetails.hasFailedOperations()) {
+                        logger.error(responseDetails.getFailureMessage());
+                        return Mono.error(new RuntimeException(responseDetails.getFailureMessage()));
+                    }
+                    return Mono.just(responseDetails);
+                }));
+    }
+
+    public Mono<Response> putAsync(String path, String body, boolean quietLogging) {
+        return client.put()
+            .uri("/" + path)
+            .send(ByteBufMono.fromString(Mono.just(body)))
+            .responseSingle((response, bytes) -> bytes.asString()
+                .map(b -> new Response(response.status().code(), b, response.status().reasonPhrase()))
+                .doOnNext(resp -> logResponse(resp, quietLogging)));
+    }
+
+    public Response put(String path, String body, boolean quietLogging) {
+        return putAsync(path, body, quietLogging).block();
+    }
+
+    private void logResponse(Response response, boolean quietLogging) {
+        if (quietLogging || (response.code == 200 || response.code == 201)) {
+            logger.debug("Response Code: " + response.code + ", Response Message: " + response.message + ", Response Body: " + response.body);
+        } else {
+            logger.error("Response Code: " + response.code + ", Response Message: " + response.message + ", Response Body: " + response.body);
         }
     }
 }

--- a/RFS/src/main/java/com/rfs/common/S3SnapshotCreator.java
+++ b/RFS/src/main/java/com/rfs/common/S3SnapshotCreator.java
@@ -10,15 +10,15 @@ public class S3SnapshotCreator extends SnapshotCreator {
     private static final Logger logger = LogManager.getLogger(S3SnapshotCreator.class);
     private static final ObjectMapper mapper = new ObjectMapper();
 
-    private final ConnectionDetails connectionDetails;
+    private final OpenSearchClient client;
     private final String snapshotName;
     private final String s3Uri;
     private final String s3Region;
 
-    public S3SnapshotCreator(String snapshotName, ConnectionDetails connectionDetails, String s3Uri, String s3Region) {
-        super(snapshotName, connectionDetails);
+    public S3SnapshotCreator(String snapshotName, OpenSearchClient client, String s3Uri, String s3Region) {
+        super(snapshotName, client);
         this.snapshotName = snapshotName;
-        this.connectionDetails = connectionDetails;
+        this.client = client;
         this.s3Uri = s3Uri;
         this.s3Region = s3Region;
     }

--- a/RFS/src/main/java/com/rfs/common/SnapshotCreator.java
+++ b/RFS/src/main/java/com/rfs/common/SnapshotCreator.java
@@ -61,7 +61,7 @@ public abstract class SnapshotCreator {
         String bodyString = body.toString();
         RestClient.Response response = client.put(targetName, bodyString, false);
         if (response.code == HttpURLConnection.HTTP_OK || response.code == HttpURLConnection.HTTP_CREATED) {
-            logger.info("Snapshot " + getSnapshotName() + " creation successful");
+            logger.info("Snapshot " + getSnapshotName() + " creation initiated");
         } else {
             logger.error("Snapshot " + getSnapshotName() + " creation failed");
             throw new SnapshotCreationFailed(getSnapshotName());

--- a/RFS/src/main/java/com/rfs/common/SnapshotCreator.java
+++ b/RFS/src/main/java/com/rfs/common/SnapshotCreator.java
@@ -13,13 +13,13 @@ public abstract class SnapshotCreator {
     private static final Logger logger = LogManager.getLogger(SnapshotCreator.class);
     private static final ObjectMapper mapper = new ObjectMapper();
 
-    private final ConnectionDetails connectionDetails;
+    private final OpenSearchClient client;
     @Getter
     private final String snapshotName;
 
-    public SnapshotCreator(String snapshotName, ConnectionDetails connectionDetails) {
+    public SnapshotCreator(String snapshotName, OpenSearchClient client) {
         this.snapshotName = snapshotName;
-        this.connectionDetails = connectionDetails;
+        this.client = client;
     }
 
     abstract ObjectNode getRequestBodyForRegisterRepo();
@@ -29,15 +29,10 @@ public abstract class SnapshotCreator {
     }
 
     public void registerRepo() throws Exception {
-        // Assemble the REST path
-        String targetName = "_snapshot/" + getRepoName();
-
-        ObjectNode body = getRequestBodyForRegisterRepo();
+        ObjectNode settings = getRequestBodyForRegisterRepo();
 
         // Register the repo; it's fine if it already exists
-        RestClient client = new RestClient(connectionDetails);
-        String bodyString = body.toString();
-        RestClient.Response response = client.put(targetName, bodyString, false);
+        RestClient.Response response = client.registerSnapshotRepo(getRepoName(), settings);
         if (response.code == HttpURLConnection.HTTP_OK || response.code == HttpURLConnection.HTTP_CREATED) {
             logger.info("Snapshot repo registration successful");
         } else {
@@ -47,19 +42,14 @@ public abstract class SnapshotCreator {
     }
 
     public void createSnapshot() throws Exception {
-        // Assemble the REST path
-        String targetName = "_snapshot/" + getRepoName() + "/" + getSnapshotName();
-
-        // Assemble the request body
+        // Assemble the settings
         ObjectNode body = mapper.createObjectNode();
         body.put("indices", "_all");
         body.put("ignore_unavailable", true);
         body.put("include_global_state", true);
 
         // Register the repo; idempotent operation
-        RestClient client = new RestClient(connectionDetails);
-        String bodyString = body.toString();
-        RestClient.Response response = client.put(targetName, bodyString, false);
+        RestClient.Response response = client.createSnapshot(getRepoName(), getSnapshotName(), body);
         if (response.code == HttpURLConnection.HTTP_OK || response.code == HttpURLConnection.HTTP_CREATED) {
             logger.info("Snapshot " + getSnapshotName() + " creation initiated");
         } else {
@@ -69,12 +59,8 @@ public abstract class SnapshotCreator {
     }
 
     public boolean isSnapshotFinished() throws Exception {
-        // Assemble the REST path
-        String targetName = "_snapshot/" + getRepoName() + "/" + getSnapshotName();
-
         // Check if the snapshot has finished
-        RestClient client = new RestClient(connectionDetails);
-        RestClient.Response response = client.get(targetName, false);
+        RestClient.Response response = client.getSnapshotStatus(getRepoName(), getSnapshotName());
         if (response.code == HttpURLConnection.HTTP_NOT_FOUND) {
             logger.error("Snapshot " + getSnapshotName() + " does not exist");
             throw new SnapshotDoesNotExist(getSnapshotName());

--- a/RFS/src/main/java/com/rfs/version_os_2_11/IndexCreator_OS_2_11.java
+++ b/RFS/src/main/java/com/rfs/version_os_2_11/IndexCreator_OS_2_11.java
@@ -1,21 +1,18 @@
 package com.rfs.version_os_2_11;
 
-import java.net.HttpURLConnection;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.rfs.common.ConnectionDetails;
 import com.rfs.common.IndexMetadata;
-import com.rfs.common.RestClient;
+import com.rfs.common.OpenSearchClient;
 
 public class IndexCreator_OS_2_11 {
     private static final Logger logger = LogManager.getLogger(IndexCreator_OS_2_11.class);
     private static final ObjectMapper mapper = new ObjectMapper();
 
-    public static void create(String targetName, IndexMetadata.Data indexMetadata, ConnectionDetails connectionDetails) throws Exception {
+    public static void create(String indexName, IndexMetadata.Data indexMetadata, OpenSearchClient client) throws Exception {
         // Remove some settings which will cause errors if you try to pass them to the API
         ObjectNode settings = indexMetadata.getSettings();
 
@@ -30,16 +27,7 @@ public class IndexCreator_OS_2_11 {
         body.set("mappings", indexMetadata.getMappings());
         body.set("settings", settings);
 
-        // Confirm the index doesn't already exist, then create it
-        RestClient client = new RestClient(connectionDetails);
-        RestClient.Response response = client.get(targetName, true);
-        if (response.code == HttpURLConnection.HTTP_NOT_FOUND) {
-            String bodyString = body.toString();
-            client.put(targetName, bodyString, false);
-        } else if (response.code == HttpURLConnection.HTTP_OK) {
-            logger.warn("Index " + targetName + " already exists. Skipping creation.");
-        } else {
-            logger.warn("Could not confirm that index " + targetName + " does not already exist. Skipping creation.");
-        }
+        // Idempotently create the index
+        client.createIndexIdempotent(indexName, body);
     }
 }


### PR DESCRIPTION
### Description
* Checkpoint commit.  Refactored the RFS code:
    * Cleaned up DocumentReindexer error handling and logging
    * Made reactor-netty the sole HTTP client provider
    * Created an OpenSearchClient layer above the RestClient

### Issues Resolved
* https://opensearch.atlassian.net/browse/MIGRATIONS-1691

### Testing
* Updated existing unit tests
* Ran locally

### Check List
- [x] New functionality includes testing
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
