### PR TITLE
Add RFS gradle tasks for jacoco test report and copying of jars

### DIFF
--- a/RFS/build.gradle
+++ b/RFS/build.gradle
@@ -72,7 +72,7 @@ clean.doFirst {
 }
 
 // Utility task to allow copying required libraries into a 'dependencies' folder for security scanning
-tasks.register('copyDependencies', Copy) {
+tasks.register('copyDependencies', Sync) {
     duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 
     from configurations.runtimeClasspath

--- a/RFS/build.gradle
+++ b/RFS/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'application'
     id 'java'
+    id 'jacoco'
     id "com.avast.gradle.docker-compose" version "0.17.4"
     id 'com.bmuschko.docker-remote-api'
     id 'io.freefair.lombok' version '8.6'
@@ -68,6 +69,23 @@ application {
 // Cleanup additional docker build directory
 clean.doFirst {
     delete project.file("./docker/build")
+}
+
+// Utility task to allow copying required libraries into a 'dependencies' folder for security scanning
+tasks.register('copyDependencies', Copy) {
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+
+    from configurations.runtimeClasspath
+    into "${buildDir}/dependencies"
+}
+
+jacocoTestReport {
+    reports {
+        xml.required = true
+        xml.destination file("${buildDir}/reports/jacoco/test/jacocoTestReport.xml")
+        html.required = true
+        html.destination file("${buildDir}/reports/jacoco/test/html")
+    }
 }
 
 task demoPrintOutSnapshot (type: JavaExec) {


### PR DESCRIPTION
### Description
As part of our Solutions scanning we need to be able to generate a jacoco test report and provide list of jars for SonarQube to scan.

### Issues Resolved
N/A

### Testing
Local gradle builds

### Check List
- [ ] New functionality includes testing
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
