### PR TITLE
Upload TrafficCapture test results as artifacts in GitHub workflow

### DIFF
--- a/.github/workflows/gradle-build-and-test.yml
+++ b/.github/workflows/gradle-build-and-test.yml
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: traffic-capture-test-reports-${{ github.event.repository.updated_at}}
+          name: traffic-capture-test-reports
           path: |
             ./TrafficCapture/*/build/reports/
   

--- a/.github/workflows/gradle-build-and-test.yml
+++ b/.github/workflows/gradle-build-and-test.yml
@@ -24,17 +24,24 @@ jobs:
           gradle-home-cache-cleanup: true
 
       - name: Run Gradle Build
-        run: ./gradlew build -x test --scan --info --stacktrace
+        run: ./gradlew build -x test --scan --stacktrace
         working-directory: TrafficCapture
         env:
           OS_MIGRATIONS_GRADLE_SCAN_TOS_AGREE_AND_ENABLED: ''
 
       - name: Run Tests with Coverage
-        run: ./gradlew test jacocoTestReport --scan --info --stacktrace
+        run: ./gradlew test jacocoTestReport --scan --stacktrace
         working-directory: TrafficCapture
         env:
           OS_MIGRATIONS_GRADLE_SCAN_TOS_AGREE_AND_ENABLED: ''
 
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: traffic-capture-test-reports-${{ github.event.repository.updated_at}}
+          path: |
+            ./TrafficCapture/*/build/reports/
+  
       - name: Upload to Codecov
         uses: codecov/codecov-action@v4
         with:


### PR DESCRIPTION
### Description
The TrafficCapture output sent to GitHub Actions is unyieldy for web broswers when you want to quickly see the source of a failure.  This change disable the 'info' logging level, causing the console output to go from ~238mb to 363kb.  Test results can be found as part of the workflow artifacts

#### How to find these artifacts
![image](https://github.com/opensearch-project/opensearch-migrations/assets/2754967/82db9e54-25c1-4dd1-b5a8-cc35964e7950)

### Check List
- [ ] ~New functionality includes testing~
  - [ ] ~All tests pass, including unit test, integration test and doctest~
- [ ] ~New functionality has been documented~
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
