### PR TITLE
Fix IllegalArgumentException in Replayer logging

### DIFF
--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/CapturedTrafficToHttpTransactionAccumulator.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/CapturedTrafficToHttpTransactionAccumulator.java
@@ -207,7 +207,7 @@ public class CapturedTrafficToHttpTransactionAccumulator {
     public CONNECTION_STATUS addObservationToAccumulation(@NonNull Accumulation accum,
                                                           @NonNull ITrafficStreamKey trafficStreamKey,
                                                           TrafficObservation observation) {
-        log.atTrace().setMessage(()->"Adding observation: "+observation+" with state="+accum.state).log();
+        log.atTrace().setMessage("{}").addArgument(()->"Adding observation: "+observation+" with state="+accum.state).log();
         var timestamp = TrafficStreamUtils.instantFromProtoTimestamp(observation.getTs());
         liveStreams.expireOldEntries(trafficStreamKey, accum, timestamp);
 

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/RequestSenderOrchestrator.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/RequestSenderOrchestrator.java
@@ -139,7 +139,7 @@ public class RequestSenderOrchestrator {
         final var replaySession = clientConnectionPool.getCachedSession(ctx, sessionNumber);
         return NettyFutureBinders.bindNettySubmitToTrackableFuture(replaySession.eventLoop)
                 .getDeferredFutureThroughHandle((v,t) -> {
-                    log.atTrace().setMessage(() -> "adding work item at slot " +
+                    log.atTrace().setMessage("{}").addArgument(() -> "adding work item at slot " +
                             channelInteractionNumber + " for " + replaySession.getChannelKeyContext() + " with " +
                             replaySession.scheduleSequencer).log();
                     return replaySession.scheduleSequencer.addFutureForWork(channelInteractionNumber,
@@ -210,7 +210,7 @@ public class RequestSenderOrchestrator {
             var itemStartTimeOfPopped = schedule.removeFirstItem();
             assert atTime.equals(itemStartTimeOfPopped):
                     "Expected to have popped the item to match the start time for the responseFuture that finished";
-            log.atDebug().setMessage(()->channelInteraction.toString() + " responseFuture completed - checking "
+            log.atDebug().setMessage("{}").addArgument(()->channelInteraction.toString() + " responseFuture completed - checking "
                     + schedule + " for the next item to schedule").log();
             Optional.ofNullable(schedule.peekFirstItem()).ifPresent(kvp ->
                     bindNettyScheduleToCompletableFuture(eventLoop, kvp.startTime, kvp.scheduleFuture));

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/TrafficReplayerCore.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/TrafficReplayerCore.java
@@ -240,7 +240,7 @@ public abstract class TrafficReplayerCore {
             log.trace("done sending and finalizing data to the packet handler");
 
             try (var requestResponseTuple = getSourceTargetCaptureTuple(tupleHandlingContext, rrPair, summary, t)) {
-                log.atDebug().setMessage(()->"Source/Target Request/Response tuple: " + requestResponseTuple).log();
+                log.atDebug().setMessage("{}").addArgument(()->"Source/Target Request/Response tuple: " + requestResponseTuple).log();
                 tupleWriter.accept(requestResponseTuple);
             }
 
@@ -379,7 +379,7 @@ public abstract class TrafficReplayerCore {
                                 .map(ts -> TrafficStreamUtils.summarizeTrafficStream(ts.getStream()))
                                 .collect(Collectors.joining(";")))
                         .filter(s -> !s.isEmpty())
-                        .ifPresent(s -> log.atInfo().log("TrafficStream Summary: {" + s + "}"));
+                        .ifPresent(s -> log.atInfo().setMessage("{}").addArgument("TrafficStream Summary: {" + s + "}").log());
             }
             trafficStreams.forEach(trafficToHttpTransactionAccumulator::accept);
         }

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/NettyPacketToHttpConsumer.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/NettyPacketToHttpConsumer.java
@@ -271,7 +271,7 @@ public class NettyPacketToHttpConsumer implements IPacketFinalizingConsumer<Aggr
     public TrackedFuture<String,Void> consumeBytes(ByteBuf packetData) {
         activeChannelFuture = activeChannelFuture.getDeferredFutureThroughHandle((v, channelException) -> {
             if (channelException == null) {
-                log.atTrace().setMessage(()->"outboundChannelFuture is ready. Writing packets (hash=" +
+                log.atTrace().setMessage("{}").addArgument(()->"outboundChannelFuture is ready. Writing packets (hash=" +
                         System.identityHashCode(packetData) + "): " + httpContext() + ": " +
                         packetData.toString(StandardCharsets.UTF_8)).log();
                 return writePacketAndUpdateFuture(packetData).whenComplete((v2,t2)->{

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/http/HttpJsonTransformingConsumer.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/http/HttpJsonTransformingConsumer.java
@@ -92,8 +92,8 @@ public class HttpJsonTransformingConsumer<R> implements IPacketFinalizingConsume
     public TrackedFuture<String, Void> consumeBytes(ByteBuf nextRequestPacket) {
         chunks.add(nextRequestPacket.retainedDuplicate());
         chunkSizes.get(chunkSizes.size() - 1).add(nextRequestPacket.readableBytes());
-        log.atTrace().log(() -> "HttpJsonTransformingConsumer[" + this + "]: writing into embedded channel: "
-                   + nextRequestPacket.toString(StandardCharsets.UTF_8));
+        log.atTrace().setMessage("{}").addArgument(() -> "HttpJsonTransformingConsumer[" + this + "]: writing into embedded channel: "
+                   + nextRequestPacket.toString(StandardCharsets.UTF_8)).log();
         return TextTrackedFuture.completedFuture(null, ()->"initialValue")
             .map(cf->cf.thenAccept(x -> channel.writeInbound(nextRequestPacket)),
                 ()->"HttpJsonTransformingConsumer sending bytes to its EmbeddedChannel");

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/kafka/KafkaTrafficCaptureSource.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/kafka/KafkaTrafficCaptureSource.java
@@ -201,7 +201,7 @@ public class KafkaTrafficCaptureSource implements ISimpleTrafficCaptureSource {
                         try {
                             TrafficStream ts = TrafficStream.parseFrom(kafkaRecord.value());
                             var trafficStreamsSoFar = trafficStreamsRead.incrementAndGet();
-                            log.atTrace().setMessage(()->"Parsed traffic stream #" + trafficStreamsSoFar +
+                            log.atTrace().setMessage("{}").addArgument(()->"Parsed traffic stream #" + trafficStreamsSoFar +
                                             ": " + offsetData + " " + ts).log();
                             var key = new TrafficStreamKeyWithKafkaRecordId(
                                     tsk -> {

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/kafka/TrackingKafkaConsumer.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/kafka/TrackingKafkaConsumer.java
@@ -275,9 +275,9 @@ public class TrackingKafkaConsumer implements ConsumerRebalanceListener {
             log.atLevel(records.isEmpty()? Level.TRACE:Level.INFO)
                     .setMessage(()->"Kafka consumer poll has fetched "+records.count() + " records.  " +
                             "Records in flight=" + kafkaRecordsLeftToCommitEventually.get()).log();
-            log.atTrace().setMessage(()->"All positions: {"+kafkaConsumer.assignment().stream()
+            log.atTrace().setMessage("{}").addArgument(()->"All positions: {"+kafkaConsumer.assignment().stream()
                     .map(tp->tp+": "+kafkaConsumer.position(tp)).collect(Collectors.joining(",")) + "}").log();
-            log.atTrace().setMessage(()->"All previously COMMITTED positions: {"+kafkaConsumer.assignment().stream()
+            log.atTrace().setMessage("{}").addArgument(()->"All previously COMMITTED positions: {"+kafkaConsumer.assignment().stream()
                     .map(tp->tp+": "+kafkaConsumer.committed(tp)).collect(Collectors.joining(",")) + "}").log();
             return records;
         } catch (RuntimeException e) {

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/util/ActiveContextMonitor.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/util/ActiveContextMonitor.java
@@ -51,7 +51,7 @@ public class ActiveContextMonitor implements Runnable {
                                 Function<TrackedFuture<String, Void>, String> formatWorkItem,
                                 Logger logger) {
         this(globalContextTracker, perActivityContextTracker, orderedRequestTracker, totalItemsToOutputLimit,
-                formatWorkItem, (level, supplier)->logger.atLevel(level).setMessage(supplier).log(),
+                formatWorkItem, (level, supplier)->logger.atLevel(level).setMessage("{}").addArgument(supplier).log(),
                 logger::isEnabledForLevel);
     }
 

--- a/TrafficCapture/trafficReplayer/src/main/resources/log4j2.properties
+++ b/TrafficCapture/trafficReplayer/src/main/resources/log4j2.properties
@@ -72,7 +72,7 @@ appender.ALL_ACTIVE_WORK_MONITOR_LOGFILE.strategy.type = DefaultRolloverStrategy
 appender.ALL_ACTIVE_WORK_MONITOR_LOGFILE.strategy.max = 4
 appender.ALL_ACTIVE_WORK_MONITOR_LOGFILE.immediateFlush = false
 
-rootLogger.level = trace
+rootLogger.level = info
 rootLogger.appenderRef.STDERR.ref = STDERR
 rootLogger.appenderRef.ReplayerLogFile.ref = ReplayerLogFile
 

--- a/TrafficCapture/trafficReplayer/src/main/resources/log4j2.properties
+++ b/TrafficCapture/trafficReplayer/src/main/resources/log4j2.properties
@@ -72,7 +72,7 @@ appender.ALL_ACTIVE_WORK_MONITOR_LOGFILE.strategy.type = DefaultRolloverStrategy
 appender.ALL_ACTIVE_WORK_MONITOR_LOGFILE.strategy.max = 4
 appender.ALL_ACTIVE_WORK_MONITOR_LOGFILE.immediateFlush = false
 
-rootLogger.level = info
+rootLogger.level = trace
 rootLogger.appenderRef.STDERR.ref = STDERR
 rootLogger.appenderRef.ReplayerLogFile.ref = ReplayerLogFile
 


### PR DESCRIPTION
### Description
This change fixes illegal argument exception in a few places where the replayer logs messages contain "{}".

* Category: Enhancement/Bug Fix
* Why these changes are required? Reduce log injection attacks and log formatting exceptions
* What is the old behavior before changes and new behavior after changes? Before this change, some logs contained errors around missing arguments. Now that is removed

### Issues Resolved
Progress towards [Bug #633](https://github.com/opensearch-project/opensearch-migrations/issues/633)

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
Ran some end to end testing locally with various log levels and checking for errors. 

### Check List
- [ x] New functionality includes testing
  - [ x] All tests pass, including unit test, integration test and doctest
- [ x] New functionality has been documented
- [ x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
