### PR TITLE
Update AsyncLogger.WaitStrategy to Block to fix high CPU

### DIFF
--- a/TrafficCapture/trafficCaptureProxyServer/src/main/resources/log4j2.component.properties
+++ b/TrafficCapture/trafficCaptureProxyServer/src/main/resources/log4j2.component.properties
@@ -1,2 +1,2 @@
 Log4jContextSelector=org.apache.logging.log4j.core.async.AsyncLoggerContextSelector
-AsyncLogger.WaitStrategy=Yield
+AsyncLogger.WaitStrategy=Block

--- a/TrafficCapture/trafficReplayer/src/main/resources/log4j2.component.properties
+++ b/TrafficCapture/trafficReplayer/src/main/resources/log4j2.component.properties
@@ -1,2 +1,2 @@
 Log4jContextSelector=org.apache.logging.log4j.core.async.AsyncLoggerContextSelector
-AsyncLogger.WaitStrategy=Yield
+AsyncLogger.WaitStrategy=Block


### PR DESCRIPTION
### Description
With the current  Yield AsyncLogger.WaitStrategy, we are seeing high CPU usage. Updating to block removes this.

The [YieldingWaitStrategy javadoc states](https://lmax-exchange.github.io/disruptor/javadoc/com.lmax.disruptor/com/lmax/disruptor/YieldingWaitStrategy.html): 
>This strategy will use 100% CPU, but will more readily give up the CPU than a busy spin strategy if other threads require CPU resource.

While this could be more performant in a production system if log flushing was the primary bottleneck, it seems like not the best default value.

Compare this with [BlockingWaitStrategy](https://lmax-exchange.github.io/disruptor/javadoc/com.lmax.disruptor/com/lmax/disruptor/BlockingWaitStrategy.html):
>This strategy can be used when throughput and low-latency are not as important as CPU resource.

Overall, we'd prefer to preserve cpu usage for the other operations in the proxy and replayer.

With my tests, i'm seeing <1% cpu usage using Block when idling locally.

* Category: Bug Fix
* Why these changes are required? Reduce unnecessary CPU Cycles in default configuration
* What is the old behavior before changes and new behavior after changes? Docker container for proxy/replayer is seen idling near 100% CPU Usage

### Issues Resolved
N/A

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
Manual testing with VisualVM and Docker 

### Check List
- [ x] New functionality includes testing
  - [ x] All tests pass, including unit test, integration test and doctest
- [ x] New functionality has been documented
- [ x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
