### PR TITLE
Update base java image to amazoncorretto:11-al2023-headless

### DIFF
--- a/RFS/docker/Dockerfile
+++ b/RFS/docker/Dockerfile
@@ -1,5 +1,5 @@
 # Using same base image as other Java containers in this repo
-FROM openjdk:11-jre
+FROM amazoncorretto:11-al2023-headless
 # Requires Gradle to genearte runtime jars initially
 COPY ./build/runtimeJars /rfs-app/jars
 WORKDIR /rfs-app

--- a/TrafficCapture/buildSrc/src/main/groovy/org/opensearch/migrations/common/CommonUtils.groovy
+++ b/TrafficCapture/buildSrc/src/main/groovy/org/opensearch/migrations/common/CommonUtils.groovy
@@ -57,8 +57,8 @@ class CommonUtils {
                 runCommand("sed -i -e \"s|mirrorlist=|#mirrorlist=|g\" /etc/yum.repos.d/CentOS-* ;  sed -i -e \"s|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g\" /etc/yum.repos.d/CentOS-*")
                 runCommand("yum -y install nmap-ncat")
             } else {
-                from 'openjdk:11-jre'
-                runCommand("apt-get update && apt-get install -y netcat")
+                from 'amazoncorretto:11-al2023-headless'
+                runCommand("dnf install -y nmap-ncat")
             }
 
             copyFile("jars", "/jars")

--- a/TrafficCapture/buildSrc/src/main/groovy/org/opensearch/migrations/common/CommonUtils.groovy
+++ b/TrafficCapture/buildSrc/src/main/groovy/org/opensearch/migrations/common/CommonUtils.groovy
@@ -55,10 +55,8 @@ class CommonUtils {
                 from "migrations/${dependentDockerImageName}:${hashNonce}"
                 dependsOn "buildDockerImage_${baseImageOverrideProjectName}"
                 runCommand("sed -i -e \"s|mirrorlist=|#mirrorlist=|g\" /etc/yum.repos.d/CentOS-* ;  sed -i -e \"s|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g\" /etc/yum.repos.d/CentOS-*")
-                runCommand("yum -y install nmap-ncat")
             } else {
                 from 'amazoncorretto:11-al2023-headless'
-                runCommand("dnf install -y nmap-ncat")
             }
 
             copyFile("jars", "/jars")


### PR DESCRIPTION
### Description
Update base java image to amazoncorretto:11-al2023-headless removing [deprecated openjdk:11-jre](https://hub.docker.com/_/openjdk)

* Category: Maintenance
* Why these changes are required? Docker Image openjdk is depreacted
* What is the old behavior before changes and new behavior after changes? Base image used now amazoncorretto instead of openjdk

### Issues Resolved
[MIGRATIONS-1724](https://opensearch.atlassian.net/browse/MIGRATIONS-1724)

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
Docker Solution startup and integration tests

### Check List
- [ x] New functionality includes testing
  - [ x] All tests pass, including unit test, integration test and doctest
- [N/A ] New functionality has been documented
- [x ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
