### PR TITLE
Add E2E large request test

### DIFF
--- a/TrafficCapture/dockerSolution/src/main/docker/elasticsearchWithSearchGuard/Dockerfile
+++ b/TrafficCapture/dockerSolution/src/main/docker/elasticsearchWithSearchGuard/Dockerfile
@@ -5,6 +5,8 @@ RUN echo y | /usr/share/elasticsearch/bin/elasticsearch-plugin install https://m
 RUN pushd /usr/share/elasticsearch/plugins/search-guard-7/tools ; chmod ugo+x ./install_demo_configuration.sh ; yes | ./install_demo_configuration.sh ; popd
 ENV ELASTIC_SEARCH_CONFIG_FILE=/usr/share/elasticsearch/config/elasticsearch.yml
 ENV PROXY_TLS_CONFIG_FILE=/usr/share/elasticsearch/config/proxy_tls.yml
+ENV ELASTIC_SEARCH_JVM_CONFIG_FILE=/usr/share/elasticsearch/config/jvm.options
+
 # without this line, elasticsearch will complain that there aren't enough nodes
 RUN echo "discovery.type: single-node" >> $ELASTIC_SEARCH_CONFIG_FILE
 COPY disableTlsConfig.sh enableTlsConfig.sh /root/
@@ -18,6 +20,12 @@ RUN sed 's/searchguard/plugins.security/g' $ELASTIC_SEARCH_CONFIG_FILE |  \
 RUN /root/enableTlsConfig.sh $ELASTIC_SEARCH_CONFIG_FILE
 # Alter this config line to either enable(searchguard.disabled: false) or disable(searchguard.disabled: true) HTTP auth
 RUN echo "searchguard.disabled: false" >> $ELASTIC_SEARCH_CONFIG_FILE
+
+RUN sed -i '/^-Xms/i # Increase default heap to 80% RAM, Requires JDK >= 10' $ELASTIC_SEARCH_JVM_CONFIG_FILE && \
+    sed -i 's/^-Xms/#&/' $ELASTIC_SEARCH_JVM_CONFIG_FILE && \
+    sed -i 's/^-Xmx/#&/' $ELASTIC_SEARCH_JVM_CONFIG_FILE && \
+    sed -i '/^#-Xmx/s/$/\n-XX:MaxRAMPercentage=80.0/' $ELASTIC_SEARCH_JVM_CONFIG_FILE
+
 
 #CMD tail -f /dev/null
 CMD /usr/local/bin/docker-entrypoint.sh eswrapper

--- a/test/README.md
+++ b/test/README.md
@@ -68,7 +68,7 @@ This script accepts various parameters to customize its behavior. Below is a lis
     - Default: `admin`
 
 - `--target_password`: Password for authentication with the target endpoint.
-    - Default: `admin`
+    - Default: `myStrongPassword123!`
 
 
 #### Clean Up

--- a/test/operations.py
+++ b/test/operations.py
@@ -1,3 +1,6 @@
+import datetime
+import random
+import string
 import json
 from requests import Session
 
@@ -27,12 +30,29 @@ def delete_document(endpoint: str, index_name: str, doc_id: str, auth,
     return response
 
 
-def create_document(endpoint: str, index_name: str, doc_id: str, auth,
-                    verify_ssl: bool = False, session: Session = Session()):
-    document = {
-        'title': 'Test Document',
-        'content': 'This is a sample document for testing OpenSearch.'
+def generate_large_doc(size_mib):
+    # Calculate number of characters needed (1 char = 1 byte)
+    num_chars = size_mib * 1024 * 1024
+
+    # Generate random string of the desired length
+    large_string = ''.join(random.choices(string.ascii_letters + string.digits, k=num_chars))
+
+    return {
+        "timestamp": datetime.datetime.now().isoformat(),
+        "large_field": large_string
     }
+
+
+def create_document(endpoint: str, index_name: str, doc_id: str, auth,
+                    verify_ssl: bool = False, doc_body: dict = None, session: Session = Session()):
+    if doc_body is None:
+        document = {
+            'title': 'Test Document',
+            'content': 'This is a sample document for testing OpenSearch.'
+        }
+    else:
+        document = doc_body
+
     url = f'{endpoint}/{index_name}/_doc/{doc_id}'
     headers = {'Content-Type': 'application/json'}
     response = session.put(url, headers=headers, data=json.dumps(document), auth=auth, verify=verify_ssl)

--- a/test/tests.py
+++ b/test/tests.py
@@ -111,7 +111,7 @@ class E2ETests(unittest.TestCase):
                 return True
         return False
 
-    def assert_source_target_doc_match(self, index_name, doc_id, doc_body : dict = None):
+    def assert_source_target_doc_match(self, index_name, doc_id, doc_body: dict = None):
         source_response = get_document(self.source_endpoint, index_name, doc_id, self.source_auth,
                                        self.source_verify_ssl)
         self.assertEqual(source_response.status_code, HTTPStatus.OK)
@@ -347,8 +347,8 @@ class E2ETests(unittest.TestCase):
         index_name = f"test_0008_{self.unique_id}"
         doc_id = "1"
 
-        # Create large document, 99MiB which is less than the default max of
-        # 100MiB in ES/OS settings (http.max_content_length)
+        # Create large document, 99MiB
+        # Default max 100MiB in ES/OS settings (http.max_content_length)
         large_doc = generate_large_doc(size_mib=99)
 
         # Measure the time taken by the create_document call
@@ -359,14 +359,14 @@ class E2ETests(unittest.TestCase):
         end_time = time.time()
         duration = end_time - start_time
 
-        # Set wait time to response time or 1 second
-        wait_time_seconds = min(round(duration, 3), 1)
+        # Set wait time to double the response time or 5 seconds
+        wait_time_seconds = min(round(duration, 3) * 2, 5)
 
         self.assertEqual(proxy_response.status_code, HTTPStatus.CREATED)
-        f" replay large doc creation")
 
         # Wait for the measured duration
         logger.debug(f"Waiting {wait_time_seconds} seconds for"
+                     f" replay of large doc creation")
 
         time.sleep(wait_time_seconds)
 


### PR DESCRIPTION
### Description
Add E2E large request test
Fix documentation for E2E target_password

This task builds on top of #637

* Category: Enhancement
* Why these changes are required? Current E2E script misses tests on large requests which can have differing behavior
* What is the old behavior before changes and new behavior after changes? New Test which checks behavior for 20MB requests

### Issues Resolved
[List any issues this PR will resolve]

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
Ran tests

### Check List
- [ x] New functionality includes testing
  - [ x] All tests pass, including unit test, integration test and doctest
- [x ] New functionality has been documented
- [x ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
