### PR TITLE
Add test that verifies replayer function when waiting a minute between requests

### DIFF
--- a/test/operations.py
+++ b/test/operations.py
@@ -1,49 +1,49 @@
-import requests
 import json
+from requests import Session
 
 
-def create_index(endpoint: str, index_name: str, auth, verify_ssl: bool = False):
-    response = requests.put(f'{endpoint}/{index_name}', auth=auth, verify=verify_ssl)
-
-    return response
-
-
-def check_index(endpoint: str, index_name: str, auth, verify_ssl: bool = False):
-    response = requests.get(f'{endpoint}/{index_name}', auth=auth, verify=verify_ssl)
+def create_index(endpoint: str, index_name: str, auth, verify_ssl: bool = False, session: Session = Session()):
+    response = session.put(f'{endpoint}/{index_name}', auth=auth, verify=verify_ssl)
 
     return response
 
 
-def delete_index(endpoint: str, index_name: str, auth, verify_ssl: bool = False):
-    response = requests.delete(f'{endpoint}/{index_name}', auth=auth, verify=verify_ssl)
+def check_index(endpoint: str, index_name: str, auth, verify_ssl: bool = False, session: Session = Session()):
+    response = session.get(f'{endpoint}/{index_name}', auth=auth, verify=verify_ssl)
+
+    return response
+
+
+def delete_index(endpoint: str, index_name: str, auth, verify_ssl: bool = False, session: Session = Session()):
+    response = session.delete(f'{endpoint}/{index_name}', auth=auth, verify=verify_ssl)
 
     return response
 
 
 def delete_document(endpoint: str, index_name: str, doc_id: str, auth,
-                    verify_ssl: bool = False):
-    response = requests.delete(f'{endpoint}/{index_name}/_doc/{doc_id}', auth=auth, verify=verify_ssl)
+                    verify_ssl: bool = False, session: Session = Session()):
+    response = session.delete(f'{endpoint}/{index_name}/_doc/{doc_id}', auth=auth, verify=verify_ssl)
 
     return response
 
 
 def create_document(endpoint: str, index_name: str, doc_id: str, auth,
-                    verify_ssl: bool = False):
+                    verify_ssl: bool = False, session: Session = Session()):
     document = {
         'title': 'Test Document',
         'content': 'This is a sample document for testing OpenSearch.'
     }
     url = f'{endpoint}/{index_name}/_doc/{doc_id}'
     headers = {'Content-Type': 'application/json'}
-    response = requests.put(url, headers=headers, data=json.dumps(document), auth=auth, verify=verify_ssl)
+    response = session.put(url, headers=headers, data=json.dumps(document), auth=auth, verify=verify_ssl)
 
     return response
 
 
 def get_document(endpoint: str, index_name: str, doc_id: str, auth,
-                 verify_ssl: bool = False):
+                 verify_ssl: bool = False, session: Session = Session()):
     url = f'{endpoint}/{index_name}/_doc/{doc_id}'
     headers = {'Content-Type': 'application/json'}
-    response = requests.get(url, headers=headers, auth=auth, verify=verify_ssl)
+    response = session.get(url, headers=headers, auth=auth, verify=verify_ssl)
 
     return response

--- a/test/tests.py
+++ b/test/tests.py
@@ -316,11 +316,9 @@ class E2ETests(unittest.TestCase):
         # requests on the same connection on the proxy that has a minute gap
         seconds_between_requests = 60  # 1 minute
 
-        # Set a consistent session to be used for this test
-        session = Session()
+        proxy_single_connection_session = Session()
         adapter = HTTPAdapter(pool_connections=1, pool_maxsize=1, max_retries=1)
-        session.mount('http://', adapter)
-        session.mount('https://', adapter)
+        proxy_single_connection_session.mount(self.proxy_endpoint, adapter)
 
         index_name = f"test_0007_{self.unique_id}"
 
@@ -329,7 +327,7 @@ class E2ETests(unittest.TestCase):
         for doc_id_int in range(number_of_docs):
             doc_id = str(doc_id_int)
             proxy_response = create_document(self.proxy_endpoint, index_name, doc_id, self.source_auth,
-                                             self.source_verify_ssl, session)
+                                             self.source_verify_ssl, proxy_single_connection_session)
             self.assertEqual(proxy_response.status_code, HTTPStatus.CREATED)
 
             if doc_id_int + 1 < number_of_docs:
@@ -340,4 +338,4 @@ class E2ETests(unittest.TestCase):
                 doc_id = str(doc_id_int)
                 self.assert_source_target_doc_match(index_name, doc_id)
         finally:
-            session.close()
+            proxy_single_connection_session.close()

--- a/test/tests.py
+++ b/test/tests.py
@@ -1,21 +1,22 @@
+import boto3
 import json
+import logging
+import pytest
+import requests
+import secrets
+import string
 import subprocess
+import time
+import unittest
+from http import HTTPStatus
+from requests import Session
+from requests.adapters import HTTPAdapter
+from requests.exceptions import ConnectionError, SSLError
+from requests_aws4auth import AWS4Auth
+from typing import Tuple, Callable
 
 from operations import create_index, check_index, create_document, \
     delete_document, delete_index, get_document
-from http import HTTPStatus
-from typing import Tuple, Callable
-import unittest
-import logging
-import time
-import requests
-import string
-import secrets
-import pytest
-import boto3
-from requests_aws4auth import AWS4Auth
-
-from requests.exceptions import ConnectionError, SSLError
 
 logger = logging.getLogger(__name__)
 
@@ -109,6 +110,24 @@ class E2ETests(unittest.TestCase):
                 return True
         return False
 
+    def assert_source_target_doc_match(self, index_name, doc_id):
+        source_response = get_document(self.source_endpoint, index_name, doc_id, self.source_auth,
+                                       self.source_verify_ssl)
+        self.assertEqual(source_response.status_code, HTTPStatus.OK)
+
+        target_response = retry_request(get_document, args=(self.target_endpoint, index_name, doc_id,
+                                                            self.target_auth, self.target_verify_ssl),
+                                        expected_status_code=HTTPStatus.OK)
+        self.assertEqual(target_response.status_code, HTTPStatus.OK)
+
+        # Comparing the document's content on both endpoints, asserting
+        # that they match.
+        source_document = source_response.json()
+        source_content = source_document['_source']
+        target_document = target_response.json()
+        target_content = target_document['_source']
+        self.assertEqual(source_content, target_content)
+
     def set_common_values(self):
         self.index_prefix_ignore_list = ["test_", ".", "searchguard", "sg7", "security-auditlog"]
 
@@ -179,21 +198,7 @@ class E2ETests(unittest.TestCase):
                                          self.source_verify_ssl)
         self.assertEqual(proxy_response.status_code, HTTPStatus.CREATED)
 
-        source_response = get_document(self.source_endpoint, index_name, doc_id, self.source_auth,
-                                       self.source_verify_ssl)
-        self.assertEqual(source_response.status_code, HTTPStatus.OK)
-
-        target_response = retry_request(get_document, args=(self.target_endpoint, index_name, doc_id,
-                                                            self.target_auth, self.target_verify_ssl),
-                                        expected_status_code=HTTPStatus.OK)
-        self.assertEqual(target_response.status_code, HTTPStatus.OK)
-
-        # Comparing the document's content on both endpoints, asserting that they match.
-        source_document = source_response.json()
-        source_content = source_document['_source']
-        target_document = target_response.json()
-        target_content = target_document['_source']
-        self.assertEqual(source_content, target_content)
+        self.assert_source_target_doc_match(index_name, doc_id)
 
         # Deleting the document that was created then asserting that it was deleted on both targets.
         proxy_response = delete_document(self.proxy_endpoint, index_name, doc_id, self.source_auth,
@@ -305,3 +310,34 @@ class E2ETests(unittest.TestCase):
             if source_count != target_count:
                 self.assertEqual(source_count, target_count, f'{index}: doc counts do not match - '
                                                              f'Source = {source_count}, Target = {target_count}')
+
+    def test_0007_timeBetweenRequestsOnSameConnection(self):
+        # This test will verify that the replayer functions correctly when
+        # requests on the same connection on the proxy that has a minute gap
+        seconds_between_requests = 60  # 1 minute
+
+        # Set a consistent session to be used for this test
+        session = Session()
+        adapter = HTTPAdapter(pool_connections=1, pool_maxsize=1, max_retries=1)
+        session.mount('http://', adapter)
+        session.mount('https://', adapter)
+
+        index_name = f"test_0007_{self.unique_id}"
+
+        number_of_docs = 3
+
+        for doc_id_int in range(number_of_docs):
+            doc_id = str(doc_id_int)
+            proxy_response = create_document(self.proxy_endpoint, index_name, doc_id, self.source_auth,
+                                             self.source_verify_ssl, session)
+            self.assertEqual(proxy_response.status_code, HTTPStatus.CREATED)
+
+            if doc_id_int + 1 < number_of_docs:
+                time.sleep(seconds_between_requests)
+
+        try:
+            for doc_id_int in range(number_of_docs):
+                doc_id = str(doc_id_int)
+                self.assert_source_target_doc_match(index_name, doc_id)
+        finally:
+            session.close()


### PR DESCRIPTION
### Description
Add test that verifies replayer function when waiting a minute between requests
Adds functionality within E2E test suite to explicitly reuse connection for requests

This was created in part to trigger potential edge cases that could have been associated with [ReadTimeoutHandler bug](https://opensearch.atlassian.net/browse/MIGRATIONS-1723)

* Category: Enhancement
* Why these changes are required? Verify no impact for bug
* What is the old behavior before changes and new behavior after changes? New test case

### Issues Resolved
[MIGRATIONS-1722](https://opensearch.atlassian.net/browse/MIGRATIONS-1722)

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
E2E testing, verified bug is triggered during test case

### Check List
- [ x] New functionality includes testing
  - [x ] All tests pass, including unit test, integration test and doctest
- [x ] New functionality has been documented
- [x ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
