### PR TITLE
Mend - fix werkzeug issue Part1

### DIFF
--- a/FetchMigration/python/dev-requirements.txt
+++ b/FetchMigration/python/dev-requirements.txt
@@ -1,5 +1,0 @@
-# Transitive dependency from moto, explicit version needed to mitigate CVE-2023-46136
-werkzeug>=3.0.1
-coverage>=7.3.2
-pur>=7.3.1
-moto>=4.2.7

--- a/FetchMigration/python/requirements.txt
+++ b/FetchMigration/python/requirements.txt
@@ -1,8 +1,0 @@
-botocore>=1.31.70
-jsondiff>=2.0.0
-jsonpath-ng>=1.6.0
-prometheus-client>=0.17.1
-pyyaml>=6.0.1
-requests>=2.31.0
-requests-aws4auth>=1.2.3
-responses>=0.23.3


### PR DESCRIPTION
### Description
We are currently getting a mend issue for werkzeug even though we’ve updated it. 
Experimentation showed that deleting the requirements.txt refreshes the mend check.

This should be merged, and after mend runs, #639 should be merged.

* Category: Maintenance 
* Why these changes are required? Refresh Mend check
* What is the old behavior before changes and new behavior after changes? Mend shows up failing for werkzeug

### Issues Resolved
[MIGRATIONS-1728](https://opensearch.atlassian.net/browse/MIGRATIONS-1728)

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
Branch testing for mend fix, commit will be reverted

### Check List
- [ x] New functionality includes testing
  - [x ] All tests pass, including unit test, integration test and doctest
- [x ] New functionality has been documented
- [x ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
