### PR TITLE
Fix ReadTimeoutException between requests

### DIFF
--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/ClientConnectionPool.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/ClientConnectionPool.java
@@ -22,7 +22,6 @@ import org.opensearch.migrations.replay.util.TextTrackedFuture;
 import org.opensearch.migrations.replay.util.TrackedFuture;
 
 import java.net.URI;
-import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 
 @Slf4j
@@ -32,7 +31,6 @@ public class ClientConnectionPool {
     private final SslContext sslContext;
     public final NioEventLoopGroup eventLoopGroup;
     private final LoadingCache<Key, ConnectionReplaySession> connectionId2ChannelCache;
-    private final Duration timeout;
 
     @EqualsAndHashCode
     @AllArgsConstructor
@@ -48,11 +46,9 @@ public class ClientConnectionPool {
     public ClientConnectionPool(@NonNull URI serverUri,
                                 SslContext sslContext,
                                 @NonNull String targetConnectionPoolName,
-                                int numThreads,
-                                @NonNull Duration timeout) {
+                                int numThreads) {
         this.serverUri = serverUri;
         this.sslContext = sslContext;
-        this.timeout = timeout;
         this.eventLoopGroup =
                 new NioEventLoopGroup(numThreads, new DefaultThreadFactory(targetConnectionPoolName));
 
@@ -80,7 +76,7 @@ public class ClientConnectionPool {
         return new AdaptiveRateLimiter<String, ChannelFuture>()
                 .get(() ->
                         NettyPacketToHttpConsumer.createClientConnection(eventLoop,
-                                        sslContext, serverUri, connectionContext, timeout)
+                                        sslContext, serverUri, connectionContext)
                                 .whenComplete((v,t)-> {
                                     if (t == null) {
                                         log.atDebug().setMessage(() -> "New network connection result for " +

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/TrafficReplayer.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/TrafficReplayer.java
@@ -309,8 +309,7 @@ public class TrafficReplayer {
             var tr = new TrafficReplayerTopLevel(topContext, uri, authTransformer,
                     new TransformationLoader().getTransformerFactoryLoader(uri.getHost(), params.userAgent, transformerConfig),
                     TrafficReplayerTopLevel.makeClientConnectionPool(
-                            uri, params.allowInsecureConnections, params.numClientThreads,
-                            Duration.ofSeconds(params.targetServerResponseTimeoutSeconds)),
+                            uri, params.allowInsecureConnections, params.numClientThreads),
                     new TrafficStreamLimiter(params.maxConcurrentRequests), orderedRequestTracker);
             activeContextMonitor = new ActiveContextMonitor(
                     globalContextTracker, perContextTracker, orderedRequestTracker, 64,
@@ -326,7 +325,9 @@ public class TrafficReplayer {
             setupShutdownHookForReplayer(tr);
             var tupleWriter = new TupleParserChainConsumer(new ResultsToLogsConsumer());
             var timeShifter = new TimeShifter(params.speedupFactor);
-            tr.setupRunAndWaitForReplayWithShutdownChecks(Duration.ofSeconds(params.observedPacketConnectionTimeout),
+            tr.setupRunAndWaitForReplayWithShutdownChecks(
+                Duration.ofSeconds(params.observedPacketConnectionTimeout),
+                Duration.ofSeconds(params.targetServerResponseTimeoutSeconds),
                     blockingTrafficSource, timeShifter, tupleWriter);
             log.info("Done processing TrafficStreams");
         } finally {

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/NettyPacketToHttpConsumer.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/NettyPacketToHttpConsumer.java
@@ -75,19 +75,20 @@ public class NettyPacketToHttpConsumer implements IPacketFinalizingConsumer<Aggr
         ConnectionClosedListenerHandler(IReplayContexts.IChannelKeyContext channelKeyContext) {
             socketContext = channelKeyContext.createSocketContext();
         }
+
         @Override
-        public void channelUnregistered(ChannelHandlerContext ctx) throws Exception {
+        public void channelInactive(ChannelHandlerContext ctx) throws Exception {
             socketContext.close();
-            super.channelUnregistered(ctx);
+            super.channelInactive(ctx);
         }
 
         @Override
-        public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
-            socketContext.close();
+        public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+            socketContext.addTraceException(cause, true);
             log.atDebug().setMessage("Exception caught in ConnectionClosedListenerHandler." +
-            "Closing channel due to exception").setCause(cause).log();
+                                     "Closing channel due to exception").setCause(cause).log();
             ctx.close();
-            ctx.fireExceptionCaught(cause);
+            super.exceptionCaught(ctx, cause);
         }
     }
 

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/netty/BacksideHttpWatcherHandler.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/netty/BacksideHttpWatcherHandler.java
@@ -1,12 +1,9 @@
 package org.opensearch.migrations.replay.netty;
 
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.SimpleChannelInboundHandler;
-import io.netty.handler.codec.http.FullHttpResponse;
 import io.netty.handler.codec.http.HttpObject;
 import io.netty.handler.codec.http.LastHttpContent;
-import io.netty.util.ReferenceCountUtil;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.opensearch.migrations.replay.AggregatedRawResponse;
@@ -54,7 +51,8 @@ public class BacksideHttpWatcherHandler extends SimpleChannelInboundHandler<Http
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
         aggregatedRawResponseBuilder.addErrorCause(cause);
         triggerResponseCallbackAndRemoveCallback();
-        super.exceptionCaught(ctx, cause);
+        // AggregatedRawResponseBuilder will contain exception context so
+        // Exception caught event should not to propagate downstream
     }
 
     private void triggerResponseCallbackAndRemoveCallback() {

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/RequestSenderOrchestratorTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/RequestSenderOrchestratorTest.java
@@ -1,5 +1,7 @@
 package org.opensearch.migrations.replay;
 
+import static org.opensearch.migrations.replay.datahandlers.NettyPacketToHttpConsumerTest.REGULAR_RESPONSE_TIMEOUT;
+
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.handler.codec.http.FullHttpResponse;
@@ -90,8 +92,7 @@ class RequestSenderOrchestratorTest extends InstrumentationTest {
         final int NUM_PACKETS = 3;
 
         var clientConnectionPool = TrafficReplayerTopLevel.makeClientConnectionPool(new URI("http://localhost"),
-                false, 1, "testFutureGraphBuildout targetConnectionPool",
-                Duration.ofSeconds(30));
+                false, 1, "testFutureGraphBuildout targetConnectionPool");
         var connectionToConsumerMap = new HashMap<Long, BlockingPacketConsumer>();
         var senderOrchestrator = new RequestSenderOrchestrator(clientConnectionPool, (s,c) ->
                 connectionToConsumerMap.get(c.getSourceRequestIndex()));
@@ -168,10 +169,10 @@ class RequestSenderOrchestratorTest extends InstrumentationTest {
                 r -> TestHttpServerContext.makeResponse(r, Duration.ofMillis(100)))) {
             var testServerUri = httpServer.localhostEndpoint();
             var clientConnectionPool = TrafficReplayerTopLevel.makeClientConnectionPool(testServerUri, false,
-                    1, "targetConnectionPool for testThatSchedulingWorks",
-                    Duration.ofSeconds(30));
+                    1, "targetConnectionPool for testThatSchedulingWorks");
             var senderOrchestrator =
-                    new RequestSenderOrchestrator(clientConnectionPool, NettyPacketToHttpConsumer::new);
+                    new RequestSenderOrchestrator(clientConnectionPool,
+                        (replaySession, ctx) -> new NettyPacketToHttpConsumer(replaySession, ctx, REGULAR_RESPONSE_TIMEOUT));
             var baseTime = Instant.now();
             Instant lastEndTime = baseTime;
             var scheduledItems = new ArrayList<TrackedFuture<String, AggregatedRawResponse>>();

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/e2etests/FullReplayerWithTracingChecksTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/e2etests/FullReplayerWithTracingChecksTest.java
@@ -97,7 +97,7 @@ public class FullReplayerWithTracingChecksTest extends FullTrafficReplayerTest {
                     RootReplayerConstructorExtensions.makeClientConnectionPool(serverUri, 10), 10 * 1024
             );
                  var blockingTrafficSource = new BlockingTrafficSource(trafficSource, Duration.ofMinutes(2))) {
-                tr.setupRunAndWaitForReplayToFinish(Duration.ofSeconds(70), blockingTrafficSource,
+                tr.setupRunAndWaitForReplayToFinish(Duration.ofSeconds(70), Duration.ofSeconds(30), blockingTrafficSource,
                         new TimeShifter(10 * 1000),
                         t -> {
                             var wasNew = tuplesReceived.add(t.getRequestKey().toString());

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/e2etests/FullTrafficReplayerTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/e2etests/FullTrafficReplayerTest.java
@@ -85,7 +85,7 @@ public class FullTrafficReplayerTest extends InstrumentationTest {
                                               String targetConnectionPoolName) throws SSLException {
             super(context, serverUri, authTransformerFactory, jsonTransformer,
                     TrafficReplayerTopLevel.makeClientConnectionPool(serverUri, allowInsecureConnections, numSendingThreads,
-                            targetConnectionPoolName, Duration.ofSeconds(30)),
+                            targetConnectionPoolName),
                     new TrafficStreamLimiter(maxConcurrentOutstandingRequests), new OrderedWorkerTracker<>());
             this.maxWaitTime = maxWaitTime;
         }

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/e2etests/SlowAndExpiredTrafficStreamBecomesTwoTargetChannelsTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/e2etests/SlowAndExpiredTrafficStreamBecomesTwoTargetChannelsTest.java
@@ -103,11 +103,10 @@ public class SlowAndExpiredTrafficStreamBecomesTwoTargetChannelsTest {
                     new StaticAuthTransformerFactory("TEST"),
                     new TransformationLoader().getTransformerFactoryLoader("localhost"),
                     RootReplayerConstructorExtensions.makeClientConnectionPool(httpServer.localhostEndpoint(), true,
-                            0, "targetConnectionPool for SlowAndExpiredTrafficStreamBecomesTwoTargetChannelsTest",
-                            Duration.ofSeconds(30)))) {
+                            0, "targetConnectionPool for SlowAndExpiredTrafficStreamBecomesTwoTargetChannelsTest"))) {
             new Thread(()->responseTracker.onCountDownFinished(Duration.ofSeconds(10),
                         ()->replayer.shutdown(null).join()));
-            replayer.setupRunAndWaitForReplayWithShutdownChecks(Duration.ofMillis(1),
+            replayer.setupRunAndWaitForReplayWithShutdownChecks(Duration.ofMillis(1), Duration.ofSeconds(30),
                     trafficSource, new TimeShifter(TIME_SPEEDUP_FACTOR), t->{});
         }
 

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/e2etests/TrafficReplayerRunner.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/e2etests/TrafficReplayerRunner.java
@@ -195,8 +195,8 @@ public class TrafficReplayerRunner {
         try (var os = new NullOutputStream();
              var trafficSource = captureSourceSupplier.get();
              var blockingTrafficSource = new BlockingTrafficSource(trafficSource, Duration.ofMinutes(2))) {
-            trafficReplayer.setupRunAndWaitForReplayWithShutdownChecks(Duration.ofSeconds(70), blockingTrafficSource,
-                    timeShifter, tupleReceiver);
+            trafficReplayer.setupRunAndWaitForReplayWithShutdownChecks(Duration.ofSeconds(70), Duration.ofSeconds(30),
+                blockingTrafficSource, timeShifter, tupleReceiver);
         }
     }
 

--- a/TrafficCapture/trafficReplayer/src/testFixtures/java/org/opensearch/migrations/replay/RootReplayerConstructorExtensions.java
+++ b/TrafficCapture/trafficReplayer/src/testFixtures/java/org/opensearch/migrations/replay/RootReplayerConstructorExtensions.java
@@ -7,11 +7,8 @@ import org.opensearch.migrations.transform.IJsonTransformer;
 
 import javax.net.ssl.SSLException;
 import java.net.URI;
-import java.time.Duration;
 
 public class RootReplayerConstructorExtensions extends TrafficReplayerTopLevel {
-
-    public static final Duration RESPONSE_TIMEOUT = Duration.ofSeconds(30);
 
     public RootReplayerConstructorExtensions(IRootReplayerContext topContext,
                                              URI uri,
@@ -43,27 +40,16 @@ public class RootReplayerConstructorExtensions extends TrafficReplayerTopLevel {
     }
 
     public static ClientConnectionPool makeClientConnectionPool(URI serverUri) throws SSLException {
-        return makeClientConnectionPool(serverUri, null, RESPONSE_TIMEOUT);
-    }
-
-    public static ClientConnectionPool makeClientConnectionPool(URI serverUri, String poolPrefix) throws SSLException {
-        return makeClientConnectionPool(serverUri, poolPrefix, RESPONSE_TIMEOUT);
+        return makeClientConnectionPool(serverUri, null);
     }
 
     public static ClientConnectionPool makeClientConnectionPool(URI serverUri,
-                                                                String poolPrefix,
-                                                                Duration timeout) throws SSLException {
-        return makeClientConnectionPool(serverUri, true, 0, poolPrefix, timeout);
+                                                                String poolPrefix) throws SSLException {
+        return makeClientConnectionPool(serverUri, true, 0, poolPrefix);
     }
 
     public static ClientConnectionPool makeClientConnectionPool(URI serverUri,
                                                                 int numSendingThreads) throws SSLException {
-        return makeClientConnectionPool(serverUri, numSendingThreads, RESPONSE_TIMEOUT);
-    }
-
-    public static ClientConnectionPool makeClientConnectionPool(URI serverUri,
-                                                                int numSendingThreads,
-                                                                Duration timeout) throws SSLException {
-        return makeClientConnectionPool(serverUri, true, numSendingThreads, null, timeout);
+        return makeClientConnectionPool(serverUri, true, numSendingThreads, null);
     }
 }


### PR DESCRIPTION
### Description
Currently with the traffic replayer, in the NettyPacketToHttpConsumer, the ReadTimeoutHandler is coupled with the  ConnectionClosedListenerHandler.

This means that we count the time in between request towards the ReadTimeout. This causes the channel to throw an exception while it is waiting to be re-used and may cause race conditions if the channel is reused exactly at the timeout interval.

This change places the ReadTimeoutHandler behind the handlers which remain between requests.

This change also fixes an issue where the BacksideHttpWatcherHandler was propagating exceptions through even though  it shouldn't since it handles them through the callback finalization.

* Category: Bug Fix
* Why these changes are required? Properly handle read timeouts
* What is the old behavior before changes and new behavior after changes? ReadTimeoutException would occur between requests on the same connection/channel, now the exception only occurs if there is a read timeout during the request and is not sent to the bottom of the pipeline.

### Issues Resolved
[MIGRATIONS-1723](https://opensearch.atlassian.net/browse/MIGRATIONS-1723)

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
Ran existing and added new unit tests. Also ran E2E tests from #637 and verified no ReadTimeoutException in logs (they were occurring before this change)

### Check List
- [ x] New functionality includes testing
  - [ x] All tests pass, including unit test, integration test and doctest
- [ x] New functionality has been documented
- [x ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
