### PR TITLE
Add grace 1% threshold on coverage check

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,6 @@
+coverage:
+  status:
+    project:
+      default:
+        # Only fail if the coverage decreases by more than 1%
+        threshold: 1%


### PR DESCRIPTION
### Description
Add grace 1% threshold on coverage check

### Issues Resolved
Seeing PRs with the following checks when code coverage isn't being ignored
![image](https://github.com/opensearch-project/opensearch-migrations/assets/2754967/03ac22e4-de9e-4d5a-8565-e83ee0e97814)

### Check List
- [ ] ~New functionality includes testing~
  - [ ] ~All tests pass, including unit test, integration test and doctest~
- [ ] ~New functionality has been documented~
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
