### PR TITLE
[Bug] Minor fix for runInteg script to use new stack name

### DIFF
--- a/test/awsE2ESolutionSetup.sh
+++ b/test/awsE2ESolutionSetup.sh
@@ -247,6 +247,10 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
+SOURCE_NETWORK_STACK_NAME="opensearch-network-stack-ec2-source-$STAGE"
+SOURCE_INFRA_STACK_NAME="opensearch-infra-stack-ec2-source-$STAGE"
+GEN_CONTEXT_FILE="$TMP_DIR_PATH/generatedCDKContext.json"
+
 if [ "$RUN_POST_ACTIONS" = true ] ; then
   restore_and_record "$STAGE"
   exit 0
@@ -255,10 +259,6 @@ fi
 if [ "$CREATE_SLR" = true ] ; then
   create_service_linked_roles
 fi
-
-SOURCE_NETWORK_STACK_NAME="opensearch-network-stack-ec2-source-$STAGE"
-SOURCE_INFRA_STACK_NAME="opensearch-infra-stack-ec2-source-$STAGE"
-GEN_CONTEXT_FILE="$TMP_DIR_PATH/generatedCDKContext.json"
 
 # Replace preliminary placeholders in CDK context into a generated context file
 mkdir -p "$TMP_DIR_PATH"

--- a/test/awsRunIntegTests.sh
+++ b/test/awsRunIntegTests.sh
@@ -57,6 +57,8 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
+SOURCE_INFRA_STACK_NAME="opensearch-infra-stack-ec2-source-$STAGE"
+
 task_arn=$(aws ecs list-tasks --cluster migration-${STAGE}-ecs-cluster --family "migration-${STAGE}-migration-console" | jq --raw-output '.taskArns[0]')
 # Delete and re-create topic
 kafka_brokers=$(aws ssm get-parameter --name "/migration/${STAGE}/default/kafkaBrokers" --query 'Parameter.Value' --output text)
@@ -66,7 +68,7 @@ unbuffer aws ecs execute-command --cluster "migration-${STAGE}-ecs-cluster" --ta
 echo "Done creating 'logging-traffic-topic'"
 
 # Remove all non-system indices
-source_lb_endpoint=$(aws cloudformation describe-stacks --stack-name opensearch-infra-stack-Migration-Source --query "Stacks[0].Outputs[?OutputKey==\`loadbalancerurl\`].OutputValue" --output text)
+source_lb_endpoint=$(aws cloudformation describe-stacks --stack-name "$SOURCE_INFRA_STACK_NAME" --query "Stacks[0].Outputs[?OutputKey==\`loadbalancerurl\`].OutputValue" --output text)
 source_endpoint="http://${source_lb_endpoint}:19200"
 proxy_endpoint="http://${source_lb_endpoint}:9200"
 target_endpoint=$(aws ssm get-parameter --name "/migration/${STAGE}/default/osClusterEndpoint" --query 'Parameter.Value' --output text)


### PR DESCRIPTION
### Description
Resolves stack name change, verified pipeline is green with this branch

### Issues Resolved
N/A

### Testing
Manual/Jenkins testing

### Check List
- [ ] New functionality includes testing
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
