### PR TITLE
Remove ECS ServiceConnect

### DIFF
--- a/TrafficCapture/dockerSolution/src/main/docker/elasticsearchTestConsole/catIndices.sh
+++ b/TrafficCapture/dockerSolution/src/main/docker/elasticsearchTestConsole/catIndices.sh
@@ -1,10 +1,14 @@
 #!/bin/bash
 
-# Default values
-source_endpoint="https://capture-proxy-es:9200"
-source_auth_user_and_pass="admin:admin"
-source_no_auth=false
-target_no_auth=false
+
+# Check for the presence of SOURCE_DOMAIN_ENDPOINT environment variable
+if [ -n "$SOURCE_DOMAIN_ENDPOINT" ]; then
+    source_endpoint="${SOURCE_DOMAIN_ENDPOINT}"
+    source_auth_user_and_pass="admin:admin"
+else
+    source_endpoint="https://capture-proxy-es:9200"
+    source_auth_user_and_pass="admin:admin"
+fi
 
 # Check for the presence of MIGRATION_DOMAIN_ENDPOINT environment variable
 if [ -n "$MIGRATION_DOMAIN_ENDPOINT" ]; then
@@ -14,6 +18,10 @@ else
     target_endpoint="https://opensearchtarget:9200"
     target_auth_user_and_pass="admin:myStrongPassword123!"
 fi
+
+# Default values
+source_no_auth=false
+target_no_auth=false
 
 usage() {
   echo ""

--- a/deployment/cdk/opensearch-service-migration/lib/fetch-migration-stack.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/fetch-migration-stack.ts
@@ -35,7 +35,7 @@ export class FetchMigrationStack extends Stack {
         const targetClusterEndpoint = StringParameter.fromStringParameterName(this, "targetClusterEndpoint", `/migration/${props.stage}/${props.defaultDeployId}/osClusterEndpoint`)
         const domainAccessGroupId = StringParameter.valueForStringParameter(this, `/migration/${props.stage}/${props.defaultDeployId}/osAccessSecurityGroupId`)
         // This SG allows outbound access for ECR access as well as communication with other services in the cluster
-        const serviceConnectGroupId = StringParameter.valueForStringParameter(this, `/migration/${props.stage}/${props.defaultDeployId}/serviceConnectSecurityGroupId`)
+        const serviceGroupId = StringParameter.valueForStringParameter(this, `/migration/${props.stage}/${props.defaultDeployId}/serviceSecurityGroupId`)
 
         const ecsCluster = Cluster.fromClusterAttributes(this, 'ecsCluster', {
             clusterName: `migration-${props.stage}-ecs-cluster`,
@@ -106,7 +106,7 @@ export class FetchMigrationStack extends Stack {
         let networkConfigJson = {
             "awsvpcConfiguration": {
                 "subnets": props.vpc.privateSubnets.map(_ => _.subnetId),
-                "securityGroups": [domainAccessGroupId, serviceConnectGroupId]
+                "securityGroups": [domainAccessGroupId, serviceGroupId]
             }
         }
         let networkConfigString = JSON.stringify(networkConfigJson)

--- a/deployment/cdk/opensearch-service-migration/lib/migration-assistance-stack.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/migration-assistance-stack.ts
@@ -211,17 +211,17 @@ export class MigrationAssistanceStack extends Stack {
             stringValue: replayerOutputEFS.fileSystemId
         });
 
-        const serviceConnectSecurityGroup = new SecurityGroup(this, 'serviceConnectSecurityGroup', {
+        const serviceSecurityGroup = new SecurityGroup(this, 'serviceSecurityGroup', {
             vpc: props.vpc,
             // Required for retrieving ECR image at service startup
             allowAllOutbound: true,
         })
-        serviceConnectSecurityGroup.addIngressRule(serviceConnectSecurityGroup, Port.allTraffic());
+        serviceSecurityGroup.addIngressRule(serviceSecurityGroup, Port.allTraffic());
 
-        new StringParameter(this, 'SSMParameterServiceConnectGroupId', {
-            description: 'OpenSearch migration parameter for Service Connect security group id',
-            parameterName: `/migration/${props.stage}/${props.defaultDeployId}/serviceConnectSecurityGroupId`,
-            stringValue: serviceConnectSecurityGroup.securityGroupId
+        new StringParameter(this, 'SSMParameterServiceGroupId', {
+            description: 'OpenSearch migration parameter for service security group id',
+            parameterName: `/migration/${props.stage}/${props.defaultDeployId}/serviceSecurityGroupId`,
+            stringValue: serviceSecurityGroup.securityGroupId
         });
 
         const artifactBucket = new Bucket(this, 'migrationArtifactsS3', {
@@ -244,7 +244,6 @@ export class MigrationAssistanceStack extends Stack {
         ecsCluster.addDefaultCloudMapNamespace( {
             name: `migration.${props.stage}.local`,
             type: NamespaceType.DNS_PRIVATE,
-            useForServiceConnect: true,
             vpc: props.vpc
         })
         const cloudMapNamespaceId = ecsCluster.defaultCloudMapNamespace!.namespaceId

--- a/deployment/cdk/opensearch-service-migration/lib/service-stacks/elasticsearch-stack.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/service-stacks/elasticsearch-stack.ts
@@ -1,6 +1,6 @@
 import {StackPropsExt} from "../stack-composer";
 import {IVpc, SecurityGroup} from "aws-cdk-lib/aws-ec2";
-import {CpuArchitecture, PortMapping, Protocol, ServiceConnectService} from "aws-cdk-lib/aws-ecs";
+import {CpuArchitecture, PortMapping, Protocol} from "aws-cdk-lib/aws-ecs";
 import {Construct} from "constructs";
 import {join} from "path";
 import {MigrationServiceCore} from "./migration-service-core";
@@ -22,7 +22,7 @@ export class ElasticsearchStack extends MigrationServiceCore {
     constructor(scope: Construct, id: string, props: ElasticsearchProps) {
         super(scope, id, props)
         let securityGroups = [
-            SecurityGroup.fromSecurityGroupId(this, "serviceConnectSG", StringParameter.valueForStringParameter(this, `/migration/${props.stage}/${props.defaultDeployId}/serviceConnectSecurityGroupId`)),
+            SecurityGroup.fromSecurityGroupId(this, "serviceSG", StringParameter.valueForStringParameter(this, `/migration/${props.stage}/${props.defaultDeployId}/serviceSecurityGroupId`)),
         ]
 
         const servicePort: PortMapping = {
@@ -31,18 +31,12 @@ export class ElasticsearchStack extends MigrationServiceCore {
             containerPort: 9200,
             protocol: Protocol.TCP
         }
-        const serviceConnectService: ServiceConnectService = {
-            portMappingName: "elasticsearch-connect",
-            dnsName: "elasticsearch",
-            port: 9200
-        }
 
         this.createService({
             serviceName: "elasticsearch",
             dockerDirectoryPath: join(__dirname, "../../../../../", "TrafficCapture/dockerSolution/src/main/docker/elasticsearchWithSearchGuard"),
             securityGroups: securityGroups,
             portMappings: [servicePort],
-            serviceConnectServices: [serviceConnectService],
             serviceDiscoveryEnabled: true,
             serviceDiscoveryPort: 9200,
             cpuArchitecture: props.fargateCpuArch,

--- a/deployment/cdk/opensearch-service-migration/lib/service-stacks/kafka-stack.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/service-stacks/kafka-stack.ts
@@ -1,6 +1,6 @@
 import {StackPropsExt} from "../stack-composer";
 import {IVpc, SecurityGroup} from "aws-cdk-lib/aws-ec2";
-import {CpuArchitecture, PortMapping, Protocol, ServiceConnectService} from "aws-cdk-lib/aws-ecs";
+import {CpuArchitecture, PortMapping, Protocol} from "aws-cdk-lib/aws-ecs";
 import {Construct} from "constructs";
 import {MigrationServiceCore} from "./migration-service-core";
 import {StringParameter} from "aws-cdk-lib/aws-ssm";
@@ -19,7 +19,7 @@ export class KafkaStack extends MigrationServiceCore {
     constructor(scope: Construct, id: string, props: KafkaBrokerProps) {
         super(scope, id, props)
         let securityGroups = [
-            SecurityGroup.fromSecurityGroupId(this, "serviceConnectSG", StringParameter.valueForStringParameter(this, `/migration/${props.stage}/${props.defaultDeployId}/serviceConnectSecurityGroupId`)),
+            SecurityGroup.fromSecurityGroupId(this, "serviceSG", StringParameter.valueForStringParameter(this, `/migration/${props.stage}/${props.defaultDeployId}/serviceSecurityGroupId`)),
             SecurityGroup.fromSecurityGroupId(this, "trafficStreamSourceAccessSG", StringParameter.valueForStringParameter(this, `/migration/${props.stage}/${props.defaultDeployId}/trafficStreamSourceAccessSecurityGroupId`))
         ]
 
@@ -28,11 +28,6 @@ export class KafkaStack extends MigrationServiceCore {
             hostPort: 9092,
             containerPort: 9092,
             protocol: Protocol.TCP
-        }
-        const serviceConnectService: ServiceConnectService = {
-            portMappingName: "kafka-connect",
-            dnsName: "kafka",
-            port: 9092
         }
 
         new StringParameter(this, 'SSMParameterKafkaBrokers', {
@@ -63,7 +58,6 @@ export class KafkaStack extends MigrationServiceCore {
                 "KAFKA_LOG_DIRS": '/tmp/kraft-combined-logs'
             },
             portMappings: [servicePort],
-            serviceConnectServices: [serviceConnectService],
             cpuArchitecture: props.fargateCpuArch,
             taskCpuUnits: 256,
             taskMemoryLimitMiB: 2048,

--- a/deployment/cdk/opensearch-service-migration/lib/service-stacks/migration-console-stack.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/service-stacks/migration-console-stack.ts
@@ -182,6 +182,8 @@ export class MigrationConsoleStack extends MigrationServiceCore {
 
         const environment: { [key: string]: string; } = {
             "MIGRATION_DOMAIN_ENDPOINT": osClusterEndpoint,
+            // Temporary fix for source domain endpoint until we move to either alb or migration console yaml configuration
+            "SOURCE_DOMAIN_ENDPOINT": `https://capture-proxy-es.migration.${props.stage}.local:9200`,
             "MIGRATION_KAFKA_BROKER_ENDPOINTS": brokerEndpoints,
             "MIGRATION_STAGE": props.stage,
             "MIGRATION_SOLUTION_VERSION": props.migrationsSolutionVersion

--- a/deployment/cdk/opensearch-service-migration/lib/service-stacks/migration-console-stack.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/service-stacks/migration-console-stack.ts
@@ -1,5 +1,5 @@
 import {StackPropsExt} from "../stack-composer";
-import {IVpc, SecurityGroup} from "aws-cdk-lib/aws-ec2";
+import {IVpc, SecurityGroup, Port, ISecurityGroup} from "aws-cdk-lib/aws-ec2";
 import {CpuArchitecture, MountPoint, Volume} from "aws-cdk-lib/aws-ecs";
 import {Construct} from "constructs";
 import {join} from "path";
@@ -107,7 +107,7 @@ export class MigrationConsoleStack extends MigrationServiceCore {
     constructor(scope: Construct, id: string, props: MigrationConsoleProps) {
         super(scope, id, props)
         let securityGroups = [
-            SecurityGroup.fromSecurityGroupId(this, "serviceConnectSG", StringParameter.valueForStringParameter(this, `/migration/${props.stage}/${props.defaultDeployId}/serviceConnectSecurityGroupId`)),
+            SecurityGroup.fromSecurityGroupId(this, "serviceSG", StringParameter.valueForStringParameter(this, `/migration/${props.stage}/${props.defaultDeployId}/serviceSecurityGroupId`)),
             SecurityGroup.fromSecurityGroupId(this, "trafficStreamSourceAccessSG", StringParameter.valueForStringParameter(this, `/migration/${props.stage}/${props.defaultDeployId}/trafficStreamSourceAccessSecurityGroupId`)),
             SecurityGroup.fromSecurityGroupId(this, "defaultDomainAccessSG", StringParameter.valueForStringParameter(this, `/migration/${props.stage}/${props.defaultDeployId}/osAccessSecurityGroupId`)),
             SecurityGroup.fromSecurityGroupId(this, "replayerOutputAccessSG", StringParameter.valueForStringParameter(this, `/migration/${props.stage}/${props.defaultDeployId}/replayerOutputAccessSecurityGroupId`))

--- a/deployment/cdk/opensearch-service-migration/lib/service-stacks/migration-service-core.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/service-stacks/migration-service-core.ts
@@ -9,7 +9,6 @@ import {
     LogDrivers,
     MountPoint,
     PortMapping,
-    ServiceConnectService,
     Ulimit,
     OperatingSystemFamily,
     Volume,
@@ -42,7 +41,6 @@ export interface MigrationServiceCoreProps extends StackPropsExt {
     readonly environment?: {
         [key: string]: string;
     },
-    readonly serviceConnectServices?: ServiceConnectService[],
     readonly serviceDiscoveryEnabled?: boolean,
     readonly serviceDiscoveryPort?: number,
     readonly taskCpuUnits?: number,
@@ -221,14 +219,6 @@ export class MigrationServiceCore extends Stack {
             enableExecuteCommand: true,
             securityGroups: props.securityGroups,
             vpcSubnets: props.vpc.selectSubnets({subnetType: SubnetType.PRIVATE_WITH_EGRESS}),
-            serviceConnectConfiguration: {
-                namespace: `migration.${props.stage}.local`,
-                services: props.serviceConnectServices ? props.serviceConnectServices : undefined,
-                logDriver: LogDrivers.awsLogs({
-                    streamPrefix: "service-connect-logs",
-                    logGroup: serviceLogGroup
-                })
-            },
             cloudMapOptions: cloudMapOptions
         });
 

--- a/deployment/cdk/opensearch-service-migration/lib/service-stacks/opensearch-container-stack.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/service-stacks/opensearch-container-stack.ts
@@ -44,7 +44,7 @@ export class OpenSearchContainerStack extends MigrationServiceCore {
         const deployId = props.addOnMigrationDeployId ? props.addOnMigrationDeployId : props.defaultDeployId
 
         let securityGroups = [
-            SecurityGroup.fromSecurityGroupId(this, "serviceConnectSG", StringParameter.valueForStringParameter(this, `/migration/${props.stage}/${props.defaultDeployId}/serviceConnectSecurityGroupId`)),
+            SecurityGroup.fromSecurityGroupId(this, "serviceSG", StringParameter.valueForStringParameter(this, `/migration/${props.stage}/${props.defaultDeployId}/serviceSecurityGroupId`)),
         ]
 
         let adminUserSecret: ISecret|undefined = props.fineGrainedManagerUserSecretManagerKeyARN ?
@@ -65,11 +65,7 @@ export class OpenSearchContainerStack extends MigrationServiceCore {
             containerPort: 9200,
             protocol: Protocol.TCP
         }
-        const serviceConnectService: ServiceConnectService = {
-            portMappingName: "opensearch-connect",
-            dnsName: dnsNameForContainer,
-            port: 9200
-        }
+
         const ulimits: Ulimit[] = [
             {
                 name: UlimitName.MEMLOCK,
@@ -96,7 +92,6 @@ export class OpenSearchContainerStack extends MigrationServiceCore {
                 "OPENSEARCH_INITIAL_ADMIN_PASSWORD": opensearch_target_initial_admin_password
             },
             portMappings: [servicePort],
-            serviceConnectServices: [serviceConnectService],
             taskCpuUnits: 1024,
             taskMemoryLimitMiB: 4096,
             cpuArchitecture: props.fargateCpuArch,

--- a/deployment/cdk/opensearch-service-migration/lib/service-stacks/reindex-from-snapshot-stack.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/service-stacks/reindex-from-snapshot-stack.ts
@@ -25,7 +25,7 @@ export class ReindexFromSnapshotStack extends MigrationServiceCore {
     constructor(scope: Construct, id: string, props: ReindexFromSnapshotProps) {
         super(scope, id, props)
         let securityGroups = [
-            SecurityGroup.fromSecurityGroupId(this, "serviceConnectSG", StringParameter.valueForStringParameter(this, `/migration/${props.stage}/${props.defaultDeployId}/serviceConnectSecurityGroupId`)),
+            SecurityGroup.fromSecurityGroupId(this, "serviceSG", StringParameter.valueForStringParameter(this, `/migration/${props.stage}/${props.defaultDeployId}/serviceSecurityGroupId`)),
             SecurityGroup.fromSecurityGroupId(this, "defaultDomainAccessSG", StringParameter.valueForStringParameter(this, `/migration/${props.stage}/${props.defaultDeployId}/osAccessSecurityGroupId`)),
         ]
 

--- a/deployment/cdk/opensearch-service-migration/lib/service-stacks/traffic-replayer-stack.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/service-stacks/traffic-replayer-stack.ts
@@ -34,7 +34,7 @@ export class TrafficReplayerStack extends MigrationServiceCore {
     constructor(scope: Construct, id: string, props: TrafficReplayerProps) {
         super(scope, id, props)
         let securityGroups = [
-            SecurityGroup.fromSecurityGroupId(this, "serviceConnectSG", StringParameter.valueForStringParameter(this, `/migration/${props.stage}/${props.defaultDeployId}/serviceConnectSecurityGroupId`)),
+            SecurityGroup.fromSecurityGroupId(this, "serviceSG", StringParameter.valueForStringParameter(this, `/migration/${props.stage}/${props.defaultDeployId}/serviceSecurityGroupId`)),
             SecurityGroup.fromSecurityGroupId(this, "trafficStreamSourceAccessSG", StringParameter.valueForStringParameter(this, `/migration/${props.stage}/${props.defaultDeployId}/trafficStreamSourceAccessSecurityGroupId`)),
             SecurityGroup.fromSecurityGroupId(this, "defaultDomainAccessSG", StringParameter.valueForStringParameter(this, `/migration/${props.stage}/${props.defaultDeployId}/osAccessSecurityGroupId`)),
             SecurityGroup.fromSecurityGroupId(this, "replayerOutputAccessSG", StringParameter.valueForStringParameter(this, `/migration/${props.stage}/${props.defaultDeployId}/replayerOutputAccessSecurityGroupId`))

--- a/deployment/cdk/opensearch-service-migration/lib/stack-composer.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/stack-composer.ts
@@ -516,8 +516,8 @@ export class StackComposer {
                 fargateCpuArch: fargateCpuArch,
                 env: props.env
             })
-            // To enable the Migration Console to make requests to other service endpoints with Service Connect,
-            // it must be deployed after any Service Connect services
+            // To enable the Migration Console to make requests to other service endpoints with services,
+            // it must be deployed after any connected services
             this.addDependentStacks(migrationConsoleStack, [captureProxyESStack, captureProxyStack, elasticsearchStack,
                 fetchMigrationStack, openSearchStack, osContainerStack, migrationStack, kafkaBrokerStack, mskUtilityStack])
             this.stacks.push(migrationConsoleStack)


### PR DESCRIPTION
### Description
Removes ECS ServiceConnect from the infrastructure. This change builds off of [MIGRATIONS-1735](https://opensearch.atlassian.net/browse/MIGRATIONS-1735) which removes a hard dependency on service-connect.

* Category: Enhancement
* Why these changes are required? Support GovCloud
* What is the old behavior before changes and new behavior after changes? Service connect is deployed within services as a sidecar, this change removes that as it is currently not used for service communication with [OTEL Sidecar Change](https://opensearch.atlassian.net/browse/MIGRATIONS-1735)

### Issues Resolved
[MIGRATIONS-1736](https://opensearch.atlassian.net/browse/MIGRATIONS-1736)

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
Deployed to AWS, verified functionality including migration console access to capture proxy and proxy/replayer/console access to kafka

### Check List
- [ x] New functionality includes testing
  - [ x] All tests pass, including unit test, integration test and doctest
- [ x] New functionality has been documented
- [ x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
