### PR TITLE
Fix lychee failures

### DIFF
--- a/.github/workflows/linkCheck.yml
+++ b/.github/workflows/linkCheck.yml
@@ -19,6 +19,7 @@ jobs:
         uses: lycheeverse/lychee-action@v1
         with:
           args: --verbose --accept=200,403,429  "**/*.html" "**/*.md" "**/*.txt" "**/*.json"
+            --offline
             --exclude "file:///github/workspace/*"
             --exclude "http://localhost*"
             --exclude "https://localhost*"


### PR DESCRIPTION
### Description
Lychee was scanning every file in the repo and then following the links to these external services... that seems overkill.  Maybe on some very specific files we can add it back in, but for our generic project we should only verify internal links. 

### Check List
- [X] New functionality includes testing
  - [X] All tests pass, including unit test, integration test and doctest
- [ ] ~New functionality has been documented~
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
