### PR TITLE
Reuse target client in doc reindexer

### DIFF
--- a/RFS/src/main/java/com/rfs/ReindexFromSnapshot.java
+++ b/RFS/src/main/java/com/rfs/ReindexFromSnapshot.java
@@ -298,13 +298,13 @@ public class ReindexFromSnapshot {
             }
             logger.info("Index Metadata read successfully");
 
+            OpenSearchClient targetClient = new OpenSearchClient(targetConnection);
             if ((movementType == MovementType.EVERYTHING) || (movementType == MovementType.METADATA)){
                 // ==========================================================================================================
                 // Recreate the Indices
                 // ==========================================================================================================
                 logger.info("==================================================================");
                 logger.info("Attempting to recreate the indices...");
-                OpenSearchClient targetClient = new OpenSearchClient(targetConnection);
                 for (IndexMetadata.Data indexMetadata : indexMetadatas) {
                     String reindexName = indexMetadata.getName() + indexSuffix;
                     logger.info("Recreating index " + indexMetadata.getName() + " as " + reindexName + " on target...");
@@ -364,7 +364,7 @@ public class ReindexFromSnapshot {
                         String targetIndex = indexMetadata.getName() + indexSuffix;
 
                         final int finalShardId = shardId; // Define in local context for the lambda
-                        DocumentReindexer.reindex(targetIndex, documents, targetConnection)
+                        DocumentReindexer.reindex(targetIndex, documents, targetClient)
                             .doOnError(error -> logger.error("Error during reindexing: " + error))
                             .doOnSuccess(done -> logger.info("Reindexing completed for index " + targetIndex + ", shard " + finalShardId))
                             // Wait for the shard reindexing to complete before proceeding; fine in this demo script, but

--- a/RFS/src/main/java/com/rfs/common/DocumentReindexer.java
+++ b/RFS/src/main/java/com/rfs/common/DocumentReindexer.java
@@ -15,8 +15,7 @@ public class DocumentReindexer {
     private static final Logger logger = LogManager.getLogger(DocumentReindexer.class);
     private static final int MAX_BATCH_SIZE = 1000; // Arbitrarily chosen
 
-    public static Mono<Void> reindex(String indexName, Flux<Document> documentStream, ConnectionDetails targetConnection) throws Exception {   
-        OpenSearchClient client = new OpenSearchClient(targetConnection);
+    public static Mono<Void> reindex(String indexName, Flux<Document> documentStream, OpenSearchClient client) throws Exception {   
 
         return documentStream
             .map(DocumentReindexer::convertDocumentToBulkSection)  // Convert each Document to part of a bulk operation


### PR DESCRIPTION
### Description
Small refactor for testability of document indexer actions, following from the snapshot test cases [1].
- [1] https://github.com/opensearch-project/opensearch-migrations/pull/664#discussion_r1609036461

### Check List
- [ ] ~New functionality includes testing~
  - [ ] ~All tests pass, including unit test, integration test and doctest~
- [ ] ~New functionality has been documented~
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
