### PR TITLE
Parameterize AWS Partition for GovCloud

### DIFF
--- a/deployment/cdk/opensearch-service-migration/lib/common-utilities.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/common-utilities.ts
@@ -4,27 +4,27 @@ import {StringParameter} from "aws-cdk-lib/aws-ssm";
 import {CpuArchitecture} from "aws-cdk-lib/aws-ecs";
 import {RemovalPolicy} from "aws-cdk-lib";
 
-export function createOpenSearchIAMAccessPolicy(region: string, accountId: string): PolicyStatement {
+export function createOpenSearchIAMAccessPolicy(partition: string, region: string, accountId: string): PolicyStatement {
     return new PolicyStatement({
         effect: Effect.ALLOW,
-        resources: [`arn:aws:es:${region}:${accountId}:domain/*`],
+        resources: [`arn:${partition}:es:${region}:${accountId}:domain/*`],
         actions: [
             "es:ESHttp*"
         ]
     })
 }
 
-export function createOpenSearchServerlessIAMAccessPolicy(region: string, accountId: string): PolicyStatement {
+export function createOpenSearchServerlessIAMAccessPolicy(partition: string, region: string, accountId: string): PolicyStatement {
     return new PolicyStatement({
         effect: Effect.ALLOW,
-        resources: [`arn:aws:aoss:${region}:${accountId}:collection/*`],
+        resources: [`arn:${partition}:aoss:${region}:${accountId}:collection/*`],
         actions: [
             "aoss:APIAccessAll"
         ]
     })
 }
 
-export function createMSKConsumerIAMPolicies(scope: Construct, region: string, accountId: string, stage: string, deployId: string): PolicyStatement[] {
+export function createMSKConsumerIAMPolicies(scope: Construct, partition: string, region: string, accountId: string, stage: string, deployId: string): PolicyStatement[] {
     const mskClusterARN = StringParameter.valueForStringParameter(scope, `/migration/${stage}/${deployId}/mskClusterARN`);
     const mskClusterName = StringParameter.valueForStringParameter(scope, `/migration/${stage}/${deployId}/mskClusterName`);
     const mskClusterConnectPolicy = new PolicyStatement({
@@ -34,7 +34,7 @@ export function createMSKConsumerIAMPolicies(scope: Construct, region: string, a
             "kafka-cluster:Connect"
         ]
     })
-    const mskClusterAllTopicArn = `arn:aws:kafka:${region}:${accountId}:topic/${mskClusterName}/*`
+    const mskClusterAllTopicArn = `arn:${partition}:kafka:${region}:${accountId}:topic/${mskClusterName}/*`
     const mskTopicConsumerPolicy = new PolicyStatement({
         effect: Effect.ALLOW,
         resources: [mskClusterAllTopicArn],
@@ -43,7 +43,7 @@ export function createMSKConsumerIAMPolicies(scope: Construct, region: string, a
             "kafka-cluster:ReadData"
         ]
     })
-    const mskClusterAllGroupArn = `arn:aws:kafka:${region}:${accountId}:group/${mskClusterName}/*`
+    const mskClusterAllGroupArn = `arn:${partition}:kafka:${region}:${accountId}:group/${mskClusterName}/*`
     const mskConsumerGroupPolicy = new PolicyStatement({
         effect: Effect.ALLOW,
         resources: [mskClusterAllGroupArn],
@@ -56,7 +56,7 @@ export function createMSKConsumerIAMPolicies(scope: Construct, region: string, a
 
 }
 
-export function createMSKProducerIAMPolicies(scope: Construct, region: string, accountId: string, stage: string, deployId: string): PolicyStatement[] {
+export function createMSKProducerIAMPolicies(scope: Construct, partition: string, region: string, accountId: string, stage: string, deployId: string): PolicyStatement[] {
     const mskClusterARN = StringParameter.valueForStringParameter(scope, `/migration/${stage}/${deployId}/mskClusterARN`);
     const mskClusterName = StringParameter.valueForStringParameter(scope, `/migration/${stage}/${deployId}/mskClusterName`);
     const mskClusterConnectPolicy = new PolicyStatement({
@@ -66,7 +66,7 @@ export function createMSKProducerIAMPolicies(scope: Construct, region: string, a
             "kafka-cluster:Connect"
         ]
     })
-    const mskClusterAllTopicArn = `arn:aws:kafka:${region}:${accountId}:topic/${mskClusterName}/*`
+    const mskClusterAllTopicArn = `arn:${partition}:kafka:${region}:${accountId}:topic/${mskClusterName}/*`
     const mskTopicProducerPolicy = new PolicyStatement({
         effect: Effect.ALLOW,
         resources: [mskClusterAllTopicArn],

--- a/deployment/cdk/opensearch-service-migration/lib/fetch-migration-stack.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/fetch-migration-stack.ts
@@ -44,8 +44,8 @@ export class FetchMigrationStack extends Stack {
 
         const serviceName = "fetch-migration"
         const ecsTaskRole = createDefaultECSTaskRole(this, serviceName)
-        const openSearchPolicy = createOpenSearchIAMAccessPolicy(this.region, this.account)
-        const openSearchServerlessPolicy = createOpenSearchServerlessIAMAccessPolicy(this.region, this.account)
+        const openSearchPolicy = createOpenSearchIAMAccessPolicy(this.partition, this.region, this.account)
+        const openSearchServerlessPolicy = createOpenSearchServerlessIAMAccessPolicy(this.partition, this.region, this.account)
         ecsTaskRole.addToPolicy(openSearchPolicy)
         ecsTaskRole.addToPolicy(openSearchServerlessPolicy)
         // ECS Task Definition

--- a/deployment/cdk/opensearch-service-migration/lib/opensearch-domain-stack.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/opensearch-domain-stack.ts
@@ -71,7 +71,7 @@ export class OpenSearchDomainStack extends Stack {
         effect: Effect.ALLOW,
         principals: [new AnyPrincipal()],
         actions: ["es:*"],
-        resources: [`arn:aws:es:${this.region}:${this.account}:domain/${domainName}/*`]
+        resources: [`arn:${this.partition}:es:${this.region}:${this.account}:domain/${domainName}/*`]
       })
   }
 

--- a/deployment/cdk/opensearch-service-migration/lib/service-stacks/capture-proxy-es-stack.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/service-stacks/capture-proxy-es-stack.ts
@@ -55,7 +55,7 @@ export class CaptureProxyESStack extends MigrationServiceCore {
             port: 19200
         }
 
-        const servicePolicies = props.streamingSourceType === StreamingSourceType.AWS_MSK ? createMSKProducerIAMPolicies(this, this.region, this.account, props.stage, props.defaultDeployId) : []
+        const servicePolicies = props.streamingSourceType === StreamingSourceType.AWS_MSK ? createMSKProducerIAMPolicies(this, this.partition, this.region, this.account, props.stage, props.defaultDeployId) : []
 
         let brokerEndpoints = StringParameter.valueForStringParameter(this, `/migration/${props.stage}/${props.defaultDeployId}/kafkaBrokers`);
         let command = `/usr/local/bin/docker-entrypoint.sh eswrapper & /runJavaWithClasspath.sh org.opensearch.migrations.trafficcapture.proxyserver.CaptureProxy --kafkaConnection ${brokerEndpoints} --destinationUri https://localhost:19200 --insecureDestination --listenPort 9200 --sslConfigFile /usr/share/elasticsearch/config/proxy_tls.yml`

--- a/deployment/cdk/opensearch-service-migration/lib/service-stacks/capture-proxy-stack.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/service-stacks/capture-proxy-stack.ts
@@ -45,7 +45,7 @@ export class CaptureProxyStack extends MigrationServiceCore {
             port: 9200
         }
 
-        const servicePolicies = props.streamingSourceType === StreamingSourceType.AWS_MSK ? createMSKProducerIAMPolicies(this, this.region, this.account, props.stage, props.defaultDeployId) : []
+        const servicePolicies = props.streamingSourceType === StreamingSourceType.AWS_MSK ? createMSKProducerIAMPolicies(this, this.partition, this.region, this.account, props.stage, props.defaultDeployId) : []
 
         const brokerEndpoints = StringParameter.valueForStringParameter(this, `/migration/${props.stage}/${props.defaultDeployId}/kafkaBrokers`);
         const sourceClusterEndpoint = props.customSourceClusterEndpoint ? props.customSourceClusterEndpoint : "https://elasticsearch:9200"

--- a/deployment/cdk/opensearch-service-migration/lib/service-stacks/migration-console-stack.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/service-stacks/migration-console-stack.ts
@@ -36,7 +36,7 @@ export class MigrationConsoleStack extends MigrationServiceCore {
                 "kafka-cluster:*"
             ]
         })
-        const mskClusterAllTopicArn = `arn:aws:kafka:${this.region}:${this.account}:topic/${mskClusterName}/*`
+        const mskClusterAllTopicArn = `arn:${this.partition}:kafka:${this.region}:${this.account}:topic/${mskClusterName}/*`
         const mskTopicAdminPolicy = new PolicyStatement({
             effect: Effect.ALLOW,
             resources: [mskClusterAllTopicArn],
@@ -44,7 +44,7 @@ export class MigrationConsoleStack extends MigrationServiceCore {
                 "kafka-cluster:*"
             ]
         })
-        const mskClusterAllGroupArn = `arn:aws:kafka:${this.region}:${this.account}:group/${mskClusterName}/*`
+        const mskClusterAllGroupArn = `arn:${this.partition}:kafka:${this.region}:${this.account}:group/${mskClusterName}/*`
         const mskConsumerGroupAdminPolicy = new PolicyStatement({
             effect: Effect.ALLOW,
             resources: [mskClusterAllGroupArn],
@@ -64,7 +64,7 @@ export class MigrationConsoleStack extends MigrationServiceCore {
         osiPipelineRole.addToPolicy(new PolicyStatement({
             effect: Effect.ALLOW,
             actions: ["es:DescribeDomain", "es:ESHttp*"],
-            resources: [`arn:aws:es:${this.region}:${this.account}:domain/*`]
+            resources: [`arn:${this.partition}:es:${this.region}:${this.account}:domain/*`]
         }))
 
         new StringParameter(this, 'SSMParameterOSIPipelineRoleArn', {
@@ -76,7 +76,7 @@ export class MigrationConsoleStack extends MigrationServiceCore {
     }
 
     createOpenSearchIngestionManagementPolicy(pipelineRoleArn: string): PolicyStatement[] {
-        const allMigrationPipelineArn = `arn:aws:osis:${this.region}:${this.account}:pipeline/*`
+        const allMigrationPipelineArn = `arn:${this.partition}:osis:${this.region}:${this.account}:pipeline/*`
         const osiManagementPolicy = new PolicyStatement({
             effect: Effect.ALLOW,
             resources: [allMigrationPipelineArn],
@@ -130,7 +130,7 @@ export class MigrationConsoleStack extends MigrationServiceCore {
             readOnly: false,
             sourceVolume: volumeName
         }
-        const replayerOutputEFSArn = `arn:aws:elasticfilesystem:${this.region}:${this.account}:file-system/${volumeId}`
+        const replayerOutputEFSArn = `arn:${this.partition}:elasticfilesystem:${this.region}:${this.account}:file-system/${volumeId}`
         const replayerOutputMountPolicy = new PolicyStatement( {
             effect: Effect.ALLOW,
             resources: [replayerOutputEFSArn],
@@ -140,7 +140,7 @@ export class MigrationConsoleStack extends MigrationServiceCore {
             ]
         })
 
-        const ecsClusterArn = `arn:aws:ecs:${this.region}:${this.account}:service/migration-${props.stage}-ecs-cluster`
+        const ecsClusterArn = `arn:${this.partition}:ecs:${this.region}:${this.account}:service/migration-${props.stage}-ecs-cluster`
         const allReplayerServiceArn = `${ecsClusterArn}/migration-${props.stage}-traffic-replayer*`
         const reindexFromSnapshotServiceArn = `${ecsClusterArn}/migration-${props.stage}-reindex-from-snapshot`
         const ecsUpdateServicePolicy = new PolicyStatement({
@@ -174,7 +174,7 @@ export class MigrationConsoleStack extends MigrationServiceCore {
         // Allow Console to retrieve SSM Parameters
         const getSSMParamsPolicy = new PolicyStatement({
             effect: Effect.ALLOW,
-            resources: [`arn:aws:ssm:${this.region}:${this.account}:parameter/migration/${props.stage}/${props.defaultDeployId}/*`],
+            resources: [`arn:${this.partition}:ssm:${this.region}:${this.account}:parameter/migration/${props.stage}/${props.defaultDeployId}/*`],
             actions: [
                 "ssm:GetParameters"
             ]
@@ -186,8 +186,8 @@ export class MigrationConsoleStack extends MigrationServiceCore {
             "MIGRATION_STAGE": props.stage,
             "MIGRATION_SOLUTION_VERSION": props.migrationsSolutionVersion
         }
-        const openSearchPolicy = createOpenSearchIAMAccessPolicy(this.region, this.account)
-        const openSearchServerlessPolicy = createOpenSearchServerlessIAMAccessPolicy(this.region, this.account)
+        const openSearchPolicy = createOpenSearchIAMAccessPolicy(this.partition, this.region, this.account)
+        const openSearchServerlessPolicy = createOpenSearchServerlessIAMAccessPolicy(this.partition, this.region, this.account)
         let servicePolicies = [replayerOutputMountPolicy, openSearchPolicy, openSearchServerlessPolicy, ecsUpdateServicePolicy, artifactS3PublishPolicy, describeVPCPolicy, getSSMParamsPolicy]
         if (props.streamingSourceType === StreamingSourceType.AWS_MSK) {
             const mskAdminPolicies = this.createMSKAdminIAMPolicies(props.stage, props.defaultDeployId)

--- a/deployment/cdk/opensearch-service-migration/lib/service-stacks/migration-service-core.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/service-stacks/migration-service-core.ts
@@ -200,7 +200,7 @@ export class MigrationServiceCore extends Stack {
             const namespace = PrivateDnsNamespace.fromPrivateDnsNamespaceAttributes(this, "PrivateDNSNamespace", {
                 namespaceName: `migration.${props.stage}.local`,
                 namespaceId: namespaceId,
-                namespaceArn: `arn:aws:servicediscovery:${this.region}:${this.account}:namespace/${namespaceId}`
+                namespaceArn: `arn:${this.partition}:servicediscovery:${this.region}:${this.account}:namespace/${namespaceId}`
             })
             cloudMapOptions = {
                 name: props.serviceName,

--- a/deployment/cdk/opensearch-service-migration/lib/service-stacks/reindex-from-snapshot-stack.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/service-stacks/reindex-from-snapshot-stack.ts
@@ -39,8 +39,8 @@ export class ReindexFromSnapshotStack extends MigrationServiceCore {
             ]
         })
 
-        const openSearchPolicy = createOpenSearchIAMAccessPolicy(this.region, this.account)
-        const openSearchServerlessPolicy = createOpenSearchServerlessIAMAccessPolicy(this.region, this.account)
+        const openSearchPolicy = createOpenSearchIAMAccessPolicy(this.partition, this.region, this.account)
+        const openSearchServerlessPolicy = createOpenSearchServerlessIAMAccessPolicy(this.partition, this.region, this.account)
         let servicePolicies = [artifactS3PublishPolicy, openSearchPolicy, openSearchServerlessPolicy]
 
         const osClusterEndpoint = StringParameter.valueForStringParameter(this, `/migration/${props.stage}/${props.defaultDeployId}/osClusterEndpoint`)

--- a/deployment/cdk/opensearch-service-migration/lib/service-stacks/traffic-replayer-stack.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/service-stacks/traffic-replayer-stack.ts
@@ -12,7 +12,7 @@ import {
     createOpenSearchServerlessIAMAccessPolicy
 } from "../common-utilities";
 import {StreamingSourceType} from "../streaming-source-type";
-import { Duration } from "aws-cdk-lib";
+import { Duration, Stack } from "aws-cdk-lib";
 import {OtelCollectorSidecar} from "./migration-otel-collector-sidecar";
 
 
@@ -54,7 +54,7 @@ export class TrafficReplayerStack extends MigrationServiceCore {
             readOnly: false,
             sourceVolume: volumeName
         }
-        const replayerOutputEFSArn = `arn:aws:elasticfilesystem:${this.region}:${this.account}:file-system/${volumeId}`
+        const replayerOutputEFSArn = `arn:${this.partition}:elasticfilesystem:${this.region}:${this.account}:file-system/${volumeId}`
         const replayerOutputMountPolicy = new PolicyStatement( {
             effect: Effect.ALLOW,
             resources: [replayerOutputEFSArn],
@@ -72,11 +72,11 @@ export class TrafficReplayerStack extends MigrationServiceCore {
                 "secretsmanager:DescribeSecret"
             ]
         })
-        const openSearchPolicy = createOpenSearchIAMAccessPolicy(this.region, this.account)
-        const openSearchServerlessPolicy = createOpenSearchServerlessIAMAccessPolicy(this.region, this.account)
+        const openSearchPolicy = createOpenSearchIAMAccessPolicy(this.partition, this.region, this.account)
+        const openSearchServerlessPolicy = createOpenSearchServerlessIAMAccessPolicy(this.partition, this.region, this.account)
         let servicePolicies = [replayerOutputMountPolicy, secretAccessPolicy, openSearchPolicy, openSearchServerlessPolicy]
         if (props.streamingSourceType === StreamingSourceType.AWS_MSK) {
-            const mskConsumerPolicies = createMSKConsumerIAMPolicies(this, this.region, this.account, props.stage, props.defaultDeployId)
+            const mskConsumerPolicies = createMSKConsumerIAMPolicies(this, this.partition, this.region, this.account, props.stage, props.defaultDeployId)
             servicePolicies = servicePolicies.concat(mskConsumerPolicies)
         }
 


### PR DESCRIPTION
### Description
We need to parameterize the partition every time we use `arn:aws` in order to support other partitions (a.k.a. gov cloud)
* Category: Enhancement
* Why these changes are required? GovCloud Support
* What is the old behavior before changes and new behavior after changes? CDK failed to deploy on gov cloud

### Issues Resolved
[MIGRATIONS-1737](https://opensearch.atlassian.net/browse/MIGRATIONS-1737)

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
Deployed to gov cloud

### Check List
- [ x] New functionality includes testing
  - [ x] All tests pass, including unit test, integration test and doctest
- [ x] New functionality has been documented
- [x ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
