### PR TITLE
[RFS] Improved RFS Worker exception logging

### DIFF
--- a/RFS/src/main/java/com/rfs/RunRfsWorker.java
+++ b/RFS/src/main/java/com/rfs/RunRfsWorker.java
@@ -2,10 +2,14 @@ package com.rfs;
 
 import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.Logger;
@@ -13,6 +17,7 @@ import org.apache.logging.log4j.LogManager;
 
 
 import com.rfs.cms.CmsClient;
+import com.rfs.cms.CmsEntry;
 import com.rfs.cms.OpenSearchCmsClient;
 import com.rfs.common.ClusterVersion;
 import com.rfs.common.ConnectionDetails;
@@ -32,7 +37,9 @@ import com.rfs.version_es_7_10.SnapshotRepoProvider_ES_7_10;
 import com.rfs.version_os_2_11.GlobalMetadataCreator_OS_2_11;
 import com.rfs.worker.GlobalState;
 import com.rfs.worker.MetadataRunner;
+import com.rfs.worker.Runner;
 import com.rfs.worker.SnapshotRunner;
+import com.rfs.worker.WorkerStep;
 
 public class RunRfsWorker {
     private static final Logger logger = LogManager.getLogger(RunRfsWorker.class);
@@ -133,9 +140,30 @@ public class RunRfsWorker {
             MetadataRunner metadataWorker = new MetadataRunner(globalState, cmsClient, snapshotName, metadataFactory, metadataCreator, transformer);
             metadataWorker.run();
             
+        } catch (Runner.PhaseFailed e) {
+            logPhaseFailureRecord(e.phase, e.nextStep, e.cmsEntry, e.e);
+            throw e;
         } catch (Exception e) {
-            logger.error("Error running RfsWorker", e);
+            logger.error("Unexpected error running RfsWorker", e);
             throw e;
         }
+    }
+
+    public static void logPhaseFailureRecord(GlobalState.Phase phase, WorkerStep nextStep, Optional<CmsEntry.Base> cmsEntry, Exception e) {
+        ObjectNode errorBlob = new ObjectMapper().createObjectNode();
+        errorBlob.put("exceptionMessage", e.getMessage());
+        errorBlob.put("exceptionClass", e.getClass().getSimpleName());
+        errorBlob.put("exceptionTrace", Arrays.toString(e.getStackTrace()));
+
+        errorBlob.put("phase", phase.toString());
+
+        String currentStep = (nextStep != null) ? nextStep.getClass().getSimpleName() : "null";
+        errorBlob.put("currentStep", currentStep);
+
+        String currentEntry = (cmsEntry.isPresent()) ? cmsEntry.toString() : "null";
+        errorBlob.put("cmsEntry", currentEntry);
+
+        
+        logger.error(errorBlob.toString());
     }
 }

--- a/RFS/src/main/java/com/rfs/cms/CmsClient.java
+++ b/RFS/src/main/java/com/rfs/cms/CmsClient.java
@@ -1,41 +1,45 @@
 package com.rfs.cms;
 
+import java.util.Optional;
+
 /*
  * Client to connect to and work with the Coordinating Metadata Store.  The CMS could be implemented by any reasonable
  * data store option (Postgres, AWS DynamoDB, Elasticsearch/Opensearch, etc).
  */
 public interface CmsClient {
     /*
-     * Creates a new entry in the CMS for the Snapshot's progress.  Returns true if we created the entry, and false if
-     * the entry already exists.
+     * Creates a new entry in the CMS for the Snapshot's progress.  Returns an Optional; if the document was created, it
+     * will be the created object and empty otherwise.
      */
-    public CmsEntry.Snapshot createSnapshotEntry(String snapshotName);
+    public Optional<CmsEntry.Snapshot> createSnapshotEntry(String snapshotName);
 
     /*
-     * Attempt to retrieve the Snapshot entry from the CMS, if it exists; null if it doesn't currently exist
+     * Attempt to retrieve the Snapshot entry from the CMS.  Returns an Optional; if the document exists, it will be the
+     * retrieved entry and empty otherwise.
      */
-    public CmsEntry.Snapshot getSnapshotEntry(String snapshotName);
+    public Optional<CmsEntry.Snapshot> getSnapshotEntry(String snapshotName);
 
     /*
-     * Updates the status of the Snapshot entry in the CMS.  Returns true if the update was successful, and false if
-     * something else updated it before we could
+     * Updates the Snapshot entry in the CMS.  Returns an Optional; if the document was updated, it will be
+     * the updated entry and empty otherwise.
      */
-    public CmsEntry.Snapshot updateSnapshotEntry(String snapshotName, CmsEntry.SnapshotStatus status);
+    public Optional<CmsEntry.Snapshot> updateSnapshotEntry(String snapshotName, CmsEntry.SnapshotStatus status);
 
     /*
-     * Creates a new entry in the CMS for the Metadata Migration's progress.  Returns the created entry if we created it,
-     * and null if the entry already exists.
+     * Creates a new entry in the CMS for the Metadata Migration's progress.  Returns an Optional; if the document was
+     * created, it will be the created entry and empty otherwise.
      */
-    public CmsEntry.Metadata createMetadataEntry();
+    public Optional<CmsEntry.Metadata> createMetadataEntry();
 
     /*
-     * Attempt to retrieve the Metadata Migration entry from the CMS, if it exists; null if it doesn't currently exist
+     * Attempt to retrieve the Metadata Migration entry from the CMS, if it exists.  Returns an Optional; if the document
+     * exists, it will be the retrieved entry and empty otherwise.
      */
-    public CmsEntry.Metadata getMetadataEntry();
+    public Optional<CmsEntry.Metadata> getMetadataEntry();
 
     /*
-     * Updates all fields of the Metadata Migration entry in the CMS.  Returns the updated entry if successful, and
-     * null if something else updated it before we could
+     * Updates the Metadata Migration entry in the CMS.  Returns an Optional; if the document was updated,
+     * it will be the updated entry and empty otherwise.
      */
-    public CmsEntry.Metadata updateMetadataEntry(CmsEntry.MetadataStatus status, String leaseExpiry, Integer numAttempts);
+    public Optional<CmsEntry.Metadata> updateMetadataEntry(CmsEntry.MetadataStatus status, String leaseExpiry, Integer numAttempts);
 }

--- a/RFS/src/main/java/com/rfs/cms/CmsClient.java
+++ b/RFS/src/main/java/com/rfs/cms/CmsClient.java
@@ -9,7 +9,7 @@ public interface CmsClient {
      * Creates a new entry in the CMS for the Snapshot's progress.  Returns true if we created the entry, and false if
      * the entry already exists.
      */
-    public boolean createSnapshotEntry(String snapshotName);
+    public CmsEntry.Snapshot createSnapshotEntry(String snapshotName);
 
     /*
      * Attempt to retrieve the Snapshot entry from the CMS, if it exists; null if it doesn't currently exist
@@ -20,13 +20,13 @@ public interface CmsClient {
      * Updates the status of the Snapshot entry in the CMS.  Returns true if the update was successful, and false if
      * something else updated it before we could
      */
-    public boolean updateSnapshotEntry(String snapshotName, CmsEntry.SnapshotStatus status);
+    public CmsEntry.Snapshot updateSnapshotEntry(String snapshotName, CmsEntry.SnapshotStatus status);
 
     /*
-     * Creates a new entry in the CMS for the Metadata Migration's progress.  Returns true if we created the entry, and
-     * false if the entry already exists.
+     * Creates a new entry in the CMS for the Metadata Migration's progress.  Returns the created entry if we created it,
+     * and null if the entry already exists.
      */
-    public boolean createMetadataEntry();
+    public CmsEntry.Metadata createMetadataEntry();
 
     /*
      * Attempt to retrieve the Metadata Migration entry from the CMS, if it exists; null if it doesn't currently exist
@@ -34,13 +34,8 @@ public interface CmsClient {
     public CmsEntry.Metadata getMetadataEntry();
 
     /*
-     * Updates just the status field of the Metadata Migration entry in the CMS.  Returns true if the update was successful,
+     * Updates all fields of the Metadata Migration entry in the CMS.  Returns the updated entry if successful, and
+     * null if something else updated it before we could
      */
-    public boolean setMetadataMigrationStatus(CmsEntry.MetadataStatus status);
-
-    /*
-     * Updates all fields of the Metadata Migration entry in the CMS.  Returns true if the update was successful, and
-     * false if something else updated it before we could
-     */
-    public boolean updateMetadataEntry(CmsEntry.MetadataStatus status, String leaseExpiry, Integer numAttempts);
+    public CmsEntry.Metadata updateMetadataEntry(CmsEntry.MetadataStatus status, String leaseExpiry, Integer numAttempts);
 }

--- a/RFS/src/main/java/com/rfs/cms/CmsEntry.java
+++ b/RFS/src/main/java/com/rfs/cms/CmsEntry.java
@@ -3,6 +3,10 @@ package com.rfs.cms;
 import com.rfs.common.RfsException;
 
 public class CmsEntry {
+    public abstract static class Base {
+        protected Base() {}
+    }
+
     public static enum SnapshotStatus {
         NOT_STARTED,
         IN_PROGRESS,
@@ -10,11 +14,12 @@ public class CmsEntry {
         FAILED,
     }
 
-    public static class Snapshot {
+    public static class Snapshot extends Base {
         public final String name;
         public final SnapshotStatus status;
 
         public Snapshot(String name, SnapshotStatus status) {
+            super();
             this.name = name;
             this.status = status;
         }
@@ -26,7 +31,7 @@ public class CmsEntry {
         FAILED,
     }
 
-    public static class Metadata {
+    public static class Metadata extends Base {
         public static final int METADATA_LEASE_MS = 1 * 60 * 1000; // 1 minute, arbitrarily chosen
         public static final int MAX_ATTEMPTS = 3; // arbitrarily chosen
 
@@ -50,6 +55,7 @@ public class CmsEntry {
         public final Integer numAttempts;
 
         public Metadata(MetadataStatus status, String leaseExpiry, int numAttempts) {
+            super();
             this.status = status;
             this.leaseExpiry = leaseExpiry;
             this.numAttempts = numAttempts;

--- a/RFS/src/main/java/com/rfs/cms/CmsEntry.java
+++ b/RFS/src/main/java/com/rfs/cms/CmsEntry.java
@@ -5,6 +5,7 @@ import com.rfs.common.RfsException;
 public class CmsEntry {
     public abstract static class Base {
         protected Base() {}
+        public abstract String toString();
     }
 
     public static enum SnapshotStatus {
@@ -22,6 +23,14 @@ public class CmsEntry {
             super();
             this.name = name;
             this.status = status;
+        }
+
+        @Override
+        public String toString() {
+            return "Snapshot("
+                + "name='" + name + ","
+                + "status=" + status +
+                ")";
         }
     }
 
@@ -59,6 +68,15 @@ public class CmsEntry {
             this.status = status;
             this.leaseExpiry = leaseExpiry;
             this.numAttempts = numAttempts;
+        }
+
+        @Override
+        public String toString() {
+            return "Metadata("
+                + "status=" + status.toString() + ","
+                + "leaseExpiry=" + leaseExpiry + ","
+                + "numAttempts=" + numAttempts.toString() +
+                ")";
         }
     }
 

--- a/RFS/src/main/java/com/rfs/cms/OpenSearchCmsClient.java
+++ b/RFS/src/main/java/com/rfs/cms/OpenSearchCmsClient.java
@@ -2,14 +2,10 @@ package com.rfs.cms;
 
 import java.net.HttpURLConnection;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.rfs.common.OpenSearchClient;
 import com.rfs.common.RestClient;
 
 public class OpenSearchCmsClient implements CmsClient {
-    private static final ObjectMapper objectMapper = new ObjectMapper();
-
     public static final String CMS_INDEX_NAME = "cms-reindex-from-snapshot";
     public static final String CMS_SNAPSHOT_DOC_ID = "snapshot_status";
     public static final String CMS_METADATA_DOC_ID = "metadata_status";
@@ -21,9 +17,14 @@ public class OpenSearchCmsClient implements CmsClient {
     }
 
     @Override
-    public boolean createSnapshotEntry(String snapshotName) {
-        ObjectNode initial = OpenSearchCmsEntry.Snapshot.getInitial(snapshotName);
-        return client.createDocument(CMS_INDEX_NAME, CMS_SNAPSHOT_DOC_ID, initial);
+    public CmsEntry.Snapshot createSnapshotEntry(String snapshotName) {
+        OpenSearchCmsEntry.Snapshot newEntry = OpenSearchCmsEntry.Snapshot.getInitial(snapshotName);
+        boolean createdEntry = client.createDocument(CMS_INDEX_NAME, CMS_SNAPSHOT_DOC_ID, newEntry.toJson());
+        if (createdEntry) {
+            return newEntry;
+        } else {
+            return null;            
+        }
     }
 
     @Override
@@ -37,15 +38,28 @@ public class OpenSearchCmsClient implements CmsClient {
     }
 
     @Override
-    public boolean updateSnapshotEntry(String snapshotName, CmsEntry.SnapshotStatus status) {
-        OpenSearchCmsEntry.Snapshot snapshot = new OpenSearchCmsEntry.Snapshot(snapshotName, status);
-        return client.updateDocument(CMS_INDEX_NAME, CMS_SNAPSHOT_DOC_ID, snapshot.toJson());
+    public CmsEntry.Snapshot updateSnapshotEntry(String snapshotName, CmsEntry.SnapshotStatus status) {
+        OpenSearchCmsEntry.Snapshot entry = new OpenSearchCmsEntry.Snapshot(snapshotName, status);
+        boolean updatedEntry = client.updateDocument(CMS_INDEX_NAME, CMS_SNAPSHOT_DOC_ID, entry.toJson());
+        if (updatedEntry) {
+            return entry;
+        } else {
+            return null;            
+        }
     }
 
     @Override
-    public boolean createMetadataEntry() {
-        ObjectNode metadataDoc = OpenSearchCmsEntry.Metadata.getInitial();
-        return client.createDocument(CMS_INDEX_NAME, CMS_METADATA_DOC_ID, metadataDoc);
+    public OpenSearchCmsEntry.Metadata createMetadataEntry() {
+        OpenSearchCmsEntry.Metadata entry = OpenSearchCmsEntry.Metadata.getInitial();
+
+        boolean docCreated = client.createDocument(CMS_INDEX_NAME, CMS_METADATA_DOC_ID, entry.toJson());
+
+        if (docCreated) {
+            return entry;
+        } else {
+            return null;
+        }
+
     }
 
     @Override
@@ -59,16 +73,17 @@ public class OpenSearchCmsClient implements CmsClient {
     }
 
     @Override
-    public boolean setMetadataMigrationStatus(CmsEntry.MetadataStatus status) {
-        ObjectNode statusUpdate = objectMapper.createObjectNode();
-        statusUpdate.put(OpenSearchCmsEntry.Metadata.FIELD_STATUS, status.toString());
-        return client.updateDocument(CMS_INDEX_NAME, CMS_METADATA_DOC_ID, statusUpdate);
-    }
-
-    @Override
-    public boolean updateMetadataEntry(CmsEntry.MetadataStatus status, String leaseExpiry, Integer numAttempts) {
+    public CmsEntry.Metadata updateMetadataEntry(CmsEntry.MetadataStatus status, String leaseExpiry, Integer numAttempts) {
         OpenSearchCmsEntry.Metadata metadata = new OpenSearchCmsEntry.Metadata(status, leaseExpiry, numAttempts);
-        return client.updateDocument(CMS_INDEX_NAME, CMS_METADATA_DOC_ID, metadata.toJson());
+
+        boolean updatedDoc = client.updateDocument(CMS_INDEX_NAME, CMS_METADATA_DOC_ID, metadata.toJson());
+
+        if (updatedDoc) {
+            return metadata;
+        } else {
+            return null;
+        }
+
     }
     
 }

--- a/RFS/src/main/java/com/rfs/cms/OpenSearchCmsClient.java
+++ b/RFS/src/main/java/com/rfs/cms/OpenSearchCmsClient.java
@@ -20,68 +20,42 @@ public class OpenSearchCmsClient implements CmsClient {
     public Optional<CmsEntry.Snapshot> createSnapshotEntry(String snapshotName) {
         OpenSearchCmsEntry.Snapshot newEntry = OpenSearchCmsEntry.Snapshot.getInitial(snapshotName);
         Optional<ObjectNode> createdEntry = client.createDocument(CMS_INDEX_NAME, CMS_SNAPSHOT_DOC_ID, newEntry.toJson());
-
-        if (createdEntry.isPresent()) {
-            return Optional.of(OpenSearchCmsEntry.Snapshot.fromJson(createdEntry.get()));
-        } else {
-            return Optional.empty();
-        }
+        return createdEntry.map(OpenSearchCmsEntry.Snapshot::fromJson);
     }
 
     @Override
     public Optional<CmsEntry.Snapshot> getSnapshotEntry(String snapshotName) {
         Optional<ObjectNode> document = client.getDocument(CMS_INDEX_NAME, CMS_SNAPSHOT_DOC_ID);
-        if (document.isEmpty()) {
-            return Optional.empty();
-        }
-
-        ObjectNode sourceNode = (ObjectNode) document.get().get("_source");
-        return Optional.of(OpenSearchCmsEntry.Snapshot.fromJson(sourceNode));
+        return document.map(doc -> (ObjectNode) doc.get("_source"))
+                       .map(OpenSearchCmsEntry.Snapshot::fromJson);
     }
 
     @Override
     public Optional<CmsEntry.Snapshot> updateSnapshotEntry(String snapshotName, CmsEntry.SnapshotStatus status) {
         OpenSearchCmsEntry.Snapshot entry = new OpenSearchCmsEntry.Snapshot(snapshotName, status);
         Optional<ObjectNode> updatedEntry = client.updateDocument(CMS_INDEX_NAME, CMS_SNAPSHOT_DOC_ID, entry.toJson());
-        if (updatedEntry.isEmpty()) {
-            return Optional.empty();
-        }
-        return Optional.of(OpenSearchCmsEntry.Snapshot.fromJson(updatedEntry.get()));
+        return updatedEntry.map(OpenSearchCmsEntry.Snapshot::fromJson);
     }
 
     @Override
     public Optional<CmsEntry.Metadata> createMetadataEntry() {
         OpenSearchCmsEntry.Metadata entry = OpenSearchCmsEntry.Metadata.getInitial();
         Optional<ObjectNode> createdEntry = client.createDocument(CMS_INDEX_NAME, CMS_METADATA_DOC_ID, entry.toJson());
-
-        if (createdEntry.isEmpty()) {
-            return Optional.empty();
-        }
-        return Optional.of(OpenSearchCmsEntry.Metadata.fromJson(createdEntry.get()));
+        return createdEntry.map(OpenSearchCmsEntry.Metadata::fromJson);
 
     }
 
     @Override
     public Optional<CmsEntry.Metadata> getMetadataEntry() {
         Optional<ObjectNode> document = client.getDocument(CMS_INDEX_NAME, CMS_METADATA_DOC_ID);
-
-        if (document.isEmpty()) {
-            return Optional.empty();
-        }
-
-        ObjectNode sourceNode = (ObjectNode) document.get().get("_source");
-        return Optional.of(OpenSearchCmsEntry.Metadata.fromJson(sourceNode));
+        return document.map(doc -> (ObjectNode) doc.get("_source"))
+                       .map(OpenSearchCmsEntry.Metadata::fromJson);
     }
 
     @Override
     public Optional<CmsEntry.Metadata> updateMetadataEntry(CmsEntry.MetadataStatus status, String leaseExpiry, Integer numAttempts) {
         OpenSearchCmsEntry.Metadata metadata = new OpenSearchCmsEntry.Metadata(status, leaseExpiry, numAttempts);
         Optional<ObjectNode> updatedEntry = client.updateDocument(CMS_INDEX_NAME, CMS_METADATA_DOC_ID, metadata.toJson());
-
-        if (updatedEntry.isEmpty()) {
-            return Optional.empty();
-        }
-        return Optional.of(OpenSearchCmsEntry.Metadata.fromJson(updatedEntry.get()));
-    }
-    
+        return updatedEntry.map(OpenSearchCmsEntry.Metadata::fromJson);
+    }    
 }

--- a/RFS/src/main/java/com/rfs/cms/OpenSearchCmsEntry.java
+++ b/RFS/src/main/java/com/rfs/cms/OpenSearchCmsEntry.java
@@ -41,6 +41,11 @@ public class OpenSearchCmsEntry {
             node.put(FIELD_STATUS, status.toString());
             return node;
         }
+
+        @Override
+        public String toString() {
+            return this.toJson().toString();
+        }
     }
 
     public static class Metadata extends CmsEntry.Metadata {
@@ -83,6 +88,11 @@ public class OpenSearchCmsEntry {
             node.put(FIELD_LEASE_EXPIRY, leaseExpiry);
             node.put(FIELD_NUM_ATTEMPTS, numAttempts);
             return node;
+        }
+
+        @Override
+        public String toString() {
+            return this.toJson().toString();
         }
     }
 

--- a/RFS/src/main/java/com/rfs/cms/OpenSearchCmsEntry.java
+++ b/RFS/src/main/java/com/rfs/cms/OpenSearchCmsEntry.java
@@ -17,17 +17,14 @@ public class OpenSearchCmsEntry {
             return new Snapshot(name, CmsEntry.SnapshotStatus.NOT_STARTED);
         }
 
-        public static Snapshot fromJsonString(String json) {
+        public static Snapshot fromJson(ObjectNode node) {
             try {
-                ObjectNode node = objectMapper.readValue(json, ObjectNode.class);
-                ObjectNode sourceNode = (ObjectNode) node.get("_source");
-
                 return new Snapshot(
-                    sourceNode.get(FIELD_STATUS).asText(),
-                    CmsEntry.SnapshotStatus.valueOf(sourceNode.get(FIELD_STATUS).asText())
+                    node.get(FIELD_STATUS).asText(),
+                    CmsEntry.SnapshotStatus.valueOf(node.get(FIELD_STATUS).asText())
                 );
             } catch (Exception e) {
-                throw new CantParseCmsEntryFromJson(Snapshot.class, json, e);
+                throw new CantParseCmsEntryFromJson(Snapshot.class, node.toString(), e);
             }
         }
 
@@ -63,18 +60,15 @@ public class OpenSearchCmsEntry {
             );
         }
 
-        public static Metadata fromJsonString(String json) {
+        public static Metadata fromJson(ObjectNode node) {
             try {
-                ObjectNode node = objectMapper.readValue(json, ObjectNode.class);
-                ObjectNode sourceNode = (ObjectNode) node.get("_source");
-
                 return new Metadata(
-                    CmsEntry.MetadataStatus.valueOf(sourceNode.get(FIELD_STATUS).asText()),
-                    sourceNode.get(FIELD_LEASE_EXPIRY).asText(),
-                    sourceNode.get(FIELD_NUM_ATTEMPTS).asInt()
+                    CmsEntry.MetadataStatus.valueOf(node.get(FIELD_STATUS).asText()),
+                    node.get(FIELD_LEASE_EXPIRY).asText(),
+                    node.get(FIELD_NUM_ATTEMPTS).asInt()
                 );
             } catch (Exception e) {
-                throw new CantParseCmsEntryFromJson(Metadata.class, json, e);
+                throw new CantParseCmsEntryFromJson(Metadata.class, node.toString(), e);
             }
         }
 

--- a/RFS/src/main/java/com/rfs/cms/OpenSearchCmsEntry.java
+++ b/RFS/src/main/java/com/rfs/cms/OpenSearchCmsEntry.java
@@ -13,11 +13,8 @@ public class OpenSearchCmsEntry {
         public static final String FIELD_NAME = "name";
         public static final String FIELD_STATUS = "status";
 
-        public static ObjectNode getInitial(String name) {
-            ObjectNode node = objectMapper.createObjectNode();
-            node.put(FIELD_STATUS, name);
-            node.put(FIELD_STATUS, CmsEntry.SnapshotStatus.NOT_STARTED.toString());
-            return node;
+        public static Snapshot getInitial(String name) {
+            return new Snapshot(name, CmsEntry.SnapshotStatus.NOT_STARTED);
         }
 
         public static Snapshot fromJsonString(String json) {
@@ -51,16 +48,14 @@ public class OpenSearchCmsEntry {
         public static final String FIELD_LEASE_EXPIRY = "leaseExpiry";
         public static final String FIELD_NUM_ATTEMPTS = "numAttempts";
 
-        public static ObjectNode getInitial() {
-            ObjectNode metadataDoc = objectMapper.createObjectNode();
-            metadataDoc.put(FIELD_STATUS, CmsEntry.MetadataStatus.IN_PROGRESS.toString());
-            metadataDoc.put(FIELD_NUM_ATTEMPTS, 1);
-
-            // TODO: We should be ideally setting the lease using the server's clock, but it's unclear on the best way
-            // to do this.  For now, we'll just use the client's clock.
-            metadataDoc.put(FIELD_LEASE_EXPIRY, CmsEntry.Metadata.getLeaseExpiry(Instant.now().toEpochMilli(), 1));
-
-            return metadataDoc;
+        public static Metadata getInitial() {
+            return new Metadata(
+                CmsEntry.MetadataStatus.IN_PROGRESS,
+                // TODO: We should be ideally setting the lease using the server's clock, but it's unclear on the best way
+                // to do this.  For now, we'll just use the client's clock.
+                CmsEntry.Metadata.getLeaseExpiry(Instant.now().toEpochMilli(), 1),
+                1
+            );
         }
 
         public static Metadata fromJsonString(String json) {

--- a/RFS/src/main/java/com/rfs/common/OpenSearchClient.java
+++ b/RFS/src/main/java/com/rfs/common/OpenSearchClient.java
@@ -122,7 +122,7 @@ public class OpenSearchClient {
         String targetPath = "_snapshot/" + repoName + "/" + snapshotName;
         return client.getAsync(targetPath)
             .flatMap(resp -> {
-                if (resp.code == HttpURLConnection.HTTP_OK) {
+                if (resp.code == HttpURLConnection.HTTP_OK || resp.code == HttpURLConnection.HTTP_NOT_FOUND) {
                     return Mono.just(resp);
                 } else {
                     String errorMessage = "Could get status of snapshot: " + targetPath + ". Response Code: " + resp.code + ", Response Body: " + resp.body;

--- a/RFS/src/main/java/com/rfs/worker/GlobalState.java
+++ b/RFS/src/main/java/com/rfs/worker/GlobalState.java
@@ -8,7 +8,7 @@ import java.util.concurrent.atomic.AtomicReference;
 public class GlobalState {
     private static final AtomicReference<GlobalState> instance = new AtomicReference<>();
 
-    enum Phase {
+    public enum Phase {
         UNSET,
         SNAPSHOT_IN_PROGRESS,
         SNAPSHOT_COMPLETED,

--- a/RFS/src/main/java/com/rfs/worker/MetadataRunner.java
+++ b/RFS/src/main/java/com/rfs/worker/MetadataRunner.java
@@ -1,9 +1,13 @@
 package com.rfs.worker;
 
 import org.apache.logging.log4j.Logger;
+
+import java.util.Optional;
+
 import org.apache.logging.log4j.LogManager;
 
 import com.rfs.cms.CmsClient;
+import com.rfs.cms.CmsEntry;
 import com.rfs.cms.CmsEntry.Metadata;
 import com.rfs.cms.CmsEntry.MetadataStatus;
 import com.rfs.common.GlobalMetadata;
@@ -24,9 +28,9 @@ public class MetadataRunner implements Runner {
         WorkerStep nextStep = null;
         try {
             logger.info("Checking if work remains in the Metadata Phase...");
-            Metadata metadataEntry = members.cmsClient.getMetadataEntry();
+            Optional<Metadata> metadataEntry = members.cmsClient.getMetadataEntry();
             
-            if (metadataEntry == null || metadataEntry.status != MetadataStatus.COMPLETED) {
+            if (metadataEntry.isEmpty() || metadataEntry.get().status != MetadataStatus.COMPLETED) {
                 nextStep = new MetadataStep.EnterPhase(members);
 
                 while (nextStep != null) {
@@ -42,7 +46,7 @@ public class MetadataRunner implements Runner {
                 getPhaseFailureRecord(
                     members.globalState.getPhase(), 
                     nextStep, 
-                    members.cmsEntry, 
+                    members.cmsEntry.map(bar -> (CmsEntry.Base) bar), 
                     e
                 ).toString()
             );

--- a/RFS/src/main/java/com/rfs/worker/MetadataStep.java
+++ b/RFS/src/main/java/com/rfs/worker/MetadataStep.java
@@ -40,10 +40,9 @@ public class MetadataStep {
         // A convient way to check if the CMS entry is present before retrieving it.  In some places, it's fine/expected
         // for the CMS entry to be missing, but in others, it's a problem.
         public CmsEntry.Metadata getCmsEntryNotMissing() {
-            if (cmsEntry.isEmpty()) {
-                throw new MissingMigrationEntry("The Metadata Migration CMS entry we expected to be stored in local memory was null");
-            }
-            return cmsEntry.get();
+            return cmsEntry.orElseThrow(
+                () -> new MissingMigrationEntry("The Metadata Migration CMS entry we expected to be stored in local memory was empty")
+            );
         }
     }
 

--- a/RFS/src/main/java/com/rfs/worker/MetadataStep.java
+++ b/RFS/src/main/java/com/rfs/worker/MetadataStep.java
@@ -23,6 +23,7 @@ public class MetadataStep {
         protected final GlobalMetadata.Factory metadataFactory;
         protected final GlobalMetadataCreator_OS_2_11 metadataCreator;
         protected final Transformer transformer;
+        protected CmsEntry.Metadata cmsEntry;
 
         public SharedMembers(GlobalState globalState, CmsClient cmsClient, String snapshotName, GlobalMetadata.Factory metadataFactory,
                 GlobalMetadataCreator_OS_2_11 metadataCreator, Transformer transformer) {
@@ -32,6 +33,16 @@ public class MetadataStep {
             this.metadataFactory = metadataFactory;
             this.metadataCreator = metadataCreator;
             this.transformer = transformer;
+            this.cmsEntry = null;
+        }
+
+        // A convient way to check if the CMS entry is null before retrieving it.  In some places, it's fine/expected
+        // for the CMS entry to be null, but in others, it's a problem.
+        public CmsEntry.Metadata getCmsEntryNotNull() {
+            if (cmsEntry == null) {
+                throw new MissingMigrationEntry("The Metadata Migration CMS entry we expected to be stored in local memory was null");
+            }
+            return cmsEntry;
         }
     }
 
@@ -74,7 +85,6 @@ public class MetadataStep {
      * Gets the current Metadata Migration entry from the CMS, if it exists
      */
     public static class GetEntry extends Base {
-        private CmsEntry.Metadata metadataEntry;
 
         public GetEntry(SharedMembers members) {
             super(members);
@@ -83,30 +93,30 @@ public class MetadataStep {
         @Override
         public void run() {
             logger.info("Pulling the Metadata Migration entry from the CMS, if it exists...");
-            this.metadataEntry = members.cmsClient.getMetadataEntry();
+            members.cmsEntry = members.cmsClient.getMetadataEntry();
         }
 
         @Override
         public WorkerStep nextStep() {
-            if (metadataEntry == null) {
+            if (members.cmsEntry == null) {
                 return new CreateEntry(members);
             } else {
-                switch (metadataEntry.status) {
+                switch (members.cmsEntry.status) {
                     case IN_PROGRESS:
                         // TODO: This uses the client-side clock to evaluate the lease expiration, when we should
                         // ideally be using the server-side clock.  Consider this a temporary solution until we find
                         // out how to use the server-side clock.
-                        long leaseExpiryMillis = Long.parseLong(metadataEntry.leaseExpiry);
+                        long leaseExpiryMillis = Long.parseLong(members.cmsEntry.leaseExpiry);
                         Instant leaseExpiryInstant = Instant.ofEpochMilli(leaseExpiryMillis);
                         boolean leaseExpired = leaseExpiryInstant.isBefore(Instant.now());
 
                         // Don't try to acquire the lease if we're already at the max number of attempts
-                        if (metadataEntry.numAttempts >= CmsEntry.Metadata.MAX_ATTEMPTS && leaseExpired) {
+                        if (members.cmsEntry.numAttempts >= CmsEntry.Metadata.MAX_ATTEMPTS && leaseExpired) {
                             return new ExitPhaseFailed(members, new MaxAttemptsExceeded());
                         }
 
                         if (leaseExpired) {
-                            return new AcquireLease(members, metadataEntry);
+                            return new AcquireLease(members);
                         } 
                         
                         logger.info("Metadata Migration entry found, but there's already a valid work lease on it");
@@ -116,14 +126,13 @@ public class MetadataStep {
                     case FAILED:
                         return new ExitPhaseFailed(members, new FoundFailedMetadataMigration());
                     default:
-                        throw new IllegalStateException("Unexpected metadata migration status: " + metadataEntry.status);
+                        throw new IllegalStateException("Unexpected metadata migration status: " + members.cmsEntry.status);
                 }
             }
         }
     }
 
     public static class CreateEntry extends Base {
-        private boolean createdEntry;
 
         public CreateEntry(SharedMembers members) {
             super(members);
@@ -132,13 +141,13 @@ public class MetadataStep {
         @Override
         public void run() {
             logger.info("Metadata Migration CMS Entry not found, attempting to create it...");
-            this.createdEntry = members.cmsClient.createMetadataEntry();
+            members.cmsEntry = members.cmsClient.createMetadataEntry();
             logger.info("Metadata Migration CMS Entry created");
         }
 
         @Override
         public WorkerStep nextStep() {
-            if (createdEntry) {
+            if (members.cmsEntry != null) {
                 return new MigrateTemplates(members);
             } else {
                 return new GetEntry(members);
@@ -147,12 +156,9 @@ public class MetadataStep {
     }
 
     public static class AcquireLease extends Base {
-        private final CmsEntry.Metadata existingEntry;
-        private boolean acquiredLease;
 
-        public AcquireLease(SharedMembers members, CmsEntry.Metadata existingEntry) {
+        public AcquireLease(SharedMembers members) {
             super(members);
-            this.existingEntry = existingEntry;
         }
 
         protected long getNowMs() {
@@ -161,16 +167,20 @@ public class MetadataStep {
 
         @Override
         public void run() {
+            // We only get here if we know we want to acquire the lock, so we know the CMS entry should not be null
+            CmsEntry.Metadata currentCmsEntry = members.getCmsEntryNotNull();
+
             logger.info("Current Metadata Migration work lease appears to have expired; attempting to acquire it...");
 
-            // TODO: Should be using the server-side clock here
-            this.acquiredLease = members.cmsClient.updateMetadataEntry(
+            // Set the next CMS entry based on the current one
+            members.cmsEntry = members.cmsClient.updateMetadataEntry(
                 CmsEntry.MetadataStatus.IN_PROGRESS,
-                CmsEntry.Metadata.getLeaseExpiry(getNowMs(), existingEntry.numAttempts + 1),
-                existingEntry.numAttempts + 1
+                // TODO: Should be using the server-side clock here
+                CmsEntry.Metadata.getLeaseExpiry(getNowMs(), currentCmsEntry.numAttempts + 1),
+                currentCmsEntry.numAttempts + 1
             );
 
-            if (acquiredLease) {
+            if (members.cmsEntry != null) {
                 logger.info("Lease acquired");
             } else {
                 logger.info("Failed to acquire lease");
@@ -179,7 +189,7 @@ public class MetadataStep {
 
         @Override
         public WorkerStep nextStep() {
-            if (acquiredLease) {
+            if (members.cmsEntry != null) {
                 return new MigrateTemplates(members);
             } else {
                 return new RandomWait(members);
@@ -188,7 +198,6 @@ public class MetadataStep {
     }
 
     public static class MigrateTemplates extends Base {
-        private boolean updatedEntry = false;
 
         public MigrateTemplates(SharedMembers members) {
             super(members);
@@ -196,6 +205,9 @@ public class MetadataStep {
 
         @Override
         public void run() {
+            // We only get here if we acquired the lock, so we know the CMS entry should not be null
+            CmsEntry.Metadata currentCmsEntry = members.getCmsEntryNotNull();
+
             logger.info("Setting the worker's current work item to be the Metadata Migration...");
             members.globalState.updateWorkItem(new OpenSearchWorkItem(OpenSearchCmsClient.CMS_INDEX_NAME, OpenSearchCmsClient.CMS_METADATA_DOC_ID));
             logger.info("Work item set");
@@ -208,7 +220,11 @@ public class MetadataStep {
             logger.info("Templates migration complete");
 
             logger.info("Updating the Metadata Migration entry to indicate completion...");
-            updatedEntry = members.cmsClient.setMetadataMigrationStatus(CmsEntry.MetadataStatus.COMPLETED);
+            members.cmsEntry = members.cmsClient.updateMetadataEntry(
+                CmsEntry.MetadataStatus.COMPLETED,
+                currentCmsEntry.leaseExpiry,
+                currentCmsEntry.numAttempts
+            );
             logger.info("Metadata Migration entry updated");
 
             logger.info("Clearing the worker's current work item...");
@@ -218,7 +234,7 @@ public class MetadataStep {
 
         @Override
         public WorkerStep nextStep() {
-            if (!updatedEntry) {
+            if (members.cmsEntry == null) {
                 // In this scenario, we've done all the work, but failed to update the CMS entry so that we know we've
                 // done the work.  We circle back around to try again, which is made more reasonable by the fact we
                 // don't re-migrate templates that already exist on the target cluster.  If we didn't circle back
@@ -267,9 +283,8 @@ public class MetadataStep {
 
         @Override
         public void run() {
-            members.cmsClient.setMetadataMigrationStatus(CmsEntry.MetadataStatus.COMPLETED);
-            members.globalState.updatePhase(GlobalState.Phase.METADATA_COMPLETED);
             logger.info("Metadata Migration completed, exiting Metadata Phase...");
+            members.globalState.updatePhase(GlobalState.Phase.METADATA_COMPLETED);
         }
 
         @Override
@@ -288,14 +303,29 @@ public class MetadataStep {
 
         @Override
         public void run() {
+            // We either failed the Metadata Migration or found it had already been failed; either way this
+            // should not be null
+            CmsEntry.Metadata currentCmsEntry = members.getCmsEntryNotNull();
+
             logger.error("Metadata Migration failed");
-            members.cmsClient.setMetadataMigrationStatus(CmsEntry.MetadataStatus.FAILED);
+            members.cmsClient.updateMetadataEntry(
+                CmsEntry.MetadataStatus.FAILED,
+                currentCmsEntry.leaseExpiry,
+                currentCmsEntry.numAttempts
+            );
             members.globalState.updatePhase(GlobalState.Phase.METADATA_FAILED);
         }
 
         @Override
         public WorkerStep nextStep() {
             throw e;
+        }
+    }
+    public static class MissingMigrationEntry extends RfsException {
+        public MissingMigrationEntry(String message) {
+            super("The Metadata Migration CMS entry we expected to be stored in local memory was null."
+                + "  This should never happen."
+            );
         }
     }
 

--- a/RFS/src/main/java/com/rfs/worker/MetadataStep.java
+++ b/RFS/src/main/java/com/rfs/worker/MetadataStep.java
@@ -147,6 +147,7 @@ public class MetadataStep {
 
         @Override
         public WorkerStep nextStep() {
+            // Migrate the templates if we successfully created the CMS entry; otherwise, circle back to the beginning
             if (members.cmsEntry != null) {
                 return new MigrateTemplates(members);
             } else {
@@ -189,6 +190,7 @@ public class MetadataStep {
 
         @Override
         public WorkerStep nextStep() {
+            // Migrate the templates if we acquired the lease; otherwise, circle back to the beginning after a backoff
             if (members.cmsEntry != null) {
                 return new MigrateTemplates(members);
             } else {

--- a/RFS/src/main/java/com/rfs/worker/Runner.java
+++ b/RFS/src/main/java/com/rfs/worker/Runner.java
@@ -1,6 +1,7 @@
 package com.rfs.worker;
 
 import java.util.Arrays;
+import java.util.Optional;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -9,7 +10,7 @@ import com.rfs.cms.CmsEntry;
 public abstract interface Runner {
     public abstract void run();
 
-    default ObjectNode getPhaseFailureRecord(GlobalState.Phase phase, WorkerStep nextStep, CmsEntry.Base cmsEntry, Exception e) {
+    default ObjectNode getPhaseFailureRecord(GlobalState.Phase phase, WorkerStep nextStep, Optional<CmsEntry.Base> cmsEntry, Exception e) {
         ObjectNode errorBlob = new ObjectMapper().createObjectNode();
         errorBlob.put("exceptionMessage", e.getMessage());
         errorBlob.put("exceptionClass", e.getClass().getSimpleName());
@@ -20,7 +21,7 @@ public abstract interface Runner {
         String currentStep = (nextStep != null) ? nextStep.getClass().getSimpleName() : "null";
         errorBlob.put("currentStep", currentStep);
 
-        String currentEntry = (cmsEntry != null) ? cmsEntry.toString() : "null";
+        String currentEntry = (cmsEntry.isPresent()) ? cmsEntry.toString() : "null";
         errorBlob.put("cmsEntry", currentEntry);
         return errorBlob;
     }

--- a/RFS/src/main/java/com/rfs/worker/Runner.java
+++ b/RFS/src/main/java/com/rfs/worker/Runner.java
@@ -1,0 +1,27 @@
+package com.rfs.worker;
+
+import java.util.Arrays;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.rfs.cms.CmsEntry;
+
+public abstract interface Runner {
+    public abstract void run();
+
+    default ObjectNode getPhaseFailureRecord(GlobalState.Phase phase, WorkerStep nextStep, CmsEntry.Base cmsEntry, Exception e) {
+        ObjectNode errorBlob = new ObjectMapper().createObjectNode();
+        errorBlob.put("exceptionMessage", e.getMessage());
+        errorBlob.put("exceptionClass", e.getClass().getSimpleName());
+        errorBlob.put("exceptionTrace", Arrays.toString(e.getStackTrace()));
+
+        errorBlob.put("phase", phase.toString());
+
+        String currentStep = (nextStep != null) ? nextStep.getClass().getSimpleName() : "null";
+        errorBlob.put("currentStep", currentStep);
+
+        String currentEntry = (cmsEntry != null) ? cmsEntry.toString() : "null";
+        errorBlob.put("cmsEntry", currentEntry);
+        return errorBlob;
+    }
+}

--- a/RFS/src/main/java/com/rfs/worker/Runner.java
+++ b/RFS/src/main/java/com/rfs/worker/Runner.java
@@ -1,28 +1,44 @@
 package com.rfs.worker;
 
+import org.apache.logging.log4j.Logger;
+
 import java.util.Arrays;
 import java.util.Optional;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.rfs.cms.CmsEntry;
+import com.rfs.common.RfsException;
 
 public abstract interface Runner {
-    public abstract void run();
+    abstract void runInternal();
+    abstract String getPhaseName();
+    abstract Logger getLogger();
 
-    default ObjectNode getPhaseFailureRecord(GlobalState.Phase phase, WorkerStep nextStep, Optional<CmsEntry.Base> cmsEntry, Exception e) {
-        ObjectNode errorBlob = new ObjectMapper().createObjectNode();
-        errorBlob.put("exceptionMessage", e.getMessage());
-        errorBlob.put("exceptionClass", e.getClass().getSimpleName());
-        errorBlob.put("exceptionTrace", Arrays.toString(e.getStackTrace()));
+    default void run() {
+        try {
+            getLogger().info("Checking if work remains in the " + getPhaseName() +" Phase...");
+            runInternal();
+            getLogger().info(getPhaseName() + " Phase is complete");
+        } catch (Exception e) {
+            getLogger().error(getPhaseName() + " Phase failed w/ an exception");
 
-        errorBlob.put("phase", phase.toString());
+            throw e;
+        }
+    }
 
-        String currentStep = (nextStep != null) ? nextStep.getClass().getSimpleName() : "null";
-        errorBlob.put("currentStep", currentStep);
+    public static class PhaseFailed extends RfsException {
+        public final GlobalState.Phase phase;
+        public final WorkerStep nextStep;
+        public final Optional<CmsEntry.Base> cmsEntry;
+        public final Exception e;
 
-        String currentEntry = (cmsEntry.isPresent()) ? cmsEntry.toString() : "null";
-        errorBlob.put("cmsEntry", currentEntry);
-        return errorBlob;
+        public PhaseFailed(String message, GlobalState.Phase phase, WorkerStep nextStep, Optional<CmsEntry.Base> cmsEntry, Exception e) {
+            super(message);
+            this.phase = phase;
+            this.nextStep = nextStep;
+            this.cmsEntry = cmsEntry;
+            this.e = e;
+        }
     }
 }

--- a/RFS/src/main/java/com/rfs/worker/Runner.java
+++ b/RFS/src/main/java/com/rfs/worker/Runner.java
@@ -2,11 +2,8 @@ package com.rfs.worker;
 
 import org.apache.logging.log4j.Logger;
 
-import java.util.Arrays;
 import java.util.Optional;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.rfs.cms.CmsEntry;
 import com.rfs.common.RfsException;
 

--- a/RFS/src/main/java/com/rfs/worker/SnapshotRunner.java
+++ b/RFS/src/main/java/com/rfs/worker/SnapshotRunner.java
@@ -1,9 +1,13 @@
 package com.rfs.worker;
 
 import org.apache.logging.log4j.Logger;
+
+import java.util.Optional;
+
 import org.apache.logging.log4j.LogManager;
 
 import com.rfs.cms.CmsClient;
+import com.rfs.cms.CmsEntry;
 import com.rfs.cms.CmsEntry.Snapshot;
 import com.rfs.cms.CmsEntry.SnapshotStatus;
 import com.rfs.common.SnapshotCreator;
@@ -22,9 +26,9 @@ public class SnapshotRunner implements Runner {
 
         try {
             logger.info("Checking if work remains in the Snapshot Phase...");
-            Snapshot snapshotEntry = members.cmsClient.getSnapshotEntry(members.snapshotCreator.getSnapshotName());
+            Optional<Snapshot> snapshotEntry = members.cmsClient.getSnapshotEntry(members.snapshotCreator.getSnapshotName());
             
-            if (snapshotEntry == null || snapshotEntry.status != SnapshotStatus.COMPLETED) {
+            if (snapshotEntry.isEmpty() || snapshotEntry.get().status != SnapshotStatus.COMPLETED) {
                 nextStep = new SnapshotStep.EnterPhase(members, snapshotEntry);
 
                 while (nextStep != null) {
@@ -40,7 +44,7 @@ public class SnapshotRunner implements Runner {
                 getPhaseFailureRecord(
                     members.globalState.getPhase(), 
                     nextStep, 
-                    members.cmsEntry, 
+                    members.cmsEntry.map(bar -> (CmsEntry.Base) bar), 
                     e
                 ).toString()
             );

--- a/RFS/src/main/java/com/rfs/worker/SnapshotRunner.java
+++ b/RFS/src/main/java/com/rfs/worker/SnapshotRunner.java
@@ -25,7 +25,8 @@ public class SnapshotRunner {
         Snapshot snapshotEntry = cmsClient.getSnapshotEntry(snapshotCreator.getSnapshotName());
         
         if (snapshotEntry == null || snapshotEntry.status != SnapshotStatus.COMPLETED) {
-            WorkerStep nextState = new SnapshotStep.EnterPhase(globalState, cmsClient, snapshotCreator, snapshotEntry);
+            SnapshotStep.SharedMembers sharedMembers = new SnapshotStep.SharedMembers(globalState, cmsClient, snapshotCreator);
+            WorkerStep nextState = new SnapshotStep.EnterPhase(sharedMembers, snapshotEntry);
 
             while (nextState != null) {
                 nextState.run();

--- a/RFS/src/main/java/com/rfs/worker/SnapshotStep.java
+++ b/RFS/src/main/java/com/rfs/worker/SnapshotStep.java
@@ -11,16 +11,26 @@ import com.rfs.common.SnapshotCreator.SnapshotCreationFailed;
 
 
 public class SnapshotStep {
-    public static abstract class Base implements WorkerStep {
-        protected final Logger logger = LogManager.getLogger(getClass());
+    public static class SharedMembers {
         protected final CmsClient cmsClient;
         protected final GlobalState globalState;
         protected final SnapshotCreator snapshotCreator;
-    
-        public Base(GlobalState globalState, CmsClient cmsClient, SnapshotCreator snapshotCreator) {
+        protected CmsEntry.Snapshot cmsEntry;
+
+        public SharedMembers(GlobalState globalState, CmsClient cmsClient, SnapshotCreator snapshotCreator) {
             this.globalState = globalState;
             this.cmsClient = cmsClient;
             this.snapshotCreator = snapshotCreator;
+            this.cmsEntry = null;
+        }
+    }
+
+    public static abstract class Base implements WorkerStep {
+        protected final Logger logger = LogManager.getLogger(getClass());
+        protected final SharedMembers members;
+    
+        public Base(SharedMembers members) {
+            this.members = members;
         }
     
         @Override
@@ -34,31 +44,30 @@ public class SnapshotStep {
      * Updates the Worker's phase to indicate we're doing work on a Snapshot
      */
     public static class EnterPhase extends Base {
-        private final CmsEntry.Snapshot snapshotEntry;
 
-        public EnterPhase(GlobalState globalState, CmsClient cmsClient, SnapshotCreator snapshotCreator, CmsEntry.Snapshot snapshotEntry) {
-            super(globalState, cmsClient, snapshotCreator);
-            this.snapshotEntry = snapshotEntry;
+        public EnterPhase(SharedMembers members, CmsEntry.Snapshot currentEntry) {
+            super(members);
+            this.members.cmsEntry = currentEntry;
         }
 
         @Override
         public void run() {
             logger.info("Snapshot not yet completed, entering Snapshot Phase...");
-            globalState.updatePhase(GlobalState.Phase.SNAPSHOT_IN_PROGRESS);
+            members.globalState.updatePhase(GlobalState.Phase.SNAPSHOT_IN_PROGRESS);
         }
 
         @Override
         public WorkerStep nextStep() {
-            if (snapshotEntry == null) {
-                return new CreateEntry(globalState, cmsClient, snapshotCreator);
+            if (members.cmsEntry == null) {
+                return new CreateEntry(members);
             } else {
-                switch (snapshotEntry.status) {
+                switch (members.cmsEntry.status) {
                     case NOT_STARTED:
-                        return new InitiateSnapshot(globalState, cmsClient, snapshotCreator);
+                        return new InitiateSnapshot(members);
                     case IN_PROGRESS:
-                        return new WaitForSnapshot(globalState, cmsClient, snapshotCreator);
+                        return new WaitForSnapshot(members);
                     default:
-                        throw new IllegalStateException("Unexpected snapshot status: " + snapshotEntry.status);
+                        throw new IllegalStateException("Unexpected snapshot status: " + members.cmsEntry.status);
                 }
             }
         }
@@ -68,20 +77,20 @@ public class SnapshotStep {
      * Idempotently create a CMS Entry for the Snapshot
      */
     public static class CreateEntry extends Base {
-        public CreateEntry(GlobalState globalState, CmsClient cmsClient, SnapshotCreator snapshotCreator) {
-            super(globalState, cmsClient, snapshotCreator);
+        public CreateEntry(SharedMembers members) {
+            super(members);
         }
 
         @Override
         public void run() {
             logger.info("Snapshot CMS Entry not found, attempting to create it...");
-            cmsClient.createSnapshotEntry(snapshotCreator.getSnapshotName());
+            members.cmsClient.createSnapshotEntry(members.snapshotCreator.getSnapshotName());
             logger.info("Snapshot CMS Entry created");
         }
 
         @Override
         public WorkerStep nextStep() {
-            return new InitiateSnapshot(globalState, cmsClient, snapshotCreator);
+            return new InitiateSnapshot(members);
         }
     }
 
@@ -89,23 +98,23 @@ public class SnapshotStep {
      * Idempotently initiate the Snapshot creation process
      */
     public static class InitiateSnapshot extends Base {
-        public InitiateSnapshot(GlobalState globalState, CmsClient cmsClient, SnapshotCreator snapshotCreator) {
-            super(globalState, cmsClient, snapshotCreator);
+        public InitiateSnapshot(SharedMembers members) {
+            super(members);
         }
 
         @Override
         public void run() {
             logger.info("Attempting to initiate the snapshot...");
-            snapshotCreator.registerRepo();
-            snapshotCreator.createSnapshot();
+            members.snapshotCreator.registerRepo();
+            members.snapshotCreator.createSnapshot();
 
             logger.info("Snapshot in progress...");
-            cmsClient.updateSnapshotEntry(snapshotCreator.getSnapshotName(), SnapshotStatus.IN_PROGRESS);
+            members.cmsClient.updateSnapshotEntry(members.snapshotCreator.getSnapshotName(), SnapshotStatus.IN_PROGRESS);
         }
 
         @Override
         public WorkerStep nextStep() {
-            return new WaitForSnapshot(globalState, cmsClient, snapshotCreator);
+            return new WaitForSnapshot(members);
         }
     }
 
@@ -115,8 +124,8 @@ public class SnapshotStep {
     public static class WaitForSnapshot extends Base {
         private SnapshotCreationFailed e = null;
 
-        public WaitForSnapshot(GlobalState globalState, CmsClient cmsClient, SnapshotCreator snapshotCreator) {
-            super(globalState, cmsClient, snapshotCreator);
+        public WaitForSnapshot(SharedMembers members) {
+            super(members);
         }
 
         protected void waitABit() throws InterruptedException {
@@ -127,12 +136,12 @@ public class SnapshotStep {
         @Override
         public void run() {
             try{
-                while (!snapshotCreator.isSnapshotFinished()) {
+                while (!members.snapshotCreator.isSnapshotFinished()) {
                     waitABit();
                 }
             } catch (InterruptedException e) {
                 logger.error("Interrupted while waiting for Snapshot to complete", e);
-                throw new SnapshotCreationFailed(snapshotCreator.getSnapshotName());
+                throw new SnapshotCreationFailed(members.snapshotCreator.getSnapshotName());
             } catch (SnapshotCreationFailed e) {
                 this.e = e;
             } 
@@ -141,9 +150,9 @@ public class SnapshotStep {
         @Override
         public WorkerStep nextStep() {
             if (e == null) {
-                return new ExitPhaseSuccess(globalState, cmsClient, snapshotCreator);                
+                return new ExitPhaseSuccess(members);                
             } else {
-                return new ExitPhaseSnapshotFailed(globalState, cmsClient, snapshotCreator, e);
+                return new ExitPhaseSnapshotFailed(members, e);
             }
         }
     }
@@ -152,14 +161,14 @@ public class SnapshotStep {
      * Update the CMS Entry and the Worker's phase to indicate the Snapshot completed successfully
      */
     public static class ExitPhaseSuccess extends Base {
-        public ExitPhaseSuccess(GlobalState globalState, CmsClient cmsClient, SnapshotCreator snapshotCreator) {
-            super(globalState, cmsClient, snapshotCreator);
+        public ExitPhaseSuccess(SharedMembers members) {
+            super(members);
         }
 
         @Override
         public void run() {
-            cmsClient.updateSnapshotEntry(snapshotCreator.getSnapshotName(), SnapshotStatus.COMPLETED);
-            globalState.updatePhase(GlobalState.Phase.SNAPSHOT_COMPLETED);
+            members.cmsClient.updateSnapshotEntry(members.snapshotCreator.getSnapshotName(), SnapshotStatus.COMPLETED);
+            members.globalState.updatePhase(GlobalState.Phase.SNAPSHOT_COMPLETED);
             logger.info("Snapshot completed, exiting Snapshot Phase...");
         }
 
@@ -175,16 +184,16 @@ public class SnapshotStep {
     public static class ExitPhaseSnapshotFailed extends Base {
         private final SnapshotCreationFailed e;
 
-        public ExitPhaseSnapshotFailed(GlobalState globalState, CmsClient cmsClient, SnapshotCreator snapshotCreator, SnapshotCreationFailed e) {
-            super(globalState, cmsClient, snapshotCreator);
+        public ExitPhaseSnapshotFailed(SharedMembers members, SnapshotCreationFailed e) {
+            super(members);
             this.e = e;
         }
 
         @Override
         public void run() {
             logger.error("Snapshot creation failed");
-            cmsClient.updateSnapshotEntry(snapshotCreator.getSnapshotName(), SnapshotStatus.FAILED);
-            globalState.updatePhase(GlobalState.Phase.SNAPSHOT_FAILED);
+            members.cmsClient.updateSnapshotEntry(members.snapshotCreator.getSnapshotName(), SnapshotStatus.FAILED);
+            members.globalState.updatePhase(GlobalState.Phase.SNAPSHOT_FAILED);
         }
 
         @Override

--- a/RFS/src/test/java/com/rfs/worker/MetadataRunnerTest.java
+++ b/RFS/src/test/java/com/rfs/worker/MetadataRunnerTest.java
@@ -1,0 +1,52 @@
+package com.rfs.worker;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.Mockito.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import com.rfs.cms.CmsClient;
+import com.rfs.common.GlobalMetadata;
+import com.rfs.common.RfsException;
+import com.rfs.common.SnapshotCreator;
+import com.rfs.transformers.Transformer;
+import com.rfs.version_os_2_11.GlobalMetadataCreator_OS_2_11;
+
+class MetadataRunnerTest {
+
+    @Test
+    void run_encountersAnException_asExpected() {
+        // Setup
+        GlobalState globalState = Mockito.mock(GlobalState.class);
+        CmsClient cmsClient = Mockito.mock(CmsClient.class);
+        String snapshotName = "testSnapshot";
+        GlobalMetadata.Factory metadataFactory = Mockito.mock(GlobalMetadata.Factory.class);
+        GlobalMetadataCreator_OS_2_11 metadataCreator = Mockito.mock(GlobalMetadataCreator_OS_2_11.class);
+        Transformer transformer = Mockito.mock(Transformer.class);
+        RfsException testException = new RfsException("Unit test");
+
+        doThrow(testException).when(cmsClient).getMetadataEntry();
+        when(globalState.getPhase()).thenReturn(GlobalState.Phase.METADATA_IN_PROGRESS);
+
+
+        MetadataRunner testRunner = new MetadataRunner(globalState, cmsClient, snapshotName, metadataFactory, metadataCreator, transformer);
+
+        // Run the test
+        try {
+            testRunner.run();
+        } catch (MetadataRunner.MetadataMigrationPhaseFailed e) {
+            assertEquals(GlobalState.Phase.METADATA_IN_PROGRESS, e.phase);
+            assertEquals(null, e.nextStep);
+            assertEquals(Optional.empty(), e.cmsEntry);
+            assertEquals(testException, e.e);
+
+        } catch (Exception e) {
+            fail("Unexpected exception thrown: " + e.getClass().getName());
+        }
+    }
+    
+}

--- a/RFS/src/test/java/com/rfs/worker/SnapshotRunnerTest.java
+++ b/RFS/src/test/java/com/rfs/worker/SnapshotRunnerTest.java
@@ -1,0 +1,45 @@
+package com.rfs.worker;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.Mockito.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+import com.rfs.cms.CmsClient;
+import com.rfs.common.RfsException;
+import com.rfs.common.SnapshotCreator;
+
+class SnapshotRunnerTest {
+
+    @Test
+    void run_encountersAnException_asExpected() {
+        // Setup
+        String snapshotName = "snapshotName";
+        GlobalState globalState = mock(GlobalState.class);
+        CmsClient cmsClient = mock(CmsClient.class);
+        SnapshotCreator snapshotCreator = mock(SnapshotCreator.class);
+        SnapshotRunner testRunner = new SnapshotRunner(globalState, cmsClient, snapshotCreator);
+        RfsException testException = new RfsException("Unit test");
+
+        doThrow(testException).when(cmsClient).getSnapshotEntry(snapshotName);
+        when(globalState.getPhase()).thenReturn(GlobalState.Phase.SNAPSHOT_IN_PROGRESS);
+        when(snapshotCreator.getSnapshotName()).thenReturn(snapshotName);
+
+        // Run the test
+        try {
+            testRunner.run();
+        } catch (SnapshotRunner.SnapshotPhaseFailed e) {
+            assertEquals(GlobalState.Phase.SNAPSHOT_IN_PROGRESS, e.phase);
+            assertEquals(null, e.nextStep);
+            assertEquals(Optional.empty(), e.cmsEntry);
+            assertEquals(testException, e.e);
+
+        } catch (Exception e) {
+            fail("Unexpected exception thrown: " + e.getClass().getName());
+        }
+    }
+    
+}

--- a/RFS/src/test/java/com/rfs/worker/SnapshotStepTest.java
+++ b/RFS/src/test/java/com/rfs/worker/SnapshotStepTest.java
@@ -25,6 +25,7 @@ import com.rfs.worker.SnapshotStep.WaitForSnapshot;
 
 import static org.mockito.Mockito.*;
 
+import java.util.Optional;
 import java.util.stream.Stream;
 
 
@@ -42,15 +43,15 @@ public class SnapshotStepTest {
 
     static Stream<Arguments > provideEnterPhaseArgs() {
         return Stream.of(
-            Arguments.of(null, SnapshotStep.CreateEntry.class),
-            Arguments.of(new Snapshot("test", SnapshotStatus.NOT_STARTED), SnapshotStep.InitiateSnapshot.class),
-            Arguments.of(new Snapshot("test", SnapshotStatus.IN_PROGRESS), SnapshotStep.WaitForSnapshot.class)
+            Arguments.of(Optional.empty(), SnapshotStep.CreateEntry.class),
+            Arguments.of(Optional.of(new Snapshot("test", SnapshotStatus.NOT_STARTED)), SnapshotStep.InitiateSnapshot.class),
+            Arguments.of(Optional.of(new Snapshot("test", SnapshotStatus.IN_PROGRESS)), SnapshotStep.WaitForSnapshot.class)
         );
     }
 
     @ParameterizedTest
     @MethodSource("provideEnterPhaseArgs")
-    void EnterPhase_AsExpected(Snapshot snapshotEntry, Class<?> expected) {
+    void EnterPhase_AsExpected(Optional<Snapshot> snapshotEntry, Class<?> expected) {
         // Run the test
         SnapshotStep.EnterPhase testStep = new SnapshotStep.EnterPhase(testMembers, snapshotEntry);
         testStep.run();

--- a/RFS/src/test/java/com/rfs/worker/SnapshotStepTest.java
+++ b/RFS/src/test/java/com/rfs/worker/SnapshotStepTest.java
@@ -20,6 +20,7 @@ import com.rfs.common.SnapshotCreator;
 import com.rfs.common.SnapshotCreator.SnapshotCreationFailed;
 import com.rfs.worker.SnapshotStep.ExitPhaseSnapshotFailed;
 import com.rfs.worker.SnapshotStep.ExitPhaseSuccess;
+import com.rfs.worker.SnapshotStep.SharedMembers;
 import com.rfs.worker.SnapshotStep.WaitForSnapshot;
 
 import static org.mockito.Mockito.*;
@@ -29,15 +30,14 @@ import java.util.stream.Stream;
 
 @ExtendWith(MockitoExtension.class)
 public class SnapshotStepTest {
-    private GlobalState globalState;
-    private CmsClient cmsClient;
-    private SnapshotCreator snapshotCreator;
+    private SharedMembers testMembers;
 
     @BeforeEach
     void setUp() {
-        this.globalState = Mockito.mock(GlobalState.class);
-        this.cmsClient = Mockito.mock(CmsClient.class);
-        this.snapshotCreator = Mockito.mock(SnapshotCreator.class);
+        GlobalState globalState = Mockito.mock(GlobalState.class);
+        CmsClient cmsClient = Mockito.mock(CmsClient.class);
+        SnapshotCreator snapshotCreator = Mockito.mock(SnapshotCreator.class);
+        testMembers = new SharedMembers(globalState, cmsClient, snapshotCreator);
     }
 
     static Stream<Arguments > provideEnterPhaseArgs() {
@@ -52,50 +52,50 @@ public class SnapshotStepTest {
     @MethodSource("provideEnterPhaseArgs")
     void EnterPhase_AsExpected(Snapshot snapshotEntry, Class<?> expected) {
         // Run the test
-        SnapshotStep.EnterPhase testStep = new SnapshotStep.EnterPhase(globalState, cmsClient, snapshotCreator, snapshotEntry);
+        SnapshotStep.EnterPhase testStep = new SnapshotStep.EnterPhase(testMembers, snapshotEntry);
         testStep.run();
         WorkerStep nextStep = testStep.nextStep();
 
         // Check the results
-        Mockito.verify(globalState, times(1)).updatePhase(GlobalState.Phase.SNAPSHOT_IN_PROGRESS);
+        Mockito.verify(testMembers.globalState, times(1)).updatePhase(GlobalState.Phase.SNAPSHOT_IN_PROGRESS);
         assertEquals(expected, nextStep.getClass());
     }
 
     @Test
     void CreateEntry_AsExpected() {
         // Set up the test
-        when(snapshotCreator.getSnapshotName()).thenReturn("test");
+        when(testMembers.snapshotCreator.getSnapshotName()).thenReturn("test");
 
         // Run the test
-        SnapshotStep.CreateEntry testStep = new SnapshotStep.CreateEntry(globalState, cmsClient, snapshotCreator);
+        SnapshotStep.CreateEntry testStep = new SnapshotStep.CreateEntry(testMembers);
         testStep.run();
         WorkerStep nextStep = testStep.nextStep();
 
         // Check the results
-        Mockito.verify(cmsClient, times(1)).createSnapshotEntry("test");
+        Mockito.verify(testMembers.cmsClient, times(1)).createSnapshotEntry("test");
         assertEquals(SnapshotStep.InitiateSnapshot.class, nextStep.getClass());
     }
 
     @Test
     void InitiateSnapshot_AsExpected() {
         // Set up the test
-        when(snapshotCreator.getSnapshotName()).thenReturn("test");
+        when(testMembers.snapshotCreator.getSnapshotName()).thenReturn("test");
 
         // Run the test
-        SnapshotStep.InitiateSnapshot testStep = new SnapshotStep.InitiateSnapshot(globalState, cmsClient, snapshotCreator);
+        SnapshotStep.InitiateSnapshot testStep = new SnapshotStep.InitiateSnapshot(testMembers);
         testStep.run();
         WorkerStep nextStep = testStep.nextStep();
 
         // Check the results
-        Mockito.verify(snapshotCreator, times(1)).registerRepo();
-        Mockito.verify(snapshotCreator, times(1)).createSnapshot();
-        Mockito.verify(cmsClient, times(1)).updateSnapshotEntry("test", SnapshotStatus.IN_PROGRESS);
+        Mockito.verify(testMembers.snapshotCreator, times(1)).registerRepo();
+        Mockito.verify(testMembers.snapshotCreator, times(1)).createSnapshot();
+        Mockito.verify(testMembers.cmsClient, times(1)).updateSnapshotEntry("test", SnapshotStatus.IN_PROGRESS);
         assertEquals(SnapshotStep.WaitForSnapshot.class, nextStep.getClass());
     }
 
     public static class TestableWaitForSnapshot extends WaitForSnapshot {
-        public TestableWaitForSnapshot(GlobalState globalState, CmsClient cmsClient, SnapshotCreator snapshotCreator) {
-            super(globalState, cmsClient, snapshotCreator);
+        public TestableWaitForSnapshot(SharedMembers testMembers) {
+            super(testMembers);
         }
 
         protected void waitABit() throws InterruptedException {
@@ -106,68 +106,68 @@ public class SnapshotStepTest {
     @Test
     void WaitForSnapshot_successful_AsExpected() {
         // Set up the test
-        when(snapshotCreator.isSnapshotFinished())
+        when(testMembers.snapshotCreator.isSnapshotFinished())
             .thenReturn(false)
             .thenReturn(true);
 
         // Run the test
-        SnapshotStep.WaitForSnapshot waitPhase = new TestableWaitForSnapshot(globalState, cmsClient, snapshotCreator);
+        SnapshotStep.WaitForSnapshot waitPhase = new TestableWaitForSnapshot(testMembers);
         waitPhase.run();
         WorkerStep nextStep = waitPhase.nextStep();
 
         // Check the results
-        Mockito.verify(snapshotCreator, times(2)).isSnapshotFinished();
+        Mockito.verify(testMembers.snapshotCreator, times(2)).isSnapshotFinished();
         assertEquals(SnapshotStep.ExitPhaseSuccess.class, nextStep.getClass());
     }
 
     @Test
     void WaitForSnapshot_failedSnapshot_AsExpected() {
         // Set up the test
-        when(snapshotCreator.isSnapshotFinished())
+        when(testMembers.snapshotCreator.isSnapshotFinished())
             .thenReturn(false)
             .thenThrow(new SnapshotCreationFailed("test"));
 
         // Run the test
-        SnapshotStep.WaitForSnapshot waitPhase = new TestableWaitForSnapshot(globalState, cmsClient, snapshotCreator);
+        SnapshotStep.WaitForSnapshot waitPhase = new TestableWaitForSnapshot(testMembers);
         waitPhase.run();
         WorkerStep nextStep = waitPhase.nextStep();
 
         // Check the results
-        Mockito.verify(snapshotCreator, times(2)).isSnapshotFinished();
+        Mockito.verify(testMembers.snapshotCreator, times(2)).isSnapshotFinished();
         assertEquals(SnapshotStep.ExitPhaseSnapshotFailed.class, nextStep.getClass());
     }
 
     @Test
     void ExitPhaseSuccess_AsExpected() {
         // Set up the test
-        when(snapshotCreator.getSnapshotName()).thenReturn("test");
+        when(testMembers.snapshotCreator.getSnapshotName()).thenReturn("test");
 
         // Run the test
-        SnapshotStep.ExitPhaseSuccess exitPhase = new ExitPhaseSuccess(globalState, cmsClient, snapshotCreator);
+        SnapshotStep.ExitPhaseSuccess exitPhase = new ExitPhaseSuccess(testMembers);
         exitPhase.run();
         WorkerStep nextStep = exitPhase.nextStep();
 
         // Check the results
-        Mockito.verify(cmsClient, times(1)).updateSnapshotEntry("test", SnapshotStatus.COMPLETED);
-        Mockito.verify(globalState, times(1)).updatePhase(GlobalState.Phase.SNAPSHOT_COMPLETED);
+        Mockito.verify(testMembers.cmsClient, times(1)).updateSnapshotEntry("test", SnapshotStatus.COMPLETED);
+        Mockito.verify(testMembers.globalState, times(1)).updatePhase(GlobalState.Phase.SNAPSHOT_COMPLETED);
         assertEquals(null, nextStep);
     }
 
     @Test
     void ExitPhaseSnapshotFailed_AsExpected() {
         // Set up the test
-        when(snapshotCreator.getSnapshotName()).thenReturn("test");
+        when(testMembers.snapshotCreator.getSnapshotName()).thenReturn("test");
         SnapshotCreationFailed e = new SnapshotCreationFailed("test");
 
         // Run the test
-        SnapshotStep.ExitPhaseSnapshotFailed exitPhase = new ExitPhaseSnapshotFailed(globalState, cmsClient, snapshotCreator, e);
+        SnapshotStep.ExitPhaseSnapshotFailed exitPhase = new ExitPhaseSnapshotFailed(testMembers, e);
         exitPhase.run();
         assertThrows(SnapshotCreationFailed.class, () -> {
             exitPhase.nextStep();
         });
 
         // Check the results
-        Mockito.verify(cmsClient, times(1)).updateSnapshotEntry("test", SnapshotStatus.FAILED);
-        Mockito.verify(globalState, times(1)).updatePhase(GlobalState.Phase.SNAPSHOT_FAILED);
+        Mockito.verify(testMembers.cmsClient, times(1)).updateSnapshotEntry("test", SnapshotStatus.FAILED);
+        Mockito.verify(testMembers.globalState, times(1)).updatePhase(GlobalState.Phase.SNAPSHOT_FAILED);
     }    
 }


### PR DESCRIPTION
### Description
* Perform some refactoring of the RFS Worker and select, underlying libraries to better log exceptional situations

### Issues Resolved
* https://opensearch.atlassian.net/browse/MIGRATIONS-1731

### Testing
* Ran the `ReindexFromSnapshot.java` all-in-one script against the docker compose test setup
* Updated unit tests
* Provoked an exception to demonstrate the new logging behavior, displayed below:

```
chelma@3c22fba4e266 RFS % gradle runRfsWorker --args='--snapshot-name reindex-from-snapshot --s3-local-dir /tmp/s3_files --s3-repo-uri s3://chelma-iad-rfs-local-testing --s3-region us-east-1 --source-host http://localhost:19200 --target-host http://localhost:29200 --min-replicas 0 --index-template-whitelist "my_index_template" --component-template-whitelist "my_component_template"'

> Task :runRfsWorker
19:21:31.379 INFO  Running RfsWorker
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
19:21:31.644 INFO  Checking if work remains in the Snapshot Phase...
19:21:32.743 INFO  Snapshot not yet completed, entering Snapshot Phase...
19:21:32.744 INFO  Snapshot CMS Entry not found, attempting to create it...
19:21:32.813 INFO  Snapshot CMS Entry created
19:21:32.813 INFO  Attempting to initiate the snapshot...
19:21:33.936 INFO  Snapshot repo registration successful
19:21:34.008 ERROR Could not create snapshot: _snapshot/migration_assistant_repo/reindex-from-snapshot. Response Code: 400, Response Message: Bad Request, Response Body: {"error":{"root_cause":[{"type":"invalid_snapshot_name_exception","reason":"[migration_assistant_repo:reindex-from-snapshot] Invalid snapshot name [reindex-from-snapshot], snapshot with the same name already exists"}],"type":"invalid_snapshot_name_exception","reason":"[migration_assistant_repo:reindex-from-snapshot] Invalid snapshot name [reindex-from-snapshot], snapshot with the same name already exists"},"status":400}
19:21:35.259 ERROR Could not create snapshot: _snapshot/migration_assistant_repo/reindex-from-snapshot. Response Code: 400, Response Message: Bad Request, Response Body: {"error":{"root_cause":[{"type":"invalid_snapshot_name_exception","reason":"[migration_assistant_repo:reindex-from-snapshot] Invalid snapshot name [reindex-from-snapshot], snapshot with the same name already exists"}],"type":"invalid_snapshot_name_exception","reason":"[migration_assistant_repo:reindex-from-snapshot] Invalid snapshot name [reindex-from-snapshot], snapshot with the same name already exists"},"status":400}
19:21:37.341 ERROR Could not create snapshot: _snapshot/migration_assistant_repo/reindex-from-snapshot. Response Code: 400, Response Message: Bad Request, Response Body: {"error":{"root_cause":[{"type":"invalid_snapshot_name_exception","reason":"[migration_assistant_repo:reindex-from-snapshot] Invalid snapshot name [reindex-from-snapshot], snapshot with the same name already exists"}],"type":"invalid_snapshot_name_exception","reason":"[migration_assistant_repo:reindex-from-snapshot] Invalid snapshot name [reindex-from-snapshot], snapshot with the same name already exists"},"status":400}
19:21:42.080 ERROR Could not create snapshot: _snapshot/migration_assistant_repo/reindex-from-snapshot. Response Code: 400, Response Message: Bad Request, Response Body: {"error":{"root_cause":[{"type":"invalid_snapshot_name_exception","reason":"[migration_assistant_repo:reindex-from-snapshot] Invalid snapshot name [reindex-from-snapshot], snapshot with the same name already exists"}],"type":"invalid_snapshot_name_exception","reason":"[migration_assistant_repo:reindex-from-snapshot] Invalid snapshot name [reindex-from-snapshot], snapshot with the same name already exists"},"status":400}
19:21:42.081 ERROR Snapshot reindex-from-snapshot creation failed
reactor.core.Exceptions$RetryExhaustedException: Retries exhausted: 3/3
        at reactor.core.Exceptions.retryExhausted(Exceptions.java:308) ~[reactor-core-3.6.5.jar:3.6.5]
        at reactor.util.retry.RetryBackoffSpec.lambda$static$0(RetryBackoffSpec.java:68) ~[reactor-core-3.6.5.jar:3.6.5]
        at reactor.util.retry.RetryBackoffSpec.lambda$null$4(RetryBackoffSpec.java:560) ~[reactor-core-3.6.5.jar:3.6.5]
        at reactor.core.publisher.FluxConcatMapNoPrefetch$FluxConcatMapNoPrefetchSubscriber.onNext(FluxConcatMapNoPrefetch.java:183) ~[reactor-core-3.6.5.jar:3.6.5]
        at reactor.core.publisher.FluxContextWrite$ContextWriteSubscriber.onNext(FluxContextWrite.java:107) ~[reactor-core-3.6.5.jar:3.6.5]
        at reactor.core.publisher.SinkManyEmitterProcessor.drain(SinkManyEmitterProcessor.java:476) ~[reactor-core-3.6.5.jar:3.6.5]
        at reactor.core.publisher.SinkManyEmitterProcessor.tryEmitNext(SinkManyEmitterProcessor.java:273) ~[reactor-core-3.6.5.jar:3.6.5]
        at reactor.core.publisher.SinkManySerialized.tryEmitNext(SinkManySerialized.java:100) ~[reactor-core-3.6.5.jar:3.6.5]
        at reactor.core.publisher.InternalManySink.emitNext(InternalManySink.java:27) ~[reactor-core-3.6.5.jar:3.6.5]
        at reactor.core.publisher.FluxRetryWhen$RetryWhenMainSubscriber.onError(FluxRetryWhen.java:194) ~[reactor-core-3.6.5.jar:3.6.5]
        at reactor.core.publisher.MonoPeekTerminal$MonoTerminalPeekSubscriber.onError(MonoPeekTerminal.java:258) ~[reactor-core-3.6.5.jar:3.6.5]
        at reactor.core.publisher.MonoFlatMap$FlatMapMain.onNext(MonoFlatMap.java:149) ~[reactor-core-3.6.5.jar:3.6.5]
        at reactor.core.publisher.MonoFlatMap$FlatMapMain.secondComplete(MonoFlatMap.java:245) ~[reactor-core-3.6.5.jar:3.6.5]
        at reactor.core.publisher.MonoFlatMap$FlatMapInner.onNext(MonoFlatMap.java:305) ~[reactor-core-3.6.5.jar:3.6.5]
        at reactor.core.publisher.FluxContextWrite$ContextWriteSubscriber.onNext(FluxContextWrite.java:107) ~[reactor-core-3.6.5.jar:3.6.5]
        at reactor.core.publisher.FluxDoFinally$DoFinallySubscriber.onNext(FluxDoFinally.java:113) ~[reactor-core-3.6.5.jar:3.6.5]
        at reactor.core.publisher.FluxMap$MapConditionalSubscriber.onNext(FluxMap.java:224) ~[reactor-core-3.6.5.jar:3.6.5]
        at reactor.core.publisher.FluxHandle$HandleSubscriber.onNext(FluxHandle.java:129) ~[reactor-core-3.6.5.jar:3.6.5]
        at reactor.core.publisher.FluxMap$MapConditionalSubscriber.onNext(FluxMap.java:224) ~[reactor-core-3.6.5.jar:3.6.5]
        at reactor.core.publisher.FluxDoFinally$DoFinallySubscriber.onNext(FluxDoFinally.java:113) ~[reactor-core-3.6.5.jar:3.6.5]
        at reactor.core.publisher.FluxHandleFuseable$HandleFuseableSubscriber.onNext(FluxHandleFuseable.java:194) ~[reactor-core-3.6.5.jar:3.6.5]
        at reactor.core.publisher.FluxContextWrite$ContextWriteSubscriber.onNext(FluxContextWrite.java:107) ~[reactor-core-3.6.5.jar:3.6.5]
        at reactor.core.publisher.Operators$BaseFluxToMonoOperator.completePossiblyEmpty(Operators.java:2097) ~[reactor-core-3.6.5.jar:3.6.5]
        at reactor.core.publisher.MonoCollectList$MonoCollectListSubscriber.onComplete(MonoCollectList.java:118) ~[reactor-core-3.6.5.jar:3.6.5]
        at reactor.core.publisher.FluxPeek$PeekSubscriber.onComplete(FluxPeek.java:260) ~[reactor-core-3.6.5.jar:3.6.5]
        at reactor.core.publisher.FluxMap$MapSubscriber.onComplete(FluxMap.java:144) ~[reactor-core-3.6.5.jar:3.6.5]
Exception in thread "main"      at reactor.netty.channel.FluxReceive.onInboundComplete(FluxReceive.java:415) ~[reactor-netty-core-1.1.18.jar:1.1.18]
        at reactor.netty.channel.ChannelOperations.onInboundComplete(ChannelOperations.java:446) ~[reactor-netty-core-1.1.18.jar:1.1.18]
        at reactor.netty.channel.ChannelOperations.terminate(ChannelOperations.java:500) ~[reactor-netty-core-1.1.18.jar:1.1.18]
com.rfs.worker.SnapshotRunner$SnapshotPhaseFailed: Snapshot Phase failed        at reactor.netty.http.client.HttpClientOperations.onInboundNext(HttpClientOperations.java:793) ~[reactor-netty-http-1.1.18.jar:1.1.18]

        at reactor.netty.channel.ChannelOperationsHandler.channelRead(ChannelOperationsHandler.java:114) ~[reactor-netty-core-1.1.18.jar:1.1.18]
        at com.rfs.worker.SnapshotRunner.runInternal(SnapshotRunner.java:42)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444) ~[netty-transport-4.1.108.Final.jar:4.1.108.Final]
        at com.rfs.worker.Runner.run(Runner.java:21)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420) ~[netty-transport-4.1.108.Final.jar:4.1.108.Final]
        at com.rfs.RunRfsWorker.main(RunRfsWorker.java:133)     at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412) ~[netty-transport-4.1.108.Final.jar:4.1.108.Final]

        at io.netty.channel.CombinedChannelDuplexHandler$DelegatingChannelHandlerContext.fireChannelRead(CombinedChannelDuplexHandler.java:436) ~[netty-transport-4.1.108.Final.jar:4.1.108.Final]
        at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:346) ~[netty-codec-4.1.108.Final.jar:4.1.108.Final]
        at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:318) ~[netty-codec-4.1.108.Final.jar:4.1.108.Final]
        at io.netty.channel.CombinedChannelDuplexHandler.channelRead(CombinedChannelDuplexHandler.java:251) ~[netty-transport-4.1.108.Final.jar:4.1.108.Final]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:442) ~[netty-transport-4.1.108.Final.jar:4.1.108.Final]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420) ~[netty-transport-4.1.108.Final.jar:4.1.108.Final]
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412) ~[netty-transport-4.1.108.Final.jar:4.1.108.Final]
        at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1410) ~[netty-transport-4.1.108.Final.jar:4.1.108.Final]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:440) ~[netty-transport-4.1.108.Final.jar:4.1.108.Final]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420) ~[netty-transport-4.1.108.Final.jar:4.1.108.Final]
        at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:919) ~[netty-transport-4.1.108.Final.jar:4.1.108.Final]
        at io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:166) ~[netty-transport-4.1.108.Final.jar:4.1.108.Final]
        at io.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:788) ~[netty-transport-4.1.108.Final.jar:4.1.108.Final]
        at io.netty.channel.nio.NioEventLoop.processSelectedKeysOptimized(NioEventLoop.java:724) ~[netty-transport-4.1.108.Final.jar:4.1.108.Final]
        at io.netty.channel.nio.NioEventLoop.processSelectedKeys(NioEventLoop.java:650) ~[netty-transport-4.1.108.Final.jar:4.1.108.Final]
        at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:562) ~[netty-transport-4.1.108.Final.jar:4.1.108.Final]
        at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:997) ~[netty-common-4.1.108.Final.jar:4.1.108.Final]
        at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74) ~[netty-common-4.1.108.Final.jar:4.1.108.Final]
        at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) ~[netty-common-4.1.108.Final.jar:4.1.108.Final]
        at java.base/java.lang.Thread.run(Thread.java:829) ~[?:?]
        Suppressed: java.lang.Exception: #block terminated with an error
                at reactor.core.publisher.BlockingSingleSubscriber.blockingGet(BlockingSingleSubscriber.java:104) ~[reactor-core-3.6.5.jar:3.6.5]
                at reactor.core.publisher.Mono.block(Mono.java:1779) ~[reactor-core-3.6.5.jar:3.6.5]
                at com.rfs.common.OpenSearchClient.createSnapshot(OpenSearchClient.java:132) ~[main/:?]
                at com.rfs.common.SnapshotCreator.createSnapshot(SnapshotCreator.java:55) [main/:?]
                at com.rfs.worker.SnapshotStep$InitiateSnapshot.run(SnapshotStep.java:112) [main/:?]
                at com.rfs.worker.SnapshotRunner.runInternal(SnapshotRunner.java:34) [main/:?]
                at com.rfs.worker.Runner.run(Runner.java:21) [main/:?]
                at com.rfs.RunRfsWorker.main(RunRfsWorker.java:133) [main/:?]
Caused by: com.rfs.common.OpenSearchClient$OperationFailed: Could not create snapshot: _snapshot/migration_assistant_repo/reindex-from-snapshot. Response Code: 400, Response Message: Bad Request, Response Body: {"error":{"root_cause":[{"type":"invalid_snapshot_name_exception","reason":"[migration_assistant_repo:reindex-from-snapshot] Invalid snapshot name [reindex-from-snapshot], snapshot with the same name already exists"}],"type":"invalid_snapshot_name_exception","reason":"[migration_assistant_repo:reindex-from-snapshot] Invalid snapshot name [reindex-from-snapshot], snapshot with the same name already exists"},"status":400}
        at com.rfs.common.OpenSearchClient.lambda$createSnapshot$4(OpenSearchClient.java:127) ~[main/:?]
        at reactor.core.publisher.MonoFlatMap$FlatMapMain.onNext(MonoFlatMap.java:132) ~[reactor-core-3.6.5.jar:3.6.5]
        ... 42 more
19:21:42.095 ERROR Snapshot Phase failed w/ an exception
19:21:42.095 ERROR {"exceptionMessage":"Failed to create snapshot reindex-from-snapshot","exceptionClass":"SnapshotCreationFailed","exceptionTrace":"[com.rfs.common.SnapshotCreator.createSnapshot(SnapshotCreator.java:59), com.rfs.worker.SnapshotStep$InitiateSnapshot.run(SnapshotStep.java:112), com.rfs.worker.SnapshotRunner.runInternal(SnapshotRunner.java:34), com.rfs.worker.Runner.run(Runner.java:21), com.rfs.RunRfsWorker.main(RunRfsWorker.java:133)]","phase":"SNAPSHOT_IN_PROGRESS","currentStep":"InitiateSnapshot","cmsEntry":"null"}
```

### Check List
- [X] New functionality includes testing
  - [X] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
