### PR TITLE
Fix Release Drafter for Gradle Restructuring

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -28,7 +28,7 @@ jobs:
         # Preface Traffic Capture version with 0. to signal interface immaturity
         run: |
           wget https://github.com/opensearch-project/opensearch-migrations/archive/refs/tags/${{ steps.get_data.outputs.version }}.tar.gz -O artifacts.tar.gz
-          (cd TrafficCapture && ../gradlew publishMavenJavaPublicationToMavenRepository -Dbuild.snapshot=false -Dbuild.version=0.${{ steps.get_data.outputs.version }} && tar -C build -cvf traffic-capture-artifacts.tar.gz repository)
+          ./gradlew publishMavenJavaPublicationToMavenRepository -Dbuild.snapshot=false -Dbuild.version=0.${{ steps.get_data.outputs.version }} && tar -C build -cvf traffic-capture-artifacts.tar.gz repository
       - name: Draft a release
         uses: softprops/action-gh-release@v2
         with:
@@ -36,4 +36,4 @@ jobs:
           generate_release_notes: true
           files: |
             artifacts.tar.gz
-            TrafficCapture/traffic-capture-artifacts.tar.gz
+            traffic-capture-artifacts.tar.gz


### PR DESCRIPTION
### Description
Current script is not correctly mapped to the build directory with https://github.com/opensearch-project/opensearch-migrations/pull/671
* Category: Bug Fix
* Why these changes are required? Current release drafter failing
* What is the old behavior before changes and new behavior after changes? Release drafter failing, with this succeeding

### Issues Resolved
N/A

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
Ran commands locally to verify correct operation

### Check List
- [x ] New functionality includes testing
  - [ x] All tests pass, including unit test, integration test and doctest
- [x ] New functionality has been documented
- [x ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
