### PR TITLE
[Console Library] Log level adjustment

### DIFF
--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/cli.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/cli.py
@@ -24,12 +24,12 @@ class Context(object):
     "--config-file", default="/etc/migration_services.yaml", help="Path to config file"
 )
 @click.option("--json", is_flag=True)
-@click.option('-v', '--verbose', count=True, help="Verbosity level. -v is warnings, -vv is info, -vvv is debug.")
+@click.option('-v', '--verbose', count=True, help="Verbosity level. Default is warn, -v is info, -vv is debug.")
 @click.pass_context
 def cli(ctx, config_file, json, verbose):
     ctx.obj = Context(config_file)
     ctx.obj.json = json
-    logging.basicConfig(level=logging.ERROR - (10 * verbose))
+    logging.basicConfig(level=logging.WARN - (10 * verbose))
     logger.info(f"Logging set to {logging.getLevelName(logger.getEffectiveLevel())}")
 
 # ##################### CLUSTERS ###################


### PR DESCRIPTION
### Description
This was supposed to be included in #667, but I missed the diff.

It adjusts the logging levels so that default is errors & warnings, `-v` adds info, and `-vv` adds debug.

### Issues Resolved
Related to https://opensearch.atlassian.net/browse/MIGRATIONS-1743

### Testing
manual

### Check List
- [x] New functionality includes testing
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
