### PR TITLE
Centralize RFS dependencies

### DIFF
--- a/RFS/build.gradle
+++ b/RFS/build.gradle
@@ -66,8 +66,7 @@ dependencies {
 
 
     // Integration tests
-    implementation platform('org.testcontainers:testcontainers-bom:1.19.8')
-    testImplementation('org.testcontainers:elasticsearch') //no version specified
+    testImplementation group: 'org.testcontainers', name: 'testcontainers'
     testImplementation group: 'org.hamcrest', name: 'hamcrest'
     testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api'
     testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine'

--- a/RFS/build.gradle
+++ b/RFS/build.gradle
@@ -33,51 +33,48 @@ ext {
 }
 
 dependencies {
+    implementation project(":commonDependencyVersionConstraints")
+
     implementation project(':coreUtilities')
 
-    implementation 'com.beust:jcommander:1.81'
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.16.2'
-    implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.16.2'
-    implementation 'com.fasterxml.jackson.core:jackson-annotations:2.16.2'
-    implementation 'com.fasterxml.jackson.core:jackson-core:2.16.2'
-    implementation 'io.netty:netty-codec-http:4.1.108.Final'
-    implementation 'org.apache.logging.log4j:log4j-api:2.23.1'
-    implementation 'org.apache.logging.log4j:log4j-core:2.23.1'
-    implementation 'org.apache.lucene:lucene-core:8.11.3'
-    implementation 'org.apache.lucene:lucene-analyzers-common:8.11.3'
-    implementation 'org.apache.lucene:lucene-backward-codecs:8.11.3'
+    implementation group: 'com.beust', name: 'jcommander'
+    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind'
+    implementation group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-smile'
+    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-annotations'
+    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-core'
+    implementation group: 'io.netty', name: 'netty-codec-http'
+    implementation group: 'org.apache.logging.log4j', name: 'log4j-api'
+    implementation group: 'org.apache.logging.log4j', name: 'log4j-core'
+    implementation group: 'org.apache.lucene', name: 'lucene-core'
+    implementation group: 'org.apache.lucene', name: 'lucene-analyzers-common'
+    implementation group: 'org.apache.lucene', name: 'lucene-backward-codecs'
 
     implementation platform('io.projectreactor:reactor-bom:2023.0.5') 
     implementation 'io.projectreactor.netty:reactor-netty-core' 
     implementation 'io.projectreactor.netty:reactor-netty-http'
 
-    implementation platform("software.amazon.awssdk:bom:$awsSdkVersion")
-    implementation 'software.amazon.awssdk:s3'
-    implementation 'software.amazon.awssdk:s3-transfer-manager'
-    implementation 'software.amazon.awssdk.crt:aws-crt:0.29.18'
+    implementation group: 'software.amazon.awssdk', name: 's3'
+    implementation group: 'software.amazon.awssdk', name: 's3-transfer-manager'
 
-    implementation    'com.github.docker-java:docker-java-core:3.3.6'
-    implementation    'com.github.docker-java:docker-java-transport-httpclient5:3.3.6'
-
-    testImplementation 'io.projectreactor:reactor-test:3.6.5'
-    testImplementation 'org.apache.logging.log4j:log4j-core:2.23.1'
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.10.2'
-    testImplementation 'org.junit.jupiter:junit-jupiter-params:5.10.2'
-    testImplementation 'org.mockito:mockito-core:5.11.0'
-    testImplementation 'org.mockito:mockito-junit-jupiter:5.11.0'
-    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.10.2'
+    testImplementation group: 'io.projectreactor', name: 'reactor-test'
+    testImplementation group: 'org.apache.logging.log4j', name: 'log4j-core'
+    testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api'
+    testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-params'
+    testImplementation group: 'org.mockito', name: 'mockito-core'
+    testImplementation group: 'org.mockito', name: 'mockito-junit-jupiter'
+    testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine'
 
 
     // Integration tests
     implementation platform('org.testcontainers:testcontainers-bom:1.19.8')
     testImplementation('org.testcontainers:elasticsearch') //no version specified
-    testImplementation 'org.hamcrest:hamcrest:2.2'
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.2'
-    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.2'
-    implementation 'org.apache.httpcomponents:httpclient:4.5.13'
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.12.3'
-    implementation 'com.fasterxml.jackson.core:jackson-core:2.12.3'
-    implementation 'com.fasterxml.jackson.core:jackson-annotations:2.12.3'
+    testImplementation group: 'org.hamcrest', name: 'hamcrest'
+    testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api'
+    testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine'
+    implementation group: 'org.apache.httpcomponents.client5', name: 'httpclient5'
+    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind'
+    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-core'
+    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-annotations'
 }
 
 application {

--- a/RFS/src/test/java/com/rfs/framework/ClusterOperations.java
+++ b/RFS/src/test/java/com/rfs/framework/ClusterOperations.java
@@ -1,10 +1,10 @@
 package com.rfs.framework;
 
-import org.apache.http.client.methods.HttpDelete;
-import org.apache.http.client.methods.HttpPut;
-import org.apache.http.entity.StringEntity;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClients;
+import org.apache.hc.client5.http.classic.methods.HttpDelete;
+import org.apache.hc.client5.http.classic.methods.HttpPut;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.core5.http.io.entity.StringEntity;
 
 import java.io.IOException;
 
@@ -40,7 +40,7 @@ public class ClusterOperations {
         createRepoRequest.setHeader("Content-Type", "application/json");
 
         try (var response = httpClient.execute(createRepoRequest)) {
-            assertThat(response.getStatusLine().getStatusCode(), equalTo(200));
+            assertThat(response.getCode(), equalTo(200));
         }
     }
 
@@ -50,7 +50,7 @@ public class ClusterOperations {
         indexDocumentRequest.setHeader("Content-Type", "application/json");
 
         try (var response = httpClient.execute(indexDocumentRequest)) {
-            assertThat(response.getStatusLine().getStatusCode(), anyOf(equalTo(201), equalTo(200)));
+            assertThat(response.getCode(), anyOf(equalTo(201), equalTo(200)));
         }
     }
 
@@ -58,7 +58,7 @@ public class ClusterOperations {
         var deleteDocumentRequest = new HttpDelete(clusterUrl + "/" + index + "/_doc/" + docId);
 
         try (var response = httpClient.execute(deleteDocumentRequest)) {
-            assertThat(response.getStatusLine().getStatusCode(), equalTo(200));
+            assertThat(response.getCode(), equalTo(200));
         }
     }
 
@@ -74,7 +74,7 @@ public class ClusterOperations {
         createSnapshotRequest.setHeader("Content-Type", "application/json");
 
         try (var response = httpClient.execute(createSnapshotRequest)) {
-            assertThat(response.getStatusLine().getStatusCode(), equalTo(200));
+            assertThat(response.getCode(), equalTo(200));
         }
     }
 }

--- a/commonDependencyVersionConstraints/build.gradle
+++ b/commonDependencyVersionConstraints/build.gradle
@@ -88,7 +88,7 @@ dependencies {
     api group: 'org.testcontainers', name: 'testcontainers', version: testcontainers
     api group: 'org.testcontainers', name: 'toxiproxy', version: testcontainers
 
-    def mockito = '4.6.1'
+    def mockito = '5.11.0'
     api group: 'org.mockito', name:'mockito-core', version: mockito
     api group: 'org.mockito', name:'mockito-junit-jupiter', version: mockito
 
@@ -100,8 +100,6 @@ dependencies {
     api group: 'org.apache.lucene', name: 'lucene-backward-codecs', version: lucene
 
     api group: 'org.hamcrest', name: 'hamcrest', version: '2.2'
-
-
 
     // ************************************************************
     // The following constraints are for mitigating transitive CVEs

--- a/commonDependencyVersionConstraints/build.gradle
+++ b/commonDependencyVersionConstraints/build.gradle
@@ -18,7 +18,6 @@ dependencies {
     api group: 'com.google.protobuf', name: 'protobuf-java', version: '3.22.2'
 
     api group: 'org.apache.httpcomponents.client5', name: 'httpclient5', version: '5.2.1'
-
     api group: 'software.amazon.msk', name:'aws-msk-iam-auth', version: '2.0.3'
 
     def log4j = '2.23.1'
@@ -63,6 +62,9 @@ dependencies {
     api group: 'software.amazon.awssdk', name: 'auth', version: awssdk
     api group: 'software.amazon.awssdk', name: 'sdk-core', version: awssdk
     api group: 'software.amazon.awssdk', name: 'secretsmanager', version: awssdk
+    api group: 'software.amazon.awssdk', name: 's3', version: awssdk
+    api group: 'software.amazon.awssdk', name: 's3-transfer-manager', version: awssdk
+
 
     api group: 'com.bazaarvoice.jolt', name: 'jolt-core', version: '0.1.7'
 
@@ -91,6 +93,15 @@ dependencies {
     api group: 'org.mockito', name:'mockito-junit-jupiter', version: mockito
 
     api group: 'eu.rekawek.toxiproxy', name: 'toxiproxy-java', version: '2.1.7'
+
+    def lucene = '8.11.3';
+    api group: 'org.apache.lucene', name: 'lucene-core', version: lucene
+    api group: 'org.apache.lucene', name: 'lucene-analyzers-common', version: lucene
+    api group: 'org.apache.lucene', name: 'lucene-backward-codecs', version: lucene
+
+    api group: 'org.hamcrest', name: 'hamcrest', version: '2.2'
+
+
 
     // ************************************************************
     // The following constraints are for mitigating transitive CVEs


### PR DESCRIPTION
### Description
Centralize RFS dependencies under the common shared `commonDependencyVersionConstraints` project

### Issues Resolved
- Resolves https://github.com/opensearch-project/opensearch-migrations/issues/669
- Resolves https://github.com/opensearch-project/opensearch-migrations/issues/687

### Check List
- [ ] ~New functionality includes testing~
  - [X] All tests pass, including unit test, integration test and doctest
- [ ] ~New functionality has been documented~
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
