### PR TITLE
[RFS] Updated RFS to perform coordinated index migration

### DIFF
--- a/RFS/src/main/java/com/rfs/DemoPrintOutSnapshot.java
+++ b/RFS/src/main/java/com/rfs/DemoPrintOutSnapshot.java
@@ -155,12 +155,12 @@ public class DemoPrintOutSnapshot {
             Map<String, IndexMetadata.Data> indexMetadatas = new HashMap<>();
             if (sourceVersion == ClusterVersion.ES_6_8) {
                 for (SnapshotRepo.Index index : repoDataProvider.getIndicesInSnapshot(snapshotName)) {
-                    IndexMetadata.Data indexMetadata = new IndexMetadataFactory_ES_6_8().fromRepo(repo, repoDataProvider, snapshotName, index.getName());
+                    IndexMetadata.Data indexMetadata = new IndexMetadataFactory_ES_6_8(repoDataProvider).fromRepo(snapshotName, index.getName());
                     indexMetadatas.put(index.getName(), indexMetadata);
                 }
             } else {
                 for (SnapshotRepo.Index index : repoDataProvider.getIndicesInSnapshot(snapshotName)) {
-                    IndexMetadata.Data indexMetadata = new IndexMetadataFactory_ES_7_10().fromRepo(repo, repoDataProvider, snapshotName, index.getName());
+                    IndexMetadata.Data indexMetadata = new IndexMetadataFactory_ES_7_10(repoDataProvider).fromRepo(snapshotName, index.getName());
                     indexMetadatas.put(index.getName(), indexMetadata);
                 }
             }

--- a/RFS/src/main/java/com/rfs/ReindexFromSnapshot.java
+++ b/RFS/src/main/java/com/rfs/ReindexFromSnapshot.java
@@ -312,8 +312,7 @@ public class ReindexFromSnapshot {
 
                     ObjectNode root = indexMetadata.toObjectNode();
                     ObjectNode transformedRoot = transformer.transformIndexMetadata(root);
-                    IndexMetadataData_OS_2_11 indexMetadataOS211 = new IndexMetadataData_OS_2_11(transformedRoot, indexMetadata.getId(), reindexName);
-                    indexCreator.create(reindexName, indexMetadataOS211);
+                    indexCreator.create(transformedRoot, reindexName, indexMetadata.getId());
                 }
             }
 

--- a/RFS/src/main/java/com/rfs/ReindexFromSnapshot.java
+++ b/RFS/src/main/java/com/rfs/ReindexFromSnapshot.java
@@ -290,9 +290,9 @@ public class ReindexFromSnapshot {
                 logger.info("Reading Index Metadata for index: " + index.getName());
                 IndexMetadata.Data indexMetadata;
                 if (sourceVersion == ClusterVersion.ES_6_8) {
-                    indexMetadata = new IndexMetadataFactory_ES_6_8().fromRepo(repo, repoDataProvider, snapshotName, index.getName());
+                    indexMetadata = new IndexMetadataFactory_ES_6_8(repoDataProvider).fromRepo(snapshotName, index.getName());
                 } else {
-                    indexMetadata = new IndexMetadataFactory_ES_7_10().fromRepo(repo, repoDataProvider, snapshotName, index.getName());
+                    indexMetadata = new IndexMetadataFactory_ES_7_10(repoDataProvider).fromRepo(snapshotName, index.getName());
                 }
                 indexMetadatas.add(indexMetadata);
             }
@@ -305,6 +305,7 @@ public class ReindexFromSnapshot {
                 // ==========================================================================================================
                 logger.info("==================================================================");
                 logger.info("Attempting to recreate the indices...");
+                IndexCreator_OS_2_11 indexCreator = new IndexCreator_OS_2_11(targetClient);
                 for (IndexMetadata.Data indexMetadata : indexMetadatas) {
                     String reindexName = indexMetadata.getName() + indexSuffix;
                     logger.info("Recreating index " + indexMetadata.getName() + " as " + reindexName + " on target...");
@@ -312,7 +313,7 @@ public class ReindexFromSnapshot {
                     ObjectNode root = indexMetadata.toObjectNode();
                     ObjectNode transformedRoot = transformer.transformIndexMetadata(root);
                     IndexMetadataData_OS_2_11 indexMetadataOS211 = new IndexMetadataData_OS_2_11(transformedRoot, indexMetadata.getId(), reindexName);
-                    IndexCreator_OS_2_11.create(reindexName, indexMetadataOS211, targetClient);
+                    indexCreator.create(reindexName, indexMetadataOS211);
                 }
             }
 

--- a/RFS/src/main/java/com/rfs/cms/CmsClient.java
+++ b/RFS/src/main/java/com/rfs/cms/CmsClient.java
@@ -1,5 +1,6 @@
 package com.rfs.cms;
 
+import java.util.List;
 import java.util.Optional;
 
 /*
@@ -23,7 +24,7 @@ public interface CmsClient {
      * Updates the Snapshot entry in the CMS.  Returns an Optional; if the document was updated, it will be
      * the updated entry and empty otherwise.
      */
-    public Optional<CmsEntry.Snapshot> updateSnapshotEntry(String snapshotName, CmsEntry.SnapshotStatus status);
+    public Optional<CmsEntry.Snapshot> updateSnapshotEntry(CmsEntry.Snapshot newEntry, CmsEntry.Snapshot lastEntry);
 
     /*
      * Creates a new entry in the CMS for the Metadata Migration's progress.  Returns an Optional; if the document was
@@ -41,5 +42,46 @@ public interface CmsClient {
      * Updates the Metadata Migration entry in the CMS.  Returns an Optional; if the document was updated,
      * it will be the updated entry and empty otherwise.
      */
-    public Optional<CmsEntry.Metadata> updateMetadataEntry(CmsEntry.MetadataStatus status, String leaseExpiry, Integer numAttempts);
+    public Optional<CmsEntry.Metadata> updateMetadataEntry(CmsEntry.Metadata newEntry, CmsEntry.Metadata lastEntry);
+
+    /*
+     * Creates a new entry in the CMS for the Index Migration's progress.  Returns an Optional; if the document was
+     * created, it will be the created entry and empty otherwise.
+     */
+    public Optional<CmsEntry.Index> createIndexEntry();
+
+    /*
+     * Attempt to retrieve the Index Migration entry from the CMS, if it exists.  Returns an Optional; if the document
+     * exists, it will be the retrieved entry and empty otherwise.
+     */
+    public Optional<CmsEntry.Index> getIndexEntry();
+
+    /*
+     * Updates the Index Migration entry in the CMS.  Returns an Optional; if the document was updated,
+     * it will be the updated entry and empty otherwise.
+     */
+    public Optional<CmsEntry.Index> updateIndexEntry(CmsEntry.Index newEntry, CmsEntry.Index lastEntry);
+
+    /*
+     * Creates a new entry in the CMS for an Index Work Item.  Returns an Optional; if the document was
+     * created, it will be the created entry and empty otherwise.
+     */
+    public Optional<CmsEntry.IndexWorkItem> createIndexWorkItem(String name, int numShards);
+
+    /*
+     * Updates the Index Work Item in the CMS.  Returns an Optional; if the document was updated,
+     * it will be the updated entry and empty otherwise.
+     */
+    public Optional<CmsEntry.IndexWorkItem> updateIndexWorkItem(CmsEntry.IndexWorkItem newEntry, CmsEntry.IndexWorkItem lastEntry);
+
+    /*
+     * Forcefully updates the Index Work Item in the CMS.  This method should be used when you don't care about collisions
+     * and just want to overwrite the existing entry no matter what.  Returns the updated entry.
+     */
+    public CmsEntry.IndexWorkItem updateIndexWorkItemForceful(CmsEntry.IndexWorkItem newEntry);
+
+    /* 
+     * Retrieves a set of Index Work Items from the CMS that appear ready to be worked on, up to the specified limit.
+     */
+    public List<CmsEntry.IndexWorkItem> getAvailableIndexWorkItems(int maxItems);
 }

--- a/RFS/src/main/java/com/rfs/cms/CmsEntry.java
+++ b/RFS/src/main/java/com/rfs/cms/CmsEntry.java
@@ -1,11 +1,64 @@
 package com.rfs.cms;
 
+
 import com.rfs.common.RfsException;
 
 public class CmsEntry {
+    public static enum EntryType {
+        SNAPSHOT,
+        METADATA,
+        INDEX,
+        INDEX_WORK_ITEM,
+    }
+
     public abstract static class Base {
         protected Base() {}
+        
+        @Override
         public abstract String toString();
+    
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null || !(obj instanceof Base)) {
+                return false;
+            }
+            Base other = (Base) obj;
+            return this.toString().equals(other.toString());
+        }
+    
+        @Override
+        public int hashCode() {
+            return this.toString().hashCode();
+        }
+    }
+
+    /*
+     * Provides a base class for leasable entry types.  Doesn't allow for customization of lease mechanics, but it's 
+     * unclear how to achieve that in Java given the constraints around static methods.
+    */
+    public abstract static class Leasable extends Base {
+        public static final int LEASE_MS = 1 * 60 * 1000; // 1 minute, arbitrarily chosen
+        public static final int MAX_ATTEMPTS = 3; // arbitrarily chosen
+
+        protected Leasable() {}
+
+        public static int getLeaseDurationMs(int numAttempts) {
+            if (numAttempts > MAX_ATTEMPTS) {
+                throw new CouldNotFindNextLeaseDuration("numAttempts=" + numAttempts + " is greater than MAX_ATTEMPTS=" + MAX_ATTEMPTS);
+            } else if (numAttempts < 1) {
+                throw new CouldNotFindNextLeaseDuration("numAttempts=" + numAttempts + " is less than 1");
+            }
+            return LEASE_MS * numAttempts; // Arbitratily chosen algorithm
+        }
+
+        // TODO: We should be ideally setting the lease expiry using the server's clock, but it's unclear on the best
+        // way to do this.  For now, we'll just use the client's clock.
+        public static String getLeaseExpiry(long currentTime, int numAttempts) {
+            return Long.toString(currentTime + getLeaseDurationMs(numAttempts));
+        }
     }
 
     public static enum SnapshotStatus {
@@ -15,7 +68,11 @@ public class CmsEntry {
         FAILED,
     }
 
+    /*
+     * Used to track the progress of taking a snapshot of the source cluster
+     */
     public static class Snapshot extends Base {
+        public final EntryType type = EntryType.SNAPSHOT;
         public final String name;
         public final SnapshotStatus status;
 
@@ -28,8 +85,9 @@ public class CmsEntry {
         @Override
         public String toString() {
             return "Snapshot("
+                + "type='" + type.toString() + ","
                 + "name='" + name + ","
-                + "status=" + status +
+                + "status=" + status.toString() +
                 ")";
         }
     }
@@ -40,25 +98,11 @@ public class CmsEntry {
         FAILED,
     }
 
-    public static class Metadata extends Base {
-        public static final int METADATA_LEASE_MS = 1 * 60 * 1000; // 1 minute, arbitrarily chosen
-        public static final int MAX_ATTEMPTS = 3; // arbitrarily chosen
-
-        public static int getLeaseDurationMs(int numAttempts) {
-            if (numAttempts > MAX_ATTEMPTS) {
-                throw new CouldNotFindNextLeaseDuration("numAttempts=" + numAttempts + " is greater than MAX_ATTEMPTS=" + MAX_ATTEMPTS);
-            } else if (numAttempts < 1) {
-                throw new CouldNotFindNextLeaseDuration("numAttempts=" + numAttempts + " is less than 1");
-            }
-            return METADATA_LEASE_MS * numAttempts; // Arbitratily chosen algorithm
-        }
-
-        // TODO: We should be ideally setting the lease expiry using the server's clock, but it's unclear on the best
-        // way to do this.  For now, we'll just use the client's clock.
-        public static String getLeaseExpiry(long currentTime, int numAttempts) {
-            return Long.toString(currentTime + getLeaseDurationMs(numAttempts));
-        }
-
+    /*
+     * Used to track the progress of migrating all the templates from the source cluster
+     */
+    public static class Metadata extends Leasable {
+        public final EntryType type = EntryType.METADATA;
         public final MetadataStatus status;
         public final String leaseExpiry;
         public final Integer numAttempts;
@@ -73,9 +117,82 @@ public class CmsEntry {
         @Override
         public String toString() {
             return "Metadata("
+                + "type='" + type.toString() + ","
                 + "status=" + status.toString() + ","
                 + "leaseExpiry=" + leaseExpiry + ","
                 + "numAttempts=" + numAttempts.toString() +
+                ")";
+        }
+    }
+
+    public static enum IndexStatus {
+        SETUP,
+        IN_PROGRESS,
+        COMPLETED,
+        FAILED,
+    }
+
+    /*
+     * Used to track the progress of migrating all the indices from the soruce cluster
+     */
+    public static class Index extends Leasable {
+        public final EntryType type = EntryType.INDEX;
+        public final IndexStatus status;
+        public final String leaseExpiry;
+        public final Integer numAttempts;
+
+        public Index(IndexStatus status, String leaseExpiry, int numAttempts) {
+            super();
+            this.status = status;
+            this.leaseExpiry = leaseExpiry;
+            this.numAttempts = numAttempts;
+        }
+
+        @Override
+        public String toString() {
+            return "Index("
+                + "type='" + type.toString() + ","
+                + "status=" + status.toString() + ","
+                + "leaseExpiry=" + leaseExpiry + ","
+                + "numAttempts=" + numAttempts.toString() +
+                ")";
+        }
+    }
+
+    public static enum IndexWorkItemStatus {
+        NOT_STARTED,
+        COMPLETED,
+        FAILED,
+    }
+
+    /*
+     * Used to track the migration of a particular index from the source cluster
+     */
+    public static class IndexWorkItem extends Base {
+        public final EntryType type = EntryType.INDEX_WORK_ITEM;
+        public static final int ATTEMPTS_SOFT_LIMIT = 3; // will make at least this many attempts; arbitrarily chosen
+
+        public final String name;
+        public final IndexWorkItemStatus status;
+        public final Integer numAttempts;
+        public final Integer numShards;
+
+        public IndexWorkItem(String name, IndexWorkItemStatus status, int numAttempts, int numShards) {
+            super();
+            this.name = name;
+            this.status = status;
+            this.numAttempts = numAttempts;
+            this.numShards = numShards;
+        }
+
+        @Override
+        public String toString() {
+            return "IndexWorkItem("
+                + "type='" + type.toString() + ","
+                + "name=" + name.toString() + ","
+                + "status=" + status.toString() + ","
+                + "numAttempts=" + numAttempts.toString() + ","
+                + "numShards=" + numShards.toString() +
                 ")";
         }
     }

--- a/RFS/src/main/java/com/rfs/cms/OpenSearchCmsClient.java
+++ b/RFS/src/main/java/com/rfs/cms/OpenSearchCmsClient.java
@@ -1,14 +1,28 @@
 package com.rfs.cms;
 
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.rfs.common.OpenSearchClient;
+import com.rfs.common.RfsException;
 
 public class OpenSearchCmsClient implements CmsClient {
+    private static final Logger logger = LogManager.getLogger(OpenSearchCmsClient.class);
+
     public static final String CMS_INDEX_NAME = "cms-reindex-from-snapshot";
     public static final String CMS_SNAPSHOT_DOC_ID = "snapshot_status";
     public static final String CMS_METADATA_DOC_ID = "metadata_status";
+    public static final String CMS_INDEX_DOC_ID = "index_status";
+
+    public static String getIndexWorkItemDocId(String name) {
+        // iwi => index work item
+        return "iwi_" + name;
+    }
 
     private final OpenSearchClient client;
 
@@ -31,9 +45,20 @@ public class OpenSearchCmsClient implements CmsClient {
     }
 
     @Override
-    public Optional<CmsEntry.Snapshot> updateSnapshotEntry(String snapshotName, CmsEntry.SnapshotStatus status) {
-        OpenSearchCmsEntry.Snapshot entry = new OpenSearchCmsEntry.Snapshot(snapshotName, status);
-        Optional<ObjectNode> updatedEntry = client.updateDocument(CMS_INDEX_NAME, CMS_SNAPSHOT_DOC_ID, entry.toJson());
+    public Optional<CmsEntry.Snapshot> updateSnapshotEntry(CmsEntry.Snapshot newEntry, CmsEntry.Snapshot lastEntry) {
+        // Pull the existing entry to ensure that it hasn't changed since we originally retrieved it
+        ObjectNode currentEntryRaw = client.getDocument(CMS_INDEX_NAME, CMS_SNAPSHOT_DOC_ID)
+            .orElseThrow(() -> new RfsException("Failed to update snapshot entry: " + CMS_SNAPSHOT_DOC_ID + " does not exist"));
+
+        OpenSearchCmsEntry.Snapshot currentEntry = OpenSearchCmsEntry.Snapshot.fromJson((ObjectNode) currentEntryRaw.get("_source"));
+        if (!currentEntry.equals(new OpenSearchCmsEntry.Snapshot(lastEntry))) {
+            logger.info("Failed to update snapshot entry: " + CMS_SNAPSHOT_DOC_ID + " has changed we first retrieved it");
+            return Optional.empty();
+        }
+
+        // Now attempt the update
+        ObjectNode newEntryJson = new OpenSearchCmsEntry.Snapshot(newEntry).toJson();
+        Optional<ObjectNode> updatedEntry = client.updateDocument(CMS_INDEX_NAME, CMS_SNAPSHOT_DOC_ID, newEntryJson, currentEntryRaw);
         return updatedEntry.map(OpenSearchCmsEntry.Snapshot::fromJson);
     }
 
@@ -53,9 +78,129 @@ public class OpenSearchCmsClient implements CmsClient {
     }
 
     @Override
-    public Optional<CmsEntry.Metadata> updateMetadataEntry(CmsEntry.MetadataStatus status, String leaseExpiry, Integer numAttempts) {
-        OpenSearchCmsEntry.Metadata metadata = new OpenSearchCmsEntry.Metadata(status, leaseExpiry, numAttempts);
-        Optional<ObjectNode> updatedEntry = client.updateDocument(CMS_INDEX_NAME, CMS_METADATA_DOC_ID, metadata.toJson());
+    public Optional<CmsEntry.Metadata> updateMetadataEntry(CmsEntry.Metadata newEntry, CmsEntry.Metadata lastEntry) {
+        // Pull the existing entry to ensure that it hasn't changed since we originally retrieved it
+        ObjectNode currentEntryRaw = client.getDocument(CMS_INDEX_NAME, CMS_METADATA_DOC_ID)
+            .orElseThrow(() -> new RfsException("Failed to update metadata entry: " + CMS_METADATA_DOC_ID + " does not exist"));
+
+        OpenSearchCmsEntry.Metadata currentEntry = OpenSearchCmsEntry.Metadata.fromJson((ObjectNode) currentEntryRaw.get("_source"));
+        if (!currentEntry.equals(new OpenSearchCmsEntry.Metadata(lastEntry))) {
+            logger.info("Failed to update metadata entry: " + CMS_METADATA_DOC_ID + " has changed we first retrieved it");
+            return Optional.empty();
+        }
+
+        // Now attempt the update
+        ObjectNode newEntryJson = new OpenSearchCmsEntry.Metadata(newEntry).toJson();
+        Optional<ObjectNode> updatedEntry = client.updateDocument(CMS_INDEX_NAME, CMS_METADATA_DOC_ID, newEntryJson, currentEntryRaw);
         return updatedEntry.map(OpenSearchCmsEntry.Metadata::fromJson);
-    }    
+    }
+
+    @Override
+    public Optional<CmsEntry.Index> createIndexEntry() {
+        OpenSearchCmsEntry.Index entry = OpenSearchCmsEntry.Index.getInitial();
+        Optional<ObjectNode> createdEntry = client.createDocument(CMS_INDEX_NAME, CMS_INDEX_DOC_ID, entry.toJson());
+        return createdEntry.map(OpenSearchCmsEntry.Index::fromJson);
+
+    }
+
+    @Override
+    public Optional<CmsEntry.Index> getIndexEntry() {
+        Optional<ObjectNode> document = client.getDocument(CMS_INDEX_NAME, CMS_INDEX_DOC_ID);
+        return document.map(doc -> (ObjectNode) doc.get("_source"))
+                       .map(OpenSearchCmsEntry.Index::fromJson);
+    }
+
+    @Override
+    public Optional<CmsEntry.Index> updateIndexEntry(CmsEntry.Index newEntry, CmsEntry.Index lastEntry) {
+        // Pull the existing entry to ensure that it hasn't changed since we originally retrieved it
+        ObjectNode currentEntryRaw = client.getDocument(CMS_INDEX_NAME, CMS_INDEX_DOC_ID)
+            .orElseThrow(() -> new RfsException("Failed to update index entry: " + CMS_INDEX_DOC_ID + " does not exist"));
+
+        OpenSearchCmsEntry.Index currentEntry = OpenSearchCmsEntry.Index.fromJson((ObjectNode) currentEntryRaw.get("_source"));
+        if (!currentEntry.equals(new OpenSearchCmsEntry.Index(lastEntry))) {
+            logger.info("Failed to update index entry: " + CMS_INDEX_DOC_ID + " has changed we first retrieved it");
+            return Optional.empty();
+        }
+
+        // Now attempt the update
+        ObjectNode newEntryJson = new OpenSearchCmsEntry.Index(newEntry).toJson();
+        Optional<ObjectNode> updatedEntry = client.updateDocument(CMS_INDEX_NAME, CMS_INDEX_DOC_ID, newEntryJson, currentEntryRaw);
+        return updatedEntry.map(OpenSearchCmsEntry.Index::fromJson);
+    }
+
+    @Override
+    public Optional<CmsEntry.IndexWorkItem> createIndexWorkItem(String name, int numShards) {
+        OpenSearchCmsEntry.IndexWorkItem entry = OpenSearchCmsEntry.IndexWorkItem.getInitial(name, numShards);
+        Optional<ObjectNode> createdEntry = client.createDocument(CMS_INDEX_NAME, getIndexWorkItemDocId(entry.name), entry.toJson());
+        return createdEntry.map(OpenSearchCmsEntry.IndexWorkItem::fromJson);
+    }
+
+    @Override
+    public Optional<CmsEntry.IndexWorkItem> updateIndexWorkItem(CmsEntry.IndexWorkItem newEntry, CmsEntry.IndexWorkItem lastEntry) {
+        // Pull the existing entry to ensure that it hasn't changed since we originally retrieved it
+        ObjectNode currentEntryRaw = client.getDocument(CMS_INDEX_NAME, getIndexWorkItemDocId(lastEntry.name))
+            .orElseThrow(() -> new RfsException("Failed to update index work item: " + lastEntry.name + " does not exist"));
+
+        OpenSearchCmsEntry.IndexWorkItem currentEntry = OpenSearchCmsEntry.IndexWorkItem.fromJson((ObjectNode) currentEntryRaw.get("_source"));
+        if (!currentEntry.equals(new OpenSearchCmsEntry.IndexWorkItem(lastEntry))) {
+            logger.info("Failed to update index work item: " + lastEntry.name + " has changed we first retrieved it");
+            return Optional.empty();
+        }
+
+        // Now attempt the update
+        ObjectNode newEntryJson = new OpenSearchCmsEntry.IndexWorkItem(newEntry).toJson();
+        Optional<ObjectNode> updatedEntry = client.updateDocument(CMS_INDEX_NAME, getIndexWorkItemDocId(newEntry.name), newEntryJson, currentEntryRaw);
+        return updatedEntry.map(OpenSearchCmsEntry.IndexWorkItem::fromJson);
+    }
+
+    @Override
+    public CmsEntry.IndexWorkItem updateIndexWorkItemForceful(CmsEntry.IndexWorkItem newEntry) {
+        // Now attempt the update
+        ObjectNode newEntryJson = new OpenSearchCmsEntry.IndexWorkItem(newEntry).toJson();
+        ObjectNode updatedEntry = client.updateDocumentForceful(CMS_INDEX_NAME, getIndexWorkItemDocId(newEntry.name), newEntryJson);
+        return OpenSearchCmsEntry.IndexWorkItem.fromJson(updatedEntry);
+    }
+
+    @Override
+    public List<CmsEntry.IndexWorkItem> getAvailableIndexWorkItems(int maxItems) {
+        String queryBody = "{\n" +
+            "  \"query\": {\n" +
+            "    \"function_score\": {\n" +
+            "      \"query\": {\n" +
+            "        \"bool\": {\n" +
+            "          \"must\": [\n" +
+            "            {\n" +
+            "              \"match\": {\n" +
+            "                \"type\": \"INDEX_WORK_ITEM\"\n" +
+            "              }\n" +
+            "            },\n" +
+            "            {\n" +
+            "              \"match\": {\n" +
+            "                \"status\": \"NOT_STARTED\"\n" +
+            "              }\n" +
+            "            },\n" +
+            "            {\n" +
+            "              \"range\": {\n" +
+            "                \"numAttempts\": {\n" +
+            "                  \"lte\": " + CmsEntry.IndexWorkItem.ATTEMPTS_SOFT_LIMIT + "\n" + // Less than or equal to
+            "                }\n" +
+            "              }\n" +
+            "            }\n" +
+            "          ]\n" +
+            "        }\n" +
+            "      },\n" +
+            "      \"random_score\": {}\n" + // Try to avoid the workers fighting for the same work items
+            "    }\n" +
+            "  },\n" +
+            "  \"size\": " + maxItems + "\n" +
+            "}";
+
+        List<ObjectNode> hits = client.searchDocuments(CMS_INDEX_NAME, queryBody);
+        List<CmsEntry.IndexWorkItem> workItems = hits.stream()
+            .map(hit -> (ObjectNode) hit.get("_source"))
+            .map(OpenSearchCmsEntry.IndexWorkItem::fromJson)
+            .collect(Collectors.toList());
+
+        return workItems;
+    }
 }

--- a/RFS/src/main/java/com/rfs/cms/OpenSearchCmsClient.java
+++ b/RFS/src/main/java/com/rfs/cms/OpenSearchCmsClient.java
@@ -163,6 +163,10 @@ public class OpenSearchCmsClient implements CmsClient {
 
     @Override
     public List<CmsEntry.IndexWorkItem> getAvailableIndexWorkItems(int maxItems) {
+        // Ensure we have a relatively fresh view of the index
+        client.refresh();
+
+        // Pull the docs
         String queryBody = "{\n" +
             "  \"query\": {\n" +
             "    \"function_score\": {\n" +
@@ -177,13 +181,6 @@ public class OpenSearchCmsClient implements CmsClient {
             "            {\n" +
             "              \"match\": {\n" +
             "                \"status\": \"NOT_STARTED\"\n" +
-            "              }\n" +
-            "            },\n" +
-            "            {\n" +
-            "              \"range\": {\n" +
-            "                \"numAttempts\": {\n" +
-            "                  \"lte\": " + CmsEntry.IndexWorkItem.ATTEMPTS_SOFT_LIMIT + "\n" + // Less than or equal to
-            "                }\n" +
             "              }\n" +
             "            }\n" +
             "          ]\n" +

--- a/RFS/src/main/java/com/rfs/cms/OpenSearchCmsEntry.java
+++ b/RFS/src/main/java/com/rfs/cms/OpenSearchCmsEntry.java
@@ -10,6 +10,7 @@ public class OpenSearchCmsEntry {
     private static final ObjectMapper objectMapper = new ObjectMapper();
 
     public static class Snapshot extends CmsEntry.Snapshot {
+        public static final String FIELD_TYPE = "type";
         public static final String FIELD_NAME = "name";
         public static final String FIELD_STATUS = "status";
 
@@ -32,8 +33,13 @@ public class OpenSearchCmsEntry {
             super(name, status);
         }
 
+        public Snapshot(CmsEntry.Snapshot entry) {
+            this(entry.name, entry.status);
+        }
+
         public ObjectNode toJson() {
             ObjectNode node = objectMapper.createObjectNode();
+            node.put(FIELD_TYPE, type.toString());
             node.put(FIELD_STATUS, name);
             node.put(FIELD_STATUS, status.toString());
             return node;
@@ -46,6 +52,7 @@ public class OpenSearchCmsEntry {
     }
 
     public static class Metadata extends CmsEntry.Metadata {
+        public static final String FIELD_TYPE = "type";
         public static final String FIELD_STATUS = "status";
         public static final String FIELD_LEASE_EXPIRY = "leaseExpiry";
         public static final String FIELD_NUM_ATTEMPTS = "numAttempts";
@@ -76,11 +83,120 @@ public class OpenSearchCmsEntry {
             super(status, leaseExpiry, numAttempts);
         }
 
+        public Metadata(CmsEntry.Metadata entry) {
+            this(entry.status, entry.leaseExpiry, entry.numAttempts);
+        }
+
         public ObjectNode toJson() {
             ObjectNode node = objectMapper.createObjectNode();
+            node.put(FIELD_TYPE, type.toString());
             node.put(FIELD_STATUS, status.toString());
             node.put(FIELD_LEASE_EXPIRY, leaseExpiry);
             node.put(FIELD_NUM_ATTEMPTS, numAttempts);
+            return node;
+        }
+
+        @Override
+        public String toString() {
+            return this.toJson().toString();
+        }
+    }
+
+    public static class Index extends CmsEntry.Index {
+        public static final String FIELD_TYPE = "type";
+        public static final String FIELD_STATUS = "status";
+        public static final String FIELD_LEASE_EXPIRY = "leaseExpiry";
+        public static final String FIELD_NUM_ATTEMPTS = "numAttempts";
+
+        public static Index getInitial() {
+            return new Index(
+                CmsEntry.IndexStatus.IN_PROGRESS,
+                // TODO: We should be ideally setting the lease using the server's clock, but it's unclear on the best way
+                // to do this.  For now, we'll just use the client's clock.
+                CmsEntry.Index.getLeaseExpiry(Instant.now().toEpochMilli(), 1),
+                1
+            );
+        }
+
+        public static Index fromJson(ObjectNode node) {
+            try {
+                return new Index(
+                    CmsEntry.IndexStatus.valueOf(node.get(FIELD_STATUS).asText()),
+                    node.get(FIELD_LEASE_EXPIRY).asText(),
+                    node.get(FIELD_NUM_ATTEMPTS).asInt()
+                );
+            } catch (Exception e) {
+                throw new CantParseCmsEntryFromJson(Index.class, node.toString(), e);
+            }
+        }
+
+        public Index(CmsEntry.IndexStatus status, String leaseExpiry, Integer numAttempts) {
+            super(status, leaseExpiry, numAttempts);
+        }
+
+        public Index(CmsEntry.Index entry) {
+            this(entry.status, entry.leaseExpiry, entry.numAttempts);
+        }
+
+        public ObjectNode toJson() {
+            ObjectNode node = objectMapper.createObjectNode();
+            node.put(FIELD_TYPE, type.toString());
+            node.put(FIELD_STATUS, status.toString());
+            node.put(FIELD_LEASE_EXPIRY, leaseExpiry);
+            node.put(FIELD_NUM_ATTEMPTS, numAttempts);
+            return node;
+        }
+
+        @Override
+        public String toString() {
+            return this.toJson().toString();
+        }
+    }
+
+    public static class IndexWorkItem extends CmsEntry.IndexWorkItem {
+        public static final String FIELD_TYPE = "type";
+        public static final String FIELD_NAME = "name";
+        public static final String FIELD_STATUS = "status";
+        public static final String FIELD_NUM_ATTEMPTS = "numAttempts";
+        public static final String FIELD_NUM_SHARDS = "numShards";
+
+        public static IndexWorkItem getInitial(String name, int numShards) {
+            return new IndexWorkItem(
+                name,
+                CmsEntry.IndexWorkItemStatus.NOT_STARTED,
+                1,
+                numShards
+            );
+        }
+
+        public static IndexWorkItem fromJson(ObjectNode node) {
+            try {
+                return new IndexWorkItem(
+                    node.get(FIELD_NAME).asText(),
+                    CmsEntry.IndexWorkItemStatus.valueOf(node.get(FIELD_STATUS).asText()),
+                    node.get(FIELD_NUM_ATTEMPTS).asInt(),
+                    node.get(FIELD_NUM_SHARDS).asInt()
+                );
+            } catch (Exception e) {
+                throw new CantParseCmsEntryFromJson(Index.class, node.toString(), e);
+            }
+        }
+
+        public IndexWorkItem(String name, CmsEntry.IndexWorkItemStatus status, Integer numAttempts, Integer numShards) {
+            super(name, status, numAttempts, numShards);
+        }
+
+        public IndexWorkItem(CmsEntry.IndexWorkItem entry) {
+            this(entry.name, entry.status, entry.numAttempts, entry.numShards);
+        }
+
+        public ObjectNode toJson() {
+            ObjectNode node = objectMapper.createObjectNode();
+            node.put(FIELD_TYPE, type.toString());
+            node.put(FIELD_NAME, name);
+            node.put(FIELD_STATUS, status.toString());
+            node.put(FIELD_NUM_ATTEMPTS, numAttempts);
+            node.put(FIELD_NUM_SHARDS, numShards);
             return node;
         }
 

--- a/RFS/src/main/java/com/rfs/version_es_6_8/IndexMetadataFactory_ES_6_8.java
+++ b/RFS/src/main/java/com/rfs/version_es_6_8/IndexMetadataFactory_ES_6_8.java
@@ -7,9 +7,14 @@ import com.rfs.common.IndexMetadata;
 import com.rfs.common.SnapshotRepo;
 
 public class IndexMetadataFactory_ES_6_8 implements com.rfs.common.IndexMetadata.Factory {
+    private final SnapshotRepo.Provider repoDataProvider;
+
+    public IndexMetadataFactory_ES_6_8(SnapshotRepo.Provider repoDataProvider) {
+        this.repoDataProvider = repoDataProvider;
+    }
     
     @Override
-    public IndexMetadata.Data fromJsonNode(JsonNode root, String indexId, String indexName) throws Exception {
+    public IndexMetadata.Data fromJsonNode(JsonNode root, String indexId, String indexName) {
         ObjectNode objectNodeRoot = (ObjectNode) root.get(indexName);
         return new IndexMetadataData_ES_6_8(objectNodeRoot, indexId, indexName);
     }
@@ -20,7 +25,12 @@ public class IndexMetadataFactory_ES_6_8 implements com.rfs.common.IndexMetadata
     }
 
     @Override
-    public String getIndexFileId(SnapshotRepo.Provider repoDataProvider, String snapshotName, String indexName) {
+    public String getIndexFileId(String snapshotName, String indexName) {
         return repoDataProvider.getSnapshotId(snapshotName);
+    }
+
+    @Override
+    public SnapshotRepo.Provider getRepoDataProvider() {
+        return repoDataProvider;
     }
 }

--- a/RFS/src/main/java/com/rfs/version_es_7_10/IndexMetadataFactory_ES_7_10.java
+++ b/RFS/src/main/java/com/rfs/version_es_7_10/IndexMetadataFactory_ES_7_10.java
@@ -7,9 +7,14 @@ import com.rfs.common.IndexMetadata;
 import com.rfs.common.SnapshotRepo;
 
 public class IndexMetadataFactory_ES_7_10 implements com.rfs.common.IndexMetadata.Factory {
+    private final SnapshotRepo.Provider repoDataProvider;
+
+    public IndexMetadataFactory_ES_7_10(SnapshotRepo.Provider repoDataProvider) {
+        this.repoDataProvider = repoDataProvider;
+    }
     
     @Override
-    public IndexMetadata.Data fromJsonNode(JsonNode root, String indexId, String indexName) throws Exception {
+    public IndexMetadata.Data fromJsonNode(JsonNode root, String indexId, String indexName) {
         ObjectNode objectNodeRoot = (ObjectNode) root.get(indexName);
         return new IndexMetadataData_ES_7_10(objectNodeRoot, indexId, indexName);
     }
@@ -20,9 +25,14 @@ public class IndexMetadataFactory_ES_7_10 implements com.rfs.common.IndexMetadat
     }
 
     @Override
-    public String getIndexFileId(SnapshotRepo.Provider repoDataProvider, String snapshotName, String indexName) {
+    public String getIndexFileId(String snapshotName, String indexName) {
         SnapshotRepoProvider_ES_7_10 providerES710 = (SnapshotRepoProvider_ES_7_10) repoDataProvider;
         return providerES710.getIndexMetadataId(snapshotName, indexName);
+    }
+
+    @Override
+    public SnapshotRepo.Provider getRepoDataProvider() {
+        return repoDataProvider;
     }
     
 }

--- a/RFS/src/main/java/com/rfs/version_os_2_11/IndexCreator_OS_2_11.java
+++ b/RFS/src/main/java/com/rfs/version_os_2_11/IndexCreator_OS_2_11.java
@@ -1,5 +1,7 @@
 package com.rfs.version_os_2_11;
 
+import java.util.Optional;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.rfs.common.IndexMetadata;
@@ -7,8 +9,13 @@ import com.rfs.common.OpenSearchClient;
 
 public class IndexCreator_OS_2_11 {
     private static final ObjectMapper mapper = new ObjectMapper();
+    protected final OpenSearchClient client;
 
-    public static void create(String indexName, IndexMetadata.Data indexMetadata, OpenSearchClient client) throws Exception {
+    public IndexCreator_OS_2_11 (OpenSearchClient client) {
+        this.client = client;
+    }
+
+    public Optional<ObjectNode> create(String indexName, IndexMetadata.Data indexMetadata) {
         // Remove some settings which will cause errors if you try to pass them to the API
         ObjectNode settings = indexMetadata.getSettings();
 
@@ -23,7 +30,7 @@ public class IndexCreator_OS_2_11 {
         body.set("mappings", indexMetadata.getMappings());
         body.set("settings", settings);
 
-        // Idempotently create the index
-        client.createIndex(indexName, body);
+        // Create the index; it's fine if it already exists
+        return client.createIndex(indexName, body);
     }
 }

--- a/RFS/src/main/java/com/rfs/version_os_2_11/IndexCreator_OS_2_11.java
+++ b/RFS/src/main/java/com/rfs/version_os_2_11/IndexCreator_OS_2_11.java
@@ -4,7 +4,6 @@ import java.util.Optional;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.rfs.common.IndexMetadata;
 import com.rfs.common.OpenSearchClient;
 
 public class IndexCreator_OS_2_11 {
@@ -15,7 +14,9 @@ public class IndexCreator_OS_2_11 {
         this.client = client;
     }
 
-    public Optional<ObjectNode> create(String indexName, IndexMetadata.Data indexMetadata) {
+    public Optional<ObjectNode> create(ObjectNode root, String indexName, String indexId) {
+        IndexMetadataData_OS_2_11 indexMetadata = new IndexMetadataData_OS_2_11(root, indexId, indexName);
+
         // Remove some settings which will cause errors if you try to pass them to the API
         ObjectNode settings = indexMetadata.getSettings();
 

--- a/RFS/src/main/java/com/rfs/worker/GlobalState.java
+++ b/RFS/src/main/java/com/rfs/worker/GlobalState.java
@@ -15,7 +15,10 @@ public class GlobalState {
         SNAPSHOT_FAILED,
         METADATA_IN_PROGRESS,
         METADATA_COMPLETED,
-        METADATA_FAILED
+        METADATA_FAILED,
+        INDEX_IN_PROGRESS,
+        INDEX_COMPLETED,
+        INDEX_FAILED
     }    
 
     private AtomicReference<Phase> phase = new AtomicReference<>(Phase.UNSET);

--- a/RFS/src/main/java/com/rfs/worker/IndexRunner.java
+++ b/RFS/src/main/java/com/rfs/worker/IndexRunner.java
@@ -1,0 +1,59 @@
+package com.rfs.worker;
+
+import java.util.Optional;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import com.rfs.cms.CmsClient;
+import com.rfs.cms.CmsEntry;
+import com.rfs.common.IndexMetadata;
+import com.rfs.transformers.Transformer;
+import com.rfs.version_os_2_11.IndexCreator_OS_2_11;
+
+public class IndexRunner implements Runner {
+    private static final Logger logger = LogManager.getLogger(IndexRunner.class);
+
+    private final IndexStep.SharedMembers members;
+
+    public IndexRunner(GlobalState globalState, CmsClient cmsClient, String snapshotName, IndexMetadata.Factory metadataFactory, 
+            IndexCreator_OS_2_11 indexCreator, Transformer transformer) {
+        this.members = new IndexStep.SharedMembers(globalState, cmsClient, snapshotName, metadataFactory, indexCreator, transformer);
+    }
+
+    @Override
+    public void runInternal() {
+        WorkerStep nextStep = null;
+        try {
+            nextStep = new IndexStep.EnterPhase(members);
+
+            while (nextStep != null) {
+                nextStep.run();
+                nextStep = nextStep.nextStep();
+            }
+        } catch (Exception e) {
+            throw new IndexMigrationPhaseFailed(
+                members.globalState.getPhase(), 
+                nextStep, 
+                members.cmsEntry.map(bar -> (CmsEntry.Base) bar), 
+                e
+            );
+        }
+    }
+
+    @Override
+    public String getPhaseName() {
+        return "Index Migration";
+    }
+
+    @Override
+    public Logger getLogger() {
+        return logger;
+    }
+
+    public static class IndexMigrationPhaseFailed extends Runner.PhaseFailed {
+        public IndexMigrationPhaseFailed(GlobalState.Phase phase, WorkerStep nextStep, Optional<CmsEntry.Base> cmsEntry, Exception e) {
+            super("Index Migration Phase failed", phase, nextStep, cmsEntry, e);
+        }
+    }    
+}

--- a/RFS/src/main/java/com/rfs/worker/IndexStep.java
+++ b/RFS/src/main/java/com/rfs/worker/IndexStep.java
@@ -16,7 +16,6 @@ import com.rfs.common.RfsException;
 import com.rfs.common.SnapshotRepo;
 import com.rfs.transformers.Transformer;
 import com.rfs.version_os_2_11.IndexCreator_OS_2_11;
-import com.rfs.version_os_2_11.IndexMetadataData_OS_2_11;
 
 public class IndexStep {
 
@@ -333,8 +332,7 @@ public class IndexStep {
                     ObjectNode root = indexMetadata.toObjectNode();
                     ObjectNode transformedRoot = members.transformer.transformIndexMetadata(root);
 
-                    IndexMetadataData_OS_2_11 indexMetadataOS211 = new IndexMetadataData_OS_2_11(transformedRoot, indexMetadata.getId(), workItem.name);
-                    members.indexCreator.create(workItem.name, indexMetadataOS211).ifPresentOrElse(
+                    members.indexCreator.create(transformedRoot, workItem.name, indexMetadata.getId()).ifPresentOrElse(
                         value -> logger.info("Index " + workItem.name + " created successfully"),
                         () -> logger.info("Index " + workItem.name + " already existed; no work required")
                     );

--- a/RFS/src/main/java/com/rfs/worker/IndexStep.java
+++ b/RFS/src/main/java/com/rfs/worker/IndexStep.java
@@ -1,0 +1,493 @@
+package com.rfs.worker;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.rfs.cms.CmsClient;
+import com.rfs.cms.CmsEntry;
+import com.rfs.cms.OpenSearchCmsClient;
+import com.rfs.cms.OpenSearchCmsEntry;
+import com.rfs.common.IndexMetadata;
+import com.rfs.common.RfsException;
+import com.rfs.common.SnapshotRepo;
+import com.rfs.transformers.Transformer;
+import com.rfs.version_os_2_11.IndexCreator_OS_2_11;
+import com.rfs.version_os_2_11.IndexMetadataData_OS_2_11;
+
+public class IndexStep {
+
+    public static class SharedMembers {
+        protected final GlobalState globalState;
+        protected final CmsClient cmsClient;
+        protected final String snapshotName;
+        protected final IndexMetadata.Factory metadataFactory;
+        protected final IndexCreator_OS_2_11 indexCreator;
+        protected final Transformer transformer;
+        protected Optional<CmsEntry.Index> cmsEntry;
+
+        public SharedMembers(GlobalState globalState, CmsClient cmsClient, String snapshotName, IndexMetadata.Factory metadataFactory,
+                IndexCreator_OS_2_11 indexCreator, Transformer transformer) {
+            this.globalState = globalState;
+            this.cmsClient = cmsClient;
+            this.snapshotName = snapshotName;
+            this.metadataFactory = metadataFactory;
+            this.indexCreator = indexCreator;
+            this.transformer = transformer;
+            this.cmsEntry = Optional.empty();
+        }
+
+        // A convient way to check if the CMS entry is present before retrieving it.  In some places, it's fine/expected
+        // for the CMS entry to be missing, but in others, it's a problem.
+        public CmsEntry.Index getCmsEntryNotMissing() {
+            return cmsEntry.orElseThrow(
+                () -> new MissingIndexEntry()
+            );
+        }
+    }
+
+    public static abstract class Base implements WorkerStep {
+        protected final Logger logger = LogManager.getLogger(getClass());
+        protected final SharedMembers members;
+    
+        public Base(SharedMembers members) {
+            this.members = members;
+        }
+    }
+
+    /*
+     * Updates the Worker's phase to indicate we're doing work on an Index Migration
+     */
+    public static class EnterPhase extends Base {
+        public EnterPhase(SharedMembers members) {
+            super(members);
+        }
+
+        @Override
+        public void run() {
+            logger.info("Index Migration not yet completed, entering Index Phase...");
+            members.globalState.updatePhase(GlobalState.Phase.INDEX_IN_PROGRESS);
+        }
+
+        @Override
+        public WorkerStep nextStep() {
+            return new GetEntry(members);
+        }
+    }
+
+    /*
+     * Gets the current Index Migration entry from the CMS, if it exists
+     */
+    public static class GetEntry extends Base {
+
+        public GetEntry(SharedMembers members) {
+            super(members);
+        }
+
+        @Override
+        public void run() {
+            logger.info("Pulling the Index Migration entry from the CMS, if it exists...");
+            members.cmsEntry = members.cmsClient.getIndexEntry();
+        }
+
+        @Override
+        public WorkerStep nextStep() {
+            if (members.cmsEntry.isEmpty()) {
+                return new CreateEntry(members);
+            } 
+            
+            CmsEntry.Index currentEntry = members.cmsEntry.get();            
+            switch (currentEntry.status) {
+                case SETUP:
+                    // TODO: This uses the client-side clock to evaluate the lease expiration, when we should
+                    // ideally be using the server-side clock.  Consider this a temporary solution until we find
+                    // out how to use the server-side clock.
+                    long leaseExpiryMillis = Long.parseLong(currentEntry.leaseExpiry);
+                    Instant leaseExpiryInstant = Instant.ofEpochMilli(leaseExpiryMillis);
+                    boolean leaseExpired = leaseExpiryInstant.isBefore(Instant.now());
+
+                    // Don't try to acquire the lease if we're already at the max number of attempts
+                    if (currentEntry.numAttempts >= CmsEntry.Index.MAX_ATTEMPTS && leaseExpired) {
+                        return new ExitPhaseFailed(members, new MaxAttemptsExceeded());
+                    }
+
+                    if (leaseExpired) {
+                        return new AcquireLease(members);
+                    } 
+                    
+                    logger.info("Index Migration entry found, but there's already a valid work lease on it");
+                    return new RandomWait(members);
+
+                case IN_PROGRESS:
+                    return new ExitPhaseSuccess(members);
+                    // return new GetIndicesToMigrate(members);
+                case COMPLETED:
+                    return new ExitPhaseSuccess(members);
+                case FAILED:
+                    return new ExitPhaseFailed(members, new FoundFailedIndexMigration());
+                default:
+                    throw new IllegalStateException("Unexpected metadata migration status: " + currentEntry.status);
+            }
+        }
+    }
+
+    public static class CreateEntry extends Base {
+
+        public CreateEntry(SharedMembers members) {
+            super(members);
+        }
+
+        @Override
+        public void run() {
+            logger.info("Index Migration CMS Entry not found, attempting to create it...");
+            members.cmsEntry = members.cmsClient.createIndexEntry();
+            logger.info("Index Migration CMS Entry created");
+        }
+
+        @Override
+        public WorkerStep nextStep() {
+            // Set up the index work entries if we successfully created the CMS entry; otherwise, circle back to the beginning
+            if (members.cmsEntry.isPresent()) {
+                return new SetupIndexWorkEntries(members);
+            } else {
+                return new GetEntry(members);
+            }
+        }
+    }
+
+    public static class AcquireLease extends Base {
+
+        public AcquireLease(SharedMembers members) {
+            super(members);
+        }
+
+        protected long getNowMs() {
+            return Instant.now().toEpochMilli();
+        }
+
+        @Override
+        public void run() {
+            // We only get here if we know we want to acquire the lock, so we know the CMS entry should not be null
+            CmsEntry.Index lastCmsEntry = members.getCmsEntryNotMissing();
+
+            logger.info("Current Metadata Migration work lease appears to have expired; attempting to acquire it...");
+            
+            CmsEntry.Index updatedEntry = new CmsEntry.Index(
+                CmsEntry.IndexStatus.IN_PROGRESS,
+                // Set the next CMS entry based on the current one
+                // TODO: Should be using the server-side clock here
+                CmsEntry.Index.getLeaseExpiry(getNowMs(), lastCmsEntry.numAttempts + 1),
+                lastCmsEntry.numAttempts + 1
+            );
+            members.cmsEntry = members.cmsClient.updateIndexEntry(updatedEntry, lastCmsEntry);
+
+            if (members.cmsEntry.isPresent()) {
+                logger.info("Lease acquired");
+            } else {
+                logger.info("Failed to acquire lease");
+            }
+        }
+
+        @Override
+        public WorkerStep nextStep() {
+            // Set up the index work entries if we acquired the lease; otherwise, circle back to the beginning after a backoff
+            if (members.cmsEntry.isPresent()) {
+                return new SetupIndexWorkEntries(members);
+            } else {
+                return new RandomWait(members);
+            }
+        }
+    }
+
+    
+    public static class SetupIndexWorkEntries extends Base {
+
+        public SetupIndexWorkEntries(SharedMembers members) {
+            super(members);
+        }
+
+        @Override
+        public void run() {
+            // We only get here if we acquired the lock, so we know the CMS entry should not be missing
+            CmsEntry.Index lastCmsEntry = members.getCmsEntryNotMissing();
+
+            logger.info("Setting the worker's current work item to be creating the index work entries...");
+            members.globalState.updateWorkItem(new OpenSearchWorkItem(OpenSearchCmsClient.CMS_INDEX_NAME, OpenSearchCmsClient.CMS_INDEX_DOC_ID));
+            logger.info("Work item set");
+
+            logger.info("Setting up the Index Work Items...");
+            SnapshotRepo.Provider repoDatProvider = members.metadataFactory.getRepoDataProvider();
+            for (SnapshotRepo.Index index : repoDatProvider.getIndicesInSnapshot(members.snapshotName)) {
+                IndexMetadata.Data indexMetadata = members.metadataFactory.fromRepo(members.snapshotName, index.getName());
+                logger.info("Creating Index Work Item for index: " + indexMetadata.getName());
+                members.cmsClient.createIndexWorkItem(indexMetadata.getName(), indexMetadata.getNumberOfShards());
+            }
+            logger.info("Finished setting up the Index Work Items.");
+
+            logger.info("Updating the Index Migration entry to indicate setup has been completed...");
+            OpenSearchCmsEntry.Index updatedEntry = new OpenSearchCmsEntry.Index(
+                CmsEntry.IndexStatus.IN_PROGRESS,
+                lastCmsEntry.leaseExpiry,
+                lastCmsEntry.numAttempts
+            );
+
+            members.cmsEntry = members.cmsClient.updateIndexEntry(updatedEntry, lastCmsEntry);
+            logger.info("Index Migration entry updated");
+
+            logger.info("Clearing the worker's current work item...");
+            members.globalState.updateWorkItem(null);
+            logger.info("Work item cleared");
+        }
+
+        @Override
+        public WorkerStep nextStep() {
+            if (members.cmsEntry.isEmpty()) {
+                // In this scenario, we've done all the work, but failed to update the CMS entry so that we know we've
+                // done the work.  We circle back around to try again, which is made more reasonable by the fact we
+                // don't re-migrate templates that already exist on the target cluster.  If we didn't circle back
+                // around, there would be a chance that the CMS entry would never be marked as completed.
+                //
+                // The CMS entry's retry limit still applies in this case, so there's a limiting factor here.
+                logger.warn("Completed creating the index work entries but failed to update the Index Migration entry; retrying...");
+                return new GetEntry(members);
+            }
+            return new GetIndicesToMigrate(members);
+        }
+    }
+
+    public static class GetIndicesToMigrate extends Base {
+        public static final int MAX_WORK_ITEMS = 10; //Arbitrarily chosen
+
+        protected List<CmsEntry.IndexWorkItem> workItems;
+
+        public GetIndicesToMigrate(SharedMembers members) {
+            super(members);
+            workItems = List.of();
+        }
+
+        @Override
+        public void run() {
+            logger.info("Pulling a list of indices to migrate from the CMS...");
+            workItems = members.cmsClient.getAvailableIndexWorkItems(MAX_WORK_ITEMS);
+            logger.info("Pulled " + workItems.size() + " indices to migrate:");
+            logger.info(workItems.toString());
+        }
+
+        @Override
+        public WorkerStep nextStep() {
+            if (workItems.isEmpty()) {
+                return new ExitPhaseSuccess(members);
+            } else {
+                return new MigrateIndices(members, workItems);
+            }
+        }
+    }
+
+    public static class MigrateIndices extends Base {
+        protected final List<CmsEntry.IndexWorkItem> workItems;
+
+        public MigrateIndices(SharedMembers members, List<CmsEntry.IndexWorkItem> workItems) {
+            super(members);
+            this.workItems = workItems;
+        }
+
+        @Override
+        public void run() {
+            logger.info("Migrating current batch of indices...");
+            for (CmsEntry.IndexWorkItem workItem : workItems) {
+                /*
+                 * Try to migrate the index.
+                 * 
+                 * If we succeed, we forcefully mark it as completed.  When we do so, we don't care if someone else has changed
+                 * the record in the meantime; *we* completed it successfully and that's what matters.  Because this is the only
+                 * forceful operation on the entry, the other operations are safe to be non-forceful.
+                 * 
+                 * If it's already exceeded the number of attempts, we attempt to mark it as failed.  If someone else
+                 * has updated the entry in the meantime, we just move on to the next work item.  This is safe because
+                 * it means someone else has either marked it as completed or failed, and either is fine.
+                 * 
+                 * If we fail to migrate it, we attempt to increment the attempt count.  It's fine if the increment
+                 * fails because we guarantee that we'll attempt the work at least N times, not exactly N times.
+                 */
+                if (workItem.numAttempts > CmsEntry.IndexWorkItem.ATTEMPTS_SOFT_LIMIT) {
+                    logger.info("Index Work Item " + workItem.name + " has exceeded the maximum number of attempts; marking it as failed...");
+                    CmsEntry.IndexWorkItem updatedEntry = new CmsEntry.IndexWorkItem(
+                        workItem.name,
+                        CmsEntry.IndexWorkItemStatus.FAILED,
+                        workItem.numAttempts,
+                        workItem.numShards
+                    );
+
+                    members.cmsClient.updateIndexWorkItem(updatedEntry, workItem).ifPresentOrElse(
+                        value -> logger.info("Index Work Item " + workItem.name + " marked as failed"),
+                        () ->logger.info("Unable to mark Index Work Item " + workItem.name + " as failed")
+                    );
+                    continue;
+                }
+
+                try {
+                    logger.info("Migrating index: " + workItem.name);
+                    IndexMetadata.Data indexMetadata = members.metadataFactory.fromRepo(members.snapshotName, workItem.name);
+
+                    ObjectNode root = indexMetadata.toObjectNode();
+                    ObjectNode transformedRoot = members.transformer.transformIndexMetadata(root);
+
+                    IndexMetadataData_OS_2_11 indexMetadataOS211 = new IndexMetadataData_OS_2_11(transformedRoot, indexMetadata.getId(), workItem.name);
+                    members.indexCreator.create(workItem.name, indexMetadataOS211).ifPresentOrElse(
+                        value -> {
+                            logger.info("Index " + workItem.name + " created successfully");
+                            logger.info("Forcefully updating the Index Work Item to indicate it has been completed...");
+                            CmsEntry.IndexWorkItem updatedEntry = new CmsEntry.IndexWorkItem(
+                                workItem.name,
+                                CmsEntry.IndexWorkItemStatus.COMPLETED,
+                                workItem.numAttempts,
+                                workItem.numShards
+                            );
+                            members.cmsClient.updateIndexWorkItemForceful(updatedEntry);
+                            logger.info("Index Work Item updated");
+                        },
+                        () -> logger.info("Index " + workItem.name + " already existed; no work required")
+                    );
+                } catch (Exception e) {
+                    logger.info("Failed to migrate index: " + workItem.name, e);
+                    logger.info("Updating the Index Work Item with incremented attempt count...");
+                    CmsEntry.IndexWorkItem updatedEntry = new CmsEntry.IndexWorkItem(
+                        workItem.name,
+                        workItem.status,
+                        workItem.numAttempts + 1,
+                        workItem.numShards
+                    );
+
+                    members.cmsClient.updateIndexWorkItem(updatedEntry, workItem).ifPresentOrElse(
+                        value -> logger.info("Index Work Item " + workItem.name + " attempt count was incremented"),
+                        () ->logger.info("Unable to increment attempt count of Index Work Item " + workItem.name)
+                    );
+                }
+            }
+        }
+
+        @Override
+        public WorkerStep nextStep() {
+            return new GetIndicesToMigrate(members);
+        }
+    }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+    public static class RandomWait extends Base {
+        private final static int WAIT_TIME_MS = 5 * 1000; // arbitrarily chosen
+
+        public RandomWait(SharedMembers members) {
+            super(members);
+        }
+
+        protected void waitABit() {
+            try {
+                Thread.sleep(WAIT_TIME_MS);
+            } catch (InterruptedException e) {
+                logger.error("Interrupted while performing a wait", e);
+                throw new IndexMigrationFailed("Interrupted");
+            }
+        }
+
+        @Override
+        public void run() {
+            logger.info("Backing off for " + WAIT_TIME_MS  + " milliseconds before checking the Index Migration entry again...");
+            waitABit();            
+        }
+
+        @Override
+        public WorkerStep nextStep() {
+            return new GetEntry(members);
+        }
+    }
+
+    public static class ExitPhaseSuccess extends Base {
+        public ExitPhaseSuccess(SharedMembers members) {
+            super(members);
+        }
+
+        @Override
+        public void run() {
+            logger.info("Index Migration completed, exiting Index Phase...");
+            members.globalState.updatePhase(GlobalState.Phase.INDEX_COMPLETED);
+        }
+
+        @Override
+        public WorkerStep nextStep() {
+            return null;
+        }
+    }
+
+    public static class ExitPhaseFailed extends Base {
+        private final IndexMigrationFailed e;
+
+        public ExitPhaseFailed(SharedMembers members, IndexMigrationFailed e) {
+            super(members);
+            this.e = e;
+        }
+
+        @Override
+        public void run() {
+            // We either failed the Metadata Migration or found it had already been failed; either way this
+            // should not be missing
+            CmsEntry.Index lastCmsEntry = members.getCmsEntryNotMissing();
+
+            logger.error("Metadata Migration failed");
+            CmsEntry.Index updatedEntry = new CmsEntry.Index(
+                CmsEntry.IndexStatus.FAILED,
+                lastCmsEntry.leaseExpiry,
+                lastCmsEntry.numAttempts
+            );
+            members.cmsClient.updateIndexEntry(updatedEntry, lastCmsEntry);
+            members.globalState.updatePhase(GlobalState.Phase.INDEX_FAILED);
+        }
+
+        @Override
+        public WorkerStep nextStep() {
+            throw e;
+        }
+    }
+
+    public static class IndexMigrationFailed extends RfsException {
+        public IndexMigrationFailed(String message) {
+            super("The Index Migration has failed.  Reason: " + message);
+        }
+    }
+
+    public static class MissingIndexEntry extends RfsException {
+        public MissingIndexEntry() {
+            super("The Index Migration CMS entry we expected to be stored in local memory was null."
+                + "  This should never happen."
+            );
+        }
+    }
+
+    public static class FoundFailedIndexMigration extends IndexMigrationFailed {
+        public FoundFailedIndexMigration() {
+            super("We checked the status in the CMS and found it had failed.  Aborting.");
+        }
+    }
+
+    public static class MaxAttemptsExceeded extends IndexMigrationFailed {
+        public MaxAttemptsExceeded() {
+            super("We reached the limit of " + CmsEntry.Index.MAX_ATTEMPTS + " attempts to complete the Index Migration");
+        }
+    }
+}

--- a/RFS/src/main/java/com/rfs/worker/MetadataStep.java
+++ b/RFS/src/main/java/com/rfs/worker/MetadataStep.java
@@ -229,7 +229,7 @@ public class MetadataStep {
                 lastCmsEntry.leaseExpiry,
                 lastCmsEntry.numAttempts
             );
-            members.cmsClient.updateMetadataEntry(updatedEntry, lastCmsEntry);
+            members.cmsEntry = members.cmsClient.updateMetadataEntry(updatedEntry, lastCmsEntry);
             logger.info("Metadata Migration entry updated");
 
             logger.info("Clearing the worker's current work item...");

--- a/RFS/src/main/java/com/rfs/worker/MetadataStep.java
+++ b/RFS/src/main/java/com/rfs/worker/MetadataStep.java
@@ -41,7 +41,7 @@ public class MetadataStep {
         // for the CMS entry to be missing, but in others, it's a problem.
         public CmsEntry.Metadata getCmsEntryNotMissing() {
             return cmsEntry.orElseThrow(
-                () -> new MissingMigrationEntry("The Metadata Migration CMS entry we expected to be stored in local memory was empty")
+                () -> new MissingMigrationEntry()
             );
         }
     }
@@ -170,17 +170,18 @@ public class MetadataStep {
         @Override
         public void run() {
             // We only get here if we know we want to acquire the lock, so we know the CMS entry should not be null
-            CmsEntry.Metadata currentCmsEntry = members.getCmsEntryNotMissing();
+            CmsEntry.Metadata lastCmsEntry = members.getCmsEntryNotMissing();
 
             logger.info("Current Metadata Migration work lease appears to have expired; attempting to acquire it...");
 
-            // Set the next CMS entry based on the current one
-            members.cmsEntry = members.cmsClient.updateMetadataEntry(
+            CmsEntry.Metadata updatedEntry = new CmsEntry.Metadata(
                 CmsEntry.MetadataStatus.IN_PROGRESS,
+                // Set the next CMS entry based on the current one
                 // TODO: Should be using the server-side clock here
-                CmsEntry.Metadata.getLeaseExpiry(getNowMs(), currentCmsEntry.numAttempts + 1),
-                currentCmsEntry.numAttempts + 1
+                CmsEntry.Metadata.getLeaseExpiry(getNowMs(), lastCmsEntry.numAttempts + 1),
+                lastCmsEntry.numAttempts + 1
             );
+            members.cmsEntry = members.cmsClient.updateMetadataEntry(updatedEntry, lastCmsEntry);
 
             if (members.cmsEntry.isPresent()) {
                 logger.info("Lease acquired");
@@ -208,8 +209,8 @@ public class MetadataStep {
 
         @Override
         public void run() {
-            // We only get here if we acquired the lock, so we know the CMS entry should not be null
-            CmsEntry.Metadata currentCmsEntry = members.getCmsEntryNotMissing();
+            // We only get here if we acquired the lock, so we know the CMS entry should not be missing
+            CmsEntry.Metadata lastCmsEntry = members.getCmsEntryNotMissing();
 
             logger.info("Setting the worker's current work item to be the Metadata Migration...");
             members.globalState.updateWorkItem(new OpenSearchWorkItem(OpenSearchCmsClient.CMS_INDEX_NAME, OpenSearchCmsClient.CMS_METADATA_DOC_ID));
@@ -223,11 +224,12 @@ public class MetadataStep {
             logger.info("Templates migration complete");
 
             logger.info("Updating the Metadata Migration entry to indicate completion...");
-            members.cmsEntry = members.cmsClient.updateMetadataEntry(
+            CmsEntry.Metadata updatedEntry = new CmsEntry.Metadata(
                 CmsEntry.MetadataStatus.COMPLETED,
-                currentCmsEntry.leaseExpiry,
-                currentCmsEntry.numAttempts
+                lastCmsEntry.leaseExpiry,
+                lastCmsEntry.numAttempts
             );
+            members.cmsClient.updateMetadataEntry(updatedEntry, lastCmsEntry);
             logger.info("Metadata Migration entry updated");
 
             logger.info("Clearing the worker's current work item...");
@@ -307,15 +309,16 @@ public class MetadataStep {
         @Override
         public void run() {
             // We either failed the Metadata Migration or found it had already been failed; either way this
-            // should not be null
-            CmsEntry.Metadata currentCmsEntry = members.getCmsEntryNotMissing();
+            // should not be missing
+            CmsEntry.Metadata lastCmsEntry = members.getCmsEntryNotMissing();
 
             logger.error("Metadata Migration failed");
-            members.cmsClient.updateMetadataEntry(
+            CmsEntry.Metadata updatedEntry = new CmsEntry.Metadata(
                 CmsEntry.MetadataStatus.FAILED,
-                currentCmsEntry.leaseExpiry,
-                currentCmsEntry.numAttempts
+                lastCmsEntry.leaseExpiry,
+                lastCmsEntry.numAttempts
             );
+            members.cmsClient.updateMetadataEntry(updatedEntry, lastCmsEntry);
             members.globalState.updatePhase(GlobalState.Phase.METADATA_FAILED);
         }
 
@@ -324,8 +327,9 @@ public class MetadataStep {
             throw e;
         }
     }
+
     public static class MissingMigrationEntry extends RfsException {
-        public MissingMigrationEntry(String message) {
+        public MissingMigrationEntry() {
             super("The Metadata Migration CMS entry we expected to be stored in local memory was null."
                 + "  This should never happen."
             );

--- a/RFS/src/test/java/com/rfs/cms/CmsEntryTest.java
+++ b/RFS/src/test/java/com/rfs/cms/CmsEntryTest.java
@@ -27,7 +27,7 @@ public class CmsEntryTest {
         String result = CmsEntry.Metadata.getLeaseExpiry(0, numAttempts);
 
         // Check the results
-        assertEquals(Long.toString(CmsEntry.Metadata.METADATA_LEASE_MS * numAttempts), result);
+        assertEquals(Long.toString(CmsEntry.Metadata.LEASE_MS * numAttempts), result);
     }
 
     static Stream<Arguments> provide_Metadata_getLeaseExpiry_UnhappyPath_args() {

--- a/RFS/src/test/java/com/rfs/framework/SimpleRestoreFromSnapshot_ES_7_10.java
+++ b/RFS/src/test/java/com/rfs/framework/SimpleRestoreFromSnapshot_ES_7_10.java
@@ -13,6 +13,7 @@ import com.rfs.common.FileSystemRepo;
 import com.rfs.common.IndexMetadata;
 import com.rfs.common.LuceneDocumentsReader;
 import com.rfs.common.OpenSearchClient;
+import com.rfs.common.SnapshotRepo;
 import com.rfs.common.SnapshotShardUnpacker;
 import com.rfs.version_es_7_10.IndexMetadataFactory_ES_7_10;
 import com.rfs.version_es_7_10.ShardMetadataFactory_ES_7_10;
@@ -29,12 +30,12 @@ public class SimpleRestoreFromSnapshot_ES_7_10 {
         IOUtils.rm(unpackedShardDataDir);
 
         final var repo = new FileSystemRepo(Path.of(localPath));
-        final var snapShotProvider = new SnapshotRepoProvider_ES_7_10(repo);
+        SnapshotRepo.Provider snapShotProvider = new SnapshotRepoProvider_ES_7_10(repo);
         final List<IndexMetadata.Data> indices = snapShotProvider.getIndicesInSnapshot(snapshotName)
             .stream()
             .map(index -> {
                 try {
-                    return new IndexMetadataFactory_ES_7_10().fromRepo(repo, snapShotProvider, snapshotName, index.getName());
+                    return new IndexMetadataFactory_ES_7_10(snapShotProvider).fromRepo(snapshotName, index.getName());
                 } catch (final Exception e) {
                     throw new RuntimeException(e);
                 }

--- a/RFS/src/test/java/com/rfs/worker/IndexRunnerTest.java
+++ b/RFS/src/test/java/com/rfs/worker/IndexRunnerTest.java
@@ -10,12 +10,12 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import com.rfs.cms.CmsClient;
-import com.rfs.common.GlobalMetadata;
+import com.rfs.common.IndexMetadata;
 import com.rfs.common.RfsException;
 import com.rfs.transformers.Transformer;
-import com.rfs.version_os_2_11.GlobalMetadataCreator_OS_2_11;
+import com.rfs.version_os_2_11.IndexCreator_OS_2_11;
 
-class MetadataRunnerTest {
+public class IndexRunnerTest {
 
     @Test
     void run_encountersAnException_asExpected() {
@@ -23,23 +23,21 @@ class MetadataRunnerTest {
         GlobalState globalState = Mockito.mock(GlobalState.class);
         CmsClient cmsClient = Mockito.mock(CmsClient.class);
         String snapshotName = "testSnapshot";
-        GlobalMetadata.Factory metadataFactory = Mockito.mock(GlobalMetadata.Factory.class);
-        GlobalMetadataCreator_OS_2_11 metadataCreator = Mockito.mock(GlobalMetadataCreator_OS_2_11.class);
+        IndexMetadata.Factory metadataFactory = Mockito.mock(IndexMetadata.Factory.class);
+        IndexCreator_OS_2_11 creator = Mockito.mock(IndexCreator_OS_2_11.class);
         Transformer transformer = Mockito.mock(Transformer.class);
         RfsException testException = new RfsException("Unit test");
 
-        doThrow(testException).when(cmsClient).getMetadataEntry();
-        when(globalState.getPhase()).thenReturn(GlobalState.Phase.METADATA_IN_PROGRESS);
-
-
-        MetadataRunner testRunner = new MetadataRunner(globalState, cmsClient, snapshotName, metadataFactory, metadataCreator, transformer);
+        doThrow(testException).when(cmsClient).getIndexEntry();
+        when(globalState.getPhase()).thenReturn(GlobalState.Phase.INDEX_IN_PROGRESS);        
 
         // Run the test
         try {
+            IndexRunner testRunner = new IndexRunner(globalState, cmsClient, snapshotName, metadataFactory, creator, transformer);
             testRunner.run();
-        } catch (MetadataRunner.MetadataMigrationPhaseFailed e) {
-            assertEquals(GlobalState.Phase.METADATA_IN_PROGRESS, e.phase);
-            assertEquals(null, e.nextStep);
+        } catch (IndexRunner.IndexMigrationPhaseFailed e) {
+            assertEquals(GlobalState.Phase.INDEX_IN_PROGRESS, e.phase);
+            assertEquals(IndexStep.GetEntry.class, e.nextStep.getClass());
             assertEquals(Optional.empty(), e.cmsEntry);
             assertEquals(testException, e.e);
 

--- a/RFS/src/test/java/com/rfs/worker/IndexRunnerTest.java
+++ b/RFS/src/test/java/com/rfs/worker/IndexRunnerTest.java
@@ -1,7 +1,7 @@
 package com.rfs.worker;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.*;
 
 import java.util.Optional;
@@ -32,18 +32,13 @@ public class IndexRunnerTest {
         when(globalState.getPhase()).thenReturn(GlobalState.Phase.INDEX_IN_PROGRESS);        
 
         // Run the test
-        try {
-            IndexRunner testRunner = new IndexRunner(globalState, cmsClient, snapshotName, metadataFactory, creator, transformer);
-            testRunner.run();
-        } catch (IndexRunner.IndexMigrationPhaseFailed e) {
-            assertEquals(GlobalState.Phase.INDEX_IN_PROGRESS, e.phase);
-            assertEquals(IndexStep.GetEntry.class, e.nextStep.getClass());
-            assertEquals(Optional.empty(), e.cmsEntry);
-            assertEquals(testException, e.e);
+        IndexRunner testRunner = new IndexRunner(globalState, cmsClient, snapshotName, metadataFactory, creator, transformer);
+        final var e = assertThrows(IndexRunner.IndexMigrationPhaseFailed.class, () -> testRunner.run());
 
-        } catch (Exception e) {
-            fail("Unexpected exception thrown: " + e.getClass().getName());
-        }
-    }
-    
+        // Verify the results
+        assertEquals(GlobalState.Phase.INDEX_IN_PROGRESS, e.phase);
+        assertEquals(IndexStep.GetEntry.class, e.nextStep.getClass());
+        assertEquals(Optional.empty(), e.cmsEntry);
+        assertEquals(testException, e.e);
+    }    
 }

--- a/RFS/src/test/java/com/rfs/worker/IndexStepTest.java
+++ b/RFS/src/test/java/com/rfs/worker/IndexStepTest.java
@@ -417,7 +417,7 @@ public class IndexStepTest {
         Mockito.when(indexMetadata.getId()).thenReturn("index-id");
         ObjectNode transformedRoot = Mockito.mock(ObjectNode.class);
         Mockito.when(testMembers.transformer.transformIndexMetadata(root)).thenReturn(transformedRoot);
-        Mockito.when(testMembers.indexCreator.create(eq(workItem.name), any(IndexMetadata.Data.class))).thenReturn(createResponse);        
+        Mockito.when(testMembers.indexCreator.create(transformedRoot,  workItem.name, "index-id")).thenReturn(createResponse);        
 
         // Run the test
         IndexStep.MigrateIndices testStep = new IndexStep.MigrateIndices(testMembers, List.of(workItem));

--- a/RFS/src/test/java/com/rfs/worker/IndexStepTest.java
+++ b/RFS/src/test/java/com/rfs/worker/IndexStepTest.java
@@ -1,0 +1,534 @@
+package com.rfs.worker;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.rfs.cms.CmsClient;
+import com.rfs.cms.CmsEntry;
+import com.rfs.cms.OpenSearchCmsClient;
+import com.rfs.common.IndexMetadata;
+import com.rfs.common.SnapshotRepo;
+import com.rfs.transformers.Transformer;
+import com.rfs.version_os_2_11.IndexCreator_OS_2_11;
+import com.rfs.worker.IndexStep.SharedMembers;
+import com.rfs.worker.IndexStep.MaxAttemptsExceeded;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class IndexStepTest {
+    private SharedMembers testMembers;
+
+    @BeforeEach
+    void setUp() {
+        GlobalState globalState = Mockito.mock(GlobalState.class);
+        CmsClient cmsClient = Mockito.mock(CmsClient.class);
+        String snapshotName = "test";
+
+        IndexMetadata.Factory metadataFactory = Mockito.mock(IndexMetadata.Factory.class);
+        IndexCreator_OS_2_11 indexCreator = Mockito.mock(IndexCreator_OS_2_11.class);
+        Transformer transformer = Mockito.mock(Transformer.class);
+        testMembers = new SharedMembers(globalState, cmsClient, snapshotName, metadataFactory, indexCreator, transformer);        
+    }
+
+    @Test
+    void EnterPhase_AsExpected() {
+        // Run the test
+        IndexStep.EnterPhase testStep = new IndexStep.EnterPhase(testMembers);
+        testStep.run();
+        WorkerStep nextStep = testStep.nextStep();
+
+        // Check the results
+        Mockito.verify(testMembers.globalState, times(1)).updatePhase(GlobalState.Phase.INDEX_IN_PROGRESS);
+        assertEquals(IndexStep.GetEntry.class, nextStep.getClass());
+    }
+
+    static Stream<Arguments> provideGetEntryArgs() {
+        return Stream.of(
+            // There is no CMS entry, so we need to create one
+            Arguments.of(
+                Optional.empty(),
+                IndexStep.CreateEntry.class
+            ),
+
+            // The CMS entry has an expired lease and is under the retry limit, so we try to acquire the lease
+            Arguments.of(
+                Optional.of(new CmsEntry.Index(
+                    CmsEntry.IndexStatus.SETUP,
+                    String.valueOf(Instant.now().minus(Duration.ofDays(1)).toEpochMilli()),
+                    CmsEntry.Index.MAX_ATTEMPTS - 1
+                )),
+                IndexStep.AcquireLease.class
+            ),
+
+            // The CMS entry has an expired lease and is at the retry limit, so we exit as failed
+            Arguments.of(
+                Optional.of(new CmsEntry.Index(
+                    CmsEntry.IndexStatus.SETUP,
+                    String.valueOf(Instant.now().minus(Duration.ofDays(1)).toEpochMilli()),
+                    CmsEntry.Index.MAX_ATTEMPTS
+                )),
+                IndexStep.ExitPhaseFailed.class
+            ),
+
+            // The CMS entry has an expired lease and is over the retry limit, so we exit as failed
+            Arguments.of(
+                Optional.of(new CmsEntry.Index(
+                    CmsEntry.IndexStatus.SETUP,
+                    String.valueOf(Instant.now().minus(Duration.ofDays(1)).toEpochMilli()),
+                    CmsEntry.Index.MAX_ATTEMPTS + 1
+                )),
+                IndexStep.ExitPhaseFailed.class
+            ),
+
+            // The CMS entry has valid lease and is under the retry limit, so we back off a bit
+            Arguments.of(
+                Optional.of(new CmsEntry.Index(
+                    CmsEntry.IndexStatus.SETUP,
+                    String.valueOf(Instant.now().plus(Duration.ofDays(1)).toEpochMilli()),
+                    CmsEntry.Index.MAX_ATTEMPTS - 1
+                )),
+                IndexStep.RandomWait.class
+            ),
+
+            // The CMS entry has valid lease and is at the retry limit, so we back off a bit
+            Arguments.of(
+                Optional.of(new CmsEntry.Index(
+                    CmsEntry.IndexStatus.SETUP,
+                    String.valueOf(Instant.now().plus(Duration.ofDays(1)).toEpochMilli()),
+                    CmsEntry.Index.MAX_ATTEMPTS
+                )),
+                IndexStep.RandomWait.class
+            ),
+
+            // The CMS entry is marked as in progress, so we try to do some work
+            Arguments.of(
+                Optional.of(new CmsEntry.Index(
+                    CmsEntry.IndexStatus.IN_PROGRESS,
+                    String.valueOf(Instant.now().plus(Duration.ofDays(1)).toEpochMilli()),
+                    CmsEntry.Index.MAX_ATTEMPTS - 1
+                )),
+                IndexStep.GetIndicesToMigrate.class
+            ),
+
+            // The CMS entry is marked as completed, so we exit as success
+            Arguments.of(
+                Optional.of(new CmsEntry.Index(
+                    CmsEntry.IndexStatus.COMPLETED,
+                    String.valueOf(Instant.now().plus(Duration.ofDays(1)).toEpochMilli()),
+                    CmsEntry.Index.MAX_ATTEMPTS - 1
+                )),
+                IndexStep.ExitPhaseSuccess.class
+            ),
+
+            // The CMS entry is marked as failed, so we exit as failed
+            Arguments.of(
+                Optional.of(new CmsEntry.Index(
+                    CmsEntry.IndexStatus.FAILED,
+                    String.valueOf(Instant.now().plus(Duration.ofDays(1)).toEpochMilli()),
+                    CmsEntry.Index.MAX_ATTEMPTS - 1
+                )),
+                IndexStep.ExitPhaseFailed.class
+            )
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideGetEntryArgs")
+    void GetEntry_AsExpected(Optional<CmsEntry.Index> index, Class<?> nextStepClass) {
+        // Set up the test
+        Mockito.when(testMembers.cmsClient.getIndexEntry()).thenReturn(index);
+
+        // Run the test
+        IndexStep.GetEntry testStep = new IndexStep.GetEntry(testMembers);
+        testStep.run();
+        WorkerStep nextStep = testStep.nextStep();
+
+        // Check the results
+        Mockito.verify(testMembers.cmsClient, times(1)).getIndexEntry();
+        assertEquals(nextStepClass, nextStep.getClass());
+    }
+
+    static Stream<Arguments> provideCreateEntryArgs() {
+        return Stream.of(
+            // We were able to create the CMS entry ourselves, so we have the work lease
+            Arguments.of(                
+                Optional.of(new CmsEntry.Index(
+                    CmsEntry.IndexStatus.IN_PROGRESS,
+                    String.valueOf(Instant.now().plus(Duration.ofDays(1)).toEpochMilli()),
+                    1
+                )),
+                IndexStep.SetupIndexWorkEntries.class
+            ),
+
+            // We were unable to create the CMS entry ourselves, so we do not have the work lease
+            Arguments.of(Optional.empty(), IndexStep.GetEntry.class)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideCreateEntryArgs")
+    void CreateEntry_AsExpected(Optional<CmsEntry.Index> createdEntry, Class<?> nextStepClass) {
+        // Set up the test
+        Mockito.when(testMembers.cmsClient.createIndexEntry()).thenReturn(createdEntry);
+
+        // Run the test
+        IndexStep.CreateEntry testStep = new IndexStep.CreateEntry(testMembers);
+        testStep.run();
+        WorkerStep nextStep = testStep.nextStep();
+
+        // Check the results
+        Mockito.verify(testMembers.cmsClient, times(1)).createIndexEntry();
+        assertEquals(nextStepClass, nextStep.getClass());
+    }
+
+    public static class TestAcquireLease extends IndexStep.AcquireLease {
+        public static final int milliSinceEpoch = 42; // Arbitrarily chosen, but predictable
+
+        public TestAcquireLease(SharedMembers members) {
+            super(members);
+        }
+
+        @Override
+        protected long getNowMs() {
+            return milliSinceEpoch;
+        }
+    }
+
+    static Stream<Arguments> provideAcquireLeaseArgs() {
+        return Stream.of(
+            // We were able to acquire the lease
+            Arguments.of(                
+                Optional.of(new CmsEntry.Index(
+                    CmsEntry.IndexStatus.IN_PROGRESS,
+                    String.valueOf(Instant.now().plus(Duration.ofDays(1)).toEpochMilli()),
+                    1
+                )),
+                IndexStep.SetupIndexWorkEntries.class
+            ),
+
+            // We were unable to acquire the lease
+            Arguments.of(Optional.empty(), IndexStep.RandomWait.class)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideAcquireLeaseArgs")
+    void AcquireLease_AsExpected(Optional<CmsEntry.Index> updatedEntry, Class<?> nextStepClass) {
+        // Set up the test
+        var existingEntry = Optional.of(new CmsEntry.Index(
+            CmsEntry.IndexStatus.IN_PROGRESS,
+            CmsEntry.Index.getLeaseExpiry(0L, CmsEntry.Index.MAX_ATTEMPTS - 1),
+            CmsEntry.Index.MAX_ATTEMPTS - 1
+        ));
+        testMembers.cmsEntry = existingEntry;
+
+        Mockito.when(testMembers.cmsClient.updateIndexEntry(
+            any(CmsEntry.Index.class), eq(existingEntry.get())
+        )).thenReturn(updatedEntry);
+
+        // Run the test
+        IndexStep.AcquireLease testStep = new TestAcquireLease(testMembers);
+        testStep.run();
+        WorkerStep nextStep = testStep.nextStep();
+
+        // Check the results
+        var expectedEntry = new CmsEntry.Index(
+            CmsEntry.IndexStatus.IN_PROGRESS,
+            CmsEntry.Index.getLeaseExpiry(TestAcquireLease.milliSinceEpoch, CmsEntry.Index.MAX_ATTEMPTS),
+            CmsEntry.Index.MAX_ATTEMPTS
+        );
+        Mockito.verify(testMembers.cmsClient, times(1)).updateIndexEntry(
+            expectedEntry, existingEntry.get()
+        );
+        assertEquals(nextStepClass, nextStep.getClass());
+    }
+
+    static Stream<Arguments> provideSetupIndexWorkEntriesArgs() {
+        return Stream.of(
+            // We were able to acquire the lease
+            Arguments.of(                
+                Optional.of(new CmsEntry.Index(
+                    CmsEntry.IndexStatus.COMPLETED,
+                    String.valueOf(42),
+                    1
+                )),
+                IndexStep.GetIndicesToMigrate.class
+            ),
+
+            // We were unable to acquire the lease
+            Arguments.of(Optional.empty(), IndexStep.GetEntry.class)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideSetupIndexWorkEntriesArgs")
+    void SetupIndexWorkEntries_AsExpected(Optional<CmsEntry.Index> updatedEntry, Class<?> nextStepClass) {
+        // Set up the test
+        var existingEntry = Optional.of(new CmsEntry.Index(
+            CmsEntry.IndexStatus.IN_PROGRESS,
+            String.valueOf(42),
+            1
+        ));
+        testMembers.cmsEntry = existingEntry;
+
+        SnapshotRepo.Provider repoDatProvider = Mockito.mock(SnapshotRepo.Provider.class);
+        Mockito.when(testMembers.metadataFactory.getRepoDataProvider()).thenReturn(repoDatProvider);
+        
+        SnapshotRepo.Index index1 = Mockito.mock(SnapshotRepo.Index.class);
+        Mockito.when(index1.getName()).thenReturn("index1");
+        SnapshotRepo.Index index2 = Mockito.mock(SnapshotRepo.Index.class);
+        Mockito.when(index2.getName()).thenReturn("index2");
+        Mockito.when(repoDatProvider.getIndicesInSnapshot(testMembers.snapshotName)).thenReturn(
+            Stream.of(index1, index2).collect(Collectors.toList())
+        );
+
+        IndexMetadata.Data indexMetadata1 = Mockito.mock(IndexMetadata.Data.class);
+        Mockito.when(indexMetadata1.getName()).thenReturn("index1");
+        Mockito.when(indexMetadata1.getNumberOfShards()).thenReturn(1);
+        Mockito.when(testMembers.metadataFactory.fromRepo(testMembers.snapshotName, "index1")).thenReturn(indexMetadata1);
+
+        IndexMetadata.Data indexMetadata2 = Mockito.mock(IndexMetadata.Data.class);
+        Mockito.when(indexMetadata2.getName()).thenReturn("index2");
+        Mockito.when(indexMetadata2.getNumberOfShards()).thenReturn(2);
+        Mockito.when(testMembers.metadataFactory.fromRepo(testMembers.snapshotName, "index2")).thenReturn(indexMetadata2);
+
+        CmsEntry.Index expectedEntry = new CmsEntry.Index(
+            CmsEntry.IndexStatus.COMPLETED,
+            existingEntry.get().leaseExpiry,
+            existingEntry.get().numAttempts
+        );
+        Mockito.when(testMembers.cmsClient.updateIndexEntry(
+            expectedEntry, existingEntry.get()
+        )).thenReturn(updatedEntry);
+
+        // Run the test
+        IndexStep.SetupIndexWorkEntries testStep = new IndexStep.SetupIndexWorkEntries(testMembers);
+        testStep.run();
+        WorkerStep nextStep = testStep.nextStep();
+
+        // Check the results
+        Mockito.verify(testMembers.globalState, times(1)).updateWorkItem(
+            argThat(argument -> {
+                if (!(argument instanceof OpenSearchWorkItem)) {
+                    return false;
+                }
+                OpenSearchWorkItem workItem = (OpenSearchWorkItem) argument;
+                return workItem.indexName.equals(OpenSearchCmsClient.CMS_INDEX_NAME) &&
+                    workItem.documentId.equals(OpenSearchCmsClient.CMS_INDEX_DOC_ID);
+            })
+        );
+        Mockito.verify(testMembers.cmsClient, times(1)).createIndexWorkItem(
+            "index1", 1       
+        );
+        Mockito.verify(testMembers.cmsClient, times(1)).createIndexWorkItem(
+            "index2", 2       
+        );
+
+        Mockito.verify(testMembers.cmsClient, times(1)).updateIndexEntry(
+            expectedEntry, existingEntry.get()
+        );
+        Mockito.verify(testMembers.globalState, times(1)).updateWorkItem(
+            null
+        );
+
+        assertEquals(nextStepClass, nextStep.getClass());
+    }
+
+    static Stream<Arguments> provideGetIndicesToMigrateArgs() {
+        return Stream.of(
+            // There's still work to do
+            Arguments.of(                
+                Stream.of(
+                    new CmsEntry.IndexWorkItem("index1", CmsEntry.IndexWorkItemStatus.NOT_STARTED, 1, 1),
+                    new CmsEntry.IndexWorkItem("index2", CmsEntry.IndexWorkItemStatus.NOT_STARTED, 1, 2)                
+                ).collect(Collectors.toList()),
+                IndexStep.MigrateIndices.class
+            ),
+
+            // There's no more work to do
+            Arguments.of(List.of(), IndexStep.ExitPhaseSuccess.class)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideGetIndicesToMigrateArgs")
+    void GetIndicesToMigrate_AsExpected(List<CmsEntry.IndexWorkItem> workItems, Class<?> nextStepClass) {
+        // Set up the test
+        Mockito.when(testMembers.cmsClient.getAvailableIndexWorkItems(IndexStep.GetIndicesToMigrate.MAX_WORK_ITEMS)).thenReturn(workItems);
+
+        // Run the test
+        IndexStep.GetIndicesToMigrate testStep = new IndexStep.GetIndicesToMigrate(testMembers);
+        testStep.run();
+        WorkerStep nextStep = testStep.nextStep();
+
+        // Check the results
+        assertEquals(nextStepClass, nextStep.getClass());
+    }
+
+    static Stream<Arguments> provideMigrateIndicesArgs() {
+        return Stream.of(
+            // We have an to migrate and we create it
+            Arguments.of(
+                new CmsEntry.IndexWorkItem("index1", CmsEntry.IndexWorkItemStatus.NOT_STARTED, 1, 1),
+                Optional.of(Mockito.mock(ObjectNode.class)),
+                new CmsEntry.IndexWorkItem("index1", CmsEntry.IndexWorkItemStatus.COMPLETED, 1, 1)
+            ),
+
+            // We have an index to migrate and someone else created it before us
+            Arguments.of(
+                new CmsEntry.IndexWorkItem("index2", CmsEntry.IndexWorkItemStatus.NOT_STARTED, 1, 2),
+                Optional.empty(),
+                new CmsEntry.IndexWorkItem("index2", CmsEntry.IndexWorkItemStatus.COMPLETED, 1, 2)
+            )
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideMigrateIndicesArgs")
+    void MigrateIndices_workToDo_AsExpected(CmsEntry.IndexWorkItem workItem, Optional<ObjectNode> createResponse, CmsEntry.IndexWorkItem updatedItem) {
+        // Set up the test
+        IndexMetadata.Data indexMetadata = Mockito.mock(IndexMetadata.Data.class);
+        Mockito.when(testMembers.metadataFactory.fromRepo(testMembers.snapshotName, workItem.name)).thenReturn(indexMetadata);
+
+        ObjectNode root = Mockito.mock(ObjectNode.class);
+        Mockito.when(indexMetadata.toObjectNode()).thenReturn(root);
+        Mockito.when(indexMetadata.getId()).thenReturn("index-id");
+        ObjectNode transformedRoot = Mockito.mock(ObjectNode.class);
+        Mockito.when(testMembers.transformer.transformIndexMetadata(root)).thenReturn(transformedRoot);
+        Mockito.when(testMembers.indexCreator.create(eq(workItem.name), any(IndexMetadata.Data.class))).thenReturn(createResponse);        
+
+        // Run the test
+        IndexStep.MigrateIndices testStep = new IndexStep.MigrateIndices(testMembers, List.of(workItem));
+        testStep.run();
+        WorkerStep nextStep = testStep.nextStep();
+
+        // Check the results
+        Mockito.verify(testMembers.cmsClient, times(1)).updateIndexWorkItemForceful(updatedItem);
+        assertEquals(IndexStep.GetIndicesToMigrate.class, nextStep.getClass());
+    }
+
+    @Test
+    void MigrateIndices_exceededAttempts_AsExpected(){
+        // Set up the test
+        CmsEntry.IndexWorkItem workItem = new CmsEntry.IndexWorkItem("index1", CmsEntry.IndexWorkItemStatus.NOT_STARTED, CmsEntry.IndexWorkItem.ATTEMPTS_SOFT_LIMIT + 1, 1);
+        CmsEntry.IndexWorkItem updatedItem = new CmsEntry.IndexWorkItem("index1", CmsEntry.IndexWorkItemStatus.FAILED, CmsEntry.IndexWorkItem.ATTEMPTS_SOFT_LIMIT + 1, 1);
+
+        // Run the test
+        IndexStep.MigrateIndices testStep = new IndexStep.MigrateIndices(testMembers, List.of(workItem));
+        testStep.run();
+        WorkerStep nextStep = testStep.nextStep();
+
+        // Check the results
+        Mockito.verify(testMembers.cmsClient, times(1)).updateIndexWorkItem(updatedItem, workItem);
+        assertEquals(IndexStep.GetIndicesToMigrate.class, nextStep.getClass());
+    }
+
+    @Test
+    void MigrateIndices_workItemFailed_AsExpected(){
+        // Set up the test
+        CmsEntry.IndexWorkItem workItem = new CmsEntry.IndexWorkItem("index1", CmsEntry.IndexWorkItemStatus.NOT_STARTED, 1, 1);
+        CmsEntry.IndexWorkItem updatedItem = new CmsEntry.IndexWorkItem("index1", CmsEntry.IndexWorkItemStatus.NOT_STARTED, 2, 1);
+        doThrow(new RuntimeException("Test exception")).when(testMembers.metadataFactory).fromRepo(testMembers.snapshotName, workItem.name);
+
+        // Run the test
+        IndexStep.MigrateIndices testStep = new IndexStep.MigrateIndices(testMembers, List.of(workItem));
+        testStep.run();
+        WorkerStep nextStep = testStep.nextStep();
+
+        // Check the results
+        Mockito.verify(testMembers.cmsClient, times(1)).updateIndexWorkItem(updatedItem, workItem);
+        assertEquals(IndexStep.GetIndicesToMigrate.class, nextStep.getClass());
+    }
+
+    public static class TestRandomWait extends IndexStep.RandomWait {
+        public TestRandomWait(SharedMembers members) {
+            super(members);
+        }
+
+        @Override
+        protected void waitABit() {
+            // do nothing
+        }
+    }
+
+    @Test
+    void RandomWait_AsExpected() {
+        // Run the test
+        IndexStep.RandomWait testStep = new TestRandomWait(testMembers);
+        testStep.run();
+        WorkerStep nextStep = testStep.nextStep();
+
+        // Check the results
+        assertEquals(IndexStep.GetEntry.class, nextStep.getClass());
+    }
+
+    @Test
+    void ExitPhaseSuccess_AsExpected() {
+        // Run the test
+        IndexStep.ExitPhaseSuccess testStep = new IndexStep.ExitPhaseSuccess(testMembers);
+        testStep.run();
+        WorkerStep nextStep = testStep.nextStep();
+
+        // Check the results
+        Mockito.verify(testMembers.globalState, times(1)).updatePhase(
+            GlobalState.Phase.INDEX_COMPLETED
+        );
+        assertEquals(null, nextStep);
+    }
+
+    @Test
+    void ExitPhaseFailed_AsExpected() {
+        // Set up the test
+        MaxAttemptsExceeded e = new MaxAttemptsExceeded();
+
+        var existingEntry = Optional.of(new CmsEntry.Index(
+            CmsEntry.IndexStatus.SETUP,
+            String.valueOf(42),
+            1
+        ));
+        testMembers.cmsEntry = existingEntry;
+
+        // Run the test
+        IndexStep.ExitPhaseFailed testStep = new IndexStep.ExitPhaseFailed(testMembers, e);
+        testStep.run();
+        assertThrows(MaxAttemptsExceeded.class, () -> {
+            testStep.nextStep();
+        });
+
+        // Check the results
+        var expectedEntry = new CmsEntry.Index(
+            CmsEntry.IndexStatus.FAILED,
+            existingEntry.get().leaseExpiry,
+            existingEntry.get().numAttempts
+        );
+        Mockito.verify(testMembers.cmsClient, times(1)).updateIndexEntry(
+            expectedEntry, existingEntry.get()
+        );
+        Mockito.verify(testMembers.globalState, times(1)).updatePhase(
+            GlobalState.Phase.INDEX_FAILED
+        );
+    }
+    
+}

--- a/RFS/src/test/java/com/rfs/worker/MetadataRunnerTest.java
+++ b/RFS/src/test/java/com/rfs/worker/MetadataRunnerTest.java
@@ -1,7 +1,7 @@
 package com.rfs.worker;
 
+import static org.junit.Assert.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.*;
 
 import java.util.Optional;
@@ -31,21 +31,15 @@ class MetadataRunnerTest {
         doThrow(testException).when(cmsClient).getMetadataEntry();
         when(globalState.getPhase()).thenReturn(GlobalState.Phase.METADATA_IN_PROGRESS);
 
-
-        MetadataRunner testRunner = new MetadataRunner(globalState, cmsClient, snapshotName, metadataFactory, metadataCreator, transformer);
-
         // Run the test
-        try {
-            testRunner.run();
-        } catch (MetadataRunner.MetadataMigrationPhaseFailed e) {
-            assertEquals(GlobalState.Phase.METADATA_IN_PROGRESS, e.phase);
-            assertEquals(null, e.nextStep);
-            assertEquals(Optional.empty(), e.cmsEntry);
-            assertEquals(testException, e.e);
+        MetadataRunner testRunner = new MetadataRunner(globalState, cmsClient, snapshotName, metadataFactory, metadataCreator, transformer);
+        final var e = assertThrows(MetadataRunner.MetadataMigrationPhaseFailed.class, () -> testRunner.run());
 
-        } catch (Exception e) {
-            fail("Unexpected exception thrown: " + e.getClass().getName());
-        }
+        // Verify the results
+        assertEquals(GlobalState.Phase.METADATA_IN_PROGRESS, e.phase);
+        assertEquals(null, e.nextStep);
+        assertEquals(Optional.empty(), e.cmsEntry);
+        assertEquals(testException, e.e);
     }
     
 }

--- a/RFS/src/test/java/com/rfs/worker/MetadataStepTest.java
+++ b/RFS/src/test/java/com/rfs/worker/MetadataStepTest.java
@@ -233,7 +233,7 @@ public class MetadataStepTest {
         testMembers.cmsEntry = existingEntry;
 
         Mockito.when(testMembers.cmsClient.updateMetadataEntry(
-            any(CmsEntry.MetadataStatus.class), anyString(), anyInt()
+            any(CmsEntry.Metadata.class), eq(existingEntry.get())
         )).thenReturn(updatedEntry);
 
         // Run the test
@@ -242,10 +242,13 @@ public class MetadataStepTest {
         WorkerStep nextStep = testStep.nextStep();
 
         // Check the results
-        Mockito.verify(testMembers.cmsClient, times(1)).updateMetadataEntry(
+        var expectedEntry = new CmsEntry.Metadata(
             CmsEntry.MetadataStatus.IN_PROGRESS,
             CmsEntry.Metadata.getLeaseExpiry(TestAcquireLease.milliSinceEpoch, CmsEntry.Metadata.MAX_ATTEMPTS),
             CmsEntry.Metadata.MAX_ATTEMPTS
+        );
+        Mockito.verify(testMembers.cmsClient, times(1)).updateMetadataEntry(
+            expectedEntry, existingEntry.get()
         );
         assertEquals(nextStepClass, nextStep.getClass());
     }
@@ -284,10 +287,14 @@ public class MetadataStepTest {
         Mockito.when(testMembers.metadataFactory.fromRepo(testMembers.snapshotName)).thenReturn(testGlobalMetadata);
         Mockito.when(testGlobalMetadata.toObjectNode()).thenReturn(testNode);
         Mockito.when(testMembers.transformer.transformGlobalMetadata(testNode)).thenReturn(testTransformedNode);
-        Mockito.when(testMembers.cmsClient.updateMetadataEntry(
+
+        var expectedEntry = new CmsEntry.Metadata(
             CmsEntry.MetadataStatus.COMPLETED,
             existingEntry.get().leaseExpiry,
             existingEntry.get().numAttempts
+        );
+        Mockito.when(testMembers.cmsClient.updateMetadataEntry(
+            eq(expectedEntry), eq(existingEntry.get())
         
         )).thenReturn(updatedEntry);
 
@@ -317,9 +324,7 @@ public class MetadataStepTest {
             testTransformedNode
         );
         Mockito.verify(testMembers.cmsClient, times(1)).updateMetadataEntry(
-            CmsEntry.MetadataStatus.COMPLETED,
-            existingEntry.get().leaseExpiry,
-            existingEntry.get().numAttempts
+            expectedEntry, existingEntry.get()
         );
         Mockito.verify(testMembers.globalState, times(1)).updateWorkItem(
             null
@@ -384,10 +389,13 @@ public class MetadataStepTest {
         });
 
         // Check the results
-        Mockito.verify(testMembers.cmsClient, times(1)).updateMetadataEntry(
+        var expectedEntry = new CmsEntry.Metadata(
             CmsEntry.MetadataStatus.FAILED,
             existingEntry.get().leaseExpiry,
             existingEntry.get().numAttempts
+        );
+        Mockito.verify(testMembers.cmsClient, times(1)).updateMetadataEntry(
+            expectedEntry, existingEntry.get()
         );
         Mockito.verify(testMembers.globalState, times(1)).updatePhase(
             GlobalState.Phase.METADATA_FAILED

--- a/RFS/src/test/java/com/rfs/worker/MetadataStepTest.java
+++ b/RFS/src/test/java/com/rfs/worker/MetadataStepTest.java
@@ -29,8 +29,6 @@ import com.rfs.worker.MetadataStep.MaxAttemptsExceeded;
 import com.rfs.worker.MetadataStep.SharedMembers;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.*;
 
@@ -130,7 +128,7 @@ public class MetadataStepTest {
                 MetadataStep.ExitPhaseSuccess.class
             ),
 
-            // The CMS entry is marked as completed, so we exit as success
+            // The CMS entry is marked as failed, so we exit as faile
             Arguments.of(
                 Optional.of(new CmsEntry.Metadata(
                     CmsEntry.MetadataStatus.FAILED,

--- a/RFS/src/test/java/com/rfs/worker/SnapshotRunnerTest.java
+++ b/RFS/src/test/java/com/rfs/worker/SnapshotRunnerTest.java
@@ -1,7 +1,7 @@
 package com.rfs.worker;
 
+import static org.junit.Assert.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.*;
 
 import java.util.Optional;
@@ -21,7 +21,6 @@ class SnapshotRunnerTest {
         GlobalState globalState = mock(GlobalState.class);
         CmsClient cmsClient = mock(CmsClient.class);
         SnapshotCreator snapshotCreator = mock(SnapshotCreator.class);
-        SnapshotRunner testRunner = new SnapshotRunner(globalState, cmsClient, snapshotCreator);
         RfsException testException = new RfsException("Unit test");
 
         doThrow(testException).when(cmsClient).getSnapshotEntry(snapshotName);
@@ -29,17 +28,14 @@ class SnapshotRunnerTest {
         when(snapshotCreator.getSnapshotName()).thenReturn(snapshotName);
 
         // Run the test
-        try {
-            testRunner.run();
-        } catch (SnapshotRunner.SnapshotPhaseFailed e) {
-            assertEquals(GlobalState.Phase.SNAPSHOT_IN_PROGRESS, e.phase);
-            assertEquals(null, e.nextStep);
-            assertEquals(Optional.empty(), e.cmsEntry);
-            assertEquals(testException, e.e);
+        SnapshotRunner testRunner = new SnapshotRunner(globalState, cmsClient, snapshotCreator);
+        final var e = assertThrows(SnapshotRunner.SnapshotPhaseFailed.class, () -> testRunner.run());
 
-        } catch (Exception e) {
-            fail("Unexpected exception thrown: " + e.getClass().getName());
-        }
+        // Verify the results
+        assertEquals(GlobalState.Phase.SNAPSHOT_IN_PROGRESS, e.phase);
+        assertEquals(null, e.nextStep);
+        assertEquals(Optional.empty(), e.cmsEntry);
+        assertEquals(testException, e.e);
     }
     
 }


### PR DESCRIPTION
### Description
* Updates the RFS Worker code to enable multi-node, coordinated index creation
* Added unit tests for the new code
* Will add component test in a follow-up PR as it is expected to require a fair amount of additional changes and I want to keep these PRs smaller if possible.

### Issues Resolved
* https://opensearch.atlassian.net/browse/MIGRATIONS-1751

### Testing
* Ran the unit tests successfully
* Ran the RFS Worker code locally using the Docker Compose setup to test the full behavior with a single node

```
chelma@3c22fba4e266 RFS % gradle runRfsWorker --args='--snapshot-name reindex-from-snapshot --s3-local-dir /tmp/s3_files --s3-repo-uri s3://chelma-iad-rfs-local-testing --s3-region us-east-1 --source-host http://localhost:19200 --target-host http://localhost:29200 --min-replicas 0 --index-template-whitelist "my_index_template" --component-template-whitelist "my_component_template"'
.
.
.
> Task :RFS:runRfsWorker
14:46:42.451 INFO  Running RfsWorker
14:46:42.736 INFO  Checking if work remains in the Snapshot Phase...
14:46:43.386 INFO  Snapshot not yet completed, entering Snapshot Phase...
14:46:43.386 INFO  Snapshot CMS Entry not found, attempting to create it...
14:46:43.557 INFO  Snapshot CMS Entry created
14:46:43.558 INFO  Attempting to initiate the snapshot...
14:46:45.230 INFO  Snapshot repo registration successful
14:46:45.515 INFO  Snapshot reindex-from-snapshot creation initiated
14:46:45.515 INFO  Snapshot in progress...
14:46:45.801 INFO  Snapshot not finished yet; sleeping for 5 seconds...
14:46:50.896 INFO  Snapshot not finished yet; sleeping for 5 seconds...
14:46:55.969 INFO  Snapshot not finished yet; sleeping for 5 seconds...
14:47:01.222 INFO  Snapshot not finished yet; sleeping for 5 seconds...
14:47:06.335 INFO  Snapshot completed, exiting Snapshot Phase...
14:47:06.335 INFO  Snapshot Phase is complete
14:47:07.076 INFO  Checking if work remains in the Metadata Migration Phase...
14:47:07.088 INFO  Metadata Migration not yet completed, entering Metadata Phase...
14:47:07.088 INFO  Pulling the Metadata Migration entry from the CMS, if it exists...
14:47:07.098 INFO  Metadata Migration CMS Entry not found, attempting to create it...
14:47:07.140 INFO  Metadata Migration CMS Entry created
14:47:07.140 INFO  Setting the worker's current work item to be the Metadata Migration...
14:47:07.141 INFO  Work item set
14:47:07.141 INFO  Migrating the Templates...
14:47:08.134 INFO  Downloading file from S3: s3://chelma-iad-rfs-local-testing/index-0 to /tmp/s3_files/index-0
14:47:08.429 INFO  Downloading file from S3: s3://chelma-iad-rfs-local-testing/meta-FZePQtmuR9-QJWW0_1G0bg.dat to /tmp/s3_files/meta-FZePQtmuR9-QJWW0_1G0bg.dat
14:47:08.601 INFO  Transforming template: my_legacy_template
14:47:08.602 INFO  Transforming template: my_index_template
14:47:08.603 INFO  Transforming template: my_component_template
14:47:08.604 INFO  Setting Global Metadata
14:47:08.604 INFO  Setting Legacy Templates...
14:47:08.604 INFO  No Legacy Templates in specified whitelist
14:47:08.604 INFO  Setting Component Templates...
14:47:08.605 INFO  Setting Component Template: my_component_template
14:47:08.648 INFO  Setting Index Templates...
14:47:08.648 INFO  Setting Index Template: my_index_template
14:47:08.687 INFO  Templates migration complete
14:47:08.688 INFO  Updating the Metadata Migration entry to indicate completion...
14:47:08.706 INFO  Metadata Migration entry updated
14:47:08.706 INFO  Clearing the worker's current work item...
14:47:08.706 INFO  Work item cleared
14:47:08.707 INFO  Metadata Migration completed, exiting Metadata Phase...
14:47:08.707 INFO  Metadata Migration Phase is complete
14:47:08.710 INFO  Checking if work remains in the Index Migration Phase...
14:47:08.717 INFO  Index Migration not yet completed, entering Index Phase...
14:47:08.717 INFO  Pulling the Index Migration entry from the CMS, if it exists...
14:47:08.724 INFO  Index Migration CMS Entry not found, attempting to create it...
14:47:08.734 INFO  Index Migration CMS Entry created
14:47:08.734 INFO  Setting the worker's current work item to be creating the index work entries...
14:47:08.734 INFO  Work item set
14:47:08.734 INFO  Setting up the Index Work Items...
14:47:08.741 INFO  Downloading file from S3: s3://chelma-iad-rfs-local-testing/indices/VHJAdKCDQTK6TViqME8KaQ/meta-QWN92o8BjiN_X2BPtS9E.dat to /tmp/s3_files/indices/VHJAdKCDQTK6TViqME8KaQ/meta-QWN92o8BjiN_X2BPtS9E.dat
14:47:08.894 INFO  Creating Index Work Item for index: logs-241998
14:47:08.936 INFO  Downloading file from S3: s3://chelma-iad-rfs-local-testing/indices/5GbKNqfmTzu9IKqcOGPL3Q/meta-QmN92o8BjiN_X2BPtS9E.dat to /tmp/s3_files/indices/5GbKNqfmTzu9IKqcOGPL3Q/meta-QmN92o8BjiN_X2BPtS9E.dat
14:47:09.093 INFO  Creating Index Work Item for index: sonested
14:47:09.104 INFO  Downloading file from S3: s3://chelma-iad-rfs-local-testing/indices/KJW7kPF_Rd2Dgmz8s1N9QA/meta-Q2N92o8BjiN_X2BPtS9E.dat to /tmp/s3_files/indices/KJW7kPF_Rd2Dgmz8s1N9QA/meta-Q2N92o8BjiN_X2BPtS9E.dat
14:47:09.266 INFO  Creating Index Work Item for index: geonames
14:47:09.276 INFO  Downloading file from S3: s3://chelma-iad-rfs-local-testing/indices/ew-6CimWSoinB-EAdO5ThQ/meta-RGN92o8BjiN_X2BPtS9E.dat to /tmp/s3_files/indices/ew-6CimWSoinB-EAdO5ThQ/meta-RGN92o8BjiN_X2BPtS9E.dat
14:47:09.443 INFO  Creating Index Work Item for index: logs-221998
14:47:09.451 INFO  Downloading file from S3: s3://chelma-iad-rfs-local-testing/indices/1Ga27MucRz6nEoa8dR6apw/meta-R2N92o8BjiN_X2BPtS_V.dat to /tmp/s3_files/indices/1Ga27MucRz6nEoa8dR6apw/meta-R2N92o8BjiN_X2BPtS_V.dat
14:47:09.592 INFO  Creating Index Work Item for index: logs-211998
14:47:09.606 INFO  Downloading file from S3: s3://chelma-iad-rfs-local-testing/indices/rZk_VPMISSS4P0O0Z-ygxQ/meta-SGN92o8BjiN_X2BPtS_b.dat to /tmp/s3_files/indices/rZk_VPMISSS4P0O0Z-ygxQ/meta-SGN92o8BjiN_X2BPtS_b.dat
14:47:09.769 INFO  Creating Index Work Item for index: logs-181998
14:47:09.782 INFO  Downloading file from S3: s3://chelma-iad-rfs-local-testing/indices/qRB1avEPThmwPLlGaRkf5g/meta-RmN92o8BjiN_X2BPtS_U.dat to /tmp/s3_files/indices/qRB1avEPThmwPLlGaRkf5g/meta-RmN92o8BjiN_X2BPtS_U.dat
14:47:09.922 INFO  Creating Index Work Item for index: reindexed-logs
14:47:09.931 INFO  Downloading file from S3: s3://chelma-iad-rfs-local-testing/indices/Kf0cDQa7SIyxqqhNaN636A/meta-RWN92o8BjiN_X2BPtS_U.dat to /tmp/s3_files/indices/Kf0cDQa7SIyxqqhNaN636A/meta-RWN92o8BjiN_X2BPtS_U.dat
14:47:10.093 INFO  Creating Index Work Item for index: logs-201998
14:47:10.102 INFO  Downloading file from S3: s3://chelma-iad-rfs-local-testing/indices/_UgP9XeHRaelYLydmtL6Bg/meta-SWN92o8BjiN_X2BPtS_c.dat to /tmp/s3_files/indices/_UgP9XeHRaelYLydmtL6Bg/meta-SWN92o8BjiN_X2BPtS_c.dat
14:47:10.242 INFO  Creating Index Work Item for index: logs-231998
14:47:10.249 INFO  Downloading file from S3: s3://chelma-iad-rfs-local-testing/indices/e6DUNTj3S96sin6vFizUqQ/meta-SmN92o8BjiN_X2BPti9Z.dat to /tmp/s3_files/indices/e6DUNTj3S96sin6vFizUqQ/meta-SmN92o8BjiN_X2BPti9Z.dat
14:47:10.395 INFO  Creating Index Work Item for index: nyc_taxis
14:47:10.404 INFO  Downloading file from S3: s3://chelma-iad-rfs-local-testing/indices/BzzB0ESoRdaONCtNt5oniQ/meta-S2N92o8BjiN_X2BPti9q.dat to /tmp/s3_files/indices/BzzB0ESoRdaONCtNt5oniQ/meta-S2N92o8BjiN_X2BPti9q.dat
14:47:10.546 INFO  Creating Index Work Item for index: logs-191998
14:47:10.555 INFO  Finished setting up the Index Work Items.
14:47:10.555 INFO  Updating the Index Migration entry to indicate setup has been completed...
14:47:10.571 INFO  Index Migration entry updated
14:47:10.571 INFO  Clearing the worker's current work item...
14:47:10.571 INFO  Work item cleared
14:47:10.571 INFO  Pulling a list of indices to migrate from the CMS...
14:47:10.691 INFO  Pulled 10 indices to migrate:
14:47:10.692 INFO  [{"type":"INDEX_WORK_ITEM","name":"geonames","status":"NOT_STARTED","numAttempts":1,"numShards":5}, {"type":"INDEX_WORK_ITEM","name":"logs-221998","status":"NOT_STARTED","numAttempts":1,"numShards":5}, {"type":"INDEX_WORK_ITEM","name":"nyc_taxis","status":"NOT_STARTED","numAttempts":1,"numShards":1}, {"type":"INDEX_WORK_ITEM","name":"reindexed-logs","status":"NOT_STARTED","numAttempts":1,"numShards":5}, {"type":"INDEX_WORK_ITEM","name":"logs-191998","status":"NOT_STARTED","numAttempts":1,"numShards":5}, {"type":"INDEX_WORK_ITEM","name":"logs-231998","status":"NOT_STARTED","numAttempts":1,"numShards":5}, {"type":"INDEX_WORK_ITEM","name":"sonested","status":"NOT_STARTED","numAttempts":1,"numShards":1}, {"type":"INDEX_WORK_ITEM","name":"logs-201998","status":"NOT_STARTED","numAttempts":1,"numShards":5}, {"type":"INDEX_WORK_ITEM","name":"logs-241998","status":"NOT_STARTED","numAttempts":1,"numShards":5}, {"type":"INDEX_WORK_ITEM","name":"logs-181998","status":"NOT_STARTED","numAttempts":1,"numShards":5}]
14:47:10.692 INFO  Migrating current batch of indices...
14:47:10.693 INFO  Migrating index: geonames
14:47:10.944 INFO  Index geonames created successfully
14:47:10.945 INFO  Forcefully updating the Index Work Item to indicate it has been completed...
14:47:10.955 INFO  Index Work Item updated
14:47:10.955 INFO  Migrating index: logs-221998
14:47:11.202 INFO  Index logs-221998 created successfully
14:47:11.202 INFO  Forcefully updating the Index Work Item to indicate it has been completed...
14:47:11.213 INFO  Index Work Item updated
14:47:11.213 INFO  Migrating index: nyc_taxis
14:47:11.355 INFO  Index nyc_taxis created successfully
14:47:11.355 INFO  Forcefully updating the Index Work Item to indicate it has been completed...
14:47:11.366 INFO  Index Work Item updated
14:47:11.366 INFO  Migrating index: reindexed-logs
14:47:11.647 INFO  Index reindexed-logs created successfully
14:47:11.647 INFO  Forcefully updating the Index Work Item to indicate it has been completed...
14:47:11.657 INFO  Index Work Item updated
14:47:11.658 INFO  Migrating index: logs-191998
14:47:11.904 INFO  Index logs-191998 created successfully
14:47:11.904 INFO  Forcefully updating the Index Work Item to indicate it has been completed...
14:47:11.913 INFO  Index Work Item updated
14:47:11.913 INFO  Migrating index: logs-231998
14:47:12.152 INFO  Index logs-231998 created successfully
14:47:12.152 INFO  Forcefully updating the Index Work Item to indicate it has been completed...
14:47:12.160 INFO  Index Work Item updated
14:47:12.160 INFO  Migrating index: sonested
14:47:12.253 INFO  Index sonested created successfully
14:47:12.253 INFO  Forcefully updating the Index Work Item to indicate it has been completed...
14:47:12.262 INFO  Index Work Item updated
14:47:12.263 INFO  Migrating index: logs-201998
14:47:12.473 INFO  Index logs-201998 created successfully
14:47:12.473 INFO  Forcefully updating the Index Work Item to indicate it has been completed...
14:47:12.482 INFO  Index Work Item updated
14:47:12.482 INFO  Migrating index: logs-241998
14:47:12.699 INFO  Index logs-241998 created successfully
14:47:12.699 INFO  Forcefully updating the Index Work Item to indicate it has been completed...
14:47:12.708 INFO  Index Work Item updated
14:47:12.708 INFO  Migrating index: logs-181998
14:47:12.926 INFO  Index logs-181998 created successfully
14:47:12.926 INFO  Forcefully updating the Index Work Item to indicate it has been completed...
14:47:12.934 INFO  Index Work Item updated
14:47:12.935 INFO  Pulling a list of indices to migrate from the CMS...
14:47:12.989 INFO  Pulled 1 indices to migrate:
14:47:12.990 INFO  [{"type":"INDEX_WORK_ITEM","name":"logs-211998","status":"NOT_STARTED","numAttempts":1,"numShards":5}]
14:47:12.990 INFO  Migrating current batch of indices...
14:47:12.990 INFO  Migrating index: logs-211998
14:47:13.231 INFO  Index logs-211998 created successfully
14:47:13.232 INFO  Forcefully updating the Index Work Item to indicate it has been completed...
14:47:13.242 INFO  Index Work Item updated
14:47:13.242 INFO  Pulling a list of indices to migrate from the CMS...
14:47:13.279 INFO  Pulled 0 indices to migrate:
14:47:13.279 INFO  []
14:47:13.279 INFO  Index Migration completed, exiting Index Phase...
14:47:13.279 INFO  Index Migration Phase is complete
```

### Check List
- [X] New functionality includes testing
  - [X] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
