### PR TITLE
Cache docker images for E2E testing workflow in Github Actions

### DIFF
--- a/.github/workflows/e2eTest.yml
+++ b/.github/workflows/e2eTest.yml
@@ -22,6 +22,19 @@ jobs:
           java-version: '11'
           distribution: 'corretto'
 
+      - name: Generate Cache Key from Dockerfiles
+        id: generate_cache_key
+        run: |
+          files=$(find . -type f \( -name 'docker-compose.yml' -o -name 'Dockerfile' \))
+          file_contents=$(cat $files)
+          key=$(echo "${file_contents}" | sha1sum | awk '{print $1}')
+          echo "key=${key}" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Docker Images
+        uses: ScribeMD/docker-cache@0.5.0
+        with:
+          key: docker-${{ runner.os }}-${{ steps.generate_cache_key.outputs.key }}
+
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
         with:


### PR DESCRIPTION
### Description
We’re frequently encountering issues where builds fail due to rate limiting in the github actions workflows for pulling docker images.

For example, see https://github.com/opensearch-project/opensearch-migrations/pull/695#issuecomment-2148465012.
While we’ve considered multiple ways to resolve this, a quick one (suggested in the comment above) is to use the github actions caching mechanism to cache our docker images.

One issue I hit along the way was that I was defining the action as:
```
      - name: Cache Docker Images
        uses: ScribeMD/docker-cache@0.5.0
        with:
          key: docker-${{ runner.os }}-${{ hashFiles('**/docker-compose.yml', '**/Dockerfile') }}
```
which does the same thing as now--a hash of the file contents of all docker-compose and Dockerfiles in the repo. However, it turns out that this key is evaluated at runtime--both during the original action (loading from cache) and the post-action (saving to cache). However, our gradle build process includes generating new dockerfiles, so the value of this key was changing from pre to post--meaning that there would almost by definition never be a cache hit.  Calculating the hash in a separate step and storing it resolves this issue.

### Issues Resolved
[MIGRATIONS-1761](https://opensearch.atlassian.net/browse/MIGRATIONS-1761)

### Testing
A lot of manual testing -- I left my former branch open as a PR in my fork to preserve the testing history: https://github.com/mikaylathompson/opensearch-migrations/pull/1

### Check List
- [ ] New functionality includes testing
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
