### PR TITLE
[RFS} Fixed a missing RFS dependency

### DIFF
--- a/RFS/build.gradle
+++ b/RFS/build.gradle
@@ -55,6 +55,7 @@ dependencies {
 
     implementation group: 'software.amazon.awssdk', name: 's3'
     implementation group: 'software.amazon.awssdk', name: 's3-transfer-manager'
+    implementation group: 'software.amazon.awssdk.crt', name: 'aws-crt'
 
     testImplementation group: 'io.projectreactor', name: 'reactor-test'
     testImplementation group: 'org.apache.logging.log4j', name: 'log4j-core'

--- a/commonDependencyVersionConstraints/build.gradle
+++ b/commonDependencyVersionConstraints/build.gradle
@@ -65,6 +65,8 @@ dependencies {
     api group: 'software.amazon.awssdk', name: 's3', version: awssdk
     api group: 'software.amazon.awssdk', name: 's3-transfer-manager', version: awssdk
 
+    def awscrt = '0.29.18'
+    api group: 'software.amazon.awssdk.crt', name: 'aws-crt', version: awscrt
 
     api group: 'com.bazaarvoice.jolt', name: 'jolt-core', version: '0.1.7'
 


### PR DESCRIPTION
### Description
Replacing a dependency that got lost in the shuffle of https://github.com/opensearch-project/opensearch-migrations/commit/fab14e282d020960ed1a9a3748cf66f1cb80ff01

### Issues Resolved
* N/A; the build was working but RFS failed at runtime

### Testing
Ran the RFS unit tests and manually performed a migration using the docker compose setup:

```
chelma@3c22fba4e266 RFS % gradle runRfsWorker --args='--snapshot-name reindex-from-snapshot --s3-local-dir /tmp/s3_files --s3-repo-uri s3://chelma-iad-rfs-local-testing --s3-region us-east-1 --source-host http://localhost:19200 --target-host http://localhost:29200 --min-replicas 0 --index-template-whitelist "my_index_template" --component-template-whitelist "my_component_template"'
.
.
.
> Task :RFS:runRfsWorker
11:22:10.903 INFO  Running RfsWorker
11:22:11.202 INFO  Checking if work remains in the Snapshot Phase...
11:22:12.015 INFO  Snapshot not yet completed, entering Snapshot Phase...
11:22:12.015 INFO  Snapshot CMS Entry not found, attempting to create it...
11:22:12.255 INFO  Snapshot CMS Entry created
11:22:12.255 INFO  Attempting to initiate the snapshot...
11:22:14.029 INFO  Snapshot repo registration successful
11:22:14.327 INFO  Snapshot reindex-from-snapshot creation initiated
11:22:14.327 INFO  Snapshot in progress...
11:22:14.617 INFO  Snapshot not finished yet; sleeping for 5 seconds...
11:22:19.707 INFO  Snapshot not finished yet; sleeping for 5 seconds...
11:22:24.785 INFO  Snapshot not finished yet; sleeping for 5 seconds...
11:22:30.057 INFO  Snapshot not finished yet; sleeping for 5 seconds...
11:22:35.176 INFO  Snapshot completed, exiting Snapshot Phase...
11:22:35.177 INFO  Snapshot Phase is complete
11:22:35.908 INFO  Checking if work remains in the Metadata Migration Phase...
11:22:35.916 INFO  Metadata Migration not yet completed, entering Metadata Phase...
11:22:35.916 INFO  Pulling the Metadata Migration entry from the CMS, if it exists...
11:22:35.921 INFO  Metadata Migration CMS Entry not found, attempting to create it...
11:22:35.964 INFO  Metadata Migration CMS Entry created
11:22:35.965 INFO  Setting the worker's current work item to be the Metadata Migration...
11:22:35.965 INFO  Work item set
11:22:35.965 INFO  Migrating the Templates...
11:22:36.927 INFO  Downloading file from S3: s3://chelma-iad-rfs-local-testing/index-0 to /tmp/s3_files/index-0
11:22:37.221 INFO  Downloading file from S3: s3://chelma-iad-rfs-local-testing/meta-2mSYxzXwQTSNqzoe7v3u1Q.dat to /tmp/s3_files/meta-2mSYxzXwQTSNqzoe7v3u1Q.dat
11:22:37.394 INFO  Setting Global Metadata
11:22:37.395 INFO  Setting Legacy Templates...
11:22:37.395 INFO  No Legacy Templates in specified whitelist
11:22:37.395 INFO  Setting Component Templates...
11:22:37.395 INFO  No Component Templates in Snapshot
11:22:37.395 INFO  Setting Index Templates...
11:22:37.395 INFO  No Index Templates in Snapshot
11:22:37.395 INFO  Templates migration complete
11:22:37.395 INFO  Updating the Metadata Migration entry to indicate completion...
11:22:37.414 INFO  Metadata Migration entry updated
11:22:37.414 INFO  Clearing the worker's current work item...
11:22:37.414 INFO  Work item cleared
11:22:37.415 INFO  Metadata Migration completed, exiting Metadata Phase...
11:22:37.415 INFO  Metadata Migration Phase is complete
11:22:37.418 INFO  Checking if work remains in the Index Migration Phase...
11:22:37.424 INFO  Index Migration not yet completed, entering Index Phase...
11:22:37.424 INFO  Pulling the Index Migration entry from the CMS, if it exists...
11:22:37.431 INFO  Index Migration CMS Entry not found, attempting to create it...
11:22:37.441 INFO  Index Migration CMS Entry created
11:22:37.441 INFO  Setting the worker's current work item to be creating the index work entries...
11:22:37.441 INFO  Work item set
11:22:37.441 INFO  Setting up the Index Work Items...
11:22:37.449 INFO  Downloading file from S3: s3://chelma-iad-rfs-local-testing/indices/8HXetiotSdm3G70zTLJlxg/meta-QH9b7o8BZjm0z27P5tCO.dat to /tmp/s3_files/indices/8HXetiotSdm3G70zTLJlxg/meta-QH9b7o8BZjm0z27P5tCO.dat
11:22:37.607 INFO  Creating Index Work Item for index: nyc_taxis
11:22:37.661 INFO  Downloading file from S3: s3://chelma-iad-rfs-local-testing/indices/-NGD3oCoSEC3J6k4tFWfqw/meta-Pn9b7o8BZjm0z27P5tCO.dat to /tmp/s3_files/indices/-NGD3oCoSEC3J6k4tFWfqw/meta-Pn9b7o8BZjm0z27P5tCO.dat
11:22:37.855 INFO  Creating Index Work Item for index: logs-241998
11:22:37.864 INFO  Downloading file from S3: s3://chelma-iad-rfs-local-testing/indices/0ZJwWKPPTUK1nH4AvjpWaw/meta-P39b7o8BZjm0z27P5tCO.dat to /tmp/s3_files/indices/0ZJwWKPPTUK1nH4AvjpWaw/meta-P39b7o8BZjm0z27P5tCO.dat
11:22:38.007 INFO  Creating Index Work Item for index: logs-221998
11:22:38.016 INFO  Downloading file from S3: s3://chelma-iad-rfs-local-testing/indices/TuySEpGBTjCGzZYM5TkaQg/meta-PX9b7o8BZjm0z27P5tCO.dat to /tmp/s3_files/indices/TuySEpGBTjCGzZYM5TkaQg/meta-PX9b7o8BZjm0z27P5tCO.dat
11:22:38.158 INFO  Creating Index Work Item for index: logs-191998
11:22:38.167 INFO  Downloading file from S3: s3://chelma-iad-rfs-local-testing/indices/ldT675wyQU2sfKjcyWAQ4Q/meta-QX9b7o8BZjm0z27P59Af.dat to /tmp/s3_files/indices/ldT675wyQU2sfKjcyWAQ4Q/meta-QX9b7o8BZjm0z27P59Af.dat
11:22:38.315 INFO  Creating Index Work Item for index: logs-211998
11:22:38.324 INFO  Downloading file from S3: s3://chelma-iad-rfs-local-testing/indices/Ub_2LhVyRxWhF06khl4tyw/meta-Q39b7o8BZjm0z27P59Af.dat to /tmp/s3_files/indices/Ub_2LhVyRxWhF06khl4tyw/meta-Q39b7o8BZjm0z27P59Af.dat
11:22:38.485 INFO  Creating Index Work Item for index: geonames
11:22:38.495 INFO  Downloading file from S3: s3://chelma-iad-rfs-local-testing/indices/L8CyLrR_SDGQXioFj8IXCQ/meta-Qn9b7o8BZjm0z27P59Af.dat to /tmp/s3_files/indices/L8CyLrR_SDGQXioFj8IXCQ/meta-Qn9b7o8BZjm0z27P59Af.dat
11:22:38.655 INFO  Creating Index Work Item for index: reindexed-logs
11:22:38.666 INFO  Downloading file from S3: s3://chelma-iad-rfs-local-testing/indices/XU4tx-yvQXWcxDYPG5AVsw/meta-RH9b7o8BZjm0z27P59Aw.dat to /tmp/s3_files/indices/XU4tx-yvQXWcxDYPG5AVsw/meta-RH9b7o8BZjm0z27P59Aw.dat
11:22:38.806 INFO  Creating Index Work Item for index: logs-231998
11:22:38.815 INFO  Downloading file from S3: s3://chelma-iad-rfs-local-testing/indices/wtN88TGfTv-kW-M_fuPIDg/meta-RX9b7o8BZjm0z27P59A2.dat to /tmp/s3_files/indices/wtN88TGfTv-kW-M_fuPIDg/meta-RX9b7o8BZjm0z27P59A2.dat
11:22:38.957 INFO  Creating Index Work Item for index: sonested
11:22:38.966 INFO  Downloading file from S3: s3://chelma-iad-rfs-local-testing/indices/J_1eFtl3RteqCGayR2nW0Q/meta-Rn9b7o8BZjm0z27P59C1.dat to /tmp/s3_files/indices/J_1eFtl3RteqCGayR2nW0Q/meta-Rn9b7o8BZjm0z27P59C1.dat
11:22:39.124 INFO  Creating Index Work Item for index: logs-201998
11:22:39.133 INFO  Downloading file from S3: s3://chelma-iad-rfs-local-testing/indices/PwMSYAGlQ2-BHWGrI5K8fQ/meta-R39b7o8BZjm0z27P59C1.dat to /tmp/s3_files/indices/PwMSYAGlQ2-BHWGrI5K8fQ/meta-R39b7o8BZjm0z27P59C1.dat
11:22:39.305 INFO  Creating Index Work Item for index: logs-181998
11:22:39.315 INFO  Finished setting up the Index Work Items.
11:22:39.316 INFO  Updating the Index Migration entry to indicate setup has been completed...
11:22:39.331 INFO  Index Migration entry updated
11:22:39.331 INFO  Clearing the worker's current work item...
11:22:39.331 INFO  Work item cleared
11:22:39.331 INFO  Pulling a list of indices to migrate from the CMS...
11:22:39.417 INFO  Pulled 10 indices to migrate:
11:22:39.418 INFO  [{"type":"INDEX_WORK_ITEM","name":"sonested","status":"NOT_STARTED","numAttempts":1,"numShards":1}, {"type":"INDEX_WORK_ITEM","name":"logs-211998","status":"NOT_STARTED","numAttempts":1,"numShards":5}, {"type":"INDEX_WORK_ITEM","name":"logs-241998","status":"NOT_STARTED","numAttempts":1,"numShards":5}, {"type":"INDEX_WORK_ITEM","name":"logs-231998","status":"NOT_STARTED","numAttempts":1,"numShards":5}, {"type":"INDEX_WORK_ITEM","name":"logs-221998","status":"NOT_STARTED","numAttempts":1,"numShards":5}, {"type":"INDEX_WORK_ITEM","name":"logs-201998","status":"NOT_STARTED","numAttempts":1,"numShards":5}, {"type":"INDEX_WORK_ITEM","name":"reindexed-logs","status":"NOT_STARTED","numAttempts":1,"numShards":5}, {"type":"INDEX_WORK_ITEM","name":"logs-191998","status":"NOT_STARTED","numAttempts":1,"numShards":5}, {"type":"INDEX_WORK_ITEM","name":"nyc_taxis","status":"NOT_STARTED","numAttempts":1,"numShards":1}, {"type":"INDEX_WORK_ITEM","name":"logs-181998","status":"NOT_STARTED","numAttempts":1,"numShards":5}]
11:22:39.418 INFO  Migrating current batch of indices...
11:22:39.418 INFO  Migrating index: sonested
11:22:39.531 INFO  Index sonested created successfully
11:22:39.531 INFO  Forcefully updating the Index Work Item to indicate it has been completed...
11:22:39.543 INFO  Index Work Item updated
11:22:39.544 INFO  Migrating index: logs-211998
11:22:39.808 INFO  Index logs-211998 created successfully
11:22:39.808 INFO  Forcefully updating the Index Work Item to indicate it has been completed...
11:22:39.817 INFO  Index Work Item updated
11:22:39.818 INFO  Migrating index: logs-241998
11:22:40.070 INFO  Index logs-241998 created successfully
11:22:40.070 INFO  Forcefully updating the Index Work Item to indicate it has been completed...
11:22:40.081 INFO  Index Work Item updated
11:22:40.081 INFO  Migrating index: logs-231998
11:22:40.421 INFO  Index logs-231998 created successfully
11:22:40.421 INFO  Forcefully updating the Index Work Item to indicate it has been completed...
11:22:40.432 INFO  Index Work Item updated
11:22:40.432 INFO  Migrating index: logs-221998
11:22:40.685 INFO  Index logs-221998 created successfully
11:22:40.685 INFO  Forcefully updating the Index Work Item to indicate it has been completed...
11:22:40.697 INFO  Index Work Item updated
11:22:40.697 INFO  Migrating index: logs-201998
11:22:40.997 INFO  Index logs-201998 created successfully
11:22:40.997 INFO  Forcefully updating the Index Work Item to indicate it has been completed...
11:22:41.011 INFO  Index Work Item updated
11:22:41.011 INFO  Migrating index: reindexed-logs
11:22:41.452 INFO  Index reindexed-logs created successfully
11:22:41.452 INFO  Forcefully updating the Index Work Item to indicate it has been completed...
11:22:41.463 INFO  Index Work Item updated
11:22:41.463 INFO  Migrating index: logs-191998
11:22:41.716 INFO  Index logs-191998 created successfully
11:22:41.716 INFO  Forcefully updating the Index Work Item to indicate it has been completed...
11:22:41.730 INFO  Index Work Item updated
11:22:41.730 INFO  Migrating index: nyc_taxis
11:22:41.871 INFO  Index nyc_taxis created successfully
11:22:41.871 INFO  Forcefully updating the Index Work Item to indicate it has been completed...
11:22:41.883 INFO  Index Work Item updated
11:22:41.883 INFO  Migrating index: logs-181998
11:22:42.139 INFO  Index logs-181998 created successfully
11:22:42.139 INFO  Forcefully updating the Index Work Item to indicate it has been completed...
11:22:42.149 INFO  Index Work Item updated
11:22:42.149 INFO  Pulling a list of indices to migrate from the CMS...
11:22:42.192 INFO  Pulled 1 indices to migrate:
11:22:42.192 INFO  [{"type":"INDEX_WORK_ITEM","name":"geonames","status":"NOT_STARTED","numAttempts":1,"numShards":5}]
11:22:42.192 INFO  Migrating current batch of indices...
11:22:42.192 INFO  Migrating index: geonames
11:22:42.468 INFO  Index geonames created successfully
11:22:42.468 INFO  Forcefully updating the Index Work Item to indicate it has been completed...
11:22:42.479 INFO  Index Work Item updated
11:22:42.479 INFO  Pulling a list of indices to migrate from the CMS...
11:22:42.599 INFO  Pulled 0 indices to migrate:
11:22:42.599 INFO  []
11:22:42.599 INFO  Index Migration completed, exiting Index Phase...
11:22:42.599 INFO  Index Migration Phase is complete
```

### Check List
- [X] New functionality includes testing
  - [X] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
