### PR TITLE
Govcloud fix

### DIFF
--- a/FetchMigration/Dockerfile
+++ b/FetchMigration/Dockerfile
@@ -9,7 +9,7 @@ RUN pip3 install --user -r requirements.txt
 ENV FM_CODE_PATH /code
 WORKDIR $FM_CODE_PATH
 # Copy only source code
-COPY python/*.py .
+COPY python/*.py ./
 
 # update PATH
 ENV PATH=/root/.local:$PATH

--- a/TrafficCapture/dockerSolution/src/main/docker/elasticsearchTestConsole/runTestBenchmarks.sh
+++ b/TrafficCapture/dockerSolution/src/main/docker/elasticsearchTestConsole/runTestBenchmarks.sh
@@ -1,7 +1,13 @@
 #!/bin/bash
 
 # Default values
-endpoint="https://capture-proxy-es:9200"
+
+# Check for the presence of SOURCE_DOMAIN_ENDPOINT environment variable
+if [ -n "$SOURCE_DOMAIN_ENDPOINT" ]; then
+    endpoint="${SOURCE_DOMAIN_ENDPOINT}"
+else
+    endpoint="https://capture-proxy-es:9200"
+fi
 auth_user="admin"
 auth_pass="admin"
 no_auth=false

--- a/deployment/cdk/opensearch-service-migration/lib/msk-utility-stack.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/msk-utility-stack.ts
@@ -32,7 +32,7 @@ export class MSKUtilityStack extends Stack {
             const lambdaInvokeStatement = new PolicyStatement({
                 effect: Effect.ALLOW,
                 actions: ["lambda:InvokeFunction"],
-                resources: [`arn:aws:lambda:${this.region}:${this.account}:function:OSMigrations*`]
+                resources: [`arn:${this.partition}:lambda:${this.region}:${this.account}:function:OSMigrations*`]
             })
             // Updating connectivity for an MSK cluster requires some VPC permissions
             // (https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazonmanagedstreamingforapachekafka.html#amazonmanagedstreamingforapachekafka-cluster)

--- a/deployment/cdk/opensearch-service-migration/lib/service-stacks/migration-console-stack.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/service-stacks/migration-console-stack.ts
@@ -159,7 +159,7 @@ export class MigrationConsoleStack extends MigrationServiceCore {
             ]
         })
 
-        const allClusterTasksArn = `arn:aws:ecs:${props.env?.region}:${props.env?.account}:task/migration-${props.stage}-ecs-cluster/*`
+        const allClusterTasksArn = `arn:${this.partition}:ecs:${this.region}:${this.account}:task/migration-${props.stage}-ecs-cluster/*`
         const clusterTasksPolicy = new PolicyStatement({
             effect: Effect.ALLOW,
             resources: [allClusterTasksArn],


### PR DESCRIPTION
### Description
This puts out a few fixes for issues encountered during a deployment to govcloud.

Fixes Fetch Migration dockerfile with older docker versions which requires a trailing / on COPY path when used with multiple files
> docker build --tag cdkasset-a31209dcc7fee0fb320f2e2f78921261a47ec36a2006da15987b8222825e3062 . exited with error code 1: When using COPY with more than one source file, the destination must be a directory and end with a /

Parameterizes aws partition in ARNs that are remaining
Fixes benchmark script when run with no parameters on AWS 

* Category: Bug Fix
* Why these changes are required? Govcloud support
* What is the old behavior before changes and new behavior after changes? On some docker versions (e.g. 20.10.25), cdk deploy would fail with fetch migration. CDK deploy also failed on govcloud due to resource arns used. 

### Issues Resolved
N/A

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
Deployed to GovCloud and ran benchmarks and fetch migration

### Check List
- [ x] New functionality includes testing
  - [ x] All tests pass, including unit test, integration test and doctest
- [ x] New functionality has been documented
- [ x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
