### PR TITLE
Update requests lib for mend

### DIFF
--- a/FetchMigration/python/requirements.txt
+++ b/FetchMigration/python/requirements.txt
@@ -3,6 +3,6 @@ jsondiff>=2.0.0
 jsonpath-ng>=1.6.0
 prometheus-client>=0.17.1
 pyyaml>=6.0.1
-requests>=2.31.0
+requests>=2.32.3
 requests-aws4auth>=1.2.3
 responses>=0.23.3

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -6,7 +6,7 @@ packaging==23.1
 pluggy==1.0.0
 pytest==7.3.1
 pytest-xdist==3.3.1
-requests>==2.31.0
+requests>==2.32.3
 urllib3>==2.0.7
 requests_aws4auth
 boto3


### PR DESCRIPTION
### Description
Mend is concerned about Requests 2.31.0. I suspect we're not actually using it because our definition is >= 2.31, but obviously it's necessary to guarantee that.

### Issues Resolved
#670
This issue is also on the security dashboard, so we get a two-for-one.

### Testing
One is a testing requirement, so it's tested via our tests. Ran unit tests for fetch.

### Check List
- [ ] New functionality includes testing
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
