### PR TITLE
[Mend] Update Werkzeug to 3.0.3 in Fetch

### DIFF
--- a/FetchMigration/python/dev-requirements.txt
+++ b/FetchMigration/python/dev-requirements.txt
@@ -1,5 +1,5 @@
 # Transitive dependency from moto, explicit version needed to mitigate CVE-2023-46136
-werkzeug>=3.0.1
+werkzeug>=3.0.3
 coverage>=7.3.2
 pur>=7.3.1
 moto>=4.2.7


### PR DESCRIPTION
### Description
I don't have particularly high hopes for this one, but Mend now says that Werkzeug needs to be at 3.0.3 due to a new concern (previously it needed to be at 3.0.1). Somewhat confusingly, both the old (satisfied by 3.0.1) and new (needs 3.0.3) vulnerabilities are handled in issue #402 .

### Issues Resolved
If we're very lucky, #402

### Testing
Ran the fetch unit tests

### Check List
- [ ] New functionality includes testing
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
