### PR TITLE
[Migration Console] Fix bugs related to putting services.yaml file on migration console in ECS

### DIFF
--- a/deployment/cdk/opensearch-service-migration/lib/service-stacks/capture-proxy-stack.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/service-stacks/capture-proxy-stack.ts
@@ -43,7 +43,7 @@ export class CaptureProxyStack extends MigrationServiceCore {
         const servicePolicies = props.streamingSourceType === StreamingSourceType.AWS_MSK ? createMSKProducerIAMPolicies(this, this.partition, this.region, this.account, props.stage, props.defaultDeployId) : []
 
         const brokerEndpoints = StringParameter.valueForStringParameter(this, `/migration/${props.stage}/${props.defaultDeployId}/kafkaBrokers`);
-        const sourceClusterEndpoint = props.customSourceClusterEndpoint ? props.customSourceClusterEndpoint : "https://elasticsearch:9200"
+        const sourceClusterEndpoint = props.customSourceClusterEndpoint ?? "https://elasticsearch:9200"
         let command = `/runJavaWithClasspath.sh org.opensearch.migrations.trafficcapture.proxyserver.CaptureProxy  --kafkaConnection ${brokerEndpoints} --destinationUri ${sourceClusterEndpoint} --insecureDestination --listenPort 9200`
         command = props.streamingSourceType === StreamingSourceType.AWS_MSK ? command.concat(" --enableMSKAuth") : command
         command = props.otelCollectorEnabled ? command.concat(` --otelCollectorEndpoint http://localhost:${OtelCollectorSidecar.OTEL_CONTAINER_PORT}`) : command

--- a/deployment/cdk/opensearch-service-migration/lib/service-stacks/migration-console-stack.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/service-stacks/migration-console-stack.ts
@@ -24,6 +24,7 @@ export interface MigrationConsoleProps extends StackPropsExt {
     readonly migrationConsoleEnableOSI: boolean,
     readonly migrationAPIEnabled?: boolean,
     readonly servicesYaml: ServicesYaml,
+    readonly sourceClusterEndpoint?: string,
 }
 
 export class MigrationConsoleStack extends MigrationServiceCore {
@@ -215,11 +216,13 @@ export class MigrationConsoleStack extends MigrationServiceCore {
                 "cloudwatch:GetMetricData"
             ]
         })
+        const sourceClusterEndpoint = props.sourceClusterEndpoint ?? `https://capture-proxy-es.migration.${props.stage}.local:9200`;
 
         // Upload the services.yaml file to Parameter Store
         let servicesYaml = props.servicesYaml
         servicesYaml.source_cluster = {
-            'endpoint': `https://capture-proxy-es.migration.${props.stage}.local:9200`,
+            'endpoint': sourceClusterEndpoint,
+            // TODO: We're not currently supporting auth here, this may need to be handled on the migration console
             'no_auth': ''
         }
         // Create a new parameter in Parameter Store
@@ -232,7 +235,7 @@ export class MigrationConsoleStack extends MigrationServiceCore {
         const environment: { [key: string]: string; } = {
             "MIGRATION_DOMAIN_ENDPOINT": osClusterEndpoint,
             // Temporary fix for source domain endpoint until we move to either alb or migration console yaml configuration
-            "SOURCE_DOMAIN_ENDPOINT": `https://capture-proxy-es.migration.${props.stage}.local:9200`,
+            "SOURCE_DOMAIN_ENDPOINT": sourceClusterEndpoint,
             "MIGRATION_KAFKA_BROKER_ENDPOINTS": brokerEndpoints,
             "MIGRATION_STAGE": props.stage,
             "MIGRATION_SOLUTION_VERSION": props.migrationsSolutionVersion,
@@ -281,7 +284,9 @@ export class MigrationConsoleStack extends MigrationServiceCore {
             }]
             serviceDiscoveryPort = 8000
             serviceDiscoveryEnabled = true
-            imageCommand = ['/bin/sh', '-c', 'python3 /root/console_api/manage.py runserver_plus 0.0.0.0:8000']
+            imageCommand = ['/bin/sh', '-c',
+                '/root/loadServicesFromParameterStore.sh && python3 /root/console_api/manage.py runserver_plus 0.0.0.0:8000'
+            ]
         }
 
         if (props.migrationConsoleEnableOSI) {

--- a/deployment/cdk/opensearch-service-migration/lib/stack-composer.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/stack-composer.ts
@@ -517,6 +517,9 @@ export class StackComposer {
                 migrationConsoleEnableOSI: migrationConsoleEnableOSI,
                 migrationAPIEnabled: migrationAPIEnabled,
                 servicesYaml: servicesYaml,
+                // The default value is correct if we deploy the capture proxy (e.g. captureProxyServiceEnabled or captureProxyESServiceEnabled),
+                // but not if the user does it on their own (in which case we use captureProxySourceEndpoint)
+                sourceClusterEndpoint: !(captureProxyServiceEnabled || captureProxyESServiceEnabled) ? captureProxySourceEndpoint : undefined,
                 stackName: `OSMigrations-${stage}-${region}-MigrationConsole`,
                 description: "This stack contains resources for the Migration Console ECS service",
                 stage: stage,


### PR DESCRIPTION
### Description
Friday's demo session was very helpful for finding bugs in my code to put the services.yaml file on the migration console in ECS.

Namely:
- better logic around what the source cluster endpoint is if we're not setting up the capture proxy ourselves
- making sure `loadServices` script is called even if the API is enabled  

### Issues Resolved
Related to #695 , which resolved [MIGRATIONS-1744](https://opensearch.atlassian.net/browse/MIGRATIONS-1744)

### Testing
Manual

### Check List
- [ ] New functionality includes testing
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
