### PR TITLE
Add docker image caching for Gradle github actions workflow

### DIFF
--- a/.github/workflows/gradle-build-and-test.yml
+++ b/.github/workflows/gradle-build-and-test.yml
@@ -17,6 +17,19 @@ jobs:
           java-version: '11'
           distribution: 'corretto'
 
+      - name: Generate Cache Key from Dockerfiles
+        id: generate_cache_key
+        run: |
+          files=$(find . -type f \( -name 'docker-compose.yml' -o -name 'Dockerfile' \))
+          file_contents=$(cat $files)
+          key=$(echo "${file_contents}" | sha1sum | awk '{print $1}')
+          echo "key=${key}" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Docker Images
+        uses: ScribeMD/docker-cache@0.5.0
+        with:
+          key: docker-${{ runner.os }}-${{ steps.generate_cache_key.outputs.key }}
+
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
         with:


### PR DESCRIPTION
### Description
This PR follows #698, which added docker image caching for the e2e tests pipeline. That has had a few days of bake time and has been working well, so this adds it to the gradle build and test workflow.

As mentioned in the JIRA task, one important consideration is that the cache key for this workflow is the same as for the e2e tests so that the cache can be shared. This is pretty straightforward because both workflows have the same first few steps, so I'm using exactly the same caching step and have verified that the results are the same (see my testing PR below).

### Issues Resolved
[MIGRATION-1766](https://opensearch.atlassian.net/browse/MIGRATIONS-1766)


### Testing
Manual, including in https://github.com/mikaylathompson/opensearch-migrations/pull/2

### Check List
- [ ] New functionality includes testing
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
