### PR TITLE
[Console] Update format of services.yaml

### DIFF
--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/README.md
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/README.md
@@ -17,33 +17,32 @@ For example:
 
 ```yaml
 source_cluster:
-	endpoint: "https://capture-proxy-es:9200"
-	allow_insecure: true
+    endpoint: "https://capture-proxy-es:9200"
+    allow_insecure: true
+    no_auth:
 target_cluster:
-	endpoint: "https://opensearchtarget:9200"
-	allow_insecure: true
-	authorization:
-		type: "basic_auth"
-		details:
-			username: "admin"
-			password: "myStrongPassword123!"
+    endpoint: "https://opensearchtarget:9200"
+    allow_insecure: true
+    basic_auth:
+        username: "admin"
+        password: "myStrongPassword123!"
 metrics_source:
-	type: "prometheus"
-	endpoint: "http://prometheus:9090"
+    prometheus:
+        endpoint: "http://prometheus:9090"
 backfill:
-	opensearch_ingestion:
-		pipeline_role_arn: "arn:aws:iam::123456789012:role/OSMigrations-aws-integ-us--pipelineRole"
-		vpc_subnet_ids:
-			- "subnet-123456789"
-		security_group_ids:
-			- "sg-123456789"
-		aws_region: "us-west-2"
-		pipeline_name: "test-cli-pipeline"
-		index_regex_selection:
-			- "test-index*"
-		log_group_name: "/aws/vendedlogs/osi-aws-integ-default"
-		tags:
-			- "migration_deployment=1.0.6"
+    opensearch_ingestion:
+        pipeline_role_arn: "arn:aws:iam::123456789012:role/OSMigrations-aws-integ-us--pipelineRole"
+        vpc_subnet_ids:
+            - "subnet-123456789"
+        security_group_ids:
+            - "sg-123456789"
+        aws_region: "us-west-2"
+        pipeline_name: "test-cli-pipeline"
+        index_regex_selection:
+            - "test-index*"
+        log_group_name: "/aws/vendedlogs/osi-aws-integ-default"
+        tags:
+            - "migration_deployment=1.0.6"
 ```
 
 ### Services.yaml spec
@@ -53,8 +52,8 @@ backfill:
 Source and target clusters have the following options:
 - `endpoint`: required, the endpoint to reach the cluster.
 - `authorization`: required, the auth method to use, if no auth the no_auth type must be specified.
-	- `type`: required, the only currently implemented options are "no_auth" and "basic_auth", but "sigv4" should be available soon
-	- `details`: for basic auth, the details should be a `username` and `password`
+    - `type`: required, the only currently implemented options are "no_auth" and "basic_auth", but "sigv4" should be available soon
+    - `details`: for basic auth, the details should be a `username` and `password`
 
 Having a `source_cluster` and `target_cluster` is required.
 

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/README.md
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/README.md
@@ -51,19 +51,26 @@ backfill:
 
 Source and target clusters have the following options:
 - `endpoint`: required, the endpoint to reach the cluster.
-- `authorization`: required, the auth method to use, if no auth the no_auth type must be specified.
-    - `type`: required, the only currently implemented options are "no_auth" and "basic_auth", but "sigv4" should be available soon
-    - `details`: for basic auth, the details should be a `username` and `password`
+
+Exactly one of the following blocks must be present:
+- `no_auth`: may be empty, no authorization to use.
+- `basic_auth`:
+    - `username`
+    - `password`
+- `sigv4`: may be empty, not yet implemented
 
 Having a `source_cluster` and `target_cluster` is required.
 
 #### Metrics Source
 
 Currently, the two supported metrics source types are `prometheus` and `cloudwatch`.
+Exactly one of the following blocks must be present:
+- `prometheus`:
+    - `endpoint`: required
 
-- `type`: required, `prometheus` or `cloudwatch`
-- `endpoint`: required for `prometheus` (ignored for `cloudwatch`)
-- `aws_region`: optional for `cloudwatch` (ignored for `prometheus`). if not provided, the usual rules are followed for determining aws region (`AWS_DEFAULT_REGION`, `~/.aws/config`)
+- `cloudwatch`: may be empty if region is not specified
+    - `aws_region`:  optional. if not provided, the usual rules are followed for determining aws region. (`AWS_DEFAULT_REGION`, `~/.aws/config`, etc.)
+
 
 #### Backfill
 

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/cluster.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/cluster.py
@@ -94,7 +94,7 @@ class Cluster:
                 self.auth_details.get("username", None),
                 self.auth_details.get("password", None)
             )
-        elif self.auth_type is None:
+        elif self.auth_type is AuthMethod.NO_AUTH:
             auth = None
         else:
             raise NotImplementedError(f"Auth type {self.auth_type} not implemented")

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/cluster.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/cluster.py
@@ -4,6 +4,7 @@ import requests
 from requests.auth import HTTPBasicAuth
 from cerberus import Validator
 import logging
+from console_link.models.schema_tools import contains_one_of
 
 requests.packages.urllib3.disable_warnings()  # ignore: type
 
@@ -12,38 +13,47 @@ logger = logging.getLogger(__name__)
 AuthMethod = Enum("AuthMethod", ["NO_AUTH", "BASIC_AUTH", "SIGV4"])
 HttpMethod = Enum("HttpMethod", ["GET", "POST", "PUT", "DELETE"])
 
-SCHEMA = {
-    "endpoint": {"type": "string", "required": True},
-    "allow_insecure": {"type": "boolean", "required": False},
-    "authorization": {
-        "type": "dict",
-        "required": True,
-        "schema": {
-            "type": {
-                "type": "string",
-                "required": True,
-                "allowed": [e.name.lower() for e in AuthMethod]
-            },
-            "details": {
-                "type": "dict",
-                "required": False,
-                "schema": {
-                    "username": {
-                        "type": "string",
-                        "required": False
-                    },
-                    "password": {
-                        "type": "string",
-                        "required": False
-                    },
-                    "aws_secret_arn": {
-                        "type": "string",
-                        "required": False
-                    },
-                }
-            }
+
+NO_AUTH_SCHEMA = {
+    "nullable": True,
+}
+
+BASIC_AUTH_SCHEMA = {
+    "type": "dict",
+    "schema": {
+        "username": {
+            "type": "string",
+            "required": False,
+        },
+        "password": {
+            "type": "string",
+            "required": False,
+            "excludes": ["aws_secret_arn"]
+        },
+        "aws_secret_arn": {
+            "type": "string",
+            "required": False,
+            "excludes": ["password"]
         }
     },
+}
+
+SIGV4_SCHEMA = {
+    "nullable": True,
+}
+
+SCHEMA = {
+    "cluster": {
+        "type": "dict",
+        "schema": {
+            "endpoint": {"type": "string", "required": True},
+            "allow_insecure": {"type": "boolean", "required": False},
+            "no_auth": NO_AUTH_SCHEMA,
+            "basic_auth": BASIC_AUTH_SCHEMA,
+            "sigv4": SIGV4_SCHEMA
+        },
+        "check_with": contains_one_of({auth.name.lower() for auth in AuthMethod})
+    }
 }
 
 
@@ -60,15 +70,19 @@ class Cluster:
     def __init__(self, config: Dict) -> None:
         logger.info(f"Initializing cluster with config: {config}")
         v = Validator(SCHEMA)
-        if not v.validate(config):
+        if not v.validate({'cluster': config}):
             raise ValueError("Invalid config file for cluster", v.errors)
 
         self.endpoint = config["endpoint"]
         if self.endpoint.startswith("https"):
             self.allow_insecure = config.get("allow_insecure", False)
-        self.auth_type = AuthMethod[config["authorization"]["type"].upper()]
-        self.auth_details = config["authorization"].get("details", None)
-        self.aws_secret_arn = None if self.auth_details is None else self.auth_details.get("aws_secret_arn", None)
+        if 'no_auth' in config:
+            self.auth_type = AuthMethod.NO_AUTH
+        elif 'basic_auth' in config:
+            self.auth_type = AuthMethod.BASIC_AUTH
+            self.auth_details = config["basic_auth"]
+        elif 'sigv4' in config:
+            self.auth_type = AuthMethod.SIGV4
 
     def call_api(self, path, method: HttpMethod = HttpMethod.GET) -> requests.Response:
         """

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/schema_tools.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/schema_tools.py
@@ -1,0 +1,14 @@
+from typing import Set
+
+
+def contains_one_of(values_to_restrict: Set):
+    """
+    Generates a validator that checks if a value contains exactly one of the specified keys.
+    """
+    def one_of(field, value, error):
+        found_objects = values_to_restrict.intersection(value.keys())
+        if len(found_objects) > 1:
+            error(field, f"More than one value is present: {sorted(found_objects)}")
+        elif len(found_objects) < 1:
+            error(field, f"No values are present from set: {sorted(values_to_restrict)}")
+    return one_of

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/services.yaml
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/services.yaml
@@ -1,21 +1,17 @@
 source_cluster:
   endpoint: "https://capture-proxy-es:9200"
   allow_insecure: true
-  authorization:
-    type: "basic_auth"
-    details:
+  basic_auth:
       username: "admin"
       password: "admin"
 target_cluster:
   endpoint: "https://opensearchtarget:9200"
   allow_insecure: true
-  authorization:
-    type: "basic_auth"
-    details:
+  basic_auth:
       username: "admin"
       password: "myStrongPassword123!"
 metrics_source:
-  type: "prometheus"
-  endpoint: "http://prometheus:9090"
+  prometheus:
+    endpoint: "http://prometheus:9090"
 replayer:
-  deployment_type: "docker"
+  docker:

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/test_cluster.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/test_cluster.py
@@ -1,6 +1,6 @@
 import pytest  # type: ignore
 from tests.utils import create_valid_cluster
-from console_link.models.cluster import Cluster
+from console_link.models.cluster import AuthMethod, Cluster
 
 # Define a valid cluster configuration
 valid_cluster_config = {
@@ -67,3 +67,13 @@ def test_missing_endpoint_refused():
         Cluster(missing_endpoint)
     assert "Invalid config file for cluster" in excinfo.value.args[0]
     assert excinfo.value.args[1]['cluster'][0]["endpoint"] == ["required field"]
+
+
+def test_valid_cluster_api_call_with_no_auth(requests_mock):
+    cluster = create_valid_cluster(auth_type=AuthMethod.NO_AUTH)
+    assert isinstance(cluster, Cluster)
+
+    requests_mock.get(f"{cluster.endpoint}/test_api", json={'test': True})
+    response = cluster.call_api("/test_api")
+    assert response.status_code == 200
+    assert response.json() == {'test': True}

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/test_cluster.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/test_cluster.py
@@ -6,10 +6,7 @@ from console_link.models.cluster import Cluster
 valid_cluster_config = {
     "endpoint": "https://opensearchtarget:9200",
     "allow_insecure": True,
-    "authorization": {
-        "type": "basic_auth",
-        "details": {"username": "admin", "password": "myStrongPassword123!"},
-    },
+    "basic_auth": {"username": "admin", "password": "myStrongPassword123!"},
 }
 
 
@@ -21,27 +18,52 @@ def test_valid_cluster_config():
 def test_invalid_auth_type_refused():
     invalid_auth_type = {
         "endpoint": "https://opensearchtarget:9200",
-        "authorization": {
-            "type": "invalid_type",
-        },
+        "invalid_authorization": {},
     }
     with pytest.raises(ValueError) as excinfo:
         Cluster(invalid_auth_type)
     assert "Invalid config file for cluster" in excinfo.value.args[0]
-    assert excinfo.value.args[1]["authorization"] == [
-        {"type": ["unallowed value invalid_type"]}
+    assert excinfo.value.args[1]["cluster"] == [
+        "No values are present from set: ['basic_auth', 'no_auth', 'sigv4']",
+        {'invalid_authorization': ['unknown field']}
+    ]
+
+
+def test_multiple_auth_types_refused():
+    multiple_auth_types = {
+        "endpoint": "https://opensearchtarget:9200",
+        "basic_auth": {
+            "username": "admin",
+            "password": "myfakepassword"
+        },
+        "no_auth": {}
+    }
+    with pytest.raises(ValueError) as excinfo:
+        Cluster(multiple_auth_types)
+    assert "Invalid config file for cluster" in excinfo.value.args[0]
+    assert excinfo.value.args[1]["cluster"] == [
+        "More than one value is present: ['basic_auth', 'no_auth']"
+    ]
+
+
+def test_missing_auth_type_refused():
+    missing_auth_type = {
+        "endpoint": "XXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+    }
+    with pytest.raises(ValueError) as excinfo:
+        Cluster(missing_auth_type)
+    assert "Invalid config file for cluster" in excinfo.value.args[0]
+    assert excinfo.value.args[1]["cluster"] == [
+        "No values are present from set: ['basic_auth', 'no_auth', 'sigv4']"
     ]
 
 
 def test_missing_endpoint_refused():
     missing_endpoint = {
         "allow_insecure": True,
-        "authorization": {
-            "type": "basic_auth",
-            "details": {"username": "XXXXX", "password": "XXXXXXXXXXXXXXXXXXX!"},
-        },
+        "no_auth": {}
     }
     with pytest.raises(ValueError) as excinfo:
         Cluster(missing_endpoint)
     assert "Invalid config file for cluster" in excinfo.value.args[0]
-    assert excinfo.value.args[1]["endpoint"] == ["required field"]
+    assert excinfo.value.args[1]['cluster'][0]["endpoint"] == ["required field"]

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/test_metrics_source.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/test_metrics_source.py
@@ -173,3 +173,11 @@ def test_prometheus_get_metrics_error(prometheus_ms):
                status_code=500)
         with pytest.raises(requests.exceptions.HTTPError):
             prometheus_ms.get_metrics()
+
+
+def test_prometheus_get_metric_for_nonexistent_component(prometheus_ms):
+    with pytest.raises(ValueError):
+        prometheus_ms.get_metric_data(
+            Component(3), "kafkaCommitCount",
+            MetricStatistic.Average, startTime=datetime.datetime.now()
+        )

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/test_metrics_source.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/test_metrics_source.py
@@ -29,8 +29,9 @@ def prometheus_ms():
     # fail if the endpoint doesn't start with http
     endpoint = "http://localhost:9090"
     return PrometheusMetricsSource({
-        "type": "prometheus",
-        "endpoint": endpoint
+        "prometheus": {
+            "endpoint": endpoint
+        }
     })
 
 
@@ -44,45 +45,48 @@ def cw_stubber():
 @pytest.fixture
 def cw_ms():
     return CloudwatchMetricsSource({
-        "type": "cloudwatch",
-        "aws_region": AWS_REGION
+        "cloudwatch": {
+            "aws_region": AWS_REGION
+        }
     })
 
 
 def test_get_metrics_source():
     cw_config = {
-        "type": "cloudwatch",
-        "aws_region": AWS_REGION
+        "cloudwatch": {
+            "aws_region": AWS_REGION
+        }
     }
     cw_metrics_source = get_metrics_source(cw_config)
     assert isinstance(cw_metrics_source, CloudwatchMetricsSource)
     assert isinstance(cw_metrics_source, MetricsSource)
 
     prometheus_config = {
-        "type": "prometheus",
-        "endpoint": "localhost:9090"
+        "prometheus": {
+            "endpoint": "localhost:9090"
+        }
     }
     prometheus_metrics_source = get_metrics_source(prometheus_config)
     assert isinstance(prometheus_metrics_source, PrometheusMetricsSource)
     assert isinstance(prometheus_metrics_source, MetricsSource)
 
     unknown_conig = {
-        "type": "made_up_metrics_source",
+        "made_up_metrics_source": {"data": "xyz"}
     }
     with pytest.raises(UnsupportedMetricsSourceError) as excinfo:
         get_metrics_source(unknown_conig)
     assert "Unsupported metrics source type" in str(excinfo.value.args[0])
-    assert unknown_conig["type"] in str(excinfo.value.args[1])
+    assert "made_up_metrics_source" in str(excinfo.value.args[1])
 
 
 def test_prometheus_metrics_source_validates_endpoint():
     wrong_prometheus_config = {
-        "type": "prometheus",
+        "prometheus": {'different-key': 'value'}
     }
     with pytest.raises(ValueError) as excinfo:
         PrometheusMetricsSource(wrong_prometheus_config)
-    assert "Invalid config file for PrometheusMetricsSource" in str(excinfo.value.args[0])
-    assert "endpoint" in str(excinfo.value.args[1])
+    assert "Invalid config file for MetricsSource" in str(excinfo.value.args[0])
+    assert "endpoint" in str(excinfo.value.args[1]['metrics'][0]['prometheus'])
 
 
 def test_cloudwatch_metrics_get_metrics(cw_ms, cw_stubber):

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/test_osi_utils.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/test_osi_utils.py
@@ -203,7 +203,7 @@ def test_valid_env_creates_pipeline(osi_client_stubber):
         ]
     }
     mock_cluster = create_valid_cluster(endpoint=SOURCE_ENDPOINT,
-                                        auth_type=AuthMethod.SIGV4.name.lower(),
+                                        auth_type=AuthMethod.SIGV4,
                                         details={"aws_secret_arn": SECRET_ARN})
     expected_osi_create_pipeline_body = {
         "MinUnits": ANY,

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/utils.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/utils.py
@@ -1,19 +1,23 @@
+from typing import Dict, Optional
 from console_link.models.cluster import Cluster, AuthMethod
 
 
-def create_valid_cluster(endpoint="https://opensearchtarget:9200",
-                         allow_insecure=True,
-                         auth_type=AuthMethod.BASIC_AUTH.name.lower(),
-                         details=None):
+def create_valid_cluster(endpoint: str = "https://opensearchtarget:9200",
+                         allow_insecure: bool = True,
+                         auth_type: AuthMethod = AuthMethod.BASIC_AUTH,
+                         details: Optional[Dict] = None):
     if details is None:
         details = {"username": "admin", "password": "myStrongPassword123!"}
+
+    auth_block = {
+        AuthMethod.NO_AUTH: {},
+        AuthMethod.BASIC_AUTH: details,
+        AuthMethod.SIGV4: {}
+    }
 
     custom_cluster_config = {
         "endpoint": endpoint,
         "allow_insecure": allow_insecure,
-        "authorization": {
-            "type": auth_type,
-            "details": details,
-        },
+        auth_type.name.lower(): auth_block[auth_type]
     }
     return Cluster(custom_cluster_config)


### PR DESCRIPTION
### Description
The services.yaml file is the core location for information about the current deployment and making the implementation clean and easy to validate will be helpful moving forward.

There were a few recent comments regarding the file format in the reviews of the e2e branch merge & the OSI backfill additions:
- ensure that the yaml file itself, and the README about it use spaces rather than tabs: https://github.com/opensearch-project/opensearch-migrations/pull/690#discussion_r1619216618
- write yaml structure with mutually-exclusive "nodes": https://github.com/opensearch-project/opensearch-migrations/pull/680#discussion_r1617504021

For the second point, the idea is to move AWAY from:
```
source_cluster:
  authorization:
    type: basic_auth
    details:
      user: abc
      password: xyz
```
And towards:
```
source_cluster:
  basic_auth:
    username: abc
    password: xyz
```

In general, instead of having a type field, each service description should instead have a node with the name of the type that contains any relevant details. The schema validation can then be written to ensure that no mutually-exclusive nodes are present.

#### Notes on Approach
The bulk of this PR is updating documentation and tests--the actual schemas involved are quite small still (hence doing this refactoring now).

There was no built-in Cerberus rule to validate that exactly one block of a selection was present. I created a generator that returns a callable to verify that exactly one key from a given list is provided. I think this should be quite widely used throughout our schemas. I also think that this PR makes the schemas a bit more modularized and readable.


### Issues Resolved
https://opensearch.atlassian.net/browse/MIGRATIONS-1754

### Testing
Unit tests, manual

### Check List
- [x] New functionality includes testing
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
