### PR TITLE
[RFS] Split RFS Worker into phase-specific entrypoints

### DIFF
--- a/RFS/build.gradle
+++ b/RFS/build.gradle
@@ -86,6 +86,21 @@ task runRfsWorker (type: JavaExec) {
     mainClass = 'com.rfs.RunRfsWorker'
 }
 
+task createSnapshot (type: JavaExec) {
+    classpath = sourceSets.main.runtimeClasspath
+    mainClass = 'com.rfs.RfsCreateSnapshot'
+}
+
+task migrateMetadata (type: JavaExec) {
+    classpath = sourceSets.main.runtimeClasspath
+    mainClass = 'com.rfs.RfsMigrateMetadata'
+}
+
+task migrateDocuments (type: JavaExec) {
+    classpath = sourceSets.main.runtimeClasspath
+    mainClass = 'com.rfs.RfsMigrateDocuments'
+}
+
 // Cleanup additional docker build directory
 clean.doFirst {
     delete project.file("./docker/build")

--- a/RFS/src/main/java/com/rfs/RfsCreateSnapshot.java
+++ b/RFS/src/main/java/com/rfs/RfsCreateSnapshot.java
@@ -1,0 +1,92 @@
+package com.rfs;
+
+import com.beust.jcommander.JCommander;
+import com.beust.jcommander.Parameter;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+
+import com.rfs.cms.CmsClient;
+import com.rfs.cms.OpenSearchCmsClient;
+import com.rfs.common.ConnectionDetails;
+import com.rfs.common.Logging;
+import com.rfs.common.OpenSearchClient;
+import com.rfs.common.SnapshotCreator;
+import com.rfs.common.TryHandlePhaseFailure;
+import com.rfs.common.S3SnapshotCreator;
+import com.rfs.worker.GlobalState;
+import com.rfs.worker.SnapshotRunner;
+
+public class RfsCreateSnapshot {
+    private static final Logger logger = LogManager.getLogger(RfsCreateSnapshot.class);
+
+    public static class Args {
+        @Parameter(names = {"--snapshot-name"}, description = "The name of the snapshot to migrate", required = true)
+        public String snapshotName;
+
+        @Parameter(names = {"--s3-repo-uri"}, description = "The S3 URI of the snapshot repo, like: s3://my-bucket/dir1/dir2", required = true)
+        public String s3RepoUri;
+
+        @Parameter(names = {"--s3-region"}, description = "The AWS Region the S3 bucket is in, like: us-east-2", required = true)
+        public String s3Region;
+
+        @Parameter(names = {"--source-host"}, description = "The source host and port (e.g. http://localhost:9200)", required = true)
+        public String sourceHost;
+
+        @Parameter(names = {"--source-username"}, description = "Optional.  The source username; if not provided, will assume no auth on source", required = false)
+        public String sourceUser = null;
+
+        @Parameter(names = {"--source-password"}, description = "Optional.  The source password; if not provided, will assume no auth on source", required = false)
+        public String sourcePass = null;
+
+        @Parameter(names = {"--target-host"}, description = "The target host and port (e.g. http://localhost:9200)", required = true)
+        public String targetHost;
+
+        @Parameter(names = {"--target-username"}, description = "Optional.  The target username; if not provided, will assume no auth on target", required = false)
+        public String targetUser = null;
+
+        @Parameter(names = {"--target-password"}, description = "Optional.  The target password; if not provided, will assume no auth on target", required = false)
+        public String targetPass = null;
+
+        @Parameter(names = {"--log-level"}, description = "What log level you want.  Default: 'info'", required = false, converter = Logging.ArgsConverter.class)
+        public Level logLevel = Level.INFO;
+    }
+
+    public static void main(String[] args) throws Exception {
+        // Grab out args
+        Args arguments = new Args();
+        JCommander.newBuilder()
+            .addObject(arguments)
+            .build()
+            .parse(args);
+
+        final String snapshotName = arguments.snapshotName;
+        final String s3RepoUri = arguments.s3RepoUri;
+        final String s3Region = arguments.s3Region;
+        final String sourceHost = arguments.sourceHost;
+        final String sourceUser = arguments.sourceUser;
+        final String sourcePass = arguments.sourcePass;
+        final String targetHost = arguments.targetHost;
+        final String targetUser = arguments.targetUser;
+        final String targetPass = arguments.targetPass;
+        final Level logLevel = arguments.logLevel;
+
+        Logging.setLevel(logLevel);
+
+        final ConnectionDetails sourceConnection = new ConnectionDetails(sourceHost, sourceUser, sourcePass);
+        final ConnectionDetails targetConnection = new ConnectionDetails(targetHost, targetUser, targetPass);
+
+        TryHandlePhaseFailure.executeWithTryCatch(() -> {
+            logger.info("Running RfsWorker");
+            GlobalState globalState = GlobalState.getInstance();
+            OpenSearchClient sourceClient = new OpenSearchClient(sourceConnection);
+            OpenSearchClient targetClient = new OpenSearchClient(targetConnection);
+            final CmsClient cmsClient = new OpenSearchCmsClient(targetClient);
+
+            final SnapshotCreator snapshotCreator = new S3SnapshotCreator(snapshotName, sourceClient, s3RepoUri, s3Region);
+            final SnapshotRunner snapshotWorker = new SnapshotRunner(globalState, cmsClient, snapshotCreator);
+            snapshotWorker.run();
+        });
+    }
+}

--- a/RFS/src/main/java/com/rfs/RfsMigrateDocuments.java
+++ b/RFS/src/main/java/com/rfs/RfsMigrateDocuments.java
@@ -5,7 +5,6 @@ import com.beust.jcommander.Parameter;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.List;
 
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.Logger;
@@ -14,11 +13,9 @@ import org.apache.logging.log4j.LogManager;
 
 import com.rfs.cms.CmsClient;
 import com.rfs.cms.OpenSearchCmsClient;
-import com.rfs.common.ClusterVersion;
 import com.rfs.common.ConnectionDetails;
 import com.rfs.common.DefaultSourceRepoAccessor;
 import com.rfs.common.DocumentReindexer;
-import com.rfs.common.GlobalMetadata;
 import com.rfs.common.IndexMetadata;
 import com.rfs.common.Logging;
 import com.rfs.common.LuceneDocumentsReader;
@@ -26,29 +23,19 @@ import com.rfs.common.OpenSearchClient;
 import com.rfs.common.S3Uri;
 import com.rfs.common.ShardMetadata;
 import com.rfs.common.S3Repo;
-import com.rfs.common.SnapshotCreator;
 import com.rfs.common.SourceRepo;
 import com.rfs.common.TryHandlePhaseFailure;
-import com.rfs.common.S3SnapshotCreator;
 import com.rfs.common.SnapshotRepo;
 import com.rfs.common.SnapshotShardUnpacker;
-import com.rfs.transformers.TransformFunctions;
-import com.rfs.transformers.Transformer;
 import com.rfs.version_es_7_10.ElasticsearchConstants_ES_7_10;
-import com.rfs.version_es_7_10.GlobalMetadataFactory_ES_7_10;
 import com.rfs.version_es_7_10.IndexMetadataFactory_ES_7_10;
 import com.rfs.version_es_7_10.ShardMetadataFactory_ES_7_10;
 import com.rfs.version_es_7_10.SnapshotRepoProvider_ES_7_10;
-import com.rfs.version_os_2_11.GlobalMetadataCreator_OS_2_11;
-import com.rfs.version_os_2_11.IndexCreator_OS_2_11;
 import com.rfs.worker.DocumentsRunner;
 import com.rfs.worker.GlobalState;
-import com.rfs.worker.IndexRunner;
-import com.rfs.worker.MetadataRunner;
-import com.rfs.worker.SnapshotRunner;
 
-public class RunRfsWorker {
-    private static final Logger logger = LogManager.getLogger(RunRfsWorker.class);
+public class RfsMigrateDocuments {
+    private static final Logger logger = LogManager.getLogger(RfsMigrateDocuments.class);
 
     public static class Args {
         @Parameter(names = {"--snapshot-name"}, description = "The name of the snapshot to migrate", required = true)
@@ -66,15 +53,6 @@ public class RunRfsWorker {
         @Parameter(names = {"--lucene-dir"}, description = "The absolute path to the directory where we'll put the Lucene docs", required = true)
         public String luceneDirPath;
 
-        @Parameter(names = {"--source-host"}, description = "The source host and port (e.g. http://localhost:9200)", required = true)
-        public String sourceHost;
-
-        @Parameter(names = {"--source-username"}, description = "Optional.  The source username; if not provided, will assume no auth on source", required = false)
-        public String sourceUser = null;
-
-        @Parameter(names = {"--source-password"}, description = "Optional.  The source password; if not provided, will assume no auth on source", required = false)
-        public String sourcePass = null;
-
         @Parameter(names = {"--target-host"}, description = "The target host and port (e.g. http://localhost:9200)", required = true)
         public String targetHost;
 
@@ -84,27 +62,9 @@ public class RunRfsWorker {
         @Parameter(names = {"--target-password"}, description = "Optional.  The target password; if not provided, will assume no auth on target", required = false)
         public String targetPass = null;
 
-        @Parameter(names = {"--index-allowlist"}, description = ("Optional.  List of index names to migrate"
-            + " (e.g. 'logs_2024_01, logs_2024_02').  Default: all indices"), required = false)
-        public List<String> indexAllowlist = List.of();
-
-        @Parameter(names = {"--index-template-allowlist"}, description = ("Optional.  List of index template names to migrate"
-            + " (e.g. 'posts_index_template1, posts_index_template2').  Default: empty list"), required = false)
-        public List<String> indexTemplateAllowlist = List.of();
-
-        @Parameter(names = {"--component-template-allowlist"}, description = ("Optional. List of component template names to migrate"
-            + " (e.g. 'posts_template1, posts_template2').  Default: empty list"), required = false)
-        public List<String> componentTemplateAllowlist = List.of();
-
         @Parameter(names = {"--max-shard-size-bytes"}, description = ("Optional. The maximum shard size, in bytes, to allow when"
             + " performing the document migration.  Useful for preventing disk overflow.  Default: 50 * 1024 * 1024 * 1024 (50 GB)"), required = false)
         public long maxShardSizeBytes = 50 * 1024 * 1024 * 1024L;
-        
-        //https://opensearch.org/docs/2.11/api-reference/cluster-api/cluster-awareness/
-        @Parameter(names = {"--min-replicas"}, description = ("Optional.  The minimum number of replicas configured for migrated indices on the target."
-            + " This can be useful for migrating to targets which use zonal deployments and require additional replicas to meet zone requirements.  Default: 0")
-            , required = false)
-        public int minNumberOfReplicas = 0;
 
         @Parameter(names = {"--log-level"}, description = "What log level you want.  Default: 'info'", required = false, converter = Logging.ArgsConverter.class)
         public Level logLevel = Level.INFO;
@@ -123,52 +83,33 @@ public class RunRfsWorker {
         final String s3RepoUri = arguments.s3RepoUri;
         final String s3Region = arguments.s3Region;
         final Path luceneDirPath = Paths.get(arguments.luceneDirPath);
-        final String sourceHost = arguments.sourceHost;
-        final String sourceUser = arguments.sourceUser;
-        final String sourcePass = arguments.sourcePass;
         final String targetHost = arguments.targetHost;
         final String targetUser = arguments.targetUser;
         final String targetPass = arguments.targetPass;
-        final List<String> indexTemplateAllowlist = arguments.indexTemplateAllowlist;
-        final List<String> componentTemplateAllowlist = arguments.componentTemplateAllowlist;
         final long maxShardSizeBytes = arguments.maxShardSizeBytes;
-        final int awarenessDimensionality = arguments.minNumberOfReplicas + 1;
         final Level logLevel = arguments.logLevel;
 
         Logging.setLevel(logLevel);
 
-        final ConnectionDetails sourceConnection = new ConnectionDetails(sourceHost, sourceUser, sourcePass);
         final ConnectionDetails targetConnection = new ConnectionDetails(targetHost, targetUser, targetPass);
 
         TryHandlePhaseFailure.executeWithTryCatch(() -> {
             logger.info("Running RfsWorker");
+
             GlobalState globalState = GlobalState.getInstance();
-            OpenSearchClient sourceClient = new OpenSearchClient(sourceConnection);
             OpenSearchClient targetClient = new OpenSearchClient(targetConnection);
             final CmsClient cmsClient = new OpenSearchCmsClient(targetClient);
 
-            final SnapshotCreator snapshotCreator = new S3SnapshotCreator(snapshotName, sourceClient, s3RepoUri, s3Region);
-            final SnapshotRunner snapshotWorker = new SnapshotRunner(globalState, cmsClient, snapshotCreator);
-            snapshotWorker.run();
-
             final SourceRepo sourceRepo = S3Repo.create(s3LocalDirPath, new S3Uri(s3RepoUri), s3Region);
             final SnapshotRepo.Provider repoDataProvider = new SnapshotRepoProvider_ES_7_10(sourceRepo);
-            final GlobalMetadata.Factory metadataFactory = new GlobalMetadataFactory_ES_7_10(repoDataProvider);
-            final GlobalMetadataCreator_OS_2_11 metadataCreator = new GlobalMetadataCreator_OS_2_11(targetClient, List.of(), componentTemplateAllowlist, indexTemplateAllowlist);
-            final Transformer transformer = TransformFunctions.getTransformer(ClusterVersion.ES_7_10, ClusterVersion.OS_2_11, awarenessDimensionality);
-            MetadataRunner metadataWorker = new MetadataRunner(globalState, cmsClient, snapshotName, metadataFactory, metadataCreator, transformer);
-            metadataWorker.run();
-
+            
             final IndexMetadata.Factory indexMetadataFactory = new IndexMetadataFactory_ES_7_10(repoDataProvider);
-            final IndexCreator_OS_2_11 indexCreator = new IndexCreator_OS_2_11(targetClient);
-            final IndexRunner indexWorker = new IndexRunner(globalState, cmsClient, snapshotName, indexMetadataFactory, indexCreator, transformer);
-            indexWorker.run();
-
             final ShardMetadata.Factory shardMetadataFactory = new ShardMetadataFactory_ES_7_10(repoDataProvider);
             final DefaultSourceRepoAccessor repoAccessor = new DefaultSourceRepoAccessor(sourceRepo);
             final SnapshotShardUnpacker.Factory unpackerFactory = new SnapshotShardUnpacker.Factory(repoAccessor, luceneDirPath, ElasticsearchConstants_ES_7_10.BUFFER_SIZE_IN_BYTES);
             final LuceneDocumentsReader reader = new LuceneDocumentsReader(luceneDirPath);
             final DocumentReindexer reindexer = new DocumentReindexer(targetClient);
+            
             DocumentsRunner documentsWorker = new DocumentsRunner(globalState, cmsClient, snapshotName, maxShardSizeBytes, indexMetadataFactory, shardMetadataFactory, unpackerFactory, reader, reindexer);
             documentsWorker.run();
         });

--- a/RFS/src/main/java/com/rfs/common/TryHandlePhaseFailure.java
+++ b/RFS/src/main/java/com/rfs/common/TryHandlePhaseFailure.java
@@ -1,0 +1,53 @@
+package com.rfs.common;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.rfs.cms.CmsEntry;
+import com.rfs.worker.GlobalState;
+import com.rfs.worker.Runner;
+import com.rfs.worker.WorkerStep;
+
+public class TryHandlePhaseFailure {
+    private static final Logger logger = LogManager.getLogger(TryHandlePhaseFailure.class);
+
+    @FunctionalInterface
+    public static interface TryBlock {
+        void run() throws Exception;
+    }
+
+    public static void executeWithTryCatch(TryBlock tryBlock) throws Exception {
+        try {
+            tryBlock.run();
+        } catch (Runner.PhaseFailed e) {
+            logPhaseFailureRecord(e.phase, e.nextStep, e.cmsEntry, e.getCause());
+            throw e;
+        } catch (Exception e) {
+            logger.error("Unexpected error running RfsWorker", e);
+            throw e;
+        }
+    }
+
+    public static void logPhaseFailureRecord(GlobalState.Phase phase, WorkerStep nextStep, Optional<CmsEntry.Base> cmsEntry, Throwable e) {
+        ObjectNode errorBlob = new ObjectMapper().createObjectNode();
+        errorBlob.put("exceptionMessage", e.getMessage());
+        errorBlob.put("exceptionClass", e.getClass().getSimpleName());
+        errorBlob.put("exceptionTrace", Arrays.toString(e.getStackTrace()));
+
+        errorBlob.put("phase", phase.toString());
+
+        String currentStep = (nextStep != null) ? nextStep.getClass().getSimpleName() : "null";
+        errorBlob.put("currentStep", currentStep);
+
+        String currentEntry = (cmsEntry.isPresent()) ? cmsEntry.get().toRepresentationString() : "null";
+        errorBlob.put("cmsEntry", currentEntry);
+
+        
+        logger.error(errorBlob.toString());
+    }    
+}

--- a/RFS/src/main/java/com/rfs/worker/DocumentsStep.java
+++ b/RFS/src/main/java/com/rfs/worker/DocumentsStep.java
@@ -370,7 +370,7 @@ public class DocumentsStep {
                 logger.info("Migrating docs: Index " + workItem.indexName + ", Shard " + workItem.shardId);
                 shardMetadata = members.shardMetadataFactory.fromRepo(members.snapshotName, workItem.indexName, workItem.shardId);
 
-                logger.info("Shard size: " + shardMetadata.getTotalSizeBytes());
+                logger.info("Shard size: " + shardMetadata.getTotalSizeBytes() + " bytes");
                 if (shardMetadata.getTotalSizeBytes() > members.maxShardSizeBytes) {
                     throw new ShardTooLarge(shardMetadata.getTotalSizeBytes(), members.maxShardSizeBytes);
                 }

--- a/RFS/src/main/java/com/rfs/worker/IndexStep.java
+++ b/RFS/src/main/java/com/rfs/worker/IndexStep.java
@@ -3,6 +3,7 @@ package com.rfs.worker;
 import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -262,7 +263,10 @@ public class IndexStep {
             logger.info("Pulling a list of indices to migrate from the CMS...");
             workItems = members.cmsClient.getAvailableIndexWorkItems(MAX_WORK_ITEMS);
             logger.info("Pulled " + workItems.size() + " indices to migrate:");
-            logger.info(workItems.toString());
+            List<String> representationStrings = workItems.stream()
+                .map(CmsEntry.IndexWorkItem::toRepresentationString)
+                .collect(Collectors.toList());
+            logger.info(representationStrings);
         }
 
         @Override


### PR DESCRIPTION
### Description
* Split the all-in-one RFS Worker into phase-specific scripts to be more compatible with the Migration Console's CLI
* Some light refactoring to avoid copy/pasting code

### Issues Resolved
* https://opensearch.atlassian.net/browse/MIGRATIONS-1785

### Testing
* Ran the scripts manually against a local ES 7.17 Docker Compose source:

```
chelma@3c22fba4e266 RFS % gradle createSnapshot --args='--snapshot-name reindex-from-snapshot --s3-repo-uri s3://chelma-iad-rfs-local-testing --s3-region us-east-1 --source-host http://localhost:19200 --target-host http://localhost:29200'

> Task :RFS:createSnapshot
08:49:46.678 INFO  Running RfsWorker
08:49:47.178 INFO  Checking if work remains in the Snapshot Phase...
08:49:48.748 INFO  Snapshot not yet completed, entering Snapshot Phase...
08:49:48.748 INFO  Snapshot CMS Entry not found, attempting to create it...
08:49:49.087 INFO  Snapshot CMS Entry created
08:49:49.088 INFO  Attempting to initiate the snapshot...
08:49:51.486 INFO  Snapshot repo registration successful
08:49:51.877 INFO  Snapshot reindex-from-snapshot creation initiated
08:49:51.877 INFO  Snapshot in progress...
08:49:52.217 INFO  Snapshot not finished yet; sleeping for 5 seconds...
08:49:57.360 INFO  Snapshot not finished yet; sleeping for 5 seconds...
08:50:02.458 INFO  Snapshot not finished yet; sleeping for 5 seconds...
08:50:07.575 INFO  Snapshot not finished yet; sleeping for 5 seconds...
08:50:12.731 INFO  Snapshot completed, exiting Snapshot Phase...
08:50:12.733 INFO  Snapshot Phase is complete
```

```
08:51:00.484 INFO  Running RfsWorker
08:51:02.074 INFO  Checking if work remains in the Metadata Migration Phase...
08:51:03.008 INFO  Metadata Migration not yet completed, entering Metadata Phase...
08:51:03.009 INFO  Pulling the Metadata Migration entry from the CMS, if it exists...
08:51:03.018 INFO  Metadata Migration CMS Entry not found, attempting to create it...
08:51:03.313 INFO  Metadata Migration CMS Entry created
08:51:03.313 INFO  Setting the worker's current work item to be the Metadata Migration...
08:51:03.314 INFO  Work item set
08:51:03.314 INFO  Migrating the Templates...
08:51:04.480 INFO  Downloading file from S3: s3://chelma-iad-rfs-local-testing/index-0 to /tmp/s3_files/index-0
08:51:04.860 INFO  Downloading file from S3: s3://chelma-iad-rfs-local-testing/meta-kdMuL_JgSiOZV6BrlnaRzA.dat to /tmp/s3_files/meta-kdMuL_JgSiOZV6BrlnaRzA.dat
08:51:05.016 INFO  Transforming template: my_legacy_template
08:51:05.018 INFO  Transforming template: my_index_template
08:51:05.019 INFO  Transforming template: my_component_template
08:51:05.020 INFO  Setting Global Metadata
08:51:05.020 INFO  Setting Legacy Templates...
08:51:05.020 INFO  No Legacy Templates in specified allowlist
08:51:05.020 INFO  Setting Component Templates...
08:51:05.021 INFO  Setting Component Template: my_component_template
08:51:05.116 INFO  Setting Index Templates...
08:51:05.117 INFO  Setting Index Template: my_index_template
08:51:05.186 INFO  Templates migration complete
08:51:05.186 INFO  Updating the Metadata Migration entry to indicate completion...
08:51:05.246 INFO  Metadata Migration entry updated
08:51:05.246 INFO  Clearing the worker's current work item...
08:51:05.246 INFO  Work item cleared
08:51:05.246 INFO  Metadata Migration completed, exiting Metadata Phase...
08:51:05.246 INFO  Metadata Migration Phase is complete
08:51:05.252 INFO  Checking if work remains in the Index Migration Phase...
08:51:05.266 INFO  Index Migration not yet completed, entering Index Phase...
08:51:05.266 INFO  Pulling the Index Migration entry from the CMS, if it exists...
08:51:05.278 INFO  Index Migration CMS Entry not found, attempting to create it...
08:51:05.298 INFO  Index Migration CMS Entry created
08:51:05.299 INFO  Setting the worker's current work item to be creating the index work entries...
08:51:05.299 INFO  Work item set
08:51:05.299 INFO  Setting up the Index Work Items...
08:51:05.309 INFO  Downloading file from S3: s3://chelma-iad-rfs-local-testing/indices/_E39AGL2QFqHydHNKehb8A/meta-dhHcEZABqt0dovRN83VA.dat to /tmp/s3_files/indices/_E39AGL2QFqHydHNKehb8A/meta-dhHcEZABqt0dovRN83VA.dat
08:51:05.458 INFO  Creating Index Work Item for index: logs-221998
08:51:05.575 INFO  Downloading file from S3: s3://chelma-iad-rfs-local-testing/indices/Sy7UBokYSNu8qCkX0zOxaA/meta-dRHcEZABqt0dovRN83VA.dat to /tmp/s3_files/indices/Sy7UBokYSNu8qCkX0zOxaA/meta-dRHcEZABqt0dovRN83VA.dat
08:51:05.812 INFO  Creating Index Work Item for index: sonested
08:51:05.835 INFO  Downloading file from S3: s3://chelma-iad-rfs-local-testing/indices/230j1NefT02fXc4l8wRc_Q/meta-eBHcEZABqt0dovRN83VA.dat to /tmp/s3_files/indices/230j1NefT02fXc4l8wRc_Q/meta-eBHcEZABqt0dovRN83VA.dat
08:51:06.106 INFO  Creating Index Work Item for index: reindexed-logs
08:51:06.125 INFO  Downloading file from S3: s3://chelma-iad-rfs-local-testing/indices/v2hI_-9hR_uEWvQmwIdtaQ/meta-dxHcEZABqt0dovRN83VA.dat to /tmp/s3_files/indices/v2hI_-9hR_uEWvQmwIdtaQ/meta-dxHcEZABqt0dovRN83VA.dat
08:51:06.313 INFO  Creating Index Work Item for index: logs-191998
08:51:06.325 INFO  Downloading file from S3: s3://chelma-iad-rfs-local-testing/indices/-x63a9gJSkeQ__ZGyJegDg/meta-eRHcEZABqt0dovRN83Xl.dat to /tmp/s3_files/indices/-x63a9gJSkeQ__ZGyJegDg/meta-eRHcEZABqt0dovRN83Xl.dat
08:51:06.483 INFO  Creating Index Work Item for index: logs-211998
08:51:06.496 INFO  Downloading file from S3: s3://chelma-iad-rfs-local-testing/indices/fRwBfJYKT-Gds8FserR8pQ/meta-ehHcEZABqt0dovRN83Xm.dat to /tmp/s3_files/indices/fRwBfJYKT-Gds8FserR8pQ/meta-ehHcEZABqt0dovRN83Xm.dat
08:51:06.653 INFO  Creating Index Work Item for index: logs-231998
08:51:06.664 INFO  Downloading file from S3: s3://chelma-iad-rfs-local-testing/indices/LgoSDqLSRFytQ38eXtghsQ/meta-exHcEZABqt0dovRN83Xq.dat to /tmp/s3_files/indices/LgoSDqLSRFytQ38eXtghsQ/meta-exHcEZABqt0dovRN83Xq.dat
08:51:06.828 INFO  Creating Index Work Item for index: logs-181998
08:51:06.841 INFO  Downloading file from S3: s3://chelma-iad-rfs-local-testing/indices/mGKv30mnQzi1ldUF7pflng/meta-fBHcEZABqt0dovRN83Xq.dat to /tmp/s3_files/indices/mGKv30mnQzi1ldUF7pflng/meta-fBHcEZABqt0dovRN83Xq.dat
08:51:07.003 INFO  Creating Index Work Item for index: logs-201998
08:51:07.013 INFO  Downloading file from S3: s3://chelma-iad-rfs-local-testing/indices/Xo-AcNoiQ8yDjslgKsqGVA/meta-fRHcEZABqt0dovRN83X8.dat to /tmp/s3_files/indices/Xo-AcNoiQ8yDjslgKsqGVA/meta-fRHcEZABqt0dovRN83X8.dat
08:51:07.177 INFO  Creating Index Work Item for index: geonames
08:51:07.187 INFO  Downloading file from S3: s3://chelma-iad-rfs-local-testing/indices/tCTDBZsHT9qiZjgZcqjvpA/meta-fhHcEZABqt0dovRN9HVy.dat to /tmp/s3_files/indices/tCTDBZsHT9qiZjgZcqjvpA/meta-fhHcEZABqt0dovRN9HVy.dat
08:51:07.353 INFO  Creating Index Work Item for index: logs-241998
08:51:07.365 INFO  Downloading file from S3: s3://chelma-iad-rfs-local-testing/indices/NceLH9w0R5GgVQTPj1oGjw/meta-fxHcEZABqt0dovRN9HV7.dat to /tmp/s3_files/indices/NceLH9w0R5GgVQTPj1oGjw/meta-fxHcEZABqt0dovRN9HV7.dat
08:51:07.529 INFO  Creating Index Work Item for index: nyc_taxis
08:51:07.538 INFO  Finished setting up the Index Work Items.
08:51:07.538 INFO  Updating the Index Migration entry to indicate setup has been completed...
08:51:07.553 INFO  Index Migration entry updated
08:51:07.553 INFO  Clearing the worker's current work item...
08:51:07.553 INFO  Work item cleared
08:51:07.554 INFO  Pulling a list of indices to migrate from the CMS...
08:51:07.724 INFO  Pulled 10 indices to migrate:
08:51:07.726 INFO  [{"type":"INDEX_WORK_ITEM","name":"logs-191998","status":"NOT_STARTED","numAttempts":1,"numShards":5}, {"type":"INDEX_WORK_ITEM","name":"reindexed-logs","status":"NOT_STARTED","numAttempts":1,"numShards":5}, {"type":"INDEX_WORK_ITEM","name":"logs-211998","status":"NOT_STARTED","numAttempts":1,"numShards":5}, {"type":"INDEX_WORK_ITEM","name":"sonested","status":"NOT_STARTED","numAttempts":1,"numShards":1}, {"type":"INDEX_WORK_ITEM","name":"logs-231998","status":"NOT_STARTED","numAttempts":1,"numShards":5}, {"type":"INDEX_WORK_ITEM","name":"logs-241998","status":"NOT_STARTED","numAttempts":1,"numShards":5}, {"type":"INDEX_WORK_ITEM","name":"geonames","status":"NOT_STARTED","numAttempts":1,"numShards":5}, {"type":"INDEX_WORK_ITEM","name":"logs-181998","status":"NOT_STARTED","numAttempts":1,"numShards":5}, {"type":"INDEX_WORK_ITEM","name":"nyc_taxis","status":"NOT_STARTED","numAttempts":1,"numShards":1}, {"type":"INDEX_WORK_ITEM","name":"logs-221998","status":"NOT_STARTED","numAttempts":1,"numShards":5}]
08:51:07.727 INFO  Migrating current batch of indices...
08:51:07.727 INFO  Migrating index: logs-191998
08:51:08.109 INFO  Index logs-191998 created successfully
08:51:08.109 INFO  Forcefully updating the Index Work Item to indicate it has been completed...
08:51:08.122 INFO  Index Work Item updated
08:51:08.123 INFO  Migrating index: reindexed-logs
08:51:08.767 INFO  Index reindexed-logs created successfully
08:51:08.767 INFO  Forcefully updating the Index Work Item to indicate it has been completed...
08:51:08.787 INFO  Index Work Item updated
08:51:08.787 INFO  Migrating index: logs-211998
08:51:09.218 INFO  Index logs-211998 created successfully
08:51:09.219 INFO  Forcefully updating the Index Work Item to indicate it has been completed...
08:51:09.255 INFO  Index Work Item updated
08:51:09.255 INFO  Migrating index: sonested
08:51:09.436 INFO  Index sonested created successfully
08:51:09.436 INFO  Forcefully updating the Index Work Item to indicate it has been completed...
08:51:09.452 INFO  Index Work Item updated
08:51:09.452 INFO  Migrating index: logs-231998
08:51:09.772 INFO  Index logs-231998 created successfully
08:51:09.772 INFO  Forcefully updating the Index Work Item to indicate it has been completed...
08:51:09.781 INFO  Index Work Item updated
08:51:09.781 INFO  Migrating index: logs-241998
08:51:10.082 INFO  Index logs-241998 created successfully
08:51:10.082 INFO  Forcefully updating the Index Work Item to indicate it has been completed...
08:51:10.090 INFO  Index Work Item updated
08:51:10.090 INFO  Migrating index: geonames
08:51:10.322 INFO  Index geonames created successfully
08:51:10.322 INFO  Forcefully updating the Index Work Item to indicate it has been completed...
08:51:10.330 INFO  Index Work Item updated
08:51:10.330 INFO  Migrating index: logs-181998
08:51:10.597 INFO  Index logs-181998 created successfully
08:51:10.597 INFO  Forcefully updating the Index Work Item to indicate it has been completed...
08:51:10.606 INFO  Index Work Item updated
08:51:10.606 INFO  Migrating index: nyc_taxis
08:51:10.732 INFO  Index nyc_taxis created successfully
08:51:10.732 INFO  Forcefully updating the Index Work Item to indicate it has been completed...
08:51:10.740 INFO  Index Work Item updated
08:51:10.741 INFO  Migrating index: logs-221998
08:51:10.968 INFO  Index logs-221998 created successfully
08:51:10.968 INFO  Forcefully updating the Index Work Item to indicate it has been completed...
08:51:10.977 INFO  Index Work Item updated
08:51:10.977 INFO  Pulling a list of indices to migrate from the CMS...
08:51:11.082 INFO  Pulled 1 indices to migrate:
08:51:11.082 INFO  [{"type":"INDEX_WORK_ITEM","name":"logs-201998","status":"NOT_STARTED","numAttempts":1,"numShards":5}]
08:51:11.082 INFO  Migrating current batch of indices...
08:51:11.082 INFO  Migrating index: logs-201998
08:51:11.313 INFO  Index logs-201998 created successfully
08:51:11.314 INFO  Forcefully updating the Index Work Item to indicate it has been completed...
08:51:11.324 INFO  Index Work Item updated
08:51:11.324 INFO  Pulling a list of indices to migrate from the CMS...
08:51:11.356 INFO  Pulled 0 indices to migrate:
08:51:11.356 INFO  []
08:51:11.356 INFO  Marking the Index Migration as completed...
08:51:11.372 INFO  Index Migration marked as completed
08:51:11.372 INFO  Index Migration completed, exiting Index Phase...
08:51:11.372 INFO  Index Migration Phase is complete
```

```
08:52:52.433 INFO  Running RfsWorker
08:52:53.872 INFO  Checking if work remains in the Documents Migration Phase...
08:52:53.881 INFO  Documents Migration not yet completed, entering Documents Phase...
08:52:53.881 INFO  Pulling the Documents Migration entry from the CMS, if it exists...
08:52:54.570 INFO  Documents Migration CMS Entry not found, attempting to create it...
08:52:54.621 INFO  Documents Migration CMS Entry created
08:52:54.622 INFO  Setting the worker's current work item to be creating the documents work entries...
08:52:54.622 INFO  Work item set
08:52:54.622 INFO  Setting up the Documents Work Items...
08:52:56.120 INFO  Index logs-221998 has 5 shards
08:52:56.123 INFO  Creating Documents Work Item for index: logs-221998, shard: 0
08:52:56.223 INFO  Creating Documents Work Item for index: logs-221998, shard: 1
08:52:56.232 INFO  Creating Documents Work Item for index: logs-221998, shard: 2
08:52:56.241 INFO  Creating Documents Work Item for index: logs-221998, shard: 3
08:52:56.250 INFO  Creating Documents Work Item for index: logs-221998, shard: 4
08:52:56.261 INFO  Index sonested has 1 shards
08:52:56.262 INFO  Creating Documents Work Item for index: sonested, shard: 0
08:52:56.273 INFO  Index reindexed-logs has 5 shards
08:52:56.273 INFO  Creating Documents Work Item for index: reindexed-logs, shard: 0
08:52:56.284 INFO  Creating Documents Work Item for index: reindexed-logs, shard: 1
08:52:56.291 INFO  Creating Documents Work Item for index: reindexed-logs, shard: 2
08:52:56.303 INFO  Creating Documents Work Item for index: reindexed-logs, shard: 3
08:52:56.313 INFO  Creating Documents Work Item for index: reindexed-logs, shard: 4
08:52:56.323 INFO  Index logs-191998 has 5 shards
08:52:56.323 INFO  Creating Documents Work Item for index: logs-191998, shard: 0
08:52:56.333 INFO  Creating Documents Work Item for index: logs-191998, shard: 1
08:52:56.341 INFO  Creating Documents Work Item for index: logs-191998, shard: 2
08:52:56.349 INFO  Creating Documents Work Item for index: logs-191998, shard: 3
08:52:56.358 INFO  Creating Documents Work Item for index: logs-191998, shard: 4
08:52:56.366 INFO  Index logs-211998 has 5 shards
08:52:56.366 INFO  Creating Documents Work Item for index: logs-211998, shard: 0
08:52:56.374 INFO  Creating Documents Work Item for index: logs-211998, shard: 1
08:52:56.383 INFO  Creating Documents Work Item for index: logs-211998, shard: 2
08:52:56.393 INFO  Creating Documents Work Item for index: logs-211998, shard: 3
08:52:56.403 INFO  Creating Documents Work Item for index: logs-211998, shard: 4
08:52:56.412 INFO  Index logs-231998 has 5 shards
08:52:56.412 INFO  Creating Documents Work Item for index: logs-231998, shard: 0
08:52:56.420 INFO  Creating Documents Work Item for index: logs-231998, shard: 1
08:52:56.429 INFO  Creating Documents Work Item for index: logs-231998, shard: 2
08:52:56.436 INFO  Creating Documents Work Item for index: logs-231998, shard: 3
08:52:56.443 INFO  Creating Documents Work Item for index: logs-231998, shard: 4
08:52:56.453 INFO  Index logs-181998 has 5 shards
08:52:56.453 INFO  Creating Documents Work Item for index: logs-181998, shard: 0
08:52:56.461 INFO  Creating Documents Work Item for index: logs-181998, shard: 1
08:52:56.474 INFO  Creating Documents Work Item for index: logs-181998, shard: 2
08:52:56.483 INFO  Creating Documents Work Item for index: logs-181998, shard: 3
08:52:56.492 INFO  Creating Documents Work Item for index: logs-181998, shard: 4
08:52:56.503 INFO  Index logs-201998 has 5 shards
08:52:56.503 INFO  Creating Documents Work Item for index: logs-201998, shard: 0
08:52:56.511 INFO  Creating Documents Work Item for index: logs-201998, shard: 1
08:52:56.519 INFO  Creating Documents Work Item for index: logs-201998, shard: 2
08:52:56.526 INFO  Creating Documents Work Item for index: logs-201998, shard: 3
08:52:56.533 INFO  Creating Documents Work Item for index: logs-201998, shard: 4
08:52:56.544 INFO  Index geonames has 5 shards
08:52:56.544 INFO  Creating Documents Work Item for index: geonames, shard: 0
08:52:56.553 INFO  Creating Documents Work Item for index: geonames, shard: 1
08:52:56.561 INFO  Creating Documents Work Item for index: geonames, shard: 2
08:52:56.568 INFO  Creating Documents Work Item for index: geonames, shard: 3
08:52:56.576 INFO  Creating Documents Work Item for index: geonames, shard: 4
08:52:56.584 INFO  Index logs-241998 has 5 shards
08:52:56.585 INFO  Creating Documents Work Item for index: logs-241998, shard: 0
08:52:56.592 INFO  Creating Documents Work Item for index: logs-241998, shard: 1
08:52:56.600 INFO  Creating Documents Work Item for index: logs-241998, shard: 2
08:52:56.609 INFO  Creating Documents Work Item for index: logs-241998, shard: 3
08:52:56.616 INFO  Creating Documents Work Item for index: logs-241998, shard: 4
08:52:56.625 INFO  Index nyc_taxis has 1 shards
08:52:56.625 INFO  Creating Documents Work Item for index: nyc_taxis, shard: 0
08:52:56.633 INFO  Finished setting up the Documents Work Items.
08:52:56.633 INFO  Updating the Documents Migration entry to indicate setup has been completed...
08:52:56.670 INFO  Documents Migration entry updated
08:52:56.670 INFO  Clearing the worker's current work item...
08:52:56.671 INFO  Work item cleared
08:52:56.671 INFO  Seeing if there are any docs left to migration according to the CMS...
08:52:56.732 INFO  Found some docs to migrate
08:52:56.732 INFO  Setting the worker's current work item to be migrating the docs...
08:52:56.733 INFO  Work item set
08:52:56.733 INFO  Migrating docs: Index logs-181998, Shard 4
08:52:56.744 INFO  Downloading file from S3: s3://chelma-iad-rfs-local-testing/indices/LgoSDqLSRFytQ38eXtghsQ/4/snap-kdMuL_JgSiOZV6BrlnaRzA.dat to /tmp/s3_files/indices/LgoSDqLSRFytQ38eXtghsQ/4/snap-kdMuL_JgSiOZV6BrlnaRzA.dat
08:52:57.015 INFO  Shard size: 36111 bytes
08:52:57.054 INFO  Downloading blob files from S3: s3://chelma-iad-rfs-local-testing/indices/LgoSDqLSRFytQ38eXtghsQ/4/ to /tmp/s3_files/indices/LgoSDqLSRFytQ38eXtghsQ/4
08:52:57.592 INFO  Blob file download(s) complete
08:52:57.604 INFO  Unpacking - Blob Name: __4Y2ZtyPHQ36lNuiL_N3uhg, Lucene Name: _2_Lucene84_0.doc
08:52:57.608 INFO  Unpacking - Blob Name: __R0K4mrGDRMGe8_ySgVzu7w, Lucene Name: _2_Lucene84_0.tim
08:52:57.609 INFO  Unpacking - Blob Name: __jy4okUOtTU2wqEByG85Upg, Lucene Name: _2.kdd
08:52:57.609 INFO  Unpacking - Blob Name: v__MajUEpXfS12F5DAkCemQjg, Lucene Name: _2.si
08:52:57.609 INFO  Unpacking - Blob Name: __o6zNWGLOSjO7-A9_Yqh_yg, Lucene Name: _2.kdi
08:52:57.610 INFO  Unpacking - Blob Name: __77ZjJRyETe-R5WeSBUNeMA, Lucene Name: _2.fdm
08:52:57.610 INFO  Unpacking - Blob Name: __mqlTsI1VSMOVUlLM5eW3OA, Lucene Name: _2_Lucene84_0.pos
08:52:57.611 INFO  Unpacking - Blob Name: __OEm2XU8xREmbaX5d99ehHg, Lucene Name: _2.fdt
08:52:57.611 INFO  Unpacking - Blob Name: __QjWRICoTS2SayJHahfVfUw, Lucene Name: _2_Lucene80_0.dvm
08:52:57.611 INFO  Unpacking - Blob Name: __CpKYWQgORXa445OOE5ofYg, Lucene Name: _2.kdm
08:52:57.612 INFO  Unpacking - Blob Name: __lAI7ByAcSDOo_6aJQTyJMw, Lucene Name: _2.fdx
08:52:57.612 INFO  Unpacking - Blob Name: v__tAarA5aHTKiRSILdIOgXMw, Lucene Name: segments_4
08:52:57.613 INFO  Unpacking - Blob Name: __dsGjEnz2RYaX06A-yuGRmw, Lucene Name: _2_Lucene84_0.tip
08:52:57.613 INFO  Unpacking - Blob Name: __c1jKnhRqQ6G3GP3i4bIVhA, Lucene Name: _2.nvd
08:52:57.614 INFO  Unpacking - Blob Name: __VkAtgkuuTwiEMXr3ntGBTA, Lucene Name: _2_Lucene80_0.dvd
08:52:57.614 INFO  Unpacking - Blob Name: __DehD-DYiS8qokst-kQA9Gw, Lucene Name: _2.nvm
08:52:57.615 INFO  Unpacking - Blob Name: __rJQmOuY-Rr6BUB5Qcrr7zg, Lucene Name: _2.fnm
08:52:57.615 INFO  Unpacking - Blob Name: __QbX5231CQ8Wk4-Z7aIIQLQ, Lucene Name: _2_Lucene84_0.tmd
08:52:57.751 INFO  218 documents found in the current Lucene index
08:52:57.787 INFO  218 documents in current bulk request
08:52:57.888 INFO  Reindexing completed for Index logs-181998, Shard 4
08:52:57.888 INFO  Docs migrated
08:52:57.896 INFO  Updating the Documents Work Item to indicate it has been completed...
08:52:57.906 INFO  Documents Work Item updated
08:52:57.906 INFO  Clearing the worker's current work item...
08:52:57.906 INFO  Work item cleared
08:52:57.906 INFO  Seeing if there are any docs left to migration according to the CMS...
.
.
.
08:53:24.922 INFO  Found some docs to migrate
08:53:24.922 INFO  Setting the worker's current work item to be migrating the docs...
08:53:24.922 INFO  Work item set
08:53:24.922 INFO  Migrating docs: Index logs-181998, Shard 2
08:53:24.923 INFO  Downloading file from S3: s3://chelma-iad-rfs-local-testing/indices/LgoSDqLSRFytQ38eXtghsQ/2/snap-kdMuL_JgSiOZV6BrlnaRzA.dat to /tmp/s3_files/indices/LgoSDqLSRFytQ38eXtghsQ/2/snap-k
dMuL_JgSiOZV6BrlnaRzA.dat
08:53:25.130 INFO  Shard size: 32008 bytes
08:53:25.130 INFO  Downloading blob files from S3: s3://chelma-iad-rfs-local-testing/indices/LgoSDqLSRFytQ38eXtghsQ/2/ to /tmp/s3_files/indices/LgoSDqLSRFytQ38eXtghsQ/2
08:53:25.411 INFO  Blob file download(s) complete
08:53:25.411 INFO  Unpacking - Blob Name: __a2iKdxyZSiin9Gl_htnANg, Lucene Name: _2_Lucene84_0.doc
08:53:25.412 INFO  Unpacking - Blob Name: __hBDg2ylwSUefjlXZhRF4-Q, Lucene Name: _2_Lucene84_0.tim
08:53:25.412 INFO  Unpacking - Blob Name: __4flxuW3BRQuE7wDu8txqdQ, Lucene Name: _2.kdd
08:53:25.413 INFO  Unpacking - Blob Name: v__W7ee8lYKSDqlSJ1-S2iPFQ, Lucene Name: _2.si
08:53:25.413 INFO  Unpacking - Blob Name: __p8zMpCyZSAGVuw0_y8j7Wg, Lucene Name: _2.kdi
08:53:25.414 INFO  Unpacking - Blob Name: __kl7lqNAiSgqXCtpVhP5HTA, Lucene Name: _2.fdm
08:53:25.414 INFO  Unpacking - Blob Name: __ByBI4q2AQP2dIvyFqspgyQ, Lucene Name: _2_Lucene84_0.pos
08:53:25.415 INFO  Unpacking - Blob Name: __V3Ax7lqjQtaZno1f8IJWdA, Lucene Name: _2.fdt
08:53:25.415 INFO  Unpacking - Blob Name: __9mIFO8zzRGuRG2wO7RA8Ag, Lucene Name: _2_Lucene80_0.dvm
08:53:25.415 INFO  Unpacking - Blob Name: __oRjaMS2uTkawSvWyyYxtNA, Lucene Name: _2.kdm
08:53:25.416 INFO  Unpacking - Blob Name: __siu84kCKTZSRdIVDgaIiAw, Lucene Name: _2.fdx
08:53:25.416 INFO  Unpacking - Blob Name: v__PWiuJSHqTVyawJTTQTHZrw, Lucene Name: segments_4
08:53:25.417 INFO  Unpacking - Blob Name: __sIxqF2EdSDePHYJkdX7KtA, Lucene Name: _2_Lucene84_0.tip
08:53:25.417 INFO  Unpacking - Blob Name: __k-fPhHqfSzSfwkafcKhYZA, Lucene Name: _2.nvd
08:53:25.418 INFO  Unpacking - Blob Name: __m_UiXHziRym956ginWTyoA, Lucene Name: _2_Lucene80_0.dvd
08:53:25.419 INFO  Unpacking - Blob Name: __5MtBMM5UQ4GYNP_jH2b3uQ, Lucene Name: _2.nvm
08:53:25.419 INFO  Unpacking - Blob Name: __S37K871wQAqDWlhKM9ivLQ, Lucene Name: _2.fnm
08:53:25.420 INFO  Unpacking - Blob Name: __d87GxyhhTzuigNrPElYiEw, Lucene Name: _2_Lucene84_0.tmd
08:53:25.426 INFO  183 documents found in the current Lucene index
08:53:25.429 INFO  183 documents in current bulk request
08:53:25.456 INFO  Reindexing completed for Index logs-181998, Shard 2
08:53:25.456 INFO  Docs migrated
08:53:25.482 INFO  Updating the Documents Work Item to indicate it has been completed...
08:53:25.496 INFO  Documents Work Item updated
08:53:25.496 INFO  Clearing the worker's current work item...
08:53:25.496 INFO  Work item cleared
08:53:25.496 INFO  Seeing if there are any docs left to migration according to the CMS...
.
.
.
08:53:27.109 INFO  No docs found to migrate
08:53:27.110 INFO  Marking the Documents Migration as completed...
08:53:27.124 INFO  Documents Migration marked as completed
08:53:27.125 INFO  Documents Migration completed, exiting Documents Phase...
08:53:27.125 INFO  Documents Migration Phase is complete
```

### Check List
- [X] New functionality includes testing
  - [X] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
