### PR TITLE
Fix Jackson deserialization for 7.17 snapshot repo data

### DIFF
--- a/RFS/src/main/java/com/rfs/version_es_7_10/SnapshotRepoData_ES_7_10.java
+++ b/RFS/src/main/java/com/rfs/version_es_7_10/SnapshotRepoData_ES_7_10.java
@@ -1,6 +1,7 @@
 package com.rfs.version_es_7_10;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.io.File;
@@ -16,6 +17,7 @@ import com.rfs.common.SnapshotRepo.CantParseRepoFile;
 public class SnapshotRepoData_ES_7_10 {
     public static SnapshotRepoData_ES_7_10 fromRepoFile(Path filePath) {
         ObjectMapper mapper = new ObjectMapper();
+        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
         try {
             SnapshotRepoData_ES_7_10 data = mapper.readValue(new File(filePath.toString()), SnapshotRepoData_ES_7_10.class);
             data.filePath = filePath;

--- a/RFS/src/test/java/com/rfs/version_es_7_10/SnapshotRepoData_ES_7_10Test.java
+++ b/RFS/src/test/java/com/rfs/version_es_7_10/SnapshotRepoData_ES_7_10Test.java
@@ -1,0 +1,89 @@
+package com.rfs.version_es_7_10;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.PrintWriter;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+
+public class SnapshotRepoData_ES_7_10Test {
+
+    private final String basicSnapshotJson = "    {\n" + //
+            "      \"snapshots\" : [ {\n" + //
+            "        \"name\" : \"snapshot-1\",\n" + //
+            "        \"uuid\" : \"DToXzBoXTha6u2KRsQZ0Yw\",\n" + //
+            "        \"state\" : 1,\n" + //
+            "        \"index_metadata_lookup\" : {\n" + //
+            "          \"VUr1hXkwQOOeWNBnvZ7pmA\" : \"4RVV4jgXRNqALWe9TxkoYA-_na_-1-2-1\"\n" + //
+            "        },\n" + //
+            "        \"version\" : \"7.10.2\"\n" + //
+            "      } ],\n" + //
+            "      \"indices\" : {\n" + //
+            "        \"my-index\" : {\n" + //
+            "          \"id\" : \"VUr1hXkwQOOeWNBnvZ7pmA\",\n" + //
+            "          \"snapshots\" : [ \"DToXzBoXTha6u2KRsQZ0Yw\" ],\n" + //
+            "          \"shard_generations\" : [ \"VcuUZNqoR8SilY8H3VY-fQ\" ]\n" + //
+            "        }\n" + //
+            "      },\n" + //
+            "      \"min_version\" : \"7.9.0\",\n" + //
+            "      \"index_metadata_identifiers\" : {\n" + //
+            "        \"4RVV4jgXRNqALWe9TxkoYA-_na_-1-2-1\" : \"-I-dMZABiRFG_R03ChN0\"\n" + //
+            "      }\n" + //
+            "    }";
+
+    @Test
+    void testFromRepoFile_default() {
+        // Setup
+        final var jsonInFile = createTempFile(basicSnapshotJson);
+
+        // Act
+        final var result = SnapshotRepoData_ES_7_10.fromRepoFile(jsonInFile);
+
+        // Verify
+        assertThat(result.minVersion, equalTo("7.9.0"));
+        assertThat(result.indices.size(), equalTo(1));
+    }
+
+    @Test
+    void testFromRepoFile_extraFields() {
+        // Setup
+        var jsonWithExtraFields = insertAtLine(basicSnapshotJson, "\"foo\":\"bar\",", 2);
+        final var jsonInFile = createTempFile(jsonWithExtraFields);
+
+        // Act
+        final var result = SnapshotRepoData_ES_7_10.fromRepoFile(jsonInFile);
+
+        // Verify
+        assertThat(result.minVersion, equalTo("7.9.0"));
+        assertThat(result.indices.size(), equalTo(1));
+    }
+
+    private String insertAtLine(final String source, final String toAdd, final int lineNumber) {
+        final var lines = source.split("\n");
+        final StringBuilder sb = new StringBuilder();
+        for (var i = 0; i < lines.length; i++) {
+            if (lineNumber == i) {
+                sb.append(toAdd);
+            }
+            sb.append(lines[i]);
+        }
+        return sb.toString();
+    }
+
+    private Path createTempFile(final String contents) {
+        try {
+            final var file = File.createTempFile("repoFile", ".txt");
+            try (final var fos = new PrintWriter(new FileOutputStream(file))) {
+                fos.append(contents);
+            }
+            file.deleteOnExit();
+            return Path.of(file.getAbsolutePath());
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
### Description
Fix Jackson deserialization for 7.17 snapshot repo data

* Category: Bug fix
* Why these changes are required? 7.17 support
* What is the old behavior before changes and new behavior after changes? 7.17 failed with "unknown field uuid"

### Issues Resolved
N/A

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
Manual testing in the cloud with a self managed 7.17.21 cluster on the migration console

TODO in a followup task. Automated testing added for various versions

### Check List
- [x] New functionality includes testing
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
