### PR TITLE
Fix broken python requirements file

### DIFF
--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -6,7 +6,7 @@ packaging==23.1
 pluggy==1.0.0
 pytest==7.3.1
 pytest-xdist==3.3.1
-requests>==2.32.3
-urllib3>==2.0.7
+requests>=2.32.3
+urllib3>=2.0.7
 requests_aws4auth
 boto3


### PR DESCRIPTION
### Description
When running `python3 -m pip install -r requirements.txt` on this file an errors occurs because `>==` isn't a validate qualifier for version information.  This is causing issue with GitHub dependency scans and might have been the source of issues with mend and other tools configuration.

- See https://github.com/opensearch-project/opensearch-migrations/security/dependabot/11

### Testing
Validated locally - with `python3 -m pip install -r requirements.txt`.  I'll follow up separaretely on #688 to make sure we are using the error checking form of this build script

### Check List
- [ ] ~New functionality includes testing~
  - [ ] ~All tests pass, including unit test, integration test and doctest~
- [ ] New functionality has been documented
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
