### PR TITLE
Add job that passed when all other CI jobs have completed

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -168,3 +168,16 @@ jobs:
           fail: true
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
+  all-ci-checks-pass:
+    needs:
+      - cdk-tests
+      - console-library-tests
+      - gradle-tests
+      - link-checker
+      - python-e2e-tests
+      - python-lint
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          echo '## :heavy_check_mark: All continous integration checks pass' >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
### Description
GitHub allows 'requiring' a job to be run before a pull request can be merged, by adding a new job that 'needs' all the other ci jobs, this job will run last and only if they all pass.

After this is merged someone from the admin team can update the repo settings to enforce this requirement.

### Check List
- [ ] ~New functionality includes testing~
  - [ ] ~All tests pass, including unit test, integration test and doctest~
- [ ] ~New functionality has been documented~
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
