### PR TITLE
Reenable large request test

### DIFF
--- a/test/tests.py
+++ b/test/tests.py
@@ -405,21 +405,20 @@ class E2ETests(unittest.TestCase):
         finally:
             proxy_single_connection_session.close()
 
-    def test_0008_largeRequest(self):
-        for i in range(10):
-            index_name = f"test_0008_{self.unique_id}_{i}"
-            doc_id = "1"
+    def test_0008_largeRequest_replayedToTarget(self):
+        index_name = f"test_0008_{self.unique_id}"
+        doc_id = "1"
 
-            # Create large document, 99MiB
-            # Default max 100MiB in ES/OS settings (http.max_content_length)
-            large_doc = generate_large_doc(size_mib=99)
+        # Create large document, 99MiB
+        # Default max 100MiB in ES/OS settings (http.max_content_length)
+        large_doc = generate_large_doc(size_mib=99)
 
-            # Measure the time taken by the create_document call
-            # Send large request to proxy and verify response
-            proxy_response = create_document(self.proxy_endpoint, index_name, doc_id, self.source_auth,
-                                             self.source_verify_ssl, doc_body=large_doc)
+        # Measure the time taken by the create_document call
+        # Send large request to proxy and verify response
+        proxy_response = create_document(self.proxy_endpoint, index_name, doc_id, self.source_auth,
+                                         self.source_verify_ssl, doc_body=large_doc)
 
-            self.assertEqual(proxy_response.status_code, HTTPStatus.CREATED)
+        self.assertEqual(proxy_response.status_code, HTTPStatus.CREATED)
 
-            # Verify document created on source and target
-            self.assert_source_target_doc_match(index_name, doc_id, doc_body=large_doc, max_attempts=60)
+        # Verify document created on source and target
+        self.assert_source_target_doc_match(index_name, doc_id, doc_body=large_doc, max_attempts=60)

--- a/test/tests.py
+++ b/test/tests.py
@@ -130,13 +130,14 @@ class E2ETests(unittest.TestCase):
                 return True
         return False
 
-    def assert_source_target_doc_match(self, index_name, doc_id, doc_body: dict = None):
+    def assert_source_target_doc_match(self, index_name, doc_id, doc_body: dict = None, max_attempts: int = 15):
         source_response = get_document(self.source_endpoint, index_name, doc_id, self.source_auth,
                                        self.source_verify_ssl)
         self.assertEqual(source_response.status_code, HTTPStatus.OK)
 
         target_response = retry_request(get_document, args=(self.target_endpoint, index_name, doc_id,
                                                             self.target_auth, self.target_verify_ssl),
+                                        max_attempts=max_attempts,
                                         expected_status_code=HTTPStatus.OK)
         self.assertEqual(target_response.status_code, HTTPStatus.OK)
 
@@ -409,28 +410,16 @@ class E2ETests(unittest.TestCase):
             index_name = f"test_0008_{self.unique_id}_{i}"
             doc_id = "1"
 
-            # Create large document, 50MiB
+            # Create large document, 99MiB
             # Default max 100MiB in ES/OS settings (http.max_content_length)
-            large_doc = generate_large_doc(size_mib=50)
+            large_doc = generate_large_doc(size_mib=99)
 
-            # Measure the time taken by the create_document call 
+            # Measure the time taken by the create_document call
             # Send large request to proxy and verify response
-            start_time = time.time()
             proxy_response = create_document(self.proxy_endpoint, index_name, doc_id, self.source_auth,
                                              self.source_verify_ssl, doc_body=large_doc)
-            end_time = time.time()
-            duration = end_time - start_time
-
-            # Set wait time to double the response time or 5 seconds
-            wait_time_seconds = max(round(duration, 3) * 2, 5)
 
             self.assertEqual(proxy_response.status_code, HTTPStatus.CREATED)
 
-            # Wait for the measured duration
-            logger.debug(f"Waiting {wait_time_seconds} seconds for"
-                         f" replay of large doc creation")
-
-            time.sleep(wait_time_seconds)
-
             # Verify document created on source and target
-            self.assert_source_target_doc_match(index_name, doc_id, doc_body=large_doc)
+            self.assert_source_target_doc_match(index_name, doc_id, doc_body=large_doc, max_attempts=60)

--- a/test/tests.py
+++ b/test/tests.py
@@ -404,14 +404,13 @@ class E2ETests(unittest.TestCase):
         finally:
             proxy_single_connection_session.close()
 
-    @unittest.skip
     def test_0008_largeRequest(self):
         index_name = f"test_0008_{self.unique_id}"
         doc_id = "1"
 
-        # Create large document, 99MiB
+        # Create large document, 50MiB
         # Default max 100MiB in ES/OS settings (http.max_content_length)
-        large_doc = generate_large_doc(size_mib=99)
+        large_doc = generate_large_doc(size_mib=50)
 
         # Measure the time taken by the create_document call
         # Send large request to proxy and verify response
@@ -422,7 +421,7 @@ class E2ETests(unittest.TestCase):
         duration = end_time - start_time
 
         # Set wait time to double the response time or 5 seconds
-        wait_time_seconds = min(round(duration, 3) * 2, 5)
+        wait_time_seconds = max(round(duration, 3) * 2, 5)
 
         self.assertEqual(proxy_response.status_code, HTTPStatus.CREATED)
 

--- a/test/tests.py
+++ b/test/tests.py
@@ -405,31 +405,32 @@ class E2ETests(unittest.TestCase):
             proxy_single_connection_session.close()
 
     def test_0008_largeRequest(self):
-        index_name = f"test_0008_{self.unique_id}"
-        doc_id = "1"
+        for i in range(10):
+            index_name = f"test_0008_{self.unique_id}_{i}"
+            doc_id = "1"
 
-        # Create large document, 50MiB
-        # Default max 100MiB in ES/OS settings (http.max_content_length)
-        large_doc = generate_large_doc(size_mib=50)
+            # Create large document, 50MiB
+            # Default max 100MiB in ES/OS settings (http.max_content_length)
+            large_doc = generate_large_doc(size_mib=50)
 
-        # Measure the time taken by the create_document call
-        # Send large request to proxy and verify response
-        start_time = time.time()
-        proxy_response = create_document(self.proxy_endpoint, index_name, doc_id, self.source_auth,
-                                         self.source_verify_ssl, doc_body=large_doc)
-        end_time = time.time()
-        duration = end_time - start_time
+            # Measure the time taken by the create_document call 
+            # Send large request to proxy and verify response
+            start_time = time.time()
+            proxy_response = create_document(self.proxy_endpoint, index_name, doc_id, self.source_auth,
+                                             self.source_verify_ssl, doc_body=large_doc)
+            end_time = time.time()
+            duration = end_time - start_time
 
-        # Set wait time to double the response time or 5 seconds
-        wait_time_seconds = max(round(duration, 3) * 2, 5)
+            # Set wait time to double the response time or 5 seconds
+            wait_time_seconds = max(round(duration, 3) * 2, 5)
 
-        self.assertEqual(proxy_response.status_code, HTTPStatus.CREATED)
+            self.assertEqual(proxy_response.status_code, HTTPStatus.CREATED)
 
-        # Wait for the measured duration
-        logger.debug(f"Waiting {wait_time_seconds} seconds for"
-                     f" replay of large doc creation")
+            # Wait for the measured duration
+            logger.debug(f"Waiting {wait_time_seconds} seconds for"
+                         f" replay of large doc creation")
 
-        time.sleep(wait_time_seconds)
+            time.sleep(wait_time_seconds)
 
-        # Verify document created on source and target
-        self.assert_source_target_doc_match(index_name, doc_id, doc_body=large_doc)
+            # Verify document created on source and target
+            self.assert_source_target_doc_match(index_name, doc_id, doc_body=large_doc)

--- a/test/tests.py
+++ b/test/tests.py
@@ -409,9 +409,9 @@ class E2ETests(unittest.TestCase):
         index_name = f"test_0008_{self.unique_id}"
         doc_id = "1"
 
-        # Create large document, 99MiB
+        # Create large document, 50MiB
         # Default max 100MiB in ES/OS settings (http.max_content_length)
-        large_doc = generate_large_doc(size_mib=99)
+        large_doc = generate_large_doc(size_mib=50)
 
         # Measure the time taken by the create_document call
         # Send large request to proxy and verify response


### PR DESCRIPTION
### Description
Reenable large request test
* Category: Test fix
* Why these changes are required? This is a required feature so should be tested. 
* What is the old behavior before changes and new behavior after changes? Test disabled, now test enabled and working

### Issues Resolved
[MIGRATIONS-1798](https://opensearch.atlassian.net/browse/MIGRATIONS-1798)

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
Github Actions E2E Workflow

### Check List
- [x] New functionality includes testing
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] ~New functionality has been documented~
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
