### PR TITLE
Add step to delete all `migrations` images from docker cache

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -132,6 +132,11 @@ jobs:
           cd test
           chmod +x ./tests.py
           pytest tests.py --unique_id="testindex"
+      - name: Clean up migrations docker images before caching
+        run: |
+          docker stop $(docker ps -q) && docker rm $(docker ps -aq)
+          docker image ls --format '{{.Repository}}:{{.Tag}}' | grep '^migrations/' | grep -v '<none>' | xargs -I {} docker image rm {}
+
 
   cdk-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -137,7 +137,6 @@ jobs:
           docker stop $(docker ps -q) && docker rm $(docker ps -aq)
           docker image ls --format '{{.Repository}}:{{.Tag}}' | grep '^migrations/' | grep -v '<none>' | xargs -I {} docker image rm {}
 
-
   cdk-tests:
     runs-on: ubuntu-latest
     defaults:

--- a/FetchMigration/Dockerfile
+++ b/FetchMigration/Dockerfile
@@ -6,6 +6,7 @@ RUN apt -y update
 RUN apt -y install python3 python3-pip
 RUN pip3 install --user -r requirements.txt
 
+
 ENV FM_CODE_PATH /code
 WORKDIR $FM_CODE_PATH
 # Copy only source code


### PR DESCRIPTION
### Description

We believe that the docker cache is causing the e2e tests to fail, possibly by taking up too much disk space and forcing the target cluster to lock indices.

One solution (assuming a correct diagnosis) is to delete docker caching altogether. This, of course, also means we lose the benefits of caching the external images (namely, not being rate limited). This PR is an attempt to split the difference--keep the cache for external images, but don't cache all the `migrations/` images, which we're rebuilding anyways.


### Issues Resolved
Hopefully https://opensearch.atlassian.net/browse/MIGRATIONS-1797

### Testing
Several tests in the commits to this PR.

- The first commit is the actual content.
- The second commit makes a change to a Dockerfile and therefore creates a fresh cache (see run here: https://github.com/opensearch-project/opensearch-migrations/actions/runs/9588463478/job/26440545131). In this one, you can see the delete images step running: https://github.com/opensearch-project/opensearch-migrations/actions/runs/9588463478/job/26440545131#step:11:1; and creating a cache entry with a smaller number of images and size: https://github.com/opensearch-project/opensearch-migrations/actions/runs/9588463478/job/26440545131#step:18:28
- The third commit is an empty commit which means it will have a cache hit on the cache created by the second commit. (see run here: https://github.com/mikaylathompson/opensearch-migrations/actions/runs/9588586214/job/26440929280). It pulls a much smaller set of images than previously: https://github.com/mikaylathompson/opensearch-migrations/actions/runs/9588586214/job/26440929280#step:7:35, and the tests pass: https://github.com/mikaylathompson/opensearch-migrations/actions/runs/9588586214/job/26440929280#step:10:46 🎉 


Before merging, I intend to roll back the final two commits.

### Check List
- [ ] New functionality includes testing
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
