### PR TITLE
Fix FetchMigration build

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -173,6 +173,16 @@ jobs:
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
+  fetch-migration-docker-build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./FetchMigration
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build Docker Image
+        run: docker build -t migrations/fetch-migration -f Dockerfile .
+  
   all-ci-checks-pass:
     needs:
       - cdk-tests
@@ -181,7 +191,9 @@ jobs:
       - python-e2e-tests
       - python-lint
       - python-tests
+      - fetch-migration-docker-build
     runs-on: ubuntu-latest
     steps:
       - run: |
           echo '## :heavy_check_mark: All continous integration checks pass' >> $GITHUB_STEP_SUMMARY
+

--- a/FetchMigration/Dockerfile
+++ b/FetchMigration/Dockerfile
@@ -1,5 +1,5 @@
 FROM opensearchproject/data-prepper:2.5.0
-COPY python/Pipfile .
+COPY python/Pipfile python/Pipfile.lock ./
 
 # Install dependencies to local user directory
 RUN apt -y update


### PR DESCRIPTION
### Description
Fix FetchMigration build
* Category: Bug Fix
* Why these changes are required? Error below
* What is the old behavior before changes and new behavior after changes? See error code below, with change, no error

### Issues Resolved
Currently getting 
```
#10 [ 6/10] RUN pipenv install --system --deploy --ignore-pipfile
#10 1.257 Usage: pipenv install [OPTIONS] [PACKAGES]...
#10 1.257 
#10 1.257 ERROR:: --system is intended to be used for Pipfile installation, not installation of specific packages. Aborting.
#10 1.257 See also: --deploy flag.
#10 ERROR: process "/bin/sh -c pipenv install --system --deploy --ignore-pipfile" did not complete successfully: exit code: 2
------
 > [ 6/10] RUN pipenv install --system --deploy --ignore-pipfile:
1.257 Usage: pipenv install [OPTIONS] [PACKAGES]...
1.257 
1.257 ERROR:: --system is intended to be used for Pipfile installation, not installation of specific packages. Aborting.
1.257 See also: --deploy flag.
------
Dockerfile:8
--------------------
   6 |     RUN apt -y install python3 python3-pip
   7 |     RUN pip3 install pipenv
   8 | >>> RUN pipenv install --system --deploy --ignore-pipfile
   9 |     
  10 |     
--------------------
ERROR: failed to solve: process "/bin/sh -c pipenv install --system --deploy --ignore-pipfile" did not complete successfully: exit code: 2
```

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
Ran build

### Check List
- [ ] New functionality includes testing
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
