### PR TITLE
Support local snapshots from CLI fro SnapshotCreate & MetadataMigration

### DIFF
--- a/CreateSnapshot/src/main/java/com/rfs/CreateSnapshot.java
+++ b/CreateSnapshot/src/main/java/com/rfs/CreateSnapshot.java
@@ -2,17 +2,17 @@ package com.rfs;
 
 import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
+import com.beust.jcommander.ParameterException;
 
-import com.rfs.common.UsernamePassword;
+import com.rfs.common.FileSystemSnapshotCreator;
+import com.rfs.common.OpenSearchClient;
+import com.rfs.common.S3SnapshotCreator;
+import com.rfs.common.SnapshotCreator;
+import com.rfs.common.TryHandlePhaseFailure;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
-import com.rfs.common.ConnectionDetails;
-import com.rfs.common.OpenSearchClient;
-import com.rfs.common.SnapshotCreator;
-import com.rfs.common.TryHandlePhaseFailure;
-import com.rfs.common.S3SnapshotCreator;
 import com.rfs.worker.SnapshotRunner;
 
 import java.util.Optional;
@@ -26,13 +26,18 @@ public class CreateSnapshot {
                 description = "The name of the snapshot to migrate")
         public String snapshotName;
 
+        @Parameter(names = {"--file-system-repo-path"},
+                required = false,
+                description = "The full path to the snapshot repo on the file system.")
+        public String fileSystemRepoPath;
+
         @Parameter(names = {"--s3-repo-uri"},
-                required = true,
+                required = false,
                 description = "The S3 URI of the snapshot repo, like: s3://my-bucket/dir1/dir2")
         public String s3RepoUri;
 
         @Parameter(names = {"--s3-region"},
-                required = true,
+                required = false,
                 description = "The AWS Region the S3 bucket is in, like: us-east-2"
         )
         public String s3Region;
@@ -70,12 +75,25 @@ public class CreateSnapshot {
                 .build()
                 .parse(args);
 
-        log.info("Running CreateSnapshot with " + String.join(" ", args));
-        run(c -> new S3SnapshotCreator(arguments.snapshotName, c, arguments.s3RepoUri, arguments.s3Region),
-                new OpenSearchClient(arguments.sourceHost, arguments.sourceUser, arguments.sourcePass, arguments.sourceInsecure));
+        if (arguments.fileSystemRepoPath == null && arguments.s3RepoUri == null) {
+            throw new ParameterException("Either file-system-repo-path or s3-repo-uri must be set");
+        }
+        if (arguments.fileSystemRepoPath != null && arguments.s3RepoUri != null) {
+            throw new ParameterException("Only one of file-system-repo-path and s3-repo-uri can be set");
+        }
+        if (arguments.s3RepoUri != null && arguments.s3Region == null) {
+            throw new ParameterException("If an s3 repo is being used, s3-region must be set");
+        }
+
+        log.info("Running CreateSnapshot with {}", String.join(" ", args));
+        run(c -> ((arguments.fileSystemRepoPath != null)
+                        ? new FileSystemSnapshotCreator(arguments.snapshotName, c, arguments.fileSystemRepoPath)
+                        : new S3SnapshotCreator(arguments.snapshotName, c, arguments.s3RepoUri, arguments.s3Region)),
+                new OpenSearchClient(arguments.sourceHost, arguments.sourceUser, arguments.sourcePass, arguments.sourceInsecure)
+        );
     }
 
-    public static void run(Function<OpenSearchClient,SnapshotCreator> snapshotCreatorFactory,
+    public static void run(Function<OpenSearchClient, SnapshotCreator> snapshotCreatorFactory,
                            OpenSearchClient openSearchClient)
             throws Exception {
         TryHandlePhaseFailure.executeWithTryCatch(() -> {

--- a/CreateSnapshot/src/main/java/com/rfs/CreateSnapshot.java
+++ b/CreateSnapshot/src/main/java/com/rfs/CreateSnapshot.java
@@ -4,18 +4,17 @@ import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.ParameterException;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+
 import com.rfs.common.FileSystemSnapshotCreator;
 import com.rfs.common.OpenSearchClient;
 import com.rfs.common.S3SnapshotCreator;
 import com.rfs.common.SnapshotCreator;
 import com.rfs.common.TryHandlePhaseFailure;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.extern.slf4j.Slf4j;
-
 import com.rfs.worker.SnapshotRunner;
 
-import java.util.Optional;
 import java.util.function.Function;
 
 @Slf4j

--- a/RFS/src/main/java/com/rfs/common/FileSystemRepo.java
+++ b/RFS/src/main/java/com/rfs/common/FileSystemRepo.java
@@ -1,9 +1,5 @@
 package com.rfs.common;
 
-import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
-import software.amazon.awssdk.regions.Region;
-import software.amazon.awssdk.services.s3.S3AsyncClient;
-
 import java.io.IOException;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;

--- a/RFS/src/main/java/com/rfs/common/FileSystemRepo.java
+++ b/RFS/src/main/java/com/rfs/common/FileSystemRepo.java
@@ -1,5 +1,9 @@
 package com.rfs.common;
 
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+
 import java.io.IOException;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;


### PR DESCRIPTION
### Description
This allows testing snapshots and metadata migration locally (and long-term supporting it in our docker option)


### Issues Resolved
My development speed

### Testing
Manual -- we're flying pretty blind here.
Steps for manual testing:
- disable password verification on source and target cluster
- create a shared volume in the docker-compose file
- for source cluster in docker-compose:
  - mount shared volume (in this case `/snapshot`)
  - set in environment: path.repo=/snapshot
- for migration console in docker-compose
  - mount shared volume
  - run `chmod -R a+rwX /snapshot/` (there is absolutely a better way to do this, which is in part why I'm not checking in the pieces of this test setup, but it works for this)
  - .`/createSnapshot/bin/CreateSnapshot --snapshot-name 2024-06-21-test-0001 --file-system-repo-path /snapshot/test --source-host http://source:9200`
  - `./metadataMigration/bin/MetadataMigration --snapshot-name 2024-06-21-test-0001 --file-system-repo-path /snapshot/test/ --target-host http://opensearchtarget:9200`

### Check List
- [ ] New functionality includes testing
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
