### PR TITLE
Cat command always shows all indices

### DIFF
--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/logic/clusters.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/logic/clusters.py
@@ -14,7 +14,7 @@ class ConnectionResult:
 
 def cat_indices(cluster: Cluster, as_json=False):
     as_json_suffix = "?format=json" if as_json else "?v"
-    cat_indices_path = f"/_cat/indices{as_json_suffix}"
+    cat_indices_path = f"/_cat/indices/_all{as_json_suffix}"
     r = cluster.call_api(cat_indices_path)
     return r.json() if as_json else r.content
 

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/test_cli.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/test_cli.py
@@ -154,10 +154,10 @@ green  open nyc_taxis                    j1HSbvtGRbG7H7SlJXrB0g 1 0 1000 0 159.3
 
 def test_cli_cat_indices_e2e(runner, env):
     with requests_mock.Mocker() as rm:
-        rm.get(f"{env.source_cluster.endpoint}/_cat/indices",
+        rm.get(f"{env.source_cluster.endpoint}/_cat/indices/_all",
                status_code=200,
                text=source_cat_indices)
-        rm.get(f"{env.target_cluster.endpoint}/_cat/indices",
+        rm.get(f"{env.target_cluster.endpoint}/_cat/indices/_all",
                status_code=200,
                text=target_cat_indices)
         result = runner.invoke(cli, ['--config-file', str(VALID_SERVICES_YAML), 'clusters', 'cat-indices'],


### PR DESCRIPTION
### Description
Between different versions of ES and OS they have different system indices definitions, this can lead to the cat outputs looking different that is confusing

### Testing
Tested the cat indices command on a ES7.10 cluster and OS2.14 cluster, no updates to existing test infrastructure

### Check List
- [ ] ~New functionality includes testing~
  - [X] All tests pass, including unit test, integration test and doctest
- [ ] ~New functionality has been documented~
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
