### PR TITLE
Updated RFS to filter out system indices by default

### DIFF
--- a/MetadataMigration/src/main/java/com/rfs/MetadataMigration.java
+++ b/MetadataMigration/src/main/java/com/rfs/MetadataMigration.java
@@ -59,7 +59,7 @@ public class MetadataMigration {
         public String targetPass = null;
 
         @Parameter(names = {"--index-allowlist"}, description = ("Optional.  List of index names to migrate"
-            + " (e.g. 'logs_2024_01, logs_2024_02').  Default: all indices"), required = false)
+            + " (e.g. 'logs_2024_01, logs_2024_02').  Default: all non-system indices (e.g. those not starting with '.')"), required = false)
         public List<String> indexAllowlist = List.of();
 
         @Parameter(names = {"--index-template-allowlist"}, description = ("Optional.  List of index template names to migrate"
@@ -103,6 +103,7 @@ public class MetadataMigration {
         final String targetHost = arguments.targetHost;
         final String targetUser = arguments.targetUser;
         final String targetPass = arguments.targetPass;
+        final List<String> indexAllowlist = arguments.indexAllowlist;
         final List<String> indexTemplateAllowlist = arguments.indexTemplateAllowlist;
         final List<String> componentTemplateAllowlist = arguments.componentTemplateAllowlist;
         final int awarenessDimensionality = arguments.minNumberOfReplicas + 1;
@@ -126,7 +127,7 @@ public class MetadataMigration {
 
             final IndexMetadata.Factory indexMetadataFactory = new IndexMetadataFactory_ES_7_10(repoDataProvider);
             final IndexCreator_OS_2_11 indexCreator = new IndexCreator_OS_2_11(targetClient);
-            new IndexRunner(snapshotName, indexMetadataFactory, indexCreator, transformer).migrateIndices();
+            new IndexRunner(snapshotName, indexMetadataFactory, indexCreator, transformer, indexAllowlist).migrateIndices();
         });
     }
 }

--- a/RFS/src/main/java/com/rfs/RunRfsWorker.java
+++ b/RFS/src/main/java/com/rfs/RunRfsWorker.java
@@ -132,7 +132,8 @@ public class RunRfsWorker {
         final String targetHost = arguments.targetHost;
         final String targetUser = arguments.targetUser;
         final String targetPass = arguments.targetPass;
-        final List<String> indexTemplateAllowlist = arguments.indexAllowlist;
+        final List<String> indexAllowlist = arguments.indexAllowlist;
+        final List<String> indexTemplateAllowlist = arguments.indexTemplateAllowlist;
         final List<String> componentTemplateAllowlist = arguments.componentTemplateAllowlist;
         final long maxShardSizeBytes = arguments.maxShardSizeBytes;
         final int awarenessDimensionality = arguments.minNumberOfReplicas + 1;
@@ -160,7 +161,7 @@ public class RunRfsWorker {
 
             IndexMetadata.Factory indexMetadataFactory = new IndexMetadataFactory_ES_7_10(repoDataProvider);
             IndexCreator_OS_2_11 indexCreator = new IndexCreator_OS_2_11(targetClient);
-            new IndexRunner(snapshotName, indexMetadataFactory, indexCreator, transformer).migrateIndices();
+            new IndexRunner(snapshotName, indexMetadataFactory, indexCreator, transformer, indexAllowlist).migrateIndices();
 
             ShardMetadata.Factory shardMetadataFactory = new ShardMetadataFactory_ES_7_10(repoDataProvider);
             DefaultSourceRepoAccessor repoAccessor = new DefaultSourceRepoAccessor(sourceRepo);
@@ -174,7 +175,7 @@ public class RunRfsWorker {
             var workCoordinator = new OpenSearchWorkCoordinator(new ApacheHttpClient(new URI(targetHost)),
                     5, UUID.randomUUID().toString());
             var scopedWorkCoordinator = new ScopedWorkCoordinator(workCoordinator, processManager);
-            new ShardWorkPreparer().run(scopedWorkCoordinator, indexMetadataFactory, snapshotName);
+            new ShardWorkPreparer().run(scopedWorkCoordinator, indexMetadataFactory, snapshotName, indexAllowlist);
             new DocumentsRunner(scopedWorkCoordinator,
                     (name,shard) -> shardMetadataFactory.fromRepo(snapshotName,name,shard),
                     unpackerFactory,

--- a/RFS/src/main/java/com/rfs/common/FilterScheme.java
+++ b/RFS/src/main/java/com/rfs/common/FilterScheme.java
@@ -1,0 +1,23 @@
+package com.rfs.common;
+
+import java.util.List;
+import java.util.function.BiConsumer;
+import java.util.function.Predicate;
+
+public class FilterScheme {
+
+    public static Predicate<SnapshotRepo.Index> filterIndicesByAllowList(List<String> indexAllowlist, BiConsumer<String, Boolean> indexNameAcceptanceObserver) {
+        return index -> {
+            boolean accepted;
+            if (indexAllowlist.isEmpty()) {
+                accepted = !index.getName().startsWith(".");
+            } else {
+                accepted = indexAllowlist.contains(index.getName());
+            }
+
+            indexNameAcceptanceObserver.accept(index.getName(), accepted);
+
+            return accepted;
+        };
+    }    
+}

--- a/RFS/src/main/java/com/rfs/worker/IndexRunner.java
+++ b/RFS/src/main/java/com/rfs/worker/IndexRunner.java
@@ -1,12 +1,13 @@
 package com.rfs.worker;
 
-import java.util.Optional;
+import java.util.List;
+import java.util.function.BiConsumer;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.rfs.common.SnapshotRepo;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
+import com.rfs.common.FilterScheme;
 import com.rfs.common.IndexMetadata;
 import com.rfs.transformers.Transformer;
 import com.rfs.version_os_2_11.IndexCreator_OS_2_11;
@@ -19,18 +20,28 @@ public class IndexRunner {
     private final IndexMetadata.Factory metadataFactory;
     private final IndexCreator_OS_2_11 indexCreator;
     private final Transformer transformer;
+    private final List<String> indexAllowlist;
 
     public void migrateIndices() {
         SnapshotRepo.Provider repoDataProvider = metadataFactory.getRepoDataProvider();
         // TODO - parallelize this, maybe ~400-1K requests per thread and do it asynchronously
-        for (SnapshotRepo.Index index : repoDataProvider.getIndicesInSnapshot(snapshotName)) {
-            var indexMetadata = metadataFactory.fromRepo(snapshotName, index.getName());
-            var root = indexMetadata.toObjectNode();
-            var transformedRoot = transformer.transformIndexMetadata(root);
-            var resultOp = indexCreator.create(transformedRoot, index.getName(), indexMetadata.getId());
-            resultOp.ifPresentOrElse(value -> log.info("Index " + index.getName() + " created successfully"),
-                    () -> log.info("Index " + index.getName() + " already existed; no work required")
-            );
-        }
+        
+        BiConsumer<String, Boolean> logger = (indexName, accepted) -> {
+            if (!accepted) {
+                log.info("Index " + indexName + " rejected by allowlist");
+            }
+        };
+        repoDataProvider.getIndicesInSnapshot(snapshotName).stream()
+            .filter(FilterScheme.filterIndicesByAllowList(indexAllowlist, logger))
+            .peek(index -> {
+                var indexMetadata = metadataFactory.fromRepo(snapshotName, index.getName());
+                var root = indexMetadata.toObjectNode();
+                var transformedRoot = transformer.transformIndexMetadata(root);
+                var resultOp = indexCreator.create(transformedRoot, index.getName(), indexMetadata.getId());
+                resultOp.ifPresentOrElse(value -> log.info("Index " + index.getName() + " created successfully"),
+                        () -> log.info("Index " + index.getName() + " already existed; no work required")
+                );
+            })
+            .count(); // Force the stream to execute
     }
 }


### PR DESCRIPTION
### Description
* Updated the RFS index creation and document migration code to filter out system indices (those starting w/ `.`) by default.  The user can still set an explicit allowlist to bypass this default behavior

### Issues Resolved
Bug fix

### Testing
Tested manually on my laptop.  Spun up the docker compose setup for RFS and manually added a new index called `.test_should_not_migrate`:

```
chelma@80a9970a4d02 opensearch-migrations % curl -X GET "http://localhost:19200/_cat/indices?v"
health status index                    uuid                   pri rep docs.count docs.deleted store.size pri.store.size
green  open   logs-221998              g2fDhAowSeO2L7bK0IFkOg   5   0       1000            0    165.7kb        165.7kb
green  open   logs-211998              GFJ4chDGT4mv9RnYCw0bVg   5   0       1000            0    162.3kb        162.3kb
green  open   geonames                 CISRqtNmQnqWDtwYuijppA   5   0       1000            0    402.9kb        402.9kb
green  open   reindexed-logs           fWxInXixRV6Fz1DKJum0vQ   5   0          0            0        1kb            1kb
green  open   logs-231998              Aa9lh7FbRd-0MpMyNGLvDA   5   0       1000            0    168.6kb        168.6kb
green  open   nyc_taxis                YYcnszK-QqCjXpYMoNajzA   1   0       1000            0    171.4kb        171.4kb
green  open   logs-241998              _ZVD86l3RWWRTs8oRZf40w   5   0       1000            0    169.8kb        169.8kb
green  open   sonested                 tJapkWRjQjOiCk4iOkgBYQ   1   0       2977            0    460.2kb        460.2kb
green  open   .test_should_not_migrate 3QyGw5UwRkGR6w-MY6eDgA   1   0          0            0       208b           208b
green  open   logs-181998              Vor2q1PXTbOsR4G0jN9VHw   5   0       1000            0    166.2kb        166.2kb
green  open   logs-201998              -GiCtDk2QqKJGFJCLMCCww   5   0       1000            0    162.4kb        162.4kb
green  open   logs-191998              VP9IYK_ZSi6ldlX6FgwJ5A   5   0       1000            0    164.2kb        164.2kb
```

I then took a snapshot and ran the metadata migration code, which skipped that that index:

```
chelma@80a9970a4d02 opensearch-migrations % ./gradlew MetadataMigration:run --args='--snapshot-name reindex-from-snapshot --s3-local-dir /tmp/s3_files --s3-repo-uri s3://chelma-iad-rfs-local-testing --s3-region us-east-1 --target-
host http://localhost:29200'

> Task :MetadataMigration:run
09:01:21.986 INFO  Running RfsWorker
09:01:22.518 INFO  Migrating the Templates...
09:01:23.198 INFO  Downloading file from S3: s3://chelma-iad-rfs-local-testing/index-0 to /tmp/s3_files/index-0
09:01:23.414 INFO  Downloading file from S3: s3://chelma-iad-rfs-local-testing/meta-kwYbF_W8Q9CxljUswfLDOQ.dat to /tmp/s3_files/meta-kwYbF_W8Q9CxljUswfLDOQ.dat
09:01:23.582 INFO  Setting Global Metadata
09:01:23.582 INFO  Setting Legacy Templates...
09:01:23.582 INFO  No Legacy Templates in specified allowlist
09:01:23.582 INFO  Setting Component Templates...
09:01:23.582 INFO  No Component Templates in Snapshot
09:01:23.582 INFO  Setting Index Templates...
09:01:23.582 INFO  No Index Templates in Snapshot
09:01:23.582 INFO  Templates migration complete
09:01:23.587 INFO  Downloading file from S3: s3://chelma-iad-rfs-local-testing/indices/uRQQooLMS9SZpVtIJL1nKA/meta-e4ezT5ABNFsALwOUKeS3.dat to /tmp/s3_files/indices/uRQQooLMS9SZpVtIJL1nKA/meta-e4ezT5ABNFsALwOUKeS3.dat
09:01:23.853 ERROR Unable to load io.netty.resolver.dns.macos.MacOSDnsServerAddressStreamProvider, fallback to system defaults. This may result in incorrect DNS resolutions on MacOS. Check whether you have a dependency on 'io.nett
y:netty-resolver-dns-native-macos'. Use DEBUG level to see the full stack: java.lang.UnsatisfiedLinkError: failed to load the required native library
09:01:24.004 INFO  Index nyc_taxis created successfully
09:01:24.004 INFO  Index .test_should_not_migrate rejected by allowlist  <---------- SEE HERE
09:01:24.004 INFO  Downloading file from S3: s3://chelma-iad-rfs-local-testing/indices/H90080DJSKuFpVRa_zs9Qg/meta-gYezT5ABNFsALwOUKuTX.dat to /tmp/s3_files/indices/H90080DJSKuFpVRa_zs9Qg/meta-gYezT5ABNFsALwOUKuTX.dat
09:01:24.206 INFO  Index sonested created successfully
.
.
.
```

And ran the document migration code, which also skipped it:

```
chelma@80a9970a4d02 opensearch-migrations % ./gradlew DocumentsFromSnapshotMigration:run --args='--snapshot-name reindex-from-snapshot --s3-local-dir /tmp/s3_files --s3-repo-uri s3://chelma-iad-rfs-local-testing --s3-region us-eas
t-1 --lucene-dir /tmp/lucene_files --target-host http://localhost:29200'

> Task :DocumentsFromSnapshotMigration:run
09:01:56.885 INFO  Running RfsWorker
09:01:57.251 INFO  Creating .migrations_working_state because it's HEAD check returned 404
09:01:57.305 WARN  Retrying setup-.migrations_working_state because the predicate failed for: (com.rfs.cms.ApacheHttpClient$1@6232ffdb,[ statusCode: 200, payload: {"acknowledged":true,"shards_acknowledged":true,"index":".migration
s_working_state"}])
09:01:57.562 INFO  Setting up the Documents Work Items...
09:01:58.200 INFO  Index nyc_taxis has 1 shards
09:01:58.201 INFO  Creating Documents Work Item for index: nyc_taxis, shard: 0
09:01:58.214 INFO  Index .test_should_not_migrate rejected by allowlist <----- SEE HERE
09:01:58.215 INFO  Index sonested has 1 shards
09:01:58.215 INFO  Creating Documents Work Item for index: sonested, shard: 0
09:01:58.222 INFO  Index logs-241998 has 5 shards
09:01:58.222 INFO  Creating Documents Work Item for index: logs-241998, shard: 0
09:01:58.227 INFO  Creating Documents Work Item for index: logs-241998, shard: 1
09:01:58.231 INFO  Creating Documents Work Item for index: logs-241998, shard: 2
09:01:58.233 INFO  Creating Documents Work Item for index: logs-241998, shard: 3
09:01:58.236 INFO  Creating Documents Work Item for index: logs-241998, shard: 4
.
.
.
```

### Check List
- [X] New functionality includes testing
  - [X] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
