### PR TITLE
Shutdown executors created by RFS LeaseExpireTrigger and KafkaTrafficCaptureSource

### DIFF
--- a/DocumentsFromSnapshotMigration/src/main/java/com/rfs/RfsMigrateDocuments.java
+++ b/DocumentsFromSnapshotMigration/src/main/java/com/rfs/RfsMigrateDocuments.java
@@ -101,33 +101,34 @@ public class RfsMigrateDocuments {
                 .parse(args);
 
         var luceneDirPath = Paths.get(arguments.luceneDirPath);
-        var processManager = new LeaseExpireTrigger(workItemId->{
+        try (var processManager = new LeaseExpireTrigger(workItemId->{
             log.error("terminating RunRfsWorker because its lease has expired for " + workItemId);
             System.exit(PROCESS_TIMED_OUT);
-        }, Clock.systemUTC());
-        var workCoordinator = new OpenSearchWorkCoordinator(new ApacheHttpClient(new URI(arguments.targetHost)),
-                TOLERABLE_CLIENT_SERVER_CLOCK_DIFFERENCE_SECONDS, UUID.randomUUID().toString());
+        }, Clock.systemUTC())) {
+            var workCoordinator = new OpenSearchWorkCoordinator(new ApacheHttpClient(new URI(arguments.targetHost)),
+                    TOLERABLE_CLIENT_SERVER_CLOCK_DIFFERENCE_SECONDS, UUID.randomUUID().toString());
 
-        TryHandlePhaseFailure.executeWithTryCatch(() -> {
-            log.info("Running RfsWorker");
+            TryHandlePhaseFailure.executeWithTryCatch(() -> {
+                log.info("Running RfsWorker");
 
-            OpenSearchClient targetClient =
-                    new OpenSearchClient(arguments.targetHost, arguments.targetUser, arguments.targetPass, false);
-            DocumentReindexer reindexer = new DocumentReindexer(targetClient);
+                OpenSearchClient targetClient =
+                        new OpenSearchClient(arguments.targetHost, arguments.targetUser, arguments.targetPass, false);
+                DocumentReindexer reindexer = new DocumentReindexer(targetClient);
 
-            SourceRepo sourceRepo = S3Repo.create(Paths.get(arguments.s3LocalDirPath),
-                    new S3Uri(arguments.s3RepoUri), arguments.s3Region);
-            SnapshotRepo.Provider repoDataProvider = new SnapshotRepoProvider_ES_7_10(sourceRepo);
+                SourceRepo sourceRepo = S3Repo.create(Paths.get(arguments.s3LocalDirPath),
+                        new S3Uri(arguments.s3RepoUri), arguments.s3Region);
+                SnapshotRepo.Provider repoDataProvider = new SnapshotRepoProvider_ES_7_10(sourceRepo);
 
-            IndexMetadata.Factory indexMetadataFactory = new IndexMetadataFactory_ES_7_10(repoDataProvider);
-            ShardMetadata.Factory shardMetadataFactory = new ShardMetadataFactory_ES_7_10(repoDataProvider);
-            DefaultSourceRepoAccessor repoAccessor = new DefaultSourceRepoAccessor(sourceRepo);
-            SnapshotShardUnpacker.Factory unpackerFactory = new SnapshotShardUnpacker.Factory(repoAccessor,
-                    luceneDirPath, ElasticsearchConstants_ES_7_10.BUFFER_SIZE_IN_BYTES);
+                IndexMetadata.Factory indexMetadataFactory = new IndexMetadataFactory_ES_7_10(repoDataProvider);
+                ShardMetadata.Factory shardMetadataFactory = new ShardMetadataFactory_ES_7_10(repoDataProvider);
+                DefaultSourceRepoAccessor repoAccessor = new DefaultSourceRepoAccessor(sourceRepo);
+                SnapshotShardUnpacker.Factory unpackerFactory = new SnapshotShardUnpacker.Factory(repoAccessor,
+                        luceneDirPath, ElasticsearchConstants_ES_7_10.BUFFER_SIZE_IN_BYTES);
 
-            run(LuceneDocumentsReader::new, reindexer, workCoordinator, processManager, indexMetadataFactory,
-                    arguments.snapshotName, shardMetadataFactory, unpackerFactory, arguments.maxShardSizeBytes);
-        });
+                run(LuceneDocumentsReader::new, reindexer, workCoordinator, processManager, indexMetadataFactory,
+                        arguments.snapshotName, shardMetadataFactory, unpackerFactory, arguments.maxShardSizeBytes);
+            });
+        }
     }
 
     public static DocumentsRunner.CompletionStatus run(Function<Path,LuceneDocumentsReader> readerFactory,

--- a/RFS/src/main/java/com/rfs/cms/LeaseExpireTrigger.java
+++ b/RFS/src/main/java/com/rfs/cms/LeaseExpireTrigger.java
@@ -16,7 +16,7 @@ import java.util.function.Consumer;
  * time unless the work is marked as complete before that expiration.  This class may, but does not need to,
  * synchronize its clock with an external source of truth for better accuracy.
  */
-public class LeaseExpireTrigger {
+public class LeaseExpireTrigger implements AutoCloseable {
     private final ScheduledExecutorService scheduledExecutorService;
     final ConcurrentHashMap<String, Instant> workItemToLeaseMap;
     final Consumer<String> onLeaseExpired;
@@ -46,5 +46,10 @@ public class LeaseExpireTrigger {
 
     public void markWorkAsCompleted(String workItemId) {
         workItemToLeaseMap.remove(workItemId);
+    }
+
+    @Override
+    public void close() throws Exception {
+        scheduledExecutorService.shutdownNow();
     }
 }

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/kafka/KafkaTrafficCaptureSource.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/kafka/KafkaTrafficCaptureSource.java
@@ -240,5 +240,6 @@ public class KafkaTrafficCaptureSource implements ISimpleTrafficCaptureSource {
     @Override
     public void close() throws IOException, InterruptedException, ExecutionException {
         kafkaExecutor.submit(trackingKafkaConsumer::close).get();
+        kafkaExecutor.shutdownNow();
     }
 }


### PR DESCRIPTION
Both of those classes used the DefaultThreadFactory, which uses daemon threads, which will keep a process alive even after main() has finished.

### Description
[Describe what this change achieves]
* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)
* Why these changes are required?
* What is the old behavior before changes and new behavior after changes?

### Issues Resolved
[List any issues this PR will resolve]

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]

### Check List
- [ ] New functionality includes testing
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
