### PR TITLE
Improve testDocumentGenerator defaults

### DIFF
--- a/TrafficCapture/dockerSolution/src/main/docker/elasticsearchTestConsole/testDocumentGenerator.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/elasticsearchTestConsole/testDocumentGenerator.py
@@ -99,8 +99,8 @@ def calculate_sleep_time(request_timestamps, target_requests_per_sec):
         return 0
     
     target_time_per_iteration = 1.0 / target_requests_per_sec
-    average_time_per_iteration = (datetime.now() -
-                                   request_timestamps[0]).total_seconds() / (len(request_timestamps) + 1)
+    average_time_per_iteration = (datetime.now() - 
+                                  request_timestamps[0]).total_seconds() / (len(request_timestamps) + 1)
     
     sleep_time = (target_time_per_iteration - average_time_per_iteration) * len(request_timestamps)
     

--- a/TrafficCapture/dockerSolution/src/main/docker/elasticsearchTestConsole/testDocumentGenerator.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/elasticsearchTestConsole/testDocumentGenerator.py
@@ -53,7 +53,7 @@ def parse_args():
     parser.add_argument("--no-clear-output", action='store_true',
                         help="Flag to not clear the output before each run. " +
                         "Helpful for piping to a file or other utility.")
-    parser.add_argument("--requests-per-sec", type=float, default=100.0, help="Target requests per second to be sent.")
+    parser.add_argument("--requests-per-sec", type=float, default=10.0, help="Target requests per second to be sent.")
     parser.add_argument("--no-refresh", action='store_true', help="Flag to disable refresh after each request.")
     return parser.parse_args()
 
@@ -99,7 +99,8 @@ def calculate_sleep_time(request_timestamps, target_requests_per_sec):
         return 0
     
     target_time_per_iteration = 1.0 / target_requests_per_sec
-    average_time_per_iteration = (datetime.now() - request_timestamps[0]).total_seconds() / len(request_timestamps)
+    average_time_per_iteration = (datetime.now() -
+                                   request_timestamps[0]).total_seconds() / (len(request_timestamps) + 1)
     
     sleep_time = (target_time_per_iteration - average_time_per_iteration) * len(request_timestamps)
     

--- a/TrafficCapture/dockerSolution/src/main/docker/elasticsearchTestConsole/testDocumentGenerator.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/elasticsearchTestConsole/testDocumentGenerator.py
@@ -99,7 +99,7 @@ def calculate_sleep_time(request_timestamps, target_requests_per_sec):
         return 0
     
     target_time_per_iteration = 1.0 / target_requests_per_sec
-    average_time_per_iteration = (datetime.now() - 
+    average_time_per_iteration = (datetime.now() -
                                   request_timestamps[0]).total_seconds() / (len(request_timestamps) + 1)
     
     sleep_time = (target_time_per_iteration - average_time_per_iteration) * len(request_timestamps)


### PR DESCRIPTION
### Description
Improve testDocumentGenerator defaults with 10 requests per second which allows for faster replay and fixes a bug that caused an incorrect sleep calculation.

* Category: Enhancement
* Why these changes are required? Improve usage
* What is the old behavior before changes and new behavior after changes?

### Issues Resolved
N/A

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
Manual Testing

### Check List
- [ ] New functionality includes testing
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
