### PR TITLE
[Console] Tiny PR to update the CLI help strings for the command groups

### DIFF
--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/cli.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/cli.py
@@ -47,7 +47,7 @@ def cli(ctx, config_file, json, verbose):
 # ##################### CLUSTERS ###################
 
 
-@cli.group(name="clusters")
+@cli.group(name="clusters", help="Commands to interact with source and target clusters")
 @click.pass_obj
 def cluster_group(ctx):
     if ctx.env.source_cluster is None:
@@ -119,25 +119,12 @@ def clear_indices_cmd(ctx, acknowledge_risk, cluster):
         else:
             click.echo("Aborting command.")
 
-# ##################### REPLAYER ###################
-
-
-@cli.group(name="replayer")
-@click.pass_obj
-def replayer_group(ctx):
-    if ctx.env.replayer is None:
-        raise click.UsageError("Replayer is not set")
-
-
-@replayer_group.command(name="start")
-@click.pass_obj
-def start_replayer_cmd(ctx):
-    ctx.env.replayer.start()
 
 # ##################### SNAPSHOT ###################
 
 
-@cli.group(name="snapshot")
+@cli.group(name="snapshot",
+           help="Commands to create and check status of snapshots of the source cluster.")
 @click.pass_obj
 def snapshot_group(ctx):
     """All actions related to snapshot creation"""
@@ -172,7 +159,7 @@ def status_snapshot_cmd(ctx, deep_check):
 # arguments depending on the type of backfill migration
 
 
-@cli.group(name="backfill")
+@cli.group(name="backfill", help="Commands related to controlling the configured backfill mechanism.")
 @click.pass_obj
 def backfill_group(ctx):
     """All actions related to historical/backfill data migrations"""
@@ -243,7 +230,7 @@ def status_backfill_cmd(ctx, deep_check):
 
 # ##################### REPLAY ###################
 
-@cli.group(name="replay")
+@cli.group(name="replay", help="Commands related to controlling the replayer.")
 @click.pass_obj
 def replay_group(ctx):
     """All actions related to replaying data"""
@@ -297,7 +284,7 @@ def status_replay_cmd(ctx):
 # ##################### METADATA ###################
 
 
-@cli.group(name="metadata")
+@cli.group(name="metadata", help="Commands related to migrating metadata to the target cluster.")
 @click.pass_obj
 def metadata_group(ctx):
     """All actions related to metadata migration"""
@@ -317,7 +304,7 @@ def migrate_metadata_cmd(ctx, detach):
 # ##################### METRICS ###################
 
 
-@cli.group(name="metrics")
+@cli.group(name="metrics", help="Commands related to checking metrics emitted by the capture proxy and replayer.")
 @click.pass_obj
 def metrics_group(ctx):
     if ctx.env.metrics_source is None:


### PR DESCRIPTION
### Description
Now you get to see all this helpful information:
```
root@aeda38bdc57b:~# console --help
Usage: console [OPTIONS] COMMAND [ARGS]...

Options:
  --config-file TEXT  Path to config file
  --json
  -v, --verbose       Verbosity level. Default is warn, -v is info, -vv is
                      debug.
  --help              Show this message and exit.

Commands:
  backfill    Commands related to controlling the configured backfill...
  clusters    Commands to interact with source and target clusters
  completion  Generate shell completion script and instructions for setup.
  metadata    Commands related to migrating metadata to the target cluster.
  metrics     Commands related to checking metrics emitted by the capture...
  replay      Commands related to controlling the replayer.
  snapshot    Commands to create and check status of snapshots of the...
```

Also I discovered some zombie replayer commands that are now deleted.

### Issues Resolved
n/a

### Testing


### Check List
- [ ] New functionality includes testing
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
