### PR TITLE
Two fixes to work coordination

### DIFF
--- a/RFS/src/test/java/com/rfs/cms/WorkCoordinatorTest.java
+++ b/RFS/src/test/java/com/rfs/cms/WorkCoordinatorTest.java
@@ -120,7 +120,7 @@ public class WorkCoordinatorTest {
 //        log.info("doc4="+doc4);
     }
 
-    //@Test
+    @Test
     public void testAcquireLeaseForQuery() throws Exception {
         var objMapper = new ObjectMapper();
         final var NUM_DOCS = 40;
@@ -151,8 +151,8 @@ public class WorkCoordinatorTest {
             try (var workCoordinator = new OpenSearchWorkCoordinator(httpClientSupplier.get(),
                     3600, "firstPass_NONE")) {
                 var nextWorkItem = workCoordinator.acquireNextWorkItem(Duration.ofSeconds(2));
-                log.error("Next work item picked=" + nextWorkItem);
-                Assertions.assertNull(nextWorkItem);
+                log.atInfo().setMessage(()->"Next work item picked=" + nextWorkItem).log();
+                Assertions.assertInstanceOf(IWorkCoordinator.NoAvailableWorkToBeDone.class, nextWorkItem);
             }
 
             Thread.sleep(expiration.multipliedBy(2).toMillis());
@@ -187,7 +187,7 @@ public class WorkCoordinatorTest {
 
                         @Override
                         public String onAcquiredWork(IWorkCoordinator.WorkItemAndDuration workItem) throws IOException {
-                            log.error("Next work item picked=" + workItem);
+                            log.info("Next work item picked=" + workItem);
                             Assertions.assertNotNull(workItem);
                             Assertions.assertNotNull(workItem.workItemId);
                             Assertions.assertTrue(workItem.leaseExpirationTime.isAfter(Instant.now()));


### PR DESCRIPTION
### Description

Make the check for the setup index more reliable and only scan for work that is currently expired.

The HEAD check has now been rolled into the doUntil block for running setup() so that even 400s from the PUT command can be ignored and retried again in a sane manner.  The HEAD call should be the authoritative call when it returns 200. The second fix is for searching for items to update.  I had been searching for items that weren't even updated yet, causing a lot more pressure to create false positives and inefficiencies all around.

* Category Bug fix
* Why these changes are required? Too much contention/no guarantee on convergence for RFS Work coordination.
* What is the old behavior before changes and new behavior after changes? Lots of thrashing to setup an initial index and a large number of PotentialClockDriftDetectedExceptions bleeding upward.

### Issues Resolved
https://opensearch.atlassian.net/browse/MIGRATIONS-1810

### Testing
Manual/gradle build

### Check List
- [ ] New functionality includes testing
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
