### PR TITLE
[Console] Remove all duplicate replayer references

### DIFF
--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/cli.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/cli.py
@@ -119,20 +119,6 @@ def clear_indices_cmd(ctx, acknowledge_risk, cluster):
         else:
             click.echo("Aborting command.")
 
-# ##################### REPLAYER ###################
-
-
-@cli.group(name="replayer")
-@click.pass_obj
-def replayer_group(ctx):
-    if ctx.env.replayer is None:
-        raise click.UsageError("Replayer is not set")
-
-
-@replayer_group.command(name="start")
-@click.pass_obj
-def start_replayer_cmd(ctx):
-    ctx.env.replayer.start()
 
 # ##################### SNAPSHOT ###################
 

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/environment.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/environment.py
@@ -31,7 +31,6 @@ def get_replayer(config: Dict):
 SCHEMA = {
     "source_cluster": {"type": "dict", "required": False},
     "target_cluster": {"type": "dict", "required": True},
-    "replayer": {"type": "dict", "required": False},
     "backfill": {"type": "dict", "required": False},
     "metrics_source": {"type": "dict", "required": False},
     "snapshot": {"type": "dict", "required": False},


### PR DESCRIPTION
### Description
Bug came up in a demo test run where the command `console replayer start` was available but didn't work. This command shouldn't even be available, the correct one is `console replay start`. There was some code from a much earlier prototype of replayer control left in that caused this.

Removing all references to it now.

### Issues Resolved
[List any issues this PR will resolve]

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]

### Check List
- [ ] New functionality includes testing
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
