### PR TITLE
Enable gradle caching over the whole project

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -63,6 +63,7 @@ jobs:
       - uses: gradle/actions/setup-gradle@v3
         with:
           gradle-version: ${{ env.gradle-version }}
+          gradle-home-cache-cleanup: true
       - name: Run Gradle Build
         run: ./gradlew build -x test -x TrafficCapture:dockerSolution:build --scan --stacktrace
         env:
@@ -182,7 +183,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Build Docker Image
         run: docker build -t migrations/fetch-migration -f Dockerfile .
-  
+
   all-ci-checks-pass:
     needs:
       - cdk-tests

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.caching=true


### PR DESCRIPTION
### Description
Now that we have multiple projects on the base, moving the TrafficCapture gradle properties to the top level will enable caching over the whole project so code changes in RFS don't trigger a rebuild of traffic capture
 
* Category: Enhancement
* Why these changes are required? Faster build and test times
* What is the old behavior before changes and new behavior after changes? GHA took ~30 min. We will see how long they take after this change is merged

### Issues Resolved
N/A - Teammate request

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
GHA, Local Building

### Check List
- [x] New functionality includes testing
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
