### PR TITLE
Updated RFS Doc Migration main() to use local snapshot

### DIFF
--- a/DocumentsFromSnapshotMigration/build.gradle
+++ b/DocumentsFromSnapshotMigration/build.gradle
@@ -148,10 +148,6 @@ test {
 }
 
 task slowTest(type: Test) {
-    doFirst {
-        println "Running slow tests..."
-    }
-
     useJUnitPlatform()
     dependsOn(':TrafficCapture:dockerSolution:buildDockerImage_elasticsearchTestConsole')
     jacoco {
@@ -163,7 +159,7 @@ task slowTest(type: Test) {
         showExceptions true
         showCauses true
         showStackTraces true
-        // showStandardStreams = true
+        // showStandardStreams true
     }
     reports {
         html.required = true
@@ -174,8 +170,6 @@ task slowTest(type: Test) {
 jacocoTestReport {
     dependsOn slowTest
     reports {
-        xml.required = true
-        xml.destination file("${buildDir}/reports/jacoco/test/jacocoTestReport.xml")
         html.required = true
         html.destination file("${buildDir}/reports/jacoco/test/html")
     }

--- a/DocumentsFromSnapshotMigration/build.gradle
+++ b/DocumentsFromSnapshotMigration/build.gradle
@@ -148,10 +148,26 @@ test {
 }
 
 task slowTest(type: Test) {
+    doFirst {
+        println "Running slow tests..."
+    }
+
     useJUnitPlatform()
     dependsOn(':TrafficCapture:dockerSolution:buildDockerImage_elasticsearchTestConsole')
     jacoco {
         enabled = true
+    }
+    testLogging {
+        events "passed", "skipped", "failed"
+        exceptionFormat "full"
+        showExceptions true
+        showCauses true
+        showStackTraces true
+        // showStandardStreams = true
+    }
+    reports {
+        html.required = true
+        html.destination file("${buildDir}/reports/tests/slowTest")
     }
 }
 

--- a/DocumentsFromSnapshotMigration/src/main/java/com/rfs/RfsMigrateDocuments.java
+++ b/DocumentsFromSnapshotMigration/src/main/java/com/rfs/RfsMigrateDocuments.java
@@ -2,6 +2,7 @@ package com.rfs;
 
 import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
+import com.beust.jcommander.ParameterException;
 
 import java.io.IOException;
 import java.net.URI;
@@ -22,6 +23,7 @@ import com.rfs.worker.ShardWorkPreparer;
 
 import com.rfs.common.DefaultSourceRepoAccessor;
 import com.rfs.common.DocumentReindexer;
+import com.rfs.common.FileSystemRepo;
 import com.rfs.common.IndexMetadata;
 import com.rfs.common.LuceneDocumentsReader;
 import com.rfs.common.OpenSearchClient;
@@ -49,20 +51,33 @@ public class RfsMigrateDocuments {
                 description = "The name of the snapshot to migrate")
         public String snapshotName;
 
+        @Parameter(names = {"--snapshot-local-dir"},
+                required = false,
+                description = ("The absolute path to the directory on local disk where the snapshot exists.  Use this parameter"
+                    + " if have a copy of the snapshot disk.  Mutually exclusive with --s3-local-dir, --s3-repo-uri, and --s3-region."
+                ))
+        public String snapshotLocalDirPath = null;
+
         @Parameter(names = {"--s3-local-dir"},
-                required = true,
-                description = "The absolute path to the directory on local disk to download S3 files to")
-        public String s3LocalDirPath;
+                required = false,
+                description = ("The absolute path to the directory on local disk to download S3 files to.  If you supply this, you must"
+                    + " also supply --s3-repo-uri and --s3-region.  Mutually exclusive with --snapshot-local-dir."
+                ))
+        public String s3LocalDirPath = null;
 
         @Parameter(names = {"--s3-repo-uri"},
-                required = true,
-                description = "The S3 URI of the snapshot repo, like: s3://my-bucket/dir1/dir2")
-        public String s3RepoUri;
+                required = false,
+                description = ("The S3 URI of the snapshot repo, like: s3://my-bucket/dir1/dir2.  If you supply this, you must"
+                    + " also supply --s3-local-dir and --s3-region.  Mutually exclusive with --snapshot-local-dir."
+                ))
+        public String s3RepoUri = null;
 
         @Parameter(names = {"--s3-region"},
-                required = true,
-                description = "The AWS Region the S3 bucket is in, like: us-east-2")
-        public String s3Region;
+                required = false,
+                description = ("The AWS Region the S3 bucket is in, like: us-east-2.  If you supply this, you must"
+                    + " also supply --s3-local-dir and --s3-repo-uri.  Mutually exclusive with --snapshot-local-dir."
+                ))
+        public String s3Region = null;
 
         @Parameter(names = {"--lucene-dir"},
                 required = true,
@@ -97,13 +112,33 @@ public class RfsMigrateDocuments {
         }
     }
 
+    public static void validateArgs(Args args) {
+        boolean isSnapshotLocalDirProvided = args.snapshotLocalDirPath != null;
+        boolean areAllS3ArgsProvided = args.s3LocalDirPath != null && args.s3RepoUri != null && args.s3Region != null;
+        boolean areAnyS3ArgsProvided = args.s3LocalDirPath != null || args.s3RepoUri != null || args.s3Region != null;
+
+        if (isSnapshotLocalDirProvided && areAnyS3ArgsProvided) {
+            throw new ParameterException("You must provide either --snapshot-local-dir or --s3-local-dir, --s3-repo-uri, and --s3-region, but not both.");
+        }
+
+        if (areAnyS3ArgsProvided && !areAllS3ArgsProvided) {
+            throw new ParameterException("If provide the S3 Snapshot args, you must provide all of them (--s3-local-dir, --s3-repo-uri and --s3-region).");
+        }
+
+        if (!isSnapshotLocalDirProvided && !areAllS3ArgsProvided) {
+            throw new ParameterException("You must provide either --snapshot-local-dir or --s3-local-dir, --s3-repo-uri, and --s3-region.");
+        }
+
+    }
+
     public static void main(String[] args) throws Exception {
-        // Grab out args
         Args arguments = new Args();
         JCommander.newBuilder()
                 .addObject(arguments)
                 .build()
                 .parse(args);
+
+        validateArgs(arguments);
 
         var luceneDirPath = Paths.get(arguments.luceneDirPath);
         try (var processManager = new LeaseExpireTrigger(workItemId->{
@@ -120,8 +155,16 @@ public class RfsMigrateDocuments {
                         new OpenSearchClient(arguments.targetHost, arguments.targetUser, arguments.targetPass, false);
                 DocumentReindexer reindexer = new DocumentReindexer(targetClient);
 
-                SourceRepo sourceRepo = S3Repo.create(Paths.get(arguments.s3LocalDirPath),
-                        new S3Uri(arguments.s3RepoUri), arguments.s3Region);
+                SourceRepo sourceRepo;
+                if (arguments.snapshotLocalDirPath == null) {
+                    sourceRepo = S3Repo.create(
+                        Paths.get(arguments.s3LocalDirPath),
+                        new S3Uri(arguments.s3RepoUri),
+                        arguments.s3Region
+                    );
+                } else {
+                    sourceRepo = new FileSystemRepo(Paths.get(arguments.snapshotLocalDirPath));
+                }
                 SnapshotRepo.Provider repoDataProvider = new SnapshotRepoProvider_ES_7_10(sourceRepo);
 
                 IndexMetadata.Factory indexMetadataFactory = new IndexMetadataFactory_ES_7_10(repoDataProvider);

--- a/RFS/build.gradle
+++ b/RFS/build.gradle
@@ -115,8 +115,8 @@ test {
     }
 
     testLogging {
-        exceptionFormat = 'full'
-        events "failed"
+        events "passed", "skipped", "failed"
+        exceptionFormat "full"
         showExceptions true
         showCauses true
         showStackTraces true


### PR DESCRIPTION
### Description
* Updated the `RfsMigrateDocuments.java` entrypoint to accept a local snapshot
* Added a new, local test that runs the full `RfsMigrateDocuments.java` against local target/source in Docker containers and a local snapshot.  The test asserts that the process exits with the expected status code.

### Issues Resolved
* https://opensearch.atlassian.net/browse/MIGRATIONS-1807
* https://opensearch.atlassian.net/browse/MIGRATIONS-1809

### Testing
Ran the new tests using `gradle DocumentsFromSnapshotMigration:slowTest`

### Check List
- [X] New functionality includes testing
  - [X] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
