### PR TITLE
Disable Mend and report success

### DIFF
--- a/.whitesource
+++ b/.whitesource
@@ -1,23 +1,22 @@
 {
   "scanSettings": {
-    "configMode": "LOCAL",
-    "configExternalURL": "",
+    "configMode": "AUTO",
     "projectToken": "",
-    "baseBranches": []
+    "baseBranches": ["main"],
+    "skipScanningStage":     {
+      "connectivity": ["maven", "npm", "nuget-csproj", "nuget-packages", "pip", "yarn"],
+      "config": ["maven", "npm", "nuget-csproj", "nuget-packages", "pip", "yarn"],
+      "preStep": ["maven", "npm", "nuget-csproj", "nuget-packages", "pip", "yarn"]
+    } 
+
   },
   "checkRunSettings": {
-    "vulnerableCheckRunConclusionLevel": "failure",
-    "displayMode": "diff",
+    "vulnerableCheckRunConclusionLevel": "none",
+    "displayMode": "baseline",
     "useMendCheckNames": true,
-    "strictMode" : "failure"
+    "strictMode" : "none"
   },
   "issueSettings": {
-    "minSeverityLevel": "LOW",
-    "issueType": "DEPENDENCY"
-  },
-  "remediateSettings": {
-    "workflowRules": {
-      "enabled": true
-    }
+    "minSeverityLevel": "NONE"
   }
 }


### PR DESCRIPTION
### Description
Mend has been failing without clear reasons and after many iterations through the debug cycle and we'd rather have reliable information, disabling the status checks on pull requests/pushes.

### Check List
- [ ] New functionality includes testing
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
