### PR TITLE
[Console] Check whether working state index exists before querying

### DIFF
--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/backfill_rfs.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/backfill_rfs.py
@@ -1,6 +1,8 @@
 from datetime import datetime
 from typing import Dict, Optional
 
+import requests
+
 from console_link.models.backfill_base import Backfill, BackfillStatus
 from console_link.models.cluster import Cluster
 from console_link.models.schema_tools import contains_one_of
@@ -76,6 +78,12 @@ class DockerRFSBackfill(RFSBackfill):
         self.target_cluster = target_cluster
         self.docker_config = self.config["reindex_from_snapshot"]["docker"]
 
+    def get_status(self, *args, **kwargs) -> CommandResult:
+        return CommandResult(True, (BackfillStatus.RUNNING, "This is my running state message"))
+
+    def scale(self, units: int, *args, **kwargs) -> CommandResult:
+        raise NotImplementedError()
+
 
 class ECSRFSBackfill(RFSBackfill):
     def __init__(self, config: Dict, target_cluster: Cluster) -> None:
@@ -122,6 +130,13 @@ class ECSRFSBackfill(RFSBackfill):
         return CommandResult(True, (BackfillStatus.STOPPED, status_string))
 
     def _get_detailed_status(self) -> Optional[str]:
+        # Check whether the working state index exists. If not, we can't run queries.
+        try:
+            self.target_cluster.call_api("/.migrations_working_state")
+        except requests.exceptions.RequestException:
+            logger.warning("Working state index does not yet exist, deep status checks can't be performed.")
+            return None
+
         current_epoch_seconds = int(datetime.now().timestamp())
         incomplete_query = {"query": {
             "bool": {"must_not": [{"exists": {"field": "completedAt"}}]}


### PR DESCRIPTION
### Description
There was a bug in the `console backfill status --deep-check` command implementation where--if it were called before the working state index was created--it would give a very messy output like:
```
root@ip-12-0-2-195:~# console backfill status --deep-check
ERROR:console_link.models.backfill_rfs:Failed to execute query: 404 Client Error: Not Found for url: [https://vpc-storage-optimized-wdbsagz46uj6ptkjxjwwsmnhgm.us-east-2.es.amazonaws.com:443/.migrations_working_state/_search](https://vpc-storage-optimized-wdbsagz46uj6ptkjxjwwsmnhgm.us-east-2.es.amazonaws.com/.migrations_working_state/_search)
ERROR:console_link.models.backfill_rfs:Failed to execute query: 404 Client Error: Not Found for url: [https://vpc-storage-optimized-wdbsagz46uj6ptkjxjwwsmnhgm.us-east-2.es.amazonaws.com:443/.migrations_working_state/_search](https://vpc-storage-optimized-wdbsagz46uj6ptkjxjwwsmnhgm.us-east-2.es.amazonaws.com/.migrations_working_state/_search)
ERROR:console_link.models.backfill_rfs:Failed to execute query: 404 Client Error: Not Found for url: [https://vpc-storage-optimized-wdbsagz46uj6ptkjxjwwsmnhgm.us-east-2.es.amazonaws.com:443/.migrations_working_state/_search](https://vpc-storage-optimized-wdbsagz46uj6ptkjxjwwsmnhgm.us-east-2.es.amazonaws.com/.migrations_working_state/_search)
ERROR:console_link.models.backfill_rfs:Failed to execute query: 404 Client Error: Not Found for url: [https://vpc-storage-optimized-wdbsagz46uj6ptkjxjwwsmnhgm.us-east-2.es.amazonaws.com:443/.migrations_working_state/_search](https://vpc-storage-optimized-wdbsagz46uj6ptkjxjwwsmnhgm.us-east-2.es.amazonaws.com/.migrations_working_state/_search)
ERROR:console_link.models.backfill_rfs:Failed to execute query: 404 Client Error: Not Found for url: [https://vpc-storage-optimized-wdbsagz46uj6ptkjxjwwsmnhgm.us-east-2.es.amazonaws.com:443/.migrations_working_state/_search](https://vpc-storage-optimized-wdbsagz46uj6ptkjxjwwsmnhgm.us-east-2.es.amazonaws.com/.migrations_working_state/_search)
WARNING:console_link.models.backfill_rfs:Failed to get values for some queries: {'total': None, 'completed': None, 'incomplete': None, 'in progress': None, 'unclaimed': None}
BackfillStatus.STARTING
Running=0
Pending=1
Desired=1
```

This PR fixes it by checking whether the index exists before it runs any of the detailed status queries.

### Issues Resolved
https://opensearch.atlassian.net/browse/MIGRATIONS-1819

### Testing
A unit test

### Check List
- [x] New functionality includes testing
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
