### PR TITLE
Python -- Sort our imports and add to CI & precommit hook

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -22,9 +22,13 @@ jobs:
        run: |
         python -m pip install --upgrade pip
         pip install flake8
+        pip install isort
      - name: Analysing the code with flake8
        run: |
         flake8 $(git ls-files '*.py')
+     - name: Checking import sorting
+       run: |
+        isort . --check --diff
 
   python-tests:
     runs-on: ubuntu-latest

--- a/FetchMigration/python/endpoint_utils.py
+++ b/FetchMigration/python/endpoint_utils.py
@@ -10,10 +10,9 @@
 import re
 from typing import Optional, Union
 
-from requests_aws4auth import AWS4Auth
 from botocore.session import Session
-
 from endpoint_info import EndpointInfo
+from requests_aws4auth import AWS4Auth
 
 # Constants
 SOURCE_KEY = "source"

--- a/FetchMigration/python/fetch_orchestrator.py
+++ b/FetchMigration/python/fetch_orchestrator.py
@@ -16,11 +16,10 @@ import subprocess
 import sys
 from typing import Optional
 
-import yaml
-
 import endpoint_utils
 import metadata_migration
 import migration_monitor
+import yaml
 from fetch_orchestrator_params import FetchOrchestratorParams
 from metadata_migration_params import MetadataMigrationParams
 from migration_monitor_params import MigrationMonitorParams

--- a/FetchMigration/python/index_diff.py
+++ b/FetchMigration/python/index_diff.py
@@ -8,7 +8,7 @@
 #
 
 import utils
-from index_management import SETTINGS_KEY, MAPPINGS_KEY
+from index_management import MAPPINGS_KEY, SETTINGS_KEY
 
 
 # Computes and captures differences in indices between a "source" cluster

--- a/FetchMigration/python/index_management.py
+++ b/FetchMigration/python/index_management.py
@@ -11,7 +11,6 @@ from typing import Optional
 
 import jsonpath_ng
 import requests
-
 from component_template_info import ComponentTemplateInfo
 from endpoint_info import EndpointInfo
 from exceptions import IndexManagementError, RequestError

--- a/FetchMigration/python/metadata_migration.py
+++ b/FetchMigration/python/metadata_migration.py
@@ -10,11 +10,10 @@
 import argparse
 import logging
 
-import yaml
-
 import endpoint_utils
 import index_management
 import utils
+import yaml
 from endpoint_info import EndpointInfo
 from exceptions import MetadataMigrationError
 from index_diff import IndexDiff

--- a/FetchMigration/python/migration_monitor.py
+++ b/FetchMigration/python/migration_monitor.py
@@ -12,15 +12,14 @@ import logging
 import subprocess
 import time
 from subprocess import Popen
-from typing import Optional, List
+from typing import List, Optional
 
 import requests
-from prometheus_client import Metric
-from prometheus_client.parser import text_string_to_metric_families
-
 from endpoint_info import EndpointInfo
 from migration_monitor_params import MigrationMonitorParams
 from progress_metrics import ProgressMetrics
+from prometheus_client import Metric
+from prometheus_client.parser import text_string_to_metric_families
 
 # Path to the Data Prepper Prometheus metrics API endpoint
 # Used to monitor the progress of the migration

--- a/FetchMigration/python/tests/test_endpoint_utils.py
+++ b/FetchMigration/python/tests/test_endpoint_utils.py
@@ -14,10 +14,9 @@ import unittest
 from typing import Optional
 from unittest.mock import MagicMock, patch
 
-from moto import mock_aws
-
 import endpoint_utils
 from endpoint_info import EndpointInfo
+from moto import mock_aws
 from tests import test_constants
 
 # Constants

--- a/FetchMigration/python/tests/test_fetch_orchestrator.py
+++ b/FetchMigration/python/tests/test_fetch_orchestrator.py
@@ -12,7 +12,7 @@ import logging
 import os
 import unittest
 from unittest import mock
-from unittest.mock import patch, MagicMock, ANY, mock_open
+from unittest.mock import ANY, MagicMock, mock_open, patch
 
 import fetch_orchestrator as orchestrator
 from fetch_orchestrator_params import FetchOrchestratorParams

--- a/FetchMigration/python/tests/test_index_management.py
+++ b/FetchMigration/python/tests/test_index_management.py
@@ -10,15 +10,14 @@
 import copy
 import unittest
 
+import index_management
 import requests
 import responses
-from responses import matchers
-
-import index_management
 from component_template_info import ComponentTemplateInfo
 from endpoint_info import EndpointInfo
 from exceptions import IndexManagementError, RequestError
 from index_template_info import IndexTemplateInfo
+from responses import matchers
 from tests import test_constants
 
 

--- a/FetchMigration/python/tests/test_metadata_migration.py
+++ b/FetchMigration/python/tests/test_metadata_migration.py
@@ -11,11 +11,10 @@ import copy
 import logging
 import pickle
 import unittest
-from unittest.mock import patch, MagicMock, ANY
-
-import requests
+from unittest.mock import ANY, MagicMock, patch
 
 import metadata_migration
+import requests
 from endpoint_info import EndpointInfo
 from exceptions import MetadataMigrationError
 from index_doc_count import IndexDocCount

--- a/FetchMigration/python/tests/test_migration_monitor.py
+++ b/FetchMigration/python/tests/test_migration_monitor.py
@@ -10,15 +10,14 @@
 import logging
 import subprocess
 import unittest
-from unittest.mock import patch, MagicMock, PropertyMock, ANY
-
-import requests
-import responses
-from prometheus_client.parser import text_string_to_metric_families
+from unittest.mock import ANY, MagicMock, PropertyMock, patch
 
 import migration_monitor
+import requests
+import responses
 from endpoint_info import EndpointInfo
 from migration_monitor_params import MigrationMonitorParams
+from prometheus_client.parser import text_string_to_metric_families
 
 # Constants
 TEST_ENDPOINT = "test"

--- a/TrafficCapture/dockerSolution/otelConfigs/consConfigSnippets.py
+++ b/TrafficCapture/dockerSolution/otelConfigs/consConfigSnippets.py
@@ -1,5 +1,6 @@
-import sys
 import subprocess
+import sys
+
 import yaml
 
 

--- a/TrafficCapture/dockerSolution/src/main/docker/elasticsearchTestConsole/testDocumentGenerator.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/elasticsearchTestConsole/testDocumentGenerator.py
@@ -1,14 +1,15 @@
 #!/usr/bin/env python
-import sys
-import requests
-import time
 import argparse
-from datetime import datetime
-import urllib3
-import os
-from collections import deque
-import logging
 import json
+import logging
+import os
+import sys
+import time
+from collections import deque
+from datetime import datetime
+
+import requests
+import urllib3
 
 # Disable InsecureRequestWarning
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)

--- a/TrafficCapture/dockerSolution/src/main/docker/elasticsearchTestConsole/testDocumentQuery.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/elasticsearchTestConsole/testDocumentQuery.py
@@ -1,13 +1,14 @@
 #!/usr/bin/env python
-import requests
-from datetime import datetime
 import argparse
+import logging
 import os
-import urllib3
 import time
 from collections import deque
 from concurrent import futures
-import logging
+from datetime import datetime
+
+import requests
+import urllib3
 
 # Suppress only the single InsecureRequestWarning from urllib3 needed for this script
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/console_api/console_api/apps/orchestrator/serializers.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/console_api/console_api/apps/orchestrator/serializers.py
@@ -1,5 +1,5 @@
-from rest_framework import serializers
 from console_link.models.cluster import AuthMethod
+from rest_framework import serializers
 
 
 class DataProviderSerializer(serializers.Serializer):

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/console_api/console_api/apps/orchestrator/urls.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/console_api/console_api/apps/orchestrator/urls.py
@@ -1,4 +1,5 @@
 from django.urls import path
+
 from . import views
 
 urlpatterns = [

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/console_api/console_api/apps/orchestrator/views.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/console_api/console_api/apps/orchestrator/views.py
@@ -1,15 +1,18 @@
-from console_api.apps.orchestrator.serializers import OpenSearchIngestionCreateRequestSerializer
-from console_link.models.osi_utils import (InvalidAuthParameters, create_pipeline_from_json, start_pipeline,
-                                           stop_pipeline)
+import datetime
+import logging
+from enum import Enum
+from pathlib import Path
+
+import boto3
+from console_api.apps.orchestrator.serializers import \
+    OpenSearchIngestionCreateRequestSerializer
+from console_link.models.osi_utils import (InvalidAuthParameters,
+                                           create_pipeline_from_json,
+                                           start_pipeline, stop_pipeline)
+from rest_framework import status
 from rest_framework.decorators import api_view, parser_classes
 from rest_framework.parsers import JSONParser
 from rest_framework.response import Response
-from rest_framework import status
-from pathlib import Path
-import boto3
-import datetime
-from enum import Enum
-import logging
 
 logger = logging.getLogger(__name__)
 

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/humanReadableLogs.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/humanReadableLogs.py
@@ -4,9 +4,9 @@ import argparse
 import base64
 import gzip
 import json
+import logging
 import pathlib
 from typing import Optional
-import logging
 
 from tqdm import tqdm
 from tqdm.contrib.logging import logging_redirect_tqdm

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/cli.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/cli.py
@@ -1,19 +1,18 @@
 import json
+import logging
 from pprint import pprint
-import click
-import console_link.logic.clusters as logic_clusters
-import console_link.logic.metrics as logic_metrics
-import console_link.logic.backfill as logic_backfill
-import console_link.logic.snapshot as logic_snapshot
-import console_link.logic.metadata as logic_metadata
-import console_link.logic.replay as logic_replay
 
-from console_link.models.utils import ExitCode
+import click
+import console_link.logic.backfill as logic_backfill
+import console_link.logic.clusters as logic_clusters
+import console_link.logic.metadata as logic_metadata
+import console_link.logic.metrics as logic_metrics
+import console_link.logic.replay as logic_replay
+import console_link.logic.snapshot as logic_snapshot
+from click.shell_completion import get_completion_class
 from console_link.environment import Environment
 from console_link.models.metrics_source import Component, MetricStatistic
-from click.shell_completion import get_completion_class
-
-import logging
+from console_link.models.utils import ExitCode
 
 logger = logging.getLogger(__name__)
 

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/environment.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/environment.py
@@ -1,18 +1,19 @@
 import logging
-from typing import Optional, Dict
-from console_link.models.cluster import Cluster
-from console_link.models.metrics_source import MetricsSource
-from console_link.logic.metrics import get_metrics_source
-from console_link.logic.backfill import get_backfill
-from console_link.models.backfill_base import Backfill
-from console_link.models.snapshot import FileSystemSnapshot, Snapshot, S3Snapshot
-from console_link.models.replayer_base import Replayer
-from console_link.models.replayer_ecs import ECSReplayer
-from console_link.models.kafka import Kafka, MSK, StandardKafka
+from typing import Dict, Optional
+
 import yaml
 from cerberus import Validator
-
+from console_link.logic.backfill import get_backfill
+from console_link.logic.metrics import get_metrics_source
+from console_link.models.backfill_base import Backfill
+from console_link.models.cluster import Cluster
+from console_link.models.kafka import MSK, Kafka, StandardKafka
 from console_link.models.metadata import Metadata
+from console_link.models.metrics_source import MetricsSource
+from console_link.models.replayer_base import Replayer
+from console_link.models.replayer_ecs import ECSReplayer
+from console_link.models.snapshot import (FileSystemSnapshot, S3Snapshot,
+                                          Snapshot)
 
 logger = logging.getLogger(__name__)
 

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/logic/backfill.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/logic/backfill.py
@@ -1,14 +1,14 @@
-from enum import Enum
 import json
 import logging
+from enum import Enum
 from typing import Dict, Optional, Tuple
-from console_link.models.utils import ExitCode
+
+import yaml
+from console_link.models.backfill_base import Backfill
 from console_link.models.backfill_osi import OpenSearchIngestionBackfill
 from console_link.models.backfill_rfs import DockerRFSBackfill, ECSRFSBackfill
 from console_link.models.cluster import Cluster
-from console_link.models.backfill_base import Backfill
-import yaml
-
+from console_link.models.utils import ExitCode
 
 logger = logging.getLogger(__name__)
 

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/logic/clusters.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/logic/clusters.py
@@ -1,6 +1,7 @@
-from console_link.models.cluster import Cluster, HttpMethod
-from dataclasses import dataclass
 import logging
+from dataclasses import dataclass
+
+from console_link.models.cluster import Cluster, HttpMethod
 
 logger = logging.getLogger(__name__)
 

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/logic/kafka.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/logic/kafka.py
@@ -1,6 +1,7 @@
 import logging
-from console_link.models.kafka import Kafka
+
 from console_link.models.command_result import CommandResult
+from console_link.models.kafka import Kafka
 
 logger = logging.getLogger(__name__)
 

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/logic/metadata.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/logic/metadata.py
@@ -1,8 +1,8 @@
+import logging
 from typing import Tuple
 
 from console_link.models.metadata import Metadata
 from console_link.models.utils import ExitCode, generate_log_file_path
-import logging
 
 logger = logging.getLogger(__name__)
 

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/logic/metrics.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/logic/metrics.py
@@ -1,8 +1,11 @@
-from typing import List, Tuple
-from console_link.models.metrics_source import MetricsSource, Component, MetricStatistic, PrometheusMetricsSource, \
-    CloudwatchMetricsSource
-from datetime import datetime, timedelta
 import logging
+from datetime import datetime, timedelta
+from typing import List, Tuple
+
+from console_link.models.metrics_source import (CloudwatchMetricsSource,
+                                                Component, MetricsSource,
+                                                MetricStatistic,
+                                                PrometheusMetricsSource)
 
 logger = logging.getLogger(__name__)
 

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/logic/replay.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/logic/replay.py
@@ -1,10 +1,10 @@
 import json
 import logging
 from typing import Tuple
-from console_link.models.utils import ExitCode
-from console_link.models.replayer_base import Replayer
-import yaml
 
+import yaml
+from console_link.models.replayer_base import Replayer
+from console_link.models.utils import ExitCode
 
 logger = logging.getLogger(__name__)
 

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/logic/snapshot.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/logic/snapshot.py
@@ -1,6 +1,7 @@
 import logging
-from console_link.models.snapshot import Snapshot
+
 from console_link.models.command_result import CommandResult
+from console_link.models.snapshot import Snapshot
 
 logger = logging.getLogger(__name__)
 

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/backfill_base.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/backfill_base.py
@@ -1,11 +1,10 @@
+from abc import ABC, abstractmethod
 from enum import Enum
 from typing import Dict
-from abc import ABC, abstractmethod
-
-from console_link.models.schema_tools import contains_one_of
-from console_link.models.command_result import CommandResult
 
 from cerberus import Validator
+from console_link.models.command_result import CommandResult
+from console_link.models.schema_tools import contains_one_of
 
 SCHEMA = {
     "backfill": {

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/backfill_osi.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/backfill_osi.py
@@ -1,12 +1,13 @@
-from console_link.models.osi_utils import (create_pipeline_from_env, start_pipeline, stop_pipeline,
-                                           OpenSearchIngestionMigrationProps)
-from console_link.models.cluster import Cluster
-from console_link.models.backfill_base import Backfill
-from console_link.models.command_result import CommandResult
 from typing import Dict
-from cerberus import Validator
-import boto3
 
+import boto3
+from cerberus import Validator
+from console_link.models.backfill_base import Backfill
+from console_link.models.cluster import Cluster
+from console_link.models.command_result import CommandResult
+from console_link.models.osi_utils import (OpenSearchIngestionMigrationProps,
+                                           create_pipeline_from_env,
+                                           start_pipeline, stop_pipeline)
 
 OSI_SCHEMA = {
     'pipeline_role_arn': {

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/backfill_rfs.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/backfill_rfs.py
@@ -1,15 +1,13 @@
+import logging
 from datetime import datetime
 from typing import Dict, Optional
 
+from cerberus import Validator
 from console_link.models.backfill_base import Backfill, BackfillStatus
 from console_link.models.cluster import Cluster
-from console_link.models.schema_tools import contains_one_of
 from console_link.models.command_result import CommandResult
 from console_link.models.ecs_service import ECSService
-
-from cerberus import Validator
-
-import logging
+from console_link.models.schema_tools import contains_one_of
 
 logger = logging.getLogger(__name__)
 

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/cluster.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/cluster.py
@@ -1,11 +1,12 @@
-from typing import Any, Dict, Optional
-from enum import Enum
-import requests
-from requests.auth import HTTPBasicAuth
-from cerberus import Validator
 import logging
 import subprocess
+from enum import Enum
+from typing import Any, Dict, Optional
+
+import requests
+from cerberus import Validator
 from console_link.models.schema_tools import contains_one_of
+from requests.auth import HTTPBasicAuth
 
 requests.packages.urllib3.disable_warnings()  # ignore: type
 

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/command_result.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/command_result.py
@@ -1,4 +1,4 @@
-from typing import NamedTuple, Any
+from typing import Any, NamedTuple
 
 
 class CommandResult(NamedTuple):

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/ecs_service.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/ecs_service.py
@@ -2,10 +2,8 @@ import logging
 from typing import NamedTuple, Optional
 
 import boto3
-
 from console_link.models.command_result import CommandResult
 from console_link.models.utils import AWSAPIError, raise_for_aws_api_error
-
 
 logger = logging.getLogger(__name__)
 

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/kafka.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/kafka.py
@@ -1,9 +1,9 @@
+import logging
 import subprocess
+from abc import ABC, abstractmethod
 from typing import List
 
 from cerberus import Validator
-import logging
-from abc import ABC, abstractmethod
 from console_link.models.command_result import CommandResult
 from console_link.models.schema_tools import contains_one_of
 

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/metadata.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/metadata.py
@@ -1,14 +1,15 @@
+import logging
 import os
 import subprocess
-from typing import Optional
-from cerberus import Validator
 import tempfile
-import logging
+from typing import Optional
 
+from cerberus import Validator
+from console_link.models.cluster import AuthMethod, Cluster
 from console_link.models.command_result import CommandResult
 from console_link.models.schema_tools import list_schema
-from console_link.models.cluster import AuthMethod, Cluster
-from console_link.models.snapshot import S3Snapshot, Snapshot, FileSystemSnapshot
+from console_link.models.snapshot import (FileSystemSnapshot, S3Snapshot,
+                                          Snapshot)
 
 logger = logging.getLogger(__name__)
 

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/metrics_source.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/metrics_source.py
@@ -1,15 +1,14 @@
+import logging
 from datetime import datetime
 from enum import Enum
 from typing import Any, Dict, List, Optional, Tuple
 
 import boto3
 import botocore
-from cerberus import Validator
-from console_link.models.utils import raise_for_aws_api_error
 import requests
-import logging
-
+from cerberus import Validator
 from console_link.models.schema_tools import contains_one_of
+from console_link.models.utils import raise_for_aws_api_error
 
 logger = logging.getLogger(__name__)
 

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/osi_utils.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/osi_utils.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python3
-from console_link.models.cluster import AuthMethod, Cluster
-from pathlib import Path
-from typing import List, Dict, Optional
-from urllib.parse import urlparse
 import logging
 import re
+from pathlib import Path
+from typing import Dict, List, Optional
+from urllib.parse import urlparse
+
+from console_link.models.cluster import AuthMethod, Cluster
 
 logger = logging.getLogger(__name__)
 DEFAULT_PIPELINE_NAME = "migration-assistant-pipeline"

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/replayer_base.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/replayer_base.py
@@ -1,11 +1,10 @@
+from abc import ABC, abstractmethod
 from enum import Enum
 from typing import Dict
-from abc import ABC, abstractmethod
-
-from console_link.models.schema_tools import contains_one_of
-from console_link.models.command_result import CommandResult
 
 from cerberus import Validator
+from console_link.models.command_result import CommandResult
+from console_link.models.schema_tools import contains_one_of
 
 DOCKER_REPLAY_SCHEMA = {
     "type": "dict",

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/replayer_ecs.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/replayer_ecs.py
@@ -1,9 +1,9 @@
+import logging
 from typing import Dict
+
 from console_link.models.command_result import CommandResult
 from console_link.models.ecs_service import ECSService
 from console_link.models.replayer_base import Replayer, ReplayStatus
-
-import logging
 
 logger = logging.getLogger(__name__)
 

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/snapshot.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/snapshot.py
@@ -8,7 +8,6 @@ from typing import Dict, Optional
 from cerberus import Validator
 from console_link.models.cluster import AuthMethod, Cluster, HttpMethod
 from console_link.models.command_result import CommandResult
-
 from console_link.models.schema_tools import contains_one_of
 
 logger = logging.getLogger(__name__)

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/utils.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/utils.py
@@ -1,7 +1,7 @@
 # define a custom exception for aws api errors
+from datetime import datetime
 from enum import Enum
 from typing import Dict
-from datetime import datetime
 
 
 class AWSAPIError(Exception):

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/setup.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup, find_packages  # ignore: type
+from setuptools import find_packages, setup  # ignore: type
 
 setup(
     name="console_link",

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/test_backfill.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/test_backfill.py
@@ -3,13 +3,12 @@ import pathlib
 
 import pytest
 import requests_mock
-
-from console_link.logic.backfill import get_backfill, UnsupportedBackfillTypeError
+from console_link.logic.backfill import (UnsupportedBackfillTypeError,
+                                         get_backfill)
 from console_link.models.backfill_base import Backfill, BackfillStatus
 from console_link.models.backfill_osi import OpenSearchIngestionBackfill
 from console_link.models.backfill_rfs import DockerRFSBackfill, ECSRFSBackfill
 from console_link.models.ecs_service import ECSService, InstanceStatuses
-
 from tests.utils import create_valid_cluster
 
 TEST_DATA_DIRECTORY = pathlib.Path(__file__).parent / "data"

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/test_backfill_logic.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/test_backfill_logic.py
@@ -1,11 +1,9 @@
 import pathlib
 
 import pytest
-
-from console_link.logic.backfill import get_backfill, describe
+from console_link.logic.backfill import describe, get_backfill
 from console_link.models.backfill_osi import OpenSearchIngestionBackfill
 from console_link.models.backfill_rfs import DockerRFSBackfill, ECSRFSBackfill
-
 from tests.utils import create_valid_cluster
 
 TEST_DATA_DIRECTORY = pathlib.Path(__file__).parent / "data"

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/test_backfill_osi.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/test_backfill_osi.py
@@ -1,7 +1,8 @@
-import pytest  # type: ignore
 import os
-from tests.utils import create_valid_cluster
+
+import pytest  # type: ignore
 from console_link.models.backfill_osi import OpenSearchIngestionBackfill
+from tests.utils import create_valid_cluster
 
 # Define a valid cluster configuration
 valid_osi_migration_config = {

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/test_cli.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/test_cli.py
@@ -1,16 +1,13 @@
 import pathlib
 
+import pytest
 import requests_mock
-from console_link.models.backfill_rfs import ECSRFSBackfill
-from console_link.models.ecs_service import ECSService, InstanceStatuses
-from console_link.models.command_result import CommandResult
-
+from click.testing import CliRunner
 from console_link.cli import cli
 from console_link.environment import Environment
-
-from click.testing import CliRunner
-import pytest
-
+from console_link.models.backfill_rfs import ECSRFSBackfill
+from console_link.models.command_result import CommandResult
+from console_link.models.ecs_service import ECSService, InstanceStatuses
 
 TEST_DATA_DIRECTORY = pathlib.Path(__file__).parent / "data"
 VALID_SERVICES_YAML = TEST_DATA_DIRECTORY / "services.yaml"

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/test_cluster.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/test_cluster.py
@@ -1,6 +1,6 @@
 import pytest
-from tests.utils import create_valid_cluster
 from console_link.models.cluster import AuthMethod, Cluster
+from tests.utils import create_valid_cluster
 
 # Define a valid cluster configuration
 valid_cluster_config = {

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/test_ecs.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/test_ecs.py
@@ -1,13 +1,11 @@
 import json
 import pathlib
 
-import pytest
-
 import botocore.session
+import pytest
 from botocore.stub import Stubber
-
-from console_link.models.utils import AWSAPIError
 from console_link.models.ecs_service import ECSService, InstanceStatuses
+from console_link.models.utils import AWSAPIError
 
 TEST_DATA_DIRECTORY = pathlib.Path(__file__).parent / "data"
 AWS_REGION = "us-east-1"

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/test_environment.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/test_environment.py
@@ -1,10 +1,10 @@
 import pathlib
 
+import pytest
 from console_link.environment import Environment
 from console_link.models.backfill_base import Backfill
 from console_link.models.cluster import Cluster
 from console_link.models.metrics_source import MetricsSource
-import pytest
 
 TEST_DATA_DIRECTORY = pathlib.Path(__file__).parent / "data"
 VALID_SERVICES_YAML = TEST_DATA_DIRECTORY / "services.yaml"

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/test_metrics_source.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/test_metrics_source.py
@@ -1,16 +1,17 @@
 import json
 import pathlib
 
-import requests
-from console_link.models.metrics_source import MetricsSource, CloudwatchMetricsSource, PrometheusMetricsSource, \
-    MetricStatistic, Component
-from console_link.logic.metrics import get_metrics_source, UnsupportedMetricsSourceError
-import pytest
-import requests_mock
-
 import botocore.session
+import pytest
+import requests
+import requests_mock
 from botocore.stub import Stubber
-
+from console_link.logic.metrics import (UnsupportedMetricsSourceError,
+                                        get_metrics_source)
+from console_link.models.metrics_source import (CloudwatchMetricsSource,
+                                                Component, MetricsSource,
+                                                MetricStatistic,
+                                                PrometheusMetricsSource)
 from console_link.models.utils import AWSAPIError
 
 TEST_DATA_DIRECTORY = pathlib.Path(__file__).parent / "data"
@@ -114,7 +115,9 @@ def test_cloudwatch_metrics_get_metrics_error(cw_ms, cw_stubber):
 
 # This one doesn't serialize to json nicely because of the datetime objects
 import datetime
+
 from dateutil.tz import tzutc  # type: ignore
+
 cw_get_metric_data = {
     'Messages': [],
     'MetricDataResults': [

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/test_osi_utils.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/test_osi_utils.py
@@ -1,13 +1,15 @@
+import os
 from pathlib import Path
-from botocore.stub import Stubber, ANY
+
 import botocore.session
 import pytest
-import os
-
-from console_link.models.osi_utils import (construct_pipeline_config, create_pipeline_from_json,
-                                           create_pipeline_from_env, InvalidAuthParameters,
-                                           OpenSearchIngestionMigrationProps)
+from botocore.stub import ANY, Stubber
 from console_link.models.cluster import AuthMethod
+from console_link.models.osi_utils import (InvalidAuthParameters,
+                                           OpenSearchIngestionMigrationProps,
+                                           construct_pipeline_config,
+                                           create_pipeline_from_env,
+                                           create_pipeline_from_json)
 from tests.utils import create_valid_cluster
 
 PIPELINE_TEMPLATE_PATH = f"{Path(__file__).parents[3]}/osiPipelineTemplate.yaml"

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/test_replay.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/test_replay.py
@@ -1,11 +1,10 @@
 import pathlib
 
 import pytest
-
 from console_link.environment import get_replayer
+from console_link.models.ecs_service import ECSService
 from console_link.models.replayer_base import Replayer
 from console_link.models.replayer_ecs import ECSReplayer
-from console_link.models.ecs_service import ECSService
 
 TEST_DATA_DIRECTORY = pathlib.Path(__file__).parent / "data"
 AWS_REGION = "us-east-1"

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/test_snapshot.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/test_snapshot.py
@@ -1,11 +1,13 @@
-from console_link.models.snapshot import S3Snapshot, FileSystemSnapshot, Snapshot
-from console_link.environment import get_snapshot
-from console_link.models.cluster import AuthMethod, Cluster, HttpMethod
-from console_link.logic import snapshot as snapshot_logic
-from tests.utils import create_valid_cluster
-import pytest
 import unittest.mock as mock
+
+import pytest
+from console_link.environment import get_snapshot
+from console_link.logic import snapshot as snapshot_logic
+from console_link.models.cluster import AuthMethod, Cluster, HttpMethod
 from console_link.models.command_result import CommandResult
+from console_link.models.snapshot import (FileSystemSnapshot, S3Snapshot,
+                                          Snapshot)
+from tests.utils import create_valid_cluster
 
 
 @pytest.fixture

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/utils.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/utils.py
@@ -1,5 +1,6 @@
 from typing import Dict, Optional
-from console_link.models.cluster import Cluster, AuthMethod
+
+from console_link.models.cluster import AuthMethod, Cluster
 
 
 def create_valid_cluster(endpoint: str = "https://opensearchtarget:9200",

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,7 +1,8 @@
 # conftest.py
-import pytest
-import uuid
 import logging
+import uuid
+
+import pytest
 
 
 def pytest_configure(config):

--- a/test/operations.py
+++ b/test/operations.py
@@ -1,11 +1,12 @@
 import datetime
-import random
-import string
 import json
-from requests import Session
-import shlex
-import subprocess
 import logging
+import random
+import shlex
+import string
+import subprocess
+
+from requests import Session
 
 logger = logging.getLogger(__name__)
 

--- a/test/tests.py
+++ b/test/tests.py
@@ -1,23 +1,23 @@
-import boto3
 import functools
 import json
 import logging
-import pytest
-import requests
 import secrets
 import string
-from operations import generate_large_doc
 import time
 import unittest
 from http import HTTPStatus
+from typing import Callable, Dict, List, Tuple
+
+import boto3
+import pytest
+import requests
+from operations import (check_index, create_document, create_index,
+                        delete_document, delete_index, generate_large_doc,
+                        get_document, run_migration_console_command)
 from requests import Session
 from requests.adapters import HTTPAdapter
 from requests.exceptions import ConnectionError, SSLError
 from requests_aws4auth import AWS4Auth
-from typing import Tuple, Callable, List, Dict
-
-from operations import create_index, check_index, create_document, \
-    delete_document, delete_index, get_document, run_migration_console_command
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
### Description
Sorting imports is nice because it makes it easier to find things, and makes it clear which imports are stdlib vs. 3rd party vs. project.

This is a big PR because it deals with sorting imports in all our existing files. It also adds a sorting check to our CI and our precommit hook.

### Issues Resolved
[List any issues this PR will resolve]

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]

### Check List
- [ ] New functionality includes testing
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
