### PR TITLE
Centralized Gradle behavior for sub-projects

### DIFF
--- a/CreateSnapshot/build.gradle
+++ b/CreateSnapshot/build.gradle
@@ -1,7 +1,6 @@
 plugins {
     id 'application'
     id 'java'
-    id 'jacoco'
     id 'io.freefair.lombok' version '8.6'
 }
 
@@ -25,23 +24,6 @@ dependencies {
 
 application {
     mainClassName = 'com.rfs.CreateSnapshot'
-}
-
-// Utility task to allow copying required libraries into a 'dependencies' folder for security scanning
-tasks.register('copyDependencies', Sync) {
-    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
-
-    from configurations.runtimeClasspath
-    into "${buildDir}/dependencies"
-}
-
-jacocoTestReport {
-    reports {
-        xml.required = true
-        xml.destination file("${buildDir}/reports/jacoco/test/jacocoTestReport.xml")
-        html.required = true
-        html.destination file("${buildDir}/reports/jacoco/test/html")
-    }
 }
 
 test {

--- a/DocumentsFromSnapshotMigration/build.gradle
+++ b/DocumentsFromSnapshotMigration/build.gradle
@@ -1,7 +1,6 @@
 plugins {
     id 'application'
     id 'java'
-    id 'jacoco'
     id 'io.freefair.lombok' version '8.6'
     id "com.avast.gradle.docker-compose" version "0.17.4"
     id 'com.bmuschko.docker-remote-api'
@@ -68,14 +67,6 @@ application {
 // Cleanup additional docker build directory
 clean.doFirst {
     delete project.file("./docker/build")
-}
-
-// Utility task to allow copying required libraries into a 'dependencies' folder for security scanning
-tasks.register('copyDependencies', Sync) {
-    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
-
-    from configurations.runtimeClasspath
-    into "${buildDir}/dependencies"
 }
 
 task copyDockerRuntimeJars (type: Sync) {
@@ -167,12 +158,6 @@ task slowTest(type: Test) {
     }
 }
 
-jacocoTestReport {
+tasks.named('jacocoTestReport').configure {
     dependsOn slowTest
-    reports {
-        xml.required = true
-        xml.destination file("${buildDir}/reports/jacoco/test/jacocoTestReport.xml")
-        html.required = true
-        html.destination file("${buildDir}/reports/jacoco/test/html")
-    }
 }

--- a/MetadataMigration/build.gradle
+++ b/MetadataMigration/build.gradle
@@ -1,7 +1,6 @@
 plugins {
     id 'application'
     id 'java'
-    id 'jacoco'
     id 'io.freefair.lombok' version '8.6'
 }
 
@@ -25,23 +24,6 @@ dependencies {
 
 application {
     mainClassName = 'com.rfs.MetadataMigration'
-}
-
-// Utility task to allow copying required libraries into a 'dependencies' folder for security scanning
-tasks.register('copyDependencies', Sync) {
-    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
-
-    from configurations.runtimeClasspath
-    into "${buildDir}/dependencies"
-}
-
-jacocoTestReport {
-    reports {
-        xml.required = true
-        xml.destination file("${buildDir}/reports/jacoco/test/jacocoTestReport.xml")
-        html.required = true
-        html.destination file("${buildDir}/reports/jacoco/test/html")
-    }
 }
 
 test {

--- a/RFS/build.gradle
+++ b/RFS/build.gradle
@@ -1,7 +1,6 @@
 plugins {
     id 'application'
     id 'java'
-    id 'jacoco'
     id 'io.freefair.lombok' version '8.6'
     id 'java-test-fixtures'
 }
@@ -92,23 +91,6 @@ task migrateMetadata (type: JavaExec) {
 task migrateDocuments (type: JavaExec) {
     classpath = sourceSets.main.runtimeClasspath
     mainClass = 'com.rfs.RfsMigrateDocuments'
-}
-
-// Utility task to allow copying required libraries into a 'dependencies' folder for security scanning
-tasks.register('copyDependencies', Sync) {
-    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
-
-    from configurations.runtimeClasspath
-    into "${buildDir}/dependencies"
-}
-
-jacocoTestReport {
-    reports {
-        xml.required = true
-        xml.destination file("${buildDir}/reports/jacoco/test/jacocoTestReport.xml")
-        html.required = true
-        html.destination file("${buildDir}/reports/jacoco/test/html")
-    }
 }
 
 test {

--- a/TrafficCapture/build.gradle
+++ b/TrafficCapture/build.gradle
@@ -77,14 +77,6 @@ allprojects {
             enabled = true
         }
     }
-
-    // Utility task to allow copying required libraries into a 'dependencies' folder for security scanning
-    tasks.register('copyDependencies', Copy) {
-        duplicatesStrategy = DuplicatesStrategy.EXCLUDE
-
-        from configurations.runtimeClasspath
-        into "${buildDir}/dependencies"
-    }
 }
 
 jacocoTestReport {

--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,7 @@ task buildDockerImages() {
 }
 
 subprojects {
+    apply plugin: 'jacoco'
     apply plugin: 'java'
     apply plugin: 'maven-publish'
 
@@ -86,6 +87,23 @@ subprojects {
                     name = 'staging'
                 }
             }
+        }
+    }
+
+    // Utility task to allow copying required libraries into a 'dependencies' folder for security scanning
+    tasks.register('copyDependencies', Sync) {
+        duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+
+        from configurations.runtimeClasspath
+        into "${buildDir}/dependencies"
+    }
+
+    jacocoTestReport {
+        reports {
+            xml.required = true
+            xml.destination file("${buildDir}/reports/jacoco/test/jacocoTestReport.xml")
+            html.required = true
+            html.destination file("${buildDir}/reports/jacoco/test/html")
         }
     }
 }

--- a/coreUtilities/build.gradle
+++ b/coreUtilities/build.gradle
@@ -20,7 +20,6 @@ plugins {
     id 'org.opensearch.migrations.java-library-conventions'
     id 'io.freefair.lombok'
     id 'java'
-    id 'jacoco'
     id 'java-test-fixtures'
 }
 
@@ -64,23 +63,6 @@ dependencies {
     testFixturesImplementation group: 'io.opentelemetry', name: 'opentelemetry-api'
     testFixturesImplementation group: 'io.opentelemetry', name: 'opentelemetry-sdk-testing'
     testFixturesImplementation group: 'org.slf4j', name: 'slf4j-api'
-}
-
-// Utility task to allow copying required libraries into a 'dependencies' folder for security scanning
-tasks.register('copyDependencies', Sync) {
-    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
-
-    from configurations.runtimeClasspath
-    into "${buildDir}/dependencies"
-}
-
-jacocoTestReport {
-    reports {
-        xml.required = true
-        xml.destination file("${buildDir}/reports/jacoco/test/jacocoTestReport.xml")
-        html.required = true
-        html.destination file("${buildDir}/reports/jacoco/test/html")
-    }
 }
 
 tasks.named('test') {


### PR DESCRIPTION
### Description
* Centralized behavior of the `copyDependencies` and `jacocoTestReport` at the root Gradle level, per discussion in https://github.com/opensearch-project/opensearch-migrations/pull/806

### Issues Resolved
* https://opensearch.atlassian.net/browse/MIGRATIONS-1826

### Testing
Ran `gradle transformation:test`, `gradle transformation:copyDependencies`, and `gradle transformation:jacocoTestReport` successfully

### Check List
- [ ] New functionality includes testing
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
