### PR TITLE
[1 line] Wrap awsRunIntegTests command

### DIFF
--- a/vars/defaultIntegPipeline.groovy
+++ b/vars/defaultIntegPipeline.groovy
@@ -80,7 +80,7 @@ def call(Map config = [:]) {
                                     def test_dir = "/root/lib/integ_test/integ_test"
                                     def test_result_file = "${test_dir}/reports/${uniqueId}/report.xml"
                                     def command = "pytest --log-file=${test_dir}/reports/${uniqueId}/pytest.log --junitxml=${test_result_file} ${test_dir}/replayer_tests.py --unique_id ${uniqueId} -s"
-                                    sh "sudo ./awsRunIntegTests.sh --command ${command} --test-result-file ${test_result_file} --stage ${stageId}"
+                                    sh "sudo ./awsRunIntegTests.sh --command '${command}' --test-result-file ${test_result_file} --stage ${stageId}"
                                 }
                             }
                         }


### PR DESCRIPTION
### Description
One-line fix to resolve spacing between command arguments as being separate args for script

### Issues Resolved
N/A

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
Cloud testing, successful pipeline run can be seen in Jenkins

### Check List
- [ ] New functionality includes testing
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
