### PR TITLE
Fixed incorrect documentation link

### DIFF
--- a/deployment/cdk/opensearch-service-migration/options.md
+++ b/deployment/cdk/opensearch-service-migration/options.md
@@ -42,7 +42,7 @@ These tables list all CDK context configuration values a user can specify for th
 | Name                              | Type    | Example                                               | Description                                                                                                                                                  |
 |-----------------------------------|---------|-------------------------------------------------------|:-------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | reindexFromSnapshotServiceEnabled | boolean | true                                                  | Create resources for deploying and configuring the RFS ECS service                                                                                           |
-| reindexFromSnapshotExtraArgs      | string  | "--log-level warn"                                    | Extra arguments to provide to the RFS command. This includes all parameters supported by [RFS](../../../RFS/src/main/java/com/rfs/ReindexFromSnapshot.java). |
+| reindexFromSnapshotExtraArgs      | string  | "--log-level warn"                                    | Extra arguments to provide to the RFS command. This includes all parameters supported by [RFS](../../../DocumentsFromSnapshotMigration/src/main/java/com/rfs/RfsMigrateDocuments.java). |
 | sourceClusterEndpoint             | string  | `"https://source-cluster.elb.us-east-1.endpoint.com"` | The endpoint for the source cluster from which RFS will take a snapshot                                                                                      |
 
 ### OpenSearch Domain Options


### PR DESCRIPTION
### Description
* Fixed an incorrect documentation link that was causing the link checker to fail in https://github.com/opensearch-project/opensearch-migrations/pull/813

### Issues Resolved
* https://opensearch.atlassian.net/browse/MIGRATIONS-1826

### Testing
N/A

### Check List
- [ ] New functionality includes testing
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
