### PR TITLE
[RFS] Added 7.10 and 7.17 sources to RFS EndToEndTest

### DIFF
--- a/RFS/src/main/java/com/rfs/common/OpenSearchClient.java
+++ b/RFS/src/main/java/com/rfs/common/OpenSearchClient.java
@@ -12,6 +12,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import com.rfs.common.RestClient.Response;
 import com.rfs.tracing.IRfsContexts;
 import lombok.NonNull;
 import reactor.core.publisher.Mono;
@@ -98,7 +99,7 @@ public class OpenSearchClient {
         ObjectNode settings,
         IRfsContexts.ICheckedIdempotentPutRequestContext context
     ) {
-        RestClient.Response response = client.getAsync(objectPath, context.createCheckRequestContext())
+        RestClient.Response getResponse = client.getAsync(objectPath, context.createCheckRequestContext())
             .flatMap(resp -> {
                 if (resp.code == HttpURLConnection.HTTP_NOT_FOUND || resp.code == HttpURLConnection.HTTP_OK) {
                     return Mono.just(resp);
@@ -118,8 +119,27 @@ public class OpenSearchClient {
             .retryWhen(Retry.backoff(3, Duration.ofSeconds(1)).maxBackoff(Duration.ofSeconds(10)))
             .block();
 
-        if (response.code == HttpURLConnection.HTTP_NOT_FOUND) {
-            client.put(objectPath, settings.toString(), context.createCheckRequestContext());
+        if (getResponse.code == HttpURLConnection.HTTP_NOT_FOUND) {
+            client.putAsync(objectPath, settings.toString(), context.createCheckRequestContext())
+                .flatMap(resp -> {
+                    if (resp.code == HttpURLConnection.HTTP_OK) {
+                        return Mono.just(resp);
+                    } else {
+                        String errorMessage = ("Could not create object: "
+                            + objectPath
+                            + ". Response Code: "
+                            + resp.code
+                            + ", Response Message: "
+                            + resp.message
+                            + ", Response Body: "
+                            + resp.body);
+                        return Mono.error(new OperationFailed(errorMessage, resp));
+                    }
+                })
+                .doOnError(e -> logger.error(e.getMessage()))
+                .retryWhen(Retry.backoff(3, Duration.ofSeconds(1)).maxBackoff(Duration.ofSeconds(10)))
+                .block();
+
             return Optional.of(settings);
         }
         // The only response code that can end up here is HTTP_OK, which means the object already existed

--- a/RFS/src/main/java/com/rfs/common/OpenSearchClient.java
+++ b/RFS/src/main/java/com/rfs/common/OpenSearchClient.java
@@ -12,7 +12,6 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import com.rfs.common.RestClient.Response;
 import com.rfs.tracing.IRfsContexts;
 import lombok.NonNull;
 import reactor.core.publisher.Mono;
@@ -120,22 +119,21 @@ public class OpenSearchClient {
             .block();
 
         if (getResponse.code == HttpURLConnection.HTTP_NOT_FOUND) {
-            client.putAsync(objectPath, settings.toString(), context.createCheckRequestContext())
-                .flatMap(resp -> {
-                    if (resp.code == HttpURLConnection.HTTP_OK) {
-                        return Mono.just(resp);
-                    } else {
-                        String errorMessage = ("Could not create object: "
-                            + objectPath
-                            + ". Response Code: "
-                            + resp.code
-                            + ", Response Message: "
-                            + resp.message
-                            + ", Response Body: "
-                            + resp.body);
-                        return Mono.error(new OperationFailed(errorMessage, resp));
-                    }
-                })
+            client.putAsync(objectPath, settings.toString(), context.createCheckRequestContext()).flatMap(resp -> {
+                if (resp.code == HttpURLConnection.HTTP_OK) {
+                    return Mono.just(resp);
+                } else {
+                    String errorMessage = ("Could not create object: "
+                        + objectPath
+                        + ". Response Code: "
+                        + resp.code
+                        + ", Response Message: "
+                        + resp.message
+                        + ", Response Body: "
+                        + resp.body);
+                    return Mono.error(new OperationFailed(errorMessage, resp));
+                }
+            })
                 .doOnError(e -> logger.error(e.getMessage()))
                 .retryWhen(Retry.backoff(3, Duration.ofSeconds(1)).maxBackoff(Duration.ofSeconds(10)))
                 .block();

--- a/RFS/src/main/java/com/rfs/transformers/Transformer_ES_7_10_OS_2_11.java
+++ b/RFS/src/main/java/com/rfs/transformers/Transformer_ES_7_10_OS_2_11.java
@@ -97,6 +97,6 @@ public class Transformer_ES_7_10_OS_2_11 implements Transformer {
         TransformFunctions.fixReplicasForDimensionality(newRoot, awarenessAttributeDimensionality);
 
         logger.debug("Transformed Object: " + newRoot.toString());
-        return indexData;
+        return copy;
     }
 }

--- a/RFS/src/main/java/com/rfs/version_es_6_8/IndexMetadataData_ES_6_8.java
+++ b/RFS/src/main/java/com/rfs/version_es_6_8/IndexMetadataData_ES_6_8.java
@@ -1,7 +1,6 @@
 package com.rfs.version_es_6_8;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import com.rfs.models.IndexMetadata;

--- a/RFS/src/main/java/com/rfs/version_es_6_8/IndexMetadataData_ES_6_8.java
+++ b/RFS/src/main/java/com/rfs/version_es_6_8/IndexMetadataData_ES_6_8.java
@@ -38,8 +38,7 @@ public class IndexMetadataData_ES_6_8 implements IndexMetadata {
             return mappings;
         }
 
-        ArrayNode mappingsArray = (ArrayNode) root.get("mappings");
-        ObjectNode mappingsNode = TransformFunctions.getMappingsFromBeneathIntermediate(mappingsArray);
+        ObjectNode mappingsNode = (ObjectNode) root.get("mappings");
         mappings = mappingsNode;
 
         return mappings;

--- a/RFS/src/main/java/com/rfs/version_es_7_10/IndexMetadataData_ES_7_10.java
+++ b/RFS/src/main/java/com/rfs/version_es_7_10/IndexMetadataData_ES_7_10.java
@@ -37,8 +37,7 @@ public class IndexMetadataData_ES_7_10 implements IndexMetadata {
             return mappings;
         }
 
-        ArrayNode mappingsArray = (ArrayNode) root.get("mappings");
-        ObjectNode mappingsNode = TransformFunctions.getMappingsFromBeneathIntermediate(mappingsArray);
+        ObjectNode mappingsNode = (ObjectNode) root.get("mappings");
         mappings = mappingsNode;
 
         return mappings;

--- a/RFS/src/main/java/com/rfs/version_es_7_10/IndexMetadataData_ES_7_10.java
+++ b/RFS/src/main/java/com/rfs/version_es_7_10/IndexMetadataData_ES_7_10.java
@@ -1,6 +1,5 @@
 package com.rfs.version_es_7_10;
 
-import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import com.rfs.models.IndexMetadata;

--- a/RFS/src/main/java/com/rfs/version_os_2_11/IndexCreator_OS_2_11.java
+++ b/RFS/src/main/java/com/rfs/version_os_2_11/IndexCreator_OS_2_11.java
@@ -37,7 +37,6 @@ public class IndexCreator_OS_2_11 {
         // Assemble the request body
         ObjectNode body = mapper.createObjectNode();
         body.set("aliases", indexMetadata.getAliases());
-        // Working around for missing OS_1_3 definition
         body.set("mappings", index.getMappings());
         body.set("settings", settings);
 

--- a/RFS/src/test/java/com/rfs/framework/ClusterOperations.java
+++ b/RFS/src/test/java/com/rfs/framework/ClusterOperations.java
@@ -36,7 +36,9 @@ public class ClusterOperations {
         final var repositoryJson = "{\n"
             + "  \"type\": \"fs\",\n"
             + "  \"settings\": {\n"
-            + "    \"location\": \"" + repoPath + "\",\n"
+            + "    \"location\": \""
+            + repoPath
+            + "\",\n"
             + "    \"compress\": false\n"
             + "  }\n"
             + "}";
@@ -80,7 +82,9 @@ public class ClusterOperations {
 
     public void takeSnapshot(final String snapshotName, final String indexPattern) throws IOException {
         final var snapshotJson = "{\n"
-            + "  \"indices\": \"" + indexPattern + "\",\n"
+            + "  \"indices\": \""
+            + indexPattern
+            + "\",\n"
             + "  \"ignore_unavailable\": true,\n"
             + "  \"include_global_state\": true\n"
             + "}";
@@ -160,7 +164,9 @@ public class ClusterOperations {
             + "    },"
             + "    \"mappings\": {"
             + "        \"properties\": {"
-            + "            \"" + fieldName + "\": {"
+            + "            \""
+            + fieldName
+            + "\": {"
             + "                \"type\": \"text\""
             + "            }"
             + "        }"
@@ -168,7 +174,6 @@ public class ClusterOperations {
             + "},"
             + "\"version\": 1"
             + "}";
-
 
         final var compTempUrl = clusterUrl + "/_component_template/" + componentTemplateName;
         final var createCompTempRequest = new HttpPut(compTempUrl);
@@ -184,8 +189,12 @@ public class ClusterOperations {
         }
 
         final var indexTemplateJson = "{"
-            + "\"index_patterns\": [\"" + indexPattern + "\"],"
-            + "\"composed_of\": [\"" + componentTemplateName + "\"],"
+            + "\"index_patterns\": [\""
+            + indexPattern
+            + "\"],"
+            + "\"composed_of\": [\""
+            + componentTemplateName
+            + "\"],"
             + "\"priority\": 1,"
             + "\"version\": 1"
             + "}";

--- a/RFS/src/test/java/com/rfs/integration/EndToEndTest.java
+++ b/RFS/src/test/java/com/rfs/integration/EndToEndTest.java
@@ -24,11 +24,16 @@ import com.rfs.transformers.TransformFunctions;
 import com.rfs.version_es_6_8.GlobalMetadataFactory_ES_6_8;
 import com.rfs.version_es_6_8.IndexMetadataFactory_ES_6_8;
 import com.rfs.version_es_6_8.SnapshotRepoProvider_ES_6_8;
+import com.rfs.version_es_7_10.GlobalMetadataFactory_ES_7_10;
+import com.rfs.version_es_7_10.IndexMetadataFactory_ES_7_10;
+import com.rfs.version_es_7_10.SnapshotRepoProvider_ES_7_10;
 import com.rfs.version_os_2_11.GlobalMetadataCreator_OS_2_11;
 import com.rfs.version_os_2_11.IndexCreator_OS_2_11;
 import com.rfs.worker.IndexRunner;
 import com.rfs.worker.MetadataRunner;
 import com.rfs.worker.SnapshotRunner;
+
+import lombok.SneakyThrows;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -144,52 +149,105 @@ public class EndToEndTest {
 
     @ParameterizedTest(name = "Target OpenSearch {0}")
     @ArgumentsSource(SupportedTargetCluster.class)
-    @Disabled
     public void migrateFrom_ES_v7_10(final SearchClusterContainer.Version targetVersion) throws Exception {
-        // Setup
-        // PSEUDO: Create a source cluster running ES 6.8
-
-        migrateFrom_ES_v7_X(null);
+        try (
+            final var sourceCluster = new SearchClusterContainer(SearchClusterContainer.ES_V7_10_2);
+            final var targetCluster = new SearchClusterContainer(targetVersion)
+        ) {
+            migrateFrom_ES_v7_X(sourceCluster, targetCluster);
+        }
     }
 
     @ParameterizedTest(name = "Target OpenSearch {0}")
     @ArgumentsSource(SupportedTargetCluster.class)
-    @Disabled
     public void migrateFrom_ES_v7_17(final SearchClusterContainer.Version targetVersion) throws Exception {
-        // Setup
-        // PSEUDO: Create a source cluster running ES 6.8
-
-        migrateFrom_ES_v7_X(null);
+        try (
+            final var sourceCluster = new SearchClusterContainer(SearchClusterContainer.ES_V7_17);
+            final var targetCluster = new SearchClusterContainer(targetVersion)
+        ) {
+            migrateFrom_ES_v7_X(sourceCluster, targetCluster);
+        }
     }
 
-    private void migrateFrom_ES_v7_X(final SearchClusterContainer sourceCluster) {
-        // PSEUDO: Create 2 index templates on the cluster, see
-        // https://www.elastic.co/guide/en/elasticsearch/reference/7.17/index-templates.html
-        // - logs-*
-        // - data-rolling
-        // PSEUDO: Create 5 indices on the cluster
-        // - logs-01-2345
-        // - logs-12-3456
-        // - data-rolling
-        // - playground
-        // - playground2
-        // PSEUDO: Add documents
-        // - 19x http-data docs into logs-01-2345
-        // - 23x http-data docs into logs-12-3456
-        // - 29x data-rolling
-        // - 5x geonames docs into playground
-        // - 7x geopoint into playground2
+    @SneakyThrows
+    private void migrateFrom_ES_v7_X(final SearchClusterContainer sourceCluster, final SearchClusterContainer targetCluster) {
 
-        // PSEUDO: Create a target cluster running OS 2.X (Where x is the latest released version)
+        var snapshotContext = SnapshotTestContext.factory().noOtelTracking();
+        var metadataContext = MetadataMigrationTestContext.factory().noOtelTracking();
+
+        // ACTION: Set up the source/target clusters
+        var bothClustersStarted = CompletableFuture.allOf(
+            CompletableFuture.runAsync(() -> sourceCluster.start()),
+            CompletableFuture.runAsync(() -> targetCluster.start())
+        );
+        bothClustersStarted.join();
+
+        // Create the component and index templates
+        var sourceClusterOperations = new ClusterOperations(sourceCluster.getUrl());
+        var compoTemplateName = "simple_component_template";
+        var indexTemplateName = "simple_index_template";
+        sourceClusterOperations.createES7Templates(compoTemplateName, indexTemplateName, "author", "blog*");
+        var indexName = "blog_2023";
+
+        // Creates a document that uses the template
+        sourceClusterOperations.createDocument(indexName, "222", "{\"author\":\"Tobias Funke\"}");
+
+        // ACTION: Take a snapshot
+        var snapshotName = "my_snap";
+        var sourceClient = new OpenSearchClient(sourceCluster.getUrl(), null, null, true);
+        var snapshotCreator = new FileSystemSnapshotCreator(
+            snapshotName,
+            sourceClient,
+            SearchClusterContainer.CLUSTER_SNAPSHOT_DIR,
+            snapshotContext.createSnapshotCreateContext()
+        );
+        SnapshotRunner.runAndWaitForCompletion(snapshotCreator);
+        sourceCluster.copySnapshotData(localDirectory.toString());
+
+        var sourceRepo = new FileSystemRepo(localDirectory.toPath());
+        var targetClient = new OpenSearchClient(targetCluster.getUrl(), null, null, true);
+
+        // ACTION: Migrate the templates
+        var repoDataProvider = new SnapshotRepoProvider_ES_7_10(sourceRepo);
+        var metadataFactory = new GlobalMetadataFactory_ES_7_10(repoDataProvider);
+        var metadataCreator = new GlobalMetadataCreator_OS_2_11(
+            targetClient,
+            List.of(),
+            List.of(compoTemplateName),
+            List.of(indexTemplateName),
+            metadataContext.createMetadataMigrationContext()
+        );
+        var transformer = TransformFunctions.getTransformer(ClusterVersion.ES_7_10, ClusterVersion.OS_2_11, 1);
+        new MetadataRunner(snapshotName, metadataFactory, metadataCreator, transformer).migrateMetadata();
+
+        // Check that the templates were migrated
+        var targetClusterOperations = new ClusterOperations(targetCluster.getUrl());
+        var res = targetClusterOperations.get("/_index_template/" + indexTemplateName);
+        assertThat(res.getValue(), res.getKey(), equalTo(200));
+        assertThat(res.getValue(), Matchers.containsString("composed_of\":[\"" + compoTemplateName + "\"]"));
+
+        // ACTION: Migrate the indices
+        res = targetClusterOperations.get("/" + indexName);
+        assertThat("Shouldn't exist yet, body:\n" + res.getValue(), res.getKey(), equalTo(404));
+
+        var indexMetadataFactory = new IndexMetadataFactory_ES_7_10(repoDataProvider);
+        var indexCreator = new IndexCreator_OS_2_11(targetClient);
+        new IndexRunner(
+            snapshotName,
+            indexMetadataFactory,
+            indexCreator,
+            transformer,
+            List.of(),
+            metadataContext.createIndexContext()
+        ).migrateIndices();
+
+        // Check that the index was migrated
+        res = targetClusterOperations.get("/" + indexName);
+        assertThat(res.getValue(), res.getKey(), equalTo(200));
 
         // Action
-        // PSEUDO: Migrate from the snapshot
-        // simpleRfsInstance.fullMigrationViaLocalSnapshot(targetCluster.toString());
-        // PSEUDO: Shutdown source cluster
-
-        // Validation
-
-        // PSEUDO: Verify creation of 2 index templates on the clustqer
+        // PSEUDO Migrate documents
+        // PSEUDO: Verify creation of 2 index templates on the cluster
         // PSEUDO: Verify creation of 5 indices on the cluster
         // - logs-01-2345
         // - logs-12-3456
@@ -199,7 +257,9 @@ public class EndToEndTest {
         // PSEUDO: Verify documents
 
         // PSEUDO: Additional validation:
-        // - Mapping type parameter is removed
-        //
+        if (SearchClusterContainer.OS_V2_14_0.equals(targetCluster.getVersion())) {
+            // - Mapping type parameter is removed
+            // https://opensearch.org/docs/latest/breaking-changes/#remove-mapping-types-parameter
+        }
     }
 }

--- a/RFS/src/test/java/com/rfs/integration/EndToEndTest.java
+++ b/RFS/src/test/java/com/rfs/integration/EndToEndTest.java
@@ -5,7 +5,6 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 import org.hamcrest.Matchers;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ArgumentsSource;
@@ -32,7 +31,6 @@ import com.rfs.version_os_2_11.IndexCreator_OS_2_11;
 import com.rfs.worker.IndexRunner;
 import com.rfs.worker.MetadataRunner;
 import com.rfs.worker.SnapshotRunner;
-
 import lombok.SneakyThrows;
 
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -170,7 +168,10 @@ public class EndToEndTest {
     }
 
     @SneakyThrows
-    private void migrateFrom_ES_v7_X(final SearchClusterContainer sourceCluster, final SearchClusterContainer targetCluster) {
+    private void migrateFrom_ES_v7_X(
+        final SearchClusterContainer sourceCluster,
+        final SearchClusterContainer targetCluster
+    ) {
 
         var snapshotContext = SnapshotTestContext.factory().noOtelTracking();
         var metadataContext = MetadataMigrationTestContext.factory().noOtelTracking();

--- a/RFS/src/testFixtures/java/com/rfs/framework/SearchClusterContainer.java
+++ b/RFS/src/testFixtures/java/com/rfs/framework/SearchClusterContainer.java
@@ -53,6 +53,7 @@ public class SearchClusterContainer extends GenericContainer<SearchClusterContai
         }
     }
 
+    @Getter
     private final Version version;
 
     @SuppressWarnings("resource")


### PR DESCRIPTION
### Description
* Updated the RFS EndToEnd test to run 7.10 and 7.17 sources
* Fixed a bug in the `OpenSearchClient` where it would consider any response in the final `put` of  `createObjectIdempotent` successful
* Fixed a bug in `Transformer_ES_7_10_OS_2_11` where we were returning the wrong object from the `transformIndexMetadata` method
* Did NOT update the end-to-end tests to perform document migration yet in order to reduce the scope of this particular PR.

### Issues Resolved
* https://opensearch.atlassian.net/browse/MIGRATIONS-1857

### Testing
* Ran the various local tests

### Check List
- [X] New functionality includes testing
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
