### PR TITLE
Fix spotless check ignore build and dependency directories

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,7 @@ task buildDockerImages() {
 spotless {
     format 'misc', {
         target '**/*.gradle', '.gitattributes', '.gitignore'
+        targetExclude '**/build/**'
         trimTrailingWhitespace()
         indentWithSpaces()
         endWithNewline()
@@ -19,6 +20,7 @@ spotless {
     }
     yaml {
         target '**/*.yml'
+        targetExclude '**/node_modules/**', '**/opensearch-cluster-cdk/**', '**/cdk.out/**'
         trimTrailingWhitespace()
         indentWithSpaces()
         endWithNewline()
@@ -34,6 +36,7 @@ subprojects {
     spotless {
         java {
             target "**/*.java"
+            targetExclude '**/build/**'
             importOrder(
                 'java|javax',
                 'io.opentelemetry|com.google|com.fasterxml|org.apache|org.hamcrest|org.junit',


### PR DESCRIPTION
### Description
Currently, spotless checks build and dependency directories (opensearch-cluster-cdk and node_modules). This can cause a failure if they are pulled through a build before the check is run.
* Category: Bug fix
* Why these changes are required? Spotless failing on non-clean workspace
* What is the old behavior before changes and new behavior after changes? Spotless fails on some yaml failures, not anymore

### Issues Resolved
N/A

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
Ran locally

### Check List
- [ ] New functionality includes testing
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
