### PR TITLE
Make the java code formatter optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Refer to [AWS Deployment](deployment/README.md) to deploy this solution to AWS.
 
 ### Code Style
 
-There are many different source type unders this project, the overall style is enforced via `./gradlew spotlessCheck` and is verified on all pull requests.  You can ask resolve the issues automatically with `./gradlew spotlessApply`.  For java files an eclipse formatter is avaliable [formatter.xml](./formatter.xml) in the root of the project, consult your IDE extensions/plugins for how to use this formatter during development.
+There are many different source type under this project, the overall style is enforced via `./gradlew spotlessCheck` and is verified on all pull requests.  Spotless can resolve these issues automatically with `./gradlew spotlessApply`.  An recommended eclipse formatter [formatter.xml](./formatter.xml) is available at the root of the project, consult your IDE extensions/plugins for how to use this formatter during development.
 
 ### Pre-commit hooks
 

--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ subprojects {
     spotless {
         java {
             target "**/*.java"
-            targetExclude '**/build/**'
+            targetExclude '**/build/**', ".gradle/**"
             importOrder(
                 'java|javax',
                 'io.opentelemetry|com.google|com.fasterxml|org.apache|org.hamcrest|org.junit',
@@ -47,7 +47,6 @@ subprojects {
             indentWithSpaces()
             endWithNewline()
             removeUnusedImports()
-            eclipse().configFile rootProject.file('formatter.xml')
         }
     }
 


### PR DESCRIPTION
### Description
Spotless will no longer require or apply the java formatter.  I've updated the documentation to make it a recommendation.

### Check List
- [ ] ~New functionality includes testing~
  - [X] All tests pass, including unit test, integration test and doctest
- [X] New functionality has been documented
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
