### PR TITLE
Added CreateSnapshot README; fixed bug in that tool

### DIFF
--- a/CreateSnapshot/README.md
+++ b/CreateSnapshot/README.md
@@ -1,0 +1,37 @@
+# create-snapshot
+
+## What is this tool?
+
+This tool exposes the underlying Reindex-From-Snapshot (RFS) core library in a executable that will create a snapshot of a source cluster consistent with the expectations of RFS.  In brief, that means taking the snapshot with the global metadata included.  Currently, there are two may ways this tool can perform the snapshot:
+
+* On-disk: The tool kick off a snapshot on the source cluster tell the cluster to store files on disk.  Keep in mind that the disk in question here is the disk of the nodes in the cluster.  This is typically used when your nodes share a filesystem, either because have have a network file system attached or they're all running on the same host.
+* S3: The tool kick off a snapshot on the source cluster tell the cluster to store files to a specified S3 URI.
+
+There's not much magic involved; the tool will reach out to the host specificed using the Elasticsearch REST API to register a new repository then create a snapshot.  This means you'll need a network path to the source cluster from where you're running the tool to the source cluster.
+
+## How do use the tool?
+
+You can kick off the tool using Gradle.
+
+### On-Disk Snapshot
+
+From the root directory of the repo, run a CLI command like so:
+
+```
+./gradlew CreateSnapshot:run --args='--snapshot-name reindex-from-snapshot --file-system-repo-path /snapshot --source-host http://hostname:9200'
+```
+
+In order for this to succeed, you must first configure your Elasticsearch source cluster register the directory you want to use as a snapshot repository.  See [the docs for ES 7.10 here](https://www.elastic.co/guide/en/elasticsearch/reference/7.10/snapshots-register-repository.html#snapshots-filesystem-repository) for an example of how to do this.
+
+### S3 Snapshot
+
+From the root directory of the repo, run a CLI command like so:
+
+```
+./gradlew CreateSnapshot:run --args='--snapshot-name reindex-from-snapshot --s3-repo-uri s3://your-s3-uri --s3-region us-fake-1 --source-host http://hostname:9200'
+```
+
+In order for this succeed, you'll need to make sure:
+* You have valid AWS Credentials in your key ring (~/.aws/credentials) with permission to operate on the S3 URI specified
+* The S3 URI currently exists, and is in the region you specify
+* There are no other snapshots present in that S3 URI

--- a/CreateSnapshot/src/main/java/com/rfs/CreateSnapshot.java
+++ b/CreateSnapshot/src/main/java/com/rfs/CreateSnapshot.java
@@ -42,7 +42,7 @@ public class CreateSnapshot {
         public String s3Region;
 
         @ParametersDelegate
-        public ConnectionDetails.SourceArgs sourceArgs;
+        public ConnectionDetails.SourceArgs sourceArgs = new ConnectionDetails.SourceArgs();
 
         @Parameter(names = {
             "--no-wait" }, description = "Optional.  If provided, the snapshot runner will not wait for completion")

--- a/RFS/src/main/java/com/rfs/common/OpenSearchClient.java
+++ b/RFS/src/main/java/com/rfs/common/OpenSearchClient.java
@@ -118,7 +118,8 @@ public class OpenSearchClient {
             .retryWhen(Retry.backoff(3, Duration.ofSeconds(1)).maxBackoff(Duration.ofSeconds(10)))
             .block();
 
-        if (getResponse.code == HttpURLConnection.HTTP_NOT_FOUND) {
+        boolean objectDoesNotExist = getResponse.code == HttpURLConnection.HTTP_NOT_FOUND;
+        if (objectDoesNotExist) {
             client.putAsync(objectPath, settings.toString(), context.createCheckRequestContext()).flatMap(resp -> {
                 if (resp.code == HttpURLConnection.HTTP_OK) {
                     return Mono.just(resp);


### PR DESCRIPTION
### Description
* Added a simple README for the CreateSnapshot tool
* Fixed a breaking bug in the CreateSnapshot tool.

### Issues Resolved
* https://opensearch.atlassian.net/browse/MIGRATIONS-1840

### Testing
Ran the CreateSnapshot tool:

```
chelma@80a9970a4d02 opensearch-migrations % ./gradlew CreateSnapshot:run --args='--snapshot-name reindex-from-snapshot --s3-repo-uri s3://chelma-iad-rfs-local-testing --s3-region us-east-1 --source-host http://localhost:19200'

> Task :CreateSnapshot:run
2024-07-17 15:45:59,921 WARN o.o.m.t.RootOtelContext [main] Collector endpoint=null, so serviceName parameter 'rfs' is being ignored since a no-op OpenTelemetry object is being created
2024-07-17 15:45:59,936 INFO c.r.CreateSnapshot [main] Running CreateSnapshot with --snapshot-name reindex-from-snapshot --s3-repo-uri s3://chelma-iad-rfs-local-testing --s3-region us-east-1 --source-host http://localhost:19200
2024-07-17 15:46:00,093 INFO c.r.w.SnapshotRunner [main] Attempting to initiate the snapshot...
2024-07-17 15:46:00,205 ERROR i.n.r.d.DnsServerAddressStreamProviders [main] Unable to load io.netty.resolver.dns.macos.MacOSDnsServerAddressStreamProvider, fallback to system defaults. This may result in incorrect DNS resolutions on MacOS. Check whether you have a dependency on 'io.netty:netty-resolver-dns-native-macos'. Use DEBUG level to see the full stack: java.lang.UnsatisfiedLinkError: failed to load the required native library
2024-07-17 15:46:01,223 INFO c.r.c.SnapshotCreator [main] Snapshot repo registration successful
2024-07-17 15:46:01,435 INFO c.r.c.SnapshotCreator [main] Snapshot reindex-from-snapshot creation initiated
2024-07-17 15:46:01,435 INFO c.r.w.SnapshotRunner [main] Snapshot in progress...
2024-07-17 15:46:01,681 INFO c.r.w.SnapshotRunner [main] Snapshot not finished yet; sleeping for 1000ms...
2024-07-17 15:46:02,745 INFO c.r.w.SnapshotRunner [main] Snapshot not finished yet; sleeping for 1000ms...
2024-07-17 15:46:03,819 INFO c.r.w.SnapshotRunner [main] Snapshot not finished yet; sleeping for 1000ms...
2024-07-17 15:46:04,886 INFO c.r.w.SnapshotRunner [main] Snapshot not finished yet; sleeping for 1000ms...
2024-07-17 15:46:05,958 INFO c.r.w.SnapshotRunner [main] Snapshot not finished yet; sleeping for 1000ms...
2024-07-17 15:46:07,033 INFO c.r.w.SnapshotRunner [main] Snapshot not finished yet; sleeping for 1000ms...
2024-07-17 15:46:08,108 INFO c.r.w.SnapshotRunner [main] Snapshot not finished yet; sleeping for 1000ms...
2024-07-17 15:46:09,188 INFO c.r.w.SnapshotRunner [main] Snapshot not finished yet; sleeping for 1000ms...
2024-07-17 15:46:10,256 INFO c.r.w.SnapshotRunner [main] Snapshot not finished yet; sleeping for 1000ms...
```

### Check List
- [X] New functionality includes testing
  - [ ] All tests pass, including unit test, integration test and doctest
- [X] New functionality has been documented
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
