### PR TITLE
Set migration console venv on bash start

### DIFF
--- a/TrafficCapture/dockerSolution/src/main/docker/elasticsearchTestConsole/Dockerfile
+++ b/TrafficCapture/dockerSolution/src/main/docker/elasticsearchTestConsole/Dockerfile
@@ -40,6 +40,8 @@ ENV PIPENV_DEFAULT_PYTHON_VERSION=3.11
 ENV PIPENV_MAX_DEPTH=1
 
 RUN python3.11 -m pip install pipenv
+WORKDIR /
+RUN python3.11 -m venv .venv
 
 # Install HDF5 and YAPPI Manually for Opensearch Benchmark compatibility with ARM
 ARG HDF5_VERSION=1.14.4

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/Dockerfile
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/Dockerfile
@@ -11,8 +11,8 @@ RUN mkdir /root/kafka-tools/aws
 
 WORKDIR /root/kafka-tools
 # Get kafka distribution and unpack to 'kafka'
-RUN wget -qO- https://archive.apache.org/dist/kafka/3.6.0/kafka_2.13-3.6.0.tgz | tar --transform 's!^[^/]*!kafka!' -xvz
-RUN wget -q -O kafka/libs/msk-iam-auth.jar https://github.com/aws/aws-msk-iam-auth/releases/download/v2.0.3/aws-msk-iam-auth-2.0.3-all.jar
+RUN wget -O- https://archive.apache.org/dist/kafka/3.6.0/kafka_2.13-3.6.0.tgz | tar --transform 's!^[^/]*!kafka!' -xvz
+RUN wget -O kafka/libs/msk-iam-auth.jar https://github.com/aws/aws-msk-iam-auth/releases/download/v2.0.3/aws-msk-iam-auth-2.0.3-all.jar
 WORKDIR /root
 
 # Add Traffic Replayer jars for running KafkaPrinter from this container
@@ -52,8 +52,11 @@ RUN pipenv install --deploy --ignore-pipfile
 
 WORKDIR /root
 
-# Ensure bash completion is installed
+# Console setup bash completion and venv for interactive access
 RUN dnf install -y bash-completion
+RUN chmod +x /etc/profile.d/bash_completion.sh && \
+    echo 'source /etc/profile.d/bash_completion.sh' >> ~/.bashrc
+RUN echo 'source /.venv/bin/activate' >> ~/.bashrc
 
 CMD /root/loadServicesFromParameterStore.sh && tail -f /dev/null
 

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/Dockerfile
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/Dockerfile
@@ -61,4 +61,4 @@ RUN echo 'source /.venv/bin/activate' >> ~/.bashrc
 CMD /root/loadServicesFromParameterStore.sh && tail -f /dev/null
 
 # Experimental console API, uncomment to use in addition to uncomment port mapping in docker-compose.yml
-#CMD /root/loadServicesFromParameterStore.sh && python3 /root/console_api/manage.py runserver_plus 0.0.0.0:8000 --cert-file cert.crt
+#CMD /root/loadServicesFromParameterStore.sh && pipenv run python /root/console_api/manage.py runserver_plus 0.0.0.0:8000 --cert-file cert.crt

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/docker-compose-console-only.yml
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/docker-compose-console-only.yml
@@ -24,7 +24,7 @@ services:
       - API_ALLOWED_HOSTS=localhost
     ports:
       - "8000:8000"
-    command: python3 /root/console_api/manage.py runserver_plus 0.0.0.0:8000
+    command: pipenv run python /root/console_api/manage.py runserver_plus 0.0.0.0:8000
 
 networks:
   migrations:

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/loadServicesFromParameterStore.sh
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/loadServicesFromParameterStore.sh
@@ -1,7 +1,14 @@
 #!/bin/bash
 
+set -eou pipefail
+
+# Generate bash completion script
+source /.venv/bin/activate
+console completion bash > /usr/share/bash-completion/completions/console
+echo "Bash completion for console command has been set up and enabled."
+
 # Check if the environment variable MIGRATION_SERVICES_YAML_PARAMETER is set
-if [ -z "$MIGRATION_SERVICES_YAML_PARAMETER" ]; then
+if [ -z "${MIGRATION_SERVICES_YAML_PARAMETER+x}" ]; then
   echo "Environment variable MIGRATION_SERVICES_YAML_PARAMETER is not set. Exiting successfully and "
   echo "assuming the migration services yaml is already in place."
   exit 0
@@ -29,14 +36,3 @@ if [ $? -ne 0 ]; then
 fi
 
 echo "Parameter value successfully written to $OUTPUT_FILE"
-
-# Generate bash completion script
-console completion bash > /usr/share/bash-completion/completions/console
-
-# Source the completion script to enable it for the current session
-source /usr/share/bash-completion/completions/console
-
-# Add sourcing of the completion script to .bashrc for persistence across sessions
-echo '. /etc/bash_completion' >> ~/.bashrc
-
-echo "Bash completion for console command has been set up and enabled."

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/loadServicesFromParameterStore.sh
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/loadServicesFromParameterStore.sh
@@ -2,10 +2,7 @@
 
 set -eou pipefail
 
-# Generate bash completion script
 source /.venv/bin/activate
-console completion bash > /usr/share/bash-completion/completions/console
-echo "Bash completion for console command has been set up and enabled."
 
 # Check if the environment variable MIGRATION_SERVICES_YAML_PARAMETER is set
 if [ -z "${MIGRATION_SERVICES_YAML_PARAMETER+x}" ]; then
@@ -34,5 +31,8 @@ if [ $? -ne 0 ]; then
   echo "Failed to write to file: $OUTPUT_FILE"
   exit 1
 fi
-
 echo "Parameter value successfully written to $OUTPUT_FILE"
+
+# Generate bash completion script
+console completion bash > /usr/share/bash-completion/completions/console
+echo "Bash completion for console command has been set up and enabled."

--- a/deployment/cdk/opensearch-service-migration/lib/service-stacks/migration-console-stack.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/service-stacks/migration-console-stack.ts
@@ -341,7 +341,7 @@ export class MigrationConsoleStack extends MigrationServiceCore {
                 protocol: Protocol.TCP
             }]
             imageCommand = ['/bin/sh', '-c',
-                '/root/loadServicesFromParameterStore.sh && python3 /root/console_api/manage.py runserver_plus 0.0.0.0:8000 --cert-file cert.crt'
+                '/root/loadServicesFromParameterStore.sh && pipenv run python /root/console_api/manage.py runserver_plus 0.0.0.0:8000 --cert-file cert.crt'
             ]
 
             const defaultAllowedHosts = 'localhost'


### PR DESCRIPTION
### Description
Set migration console venv on bash start
* Category: Bug fix
* Why these changes are required? Enable migration console to be accessible throughout image
* What is the old behavior before changes and new behavior after changes? Console was not accessible without manually loading the venv

### Issues Resolved
N/A

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
Local testing with docker solution
Tested in AWS with Migration Console API Enabled

### Check List
- [x] New functionality includes testing
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
