### PR TITLE
Add venv in path, install dev dependencies

### DIFF
--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/Dockerfile
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/Dockerfile
@@ -43,14 +43,12 @@ WORKDIR /root
 COPY lib /root/lib
 WORKDIR /root/lib/console_link
 RUN pipenv install --deploy
-RUN pipenv install --dev
 WORKDIR /root/lib/integ_test
 RUN pipenv install --deploy
 
 COPY console_api /root/console_api
 WORKDIR /root/console_api
 RUN pipenv install --deploy
-RUN pipenv install --dev
 
 WORKDIR /root
 

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/Dockerfile
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/Dockerfile
@@ -43,22 +43,22 @@ WORKDIR /root
 COPY lib /root/lib
 WORKDIR /root/lib/console_link
 RUN pipenv install --deploy
+RUN pipenv install --dev
 WORKDIR /root/lib/integ_test
 RUN pipenv install --deploy
 
 COPY console_api /root/console_api
 WORKDIR /root/console_api
 RUN pipenv install --deploy
+RUN pipenv install --dev
 
 WORKDIR /root
 
 # Console setup bash completion and venv for interactive access
-RUN echo '. /.venv/bin/activate' >> /etc/profile.d/venv.sh
 RUN dnf install -y bash-completion
-RUN echo '. /etc/profile.d/bash_completion.sh' >> ~/.bashrc && \
-    echo '. /etc/profile.d/venv.sh' >> ~/.bashrc
-# Set ENV to control startup script in /bin/sh mode
-ENV ENV=/root/.bashrc
+RUN echo '. /etc/profile.d/bash_completion.sh' >> ~/.bashrc
+
+ENV PATH="/.venv/bin:$PATH"
 
 CMD /root/loadServicesFromParameterStore.sh && tail -f /dev/null
 


### PR DESCRIPTION
### Description
The [latest attempts](https://github.com/opensearch-project/opensearch-migrations/pull/842) to activate the virtualenv on the migration console were not successful because they only activated when the user interacted with the migration console directly through a shell (e.g. the `./accessContainer` script). But in some cases (namely our integ tests), we run pytest directly:
```
aws ecs execute-command ... --container migration-console --interactive --command 'pytest ...'
```

We were getting the error message:
```
SessionId: ecs-execute-command-7uqlsa5qexm57fv4qklntiusc4 : 
----------ERROR-------
Unable to start command: Failed to start pty: exec: "pytest": executable file not found in $PATH
```

This was reproduced in local testing with docker.

This PR fixes that by adding the virtualenv to the PATH, which is exactly what [activating it does under the hood](https://github.com/python/cpython/blob/main/Lib/venv/scripts/common/activate#L53).

~~Additionally, once the venv was made accessible via the $PATH, it turned out that the dev dependencies weren't being installed, which are clearly necessary to run the unit tests.~~
^ This is wrong. The dev dependencies aren't being installed, but they're unnecessary. The integ_test Pipfile contains everything it needs to run in its standard dependencies. The other libraries would need `--dev` to run their unit tests, but that's not happening on the migration console by default.


### Issues Resolved
[List any issues this PR will resolve]

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]

### Check List
- [ ] New functionality includes testing
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
