### PR TITLE
Install java on migration console

### DIFF
--- a/TrafficCapture/dockerSolution/src/main/docker/elasticsearchTestConsole/Dockerfile
+++ b/TrafficCapture/dockerSolution/src/main/docker/elasticsearchTestConsole/Dockerfile
@@ -11,6 +11,7 @@ RUN dnf install -y --setopt=install_weak_deps=False \
         git \
         glibc-devel \
         hostname \
+        java-11-amazon-corretto \
         jq \
         less \
         make \


### PR DESCRIPTION
### Description
In [this change](https://github.com/opensearch-project/opensearch-migrations/pull/836/files#diff-7a2cd35c5f7cc5312dfb67e949e2cdc97ed00459df4214de5c8cd15887123415L10), the line that installs java onto the elasticsearch_test_console (and therefore the migration console) was removed from the install list. This was causing Jenkins failures, first of all because of Kafka tools not being runnable, but it would presumably proceed to Snapshot Creation & Metdata Migration failures as well.

### Issues Resolved
Broken build in Jenkins pipeline

### Testing
Manually tested locally.

### Check List
- [x] New functionality includes testing
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
