### PR TITLE
DockerHub Build and Tag on Release

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -11,37 +11,6 @@ env:
   node-version: '18.x'
 
 jobs:
-  docker-publish:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
-        with:
-          java-version: ${{ env.java-version }}
-          distribution: 'corretto'
-      - uses: gradle/actions/setup-gradle@v3
-        with:
-          gradle-version: ${{ env.gradle-version }}
-      - name: Build Docker Images
-        run: |
-          ./deployment/cdk/opensearch-service-migration/buildDockerImages.sh
-      - name: Tag Docker image
-        run: |
-          docker tag migrations/migration_console:latest opensearchstaging/opensearch-migrations-console:1.0.0
-          docker tag migrations/traffic_replayer:latest opensearchstaging/opensearch-migrations-traffic-replayer:1.0.0
-          docker tag migrations/capture_proxy:latest opensearchstaging/opensearch-migrations-traffic-capture-proxy:1.0.0
-          docker tag migrations/reindex_from_snapshot:latest opensearchstaging/opensearch-migrations-reindex-from-snapshot:1.0.0
-#      - name: Login to DockerHub
-#        uses: docker/login-action@v1
-#        with:
-#          username: ${{ secrets.DOCKERHUB_USERNAME }}
-#          password: ${{ secrets.DOCKERHUB_TOKEN }}
-#      - name: Push Docker image to Docker Hub
-#        run: |
-#          docker push opensearchstaging/opensearch-migrations-console:1.0.0
-#          docker push opensearchstaging/opensearch-migrations-traffic-replayer:1.0.0
-#          docker push opensearchstaging/opensearch-migrations-traffic-capture-proxy:1.0.0
-#          docker push opensearchstaging/opensearch-migrations-reindex-from-snapshot:1.0.0
   style-check:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -11,6 +11,37 @@ env:
   node-version: '18.x'
 
 jobs:
+  docker-publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          java-version: ${{ env.java-version }}
+          distribution: 'corretto'
+      - uses: gradle/actions/setup-gradle@v3
+        with:
+          gradle-version: ${{ env.gradle-version }}
+      - name: Build Docker Images
+        run: |
+          ./deployment/cdk/opensearch-service-migration/buildDockerImages.sh
+      - name: Tag Docker image
+        run: |
+          docker tag migrations/migration_console:latest opensearchstaging/opensearch-migrations-console:1.0.0
+          docker tag migrations/traffic_replayer:latest opensearchstaging/opensearch-migrations-traffic-replayer:1.0.0
+          docker tag migrations/capture_proxy:latest opensearchstaging/opensearch-migrations-traffic-capture-proxy:1.0.0
+          docker tag migrations/reindex_from_snapshot:latest opensearchstaging/opensearch-migrations-reindex-from-snapshot:1.0.0
+#      - name: Login to DockerHub
+#        uses: docker/login-action@v1
+#        with:
+#          username: ${{ secrets.DOCKERHUB_USERNAME }}
+#          password: ${{ secrets.DOCKERHUB_TOKEN }}
+#      - name: Push Docker image to Docker Hub
+#        run: |
+#          docker push opensearchstaging/opensearch-migrations-console:1.0.0
+#          docker push opensearchstaging/opensearch-migrations-traffic-replayer:1.0.0
+#          docker push opensearchstaging/opensearch-migrations-traffic-capture-proxy:1.0.0
+#          docker push opensearchstaging/opensearch-migrations-reindex-from-snapshot:1.0.0
   style-check:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -5,12 +5,22 @@ on:
   push:
     tags:
       - "*"
+env:
+  java-version: '11'
+  gradle-version: '8.0.2'
 
 jobs:
   draft-a-release:
     name: Draft a release
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/setup-java@v4
+        with:
+          java-version: ${{ env.java-version }}
+          distribution: 'corretto'
+      - uses: gradle/actions/setup-gradle@v3
+        with:
+          gradle-version: ${{ env.gradle-version }}
       - uses: actions/checkout@v4
       - id: get_data
         run: |
@@ -29,6 +39,26 @@ jobs:
         run: |
           wget https://github.com/opensearch-project/opensearch-migrations/archive/refs/tags/${{ steps.get_data.outputs.version }}.tar.gz -O artifacts.tar.gz
           ./gradlew publishMavenJavaPublicationToMavenRepository -Dbuild.snapshot=false -Dbuild.version=0.${{ steps.get_data.outputs.version }} && tar -C build -cvf traffic-capture-artifacts.tar.gz repository
+      - name: Build Docker Images
+        run: |
+          ./deployment/cdk/opensearch-service-migration/buildDockerImages.sh
+      - name: Tag Docker image
+        run: |
+          docker tag migrations/migration_console:latest opensearchstaging/opensearch-migrations-console:${{ steps.get_data.outputs.version }}
+          docker tag migrations/traffic_replayer:latest opensearchstaging/opensearch-migrations-traffic-replayer:${{ steps.get_data.outputs.version }}
+          docker tag migrations/capture_proxy:latest opensearchstaging/opensearch-migrations-traffic-capture-proxy:${{ steps.get_data.outputs.version }}
+          docker tag migrations/reindex_from_snapshot:latest opensearchstaging/opensearch-migrations-reindex-from-snapshot:${{ steps.get_data.outputs.version }}
+#      - name: Login to DockerHub
+#        uses: docker/login-action@v1
+#        with:
+#          username: ${{ secrets.DOCKERHUB_USERNAME }}
+#          password: ${{ secrets.DOCKERHUB_TOKEN }}
+#      - name: Push Docker image to Docker Hub
+#        run: |
+#          docker push opensearchstaging/opensearch-migrations-console:${{ steps.get_data.outputs.version }}
+#          docker push opensearchstaging/opensearch-migrations-traffic-replayer:${{ steps.get_data.outputs.version }}
+#          docker push opensearchstaging/opensearch-migrations-traffic-capture-proxy:${{ steps.get_data.outputs.version }}
+#          docker push opensearchstaging/opensearch-migrations-reindex-from-snapshot:${{ steps.get_data.outputs.version }}
       - name: Draft a release
         uses: softprops/action-gh-release@v2
         with:


### PR DESCRIPTION
### Description
Adding a workflow on our release action to build and tag the docker images. I've commented out the section for engineering-effectiveness to add their secrets for the staging account.

Currently only builds the architecture the runner is on, will add cross arch build in a followup pr.

* Category: Enhancement
* Why these changes are required? Publishing to docker enables our solution to be consumed by other partners without building from source
* What is the old behavior before changes and new behavior after changes? Release action will build docker images, no publishing occurring at this step

### Issues Resolved
https://opensearch.atlassian.net/browse/MIGRATIONS-1570

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
Tested in GHA https://github.com/opensearch-project/opensearch-migrations/actions/runs/10115830331/job/27977434308

### Check List
- [x] New functionality includes testing
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
