### PR TITLE
Always run all checks job

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -215,6 +215,7 @@ jobs:
       - python-lint
       - python-tests
       - fetch-migration-docker-build
+    if: always()
     runs-on: ubuntu-latest
     steps:
       - run: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -218,5 +218,8 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     steps:
+      - if: ${{ contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'failure') || contains(needs.*.result, 'skipped') }}
+        run: |
+          echo "One or more job cancelled, failed, or skipped" && exit 1
       - run: |
           echo '## :heavy_check_mark: All continous integration checks pass' >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
### Description
When the "all-ci-checks-pass" was marked as `Skipped` it wouldn't prevent merging.  I've change the job to always run, even if a downstream job hasn't passed, and it validates the results to be sure that all jobs completed successful.

Note; created this PR as a follow up after contacting GitHub support over the `Required` check not working as expected.

### Testing
- Failure case verified with [#1](https://github.com/peternied/opensearch-migrations/actions/runs/10152498555)
![image](https://github.com/user-attachments/assets/349253ba-6e94-4dbc-8c78-bd2b458e6849)
- Passing case should be confirmed with this PR without any failures.

### Check List
- [ ] ~New functionality includes testing~
  - [X] All tests pass, including unit test, integration test and doctest
- [ ] ~New functionality has been documented~
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
