### PR TITLE
Fix connection metering for reactor clients.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,2 @@
 org.gradle.caching=true
+org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8


### PR DESCRIPTION
As it was, there was potential for an unbounded amount of repetitive counting because each request had a new pair of metering handlers attached to the connection.  Since reactor doesn't have a clear way to cleanup after each and every single request (consider retries), I've taken the view that every request that we make, first we try to remove any handlers that might have been present for the last request + removing them entirely in the doFinally() block.  Notice that we want to track the values on a request by request basis, hence the reason that we don't want to even reuse the handlers on different requests. I had to update the test to trigger this because the reactor HttpClient will use multiple connections by default, hence the reason that we weren't previously seeing this within the test, though it had become flaky, which is how this was caught.

### Description
Read/Write metering for reactor clients will be more (hopefully, completely) accurate.
* Category: Bug fix/Test fix
* Why these changes are required? We were misrepresenting how many bytes went over the wire and we were also severely bloating memory utilization, to the point that heavily reused clients could have created significant performance penalties.
* What is the old behavior before changes and new behavior after changes? See above

### Issues Resolved
https://opensearch.atlassian.net/browse/MIGRATIONS-1890

### Testing
Unit testing

### Check List
- [x] New functionality includes testing
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
