### PR TITLE
[CVE] Update fast-xml-parser to version 4.4.1

### DIFF
--- a/deployment/cdk/opensearch-service-migration/package-lock.json
+++ b/deployment/cdk/opensearch-service-migration/package-lock.json
@@ -95,7 +95,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
       "integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
-      "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/util": "^5.2.0",
         "@aws-sdk/types": "^3.222.0",
@@ -231,52 +230,51 @@
       }
     },
     "node_modules/@aws-sdk/client-acm": {
-      "version": "3.598.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-acm/-/client-acm-3.598.0.tgz",
-      "integrity": "sha512-21dmLqzDuTdIUE4QiE862Q4FU+SPwAUcSUcvDRl3V3J1Ly/QLllwK3YXndwdbvUuq5u5f7SSFDJEk1y/wdgecg==",
-      "license": "Apache-2.0",
+      "version": "3.621.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-acm/-/client-acm-3.621.0.tgz",
+      "integrity": "sha512-bFeS4pXq8Zl5KJb7bBUe3qzeECagDCcPKLley2DXTIimw4GWZtXzYm8uHHB7r5dPGiub791ZQU47XmvjHDcmxA==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/client-sso-oidc": "3.598.0",
-        "@aws-sdk/client-sts": "3.598.0",
-        "@aws-sdk/core": "3.598.0",
-        "@aws-sdk/credential-provider-node": "3.598.0",
-        "@aws-sdk/middleware-host-header": "3.598.0",
-        "@aws-sdk/middleware-logger": "3.598.0",
-        "@aws-sdk/middleware-recursion-detection": "3.598.0",
-        "@aws-sdk/middleware-user-agent": "3.598.0",
-        "@aws-sdk/region-config-resolver": "3.598.0",
-        "@aws-sdk/types": "3.598.0",
-        "@aws-sdk/util-endpoints": "3.598.0",
-        "@aws-sdk/util-user-agent-browser": "3.598.0",
-        "@aws-sdk/util-user-agent-node": "3.598.0",
-        "@smithy/config-resolver": "^3.0.2",
-        "@smithy/core": "^2.2.1",
-        "@smithy/fetch-http-handler": "^3.0.2",
-        "@smithy/hash-node": "^3.0.1",
-        "@smithy/invalid-dependency": "^3.0.1",
-        "@smithy/middleware-content-length": "^3.0.1",
-        "@smithy/middleware-endpoint": "^3.0.2",
-        "@smithy/middleware-retry": "^3.0.4",
-        "@smithy/middleware-serde": "^3.0.1",
-        "@smithy/middleware-stack": "^3.0.1",
-        "@smithy/node-config-provider": "^3.1.1",
-        "@smithy/node-http-handler": "^3.0.1",
-        "@smithy/protocol-http": "^4.0.1",
-        "@smithy/smithy-client": "^3.1.2",
-        "@smithy/types": "^3.1.0",
-        "@smithy/url-parser": "^3.0.1",
+        "@aws-sdk/client-sso-oidc": "3.621.0",
+        "@aws-sdk/client-sts": "3.621.0",
+        "@aws-sdk/core": "3.621.0",
+        "@aws-sdk/credential-provider-node": "3.621.0",
+        "@aws-sdk/middleware-host-header": "3.620.0",
+        "@aws-sdk/middleware-logger": "3.609.0",
+        "@aws-sdk/middleware-recursion-detection": "3.620.0",
+        "@aws-sdk/middleware-user-agent": "3.620.0",
+        "@aws-sdk/region-config-resolver": "3.614.0",
+        "@aws-sdk/types": "3.609.0",
+        "@aws-sdk/util-endpoints": "3.614.0",
+        "@aws-sdk/util-user-agent-browser": "3.609.0",
+        "@aws-sdk/util-user-agent-node": "3.614.0",
+        "@smithy/config-resolver": "^3.0.5",
+        "@smithy/core": "^2.3.1",
+        "@smithy/fetch-http-handler": "^3.2.4",
+        "@smithy/hash-node": "^3.0.3",
+        "@smithy/invalid-dependency": "^3.0.3",
+        "@smithy/middleware-content-length": "^3.0.5",
+        "@smithy/middleware-endpoint": "^3.1.0",
+        "@smithy/middleware-retry": "^3.0.13",
+        "@smithy/middleware-serde": "^3.0.3",
+        "@smithy/middleware-stack": "^3.0.3",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/node-http-handler": "^3.1.4",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/smithy-client": "^3.1.11",
+        "@smithy/types": "^3.3.0",
+        "@smithy/url-parser": "^3.0.3",
         "@smithy/util-base64": "^3.0.0",
         "@smithy/util-body-length-browser": "^3.0.0",
         "@smithy/util-body-length-node": "^3.0.0",
-        "@smithy/util-defaults-mode-browser": "^3.0.4",
-        "@smithy/util-defaults-mode-node": "^3.0.4",
-        "@smithy/util-endpoints": "^2.0.2",
-        "@smithy/util-middleware": "^3.0.1",
-        "@smithy/util-retry": "^3.0.1",
+        "@smithy/util-defaults-mode-browser": "^3.0.13",
+        "@smithy/util-defaults-mode-node": "^3.0.13",
+        "@smithy/util-endpoints": "^2.0.5",
+        "@smithy/util-middleware": "^3.0.3",
+        "@smithy/util-retry": "^3.0.3",
         "@smithy/util-utf8": "^3.0.0",
-        "@smithy/util-waiter": "^3.0.1",
+        "@smithy/util-waiter": "^3.1.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -284,50 +282,49 @@
       }
     },
     "node_modules/@aws-sdk/client-kafka": {
-      "version": "3.598.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-kafka/-/client-kafka-3.598.0.tgz",
-      "integrity": "sha512-37SIEeYgrPbjJoihsUBshikBtvjvyKQJiVEM6Ct/B4hFs/WhuUrIfh4RuKgXtxQdEnMJtuwz9ox7mvvC2BGLOw==",
-      "license": "Apache-2.0",
+      "version": "3.621.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-kafka/-/client-kafka-3.621.0.tgz",
+      "integrity": "sha512-lNxKOTg6iVAQPx+zAKnw1LLwIfHuCMQZWjnkITCOFNqKqcXzodGnz8todEAT7bbSxATDkYwD1ghGzLOKeiJZCg==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/client-sso-oidc": "3.598.0",
-        "@aws-sdk/client-sts": "3.598.0",
-        "@aws-sdk/core": "3.598.0",
-        "@aws-sdk/credential-provider-node": "3.598.0",
-        "@aws-sdk/middleware-host-header": "3.598.0",
-        "@aws-sdk/middleware-logger": "3.598.0",
-        "@aws-sdk/middleware-recursion-detection": "3.598.0",
-        "@aws-sdk/middleware-user-agent": "3.598.0",
-        "@aws-sdk/region-config-resolver": "3.598.0",
-        "@aws-sdk/types": "3.598.0",
-        "@aws-sdk/util-endpoints": "3.598.0",
-        "@aws-sdk/util-user-agent-browser": "3.598.0",
-        "@aws-sdk/util-user-agent-node": "3.598.0",
-        "@smithy/config-resolver": "^3.0.2",
-        "@smithy/core": "^2.2.1",
-        "@smithy/fetch-http-handler": "^3.0.2",
-        "@smithy/hash-node": "^3.0.1",
-        "@smithy/invalid-dependency": "^3.0.1",
-        "@smithy/middleware-content-length": "^3.0.1",
-        "@smithy/middleware-endpoint": "^3.0.2",
-        "@smithy/middleware-retry": "^3.0.4",
-        "@smithy/middleware-serde": "^3.0.1",
-        "@smithy/middleware-stack": "^3.0.1",
-        "@smithy/node-config-provider": "^3.1.1",
-        "@smithy/node-http-handler": "^3.0.1",
-        "@smithy/protocol-http": "^4.0.1",
-        "@smithy/smithy-client": "^3.1.2",
-        "@smithy/types": "^3.1.0",
-        "@smithy/url-parser": "^3.0.1",
+        "@aws-sdk/client-sso-oidc": "3.621.0",
+        "@aws-sdk/client-sts": "3.621.0",
+        "@aws-sdk/core": "3.621.0",
+        "@aws-sdk/credential-provider-node": "3.621.0",
+        "@aws-sdk/middleware-host-header": "3.620.0",
+        "@aws-sdk/middleware-logger": "3.609.0",
+        "@aws-sdk/middleware-recursion-detection": "3.620.0",
+        "@aws-sdk/middleware-user-agent": "3.620.0",
+        "@aws-sdk/region-config-resolver": "3.614.0",
+        "@aws-sdk/types": "3.609.0",
+        "@aws-sdk/util-endpoints": "3.614.0",
+        "@aws-sdk/util-user-agent-browser": "3.609.0",
+        "@aws-sdk/util-user-agent-node": "3.614.0",
+        "@smithy/config-resolver": "^3.0.5",
+        "@smithy/core": "^2.3.1",
+        "@smithy/fetch-http-handler": "^3.2.4",
+        "@smithy/hash-node": "^3.0.3",
+        "@smithy/invalid-dependency": "^3.0.3",
+        "@smithy/middleware-content-length": "^3.0.5",
+        "@smithy/middleware-endpoint": "^3.1.0",
+        "@smithy/middleware-retry": "^3.0.13",
+        "@smithy/middleware-serde": "^3.0.3",
+        "@smithy/middleware-stack": "^3.0.3",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/node-http-handler": "^3.1.4",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/smithy-client": "^3.1.11",
+        "@smithy/types": "^3.3.0",
+        "@smithy/url-parser": "^3.0.3",
         "@smithy/util-base64": "^3.0.0",
         "@smithy/util-body-length-browser": "^3.0.0",
         "@smithy/util-body-length-node": "^3.0.0",
-        "@smithy/util-defaults-mode-browser": "^3.0.4",
-        "@smithy/util-defaults-mode-node": "^3.0.4",
-        "@smithy/util-endpoints": "^2.0.2",
-        "@smithy/util-middleware": "^3.0.1",
-        "@smithy/util-retry": "^3.0.1",
+        "@smithy/util-defaults-mode-browser": "^3.0.13",
+        "@smithy/util-defaults-mode-node": "^3.0.13",
+        "@smithy/util-endpoints": "^2.0.5",
+        "@smithy/util-middleware": "^3.0.3",
+        "@smithy/util-retry": "^3.0.3",
         "@smithy/util-utf8": "^3.0.0",
         "tslib": "^2.6.2"
       },
@@ -336,56 +333,55 @@
       }
     },
     "node_modules/@aws-sdk/client-lambda": {
-      "version": "3.598.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-lambda/-/client-lambda-3.598.0.tgz",
-      "integrity": "sha512-PtTdBNBp1MFWMdgE3T6/f5ZLLbGcenLwEWlgXBsWzHl5lvHnI4SjH54hhZM17JiqRmoz+0EAufl+JbDd5yqfsg==",
-      "license": "Apache-2.0",
+      "version": "3.621.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-lambda/-/client-lambda-3.621.0.tgz",
+      "integrity": "sha512-QD3FOMOLc9CQqfYOEzpTlB9LZbpN+0BrLUpc4+kNa+IheD5kes6gRRLB3Y1OLY4GIRTfPnYPTeFnW8AsSbcNzQ==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/client-sso-oidc": "3.598.0",
-        "@aws-sdk/client-sts": "3.598.0",
-        "@aws-sdk/core": "3.598.0",
-        "@aws-sdk/credential-provider-node": "3.598.0",
-        "@aws-sdk/middleware-host-header": "3.598.0",
-        "@aws-sdk/middleware-logger": "3.598.0",
-        "@aws-sdk/middleware-recursion-detection": "3.598.0",
-        "@aws-sdk/middleware-user-agent": "3.598.0",
-        "@aws-sdk/region-config-resolver": "3.598.0",
-        "@aws-sdk/types": "3.598.0",
-        "@aws-sdk/util-endpoints": "3.598.0",
-        "@aws-sdk/util-user-agent-browser": "3.598.0",
-        "@aws-sdk/util-user-agent-node": "3.598.0",
-        "@smithy/config-resolver": "^3.0.2",
-        "@smithy/core": "^2.2.1",
-        "@smithy/eventstream-serde-browser": "^3.0.2",
-        "@smithy/eventstream-serde-config-resolver": "^3.0.1",
-        "@smithy/eventstream-serde-node": "^3.0.2",
-        "@smithy/fetch-http-handler": "^3.0.2",
-        "@smithy/hash-node": "^3.0.1",
-        "@smithy/invalid-dependency": "^3.0.1",
-        "@smithy/middleware-content-length": "^3.0.1",
-        "@smithy/middleware-endpoint": "^3.0.2",
-        "@smithy/middleware-retry": "^3.0.4",
-        "@smithy/middleware-serde": "^3.0.1",
-        "@smithy/middleware-stack": "^3.0.1",
-        "@smithy/node-config-provider": "^3.1.1",
-        "@smithy/node-http-handler": "^3.0.1",
-        "@smithy/protocol-http": "^4.0.1",
-        "@smithy/smithy-client": "^3.1.2",
-        "@smithy/types": "^3.1.0",
-        "@smithy/url-parser": "^3.0.1",
+        "@aws-sdk/client-sso-oidc": "3.621.0",
+        "@aws-sdk/client-sts": "3.621.0",
+        "@aws-sdk/core": "3.621.0",
+        "@aws-sdk/credential-provider-node": "3.621.0",
+        "@aws-sdk/middleware-host-header": "3.620.0",
+        "@aws-sdk/middleware-logger": "3.609.0",
+        "@aws-sdk/middleware-recursion-detection": "3.620.0",
+        "@aws-sdk/middleware-user-agent": "3.620.0",
+        "@aws-sdk/region-config-resolver": "3.614.0",
+        "@aws-sdk/types": "3.609.0",
+        "@aws-sdk/util-endpoints": "3.614.0",
+        "@aws-sdk/util-user-agent-browser": "3.609.0",
+        "@aws-sdk/util-user-agent-node": "3.614.0",
+        "@smithy/config-resolver": "^3.0.5",
+        "@smithy/core": "^2.3.1",
+        "@smithy/eventstream-serde-browser": "^3.0.5",
+        "@smithy/eventstream-serde-config-resolver": "^3.0.3",
+        "@smithy/eventstream-serde-node": "^3.0.4",
+        "@smithy/fetch-http-handler": "^3.2.4",
+        "@smithy/hash-node": "^3.0.3",
+        "@smithy/invalid-dependency": "^3.0.3",
+        "@smithy/middleware-content-length": "^3.0.5",
+        "@smithy/middleware-endpoint": "^3.1.0",
+        "@smithy/middleware-retry": "^3.0.13",
+        "@smithy/middleware-serde": "^3.0.3",
+        "@smithy/middleware-stack": "^3.0.3",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/node-http-handler": "^3.1.4",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/smithy-client": "^3.1.11",
+        "@smithy/types": "^3.3.0",
+        "@smithy/url-parser": "^3.0.3",
         "@smithy/util-base64": "^3.0.0",
         "@smithy/util-body-length-browser": "^3.0.0",
         "@smithy/util-body-length-node": "^3.0.0",
-        "@smithy/util-defaults-mode-browser": "^3.0.4",
-        "@smithy/util-defaults-mode-node": "^3.0.4",
-        "@smithy/util-endpoints": "^2.0.2",
-        "@smithy/util-middleware": "^3.0.1",
-        "@smithy/util-retry": "^3.0.1",
-        "@smithy/util-stream": "^3.0.2",
+        "@smithy/util-defaults-mode-browser": "^3.0.13",
+        "@smithy/util-defaults-mode-node": "^3.0.13",
+        "@smithy/util-endpoints": "^2.0.5",
+        "@smithy/util-middleware": "^3.0.3",
+        "@smithy/util-retry": "^3.0.3",
+        "@smithy/util-stream": "^3.1.3",
         "@smithy/util-utf8": "^3.0.0",
-        "@smithy/util-waiter": "^3.0.1",
+        "@smithy/util-waiter": "^3.1.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -393,47 +389,46 @@
       }
     },
     "node_modules/@aws-sdk/client-sso": {
-      "version": "3.598.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.598.0.tgz",
-      "integrity": "sha512-nOI5lqPYa+YZlrrzwAJywJSw3MKVjvu6Ge2fCqQUNYMfxFB0NAaDFnl0EPjXi+sEbtCuz/uWE77poHbqiZ+7Iw==",
-      "license": "Apache-2.0",
+      "version": "3.621.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.621.0.tgz",
+      "integrity": "sha512-xpKfikN4u0BaUYZA9FGUMkkDmfoIP0Q03+A86WjqDWhcOoqNA1DkHsE4kZ+r064ifkPUfcNuUvlkVTEoBZoFjA==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.598.0",
-        "@aws-sdk/middleware-host-header": "3.598.0",
-        "@aws-sdk/middleware-logger": "3.598.0",
-        "@aws-sdk/middleware-recursion-detection": "3.598.0",
-        "@aws-sdk/middleware-user-agent": "3.598.0",
-        "@aws-sdk/region-config-resolver": "3.598.0",
-        "@aws-sdk/types": "3.598.0",
-        "@aws-sdk/util-endpoints": "3.598.0",
-        "@aws-sdk/util-user-agent-browser": "3.598.0",
-        "@aws-sdk/util-user-agent-node": "3.598.0",
-        "@smithy/config-resolver": "^3.0.2",
-        "@smithy/core": "^2.2.1",
-        "@smithy/fetch-http-handler": "^3.0.2",
-        "@smithy/hash-node": "^3.0.1",
-        "@smithy/invalid-dependency": "^3.0.1",
-        "@smithy/middleware-content-length": "^3.0.1",
-        "@smithy/middleware-endpoint": "^3.0.2",
-        "@smithy/middleware-retry": "^3.0.4",
-        "@smithy/middleware-serde": "^3.0.1",
-        "@smithy/middleware-stack": "^3.0.1",
-        "@smithy/node-config-provider": "^3.1.1",
-        "@smithy/node-http-handler": "^3.0.1",
-        "@smithy/protocol-http": "^4.0.1",
-        "@smithy/smithy-client": "^3.1.2",
-        "@smithy/types": "^3.1.0",
-        "@smithy/url-parser": "^3.0.1",
+        "@aws-sdk/core": "3.621.0",
+        "@aws-sdk/middleware-host-header": "3.620.0",
+        "@aws-sdk/middleware-logger": "3.609.0",
+        "@aws-sdk/middleware-recursion-detection": "3.620.0",
+        "@aws-sdk/middleware-user-agent": "3.620.0",
+        "@aws-sdk/region-config-resolver": "3.614.0",
+        "@aws-sdk/types": "3.609.0",
+        "@aws-sdk/util-endpoints": "3.614.0",
+        "@aws-sdk/util-user-agent-browser": "3.609.0",
+        "@aws-sdk/util-user-agent-node": "3.614.0",
+        "@smithy/config-resolver": "^3.0.5",
+        "@smithy/core": "^2.3.1",
+        "@smithy/fetch-http-handler": "^3.2.4",
+        "@smithy/hash-node": "^3.0.3",
+        "@smithy/invalid-dependency": "^3.0.3",
+        "@smithy/middleware-content-length": "^3.0.5",
+        "@smithy/middleware-endpoint": "^3.1.0",
+        "@smithy/middleware-retry": "^3.0.13",
+        "@smithy/middleware-serde": "^3.0.3",
+        "@smithy/middleware-stack": "^3.0.3",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/node-http-handler": "^3.1.4",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/smithy-client": "^3.1.11",
+        "@smithy/types": "^3.3.0",
+        "@smithy/url-parser": "^3.0.3",
         "@smithy/util-base64": "^3.0.0",
         "@smithy/util-body-length-browser": "^3.0.0",
         "@smithy/util-body-length-node": "^3.0.0",
-        "@smithy/util-defaults-mode-browser": "^3.0.4",
-        "@smithy/util-defaults-mode-node": "^3.0.4",
-        "@smithy/util-endpoints": "^2.0.2",
-        "@smithy/util-middleware": "^3.0.1",
-        "@smithy/util-retry": "^3.0.1",
+        "@smithy/util-defaults-mode-browser": "^3.0.13",
+        "@smithy/util-defaults-mode-node": "^3.0.13",
+        "@smithy/util-endpoints": "^2.0.5",
+        "@smithy/util-middleware": "^3.0.3",
+        "@smithy/util-retry": "^3.0.3",
         "@smithy/util-utf8": "^3.0.0",
         "tslib": "^2.6.2"
       },
@@ -442,100 +437,100 @@
       }
     },
     "node_modules/@aws-sdk/client-sso-oidc": {
-      "version": "3.598.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.598.0.tgz",
-      "integrity": "sha512-jfdH1pAO9Tt8Nkta/JJLoUnwl7jaRdxToQTJfUtE+o3+0JP5sA4LfC2rBkJSWcU5BdAA+kyOs5Lv776DlN04Vg==",
-      "license": "Apache-2.0",
+      "version": "3.621.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.621.0.tgz",
+      "integrity": "sha512-mMjk3mFUwV2Y68POf1BQMTF+F6qxt5tPu6daEUCNGC9Cenk3h2YXQQoS4/eSyYzuBiYk3vx49VgleRvdvkg8rg==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/client-sts": "3.598.0",
-        "@aws-sdk/core": "3.598.0",
-        "@aws-sdk/credential-provider-node": "3.598.0",
-        "@aws-sdk/middleware-host-header": "3.598.0",
-        "@aws-sdk/middleware-logger": "3.598.0",
-        "@aws-sdk/middleware-recursion-detection": "3.598.0",
-        "@aws-sdk/middleware-user-agent": "3.598.0",
-        "@aws-sdk/region-config-resolver": "3.598.0",
-        "@aws-sdk/types": "3.598.0",
-        "@aws-sdk/util-endpoints": "3.598.0",
-        "@aws-sdk/util-user-agent-browser": "3.598.0",
-        "@aws-sdk/util-user-agent-node": "3.598.0",
-        "@smithy/config-resolver": "^3.0.2",
-        "@smithy/core": "^2.2.1",
-        "@smithy/fetch-http-handler": "^3.0.2",
-        "@smithy/hash-node": "^3.0.1",
-        "@smithy/invalid-dependency": "^3.0.1",
-        "@smithy/middleware-content-length": "^3.0.1",
-        "@smithy/middleware-endpoint": "^3.0.2",
-        "@smithy/middleware-retry": "^3.0.4",
-        "@smithy/middleware-serde": "^3.0.1",
-        "@smithy/middleware-stack": "^3.0.1",
-        "@smithy/node-config-provider": "^3.1.1",
-        "@smithy/node-http-handler": "^3.0.1",
-        "@smithy/protocol-http": "^4.0.1",
-        "@smithy/smithy-client": "^3.1.2",
-        "@smithy/types": "^3.1.0",
-        "@smithy/url-parser": "^3.0.1",
+        "@aws-sdk/core": "3.621.0",
+        "@aws-sdk/credential-provider-node": "3.621.0",
+        "@aws-sdk/middleware-host-header": "3.620.0",
+        "@aws-sdk/middleware-logger": "3.609.0",
+        "@aws-sdk/middleware-recursion-detection": "3.620.0",
+        "@aws-sdk/middleware-user-agent": "3.620.0",
+        "@aws-sdk/region-config-resolver": "3.614.0",
+        "@aws-sdk/types": "3.609.0",
+        "@aws-sdk/util-endpoints": "3.614.0",
+        "@aws-sdk/util-user-agent-browser": "3.609.0",
+        "@aws-sdk/util-user-agent-node": "3.614.0",
+        "@smithy/config-resolver": "^3.0.5",
+        "@smithy/core": "^2.3.1",
+        "@smithy/fetch-http-handler": "^3.2.4",
+        "@smithy/hash-node": "^3.0.3",
+        "@smithy/invalid-dependency": "^3.0.3",
+        "@smithy/middleware-content-length": "^3.0.5",
+        "@smithy/middleware-endpoint": "^3.1.0",
+        "@smithy/middleware-retry": "^3.0.13",
+        "@smithy/middleware-serde": "^3.0.3",
+        "@smithy/middleware-stack": "^3.0.3",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/node-http-handler": "^3.1.4",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/smithy-client": "^3.1.11",
+        "@smithy/types": "^3.3.0",
+        "@smithy/url-parser": "^3.0.3",
         "@smithy/util-base64": "^3.0.0",
         "@smithy/util-body-length-browser": "^3.0.0",
         "@smithy/util-body-length-node": "^3.0.0",
-        "@smithy/util-defaults-mode-browser": "^3.0.4",
-        "@smithy/util-defaults-mode-node": "^3.0.4",
-        "@smithy/util-endpoints": "^2.0.2",
-        "@smithy/util-middleware": "^3.0.1",
-        "@smithy/util-retry": "^3.0.1",
+        "@smithy/util-defaults-mode-browser": "^3.0.13",
+        "@smithy/util-defaults-mode-node": "^3.0.13",
+        "@smithy/util-endpoints": "^2.0.5",
+        "@smithy/util-middleware": "^3.0.3",
+        "@smithy/util-retry": "^3.0.3",
         "@smithy/util-utf8": "^3.0.0",
         "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.621.0"
       }
     },
     "node_modules/@aws-sdk/client-sts": {
-      "version": "3.598.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.598.0.tgz",
-      "integrity": "sha512-bXhz/cHL0iB9UH9IFtMaJJf4F8mV+HzncETCRFzZ9SyUMt5rP9j8A7VZknqGYSx/6mI8SsB1XJQkWSbhn6FiSQ==",
-      "license": "Apache-2.0",
+      "version": "3.621.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.621.0.tgz",
+      "integrity": "sha512-707uiuReSt+nAx6d0c21xLjLm2lxeKc7padxjv92CIrIocnQSlJPxSCM7r5zBhwiahJA6MNQwmTl2xznU67KgA==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/client-sso-oidc": "3.598.0",
-        "@aws-sdk/core": "3.598.0",
-        "@aws-sdk/credential-provider-node": "3.598.0",
-        "@aws-sdk/middleware-host-header": "3.598.0",
-        "@aws-sdk/middleware-logger": "3.598.0",
-        "@aws-sdk/middleware-recursion-detection": "3.598.0",
-        "@aws-sdk/middleware-user-agent": "3.598.0",
-        "@aws-sdk/region-config-resolver": "3.598.0",
-        "@aws-sdk/types": "3.598.0",
-        "@aws-sdk/util-endpoints": "3.598.0",
-        "@aws-sdk/util-user-agent-browser": "3.598.0",
-        "@aws-sdk/util-user-agent-node": "3.598.0",
-        "@smithy/config-resolver": "^3.0.2",
-        "@smithy/core": "^2.2.1",
-        "@smithy/fetch-http-handler": "^3.0.2",
-        "@smithy/hash-node": "^3.0.1",
-        "@smithy/invalid-dependency": "^3.0.1",
-        "@smithy/middleware-content-length": "^3.0.1",
-        "@smithy/middleware-endpoint": "^3.0.2",
-        "@smithy/middleware-retry": "^3.0.4",
-        "@smithy/middleware-serde": "^3.0.1",
-        "@smithy/middleware-stack": "^3.0.1",
-        "@smithy/node-config-provider": "^3.1.1",
-        "@smithy/node-http-handler": "^3.0.1",
-        "@smithy/protocol-http": "^4.0.1",
-        "@smithy/smithy-client": "^3.1.2",
-        "@smithy/types": "^3.1.0",
-        "@smithy/url-parser": "^3.0.1",
+        "@aws-sdk/client-sso-oidc": "3.621.0",
+        "@aws-sdk/core": "3.621.0",
+        "@aws-sdk/credential-provider-node": "3.621.0",
+        "@aws-sdk/middleware-host-header": "3.620.0",
+        "@aws-sdk/middleware-logger": "3.609.0",
+        "@aws-sdk/middleware-recursion-detection": "3.620.0",
+        "@aws-sdk/middleware-user-agent": "3.620.0",
+        "@aws-sdk/region-config-resolver": "3.614.0",
+        "@aws-sdk/types": "3.609.0",
+        "@aws-sdk/util-endpoints": "3.614.0",
+        "@aws-sdk/util-user-agent-browser": "3.609.0",
+        "@aws-sdk/util-user-agent-node": "3.614.0",
+        "@smithy/config-resolver": "^3.0.5",
+        "@smithy/core": "^2.3.1",
+        "@smithy/fetch-http-handler": "^3.2.4",
+        "@smithy/hash-node": "^3.0.3",
+        "@smithy/invalid-dependency": "^3.0.3",
+        "@smithy/middleware-content-length": "^3.0.5",
+        "@smithy/middleware-endpoint": "^3.1.0",
+        "@smithy/middleware-retry": "^3.0.13",
+        "@smithy/middleware-serde": "^3.0.3",
+        "@smithy/middleware-stack": "^3.0.3",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/node-http-handler": "^3.1.4",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/smithy-client": "^3.1.11",
+        "@smithy/types": "^3.3.0",
+        "@smithy/url-parser": "^3.0.3",
         "@smithy/util-base64": "^3.0.0",
         "@smithy/util-body-length-browser": "^3.0.0",
         "@smithy/util-body-length-node": "^3.0.0",
-        "@smithy/util-defaults-mode-browser": "^3.0.4",
-        "@smithy/util-defaults-mode-node": "^3.0.4",
-        "@smithy/util-endpoints": "^2.0.2",
-        "@smithy/util-middleware": "^3.0.1",
-        "@smithy/util-retry": "^3.0.1",
+        "@smithy/util-defaults-mode-browser": "^3.0.13",
+        "@smithy/util-defaults-mode-node": "^3.0.13",
+        "@smithy/util-endpoints": "^2.0.5",
+        "@smithy/util-middleware": "^3.0.3",
+        "@smithy/util-retry": "^3.0.3",
         "@smithy/util-utf8": "^3.0.0",
         "tslib": "^2.6.2"
       },
@@ -544,17 +539,18 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.598.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.598.0.tgz",
-      "integrity": "sha512-HaSjt7puO5Cc7cOlrXFCW0rtA0BM9lvzjl56x0A20Pt+0wxXGeTOZZOkXQIepbrFkV2e/HYukuT9e99vXDm59g==",
-      "license": "Apache-2.0",
+      "version": "3.621.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.621.0.tgz",
+      "integrity": "sha512-CtOwWmDdEiINkGXD93iGfXjN0WmCp9l45cDWHHGa8lRgEDyhuL7bwd/pH5aSzj0j8SiQBG2k0S7DHbd5RaqvbQ==",
       "dependencies": {
-        "@smithy/core": "^2.2.1",
-        "@smithy/protocol-http": "^4.0.1",
-        "@smithy/signature-v4": "^3.1.0",
-        "@smithy/smithy-client": "^3.1.2",
-        "@smithy/types": "^3.1.0",
-        "fast-xml-parser": "4.2.5",
+        "@smithy/core": "^2.3.1",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/signature-v4": "^4.1.0",
+        "@smithy/smithy-client": "^3.1.11",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-middleware": "^3.0.3",
+        "fast-xml-parser": "4.4.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -562,14 +558,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.598.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.598.0.tgz",
-      "integrity": "sha512-vi1khgn7yXzLCcgSIzQrrtd2ilUM0dWodxj3PQ6BLfP0O+q1imO3hG1nq7DVyJtq7rFHs6+9N8G4mYvTkxby2w==",
-      "license": "Apache-2.0",
+      "version": "3.620.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.620.1.tgz",
+      "integrity": "sha512-ExuILJ2qLW5ZO+rgkNRj0xiAipKT16Rk77buvPP8csR7kkCflT/gXTyzRe/uzIiETTxM7tr8xuO9MP/DQXqkfg==",
       "dependencies": {
-        "@aws-sdk/types": "3.598.0",
-        "@smithy/property-provider": "^3.1.1",
-        "@smithy/types": "^3.1.0",
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -577,19 +572,18 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.598.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.598.0.tgz",
-      "integrity": "sha512-N7cIafi4HVlQvEgvZSo1G4T9qb/JMLGMdBsDCT5XkeJrF0aptQWzTFH0jIdZcLrMYvzPcuEyO3yCBe6cy/ba0g==",
-      "license": "Apache-2.0",
+      "version": "3.621.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.621.0.tgz",
+      "integrity": "sha512-/jc2tEsdkT1QQAI5Dvoci50DbSxtJrevemwFsm0B73pwCcOQZ5ZwwSdVqGsPutzYzUVx3bcXg3LRL7jLACqRIg==",
       "dependencies": {
-        "@aws-sdk/types": "3.598.0",
-        "@smithy/fetch-http-handler": "^3.0.2",
-        "@smithy/node-http-handler": "^3.0.1",
-        "@smithy/property-provider": "^3.1.1",
-        "@smithy/protocol-http": "^4.0.1",
-        "@smithy/smithy-client": "^3.1.2",
-        "@smithy/types": "^3.1.0",
-        "@smithy/util-stream": "^3.0.2",
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/fetch-http-handler": "^3.2.4",
+        "@smithy/node-http-handler": "^3.1.4",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/smithy-client": "^3.1.11",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-stream": "^3.1.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -597,47 +591,45 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.598.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.598.0.tgz",
-      "integrity": "sha512-/ppcIVUbRwDIwJDoYfp90X3+AuJo2mvE52Y1t2VSrvUovYn6N4v95/vXj6LS8CNDhz2jvEJYmu+0cTMHdhI6eA==",
-      "license": "Apache-2.0",
+      "version": "3.621.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.621.0.tgz",
+      "integrity": "sha512-0EWVnSc+JQn5HLnF5Xv405M8n4zfdx9gyGdpnCmAmFqEDHA8LmBdxJdpUk1Ovp/I5oPANhjojxabIW5f1uU0RA==",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.598.0",
-        "@aws-sdk/credential-provider-http": "3.598.0",
-        "@aws-sdk/credential-provider-process": "3.598.0",
-        "@aws-sdk/credential-provider-sso": "3.598.0",
-        "@aws-sdk/credential-provider-web-identity": "3.598.0",
-        "@aws-sdk/types": "3.598.0",
-        "@smithy/credential-provider-imds": "^3.1.1",
-        "@smithy/property-provider": "^3.1.1",
-        "@smithy/shared-ini-file-loader": "^3.1.1",
-        "@smithy/types": "^3.1.0",
+        "@aws-sdk/credential-provider-env": "3.620.1",
+        "@aws-sdk/credential-provider-http": "3.621.0",
+        "@aws-sdk/credential-provider-process": "3.620.1",
+        "@aws-sdk/credential-provider-sso": "3.621.0",
+        "@aws-sdk/credential-provider-web-identity": "3.621.0",
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/credential-provider-imds": "^3.2.0",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "@aws-sdk/client-sts": "^3.598.0"
+        "@aws-sdk/client-sts": "^3.621.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.598.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.598.0.tgz",
-      "integrity": "sha512-sXTlqL5I/awlF9Dg2MQ17SfrEaABVnsj2mf4jF5qQrIRhfbvQOIYdEqdy8Rn1AWlJMz/N450SGzc0XJ5owxxqw==",
-      "license": "Apache-2.0",
+      "version": "3.621.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.621.0.tgz",
+      "integrity": "sha512-4JqpccUgz5Snanpt2+53hbOBbJQrSFq7E1sAAbgY6BKVQUsW5qyXqnjvSF32kDeKa5JpBl3bBWLZl04IadcPHw==",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.598.0",
-        "@aws-sdk/credential-provider-http": "3.598.0",
-        "@aws-sdk/credential-provider-ini": "3.598.0",
-        "@aws-sdk/credential-provider-process": "3.598.0",
-        "@aws-sdk/credential-provider-sso": "3.598.0",
-        "@aws-sdk/credential-provider-web-identity": "3.598.0",
-        "@aws-sdk/types": "3.598.0",
-        "@smithy/credential-provider-imds": "^3.1.1",
-        "@smithy/property-provider": "^3.1.1",
-        "@smithy/shared-ini-file-loader": "^3.1.1",
-        "@smithy/types": "^3.1.0",
+        "@aws-sdk/credential-provider-env": "3.620.1",
+        "@aws-sdk/credential-provider-http": "3.621.0",
+        "@aws-sdk/credential-provider-ini": "3.621.0",
+        "@aws-sdk/credential-provider-process": "3.620.1",
+        "@aws-sdk/credential-provider-sso": "3.621.0",
+        "@aws-sdk/credential-provider-web-identity": "3.621.0",
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/credential-provider-imds": "^3.2.0",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -645,15 +637,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.598.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.598.0.tgz",
-      "integrity": "sha512-rM707XbLW8huMk722AgjVyxu2tMZee++fNA8TJVNgs1Ma02Wx6bBrfIvlyK0rCcIRb0WdQYP6fe3Xhiu4e8IBA==",
-      "license": "Apache-2.0",
+      "version": "3.620.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.620.1.tgz",
+      "integrity": "sha512-hWqFMidqLAkaV9G460+1at6qa9vySbjQKKc04p59OT7lZ5cO5VH5S4aI05e+m4j364MBROjjk2ugNvfNf/8ILg==",
       "dependencies": {
-        "@aws-sdk/types": "3.598.0",
-        "@smithy/property-provider": "^3.1.1",
-        "@smithy/shared-ini-file-loader": "^3.1.1",
-        "@smithy/types": "^3.1.0",
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -661,17 +652,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.598.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.598.0.tgz",
-      "integrity": "sha512-5InwUmrAuqQdOOgxTccRayMMkSmekdLk6s+az9tmikq0QFAHUCtofI+/fllMXSR9iL6JbGYi1940+EUmS4pHJA==",
-      "license": "Apache-2.0",
+      "version": "3.621.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.621.0.tgz",
+      "integrity": "sha512-Kza0jcFeA/GEL6xJlzR2KFf1PfZKMFnxfGzJzl5yN7EjoGdMijl34KaRyVnfRjnCWcsUpBWKNIDk9WZVMY9yiw==",
       "dependencies": {
-        "@aws-sdk/client-sso": "3.598.0",
-        "@aws-sdk/token-providers": "3.598.0",
-        "@aws-sdk/types": "3.598.0",
-        "@smithy/property-provider": "^3.1.1",
-        "@smithy/shared-ini-file-loader": "^3.1.1",
-        "@smithy/types": "^3.1.0",
+        "@aws-sdk/client-sso": "3.621.0",
+        "@aws-sdk/token-providers": "3.614.0",
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -679,32 +669,30 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.598.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.598.0.tgz",
-      "integrity": "sha512-GV5GdiMbz5Tz9JO4NJtRoFXjW0GPEujA0j+5J/B723rTN+REHthJu48HdBKouHGhdzkDWkkh1bu52V02Wprw8w==",
-      "license": "Apache-2.0",
+      "version": "3.621.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.621.0.tgz",
+      "integrity": "sha512-w7ASSyfNvcx7+bYGep3VBgC3K6vEdLmlpjT7nSIHxxQf+WSdvy+HynwJosrpZax0sK5q0D1Jpn/5q+r5lwwW6w==",
       "dependencies": {
-        "@aws-sdk/types": "3.598.0",
-        "@smithy/property-provider": "^3.1.1",
-        "@smithy/types": "^3.1.0",
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "@aws-sdk/client-sts": "^3.598.0"
+        "@aws-sdk/client-sts": "^3.621.0"
       }
     },
     "node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.598.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.598.0.tgz",
-      "integrity": "sha512-WiaG059YBQwQraNejLIi0gMNkX7dfPZ8hDIhvMr5aVPRbaHH8AYF3iNSsXYCHvA2Cfa1O9haYXsuMF9flXnCmA==",
-      "license": "Apache-2.0",
+      "version": "3.620.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.620.0.tgz",
+      "integrity": "sha512-VMtPEZwqYrII/oUkffYsNWY9PZ9xpNJpMgmyU0rlDQ25O1c0Hk3fJmZRe6pEkAJ0omD7kLrqGl1DUjQVxpd/Rg==",
       "dependencies": {
-        "@aws-sdk/types": "3.598.0",
-        "@smithy/protocol-http": "^4.0.1",
-        "@smithy/types": "^3.1.0",
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -712,13 +700,12 @@
       }
     },
     "node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.598.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.598.0.tgz",
-      "integrity": "sha512-bxBjf/VYiu3zfu8SYM2S9dQQc3tz5uBAOcPz/Bt8DyyK3GgOpjhschH/2XuUErsoUO1gDJqZSdGOmuHGZQn00Q==",
-      "license": "Apache-2.0",
+      "version": "3.609.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.609.0.tgz",
+      "integrity": "sha512-S62U2dy4jMDhDFDK5gZ4VxFdWzCtLzwbYyFZx2uvPYTECkepLUfzLic2BHg2Qvtu4QjX+oGE3P/7fwaGIsGNuQ==",
       "dependencies": {
-        "@aws-sdk/types": "3.598.0",
-        "@smithy/types": "^3.1.0",
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -726,14 +713,13 @@
       }
     },
     "node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.598.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.598.0.tgz",
-      "integrity": "sha512-vjT9BeFY9FeN0f8hm2l6F53tI0N5bUq6RcDkQXKNabXBnQxKptJRad6oP2X5y3FoVfBLOuDkQgiC2940GIPxtQ==",
-      "license": "Apache-2.0",
+      "version": "3.620.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.620.0.tgz",
+      "integrity": "sha512-nh91S7aGK3e/o1ck64sA/CyoFw+gAYj2BDOnoNa6ouyCrVJED96ZXWbhye/fz9SgmNUZR2g7GdVpiLpMKZoI5w==",
       "dependencies": {
-        "@aws-sdk/types": "3.598.0",
-        "@smithy/protocol-http": "^4.0.1",
-        "@smithy/types": "^3.1.0",
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -741,15 +727,14 @@
       }
     },
     "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.598.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.598.0.tgz",
-      "integrity": "sha512-4tjESlHG5B5MdjUaLK7tQs/miUtHbb6deauQx8ryqSBYOhfHVgb1ZnzvQR0bTrhpqUg0WlybSkDaZAICf9xctg==",
-      "license": "Apache-2.0",
+      "version": "3.620.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.620.0.tgz",
+      "integrity": "sha512-bvS6etn+KsuL32ubY5D3xNof1qkenpbJXf/ugGXbg0n98DvDFQ/F+SMLxHgbnER5dsKYchNnhmtI6/FC3HFu/A==",
       "dependencies": {
-        "@aws-sdk/types": "3.598.0",
-        "@aws-sdk/util-endpoints": "3.598.0",
-        "@smithy/protocol-http": "^4.0.1",
-        "@smithy/types": "^3.1.0",
+        "@aws-sdk/types": "3.609.0",
+        "@aws-sdk/util-endpoints": "3.614.0",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -757,16 +742,15 @@
       }
     },
     "node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.598.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.598.0.tgz",
-      "integrity": "sha512-oYXhmTokSav4ytmWleCr3rs/1nyvZW/S0tdi6X7u+dLNL5Jee+uMxWGzgOrWK6wrQOzucLVjS4E/wA11Kv2GTw==",
-      "license": "Apache-2.0",
+      "version": "3.614.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.614.0.tgz",
+      "integrity": "sha512-vDCeMXvic/LU0KFIUjpC3RiSTIkkvESsEfbVHiHH0YINfl8HnEqR5rj+L8+phsCeVg2+LmYwYxd5NRz4PHxt5g==",
       "dependencies": {
-        "@aws-sdk/types": "3.598.0",
-        "@smithy/node-config-provider": "^3.1.1",
-        "@smithy/types": "^3.1.0",
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/types": "^3.3.0",
         "@smithy/util-config-provider": "^3.0.0",
-        "@smithy/util-middleware": "^3.0.1",
+        "@smithy/util-middleware": "^3.0.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -774,31 +758,29 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.598.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.598.0.tgz",
-      "integrity": "sha512-TKY1EVdHVBnZqpyxyTHdpZpa1tUpb6nxVeRNn1zWG8QB5MvH4ALLd/jR+gtmWDNQbIG4cVuBOZFVL8hIYicKTA==",
-      "license": "Apache-2.0",
+      "version": "3.614.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.614.0.tgz",
+      "integrity": "sha512-okItqyY6L9IHdxqs+Z116y5/nda7rHxLvROxtAJdLavWTYDydxrZstImNgGWTeVdmc0xX2gJCI77UYUTQWnhRw==",
       "dependencies": {
-        "@aws-sdk/types": "3.598.0",
-        "@smithy/property-provider": "^3.1.1",
-        "@smithy/shared-ini-file-loader": "^3.1.1",
-        "@smithy/types": "^3.1.0",
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "@aws-sdk/client-sso-oidc": "^3.598.0"
+        "@aws-sdk/client-sso-oidc": "^3.614.0"
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.598.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.598.0.tgz",
-      "integrity": "sha512-742uRl6z7u0LFmZwDrFP6r1wlZcgVPw+/TilluDJmCAR8BgRw3IR+743kUXKBGd8QZDRW2n6v/PYsi/AWCDDMQ==",
-      "license": "Apache-2.0",
+      "version": "3.609.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.609.0.tgz",
+      "integrity": "sha512-+Tqnh9w0h2LcrUsdXyT1F8mNhXz+tVYBtP19LpeEGntmvHwa2XzvLUCWpoIAIVsHp5+HdB2X9Sn0KAtmbFXc2Q==",
       "dependencies": {
-        "@smithy/types": "^3.1.0",
+        "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -806,14 +788,13 @@
       }
     },
     "node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.598.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.598.0.tgz",
-      "integrity": "sha512-Qo9UoiVVZxcOEdiOMZg3xb1mzkTxrhd4qSlg5QQrfWPJVx/QOg+Iy0NtGxPtHtVZNHZxohYwDwV/tfsnDSE2gQ==",
-      "license": "Apache-2.0",
+      "version": "3.614.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.614.0.tgz",
+      "integrity": "sha512-wK2cdrXHH4oz4IomV/yrGkftU9A+ITB6nFL+rxxyO78is2ifHJpFdV4aqk4LSkXYPi6CXWNru/Dqc7yiKXgJPw==",
       "dependencies": {
-        "@aws-sdk/types": "3.598.0",
-        "@smithy/types": "^3.1.0",
-        "@smithy/util-endpoints": "^2.0.2",
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-endpoints": "^2.0.5",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -833,26 +814,24 @@
       }
     },
     "node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.598.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.598.0.tgz",
-      "integrity": "sha512-36Sxo6F+ykElaL1mWzWjlg+1epMpSe8obwhCN1yGE7Js9ywy5U6k6l+A3q3YM9YRbm740sNxncbwLklMvuhTKw==",
-      "license": "Apache-2.0",
+      "version": "3.609.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.609.0.tgz",
+      "integrity": "sha512-fojPU+mNahzQ0YHYBsx0ZIhmMA96H+ZIZ665ObU9tl+SGdbLneVZVikGve+NmHTQwHzwkFsZYYnVKAkreJLAtA==",
       "dependencies": {
-        "@aws-sdk/types": "3.598.0",
-        "@smithy/types": "^3.1.0",
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/types": "^3.3.0",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.598.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.598.0.tgz",
-      "integrity": "sha512-oyWGcOlfTdzkC6SVplyr0AGh54IMrDxbhg5RxJ5P+V4BKfcDoDcZV9xenUk9NsOi9MuUjxMumb9UJGkDhM1m0A==",
-      "license": "Apache-2.0",
+      "version": "3.614.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.614.0.tgz",
+      "integrity": "sha512-15ElZT88peoHnq5TEoEtZwoXTXRxNrk60TZNdpl/TUBJ5oNJ9Dqb5Z4ryb8ofN6nm9aFf59GVAerFDz8iUoHBA==",
       "dependencies": {
-        "@aws-sdk/types": "3.598.0",
-        "@smithy/node-config-provider": "^3.1.1",
-        "@smithy/types": "^3.1.0",
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2259,12 +2238,11 @@
       }
     },
     "node_modules/@smithy/abort-controller": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-3.0.1.tgz",
-      "integrity": "sha512-Jb7jg4E+C+uvrUQi+h9kbILY6ts6fglKZzseMCHlH9ayq+1f5QdpYf8MV/xppuiN6DAMJAmwGz53GwP3213dmA==",
-      "license": "Apache-2.0",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-3.1.1.tgz",
+      "integrity": "sha512-MBJBiidoe+0cTFhyxT8g+9g7CeVccLM0IOKKUMCNQ1CNMJ/eIfoo0RTfVrXOONEI1UCN1W+zkiHSbzUNE9dZtQ==",
       "dependencies": {
-        "@smithy/types": "^3.1.0",
+        "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2272,15 +2250,14 @@
       }
     },
     "node_modules/@smithy/config-resolver": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-3.0.2.tgz",
-      "integrity": "sha512-wUyG6ezpp2sWAvfqmSYTROwFUmJqKV78GLf55WODrosBcT0BAMd9bOLO4HRhynWBgAobPml2cF9ZOdgCe00r+g==",
-      "license": "Apache-2.0",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-3.0.5.tgz",
+      "integrity": "sha512-SkW5LxfkSI1bUC74OtfBbdz+grQXYiPYolyu8VfpLIjEoN/sHVBlLeGXMQ1vX4ejkgfv6sxVbQJ32yF2cl1veA==",
       "dependencies": {
-        "@smithy/node-config-provider": "^3.1.1",
-        "@smithy/types": "^3.1.0",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/types": "^3.3.0",
         "@smithy/util-config-provider": "^3.0.0",
-        "@smithy/util-middleware": "^3.0.1",
+        "@smithy/util-middleware": "^3.0.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2288,18 +2265,17 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-2.2.2.tgz",
-      "integrity": "sha512-bxZr4ZTqS6hMSQGYdcsfFQTFU0MO2xKLbkqZMSRDM+ruQ0nY00lFJUeLhXe7fqohSEd1y5wKu1Ap0bVJPzpmHg==",
-      "license": "Apache-2.0",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-2.3.1.tgz",
+      "integrity": "sha512-BC7VMXx/1BCmRPCVzzn4HGWAtsrb7/0758EtwOGFJQrlSwJBEjCcDLNZLFoL/68JexYa2s+KmgL/UfmXdG6v1w==",
       "dependencies": {
-        "@smithy/middleware-endpoint": "^3.0.2",
-        "@smithy/middleware-retry": "^3.0.5",
-        "@smithy/middleware-serde": "^3.0.1",
-        "@smithy/protocol-http": "^4.0.1",
-        "@smithy/smithy-client": "^3.1.3",
-        "@smithy/types": "^3.1.0",
-        "@smithy/util-middleware": "^3.0.1",
+        "@smithy/middleware-endpoint": "^3.1.0",
+        "@smithy/middleware-retry": "^3.0.13",
+        "@smithy/middleware-serde": "^3.0.3",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/smithy-client": "^3.1.11",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-middleware": "^3.0.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2307,15 +2283,14 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-3.1.1.tgz",
-      "integrity": "sha512-htndP0LwHdE3R3Nam9ZyVWhwPYOmD4xCL79kqvNxy8u/bv0huuy574CSiRY4cvEICgimv8jlVfLeZ7zZqbnB2g==",
-      "license": "Apache-2.0",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-3.2.0.tgz",
+      "integrity": "sha512-0SCIzgd8LYZ9EJxUjLXBmEKSZR/P/w6l7Rz/pab9culE/RWuqelAKGJvn5qUOl8BgX8Yj5HWM50A5hiB/RzsgA==",
       "dependencies": {
-        "@smithy/node-config-provider": "^3.1.1",
-        "@smithy/property-provider": "^3.1.1",
-        "@smithy/types": "^3.1.0",
-        "@smithy/url-parser": "^3.0.1",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/types": "^3.3.0",
+        "@smithy/url-parser": "^3.0.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2323,25 +2298,23 @@
       }
     },
     "node_modules/@smithy/eventstream-codec": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-3.1.0.tgz",
-      "integrity": "sha512-XFDl70ZY+FabSnTX3oQGGYvdbEaC8vPEFkCEOoBkumqaZIwR1WjjJCDu2VMXlHbKWKshefWXdT0NYteL5v6uFw==",
-      "license": "Apache-2.0",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-3.1.2.tgz",
+      "integrity": "sha512-0mBcu49JWt4MXhrhRAlxASNy0IjDRFU+aWNDRal9OtUJvJNiwDuyKMUONSOjLjSCeGwZaE0wOErdqULer8r7yw==",
       "dependencies": {
         "@aws-crypto/crc32": "5.2.0",
-        "@smithy/types": "^3.1.0",
+        "@smithy/types": "^3.3.0",
         "@smithy/util-hex-encoding": "^3.0.0",
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@smithy/eventstream-serde-browser": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-3.0.2.tgz",
-      "integrity": "sha512-6147vdedQGaWn3Nt4P1KV0LuV8IH4len1SAeycyko0p8oRLWFyYyx0L8JHGclePDSphkjxZqBHtyIfyupCaTGg==",
-      "license": "Apache-2.0",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-3.0.5.tgz",
+      "integrity": "sha512-dEyiUYL/ekDfk+2Ra4GxV+xNnFoCmk1nuIXg+fMChFTrM2uI/1r9AdiTYzPqgb72yIv/NtAj6C3dG//1wwgakQ==",
       "dependencies": {
-        "@smithy/eventstream-serde-universal": "^3.0.2",
-        "@smithy/types": "^3.1.0",
+        "@smithy/eventstream-serde-universal": "^3.0.4",
+        "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2349,12 +2322,11 @@
       }
     },
     "node_modules/@smithy/eventstream-serde-config-resolver": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.0.1.tgz",
-      "integrity": "sha512-6+B8P+5Q1mll4u7IoI7mpmYOSW3/c2r3WQoYLdqOjbIKMixJFGmN79ZjJiNMy4X2GZ4We9kQ6LfnFuczSlhcyw==",
-      "license": "Apache-2.0",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.0.3.tgz",
+      "integrity": "sha512-NVTYjOuYpGfrN/VbRQgn31x73KDLfCXCsFdad8DiIc3IcdxL+dYA9zEQPyOP7Fy2QL8CPy2WE4WCUD+ZsLNfaQ==",
       "dependencies": {
-        "@smithy/types": "^3.1.0",
+        "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2362,13 +2334,12 @@
       }
     },
     "node_modules/@smithy/eventstream-serde-node": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-3.0.2.tgz",
-      "integrity": "sha512-DLtmGAfqxZAql8rB+HqyPlUne22u3EEVj+hxlUjgXk0hXt+SfLGK0ljzRFmiWQ3qGpHu1NdJpJA9e5JE/dJxFw==",
-      "license": "Apache-2.0",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-3.0.4.tgz",
+      "integrity": "sha512-mjlG0OzGAYuUpdUpflfb9zyLrBGgmQmrobNT8b42ZTsGv/J03+t24uhhtVEKG/b2jFtPIHF74Bq+VUtbzEKOKg==",
       "dependencies": {
-        "@smithy/eventstream-serde-universal": "^3.0.2",
-        "@smithy/types": "^3.1.0",
+        "@smithy/eventstream-serde-universal": "^3.0.4",
+        "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2376,13 +2347,12 @@
       }
     },
     "node_modules/@smithy/eventstream-serde-universal": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-3.0.2.tgz",
-      "integrity": "sha512-d3SgAIQ/s4EbU8HAHJ8m2MMJPAL30nqJktyVgvqZWNznA8PJl61gJw5gj/yjIt/Fvs3d4fU8FmPPAhdp2yr/7A==",
-      "license": "Apache-2.0",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-3.0.4.tgz",
+      "integrity": "sha512-Od9dv8zh3PgOD7Vj4T3HSuox16n0VG8jJIM2gvKASL6aCtcS8CfHZDWe1Ik3ZXW6xBouU+45Q5wgoliWDZiJ0A==",
       "dependencies": {
-        "@smithy/eventstream-codec": "^3.1.0",
-        "@smithy/types": "^3.1.0",
+        "@smithy/eventstream-codec": "^3.1.2",
+        "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2390,25 +2360,23 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-3.0.3.tgz",
-      "integrity": "sha512-31x2MokxJL/u5U/BdElvVRotOGjUcOOvI2pb5TZ02umBLw+vVHImiLn+khbN0SblaFXNRzPoGrKwXylNjV3skw==",
-      "license": "Apache-2.0",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-3.2.4.tgz",
+      "integrity": "sha512-kBprh5Gs5h7ug4nBWZi1FZthdqSM+T7zMmsZxx0IBvWUn7dK3diz2SHn7Bs4dQGFDk8plDv375gzenDoNwrXjg==",
       "dependencies": {
-        "@smithy/protocol-http": "^4.0.1",
-        "@smithy/querystring-builder": "^3.0.1",
-        "@smithy/types": "^3.1.0",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/querystring-builder": "^3.0.3",
+        "@smithy/types": "^3.3.0",
         "@smithy/util-base64": "^3.0.0",
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@smithy/hash-node": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-3.0.1.tgz",
-      "integrity": "sha512-w2ncjgk2EYO2+WhAsSQA8owzoOSY7IL1qVytlwpnL1pFGWTjIoIh5nROkEKXY51unB63bMGZqDiVoXaFbyKDlg==",
-      "license": "Apache-2.0",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-3.0.3.tgz",
+      "integrity": "sha512-2ctBXpPMG+B3BtWSGNnKELJ7SH9e4TNefJS0cd2eSkOOROeBnnVBnAy9LtJ8tY4vUEoe55N4CNPxzbWvR39iBw==",
       "dependencies": {
-        "@smithy/types": "^3.1.0",
+        "@smithy/types": "^3.3.0",
         "@smithy/util-buffer-from": "^3.0.0",
         "@smithy/util-utf8": "^3.0.0",
         "tslib": "^2.6.2"
@@ -2418,12 +2386,11 @@
       }
     },
     "node_modules/@smithy/invalid-dependency": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-3.0.1.tgz",
-      "integrity": "sha512-RSNF/32BKygXKKMyS7koyuAq1rcdW5p5c4EFa77QenBFze9As+JiRnV9OWBh2cB/ejGZalEZjvIrMLHwJl7aGA==",
-      "license": "Apache-2.0",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-3.0.3.tgz",
+      "integrity": "sha512-ID1eL/zpDULmHJbflb864k72/SNOZCADRc9i7Exq3RUNJw6raWUSlFEQ+3PX3EYs++bTxZB2dE9mEHTQLv61tw==",
       "dependencies": {
-        "@smithy/types": "^3.1.0",
+        "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       }
     },
@@ -2440,13 +2407,12 @@
       }
     },
     "node_modules/@smithy/middleware-content-length": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-3.0.1.tgz",
-      "integrity": "sha512-6QdK/VbrCfXD5/QolE2W/ok6VqxD+SM28Ds8iSlEHXZwv4buLsvWyvoEEy0322K/g5uFgPzBmZjGqesTmPL+yQ==",
-      "license": "Apache-2.0",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-3.0.5.tgz",
+      "integrity": "sha512-ILEzC2eyxx6ncej3zZSwMpB5RJ0zuqH7eMptxC4KN3f+v9bqT8ohssKbhNR78k/2tWW+KS5Spw+tbPF4Ejyqvw==",
       "dependencies": {
-        "@smithy/protocol-http": "^4.0.1",
-        "@smithy/types": "^3.1.0",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2454,17 +2420,16 @@
       }
     },
     "node_modules/@smithy/middleware-endpoint": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-3.0.2.tgz",
-      "integrity": "sha512-gWEaGYB3Bei17Oiy/F2IlUPpBazNXImytoOdJ1xbrUOaJKAOiUhx8/4FOnYLLJHdAwa9PlvJ2ULda2f/Dnwi9w==",
-      "license": "Apache-2.0",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-3.1.0.tgz",
+      "integrity": "sha512-5y5aiKCEwg9TDPB4yFE7H6tYvGFf1OJHNczeY10/EFF8Ir8jZbNntQJxMWNfeQjC1mxPsaQ6mR9cvQbf+0YeMw==",
       "dependencies": {
-        "@smithy/middleware-serde": "^3.0.1",
-        "@smithy/node-config-provider": "^3.1.1",
-        "@smithy/shared-ini-file-loader": "^3.1.1",
-        "@smithy/types": "^3.1.0",
-        "@smithy/url-parser": "^3.0.1",
-        "@smithy/util-middleware": "^3.0.1",
+        "@smithy/middleware-serde": "^3.0.3",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "@smithy/url-parser": "^3.0.3",
+        "@smithy/util-middleware": "^3.0.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2472,18 +2437,17 @@
       }
     },
     "node_modules/@smithy/middleware-retry": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-3.0.5.tgz",
-      "integrity": "sha512-nKAmmea9Wm0d94obPqVgjxW2zzaNemxcTzjgd17LhGKI23D66UQKI5gpoWDsnE+R4tfuZe9dCcw8gmTVEwFpRA==",
-      "license": "Apache-2.0",
+      "version": "3.0.13",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-3.0.13.tgz",
+      "integrity": "sha512-zvCLfaRYCaUmjbF2yxShGZdolSHft7NNCTA28HVN9hKcEbOH+g5irr1X9s+in8EpambclGnevZY4A3lYpvDCFw==",
       "dependencies": {
-        "@smithy/node-config-provider": "^3.1.1",
-        "@smithy/protocol-http": "^4.0.1",
-        "@smithy/service-error-classification": "^3.0.1",
-        "@smithy/smithy-client": "^3.1.3",
-        "@smithy/types": "^3.1.0",
-        "@smithy/util-middleware": "^3.0.1",
-        "@smithy/util-retry": "^3.0.1",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/service-error-classification": "^3.0.3",
+        "@smithy/smithy-client": "^3.1.11",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-middleware": "^3.0.3",
+        "@smithy/util-retry": "^3.0.3",
         "tslib": "^2.6.2",
         "uuid": "^9.0.1"
       },
@@ -2492,12 +2456,11 @@
       }
     },
     "node_modules/@smithy/middleware-serde": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-3.0.1.tgz",
-      "integrity": "sha512-ak6H/ZRN05r5+SR0/IUc5zOSyh2qp3HReg1KkrnaSLXmncy9lwOjNqybX4L4x55/e5mtVDn1uf/gQ6bw5neJPw==",
-      "license": "Apache-2.0",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-3.0.3.tgz",
+      "integrity": "sha512-puUbyJQBcg9eSErFXjKNiGILJGtiqmuuNKEYNYfUD57fUl4i9+mfmThtQhvFXU0hCVG0iEJhvQUipUf+/SsFdA==",
       "dependencies": {
-        "@smithy/types": "^3.1.0",
+        "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2505,12 +2468,11 @@
       }
     },
     "node_modules/@smithy/middleware-stack": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-3.0.1.tgz",
-      "integrity": "sha512-fS5uT//y1SlBdkzIvgmWQ9FufwMXrHSSbuR25ygMy1CRDIZkcBMoF4oTMYNfR9kBlVBcVzlv7joFdNrFuQirPA==",
-      "license": "Apache-2.0",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-3.0.3.tgz",
+      "integrity": "sha512-r4klY9nFudB0r9UdSMaGSyjyQK5adUyPnQN/ZM6M75phTxOdnc/AhpvGD1fQUvgmqjQEBGCwpnPbDm8pH5PapA==",
       "dependencies": {
-        "@smithy/types": "^3.1.0",
+        "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2518,14 +2480,13 @@
       }
     },
     "node_modules/@smithy/node-config-provider": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.1.tgz",
-      "integrity": "sha512-z5G7+ysL4yUtMghUd2zrLkecu0mTfnYlt5dR76g/HsFqf7evFazwiZP1ag2EJenGxNBDwDM5g8nm11NPogiUVA==",
-      "license": "Apache-2.0",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.4.tgz",
+      "integrity": "sha512-YvnElQy8HR4vDcAjoy7Xkx9YT8xZP4cBXcbJSgm/kxmiQu08DwUwj8rkGnyoJTpfl/3xYHH+d8zE+eHqoDCSdQ==",
       "dependencies": {
-        "@smithy/property-provider": "^3.1.1",
-        "@smithy/shared-ini-file-loader": "^3.1.1",
-        "@smithy/types": "^3.1.0",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2533,15 +2494,14 @@
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-3.0.1.tgz",
-      "integrity": "sha512-hlBI6MuREA4o1wBMEt+QNhUzoDtFFvwR6ecufimlx9D79jPybE/r8kNorphXOi91PgSO9S2fxRjcKCLk7Jw8zA==",
-      "license": "Apache-2.0",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-3.1.4.tgz",
+      "integrity": "sha512-+UmxgixgOr/yLsUxcEKGH0fMNVteJFGkmRltYFHnBMlogyFdpzn2CwqWmxOrfJELhV34v0WSlaqG1UtE1uXlJg==",
       "dependencies": {
-        "@smithy/abort-controller": "^3.0.1",
-        "@smithy/protocol-http": "^4.0.1",
-        "@smithy/querystring-builder": "^3.0.1",
-        "@smithy/types": "^3.1.0",
+        "@smithy/abort-controller": "^3.1.1",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/querystring-builder": "^3.0.3",
+        "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2549,12 +2509,11 @@
       }
     },
     "node_modules/@smithy/property-provider": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.1.1.tgz",
-      "integrity": "sha512-YknOMZcQkB5on+MU0DvbToCmT2YPtTETMXW0D3+/Iln7ezT+Zm1GMHhCW1dOH/X/+LkkQD9aXEoCX/B10s4Xdw==",
-      "license": "Apache-2.0",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.1.3.tgz",
+      "integrity": "sha512-zahyOVR9Q4PEoguJ/NrFP4O7SMAfYO1HLhB18M+q+Z4KFd4V2obiMnlVoUFzFLSPeVt1POyNWneHHrZaTMoc/g==",
       "dependencies": {
-        "@smithy/types": "^3.1.0",
+        "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2562,12 +2521,11 @@
       }
     },
     "node_modules/@smithy/protocol-http": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.0.1.tgz",
-      "integrity": "sha512-eBhm9zwcFPEazc654c0BEWtxYAzrw+OhoSf5pkwKzfftWKXRoqEhwOE2Pvn30v0iAdo7Mfsfb6pi1NnZlGCMpg==",
-      "license": "Apache-2.0",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.1.0.tgz",
+      "integrity": "sha512-dPVoHYQ2wcHooGXg3LQisa1hH0e4y0pAddPMeeUPipI1tEOqL6A4N0/G7abeq+K8wrwSgjk4C0wnD1XZpJm5aA==",
       "dependencies": {
-        "@smithy/types": "^3.1.0",
+        "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2575,12 +2533,11 @@
       }
     },
     "node_modules/@smithy/querystring-builder": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-3.0.1.tgz",
-      "integrity": "sha512-vKitpnG/2KOMVlx3x1S3FkBH075EROG3wcrcDaNerQNh8yuqnSL23btCD2UyX4i4lpPzNW6VFdxbn2Z25b/g5Q==",
-      "license": "Apache-2.0",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-3.0.3.tgz",
+      "integrity": "sha512-vyWckeUeesFKzCDaRwWLUA1Xym9McaA6XpFfAK5qI9DKJ4M33ooQGqvM4J+LalH4u/Dq9nFiC8U6Qn1qi0+9zw==",
       "dependencies": {
-        "@smithy/types": "^3.1.0",
+        "@smithy/types": "^3.3.0",
         "@smithy/util-uri-escape": "^3.0.0",
         "tslib": "^2.6.2"
       },
@@ -2589,12 +2546,11 @@
       }
     },
     "node_modules/@smithy/querystring-parser": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-3.0.1.tgz",
-      "integrity": "sha512-Qt8DMC05lVS8NcQx94lfVbZSX+2Ym7032b/JR8AlboAa/D669kPzqb35dkjkvAG6+NWmUchef3ENtrD6F+5n8Q==",
-      "license": "Apache-2.0",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-3.0.3.tgz",
+      "integrity": "sha512-zahM1lQv2YjmznnfQsWbYojFe55l0SLG/988brlLv1i8z3dubloLF+75ATRsqPBboUXsW6I9CPGE5rQgLfY0vQ==",
       "dependencies": {
-        "@smithy/types": "^3.1.0",
+        "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2602,24 +2558,22 @@
       }
     },
     "node_modules/@smithy/service-error-classification": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.1.tgz",
-      "integrity": "sha512-ubFUvIePjDCyIzZ+pLETqNC6KXJ/fc6g+/baqel7Zf6kJI/kZKgjwkCI7zbUhoUuOZ/4eA/87YasVu40b/B4bA==",
-      "license": "Apache-2.0",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.3.tgz",
+      "integrity": "sha512-Jn39sSl8cim/VlkLsUhRFq/dKDnRUFlfRkvhOJaUbLBXUsLRLNf9WaxDv/z9BjuQ3A6k/qE8af1lsqcwm7+DaQ==",
       "dependencies": {
-        "@smithy/types": "^3.1.0"
+        "@smithy/types": "^3.3.0"
       },
       "engines": {
         "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/shared-ini-file-loader": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.1.tgz",
-      "integrity": "sha512-nD6tXIX2126/P9e3wqRY1bm9dTtPZwRDyjVOd18G28o+1UOG+kOVgUwujE795HslSuPlEgqzsH5sgNP1hDjj9g==",
-      "license": "Apache-2.0",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.4.tgz",
+      "integrity": "sha512-qMxS4hBGB8FY2GQqshcRUy1K6k8aBWP5vwm8qKkCT3A9K2dawUwOIJfqh9Yste/Bl0J2lzosVyrXDj68kLcHXQ==",
       "dependencies": {
-        "@smithy/types": "^3.1.0",
+        "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2627,15 +2581,15 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-3.1.0.tgz",
-      "integrity": "sha512-m0/6LW3IQ3/JBcdhqjpkpABPTPhcejqeAn0U877zxBdNLiWAnG2WmCe5MfkUyVuvpFTPQnQwCo/0ZBR4uF5kxg==",
-      "license": "Apache-2.0",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-4.1.0.tgz",
+      "integrity": "sha512-aRryp2XNZeRcOtuJoxjydO6QTaVhxx/vjaR+gx7ZjaFgrgPRyZ3HCTbfwqYj6ZWEBHkCSUfcaymKPURaByukag==",
       "dependencies": {
         "@smithy/is-array-buffer": "^3.0.0",
-        "@smithy/types": "^3.1.0",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/types": "^3.3.0",
         "@smithy/util-hex-encoding": "^3.0.0",
-        "@smithy/util-middleware": "^3.0.1",
+        "@smithy/util-middleware": "^3.0.3",
         "@smithy/util-uri-escape": "^3.0.0",
         "@smithy/util-utf8": "^3.0.0",
         "tslib": "^2.6.2"
@@ -2645,16 +2599,15 @@
       }
     },
     "node_modules/@smithy/smithy-client": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.1.3.tgz",
-      "integrity": "sha512-YVz+akpR5lIIRPJfhE4sqoHYwMys6/33vsFvDof+71FCwa4jkVfMpzKv9TKrG/EDb5TV+YtjdXkwywdqlUOQXA==",
-      "license": "Apache-2.0",
+      "version": "3.1.11",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.1.11.tgz",
+      "integrity": "sha512-l0BpyYkciNyMaS+PnFFz4aO5sBcXvGLoJd7mX9xrMBIm2nIQBVvYgp2ZpPDMzwjKCavsXu06iuCm0F6ZJZc6yQ==",
       "dependencies": {
-        "@smithy/middleware-endpoint": "^3.0.2",
-        "@smithy/middleware-stack": "^3.0.1",
-        "@smithy/protocol-http": "^4.0.1",
-        "@smithy/types": "^3.1.0",
-        "@smithy/util-stream": "^3.0.3",
+        "@smithy/middleware-endpoint": "^3.1.0",
+        "@smithy/middleware-stack": "^3.0.3",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-stream": "^3.1.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2662,10 +2615,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.1.0.tgz",
-      "integrity": "sha512-qi4SeCVOUPjhSSZrxxB/mB8DrmuSFUcJnD9KXjuP+7C3LV/KFV4kpuUSH3OHDZgQB9TEH/1sO/Fq/5HyaK9MPw==",
-      "license": "Apache-2.0",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -2674,13 +2626,12 @@
       }
     },
     "node_modules/@smithy/url-parser": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-3.0.1.tgz",
-      "integrity": "sha512-G140IlNFlzYWVCedC4E2d6NycM1dCUbe5CnsGW1hmGt4hYKiGOw0v7lVru9WAn5T2w09QEjl4fOESWjGmCvVmg==",
-      "license": "Apache-2.0",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-3.0.3.tgz",
+      "integrity": "sha512-pw3VtZtX2rg+s6HMs6/+u9+hu6oY6U7IohGhVNnjbgKy86wcIsSZwgHrFR+t67Uyxvp4Xz3p3kGXXIpTNisq8A==",
       "dependencies": {
-        "@smithy/querystring-parser": "^3.0.1",
-        "@smithy/types": "^3.1.0",
+        "@smithy/querystring-parser": "^3.0.3",
+        "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       }
     },
@@ -2736,7 +2687,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-3.0.0.tgz",
       "integrity": "sha512-pbjk4s0fwq3Di/ANL+rCvJMKM5bzAQdE5S/6RL5NXgMExFAi6UgQMPOm5yPaIWPpr+EOXKXRonJ3FoxKf4mCJQ==",
-      "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -2745,14 +2695,13 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-3.0.5.tgz",
-      "integrity": "sha512-VZkJ+bXCHcNSMhX8EReGyFcc/Err94YGqeEKbbxkVz2TgKlacsoplpi+kxOMVbQq/tq9sQx5ajBKG+nl2GNuxw==",
-      "license": "Apache-2.0",
+      "version": "3.0.13",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-3.0.13.tgz",
+      "integrity": "sha512-ZIRSUsnnMRStOP6OKtW+gCSiVFkwnfQF2xtf32QKAbHR6ACjhbAybDvry+3L5qQYdh3H6+7yD/AiUE45n8mTTw==",
       "dependencies": {
-        "@smithy/property-provider": "^3.1.1",
-        "@smithy/smithy-client": "^3.1.3",
-        "@smithy/types": "^3.1.0",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/smithy-client": "^3.1.11",
+        "@smithy/types": "^3.3.0",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       },
@@ -2761,17 +2710,16 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-node": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-3.0.5.tgz",
-      "integrity": "sha512-jy19cFQA0k4f8VUDFsZVBey3rmI8EuXCw/xh/abdiq6S1qdwdfZ5coviuyYd//LPszf2yWIYkLpvmLF9qbhLGg==",
-      "license": "Apache-2.0",
+      "version": "3.0.13",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-3.0.13.tgz",
+      "integrity": "sha512-voUa8TFJGfD+U12tlNNLCDlXibt9vRdNzRX45Onk/WxZe7TS+hTOZouEZRa7oARGicdgeXvt1A0W45qLGYdy+g==",
       "dependencies": {
-        "@smithy/config-resolver": "^3.0.2",
-        "@smithy/credential-provider-imds": "^3.1.1",
-        "@smithy/node-config-provider": "^3.1.1",
-        "@smithy/property-provider": "^3.1.1",
-        "@smithy/smithy-client": "^3.1.3",
-        "@smithy/types": "^3.1.0",
+        "@smithy/config-resolver": "^3.0.5",
+        "@smithy/credential-provider-imds": "^3.2.0",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/smithy-client": "^3.1.11",
+        "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2779,13 +2727,12 @@
       }
     },
     "node_modules/@smithy/util-endpoints": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-2.0.2.tgz",
-      "integrity": "sha512-4zFOcBFQvifd2LSD4a1dKvfIWWwh4sWNtS3oZ7mpob/qPPmJseqKB148iT+hWCDsG//TmI+8vjYPgZdvnkYlTg==",
-      "license": "Apache-2.0",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-2.0.5.tgz",
+      "integrity": "sha512-ReQP0BWihIE68OAblC/WQmDD40Gx+QY1Ez8mTdFMXpmjfxSyz2fVQu3A4zXRfQU9sZXtewk3GmhfOHswvX+eNg==",
       "dependencies": {
-        "@smithy/node-config-provider": "^3.1.1",
-        "@smithy/types": "^3.1.0",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2796,7 +2743,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-3.0.0.tgz",
       "integrity": "sha512-eFndh1WEK5YMUYvy3lPlVmYY/fZcQE1D8oSf41Id2vCeIkKJXPcYDCZD+4+xViI6b1XSd7tE+s5AmXzz5ilabQ==",
-      "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -2805,12 +2751,11 @@
       }
     },
     "node_modules/@smithy/util-middleware": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-3.0.1.tgz",
-      "integrity": "sha512-WRODCQtUsO7vIvfrdxS8RFPeLKcewYtaCglZsBsedIKSUGIIvMlZT5oh+pCe72I+1L+OjnZuqRNpN2LKhWA4KQ==",
-      "license": "Apache-2.0",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-3.0.3.tgz",
+      "integrity": "sha512-l+StyYYK/eO3DlVPbU+4Bi06Jjal+PFLSMmlWM1BEwyLxZ3aKkf1ROnoIakfaA7mC6uw3ny7JBkau4Yc+5zfWw==",
       "dependencies": {
-        "@smithy/types": "^3.1.0",
+        "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2818,13 +2763,12 @@
       }
     },
     "node_modules/@smithy/util-retry": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.1.tgz",
-      "integrity": "sha512-5lRtYm+8fNFEUTdqZXg5M4ppVp40rMIJfR1TpbHAhKQgPIDpWT+iYMaqgnwEbtpi9U1smyUOPv5Sg+M1neOBgw==",
-      "license": "Apache-2.0",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.3.tgz",
+      "integrity": "sha512-AFw+hjpbtVApzpNDhbjNG5NA3kyoMs7vx0gsgmlJF4s+yz1Zlepde7J58zpIRIsdjc+emhpAITxA88qLkPF26w==",
       "dependencies": {
-        "@smithy/service-error-classification": "^3.0.1",
-        "@smithy/types": "^3.1.0",
+        "@smithy/service-error-classification": "^3.0.3",
+        "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2832,14 +2776,13 @@
       }
     },
     "node_modules/@smithy/util-stream": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-3.0.3.tgz",
-      "integrity": "sha512-ztOvXkXKJromRHNzvrLEW/vvTQPnxPBRHA0gR0QX61LnHDgrm4TBT4EQNpWwwHCD1N0nnEL5bEkzo2dt2t34Kg==",
-      "license": "Apache-2.0",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-3.1.3.tgz",
+      "integrity": "sha512-FIv/bRhIlAxC0U7xM1BCnF2aDRPq0UaelqBHkM2lsCp26mcBbgI0tCVTv+jGdsQLUmAMybua/bjDsSu8RQHbmw==",
       "dependencies": {
-        "@smithy/fetch-http-handler": "^3.0.3",
-        "@smithy/node-http-handler": "^3.0.1",
-        "@smithy/types": "^3.1.0",
+        "@smithy/fetch-http-handler": "^3.2.4",
+        "@smithy/node-http-handler": "^3.1.4",
+        "@smithy/types": "^3.3.0",
         "@smithy/util-base64": "^3.0.0",
         "@smithy/util-buffer-from": "^3.0.0",
         "@smithy/util-hex-encoding": "^3.0.0",
@@ -2854,7 +2797,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-3.0.0.tgz",
       "integrity": "sha512-LqR7qYLgZTD7nWLBecUi4aqolw8Mhza9ArpNEQ881MJJIU2sE5iHCK6TdyqqzcDLy0OPe10IY4T8ctVdtynubg==",
-      "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -2876,13 +2818,12 @@
       }
     },
     "node_modules/@smithy/util-waiter": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-3.0.1.tgz",
-      "integrity": "sha512-wwnrVQdjQxvWGOAiLmqlEhENGCcDIN+XJ/+usPOgSZObAslrCXgKlkX7rNVwIWW2RhPguTKthvF+4AoO0Z6KpA==",
-      "license": "Apache-2.0",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-3.1.2.tgz",
+      "integrity": "sha512-4pP0EV3iTsexDx+8PPGAKCQpd/6hsQBaQhqWzU4hqKPHN5epPsxKbvUTIiYIHTxaKt6/kEaqPBpu/ufvfbrRzw==",
       "dependencies": {
-        "@smithy/abort-controller": "^3.0.1",
-        "@smithy/types": "^3.1.0",
+        "@smithy/abort-controller": "^3.1.1",
+        "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3751,8 +3692,7 @@
     "node_modules/bowser": {
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
-      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==",
-      "license": "MIT"
+      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
@@ -4374,20 +4314,19 @@
       "license": "MIT"
     },
     "node_modules/fast-xml-parser": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.5.tgz",
-      "integrity": "sha512-B9/wizE4WngqQftFPmdaMYlXoJlJOYxGQOanC77fq9k8+Z0v5dDSVh+3glErdIROP//s/jgb7ZuxKfB8nVyo0g==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz",
+      "integrity": "sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==",
       "funding": [
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/naturalintelligence"
-        },
         {
           "type": "github",
           "url": "https://github.com/sponsors/NaturalIntelligence"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/naturalintelligence"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "strnum": "^1.0.5"
       },
@@ -6318,8 +6257,7 @@
     "node_modules/strnum": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
-      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==",
-      "license": "MIT"
+      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
     },
     "node_modules/supports-color": {
       "version": "7.2.0",
@@ -6589,7 +6527,6 @@
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
-      "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
       }


### PR DESCRIPTION
### Description

`npm audit` details:

```
node_modules/fast-xml-parser
  @aws-sdk/core  3.529.1 - 3.620.1
  Depends on vulnerable versions of fast-xml-parser
  node_modules/@aws-sdk/core
    @aws-sdk/client-acm  3.529.1 - 3.620.1
    Depends on vulnerable versions of @aws-sdk/client-sso-oidc
    Depends on vulnerable versions of @aws-sdk/client-sts
    Depends on vulnerable versions of @aws-sdk/core
    Depends on vulnerable versions of @aws-sdk/credential-provider-node
    node_modules/@aws-sdk/client-acm
    @aws-sdk/client-kafka  3.529.1 - 3.620.1
    Depends on vulnerable versions of @aws-sdk/client-sso-oidc
    Depends on vulnerable versions of @aws-sdk/client-sts
    Depends on vulnerable versions of @aws-sdk/core
    Depends on vulnerable versions of @aws-sdk/credential-provider-node
    node_modules/@aws-sdk/client-kafka
    @aws-sdk/client-lambda  3.529.1 - 3.620.1
    Depends on vulnerable versions of @aws-sdk/client-sso-oidc
    Depends on vulnerable versions of @aws-sdk/client-sts
    Depends on vulnerable versions of @aws-sdk/core
    Depends on vulnerable versions of @aws-sdk/credential-provider-node
    node_modules/@aws-sdk/client-lambda
    @aws-sdk/client-sso  3.529.1 - 3.620.1
    Depends on vulnerable versions of @aws-sdk/core
    node_modules/@aws-sdk/client-sso
      @aws-sdk/credential-provider-sso  3.529.1 - 3.620.1
      Depends on vulnerable versions of @aws-sdk/client-sso
      node_modules/@aws-sdk/credential-provider-sso
        @aws-sdk/credential-provider-ini  3.529.1 - 3.620.1
        Depends on vulnerable versions of @aws-sdk/credential-provider-sso
        node_modules/@aws-sdk/credential-provider-ini
        @aws-sdk/credential-provider-node  3.529.1 - 3.620.1
        Depends on vulnerable versions of @aws-sdk/credential-provider-ini
        Depends on vulnerable versions of @aws-sdk/credential-provider-sso
        node_modules/@aws-sdk/credential-provider-node
          @aws-sdk/client-sso-oidc  3.529.1 - 3.620.1
          Depends on vulnerable versions of @aws-sdk/client-sts
          Depends on vulnerable versions of @aws-sdk/core
          Depends on vulnerable versions of @aws-sdk/credential-provider-node
          node_modules/@aws-sdk/client-sso-oidc
            @aws-sdk/client-sts  3.529.1 - 3.620.1
            Depends on vulnerable versions of @aws-sdk/client-sso-oidc
            Depends on vulnerable versions of @aws-sdk/core
            Depends on vulnerable versions of @aws-sdk/credential-provider-node
            node_modules/@aws-sdk/client-sts
```

### Check List
- [ ] ~New functionality includes testing~
  - [X] All tests pass, including unit test, integration test and doctest
- [ ] ~New functionality has been documented~
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
