### PR TITLE
[CVE] Update org.apache.httpcomponents:httpclient to version '4.5.13'

### DIFF
--- a/commonDependencyVersionConstraints/build.gradle
+++ b/commonDependencyVersionConstraints/build.gradle
@@ -129,6 +129,7 @@ dependencies {
     implementation group: 'org.jsoup', name: 'jsoup', version: '1.15.3'
     implementation group: 'org.apache.tika', name: 'tika-core', version: '1.28.4'
     implementation group: 'com.jayway.jsonpath', name: 'json-path', version: '2.9.0'
+    api group: 'org.apache.httpcomponents', 'name': 'httpclient', version: '4.5.13'
 
   }
 }


### PR DESCRIPTION
### Description
Fix for [CVE-2020-13956](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-13956)

### Issues Resolved


### Testing
Only automated tests.  The existing versions were either already this version or 4.5.12. Given it's a patch update, I beleive the automated tests should be sufficient, but let me know if there are any specific areas of concern.

### Check List
- [ ] New functionality includes testing
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
