### PR TITLE
[Console] Use credentials from secrets manager (python & CDK)

### DIFF
--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/README.md
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/README.md
@@ -97,8 +97,10 @@ Exactly one of the following blocks must be present:
 - `no_auth`: may be empty, no authorization to use.
 - `basic_auth`:
     - `username`
-    - `password`
+    - `password` OR `password_from_secret_arn`
 - `sigv4`: may be empty, not yet implemented
+
+Within a `basic_auth` block, either a password can be provided directly, or it can contain the ARN of a secret in secrets manager which contains the password to use.
 
 Having a `source_cluster` and `target_cluster` is required.
 

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/cluster.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/cluster.py
@@ -94,7 +94,7 @@ class Cluster:
         if "password" in self.auth_details:
             return self.auth_details["password"]
         # Pull password from AWS Secrets Manager
-        assert "password_from_secret_arn" in self.auth_details
+        assert "password_from_secret_arn" in self.auth_details  # for mypy's sake
         client = boto3.client('secretsmanager')
         password = client.get_secret_value(SecretId=self.auth_details["password_from_secret_arn"])
         return password["SecretString"]

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/cluster.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/cluster.py
@@ -96,7 +96,7 @@ class Cluster:
         # Pull password from AWS Secrets Manager
         assert "password_from_secret_arn" in self.auth_details
         client = boto3.client('secretsmanager')
-        password = client.get_secret_value(self.auth_details["password_from_secret_arn"])
+        password = client.get_secret_value(SecretId=self.auth_details["password_from_secret_arn"])
         return password["SecretString"]
 
     def _generate_auth_object(self) -> requests.auth.AuthBase | None:

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/test_cluster.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/test_cluster.py
@@ -1,15 +1,13 @@
+from base64 import b64encode
+import os
+
 import pytest
+from moto import mock_aws
+import boto3
 
 import console_link.middleware.clusters as clusters_
 from console_link.models.cluster import AuthMethod, Cluster
 from tests.utils import create_valid_cluster
-
-# Define a valid cluster configuration
-valid_cluster_config = {
-    "endpoint": "https://opensearchtarget:9200",
-    "allow_insecure": True,
-    "basic_auth": {"username": "admin", "password": "myStrongPassword123!"},
-}
 
 
 def test_valid_cluster_config():
@@ -71,6 +69,53 @@ def test_missing_endpoint_refused():
     assert excinfo.value.args[1]['cluster'][0]["endpoint"] == ["required field"]
 
 
+def test_valid_cluster_with_secrets_auth_created():
+    valid_with_secrets = {
+        "endpoint": "https://opensearchtarget:9200",
+        "allow_insecure": True,
+        "basic_auth": {
+            "username": "admin",
+            "password_from_secret_arn": "arn:aws:secretsmanager:us-east-1:12345678912:secret:master-user-os-pass"
+        },
+    }
+    cluster = Cluster(valid_with_secrets)
+    assert isinstance(cluster, Cluster)
+
+
+def test_invalid_cluster_with_two_passwords_refused():
+    two_passwords = {
+        "endpoint": "XXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+        "allow_insecure": True,
+        "basic_auth": {
+            "username": "XXXXX",
+            "password": "XXXXXXXXXXXXXX",
+            "password_from_secret_arn": "arn:aws:secretsmanager:us-east-1:12345678912:secret:master-user-os-pass"
+        },
+    }
+    with pytest.raises(ValueError) as excinfo:
+        Cluster(two_passwords)
+    assert "Invalid config file for cluster" in excinfo.value.args[0]
+    assert excinfo.value.args[1]["cluster"][0]['basic_auth'] == [
+        "More than one value is present: ['password', 'password_from_secret_arn']"
+    ]
+
+
+def test_invalid_cluster_with_zero_passwords_refused():
+    two_passwords = {
+        "endpoint": "XXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+        "allow_insecure": True,
+        "basic_auth": {
+            "username": "XXXXX",
+        },
+    }
+    with pytest.raises(ValueError) as excinfo:
+        Cluster(two_passwords)
+    assert "Invalid config file for cluster" in excinfo.value.args[0]
+    assert excinfo.value.args[1]["cluster"][0]['basic_auth'] == [
+        "No values are present from set: ['password', 'password_from_secret_arn']"
+    ]
+
+
 def test_valid_cluster_api_call_with_no_auth(requests_mock):
     cluster = create_valid_cluster(auth_type=AuthMethod.NO_AUTH)
     assert isinstance(cluster, Cluster)
@@ -99,3 +144,47 @@ def test_connection_check_succesful(requests_mock):
     assert result.connection_established
     assert result.connection_message == 'Successfully connected!'
     assert result.cluster_version == '2.15'
+
+
+@pytest.fixture(scope="function")
+def aws_credentials():
+    """Mocked AWS Credentials for moto."""
+    os.environ["AWS_ACCESS_KEY_ID"] = "testing"
+    os.environ["AWS_SECRET_ACCESS_KEY"] = "testing"
+    os.environ["AWS_SECURITY_TOKEN"] = "testing"
+    os.environ["AWS_SESSION_TOKEN"] = "testing"
+    os.environ["AWS_DEFAULT_REGION"] = "us-west-1"
+
+
+def test_valid_cluster_api_call_with_secrets_auth(requests_mock, aws_credentials):
+    valid_with_secrets = {
+        "endpoint": "https://opensearchtarget:9200",
+        "allow_insecure": True,
+        "basic_auth": {
+            "username": "admin",
+            "password_from_secret_arn": None  # Will be set later
+        },
+    }
+    secret_value = "myfakepassword"
+    username = valid_with_secrets["basic_auth"]["username"]
+    b64encoded_token = b64encode(f"{username}:{secret_value}".encode('utf-8')).decode("ascii")
+    auth_header_should_be = f"Basic {b64encoded_token}"
+
+    requests_mock.get(f"{valid_with_secrets['endpoint']}/test_api", json={'test': True})
+
+    with mock_aws():
+        # Create cluster
+        secrets_client = boto3.client("secretsmanager")
+        secret = secrets_client.create_secret(
+            Name="test-cluster-password",
+            SecretString=secret_value,
+        )
+        valid_with_secrets["basic_auth"]["password_from_secret_arn"] = secret['ARN']
+        cluster = Cluster(valid_with_secrets)
+        assert isinstance(cluster, Cluster)
+
+        response = cluster.call_api("/test_api")
+        assert response.status_code == 200
+        assert response.json() == {'test': True}
+        print(requests_mock.last_request.headers)
+        assert requests_mock.last_request.headers['Authorization'] == auth_header_should_be

--- a/deployment/cdk/opensearch-service-migration/lib/migration-services-yaml.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/migration-services-yaml.ts
@@ -1,9 +1,34 @@
 import * as yaml from 'yaml';
 
+export class ClusterBasicAuth {
+    username: string;
+    password?: string;
+    password_from_secret_arn?: string;
+
+    constructor({
+        username,
+        password,
+        password_from_secret_arn,
+    }: {
+        username: string;
+        password?: string;
+        password_from_secret_arn?: string;
+    }) {
+        this.username = username;
+        this.password = password;
+        this.password_from_secret_arn = password_from_secret_arn;
+
+        // Validation: Exactly one of password or password_from_secret_arn must be provided
+        if ((password && password_from_secret_arn) || (!password && !password_from_secret_arn)) {
+            throw new Error('Exactly one of password or password_from_secret_arn must be provided');
+        }
+    }
+}
+
 export class ClusterYaml {
     endpoint: string = '';
     no_auth?: string | null;
-    basic_auth?: object | null;
+    basic_auth?: ClusterBasicAuth | null;
 }
 
 export class MetricsSourceYaml {

--- a/deployment/cdk/opensearch-service-migration/lib/service-stacks/migration-console-stack.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/service-stacks/migration-console-stack.ts
@@ -256,13 +256,13 @@ export class MigrationConsoleStack extends MigrationServiceCore {
             ]
         })
 
-        const getSecretsPolicy = new PolicyStatement({
+        const getSecretsPolicy = props.servicesYaml.target_cluster.basic_auth?.password_from_secret_arn ? new PolicyStatement({
             effect: Effect.ALLOW,
-            resources: [props.servicesYaml.target_cluster.basic_auth?.password_from_secret_arn ?? ""],
+            resources: [props.servicesYaml.target_cluster.basic_auth?.password_from_secret_arn],
             actions: [
                 "secretsmanager:GetSecretValue"
             ]
-        });
+        }) : null;
 
         // Upload the services.yaml file to Parameter Store
         let servicesYaml = props.servicesYaml
@@ -299,7 +299,9 @@ export class MigrationConsoleStack extends MigrationServiceCore {
         const openSearchPolicy = createOpenSearchIAMAccessPolicy(this.partition, this.region, this.account)
         const openSearchServerlessPolicy = createOpenSearchServerlessIAMAccessPolicy(this.partition, this.region, this.account)
         let servicePolicies = [replayerOutputMountPolicy, openSearchPolicy, openSearchServerlessPolicy, ecsUpdateServicePolicy, clusterTasksPolicy,
-            listTasksPolicy, artifactS3PublishPolicy, describeVPCPolicy, getSSMParamsPolicy, getMetricsPolicy, getSecretsPolicy]
+            listTasksPolicy, artifactS3PublishPolicy, describeVPCPolicy, getSSMParamsPolicy, getMetricsPolicy,
+            ...(getSecretsPolicy ? [getSecretsPolicy] : []) // only add secrets policy if it's non-null
+        ]
         if (props.streamingSourceType === StreamingSourceType.AWS_MSK) {
             const mskAdminPolicies = this.createMSKAdminIAMPolicies(props.stage, props.defaultDeployId)
             servicePolicies = servicePolicies.concat(mskAdminPolicies)

--- a/deployment/cdk/opensearch-service-migration/lib/service-stacks/migration-console-stack.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/service-stacks/migration-console-stack.ts
@@ -9,6 +9,7 @@ import {
     createOpenSearchIAMAccessPolicy,
     createOpenSearchServerlessIAMAccessPolicy,
     getMigrationStringParameterValue,
+    getMigrationStringParameter,
     MigrationSSMParameter
 } from "../common-utilities";
 import {StreamingSourceType} from "../streaming-source-type";
@@ -255,6 +256,14 @@ export class MigrationConsoleStack extends MigrationServiceCore {
             ]
         })
 
+        const getSecretsPolicy = new PolicyStatement({
+            effect: Effect.ALLOW,
+            resources: [props.servicesYaml.target_cluster.basic_auth?.password_from_secret_arn ?? ""],
+            actions: [
+                "secretsmanager:GetSecretValue"
+            ]
+        });
+
         // Upload the services.yaml file to Parameter Store
         let servicesYaml = props.servicesYaml
         servicesYaml.source_cluster = {
@@ -290,7 +299,7 @@ export class MigrationConsoleStack extends MigrationServiceCore {
         const openSearchPolicy = createOpenSearchIAMAccessPolicy(this.partition, this.region, this.account)
         const openSearchServerlessPolicy = createOpenSearchServerlessIAMAccessPolicy(this.partition, this.region, this.account)
         let servicePolicies = [replayerOutputMountPolicy, openSearchPolicy, openSearchServerlessPolicy, ecsUpdateServicePolicy, clusterTasksPolicy,
-            listTasksPolicy, artifactS3PublishPolicy, describeVPCPolicy, getSSMParamsPolicy, getMetricsPolicy]
+            listTasksPolicy, artifactS3PublishPolicy, describeVPCPolicy, getSSMParamsPolicy, getMetricsPolicy, getSecretsPolicy]
         if (props.streamingSourceType === StreamingSourceType.AWS_MSK) {
             const mskAdminPolicies = this.createMSKAdminIAMPolicies(props.stage, props.defaultDeployId)
             servicePolicies = servicePolicies.concat(mskAdminPolicies)

--- a/deployment/cdk/opensearch-service-migration/lib/stack-composer.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/stack-composer.ts
@@ -19,7 +19,7 @@ import {OpenSearchContainerStack} from "./service-stacks/opensearch-container-st
 import {determineStreamingSourceType, StreamingSourceType} from "./streaming-source-type";
 import {MigrationSSMParameter, parseRemovalPolicy, validateFargateCpuArch} from "./common-utilities";
 import {ReindexFromSnapshotStack} from "./service-stacks/reindex-from-snapshot-stack";
-import {ServicesYaml} from "./migration-services-yaml";
+import {ClusterBasicAuth, ServicesYaml} from "./migration-services-yaml";
 
 export interface StackPropsExt extends StackProps {
     readonly stage: string,
@@ -330,7 +330,14 @@ export class StackComposer {
             this.stacks.push(openSearchStack)
             servicesYaml.target_cluster = openSearchStack.targetClusterYaml;
         } else {
-            servicesYaml.target_cluster = { endpoint: targetEndpoint, no_auth: '' }
+            servicesYaml.target_cluster = { endpoint: targetEndpoint }
+            if (fineGrainedManagerUserName) {
+                servicesYaml.target_cluster.basic_auth = new ClusterBasicAuth({username: fineGrainedManagerUserName,
+                    password_from_secret_arn: fineGrainedManagerUserSecretManagerKeyARN
+                })
+            } else {
+                servicesYaml.target_cluster.no_auth = ""
+            }
         }
 
         // Currently, placing a requirement on a VPC for a migration stack but this can be revisited

--- a/deployment/cdk/opensearch-service-migration/lib/stack-composer.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/stack-composer.ts
@@ -331,7 +331,7 @@ export class StackComposer {
             servicesYaml.target_cluster = openSearchStack.targetClusterYaml;
         } else {
             servicesYaml.target_cluster = { endpoint: targetEndpoint }
-            if (fineGrainedManagerUserName) {
+            if (fineGrainedManagerUserName && fineGrainedManagerUserSecretManagerKeyARN) {
                 servicesYaml.target_cluster.basic_auth = new ClusterBasicAuth({username: fineGrainedManagerUserName,
                     password_from_secret_arn: fineGrainedManagerUserSecretManagerKeyARN
                 })

--- a/deployment/cdk/opensearch-service-migration/test/migration-services-yaml.test.ts
+++ b/deployment/cdk/opensearch-service-migration/test/migration-services-yaml.test.ts
@@ -1,5 +1,5 @@
 import { ContainerImage } from "aws-cdk-lib/aws-ecs";
-import { ClusterYaml, RFSBackfillYaml, ServicesYaml, SnapshotYaml } from "../lib/migration-services-yaml"
+import { ClusterBasicAuth, ClusterYaml, RFSBackfillYaml, ServicesYaml, SnapshotYaml } from "../lib/migration-services-yaml"
 import { Template, Capture, Match } from "aws-cdk-lib/assertions";
 import { MigrationConsoleStack } from "../lib/service-stacks/migration-console-stack";
 import { createStackComposer } from "./test-utils";
@@ -35,13 +35,15 @@ test('Test servicesYaml with source and target cluster can be stringified', () =
     servicesYaml.target_cluster = targetCluster;
     const sourceClusterUser = "abc";
     const sourceClusterPassword = "XXXXX";
-    const sourceCluster: ClusterYaml = { 'endpoint': 'https://xyz.com:9200', 'basic_auth': { user: sourceClusterUser, password: sourceClusterPassword } };
+    const sourceCluster: ClusterYaml = { 'endpoint': 'https://xyz.com:9200',
+        'basic_auth': new ClusterBasicAuth({ username: sourceClusterUser, password: sourceClusterPassword })
+    };
     servicesYaml.source_cluster = sourceCluster;
 
     expect(servicesYaml.target_cluster).toBeDefined();
     expect(servicesYaml.source_cluster).toBeDefined();
     const yaml = servicesYaml.stringify();
-    const sourceClusterYaml = `source_cluster:\n  endpoint: ${sourceCluster.endpoint}\n  basic_auth:\n    user: ${sourceClusterUser}\n    password: ${sourceClusterPassword}\n`
+    const sourceClusterYaml = `source_cluster:\n  endpoint: ${sourceCluster.endpoint}\n  basic_auth:\n    username: ${sourceClusterUser}\n    password: ${sourceClusterPassword}\n`
     expect(yaml).toBe(`${sourceClusterYaml}target_cluster:\n  endpoint: ${targetCluster.endpoint}\n  no_auth: ""\nmetrics_source:\n  cloudwatch:\n`);
 })
 
@@ -90,7 +92,7 @@ test('Test SnapshotYaml for s3 only includes s3', () => {
     expect(s3SnapshotDict).not.toHaveProperty("fs");
 })
 
-test('Test that services yaml parameter is created by mgiration console stack', () => {
+test('Test that services yaml parameter is created by migration console stack', () => {
     const contextOptions = {
         vpcEnabled: true,
         migrationAssistanceEnabled: true,

--- a/deployment/cdk/opensearch-service-migration/test/migration-services-yaml.test.ts
+++ b/deployment/cdk/opensearch-service-migration/test/migration-services-yaml.test.ts
@@ -99,7 +99,12 @@ test('Test that services yaml parameter is created by migration console stack', 
         migrationConsoleServiceEnabled: true,
         sourceClusterEndpoint: "https://test-cluster",
         reindexFromSnapshotServiceEnabled: true,
-        trafficReplayerServiceEnabled: true
+        trafficReplayerServiceEnabled: true,
+        fineGrainedManagerUserName: "admin",
+        fineGrainedManagerUserSecretManagerKeyARN: "arn:aws:secretsmanager:us-east-1:12345678912:secret:master-user-os-pass-123abc",
+        nodeToNodeEncryptionEnabled: true, // required if FGAC is being used
+        encryptionAtRestEnabled: true, // required if FGAC is being used
+        enforceHTTPS: true // required if FGAC is being used
     }
 
     const stacks = createStackComposer(contextOptions)
@@ -121,6 +126,10 @@ test('Test that services yaml parameter is created by migration console stack', 
     const yamlFileContents = value['Fn::Join'][1].join('')
     expect(yamlFileContents).toContain('source_cluster')
     expect(yamlFileContents).toContain('target_cluster')
+
+    expect(yamlFileContents).toContain('basic_auth')
+    expect(yamlFileContents).toContain(`username: ${contextOptions.fineGrainedManagerUserName}`)
+    expect(yamlFileContents).toContain(`password_from_secret_arn: ${contextOptions.fineGrainedManagerUserSecretManagerKeyARN}`)
     expect(yamlFileContents).toContain('metrics_source:\n  cloudwatch:')
     expect(yamlFileContents).toContain('kafka')
     // Validates that the file can be parsed as valid yaml and has the expected fields


### PR DESCRIPTION
## Before Merging
Migration console side is verified in a real deployment; currently workign on CDK.


### Description
Adds support for a secrets manager secret to be used as the password value.

### Issues Resolved
[MIGRATIONS-1760](https://opensearch.atlassian.net/browse/MIGRATIONS-1760) & [MIGRATIONS-1900](https://opensearch.atlassian.net/browse/MIGRATIONS-1900)

### Testing
Good unit test coverage. Need to manually test.

### Check List
- [x] New functionality includes testing
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
