### PR TITLE
Replace Fetch with RFS for default demo deploy

### DIFF
--- a/deployment/cdk/opensearch-service-migration/cdk.context.json
+++ b/deployment/cdk/opensearch-service-migration/cdk.context.json
@@ -10,7 +10,7 @@
     "enableDemoAdmin": true,
     "trafficReplayerEnableClusterFGACAuth": true,
     "captureProxyESServiceEnabled": true,
-    "fetchMigrationEnabled": true,
+    "reindexFromSnapshotEnabled": true,
     "otelCollectorEnabled": true
   }
 }


### PR DESCRIPTION
### Description
Our default CDK still deploys Fetch. This is in a pretty unsupported and untested state in our repo. It makes more sense to deploy RFS as our default, including because all of our documentation handles the RFS case.

### Issues Resolved


### Testing
Manual

### Check List
- [ ] New functionality includes testing
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
