### PR TITLE
Add reindexed-logs to default ignore list

### DIFF
--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/integ_test/integ_test/common_operations.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/integ_test/integ_test/common_operations.py
@@ -13,7 +13,7 @@ from console_link.models.replayer_base import Replayer, ReplayStatus
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_INDEX_IGNORE_LIST = [".", "searchguard", "sg7", "security-auditlog", "reindexed-logs"]
+DEFAULT_INDEX_IGNORE_LIST = ["test_", ".", "searchguard", "sg7", "security-auditlog", "reindexed-logs"]
 
 EXPECTED_BENCHMARK_DOCS = {
     "geonames": {"docs.count": "1000"},

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/integ_test/integ_test/common_operations.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/integ_test/integ_test/common_operations.py
@@ -13,7 +13,7 @@ from console_link.models.replayer_base import Replayer, ReplayStatus
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_INDEX_IGNORE_LIST = ["test_", ".", "searchguard", "sg7", "security-auditlog"]
+DEFAULT_INDEX_IGNORE_LIST = [".", "searchguard", "sg7", "security-auditlog", "reindexed-logs"]
 
 EXPECTED_BENCHMARK_DOCS = {
     "geonames": {"docs.count": "1000"},
@@ -25,7 +25,6 @@ EXPECTED_BENCHMARK_DOCS = {
     "logs-201998": {"docs.count": "1000"},
     "logs-191998": {"docs.count": "1000"},
     "sonested": {"docs.count": "2977"},
-    "reindexed-logs": {"docs.count": "0"},
     "nyc_taxis": {"docs.count": "1000"}
 }
 

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/integ_test/integ_test/e2e_tests.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/integ_test/integ_test/e2e_tests.py
@@ -95,15 +95,16 @@ class E2ETests(unittest.TestCase):
         create_document(cluster=source_cluster, index_name=index_name, doc_id=doc_id_base + "_2",
                         expected_status_code=HTTPStatus.CREATED, test_case=self)
 
+        ignore_list = [".", "searchguard", "sg7", "security-auditlog", "reindexed-logs"]
         expected_docs = dict(EXPECTED_BENCHMARK_DOCS)
         # Source should have both documents
         expected_docs[index_name] = {"docs.count": "2"}
         check_doc_counts_match(cluster=source_cluster, expected_index_details=expected_docs,
-                               test_case=self)
+                               index_prefix_ignore_list=ignore_list, test_case=self)
         # Target should have one document from snapshot
         expected_docs[index_name] = {"docs.count": "1"}
         check_doc_counts_match(cluster=target_cluster, expected_index_details=expected_docs,
-                               max_attempts=40, delay=30.0, test_case=self)
+                               index_prefix_ignore_list=ignore_list, max_attempts=40, delay=30.0, test_case=self)
 
         backfill.stop()
 
@@ -115,7 +116,7 @@ class E2ETests(unittest.TestCase):
 
         expected_docs[index_name] = {"docs.count": "3"}
         check_doc_counts_match(cluster=source_cluster, expected_index_details=expected_docs,
-                               test_case=self)
+                               index_prefix_ignore_list=ignore_list, test_case=self)
 
         check_doc_counts_match(cluster=target_cluster, expected_index_details=expected_docs,
-                               max_attempts=30, delay=10.0, test_case=self)
+                               index_prefix_ignore_list=ignore_list, max_attempts=30, delay=10.0, test_case=self)

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/integ_test/integ_test/e2e_tests.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/integ_test/integ_test/e2e_tests.py
@@ -95,16 +95,15 @@ class E2ETests(unittest.TestCase):
         create_document(cluster=source_cluster, index_name=index_name, doc_id=doc_id_base + "_2",
                         expected_status_code=HTTPStatus.CREATED, test_case=self)
 
-        ignore_list = [".", "searchguard", "sg7", "security-auditlog"]
         expected_docs = dict(EXPECTED_BENCHMARK_DOCS)
         # Source should have both documents
         expected_docs[index_name] = {"docs.count": "2"}
         check_doc_counts_match(cluster=source_cluster, expected_index_details=expected_docs,
-                               index_prefix_ignore_list=ignore_list, test_case=self)
+                               test_case=self)
         # Target should have one document from snapshot
         expected_docs[index_name] = {"docs.count": "1"}
         check_doc_counts_match(cluster=target_cluster, expected_index_details=expected_docs,
-                               index_prefix_ignore_list=ignore_list, max_attempts=40, delay=30.0, test_case=self)
+                               max_attempts=40, delay=30.0, test_case=self)
 
         backfill.stop()
 
@@ -116,7 +115,7 @@ class E2ETests(unittest.TestCase):
 
         expected_docs[index_name] = {"docs.count": "3"}
         check_doc_counts_match(cluster=source_cluster, expected_index_details=expected_docs,
-                               index_prefix_ignore_list=ignore_list, test_case=self)
+                               test_case=self)
 
         check_doc_counts_match(cluster=target_cluster, expected_index_details=expected_docs,
-                               index_prefix_ignore_list=ignore_list, max_attempts=30, delay=10.0, test_case=self)
+                               max_attempts=30, delay=10.0, test_case=self)


### PR DESCRIPTION
### Description
The `reindexed-logs` has been known to sometimes appear on clusters based on if the reindexing operation has run - even if there are zero items in it.  This can cause our test cases to fail intermittently if a background reindex was run, but no documents were created - excluding this index entirely.

I've also modified the code to use the default ignore list for all the existing cases - we can always tweak if need be in the future.

#### Example issue that is fix with this PR
```
_____________________ ReplayerTests.test_replayer_0006_OSB _____________________

self = <replayer_tests.ReplayerTests testMethod=test_replayer_0006_OSB>

    def test_replayer_0006_OSB(self):
        source_cluster: Cluster = pytest.console_env.source_cluster
        target_cluster: Cluster = pytest.console_env.target_cluster
    
        run_test_benchmarks(cluster=source_cluster)
        # Confirm documents on source
        check_doc_counts_match(cluster=source_cluster, expected_index_details=EXPECTED_BENCHMARK_DOCS,
                               test_case=self)
        # Confirm documents on target after replay
>       check_doc_counts_match(cluster=target_cluster, expected_index_details=EXPECTED_BENCHMARK_DOCS,
                               test_case=self)

lib/integ_test/integ_test/replayer_tests.py:183: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
lib/integ_test/integ_test/common_operations.py:169: in check_doc_counts_match
    test_case.fail(error_message)
E   AssertionError: Indices are different: 
E    Expected: dict_keys(['geonames', 'logs-221998', 'logs-211998', 'logs-231998', 'logs-241998', 'logs-181998', 'logs-201998', 'logs-191998', 'sonested', 'reindexed-logs', 'nyc_taxis']) 
E    Actual: dict_keys(['logs-221998', 'geonames', 'nyc_taxis', 'logs-241998', 'sonested', 'logs-181998', 'logs-201998', 'logs-211998', 'logs-231998', 'logs-191998'])
------------------------------ Captured log call -------------------------------
```
- Impacted PR https://github.com/opensearch-project/opensearch-migrations/pull/858

### Issues Resolved
- Related https://github.com/opensearch-project/opensearch-migrations/pull/801

### Check List
- [X] New functionality includes testing
  - [X] All tests pass, including unit test, integration test and doctest
- [ ] ~New functionality has been documented~
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
