### PR TITLE
RFS container uses entrypoint script for arg configuration

### DIFF
--- a/DocumentsFromSnapshotMigration/docker/Dockerfile
+++ b/DocumentsFromSnapshotMigration/docker/Dockerfile
@@ -2,10 +2,7 @@
 FROM amazoncorretto:11-al2023-headless
 
 # Install the AWS CLI in the container
-RUN yum update -y && yum install -y unzip
-RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip" -o "awscliv2.zip" && \
-    unzip awscliv2.zip && \
-    ./aws/install
+RUN dnf update -y && dnf install -y aws-cli
 
 # Requires Gradle to genearte runtime jars initially
 COPY ./build/runtimeJars /rfs-app/jars

--- a/DocumentsFromSnapshotMigration/docker/Dockerfile
+++ b/DocumentsFromSnapshotMigration/docker/Dockerfile
@@ -1,8 +1,20 @@
 # Using same base image as other Java containers in this repo
 FROM amazoncorretto:11-al2023-headless
+
+# Install the AWS CLI in the container
+RUN yum update -y && yum install -y unzip
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip" -o "awscliv2.zip" && \
+    unzip awscliv2.zip && \
+    ./aws/install
+
 # Requires Gradle to genearte runtime jars initially
 COPY ./build/runtimeJars /rfs-app/jars
 WORKDIR /rfs-app
 RUN printf "#!/bin/sh\njava -XX:MaxRAMPercentage=80.0 -cp /rfs-app/jars/*:. \"\$@\" " > /rfs-app/runJavaWithClasspath.sh
 RUN chmod +x /rfs-app/runJavaWithClasspath.sh
+
+# Copy the entry point script into the container
+COPY ./entrypoint.sh /rfs-app/entrypoint.sh
+RUN chmod +x /rfs-app/entrypoint.sh
+
 CMD ["tail", "-f", "/dev/null"]

--- a/DocumentsFromSnapshotMigration/docker/entrypoint.sh
+++ b/DocumentsFromSnapshotMigration/docker/entrypoint.sh
@@ -6,9 +6,18 @@ set -e
 # Print our ENV variables
 echo "RFS_COMMAND: $RFS_COMMAND"
 echo "RFS_TARGET_USER: $RFS_TARGET_USER"
+echo "RFS_TARGET_PASSWORD: <redacted>"
 echo "RFS_TARGET_PASSWORD_ARN: $RFS_TARGET_PASSWORD_ARN"
 
-# Check if the RFS Command already contains a password; only do special work in if does not
+# Check if the RFS Command already contains a username; only do special work if it does not
+if [[ $RFS_COMMAND != *"--target-username"* ]]; then
+    if [[ -n "$RFS_TARGET_USER" ]]; then
+        echo "Using username from ENV variable RFS_TARGET_USER.  Updating RFS Command with username."
+        RFS_COMMAND="$RFS_COMMAND --target-username $RFS_TARGET_USER"
+    fi
+fi
+
+# Check if the RFS Command already contains a password; only do special work if it does not
 if [[ $RFS_COMMAND != *"--target-password"* ]]; then
     PASSWORD_TO_USE=""
 
@@ -16,14 +25,17 @@ if [[ $RFS_COMMAND != *"--target-password"* ]]; then
     if [[ -n "$RFS_TARGET_PASSWORD" ]]; then
         echo "Using plaintext password from ENV variable RFS_TARGET_PASSWORD"
         PASSWORD_TO_USE="$RFS_TARGET_PASSWORD"
-    else
-        echo "Using password from AWS Secrets Manager"
-        PASSWORD_TO_USE=$(aws secretsmanager get-secret-value --secret-id $RFS_TARGET_PASSWORD_ARN --query SecretString --output text)
+    elif [[ -n "$RFS_TARGET_PASSWORD_ARN" ]]; then
+        # Retrieve password from AWS Secrets Manager if ARN is provided
+        echo "Using password from AWS Secrets Manager ARN in ENV variable RFS_TARGET_PASSWORD_ARN"
+        PASSWORD_TO_USE=$(aws secretsmanager get-secret-value --secret-id "$RFS_TARGET_PASSWORD_ARN" --query SecretString --output text)
     fi
 
-    # Append the password to the RFS Command
-    echo "Updated RFS Command with username/password"
-    RFS_COMMAND="$RFS_COMMAND --target-username $RFS_TARGET_USER --target-password $PASSWORD_TO_USE"
+    # Append the username/password to the RFS Command if have an updated password
+    if [[ -n "$PASSWORD_TO_USE" ]]; then
+        echo "Updating RFS Command with password."
+        RFS_COMMAND="$RFS_COMMAND --target-password $PASSWORD_TO_USE"
+    fi
 fi
 
 echo "Executing RFS Command"

--- a/DocumentsFromSnapshotMigration/docker/entrypoint.sh
+++ b/DocumentsFromSnapshotMigration/docker/entrypoint.sh
@@ -6,7 +6,7 @@ set -e
 # Print our ENV variables
 if [[ $RFS_COMMAND != *"--target-password"* ]]; then
     echo "RFS_COMMAND: $RFS_COMMAND"
-else; then
+else
     echo "RFS Target Cluster password found in RFS_COMMAND; skipping logging of the value"
 fi
 

--- a/DocumentsFromSnapshotMigration/docker/entrypoint.sh
+++ b/DocumentsFromSnapshotMigration/docker/entrypoint.sh
@@ -4,7 +4,12 @@
 set -e
 
 # Print our ENV variables
-echo "RFS_COMMAND: $RFS_COMMAND"
+if [[ $RFS_COMMAND != *"--target-password"* ]]; then
+    echo "RFS_COMMAND: $RFS_COMMAND"
+else; then
+    echo "RFS Target Cluster password found in RFS_COMMAND; skipping logging of the value"
+fi
+
 echo "RFS_TARGET_USER: $RFS_TARGET_USER"
 echo "RFS_TARGET_PASSWORD: <redacted>"
 echo "RFS_TARGET_PASSWORD_ARN: $RFS_TARGET_PASSWORD_ARN"

--- a/DocumentsFromSnapshotMigration/docker/entrypoint.sh
+++ b/DocumentsFromSnapshotMigration/docker/entrypoint.sh
@@ -1,0 +1,30 @@
+#! /bin/bash
+
+# Fail the script if any command fails
+set -e
+
+# Print our ENV variables
+echo "RFS_COMMAND: $RFS_COMMAND"
+echo "RFS_TARGET_USER: $RFS_TARGET_USER"
+echo "RFS_TARGET_PASSWORD_ARN: $RFS_TARGET_PASSWORD_ARN"
+
+# Check if the RFS Command already contains a password; only do special work in if does not
+if [[ $RFS_COMMAND != *"--target-password"* ]]; then
+    PASSWORD_TO_USE=""
+
+    # Check if the password is available in plaintext; if, use it.  Otherwise, retrieve it from AWS Secrets Manager
+    if [[ -n "$RFS_TARGET_PASSWORD" ]]; then
+        echo "Using plaintext password from ENV variable RFS_TARGET_PASSWORD"
+        PASSWORD_TO_USE="$RFS_TARGET_PASSWORD"
+    else
+        echo "Using password from AWS Secrets Manager"
+        PASSWORD_TO_USE=$(aws secretsmanager get-secret-value --secret-id $RFS_TARGET_PASSWORD_ARN --query SecretString --output text)
+    fi
+
+    # Append the password to the RFS Command
+    echo "Updated RFS Command with username/password"
+    RFS_COMMAND="$RFS_COMMAND --target-username $RFS_TARGET_USER --target-password $PASSWORD_TO_USE"
+fi
+
+echo "Executing RFS Command"
+eval $RFS_COMMAND

--- a/deployment/cdk/opensearch-service-migration/lib/common-utilities.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/common-utilities.ts
@@ -78,7 +78,7 @@ export function parseAndMergeArgs(baseCommand: string, extraArgs?: string): stri
     return fullCommand;
 }
 
-export function createTargetPasswordAccessPolicy(targetPasswordSecretArn: string): PolicyStatement {
+export function getTargetPasswordAccessPolicy(targetPasswordSecretArn: string): PolicyStatement {
     return new PolicyStatement({
         effect: Effect.ALLOW,
         resources: [targetPasswordSecretArn],

--- a/deployment/cdk/opensearch-service-migration/lib/common-utilities.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/common-utilities.ts
@@ -83,7 +83,8 @@ export function getTargetPasswordAccessPolicy(targetPasswordSecretArn: string): 
         effect: Effect.ALLOW,
         resources: [targetPasswordSecretArn],
         actions: [
-            "secretsmanager:GetSecretValue"
+            "secretsmanager:GetSecretValue",
+            "secretsmanager:DescribeSecret"
         ]
     })
 }

--- a/deployment/cdk/opensearch-service-migration/lib/common-utilities.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/common-utilities.ts
@@ -78,6 +78,15 @@ export function parseAndMergeArgs(baseCommand: string, extraArgs?: string): stri
     return fullCommand;
 }
 
+export function createTargetPasswordAccessPolicy(targetPasswordSecretArn: string): PolicyStatement {
+    return new PolicyStatement({
+        effect: Effect.ALLOW,
+        resources: [targetPasswordSecretArn],
+        actions: [
+            "secretsmanager:GetSecretValue"
+        ]
+    })
+}
 
 export function createOpenSearchIAMAccessPolicy(partition: string, region: string, accountId: string): PolicyStatement {
     return new PolicyStatement({

--- a/deployment/cdk/opensearch-service-migration/lib/common-utilities.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/common-utilities.ts
@@ -83,8 +83,7 @@ export function getTargetPasswordAccessPolicy(targetPasswordSecretArn: string): 
         effect: Effect.ALLOW,
         resources: [targetPasswordSecretArn],
         actions: [
-            "secretsmanager:GetSecretValue",
-            "secretsmanager:DescribeSecret"
+            "secretsmanager:GetSecretValue"
         ]
     })
 }

--- a/deployment/cdk/opensearch-service-migration/lib/service-stacks/migration-console-stack.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/service-stacks/migration-console-stack.ts
@@ -8,6 +8,7 @@ import {
     createMigrationStringParameter,
     createOpenSearchIAMAccessPolicy,
     createOpenSearchServerlessIAMAccessPolicy,
+    createTargetPasswordAccessPolicy,
     getMigrationStringParameterValue,
     hashStringSHA256,
     MigrationSSMParameter
@@ -256,13 +257,8 @@ export class MigrationConsoleStack extends MigrationServiceCore {
             ]
         })
 
-        const getSecretsPolicy = props.servicesYaml.target_cluster.basic_auth?.password_from_secret_arn ? new PolicyStatement({
-            effect: Effect.ALLOW,
-            resources: [props.servicesYaml.target_cluster.basic_auth?.password_from_secret_arn],
-            actions: [
-                "secretsmanager:GetSecretValue"
-            ]
-        }) : null;
+        const getSecretsPolicy = props.servicesYaml.target_cluster.basic_auth?.password_from_secret_arn ? 
+            createTargetPasswordAccessPolicy(props.servicesYaml.target_cluster.basic_auth.password_from_secret_arn) : null;
 
         // Upload the services.yaml file to Parameter Store
         let servicesYaml = props.servicesYaml

--- a/deployment/cdk/opensearch-service-migration/lib/service-stacks/migration-console-stack.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/service-stacks/migration-console-stack.ts
@@ -8,7 +8,7 @@ import {
     createMigrationStringParameter,
     createOpenSearchIAMAccessPolicy,
     createOpenSearchServerlessIAMAccessPolicy,
-    createTargetPasswordAccessPolicy,
+    getTargetPasswordAccessPolicy,
     getMigrationStringParameterValue,
     hashStringSHA256,
     MigrationSSMParameter
@@ -258,7 +258,7 @@ export class MigrationConsoleStack extends MigrationServiceCore {
         })
 
         const getSecretsPolicy = props.servicesYaml.target_cluster.basic_auth?.password_from_secret_arn ? 
-            createTargetPasswordAccessPolicy(props.servicesYaml.target_cluster.basic_auth.password_from_secret_arn) : null;
+            getTargetPasswordAccessPolicy(props.servicesYaml.target_cluster.basic_auth.password_from_secret_arn) : null;
 
         // Upload the services.yaml file to Parameter Store
         let servicesYaml = props.servicesYaml

--- a/deployment/cdk/opensearch-service-migration/lib/service-stacks/reindex-from-snapshot-stack.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/service-stacks/reindex-from-snapshot-stack.ts
@@ -9,17 +9,20 @@ import {
     MigrationSSMParameter,
     createOpenSearchIAMAccessPolicy,
     createOpenSearchServerlessIAMAccessPolicy,
+    createTargetPasswordAccessPolicy,
     getMigrationStringParameterValue,
     parseAndMergeArgs
 } from "../common-utilities";
-import { RFSBackfillYaml, SnapshotYaml } from "../migration-services-yaml";
+import { ClusterYaml, RFSBackfillYaml, SnapshotYaml } from "../migration-services-yaml";
+import cluster from "cluster";
 
 
 export interface ReindexFromSnapshotProps extends StackPropsExt {
     readonly vpc: IVpc,
     readonly fargateCpuArch: CpuArchitecture,
     readonly extraArgs?: string,
-    readonly otelCollectorEnabled?: boolean
+    readonly otelCollectorEnabled?: boolean,
+    readonly clusterAuthDetails: ClusterYaml
 }
 
 export class ReindexFromSnapshotStack extends MigrationServiceCore {
@@ -58,10 +61,6 @@ export class ReindexFromSnapshotStack extends MigrationServiceCore {
             ]
         })
 
-        const openSearchPolicy = createOpenSearchIAMAccessPolicy(this.partition, this.region, this.account)
-        const openSearchServerlessPolicy = createOpenSearchServerlessIAMAccessPolicy(this.partition, this.region, this.account)
-        let servicePolicies = [artifactS3PublishPolicy, openSearchPolicy, openSearchServerlessPolicy]
-
         const osClusterEndpoint = getMigrationStringParameterValue(this, {
             ...props,
             parameter: MigrationSSMParameter.OS_CLUSTER_ENDPOINT,
@@ -70,17 +69,42 @@ export class ReindexFromSnapshotStack extends MigrationServiceCore {
         let rfsCommand = `/rfs-app/runJavaWithClasspath.sh com.rfs.RfsMigrateDocuments --s3-local-dir /tmp/s3_files --s3-repo-uri ${s3Uri} --s3-region ${this.region} --snapshot-name rfs-snapshot --lucene-dir '/lucene' --target-host ${osClusterEndpoint}`
         rfsCommand = parseAndMergeArgs(rfsCommand, props.extraArgs);
 
+        let targetUser = "";
+        let targetPassword = "";
+        let targetPasswordArn = "";
+        if (props.clusterAuthDetails.basic_auth) {
+            targetUser = props.clusterAuthDetails.basic_auth.username,
+            targetPassword = props.clusterAuthDetails.basic_auth.password? props.clusterAuthDetails.basic_auth.password : "",
+            targetPasswordArn = props.clusterAuthDetails.basic_auth.password_from_secret_arn? props.clusterAuthDetails.basic_auth.password_from_secret_arn : ""            
+        };
+
+        const openSearchPolicy = createOpenSearchIAMAccessPolicy(this.partition, this.region, this.account);
+        const openSearchServerlessPolicy = createOpenSearchServerlessIAMAccessPolicy(this.partition, this.region, this.account);
+        let servicePolicies = [artifactS3PublishPolicy, openSearchPolicy, openSearchServerlessPolicy];
+
+        const getSecretsPolicy = props.clusterAuthDetails.basic_auth?.password_from_secret_arn ? 
+            createTargetPasswordAccessPolicy(props.clusterAuthDetails.basic_auth.password_from_secret_arn) : null;
+        if (getSecretsPolicy) {
+            servicePolicies.push(getSecretsPolicy);
+        }
+
         this.createService({
             serviceName: 'reindex-from-snapshot',
             taskInstanceCount: 0,
             dockerDirectoryPath: join(__dirname, "../../../../../", "DocumentsFromSnapshotMigration/docker"),
-            dockerImageCommand: ['/bin/sh', '-c', rfsCommand],
+            dockerImageCommand: ['/bin/sh', '-c', "/rfs-app/entrypoint.sh"],
             securityGroups: securityGroups,
             taskRolePolicies: servicePolicies,
             cpuArchitecture: props.fargateCpuArch,
             taskCpuUnits: 1024,
             taskMemoryLimitMiB: 4096,
             ephemeralStorageGiB: 200,
+            environment: {
+                "RFS_COMMAND": rfsCommand,
+                "RFS_TARGET_USER": targetUser,
+                "RFS_TARGET_PASSWORD": targetPassword,
+                "RFS_TARGET_PASSWORD_ARN": targetPasswordArn,
+            },
             ...props
         });
 

--- a/deployment/cdk/opensearch-service-migration/lib/service-stacks/reindex-from-snapshot-stack.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/service-stacks/reindex-from-snapshot-stack.ts
@@ -9,7 +9,7 @@ import {
     MigrationSSMParameter,
     createOpenSearchIAMAccessPolicy,
     createOpenSearchServerlessIAMAccessPolicy,
-    createTargetPasswordAccessPolicy,
+    getTargetPasswordAccessPolicy,
     getMigrationStringParameterValue,
     parseAndMergeArgs
 } from "../common-utilities";
@@ -83,7 +83,7 @@ export class ReindexFromSnapshotStack extends MigrationServiceCore {
         let servicePolicies = [artifactS3PublishPolicy, openSearchPolicy, openSearchServerlessPolicy];
 
         const getSecretsPolicy = props.clusterAuthDetails.basic_auth?.password_from_secret_arn ? 
-            createTargetPasswordAccessPolicy(props.clusterAuthDetails.basic_auth.password_from_secret_arn) : null;
+            getTargetPasswordAccessPolicy(props.clusterAuthDetails.basic_auth.password_from_secret_arn) : null;
         if (getSecretsPolicy) {
             servicePolicies.push(getSecretsPolicy);
         }

--- a/deployment/cdk/opensearch-service-migration/lib/stack-composer.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/stack-composer.ts
@@ -435,6 +435,7 @@ export class StackComposer {
             reindexFromSnapshotStack = new ReindexFromSnapshotStack(scope, "reindexFromSnapshotStack", {
                 vpc: networkStack.vpc,
                 extraArgs: reindexFromSnapshotExtraArgs,
+                clusterAuthDetails: servicesYaml.target_cluster,
                 stackName: `OSMigrations-${stage}-${region}-ReindexFromSnapshot`,
                 description: "This stack contains resources to assist migrating historical data, via Reindex from Snapshot, to a target cluster",
                 stage: stage,

--- a/deployment/cdk/opensearch-service-migration/test/reindex-from-snapshot-stack.test.ts
+++ b/deployment/cdk/opensearch-service-migration/test/reindex-from-snapshot-stack.test.ts
@@ -79,6 +79,11 @@ describe('ReindexFromSnapshotStack Tests', () => {
       reindexFromSnapshotServiceEnabled: true,
       stage: 'unit-test',
       migrationAssistanceEnabled: true,
+      fineGrainedManagerUserName: "test-user",
+      fineGrainedManagerUserSecretManagerKeyARN: "arn:aws:secretsmanager:us-east-1:123456789012:secret:test-secret",
+      nodeToNodeEncryptionEnabled: true,
+      encryptionAtRestEnabled: true,
+      enforceHTTPS: true
     };
 
     const stacks = createStackComposer(contextOptions);
@@ -96,16 +101,34 @@ describe('ReindexFromSnapshotStack Tests', () => {
     expect(containerDefinitions[0].Command).toEqual([
       '/bin/sh',
       '-c',
+      '/rfs-app/entrypoint.sh'
+    ]);
+    expect(containerDefinitions[0].Environment).toEqual([
       {
-        "Fn::Join": [
-          "",
-          [ "/rfs-app/runJavaWithClasspath.sh com.rfs.RfsMigrateDocuments --s3-local-dir /tmp/s3_files --s3-repo-uri s3://migration-artifacts-test-account-unit-test-us-east-1/rfs-snapshot-repo --s3-region us-east-1 --snapshot-name rfs-snapshot --lucene-dir '/lucene' --target-host ",
-            {
-              "Ref": "SsmParameterValuemigrationunittestdefaultosClusterEndpointC96584B6F00A464EAD1953AFF4B05118Parameter",
-            },
+        Name: 'RFS_COMMAND',
+        Value: {
+          "Fn::Join": [
+            "",
+            [ "/rfs-app/runJavaWithClasspath.sh com.rfs.RfsMigrateDocuments --s3-local-dir /tmp/s3_files --s3-repo-uri s3://migration-artifacts-test-account-unit-test-us-east-1/rfs-snapshot-repo --s3-region us-east-1 --snapshot-name rfs-snapshot --lucene-dir '/lucene' --target-host ",
+              {
+                "Ref": "SsmParameterValuemigrationunittestdefaultosClusterEndpointC96584B6F00A464EAD1953AFF4B05118Parameter",
+              },
+            ],
           ],
-        ],
+        }
       },
+      {
+        Name: 'RFS_TARGET_USER',
+        Value: 'test-user'
+      },
+      {
+        Name: 'RFS_TARGET_PASSWORD',
+        Value: ''
+      },
+      {
+        Name: 'RFS_TARGET_PASSWORD_ARN',
+        Value: 'arn:aws:secretsmanager:us-east-1:123456789012:secret:test-secret'
+      }
     ]);
   });
 
@@ -156,16 +179,34 @@ describe('ReindexFromSnapshotStack Tests', () => {
     expect(containerDefinitions[0].Command).toEqual([
       '/bin/sh',
       '-c',
+      '/rfs-app/entrypoint.sh'
+    ]);
+    expect(containerDefinitions[0].Environment).toEqual([
       {
-        "Fn::Join": [
-          "",
-          [ "/rfs-app/runJavaWithClasspath.sh com.rfs.RfsMigrateDocuments --s3-local-dir /tmp/s3_files --s3-repo-uri s3://migration-artifacts-test-account-unit-test-us-east-1/rfs-snapshot-repo --s3-region us-east-1 --snapshot-name custom-snapshot --lucene-dir /lucene --target-host ",
-            {
-              "Ref": "SsmParameterValuemigrationunittestdefaultosClusterEndpointC96584B6F00A464EAD1953AFF4B05118Parameter",
-            },
-            " --custom-arg value --flag"
+        Name: 'RFS_COMMAND',
+        Value: {
+          "Fn::Join": [
+            "",
+            [ "/rfs-app/runJavaWithClasspath.sh com.rfs.RfsMigrateDocuments --s3-local-dir /tmp/s3_files --s3-repo-uri s3://migration-artifacts-test-account-unit-test-us-east-1/rfs-snapshot-repo --s3-region us-east-1 --snapshot-name custom-snapshot --lucene-dir /lucene --target-host ",
+              {
+                "Ref": "SsmParameterValuemigrationunittestdefaultosClusterEndpointC96584B6F00A464EAD1953AFF4B05118Parameter",
+              },
+              " --custom-arg value --flag"
+            ]
           ]
-        ]
+        }
+      },
+      {
+        Name: 'RFS_TARGET_USER',
+        Value: ''
+      },
+      {
+        Name: 'RFS_TARGET_PASSWORD',
+        Value: ''
+      },
+      {
+        Name: 'RFS_TARGET_PASSWORD_ARN',
+        Value: ''
       }
     ]);
   });


### PR DESCRIPTION
### Description
* Updated the RFS Documents Migration Container to use user-supplied values for the username/password if they are supplied via ENV variables and an entrypoint script.  In the event the password is supplied as an AWS Secret ARN, we unpack it in the entrypoint script.
* If the user has already supplied a username/password in the Run Command for RFS (also an ENV variable), we neglect the values specified in the ENV Variables for them.  This is to support the user being able to explicitly set those values via a top-level "Extra Args" setting in a previous PR (see: https://github.com/opensearch-project/opensearch-migrations/pull/861).
* Longer term, it is anticipated we'll pull all the args for RFS from a centralized configuration management store via the new entrypoint script.  This will enable more dynamic reconfiguration of the RFS Worker fleet.

### Issues Resolved
* https://opensearch.atlassian.net/browse/MIGRATIONS-1901

### Testing
* Enabled the `enableDemoAdmin` and deployed our test stacks using `awsE2ESolutionSetup.sh`.  This generated an username/password for the AOS target cluster.  Confirmed that the RFS container was able to retrieve and use the password to access the cluster:

```
RFS_COMMAND: /rfs-app/runJavaWithClasspath.sh com.rfs.RfsMigrateDocuments --s3-local-dir /tmp/s3_files --s3-repo-uri s3://migration-artifacts-672500112149-aws-integ-us-east-1/rfs-snapshot-repo --s3-region us-east-1 --snapshot-name rfs-snapshot --lucene-dir '/lucene' --target-host https://vpc-os-cluster-aws-integ-fm3taxbkynw4cyo7otpiirhlxe.us-east-1.es.amazonaws.com:443 RFS_TARGET_USER: admin RFS_TARGET_PASSWORD: <redacted> RFS_TARGET_PASSWORD_ARN: arn:aws:secretsmanager:us-east-1:672500112149:secret:demo-user-secret-aws-integ-default-5k6uky Using username from ENV variable RFS_TARGET_USER. Updating RFS Command with username. Using password from AWS Secrets Manager ARN in ENV variable RFS_TARGET_PASSWORD_ARN Updating RFS Command with password. Executing RFS Command
    
2024-08-05 18:26:08,138 WARN o.o.m.t.RootOtelContext [main] Collector endpoint=null, so serviceName parameter 'docMigration' is being ignored since a no-op OpenTelemetry object is being created
    
2024-08-05 18:26:09,230 INFO c.r.RfsMigrateDocuments [main] Running RfsWorker
    
2024-08-05 18:26:12,186 INFO c.r.c.OpenSearchWorkCoordinator [main] Not creating .migrations_working_state because it already exists
    
2024-08-05 18:26:12,583 WARN c.r.c.OpenSearchWorkCoordinator [main] Switch this to use _count
    
2024-08-05 18:26:12,700 INFO c.r.c.OpenSearchWorkCoordinator [main] Returning work item and lease: IWorkCoordinator.WorkItemAndDuration(workItemId=logs-241998__4, leaseExpirationTime=2024-08-05T18:36:12Z)
    
2024-08-05 18:26:12,708 INFO c.r.w.DocumentsRunner [main] Migrating docs for IndexAndShard(indexName=logs-241998, shard=4)
    
2024-08-05 18:26:13,598 INFO c.r.c.S3Repo [main] Downloading file from S3: s3://migration-artifacts-672500112149-aws-integ-us-east-1/rfs-snapshot-repo/index-0 to /tmp/s3_files/index-0
    
2024-08-05 18:26:13,850 INFO c.r.c.S3Repo [main] Downloading file from S3: s3://migration-artifacts-672500112149-aws-integ-us-east-1/rfs-snapshot-repo/indices/ehgiieixSfiLDOpLcZJJig/4/snap-El1-ZMhpTeCLc3wL2ra0pg.dat to /tmp/s3_files/indices/ehgiieixSfiLDOpLcZJJig/4/snap-El1-ZMhpTeCLc3wL2ra0pg.dat
    
2024-08-05 18:26:14,055 INFO c.r.RfsMigrateDocuments [main] Shard size: 39962
    
2024-08-05 18:26:14,119 INFO c.r.c.S3Repo [main] Downloading blob files from S3: s3://%s/%s to %s
    
2024-08-05 18:26:14,201 INFO c.r.c.S3Repo [main] Blob file download(s) complete
    
2024-08-05 18:26:14,217 INFO c.r.c.SnapshotShardUnpacker [main] Unpacking - Blob Name: __bwmiblw5TX6Rm3gsYAXPpg, Lucene Name: _0.cfe
    
2024-08-05 18:26:14,230 INFO c.r.c.S3Repo [main] Downloading file from S3: s3://migration-artifacts-672500112149-aws-integ-us-east-1/rfs-snapshot-repo/indices/ehgiieixSfiLDOpLcZJJig/4/__bwmiblw5TX6Rm3gsYAXPpg to /tmp/s3_files/indices/ehgiieixSfiLDOpLcZJJig/4/__bwmiblw5TX6Rm3gsYAXPpg
    
2024-08-05 18:26:14,320 INFO c.r.c.SnapshotShardUnpacker [main] Unpacking - Blob Name: v__xVj1L-K4S0-lqx8Gx9fxyw, Lucene Name: _0.si
    
2024-08-05 18:26:14,320 INFO c.r.c.SnapshotShardUnpacker [main] Unpacking - Blob Name: __tg7FmdyhQG2clo_fCYq_oA, Lucene Name: _0.cfs
    
2024-08-05 18:26:14,321 INFO c.r.c.S3Repo [main] Downloading file from S3: s3://migration-artifacts-672500112149-aws-integ-us-east-1/rfs-snapshot-repo/indices/ehgiieixSfiLDOpLcZJJig/4/__tg7FmdyhQG2clo_fCYq_oA to /tmp/s3_files/indices/ehgiieixSfiLDOpLcZJJig/4/__tg7FmdyhQG2clo_fCYq_oA
    
2024-08-05 18:26:14,400 INFO c.r.c.SnapshotShardUnpacker [main] Unpacking - Blob Name: v__IOj8O_NYRLyyWZca_NvFXA, Lucene Name: segments_3
    
2024-08-05 18:26:14,641 INFO c.r.c.LuceneDocumentsReader [main] 240 documents found in the current Lucene index
    
2024-08-05 18:26:14,740 INFO c.r.c.DocumentReindexer [main] 240 documents in current bulk request
    
2024-08-05 18:26:14,907 INFO c.r.w.DocumentsRunner [reactor-http-nio-2] Reindexing completed for Index logs-241998, Shard 4
    
2024-08-05 18:26:14,908 INFO c.r.w.DocumentsRunner [main] Docs migrated 
```

### Check List
- [X] New functionality includes testing
  - [X] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
