### PR TITLE
Switch from _cat/indices to {index}/_count for reliable doc count

### DIFF
--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/integ_test/integ_test/common_operations.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/integ_test/integ_test/common_operations.py
@@ -128,7 +128,8 @@ def get_all_index_details(cluster: Cluster, index_prefix_ignore_list=None, **kwa
         valid_index = not index_matches_ignored_index(index_name,
                                                       index_prefix_ignore_list=index_prefix_ignore_list)
         if index_prefix_ignore_list is None or valid_index:
-            index_dict[index_name] = execute_api_call(cluster=cluster, path=f"/{index_name}/_count?format=json", **kwargs).json()
+            count_response = execute_api_call(cluster=cluster, path=f"/{index_name}/_count?format=json", **kwargs)
+            index_dict[index_name] = count_response.json()
     return index_dict
 
 

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/integ_test/integ_test/common_operations.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/integ_test/integ_test/common_operations.py
@@ -124,8 +124,8 @@ def get_all_index_details(cluster: Cluster, index_prefix_ignore_list=None, **kwa
     all_index_details = execute_api_call(cluster=cluster, path="/_cat/indices?format=json", **kwargs).json()
     index_dict = {}
     for index_details in all_index_details:
-        # While cat/indices returns a doc count metric, the underlying implementation bleeds through details, only 
-        # capture the index name and make a separate api call for the doc count 
+        # While cat/indices returns a doc count metric, the underlying implementation bleeds through details, only
+        # capture the index name and make a separate api call for the doc count
         index_name = index_details['index']
         valid_index = not index_matches_ignored_index(index_name,
                                                       index_prefix_ignore_list=index_prefix_ignore_list)
@@ -135,6 +135,7 @@ def get_all_index_details(cluster: Cluster, index_prefix_ignore_list=None, **kwa
 
             count_response = execute_api_call(cluster=cluster, path=f"/{index_name}/_count?format=json", **kwargs)
             index_dict[index_name] = count_response.json()
+            index_dict['index'] = index_name
     return index_dict
 
 

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/integ_test/integ_test/common_operations.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/integ_test/integ_test/common_operations.py
@@ -155,8 +155,8 @@ def check_doc_counts_match(cluster: Cluster,
         else:
             for index_details in actual_index_details.values():
                 index_name = index_details['index']
-                actual_doc_count = index_details['docs.count']
-                expected_doc_count = expected_index_details[index_name]['docs.count']
+                actual_doc_count = index_details['count']
+                expected_doc_count = expected_index_details[index_name]['count']
                 if actual_doc_count != expected_doc_count:
                     error_message = (f"Index {index_name} has {actual_doc_count} documents but {expected_doc_count} "
                                      f"were expected")

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/integ_test/integ_test/common_operations.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/integ_test/integ_test/common_operations.py
@@ -135,7 +135,7 @@ def get_all_index_details(cluster: Cluster, index_prefix_ignore_list=None, **kwa
 
             count_response = execute_api_call(cluster=cluster, path=f"/{index_name}/_count?format=json", **kwargs)
             index_dict[index_name] = count_response.json()
-            index_dict['index'] = index_name
+            index_dict[index_name]['index'] = index_name
     return index_dict
 
 

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/integ_test/integ_test/common_operations.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/integ_test/integ_test/common_operations.py
@@ -16,16 +16,16 @@ logger = logging.getLogger(__name__)
 DEFAULT_INDEX_IGNORE_LIST = ["test_", ".", "searchguard", "sg7", "security-auditlog", "reindexed-logs"]
 
 EXPECTED_BENCHMARK_DOCS = {
-    "geonames": {"count": "1000"},
-    "logs-221998": {"count": "1000"},
-    "logs-211998": {"count": "1000"},
-    "logs-231998": {"count": "1000"},
-    "logs-241998": {"count": "1000"},
-    "logs-181998": {"count": "1000"},
-    "logs-201998": {"count": "1000"},
-    "logs-191998": {"count": "1000"},
-    "sonested": {"count": "1000"},
-    "nyc_taxis": {"count": "1000"}
+    "geonames": {"count": 1000},
+    "logs-221998": {"count": 1000},
+    "logs-211998": {"count": 1000},
+    "logs-231998": {"count": 1000},
+    "logs-241998": {"count": 1000},
+    "logs-181998": {"count": 1000},
+    "logs-201998": {"count": 1000},
+    "logs-191998": {"count": 1000},
+    "sonested": {"count": 1000},
+    "nyc_taxis": {"count": 1000}
 }
 
 

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/integ_test/integ_test/common_operations.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/integ_test/integ_test/common_operations.py
@@ -16,16 +16,16 @@ logger = logging.getLogger(__name__)
 DEFAULT_INDEX_IGNORE_LIST = ["test_", ".", "searchguard", "sg7", "security-auditlog", "reindexed-logs"]
 
 EXPECTED_BENCHMARK_DOCS = {
-    "geonames": {"docs.count": "1000"},
-    "logs-221998": {"docs.count": "1000"},
-    "logs-211998": {"docs.count": "1000"},
-    "logs-231998": {"docs.count": "1000"},
-    "logs-241998": {"docs.count": "1000"},
-    "logs-181998": {"docs.count": "1000"},
-    "logs-201998": {"docs.count": "1000"},
-    "logs-191998": {"docs.count": "1000"},
-    "sonested": {"docs.count": "2977"},
-    "nyc_taxis": {"docs.count": "1000"}
+    "geonames": {"count": "1000"},
+    "logs-221998": {"count": "1000"},
+    "logs-211998": {"count": "1000"},
+    "logs-231998": {"count": "1000"},
+    "logs-241998": {"count": "1000"},
+    "logs-181998": {"count": "1000"},
+    "logs-201998": {"count": "1000"},
+    "logs-191998": {"count": "1000"},
+    "sonested": {"count": "1000"},
+    "nyc_taxis": {"count": "1000"}
 }
 
 
@@ -124,10 +124,11 @@ def get_all_index_details(cluster: Cluster, index_prefix_ignore_list=None, **kwa
     all_index_details = execute_api_call(cluster=cluster, path="/_cat/indices?format=json", **kwargs).json()
     index_dict = {}
     for index_details in all_index_details:
-        valid_index = not index_matches_ignored_index(index_name=index_details['index'],
+        index_name = index_details['index']
+        valid_index = not index_matches_ignored_index(index_name,
                                                       index_prefix_ignore_list=index_prefix_ignore_list)
         if index_prefix_ignore_list is None or valid_index:
-            index_dict[index_details['index']] = index_details
+            index_dict[index_name] = execute_api_call(cluster=cluster, path=f"/{index_name}/_count?format=json", **kwargs).json()
     return index_dict
 
 


### PR DESCRIPTION
### Description
Switch from _cat/indices to {index}/_count for reliable doc count - mirroring the same changes from the java codebase.

#### How does this fix it?  
I consider the results on `_cat/indices` to be wrong, based on this comment [1] it checks the raw lucene count, whereas `{index}/_count` correctly maths together created / deleted / updated docs in that specific index.  The reason this count could fluctuate time could be relayed to when refreshes are triggered or segment merges that would cause the consolidation of delete/updated items.   It is hard to know the full set of potential triggers / edge cases with any given version of Elasticsearch or OpenSearch cluster.

- [1] https://stackoverflow.com/a/36857604/533057

### Issues Resolved
- Related https://github.com/opensearch-project/opensearch-migrations/pull/801
- Fixes https://opensearch.atlassian.net/browse/MIGRATIONS-1917

### Testing
Locally verified and is exercised with GitHub Actions

### Check List
- [X] New functionality includes testing
  - [X] All tests pass, including unit test, integration test and doctest
- [ ] ~New functionality has been documented~
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
