### PR TITLE
Fix permissions for github release

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # This should match the owning team set up in https://github.com/orgs/opensearch-project/teams
-*   @andrekurait @chelma @gregschohn @lewijacn @mikaylathompson @okhasawn @peternied @sumobrian
+*   @AndreKurait @chelma @gregschohn @lewijacn @mikaylathompson @okhasawn @peternied @sumobrian

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -12,6 +12,7 @@ env:
 permissions:
   id-token: write
   contents: read
+  issues: write
 
 jobs:
   draft-a-release:
@@ -55,7 +56,8 @@ jobs:
           docker tag migrations/traffic_replayer:latest opensearchstaging/opensearch-migrations-traffic-replayer:${{ steps.get_data.outputs.version }}
           docker tag migrations/capture_proxy:latest opensearchstaging/opensearch-migrations-traffic-capture-proxy:${{ steps.get_data.outputs.version }}
           docker tag migrations/reindex_from_snapshot:latest opensearchstaging/opensearch-migrations-reindex-from-snapshot:${{ steps.get_data.outputs.version }}
-      - uses: aws-actions/configure-aws-credentials@v4
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.MIGRATIONS_DOCKER_ROLE }}
           aws-region: us-east-1

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -4,16 +4,16 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 
 ## Current Maintainers
 
-| Maintainer         | GitHub ID                                               | Affiliation |
-| ------------------ | ------------------------------------------------------- | ----------- |
-| Chris Helma        | [chelma](https://github.com/chelma)                     | Amazon      |
-| Greg Schohn        | [gregschohn](https://github.com/gregschohn)             | Amazon      |
-| Tanner Lewis       | [lewijacn](https://github.com/lewijacn)                 | Amazon      |
-| Mikayla Thompson   | [mikaylathompson](https://github.com/mikaylathompson)   | Amazon      |
-| Omar Khasawneh     | [okhasawn](https://github.com/okhasawn)                 | Amazon      |
-| Brian Presley      | [sumobrian](https://github.com/sumobrian)               | Amazon      |
-| Andre Kurait       | [andrekurait](https://github.com/andrekurait)           | Amazon      |
-| Peter Nied         | [peternied](https://github.com/peternied)               | Amazon      |
+| Maintainer         | GitHub ID                                             | Affiliation |
+| ------------------ |-------------------------------------------------------| ----------- |
+| Chris Helma        | [chelma](https://github.com/chelma)                   | Amazon      |
+| Greg Schohn        | [gregschohn](https://github.com/gregschohn)           | Amazon      |
+| Tanner Lewis       | [lewijacn](https://github.com/lewijacn)               | Amazon      |
+| Mikayla Thompson   | [mikaylathompson](https://github.com/mikaylathompson) | Amazon      |
+| Omar Khasawneh     | [okhasawn](https://github.com/okhasawn)               | Amazon      |
+| Brian Presley      | [sumobrian](https://github.com/sumobrian)             | Amazon      |
+| Andre Kurait       | [andrekurait](https://github.com/AndreKurait)         | Amazon      |
+| Peter Nied         | [peternied](https://github.com/peternied)             | Amazon      |
 
 
 ## Emeritus


### PR DESCRIPTION
### Description
Fixes github actions for release, the release workflow needed issue permission.
Fixes AndreKurait maintainer (the approval workflow is case sensitive) 

* Category: Bug Fix
* Why these changes are required? Fix release workflow
* What is the old behavior before changes and new behavior after changes? Release workflow wouldn't accept andre as approver, it also failed on permission creating issues.

### Issues Resolved
[MIGRATIONS-1570](https://opensearch.atlassian.net/browse/MIGRATIONS-1570)

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
Tested in github actions by triggering workflow, was not able to test anything with assuming the role and after since it requires to be cut on the tag.

### Check List
- [x] New functionality includes testing
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
