### PR TITLE
Handle InvalidResponse cases during index creation

### DIFF
--- a/RFS/src/main/java/com/rfs/common/InvalidResponse.java
+++ b/RFS/src/main/java/com/rfs/common/InvalidResponse.java
@@ -9,13 +9,14 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.databind.JsonNode;
-
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.rfs.common.http.HttpResponse;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class InvalidResponse extends RfsException {
     private static final Pattern unknownSetting = Pattern.compile("unknown setting \\[(.+)\\].+");
+    private static final ObjectMapper objectMapper = new ObjectMapper();
     private final HttpResponse response;
 
     public InvalidResponse(String message, HttpResponse response) {
@@ -30,7 +31,7 @@ public class InvalidResponse extends RfsException {
     public Set<String> getIllegalArguments() {
         try {
             var interimResults = new ArrayList<Map.Entry<String, String>>();
-            var bodyNode = OpenSearchClient.objectMapper.readTree(response.body);
+            var bodyNode = objectMapper.readTree(response.body);
 
             var errorBody = Optional.ofNullable(bodyNode).map(node -> node.get("error"));
 

--- a/RFS/src/main/java/com/rfs/common/InvalidResponse.java
+++ b/RFS/src/main/java/com/rfs/common/InvalidResponse.java
@@ -10,6 +10,7 @@ import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+
 import com.rfs.common.http.HttpResponse;
 import lombok.extern.slf4j.Slf4j;
 

--- a/RFS/src/main/java/com/rfs/common/InvalidResponse.java
+++ b/RFS/src/main/java/com/rfs/common/InvalidResponse.java
@@ -1,0 +1,98 @@
+package com.rfs.common;
+
+import java.util.Set;
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.Map.Entry;
+import java.util.regex.Pattern;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.rfs.common.http.HttpResponse;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class InvalidResponse extends RfsException {
+    private static final Pattern unknownSetting = Pattern.compile("unknown setting \\[(.+)\\].+");
+    private final HttpResponse response;
+
+    public InvalidResponse(String message, HttpResponse response) {
+        super(message);
+        this.response = response;
+    }
+
+    /**
+     * Looks in the invalid error response for any illegal arguments can be removed and the request would succeed.
+     * @return The set of illegal arguments to remove from the request. If empty returned, then the request should not be assumed to be safe to repeat.
+     */
+    public Set<String> getIllegalArguments() {
+        try {
+            var interimResults = new ArrayList<Map.Entry<String, String>>();
+            var bodyNode = OpenSearchClient.objectMapper.readTree(response.body);
+
+            var errorBody = Optional.ofNullable(bodyNode)
+                .map(node -> node.get("error"));
+
+            // Check high level cause
+            errorBody
+                .map(InvalidResponse::getUnknownSetting)
+                .ifPresent(interimResults::add);
+
+            // Check root cause errors
+            errorBody
+                .map(node -> node.get("root_cause"))
+                .ifPresent(nodes -> {
+                    nodes.forEach(node -> {
+                        Optional.of(node)
+                            .map(InvalidResponse::getUnknownSetting)
+                            .ifPresent(interimResults::add);
+                    });
+                });
+            
+            // Check all suppressed errors
+            errorBody
+                .map(node -> node.get("suppressed"))
+                .ifPresent(nodes -> {
+                    nodes.forEach(node -> {
+                        Optional.of(node)
+                            .map(InvalidResponse::getUnknownSetting)
+                            .ifPresent(interimResults::add);
+                    });
+                });
+
+            var onlyExpectedErrors = interimResults.stream().map(Entry::getKey).allMatch("illegal_argument_exception"::equals);
+            if (!onlyExpectedErrors) {
+                log.warn("Expecting only invalid argument errors, found additional error types " + interimResults);
+                return Set.of();
+            }
+
+            return interimResults.stream().map(Entry::getValue).collect(Collectors.toSet());
+        } catch (Exception e) {
+            log.warn("Error parsing error message to attempt recovery" + response.body, e);
+            return Set.of();
+        }
+    }
+
+    private static Map.Entry<String, String> getUnknownSetting(JsonNode json) {
+        return Optional.ofNullable(json)
+            .map(node -> {
+                var typeNode = node.get("type");
+                var reasonNode = node.get("reason");
+                if (typeNode == null || reasonNode == null) {
+                    return null;
+                }
+                return Map.entry(typeNode, reasonNode);
+            })
+            .map(entry -> {
+                var matcher = unknownSetting.matcher(entry.getValue().asText());
+                if (!matcher.matches()) {
+                    return null;
+                }
+
+                return Map.entry(entry.getKey().asText(), matcher.group(1));
+            })
+            .orElse(null);
+    }
+}

--- a/RFS/src/main/java/com/rfs/common/OpenSearchClient.java
+++ b/RFS/src/main/java/com/rfs/common/OpenSearchClient.java
@@ -21,7 +21,7 @@ import reactor.util.retry.Retry;
 
 public class OpenSearchClient {
     private static final Logger logger = LogManager.getLogger(OpenSearchClient.class);
-    static final ObjectMapper objectMapper = new ObjectMapper();
+    private static final ObjectMapper objectMapper = new ObjectMapper();
 
     static {
         objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);

--- a/RFS/src/main/java/com/rfs/common/OpenSearchClient.java
+++ b/RFS/src/main/java/com/rfs/common/OpenSearchClient.java
@@ -114,12 +114,13 @@ public class OpenSearchClient {
             + " should have been thrown.");
         boolean objectDoesNotExist = getResponse.statusCode == HttpURLConnection.HTTP_NOT_FOUND;
         if (objectDoesNotExist) {
-            logger.debug("Creating object " + objectPath + "\r\n" + settings.toPrettyString());
             client.putAsync(objectPath, settings.toString(), context.createCheckRequestContext()).flatMap(resp -> {
                 if (resp.statusCode == HttpURLConnection.HTTP_OK) {
                     return Mono.just(resp);
                 } else if (resp.statusCode == HttpURLConnection.HTTP_BAD_REQUEST) {
-                    return Mono.error(new InvalidResponse("Create object failed for " + objectPath + "\r\n" + resp.body, resp));
+                    return Mono.error(
+                        new InvalidResponse("Create object failed for " + objectPath + "\r\n" + resp.body, resp)
+                    );
                 } else {
                     String errorMessage = ("Could not create object: "
                         + objectPath
@@ -133,7 +134,11 @@ public class OpenSearchClient {
                 }
             })
                 .doOnError(e -> logger.error(e.getMessage()))
-                .retryWhen(Retry.backoff(3, Duration.ofSeconds(1)).maxBackoff(Duration.ofSeconds(10)).filter(OperationFailed.class::isInstance))
+                .retryWhen(
+                    Retry.backoff(3, Duration.ofSeconds(1))
+                        .maxBackoff(Duration.ofSeconds(10))
+                        .filter(OperationFailed.class::isInstance)
+                )
                 .block();
 
             return Optional.of(settings);

--- a/RFS/src/main/java/com/rfs/common/OpenSearchClient.java
+++ b/RFS/src/main/java/com/rfs/common/OpenSearchClient.java
@@ -21,7 +21,7 @@ import reactor.util.retry.Retry;
 
 public class OpenSearchClient {
     private static final Logger logger = LogManager.getLogger(OpenSearchClient.class);
-    private static final ObjectMapper objectMapper = new ObjectMapper();
+    static final ObjectMapper objectMapper = new ObjectMapper();
 
     static {
         objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
@@ -114,9 +114,12 @@ public class OpenSearchClient {
             + " should have been thrown.");
         boolean objectDoesNotExist = getResponse.statusCode == HttpURLConnection.HTTP_NOT_FOUND;
         if (objectDoesNotExist) {
+            logger.debug("Creating object " + objectPath + "\r\n" + settings.toPrettyString());
             client.putAsync(objectPath, settings.toString(), context.createCheckRequestContext()).flatMap(resp -> {
                 if (resp.statusCode == HttpURLConnection.HTTP_OK) {
                     return Mono.just(resp);
+                } else if (resp.statusCode == HttpURLConnection.HTTP_BAD_REQUEST) {
+                    return Mono.error(new InvalidResponse("Create object failed for " + objectPath + "\r\n" + resp.body, resp));
                 } else {
                     String errorMessage = ("Could not create object: "
                         + objectPath
@@ -130,7 +133,7 @@ public class OpenSearchClient {
                 }
             })
                 .doOnError(e -> logger.error(e.getMessage()))
-                .retryWhen(Retry.backoff(3, Duration.ofSeconds(1)).maxBackoff(Duration.ofSeconds(10)))
+                .retryWhen(Retry.backoff(3, Duration.ofSeconds(1)).maxBackoff(Duration.ofSeconds(10)).filter(OperationFailed.class::isInstance))
                 .block();
 
             return Optional.of(settings);

--- a/RFS/src/main/java/com/rfs/version_os_2_11/IndexCreator_OS_2_11.java
+++ b/RFS/src/main/java/com/rfs/version_os_2_11/IndexCreator_OS_2_11.java
@@ -2,7 +2,6 @@ package com.rfs.version_os_2_11;
 
 import java.util.Optional;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
@@ -11,7 +10,6 @@ import org.opensearch.migrations.metadata.tracing.IMetadataMigrationContexts;
 import com.rfs.common.InvalidResponse;
 import com.rfs.common.OpenSearchClient;
 import com.rfs.models.IndexMetadata;
-
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -61,7 +59,7 @@ public class IndexCreator_OS_2_11 {
                     log.warn("Expecting all retryable errors to start with 'index.', instead saw " + illegalArgument);
                     return Optional.empty();
                 }
-                
+
                 var shortenedIllegalArgument = illegalArgument.replaceFirst("index.", "");
                 removeFieldsByPath(settings, shortenedIllegalArgument);
             }

--- a/RFS/src/main/java/com/rfs/version_os_2_11/IndexCreator_OS_2_11.java
+++ b/RFS/src/main/java/com/rfs/version_os_2_11/IndexCreator_OS_2_11.java
@@ -34,10 +34,10 @@ public class IndexCreator_OS_2_11 {
         // Remove some settings which will cause errors if you try to pass them to the API
         ObjectNode settings = indexMetadata.getSettings();
 
-        // String[] problemFields = { "creation_date", "provided_name", "uuid", "version" };
-        // for (String field : problemFields) {
-        //     settings.remove(field);
-        // }
+        String[] problemFields = { "creation_date", "provided_name", "uuid", "version" };
+        for (String field : problemFields) {
+            settings.remove(field);
+        }
 
         // Assemble the request body
         ObjectNode body = mapper.createObjectNode();
@@ -52,7 +52,7 @@ public class IndexCreator_OS_2_11 {
             var illegalArguments = invalidResponse.getIllegalArguments();
 
             if (illegalArguments.isEmpty()) {
-                log.debug("Unable to alter index creation request to retry");
+                log.debug("Cannot retry invalid response.");
                 return Optional.empty();
             }
 
@@ -85,12 +85,9 @@ public class IndexCreator_OS_2_11 {
             if (nextNode != null && nextNode.isObject()) {
                 currentNode = (ObjectNode) nextNode;
             } else {
-                // Path is invalid or does not exist
-                log.debug("Unable to remove path " + path + " , on current node " + node.toPrettyString());
                 return;
             }
         }
-        log.debug("Removing " + pathParts[pathParts.length - 1] + " on node " + currentNode.toPrettyString());
         currentNode.remove(pathParts[pathParts.length - 1]);
     }
 }

--- a/RFS/src/main/java/com/rfs/version_os_2_11/IndexCreator_OS_2_11.java
+++ b/RFS/src/main/java/com/rfs/version_os_2_11/IndexCreator_OS_2_11.java
@@ -50,7 +50,7 @@ public class IndexCreator_OS_2_11 {
             var illegalArguments = invalidResponse.getIllegalArguments();
 
             if (illegalArguments.isEmpty()) {
-                log.debug("Cannot retry invalid response.");
+                log.debug("Cannot retry invalid response, there are no illegal arguments to remove.");
                 return Optional.empty();
             }
 
@@ -64,7 +64,7 @@ public class IndexCreator_OS_2_11 {
                 removeFieldsByPath(settings, shortenedIllegalArgument);
             }
 
-            log.debug("Reattempting creation of index after removing illegal arguments; " + illegalArguments);
+            log.info("Reattempting creation of index '" + indexName + "' after removing illegal arguments; " + illegalArguments);
             return client.createIndex(indexName, body, context);
         }
     }

--- a/RFS/src/main/java/com/rfs/version_os_2_11/IndexCreator_OS_2_11.java
+++ b/RFS/src/main/java/com/rfs/version_os_2_11/IndexCreator_OS_2_11.java
@@ -2,14 +2,19 @@ package com.rfs.version_os_2_11;
 
 import java.util.Optional;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import org.opensearch.migrations.metadata.tracing.IMetadataMigrationContexts;
 
+import com.rfs.common.InvalidResponse;
 import com.rfs.common.OpenSearchClient;
 import com.rfs.models.IndexMetadata;
 
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
 public class IndexCreator_OS_2_11 {
     private static final ObjectMapper mapper = new ObjectMapper();
     protected final OpenSearchClient client;
@@ -29,10 +34,10 @@ public class IndexCreator_OS_2_11 {
         // Remove some settings which will cause errors if you try to pass them to the API
         ObjectNode settings = indexMetadata.getSettings();
 
-        String[] problemFields = { "creation_date", "provided_name", "uuid", "version" };
-        for (String field : problemFields) {
-            settings.remove(field);
-        }
+        // String[] problemFields = { "creation_date", "provided_name", "uuid", "version" };
+        // for (String field : problemFields) {
+        //     settings.remove(field);
+        // }
 
         // Assemble the request body
         ObjectNode body = mapper.createObjectNode();
@@ -41,6 +46,51 @@ public class IndexCreator_OS_2_11 {
         body.set("settings", settings);
 
         // Create the index; it's fine if it already exists
-        return client.createIndex(indexName, body, context);
+        try {
+            return client.createIndex(indexName, body, context);
+        } catch (InvalidResponse invalidResponse) {
+            var illegalArguments = invalidResponse.getIllegalArguments();
+
+            if (illegalArguments.isEmpty()) {
+                log.debug("Unable to alter index creation request to retry");
+                return Optional.empty();
+            }
+
+            for (var illegalArgument : illegalArguments) {
+                if (!illegalArgument.startsWith("index.")) {
+                    log.warn("Expecting all retryable errors to start with 'index.', instead saw " + illegalArgument);
+                    return Optional.empty();
+                }
+                
+                var shortenedIllegalArgument = illegalArgument.replaceFirst("index.", "");
+                removeFieldsByPath(settings, shortenedIllegalArgument);
+            }
+
+            log.debug("Reattempting creation of index after removing illegal arguments; " + illegalArguments);
+            return client.createIndex(indexName, body, context);
+        }
+    }
+
+    private void removeFieldsByPath(ObjectNode node, String path) {
+        var pathParts = path.split("\\.");
+
+        if (pathParts.length == 1) {
+            node.remove(pathParts[0]);
+            return;
+        }
+
+        var currentNode = node;
+        for (int i = 0; i < pathParts.length - 1; i++) {
+            var nextNode = currentNode.get(pathParts[i]);
+            if (nextNode != null && nextNode.isObject()) {
+                currentNode = (ObjectNode) nextNode;
+            } else {
+                // Path is invalid or does not exist
+                log.debug("Unable to remove path " + path + " , on current node " + node.toPrettyString());
+                return;
+            }
+        }
+        log.debug("Removing " + pathParts[pathParts.length - 1] + " on node " + currentNode.toPrettyString());
+        currentNode.remove(pathParts[pathParts.length - 1]);
     }
 }

--- a/RFS/src/test/java/com/rfs/common/InvalidResponseTest.java
+++ b/RFS/src/test/java/com/rfs/common/InvalidResponseTest.java
@@ -1,0 +1,100 @@
+package com.rfs.common;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.util.Map;
+import com.rfs.common.http.HttpResponse;
+
+class InvalidResponseTest {
+
+    @Test
+    void testGetIllegalArguments_noIllegalArguments() {
+        var errorBody = "{\r\n" + //
+            "  \"error\": \"Incorrect HTTP method for uri [/a/bc] and method [PUT], allowed: [POST]\",\r\n" + //
+            "  \"status\": 405\r\n" + //
+            "}";
+        var response = new HttpResponse(200, "statusText", Map.of(), errorBody);
+        var iar = new InvalidResponse("ignored", response);
+
+        var result = iar.getIllegalArguments();
+
+        assertThat(result, empty());
+    }
+
+    @Test
+    void testGetIllegalArguments() {
+        var errorBody = "{\r\n" + //
+            "  \"error\": {\r\n" + //
+            "    \"type\": \"illegal_argument_exception\",\r\n" + //
+            "    \"reason\": \"unknown setting [index.creation_date] please check that any required plugins are installed, or check the breaking changes documentation for removed settings\"\r\n" + //
+            "  },\r\n" + //
+            "  \"status\": 400\r\n" + //
+            "}";
+        var response = new HttpResponse(200, "statusText", Map.of(), errorBody);
+        var iar = new InvalidResponse("ignored", response);
+
+        var result = iar.getIllegalArguments();
+
+        assertThat(result, containsInAnyOrder("index.creation_date"));
+    }
+
+    @Test
+    void testGetIllegalArguments_inRootCause() {
+        var errorBody = "{\r\n" + //
+            "  \"error\": {\r\n" + //
+            "    \"root_cause\": [\r\n" + //
+            "      {\r\n" + //
+            "        \"type\": \"illegal_argument_exception\",\r\n" + //
+            "        \"reason\": \"unknown setting [index.creation_date] please check that any required plugins are installed, or check the breaking changes documentation for removed settings\"\r\n" + //
+            "      }\r\n" + //
+            "    ],\r\n" + //
+            "    \"type\": \"illegal_argument_exception\",\r\n" + //
+            "    \"reason\": \"unknown setting [index.creation_date] please check that any required plugins are installed, or check the breaking changes documentation for removed settings\"\r\n" + //
+            "  },\r\n" + //
+            "  \"status\": 400\r\n" + //
+            "}";
+        var response = new HttpResponse(200, "statusText", Map.of(), errorBody);
+        var iar = new InvalidResponse("ignored", response);
+
+        var result = iar.getIllegalArguments();
+
+        assertThat(result, containsInAnyOrder("index.creation_date"));
+    }
+
+    @Test
+    void testGetIllegalArguments_inRootCauseAndSuppressed() {
+        var errorBody = "{\r\n" + //
+            "  \"error\": {\r\n" + //
+            "    \"root_cause\": [\r\n" + //
+            "      {\r\n" + //
+            "        \"type\": \"illegal_argument_exception\",\r\n" + //
+            "        \"reason\": \"unknown setting [index.creation_date] please check that any required plugins are installed, or check the breaking changes documentation for removed settings\"\r\n" + //
+            "      }\r\n" + //
+            "    ],\r\n" + //
+            "    \"type\": \"illegal_argument_exception\",\r\n" + //
+            "    \"reason\": \"unknown setting [index.creation_date] please check that any required plugins are installed, or check the breaking changes documentation for removed settings\",\r\n" + //
+            "    \"suppressed\": [\r\n" + //
+            "      {\r\n" + //
+            "        \"type\": \"illegal_argument_exception\",\r\n" + //
+            "        \"reason\": \"unknown setting [index.lifecycle.name] please check that any required plugins are installed, or check the breaking changes documentation for removed settings\"\r\n" + //
+            "      },\r\n" + //
+            "      {\r\n" + //
+            "        \"type\": \"illegal_argument_exception\",\r\n" + //
+            "        \"reason\": \"unknown setting [index.provided_name] please check that any required plugins are installed, or check the breaking changes documentation for removed settings\"\r\n" + //
+            "      }\r\n" + //
+            "    ]\r\n" + //
+            "  },\r\n" + //
+            "  \"status\": 400\r\n" + //
+            "}";
+        var response = new HttpResponse(200, "statusText", Map.of(), errorBody);
+        var iar = new InvalidResponse("ignored", response);
+
+        var result = iar.getIllegalArguments();
+
+        assertThat(result, containsInAnyOrder("index.provided_name", "index.lifecycle.name", "index.creation_date"));
+    }
+
+}

--- a/RFS/src/test/java/com/rfs/common/InvalidResponseTest.java
+++ b/RFS/src/test/java/com/rfs/common/InvalidResponseTest.java
@@ -1,12 +1,14 @@
 package com.rfs.common;
-import org.junit.jupiter.api.Test;
-
-import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
 import com.rfs.common.http.HttpResponse;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
 
 class InvalidResponseTest {
 
@@ -29,9 +31,12 @@ class InvalidResponseTest {
         var errorBody = "{\r\n" + //
             "  \"error\": {\r\n" + //
             "    \"type\": \"illegal_argument_exception\",\r\n" + //
-            "    \"reason\": \"unknown setting [index.creation_date] please check that any required plugins are installed, or check the breaking changes documentation for removed settings\"\r\n" + //
-            "  },\r\n" + //
-            "  \"status\": 400\r\n" + //
+            "    \"reason\": \"unknown setting [index.creation_date] please check that any required plugins are installed, or check the breaking changes documentation for removed settings\"\r\n"
+            + //
+            "  },\r\n"
+            + //
+            "  \"status\": 400\r\n"
+            + //
             "}";
         var response = new HttpResponse(200, "statusText", Map.of(), errorBody);
         var iar = new InvalidResponse("ignored", response);
@@ -48,13 +53,20 @@ class InvalidResponseTest {
             "    \"root_cause\": [\r\n" + //
             "      {\r\n" + //
             "        \"type\": \"illegal_argument_exception\",\r\n" + //
-            "        \"reason\": \"unknown setting [index.creation_date] please check that any required plugins are installed, or check the breaking changes documentation for removed settings\"\r\n" + //
-            "      }\r\n" + //
-            "    ],\r\n" + //
-            "    \"type\": \"illegal_argument_exception\",\r\n" + //
-            "    \"reason\": \"unknown setting [index.creation_date] please check that any required plugins are installed, or check the breaking changes documentation for removed settings\"\r\n" + //
-            "  },\r\n" + //
-            "  \"status\": 400\r\n" + //
+            "        \"reason\": \"unknown setting [index.creation_date] please check that any required plugins are installed, or check the breaking changes documentation for removed settings\"\r\n"
+            + //
+            "      }\r\n"
+            + //
+            "    ],\r\n"
+            + //
+            "    \"type\": \"illegal_argument_exception\",\r\n"
+            + //
+            "    \"reason\": \"unknown setting [index.creation_date] please check that any required plugins are installed, or check the breaking changes documentation for removed settings\"\r\n"
+            + //
+            "  },\r\n"
+            + //
+            "  \"status\": 400\r\n"
+            + //
             "}";
         var response = new HttpResponse(200, "statusText", Map.of(), errorBody);
         var iar = new InvalidResponse("ignored", response);
@@ -71,23 +83,40 @@ class InvalidResponseTest {
             "    \"root_cause\": [\r\n" + //
             "      {\r\n" + //
             "        \"type\": \"illegal_argument_exception\",\r\n" + //
-            "        \"reason\": \"unknown setting [index.creation_date] please check that any required plugins are installed, or check the breaking changes documentation for removed settings\"\r\n" + //
-            "      }\r\n" + //
-            "    ],\r\n" + //
-            "    \"type\": \"illegal_argument_exception\",\r\n" + //
-            "    \"reason\": \"unknown setting [index.creation_date] please check that any required plugins are installed, or check the breaking changes documentation for removed settings\",\r\n" + //
-            "    \"suppressed\": [\r\n" + //
-            "      {\r\n" + //
-            "        \"type\": \"illegal_argument_exception\",\r\n" + //
-            "        \"reason\": \"unknown setting [index.lifecycle.name] please check that any required plugins are installed, or check the breaking changes documentation for removed settings\"\r\n" + //
-            "      },\r\n" + //
-            "      {\r\n" + //
-            "        \"type\": \"illegal_argument_exception\",\r\n" + //
-            "        \"reason\": \"unknown setting [index.provided_name] please check that any required plugins are installed, or check the breaking changes documentation for removed settings\"\r\n" + //
-            "      }\r\n" + //
-            "    ]\r\n" + //
-            "  },\r\n" + //
-            "  \"status\": 400\r\n" + //
+            "        \"reason\": \"unknown setting [index.creation_date] please check that any required plugins are installed, or check the breaking changes documentation for removed settings\"\r\n"
+            + //
+            "      }\r\n"
+            + //
+            "    ],\r\n"
+            + //
+            "    \"type\": \"illegal_argument_exception\",\r\n"
+            + //
+            "    \"reason\": \"unknown setting [index.creation_date] please check that any required plugins are installed, or check the breaking changes documentation for removed settings\",\r\n"
+            + //
+            "    \"suppressed\": [\r\n"
+            + //
+            "      {\r\n"
+            + //
+            "        \"type\": \"illegal_argument_exception\",\r\n"
+            + //
+            "        \"reason\": \"unknown setting [index.lifecycle.name] please check that any required plugins are installed, or check the breaking changes documentation for removed settings\"\r\n"
+            + //
+            "      },\r\n"
+            + //
+            "      {\r\n"
+            + //
+            "        \"type\": \"illegal_argument_exception\",\r\n"
+            + //
+            "        \"reason\": \"unknown setting [index.provided_name] please check that any required plugins are installed, or check the breaking changes documentation for removed settings\"\r\n"
+            + //
+            "      }\r\n"
+            + //
+            "    ]\r\n"
+            + //
+            "  },\r\n"
+            + //
+            "  \"status\": 400\r\n"
+            + //
             "}";
         var response = new HttpResponse(200, "statusText", Map.of(), errorBody);
         var iar = new InvalidResponse("ignored", response);

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/integ_test/integ_test/replayer_tests.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/integ_test/integ_test/replayer_tests.py
@@ -94,6 +94,7 @@ class ReplayerTests(unittest.TestCase):
         get_index(cluster=target_cluster, index_name=index_name, expected_status_code=HTTPStatus.NOT_FOUND,
                   test_case=self)
 
+    @unittest.skip("Flaky test - https://opensearch.atlassian.net/browse/MIGRATIONS-1925")
     def test_replayer_0002_single_document(self):
         # This test will verify that a document will be created (then deleted) on the target cluster when one is created
         # on the source cluster by going through the proxy first. It will verify that the traffic is captured by the


### PR DESCRIPTION
### Description
We've found issues when creating indexes from Elasticsearch contain schema elements that are not supported in OpenSearch.  Rather than attempting to write these all down we are parsing out the error response on 400 requests and attempting to remove these illegal arguments.

Here is an example where the index the creation date and other information included and the service returns an error, and then by parsing the error the illegal arguments can be stripped of a reattempted request.
#### PUT `/blog_2023`
```json
{
  "aliases" : { },
  "mappings" : {...},
  "settings" : {
    "creation_date" : "1723061506227",
    "number_of_replicas" : 1,
    "number_of_shards" : "1",
    "provided_name" : "blog_2023",
    "uuid" : "2IpsjQoHQsm7tSobRZmCJg"
  }
}
```
#### 400 Response
```json
{
    "error": {
        "root_cause": [
            {
                "type": "illegal_argument_exception",
                "reason": "unknown setting [index.creation_date] please check that any required plugins are installed, or check the breaking changes documentation for removed settings"
            }
        ],
        "type": "illegal_argument_exception",
        "reason": "unknown setting [index.creation_date] please check that any required plugins are installed, or check the breaking changes documentation for removed settings",
        "suppressed": [
            {
                "type": "illegal_argument_exception",
                "reason": "unknown setting [index.provided_name] please check that any required plugins are installed, or check the breaking changes documentation for removed settings"
            },
            {
                "type": "illegal_argument_exception",
                "reason": "unknown setting [index.uuid] please check that any required plugins are installed, or check the breaking changes documentation for removed settings"
            }
        ]
    },
    "status": 400
}
```


#### Filtered response
```json
{
  "aliases" : { },
  "mappings" : {...},
  "settings" : {
    "number_of_replicas" : 1,
    "number_of_shards" : "1"
  }
}
```

### Issues Resolved
- Resolves https://opensearch.atlassian.net/browse/MIGRATIONS-1918

### Testing
Note; I was unable to test the root cause which was due to `unknown setting [index.lifecycle.name] ...` because our test clusters are not setup with X-Pack features.
By commenting out entries, creation_date or provided_name from the the IndexCreator I was able to reproduce the issue and verify the fix worked as expected.
https://github.com/opensearch-project/opensearch-migrations/blob/9bed7da6dcfde7c8db08e1acc3c985a93e339ebe/RFS/src/main/java/com/rfs/version_os_2_11/IndexCreator_OS_2_11.java#L32-L35

### Check List
- [X] New functionality includes testing
  - [X] All tests pass, including unit test, integration test and doctest
- [X] New functionality has been documented
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
