### PR TITLE
Updated default max shard size for RFS to 80 GB

### DIFF
--- a/DocumentsFromSnapshotMigration/src/main/java/com/rfs/RfsMigrateDocuments.java
+++ b/DocumentsFromSnapshotMigration/src/main/java/com/rfs/RfsMigrateDocuments.java
@@ -100,8 +100,8 @@ public class RfsMigrateDocuments {
 
         @Parameter(names = {
             "--max-shard-size-bytes" }, description = ("Optional. The maximum shard size, in bytes, to allow when"
-                + " performing the document migration.  Useful for preventing disk overflow.  Default: 50 * 1024 * 1024 * 1024 (50 GB)"), required = false)
-        public long maxShardSizeBytes = 50 * 1024 * 1024 * 1024L;
+                + " performing the document migration.  Useful for preventing disk overflow.  Default: 80 * 1024 * 1024 * 1024 (80 GB)"), required = false)
+        public long maxShardSizeBytes = 80 * 1024 * 1024 * 1024L;
 
         @Parameter(names = { "--max-initial-lease-duration" }, description = ("Optional. The maximum time that the "
             + "first attempt to migrate a shard's documents should take.  If a process takes longer than this "


### PR DESCRIPTION
### Description
* Updated the default, maximum shard size for RFS doc migrations from 50 GB to 80 GB.  This is to better match the available disk space on the ECS Fargate Containers the process runs on, which [have 200 GB of disk](https://github.com/opensearch-project/opensearch-migrations/blob/main/deployment/cdk/opensearch-service-migration/lib/service-stacks/reindex-from-snapshot-stack.ts#L101).
* RFS currently requires ~2X shard-size disk space in order to do its work.  This is because it first needs to download the shard from S3, then unpack/reassemble it into a Lucene index on disk.  This creates two copies of the shard in different formats.
* We have a task (https://opensearch.atlassian.net/browse/MIGRATIONS-1750) to switch from Fargate ephemeral storage to EBS/EFS and resolve this problem.

### Issues Resolved
N/A

### Testing
N/A

### Check List
- [ ] New functionality includes testing
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
