### PR TITLE
Change the name of the CloudWatch metric namespace for all otel metri…

### DIFF
--- a/TrafficCapture/dockerSolution/otelConfigs/configSnippets/awsCloudWatch.yaml
+++ b/TrafficCapture/dockerSolution/otelConfigs/configSnippets/awsCloudWatch.yaml
@@ -1,6 +1,6 @@
 exporters:
   awsemf:
-    namespace: 'TrafficCaptureReplay'
+    namespace: 'OpenSearchMigrations'
 
 service:
   pipelines:

--- a/TrafficCapture/dockerSolution/src/main/docker/composeExtensions/configs/otel-config-everything.yaml
+++ b/TrafficCapture/dockerSolution/src/main/docker/composeExtensions/configs/otel-config-everything.yaml
@@ -19,7 +19,7 @@ exporters:
     sampling_initial: 5
     sampling_thereafter: 200
   awsemf:
-    namespace: 'TrafficCaptureReplay'
+    namespace: 'OpenSearchMigrations'
   awsxray:
     index_all_attributes: true
   prometheus:

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/metrics_source.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/metrics_source.py
@@ -82,7 +82,7 @@ class MetricsSource:
         raise NotImplementedError
 
 
-CLOUDWATCH_METRICS_NAMESPACE = "TrafficCaptureReplay"
+CLOUDWATCH_METRICS_NAMESPACE = "OpenSearchMigrations"
 
 
 class CloudwatchMetricMetadata:
@@ -95,7 +95,7 @@ class CloudwatchMetricMetadata:
                              {'Name': 'OTelLib', 'Value': 'replayer'},
                              {'Name': 'statusCodesMatch', 'Value': 'true'}],
               'MetricName': 'tupleComparison',
-              'Namespace': 'TrafficCaptureReplay'},
+              'Namespace': 'OpenSearchMigrations'},
         """
         assert "Namespace" in list_metric_data, "Namespace is missing"
         assert "MetricName" in list_metric_data, "MetricName is missing"

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/data/cloudwatch_list_metrics_response.json
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/data/cloudwatch_list_metrics_response.json
@@ -1,7 +1,7 @@
 {
     "Metrics": [
         {
-            "Namespace": "TrafficCaptureReplay",
+            "Namespace": "OpenSearchMigrations",
             "MetricName": "kafkaCommitCount",
             "Dimensions": [
                 {
@@ -11,7 +11,7 @@
             ]
         },
         {
-            "Namespace": "TrafficCaptureReplay",
+            "Namespace": "OpenSearchMigrations",
             "MetricName": "captureConnectionDuration",
             "Dimensions": [
                 {
@@ -21,7 +21,7 @@
             ]
         },
         {
-            "Namespace": "TrafficCaptureReplay",
+            "Namespace": "OpenSearchMigrations",
             "MetricName": "kafkaCommitCount",
             "Dimensions": [
                 {

--- a/TrafficCapture/dockerSolution/src/main/docker/otelCollector/otel-config-aws-debug.yaml
+++ b/TrafficCapture/dockerSolution/src/main/docker/otelCollector/otel-config-aws-debug.yaml
@@ -15,7 +15,7 @@ exporters:
     sampling_initial: 5
     sampling_thereafter: 200
   awsemf:
-    namespace: 'TrafficCaptureReplay'
+    namespace: 'OpenSearchMigrations'
   awsxray:
     index_all_attributes: true
 service:

--- a/TrafficCapture/dockerSolution/src/main/docker/otelCollector/otel-config-aws.yaml
+++ b/TrafficCapture/dockerSolution/src/main/docker/otelCollector/otel-config-aws.yaml
@@ -11,7 +11,7 @@ extensions:
   health_check:
 exporters:
   awsemf:
-    namespace: 'TrafficCaptureReplay'
+    namespace: 'OpenSearchMigrations'
   awsxray:
     index_all_attributes: true
 service:


### PR DESCRIPTION
Change the name of the CloudWatch metric namespace from TrafficCaptureReplay to "OpenSearchMigrationMetrics".

<img width="818" alt="image" src="https://github.com/user-attachments/assets/d7b46328-9ffc-43a4-ba6f-e7b9a8e54e78">

### Testing
`agradle :TrafficCapture:dockerSolution:composeUp -Potel-collector=otel-aws.yml` - 

### Check List
- [ ] New functionality includes testing
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
