### PR TITLE
Rfs root metric name switchout

### DIFF
--- a/RFS/src/main/java/com/rfs/tracing/BaseRootRfsContext.java
+++ b/RFS/src/main/java/com/rfs/tracing/BaseRootRfsContext.java
@@ -6,13 +6,12 @@ import org.opensearch.migrations.tracing.IContextTracker;
 import org.opensearch.migrations.tracing.RootOtelContext;
 
 public class BaseRootRfsContext extends RootOtelContext {
-    public static final String SCOPE_NAME = "rfs";
     public final RfsContexts.GenericRequestContext.MetricInstruments genericRequestInstruments;
     public final RfsContexts.CheckedIdempotentPutRequestContext.MetricInstruments getTwoStepIdempotentRequestInstruments;
 
-    public BaseRootRfsContext(OpenTelemetry sdk, IContextTracker contextTracker) {
-        super(SCOPE_NAME, contextTracker, sdk);
-        var meter = this.getMeterProvider().get(SCOPE_NAME);
+    public BaseRootRfsContext(String scopeName, OpenTelemetry sdk, IContextTracker contextTracker) {
+        super(scopeName, contextTracker, sdk);
+        var meter = this.getMeterProvider().get(scopeName);
 
         genericRequestInstruments = RfsContexts.GenericRequestContext.makeMetrics(meter);
         getTwoStepIdempotentRequestInstruments = RfsContexts.CheckedIdempotentPutRequestContext.makeMetrics(meter);

--- a/RFS/src/main/java/org/opensearch/migrations/metadata/tracing/RootMetadataMigrationContext.java
+++ b/RFS/src/main/java/org/opensearch/migrations/metadata/tracing/RootMetadataMigrationContext.java
@@ -7,7 +7,7 @@ import org.opensearch.migrations.tracing.IContextTracker;
 import com.rfs.tracing.BaseRootRfsContext;
 
 public class RootMetadataMigrationContext extends BaseRootRfsContext {
-    public static final String SCOPE_NAME = "metadata";
+    public static final String SCOPE_NAME = "metadataMigration";
 
     public final MetadataMigrationContexts.ClusterMetadataContext.MetricInstruments metadataMetrics;
     public final MetadataMigrationContexts.MigrateTemplateContext.MetricInstruments indexTemplateInstruments;

--- a/RFS/src/main/java/org/opensearch/migrations/metadata/tracing/RootMetadataMigrationContext.java
+++ b/RFS/src/main/java/org/opensearch/migrations/metadata/tracing/RootMetadataMigrationContext.java
@@ -14,7 +14,7 @@ public class RootMetadataMigrationContext extends BaseRootRfsContext {
     public final MetadataMigrationContexts.CreateIndexContext.MetricInstruments createIndexInstruments;
 
     public RootMetadataMigrationContext(OpenTelemetry sdk, IContextTracker contextTracker) {
-        super(sdk, contextTracker);
+        super(SCOPE_NAME, sdk, contextTracker);
         var meter = this.getMeterProvider().get(SCOPE_NAME);
 
         metadataMetrics = MetadataMigrationContexts.ClusterMetadataContext.makeMetrics(meter);

--- a/RFS/src/main/java/org/opensearch/migrations/reindexer/tracing/RootDocumentMigrationContext.java
+++ b/RFS/src/main/java/org/opensearch/migrations/reindexer/tracing/RootDocumentMigrationContext.java
@@ -22,7 +22,7 @@ public class RootDocumentMigrationContext extends BaseRootRfsContext implements 
         IContextTracker contextTracker,
         RootWorkCoordinationContext workCoordinationContext
     ) {
-        super(sdk, contextTracker);
+        super(SCOPE_NAME, sdk, contextTracker);
         var meter = this.getMeterProvider().get(SCOPE_NAME);
         this.workCoordinationContext = workCoordinationContext;
         documentReindexInstruments = DocumentMigrationContexts.DocumentReindexContext.makeMetrics(meter);

--- a/RFS/src/main/java/org/opensearch/migrations/reindexer/tracing/RootDocumentMigrationContext.java
+++ b/RFS/src/main/java/org/opensearch/migrations/reindexer/tracing/RootDocumentMigrationContext.java
@@ -9,7 +9,7 @@ import com.rfs.tracing.RootWorkCoordinationContext;
 import lombok.Getter;
 
 public class RootDocumentMigrationContext extends BaseRootRfsContext implements IRootDocumentMigrationContext {
-    public static final String SCOPE_NAME = "snapshotDocumentReindex";
+    public static final String SCOPE_NAME = "documentMigration";
 
     @Getter
     private final RootWorkCoordinationContext workCoordinationContext;

--- a/RFS/src/main/java/org/opensearch/migrations/snapshot/creation/tracing/RootSnapshotContext.java
+++ b/RFS/src/main/java/org/opensearch/migrations/snapshot/creation/tracing/RootSnapshotContext.java
@@ -8,7 +8,7 @@ import com.rfs.tracing.BaseRootRfsContext;
 import com.rfs.tracing.IRfsContexts;
 
 public class RootSnapshotContext extends BaseRootRfsContext implements IRootSnapshotContext {
-    public static final String SCOPE_NAME = "createSnapshot";
+    public static final String SCOPE_NAME = "snapshotCreation";
     public final CreateSnapshotContext.MetricInstruments snapshotInstruments;
 
     public RootSnapshotContext(OpenTelemetry sdk, IContextTracker contextTracker) {

--- a/RFS/src/main/java/org/opensearch/migrations/snapshot/creation/tracing/RootSnapshotContext.java
+++ b/RFS/src/main/java/org/opensearch/migrations/snapshot/creation/tracing/RootSnapshotContext.java
@@ -12,7 +12,7 @@ public class RootSnapshotContext extends BaseRootRfsContext implements IRootSnap
     public final CreateSnapshotContext.MetricInstruments snapshotInstruments;
 
     public RootSnapshotContext(OpenTelemetry sdk, IContextTracker contextTracker) {
-        super(sdk, contextTracker);
+        super(SCOPE_NAME, sdk, contextTracker);
         var meter = this.getMeterProvider().get(SCOPE_NAME);
 
         snapshotInstruments = CreateSnapshotContext.makeMetrics(meter);


### PR DESCRIPTION
### Description

Sets the names snapshotCreation, metadataMigration, and documentMigration instead of "rfs" for all of them. 

### Check List
- [ ] New functionality includes testing
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
