### PR TITLE
Add two new command line flags for RfsMigrateDocuments 

### DIFF
--- a/DocumentsFromSnapshotMigration/src/main/java/com/rfs/RfsMigrateDocuments.java
+++ b/DocumentsFromSnapshotMigration/src/main/java/com/rfs/RfsMigrateDocuments.java
@@ -113,6 +113,17 @@ public class RfsMigrateDocuments {
             "--otel-collector-endpoint" }, arity = 1, description = "Endpoint (host:port) for the OpenTelemetry Collector to which metrics logs should be"
                 + "forwarded. If no value is provided, metrics will not be forwarded.")
         String otelCollectorEndpoint;
+
+        @Parameter(required = false,
+        names = "--documents-per-bulk-request",
+        description = "Optional.  The number of documents to be included within each bulk request sent.")
+        int numDocsPerBulkRequest = 1000;
+
+        @Parameter(required = false,
+            names = "--max-connections",
+            description = "Optional.  The maximum number of connections to simultaneously " +
+                "used to communicate to the target.")
+        int maxConnections = -1;
     }
 
     public static class NoWorkLeftException extends Exception {
@@ -175,8 +186,8 @@ public class RfsMigrateDocuments {
             TryHandlePhaseFailure.executeWithTryCatch(() -> {
                 log.info("Running RfsWorker");
 
-                OpenSearchClient targetClient = new OpenSearchClient(connectionContext);
-                DocumentReindexer reindexer = new DocumentReindexer(targetClient);
+                OpenSearchClient targetClient = new OpenSearchClient(connectionContext, arguments.maxConnections);
+                DocumentReindexer reindexer = new DocumentReindexer(targetClient, arguments.numDocsPerBulkRequest);
 
                 SourceRepo sourceRepo;
                 if (snapshotLocalDirPath == null) {

--- a/DocumentsFromSnapshotMigration/src/test/java/com/rfs/ParallelDocumentMigrationsTest.java
+++ b/DocumentsFromSnapshotMigration/src/test/java/com/rfs/ParallelDocumentMigrationsTest.java
@@ -395,7 +395,7 @@ public class ParallelDocumentMigrationsTest extends SourceTestBase {
                 new DocumentReindexer(new OpenSearchClient(ConnectionContextTestParams.builder()
                     .host(targetAddress)
                     .build()
-                    .toConnectionContext())),
+                    .toConnectionContext()), 1000),
                 new OpenSearchWorkCoordinator(
                     new CoordinateWorkHttpClient(ConnectionContextTestParams.builder()
                         .host(targetAddress)

--- a/RFS/src/main/java/com/rfs/common/OpenSearchClient.java
+++ b/RFS/src/main/java/com/rfs/common/OpenSearchClient.java
@@ -33,6 +33,10 @@ public class OpenSearchClient {
         this.client = new RestClient(connectionContext);
     }
 
+    public OpenSearchClient(ConnectionContext connectionContext, int maxConnections) {
+        this.client = new RestClient(connectionContext, maxConnections);
+    }
+
     /*
      * Create a legacy template if it does not already exist.  Returns an Optional; if the template was created, it
      * will be the created object and empty otherwise.

--- a/RFS/src/test/java/com/rfs/framework/SimpleRestoreFromSnapshot.java
+++ b/RFS/src/test/java/com/rfs/framework/SimpleRestoreFromSnapshot.java
@@ -32,7 +32,7 @@ public interface SimpleRestoreFromSnapshot {
         final var targetClusterClient = new OpenSearchClient(ConnectionContextTestParams.builder()
             .host(targetClusterUrl)
             .build()
-            .toConnectionContext());
+            .toConnectionContext(), 4);
 
         // TODO: This should update the following metdata:
         // - Global cluster state

--- a/RFS/src/test/java/com/rfs/framework/SimpleRestoreFromSnapshot_ES_7_10.java
+++ b/RFS/src/test/java/com/rfs/framework/SimpleRestoreFromSnapshot_ES_7_10.java
@@ -80,7 +80,7 @@ public class SimpleRestoreFromSnapshot_ES_7_10 implements SimpleRestoreFromSnaps
                 ).readDocuments();
 
                 final var finalShardId = shardId;
-                new DocumentReindexer(client).reindex(index.getName(), documents, context)
+                new DocumentReindexer(client, 1000).reindex(index.getName(), documents, context)
                     .doOnError(error -> logger.error("Error during reindexing: " + error))
                     .doOnSuccess(
                         done -> logger.info(


### PR DESCRIPTION
New args are --documents-per-bulk-request and --max-connections.

Now users can specify:
* how many documents should be put into each bulk request to the target server.
* the maxConnection value to the ConnectionProvider that the reactor HttpClients will use.


### Testing
gradle testing

### Check List
- [ ] New functionality includes testing
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
