### PR TITLE
Improve robustness on docker wget calls

### DIFF
--- a/TrafficCapture/dockerSolution/src/main/docker/elasticsearchTestConsole/Dockerfile
+++ b/TrafficCapture/dockerSolution/src/main/docker/elasticsearchTestConsole/Dockerfile
@@ -32,7 +32,7 @@ RUN dnf install -y --setopt=install_weak_deps=False \
 
 # Install HDF5 from source for Opensearch Benchmark compatibility with ARM
 ARG HDF5_VERSION=1.14.4
-RUN wget -q https://github.com/HDFGroup/hdf5/archive/refs/tags/hdf5_${HDF5_VERSION}.tar.gz -O /tmp/hdf5.tar.gz && \
+RUN wget --tries=5 --retry-connrefused --waitretry=15 -q https://github.com/HDFGroup/hdf5/archive/refs/tags/hdf5_${HDF5_VERSION}.tar.gz -O /tmp/hdf5.tar.gz && \
     mkdir /tmp/hdf5 && \
     tar -xzf /tmp/hdf5.tar.gz -C /tmp/hdf5 --strip-components=1 && \
     rm /tmp/hdf5.tar.gz

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/Dockerfile
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/Dockerfile
@@ -11,8 +11,8 @@ RUN mkdir /root/kafka-tools/aws
 
 WORKDIR /root/kafka-tools
 # Get kafka distribution and unpack to 'kafka'
-RUN wget -O- https://archive.apache.org/dist/kafka/3.6.0/kafka_2.13-3.6.0.tgz | tar --transform 's!^[^/]*!kafka!' -xvz
-RUN wget -O kafka/libs/msk-iam-auth.jar https://github.com/aws/aws-msk-iam-auth/releases/download/v2.0.3/aws-msk-iam-auth-2.0.3-all.jar
+RUN wget --tries=5 --retry-connrefused --waitretry=15 -O-  https://archive.apache.org/dist/kafka/3.6.0/kafka_2.13-3.6.0.tgz | tar --transform 's!^[^/]*!kafka!' -xvz
+RUN wget --tries=5 --retry-connrefused --waitretry=15 -O kafka/libs/msk-iam-auth.jar https://github.com/aws/aws-msk-iam-auth/releases/download/v2.0.3/aws-msk-iam-auth-2.0.3-all.jar
 WORKDIR /root
 
 # Add Traffic Replayer jars for running KafkaPrinter from this container


### PR DESCRIPTION
### Description
Build failures have occurred when the 'Connection timed out.' or 'Network is unreachable.' errors have been seen by wget calls to download Kafka.  To make this more rebust add a set of retry parameters to all usages of wget during docker builds.

### Check List
- [ ] ~New functionality includes testing~
  - [X] All tests pass, including unit test, integration test and doctest
- [ ] ~New functionality has been documented~
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
