### PR TITLE
Remove the max report age requirement on codecov

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,3 +1,5 @@
+codecov:
+  max_report_age: off
 coverage:
   status:
     project:


### PR DESCRIPTION
### Description
I noticed that java hasn't be producing code coverage reports on pull requests and according to code cov the uploaded java report are outside the 12h allowed window.  Inspecting the python report 1723150943042 was the start time vs 1722619505248 in java.  Translated the java report is 6 days behind - unsure how this happened.

Since the time recorded in the report isn't critical disabling the codecov max_report_age check.

![image](https://github.com/user-attachments/assets/2fff0d46-c278-4f4e-ae8b-2a9cf7829f5c)
_Report from a recent pull request [[link]](https://app.codecov.io/gh/opensearch-project/opensearch-migrations/commit/1b08cfe79059780f991b813a3f81a7c656d724a7)_

### Issues Resolved
- Resolves https://opensearch.atlassian.net/browse/MIGRATIONS-1934

### Testing
Verified the new file with the following command:

`curl --data-binary @.codecov.yml https://codecov.io/validate`

### Check List
- [ ] ~New functionality includes testing~
  - [X] All tests pass, including unit test, integration test and doctest
- [ ] ~New functionality has been documented~
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
