### PR TITLE
Properly implement max connections through flux concurrency in RFS

### DIFF
--- a/DocumentsFromSnapshotMigration/README.md
+++ b/DocumentsFromSnapshotMigration/README.md
@@ -71,3 +71,5 @@ To see the default shard size, use the `--help` CLI option:
 | --target-aws-region               | The AWS region for the target cluster. Required if using SigV4 authentication                                                                           |
 | --target-aws-service-signing-name | The AWS service signing name (e.g. 'es' for Amazon OpenSearch Service, 'aoss' for Amazon OpenSearch Serverless). Required if using SigV4 authentication |
 | --target-insecure                 | Flag to allow untrusted SSL certificates for target cluster                                                                                             |
+| --documents-per-bulk-request      | The number of documents to be included within each bulk request sent, default 1000                                                                      |
+| --max-connections                 | The maximum number of connections to simultaneously used to communicate to the target, default 50                                                       |

--- a/DocumentsFromSnapshotMigration/src/main/java/com/rfs/RfsMigrateDocuments.java
+++ b/DocumentsFromSnapshotMigration/src/main/java/com/rfs/RfsMigrateDocuments.java
@@ -116,14 +116,14 @@ public class RfsMigrateDocuments {
 
         @Parameter(required = false,
         names = "--documents-per-bulk-request",
-        description = "Optional.  The number of documents to be included within each bulk request sent.")
+        description = "Optional.  The number of documents to be included within each bulk request sent, default 1000")
         int numDocsPerBulkRequest = 1000;
 
         @Parameter(required = false,
             names = "--max-connections",
             description = "Optional.  The maximum number of connections to simultaneously " +
-                "used to communicate to the target.")
-        int maxConnections = -1;
+                "used to communicate to the target, default 50")
+        int maxConnections = 50;
     }
 
     public static class NoWorkLeftException extends Exception {
@@ -186,8 +186,9 @@ public class RfsMigrateDocuments {
             TryHandlePhaseFailure.executeWithTryCatch(() -> {
                 log.info("Running RfsWorker");
 
-                OpenSearchClient targetClient = new OpenSearchClient(connectionContext, arguments.maxConnections);
-                DocumentReindexer reindexer = new DocumentReindexer(targetClient, arguments.numDocsPerBulkRequest);
+                OpenSearchClient targetClient = new OpenSearchClient(connectionContext);
+                DocumentReindexer reindexer = new DocumentReindexer(targetClient, arguments.numDocsPerBulkRequest,
+                    arguments.maxConnections);
 
                 SourceRepo sourceRepo;
                 if (snapshotLocalDirPath == null) {

--- a/DocumentsFromSnapshotMigration/src/test/java/com/rfs/ParallelDocumentMigrationsTest.java
+++ b/DocumentsFromSnapshotMigration/src/test/java/com/rfs/ParallelDocumentMigrationsTest.java
@@ -395,7 +395,7 @@ public class ParallelDocumentMigrationsTest extends SourceTestBase {
                 new DocumentReindexer(new OpenSearchClient(ConnectionContextTestParams.builder()
                     .host(targetAddress)
                     .build()
-                    .toConnectionContext()), 1000),
+                    .toConnectionContext()), 1000, 1),
                 new OpenSearchWorkCoordinator(
                     new CoordinateWorkHttpClient(ConnectionContextTestParams.builder()
                         .host(targetAddress)

--- a/RFS/src/main/java/com/rfs/common/DocumentReindexer.java
+++ b/RFS/src/main/java/com/rfs/common/DocumentReindexer.java
@@ -39,7 +39,8 @@ public class DocumentReindexer {
                     .doOnSuccess(unused -> logger.debug("Batch succeeded"))
                     .doOnError(error -> logger.error("Batch failed", error))
                     // Prevent the error from stopping the entire stream
-                    .onErrorResume(e -> Mono.empty()), maxConcurrentRequests)
+                    .onErrorResume(e -> Mono.empty()),
+                maxConcurrentRequests)
             .doOnComplete(() -> logger.debug("All batches processed"))
             .then();
     }

--- a/RFS/src/main/java/com/rfs/common/DocumentReindexer.java
+++ b/RFS/src/main/java/com/rfs/common/DocumentReindexer.java
@@ -1,6 +1,5 @@
 package com.rfs.common;
 
-import java.time.Duration;
 import java.util.List;
 
 import org.apache.logging.log4j.LogManager;
@@ -12,7 +11,6 @@ import org.opensearch.migrations.reindexer.tracing.IDocumentMigrationContexts;
 import lombok.RequiredArgsConstructor;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
-import reactor.util.retry.Retry;
 
 @RequiredArgsConstructor
 public class DocumentReindexer {

--- a/RFS/src/main/java/com/rfs/common/OpenSearchClient.java
+++ b/RFS/src/main/java/com/rfs/common/OpenSearchClient.java
@@ -33,10 +33,6 @@ public class OpenSearchClient {
         this.client = new RestClient(connectionContext);
     }
 
-    public OpenSearchClient(ConnectionContext connectionContext, int maxConnections) {
-        this.client = new RestClient(connectionContext, maxConnections);
-    }
-
     /*
      * Create a legacy template if it does not already exist.  Returns an Optional; if the template was created, it
      * will be the created object and empty otherwise.

--- a/RFS/src/main/java/com/rfs/common/OpenSearchClient.java
+++ b/RFS/src/main/java/com/rfs/common/OpenSearchClient.java
@@ -265,7 +265,8 @@ public class OpenSearchClient {
                 }
                 return Mono.just(resp);
             })
-            .retryWhen(Retry.backoff(3, Duration.ofSeconds(1)).maxBackoff(Duration.ofSeconds(10)));
+            // In throttle cases, this will be low enough to get down to 1tps with 50 concurrency
+            .retryWhen(Retry.backoff(6, Duration.ofSeconds(2)).maxBackoff(Duration.ofSeconds(60)));
     }
 
     public HttpResponse refresh(IRfsContexts.IRequestContext context) {

--- a/RFS/src/test/java/com/rfs/framework/SimpleRestoreFromSnapshot.java
+++ b/RFS/src/test/java/com/rfs/framework/SimpleRestoreFromSnapshot.java
@@ -32,7 +32,7 @@ public interface SimpleRestoreFromSnapshot {
         final var targetClusterClient = new OpenSearchClient(ConnectionContextTestParams.builder()
             .host(targetClusterUrl)
             .build()
-            .toConnectionContext(), 4);
+            .toConnectionContext());
 
         // TODO: This should update the following metdata:
         // - Global cluster state

--- a/RFS/src/test/java/com/rfs/framework/SimpleRestoreFromSnapshot_ES_7_10.java
+++ b/RFS/src/test/java/com/rfs/framework/SimpleRestoreFromSnapshot_ES_7_10.java
@@ -80,7 +80,7 @@ public class SimpleRestoreFromSnapshot_ES_7_10 implements SimpleRestoreFromSnaps
                 ).readDocuments();
 
                 final var finalShardId = shardId;
-                new DocumentReindexer(client, 1000).reindex(index.getName(), documents, context)
+                new DocumentReindexer(client, 1000, 1).reindex(index.getName(), documents, context)
                     .doOnError(error -> logger.error("Error during reindexing: " + error))
                     .doOnSuccess(
                         done -> logger.info(


### PR DESCRIPTION
### Description
Properly implement max connections through flux concurrency in RFS with flatmap(_, concurrency)
> @param concurrency the maximum number of in-flight inner sequences

Current implementation with client connection provider resulted in exceptions being thrown when the flux requested more than were available.

Also, fixed a bug where the backoff logic appeared to occur in two places.

Set's the max concurrency here to 50 by default (previously was reactor.util.concurrent.Queues.SMALL_BUFFER_SIZE which is default to 256

* Category: Bug Fix
* Why these changes are required? Correct backoff and concurrency, will allow for greater horizontal scaling
* What is the old behavior before changes and new behavior after changes? Concurrency was at 256 and threw errors if trying to set lower than that.

Note: @gregschohn will take care of unit tests for this stuff today

### Issues Resolved
Issues with ThousandEyes

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]

### Check List
- [ ] New functionality includes testing
  - [ ] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
