### PR TITLE
[Console] Add more flexibility around which clusters are defined

### DIFF
--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/environment.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/environment.py
@@ -19,7 +19,7 @@ logger = logging.getLogger(__name__)
 
 SCHEMA = {
     "source_cluster": {"type": "dict", "required": False},
-    "target_cluster": {"type": "dict", "required": True},
+    "target_cluster": {"type": "dict", "required": False},
     "backfill": {"type": "dict", "required": False},
     "metrics_source": {"type": "dict", "required": False},
     "snapshot": {"type": "dict", "required": False},
@@ -58,8 +58,11 @@ class Environment:
 
         # At some point, target and replayers should be stored as pairs, but for the time being
         # we can probably assume one target cluster.
-        self.target_cluster: Cluster = Cluster(self.config["target_cluster"])
-        logger.info(f"Target cluster initialized: {self.target_cluster.endpoint}")
+        if 'target_cluster' in self.config:
+            self.target_cluster: Cluster = Cluster(self.config["target_cluster"])
+            logger.info(f"Target cluster initialized: {self.target_cluster.endpoint}")
+        else:
+            logger.warn("No target cluster provided. This may prevent other actions from proceeding.")
 
         if 'metrics_source' in self.config:
             self.metrics_source: MetricsSource = get_metrics_source(


### PR DESCRIPTION
### Description
We're currently working on a scenario in which a target cluster is defined, but the source cluster is not and all work proceeds off of a snapshot.
The console lib _tolerates_ this, but it doesn't handle it particularly well. This PR allows it to specifically handle undefined source clusters.

It's also plausible for user to want to use the create snapshot tooling without having a target cluster defined, so I'm supporting that scenario as well, but giving a warning log message to make it clear that functionality may be impaired without a target cluster (e.g. metadata migration, backfill status checks, etc.).

Example output with no source cluster defined:
```
(.venv) bash-5.2# console clusters connection-check
SOURCE CLUSTER
No source cluster defined.
TARGET CLUSTER
ConnectionResult(connection_message='Successfully connected!', connection_established=True, cluster_version='2.13.0')
```

### Issues Resolved
N/a, testing for Thousand Eyes scenario.

### Testing
Manually, via deployment to AWS.

### Check List
- [ ] New functionality includes testing
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
