### PR TITLE
Fix replayer sigv4 logic without payload

### DIFF
--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/transform/SigV4AuthTransformerFactory.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/transform/SigV4AuthTransformerFactory.java
@@ -72,7 +72,9 @@ public class SigV4AuthTransformerFactory implements IAuthTransformerFactory {
 
                 @Override
                 public Optional<String> getFirstHeaderValueCaseInsensitive(String key) {
-                    return Optional.ofNullable(message.headers().getInsensitive(key).get(0));
+                    return Optional.ofNullable(message.headers().getInsensitive(key))
+                        .filter(l -> !l.isEmpty())
+                        .map(l -> l.get(0));
                 }
 
                 @Override

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/transform/SigV4AuthTransformerFactoryTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/transform/SigV4AuthTransformerFactoryTest.java
@@ -3,11 +3,13 @@ package org.opensearch.migrations.replay.transform;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneOffset;
+import java.util.List;
 import java.util.Random;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import org.opensearch.migrations.replay.TestUtils;
 import org.opensearch.migrations.testutils.WrapWithNettyLeakDetection;
@@ -31,22 +33,28 @@ public class SigV4AuthTransformerFactoryTest extends InstrumentationTest {
         }
     }
 
-    @Test
+    @ParameterizedTest
+    @ValueSource(strings = {"content-type", "Content-Type", "CoNteNt-Type"})
     @WrapWithNettyLeakDetection(repetitions = 2)
-    public void testSignatureProperlyApplied() throws Exception {
+    public void testSignatureProperlyApplied(String contentTypeHeaderKey) throws Exception {
         ResourceLeakDetector.setLevel(ResourceLeakDetector.Level.PARANOID);
 
         Random r = new Random(2);
+        var mockCredentialsProvider = new MockCredentialsProvider();
+
+        // Test with payload
+        testWithPayload(r, mockCredentialsProvider, contentTypeHeaderKey);
+
+        // Test without payload
+        testWithoutPayload(mockCredentialsProvider, contentTypeHeaderKey);
+    }
+
+    private void testWithPayload(Random r, MockCredentialsProvider mockCredentialsProvider, String contentTypeHeaderKey) throws Exception {
         var stringParts = IntStream.range(0, 1)
             .mapToObj(i -> TestUtils.makeRandomString(r, 64))
             .collect(Collectors.toList());
 
-        var mockCredentialsProvider = new MockCredentialsProvider();
         DefaultHttpHeaders expectedRequestHeaders = new DefaultHttpHeaders();
-        // netty's decompressor and aggregator remove some header values (& add others)
-
-        // Using unusual spelling to verify SigV4 signer behavior with list insensitive map
-        var contentTypeHeaderKey = "CoNteNt-Type";
         var contentTypeHeaderValue = "application/json";
 
         expectedRequestHeaders.add("Host", "localhost");
@@ -62,9 +70,28 @@ public class SigV4AuthTransformerFactoryTest extends InstrumentationTest {
             "x-amz-content-sha256",
             "fc0e8e9a1f7697f510bfdd4d55b8612df8a0140b4210967efd87ee9cb7104362"
         );
+        expectedRequestHeaders.add("X-Amz-Date", "19700101T000000Z");
+        runTest(mockCredentialsProvider, contentTypeHeaderKey, contentTypeHeaderValue, expectedRequestHeaders, stringParts);
+    }
 
-        expectedRequestHeaders.add("x-amz-date", "19700101T000000Z");
+    private void testWithoutPayload(MockCredentialsProvider mockCredentialsProvider, String contentTypeHeaderKey) throws Exception {
+        DefaultHttpHeaders expectedRequestHeaders = new DefaultHttpHeaders();
+        var contentTypeHeaderValue = "application/x-www-form-urlencoded";
 
+        expectedRequestHeaders.add("Host", "localhost");
+        expectedRequestHeaders.add(contentTypeHeaderKey, contentTypeHeaderValue);
+        expectedRequestHeaders.add("Content-Length", "0");
+        expectedRequestHeaders.add(
+            "Authorization",
+            "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/19700101/us-east-1/es/aws4_request, "
+                + "SignedHeaders=" + contentTypeHeaderKey.toLowerCase() + ";host;x-amz-date, "
+                + "Signature=e3ccd4a50fa927578ca6de84b138f671d2d57ae3ad2932953ac7f3fc3d0f8a5d"
+        );
+        expectedRequestHeaders.add("X-Amz-Date", "19700101T000000Z");
+        runTest(mockCredentialsProvider, contentTypeHeaderKey, contentTypeHeaderValue, expectedRequestHeaders, List.of());
+    }
+
+    private void runTest(MockCredentialsProvider mockCredentialsProvider, String contentTypeHeaderKey, String contentTypeHeaderValue, DefaultHttpHeaders expectedRequestHeaders, java.util.List<String> stringParts) throws Exception {
         try (var factory = new SigV4AuthTransformerFactory(
             mockCredentialsProvider,
             "es",
@@ -75,7 +102,7 @@ public class SigV4AuthTransformerFactoryTest extends InstrumentationTest {
             TestUtils.runPipelineAndValidate(
                 rootContext,
                 factory,
-                contentTypeHeaderKey + ": "+ contentTypeHeaderValue + "\r\n",
+                contentTypeHeaderKey + ": " + contentTypeHeaderValue + "\r\n",
                 stringParts,
                 expectedRequestHeaders,
                 TestUtils::resolveReferenceString

--- a/TrafficCapture/trafficReplayer/src/testFixtures/java/org/opensearch/migrations/replay/TestUtils.java
+++ b/TrafficCapture/trafficReplayer/src/testFixtures/java/org/opensearch/migrations/replay/TestUtils.java
@@ -13,6 +13,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.function.IntFunction;
+import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Assertions;
 
@@ -132,6 +133,9 @@ public class TestUtils {
 
         Assertions.assertEquals((expectedPayloadString), getStringFromContent(fullRequest));
         Assertions.assertEquals(expectedRequestHeaders, fullRequest.headers());
+        // Test casing on keys match
+        Assertions.assertEquals(expectedRequestHeaders.names().stream().sorted().collect(Collectors.toList()),
+            fullRequest.headers().names().stream().sorted().collect(Collectors.toList()));
         fullRequest.release();
     }
 

--- a/TrafficCapture/transformationPlugins/jsonMessageTransformers/jsonJoltMessageTransformerProvider/src/test/java/org/opensearch/migrations/replay/PayloadRepackingTest.java
+++ b/TrafficCapture/transformationPlugins/jsonMessageTransformers/jsonJoltMessageTransformerProvider/src/test/java/org/opensearch/migrations/replay/PayloadRepackingTest.java
@@ -62,8 +62,13 @@ public class PayloadRepackingTest extends InstrumentationTest {
 
         DefaultHttpHeaders expectedRequestHeaders = new DefaultHttpHeaders();
         // netty's decompressor and aggregator remove some header values (& add others)
-        expectedRequestHeaders.add("host", "localhost");
-        expectedRequestHeaders.add("Content-Length", "46");
+        expectedRequestHeaders.add("Host", "localhost");
+        if (!doGzip && !doChunked) {
+            expectedRequestHeaders.add("Content-Length", "46");
+        } else {
+            // Content-Length added with different casing with netty
+            expectedRequestHeaders.add("content-length", "46");
+        }
 
         TestUtils.runPipelineAndValidate(
             rootContext,
@@ -115,7 +120,7 @@ public class PayloadRepackingTest extends InstrumentationTest {
 
         DefaultHttpHeaders expectedRequestHeaders = new DefaultHttpHeaders();
         // netty's decompressor and aggregator remove some header values (& add others)
-        expectedRequestHeaders.add("host", "localhost");
+        expectedRequestHeaders.add("Host", "localhost");
         expectedRequestHeaders.add("content-type", "application/json; charset=UTF-8");
         expectedRequestHeaders.add("Content-Length", "55");
 


### PR DESCRIPTION
### Description
Fixed a bug that was in the replayer on sigv4 requests without payloads when content-type did not exist.
Cleaned up the unit tests for this 

* Category: Bug fix
* Why these changes are required? sigv4 failures without payloads
* What is the old behavior before changes and new behavior after changes? sigv4 failures without payloads

### Issues Resolved

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
Added unit tests

### Check List
- [x] New functionality includes testing
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
