### PR TITLE
Throughput improvements

### DIFF
--- a/RFS/src/main/java/com/rfs/common/LuceneDocumentsReader.java
+++ b/RFS/src/main/java/com/rfs/common/LuceneDocumentsReader.java
@@ -2,21 +2,23 @@ package com.rfs.common;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.Objects;
 import java.util.function.Function;
 
 import org.apache.lucene.document.Document;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexReader;
-import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.SoftDeletesDirectoryReaderWrapper;
 import org.apache.lucene.store.FSDirectory;
-import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.BytesRef;
 
 import lombok.Lombok;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import reactor.core.publisher.Flux;
+import reactor.core.scheduler.Scheduler;
+import reactor.core.scheduler.Schedulers;
+import reactor.util.function.Tuples;
 
 @RequiredArgsConstructor
 @Slf4j
@@ -24,7 +26,6 @@ public class LuceneDocumentsReader {
     public static Function<Path, LuceneDocumentsReader> getFactory(boolean softDeletesPossible, String softDeletesField) {
         return path -> new LuceneDocumentsReader(path, softDeletesPossible, softDeletesField);
     }
-    public static final int NUM_DOCUMENTS_BUFFERED = 1024;
 
     protected final Path indexDirectoryPath;
     protected final boolean softDeletesPossible;
@@ -64,26 +65,28 @@ public class LuceneDocumentsReader {
 
     */
     public Flux<Document> readDocuments() {
+        // Create elastic scheduler for i/o bound lucene document reading
+        int luceneReaderThreadCount = Schedulers.DEFAULT_BOUNDED_ELASTIC_SIZE;
+        Scheduler luceneReaderScheduler = Schedulers.newBoundedElastic(luceneReaderThreadCount, Integer.MAX_VALUE, "luceneReaderScheduler");
+
         return Flux.using(() -> wrapReader(DirectoryReader.open(FSDirectory.open(indexDirectoryPath)), softDeletesPossible, softDeletesField), reader -> {
             log.atInfo().log(reader.maxDoc() + " documents found in the current Lucene index");
 
             return Flux.fromIterable(reader.leaves()) // Iterate over each segment
-                .flatMap(leaf -> {
-                    LeafReader leafReader = leaf.reader();
-                    Bits liveDocs = leafReader.getLiveDocs(); // Get live docs bits
-
-                    return Flux.range(0, leafReader.maxDoc())
-                        .handle((docId, sink) -> {
-                            // Check if the document is live (not hard deleted/updated)
-                            boolean isLive = liveDocs == null || liveDocs.get(docId);
-                            Document doc = getDocument(leafReader, docId, isLive);
-
-                            if (doc != null) { // Skip malformed docs
-                                sink.next(doc);
-                            }
-                        });
-                })
-                .cast(Document.class);
+                .flatMap(leafReaderContext -> {
+                        var leafReader = leafReaderContext.reader();
+                        var liveDocs = leafReader.getLiveDocs();
+                        return Flux.range(0, leafReader.maxDoc())
+                            .filter(docIdx -> liveDocs == null || liveDocs.get(docIdx)) // Filter for live docs
+                            .map(liveDocIdx -> Tuples.of(leafReader, liveDocIdx)); // Build a Tuple2<LeafReader, Integer>
+                    }
+                )
+                .parallel(luceneReaderThreadCount)
+                .runOn(luceneReaderScheduler)
+                .map(tuple -> getDocument(tuple.getT1(), tuple.getT2(), true)) // Retrieve the document
+                .filter(Objects::nonNull) // Skip malformed docs
+                .sequential() // Merge parallel streams
+                .doFinally(unused -> luceneReaderScheduler.dispose());
         }, reader -> { // Close the DirectoryReader when done
             try {
                 reader.close();
@@ -108,7 +111,7 @@ public class LuceneDocumentsReader {
             String id;
             try {
                 id = Uid.decodeId(document.getBinaryValue("_id").bytes);
-                log.atDebug().log("Reading document " + id);
+                log.atDebug().setMessage("Reading document {}").addArgument(id).log();
             } catch (Exception e) {
                 StringBuilder errorMessage = new StringBuilder();
                 errorMessage.append("Unable to parse Document id from Document.  The Document's Fields: ");
@@ -118,19 +121,19 @@ public class LuceneDocumentsReader {
             }
 
             if (!isLive) {
-                log.atDebug().log("Document " + id + " is not live");
+                log.atDebug().setMessage("Document {} is not live").addArgument(id).log();
                 return null; // Skip these
             }
 
             if (sourceBytes == null || sourceBytes.bytes.length == 0) {
-                log.warn("Document " + id + " doesn't have the _source field enabled");
+                log.atWarn().setMessage("Document {} doesn't have the _source field enabled").addArgument(id).log();
                 return null;  // Skip these
             }
 
-            log.atDebug().log("Document " + id + " read successfully");
+            log.atDebug().setMessage("Document {} read successfully").addArgument(id).log();
             return document;
         } catch (Exception e) {
-            log.atError().setMessage("Failed to read document at Lucene index location " + docId).setCause(e).log();
+            log.atError().setMessage("Failed to read document at Lucene index location {}").addArgument(docId).setCause(e).log();
             return null;
         }
     }

--- a/RFS/src/test/java/com/rfs/integration/SnapshotStateTest.java
+++ b/RFS/src/test/java/com/rfs/integration/SnapshotStateTest.java
@@ -71,7 +71,7 @@ public class SnapshotStateTest {
         final var testContext = DocumentMigrationTestContext.factory(workCoordinationContext).noOtelTracking();
         final var indexName = "my-index";
         final var document1Id = "doc1";
-        final var document1Body = "   \n {\n\t\"fo$o\":\"bar\"\n} \n"; // Wacky whitespace added to ensure we can handle it
+        final var document1Body = "   \n {\n\"fo$o\":\"bar\"\n}\t \n"; // Verify that we trim and remove newlines
         operations.createDocument(indexName, document1Id, document1Body);
 
         final var snapshotName = "snapshot-1";

--- a/buildSrc/src/main/groovy/org/opensearch/migrations/common/CommonUtils.groovy
+++ b/buildSrc/src/main/groovy/org/opensearch/migrations/common/CommonUtils.groovy
@@ -65,7 +65,8 @@ class CommonUtils {
             }
 
             copyFile("jars", "/jars")
-            def jvmParams = "-XX:MaxRAMPercentage=80.0 -XX:+ExitOnOutOfMemoryError"
+            // Leave memory headroom for native execution which allocates memory outside jvm
+            def jvmParams = "-XX:+UseContainerSupport -XX:MaxRAMPercentage=60.0 -XX:+ExitOnOutOfMemoryError"
             // can't set the environment variable from the runtimeClasspath because the Dockerfile is
             // constructed in the configuration phase and the classpath won't be realized until the
             // execution phase.  Therefore, we need to have docker run the command to resolve the classpath


### PR DESCRIPTION
### Description
Currently, reindexing documents had inefficient processing and single thread operations causing a slowdown in max throughput (from 480 -> 170 10MB requests/min with AWS Fargate 2vcpu) from a few PRs ago.

This change alleviates these bottlenecks with the following:
* Refactored the LuceneDocumentReader to process segments and docs in parallel and set aside I/O bound reading on a dedicated elastic threadpool
* Modified source doc "minimizing" in DocumentReindexer to use string replace instead of ObjectMapper
* Modified BulkDocSection to optimistically construct and persist index strings
* Split up dedicated threadpools in DocumentReindexer based on I/O vs CPU tasks.

* Category: Enhancement
* Why these changes are required? Throughput improvements to reduce cost and risk with long running shard migrations. 
* What is the old behavior before changes and new behavior after changes? With Fargate 2cpu 4gb tasks, went from ~170 requests/min -> 580 10MB requests (14k docs)

### Issues Resolved

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
Unit testing and cloud testing

### Check List
- [x] New functionality includes testing
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
