### PR TITLE
Update release drafter permissions

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -11,7 +11,7 @@ env:
 
 permissions:
   id-token: write
-  contents: read
+  contents: write
   issues: write
 
 jobs:


### PR DESCRIPTION
### Description
Update release drafter permission with `content: write` to submit releases as specified in https://github.com/softprops/action-gh-release?tab=readme-ov-file#permissions

* Category: Bug fix
* Why these changes are required? Required to publish a release with the github action (new since the docker changes started specifying permissions)
* What is the old behavior before changes and new behavior after changes? Release failed to publish since https://github.com/opensearch-project/opensearch-migrations/pull/860

### Issues Resolved
N/A

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
N/A, verified through documentation

### Check List
- [ ] ~New functionality includes testing~
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
