### PR TITLE
Remove Migration Console API from ALB

### DIFF
--- a/deployment/cdk/opensearch-service-migration/lib/common-utilities.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/common-utilities.ts
@@ -287,8 +287,6 @@ export function getMigrationStringParameterName(props: MigrationSSMConfig): stri
 }
 
 export enum MigrationSSMParameter {
-    MIGRATION_API_URL = 'albMigrationApiUrl',
-    MIGRATION_API_URL_ALIAS = 'albMigrationApiUrlAlias',
     SOURCE_PROXY_URL = 'albSourceProxyUrl',
     SOURCE_PROXY_URL_ALIAS = 'albSourceProxyUrlAlias',
     TARGET_PROXY_URL = 'albTargetProxyUrl',

--- a/deployment/cdk/opensearch-service-migration/lib/network-stack.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/network-stack.ts
@@ -36,7 +36,7 @@ export class NetworkStack extends Stack {
     public readonly albSourceProxyTG: IApplicationTargetGroup;
     public readonly albTargetProxyTG: IApplicationTargetGroup;
     public readonly albSourceClusterTG: IApplicationTargetGroup;
-    public readonly albMigrationConsoleTG: IApplicationTargetGroup;
+    public readonly migrationConsoleTG: IApplicationTargetGroup;
 
     // Validate a proper url string is provided and return an url string which contains a protocol, host name, and port.
     // If a port is not provided, the default protocol port (e.g. 443, 80) will be explicitly added
@@ -139,7 +139,6 @@ export class NetworkStack extends Stack {
 
         const needAlb = props.captureProxyServiceEnabled ||
             props.elasticsearchServiceEnabled ||
-            props.migrationAPIEnabled ||
             props.captureProxyESServiceEnabled ||
             props.targetClusterProxyServiceEnabled;
 
@@ -191,14 +190,6 @@ export class NetworkStack extends Stack {
                 createALBListenerUrlParameter(9999, MigrationSSMParameter.SOURCE_CLUSTER_ENDPOINT);
             }
 
-            // Setup when deploying migration console api on ecs
-            if (props.migrationAPIEnabled) {
-                this.albMigrationConsoleTG = this.createSecureTargetGroup('ALBMigrationConsole', props.stage, 8000, this.vpc);
-                this.createSecureListener('MigrationConsole', 8000, alb, cert, this.albMigrationConsoleTG);
-                createALBListenerUrlParameter(8000, MigrationSSMParameter.MIGRATION_API_URL);
-                createALBListenerUrlParameterAlias(8000, MigrationSSMParameter.MIGRATION_API_URL_ALIAS);
-            }
-
             // Setup when deploying capture proxy in ECS
             if (props.captureProxyServiceEnabled || props.captureProxyESServiceEnabled) {
                 this.albSourceProxyTG = this.createSecureTargetGroup('ALBSourceProxy', props.stage, 9200, this.vpc);
@@ -227,6 +218,11 @@ export class NetworkStack extends Stack {
                 createALBListenerUrlParameter(9200, MigrationSSMParameter.MIGRATION_LISTENER_URL);
                 createALBListenerUrlParameterAlias(9200, MigrationSSMParameter.MIGRATION_LISTENER_URL_ALIAS);
             }
+        }
+
+        // TG for Migration Console on ecs when migration API is enabled
+        if (props.migrationAPIEnabled) {
+            this.migrationConsoleTG = this.createSecureTargetGroup('MigrationConsole', props.stage, 8000, this.vpc);
         }
 
         // Create Source SSM Parameter

--- a/deployment/cdk/opensearch-service-migration/lib/service-stacks/migration-console-stack.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/service-stacks/migration-console-stack.ts
@@ -162,7 +162,7 @@ export class MigrationConsoleStack extends MigrationServiceCore {
             }) : "";
 
         const sharedLogFileSystem = new SharedLogFileSystem(this, props.stage, props.defaultDeployId);
-        
+
 
         const ecsClusterArn = `arn:${this.partition}:ecs:${this.region}:${this.account}:service/migration-${props.stage}-ecs-cluster`
         const allReplayerServiceArn = `${ecsClusterArn}/migration-${props.stage}-traffic-replayer*`
@@ -236,7 +236,7 @@ export class MigrationConsoleStack extends MigrationServiceCore {
             ]
         })
 
-        const getSecretsPolicy = props.servicesYaml.target_cluster.basic_auth?.password_from_secret_arn ? 
+        const getSecretsPolicy = props.servicesYaml.target_cluster.basic_auth?.password_from_secret_arn ?
             getTargetPasswordAccessPolicy(props.servicesYaml.target_cluster.basic_auth.password_from_secret_arn) : null;
 
         // Upload the services.yaml file to Parameter Store
@@ -334,16 +334,6 @@ export class MigrationConsoleStack extends MigrationServiceCore {
 
             const defaultAllowedHosts = 'localhost'
             environment["API_ALLOWED_HOSTS"] = props.migrationAPIAllowedHosts ? `${defaultAllowedHosts},${props.migrationAPIAllowedHosts}` : defaultAllowedHosts
-            const migrationApiUrl = getMigrationStringParameterValue(this, {
-                ...props,
-                parameter: MigrationSSMParameter.MIGRATION_API_URL
-            });
-            const migrationApiUrlAlias = getMigrationStringParameterValue(this, {
-                ...props,
-                parameter: MigrationSSMParameter.MIGRATION_API_URL_ALIAS
-            });
-            environment["API_ALLOWED_HOSTS"] += migrationApiUrl ? `,${this.getHostname(migrationApiUrl)}` : ""
-            environment["API_ALLOWED_HOSTS"] += migrationApiUrlAlias ? `,${this.getHostname(migrationApiUrlAlias)}` : ""
         }
 
         if (props.migrationConsoleEnableOSI) {

--- a/deployment/cdk/opensearch-service-migration/lib/stack-composer.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/stack-composer.ts
@@ -558,7 +558,7 @@ export class StackComposer {
                 fetchMigrationEnabled: fetchMigrationEnabled,
                 migrationConsoleEnableOSI: migrationConsoleEnableOSI,
                 migrationAPIEnabled: migrationAPIEnabled,
-                targetGroups: [networkStack.albMigrationConsoleTG],
+                targetGroups: [networkStack.migrationConsoleTG],
                 servicesYaml: servicesYaml,
                 migrationAPIAllowedHosts: migrationAPIAllowedHosts,
                 sourceClusterDisabled,


### PR DESCRIPTION
### Description

Remove Migration Console API from ALB to simplify security story since this API is experimental and does not support auth.

* Category: Simplification
* Why these changes are required? Simplify Security
* What is the old behavior before changes and new behavior after changes? No ALB Listener for Migration Console API, TG remains for customer to associate with their own listener.

### Issues Resolved
[MIGRATIONS-1971](https://opensearch.atlassian.net/browse/MIGRATIONS-1971)

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
Existing unit tests for cdk synth.

### Check List
- [ ] ~New functionality includes testing~ Experimental feature, no unit testing at the moment
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
