### PR TITLE
Support for OpenSearch 1.3 to be a source cluster

### DIFF
--- a/DocumentsFromSnapshotMigration/src/test/java/com/rfs/EndToEndTest.java
+++ b/DocumentsFromSnapshotMigration/src/test/java/com/rfs/EndToEndTest.java
@@ -145,6 +145,17 @@ public class EndToEndTest extends SourceTestBase {
         }
     }
 
+    @ParameterizedTest(name = "Target {0}")
+    @ArgumentsSource(SupportedTargetCluster.class)
+    public void migrateFrom_OS_v1_3(final SearchClusterContainer.ContainerVersion targetVersion) throws Exception {
+        try (
+            final var sourceCluster = new SearchClusterContainer(SearchClusterContainer.OS_V1_3_16);
+            final var targetCluster = new SearchClusterContainer(targetVersion)
+        ) {
+            migrateFrom_ES_v7_X(sourceCluster, targetCluster);
+        }
+    }
+
     @SneakyThrows
     private void migrateFrom_ES_v7_X(
         final SearchClusterContainer sourceCluster,

--- a/DocumentsFromSnapshotMigration/src/test/java/com/rfs/ParallelDocumentMigrationsTest.java
+++ b/DocumentsFromSnapshotMigration/src/test/java/com/rfs/ParallelDocumentMigrationsTest.java
@@ -39,9 +39,7 @@ import lombok.extern.slf4j.Slf4j;
 public class ParallelDocumentMigrationsTest extends SourceTestBase {
 
     final static List<SearchClusterContainer.ContainerVersion> SOURCE_IMAGES = List.of(
-        SearchClusterContainer.ES_V7_10_2,
-        SearchClusterContainer.ES_V7_17,
-        SearchClusterContainer.OS_V1_3_16
+        SearchClusterContainer.ES_V7_10_2
     );
     final static List<SearchClusterContainer.ContainerVersion> TARGET_IMAGES = List.of(SearchClusterContainer.OS_V2_14_0);
 

--- a/DocumentsFromSnapshotMigration/src/test/java/com/rfs/ParallelDocumentMigrationsTest.java
+++ b/DocumentsFromSnapshotMigration/src/test/java/com/rfs/ParallelDocumentMigrationsTest.java
@@ -40,7 +40,8 @@ public class ParallelDocumentMigrationsTest extends SourceTestBase {
 
     final static List<SearchClusterContainer.ContainerVersion> SOURCE_IMAGES = List.of(
         SearchClusterContainer.ES_V7_10_2,
-        SearchClusterContainer.ES_V7_17
+        SearchClusterContainer.ES_V7_17,
+        SearchClusterContainer.OS_V1_3_16
     );
     final static List<SearchClusterContainer.ContainerVersion> TARGET_IMAGES = List.of(SearchClusterContainer.OS_V2_14_0);
 

--- a/MetadataMigration/src/test/java/org/opensearch/migrations/EndToEndTest.java
+++ b/MetadataMigration/src/test/java/org/opensearch/migrations/EndToEndTest.java
@@ -69,6 +69,17 @@ class EndToEndTest {
         }
     }
 
+    @ParameterizedTest(name = "Medium of transfer {0}")
+    @EnumSource(TransferMedium.class)
+    void metadataMigrateFrom_OS_v1_3(TransferMedium medium) throws Exception {
+        try (
+            final var sourceCluster = new SearchClusterContainer(SearchClusterContainer.OS_V1_3_16);
+            final var targetCluster = new SearchClusterContainer(SearchClusterContainer.OS_V2_14_0)
+        ) {
+            migrateFrom_ES(sourceCluster, targetCluster, medium);
+        }
+    }
+
     private enum TransferMedium {
         SnapshotImage,
         Http
@@ -89,7 +100,7 @@ class EndToEndTest {
 
         Version sourceVersion = sourceCluster.getContainerVersion().getVersion();
         var sourceIsES6_8 = VersionMatchers.isES_6_8.test(sourceVersion);
-        var sourceIsES7_X = VersionMatchers.isES_7_X.test(sourceVersion);
+        var sourceIsES7_X = VersionMatchers.isES_7_X.test(sourceVersion) || VersionMatchers.isOS_1_X.test(sourceVersion);
 
         if (!(sourceIsES6_8 || sourceIsES7_X)) {
             throw new RuntimeException("This test cannot handle the source cluster version" + sourceVersion);

--- a/RFS/src/main/java/com/rfs/transformers/TransformFunctions.java
+++ b/RFS/src/main/java/com/rfs/transformers/TransformFunctions.java
@@ -22,6 +22,9 @@ public class TransformFunctions {
             if (VersionMatchers.equalOrGreaterThanES_7_10.test(sourceVersion)) {
                 return new Transformer_ES_7_10_OS_2_11(dimensionality);
             }
+            if (VersionMatchers.isOS_1_X.test(sourceVersion)) {
+                return new Transformer_ES_7_10_OS_2_11(dimensionality);
+            }
         }
 
         throw new IllegalArgumentException("Unsupported transformation requested");

--- a/RFS/src/main/java/com/rfs/version_es_7_10/SnapshotReader_ES_7_10.java
+++ b/RFS/src/main/java/com/rfs/version_es_7_10/SnapshotReader_ES_7_10.java
@@ -17,7 +17,9 @@ public class SnapshotReader_ES_7_10 implements ClusterSnapshotReader {
 
     @Override
     public boolean compatibleWith(Version version) {
-        return VersionMatchers.equalOrGreaterThanES_7_10.test(version);
+        return VersionMatchers.equalOrGreaterThanES_7_10
+            .or(VersionMatchers.isOS_1_X)
+            .test(version);
     }
 
     @Override


### PR DESCRIPTION
### Description
Support for OpenSearch 1.3 to be a source cluster & readme updates

### Testing
Expanded end to end test to include OS 1.3 in all tests that we had for ES 7.17

### Check List
- [X] New functionality includes testing
  - [X] All tests pass, including unit test, integration test and doctest
- [X] New functionality has been documented
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
