### PR TITLE
Unified code coverage

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -112,12 +112,13 @@ jobs:
         with:
           name: test-reports
           path: |
+            **/build/reports/tests/
             **/reports/jacoco/mergedReport/
 
       - name: Upload to Codecov
         uses: codecov/codecov-action@v4
         with:
-          file: "./build/reports/jacoco/mergedReport/jacocoMergedReport.xml"
+          files: ${{ github.workspace }}/build/reports/jacoco/mergedReport/jacocoMergedReport.xml
           flags: gradle-test
           fail_ci_if_error: true
           disable_search: true

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -103,7 +103,7 @@ jobs:
           OS_MIGRATIONS_GRADLE_SCAN_TOS_AGREE_AND_ENABLED: ''
 
       - name: Run Tests with Coverage
-        run: ./gradlew test -x TrafficCapture:dockerSolution:build -x spotlessCheck jacocoTestReport --scan --stacktrace
+        run: ./gradlew mergeJacocoReports -x TrafficCapture:dockerSolution:build -x spotlessCheck --scan --stacktrace
         env:
           OS_MIGRATIONS_GRADLE_SCAN_TOS_AGREE_AND_ENABLED: ''
 
@@ -117,7 +117,7 @@ jobs:
       - name: Upload to Codecov
         uses: codecov/codecov-action@v4
         with:
-          files: "**/jacocoTestReport.xml"
+          files: "**/reports/jacoco/mergedReport/jacocoMergedReport.xml"
           flags: gradle-test
           fail_ci_if_error: false
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -112,14 +112,15 @@ jobs:
         with:
           name: test-reports
           path: |
-            **/build/reports/tests/
+            **/reports/jacoco/mergedReport/
 
       - name: Upload to Codecov
         uses: codecov/codecov-action@v4
         with:
-          files: "**/reports/jacoco/mergedReport/jacocoMergedReport.xml"
+          file: "./build/reports/jacoco/mergedReport/jacocoMergedReport.xml"
           flags: gradle-test
-          fail_ci_if_error: false
+          fail_ci_if_error: true
+          disable_search: true
 
   python-e2e-tests:
     runs-on: ubuntu-latest

--- a/CreateSnapshot/build.gradle
+++ b/CreateSnapshot/build.gradle
@@ -9,10 +9,6 @@ import org.opensearch.migrations.common.CommonUtils
 java.sourceCompatibility = JavaVersion.VERSION_11
 java.targetCompatibility = JavaVersion.VERSION_11
 
-repositories {
-    mavenCentral()
-}
-
 dependencies {
     implementation project(":commonDependencyVersionConstraints")
 
@@ -26,8 +22,4 @@ dependencies {
 
 application {
     mainClassName = 'com.rfs.CreateSnapshot'
-}
-
-test {
-    useJUnitPlatform()
 }

--- a/DocumentsFromSnapshotMigration/build.gradle
+++ b/DocumentsFromSnapshotMigration/build.gradle
@@ -22,10 +22,6 @@ class DockerServiceProps {
     List<String> taskDependencies = []
 }
 
-repositories {
-    mavenCentral()
-}
-
 dependencies {
     implementation project(":commonDependencyVersionConstraints")
     implementation platform('io.projectreactor:reactor-bom:2023.0.5')
@@ -143,39 +139,11 @@ task buildDockerImages {
     }
 }
 
-tasks.getByName('composeUp')
-        .dependsOn(tasks.getByName('buildDockerImages'))
-
-
-test {
-    useJUnitPlatform {
-        excludeTags 'longTest'
-    }
-    jacoco {
-        enabled = false
-    }
+tasks.named('composeUp') {
+    dependsOn(tasks.named('buildDockerImages'))
 }
 
-task slowTest(type: Test) {
-    useJUnitPlatform()
+tasks.named('slowTest') {
     dependsOn(':TrafficCapture:dockerSolution:buildDockerImage_elasticsearchTestConsole')
-    jacoco {
-        enabled = true
-    }
-    testLogging {
-        events "passed", "skipped", "failed"
-        exceptionFormat "full"
-        showExceptions true
-        showCauses true
-        showStackTraces true
-        // showStandardStreams true
-    }
-    reports {
-        html.required = true
-        html.destination file("${buildDir}/reports/tests/slowTest")
-    }
-}
-
-tasks.named('jacocoTestReport').configure {
-    dependsOn slowTest
+    testLogging.showStandardStreams = false
 }

--- a/MetadataMigration/build.gradle
+++ b/MetadataMigration/build.gradle
@@ -7,10 +7,6 @@ plugins {
 java.sourceCompatibility = JavaVersion.VERSION_11
 java.targetCompatibility = JavaVersion.VERSION_11
 
-repositories {
-    mavenCentral()
-}
-
 dependencies {
     implementation project(":commonDependencyVersionConstraints")
 
@@ -37,33 +33,4 @@ dependencies {
 
 application {
     mainClassName = 'org.opensearch.migrations.MetadataMigration'
-}
-
-test {
-    useJUnitPlatform {
-        excludeTags 'longTest'
-    }
-    testLogging {
-        events "passed", "skipped", "failed"
-        exceptionFormat "full"
-        showExceptions true
-        showCauses true
-    }
-}
-
-task slowTest(type: Test) {
-    useJUnitPlatform {}
-    jacoco {
-        enabled = true
-    }
-    testLogging {
-        events "passed", "skipped", "failed"
-        exceptionFormat "full"
-        showExceptions true
-        showCauses true
-    }
-}
-
-tasks.named('jacocoTestReport').configure {
-    dependsOn slowTest
 }

--- a/RFS/build.gradle
+++ b/RFS/build.gradle
@@ -9,11 +9,6 @@ plugins {
 java.sourceCompatibility = JavaVersion.VERSION_11
 java.targetCompatibility = JavaVersion.VERSION_11
 
-
-repositories {
-    mavenCentral()
-}
-
 ext {
     awsSdkVersion = '2.25.16'
     dataset = findProperty('dataset') ?: 'skip_dataset'
@@ -88,28 +83,6 @@ dependencies {
     testFixturesImplementation group: 'org.testcontainers', name: 'testcontainers'
 
     testFixturesImplementation group: 'org.hamcrest', name: 'hamcrest'
-}
-
-test {
-    useJUnitPlatform {
-        excludeTags 'longTest'
-    }
-
-    testLogging {
-        events "passed", "skipped", "failed"
-        exceptionFormat "full"
-        showExceptions true
-        showCauses true
-        showStackTraces true
-        showStandardStreams = true
-    }
-}
-
-task slowTest(type: Test) {
-    // include longTest
-    jacoco {
-        enabled = true
-    }
 }
 
 jmh {

--- a/TrafficCapture/build.gradle
+++ b/TrafficCapture/build.gradle
@@ -32,3 +32,16 @@ allprojects {
         }
     }
 }
+
+tasks.named('test', Test) {
+    // Memory leak tests are adding too much execution time on `test` in TrafficCapture
+    // Disabling and will test in `slowTest`
+    systemProperty 'disableMemoryLeakTests', 'true'
+}
+
+tasks.named('slowTest', Test) {
+    useJUnitPlatform {
+        // Ensure rerunning all tests to run with leak detection
+        includeTags = []
+    }
+}

--- a/TrafficCapture/build.gradle
+++ b/TrafficCapture/build.gradle
@@ -1,12 +1,5 @@
 plugins {
-    id 'jacoco'
     id 'org.owasp.dependencycheck' version '8.2.1'
-}
-
-allprojects {
-    repositories {
-        mavenCentral()
-    }
 }
 
 subprojects {
@@ -31,73 +24,11 @@ subprojects {
 
 allprojects {
     apply plugin: 'java'
-    apply plugin: 'jacoco'
     apply plugin: 'org.owasp.dependencycheck'
 
     java {
         toolchain {
             languageVersion = JavaLanguageVersion.of(11)
         }
-    }
-
-    jacoco {
-        toolVersion = '0.8.11'
-    }
-
-    tasks.withType(Test) {
-        // Getting javadoc to compile is part of the test suite to ensure we are able to publish our artifacts
-        dependsOn project.javadoc
-
-        // Provide way to exclude particular tests from CLI
-        // e.g. ../gradlew test -PexcludeTests=**/KafkaProtobufConsumerLongTermTest*
-        if (project.hasProperty('excludeTests')) {
-            exclude project.property('excludeTests')
-        }
-        useJUnitPlatform {
-            //  Disable parallel test execution, see MIGRATIONS-1666
-            systemProperty 'junit.jupiter.execution.parallel.enabled', 'false'
-        }
-        systemProperty 'log4j2.contextSelector', 'org.apache.logging.log4j.core.selector.BasicContextSelector'
-        jvmArgs '-ea'
-    }
-
-    test {
-        systemProperty 'disableMemoryLeakTests', 'true'
-        useJUnitPlatform {
-            excludeTags 'longTest'
-        }
-        jacoco {
-            enabled = false
-        }
-    }
-
-    task slowTest(type: Test) {
-        systemProperty 'disableMemoryLeakTests', 'false'
-        jacoco {
-            enabled = true
-        }
-    }
-}
-
-jacocoTestReport {
-    dependsOn subprojects*.slowTest
-    additionalSourceDirs.from(files(subprojects.sourceSets.main.allSource.srcDirs))
-    sourceDirectories.from(files(subprojects.sourceSets.main.allSource.srcDirs))
-    classDirectories.from(files(subprojects.sourceSets.main.output))
-    executionData.from(subprojects.collect {
-        "${it.buildDir}/jacoco/slowTest.exec"
-    })
-
-    afterEvaluate {
-        classDirectories.setFrom(files(classDirectories.files.collect {
-            fileTree(dir: it, exclude: ['**/protos/**', '**/JMeterLoadTest**'])
-        }))
-    }
-
-    reports {
-        xml.required = true
-        xml.destination file("${buildDir}/reports/jacoco/test/jacocoTestReport.xml")
-        html.required = true
-        html.destination file("${buildDir}/reports/jacoco/test/html")
     }
 }

--- a/TrafficCapture/captureKafkaOffloader/build.gradle
+++ b/TrafficCapture/captureKafkaOffloader/build.gradle
@@ -4,10 +4,6 @@ plugins {
     id 'io.freefair.lombok'
 }
 
-repositories {
-    mavenCentral()
-}
-
 dependencies {
     api project(":commonDependencyVersionConstraints")
     implementation project(':TrafficCapture:captureOffloader')

--- a/TrafficCapture/captureOffloader/build.gradle
+++ b/TrafficCapture/captureOffloader/build.gradle
@@ -8,10 +8,6 @@ plugins {
     id 'java-test-fixtures'
 }
 
-repositories {
-    mavenCentral()
-}
-
 sourceSets {
     main {
         java {

--- a/TrafficCapture/captureProtobufs/build.gradle
+++ b/TrafficCapture/captureProtobufs/build.gradle
@@ -7,10 +7,6 @@ plugins {
     id 'com.google.protobuf' version "0.9.2"
 }
 
-repositories {
-    mavenCentral()
-}
-
 dependencies {
     api project(":commonDependencyVersionConstraints")
     api group: 'com.google.protobuf', name: 'protobuf-java', version: '3.22.2'

--- a/TrafficCapture/trafficReplayer/build.gradle
+++ b/TrafficCapture/trafficReplayer/build.gradle
@@ -15,10 +15,6 @@ plugins {
     id 'java-test-fixtures'
 }
 
-repositories {
-    mavenCentral()
-}
-
 dependencies {
     implementation project(":commonDependencyVersionConstraints")
 

--- a/TrafficCapture/transformationPlugins/build.gradle
+++ b/TrafficCapture/transformationPlugins/build.gradle
@@ -1,5 +1,1 @@
-subprojects {
-    repositories {
-        mavenCentral()
-    }
-}
+

--- a/TrafficCapture/transformationPlugins/jsonMessageTransformers/jsonMessageTransformerInterface/build.gradle
+++ b/TrafficCapture/transformationPlugins/jsonMessageTransformers/jsonMessageTransformerInterface/build.gradle
@@ -22,14 +22,6 @@ plugins {
     id 'io.freefair.lombok'
 }
 
-repositories {
-    mavenCentral()
-}
-
 dependencies {
     api project(":commonDependencyVersionConstraints")
-}
-
-tasks.named('test') {
-    useJUnitPlatform()
 }

--- a/awsUtilities/build.gradle
+++ b/awsUtilities/build.gradle
@@ -25,10 +25,6 @@ plugins {
 java.sourceCompatibility = JavaVersion.VERSION_11
 java.targetCompatibility = JavaVersion.VERSION_11
 
-repositories {
-    mavenCentral()
-}
-
 dependencies {
     api project(":commonDependencyVersionConstraints")
 

--- a/build.gradle
+++ b/build.gradle
@@ -71,7 +71,6 @@ subprojects {
             showStackTraces true
             showStandardStreams = true
         }
-        systemProperty 'disableMemoryLeakTests', 'true'
 
         // Provide way to exclude particular tests from CLI
         // e.g. ../gradlew test -PexcludeTests=**/KafkaProtobufConsumerLongTermTest*
@@ -99,7 +98,6 @@ subprojects {
         useJUnitPlatform {
             includeTags 'longTest'
         }
-        systemProperty 'disableMemoryLeakTests', 'false'
         jacoco.enabled = true
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,14 @@ plugins {
     id 'io.freefair.lombok' version '8.6' apply false
     id "com.diffplug.spotless" version '6.25.0'
     id 'me.champeau.jmh' version '0.7.2' apply false
+    id 'jacoco'
+}
+
+allprojects {
+    apply plugin: 'jacoco'
+    repositories {
+        mavenCentral()
+    }
 }
 
 task buildDockerImages() {
@@ -54,6 +62,45 @@ subprojects {
     tasks.withType(Test) {
         // Getting javadoc to compile is part of the test suite to ensure we are able to publish our artifacts
         dependsOn project.javadoc
+
+        testLogging {
+            events "passed", "skipped", "failed"
+            exceptionFormat "full"
+            showExceptions true
+            showCauses true
+            showStackTraces true
+            showStandardStreams = true
+        }
+        systemProperty 'disableMemoryLeakTests', 'true'
+
+        // Provide way to exclude particular tests from CLI
+        // e.g. ../gradlew test -PexcludeTests=**/KafkaProtobufConsumerLongTermTest*
+        if (project.hasProperty('excludeTests')) {
+            exclude project.property('excludeTests')
+        }
+
+        useJUnitPlatform()
+        //  Disable parallel test execution, see MIGRATIONS-1666
+        systemProperty 'junit.jupiter.execution.parallel.enabled', 'false'
+        systemProperty 'log4j2.contextSelector', 'org.apache.logging.log4j.core.selector.BasicContextSelector'
+        // Verify assertions in tests
+        jvmArgs '-ea'
+    }
+
+    // Mutually exclusive tests to avoid duplication
+    tasks.named('test') {
+        useJUnitPlatform {
+            excludeTags 'longTest'
+        }
+        jacoco.enabled = true
+    }
+
+    tasks.register('slowTest', Test) {
+        useJUnitPlatform {
+            includeTags 'longTest'
+        }
+        systemProperty 'disableMemoryLeakTests', 'false'
+        jacoco.enabled = true
     }
 
     task javadocJar(type: Jar, dependsOn: javadoc) {
@@ -137,12 +184,42 @@ subprojects {
     }
 
     jacocoTestReport {
+        dependsOn = project.tasks.withType(Test).matching { it.jacoco && it.jacoco.enabled }
+        executionData.from = project.tasks.withType(Test).matching { it.jacoco && it.jacoco.enabled }.collect { it.jacoco.destinationFile }
+        // Exclude protos and load tests from test coverage
+        classDirectories.from = files(subprojects.collect { it.sourceSets.main.output.collect {
+            fileTree(dir: it) {
+                exclude '**/protos/**'
+                exclude '**/JMeterLoadTest**'
+            }
+        } })
         reports {
             xml.required = true
             xml.destination file("${buildDir}/reports/jacoco/test/jacocoTestReport.xml")
             html.required = true
             html.destination file("${buildDir}/reports/jacoco/test/html")
         }
+    }
+}
+
+task mergeJacocoReports(type: JacocoReport) {
+    def jacocoReportTasks = subprojects.collect { it.tasks.withType(JacocoReport).matching { it.name == "jacocoTestReport" } }.flatten()
+    dependsOn jacocoReportTasks
+
+    additionalSourceDirs.setFrom(files(jacocoReportTasks.collect { it.additionalSourceDirs }.flatten()))
+    sourceDirectories.setFrom(files(jacocoReportTasks.collect { it.sourceDirectories }.flatten()))
+    classDirectories.setFrom(files(subprojects.collect { subproject ->
+        subproject.sourceSets.main.output.classesDirs.filter { dir ->
+            !dir.path.contains('captureProtobufs') && !dir.path.contains('trafficCaptureProxyServerTest')
+        }
+    }))
+    executionData.setFrom(files(jacocoReportTasks.collect { it.executionData }.flatten()))
+
+    reports {
+        xml.required = true
+        xml.destination = file("${buildDir}/reports/jacoco/mergedReport/jacocoMergedReport.xml")
+        html.required = true
+        html.destination = file("${buildDir}/reports/jacoco/mergedReport/html")
     }
 }
 

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -14,7 +14,6 @@ java.targetCompatibility = JavaVersion.VERSION_11
 repositories {
     // Use the plugin portal to apply community plugins in convention plugins.
     gradlePluginPortal()
-    mavenCentral()
 }
 
 dependencies {

--- a/buildSrc/src/main/groovy/org.opensearch.migrations.java-common-conventions.gradle
+++ b/buildSrc/src/main/groovy/org.opensearch.migrations.java-common-conventions.gradle
@@ -7,11 +7,6 @@ plugins {
     id 'java'
 }
 
-repositories {
-    // Use Maven Central for resolving dependencies.
-    mavenCentral()
-}
-
 dependencies {
     constraints {
         // Define dependency versions as constraints

--- a/commonDependencyVersionConstraints/build.gradle
+++ b/commonDependencyVersionConstraints/build.gradle
@@ -5,10 +5,6 @@ plugins {
 java.sourceCompatibility = JavaVersion.VERSION_11
 java.targetCompatibility = JavaVersion.VERSION_11
 
-repositories {
-  mavenCentral()
-}
-
 dependencies {
 
   constraints {

--- a/coreUtilities/build.gradle
+++ b/coreUtilities/build.gradle
@@ -26,10 +26,6 @@ plugins {
 java.sourceCompatibility = JavaVersion.VERSION_11
 java.targetCompatibility = JavaVersion.VERSION_11
 
-repositories {
-    mavenCentral()
-}
-
 dependencies {
     api project(":commonDependencyVersionConstraints")
 
@@ -63,8 +59,4 @@ dependencies {
     testFixturesImplementation group: 'io.opentelemetry', name: 'opentelemetry-api'
     testFixturesImplementation group: 'io.opentelemetry', name: 'opentelemetry-sdk-testing'
     testFixturesImplementation group: 'org.slf4j', name: 'slf4j-api'
-}
-
-tasks.named('test') {
-    useJUnitPlatform()
 }

--- a/testHelperFixtures/build.gradle
+++ b/testHelperFixtures/build.gradle
@@ -24,10 +24,6 @@ plugins {
     id 'java-test-fixtures'
 }
 
-repositories {
-    mavenCentral()
-}
-
 dependencies {
     api project(":commonDependencyVersionConstraints")
 
@@ -46,8 +42,4 @@ dependencies {
     testFixturesImplementation group: 'org.apache.logging.log4j', name: 'log4j-api'
     testFixturesImplementation group: 'org.apache.logging.log4j', name: 'log4j-core'
     testFixturesImplementation group: 'org.apache.logging.log4j', name: 'log4j-slf4j2-impl'
-}
-
-tasks.named('test') {
-    useJUnitPlatform()
 }

--- a/transformation/build.gradle
+++ b/transformation/build.gradle
@@ -26,10 +26,6 @@ plugins {
 java.sourceCompatibility = JavaVersion.VERSION_11
 java.targetCompatibility = JavaVersion.VERSION_11
 
-repositories {
-    mavenCentral()
-}
-
 dependencies {
     api project(":commonDependencyVersionConstraints")
 
@@ -49,8 +45,4 @@ dependencies {
 
     testImplementation group: 'org.mockito', name: 'mockito-core'
     testImplementation group: 'org.hamcrest', name: 'hamcrest'
-}
-
-tasks.named('test') {
-    useJUnitPlatform()
 }


### PR DESCRIPTION
### Description
Generates a task mergeJacocoReports which runs all tests that run jacoco and generates one shared report.

Cleans up some of the duplicated definitions in build.gradle

Fixes an issue where some classes weren't showing adequate coverage when tested by a different project.

* Category: Bug Fix, Refactoring
* Why these changes are required?
* What is the old behavior before changes and new behavior after changes?

### Issues Resolved
[MIGRATIONS-1976](https://opensearch.atlassian.net/browse/MIGRATIONS-1976)

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
Missing coverage verified to exist
<img width="811" alt="image" src="https://github.com/user-attachments/assets/3331e194-d16c-4ac2-a540-fff0d4f7aed4">

Overall coverage + 7%

### Check List
- [x] New functionality includes testing
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
