### PR TITLE
Detect when the snapshot repo bucket cannot be found and return a clear error message

### DIFF
--- a/RFS/src/main/java/com/rfs/common/S3Repo.java
+++ b/RFS/src/main/java/com/rfs/common/S3Repo.java
@@ -59,7 +59,7 @@ public class S3Repo implements SourceRepo {
             .max(Comparator.comparingInt(s3Object -> extractVersion(s3Object.key())));
 
         String rawUri = highestVersionedIndexFile.map(s3Object -> "s3://" + s3RepoUri.bucketName + "/" + s3Object.key())
-            .orElse("");
+            .orElseThrow(() -> new CannotFindSnapshotRepoRoot(s3RepoUri.bucketName, s3RepoUri.key));
         return new S3Uri(rawUri);
     }
 
@@ -213,6 +213,12 @@ public class S3Repo implements SourceRepo {
 
         // Print out any failed downloads
         completedDirectoryDownload.failedTransfers().forEach(logger::error);
+    }
+
+    public static class CannotFindSnapshotRepoRoot extends RfsException {
+        public CannotFindSnapshotRepoRoot(String bucket, String prefix) {
+            super("Cannot find the snapshot repository root in S3 bucket: " + bucket + ", prefix: " + prefix);
+        }
     }
 
     public static class CantCreateS3LocalDir extends RfsException {


### PR DESCRIPTION
### Description
Fix for this error because the snapshot repo doesn't exist:
```
2024-09-05 21:56:33,737 INFO o.o.m.MetadataMigration [main] Starting Metadata Migration
2024-09-05 21:56:33,758 INFO o.o.m.c.Migrate [main] Command line arguments {0}
2024-09-05 21:56:33,758 INFO o.o.m.c.Migrate [main] Running Metadata worker
2024-09-05 21:56:35,523 INFO o.o.m.c.ClusterProviderRegistry [main] Found snapshot resource reader for version: Elasticsearch 7.10.2
2024-09-05 21:56:38,340 INFO o.o.m.c.ClusterProviderRegistry [main] Found remote writer for version: OpenSearch 2.9.0
2024-09-05 21:56:38,677 INFO o.o.m.c.Migrate [main] Using transformation com.rfs.transformers.Transformer_ES_7_10_OS_2_11@3a1f2a1
2024-09-05 21:56:38,730 INFO c.r.w.MetadataRunner [main] Migrating the Templates...
2024-09-05 21:56:39,514 ERROR o.o.m.c.Migrate [main] Unexpected failure
java.lang.StringIndexOutOfBoundsException: String index out of range: -5
        at java.base/java.lang.String.substring(String.java:1841) ~[?:?]
        at com.rfs.common.S3Uri.<init>(S3Uri.java:9) ~[RFS.jar:?]
        at com.rfs.common.S3Repo.findRepoFileUri(S3Repo.java:63) ~[RFS.jar:?]
        at com.rfs.common.S3Repo.getSnapshotRepoDataFilePath(S3Repo.java:119) ~[RFS.jar:?]
        at com.rfs.version_es_7_10.SnapshotRepoData_ES_7_10.fromRepo(SnapshotRepoData_ES_7_10.java:34) ~[RFS.jar:?]
        at com.rfs.version_es_7_10.SnapshotRepoProvider_ES_7_10.getRepoData(SnapshotRepoProvider_ES_7_10.java:20) ~[RFS.jar:?]
        at com.rfs.version_es_7_10.SnapshotRepoProvider_ES_7_10.getSnapshotId(SnapshotRepoProvider_ES_7_10.java:59) ~[RFS.jar:?]
        at com.rfs.models.GlobalMetadata$Factory.getJsonNode(GlobalMetadata.java:37) ~[RFS.jar:?]
        at com.rfs.models.GlobalMetadata$Factory.fromRepo(GlobalMetadata.java:67) ~[RFS.jar:?]
        at com.rfs.worker.MetadataRunner.migrateMetadata(MetadataRunner.java:23) ~[RFS.jar:?]
        at org.opensearch.migrations.commands.Migrate.execute(Migrate.java:59) [MetadataMigration.jar:?]
        at org.opensearch.migrations.MetadataMigration.main(MetadataMigration.java:37) [MetadataMigration.jar:?]
```

### Issues Resolved
- https://opensearch.atlassian.net/browse/MIGRATIONS-1978

### Check List
- [X] New functionality includes testing
  - [X] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
