### PR TITLE
Only run codecov on pr

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -55,16 +55,20 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-         python-version: ${{ env.python-version }}
+          python-version: ${{ env.python-version }}
       - run: |
           python3 -m pip install --upgrade pipenv
           pipenv install --deploy --dev
           pipenv run coverage run -m pytest
           pipenv run coverage xml
-      - uses: codecov/codecov-action@v4
+      - name: Upload to Codecov
+        # TODO: MIGRATIONS-1991 to remove this condition
+        if: github.event_name == 'pull_request'
+        uses: codecov/codecov-action@v4
         with:
           files: ./coverage.xml
           flags: python-test
+          fail_ci_if_error: true
 
   console-api-tests:
     runs-on: ubuntu-latest
@@ -81,9 +85,13 @@ jobs:
           pipenv install --deploy --dev
           pipenv run coverage run --source='.' manage.py test console_api
           pipenv run coverage xml
-      - uses: codecov/codecov-action@v4
+      - name: Upload to Codecov
+        # TODO: MIGRATIONS-1991 to remove this condition
+        if: github.event_name == 'pull_request'
+        uses: codecov/codecov-action@v4
         with:
           files: ./coverage.xml
+          fail_ci_if_error: true
 
   gradle-tests:
     runs-on: ubuntu-latest
@@ -116,6 +124,8 @@ jobs:
             **/reports/jacoco/mergedReport/
 
       - name: Upload to Codecov
+        # TODO: MIGRATIONS-1991 to remove this condition
+        if: github.event_name == 'pull_request'
         uses: codecov/codecov-action@v4
         with:
           files: ${{ github.workspace }}/build/reports/jacoco/mergedReport/jacocoMergedReport.xml


### PR DESCRIPTION
### Description
Fixes codcov failues by not running on push events. Codecov has been failing on push events for a long time, but recently in #928 codecov was modified to fail on error instead of silently failing. This caused the push events to fail.

This is because of the codecov token requirements as mentioned in the comment. 

* Category: Bug Fix
* Why these changes are required? Codecov failures on main
* What is the old behavior before changes and new behavior after changes? Codecov failures on main

### Issues Resolved
N/A

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
Testing on GHA, will verify on the push event after merging

### Check List
- [x] New functionality includes testing
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
