### PR TITLE
Add codecov token

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -62,10 +62,9 @@ jobs:
           pipenv run coverage run -m pytest
           pipenv run coverage xml
       - name: Upload to Codecov
-        # TODO: MIGRATIONS-1991 to remove this condition
-        if: github.event_name == 'pull_request'
         uses: codecov/codecov-action@v4
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.xml
           flags: python-test
           fail_ci_if_error: true
@@ -86,10 +85,9 @@ jobs:
           pipenv run coverage run --source='.' manage.py test console_api
           pipenv run coverage xml
       - name: Upload to Codecov
-        # TODO: MIGRATIONS-1991 to remove this condition
-        if: github.event_name == 'pull_request'
         uses: codecov/codecov-action@v4
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.xml
           fail_ci_if_error: true
 
@@ -124,10 +122,9 @@ jobs:
             **/reports/jacoco/mergedReport/
 
       - name: Upload to Codecov
-        # TODO: MIGRATIONS-1991 to remove this condition
-        if: github.event_name == 'pull_request'
         uses: codecov/codecov-action@v4
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: ${{ github.workspace }}/build/reports/jacoco/mergedReport/jacocoMergedReport.xml
           flags: gradle-test
           fail_ci_if_error: true


### PR DESCRIPTION
### Description
Add codecov token to fix codecov on push 

* Category: Bug fix
* Why these changes are required? codecov on push requires token
* What is the old behavior before changes and new behavior after changes? codecov on push or PRs not made from a fork wouldn't run or failed, now working

### Issues Resolved
https://opensearch.atlassian.net/browse/MIGRATIONS-1991

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
See GHA

### Check List
- [x] New functionality includes testing
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
