### PR TITLE
Add default source version for metadata migration

### DIFF
--- a/MetadataMigration/src/main/java/org/opensearch/migrations/MetadataArgs.java
+++ b/MetadataMigration/src/main/java/org/opensearch/migrations/MetadataArgs.java
@@ -49,6 +49,6 @@ public class MetadataArgs {
             + "forwarded. If no value is provided, metrics will not be forwarded.")
     String otelCollectorEndpoint;
 
-    @Parameter(names = {"--source-version" }, description = "Version of the source cluster, for example: Elasticsearch 7.10 or OS 1.3", converter = VersionConverter.class)
-    public Version sourceVersion;
+    @Parameter(names = {"--source-version" }, description = "Version of the source cluster, for example: Elasticsearch 7.10 or OS 1.3.  Defaults to: ES_7.10", converter = VersionConverter.class)
+    public Version sourceVersion = Version.fromString("ES 7.10");
 }


### PR DESCRIPTION
### Description
Metadata migration requires a default version parameter just like RFS when reading from snapshot.  RFS was defaulting to ES 7.10, doing the same for metadata tool.

### Issues
- Resolves https://opensearch.atlassian.net/browse/MIGRATIONS-1995

### Check List
- [ ] ~New functionality includes testing~
  - [ ] ~All tests pass, including unit test, integration test and doctest~
- [X] New functionality has been documented
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
