### PR TITLE
Add aliases to the metadata migration output

### DIFF
--- a/MetadataMigration/src/main/java/org/opensearch/migrations/cli/Items.java
+++ b/MetadataMigration/src/main/java/org/opensearch/migrations/cli/Items.java
@@ -16,6 +16,7 @@ public class Items {
     public List<String> indexTemplates;
     public List<String> componentTemplates;
     public List<String> indexes;
+    public List<String> aliases;
 
     public String toString() {
         var sb = new StringBuilder();
@@ -33,6 +34,9 @@ public class Items {
         sb.append("   Indexes:" + System.lineSeparator());
         sb.append("      " + getPrintableList(getIndexes()) + System.lineSeparator());
         sb.append(System.lineSeparator());
+        sb.append("   Aliases:" + System.lineSeparator());
+        sb.append("      " + getPrintableList(getAliases()) + System.lineSeparator());
+        sb.append(System.lineSeparator());
         return sb.toString();
     }
 
@@ -40,6 +44,6 @@ public class Items {
         if (list == null || list.isEmpty()) {
             return "<NONE FOUND>";
         }
-        return list.stream().collect(Collectors.joining(", "));
+        return list.stream().sorted().collect(Collectors.joining(", "));
     }
 }

--- a/MetadataMigration/src/main/java/org/opensearch/migrations/commands/Migrate.java
+++ b/MetadataMigration/src/main/java/org/opensearch/migrations/commands/Migrate.java
@@ -67,14 +67,15 @@ public class Migrate {
 
             log.info("Metadata copy complete.");
 
-            var indexes = new IndexRunner(
+            var indexResults = new IndexRunner(
                 arguments.snapshotName,
                 sourceCluster.getIndexMetadata(),
                 targetCluster.getIndexCreator(),
                 transformer,
                 arguments.dataFilterArgs.indexAllowlist
             ).migrateIndices(context.createIndexContext());
-            items.indexes(indexes);
+            items.indexes(indexResults.getIndexNames());
+            items.aliases(indexResults.getAliases());
             migrateResult.items(items.build());
             log.info("Index copy complete.");
         } catch (ParameterException pe) {

--- a/RFS/src/main/java/com/rfs/worker/IndexMetadataResults.java
+++ b/RFS/src/main/java/com/rfs/worker/IndexMetadataResults.java
@@ -1,0 +1,16 @@
+package com.rfs.worker;
+
+import java.util.List;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.Singular;
+
+@Builder
+@Data
+public class IndexMetadataResults {
+    @Singular
+    private final List<String> indexNames;
+    @Singular
+    private final List<String> aliases;
+}

--- a/RFS/src/main/java/com/rfs/worker/IndexRunner.java
+++ b/RFS/src/main/java/com/rfs/worker/IndexRunner.java
@@ -2,7 +2,6 @@ package com.rfs.worker;
 
 import java.util.List;
 import java.util.function.BiConsumer;
-import java.util.stream.Collectors;
 
 import org.opensearch.migrations.metadata.IndexCreator;
 import org.opensearch.migrations.metadata.tracing.IMetadataMigrationContexts.ICreateIndexContext;
@@ -24,7 +23,7 @@ public class IndexRunner {
     private final Transformer transformer;
     private final List<String> indexAllowlist;
 
-    public List<String> migrateIndices(ICreateIndexContext context) {
+    public IndexMetadataResults migrateIndices(ICreateIndexContext context) {
         SnapshotRepo.Provider repoDataProvider = metadataFactory.getRepoDataProvider();
         // TODO - parallelize this, maybe ~400-1K requests per thread and do it asynchronously
 
@@ -33,19 +32,23 @@ public class IndexRunner {
                 log.info("Index " + indexName + " rejected by allowlist");
             }
         };
-        return repoDataProvider.getIndicesInSnapshot(snapshotName)
+        var results = IndexMetadataResults.builder();
+
+        repoDataProvider.getIndicesInSnapshot(snapshotName)
             .stream()
             .filter(FilterScheme.filterIndicesByAllowList(indexAllowlist, logger))
-            .map(index -> {
-                var indexMetadata = metadataFactory.fromRepo(snapshotName, index.getName());
+            .forEach(index -> {
+                var indexName = index.getName();
+                var indexMetadata = metadataFactory.fromRepo(snapshotName, indexName);
                 var transformedRoot = transformer.transformIndexMetadata(indexMetadata);
                 var resultOp = indexCreator.create(transformedRoot, context);
                 resultOp.ifPresentOrElse(
-                    value -> log.info("Index " + index.getName() + " created successfully"),
-                    () -> log.info("Index " + index.getName() + " already existed; no work required")
+                    value -> log.info("Index " + indexName + " created successfully"),
+                    () -> log.info("Index " + indexName + " already existed; no work required")
                 );
-                return index.getName();
-            })
-            .collect(Collectors.toList());
+                results.indexName(indexName);
+                transformedRoot.getAliases().fieldNames().forEachRemaining(results::alias);
+            });
+        return results.build();
     }
 }

--- a/RFS/src/testFixtures/java/com/rfs/http/ClusterOperations.java
+++ b/RFS/src/testFixtures/java/com/rfs/http/ClusterOperations.java
@@ -6,6 +6,7 @@ import java.util.Map;
 
 import org.apache.hc.client5.http.classic.methods.HttpDelete;
 import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.client5.http.classic.methods.HttpPost;
 import org.apache.hc.client5.http.classic.methods.HttpPut;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.client5.http.impl.classic.HttpClients;
@@ -170,6 +171,9 @@ public class ClusterOperations {
             + "                \"type\": \"text\""
             + "            }"
             + "        }"
+            + "    },"
+            + "    \"aliases\": {"
+            + "        \"alias1\": {}"
             + "    }"
             + "},"
             + "\"version\": 1"
@@ -205,6 +209,32 @@ public class ClusterOperations {
         createIndexTempRequest.setHeader("Content-Type", "application/json");
 
         try (var response = httpClient.execute(createIndexTempRequest)) {
+            assertThat(
+                EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8),
+                response.getCode(),
+                equalTo(200)
+            );
+        }
+    }
+
+    @SneakyThrows
+    public void createAlias(String aliasName, String indexPattern) {
+        final var requestBodyJson = "{\r\n" + //
+            "  \"actions\": [\r\n" + //
+            "    {\r\n" + //
+            "      \"add\": {\r\n" + //
+            "        \"index\": \"" + indexPattern + "\",\r\n" + //
+            "        \"alias\": \"" + aliasName + "\"\r\n" + //
+            "      }\r\n" + //
+            "    }\r\n" + //
+            "  ]\r\n" + //
+            "}";
+
+        final var aliasRequest = new HttpPost(this.clusterUrl + "/_aliases");
+        aliasRequest.setEntity(new StringEntity(requestBodyJson));
+        aliasRequest.setHeader("Content-Type", "application/json");
+
+        try (var response = httpClient.execute(aliasRequest)) {
             assertThat(
                 EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8),
                 response.getCode(),


### PR DESCRIPTION
### Description
Add aliases to the metadata migration output
- Updated end to end test verification

### Example UX
```
Clusters:
   Source:
      Snapshot: Elasticsearch 6.8.23 FileSystemRepo(repoRootDir=/tmp/junit1212427663916343992)

   Target:
      Remote Cluster: OpenSearch 2.14.0 ConnectionContext(uri=http://localhost:32911, protocol=HTTP, insecure=false, compressionSupported=false)


Migrated Items:
   Index Templates:
      simple_index_template

   Component Templates:
      <NONE FOUND>

   Indexes:
      blog_2023, movies_2023

   Aliases:
      alias1, movies-alias


Results:
   0 issue(s) detected
```

### Issues
- Resolves https://opensearch.atlassian.net/browse/MIGRATIONS-1997
- Related https://opensearch.atlassian.net/browse/MIGRATIONS-1867

### Check List
- [X] New functionality includes testing
  - [X] All tests pass, including unit test, integration test and doctest
- [X] New functionality has been documented
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
