### PR TITLE
Add trace null appender to all test log4j properties

### DIFF
--- a/DocumentsFromSnapshotMigration/src/test/resources/log4j2.properties
+++ b/DocumentsFromSnapshotMigration/src/test/resources/log4j2.properties
@@ -34,3 +34,22 @@ rootLogger.appenderRef.console.ref = Console
 logger.wireLogger.name = org.apache.http.wire
 logger.wireLogger.level = OFF
 logger.wireLogger.additivity = false
+
+# Run and discard TRACE logs from owned packages to test executed paths
+appender.testTraceIgnoreAppender.type = Null
+appender.testTraceIgnoreAppender.name = TestTraceIgnoreAppender
+logger.migrationsTraceIgnoreLogger.name = org.opensearch.migrations
+logger.migrationsTraceIgnoreLogger.additivity = false
+logger.migrationsTraceIgnoreLogger.appenderRef.0.ref = TestTraceIgnoreAppender
+logger.migrationsTraceIgnoreLogger.appenderRef.0.level = all
+logger.migrationsTraceIgnoreLogger.appenderRef.1.ref = Console
+logger.migrationsTraceIgnoreLogger.appenderRef.1.level = info
+logger.migrationsTraceIgnoreLogger.level = all
+
+logger.rfsTraceIgnoreLogger.name = com.rfs
+logger.rfsTraceIgnoreLogger.additivity = false
+logger.rfsTraceIgnoreLogger.appenderRef.0.ref = TestTraceIgnoreAppender
+logger.rfsTraceIgnoreLogger.appenderRef.0.level = all
+logger.rfsTraceIgnoreLogger.appenderRef.1.ref = Console
+logger.rfsTraceIgnoreLogger.appenderRef.1.level = info
+logger.rfsTraceIgnoreLogger.level = all

--- a/MetadataMigration/src/test/resources/log4j2.properties
+++ b/MetadataMigration/src/test/resources/log4j2.properties
@@ -11,12 +11,6 @@ appender.console.layout.pattern = %m%n
 rootLogger.level = info
 rootLogger.appenderRef.console.ref = Console
 
-logger.rfs.name = com.rfs
-logger.rfs.level = debug
-
-logger.migrations.name = com.opensearch.migrations
-logger.migrations.level = debug
-
 logger.transformer.name = com.rfs.transformers.Transformer_ES_6_8_to_OS_2_11
 logger.transformer.level = debug
 
@@ -33,3 +27,22 @@ logger.dockerclientdeps.level = info
 logger.wireLogger.name = org.apache.http.wire
 logger.wireLogger.level = OFF
 logger.wireLogger.additivity = false
+
+# Run and discard TRACE logs from owned packages to test executed paths
+appender.testTraceIgnoreAppender.type = Null
+appender.testTraceIgnoreAppender.name = TestTraceIgnoreAppender
+logger.migrationsTraceIgnoreLogger.name = org.opensearch.migrations
+logger.migrationsTraceIgnoreLogger.additivity = false
+logger.migrationsTraceIgnoreLogger.appenderRef.0.ref = TestTraceIgnoreAppender
+logger.migrationsTraceIgnoreLogger.appenderRef.0.level = all
+logger.migrationsTraceIgnoreLogger.appenderRef.1.ref = Console
+logger.migrationsTraceIgnoreLogger.appenderRef.1.level = info
+logger.migrationsTraceIgnoreLogger.level = all
+
+logger.rfsTraceIgnoreLogger.name = com.rfs
+logger.rfsTraceIgnoreLogger.additivity = false
+logger.rfsTraceIgnoreLogger.appenderRef.0.ref = TestTraceIgnoreAppender
+logger.rfsTraceIgnoreLogger.appenderRef.0.level = all
+logger.rfsTraceIgnoreLogger.appenderRef.1.ref = Console
+logger.rfsTraceIgnoreLogger.appenderRef.1.level = info
+logger.rfsTraceIgnoreLogger.level = all

--- a/RFS/src/test/resources/log4j2.properties
+++ b/RFS/src/test/resources/log4j2.properties
@@ -11,10 +11,6 @@ appender.console.name = Console
 appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = %d{HH:mm:ss.SSS} %threadName %-5p %c{1}:%L - %m%n
 
-# Logger definitions
-logger.rfs.name = com.rfs
-logger.rfs.level = debug
-
 logger.wire.name = org.apache.hc.client5.http
 logger.wire.level = info
 
@@ -34,3 +30,22 @@ appender.WorkCoordinator.type = Console
 appender.WorkCoordinator.name = WorkCoordinator
 appender.WorkCoordinator.layout.type = PatternLayout
 appender.WorkCoordinator.layout.pattern = %d{HH:mm:ss.SSS} [%t] %-5level %logger{36} [worker=%X{workerId}]- %msg%n
+
+# Run and discard TRACE logs from owned packages to test executed paths
+appender.testTraceIgnoreAppender.type = Null
+appender.testTraceIgnoreAppender.name = TestTraceIgnoreAppender
+logger.migrationsTraceIgnoreLogger.name = org.opensearch.migrations
+logger.migrationsTraceIgnoreLogger.additivity = false
+logger.migrationsTraceIgnoreLogger.appenderRef.0.ref = TestTraceIgnoreAppender
+logger.migrationsTraceIgnoreLogger.appenderRef.0.level = all
+logger.migrationsTraceIgnoreLogger.appenderRef.1.ref = Console
+logger.migrationsTraceIgnoreLogger.appenderRef.1.level = info
+logger.migrationsTraceIgnoreLogger.level = all
+
+logger.rfsTraceIgnoreLogger.name = com.rfs
+logger.rfsTraceIgnoreLogger.additivity = false
+logger.rfsTraceIgnoreLogger.appenderRef.0.ref = TestTraceIgnoreAppender
+logger.rfsTraceIgnoreLogger.appenderRef.0.level = all
+logger.rfsTraceIgnoreLogger.appenderRef.1.ref = Console
+logger.rfsTraceIgnoreLogger.appenderRef.1.level = info
+logger.rfsTraceIgnoreLogger.level = all

--- a/TrafficCapture/captureKafkaOffloader/src/test/resources/log4j2.properties
+++ b/TrafficCapture/captureKafkaOffloader/src/test/resources/log4j2.properties
@@ -9,3 +9,22 @@ appender.console.type = Console
 appender.console.name = Console
 appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss,SSS}{UTC} %p %c{1.} [%t] %m%equals{ ctx=%mdc}{ ctx=\{\}}{}%n
+
+# Run and discard TRACE logs from owned packages to test executed paths
+appender.testTraceIgnoreAppender.type = Null
+appender.testTraceIgnoreAppender.name = TestTraceIgnoreAppender
+logger.migrationsTraceIgnoreLogger.name = org.opensearch.migrations
+logger.migrationsTraceIgnoreLogger.additivity = false
+logger.migrationsTraceIgnoreLogger.appenderRef.0.ref = TestTraceIgnoreAppender
+logger.migrationsTraceIgnoreLogger.appenderRef.0.level = all
+logger.migrationsTraceIgnoreLogger.appenderRef.1.ref = Console
+logger.migrationsTraceIgnoreLogger.appenderRef.1.level = info
+logger.migrationsTraceIgnoreLogger.level = all
+
+logger.rfsTraceIgnoreLogger.name = com.rfs
+logger.rfsTraceIgnoreLogger.additivity = false
+logger.rfsTraceIgnoreLogger.appenderRef.0.ref = TestTraceIgnoreAppender
+logger.rfsTraceIgnoreLogger.appenderRef.0.level = all
+logger.rfsTraceIgnoreLogger.appenderRef.1.ref = Console
+logger.rfsTraceIgnoreLogger.appenderRef.1.level = info
+logger.rfsTraceIgnoreLogger.level = all

--- a/TrafficCapture/captureOffloader/src/test/resources/log4j2.properties
+++ b/TrafficCapture/captureOffloader/src/test/resources/log4j2.properties
@@ -9,3 +9,22 @@ appender.console.type = Console
 appender.console.name = Console
 appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss,SSS}{UTC} %p %c{1.} [%t] %m%equals{ ctx=%mdc}{ ctx=\{\}}{}%n
+
+# Run and discard TRACE logs from owned packages to test executed paths
+appender.testTraceIgnoreAppender.type = Null
+appender.testTraceIgnoreAppender.name = TestTraceIgnoreAppender
+logger.migrationsTraceIgnoreLogger.name = org.opensearch.migrations
+logger.migrationsTraceIgnoreLogger.additivity = false
+logger.migrationsTraceIgnoreLogger.appenderRef.0.ref = TestTraceIgnoreAppender
+logger.migrationsTraceIgnoreLogger.appenderRef.0.level = all
+logger.migrationsTraceIgnoreLogger.appenderRef.1.ref = Console
+logger.migrationsTraceIgnoreLogger.appenderRef.1.level = info
+logger.migrationsTraceIgnoreLogger.level = all
+
+logger.rfsTraceIgnoreLogger.name = com.rfs
+logger.rfsTraceIgnoreLogger.additivity = false
+logger.rfsTraceIgnoreLogger.appenderRef.0.ref = TestTraceIgnoreAppender
+logger.rfsTraceIgnoreLogger.appenderRef.0.level = all
+logger.rfsTraceIgnoreLogger.appenderRef.1.ref = Console
+logger.rfsTraceIgnoreLogger.appenderRef.1.level = info
+logger.rfsTraceIgnoreLogger.level = all

--- a/TrafficCapture/nettyWireLogging/src/test/resources/log4j2.properties
+++ b/TrafficCapture/nettyWireLogging/src/test/resources/log4j2.properties
@@ -9,3 +9,22 @@ appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = [%-5level] %d{yyyy-MM-dd HH:mm:ss,SSS}{UTC} [%t] %c{1} - %msg%equals{ ctx=%mdc}{ ctx=\{\}}{}%n
 
 rootLogger.appenderRef.stderr.ref = STDERR
+
+# Run and discard TRACE logs from owned packages to test executed paths
+appender.testTraceIgnoreAppender.type = Null
+appender.testTraceIgnoreAppender.name = TestTraceIgnoreAppender
+logger.migrationsTraceIgnoreLogger.name = org.opensearch.migrations
+logger.migrationsTraceIgnoreLogger.additivity = false
+logger.migrationsTraceIgnoreLogger.appenderRef.0.ref = TestTraceIgnoreAppender
+logger.migrationsTraceIgnoreLogger.appenderRef.0.level = all
+logger.migrationsTraceIgnoreLogger.appenderRef.1.ref = Console
+logger.migrationsTraceIgnoreLogger.appenderRef.1.level = info
+logger.migrationsTraceIgnoreLogger.level = all
+
+logger.rfsTraceIgnoreLogger.name = com.rfs
+logger.rfsTraceIgnoreLogger.additivity = false
+logger.rfsTraceIgnoreLogger.appenderRef.0.ref = TestTraceIgnoreAppender
+logger.rfsTraceIgnoreLogger.appenderRef.0.level = all
+logger.rfsTraceIgnoreLogger.appenderRef.1.ref = Console
+logger.rfsTraceIgnoreLogger.appenderRef.1.level = info
+logger.rfsTraceIgnoreLogger.level = all

--- a/TrafficCapture/trafficReplayer/src/test/resources/log4j2.properties
+++ b/TrafficCapture/trafficReplayer/src/test/resources/log4j2.properties
@@ -14,3 +14,22 @@ appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss,SSS}{UTC} %p %c{1.} [%t
 # of the logs for tests
 logger.OutputTupleJsonLogger.name = OutputTupleJsonLogger
 logger.OutputTupleJsonLogger.level = OFF
+
+# Run and discard TRACE logs from owned packages to test executed paths
+appender.testTraceIgnoreAppender.type = Null
+appender.testTraceIgnoreAppender.name = TestTraceIgnoreAppender
+logger.migrationsTraceIgnoreLogger.name = org.opensearch.migrations
+logger.migrationsTraceIgnoreLogger.additivity = false
+logger.migrationsTraceIgnoreLogger.appenderRef.0.ref = TestTraceIgnoreAppender
+logger.migrationsTraceIgnoreLogger.appenderRef.0.level = all
+logger.migrationsTraceIgnoreLogger.appenderRef.1.ref = Console
+logger.migrationsTraceIgnoreLogger.appenderRef.1.level = info
+logger.migrationsTraceIgnoreLogger.level = all
+
+logger.rfsTraceIgnoreLogger.name = com.rfs
+logger.rfsTraceIgnoreLogger.additivity = false
+logger.rfsTraceIgnoreLogger.appenderRef.0.ref = TestTraceIgnoreAppender
+logger.rfsTraceIgnoreLogger.appenderRef.0.level = all
+logger.rfsTraceIgnoreLogger.appenderRef.1.ref = Console
+logger.rfsTraceIgnoreLogger.appenderRef.1.level = info
+logger.rfsTraceIgnoreLogger.level = all

--- a/TrafficCapture/transformationPlugins/jsonMessageTransformers/jsonJMESPathMessageTransformerProvider/src/test/resources/log4j2.properties
+++ b/TrafficCapture/transformationPlugins/jsonMessageTransformers/jsonJMESPathMessageTransformerProvider/src/test/resources/log4j2.properties
@@ -1,14 +1,14 @@
-status = error
+status = warn
 
-appender.console.type = Console
-appender.console.name = STDERR
-appender.console.target = SYSTEM_ERR
-appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = [%-5level] %d{yyyy-MM-dd HH:mm:ss,SSS}{UTC} [%t] %c{1} - %msg%equals{ ctx=%mdc}{ ctx=\{\}}{}%n
-
+# Root logger options
 rootLogger.level = debug
-rootLogger.appenderRefs = stderr
-rootLogger.appenderRef.stderr.ref = STDERR
+rootLogger.appenderRef.console.ref = Console
+
+# Console appender configuration
+appender.console.type = Console
+appender.console.name = Console
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss,SSS}{UTC} %p %c{1.} [%t] %m%equals{ ctx=%mdc}{ ctx=\{\}}{}%n
 
 # Run and discard TRACE logs from owned packages to test executed paths
 appender.testTraceIgnoreAppender.type = Null

--- a/TrafficCapture/transformationPlugins/jsonMessageTransformers/jsonJoltMessageTransformerProvider/src/test/resources/log4j2.properties
+++ b/TrafficCapture/transformationPlugins/jsonMessageTransformers/jsonJoltMessageTransformerProvider/src/test/resources/log4j2.properties
@@ -1,14 +1,14 @@
-status = error
+status = warn
 
-appender.console.type = Console
-appender.console.name = STDERR
-appender.console.target = SYSTEM_ERR
-appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = [%-5level] %d{yyyy-MM-dd HH:mm:ss,SSS}{UTC} [%t] %c{1} - %msg%equals{ ctx=%mdc}{ ctx=\{\}}{}%n
-
+# Root logger options
 rootLogger.level = debug
-rootLogger.appenderRefs = stderr
-rootLogger.appenderRef.stderr.ref = STDERR
+rootLogger.appenderRef.console.ref = Console
+
+# Console appender configuration
+appender.console.type = Console
+appender.console.name = Console
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss,SSS}{UTC} %p %c{1.} [%t] %m%equals{ ctx=%mdc}{ ctx=\{\}}{}%n
 
 # Run and discard TRACE logs from owned packages to test executed paths
 appender.testTraceIgnoreAppender.type = Null

--- a/TrafficCapture/transformationPlugins/jsonMessageTransformers/openSearch23PlusTargetTransformerProvider/src/test/resources/log4j2.properties
+++ b/TrafficCapture/transformationPlugins/jsonMessageTransformers/openSearch23PlusTargetTransformerProvider/src/test/resources/log4j2.properties
@@ -1,14 +1,14 @@
-status = error
+status = warn
 
-appender.console.type = Console
-appender.console.name = STDERR
-appender.console.target = SYSTEM_ERR
-appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = [%-5level] %d{yyyy-MM-dd HH:mm:ss,SSS}{UTC} [%t] %c{1} - %msg%equals{ ctx=%mdc}{ ctx=\{\}}{}%n
-
+# Root logger options
 rootLogger.level = debug
-rootLogger.appenderRefs = stderr
-rootLogger.appenderRef.stderr.ref = STDERR
+rootLogger.appenderRef.console.ref = Console
+
+# Console appender configuration
+appender.console.type = Console
+appender.console.name = Console
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss,SSS}{UTC} %p %c{1.} [%t] %m%equals{ ctx=%mdc}{ ctx=\{\}}{}%n
 
 # Run and discard TRACE logs from owned packages to test executed paths
 appender.testTraceIgnoreAppender.type = Null

--- a/awsUtilities/src/test/resources/log4j2.properties
+++ b/awsUtilities/src/test/resources/log4j2.properties
@@ -1,14 +1,14 @@
-status = error
+status = warn
 
-appender.console.type = Console
-appender.console.name = STDERR
-appender.console.target = SYSTEM_ERR
-appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = [%-5level] %d{yyyy-MM-dd HH:mm:ss,SSS}{UTC} [%t] %c{1} - %msg%equals{ ctx=%mdc}{ ctx=\{\}}{}%n
-
+# Root logger options
 rootLogger.level = debug
-rootLogger.appenderRefs = stderr
-rootLogger.appenderRef.stderr.ref = STDERR
+rootLogger.appenderRef.console.ref = Console
+
+# Console appender configuration
+appender.console.type = Console
+appender.console.name = Console
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss,SSS}{UTC} %p %c{1.} [%t] %m%equals{ ctx=%mdc}{ ctx=\{\}}{}%n
 
 # Run and discard TRACE logs from owned packages to test executed paths
 appender.testTraceIgnoreAppender.type = Null

--- a/coreUtilities/src/test/resources/log4j2.properties
+++ b/coreUtilities/src/test/resources/log4j2.properties
@@ -1,14 +1,14 @@
-status = error
+status = warn
 
-appender.console.type = Console
-appender.console.name = STDERR
-appender.console.target = SYSTEM_ERR
-appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = [%-5level] %d{yyyy-MM-dd HH:mm:ss,SSS}{UTC} [%t] %c{1} - %msg%equals{ ctx=%mdc}{ ctx=\{\}}{}%n
-
+# Root logger options
 rootLogger.level = debug
-rootLogger.appenderRefs = stderr
-rootLogger.appenderRef.stderr.ref = STDERR
+rootLogger.appenderRef.console.ref = Console
+
+# Console appender configuration
+appender.console.type = Console
+appender.console.name = Console
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss,SSS}{UTC} %p %c{1.} [%t] %m%equals{ ctx=%mdc}{ ctx=\{\}}{}%n
 
 # Run and discard TRACE logs from owned packages to test executed paths
 appender.testTraceIgnoreAppender.type = Null

--- a/transformation/src/test/resources/log4j2.properties
+++ b/transformation/src/test/resources/log4j2.properties
@@ -9,3 +9,22 @@ appender.console.type = Console
 appender.console.name = Console
 appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss,SSS}{UTC} %p %c{1.} [%t] %m%equals{ ctx=%mdc}{ ctx=\{\}}{}%n
+
+# Run and discard TRACE logs from owned packages to test executed paths
+appender.testTraceIgnoreAppender.type = Null
+appender.testTraceIgnoreAppender.name = TestTraceIgnoreAppender
+logger.migrationsTraceIgnoreLogger.name = org.opensearch.migrations
+logger.migrationsTraceIgnoreLogger.additivity = false
+logger.migrationsTraceIgnoreLogger.appenderRef.0.ref = TestTraceIgnoreAppender
+logger.migrationsTraceIgnoreLogger.appenderRef.0.level = all
+logger.migrationsTraceIgnoreLogger.appenderRef.1.ref = Console
+logger.migrationsTraceIgnoreLogger.appenderRef.1.level = info
+logger.migrationsTraceIgnoreLogger.level = all
+
+logger.rfsTraceIgnoreLogger.name = com.rfs
+logger.rfsTraceIgnoreLogger.additivity = false
+logger.rfsTraceIgnoreLogger.appenderRef.0.ref = TestTraceIgnoreAppender
+logger.rfsTraceIgnoreLogger.appenderRef.0.level = all
+logger.rfsTraceIgnoreLogger.appenderRef.1.ref = Console
+logger.rfsTraceIgnoreLogger.appenderRef.1.level = info
+logger.rfsTraceIgnoreLogger.level = all


### PR DESCRIPTION
### Description

Adds a trace null appender to all test log4j properties. This allows us to verify code paths which would otherwise only be executed with trace logging on. This uses the null appender to not impact performance through sending the message through a real output stream.

* Category: Enhancement
* Why these changes are required? Add test coverage on trace logging logic
* What is the old behavior before changes and new behavior after changes? Trace logging supplied functions wouldn't be executed, now executed in tests

### Issues Resolved
[List any issues this PR will resolve]

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
Performed some unit testing to verify trace suppliers were executed.
```
    @Test
    void verifyTraceLogSupplersExecuted() {
        var traceArgExecuted = new AtomicInteger(0);
        log.atTrace().setMessage("TraceArgExecuted {} times").addArgument(traceArgExecuted::incrementAndGet).log();
        Assertions.assertEquals(1, traceArgExecuted.get());
    }
```

### Check List
- [ ] New functionality includes testing
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
