### PR TITLE
Reduce gradle test output from +599 MB -> 300kb

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,7 +69,6 @@ subprojects {
             showExceptions true
             showCauses true
             showStackTraces true
-            showStandardStreams = true
         }
 
         // Provide way to exclude particular tests from CLI


### PR DESCRIPTION
### Description
When running full test suites printing all the output to std out blows out the console window and overloads the github action logs.  All this data is still avaliable in the junit reports that can be downloaded from the GitHub actions or avaliable in
`${project.dir}/build/reports/tests/...`

### Issues
- Related https://github.com/opensearch-project/opensearch-migrations/pull/928

### Testing
I consulted the most recent build [1] after downloading the job logs, the gradle check was _600mb_, and this was truncated by GitHubs systems.
Doing the same check on [2] which was before the unified CC job, the gradle check was _277kb_.

- [1] https://github.com/opensearch-project/opensearch-migrations/actions/runs/10800784819/job/29959542405
- [2] https://github.com/opensearch-project/opensearch-migrations/actions/runs/10745741358/job/29805359911
### Check List
- [ ] ~New functionality includes testing~
  - [X] All tests pass, including unit test, integration test and doctest
- [ ] ~New functionality has been documented~
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
