### PR TITLE
Add Evaluate command and documentation for Metadata Migration 

### DIFF
--- a/MetadataMigration/DEVELOPER_GUIDE.md
+++ b/MetadataMigration/DEVELOPER_GUIDE.md
@@ -1,0 +1,83 @@
+## Metadata Migration Developer Guide
+
+- [Metadata Migration Developer Guide](#metadata-migration-developer-guide)
+- [Architecture](#architecture)
+- [How to run tests](#how-to-run-tests)
+- [How to use the tool interactively](#how-to-use-the-tool-interactively)
+  - [S3 Snapshot](#s3-snapshot)
+  - [On-Disk Snapshot](#on-disk-snapshot)
+  - [Handling Auth](#handling-auth)
+  - [Allowlisting the templates and indices to migrate](#allowlisting-the-templates-and-indices-to-migrate)
+
+## Architecture
+
+The Metadata migration project holds classes that is specific only to the CLI tool and end to end test cases for the CLI.  The majority of the business logic is in the RFS library as it is shared between [CreateSnapshot](../CreateSnapshot/README.md) and [DocumentFromSnapshotMigration](../DocumentsFromSnapshotMigration/README.md) tools.   
+
+```mermaid
+graph LR
+    mm[MetadataMigration] --> |Data models, Cluster Readers/Writers| RFS
+    mm --> |Transformation logic| t[transformation]
+    mm --> |Authentication, Telemetry| cu[coreUtilities]
+    mm --> |AWS functionality|au[awsUtilities]
+```
+
+## How to run tests
+
+Runs all unit test cases, very fast for running unit tests
+```shell
+./gradlew MetadataMigration:test
+```
+
+Run all test cases include starting up docker images for end to end verification, runtime will be at least 5 minutes.
+
+```shell
+./gradlew MetadataMigration:slowTest
+```
+
+(Often Used) Run end to end test cases for only a single source platform, tests all commands with a runtime of ~1 minute.
+```shell
+./gradlew MetadataMigration:slowTest --tests *metadataMigrateFrom_OS_v1_3*`
+```
+
+## How to use the tool interactively
+
+You can kick off the locally tool using Gradle.
+
+### S3 Snapshot
+
+From the root directory of the repo, run a CLI command like so:
+
+```shell
+./gradlew MetadataMigration:run --args='--snapshot-name reindex-from-snapshot --s3-local-dir /tmp/s3_files --s3-repo-uri s3://your-s3-uri --s3-region us-fake-1 --target-host http://hostname:9200'
+```
+
+In order for this succeed, you'll need to make sure you have valid AWS Credentials in your key ring (~/.aws/credentials) with permission to operate on the S3 URI specified.
+
+### On-Disk Snapshot
+
+From the root directory of the repo, run a CLI command like so:
+
+```shell
+./gradlew MetadataMigration:run --args='--snapshot-name reindex-from-snapshot --file-system-repo-path /snapshot --s3-region us-fake-1 --target-host http://hostname:9200'
+```
+
+### Handling Auth
+
+If your target cluster has basic auth enabled on it, you can supply those credentials to the tool via the CLI:
+
+```shell
+./gradlew MetadataMigration:run --args='--snapshot-name reindex-from-snapshot --s3-local-dir /tmp/s3_files --s3-repo-uri s3://your-s3-uri --s3-region us-fake-1 --target-host http://hostname:9200 --target-username <user> --target-password <pass>'
+```
+
+### Allowlisting the templates and indices to migrate
+
+By default, the tool has an empty allowlist for templates, meaning none will be migrated.  In contrast, the default allowlist for indices is open, meaning all non-system indices (those not prefixed with `.`) will be migrated.  You can tweak these allowlists with a comma-separated list of items you specifically with to migrate.  If you specify an custom allowlist for the templates or indices, the default allowlist is disregarded and **only** the items you have in your allowlist will be moved.
+
+```shell
+./gradlew MetadataMigration:run --args='--snapshot-name reindex-from-snapshot --s3-local-dir /tmp/s3_files --s3-repo-uri s3://your-s3-uri --s3-region us-fake-1 --target-host http://hostname:9200 --index-allowlist Index1,.my_system_index,logs-2023 --index-template-allowlist logs_template --component-template-allowlist component2,component7'
+```
+
+In the above example, the tool will migrate the following items from the snapshot per the allowlist:
+* The indices `Index1`, `.my_system_index`, and `logs-2023`
+* The index template `logs_template`
+* The component templates `component2` and `component7`

--- a/MetadataMigration/README.md
+++ b/MetadataMigration/README.md
@@ -1,50 +1,138 @@
-# metadata-migration
 
-## What is this tool?
+## Metadata Migration
+When performing a migration of a search cluster, the metadata items such as indexes, templates, configuration and processes need to be in place before document data can be moved.  The metadata migration tool provides insight into what can be moved, if there are any issues moving data to the target cluster, and can deploy those changes.  By inspecting and analyzing the metadata, issues can be discovered early in the overall migration timeline.
 
-This tool exposes the underlying Reindex-From-Snapshot (RFS) core library in a executable that will migrate the templates and indices in a specified snapshot of a source cluster to a target cluster.  In brief, it parses the contents of the snapshot to extract the settings/configuration of the templates and indices in the snapshot and then migrates those to the target cluster.  The snapshot can either be local on disk or in S3.  The user can apply allowlists to filter which templates/indices are migrated.  If a template or index of the same name already exists on the target cluster, this tool will not overwrite the existing one on the target.  
+- [Metadata Migration](#metadata-migration)
+- [Run Metadata Migration](#run-metadata-migration)
+  - [Metadata verification with evaluate command](#metadata-verification-with-evaluate-command)
+  - [Metadata migration with migrate command](#metadata-migration-with-migrate-command)
+  - [Metadata verification process](#metadata-verification-process)
+- [How does this tool work?](#how-does-this-tool-work)
+  - [Breaking change compatibility](#breaking-change-compatibility)
+    - [Deprecation of Mapping Types](#deprecation-of-mapping-types)
 
-The tool will also apply some basic transformations to the template and index settings in an attempt to handle upgrades between version-specific behavior.  Further work is planned to flesh out this process; see [this design doc](./docs/DESIGN.md).
+## Run Metadata Migration
 
-## How to use the tool
+Metadata migration is part of the Migration Assistant and can be accessed through the migration console. This is the recommended way to run this tool.  If you are feeling adventurous, the tool can be run locally by following the instructions in the [DEVELOPER_GUIDE.md](./DEVELOPER_GUIDE.md).
 
-You can kick off the locally tool using Gradle.
+Metadata migration is a relatively fast process to execute so we recommend attempting this workflow as quickly as possible to discover any issues which could impact longer running migration steps.
 
-### S3 Snapshot
-
-From the root directory of the repo, run a CLI command like so:
-
+### Metadata verification with evaluate command
 ```shell
-./gradlew MetadataMigration:run --args='--snapshot-name reindex-from-snapshot --s3-local-dir /tmp/s3_files --s3-repo-uri s3://your-s3-uri --s3-region us-fake-1 --target-host http://hostname:9200'
+console metadata evaluate
 ```
 
-In order for this succeed, you'll need to make sure you have valid AWS Credentials in your key ring (~/.aws/credentials) with permission to operate on the S3 URI specified.
+**Example evaluate command output:**
+```
+Starting Metadata Evaluation
+Clusters:
+   Source:q
+      Remote Cluster: OpenSearch 1.3.16 ConnectionContext(uri=http://localhost:33039, protocol=HTTP, insecure=false, compressionSupported=false)
 
-### On-Disk Snapshot
+   Target:
+      Remote Cluster: OpenSearch 2.14.0 ConnectionContext(uri=http://localhost:33037, protocol=HTTP, insecure=false, compressionSupported=false)
 
-From the root directory of the repo, run a CLI command like so:
 
-```shell
-./gradlew MetadataMigration:run --args='--snapshot-name reindex-from-snapshot --file-system-repo-path /snapshot --s3-region us-fake-1 --target-host http://hostname:9200'
+Migration Candidates:
+   Index Templates:
+      simple_index_template
+
+   Component Templates:
+      simple_component_template
+
+   Indexes:
+      blog_2023, movies_2023
+
+   Aliases:
+      alias1, movies-alias
+
+
+Results:
+   0 issue(s) detected
 ```
 
-### Handling Auth
-
-If your target cluster has basic auth enabled on it, you can supply those credentials to the tool via the CLI:
+### Metadata migration with migrate command
 
 ```shell
-./gradlew MetadataMigration:run --args='--snapshot-name reindex-from-snapshot --s3-local-dir /tmp/s3_files --s3-repo-uri s3://your-s3-uri --s3-region us-fake-1 --target-host http://hostname:9200 --target-username <user> --target-password <pass>'
+console metadata migrate
 ```
 
-### Allowlisting the templates and indices to migrate
+**Example migrate command output:**
+```
+Starting Metadata Migration
 
-By default, the tool has an empty allowlist for templates, meaning none will be migrated.  In contrast, the default allowlist for indices is open, meaning all non-system indices (those not prefixed with `.`) will be migrated.  You can tweak these allowlists with a comma-separated list of items you specifically with to migrate.  If you specify an custom allowlist for the templates or indices, the default allowlist is disregarded and **only** the items you have in your allowlist will be moved.
+Clusters:
+   Source:
+      Snapshot: OpenSearch 1.3.16 FileSystemRepo(repoRootDir=/tmp/junit10626813752669559861)
 
-```shell
-./gradlew MetadataMigration:run --args='--snapshot-name reindex-from-snapshot --s3-local-dir /tmp/s3_files --s3-repo-uri s3://your-s3-uri --s3-region us-fake-1 --target-host http://hostname:9200 --index-allowlist Index1,.my_system_index,logs-2023 --index-template-allowlist logs_template --component-template-allowlist component2,component7'
+   Target:
+      Remote Cluster: OpenSearch 2.14.0 ConnectionContext(uri=http://localhost:33042, protocol=HTTP, insecure=false, compressionSupported=false)
+
+
+Migrated Items:
+   Index Templates:
+      simple_index_template
+
+   Component Templates:
+      simple_component_template
+
+   Indexes:
+      blog_2023, movies_2023
+
+   Aliases:
+      alias1, movies-alias
+
+
+Results:
+   0 issue(s) detected
 ```
 
-In the above example, the tool will migrate the following items from the snapshot per the allowlist:
-* The indices `Index1`, `.my_system_index`, and `logs-2023`
-* The index template `logs_template`
-* The component templates `component2` and `component7`
+### Metadata verification process
+
+Before moving on to additional migration steps, it is recommended to confirm details of your cluster.  Depending on your configuration, this could be checking the sharding strategy or making sure index mappings are correctly defined by ingesting a test document.
+
+## How does this tool work?
+
+This tool gathers information from a source cluster, through a snapshot or through HTTP requests against the source cluster.  These snapshots are fully compatible with Reindex-From-Snapshot (RFS) scenarios, [learn more](../DocumentsFromSnapshotMigration/README.md).
+
+After collecting information on the source cluster comparisons are made on the target cluster.  If running a migration, any metadata items do not already exist will be created on the target cluster.
+
+### Breaking change compatibility
+
+Metadata migration needs to modify data from the source to the target versions to recreate items.  Sometimes these features are no longer supported and have been removed from the target version.  Sometimes these features are not available on the target version, which is especially true when downgrading.  While this tool is meant to make this process easier, it is not exhaustive in its support.  When encountering a compatibility issue or an important feature gap for your migration, please [search the issues](https://github.com/opensearch-project/opensearch-migrations/issues) and comment + upvote or a [create a new](https://github.com/opensearch-project/opensearch-migrations/issues/new/choose) issue if one cannot be found.
+
+#### Deprecation of Mapping Types
+In Elasticsearch 6.8 the mapping types feature was discontinued in Elasticsearch 7.0+ which has created complexity in migrating to newer versions of Elasticsearch and OpenSearch, [learn more](https://www.elastic.co/guide/en/elasticsearch/reference/7.17/removal-of-types.html).
+
+As Metadata migration supports migrating from ES 6.8 on to the latest versions of OpenSearch this scenario is handled by removing the type mapping types and restructuring the template or index properties.  Note that, at the time of this writing multiple type mappings are not supported, [tracking task](https://opensearch.atlassian.net/browse/MIGRATIONS-1778).
+
+
+**Example starting state with mapping type foo (ES 6):**
+```json
+{
+  "mappings": [
+    {
+      "foo": {
+        "properties": {
+          "field1": { "type": "text" },
+          "field2": { "type": "keyword" }
+        }
+      }
+    }
+  ]
+}
+```
+
+**Example ending state with foo removed (ES 7):**
+```json
+{
+  "mappings": {
+    "properties": {
+      "field1": { "type": "text" },
+      "field2": { "type": "keyword" },
+    }
+  }
+}
+```
+
+*Technical details are available, [view source code](../transformation/src/main/java/org/opensearch/migrations/transformation/rules/IndexMappingTypeRemoval.java).*

--- a/MetadataMigration/src/main/java/org/opensearch/migrations/MetadataCommands.java
+++ b/MetadataMigration/src/main/java/org/opensearch/migrations/MetadataCommands.java
@@ -1,0 +1,10 @@
+package org.opensearch.migrations;
+
+/** The list of supported commands for the metadata tool */
+public enum MetadataCommands {
+    /** Migrates items from a source and recreates them on the target cluster */
+    Migrate,
+
+    /** Inspects items from a source to determine which can be placed on a target cluster */
+    Evaluate;
+}

--- a/MetadataMigration/src/main/java/org/opensearch/migrations/MetadataMigration.java
+++ b/MetadataMigration/src/main/java/org/opensearch/migrations/MetadataMigration.java
@@ -1,8 +1,13 @@
 package org.opensearch.migrations;
 
+import java.util.Optional;
+
 import org.opensearch.migrations.commands.Configure;
 import org.opensearch.migrations.commands.Evaluate;
+import org.opensearch.migrations.commands.EvaluateArgs;
 import org.opensearch.migrations.commands.Migrate;
+import org.opensearch.migrations.commands.MigrateArgs;
+import org.opensearch.migrations.commands.Result;
 import org.opensearch.migrations.metadata.tracing.RootMetadataMigrationContext;
 import org.opensearch.migrations.tracing.ActiveContextTracker;
 import org.opensearch.migrations.tracing.ActiveContextTrackerByActivityType;
@@ -18,13 +23,14 @@ public class MetadataMigration {
 
     public static void main(String[] args) throws Exception {
         var arguments = new MetadataArgs();
-        var jCommander = JCommander.newBuilder().addObject(arguments).build();
+        var migrateArgs = new MigrateArgs();
+        var evaluateArgs = new EvaluateArgs(); 
+        var jCommander = JCommander.newBuilder()
+            .addObject(arguments)
+            .addCommand(migrateArgs)
+            .addCommand(evaluateArgs)
+            .build();
         jCommander.parse(args);
-
-        if (arguments.help) {
-            jCommander.usage();
-            return;
-        }
 
         var context = new RootMetadataMigrationContext(
             RootOtelContext.initializeOpenTelemetryWithCollectorOrAsNoop(arguments.otelCollectorEndpoint, "metadata",
@@ -34,10 +40,28 @@ public class MetadataMigration {
 
         var meta = new MetadataMigration(arguments);
 
-        log.info("Starting Metadata Migration");
+        log.atInfo().setMessage("Command line arguments: {}").addArgument(String.join(" ", args)).log();
 
-        var result = meta.migrate().execute(context);
+        if (arguments.help || jCommander.getParsedCommand() == null) {
+            jCommander.usage();
+            return;
+        }
 
+        var command = Optional.ofNullable(jCommander.getParsedCommand())
+            .map(cmd -> Enum.valueOf(MetadataCommands.class, cmd))
+            .orElse(MetadataCommands.Migrate);
+        Result result;
+        switch (command) {
+            default:
+            case Migrate:
+                log.info("Starting Metadata Migration");
+                result = meta.migrate().execute(context);
+                break;
+            case Evaluate:
+                log.info("Starting Metadata Evaluation");
+                result = meta.evaluate().execute(context);
+                break;
+        }
         log.info(result.toString());
         System.exit(result.getExitCode());
     }
@@ -53,7 +77,7 @@ public class MetadataMigration {
     }
 
     public Evaluate evaluate() {
-        return new Evaluate();
+        return new Evaluate(arguments);
     }
 
     public Migrate migrate() {

--- a/MetadataMigration/src/main/java/org/opensearch/migrations/cli/Items.java
+++ b/MetadataMigration/src/main/java/org/opensearch/migrations/cli/Items.java
@@ -16,6 +16,7 @@ public class Items {
     public List<String> indexTemplates;
     public List<String> componentTemplates;
     public List<String> indexes;
+    public List<String> aliases;
 
     public String toString() {
         var sb = new StringBuilder();
@@ -33,6 +34,9 @@ public class Items {
         sb.append("   Indexes:" + System.lineSeparator());
         sb.append("      " + getPrintableList(getIndexes()) + System.lineSeparator());
         sb.append(System.lineSeparator());
+        sb.append("   Aliases:" + System.lineSeparator());
+        sb.append("      " + getPrintableList(getAliases()) + System.lineSeparator());
+        sb.append(System.lineSeparator());
         return sb.toString();
     }
 
@@ -40,6 +44,6 @@ public class Items {
         if (list == null || list.isEmpty()) {
             return "<NONE FOUND>";
         }
-        return list.stream().collect(Collectors.joining(", "));
+        return list.stream().sorted().collect(Collectors.joining(", "));
     }
 }

--- a/MetadataMigration/src/main/java/org/opensearch/migrations/commands/Evaluate.java
+++ b/MetadataMigration/src/main/java/org/opensearch/migrations/commands/Evaluate.java
@@ -1,12 +1,47 @@
 package org.opensearch.migrations.commands;
 
+import org.opensearch.migrations.MetadataArgs;
+import org.opensearch.migrations.MigrationMode;
+import org.opensearch.migrations.metadata.tracing.RootMetadataMigrationContext;
+
+import com.beust.jcommander.ParameterException;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
-public class Evaluate {
+public class Evaluate extends MigratorEvaluatorBase {
 
-    public EvaluateResult execute() {
-        log.atError().setMessage("evaluate is not supported").log();
-        return new EvaluateResult(9999);
+    public Evaluate(MetadataArgs arguments) {
+        super(arguments);
+    }
+
+    public EvaluateResult execute(RootMetadataMigrationContext context) {
+        var migrationMode = MigrationMode.SIMULATE;
+        var evaluateResult = EvaluateResult.builder();
+
+        try {
+            log.info("Running Metadata Evaluation");
+
+            var clusters = createClusters();
+            evaluateResult.clusters(clusters);
+
+            var transformer = selectTransformer(clusters);
+
+            var items = migrateAllItems(migrationMode, clusters, transformer, context);
+            evaluateResult.items(items);
+        } catch (ParameterException pe) {
+            log.atError().setMessage("Invalid parameter").setCause(pe).log();
+            evaluateResult
+                .exitCode(INVALID_PARAMETER_CODE)
+                .errorMessage("Invalid parameter: " + pe.getMessage())
+                .build();
+        } catch (Throwable e) {
+            log.atError().setMessage("Unexpected failure").setCause(e).log();
+            evaluateResult
+                .exitCode(UNEXPECTED_FAILURE_CODE)
+                .errorMessage("Unexpected failure: " + e.getMessage())
+                .build();
+        }
+
+        return evaluateResult.build();
     }
 }

--- a/MetadataMigration/src/main/java/org/opensearch/migrations/commands/EvaluateArgs.java
+++ b/MetadataMigration/src/main/java/org/opensearch/migrations/commands/EvaluateArgs.java
@@ -1,0 +1,7 @@
+package org.opensearch.migrations.commands;
+
+import com.beust.jcommander.Parameters;
+
+@Parameters(commandNames = "Evaluate", commandDescription = "Inspects items from a source to determine which can be placed on a target cluster")
+public class EvaluateArgs {
+}

--- a/MetadataMigration/src/main/java/org/opensearch/migrations/commands/EvaluateResult.java
+++ b/MetadataMigration/src/main/java/org/opensearch/migrations/commands/EvaluateResult.java
@@ -1,10 +1,37 @@
 package org.opensearch.migrations.commands;
 
-import lombok.AllArgsConstructor;
+import org.apache.logging.log4j.util.Strings;
+
+import org.opensearch.migrations.cli.Clusters;
+import org.opensearch.migrations.cli.Items;
+
+import lombok.Builder;
 import lombok.Getter;
 
-@AllArgsConstructor
-public class EvaluateResult implements Result {
-    @Getter
+@Builder
+@Getter
+public class EvaluateResult implements MigrationItemResult {
+    private final Clusters clusters;
+    private final Items items;
+    private final String errorMessage;
     private final int exitCode;
+
+    public String toString() {
+        var sb = new StringBuilder();
+        if (getClusters() != null) {
+            sb.append(getClusters() + System.lineSeparator());
+        }
+        if (getItems() != null) {
+            sb.append(getItems() + System.lineSeparator());
+        }
+        sb.append("Results:" + System.lineSeparator());
+        if (Strings.isNotBlank(getErrorMessage())) {
+            sb.append("   Issue(s) detected" + System.lineSeparator());
+            sb.append("Issues:" + System.lineSeparator());
+            sb.append("   " + getErrorMessage() + System.lineSeparator());
+        } else {
+            sb.append("   " + getExitCode() + " issue(s) detected" + System.lineSeparator());
+        }
+        return sb.toString();
+    }
 }

--- a/MetadataMigration/src/main/java/org/opensearch/migrations/commands/Migrate.java
+++ b/MetadataMigration/src/main/java/org/opensearch/migrations/commands/Migrate.java
@@ -1,96 +1,47 @@
 package org.opensearch.migrations.commands;
 
-import java.util.ArrayList;
-
 import org.opensearch.migrations.MetadataArgs;
-import org.opensearch.migrations.cli.ClusterReaderExtractor;
-import org.opensearch.migrations.cli.Clusters;
-import org.opensearch.migrations.cli.Items;
-import org.opensearch.migrations.cluster.ClusterProviderRegistry;
+import org.opensearch.migrations.MigrationMode;
 import org.opensearch.migrations.metadata.tracing.RootMetadataMigrationContext;
 
 import com.beust.jcommander.ParameterException;
-import com.rfs.transformers.TransformFunctions;
-import com.rfs.worker.IndexRunner;
-import com.rfs.worker.MetadataRunner;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
-public class Migrate {
-
-    static final int INVALID_PARAMETER_CODE = 999;
-    static final int UNEXPECTED_FAILURE_CODE = 888;
-    private final MetadataArgs arguments;
-    private final ClusterReaderExtractor clusterReaderCliExtractor;
+public class Migrate extends MigratorEvaluatorBase {
 
     public Migrate(MetadataArgs arguments) {
-        this.arguments = arguments;
-        clusterReaderCliExtractor = new ClusterReaderExtractor(arguments);
+        super(arguments);
     }
 
     public MigrateResult execute(RootMetadataMigrationContext context) {
-        var migrateResult = MigrateResult.builder();
-        log.atInfo().setMessage("Command line arguments {0}").addArgument(arguments::toString).log();
+        var migrationMode = MigrationMode.PERFORM;
+        var evaluateResult = MigrateResult.builder();
 
         try {
-            log.info("Running Metadata worker");
+            log.info("Running Metadata Evaluation");
 
-            var clusters = Clusters.builder();
-            var sourceCluster = clusterReaderCliExtractor.extractClusterReader();
-            clusters.source(sourceCluster);
+            var clusters = createClusters();
+            evaluateResult.clusters(clusters);
 
-            var targetCluster = ClusterProviderRegistry.getRemoteWriter(arguments.targetArgs.toConnectionContext(), arguments.dataFilterArgs);
-            clusters.target(targetCluster);
-            migrateResult.clusters(clusters.build());
+            var transformer = selectTransformer(clusters);
 
-            var transformer = TransformFunctions.getTransformer(
-                sourceCluster.getVersion(),
-                targetCluster.getVersion(),
-                arguments.minNumberOfReplicas
-            );
-
-            log.info("Using transformation " + transformer.toString());
-
-            var metadataResults = new MetadataRunner(
-                arguments.snapshotName,
-                sourceCluster.getGlobalMetadata(),
-                targetCluster.getGlobalMetadataCreator(),
-                transformer
-            ).migrateMetadata(context.createMetadataMigrationContext());
-
-            var items = Items.builder();
-            var indexTemplates = new ArrayList<String>();
-            indexTemplates.addAll(metadataResults.getLegacyTemplates());
-            indexTemplates.addAll(metadataResults.getIndexTemplates());
-            items.indexTemplates(indexTemplates);
-            items.componentTemplates(metadataResults.getComponentTemplates());
-
-            log.info("Metadata copy complete.");
-
-            var indexes = new IndexRunner(
-                arguments.snapshotName,
-                sourceCluster.getIndexMetadata(),
-                targetCluster.getIndexCreator(),
-                transformer,
-                arguments.dataFilterArgs.indexAllowlist
-            ).migrateIndices(context.createIndexContext());
-            items.indexes(indexes);
-            migrateResult.items(items.build());
-            log.info("Index copy complete.");
+            var items = migrateAllItems(migrationMode, clusters, transformer, context);
+            evaluateResult.items(items);
         } catch (ParameterException pe) {
             log.atError().setMessage("Invalid parameter").setCause(pe).log();
-            migrateResult
+            evaluateResult
                 .exitCode(INVALID_PARAMETER_CODE)
                 .errorMessage("Invalid parameter: " + pe.getMessage())
                 .build();
         } catch (Throwable e) {
             log.atError().setMessage("Unexpected failure").setCause(e).log();
-            migrateResult
+            evaluateResult
                 .exitCode(UNEXPECTED_FAILURE_CODE)
                 .errorMessage("Unexpected failure: " + e.getMessage())
                 .build();
         }
 
-        return migrateResult.build();
+        return evaluateResult.build();
     }
 }

--- a/MetadataMigration/src/main/java/org/opensearch/migrations/commands/MigrateArgs.java
+++ b/MetadataMigration/src/main/java/org/opensearch/migrations/commands/MigrateArgs.java
@@ -1,0 +1,7 @@
+package org.opensearch.migrations.commands;
+
+import com.beust.jcommander.Parameters;
+
+@Parameters(commandNames = "migrate", commandDescription = "Migrates items from a source and recreates them on the target cluster")
+public class MigrateArgs {
+}

--- a/MetadataMigration/src/main/java/org/opensearch/migrations/commands/MigrateResult.java
+++ b/MetadataMigration/src/main/java/org/opensearch/migrations/commands/MigrateResult.java
@@ -10,7 +10,7 @@ import lombok.Getter;
 
 @Builder
 @Getter
-public class MigrateResult implements Result {
+public class MigrateResult implements MigrationItemResult {
     private final Clusters clusters;
     private final Items items;
     private final String errorMessage;

--- a/MetadataMigration/src/main/java/org/opensearch/migrations/commands/MigrationItemResult.java
+++ b/MetadataMigration/src/main/java/org/opensearch/migrations/commands/MigrationItemResult.java
@@ -1,0 +1,10 @@
+package org.opensearch.migrations.commands;
+
+import org.opensearch.migrations.cli.Clusters;
+import org.opensearch.migrations.cli.Items;
+
+/** All shared cli result information */
+public interface MigrationItemResult extends Result {
+    Clusters getClusters();
+    Items getItems();
+}

--- a/MetadataMigration/src/main/java/org/opensearch/migrations/commands/MigratorEvaluatorBase.java
+++ b/MetadataMigration/src/main/java/org/opensearch/migrations/commands/MigratorEvaluatorBase.java
@@ -1,0 +1,97 @@
+package org.opensearch.migrations.commands;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.opensearch.migrations.MetadataArgs;
+import org.opensearch.migrations.MigrationMode;
+import org.opensearch.migrations.cli.ClusterReaderExtractor;
+import org.opensearch.migrations.cli.Clusters;
+import org.opensearch.migrations.cli.Items;
+import org.opensearch.migrations.cluster.ClusterProviderRegistry;
+import org.opensearch.migrations.metadata.GlobalMetadataCreatorResults;
+import org.opensearch.migrations.metadata.tracing.RootMetadataMigrationContext;
+
+import com.rfs.transformers.TransformFunctions;
+import com.rfs.transformers.Transformer;
+import com.rfs.worker.IndexRunner;
+import com.rfs.worker.MetadataRunner;
+import lombok.extern.slf4j.Slf4j;
+
+/** Shared functionality between migration and evaluation commands */
+@Slf4j
+public abstract class MigratorEvaluatorBase {
+
+    static final int INVALID_PARAMETER_CODE = 999;
+    static final int UNEXPECTED_FAILURE_CODE = 888;
+
+    protected final MetadataArgs arguments;
+    protected final ClusterReaderExtractor clusterReaderCliExtractor;
+
+    protected MigratorEvaluatorBase(MetadataArgs arguments) {
+        this.arguments = arguments;
+        this.clusterReaderCliExtractor = new ClusterReaderExtractor(arguments);
+    }
+
+    protected Clusters createClusters() {
+        var clusters = Clusters.builder();
+        var sourceCluster = clusterReaderCliExtractor.extractClusterReader();
+        clusters.source(sourceCluster);
+
+        var targetCluster = ClusterProviderRegistry.getRemoteWriter(arguments.targetArgs.toConnectionContext(), arguments.dataFilterArgs);
+        clusters.target(targetCluster);
+        return clusters.build();
+    }
+
+    protected Transformer selectTransformer(Clusters clusters) {
+        var transformer = TransformFunctions.getTransformer(
+            clusters.getSource().getVersion(),
+            clusters.getTarget().getVersion(),
+            arguments.minNumberOfReplicas
+        );
+        log.info("Selected transformer " + transformer.toString());
+        return transformer;
+    }
+
+    protected Items migrateAllItems(MigrationMode migrationMode, Clusters clusters, Transformer transformer, RootMetadataMigrationContext context) {
+        var items = Items.builder();
+        items.dryRun(migrationMode.equals(MigrationMode.SIMULATE));
+        var metadataResults = migrateGlobalMetadata(migrationMode, clusters, transformer, context);
+
+        var indexTemplates = new ArrayList<String>();
+        indexTemplates.addAll(metadataResults.getLegacyTemplates());
+        indexTemplates.addAll(metadataResults.getIndexTemplates());
+        items.indexTemplates(indexTemplates);
+        items.componentTemplates(metadataResults.getComponentTemplates());
+
+        var indexes = migrateIndices(migrationMode, clusters, transformer, context);
+
+        items.indexes(indexes);
+        return items.build();
+    }
+
+    private GlobalMetadataCreatorResults migrateGlobalMetadata(MigrationMode mode, Clusters clusters, Transformer transformer, RootMetadataMigrationContext context) {
+        var metadataRunner = new MetadataRunner(
+            arguments.snapshotName,
+            clusters.getSource().getGlobalMetadata(),
+            clusters.getTarget().getGlobalMetadataCreator(),
+            transformer
+        );
+        var metadataResults = metadataRunner.migrateMetadata(mode, context.createMetadataMigrationContext());
+        log.info("Metadata copy complete.");
+        return metadataResults;
+    }
+
+    private List<String> migrateIndices(MigrationMode mode, Clusters clusters, Transformer transformer, RootMetadataMigrationContext context) {
+        var indexRunner = new IndexRunner(
+            arguments.snapshotName,
+            clusters.getSource().getIndexMetadata(),
+            clusters.getTarget().getIndexCreator(),
+            transformer,
+            arguments.dataFilterArgs.indexAllowlist
+        );
+        var indexes = indexRunner.migrateIndices(mode, context.createIndexContext());
+        log.info("Index copy complete.");
+        return indexes;
+    } 
+}

--- a/MetadataMigration/src/test/java/org/opensearch/migrations/EndToEndTest.java
+++ b/MetadataMigration/src/test/java/org/opensearch/migrations/EndToEndTest.java
@@ -5,14 +5,12 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Stream;
 
-import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.ArgumentsSource;
-import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
+
 import org.opensearch.migrations.commands.MigrationItemResult;
 import org.opensearch.migrations.metadata.tracing.MetadataMigrationTestContext;
 import org.opensearch.migrations.snapshot.creation.tracing.SnapshotTestContext;
@@ -27,8 +25,12 @@ import com.rfs.worker.SnapshotRunner;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 
+import static org.hamcrest.CoreMatchers.allOf;
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 
 /**
  * Tests focused on setting up whole source clusters, performing a migration, and validation on the target cluster
@@ -119,21 +121,20 @@ class EndToEndTest {
             throw new RuntimeException("This test cannot handle the source cluster version" + sourceVersion);
         }
 
+        var testData = new TestData();
         // Create the component and index templates
         var sourceClusterOperations = new ClusterOperations(sourceCluster.getUrl());
-        var compoTemplateName = "simple_component_template";
-        var indexTemplateName = "simple_index_template";
         if (sourceIsES7_X) {
-            sourceClusterOperations.createES7Templates(compoTemplateName, indexTemplateName, "author", "blog*");
+            sourceClusterOperations.createES7Templates(testData.compoTemplateName, testData.indexTemplateName, "author", "blog*");
         } else if (sourceIsES6_8) {
-            sourceClusterOperations.createES6LegacyTemplate(indexTemplateName, "movies*");
+            sourceClusterOperations.createES6LegacyTemplate(testData.indexTemplateName, "movies*");
         }
 
         // Creates a document that uses the template
-        var blogIndexName = "blog_2023";
-        sourceClusterOperations.createDocument(blogIndexName, "222", "{\"author\":\"Tobias Funke\"}");
-        var movieIndexName = "movies_2023";
-        sourceClusterOperations.createDocument(movieIndexName,"123", "{\"title\":\"This is spinal tap\"}");
+        sourceClusterOperations.createDocument(testData.blogIndexName, "222", "{\"author\":\"Tobias Funke\"}");
+        sourceClusterOperations.createDocument(testData.movieIndexName,"123", "{\"title\":\"This is spinal tap\"}");
+
+        sourceClusterOperations.createAlias(testData.aliasName, "movies*");
 
         var arguments = new MetadataArgs();
 
@@ -168,9 +169,9 @@ class EndToEndTest {
         arguments.targetArgs.host = targetCluster.getUrl();
 
         var dataFilterArgs = new DataFilterArgs();
-        dataFilterArgs.indexAllowlist = List.of(blogIndexName, movieIndexName);
-        dataFilterArgs.componentTemplateAllowlist = List.of(compoTemplateName);
-        dataFilterArgs.indexTemplateAllowlist = List.of(indexTemplateName);
+        dataFilterArgs.indexAllowlist = List.of(testData.blogIndexName, testData.movieIndexName);
+        dataFilterArgs.componentTemplateAllowlist = List.of(testData.compoTemplateName);
+        dataFilterArgs.indexTemplateAllowlist = List.of(testData.indexTemplateName);
         arguments.dataFilterArgs = dataFilterArgs;
 
 
@@ -179,35 +180,78 @@ class EndToEndTest {
         var metadata = new MetadataMigration(arguments);
         
         MigrationItemResult result;
-        int expectedResponseCode;
-        if (MetadataCommands.Evaluate.equals(command)) {
-            result = metadata.evaluate().execute(metadataContext);
-            expectedResponseCode = 404;
-        } else if (MetadataCommands.Migrate.equals(command)) {
+        if (MetadataCommands.Migrate.equals(command)) {
             result = metadata.migrate().execute(metadataContext);
-            expectedResponseCode = 200;
         } else {
-            throw new RuntimeException("Unexpected command " + command);
+            result = metadata.evaluate().execute(metadataContext);
         }
 
+        verifyCommandResults(result, sourceIsES6_8, testData);
+
+        verifyTargetCluster(targetCluster, command, sourceIsES6_8, testData);
+    }
+
+    private static class TestData {
+        final String compoTemplateName = "simple_component_template";
+        final String indexTemplateName = "simple_index_template";
+        final String aliasInTemplate = "alias1";
+        final String blogIndexName = "blog_2023";
+        final String movieIndexName = "movies_2023";
+        final String aliasName = "movies-alias";
+    }
+
+    private void verifyCommandResults(
+        MigrationItemResult result,
+        boolean sourceIsES6_8,
+        TestData testData) {
         log.info(result.toString());
         assertThat(result.getExitCode(), equalTo(0));
 
+        var migratedItems = result.getItems();
+        assertThat(migratedItems.getIndexTemplates(), containsInAnyOrder(testData.indexTemplateName));
+        assertThat(migratedItems.getComponentTemplates(), equalTo(sourceIsES6_8 ? List.of() : List.of(testData.compoTemplateName)));
+        assertThat(migratedItems.getIndexes(), containsInAnyOrder(testData.blogIndexName, testData.movieIndexName));
+        assertThat(migratedItems.getAliases(), containsInAnyOrder(testData.aliasInTemplate, testData.aliasName));
+    }
+
+    private void verifyTargetCluster(
+        SearchClusterContainer targetCluster,
+        MetadataCommands command,
+        boolean sourceIsES6_8,
+        TestData testData
+        ) {
+        var expectUpdatesOnTarget = MetadataCommands.Migrate.equals(command);
+        // If the command was migrate, the target cluster should have the items, if not they
+        var verifyResponseCode = expectUpdatesOnTarget ? equalTo(200) : equalTo(404);
+
         // Check that the index was migrated
         var targetClusterOperations = new ClusterOperations(targetCluster.getUrl());
-        var res = targetClusterOperations.get("/" + blogIndexName);
-        assertThat(res.getValue(), res.getKey(), equalTo(expectedResponseCode));
+        var res = targetClusterOperations.get("/" + testData.blogIndexName);
+        assertThat(res.getValue(), res.getKey(), verifyResponseCode);
 
-        res = targetClusterOperations.get("/" + movieIndexName);
-        assertThat(res.getValue(), res.getKey(), equalTo(expectedResponseCode));
-        
+        res = targetClusterOperations.get("/" + testData.movieIndexName);
+        assertThat(res.getValue(), res.getKey(), verifyResponseCode);
+
+        res = targetClusterOperations.get("/" + testData.aliasName);
+        assertThat(res.getValue(), res.getKey(), verifyResponseCode);
+        if (expectUpdatesOnTarget) {
+            assertThat(res.getValue(), containsString(testData.movieIndexName));
+        }
+
+        res = targetClusterOperations.get("/_aliases");
+        assertThat(res.getValue(), res.getKey(), equalTo(200));
+        var verifyAliasWasListed = allOf(containsString(testData.aliasInTemplate), containsString(testData.aliasName));
+        assertThat(res.getValue(), expectUpdatesOnTarget ? verifyAliasWasListed : not(expectUpdatesOnTarget));
+
         // Check that the templates were migrated
-        if (sourceIsES7_X) {
-            res = targetClusterOperations.get("/_index_template/" + indexTemplateName);
-            assertThat(res.getValue(), res.getKey(), equalTo(expectedResponseCode));
-        } else if (sourceIsES6_8) {
-            res = targetClusterOperations.get("/_template/" + indexTemplateName);
-            assertThat(res.getValue(), res.getKey(), equalTo(expectedResponseCode));
+        if (sourceIsES6_8) {
+            res = targetClusterOperations.get("/_template/" + testData.indexTemplateName);
+            assertThat(res.getValue(), res.getKey(), verifyResponseCode);
+            var verifyBodyHasComponentTemplate = containsString("composed_of\":[\"" + testData.compoTemplateName + "\"]");
+            assertThat(res.getValue(), expectUpdatesOnTarget ? verifyBodyHasComponentTemplate : not(verifyBodyHasComponentTemplate));
+        } else {
+            res = targetClusterOperations.get("/_index_template/" + testData.indexTemplateName);
+            assertThat(res.getValue(), res.getKey(), verifyResponseCode);
         }
     }
 }

--- a/MetadataMigration/src/test/java/org/opensearch/migrations/commands/EvaluateTest.java
+++ b/MetadataMigration/src/test/java/org/opensearch/migrations/commands/EvaluateTest.java
@@ -4,6 +4,8 @@ import org.junit.jupiter.api.Test;
 
 import org.opensearch.migrations.MetadataArgs;
 import org.opensearch.migrations.MetadataMigration;
+import org.opensearch.migrations.Version;
+import org.opensearch.migrations.metadata.tracing.RootMetadataMigrationContext;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -12,12 +14,16 @@ import static org.mockito.Mockito.mock;
 class EvaluateTest {
 
     @Test
-    void evaluate_notImplemented() {
-        var meta = new MetadataMigration(mock(MetadataArgs.class));
+    void evaluate_failsUnexpectedException() {
+        var args = new MetadataArgs();
+        args.sourceVersion = Version.fromString("ES 7.10");
+        args.fileSystemRepoPath = "";
 
-        var configureSource = meta.evaluate()
-            .execute();
+        var meta = new MetadataMigration(args);
+        var context = mock(RootMetadataMigrationContext.class);
+ 
+        var results = meta.evaluate().execute(context);
 
-        assertThat(configureSource.getExitCode(), equalTo(9999));
+        assertThat(results.getExitCode(), equalTo(Evaluate.UNEXPECTED_FAILURE_CODE));
     }
 }

--- a/RFS/src/main/java/com/rfs/common/OpenSearchClient.java
+++ b/RFS/src/main/java/com/rfs/common/OpenSearchClient.java
@@ -230,24 +230,24 @@ public class OpenSearchClient {
             .map(c -> c.createCheckRequestContext())
             .orElse(null);
         var getResponse = client.getAsync(objectPath, requestContext)
-        .flatMap(resp -> {
-            if (resp.statusCode == HttpURLConnection.HTTP_NOT_FOUND || resp.statusCode == HttpURLConnection.HTTP_OK) {
-                return Mono.just(resp);
-            } else {
-                String errorMessage = ("Could not create object: "
-                    + objectPath
-                    + ". Response Code: "
-                    + resp.statusCode
-                    + ", Response Message: "
-                    + resp.statusText
-                    + ", Response Body: "
-                    + resp.body);
-                return Mono.error(new OperationFailed(errorMessage, resp));
-            }
-        })
-        .doOnError(e -> log.error(e.getMessage()))
-        .retryWhen(checkIfItemExistsRetryStrategy)
-        .block();
+            .flatMap(resp -> {
+                if (resp.statusCode == HttpURLConnection.HTTP_NOT_FOUND || resp.statusCode == HttpURLConnection.HTTP_OK) {
+                    return Mono.just(resp);
+                } else {
+                    String errorMessage = ("Could not create object: "
+                        + objectPath
+                        + ". Response Code: "
+                        + resp.statusCode
+                        + ", Response Message: "
+                        + resp.statusText
+                        + ", Response Body: "
+                        + resp.body);
+                    return Mono.error(new OperationFailed(errorMessage, resp));
+                }
+            })
+            .doOnError(e -> log.error(e.getMessage()))
+            .retryWhen(checkIfItemExistsRetryStrategy)
+            .block();
 
         assert getResponse != null : ("getResponse should not be null; it should either be a valid response or an exception"
             + " should have been thrown.");

--- a/RFS/src/main/java/com/rfs/common/OpenSearchClient.java
+++ b/RFS/src/main/java/com/rfs/common/OpenSearchClient.java
@@ -148,6 +148,29 @@ public class OpenSearchClient {
         return createObjectIdempotent(targetPath, settings, context);
     }
 
+    /** Returns true if this template already exists */
+    public boolean hasLegacyTemplate(String templateName) {
+        var targetPath = "_template/" + templateName;
+        return hasObjectCheck(targetPath, null);
+    }
+
+    /** Returns true if this template already exists */
+    public boolean hasComponentTemplate(String templateName) {
+        var targetPath = "_component_template/" + templateName;
+        return hasObjectCheck(targetPath, null);
+    }
+
+    /** Returns true if this template already exists */
+    public boolean hasIndexTemplate(String templateName) {
+        var targetPath = "_index_template/" + templateName;
+        return hasObjectCheck(targetPath, null);
+    }
+
+    /** Returns true if this index already exists */
+    public boolean hasIndex(String indexName) {
+        return hasObjectCheck(indexName, null);
+    }
+
     /*
      * Create an index if it does not already exist.  Returns an Optional; if the index was created, it
      * will be the created object and empty otherwise.
@@ -166,29 +189,7 @@ public class OpenSearchClient {
         ObjectNode settings,
         IRfsContexts.ICheckedIdempotentPutRequestContext context
     ) {
-        HttpResponse getResponse = client.getAsync(objectPath, context.createCheckRequestContext())
-            .flatMap(resp -> {
-                if (resp.statusCode == HttpURLConnection.HTTP_NOT_FOUND || resp.statusCode == HttpURLConnection.HTTP_OK) {
-                    return Mono.just(resp);
-                } else {
-                    String errorMessage = ("Could not create object: "
-                        + objectPath
-                        + ". Response Code: "
-                        + resp.statusCode
-                        + ", Response Message: "
-                        + resp.statusText
-                        + ", Response Body: "
-                        + resp.body);
-                    return Mono.error(new OperationFailed(errorMessage, resp));
-                }
-            })
-            .doOnError(e -> log.error(e.getMessage()))
-            .retryWhen(checkIfItemExistsRetryStrategy)
-            .block();
-
-        assert getResponse != null : ("getResponse should not be null; it should either be a valid response or an exception"
-            + " should have been thrown.");
-        boolean objectDoesNotExist = getResponse.statusCode == HttpURLConnection.HTTP_NOT_FOUND;
+        var objectDoesNotExist = !hasObjectCheck(objectPath, context);
         if (objectDoesNotExist) {
             client.putAsync(objectPath, settings.toString(), context.createCheckRequestContext()).flatMap(resp -> {
                 if (resp.statusCode == HttpURLConnection.HTTP_OK) {
@@ -214,9 +215,43 @@ public class OpenSearchClient {
                 .block();
 
             return Optional.of(settings);
+        } else {
+            log.debug("Object at path {} already exists, not attempting to create.", objectPath);
         }
         // The only response code that can end up here is HTTP_OK, which means the object already existed
         return Optional.empty();
+    }
+
+    private boolean hasObjectCheck(
+        String objectPath,
+        IRfsContexts.ICheckedIdempotentPutRequestContext context
+    ) {
+        var requestContext = Optional.ofNullable(context)
+            .map(c -> c.createCheckRequestContext())
+            .orElse(null);
+        var getResponse = client.getAsync(objectPath, requestContext)
+        .flatMap(resp -> {
+            if (resp.statusCode == HttpURLConnection.HTTP_NOT_FOUND || resp.statusCode == HttpURLConnection.HTTP_OK) {
+                return Mono.just(resp);
+            } else {
+                String errorMessage = ("Could not create object: "
+                    + objectPath
+                    + ". Response Code: "
+                    + resp.statusCode
+                    + ", Response Message: "
+                    + resp.statusText
+                    + ", Response Body: "
+                    + resp.body);
+                return Mono.error(new OperationFailed(errorMessage, resp));
+            }
+        })
+        .doOnError(e -> log.error(e.getMessage()))
+        .retryWhen(checkIfItemExistsRetryStrategy)
+        .block();
+
+        assert getResponse != null : ("getResponse should not be null; it should either be a valid response or an exception"
+            + " should have been thrown.");
+        return getResponse.statusCode == HttpURLConnection.HTTP_OK;
     }
 
     /*

--- a/RFS/src/main/java/com/rfs/common/RestClient.java
+++ b/RFS/src/main/java/com/rfs/common/RestClient.java
@@ -41,6 +41,7 @@ import reactor.util.annotation.Nullable;
 public class RestClient {
     private final ConnectionContext connectionContext;
     private final HttpClient client;
+    private boolean disableWriteOperations;
 
     public static final String READ_METERING_HANDLER_NAME = "REST_CLIENT_READ_METERING_HANDLER";
     public static final String WRITE_METERING_HANDLER_NAME = "REST_CLIENT_WRITE_METERING_HANDLER";
@@ -239,6 +240,10 @@ public class RestClient {
 
     public HttpResponse put(String path, String body, IRfsContexts.IRequestContext context) {
         return putAsync(path, body, context).block();
+    }
+
+    public void disableRightOperations() {
+
     }
 
     private static void removeIfPresent(ChannelPipeline p, String name) {

--- a/RFS/src/main/java/com/rfs/version_os_2_11/GlobalMetadataCreator_OS_2_11.java
+++ b/RFS/src/main/java/com/rfs/version_os_2_11/GlobalMetadataCreator_OS_2_11.java
@@ -1,12 +1,13 @@
 package com.rfs.version_os_2_11;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Optional;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
+import org.opensearch.migrations.MigrationMode;
 import org.opensearch.migrations.metadata.GlobalMetadataCreator;
 import org.opensearch.migrations.metadata.GlobalMetadataCreatorResults;
 import org.opensearch.migrations.metadata.tracing.IMetadataMigrationContexts.IClusterMetadataContext;
@@ -14,147 +15,120 @@ import org.opensearch.migrations.metadata.tracing.IMetadataMigrationContexts.ICl
 import com.rfs.common.OpenSearchClient;
 import com.rfs.models.GlobalMetadata;
 import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @AllArgsConstructor
+@Slf4j
 public class GlobalMetadataCreator_OS_2_11 implements GlobalMetadataCreator {
-    private static final Logger logger = LogManager.getLogger(GlobalMetadataCreator_OS_2_11.class);
 
     private final OpenSearchClient client;
     private final List<String> legacyTemplateAllowlist;
     private final List<String> componentTemplateAllowlist;
     private final List<String> indexTemplateAllowlist;
 
-    public GlobalMetadataCreatorResults create(GlobalMetadata root, IClusterMetadataContext context) {
-        logger.info("Setting Global Metadata");
+    public GlobalMetadataCreatorResults create(
+        GlobalMetadata root,
+        MigrationMode mode,
+        IClusterMetadataContext context) {
+        log.info("Setting Global Metadata");
 
         var results = GlobalMetadataCreatorResults.builder();
         GlobalMetadataData_OS_2_11 globalMetadata = new GlobalMetadataData_OS_2_11(root.toObjectNode());
-        results.legacyTemplates(createLegacyTemplates(globalMetadata, client, legacyTemplateAllowlist, context));
-        results.componentTemplates(createComponentTemplates(globalMetadata, client, componentTemplateAllowlist, context));
-        results.indexTemplates(createIndexTemplates(globalMetadata, client, indexTemplateAllowlist, context));
+        results.legacyTemplates(createLegacyTemplates(globalMetadata, mode, context));
+        results.componentTemplates(createComponentTemplates(globalMetadata, mode, context));
+        results.indexTemplates(createIndexTemplates(globalMetadata, mode, context));
         return results.build();
     }
 
-    protected List<String> createLegacyTemplates(
-        GlobalMetadataData_OS_2_11 globalMetadata,
-        OpenSearchClient client,
-        List<String> templateAllowlist,
-        IClusterMetadataContext context
-    ) {
-        var legacyTemplates = new ArrayList<String>();
-        logger.info("Setting Legacy Templates...");
-        ObjectNode templates = globalMetadata.getTemplates();
-
-        if (templates == null) {
-            logger.info("No Legacy Templates in Snapshot");
-            return legacyTemplates;
-        }
-
-        if (templateAllowlist != null && templateAllowlist.size() == 0) {
-            logger.info("No Legacy Templates in specified allowlist");
-        } else if (templateAllowlist != null) {
-            for (String templateName : templateAllowlist) {
-                if (!templates.has(templateName) || templates.get(templateName) == null) {
-                    logger.warn("Legacy Template not found: " + templateName);
-                    continue;
-                }
-
-                logger.info("Setting Legacy Template: " + templateName);
-                ObjectNode settings = (ObjectNode) globalMetadata.getTemplates().get(templateName);
-                client.createLegacyTemplate(templateName, settings, context.createMigrateLegacyTemplateContext());
-                legacyTemplates.add(templateName);
-            }
-        } else {
-            // Get the template names
-            List<String> templateKeys = new ArrayList<>();
-            templates.fieldNames().forEachRemaining(templateKeys::add);
-
-            // Create each template
-            for (String templateName : templateKeys) {
-                logger.info("Setting Legacy Template: " + templateName);
-                ObjectNode settings = (ObjectNode) templates.get(templateName);
-                client.createLegacyTemplate(templateName, settings, context.createMigrateLegacyTemplateContext());
-                legacyTemplates.add(templateName);
-            }
-        }
-        return legacyTemplates;
+    public List<String> createLegacyTemplates(GlobalMetadataData_OS_2_11 metadata, MigrationMode mode, IClusterMetadataContext context) {
+        return createTemplates(
+            metadata.getTemplates(),
+            legacyTemplateAllowlist,
+            TemplateTypes.LegacyIndexTemplate,
+            mode,
+            context
+        );
     }
 
-    protected List<String> createComponentTemplates(
-        GlobalMetadataData_OS_2_11 globalMetadata,
-        OpenSearchClient client,
-        List<String> templateAllowlist,
-        IClusterMetadataContext context
-    ) {
-        var componentTemplates = new ArrayList<String>();
-        logger.info("Setting Component Templates...");
-        ObjectNode templates = globalMetadata.getComponentTemplates();
-
-        if (templates == null) {
-            logger.info("No Component Templates in Snapshot");
-            return componentTemplates;
-        }
-
-        if (templateAllowlist != null && templateAllowlist.size() == 0) {
-            logger.info("No Component Templates in specified allowlist");
-            return componentTemplates;
-        } else if (templateAllowlist != null) {
-            for (String templateName : templateAllowlist) {
-                if (!templates.has(templateName) || templates.get(templateName) == null) {
-                    logger.warn("Component Template not found: " + templateName);
-                    continue;
-                }
-
-                logger.info("Setting Component Template: " + templateName);
-                ObjectNode settings = (ObjectNode) templates.get(templateName);
-                client.createComponentTemplate(templateName, settings, context.createComponentTemplateContext());
-                componentTemplates.add(templateName);
-            }
-        } else {
-            // Get the template names
-            List<String> templateKeys = new ArrayList<>();
-            templates.fieldNames().forEachRemaining(templateKeys::add);
-
-            // Create each template
-            for (String templateName : templateKeys) {
-                logger.info("Setting Component Template: " + templateName);
-                ObjectNode settings = (ObjectNode) templates.get(templateName);
-                client.createComponentTemplate(templateName, settings, context.createComponentTemplateContext());
-                componentTemplates.add(templateName);
-            }
-        }
-        return componentTemplates;
+    public List<String> createComponentTemplates(GlobalMetadataData_OS_2_11 metadata, MigrationMode mode, IClusterMetadataContext context) {
+        return createTemplates(
+            metadata.getComponentTemplates(),
+            componentTemplateAllowlist,
+            TemplateTypes.ComponentTemplates,
+            mode,
+            context
+        );
     }
 
-    protected List<String> createIndexTemplates(
-        GlobalMetadataData_OS_2_11 globalMetadata,
-        OpenSearchClient client,
+    public List<String> createIndexTemplates(GlobalMetadataData_OS_2_11 metadata, MigrationMode mode, IClusterMetadataContext context) {
+        return createTemplates(
+            metadata.getIndexTemplates(),
+            indexTemplateAllowlist,
+            TemplateTypes.IndexTemplate,
+            mode,
+            context
+        );
+    }
+
+    @AllArgsConstructor
+    private enum TemplateTypes {
+        IndexTemplate(
+            (client, name, body, context) -> client.createIndexTemplate(name, body, context.createMigrateTemplateContext()),
+            (client, name) -> client.hasIndexTemplate(name)
+        ),
+
+        LegacyIndexTemplate(
+            (client, name, body, context) -> client.createLegacyTemplate(name, body, context.createMigrateLegacyTemplateContext()),
+            (client, name) -> client.hasLegacyTemplate(name)
+        ),
+
+        ComponentTemplates(
+            (client, name, body, context) -> client.createComponentTemplate(name, body, context.createComponentTemplateContext()),
+            (client, name) -> client.hasComponentTemplate(name)
+        );
+        final TemplateCreator creator;
+        final TemplateExistsCheck alreadyExistsCheck;
+    }
+
+    @FunctionalInterface
+    interface TemplateCreator {
+        Optional<ObjectNode> createTemplate(OpenSearchClient client, String name, ObjectNode body, IClusterMetadataContext context);
+    }
+
+    @FunctionalInterface
+    interface TemplateExistsCheck {
+        boolean templateAlreadyExists(OpenSearchClient client, String name);
+    }
+
+
+    private List<String> createTemplates(
+        ObjectNode templates,
         List<String> templateAllowlist,
+        TemplateTypes templateType,
+        MigrationMode mode,
         IClusterMetadataContext context
     ) {
-        var indexTemplates = new ArrayList<String>();
-        logger.info("Setting Index Templates...");
-        ObjectNode templates = globalMetadata.getIndexTemplates();
+
+        var templatesToCreate = new HashMap<String, ObjectNode>();
+        var templateList = new ArrayList<String>();
+        log.info("Setting {} ...", templateType);
 
         if (templates == null) {
-            logger.info("No Index Templates in Snapshot");
-            return indexTemplates;
+            log.info("No {} in Snapshot", templateType);
+            return List.of();
         }
 
         if (templateAllowlist != null && templateAllowlist.size() == 0) {
-            logger.info("No Index Templates in specified allowlist");
-            return indexTemplates;
+            log.info("No {} in specified allowlist", templateType);
+            return List.of();
         } else if (templateAllowlist != null) {
             for (String templateName : templateAllowlist) {
                 if (!templates.has(templateName) || templates.get(templateName) == null) {
-                    logger.warn("Index Template not found: " + templateName);
+                    log.warn("{} not found: {}", templateType, templateName);
                     continue;
                 }
-
-                logger.info("Setting Index Template: " + templateName);
-                ObjectNode settings = (ObjectNode) globalMetadata.getIndexTemplates().get(templateName);
-                client.createIndexTemplate(templateName, settings, context.createMigrateTemplateContext());
-                indexTemplates.add(templateName);
+                ObjectNode settings = (ObjectNode) templates.get(templateName);
+                templatesToCreate.put(templateName, settings);
             }
         } else {
             // Get the template names
@@ -163,12 +137,34 @@ public class GlobalMetadataCreator_OS_2_11 implements GlobalMetadataCreator {
 
             // Create each template
             for (String templateName : templateKeys) {
-                logger.info("Setting Index Template: " + templateName);
                 ObjectNode settings = (ObjectNode) templates.get(templateName);
-                client.createIndexTemplate(templateName, settings, context.createMigrateTemplateContext());
-                indexTemplates.add(templateName);
+                templatesToCreate.put(templateName, settings);
             }
         }
-        return indexTemplates;
+
+        templatesToCreate.forEach((templateName, templateBody) -> {
+            log.info("Creating {}: {}", templateType, templateName);
+            switch (mode) {
+                case SIMULATE:
+                    var alreadyExists = templateType.alreadyExistsCheck.templateAlreadyExists(client, templateName);
+                    if (!alreadyExists) {
+                        templateList.add(templateName);
+                    } else {
+                        log.warn("Template {} already exists on the target, it will not be created during a migration", templateName);
+                    }
+                    break;                    
+
+                case PERFORM:
+                    var createdTemplate = templateType.creator.createTemplate(client, templateName, templateBody, context);
+                    if (createdTemplate.isPresent()) {
+                        templateList.add(templateName);
+                    } else {
+                        log.warn("Template {} already exists on the target, unable to create", templateName);
+                    }
+                    break;
+            }
+        });
+
+        return templateList;
     }
 }

--- a/RFS/src/main/java/com/rfs/worker/IndexMetadataResults.java
+++ b/RFS/src/main/java/com/rfs/worker/IndexMetadataResults.java
@@ -1,0 +1,16 @@
+package com.rfs.worker;
+
+import java.util.List;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.Singular;
+
+@Builder
+@Data
+public class IndexMetadataResults {
+    @Singular
+    private final List<String> indexNames;
+    @Singular
+    private final List<String> aliases;
+}

--- a/RFS/src/main/java/com/rfs/worker/MetadataRunner.java
+++ b/RFS/src/main/java/com/rfs/worker/MetadataRunner.java
@@ -1,5 +1,6 @@
 package com.rfs.worker;
 
+import org.opensearch.migrations.MigrationMode;
 import org.opensearch.migrations.metadata.GlobalMetadataCreator;
 import org.opensearch.migrations.metadata.GlobalMetadataCreatorResults;
 import org.opensearch.migrations.metadata.tracing.IMetadataMigrationContexts.IClusterMetadataContext;
@@ -18,11 +19,11 @@ public class MetadataRunner {
     private final GlobalMetadataCreator metadataCreator;
     private final Transformer transformer;
 
-    public GlobalMetadataCreatorResults migrateMetadata(IClusterMetadataContext context) {
+    public GlobalMetadataCreatorResults migrateMetadata(MigrationMode mode, IClusterMetadataContext context) {
         log.info("Migrating the Templates...");
         var globalMetadata = metadataFactory.fromRepo(snapshotName);
         var transformedRoot = transformer.transformGlobalMetadata(globalMetadata);
-        var results = metadataCreator.create(transformedRoot, context);
+        var results = metadataCreator.create(transformedRoot, mode, context);
         log.info("Templates migration complete");
         return results;
     }

--- a/RFS/src/main/java/org/opensearch/migrations/MigrationMode.java
+++ b/RFS/src/main/java/org/opensearch/migrations/MigrationMode.java
@@ -1,0 +1,6 @@
+package org.opensearch.migrations;
+
+public enum MigrationMode {
+    SIMULATE,
+    PERFORM
+}

--- a/RFS/src/main/java/org/opensearch/migrations/metadata/GlobalMetadataCreator.java
+++ b/RFS/src/main/java/org/opensearch/migrations/metadata/GlobalMetadataCreator.java
@@ -1,9 +1,13 @@
 package org.opensearch.migrations.metadata;
 
+import org.opensearch.migrations.MigrationMode;
 import org.opensearch.migrations.metadata.tracing.IMetadataMigrationContexts.IClusterMetadataContext;
 
 import com.rfs.models.GlobalMetadata;
 
 public interface GlobalMetadataCreator {
-    public GlobalMetadataCreatorResults create(GlobalMetadata metadata, IClusterMetadataContext context);
+    public GlobalMetadataCreatorResults create(
+        GlobalMetadata metadata,
+        MigrationMode mode,
+        IClusterMetadataContext context);
 }

--- a/RFS/src/main/java/org/opensearch/migrations/metadata/IndexCreator.java
+++ b/RFS/src/main/java/org/opensearch/migrations/metadata/IndexCreator.java
@@ -1,16 +1,14 @@
 package org.opensearch.migrations.metadata;
 
-import java.util.Optional;
-
-import com.fasterxml.jackson.databind.node.ObjectNode;
-
+import org.opensearch.migrations.MigrationMode;
 import org.opensearch.migrations.metadata.tracing.IMetadataMigrationContexts.ICreateIndexContext;
 
 import com.rfs.models.IndexMetadata;
 
 public interface IndexCreator {
-    public Optional<ObjectNode> create(
+    public boolean create(
         IndexMetadata index,
+        MigrationMode mode,
         ICreateIndexContext context
     );
 }

--- a/RFS/src/testFixtures/java/com/rfs/http/ClusterOperations.java
+++ b/RFS/src/testFixtures/java/com/rfs/http/ClusterOperations.java
@@ -6,6 +6,7 @@ import java.util.Map;
 
 import org.apache.hc.client5.http.classic.methods.HttpDelete;
 import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.client5.http.classic.methods.HttpPost;
 import org.apache.hc.client5.http.classic.methods.HttpPut;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.client5.http.impl.classic.HttpClients;
@@ -170,6 +171,9 @@ public class ClusterOperations {
             + "                \"type\": \"text\""
             + "            }"
             + "        }"
+            + "    },"
+            + "    \"aliases\": {"
+            + "        \"alias1\": {}"
             + "    }"
             + "},"
             + "\"version\": 1"
@@ -205,6 +209,32 @@ public class ClusterOperations {
         createIndexTempRequest.setHeader("Content-Type", "application/json");
 
         try (var response = httpClient.execute(createIndexTempRequest)) {
+            assertThat(
+                EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8),
+                response.getCode(),
+                equalTo(200)
+            );
+        }
+    }
+
+    @SneakyThrows
+    public void createAlias(String aliasName, String indexPattern) {
+        final var requestBodyJson = "{\r\n" + //
+            "  \"actions\": [\r\n" + //
+            "    {\r\n" + //
+            "      \"add\": {\r\n" + //
+            "        \"index\": \"" + indexPattern + "\",\r\n" + //
+            "        \"alias\": \"" + aliasName + "\"\r\n" + //
+            "      }\r\n" + //
+            "    }\r\n" + //
+            "  ]\r\n" + //
+            "}";
+
+        final var aliasRequest = new HttpPost(this.clusterUrl + "/_aliases");
+        aliasRequest.setEntity(new StringEntity(requestBodyJson));
+        aliasRequest.setHeader("Content-Type", "application/json");
+
+        try (var response = httpClient.execute(aliasRequest)) {
             assertThat(
                 EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8),
                 response.getCode(),


### PR DESCRIPTION
### Description
Add the evaluate command to metadata migration, it can inspect the target cluster and will not make any changes to it.
- Refactored several shared code paths to reduce redundant functionality, namely the Migrate and GlobalMetadataCreator_OS_2_11 classes.
- Updated the End to End test cases to include evaluate since the setup was nearly identical, refactored the test class to make this cleaner for inspection.

### TODOs
- [ ] Merge of https://github.com/opensearch-project/opensearch-migrations/pull/942
- [ ] Update console link to support evaulate
- [ ] Detailed documentation pass

### Issues Resolved
- Resolves https://opensearch.atlassian.net/browse/MIGRATIONS-1858

### Testing
New end to end test cases

### Check List
- [X] New functionality includes testing
  - [X] All tests pass, including unit test, integration test and doctest
- [X] New functionality has been documented
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
