### PR TITLE
"Back to the Future" - Upgrading to Lucene 9 to read Lucene 6

### DIFF
--- a/DocumentsFromSnapshotMigration/src/main/java/com/rfs/RfsMigrateDocuments.java
+++ b/DocumentsFromSnapshotMigration/src/main/java/com/rfs/RfsMigrateDocuments.java
@@ -225,8 +225,7 @@ public class RfsMigrateDocuments {
                 );
 
                 run(
-                    LuceneDocumentsReader.getFactory(sourceResourceProvider.getSoftDeletesPossible(),
-                        sourceResourceProvider.getSoftDeletesFieldData()),
+                    LuceneDocumentsReader.getFactory(sourceResourceProvider),
                     reindexer,
                     workCoordinator,
                     arguments.initialLeaseDuration,

--- a/DocumentsFromSnapshotMigration/src/test/java/com/rfs/PerformanceVerificationTest.java
+++ b/DocumentsFromSnapshotMigration/src/test/java/com/rfs/PerformanceVerificationTest.java
@@ -21,6 +21,7 @@ import com.rfs.common.DocumentReindexer;
 import com.rfs.common.LuceneDocumentsReader;
 import com.rfs.common.OpenSearchClient;
 import com.rfs.common.OpenSearchClient.BulkResponse;
+import com.rfs.common.RfsLuceneDocument;
 import com.rfs.tracing.IRfsContexts;
 import lombok.extern.slf4j.Slf4j;
 import reactor.core.publisher.Mono;
@@ -68,7 +69,7 @@ public class PerformanceVerificationTest {
             }
 
             @Override
-            protected Document getDocument(IndexReader reader, int docId, boolean isLive) {
+            protected RfsLuceneDocument getDocument(IndexReader reader, int docId, boolean isLive) {
                 ingestedDocuments.incrementAndGet();
                 return super.getDocument(reader, docId, isLive);
             }

--- a/DocumentsFromSnapshotMigration/src/test/java/com/rfs/SourceTestBase.java
+++ b/DocumentsFromSnapshotMigration/src/test/java/com/rfs/SourceTestBase.java
@@ -15,7 +15,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import java.util.function.UnaryOperator;
 
-import org.apache.lucene.document.Document;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
@@ -34,6 +33,7 @@ import com.rfs.common.FileSystemRepo;
 import com.rfs.common.LuceneDocumentsReader;
 import com.rfs.common.OpenSearchClient;
 import com.rfs.common.RestClient;
+import com.rfs.common.RfsLuceneDocument;
 import com.rfs.common.SnapshotShardUnpacker;
 import com.rfs.common.SourceRepo;
 import com.rfs.common.http.ConnectionContextTestParams;
@@ -181,15 +181,15 @@ public class SourceTestBase {
     }
 
     public static class FilteredLuceneDocumentsReader extends LuceneDocumentsReader {
-        private final UnaryOperator<Document> docTransformer;
+        private final UnaryOperator<RfsLuceneDocument> docTransformer;
 
-        public FilteredLuceneDocumentsReader(Path luceneFilesBasePath, boolean softDeletesPossible, String softDeletesField, UnaryOperator<Document> docTransformer) {
+        public FilteredLuceneDocumentsReader(Path luceneFilesBasePath, boolean softDeletesPossible, String softDeletesField, UnaryOperator<RfsLuceneDocument> docTransformer) {
             super(luceneFilesBasePath, softDeletesPossible, softDeletesField);
             this.docTransformer = docTransformer;
         }
 
         @Override
-        public Flux<Document> readDocuments() {
+        public Flux<RfsLuceneDocument> readDocuments() {
             return super.readDocuments().map(docTransformer::apply);
         }
     }
@@ -213,7 +213,7 @@ public class SourceTestBase {
             log.atDebug().setMessage("Lease expired for " + workItemId + " making next document get throw").log();
             shouldThrow.set(true);
         })) {
-            UnaryOperator<Document> terminatingDocumentFilter = d -> {
+            UnaryOperator<RfsLuceneDocument> terminatingDocumentFilter = d -> {
                 if (shouldThrow.get()) {
                     throw new LeasePastError();
                 }

--- a/RFS/build.gradle
+++ b/RFS/build.gradle
@@ -31,7 +31,7 @@ dependencies {
     implementation group: 'org.apache.logging.log4j', name: 'log4j-core'
     implementation group: 'org.apache.logging.log4j', name: 'log4j-slf4j2-impl'
     implementation group: 'org.apache.lucene', name: 'lucene-core'
-    implementation group: 'org.apache.lucene', name: 'lucene-analyzers-common'
+    implementation group: 'org.apache.lucene', name: 'lucene-analysis-common'
     implementation group: 'org.apache.lucene', name: 'lucene-backward-codecs'
     implementation group: 'software.amazon.awssdk', name: 's3'
     implementation group: 'software.amazon.awssdk', name: 's3-transfer-manager'
@@ -49,6 +49,7 @@ dependencies {
     testImplementation 'com.github.docker-java:docker-java-transport-httpclient5:3.3.6'
 
     testImplementation testFixtures(project(path: ':RFS'))
+    testImplementation group: 'org.apache.lucene', name: 'lucene-backward-codecs'
     testImplementation group: 'io.projectreactor', name: 'reactor-test'
     testImplementation group: 'org.apache.logging.log4j', name: 'log4j-core'
     testImplementation group: 'org.apache.logging.log4j', name: 'log4j-slf4j2-impl'

--- a/RFS/src/main/java/com/rfs/common/LuceneDocumentsReader.java
+++ b/RFS/src/main/java/com/rfs/common/LuceneDocumentsReader.java
@@ -160,7 +160,6 @@ public class LuceneDocumentsReader {
             BytesRef sourceBytes = null;
             try {
                 for (var field : document.getFields()) {
-                    log.atDebug().setMessage("Field: {}").addArgument(field.name()).log();
                     String fieldName = field.name();
                     switch (fieldName) {
                         case "_id": {

--- a/RFS/src/main/java/com/rfs/common/LuceneDocumentsReader.java
+++ b/RFS/src/main/java/com/rfs/common/LuceneDocumentsReader.java
@@ -2,9 +2,9 @@ package com.rfs.common;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.function.Function;
-import java.util.List;
 
 import org.apache.lucene.document.Document;
 import org.apache.lucene.index.DirectoryReader;
@@ -14,6 +14,7 @@ import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.SoftDeletesDirectoryReaderWrapper;
 import org.apache.lucene.store.FSDirectory;
 import org.apache.lucene.util.BytesRef;
+
 import org.opensearch.migrations.cluster.ClusterSnapshotReader;
 
 import lombok.Lombok;

--- a/RFS/src/main/java/com/rfs/common/LuceneDocumentsReader.java
+++ b/RFS/src/main/java/com/rfs/common/LuceneDocumentsReader.java
@@ -4,14 +4,17 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.concurrent.Callable;
 import java.util.function.Function;
+import java.util.List;
 
 import org.apache.lucene.document.Document;
 import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexCommit;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.SoftDeletesDirectoryReaderWrapper;
 import org.apache.lucene.store.FSDirectory;
 import org.apache.lucene.util.BytesRef;
+import org.opensearch.migrations.cluster.ClusterSnapshotReader;
 
 import lombok.Lombok;
 import lombok.RequiredArgsConstructor;
@@ -24,8 +27,13 @@ import reactor.core.scheduler.Schedulers;
 @RequiredArgsConstructor
 @Slf4j
 public class LuceneDocumentsReader {
-    public static Function<Path, LuceneDocumentsReader> getFactory(boolean softDeletesPossible, String softDeletesField) {
-        return path -> new LuceneDocumentsReader(path, softDeletesPossible, softDeletesField);
+
+    public static Function<Path, LuceneDocumentsReader> getFactory(ClusterSnapshotReader snapshotReader) {
+        return path -> new LuceneDocumentsReader(
+            path,
+            snapshotReader.getSoftDeletesPossible(),
+            snapshotReader.getSoftDeletesFieldData()
+        );
     }
 
     protected final Path indexDirectoryPath;
@@ -79,7 +87,7 @@ public class LuceneDocumentsReader {
      *    Lucene Index.
 
      */
-    public Flux<Document> readDocuments() {
+    public Flux<RfsLuceneDocument> readDocuments() {
         return Flux.using(
             () -> wrapReader(getReader(), softDeletesPossible, softDeletesField),
             this::readDocsByLeavesInParallel,
@@ -93,11 +101,20 @@ public class LuceneDocumentsReader {
         });
     }
 
-    protected DirectoryReader getReader() throws IOException {
-        return DirectoryReader.open(FSDirectory.open(indexDirectoryPath));
+    protected DirectoryReader getReader() throws IOException {// Get the list of commits and pick the latest one
+        try (FSDirectory directory = FSDirectory.open(indexDirectoryPath)) {
+            List  <IndexCommit> commits = DirectoryReader.listCommits(directory);
+            IndexCommit latestCommit = commits.get(commits.size() - 1);
+
+            return DirectoryReader.open(
+                latestCommit,
+                6, // Minimum supported major version - Elastic 5/Lucene 6
+                null // No specific sorting required
+            );
+        }
     }
 
-    Publisher<Document> readDocsByLeavesInParallel(DirectoryReader reader) {
+    Publisher<RfsLuceneDocument> readDocsByLeavesInParallel(DirectoryReader reader) {
         var segmentsToReadAtOnce = 5; // Arbitrary value
         var maxDocumentsToReadAtOnce = 100; // Arbitrary value
         log.atInfo().setMessage("{} documents in {} leaves found in the current Lucene index")
@@ -116,7 +133,7 @@ public class LuceneDocumentsReader {
             .doOnTerminate(sharedSegmentReaderScheduler::dispose);
     }
 
-    Publisher<Callable<Document>> getReadDocCallablesFromSegments(LeafReaderContext leafReaderContext) {
+    Publisher<Callable<RfsLuceneDocument>> getReadDocCallablesFromSegments(LeafReaderContext leafReaderContext) {
         @SuppressWarnings("resource") // segmentReader will be closed by parent DirectoryReader
         var segmentReader = leafReaderContext.reader();
         var liveDocs = segmentReader.getLiveDocs();
@@ -135,18 +152,44 @@ public class LuceneDocumentsReader {
         return reader;
     }
 
-    protected Document getDocument(IndexReader reader, int docId, boolean isLive) {
+    protected RfsLuceneDocument getDocument(IndexReader reader, int docId, boolean isLive) {
         try {
             Document document = reader.document(docId);
-            BytesRef sourceBytes = document.getBinaryValue("_source");
-            String id;
+            String id = null;
+            BytesRef sourceBytes = null;
             try {
-                var idValue = document.getBinaryValue("_id");
-                if (idValue == null) {
+                for (var field : document.getFields()) {
+                    log.atDebug().setMessage("Field: {}").addArgument(field.name()).log();
+                    String fieldName = field.name();
+                    switch (fieldName) {
+                        case "_id": {
+                            // ES 6+
+                            var idBytes = field.binaryValue();
+                            id = Uid.decodeId(idBytes.bytes);
+                            break;
+                        }
+                        case "_uid": {
+                            // ES 5
+                            id = field.stringValue();
+                            break;
+                        }
+                        case "_source": {
+                            // All versions (?)
+                            sourceBytes = field.binaryValue();
+                            break;
+                        }
+                    }
+                }
+                if (id == null) {
                     log.atError().setMessage("Document with index" + docId + " does not have an id. Skipping").log();
                     return null;  // Skip documents with missing id
                 }
-                id = Uid.decodeId(idValue.bytes);
+
+                if (sourceBytes == null || sourceBytes.bytes.length == 0) {
+                    log.atWarn().setMessage("Document {} doesn't have the _source field enabled").addArgument(id).log();
+                    return null;  // Skip these
+                }
+
                 log.atDebug().setMessage("Reading document {}").addArgument(id).log();
             } catch (Exception e) {
                 StringBuilder errorMessage = new StringBuilder();
@@ -161,13 +204,8 @@ public class LuceneDocumentsReader {
                 return null; // Skip these
             }
 
-            if (sourceBytes == null || sourceBytes.bytes.length == 0) {
-                log.atWarn().setMessage("Document {} doesn't have the _source field enabled").addArgument(id).log();
-                return null;  // Skip these
-            }
-
             log.atDebug().setMessage("Document {} read successfully").addArgument(id).log();
-            return document;
+            return new RfsLuceneDocument(id, sourceBytes.utf8ToString());
         } catch (Exception e) {
             log.atError().setMessage("Failed to read document at Lucene index location {}").addArgument(docId).setCause(e).log();
             return null;

--- a/RFS/src/main/java/com/rfs/common/RfsLuceneDocument.java
+++ b/RFS/src/main/java/com/rfs/common/RfsLuceneDocument.java
@@ -1,0 +1,9 @@
+package com.rfs.common;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class RfsLuceneDocument {
+    public final String id;
+    public final String source;
+}

--- a/RFS/src/main/java/com/rfs/worker/DocumentsRunner.java
+++ b/RFS/src/main/java/com/rfs/worker/DocumentsRunner.java
@@ -7,8 +7,6 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
-import org.apache.lucene.document.Document;
-
 import org.opensearch.migrations.reindexer.tracing.IDocumentMigrationContexts;
 
 import com.rfs.cms.IWorkCoordinator;
@@ -16,6 +14,7 @@ import com.rfs.cms.ScopedWorkCoordinator;
 import com.rfs.common.DocumentReindexer;
 import com.rfs.common.LuceneDocumentsReader;
 import com.rfs.common.RfsException;
+import com.rfs.common.RfsLuceneDocument;
 import com.rfs.common.SnapshotShardUnpacker;
 import com.rfs.models.ShardMetadata;
 import lombok.AllArgsConstructor;
@@ -94,7 +93,7 @@ public class DocumentsRunner {
 
         var unpacker = unpackerFactory.create(shardMetadata);
         var reader = readerFactory.apply(unpacker.unpack());
-        Flux<Document> documents = reader.readDocuments();
+        Flux<RfsLuceneDocument> documents = reader.readDocuments();
 
         reindexer.reindex(shardMetadata.getIndexName(), documents, context)
             .doOnError(error -> log.error("Error during reindexing: " + error))

--- a/RFS/src/test/java/com/rfs/common/LuceneDocumentsReaderTest.java
+++ b/RFS/src/test/java/com/rfs/common/LuceneDocumentsReaderTest.java
@@ -97,36 +97,87 @@ public class LuceneDocumentsReaderTest {
         Path luceneDir = unpacker.unpack();
 
         // Use the LuceneDocumentsReader to get the documents
-        Flux<Document> documents = new LuceneDocumentsReader(
-            luceneDir,
-            sourceResourceProvider.getSoftDeletesPossible(),
-            sourceResourceProvider.getSoftDeletesFieldData()
-        ).readDocuments()
-            .sort(Comparator.comparing(doc -> Uid.decodeId(doc.getBinaryValue("_id").bytes))); // Sort for consistent order given LuceneDocumentsReader may interleave
+        var reader = LuceneDocumentsReader.getFactory(sourceResourceProvider).apply(luceneDir);
+
+        Flux<RfsLuceneDocument> documents = reader.readDocuments()
+            .sort(Comparator.comparing(doc -> doc.id)); // Sort for consistent order given LuceneDocumentsReader may interleave
 
         // Verify that the results are as expected
         StepVerifier.create(documents).expectNextMatches(doc -> {
             String expectedId = "complexdoc";
-            String actualId = Uid.decodeId(doc.getBinaryValue("_id").bytes);
+            String actualId = doc.id;
 
             String expectedSource = "{\"title\":\"This is a doc with complex history\",\"content\":\"Updated!\"}";
-            String actualSource = doc.getBinaryValue("_source").utf8ToString();
+            String actualSource = doc.source;
             assertDocsEqual(expectedId, actualId, expectedSource, actualSource);
             return true;
         }).expectNextMatches(doc -> {
             String expectedId = "unchangeddoc";
-            String actualId = Uid.decodeId(doc.getBinaryValue("_id").bytes);
+            String actualId = doc.id;
 
             String expectedSource = "{\"title\":\"This doc will not be changed\\nIt has multiple lines of text\\nIts source doc has extra newlines.\",\"content\":\"bluh bluh\"}";
-            String actualSource = doc.getBinaryValue("_source").utf8ToString();
+            String actualSource = doc.source;
             assertDocsEqual(expectedId, actualId, expectedSource, actualSource);
             return true;
         }).expectNextMatches(doc -> {
             String expectedId = "updateddoc";
-            String actualId = Uid.decodeId(doc.getBinaryValue("_id").bytes);
+            String actualId = doc.id;
 
             String expectedSource = "{\"title\":\"This is doc that will be updated\",\"content\":\"Updated!\"}";
-            String actualSource = doc.getBinaryValue("_source").utf8ToString();
+            String actualSource = doc.source;
+            assertDocsEqual(expectedId, actualId, expectedSource, actualSource);
+            return true;
+        }).expectComplete().verify();
+    }
+
+    @Test
+    public void ReadDocuments_ES5_Origin_AsExpected() throws Exception {
+        Snapshot snapshot = TestResources.SNAPSHOT_ES_6_8_MERGED;
+        Version version = Version.fromString("ES 6.8");
+
+        final var repo = new FileSystemRepo(snapshot.dir);
+        var sourceResourceProvider = ClusterProviderRegistry.getSnapshotReader(version, repo);
+        DefaultSourceRepoAccessor repoAccessor = new DefaultSourceRepoAccessor(repo);
+
+        final ShardMetadata shardMetadata = sourceResourceProvider.getShardMetadata().fromRepo(snapshot.name, "test_updates_deletes", 0);
+
+        SnapshotShardUnpacker unpacker = new SnapshotShardUnpacker(
+                    repoAccessor,
+                    tempDirectory,
+                    shardMetadata,
+                    Integer.MAX_VALUE
+                );
+        Path luceneDir = unpacker.unpack();
+
+        // Use the LuceneDocumentsReader to get the documents
+        var reader = LuceneDocumentsReader.getFactory(sourceResourceProvider).apply(luceneDir);
+
+        Flux<RfsLuceneDocument> documents = reader.readDocuments()
+            .sort(Comparator.comparing(doc -> doc.id)); // Sort for consistent order given LuceneDocumentsReader may interleave
+
+        // Verify that the results are as expected
+        StepVerifier.create(documents).expectNextMatches(doc -> {
+            String expectedId = "type1#complexdoc";
+            String actualId = doc.id;
+
+            String expectedSource = "{\"title\":\"This is a doc with complex history. Updated!\"}";
+            String actualSource = doc.source;
+            assertDocsEqual(expectedId, actualId, expectedSource, actualSource);
+            return true;
+        }).expectNextMatches(doc -> {
+            String expectedId = "type2#unchangeddoc";
+            String actualId = doc.id;
+
+            String expectedSource = "{\"content\":\"This doc will not be changed\nIt has multiple lines of text\nIts source doc has extra newlines.\"}";
+            String actualSource = doc.source;
+            assertDocsEqual(expectedId, actualId, expectedSource, actualSource);
+            return true;
+        }).expectNextMatches(doc -> {
+            String expectedId = "type2#updateddoc";
+            String actualId = doc.id;
+
+            String expectedSource = "{\"content\":\"Updated!\"}";
+            String actualSource = doc.source;
             assertDocsEqual(expectedId, actualId, expectedSource, actualSource);
             return true;
         }).expectComplete().verify();
@@ -188,7 +239,7 @@ public class LuceneDocumentsReaderTest {
         }, 500, TimeUnit.MILLISECONDS);
 
         // Read documents
-        List<Document> actualDocuments = reader.readDocuments()
+        List<RfsLuceneDocument> actualDocuments = reader.readDocuments()
             .subscribeOn(Schedulers.parallel())
             .collectList()
             .block(Duration.ofSeconds(2));
@@ -206,8 +257,12 @@ public class LuceneDocumentsReaderTest {
 
     protected void assertDocsEqual(String expectedId, String actualId, String expectedSource, String actualSource) {
         try {
-            JsonNode expectedNode = objectMapper.readTree(expectedSource);
-            JsonNode actualNode = objectMapper.readTree(actualSource);
+            String sanitizedExpected = expectedSource.trim().replace("\n", "").replace("\\n", "");
+            String sanitizedActual = actualSource.trim().replace("\n", "").replace("\\n", "");
+
+
+            JsonNode expectedNode = objectMapper.readTree(sanitizedExpected);
+            JsonNode actualNode = objectMapper.readTree(sanitizedActual);
             assertEquals(expectedId, actualId);
             assertEquals(expectedNode, actualNode);
         } catch (JsonProcessingException e) {

--- a/commonDependencyVersionConstraints/build.gradle
+++ b/commonDependencyVersionConstraints/build.gradle
@@ -104,9 +104,9 @@ dependencies {
 
     api group: 'eu.rekawek.toxiproxy', name: 'toxiproxy-java', version: '2.1.7'
 
-    def lucene = '8.11.3';
+    def lucene = '9.11.1';
     api group: 'org.apache.lucene', name: 'lucene-core', version: lucene
-    api group: 'org.apache.lucene', name: 'lucene-analyzers-common', version: lucene
+    api group: 'org.apache.lucene', name: 'lucene-analysis-common', version: lucene
     api group: 'org.apache.lucene', name: 'lucene-backward-codecs', version: lucene
 
     api group: 'org.hamcrest', name: 'hamcrest', version: '2.2'


### PR DESCRIPTION
### Description
* This change enables reading Lucene indices v6+ by upgrading RFS to use Lucene 9 and leveraging the backwards compatibility codecs embedded in that release.
* Add a new test for the LuceneDocumentsReader that ensures it's able to read an ES 6.8 snapshot whose indices were created in ES 5.X
* Updated unit tests elsewhere in the code where necessary

### Issues Resolved
* https://opensearch.atlassian.net/browse/MIGRATIONS-1965

### Testing
Unit tests; manually running RFS against a Snapshot created in ES 5 and upgraded to ES 6

### Check List
- [x] New functionality includes testing
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
