### PR TITLE
Enable trace/debug logging during test/slowTest

### DIFF
--- a/CreateSnapshot/src/test/resources/log4j2.properties
+++ b/CreateSnapshot/src/test/resources/log4j2.properties
@@ -1,16 +1,15 @@
 status = WARN
 
-property.ownedPackagesLogLevel=${sys:migrationLogLevel:-debug}
+property.ownedPackagesLogLevel=${sys:migrationLogLevel:-INFO}
 
-# Root logger options
-rootLogger.level = debug
-rootLogger.appenderRef.console.ref = Console
-
-# Console appender configuration
 appender.console.type = Console
 appender.console.name = Console
+appender.console.target = SYSTEM_OUT
 appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss,SSS}{UTC} %p %c{1.} [%t] %m%equals{ ctx=%mdc}{ ctx=\{\}}{}%n
+appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss,SSS}{UTC} %p %c{1.} [%t] %m%n
+
+rootLogger.level = info
+rootLogger.appenderRef.console.ref = Console
 
 # Allow customization of owned package logs
 logger.rfs.name = com.rfs

--- a/DocumentsFromSnapshotMigration/src/test/resources/log4j2.properties
+++ b/DocumentsFromSnapshotMigration/src/test/resources/log4j2.properties
@@ -1,7 +1,8 @@
-status = ERROR
+status = WARN
 
 property.logsDir = ${env:SHARED_LOGS_DIR_PATH:-./logs}
 property.failedLoggerFileNamePrefix = ${logsDir}/${hostName}/failedRequests/failedRequests
+property.ownedPackagesLogLevel=${sys:migrationLogLevel:-INFO}
 
 appenders = console, FailedRequests
 
@@ -26,10 +27,16 @@ appender.console.type = Console
 appender.console.name = Console
 appender.console.target = SYSTEM_OUT
 appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = %d{HH:mm:ss.SSS} %threadName %-5p %c{1}:%L - %m%n
+appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss,SSS}{UTC} %p %c{1.} [%t] %m%n
 
 rootLogger.level = info
 rootLogger.appenderRef.console.ref = Console
+
+# Allow customization of owned package logs
+logger.rfs.name = com.rfs
+logger.rfs.level = ${ownedPackagesLogLevel}
+logger.migration.name = org.opensearch.migrations
+logger.migration.level = ${ownedPackagesLogLevel}
 
 logger.wireLogger.name = org.apache.http.wire
 logger.wireLogger.level = OFF

--- a/MetadataMigration/src/test/resources/log4j2.properties
+++ b/MetadataMigration/src/test/resources/log4j2.properties
@@ -8,11 +8,16 @@ appender.console.target = SYSTEM_OUT
 appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = %m%n
 
+property.ownedPackagesLogLevel=${sys:migrationLogLevel:-DEBUG}
+
 rootLogger.level = info
 rootLogger.appenderRef.console.ref = Console
 
+# Allow customization of owned package logs
 logger.rfs.name = com.rfs
-logger.rfs.level = debug
+logger.rfs.level = ${ownedPackagesLogLevel}
+logger.migration.name = org.opensearch.migrations
+logger.migration.level = ${ownedPackagesLogLevel}
 
 logger.migrations.name = com.opensearch.migrations
 logger.migrations.level = debug

--- a/RFS/src/test/resources/log4j2.properties
+++ b/RFS/src/test/resources/log4j2.properties
@@ -1,6 +1,8 @@
 # Set the status level for the configuration
 status = DEBUG
 
+property.ownedPackagesLogLevel=${sys:migrationLogLevel:-DEBUG}
+
 # Define the root logger
 rootLogger.level = info
 rootLogger.appenderRef.console.ref = Console
@@ -9,11 +11,13 @@ rootLogger.appenderRef.console.ref = Console
 appender.console.type = Console
 appender.console.name = Console
 appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = %d{HH:mm:ss.SSS} %threadName %-5p %c{1}:%L - %m%n
+appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss,SSS}{UTC} %p %c{1.} [%t] %m%n
 
-# Logger definitions
+# Allow customization of owned package logs
 logger.rfs.name = com.rfs
-logger.rfs.level = debug
+logger.rfs.level = ${ownedPackagesLogLevel}
+logger.migration.name = org.opensearch.migrations
+logger.migration.level = ${ownedPackagesLogLevel}
 
 logger.wire.name = org.apache.hc.client5.http
 logger.wire.level = info

--- a/TrafficCapture/captureKafkaOffloader/src/test/resources/log4j2.properties
+++ b/TrafficCapture/captureKafkaOffloader/src/test/resources/log4j2.properties
@@ -1,4 +1,6 @@
-status = error
+status = WARN
+
+property.ownedPackagesLogLevel=${sys:migrationLogLevel:-DEBUG}
 
 # Root logger options
 rootLogger.level = debug
@@ -9,3 +11,9 @@ appender.console.type = Console
 appender.console.name = Console
 appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss,SSS}{UTC} %p %c{1.} [%t] %m%equals{ ctx=%mdc}{ ctx=\{\}}{}%n
+
+# Allow customization of owned package logs
+logger.rfs.name = com.rfs
+logger.rfs.level = ${ownedPackagesLogLevel}
+logger.migration.name = org.opensearch.migrations
+logger.migration.level = ${ownedPackagesLogLevel}

--- a/TrafficCapture/captureOffloader/src/test/resources/log4j2.properties
+++ b/TrafficCapture/captureOffloader/src/test/resources/log4j2.properties
@@ -1,4 +1,6 @@
-status = error
+status = WARN
+
+property.ownedPackagesLogLevel=${sys:migrationLogLevel:-DEBUG}
 
 # Root logger options
 rootLogger.level = debug
@@ -9,3 +11,9 @@ appender.console.type = Console
 appender.console.name = Console
 appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss,SSS}{UTC} %p %c{1.} [%t] %m%equals{ ctx=%mdc}{ ctx=\{\}}{}%n
+
+# Allow customization of owned package logs
+logger.rfs.name = com.rfs
+logger.rfs.level = ${ownedPackagesLogLevel}
+logger.migration.name = org.opensearch.migrations
+logger.migration.level = ${ownedPackagesLogLevel}

--- a/TrafficCapture/nettyWireLogging/src/test/resources/log4j2.properties
+++ b/TrafficCapture/nettyWireLogging/src/test/resources/log4j2.properties
@@ -1,5 +1,8 @@
-status = error
+status = WARN
 
+property.ownedPackagesLogLevel=${sys:migrationLogLevel:-DEBUG}
+
+# Root logger options
 rootLogger.level = debug
 
 appender.console.type = Console
@@ -8,4 +11,8 @@ appender.console.target = SYSTEM_ERR
 appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = [%-5level] %d{yyyy-MM-dd HH:mm:ss,SSS}{UTC} [%t] %c{1} - %msg%equals{ ctx=%mdc}{ ctx=\{\}}{}%n
 
-rootLogger.appenderRef.stderr.ref = STDERR
+# Allow customization of owned package logs
+logger.rfs.name = com.rfs
+logger.rfs.level = ${ownedPackagesLogLevel}
+logger.migration.name = org.opensearch.migrations
+logger.migration.level = ${ownedPackagesLogLevel}

--- a/TrafficCapture/trafficCaptureProxyServer/src/test/resources/log4j2.properties
+++ b/TrafficCapture/trafficCaptureProxyServer/src/test/resources/log4j2.properties
@@ -1,4 +1,6 @@
-status = error
+status = WARN
+
+property.ownedPackagesLogLevel=${sys:migrationLogLevel:-INFO}
 
 appender.console.type = Console
 appender.console.name = STDERR
@@ -9,3 +11,9 @@ appender.console.layout.pattern = [%-5level] %d{yyyy-MM-dd HH:mm:ss,SSS}{UTC} [%
 rootLogger.level = info
 rootLogger.appenderRefs = stderr
 rootLogger.appenderRef.stderr.ref = STDERR
+
+# Allow customization of owned package logs
+logger.rfs.name = com.rfs
+logger.rfs.level = ${ownedPackagesLogLevel}
+logger.migration.name = org.opensearch.migrations
+logger.migration.level = ${ownedPackagesLogLevel}

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/ExhaustiveCapturedTrafficToHttpTransactionAccumulatorTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/ExhaustiveCapturedTrafficToHttpTransactionAccumulatorTest.java
@@ -10,6 +10,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.IntStream;
 
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -23,6 +24,7 @@ import org.opensearch.migrations.trafficcapture.protos.TrafficStreamUtils;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
+@Tag("longTest")
 public class ExhaustiveCapturedTrafficToHttpTransactionAccumulatorTest extends InstrumentationTest {
 
     public static Arguments[] generateAllTestsAndConfirmComplete(IntStream seedStream) {

--- a/TrafficCapture/trafficReplayer/src/test/resources/log4j2.properties
+++ b/TrafficCapture/trafficReplayer/src/test/resources/log4j2.properties
@@ -1,4 +1,6 @@
-status = error
+status = WARN
+
+property.ownedPackagesLogLevel=${sys:migrationLogLevel:-INFO}
 
 # Root logger options
 rootLogger.level = info
@@ -14,3 +16,9 @@ appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss,SSS}{UTC} %p %c{1.} [%t
 # of the logs for tests
 logger.OutputTupleJsonLogger.name = OutputTupleJsonLogger
 logger.OutputTupleJsonLogger.level = OFF
+
+# Allow customization of owned package logs
+logger.rfs.name = com.rfs
+logger.rfs.level = ${ownedPackagesLogLevel}
+logger.migration.name = org.opensearch.migrations
+logger.migration.level = ${ownedPackagesLogLevel}

--- a/TrafficCapture/transformationPlugins/jsonMessageTransformers/jsonJMESPathMessageTransformerProvider/src/test/resources/log4j2.properties
+++ b/TrafficCapture/transformationPlugins/jsonMessageTransformers/jsonJMESPathMessageTransformerProvider/src/test/resources/log4j2.properties
@@ -1,16 +1,15 @@
 status = WARN
 
-property.ownedPackagesLogLevel=${sys:migrationLogLevel:-debug}
+property.ownedPackagesLogLevel=${sys:migrationLogLevel:-INFO}
 
-# Root logger options
-rootLogger.level = debug
-rootLogger.appenderRef.console.ref = Console
-
-# Console appender configuration
 appender.console.type = Console
 appender.console.name = Console
+appender.console.target = SYSTEM_OUT
 appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss,SSS}{UTC} %p %c{1.} [%t] %m%equals{ ctx=%mdc}{ ctx=\{\}}{}%n
+appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss,SSS}{UTC} %p %c{1.} [%t] %m%n
+
+rootLogger.level = info
+rootLogger.appenderRef.console.ref = Console
 
 # Allow customization of owned package logs
 logger.rfs.name = com.rfs

--- a/TrafficCapture/transformationPlugins/jsonMessageTransformers/jsonJoltMessageTransformerProvider/src/test/resources/log4j2.properties
+++ b/TrafficCapture/transformationPlugins/jsonMessageTransformers/jsonJoltMessageTransformerProvider/src/test/resources/log4j2.properties
@@ -1,16 +1,15 @@
 status = WARN
 
-property.ownedPackagesLogLevel=${sys:migrationLogLevel:-debug}
+property.ownedPackagesLogLevel=${sys:migrationLogLevel:-INFO}
 
-# Root logger options
-rootLogger.level = debug
-rootLogger.appenderRef.console.ref = Console
-
-# Console appender configuration
 appender.console.type = Console
 appender.console.name = Console
+appender.console.target = SYSTEM_OUT
 appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss,SSS}{UTC} %p %c{1.} [%t] %m%equals{ ctx=%mdc}{ ctx=\{\}}{}%n
+appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss,SSS}{UTC} %p %c{1.} [%t] %m%n
+
+rootLogger.level = info
+rootLogger.appenderRef.console.ref = Console
 
 # Allow customization of owned package logs
 logger.rfs.name = com.rfs

--- a/TrafficCapture/transformationPlugins/jsonMessageTransformers/openSearch23PlusTargetTransformerProvider/src/test/resources/log4j2.properties
+++ b/TrafficCapture/transformationPlugins/jsonMessageTransformers/openSearch23PlusTargetTransformerProvider/src/test/resources/log4j2.properties
@@ -1,16 +1,15 @@
 status = WARN
 
-property.ownedPackagesLogLevel=${sys:migrationLogLevel:-debug}
+property.ownedPackagesLogLevel=${sys:migrationLogLevel:-INFO}
 
-# Root logger options
-rootLogger.level = debug
-rootLogger.appenderRef.console.ref = Console
-
-# Console appender configuration
 appender.console.type = Console
 appender.console.name = Console
+appender.console.target = SYSTEM_OUT
 appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss,SSS}{UTC} %p %c{1.} [%t] %m%equals{ ctx=%mdc}{ ctx=\{\}}{}%n
+appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss,SSS}{UTC} %p %c{1.} [%t] %m%n
+
+rootLogger.level = info
+rootLogger.appenderRef.console.ref = Console
 
 # Allow customization of owned package logs
 logger.rfs.name = com.rfs

--- a/awsUtilities/src/test/resources/log4j2.properties
+++ b/awsUtilities/src/test/resources/log4j2.properties
@@ -1,16 +1,15 @@
 status = WARN
 
-property.ownedPackagesLogLevel=${sys:migrationLogLevel:-debug}
+property.ownedPackagesLogLevel=${sys:migrationLogLevel:-INFO}
 
-# Root logger options
-rootLogger.level = debug
-rootLogger.appenderRef.console.ref = Console
-
-# Console appender configuration
 appender.console.type = Console
 appender.console.name = Console
+appender.console.target = SYSTEM_OUT
 appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss,SSS}{UTC} %p %c{1.} [%t] %m%equals{ ctx=%mdc}{ ctx=\{\}}{}%n
+appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss,SSS}{UTC} %p %c{1.} [%t] %m%n
+
+rootLogger.level = info
+rootLogger.appenderRef.console.ref = Console
 
 # Allow customization of owned package logs
 logger.rfs.name = com.rfs

--- a/build.gradle
+++ b/build.gradle
@@ -89,12 +89,14 @@ subprojects {
 
     // Mutually exclusive tests to avoid duplication
     tasks.named('test') {
+        systemProperty 'migrationLogLevel', 'TRACE'
         useJUnitPlatform {
             excludeTags('longTest', 'isolatedTest')
         }
     }
 
     tasks.register('slowTest', Test) {
+        systemProperty 'migrationLogLevel', 'DEBUG'
         useJUnitPlatform {
             includeTags 'longTest'
             excludeTags 'isolatedTest'

--- a/coreUtilities/src/test/resources/log4j2.properties
+++ b/coreUtilities/src/test/resources/log4j2.properties
@@ -1,16 +1,15 @@
 status = WARN
 
-property.ownedPackagesLogLevel=${sys:migrationLogLevel:-debug}
+property.ownedPackagesLogLevel=${sys:migrationLogLevel:-INFO}
 
-# Root logger options
-rootLogger.level = debug
-rootLogger.appenderRef.console.ref = Console
-
-# Console appender configuration
 appender.console.type = Console
 appender.console.name = Console
+appender.console.target = SYSTEM_OUT
 appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss,SSS}{UTC} %p %c{1.} [%t] %m%equals{ ctx=%mdc}{ ctx=\{\}}{}%n
+appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss,SSS}{UTC} %p %c{1.} [%t] %m%n
+
+rootLogger.level = info
+rootLogger.appenderRef.console.ref = Console
 
 # Allow customization of owned package logs
 logger.rfs.name = com.rfs

--- a/dashboardsSanitizer/src/test/resources/log4j2.properties
+++ b/dashboardsSanitizer/src/test/resources/log4j2.properties
@@ -1,16 +1,15 @@
 status = WARN
 
-property.ownedPackagesLogLevel=${sys:migrationLogLevel:-debug}
+property.ownedPackagesLogLevel=${sys:migrationLogLevel:-INFO}
 
-# Root logger options
-rootLogger.level = debug
-rootLogger.appenderRef.console.ref = Console
-
-# Console appender configuration
 appender.console.type = Console
 appender.console.name = Console
+appender.console.target = SYSTEM_OUT
 appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss,SSS}{UTC} %p %c{1.} [%t] %m%equals{ ctx=%mdc}{ ctx=\{\}}{}%n
+appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss,SSS}{UTC} %p %c{1.} [%t] %m%n
+
+rootLogger.level = info
+rootLogger.appenderRef.console.ref = Console
 
 # Allow customization of owned package logs
 logger.rfs.name = com.rfs


### PR DESCRIPTION
### Description
Enable trace logging during `./gradlew test`, and debug logging for slowTests.

Enables unit tests to execute code paths at trace logging which were otherwise unexecuted.

Adds system property `migrationLogLevel` which controls the test logging level
Retains existing test logging level when `migrationLogLevel` is not provided

Note: Changed `status = ERROR` in test log4j2 to WARN in order to identify misconfigurations in log4j2 properties 

Unified appender.console.layout.pattern across across the packages for consistent timestamp and formatting

* Category: Test Fix
* Why these changes are required? Enable unit tests to cover branches in trace/debug logging
* What is the old behavior before changes and new behavior after changes? Only changes to test log4j2 properties and behavior. Some tests before were only running on info/debug logging and now is trace/debug

### Issues Resolved
N/A

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
Local Testing and GHA

### Check List
- [x] New functionality includes testing
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
