### PR TITLE
Improve migration console cli.py test coverage

### DIFF
--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/cli.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/cli.py
@@ -7,6 +7,7 @@ import console_link.middleware.backfill as backfill_
 import console_link.middleware.snapshot as snapshot_
 import console_link.middleware.metadata as metadata_
 import console_link.middleware.replay as replay_
+import console_link.middleware.kafka as kafka_
 
 from console_link.models.utils import ExitCode
 from console_link.environment import Environment
@@ -397,7 +398,7 @@ def kafka_group(ctx):
 @click.option('--topic-name', default="logging-traffic-topic", help='Specify a topic name to create')
 @click.pass_obj
 def create_topic_cmd(ctx, topic_name):
-    result = ctx.env.kafka.create_topic(topic_name=topic_name)
+    result = kafka_.create_topic(ctx.env.kafka, topic_name=topic_name)
     click.echo(result.value)
 
 
@@ -408,13 +409,13 @@ def create_topic_cmd(ctx, topic_name):
 @click.pass_obj
 def delete_topic_cmd(ctx, acknowledge_risk, topic_name):
     if acknowledge_risk:
-        result = ctx.env.kafka.delete_topic(topic_name=topic_name)
+        result = kafka_.delete_topic(ctx.env.kafka, topic_name=topic_name)
         click.echo(result.value)
     else:
         if click.confirm('Deleting a topic will irreversibly delete all captured traffic records stored in that '
                          'topic. Are you sure you want to continue?'):
             click.echo(f"Performing delete topic operation on {topic_name} topic...")
-            result = ctx.env.kafka.delete_topic(topic_name=topic_name)
+            result = kafka_.delete_topic(ctx.env.kafka, topic_name=topic_name)
             click.echo(result.value)
         else:
             click.echo("Aborting command.")
@@ -424,7 +425,7 @@ def delete_topic_cmd(ctx, acknowledge_risk, topic_name):
 @click.option('--group-name', default="logging-group-default", help='Specify a group name to describe')
 @click.pass_obj
 def describe_group_command(ctx, group_name):
-    result = ctx.env.kafka.describe_consumer_group(group_name=group_name)
+    result = kafka_.describe_consumer_group(ctx.env.kafka, group_name=group_name)
     click.echo(result.value)
 
 
@@ -432,7 +433,7 @@ def describe_group_command(ctx, group_name):
 @click.option('--topic-name', default="logging-traffic-topic", help='Specify a topic name to describe')
 @click.pass_obj
 def describe_topic_records_cmd(ctx, topic_name):
-    result = ctx.env.kafka.describe_topic_records(topic_name=topic_name)
+    result = kafka_.describe_topic_records(ctx.env.kafka, topic_name=topic_name)
     click.echo(result.value)
 
 # ##################### UTILITIES ###################

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/environment.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/environment.py
@@ -62,7 +62,7 @@ class Environment:
             self.target_cluster: Cluster = Cluster(self.config["target_cluster"])
             logger.info(f"Target cluster initialized: {self.target_cluster.endpoint}")
         else:
-            logger.warn("No target cluster provided. This may prevent other actions from proceeding.")
+            logger.warning("No target cluster provided. This may prevent other actions from proceeding.")
 
         if 'metrics_source' in self.config:
             self.metrics_source: MetricsSource = get_metrics_source(

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/middleware/kafka.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/middleware/kafka.py
@@ -21,5 +21,5 @@ def describe_consumer_group(kafka: Kafka, group_name: str) -> CommandResult:
 
 
 def describe_topic_records(kafka: Kafka, topic_name: str) -> CommandResult:
-    result = kafka.delete_topic(topic_name=topic_name)
+    result = kafka.describe_topic_records(topic_name=topic_name)
     return result

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/test_cli.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/test_cli.py
@@ -14,6 +14,7 @@ from console_link.models.cluster import Cluster
 from console_link.models.command_result import CommandResult
 from console_link.models.ecs_service import ECSService, InstanceStatuses
 from console_link.models.kafka import StandardKafka
+from console_link.models.metrics_source import Component
 from console_link.models.replayer_ecs import ECSReplayer
 
 TEST_DATA_DIRECTORY = pathlib.Path(__file__).parent / "data"
@@ -42,6 +43,38 @@ def set_fake_aws_credentials():
     os.environ['AWS_ACCESS_KEY_ID'] = 'AKIAIOSFODNN7EXAMPLE'
     os.environ['AWS_SECRET_ACCESS_KEY'] = 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY'
 
+
+@pytest.fixture
+def source_cluster_only_yaml_path(tmp_path):
+    source_cluster_only_path = tmp_path / "source_cluster_only.yaml"
+    source_cluster_only_yaml = """
+source_cluster:
+  endpoint: "https://elasticsearch:9200"
+  allow_insecure: true
+  basic_auth:
+    username: "admin"
+    password: "admin"
+"""
+    with open(source_cluster_only_path, 'w') as f:
+        f.write(source_cluster_only_yaml)
+    return source_cluster_only_path
+
+
+@pytest.fixture
+def target_cluster_only_yaml_path(tmp_path):
+    target_cluster_only_path = tmp_path / "target_cluster_only.yaml"
+    target_cluster_only_yaml = """
+target_cluster:
+  endpoint: "https://opensearchtarget:9200"
+  allow_insecure: true
+  basic_auth:
+    username: "admin"
+    password: "myStrongPassword123!"
+"""
+    with open(target_cluster_only_path, 'w') as f:
+        f.write(target_cluster_only_yaml)
+    return target_cluster_only_path
+
 # Tests around the general CLI functionality
 
 
@@ -58,11 +91,35 @@ def test_cli_with_valid_services_file_does_not_raise_error(runner):
     assert result.exit_code == 0
 
 
+def test_cli_with_no_clusters_in_services_raises_error(runner, tmp_path):
+    no_cluster_services = """
+metrics_source:
+  prometheus:
+    endpoint: "http://prometheus:9090"
+backfill:
+  reindex_from_snapshot:
+    docker:
+snapshot:
+  snapshot_name: "test_snapshot"
+  fs:
+    repo_path: "/snapshot/test-console"
+  otel_endpoint: "http://otel-collector:4317"
+  """
+    yaml_path = tmp_path / "services.yaml"
+    with open(yaml_path, 'w') as f:
+        f.write(no_cluster_services)
+
+    result = runner.invoke(cli, ['--config-file', str(yaml_path), 'clusters', 'connection-check'],
+                           catch_exceptions=True)
+    assert result.exit_code == 1
+    assert isinstance(result.exception, SystemExit)
+
 # The following tests are mostly smoke-tests with a goal of covering every CLI command and option.
 # They generally mock functions either at the logic or the model layer, though occasionally going all the way to
 # an external endpoint call.
 # Standardizing these in the future would be great, but the priority right now is getting overall coverage, and
 # testing that .
+
 
 def test_cli_cluster_cat_indices(runner, mocker):
     middleware_mock = mocker.spy(middleware.clusters, 'cat_indices')
@@ -100,6 +157,52 @@ def test_cli_cluster_connection_check(runner, mocker):
     api_mock.assert_called()
 
 
+def test_cli_cluster_cat_indices_and_connection_check_with_one_cluster(runner, mocker,
+                                                                       target_cluster_only_yaml_path,
+                                                                       source_cluster_only_yaml_path):
+    middleware_connection_check_mock = mocker.spy(middleware.clusters, 'connection_check')
+    middleware_cat_indices_mock = mocker.spy(middleware.clusters, 'cat_indices')
+    api_mock = mocker.patch.object(Cluster, 'call_api', autospec=True)
+    # Connection check with no target cluster
+    result = runner.invoke(cli, ['--config-file', str(source_cluster_only_yaml_path), 'clusters', 'connection-check'],
+                           catch_exceptions=True)
+    assert result.exit_code == 0
+    assert "SOURCE CLUSTER" in result.output
+    assert "No target cluster defined." in result.output
+    middleware_connection_check_mock.assert_called_once()
+    api_mock.assert_called_once()
+    middleware_connection_check_mock.reset_mock()
+    api_mock.reset_mock()
+    # Connection check with no source cluster
+    result = runner.invoke(cli, ['--config-file', str(target_cluster_only_yaml_path), 'clusters', 'connection-check'],
+                           catch_exceptions=True)
+    assert result.exit_code == 0
+    assert "TARGET CLUSTER" in result.output
+    assert "No source cluster defined." in result.output
+    middleware_connection_check_mock.assert_called_once()
+    api_mock.assert_called_once()
+    middleware_connection_check_mock.reset_mock()
+    api_mock.reset_mock()
+    # Cat indices with no target cluster
+    result = runner.invoke(cli, ['--config-file', str(source_cluster_only_yaml_path), 'clusters', 'cat-indices'],
+                           catch_exceptions=True)
+    assert result.exit_code == 0
+    assert "SOURCE CLUSTER" in result.output
+    assert "No target cluster defined." in result.output
+    middleware_cat_indices_mock.assert_called_once()
+    api_mock.assert_called_once()
+    middleware_cat_indices_mock.reset_mock()
+    api_mock.reset_mock()
+    # Cat indices with no source cluster
+    result = runner.invoke(cli, ['--config-file', str(target_cluster_only_yaml_path), 'clusters', 'cat-indices'],
+                           catch_exceptions=True)
+    assert result.exit_code == 0
+    assert "TARGET CLUSTER" in result.output
+    assert "No source cluster defined." in result.output
+    middleware_cat_indices_mock.assert_called_once()
+    api_mock.assert_called_once()
+
+
 def test_cli_cluster_run_test_benchmarks(runner, mocker):
     middleware_mock = mocker.spy(middleware.clusters, 'run_test_benchmarks')
     model_mock = mocker.patch.object(Cluster, 'execute_benchmark_workload')
@@ -108,6 +211,16 @@ def test_cli_cluster_run_test_benchmarks(runner, mocker):
     middleware_mock.assert_called_once()
     model_mock.assert_called()
     assert result.exit_code == 0
+
+
+def test_cli_cluster_run_test_benchmarks_without_source_raises_error(runner, mocker, target_cluster_only_yaml_path):
+    middleware_mock = mocker.spy(middleware.clusters, 'run_test_benchmarks')
+    model_mock = mocker.patch.object(Cluster, 'execute_benchmark_workload')
+    result = runner.invoke(cli, ['--config-file', target_cluster_only_yaml_path, 'clusters', 'run-test-benchmarks'],
+                           catch_exceptions=True)
+    middleware_mock.assert_not_called()
+    model_mock.assert_not_called()
+    assert result.exit_code == 2
 
 
 def test_cli_cluster_clear_indices(runner, mocker):
@@ -160,6 +273,13 @@ def test_cli_cat_indices_e2e(runner, env):
     assert target_cat_indices in result.output
 
 
+def test_cli_snapshot_when_not_defined_raises_error(runner, source_cluster_only_yaml_path):
+    result = runner.invoke(cli, ['--config-file', source_cluster_only_yaml_path, 'snapshot', 'create'],
+                           catch_exceptions=True)
+    assert result.exit_code == 2
+    assert "Snapshot is not set" in result.output
+
+
 def test_cli_snapshot_create(runner, mocker):
     mock = mocker.patch('console_link.middleware.snapshot.create')
 
@@ -199,6 +319,13 @@ def test_cli_with_backfill_describe(runner, mocker):
                            catch_exceptions=True)
     mock.assert_called_once()
     assert result.exit_code == 0
+
+
+def test_cli_backfill_when_not_defined(runner, source_cluster_only_yaml_path):
+    result = runner.invoke(cli, ['--config-file', source_cluster_only_yaml_path, 'backfill', 'start'],
+                           catch_exceptions=True)
+    assert result.exit_code == 2
+    assert "Backfill migration is not set" in result.output
 
 
 def test_cli_backfill_create_rfs(runner, mocker):
@@ -293,6 +420,13 @@ def test_get_backfill_status_with_deep_check(runner, mocker):
     mock_detailed_status_call.assert_called_once()
 
 
+def test_cli_replay_when_not_defined(runner, source_cluster_only_yaml_path):
+    result = runner.invoke(cli, ['--config-file', source_cluster_only_yaml_path, 'replay', 'describe'],
+                           catch_exceptions=True)
+    assert result.exit_code == 2
+    assert "Replay is not set" in result.output
+
+
 def test_replay_describe(runner, mocker):
     mock = mocker.patch('console_link.middleware.replay.describe')
     result = runner.invoke(cli, ['--config-file', str(VALID_SERVICES_YAML), 'replay', 'describe'],
@@ -341,6 +475,13 @@ def test_replay_status(runner, mocker):
     assert result.exit_code == 0
 
 
+def test_cli_metadata_when_not_defined(runner, source_cluster_only_yaml_path):
+    result = runner.invoke(cli, ['--config-file', source_cluster_only_yaml_path, 'metadata', 'migrate'],
+                           catch_exceptions=True)
+    assert result.exit_code == 2
+    assert "Metadata is not set" in result.output
+
+
 def test_cli_metadata_migrate(runner, mocker):
     mock = mocker.patch("subprocess.run")
     result = runner.invoke(cli, ['--config-file', str(VALID_SERVICES_YAML), 'metadata', 'migrate'],
@@ -357,12 +498,66 @@ def test_cli_metadata_evaluate(runner, mocker):
     assert result.exit_code == 0
 
 
-def test_cli_with_metrics_get_data(runner, mocker):
+def test_cli_metrics_when_not_defined(runner, source_cluster_only_yaml_path):
+    result = runner.invoke(cli, ['--config-file', source_cluster_only_yaml_path, 'metrics', 'list'],
+                           catch_exceptions=True)
+    assert result.exit_code == 2
+    assert "Metrics source is not set" in result.output
+
+
+def test_cli_with_metrics_list_metrics(runner, mocker):
     mock = mocker.patch('console_link.models.metrics_source.PrometheusMetricsSource.get_metrics')
     result = runner.invoke(cli, ['--config-file', str(VALID_SERVICES_YAML), 'metrics', 'list'],
                            catch_exceptions=True)
     mock.assert_called_once()
     assert result.exit_code == 0
+
+
+def test_cli_with_metrics_list_metrics_as_json(runner, mocker):
+    mock = mocker.patch('console_link.models.metrics_source.PrometheusMetricsSource.get_metrics',
+                        return_value={'captureProxy': ['kafkaCommitCount', 'captureConnectionDuration'],
+                                      'replayer': ['kafkaCommitCount']}, autospec=True)
+    result = runner.invoke(cli, ['--config-file', str(VALID_SERVICES_YAML), '--json', 'metrics', 'list'],
+                           catch_exceptions=True)
+    mock.assert_called_once()
+    assert result.exit_code == 0
+
+
+def test_cli_with_metrics_get_data(runner, mocker):
+    mock = mocker.patch('console_link.models.metrics_source.PrometheusMetricsSource.get_metric_data',
+                        return_value=[('2024-05-22T20:06:00+00:00', 0.0), ('2024-05-22T20:07:00+00:00', 1.0),
+                                      ('2024-05-22T20:08:00+00:00', 2.0), ('2024-05-22T20:09:00+00:00', 3.0),
+                                      ('2024-05-22T20:10:00+00:00', 4.0)],
+                        autospec=True)
+    result = runner.invoke(cli, ['--config-file', str(VALID_SERVICES_YAML), 'metrics', 'get-data',
+                                 'replayer', 'kafkaCommitCount'],
+                           catch_exceptions=True)
+    assert result.exit_code == 0
+    mock.assert_called_once()
+    assert mock.call_args.args[1] == Component.REPLAYER
+    assert mock.call_args.args[2] == 'kafkaCommitCount'
+
+
+def test_cli_with_metrics_get_data_as_json(runner, mocker):
+    mock = mocker.patch('console_link.models.metrics_source.PrometheusMetricsSource.get_metric_data',
+                        return_value=[('2024-05-22T20:06:00+00:00', 0.0), ('2024-05-22T20:07:00+00:00', 1.0),
+                                      ('2024-05-22T20:08:00+00:00', 2.0), ('2024-05-22T20:09:00+00:00', 3.0),
+                                      ('2024-05-22T20:10:00+00:00', 4.0)],
+                        autospec=True)
+    result = runner.invoke(cli, ['--config-file', str(VALID_SERVICES_YAML), '--json', 'metrics', 'get-data',
+                                 'replayer', 'kafkaCommitCount'],
+                           catch_exceptions=True)
+    assert result.exit_code == 0
+    mock.assert_called_once()
+    assert mock.call_args.args[1] == Component.REPLAYER
+    assert mock.call_args.args[2] == 'kafkaCommitCount'
+
+
+def test_cli_kafka_when_not_defined(runner, source_cluster_only_yaml_path):
+    result = runner.invoke(cli, ['--config-file', source_cluster_only_yaml_path, 'kafka', 'create-topic'],
+                           catch_exceptions=True)
+    assert result.exit_code == 2
+    assert "Kafka is not set" in result.output
 
 
 def test_cli_kafka_create_topic(runner, mocker):
@@ -402,4 +597,9 @@ def test_cli_kafka_describe_topic(runner, mocker):
                                  '--topic-name', 'test'],
                            catch_exceptions=True)
     model_mock.assert_called_once_with(topic_name='test')
+    assert result.exit_code == 0
+
+
+def test_completion_script(runner):
+    result = runner.invoke(cli, [str(VALID_SERVICES_YAML), 'completion', 'bash'], catch_exceptions=True)
     assert result.exit_code == 0

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/test_cli.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/test_cli.py
@@ -561,42 +561,47 @@ def test_cli_kafka_when_not_defined(runner, source_cluster_only_yaml_path):
 
 
 def test_cli_kafka_create_topic(runner, mocker):
-    # These commands _should_ go through the middleware layer but currently don't
-    # middleware_mock = mocker.spy(middleware.kafka, 'create_topic')
-    # middleware_mock.assert_called_once_with(env.kafka, 'test')
-
+    middleware_mock = mocker.spy(middleware.kafka, 'create_topic')
     model_mock = mocker.patch.object(StandardKafka, 'create_topic')
     result = runner.invoke(cli, ['-vv', '--config-file', str(VALID_SERVICES_YAML), 'kafka', 'create-topic',
                                  '--topic-name', 'test'],
                            catch_exceptions=True)
+
     model_mock.assert_called_once_with(topic_name='test')
+    middleware_mock.assert_called_once()
     assert result.exit_code == 0
 
 
 def test_cli_kafka_delete_topic(runner, mocker):
     model_mock = mocker.patch.object(StandardKafka, 'delete_topic')
+    middleware_mock = mocker.spy(middleware.kafka, 'delete_topic')
     result = runner.invoke(cli, ['-vv', '--config-file', str(VALID_SERVICES_YAML), 'kafka', 'delete-topic',
                                  '--topic-name', 'test', '--acknowledge-risk'],
                            catch_exceptions=True)
     model_mock.assert_called_once_with(topic_name='test')
+    middleware_mock.assert_called_once()
     assert result.exit_code == 0
 
 
 def test_cli_kafka_describe_consumer_group(runner, mocker):
     model_mock = mocker.patch.object(StandardKafka, 'describe_consumer_group')
+    middleware_mock = mocker.spy(middleware.kafka, 'describe_consumer_group')
     result = runner.invoke(cli, ['-vv', '--config-file', str(VALID_SERVICES_YAML), 'kafka', 'describe-consumer-group',
                                  '--group-name', 'test-group'],
                            catch_exceptions=True)
     model_mock.assert_called_once_with(group_name='test-group')
+    middleware_mock.assert_called_once()
     assert result.exit_code == 0
 
 
 def test_cli_kafka_describe_topic(runner, mocker):
     model_mock = mocker.patch.object(StandardKafka, 'describe_topic_records')
+    middleware_mock = mocker.spy(middleware.kafka, 'describe_topic_records')
     result = runner.invoke(cli, ['-vv', '--config-file', str(VALID_SERVICES_YAML), 'kafka', 'describe-topic-records',
                                  '--topic-name', 'test'],
                            catch_exceptions=True)
     model_mock.assert_called_once_with(topic_name='test')
+    middleware_mock.assert_called_once()
     assert result.exit_code == 0
 
 


### PR DESCRIPTION
### Description
Test Coverage PR #1 of the day.

These tests bring the overall `console_link` uncovered lines from 378 to 330.

### Issues Resolved


### Testing

### Check List
- [x] New functionality includes testing
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
