### PR TITLE
Extend acceptable docker container startup time in tests

### DIFF
--- a/RFS/src/test/java/com/rfs/cms/WorkCoordinatorTest.java
+++ b/RFS/src/test/java/com/rfs/cms/WorkCoordinatorTest.java
@@ -84,7 +84,6 @@ public class WorkCoordinatorTest {
 
     @Test
     public void testAcquireLeaseHasNoUnnecessaryConflicts() throws Exception {
-        log.error("Hello");
         var testContext = WorkCoordinationTestContext.factory().withAllTracking();
         final var NUM_DOCS = 100;
         try (var workCoordinator = new OpenSearchWorkCoordinator(httpClientSupplier.get(), 3600, "docCreatorWorker")) {

--- a/RFS/src/testFixtures/java/com/rfs/framework/SearchClusterContainer.java
+++ b/RFS/src/testFixtures/java/com/rfs/framework/SearchClusterContainer.java
@@ -72,7 +72,7 @@ public class SearchClusterContainer extends GenericContainer<SearchClusterContai
         super(DockerImageName.parse(version.imageName));
         this.withExposedPorts(9200, 9300)
             .withEnv(version.getInitializationType().getEnvVariables())
-            .waitingFor(Wait.forHttp("/").forPort(9200).forStatusCode(200).withStartupTimeout(Duration.ofMinutes(1)));
+            .waitingFor(Wait.forHttp("/").forPort(9200).forStatusCode(200).withStartupTimeout(Duration.ofMinutes(5)));
 
         this.containerVersion = version;
     }
@@ -130,7 +130,7 @@ public class SearchClusterContainer extends GenericContainer<SearchClusterContai
 
         public ContainerVersion(final String imageName, final Version version, INITIALIZATION_FLAVOR initializationType) {
             this.imageName = imageName;
-            this.version = version; 
+            this.version = version;
             this.initializationType = initializationType;
         }
 

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/http/retries/HttpRetryTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/http/retries/HttpRetryTest.java
@@ -218,7 +218,7 @@ public class HttpRetryTest {
              var server = new GenericContainer<>(HTTPD_IMAGE)
                  .withNetwork(network)
                  .withNetworkAliases(SERVERNAME_ALIAS)
-                 .waitingFor(Wait.forHttp("/").forStatusCode(200));
+                 .waitingFor(Wait.forHttp("/").forStatusCode(200)).withStartupTimeout(Duration.ofMinutes(5));
              var toxiproxy = new ToxiProxyWrapper(network))
         {
             server.start();


### PR DESCRIPTION
### Description
Extend acceptible docker container startup time in tests to 5 minutes from the default 1 minute.
* Category:  Test fix
* Why these changes are required? Make tests more reliable on hosts with more parallelization
* What is the old behavior before changes and new behavior after changes? Sometimes this would fail when run in parallel on larger hosts (8vcpu)

### Issues Resolved

Fix issue:
```
WorkCoordinatorTest > testAcquireLeaseHasNoUnnecessaryConflicts() FAILED
4241 | org.testcontainers.containers.ContainerLaunchException: Container startup failed for image opensearchproject/opensearch:1.3.16
4242 | at app//org.testcontainers.containers.GenericContainer.doStart(GenericContainer.java:359)
4243 | at app//org.testcontainers.containers.GenericContainer.start(GenericContainer.java:330)
4244 | at app//com.rfs.framework.SearchClusterContainer.start(SearchClusterContainer.java:106)
4245 | at app//com.rfs.cms.WorkCoordinatorTest.setupOpenSearchContainer(WorkCoordinatorTest.java:54)
4246 |  
4247 | Caused by:
4248 | org.rnorth.ducttape.RetryCountExceededException: Retry limit hit with exception
4249 | at app//org.rnorth.ducttape.unreliables.Unreliables.retryUntilSuccess(Unreliables.java:88)
4250 | at app//org.testcontainers.containers.GenericContainer.doStart(GenericContainer.java:344)
4251 | ... 3 more
4252 |  
4253 | Caused by:
4254 | org.testcontainers.containers.ContainerLaunchException: Could not create/start container
4255 | at app//org.testcontainers.containers.GenericContainer.tryStart(GenericContainer.java:563)
4256 | at app//org.testcontainers.containers.GenericContainer.lambda$doStart$0(GenericContainer.java:354)
4257 | at app//org.rnorth.ducttape.unreliables.Unreliables.retryUntilSuccess(Unreliables.java:81)
4258 | ... 4 more
4259 |  
4260 | Caused by:
4261 | org.testcontainers.containers.ContainerLaunchException: Timed out waiting for URL to be accessible (http://172.18.0.1:32778/ should return HTTP [200])
4262 | at app//org.testcontainers.containers.wait.strategy.HttpWaitStrategy.waitUntilReady(HttpWaitStrategy.java:320)
4263 | at app//org.testcontainers.containers.wait.strategy.AbstractWaitStrategy.waitUntilReady(AbstractWaitStrategy.java:52)
4264 | at app//org.testcontainers.containers.GenericContainer.waitUntilContainerStarted(GenericContainer.java:909)
4265 | at app//org.testcontainers.containers.GenericContainer.tryStart(GenericContainer.java:500)
4266 | ... 6 more
4267 |  
4268 | Caused by:
4269 | org.rnorth.ducttape.TimeoutException: Timeout waiting for result with exception
4270 | at app//org.rnorth.ducttape.unreliables.Unreliables.retryUntilSuccess(Unreliables.java:54)
4271 | at app//org.testcontainers.containers.wait.strategy.HttpWaitStrategy.waitUntilReady(HttpWaitStrategy.java:252)
4272 | ... 9 more
4273 |  
4274 | Caused by:
4275 | java.lang.RuntimeException: java.net.SocketException: Connection reset
4276 | at org.testcontainers.containers.wait.strategy.HttpWaitStrategy.lambda$null$6(HttpWaitStrategy.java:312)
4277 | at org.rnorth.ducttape.ratelimits.RateLimiter.doWhenReady(RateLimiter.java:27)
4278 | at org.testcontainers.containers.wait.strategy.HttpWaitStrategy.lambda$waitUntilReady$7(HttpWaitStrategy.java:257)
4279 | at org.rnorth.ducttape.unreliables.Unreliables.lambda$retryUntilSuccess$0(Unreliables.java:43)
4280 | at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
4281 | at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
4282 | at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
4283 | at java.base/java.lang.Thread.run(Thread.java:829)
4284 |  
4285 | Caused by:
4286 | java.net.SocketException: Connection reset
4287 | at java.base/java.net.SocketInputStream.read(SocketInputStream.java:186)
4288 | at java.base/java.net.SocketInputStream.read(SocketInputStream.java:140)
4289 | at java.base/java.io.BufferedInputStream.fill(BufferedInputStream.java:252)
4290 | at java.base/java.io.BufferedInputStream.read1(BufferedInputStream.java:292)
4291 | at java.base/java.io.BufferedInputStream.read(BufferedInputStream.java:351)
4292 | at java.base/sun.net.www.http.HttpClient.parseHTTPHeader(HttpClient.java:789)
4293 | at java.base/sun.net.www.http.HttpClient.parseHTTP(HttpClient.java:724)
4294 | at java.base/sun.net.www.http.HttpClient.parseHTTP(HttpClient.java:748)
4295 | at java.base/sun.net.www.protocol.http.HttpURLConnection.getInputStream0(HttpURLConnection.java:1636)
4296 | at java.base/sun.net.www.protocol.http.HttpURLConnection.getInputStream(HttpURLConnection.java:1541)
4297 | at java.base/java.net.HttpURLConnection.getResponseCode(HttpURLConnection.java:527)
4298 | at org.testcontainers.containers.wait.strategy.HttpWaitStrategy.lambda$null$6(HttpWaitStrategy.java:276)
4299 | ... 7 more
4300 |  
4301
```

Is this a backport? If so, please add backport PR # and/or commits #

### Testing

### Check List
- [x] New functionality includes testing
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
