### PR TITLE
Fix code smells in Metadata Cli

### DIFF
--- a/MetadataMigration/build.gradle
+++ b/MetadataMigration/build.gradle
@@ -18,7 +18,8 @@ dependencies {
     implementation group: 'org.slf4j', name: 'slf4j-api'
     implementation group: 'org.apache.logging.log4j', name: 'log4j-slf4j2-impl'
 
-    testImplementation testFixtures(project(path: ':RFS'))
+    testImplementation testFixtures(project(':RFS'))
+    testImplementation testFixtures(project(':testHelperFixtures'))
     testImplementation group: 'org.apache.logging.log4j', name: 'log4j-core'
     testImplementation group: 'org.apache.logging.log4j', name: 'log4j-slf4j2-impl'
     testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api'

--- a/MetadataMigration/src/main/java/org/opensearch/migrations/MetadataMigration.java
+++ b/MetadataMigration/src/main/java/org/opensearch/migrations/MetadataMigration.java
@@ -94,18 +94,20 @@ public class MetadataMigration {
     }
 
     private static void printTopLevelHelp(JCommander commander) {
-        log.info("Usage: [options] [command] [commandOptions]");
-        log.info("Options:");
+        var sb = new StringBuilder();
+        sb.append("Usage: [options] [command] [commandOptions]");
+        sb.append("Options:");
         for (var parameter : commander.getParameters()) {
-            log.info("  " + parameter.getNames());
-            log.info("    " + parameter.getDescription());
+            sb.append("  " + parameter.getNames());
+            sb.append("    " + parameter.getDescription());
         }
 
-        log.info("Commands:");
+        sb.append("Commands:");
         for (var command : commander.getCommands().entrySet()) {
-            log.info("  " + command.getKey());
+            sb.append("  " + command.getKey());
         }
-        log.info("\nUse --help with a specific command for more information.");
+        sb.append("\nUse --help with a specific command for more information.");
+        log.info(sb.toString());
     }
 
     private static void printCommandUsage(JCommander jCommander) {

--- a/MetadataMigration/src/main/java/org/opensearch/migrations/MetadataMigration.java
+++ b/MetadataMigration/src/main/java/org/opensearch/migrations/MetadataMigration.java
@@ -77,7 +77,7 @@ public class MetadataMigration {
                 result = meta.evaluate(evaluateArgs).execute(context);
                 break;
         }
-        log.info(result.toString());
+        log.atInfo().setMessage("{}").addArgument(result::asCliOutput).log();
         System.exit(result.getExitCode());
     }
 

--- a/MetadataMigration/src/main/java/org/opensearch/migrations/cli/Clusters.java
+++ b/MetadataMigration/src/main/java/org/opensearch/migrations/cli/Clusters.java
@@ -14,17 +14,17 @@ public class Clusters {
     private ClusterReader source;
     private ClusterWriter target;
 
-    public String toString() {
+    public String asCliOutput() {
         var sb = new StringBuilder();
         sb.append("Clusters:" + System.lineSeparator());
         if (getSource() != null) {
-            sb.append("   Source:" + System.lineSeparator());
-            sb.append("      " + getSource() + System.lineSeparator());
+            sb.append(Format.indentToLevel(1) + "Source:" + System.lineSeparator());
+            sb.append(Format.indentToLevel(2) + getSource() + System.lineSeparator());
             sb.append(System.lineSeparator());
         }
         if (getTarget() != null) {
-            sb.append("   Target:" + System.lineSeparator());
-            sb.append("      " + getTarget() + System.lineSeparator());
+            sb.append(Format.indentToLevel(1) + "Target:" + System.lineSeparator());
+            sb.append(Format.indentToLevel(2) + getTarget() + System.lineSeparator());
             sb.append(System.lineSeparator());
         }
         return sb.toString();

--- a/MetadataMigration/src/main/java/org/opensearch/migrations/cli/Format.java
+++ b/MetadataMigration/src/main/java/org/opensearch/migrations/cli/Format.java
@@ -1,0 +1,15 @@
+package org.opensearch.migrations.cli;
+
+import lombok.experimental.UtilityClass;
+
+/** Shared formatting for command line interface components */
+@UtilityClass
+public class Format {
+
+    private static final String INDENT = "   ";
+
+    /** Indents to a given level for printing to the console */
+    public static String indentToLevel(final int level) {
+        return INDENT.repeat(level);
+    }
+}

--- a/MetadataMigration/src/main/java/org/opensearch/migrations/cli/Items.java
+++ b/MetadataMigration/src/main/java/org/opensearch/migrations/cli/Items.java
@@ -13,6 +13,7 @@ import lombok.NonNull;
 @Builder
 @Data
 public class Items {
+    static final String NONE_FOUND_MARKER = "<NONE FOUND>";
     private final boolean dryRun;
     @NonNull
     private final List<String> indexTemplates;
@@ -36,7 +37,7 @@ public class Items {
         sb.append(Format.indentToLevel(1) + "Component Templates:" + System.lineSeparator());
         sb.append(Format.indentToLevel(2) +getPrintableList(getComponentTemplates()) + System.lineSeparator());
         sb.append(System.lineSeparator());
-        sb.append(Format.indentToLevel(1) + System.lineSeparator());
+        sb.append(Format.indentToLevel(1) + "Indexes:" + System.lineSeparator());
         sb.append(Format.indentToLevel(2) + getPrintableList(getIndexes()) + System.lineSeparator());
         sb.append(System.lineSeparator());
         sb.append(Format.indentToLevel(1) + "Aliases:" + System.lineSeparator());
@@ -47,7 +48,7 @@ public class Items {
 
     private String getPrintableList(List<String> list) {
         if (list == null || list.isEmpty()) {
-            return "<NONE FOUND>";
+            return NONE_FOUND_MARKER;
         }
         return list.stream().sorted().collect(Collectors.joining(", "));
     }

--- a/MetadataMigration/src/main/java/org/opensearch/migrations/cli/Items.java
+++ b/MetadataMigration/src/main/java/org/opensearch/migrations/cli/Items.java
@@ -5,6 +5,7 @@ import java.util.stream.Collectors;
 
 import lombok.Builder;
 import lombok.Data;
+import lombok.NonNull;
 
 /**
  * Either items that are candidates for migration or have been migrated;
@@ -12,30 +13,34 @@ import lombok.Data;
 @Builder
 @Data
 public class Items {
-    public boolean dryRun;
-    public List<String> indexTemplates;
-    public List<String> componentTemplates;
-    public List<String> indexes;
-    public List<String> aliases;
+    private final boolean dryRun;
+    @NonNull
+    private final List<String> indexTemplates;
+    @NonNull
+    private final List<String> componentTemplates;
+    @NonNull
+    private final List<String> indexes;
+    @NonNull
+    private final List<String> aliases;
 
-    public String toString() {
+    public String asCliOutput() {
         var sb = new StringBuilder();
         if (isDryRun()) {
             sb.append("Migration Candidates:" + System.lineSeparator());
         } else {
             sb.append("Migrated Items:" + System.lineSeparator());
         }
-        sb.append("   Index Templates:" + System.lineSeparator());
-        sb.append("      " + getPrintableList(getIndexTemplates()) + System.lineSeparator());
+        sb.append(Format.indentToLevel(1) + "Index Templates:" + System.lineSeparator());
+        sb.append(Format.indentToLevel(2) + getPrintableList(getIndexTemplates()) + System.lineSeparator());
         sb.append(System.lineSeparator());
-        sb.append("   Component Templates:" + System.lineSeparator());
-        sb.append("      " + getPrintableList(getComponentTemplates()) + System.lineSeparator());
+        sb.append(Format.indentToLevel(1) + "Component Templates:" + System.lineSeparator());
+        sb.append(Format.indentToLevel(2) +getPrintableList(getComponentTemplates()) + System.lineSeparator());
         sb.append(System.lineSeparator());
-        sb.append("   Indexes:" + System.lineSeparator());
-        sb.append("      " + getPrintableList(getIndexes()) + System.lineSeparator());
+        sb.append(Format.indentToLevel(1) + System.lineSeparator());
+        sb.append(Format.indentToLevel(2) + getPrintableList(getIndexes()) + System.lineSeparator());
         sb.append(System.lineSeparator());
-        sb.append("   Aliases:" + System.lineSeparator());
-        sb.append("      " + getPrintableList(getAliases()) + System.lineSeparator());
+        sb.append(Format.indentToLevel(1) + "Aliases:" + System.lineSeparator());
+        sb.append(Format.indentToLevel(2) +getPrintableList(getAliases()) + System.lineSeparator());
         sb.append(System.lineSeparator());
         return sb.toString();
     }

--- a/MetadataMigration/src/main/java/org/opensearch/migrations/commands/Configure.java
+++ b/MetadataMigration/src/main/java/org/opensearch/migrations/commands/Configure.java
@@ -6,7 +6,8 @@ import lombok.extern.slf4j.Slf4j;
 public class Configure {
 
     public ConfigureResult execute() {
-        log.atError().setMessage("configure is not supported").log();
-        return new ConfigureResult(9999);
+        var message = "configure is not supported";
+        log.atError().setMessage(message).log();
+        return new ConfigureResult(9999, message);
     }
 }

--- a/MetadataMigration/src/main/java/org/opensearch/migrations/commands/ConfigureResult.java
+++ b/MetadataMigration/src/main/java/org/opensearch/migrations/commands/ConfigureResult.java
@@ -2,9 +2,18 @@ package org.opensearch.migrations.commands;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.ToString;
 
 @AllArgsConstructor
+@ToString
 public class ConfigureResult implements Result {
     @Getter
     private final int exitCode;
+
+    @Getter
+    private final String errorMessage;
+
+    public String asCliOutput() {
+        return this.toString();
+    }
 }

--- a/MetadataMigration/src/main/java/org/opensearch/migrations/commands/EvaluateResult.java
+++ b/MetadataMigration/src/main/java/org/opensearch/migrations/commands/EvaluateResult.java
@@ -1,7 +1,5 @@
 package org.opensearch.migrations.commands;
 
-import org.apache.logging.log4j.util.Strings;
-
 import org.opensearch.migrations.cli.Clusters;
 import org.opensearch.migrations.cli.Items;
 
@@ -15,23 +13,4 @@ public class EvaluateResult implements MigrationItemResult {
     private final Items items;
     private final String errorMessage;
     private final int exitCode;
-
-    public String toString() {
-        var sb = new StringBuilder();
-        if (getClusters() != null) {
-            sb.append(getClusters() + System.lineSeparator());
-        }
-        if (getItems() != null) {
-            sb.append(getItems() + System.lineSeparator());
-        }
-        sb.append("Results:" + System.lineSeparator());
-        if (Strings.isNotBlank(getErrorMessage())) {
-            sb.append("   Issue(s) detected" + System.lineSeparator());
-            sb.append("Issues:" + System.lineSeparator());
-            sb.append("   " + getErrorMessage() + System.lineSeparator());
-        } else {
-            sb.append("   " + getExitCode() + " issue(s) detected" + System.lineSeparator());
-        }
-        return sb.toString();
-    }
 }

--- a/MetadataMigration/src/main/java/org/opensearch/migrations/commands/MigrateResult.java
+++ b/MetadataMigration/src/main/java/org/opensearch/migrations/commands/MigrateResult.java
@@ -1,7 +1,5 @@
 package org.opensearch.migrations.commands;
 
-import org.apache.logging.log4j.util.Strings;
-
 import org.opensearch.migrations.cli.Clusters;
 import org.opensearch.migrations.cli.Items;
 
@@ -15,23 +13,4 @@ public class MigrateResult implements MigrationItemResult {
     private final Items items;
     private final String errorMessage;
     private final int exitCode;
-
-    public String toString() {
-        var sb = new StringBuilder();
-        if (getClusters() != null) {
-            sb.append(getClusters() + System.lineSeparator());
-        }
-        if (getItems() != null) {
-            sb.append(getItems() + System.lineSeparator());
-        }
-        sb.append("Results:" + System.lineSeparator());
-        if (Strings.isNotBlank(getErrorMessage())) {
-            sb.append("   Issue(s) detected" + System.lineSeparator());
-            sb.append("Issues:" + System.lineSeparator());
-            sb.append("   " + getErrorMessage() + System.lineSeparator());
-        } else {
-            sb.append("   " + getExitCode() + " issue(s) detected" + System.lineSeparator());
-        }
-        return sb.toString();
-    }
 }

--- a/MetadataMigration/src/main/java/org/opensearch/migrations/commands/MigrationItemResult.java
+++ b/MetadataMigration/src/main/java/org/opensearch/migrations/commands/MigrationItemResult.java
@@ -1,10 +1,32 @@
 package org.opensearch.migrations.commands;
 
+import org.apache.logging.log4j.util.Strings;
+
 import org.opensearch.migrations.cli.Clusters;
+import org.opensearch.migrations.cli.Format;
 import org.opensearch.migrations.cli.Items;
 
 /** All shared cli result information */
 public interface MigrationItemResult extends Result {
     Clusters getClusters();
     Items getItems();
+
+    default String asCliOutput() {
+        var sb = new StringBuilder();
+        if (getClusters() != null) {
+            sb.append(getClusters().asCliOutput() + System.lineSeparator());
+        }
+        if (getItems() != null) {
+            sb.append(getItems().asCliOutput() + System.lineSeparator());
+        }
+        sb.append("Results:" + System.lineSeparator());
+        if (Strings.isNotBlank(getErrorMessage())) {
+            sb.append(Format.indentToLevel(1) + "Issue(s) detected" + System.lineSeparator());
+            sb.append("Issues:" + System.lineSeparator());
+            sb.append(Format.indentToLevel(1) + getErrorMessage() + System.lineSeparator());
+        } else {
+            sb.append(Format.indentToLevel(1) + getExitCode() + " issue(s) detected" + System.lineSeparator());
+        }
+        return sb.toString();
+    }
 }

--- a/MetadataMigration/src/main/java/org/opensearch/migrations/commands/Result.java
+++ b/MetadataMigration/src/main/java/org/opensearch/migrations/commands/Result.java
@@ -3,4 +3,7 @@ package org.opensearch.migrations.commands;
 /** All shared cli result information */
 public interface Result {
     int getExitCode();
+    String getErrorMessage();
+    /** Render this result as a string for displaying on the command line  */
+    String asCliOutput();
 }

--- a/MetadataMigration/src/test/java/org/opensearch/migrations/MetadataMigrationTest.java
+++ b/MetadataMigration/src/test/java/org/opensearch/migrations/MetadataMigrationTest.java
@@ -1,0 +1,53 @@
+package org.opensearch.migrations;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import org.opensearch.migrations.testutils.CloseableLogSetup;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+
+public class MetadataMigrationTest {
+
+    @Test
+    void testMain_expectTopLevelHelp() throws Exception {
+        var testCases = List.of(
+            new String[]{},
+            new String[]{"-h"},
+            new String[]{"--help"}
+        );
+        for (var testCase : testCases) {
+            try (var closeableLogSetup = new CloseableLogSetup(MetadataMigration.class.getName())) {
+                MetadataMigration.main(testCase);
+
+                var logEvents = closeableLogSetup.getLogEvents();
+
+                assertThat(logEvents, hasSize(2));
+                assertThat(logEvents.get(0), containsString("Command line arguments"));
+                assertThat(logEvents.get(1), containsString("Usage: [options] [command] [commandOptions]"));
+            }
+        }
+    }
+
+    @Test
+    void testMain_expectCommandHelp() throws Exception {
+        var testCases = List.of(
+            new String[]{"evaluate", "-h"},
+            new String[]{"migrate", "--help"}
+        );
+        for (var testCase : testCases) {
+            try (var closeableLogSetup = new CloseableLogSetup(MetadataMigration.class.getName())) {
+                MetadataMigration.main(testCase);
+
+                var logEvents = closeableLogSetup.getLogEvents();
+
+                assertThat(logEvents, hasSize(2));
+                assertThat(logEvents.get(0), containsString("Command line arguments"));
+                assertThat(logEvents.get(1), containsString("Usage: " + testCase[0] + " [options]"));
+            }
+        }
+    }
+}

--- a/MetadataMigration/src/test/java/org/opensearch/migrations/cli/ClusterReaderExtractorTest.java
+++ b/MetadataMigration/src/test/java/org/opensearch/migrations/cli/ClusterReaderExtractorTest.java
@@ -1,0 +1,105 @@
+package org.opensearch.migrations.cli;
+
+import org.junit.jupiter.api.Test;
+
+import org.opensearch.migrations.MigrateOrEvaluateArgs;
+import org.opensearch.migrations.Version;
+import org.opensearch.migrations.cluster.ClusterReader;
+
+import com.beust.jcommander.ParameterException;
+import com.rfs.common.FileSystemRepo;
+import com.rfs.common.S3Repo;
+import com.rfs.common.http.ConnectionContext;
+import org.mockito.ArgumentCaptor;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+
+public class ClusterReaderExtractorTest {
+    @Test
+    void testExtractClusterReader_noSnapshotOrRemote() {
+        var args = new MigrateOrEvaluateArgs();
+        var extractor = new ClusterReaderExtractor(args);
+
+        var exception = assertThrows(ParameterException.class, () -> extractor.extractClusterReader());
+        assertThat(args.toString(), exception.getMessage(), equalTo("No details on the source cluster found, please supply a connection details or a snapshot"));
+    }
+
+    @Test
+    void testExtractClusterReader_invalidS3Snapshot_missingRegion() {
+        var args = new MigrateOrEvaluateArgs();
+        args.s3RepoUri = "foo.bar";
+        args.s3LocalDirPath = "fizz.buzz";
+        var extractor = new ClusterReaderExtractor(args);
+
+        var exception = assertThrows(ParameterException.class, () -> extractor.extractClusterReader());
+        assertThat(exception.getMessage(), equalTo("If an s3 repo is being used, s3-region and s3-local-dir-path must be set"));
+    }
+
+    @Test
+    void testExtractClusterReader_invalidS3Snapshot_missingLocalDirPath() {
+        var args = new MigrateOrEvaluateArgs();
+        args.s3RepoUri = "foo.bar";
+        args.s3Region = "us-west-1";
+        var extractor = new ClusterReaderExtractor(args);
+
+        var exception = assertThrows(ParameterException.class, () -> extractor.extractClusterReader());
+        assertThat(exception.getMessage(), equalTo("If an s3 repo is being used, s3-region and s3-local-dir-path must be set"));
+    }
+
+    @Test
+    void testExtractClusterReader_validLocalSnapshot() {
+        var args = new MigrateOrEvaluateArgs();
+        args.fileSystemRepoPath = "foo.bar";
+        args.sourceVersion = Version.fromString("OS 1.1.1");
+        var extractor = spy(new ClusterReaderExtractor(args));
+        var mockReader = mock(ClusterReader.class);
+        doReturn(mockReader).when(extractor).getSnapshotReader(eq(args.sourceVersion), any(FileSystemRepo.class));
+
+        var result = extractor.extractClusterReader();
+        assertThat(result, equalTo(mockReader));
+
+        verify(extractor).getSnapshotReader(eq(args.sourceVersion), any(FileSystemRepo.class));
+    }
+
+    @Test
+    void testExtractClusterReader_validS3Snapshot() {
+        var args = new MigrateOrEvaluateArgs();
+        args.s3RepoUri = "foo.bar";
+        args.s3Region = "us-west-1";
+        args.s3LocalDirPath = "fizz.buzz";
+        args.sourceVersion = Version.fromString("OS 9.9.9");
+        var extractor = spy(new ClusterReaderExtractor(args));
+        var mockReader = mock(ClusterReader.class);
+        doReturn(mockReader).when(extractor).getSnapshotReader(eq(args.sourceVersion), any(S3Repo.class));
+
+        var result = extractor.extractClusterReader();
+        assertThat(result, equalTo(mockReader));
+
+        verify(extractor).getSnapshotReader(eq(args.sourceVersion), any(S3Repo.class));
+    }
+
+    @Test
+    void testExtractClusterReader_validRemote() {
+        var args = new MigrateOrEvaluateArgs();
+        args.sourceArgs.host = "http://foo.bar";
+        var extractor = spy(new ClusterReaderExtractor(args));
+        var mockReader = mock(ClusterReader.class);
+        doReturn(mockReader).when(extractor).getRemoteReader(any());
+
+        var result = extractor.extractClusterReader();
+        assertThat(result, equalTo(mockReader));
+
+        var foundContext = ArgumentCaptor.forClass(ConnectionContext.class);
+        verify(extractor).getRemoteReader(foundContext.capture());
+        assertThat(args.sourceArgs.toConnectionContext(), equalTo(foundContext.getValue()));
+    }
+}

--- a/MetadataMigration/src/test/java/org/opensearch/migrations/cli/ClustersTest.java
+++ b/MetadataMigration/src/test/java/org/opensearch/migrations/cli/ClustersTest.java
@@ -1,0 +1,55 @@
+package org.opensearch.migrations.cli;
+
+import org.junit.jupiter.api.Test;
+
+import org.opensearch.migrations.cluster.ClusterReader;
+import org.opensearch.migrations.cluster.ClusterWriter;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.opensearch.migrations.matchers.HasLineCount.hasLineCount;
+import static org.mockito.Mockito.mock;
+
+public class ClustersTest {
+    @Test
+    void testAsString_empty() {
+        var clusters = Clusters.builder().build();
+
+        var result = clusters.asCliOutput();
+
+        assertThat(result, containsString("Clusters:"));
+        assertThat(result, not(containsString("Source:")));
+        assertThat(result, not(containsString("Target:")));
+        assertThat(result, hasLineCount(1));
+    }
+
+    @Test
+    void testAsString_withSource() {
+        var clusters = Clusters.builder()
+            .source(mock(ClusterReader.class))
+            .build();
+
+        var result = clusters.asCliOutput();
+
+        assertThat(result, containsString("Clusters:"));
+        assertThat(result, containsString("Source:"));
+        assertThat(result, not(containsString("Target:")));
+        assertThat(result, hasLineCount(3));
+    }
+
+    @Test
+    void testAsString_withSourceAndTarget() {
+        var clusters = Clusters.builder()
+            .source(mock(ClusterReader.class))
+            .target(mock(ClusterWriter.class))
+            .build();
+
+        var result = clusters.asCliOutput();
+
+        assertThat(result, containsString("Clusters:"));
+        assertThat(result, containsString("Source:"));
+        assertThat(result, containsString("Target:"));
+        assertThat(result, hasLineCount(6));
+    }
+}

--- a/MetadataMigration/src/test/java/org/opensearch/migrations/cli/ItemsTest.java
+++ b/MetadataMigration/src/test/java/org/opensearch/migrations/cli/ItemsTest.java
@@ -1,0 +1,77 @@
+package org.opensearch.migrations.cli;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.opensearch.migrations.matchers.ContainsStringCount.containsStringCount;
+import static org.opensearch.migrations.matchers.HasLineCount.hasLineCount;
+
+public class ItemsTest {
+    @Test
+    void testAsString_empty() {
+        var items = Items.builder()
+            .indexTemplates(List.of())
+            .componentTemplates(List.of())
+            .indexes(List.of())
+            .aliases(List.of())
+            .build();
+
+        var result = items.asCliOutput();
+
+        assertThat(result, containsString("Migrated Items:"));
+        assertThat(result, containsString("Index Templates:"));
+        assertThat(result, containsString("Component Templates:"));
+        assertThat(result, containsString("Indexes:"));
+        assertThat(result, containsString("Aliases:"));
+        assertThat(result, containsStringCount(Items.NONE_FOUND_MARKER, 4));
+        assertThat(result, hasLineCount(12));
+    }
+
+    @Test
+    void testAsString_full() {
+        var items = Items.builder()
+            .indexTemplates(List.of("it1", "it2"))
+            .componentTemplates(List.of("ct1", "ct2"))
+            .indexes(List.of("i1", "i2"))
+            .aliases(List.of("a1", "a2"))
+            .build();
+
+        var result = items.asCliOutput();
+
+        assertThat(result, containsString("Migrated Items:"));
+        assertThat(result, containsString("Index Templates:"));
+        assertThat(result, containsString("it1, it2"));
+        assertThat(result, containsString("Component Templates:"));
+        assertThat(result, containsString("ct1, ct2"));
+        assertThat(result, containsString("Indexes:"));
+        assertThat(result, containsString("i1, i2"));
+        assertThat(result, containsString("Aliases:"));
+        assertThat(result, containsString("a1, a2"));
+        assertThat(result, containsStringCount(Items.NONE_FOUND_MARKER, 0));
+        assertThat(result, hasLineCount(12));
+    }
+
+    @Test
+    void testAsString_itemOrdering() {
+        var items = Items.builder()
+            .indexTemplates(List.of())
+            .componentTemplates(List.of())
+            .indexes(List.of("i1", "i2", "i5", "i3", "i4"))
+            .aliases(List.of())
+            .build();
+
+        var result = items.asCliOutput();
+
+        assertThat(result, containsString("Migrated Items:"));
+        assertThat(result, containsString("Index Templates:"));
+        assertThat(result, containsString("i1, i2, i3, i4, i5"));
+        assertThat(result, containsString("Component Templates:"));
+        assertThat(result, containsString("Indexes:"));
+        assertThat(result, containsString("Aliases:"));
+        assertThat(result, containsStringCount(Items.NONE_FOUND_MARKER, 3));
+        assertThat(result, hasLineCount(12));
+    }
+}

--- a/MetadataMigration/src/test/java/org/opensearch/migrations/commands/MigrationItemResultTest.java
+++ b/MetadataMigration/src/test/java/org/opensearch/migrations/commands/MigrationItemResultTest.java
@@ -1,0 +1,75 @@
+package org.opensearch.migrations.commands;
+
+import org.junit.jupiter.api.Test;
+
+import org.opensearch.migrations.cli.Clusters;
+import org.opensearch.migrations.cli.Items;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+public class MigrationItemResultTest {
+    @Test
+    void testAsString_fullResults_withMessage() {
+        var clusters = mock(Clusters.class);
+        var items = mock(Items.class);
+        var testObject = EvaluateResult.builder()
+            .clusters(clusters)
+            .items(items)
+            .exitCode(10)
+            .errorMessage("Full results")
+            .build();
+
+        var result = testObject.asCliOutput();
+        assertThat(result, containsString("Issue(s) detected"));
+        assertThat(result, containsString("Issues:"));
+
+        verify(clusters).asCliOutput();
+        verify(items).asCliOutput();
+        verifyNoMoreInteractions(items, clusters);
+    }
+
+    @Test
+    void testAsString_fullResults_withNoMessage() {
+        var clusters = mock(Clusters.class);
+        var items = mock(Items.class);
+        var testObject = EvaluateResult.builder()
+            .clusters(clusters)
+            .items(items)
+            .exitCode(10)
+            .build();
+
+        var result = testObject.asCliOutput();
+        assertThat(result, containsString("10 issue(s) detected"));
+        verify(clusters).asCliOutput();
+        verify(items).asCliOutput();
+        verifyNoMoreInteractions(items, clusters);
+    }
+
+    @Test
+    void testAsString_noItems() {
+        var clusters = mock(Clusters.class);
+        var testObject = EvaluateResult.builder()
+            .clusters(clusters)
+            .exitCode(0)
+            .build();
+
+        var result = testObject.asCliOutput();
+        assertThat(result, containsString("0 issue(s) detected"));
+        verify(clusters).asCliOutput();
+        verifyNoMoreInteractions(clusters);
+    }
+
+    @Test
+    void testAsString_nothing() {
+        var testObject = EvaluateResult.builder()
+            .exitCode(0)
+            .build();
+
+        var result = testObject.asCliOutput();
+        assertThat(result, containsString("0 issue(s) detected"));
+    }
+}

--- a/RFS/src/main/java/com/rfs/common/http/ConnectionContext.java
+++ b/RFS/src/main/java/com/rfs/common/http/ConnectionContext.java
@@ -6,6 +6,7 @@ import java.time.Clock;
 
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.ParametersDelegate;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
@@ -14,6 +15,7 @@ import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
  * Stores the connection context for an Elasticsearch/OpenSearch cluster
  */
 @Getter
+@EqualsAndHashCode(exclude={"requestTransformer"})
 @ToString(exclude={"requestTransformer"})
 public class ConnectionContext {
     public enum Protocol {
@@ -140,7 +142,7 @@ public class ConnectionContext {
         public boolean compressionEnabled = false;
     }
 
-        @Getter
+    @Getter
     public static class SourceArgs implements IParams {
         @Parameter(names = {
             "--source-host" }, description = "The source host and port (e.g. http://localhost:9200)", required = false)

--- a/testHelperFixtures/build.gradle
+++ b/testHelperFixtures/build.gradle
@@ -35,6 +35,7 @@ dependencies {
     testFixturesImplementation group: 'org.bouncycastle', name: 'bcprov-jdk18on'
     testFixturesImplementation group: 'org.bouncycastle', name: 'bcpkix-jdk18on'
     testFixturesImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api'
+    testFixturesImplementation group: 'org.hamcrest', name: 'hamcrest'
     testFixturesImplementation group: 'org.slf4j', name: 'slf4j-api'
     testFixturesApi group: 'org.testcontainers', name: 'testcontainers'
     testFixturesApi group: 'org.testcontainers', name: 'toxiproxy'

--- a/testHelperFixtures/src/testFixtures/java/org/opensearch/migrations/matchers/ContainsStringCount.java
+++ b/testHelperFixtures/src/testFixtures/java/org/opensearch/migrations/matchers/ContainsStringCount.java
@@ -1,0 +1,35 @@
+package org.opensearch.migrations.matchers;
+
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeMatcher;
+
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public class ContainsStringCount extends TypeSafeMatcher<String> {
+    private final String expectedString;
+    private final int expectedCount;
+
+    @Override
+    public void describeTo(Description description) {
+        description.appendText("a string containing '" + expectedString + "' " + expectedCount + " times");
+    }
+
+    @Override
+    protected void describeMismatchSafely(String item, Description mismatchDescription) {
+        mismatchDescription.appendText("was found " + containsStringCount(item) + " times");
+    }
+
+    @Override
+    protected boolean matchesSafely(String item) {
+        return containsStringCount(item) == expectedCount;
+    }
+
+    private int containsStringCount(String item) {
+        return item == null ? 0 : item.split(expectedString, -1).length - 1;
+    }
+    
+    public static ContainsStringCount containsStringCount(String s, int n) {
+        return new ContainsStringCount(s, n);
+    }
+}

--- a/testHelperFixtures/src/testFixtures/java/org/opensearch/migrations/matchers/HasLineCount.java
+++ b/testHelperFixtures/src/testFixtures/java/org/opensearch/migrations/matchers/HasLineCount.java
@@ -1,0 +1,34 @@
+package org.opensearch.migrations.matchers;
+
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeMatcher;
+
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public class HasLineCount extends TypeSafeMatcher<String> {
+    private int expectedLineCount;
+
+    @Override
+    public void describeTo(Description description) {
+        description.appendText("a string with " + expectedLineCount + " lines");
+    }
+
+    @Override
+    protected void describeMismatchSafely(String item, Description mismatchDescription) {
+        mismatchDescription.appendText("was a string with " + item.split(System.lineSeparator()).length + " lines");
+    }
+
+    @Override
+    protected boolean matchesSafely(String item) {
+        return newlineCount(item) == expectedLineCount;
+    }
+
+    private int newlineCount(String item) {
+        return item == null ? 0 : item.split("\n").length;
+    }
+
+    public static HasLineCount hasLineCount(int n) {
+        return new HasLineCount(n);
+    }
+}


### PR DESCRIPTION
### Description
Fix code smells in Metadata Cli
- Reduce access on fields and make final
- Create indentation function to ensure consistant output, reduce duplicate logic
- Improve code coverage on command line parsing code
- Bonus fix bugs where some error messages were not being thrown

### Issues Resolved
- Related https://opensearch.atlassian.net/browse/MIGRATIONS-2004

### Check List
- [X] New functionality includes testing
  - [X] All tests pass, including unit test, integration test and doctest
- [ ] ~New functionality has been documented~
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
