### PR TITLE
Resolve some sonar lint issues in captureOffloader

### DIFF
--- a/TrafficCapture/captureOffloader/src/main/java/org/opensearch/migrations/trafficcapture/StreamChannelConnectionCaptureSerializer.java
+++ b/TrafficCapture/captureOffloader/src/main/java/org/opensearch/migrations/trafficcapture/StreamChannelConnectionCaptureSerializer.java
@@ -124,10 +124,10 @@ public class StreamChannelConnectionCaptureSerializer<T> implements IChannelConn
         } else {
             currentCodedOutputStreamHolderOrNull = streamManager.createStream();
             var currentCodedOutputStream = currentCodedOutputStreamHolderOrNull.getOutputStream();
-            // e.g. 1: "9a25a4fffe620014-00034cfa-00000001-d208faac76346d02-864e38e2"
+            // e.g. <pre> 1: "9a25a4fffe620014-00034cfa-00000001-d208faac76346d02-864e38e2" </pre>
             currentCodedOutputStream.writeString(TrafficStream.CONNECTIONID_FIELD_NUMBER, connectionIdString);
             if (nodeIdString != null) {
-                // e.g. 5: "5ae27fca-0ac4-11ee-be56-0242ac120002"
+                // e.g. <pre> 5: "5ae27fca-0ac4-11ee-be56-0242ac120002" </pre>
                 currentCodedOutputStream.writeString(TrafficStream.NODEID_FIELD_NUMBER, nodeIdString);
             }
             if (eomsSoFar > 0) {
@@ -213,11 +213,11 @@ public class StreamChannelConnectionCaptureSerializer<T> implements IChannelConn
                 numFlushesSoFar + 1
             )
         );
-        // e.g. 2 {
+        // e.g. <pre> 2 { </pre>
         writeTrafficStreamTag(TrafficStream.SUBSTREAM_FIELD_NUMBER);
         // Write observation content length
         getOrCreateCodedOutputStream().writeUInt32NoTag(observationContentSize);
-        // e.g. 1 { 1: 1234 2: 1234 }
+        // e.g. <pre> 1 { 1: 1234 2: 1234 } </pre>
         writeTimestampForNowToCurrentStream(timestamp);
     }
 
@@ -371,7 +371,7 @@ public class StreamChannelConnectionCaptureSerializer<T> implements IChannelConn
             lengthSize = CodedOutputStream.computeInt32SizeNoTag(dataSize);
         }
         beginSubstreamObservation(timestamp, captureFieldNumber, dataSize + lengthSize);
-        // e.g. 4 {
+        // e.g. <pre> 4 { </pre>
         writeObservationTag(captureFieldNumber);
         if (dataSize > 0) {
             getOrCreateCodedOutputStream().writeInt32NoTag(dataSize);
@@ -461,7 +461,7 @@ public class StreamChannelConnectionCaptureSerializer<T> implements IChannelConn
             captureClosureLength = CodedOutputStream.computeInt32SizeNoTag(dataSize + segmentCountSize);
         }
         beginSubstreamObservation(timestamp, captureFieldNumber, captureClosureLength + dataSize + segmentCountSize);
-        // e.g. 4 {
+        // e.g. <pre> 4 {  </pre>
         writeObservationTag(captureFieldNumber);
         if (dataSize > 0) {
             // Write size of data after capture tag
@@ -578,7 +578,7 @@ public class StreamChannelConnectionCaptureSerializer<T> implements IChannelConn
         );
         int eomDataSize = eomPairSize + CodedOutputStream.computeInt32SizeNoTag(eomPairSize);
         beginSubstreamObservation(timestamp, TrafficObservation.ENDOFMESSAGEINDICATOR_FIELD_NUMBER, eomDataSize);
-        // e.g. 15 {
+        // e.g. <pre> 15 { </pre>
         writeObservationTag(TrafficObservation.ENDOFMESSAGEINDICATOR_FIELD_NUMBER);
         getOrCreateCodedOutputStream().writeUInt32NoTag(eomPairSize);
         getOrCreateCodedOutputStream().writeInt32(
@@ -650,6 +650,8 @@ public class StreamChannelConnectionCaptureSerializer<T> implements IChannelConn
         }
 
         @Override
-        public void close() {}
+        public void close() {
+            // No resources to close
+        }
     }
 }


### PR DESCRIPTION
### Description

Resolve some sonar lint issues in captureOffloader

* Category: Maintenance
* Why these changes are required? SonarLint Issues
* What is the old behavior before changes and new behavior after changes? No behavior changes

### Issues Resolved

https://opensearch.atlassian.net/browse/MIGRATIONS-2015

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
Ran SonarQube locally, resolved all issues except FileConnectionCaptureFactory deprecation notice.

### Check List
- [x] New functionality includes testing
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
