### PR TITLE
Ensure the migration console welcome message appears correctly

### DIFF
--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/Dockerfile
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/Dockerfile
@@ -57,7 +57,7 @@ RUN echo '. /.venv/bin/activate' >> /etc/profile.d/venv.sh
 RUN dnf install -y bash-completion
 RUN echo '. /etc/profile.d/bash_completion.sh' >> ~/.bashrc && \
     echo '. /etc/profile.d/venv.sh' >> ~/.bashrc && \
-    echo '@echo Welcome to the Migration Assistant Console' >> ~/.bashrc
+    echo 'echo Welcome to the Migration Assistant Console' >> ~/.bashrc
 # Set ENV to control startup script in /bin/sh mode
 ENV ENV=/root/.bashrc
 


### PR DESCRIPTION
### Description
When I started up the migration console from I notice that I was getting an error message instead of the welcome message, I believe that I spaced when adding the echo command - `@echo` is a windows thing.  

### Testing
Verified locally with ` ./gradlew TrafficCapture:dockerSolution:composeUp`, here is the output:
```shell
ubuntu@ip-172-31-18-157:~/git/opensearch-migrations$ docker exec -i -t $(docker ps -aqf "ancestor=migrations/migration_console:latest") /bin/bash
Welcome to the Migration Assistant Console
(.venv) bash-5.2# 
```

### Check List
- [ ] ~New functionality includes testing~
  - [ ] ~All tests pass, including unit test, integration test and doctest~
- [ ] ~New functionality has been documented~
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
