### PR TITLE
[Console] Test Coverage & `snapshot create` passes through extra args

### DIFF
--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/cli.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/cli.py
@@ -150,16 +150,18 @@ def snapshot_group(ctx):
         raise click.UsageError("Snapshot is not set")
 
 
-@snapshot_group.command(name="create")
+@snapshot_group.command(name="create", context_settings=dict(ignore_unknown_options=True))
 @click.option('--wait', is_flag=True, default=False, help='Wait for snapshot completion')
 @click.option('--max-snapshot-rate-mb-per-node', type=int, default=None,
               help='Maximum snapshot rate in MB/s per node')
+@click.argument('extra_args', nargs=-1, type=click.UNPROCESSED)
 @click.pass_obj
-def create_snapshot_cmd(ctx, wait, max_snapshot_rate_mb_per_node):
+def create_snapshot_cmd(ctx, wait, max_snapshot_rate_mb_per_node, extra_args):
     """Create a snapshot of the source cluster"""
     snapshot = ctx.env.snapshot
     result = snapshot_.create(snapshot, wait=wait,
-                              max_snapshot_rate_mb_per_node=max_snapshot_rate_mb_per_node)
+                              max_snapshot_rate_mb_per_node=max_snapshot_rate_mb_per_node,
+                              extra_args=extra_args)
     click.echo(result.value)
 
 

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/snapshot.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/snapshot.py
@@ -1,4 +1,3 @@
-import argparse
 import datetime
 import logging
 from abc import ABC, abstractmethod
@@ -185,17 +184,6 @@ class FileSystemSnapshot(Snapshot):
 
     def delete(self, *args, **kwargs) -> CommandResult:
         return delete_snapshot(self.source_cluster, self.snapshot_name)
-
-
-def parse_args():
-    parser = argparse.ArgumentParser(description="Elasticsearch snapshot status checker.")
-    parser.add_argument("--endpoint", help="Elasticsearch endpoint.", required=True)
-    parser.add_argument("--username", help="Cluster username.", default=None)
-    parser.add_argument("--password", help="Cluster password.", default=None)
-    parser.add_argument("--no-auth", action='store_true', help="Flag to provide no auth in requests.")
-    parser.add_argument("--debug", action='store_true', help="Enable debug logging.")
-    parser.add_argument("--detailed", action='store_true', help="Always get detailed status for completed snapshots.")
-    return parser.parse_args()
 
 
 def get_snapshot_status(cluster: Cluster, snapshot: str,

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/snapshot.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/snapshot.py
@@ -125,11 +125,15 @@ class S3Snapshot(Snapshot):
 
         wait = kwargs.get('wait', False)
         max_snapshot_rate_mb_per_node = kwargs.get('max_snapshot_rate_mb_per_node')
+        extra_args = kwargs.get('extra_args')
 
         if not wait:
             command_args["--no-wait"] = FlagOnlyArgument
         if max_snapshot_rate_mb_per_node is not None:
             command_args["--max-snapshot-rate-mb-per-node"] = max_snapshot_rate_mb_per_node
+        if extra_args:
+            for arg in extra_args:
+                command_args[arg] = FlagOnlyArgument
 
         command_runner = CommandRunner(base_command, command_args, sensitive_fields=["--source-password"])
         try:
@@ -165,9 +169,13 @@ class FileSystemSnapshot(Snapshot):
         command_args["--file-system-repo-path"] = self.repo_path
 
         max_snapshot_rate_mb_per_node = kwargs.get('max_snapshot_rate_mb_per_node')
+        extra_args = kwargs.get('extra_args')
 
         if max_snapshot_rate_mb_per_node is not None:
             command_args["--max-snapshot-rate-mb-per-node"] = max_snapshot_rate_mb_per_node
+        if extra_args:
+            for arg in extra_args:
+                command_args[arg] = FlagOnlyArgument
 
         command_runner = CommandRunner(base_command, command_args, sensitive_fields=["--source-password"])
         try:

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/test_cli.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/test_cli.py
@@ -297,6 +297,18 @@ def test_cli_snapshot_create(runner, mocker):
     mock.assert_called_once()
 
 
+def test_cli_snapshot_create_with_extra_args(runner, mocker):
+    mock = mocker.patch('subprocess.run', autospec=True)
+
+    extra_args = ['--extra-flag', '--extra-arg', 'extra-arg-value', 'this-is-an-option']
+    result = runner.invoke(cli, ['--config-file', str(VALID_SERVICES_YAML), 'snapshot', 'create'] + extra_args,
+                           catch_exceptions=True)
+
+    assert result.exit_code == 0
+    mock.assert_called_once()
+    assert all([arg in mock.call_args.args[0] for arg in extra_args])
+
+
 def test_cli_snapshot_status(runner, mocker):
     mock = mocker.patch('console_link.middleware.snapshot.status')
 

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/test_snapshot.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/test_snapshot.py
@@ -371,3 +371,16 @@ def test_get_snapshot_repository_via_delete(s3_snapshot):
         ('/_snapshot/*/test_snapshot', HttpMethod.GET),  # This is the get_snapshot_repository call
         ('/_snapshot/None/test_snapshot', HttpMethod.DELETE)  # This is the delete_snapshot call
     ]
+
+
+@pytest.mark.parametrize("snapshot_fixture", ['s3_snapshot', 'fs_snapshot'])
+def test_handling_extra_args(mocker, request, snapshot_fixture):
+    snapshot = request.getfixturevalue(snapshot_fixture)
+    mock = mocker.patch('subprocess.run', autospec=True)
+    extra_args = ['--extra-flag', '--extra-arg', 'extra-arg-value', 'this-is-an-option']
+    
+    result = snapshot.create(extra_args=extra_args)
+
+    assert result.success
+    mock.assert_called_once()
+    assert all([arg in mock.call_args.args[0] for arg in extra_args])

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/test_snapshot.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/test_snapshot.py
@@ -2,13 +2,14 @@ import unittest.mock as mock
 
 import pytest
 
+from console_link.models.command_runner import CommandRunner, CommandRunnerError
 from console_link.middleware import snapshot as snapshot_
 from console_link.models.cluster import AuthMethod, Cluster, HttpMethod
 from console_link.models.command_result import CommandResult
 from console_link.models.factories import (UnsupportedSnapshotError,
                                            get_snapshot)
 from console_link.models.snapshot import (FileSystemSnapshot, S3Snapshot,
-                                          Snapshot)
+                                          Snapshot, delete_snapshot)
 from tests.utils import create_valid_cluster
 
 
@@ -28,6 +29,19 @@ def s3_snapshot(mock_cluster):
         }
     }
     return S3Snapshot(config, mock_cluster)
+
+
+@pytest.fixture
+def fs_snapshot(mock_cluster):
+    config = {
+        "snapshot": {
+            "snapshot_name": "reindex_from_snapshot",
+            "fs": {
+                "repo_path": "/path/for/snapshot/repo"
+            },
+        }
+    }
+    return FileSystemSnapshot(config["snapshot"], mock_cluster)
 
 
 def test_s3_snapshot_status(s3_snapshot, mock_cluster):
@@ -229,11 +243,12 @@ def test_s3_snapshot_create_calls_subprocess_run_with_correct_args(mocker):
             },
         }
     }
+    max_snapshot_rate = 100
     source = create_valid_cluster(auth_type=AuthMethod.NO_AUTH)
     snapshot = S3Snapshot(config["snapshot"], source)
 
     mock = mocker.patch("subprocess.run")
-    snapshot.create()
+    snapshot.create(max_snapshot_rate_mb_per_node=max_snapshot_rate)
 
     mock.assert_called_once_with(["/root/createSnapshot/bin/CreateSnapshot",
                                   "--snapshot-name", config["snapshot"]["snapshot_name"],
@@ -243,6 +258,7 @@ def test_s3_snapshot_create_calls_subprocess_run_with_correct_args(mocker):
                                   "--s3-repo-uri", config["snapshot"]["s3"]["repo_uri"],
                                   "--s3-region", config["snapshot"]["s3"]["aws_region"],
                                   "--no-wait",
+                                  "--max-snapshot-rate-mb-per-node", str(max_snapshot_rate),
                                   ], stdout=None, stderr=None, text=True, check=True)
 
 
@@ -280,9 +296,10 @@ def test_fs_snapshot_create_works_for_clusters_with_basic_auth(mocker):
             },
         }
     }
+    max_snapshot_rate = 100
     snapshot = FileSystemSnapshot(config["snapshot"], create_valid_cluster(auth_type=AuthMethod.BASIC_AUTH))
     mock = mocker.patch("subprocess.run")
-    snapshot.create()
+    snapshot.create(max_snapshot_rate_mb_per_node=max_snapshot_rate)
     mock.assert_called_once_with(["/root/createSnapshot/bin/CreateSnapshot",
                                   "--snapshot-name", config["snapshot"]["snapshot_name"],
                                   "--source-host", snapshot.source_cluster.endpoint,
@@ -290,6 +307,7 @@ def test_fs_snapshot_create_works_for_clusters_with_basic_auth(mocker):
                                   "--source-password", snapshot.source_cluster.get_basic_auth_password(),
                                   "--source-insecure",
                                   "--file-system-repo-path", config["snapshot"]["fs"]["repo_path"],
+                                  "--max-snapshot-rate-mb-per-node", str(max_snapshot_rate),
                                   ], stdout=None, stderr=None, text=True, check=True)
 
 
@@ -318,3 +336,38 @@ def test_fs_snapshot_create_works_for_clusters_with_sigv4(mocker):
                                   "--source-insecure",
                                   "--file-system-repo-path", config["snapshot"]["fs"]["repo_path"],
                                   ], stdout=None, stderr=None, text=True, check=True)
+
+
+@pytest.mark.parametrize("snapshot_fixture", ['s3_snapshot', 'fs_snapshot'])
+def test_snapshot_delete(request, snapshot_fixture):
+    snapshot = request.getfixturevalue(snapshot_fixture)
+    snapshot.delete()
+    snapshot.source_cluster.call_api.assert_called_once()
+    assert snapshot.source_cluster.call_api.call_args.args[1] == HttpMethod.DELETE
+
+
+@pytest.mark.parametrize("snapshot_fixture", ['s3_snapshot', 'fs_snapshot'])
+def test_snapshot_create_catches_error(mocker, request, snapshot_fixture):
+    snapshot = request.getfixturevalue(snapshot_fixture)
+    fake_command = "/root/createSnapshot/bin/CreateSnapshot --snapshot_name=reindex_from_snapshot"
+    mock = mocker.patch.object(CommandRunner, 'run', cmd="abc", autospec=True,
+                               side_effect=CommandRunnerError(2, cmd=fake_command, output="Snapshot failure"))
+
+    result = snapshot.create()
+
+    mock.assert_called_once()
+    assert not result.success
+    assert fake_command in result.value
+
+
+def test_get_snapshot_repository_via_delete(s3_snapshot):
+    mock_cluster = s3_snapshot.source_cluster
+    mock_cluster.call_api.return_value.json = lambda: {"snapshots": [{"snapshot": "test_snapshot"}]}
+    mock_cluster.call_api.return_value.text = str({"snapshots": [{"snapshot": "test_snapshot"}]})
+    delete_snapshot(mock_cluster, s3_snapshot.snapshot_name, repository="*")
+
+    mock_cluster.call_api.assert_called()
+    mock_cluster.call_api.calls_args_list = [
+        ('/_snapshot/*/test_snapshot', HttpMethod.GET),  # This is the get_snapshot_repository call
+        ('/_snapshot/None/test_snapshot', HttpMethod.DELETE)  # This is the delete_snapshot call
+    ]


### PR DESCRIPTION
### Description
1. Code coverage 💪 So far, this resolves another 33 uncovered lines with a combo of deleting unused code & adding tests.
2. Passes any extra args submitted with `snapshot create` through to the underlying `subprocess.run` call (and therefore to the java snapshot tool). This is a prereq for allowing filtered snapshots (only certain indices, etc.).

### Issues Resolved
Sonarqube

### Testing

### Check List
- [x] New functionality includes testing
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
