### PR TITLE
[Bug] Fix invalid character in default-values

### DIFF
--- a/deployment/cdk/opensearch-service-migration/default-values.json
+++ b/deployment/cdk/opensearch-service-migration/default-values.json
@@ -13,5 +13,5 @@
   "replayerOutputEFSRemovalPolicy": "DESTROY",
   "migrationConsoleServiceEnabled": true,
   "trafficReplayerServiceEnabled": false,
-  "otelCollectorEnabled": true,
+  "otelCollectorEnabled": true
 }


### PR DESCRIPTION
### Description
Bug fix for invalid default-values

```
SyntaxError: /home/ec2-user/workspace/rfs-default-e2e-test/deployment/cdk/opensearch-service-migration/default-values.json: Unexpected token } in JSON at position 482
    at parse (<anonymous>)
    at Object.Module._extensions..json (node:internal/modules/cjs/loader:1440:39)
    at Module.load (node:internal/modules/cjs/loader:1203:32)
    at Function.Module._load (node:internal/modules/cjs/loader:1019:12)
    at Module.require (node:internal/modules/cjs/loader:1231:19)
    at require (node:internal/modules/helpers:177:18)
    at Object.<anonymous> (/home/ec2-user/workspace/rfs-default-e2e-test/deployment/cdk/opensearch-service-migration/lib/stack-composer.ts:6:1)
    at Module._compile (node:internal/modules/cjs/loader:1364:14)
    at Module.m._compile (/home/ec2-user/workspace/rfs-default-e2e-test/deployment/cdk/opensearch-service-migration/node_modules/ts-node/src/index.ts:1618:23)
    at Module._extensions..js (node:internal/modules/cjs/loader:1422:10)
```

### Issues Resolved
[List any issues this PR will resolve]

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]

### Check List
- [ ] New functionality includes testing
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
