### PR TITLE
Reduce verbosity to trace for parsing bulk responses when determining to retry or not

### DIFF
--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/http/retries/OpenSearchDefaultRetry.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/http/retries/OpenSearchDefaultRetry.java
@@ -75,7 +75,7 @@ public class OpenSearchDefaultRetry extends DefaultRetry {
                 token != JsonToken.NOT_AVAILABLE)
             {
                 JsonToken finalToken = token;
-                log.atInfo().setMessage(() -> "Got token: " + finalToken).log();
+                log.atTrace().setMessage(() -> "Got token: " + finalToken).log();
                 if (token == JsonToken.FIELD_NAME && "errors".equals(parser.getCurrentName())) {
                     parser.nextToken();
                     errorField = parser.getValueAsBoolean();


### PR DESCRIPTION
One liner to quiet down the logs

### Check List
- [ ] New functionality includes testing
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
