### PR TITLE
Fix double trailing slash in getClusterVersion

### DIFF
--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/common/OpenSearchClient.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/common/OpenSearchClient.java
@@ -67,7 +67,7 @@ public class OpenSearchClient {
     }
 
     public Version getClusterVersion() {
-        return client.getAsync("/", null)
+        return client.getAsync("", null)
             .flatMap(resp -> {
                 try {
                     return Mono.just(versionFromResponse(resp));

--- a/RFS/src/test/java/org/opensearch/migrations/bulkload/common/OpenSearchClientTest.java
+++ b/RFS/src/test/java/org/opensearch/migrations/bulkload/common/OpenSearchClientTest.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.junit.jupiter.api.Test;
 
+import org.opensearch.migrations.Version;
 import org.opensearch.migrations.bulkload.common.DocumentReindexer.BulkDocSection;
 import org.opensearch.migrations.bulkload.common.http.HttpResponse;
 import org.opensearch.migrations.bulkload.http.BulkRequestGenerator;
@@ -33,6 +34,7 @@ import static org.opensearch.migrations.bulkload.http.BulkRequestGenerator.itemE
 import static org.opensearch.migrations.bulkload.http.BulkRequestGenerator.itemEntryFailure;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -122,6 +124,30 @@ class OpenSearchClientTest {
 
         // Assertions
         assertThat(exception.getMessage(), containsString("illegal_argument_exception"));
+    }
+
+    @Test
+    void getVersion() {
+        var restClient = mock(RestClient.class);
+        var failedRequestLogger = mock(FailedRequestsLogger.class);
+        var openSearchClient = new OpenSearchClient(restClient, failedRequestLogger);
+
+        var versionJson = "{\"version\": {\"number\": \"7.10.2\"}}";
+        var successResponse = new HttpResponse(200, "OK", Map.of(), versionJson);
+
+        ArgumentCaptor<String> pathCaptor = ArgumentCaptor.forClass(String.class);
+
+        when(restClient.getAsync(pathCaptor.capture(), any()))
+            .thenReturn(Mono.just(successResponse));
+
+        Version version = openSearchClient.getClusterVersion();
+
+        assertThat(version, equalTo(Version.fromString("ES 7.10.2")));
+
+        String capturedPath = pathCaptor.getValue();
+        assertThat(capturedPath, equalTo(""));
+
+        verify(restClient, times(1)).getAsync(anyString(), any());
     }
 
     @Test

--- a/RFS/src/test/java/org/opensearch/migrations/bulkload/common/OpenSearchClientTest.java
+++ b/RFS/src/test/java/org/opensearch/migrations/bulkload/common/OpenSearchClientTest.java
@@ -127,7 +127,7 @@ class OpenSearchClientTest {
     }
 
     @Test
-    void getVersion() {
+    void testGetClusterVersion() {
         var restClient = mock(RestClient.class);
         var failedRequestLogger = mock(FailedRequestsLogger.class);
         var openSearchClient = new OpenSearchClient(restClient, failedRequestLogger);


### PR DESCRIPTION
### Description
Fix double trailing slash in getClusterVersion since rest client was adding "/" which was causing 400 Bad Request in AWS against OS 2.15 (Note, was not causing issues in containers or other versions) 

Bug Introduced in #922 

* Category: Bug Fix
* Why these changes are required? AWS Opensearch Service Support
* What is the old behavior before changes and new behavior after changes? Any Metadata Migrations to AWS Opensearch Service failed for this getVersionCall since #922 

### Issues Resolved

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
Testing in AWS and unit tests added

### Check List
- [x] New functionality includes testing
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
