### PR TITLE
Fix metadata migrate get version

### DIFF
--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/common/OpenSearchClient.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/common/OpenSearchClient.java
@@ -67,7 +67,7 @@ public class OpenSearchClient {
     }
 
     public Version getClusterVersion() {
-        return client.getAsync("/", null)
+        return client.getAsync("", null)
             .flatMap(resp -> {
                 try {
                     return Mono.just(versionFromResponse(resp));


### PR DESCRIPTION
### Description
Fix double trailing slash in getClusterVersion since rest client was adding "/" which was causing 400 Bad Request in AWS against OS 2.15 (Note, was not causing issues in containers or other versions) 

Bug Introduced in #922 

* Category: Bug Fix
* Why these changes are required? AWS Opensearch Service Support
* What is the old behavior before changes and new behavior after changes? Any Metadata Migrations to AWS Opensearch Service failed for this getVersionCall since #922 

### Issues Resolved

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
Testing in AWS and unit tests added

### Check List
- [x] New functionality includes testing
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
