### PR TITLE
Upgrade protobuf version

### DIFF
--- a/TrafficCapture/captureProtobufs/build.gradle
+++ b/TrafficCapture/captureProtobufs/build.gradle
@@ -9,11 +9,11 @@ plugins {
 
 dependencies {
     api project(":commonDependencyVersionConstraints")
-    api group: 'com.google.protobuf', name: 'protobuf-java', version: '3.22.2'
+    api group: 'com.google.protobuf', name: 'protobuf-java', version: '3.25.5'
 }
 
 protobuf {
     protoc {
-        artifact = "com.google.protobuf:protoc:3.22.2"
+        artifact = "com.google.protobuf:protoc:3.25.5"
     }
 }

--- a/commonDependencyVersionConstraints/build.gradle
+++ b/commonDependencyVersionConstraints/build.gradle
@@ -24,7 +24,7 @@ dependencies {
 
     api group: 'com.google.guava', name: 'guava', version: '32.0.1-jre'
 
-    api group: 'com.google.protobuf', name: 'protobuf-java', version: '3.22.2'
+    api group: 'com.google.protobuf', name: 'protobuf-java', version: '3.25.5'
 
     api group: 'org.apache.httpcomponents.client5', name: 'httpclient5', version: '5.2.1'
     api group: 'software.amazon.msk', name:'aws-msk-iam-auth', version: '2.0.3'
@@ -38,7 +38,7 @@ dependencies {
 
     api group: 'org.apache.kafka', name:'kafka-clients', version:'3.6.0'
 
-    api group: 'com.google.protobuf', name: 'protoc', version: '3.22.2'
+    api group: 'com.google.protobuf', name: 'protoc', version: '3.25.5'
 
     def jmeter = '5.6.3'
     api group: 'org.apache.jmeter', name: 'ApacheJMeter_core', version: jmeter


### PR DESCRIPTION
### Description
Current protobuf version has a risk that can be remediated by upgrading to latest version: https://ossindex.sonatype.org/component/pkg:maven/com.google.protobuf/protobuf-java@3.22.2

3.22.2 -> 3.25.5

### Issues Resolved
N/A

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]

### Check List
- [ ] New functionality includes testing
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
