### PR TITLE
Removed greedy matching from a regex to address DOS concern.

### DIFF
--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/common/InvalidResponse.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/common/InvalidResponse.java
@@ -17,7 +17,7 @@ import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class InvalidResponse extends RfsException {
-    private static final Pattern unknownSetting = Pattern.compile("unknown setting \\[(.+)\\].+");
+    private static final Pattern unknownSetting = Pattern.compile("unknown setting \\[(.+?)\\].+");
     private static final ObjectMapper objectMapper = new ObjectMapper();
     private final HttpResponse response;
 


### PR DESCRIPTION
### Description
* Per the title, removing some greedy matching to mitigate DOS concern

### Issues Resolved
* https://tiny.amazon.com/wtrxh53p/sonar

### Testing
* Ran the existing unit tests

### Check List
- [X] New functionality includes testing
  - [X] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
