### PR TITLE
Look for metadata logs and display path

### DIFF
--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/metadata.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/metadata.py
@@ -262,8 +262,7 @@ def get_latest_metadata_logs_path() -> Optional[str]:
     host = os.getenv("HOSTNAME", "*")
     directory = pathlib.Path(shared_logs_dir) / host / "metadata"
     file_pattern = "metadata_*.log"
-    files = directory.glob(file_pattern)
-    # If no files are found, return None
+    files = list(directory.glob(file_pattern))
     if not files:
         return None
     # Find the file with the most recent modification time


### PR DESCRIPTION
### Description
We saw in customer testing yesterday that not having the metadata logs path easily available complicates user debugging.
This PR checks for a new metadata migration log from the python code and prints it out in the output.

```
Results:
   Issue(s) detected
Issues:
   Unexpected failure: Couldn't open the repo directory for some reason

ERROR:console_link.models.metadata:Metadata migration failed: Command '['/root/metadataMigration/bin/MetadataMigration', '--otel-collector-endpoint', 'http://otel-collector:4317', 'migrate', '--snapshot-name', 'snapshot_2023_01_01', '--target-host', 'https://opensearchtarget:9200', '--min-replicas', '0', '--file-system-repo-path', '/snapshot/test-console', '--target-username', 'admin', '--target-password', '********', '--target-insecure']' returned non-zero exit status 120.
Metadata migration failed: Command '['/root/metadataMigration/bin/MetadataMigration', '--otel-collector-endpoint', 'http://otel-collector:4317', 'migrate', '--snapshot-name', 'snapshot_2023_01_01', '--target-host', 'https://opensearchtarget:9200', '--min-replicas', '0', '--file-system-repo-path', '/snapshot/test-console', '--target-username', 'admin', '--target-password', '********', '--target-insecure']' returned non-zero exit status 120.

Logs for this run are available at /shared-logs-output/1b494f5645df/metadata/metadata_2024-09-24_15-42-34.log
(.venv) sh-5.2# 
```

### Issues Resolved
n/a

### Testing
Manual (aghgh, I should add a unit test)

### Check List
- [ ] New functionality includes testing
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
