### PR TITLE
Add VPCe for all aws services

### DIFF
--- a/deployment/cdk/opensearch-service-migration/lib/common-utilities.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/common-utilities.ts
@@ -1,7 +1,7 @@
 import {Effect, PolicyStatement, Role, ServicePrincipal} from "aws-cdk-lib/aws-iam";
 import {Construct} from "constructs";
 import {CpuArchitecture} from "aws-cdk-lib/aws-ecs";
-import {RemovalPolicy} from "aws-cdk-lib";
+import {RemovalPolicy, Stack} from "aws-cdk-lib";
 import { IStringParameter, StringParameter } from "aws-cdk-lib/aws-ssm";
 import * as forge from 'node-forge';
 import * as yargs from 'yargs';
@@ -420,4 +420,12 @@ export function parseClusterDefinition(json: any): ClusterYaml {
         throw new Error(`Invalid auth type when parsing cluster definition: ${json.auth.type}`)
     }
     return new ClusterYaml({endpoint, version, auth})
+}
+
+export function isStackInGovCloud(stack: Stack): boolean {
+        return isRegionGovCloud(stack.region);
+}
+
+export function isRegionGovCloud(region: string): boolean {
+    return region.startsWith('us-gov-');
 }

--- a/deployment/cdk/opensearch-service-migration/lib/stack-composer.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/stack-composer.ts
@@ -344,7 +344,7 @@ export class StackComposer {
                 sourceClusterEndpoint,
                 targetClusterUsername: targetCluster ? targetClusterAuth?.basicAuth?.username : fineGrainedManagerUserName,
                 targetClusterPasswordSecretArn: targetCluster ? targetClusterAuth?.basicAuth?.password_from_secret_arn : fineGrainedManagerUserSecretManagerKeyARN,
-                env: props.env
+                env: props.env,
             })
             this.stacks.push(networkStack)
         }

--- a/deployment/cdk/opensearch-service-migration/test/network-stack.test.ts
+++ b/deployment/cdk/opensearch-service-migration/test/network-stack.test.ts
@@ -4,8 +4,32 @@ import { createStackComposer } from "./test-utils";
 import { ContainerImage } from "aws-cdk-lib/aws-ecs";
 import { StringParameter } from "aws-cdk-lib/aws-ssm";
 import { describe, beforeEach, afterEach, test, expect, jest } from '@jest/globals';
+import { GatewayVpcEndpointAwsService, InterfaceVpcEndpointAwsService } from "aws-cdk-lib/aws-ec2";
+import { Stack } from "aws-cdk-lib";
 
 jest.mock('aws-cdk-lib/aws-ecr-assets');
+
+function getExpectedEndpoints(networkStack: NetworkStack): (InterfaceVpcEndpointAwsService | GatewayVpcEndpointAwsService)[] {
+    return [
+        InterfaceVpcEndpointAwsService.CLOUDWATCH_LOGS,
+        InterfaceVpcEndpointAwsService.CLOUDWATCH_MONITORING,
+        InterfaceVpcEndpointAwsService.ECR,
+        InterfaceVpcEndpointAwsService.ECR_DOCKER,
+        InterfaceVpcEndpointAwsService.ECS_AGENT,
+        InterfaceVpcEndpointAwsService.ECS_TELEMETRY,
+        InterfaceVpcEndpointAwsService.ECS,
+        InterfaceVpcEndpointAwsService.ELASTIC_LOAD_BALANCING,
+        InterfaceVpcEndpointAwsService.SECRETS_MANAGER,
+        InterfaceVpcEndpointAwsService.SSM,
+        InterfaceVpcEndpointAwsService.SSM_MESSAGES,
+        InterfaceVpcEndpointAwsService.XRAY,
+        GatewayVpcEndpointAwsService.S3,
+        Stack.of(networkStack).region.startsWith('us-gov-')
+            ? InterfaceVpcEndpointAwsService.ELASTIC_FILESYSTEM_FIPS
+            : InterfaceVpcEndpointAwsService.ELASTIC_FILESYSTEM,
+    ];
+}
+
 describe('NetworkStack Tests', () => {
     beforeEach(() => {
         // Mock value returned from SSM call
@@ -49,7 +73,7 @@ describe('NetworkStack Tests', () => {
         const networkTemplate = Template.fromStack(networkStack)
 
         networkTemplate.resourceCountIs("AWS::EC2::VPC", 1)
-        networkTemplate.resourceCountIs("AWS::EC2::SecurityGroup", 1)
+        networkTemplate.resourceCountIs("AWS::EC2::SecurityGroup", getExpectedEndpoints(networkStack).length)
         // For each AZ, a private and public subnet is created
         networkTemplate.resourceCountIs("AWS::EC2::Subnet", 4)
 
@@ -76,6 +100,63 @@ describe('NetworkStack Tests', () => {
 
         networkTemplate.resourceCountIs("AWS::EC2::VPC", 0)
         networkTemplate.resourceCountIs("AWS::EC2::SecurityGroup", 0)
+    });
+
+    test('Test VPC Endpoints are created correctly', () => {
+        const contextOptions = {
+            vpcEnabled: true,
+            vpcAZCount: 2,
+            sourceCluster: {
+                "endpoint": "https://test-cluster",
+                "auth": {"type": "none"}
+            }
+        }
+
+        const openSearchStacks = createStackComposer(contextOptions)
+        const networkStack: NetworkStack = (openSearchStacks.stacks.filter((s) => s instanceof NetworkStack)[0]) as NetworkStack
+        const networkTemplate = Template.fromStack(networkStack)
+
+        // Define the expected VPC endpoints
+        const expectedEndpoints = getExpectedEndpoints(networkStack);
+
+        // Check for S3 Gateway Endpoint
+        networkTemplate.hasResourceProperties('AWS::EC2::VPCEndpoint', {
+            VpcEndpointType: 'Gateway',
+        });
+
+        // Loop through the VPC endpoints in the network stack and check that the service name is unique and in the list of expectedEndpoints
+        const vpcEndpoints = networkTemplate.findResources('AWS::EC2::VPCEndpoint');
+        const uniqueServiceNames = new Set<string>();
+
+        const expectedServiceNames = expectedEndpoints.map(endpoint => {
+            return endpoint instanceof GatewayVpcEndpointAwsService ?
+             endpoint.name.toLowerCase().split('.').pop() as string : endpoint.shortName.toLowerCase();
+        });
+
+        for (const endpointKey in vpcEndpoints) {
+            const endpoint = vpcEndpoints[endpointKey];
+            let serviceName: string;
+            if (endpoint.Properties.ServiceName['Fn::Join']) {
+                const joinParts = endpoint.Properties.ServiceName['Fn::Join'][1];
+                serviceName = (joinParts[joinParts.length - 1] as string).split('.').slice(1).join('.') as string;
+            } else {
+                serviceName = endpoint.Properties.ServiceName.split('.').slice(3).join('.');
+            }
+            expect(uniqueServiceNames.has(serviceName)).toBe(false);
+            uniqueServiceNames.add(serviceName);
+
+            const matchingEndpoint = expectedServiceNames.find(e => serviceName.includes(e));
+            if (!matchingEndpoint) {
+                console.error(`Failed assertion for service: ${serviceName}`);
+                console.error(`Expected: ${serviceName} to be in ${expectedServiceNames.join(', ')}`);
+                console.error(`Received: ${matchingEndpoint}`);
+            }
+            expect(matchingEndpoint).toBeDefined();
+        }
+
+        expect(uniqueServiceNames.size).toBe(expectedEndpoints.length);
+        // Verify the total number of VPC Endpoints
+        networkTemplate.resourceCountIs('AWS::EC2::VPCEndpoint', expectedEndpoints.length);
     });
 
     test('Test valid https imported target cluster endpoint with port is formatted correctly', () => {


### PR DESCRIPTION
### Description

Remove public communication from migration assistant services by removing VPC and declaring VPCe's for all services.

* Category: Enhancement
* Why these changes are required? Cost and Security requirements
* What is the old behavior before changes and new behavior after changes? Communication went through nat gateway

### Issues Resolved
https://opensearch.atlassian.net/browse/MIGRATIONS-1969

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
Deployed and ran migration console commands in us-east-1 and us-gov-west-1

### Check List
- [x] New functionality includes testing
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
