### PR TITLE
Support multi arg extraArgs

### DIFF
--- a/CreateSnapshot/src/main/java/org/opensearch/migrations/CreateSnapshot.java
+++ b/CreateSnapshot/src/main/java/org/opensearch/migrations/CreateSnapshot.java
@@ -74,7 +74,10 @@ public class CreateSnapshot {
 
     public static void main(String[] args) throws Exception {
         Args arguments = new Args();
-        JCommander jCommander = JCommander.newBuilder().addObject(arguments).build();
+        JCommander jCommander = JCommander.newBuilder()
+            .allowParameterOverwriting(true)
+            .addObject(arguments)
+            .build();
         jCommander.parse(args);
 
         if (arguments.help) {

--- a/DocumentsFromSnapshotMigration/docker/entrypoint.sh
+++ b/DocumentsFromSnapshotMigration/docker/entrypoint.sh
@@ -18,7 +18,7 @@ echo "RFS_TARGET_PASSWORD_ARN: $RFS_TARGET_PASSWORD_ARN"
 if [[ $RFS_COMMAND != *"--target-username"* ]]; then
     if [[ -n "$RFS_TARGET_USER" ]]; then
         echo "Using username from ENV variable RFS_TARGET_USER.  Updating RFS Command with username."
-        RFS_COMMAND="$RFS_COMMAND --target-username $RFS_TARGET_USER"
+        RFS_COMMAND="$RFS_COMMAND --target-username \"$RFS_TARGET_USER\""
     fi
 fi
 
@@ -39,7 +39,7 @@ if [[ $RFS_COMMAND != *"--target-password"* ]]; then
     # Append the username/password to the RFS Command if have an updated password
     if [[ -n "$PASSWORD_TO_USE" ]]; then
         echo "Updating RFS Command with password."
-        RFS_COMMAND="$RFS_COMMAND --target-password $PASSWORD_TO_USE"
+        RFS_COMMAND="$RFS_COMMAND --target-password \"$PASSWORD_TO_USE\""
     fi
 fi
 

--- a/DocumentsFromSnapshotMigration/src/main/java/org/opensearch/migrations/RfsMigrateDocuments.java
+++ b/DocumentsFromSnapshotMigration/src/main/java/org/opensearch/migrations/RfsMigrateDocuments.java
@@ -127,7 +127,7 @@ public class RfsMigrateDocuments {
                 "used to communicate to the target, default 10")
         int maxConnections = 10;
 
-        @Parameter(names = { "--source-version" }, description = ("Optional. Version of the source cluster.  Default: ES_7.10"), required = false,
+        @Parameter(names = { "--source-version" }, description = ("Optional. Version of the source cluster.  Default: ES 7.10"), required = false,
             converter = VersionConverter.class)
         public Version sourceVersion = Version.fromString("ES 7.10");
     }

--- a/MetadataMigration/src/main/java/org/opensearch/migrations/MetadataMigration.java
+++ b/MetadataMigration/src/main/java/org/opensearch/migrations/MetadataMigration.java
@@ -24,8 +24,9 @@ public class MetadataMigration {
     public static void main(String[] args) throws Exception {
         var metadataArgs = new MetadataArgs();
         var migrateArgs = new MigrateArgs();
-        var evaluateArgs = new EvaluateArgs(); 
+        var evaluateArgs = new EvaluateArgs();
         var jCommander = JCommander.newBuilder()
+            .allowParameterOverwriting(true)
             .addObject(metadataArgs)
             .addCommand(migrateArgs)
             .addCommand(evaluateArgs)

--- a/MetadataMigration/src/main/java/org/opensearch/migrations/MigrateOrEvaluateArgs.java
+++ b/MetadataMigration/src/main/java/org/opensearch/migrations/MigrateOrEvaluateArgs.java
@@ -38,7 +38,7 @@ public class MigrateOrEvaluateArgs {
     public ConnectionContext.TargetArgs targetArgs = new ConnectionContext.TargetArgs();
 
     @ParametersDelegate
-    public DataFilterArgs dataFilterArgs = new DataFilterArgs(); 
+    public DataFilterArgs dataFilterArgs = new DataFilterArgs();
 
     // https://opensearch.org/docs/2.11/api-reference/cluster-api/cluster-awareness/
     @Parameter(names = {"--min-replicas" }, description = "Optional.  The minimum number of replicas configured for migrated indices on the target."
@@ -50,6 +50,6 @@ public class MigrateOrEvaluateArgs {
             + "forwarded. If no value is provided, metrics will not be forwarded.")
     String otelCollectorEndpoint;
 
-    @Parameter(names = {"--source-version" }, description = "Version of the source cluster, for example: Elasticsearch 7.10 or OS 1.3.  Defaults to: ES_7.10", converter = VersionConverter.class)
+    @Parameter(names = {"--source-version" }, description = "Version of the source cluster, for example: Elasticsearch 7.10 or OS 1.3.  Defaults to: ES 7.10", converter = VersionConverter.class)
     public Version sourceVersion = Version.fromString("ES 7.10");
 }

--- a/TrafficCapture/trafficCaptureProxyServer/src/main/java/org/opensearch/migrations/trafficcapture/proxyserver/CaptureProxy.java
+++ b/TrafficCapture/trafficCaptureProxyServer/src/main/java/org/opensearch/migrations/trafficcapture/proxyserver/CaptureProxy.java
@@ -33,6 +33,7 @@ import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.config.SaslConfigs;
 
 import org.opensearch.common.settings.Settings;
+import org.opensearch.migrations.jcommander.NoSplitter;
 import org.opensearch.migrations.tracing.ActiveContextTracker;
 import org.opensearch.migrations.tracing.ActiveContextTrackerByActivityType;
 import org.opensearch.migrations.tracing.CompositeContextTracker;
@@ -159,12 +160,14 @@ public class CaptureProxy {
         @Parameter(required = false,
             names = "--setHeader",
             arity = 2,
+            splitter = NoSplitter.class,
             description = "[header-name header-value] Set an HTTP header (first argument) with to the specified value" +
                 " (second argument).  Any existing headers with that name will be removed.")
         public List<String> headerOverrides = new ArrayList<>();
         @Parameter(required = false,
             names = "--suppressCaptureForHeaderMatch",
             arity = 2,
+            splitter = NoSplitter.class,
             description = "The header name (which will be interpreted in a case-insensitive manner) and a regex "
                 + "pattern.  When the incoming request has a header that matches the regex, it will be passed "
                 + "through to the service but will NOT be captured.  E.g. user-agent 'healthcheck'.")
@@ -174,6 +177,7 @@ public class CaptureProxy {
     static Parameters parseArgs(String[] args) {
         Parameters p = new Parameters();
         JCommander jCommander = new JCommander(p);
+        jCommander.setAllowParameterOverwriting(true);
         try {
             jCommander.parse(args);
             // Exactly one these 3 options are required. See that exactly one is set by summing up their presence

--- a/TrafficCapture/trafficCaptureProxyServer/src/test/java/org/opensearch/migrations/trafficcapture/proxyserver/TestHeaderRewrites.java
+++ b/TrafficCapture/trafficCaptureProxyServer/src/test/java/org/opensearch/migrations/trafficcapture/proxyserver/TestHeaderRewrites.java
@@ -25,6 +25,7 @@ import lombok.extern.slf4j.Slf4j;
 public class TestHeaderRewrites {
 
     public static final String ONLY_FOR_HEADERS_VALUE = "this is only for headers";
+    public static final String ONLY_FOR_HEADERS_VALUE_SPECIAL_CHARACTERS = "!@#$%^&*()_+,./:\":;\\/";
     public static final String BODY_WITH_HEADERS_CONTENTS = "\n" +
         "body: should stay\n" +
         "body: untouched\n" +
@@ -43,6 +44,9 @@ public class TestHeaderRewrites {
             "--setHeader",
             "host",
             "localhost",
+            "--setHeader",
+            "specialCharacters",
+            ONLY_FOR_HEADERS_VALUE_SPECIAL_CHARACTERS,
             "--setHeader",
             "X-new-header",
             "insignificant value"
@@ -70,7 +74,9 @@ public class TestHeaderRewrites {
             var capturedRequest = capturedRequestList.get(capturedRequestList.size()-1).getHeaders().stream()
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
             Assertions.assertEquals("localhost", capturedRequest.get("host"));
+            Assertions.assertEquals(ONLY_FOR_HEADERS_VALUE_SPECIAL_CHARACTERS, capturedRequest.get("specialCharacters"));
             Assertions.assertEquals("insignificant value", capturedRequest.get("X-new-header"));
+
         }
     }
 

--- a/TrafficCapture/trafficCaptureProxyServerTest/src/main/java/org/opensearch/migrations/trafficcapture/JMeterLoadTest.java
+++ b/TrafficCapture/trafficCaptureProxyServerTest/src/main/java/org/opensearch/migrations/trafficcapture/JMeterLoadTest.java
@@ -42,6 +42,7 @@ public class JMeterLoadTest {
     public static Parameters parseArgs(String[] args) {
         Parameters p = new Parameters();
         JCommander jCommander = new JCommander(p);
+        jCommander.setAllowParameterOverwriting(true);
         try {
             jCommander.parse(args);
             return p;

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/TrafficReplayer.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/TrafficReplayer.java
@@ -15,6 +15,7 @@ import java.util.Optional;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
+import org.opensearch.migrations.jcommander.NoSplitter;
 import org.opensearch.migrations.replay.tracing.RootReplayerContext;
 import org.opensearch.migrations.replay.traffic.source.TrafficStreamLimiter;
 import org.opensearch.migrations.replay.util.ActiveContextMonitor;
@@ -117,6 +118,7 @@ public class TrafficReplayer {
         @Parameter(
             required = false, names = {
             AWS_AUTH_HEADER_USER_AND_SECRET_ARG },
+            splitter = NoSplitter.class,
             arity = 2,
             description = "<USERNAME> <SECRET_ARN> pair to specify "
                 + "\"authorization\" header value for each request.  "
@@ -258,6 +260,7 @@ public class TrafficReplayer {
     private static Parameters parseArgs(String[] args) {
         Parameters p = new Parameters();
         JCommander jCommander = new JCommander(p);
+        jCommander.setAllowParameterOverwriting(true);
         try {
             jCommander.parse(args);
             return p;

--- a/coreUtilities/build.gradle
+++ b/coreUtilities/build.gradle
@@ -41,6 +41,9 @@ dependencies {
     implementation group: 'org.apache.logging.log4j', name: 'log4j-core'
     implementation group: 'org.apache.logging.log4j', name: 'log4j-slf4j2-impl'
 
+    // JCommander
+    compileOnly group: 'org.jcommander', name: 'jcommander'
+
     // OpenTelemetry core
     api group: 'io.opentelemetry', name: 'opentelemetry-api'
     api group: 'io.opentelemetry', name: 'opentelemetry-sdk'

--- a/coreUtilities/src/main/java/org/opensearch/migrations/jcommander/NoSplitter.java
+++ b/coreUtilities/src/main/java/org/opensearch/migrations/jcommander/NoSplitter.java
@@ -1,0 +1,12 @@
+package org.opensearch.migrations.jcommander;
+
+import java.util.List;
+
+import com.beust.jcommander.converters.IParameterSplitter;
+
+public class NoSplitter implements IParameterSplitter {
+    @Override
+    public List<String> split(String value) {
+        return List.of(value);
+    }
+}

--- a/deployment/cdk/opensearch-service-migration/lib/service-stacks/capture-proxy-es-stack.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/service-stacks/capture-proxy-es-stack.ts
@@ -9,7 +9,6 @@ import {
     MigrationSSMParameter,
     createMSKProducerIAMPolicies,
     getMigrationStringParameterValue,
-    parseAndMergeArgs
 } from "../common-utilities";
 import {OtelCollectorSidecar} from "./migration-otel-collector-sidecar";
 
@@ -67,7 +66,7 @@ export class CaptureProxyESStack extends MigrationServiceCore {
         command = props.streamingSourceType !== StreamingSourceType.DISABLED ? command.concat(`  --kafkaConnection ${brokerEndpoints}`) : command
         command = props.streamingSourceType === StreamingSourceType.AWS_MSK ? command.concat(" --enableMSKAuth") : command
         command = props.otelCollectorEnabled ? command.concat(` --otelCollectorEndpoint ${OtelCollectorSidecar.getOtelLocalhostEndpoint()}`) : command
-        command = parseAndMergeArgs(command, props.extraArgs);
+        command = props.extraArgs ? command.concat(` ${props.extraArgs}`) : command
 
         this.createService({
             serviceName: "capture-proxy-es",

--- a/deployment/cdk/opensearch-service-migration/lib/service-stacks/capture-proxy-stack.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/service-stacks/capture-proxy-stack.ts
@@ -10,7 +10,6 @@ import {
     createMSKProducerIAMPolicies,
     getCustomStringParameterValue,
     getMigrationStringParameterValue,
-    parseAndMergeArgs
 } from "../common-utilities";
 import {OtelCollectorSidecar} from "./migration-otel-collector-sidecar";
 
@@ -126,7 +125,7 @@ export class CaptureProxyStack extends MigrationServiceCore {
         command = props.streamingSourceType !== StreamingSourceType.DISABLED ? command.concat(`  --kafkaConnection ${brokerEndpoints}`) : command
         command = props.streamingSourceType === StreamingSourceType.AWS_MSK ? command.concat(" --enableMSKAuth") : command
         command = props.otelCollectorEnabled ? command.concat(` --otelCollectorEndpoint ${OtelCollectorSidecar.getOtelLocalhostEndpoint()}`) : command
-        command = parseAndMergeArgs(command, props.extraArgs);
+        command = props.extraArgs ? command.concat(` ${props.extraArgs}`) : command
 
         this.createService({
             serviceName: serviceName,

--- a/deployment/cdk/opensearch-service-migration/lib/service-stacks/reindex-from-snapshot-stack.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/service-stacks/reindex-from-snapshot-stack.ts
@@ -11,7 +11,6 @@ import {
     createOpenSearchServerlessIAMAccessPolicy,
     getTargetPasswordAccessPolicy,
     getMigrationStringParameterValue,
-    parseAndMergeArgs,
     ClusterAuth
 } from "../common-utilities";
 import { RFSBackfillYaml, SnapshotYaml } from "../migration-services-yaml";
@@ -69,11 +68,12 @@ export class ReindexFromSnapshotStack extends MigrationServiceCore {
             parameter: MigrationSSMParameter.OS_CLUSTER_ENDPOINT,
         });
         const s3Uri = `s3://migration-artifacts-${this.account}-${props.stage}-${this.region}/rfs-snapshot-repo`;
-        let rfsCommand = `/rfs-app/runJavaWithClasspath.sh org.opensearch.migrations.RfsMigrateDocuments --s3-local-dir /tmp/s3_files --s3-repo-uri ${s3Uri} --s3-region ${this.region} --snapshot-name rfs-snapshot --lucene-dir '/lucene' --target-host ${osClusterEndpoint}`
+        let rfsCommand = `/rfs-app/runJavaWithClasspath.sh org.opensearch.migrations.RfsMigrateDocuments --s3-local-dir /tmp/s3_files --s3-repo-uri \"${s3Uri}\" --s3-region ${this.region} --snapshot-name rfs-snapshot --lucene-dir '/lucene' --target-host ${osClusterEndpoint}`
         rfsCommand = props.clusterAuthDetails.sigv4 ? rfsCommand.concat(`--target-aws-service-signing-name ${props.clusterAuthDetails.sigv4.serviceSigningName} --target-aws-region ${props.clusterAuthDetails.sigv4.region}`) : rfsCommand
         rfsCommand = props.otelCollectorEnabled ? rfsCommand.concat(` --otel-collector-endpoint ${OtelCollectorSidecar.getOtelLocalhostEndpoint()}`) : rfsCommand
-        rfsCommand = props.sourceClusterVersion ? rfsCommand.concat(` --source-version ${props.sourceClusterVersion}`) : rfsCommand
-        rfsCommand = parseAndMergeArgs(rfsCommand, props.extraArgs);
+        rfsCommand = props.sourceClusterVersion ? rfsCommand.concat(` --source-version \"${props.sourceClusterVersion}\"`) : rfsCommand
+        // TODO: This approach with extraArgs may not work with the entryPoint env arg processing that is occurring here. https://opensearch.atlassian.net/browse/MIGRATIONS-2025
+        rfsCommand = props.extraArgs ? rfsCommand.concat(` ${props.extraArgs}`) : rfsCommand
 
         let targetUser = "";
         let targetPassword = "";

--- a/deployment/cdk/opensearch-service-migration/options.md
+++ b/deployment/cdk/opensearch-service-migration/options.md
@@ -142,8 +142,6 @@ A number of options are currently available but deprecated. While they function 
 <!-- Footnotes -->
 
 [^1]: Extra arguments can be added, overridden, or removed as follows:
-    - To add a new argument: Include the argument with the value, e.g., `"--new-arg value"`
-    - To override an existing argument: Include the argument with the new value, e.g., `"--override-arg new-value"`
-    - To remove an argument: Use the negated form, e.g., `"--no-existing-arg"`
+    - To add/override an argument: Include the argument with the value, e.g., `"--new-arg value"`
+    - Include quotes/escaping as appropriate for bash processing  `"--new-arg \"my value\""`
 
-    Example: `"--new-arg value --existing-arg new-value --no-unwanted-arg"`

--- a/deployment/cdk/opensearch-service-migration/package-lock.json
+++ b/deployment/cdk/opensearch-service-migration/package-lock.json
@@ -18,8 +18,7 @@
         "node-forge": "^1.1.0",
         "semver": "^7.5.4",
         "source-map-support": "^0.5.21",
-        "yaml": "^2.4.3",
-        "yargs": "^17.7.2"
+        "yaml": "^2.4.3"
       },
       "devDependencies": {
         "@aws-cdk/aws-msk-alpha": "^2.150.0-alpha.0",
@@ -74,9 +73,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@aws-cdk/asset-node-proxy-agent-v6": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.0.3.tgz",
-      "integrity": "sha512-twhuEG+JPOYCYPx/xy5uH2+VUsIEhPTzDY0F1KuB+ocjWWB/KEDiOVL19nHvbPCB6fhWnkykXEMJ4HHcKvjtvg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.1.0.tgz",
+      "integrity": "sha512-7bY3J8GCVxLupn/kNmpPc5VJz8grx+4RKfnnJiO1LG+uxkZfANZG3RMHhE+qQxxwkyQ9/MfPtTpf748UhR425A==",
       "dev": true,
       "license": "Apache-2.0"
     },
@@ -2707,6 +2706,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -2716,6 +2716,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -2783,6 +2784,7 @@
       "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.150.0.tgz",
       "integrity": "sha512-leo4J70QrJp+SYm/87VuoOVfALsW11F7JpkAGu5TLL/qd2k/CbovZ8k9/3Ov+jCVsvAgdn9DeHL01Sn6hSl6Zg==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "cdk": "bin/cdk"
       },
@@ -2811,6 +2813,7 @@
         "mime-types"
       ],
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@aws-cdk/asset-awscli-v1": "^2.2.202",
         "@aws-cdk/asset-kubectl-v20": "^2.1.2",
@@ -3572,6 +3575,7 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
       "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "string-width": "^4.2.0",
@@ -3604,6 +3608,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -3616,6 +3621,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/commander": {
@@ -3821,6 +3827,7 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/error-ex": {
@@ -3896,6 +3903,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.2.tgz",
       "integrity": "sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -4132,6 +4140,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
@@ -4431,6 +4440,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5725,6 +5735,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -5919,6 +5930,7 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -5933,6 +5945,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -6335,6 +6348,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -6395,6 +6409,7 @@
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=10"
@@ -6423,6 +6438,7 @@
       "version": "17.7.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
       "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cliui": "^8.0.1",
@@ -6441,6 +6457,7 @@
       "version": "21.1.1",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
       "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"

--- a/deployment/cdk/opensearch-service-migration/package.json
+++ b/deployment/cdk/opensearch-service-migration/package.json
@@ -66,8 +66,7 @@
     "node-forge": "^1.1.0",
     "semver": "^7.5.4",
     "source-map-support": "^0.5.21",
-    "yaml": "^2.4.3",
-    "yargs": "^17.7.2"
+    "yaml": "^2.4.3"
   },
   "peerDependencies": {
     "@aws-cdk/aws-servicecatalogappregistry-alpha": "^2.150.0-alpha.0",

--- a/deployment/cdk/opensearch-service-migration/test/common-utilities.test.ts
+++ b/deployment/cdk/opensearch-service-migration/test/common-utilities.test.ts
@@ -1,5 +1,5 @@
 import {CpuArchitecture} from "aws-cdk-lib/aws-ecs";
-import {parseAndMergeArgs, parseClusterDefinition, validateFargateCpuArch} from "../lib/common-utilities";
+import {parseClusterDefinition, validateFargateCpuArch} from "../lib/common-utilities";
 import {describe, test, expect} from '@jest/globals';
 
 describe('validateFargateCpuArch', () => {
@@ -35,85 +35,6 @@ describe('validateFargateCpuArch', () => {
         const cpuArch = validateFargateCpuArch()
         expect(cpuArch).toEqual(expectedCpuArch)
     })
-    test('Test parseAndMergeArgs function', () => {
-        const baseCommand = 'node script.js --foo bar --baz --foo-bar bar';
-        const extraArgs = '--qux quux --foo override';
-
-        const result = parseAndMergeArgs(baseCommand, extraArgs);
-
-        expect(result).toBe('node script.js --foo override --baz --foo-bar bar --qux quux');
-    });
-
-    test('Test parseAndMergeArgs function with only args', () => {
-        const baseCommand = '--foo bar --baz --foo-bar bar';
-        const extraArgs = '--qux quux --foo override';
-
-        const result = parseAndMergeArgs(baseCommand, extraArgs);
-
-        expect(result).toBe('--foo override --baz --foo-bar bar --qux quux');
-    });
-
-    test('parseAndMergeArgs handles boolean flags correctly', () => {
-        const baseCommand = 'node script.js --verbose --quiet false';
-        const extraArgs = '--debug';
-
-        const result = parseAndMergeArgs(baseCommand, extraArgs);
-
-        expect(result).toBe('node script.js --verbose --quiet false --debug');
-    });
-
-    test('parseAndMergeArgs works without extra args', () => {
-        const baseCommand = 'node script.js --foo bar --baz';
-
-        const result = parseAndMergeArgs(baseCommand);
-
-        expect(result).toBe('node script.js --foo bar --baz');
-    });
-
-    test('parseAndMergeArgs propagates commands that start with --no in base command', () => {
-        const baseCommand = 'node script.js --no-verbose --debug';
-        const extraArgs = '--foo bar';
-
-        const result = parseAndMergeArgs(baseCommand, extraArgs);
-
-        expect(result).toBe('node script.js --no-verbose --debug --foo bar');
-    });
-
-    test('parseAndMergeArgs negates commands that start with --no in base command', () => {
-        const baseCommand = 'node script.js --no-verbose';
-        const extraArgs = '--no-no-verbose';
-
-        const result = parseAndMergeArgs(baseCommand, extraArgs);
-
-        expect(result).toBe('node script.js');
-    });
-
-    test('parseAndMergeArgs handles boolean negation in extra args removing boolean flags', () => {
-        const baseCommand = 'node script.js --verbose --debug';
-        const extraArgs = '--no-verbose --foo bar';
-
-        const result = parseAndMergeArgs(baseCommand, extraArgs);
-
-        expect(result).toBe('node script.js --debug --foo bar');
-    });
-
-    test('parseAndMergeArgs handles extraArgs boolean negations including only true flags in command', () => {
-        const baseCommand = 'node script.js --debug';
-        const extraArgs = '--no-debug --verbose --quiet';
-
-        const result = parseAndMergeArgs(baseCommand, extraArgs);
-
-        expect(result).toBe('node script.js --verbose --quiet');
-    });
-
-    test('parseAndMergeArgs handles extraArgs boolean negations on non-boolean fields', () => {
-        const baseCommand = 'node script.js --foo bar';
-        const extraArgs = '--no-foo';
-
-        const result = parseAndMergeArgs(baseCommand, extraArgs);
-
-        expect(result).toBe('node script.js');
-    });
 
     test('parseClusterDefinition with basic auth parameters', () => {
         const clusterDefinition = {

--- a/deployment/cdk/opensearch-service-migration/test/reindex-from-snapshot-stack.test.ts
+++ b/deployment/cdk/opensearch-service-migration/test/reindex-from-snapshot-stack.test.ts
@@ -115,7 +115,7 @@ describe('ReindexFromSnapshotStack Tests', () => {
         Value: {
           "Fn::Join": [
             "",
-            [ "/rfs-app/runJavaWithClasspath.sh org.opensearch.migrations.RfsMigrateDocuments --s3-local-dir /tmp/s3_files --s3-repo-uri s3://migration-artifacts-test-account-unit-test-us-east-1/rfs-snapshot-repo --s3-region us-east-1 --snapshot-name rfs-snapshot --lucene-dir '/lucene' --target-host ",
+            [ "/rfs-app/runJavaWithClasspath.sh org.opensearch.migrations.RfsMigrateDocuments --s3-local-dir /tmp/s3_files --s3-repo-uri \"s3://migration-artifacts-test-account-unit-test-us-east-1/rfs-snapshot-repo\" --s3-region us-east-1 --snapshot-name rfs-snapshot --lucene-dir '/lucene' --target-host ",
               {
                 "Ref": "SsmParameterValuemigrationunittestdefaultosClusterEndpointC96584B6F00A464EAD1953AFF4B05118Parameter",
               },
@@ -182,7 +182,7 @@ describe('ReindexFromSnapshotStack Tests', () => {
         Value: {
           "Fn::Join": [
             "",
-            [ "/rfs-app/runJavaWithClasspath.sh org.opensearch.migrations.RfsMigrateDocuments --s3-local-dir /tmp/s3_files --s3-repo-uri s3://migration-artifacts-test-account-unit-test-us-east-1/rfs-snapshot-repo --s3-region us-east-1 --snapshot-name rfs-snapshot --lucene-dir '/lucene' --target-host ",
+            [ "/rfs-app/runJavaWithClasspath.sh org.opensearch.migrations.RfsMigrateDocuments --s3-local-dir /tmp/s3_files --s3-repo-uri \"s3://migration-artifacts-test-account-unit-test-us-east-1/rfs-snapshot-repo\" --s3-region us-east-1 --snapshot-name rfs-snapshot --lucene-dir '/lucene' --target-host ",
               {
                 "Ref": "SsmParameterValuemigrationunittestdefaultosClusterEndpointC96584B6F00A464EAD1953AFF4B05118Parameter",
               },
@@ -235,7 +235,7 @@ describe('ReindexFromSnapshotStack Tests', () => {
     expect(reindexStack.rfsSnapshotYaml.snapshot_name).toBe('rfs-snapshot');
   });
 
-  test('ReindexFromSnapshotStack correctly merges extraArgs', () => {
+  test('ReindexFromSnapshotStack correctly appends extraArgs', () => {
     const contextOptions = {
       vpcEnabled: true,
       reindexFromSnapshotServiceEnabled: true,
@@ -244,7 +244,7 @@ describe('ReindexFromSnapshotStack Tests', () => {
         "endpoint": "https://test-cluster",
         "auth": {"type": "none"}
       },
-      reindexFromSnapshotExtraArgs: '--custom-arg value --flag --snapshot-name custom-snapshot',
+      reindexFromSnapshotExtraArgs: '--custom-arg value --flag --snapshot-name \"custom-snapshot\"',
       migrationAssistanceEnabled: true,
     };
 
@@ -271,11 +271,11 @@ describe('ReindexFromSnapshotStack Tests', () => {
         Value: {
           "Fn::Join": [
             "",
-            [ "/rfs-app/runJavaWithClasspath.sh org.opensearch.migrations.RfsMigrateDocuments --s3-local-dir /tmp/s3_files --s3-repo-uri s3://migration-artifacts-test-account-unit-test-us-east-1/rfs-snapshot-repo --s3-region us-east-1 --snapshot-name custom-snapshot --lucene-dir /lucene --target-host ",
+            [ "/rfs-app/runJavaWithClasspath.sh org.opensearch.migrations.RfsMigrateDocuments --s3-local-dir /tmp/s3_files --s3-repo-uri \"s3://migration-artifacts-test-account-unit-test-us-east-1/rfs-snapshot-repo\" --s3-region us-east-1 --snapshot-name rfs-snapshot --lucene-dir '/lucene' --target-host ",
               {
                 "Ref": "SsmParameterValuemigrationunittestdefaultosClusterEndpointC96584B6F00A464EAD1953AFF4B05118Parameter",
               },
-              " --custom-arg value --flag"
+              " --custom-arg value --flag --snapshot-name \"custom-snapshot\""
             ]
           ]
         }


### PR DESCRIPTION
### Description
Support multi arg extraArgs like `--setHeader Host example.com`

* Category: Bug Fix
* Why these changes are required? Enable customers to use setHeader in extra args
* What is the old behavior before changes and new behavior after changes? args would be parsed as `--setHeader Host` and proxy would crash on startup

### Issues Resolved
N/A

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
Tested in AWS

### Check List
- [x] New functionality includes testing
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
