### PR TITLE
Move okhasawn to emeritus maintainer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # This should match the owning team set up in https://github.com/orgs/opensearch-project/teams
-*   @AndreKurait @chelma @gregschohn @lewijacn @mikaylathompson @okhasawn @peternied @sumobrian
+*   @AndreKurait @chelma @gregschohn @lewijacn @mikaylathompson @peternied @sumobrian

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -10,7 +10,6 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Greg Schohn        | [gregschohn](https://github.com/gregschohn)           | Amazon      |
 | Tanner Lewis       | [lewijacn](https://github.com/lewijacn)               | Amazon      |
 | Mikayla Thompson   | [mikaylathompson](https://github.com/mikaylathompson) | Amazon      |
-| Omar Khasawneh     | [okhasawn](https://github.com/okhasawn)               | Amazon      |
 | Brian Presley      | [sumobrian](https://github.com/sumobrian)             | Amazon      |
 | Andre Kurait       | [andrekurait](https://github.com/AndreKurait)         | Amazon      |
 | Peter Nied         | [peternied](https://github.com/peternied)             | Amazon      |
@@ -20,3 +19,5 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Maintainer         | GitHub ID                                               | Affiliation |
 | ------------------ | ------------------------------------------------------- | ----------- |
 | Kartik Ganesh      | [kartg](https://github.com/kartg)                       | Amazon      |
+| Omar Khasawneh     | [okhasawn](https://github.com/okhasawn)                 | Amazon      |
+


### PR DESCRIPTION
### Description

okhasawn has been removed from having write access, updating contributors

### Check List
- [ ] New functionality includes testing
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
