### PR TITLE
Add snapshot delete to cli

### DIFF
--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/cli.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/cli.py
@@ -176,6 +176,14 @@ def status_snapshot_cmd(ctx, deep_check):
     result = snapshot_.status(ctx.env.snapshot, deep_check=deep_check)
     click.echo(result.value)
 
+
+@snapshot_group.command(name="delete")
+@click.pass_obj
+def delete_snapshot_cmd(ctx):
+    """Delete the snapshot"""
+    result = snapshot_.delete(ctx.env.snapshot)
+    click.echo(result.value)
+
 # ##################### BACKFILL ###################
 
 # As we add other forms of backfill migrations, we should incorporate a way to dynamically allow different sets of

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/cli.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/cli.py
@@ -178,9 +178,18 @@ def status_snapshot_cmd(ctx, deep_check):
 
 
 @snapshot_group.command(name="delete")
+@click.option("--acknowledge-risk", is_flag=True, show_default=True, default=False,
+              help="Flag to acknowledge risk and skip confirmation")
 @click.pass_obj
-def delete_snapshot_cmd(ctx):
+def delete_snapshot_cmd(ctx, acknowledge_risk: bool):
     """Delete the snapshot"""
+    if not acknowledge_risk:
+        confirmed = click.confirm('If you proceed with deleting the snapshot, the cluster will delete underlying local '
+                                  'and remote files associated with the snapshot. Are you sure you want to continue?')
+        if not confirmed:
+            click.echo("Aborting the command to delete snapshot.")
+            return
+    logger.info("Deleting snapshot")
     result = snapshot_.delete(ctx.env.snapshot)
     click.echo(result.value)
 

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/middleware/snapshot.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/middleware/snapshot.py
@@ -22,7 +22,7 @@ def status(snapshot: Snapshot, *args, **kwargs) -> CommandResult:
 def delete(snapshot: Snapshot, *args, **kwargs) -> CommandResult:
     logger.info(f"Deleting snapshot with {args=} and {kwargs=}")
     try:
-        return snapshot.delete(*args, **kwargs)
+        return CommandResult(success=True, value=snapshot.delete(*args, **kwargs))
     except Exception as e:
         logger.error(f"Failure running delete snapshot: {e}")
-        return CommandResult(status=False, message=f"Failure running delete snapshot: {e}")
+        return CommandResult(success=False, value=f"Failure running delete snapshot: {e}")

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/test_cli.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/test_cli.py
@@ -325,6 +325,19 @@ def test_cli_snapshot_status(runner, mocker):
     mock.assert_called_once()
 
 
+def test_cli_snapshot_delete(runner, mocker):
+    mock = mocker.patch.object(Cluster, 'call_api', autospec=True)
+    mock.return_value.text = "Successfully deleted"
+
+    # Test snapshot status
+    result = runner.invoke(cli, ['--config-file', str(VALID_SERVICES_YAML), 'snapshot', 'delete'],
+                           catch_exceptions=True)
+    assert result.exit_code == 0
+
+    # Ensure the mocks were called
+    mock.assert_called_once()
+
+
 def test_cli_with_backfill_describe(runner, mocker):
     mock = mocker.patch('console_link.middleware.backfill.describe')
     result = runner.invoke(cli, ['--config-file', str(VALID_SERVICES_YAML), 'backfill', 'describe'],

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/test_cli.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/test_cli.py
@@ -325,17 +325,30 @@ def test_cli_snapshot_status(runner, mocker):
     mock.assert_called_once()
 
 
-def test_cli_snapshot_delete(runner, mocker):
+def test_cli_snapshot_delete_with_acknowledgement(runner, mocker):
     mock = mocker.patch.object(Cluster, 'call_api', autospec=True)
     mock.return_value.text = "Successfully deleted"
 
     # Test snapshot status
-    result = runner.invoke(cli, ['--config-file', str(VALID_SERVICES_YAML), 'snapshot', 'delete'],
+    result = runner.invoke(cli, ['--config-file', str(VALID_SERVICES_YAML), 'snapshot', 'delete', '--acknowledge-risk'],
                            catch_exceptions=True)
     assert result.exit_code == 0
 
     # Ensure the mocks were called
     mock.assert_called_once()
+
+
+def test_cli_snapshot_delete_without_acknowledgement_doesnt_run(runner, mocker):
+    mock = mocker.patch.object(Cluster, 'call_api', autospec=True)
+    mock.return_value.text = "Successfully deleted"
+
+    # Test snapshot status
+    result = runner.invoke(cli, ['--config-file', str(VALID_SERVICES_YAML), 'snapshot', 'delete'], input="n",
+                           catch_exceptions=True)
+    assert result.exit_code == 0
+
+    # Ensure the mocks were called
+    mock.assert_not_called()
 
 
 def test_cli_with_backfill_describe(runner, mocker):


### PR DESCRIPTION
### Description
We had `snapshot delete` implemented in the backend, but not extended to the CLI.

### Issues Resolved


### Testing
Added a cli-level test.

### Check List
- [x] New functionality includes testing
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
