### PR TITLE
Make cdk.context.json valid json

### DIFF
--- a/deployment/cdk/opensearch-service-migration/cdk.context.json
+++ b/deployment/cdk/opensearch-service-migration/cdk.context.json
@@ -5,10 +5,10 @@
       "endpoint": "<TARGET_CLUSTER_ENDPOINT>",
       "auth": {
         "type": "none | basic | sigv4",
-        // if basic
+        "// basic auth documentation": "The next two lines are releavant for basic auth only",
         "username": "<USERNAME>",
         "password_from_secret_arn": "<ARN_OF_SECRET_CONTAINING_PASSWORD>",
-        // if sigv4
+        "// sigv4 documentation": "The next two lines are releavant for sigv4 only",
         "region": "<REGION>",
         "serviceSigningName": "es | aoss"
       }
@@ -17,10 +17,10 @@
       "endpoint": "<SOURCE_CLUSTER_ENDPOINT>",
       "auth": {
         "type": "none | basic | sigv4",
-        // if basic
+        "// basic auth documentation": "The next two lines are releavant for basic auth only",
         "username": "<USERNAME>",
         "password_from_secret_arn": "<ARN_OF_SECRET_CONTAINING_PASSWORD>",
-        // if sigv4
+        "// sigv4 documentation": "The next two lines are releavant for sigv4 only",
         "region": "<REGION>",
         "serviceSigningName": "es | aoss"
       }

--- a/test/defaultMigrationContext.json
+++ b/test/defaultMigrationContext.json
@@ -13,6 +13,14 @@
     "reindexFromSnapshotServiceEnabled": true,
     "sourceClusterEndpoint": "<SOURCE_CLUSTER_ENDPOINT>",
     "migrationConsoleEnableOSI": true,
-    "migrationAPIEnabled": true
+    "migrationAPIEnabled": true,
+    "tlsSecurityPolicy": "TLS_1_2",
+    "enforceHTTPS": true,
+    "nodeToNodeEncryptionEnabled": true,
+    "encryptionAtRestEnabled": true,
+    "vpcAZCount": 2,
+    "domainAZCount": 2,
+    "mskAZCount": 2,
+    "replayerOutputEFSRemovalPolicy": "DESTROY"
   }
 }

--- a/vars/rfsDefaultE2ETest.groovy
+++ b/vars/rfsDefaultE2ETest.groovy
@@ -39,7 +39,19 @@ def call(Map config = [:]) {
             "artifactBucketRemovalPolicy": "DESTROY",
             "trafficReplayerServiceEnabled": false,
             "reindexFromSnapshotServiceEnabled": true,
-            "sourceClusterEndpoint": "<SOURCE_CLUSTER_ENDPOINT>"
+            "sourceClusterEndpoint": "<SOURCE_CLUSTER_ENDPOINT>",
+            "tlsSecurityPolicy": "TLS_1_2",
+            "enforceHTTPS": true,
+            "nodeToNodeEncryptionEnabled": true,
+            "encryptionAtRestEnabled": true,
+            "vpcEnabled": true,
+            "vpcAZCount": 2,
+            "domainAZCount": 2,
+            "mskAZCount": 2,
+            "migrationAssistanceEnabled": true,
+            "replayerOutputEFSRemovalPolicy": "DESTROY",
+            "migrationConsoleServiceEnabled": true,
+            "otelCollectorEnabled": true
           }
         }
     """

--- a/vars/trafficReplayDefaultE2ETest.groovy
+++ b/vars/trafficReplayDefaultE2ETest.groovy
@@ -43,7 +43,19 @@ def call(Map config = [:]) {
         "reindexFromSnapshotServiceEnabled": true,
         "sourceClusterEndpoint": "<SOURCE_CLUSTER_ENDPOINT>",
         "migrationConsoleEnableOSI": true,
-        "migrationAPIEnabled": true
+        "migrationAPIEnabled": true,
+        "tlsSecurityPolicy": "TLS_1_2",
+        "enforceHTTPS": true,
+        "nodeToNodeEncryptionEnabled": true,
+        "encryptionAtRestEnabled": true,
+        "vpcEnabled": true,
+        "vpcAZCount": 2,
+        "domainAZCount": 2,
+        "mskAZCount": 2,
+        "migrationAssistanceEnabled": true,
+        "replayerOutputEFSRemovalPolicy": "DESTROY",
+        "migrationConsoleServiceEnabled": true,
+        "otelCollectorEnabled": true
       }
     }
     """


### PR DESCRIPTION
### Description
My last PR, #1021, broke the build.  Having a not-quite-json `cdk.context.json` was bad anytime a `cdk` command was used, _even_ if it specifically specified a different context file.

So first, I just made it valid (if kind of ugly) JSON, but that broke the build in a different way because removing a lot of the default values changed the behavior of the cdk deployments in the CI pipelines. I copied the old values from the defaults into these blocks and have tested redeploying, successfully now.

### Issues Resolved

### Testing


### Check List
- [ ] New functionality includes testing
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
