### PR TITLE
Remove arg printing from command line apps with secret values

### DIFF
--- a/CreateSnapshot/src/main/java/org/opensearch/migrations/CreateSnapshot.java
+++ b/CreateSnapshot/src/main/java/org/opensearch/migrations/CreateSnapshot.java
@@ -73,6 +73,7 @@ public class CreateSnapshot {
     }
 
     public static void main(String[] args) throws Exception {
+        // TODO: Add back arg printing after not consuming plaintext password MIGRATIONS-1915
         Args arguments = new Args();
         JCommander jCommander = JCommander.newBuilder().addObject(arguments).build();
         jCommander.parse(args);
@@ -98,7 +99,6 @@ public class CreateSnapshot {
             throw new ParameterException("If an s3 repo is being used, s3-region must be set");
         }
 
-        log.info("Running CreateSnapshot with {}", String.join(" ", args));
         var snapshotCreator = new CreateSnapshot(arguments, rootContext.createSnapshotCreateContext());
         snapshotCreator.run();
     }

--- a/DocumentsFromSnapshotMigration/src/main/java/org/opensearch/migrations/RfsMigrateDocuments.java
+++ b/DocumentsFromSnapshotMigration/src/main/java/org/opensearch/migrations/RfsMigrateDocuments.java
@@ -164,7 +164,7 @@ public class RfsMigrateDocuments {
     }
 
     public static void main(String[] args) throws Exception {
-        log.info("Got args: " + String.join("; ", args));
+        // TODO: Add back arg printing after not consuming plaintext password MIGRATIONS-1915
         var workerId = ProcessHelpers.getNodeInstanceName();
         log.info("Starting RfsMigrateDocuments with workerId =" + workerId);
 

--- a/MetadataMigration/src/main/java/org/opensearch/migrations/MetadataMigration.java
+++ b/MetadataMigration/src/main/java/org/opensearch/migrations/MetadataMigration.java
@@ -24,7 +24,7 @@ public class MetadataMigration {
     public static void main(String[] args) throws Exception {
         var metadataArgs = new MetadataArgs();
         var migrateArgs = new MigrateArgs();
-        var evaluateArgs = new EvaluateArgs(); 
+        var evaluateArgs = new EvaluateArgs();
         var jCommander = JCommander.newBuilder()
             .addObject(metadataArgs)
             .addCommand(migrateArgs)
@@ -40,7 +40,7 @@ public class MetadataMigration {
 
         var meta = new MetadataMigration();
 
-        log.atInfo().setMessage("Command line arguments: {}\n").addArgument(String.join(" ", args)).log();
+        // TODO: Add back arg printing after not consuming plaintext password MIGRATIONS-1915
 
         if (metadataArgs.help || jCommander.getParsedCommand() == null) {
             printTopLevelHelp(jCommander);

--- a/MetadataMigration/src/test/java/org/opensearch/migrations/MetadataMigrationTest.java
+++ b/MetadataMigration/src/test/java/org/opensearch/migrations/MetadataMigrationTest.java
@@ -9,8 +9,28 @@ import org.opensearch.migrations.testutils.CloseableLogSetup;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class MetadataMigrationTest {
+
+    @Test
+    void testMain_expectNoPasswordLogged() {
+        List<String[]> testCases = List.of(
+            new String[]{"--source-password", "mySecretPassword", "--target-host", "http://localhost"},
+            new String[]{"--target-password", "mySecretPassword", "--target-host", "http://localhost"}
+        );
+        for (var testCase : testCases) {
+            try (var closeableLogSetup = new CloseableLogSetup(MetadataMigration.class.getName())) {
+
+                assertThrows(com.beust.jcommander.ParameterException.class, () -> MetadataMigration.main(testCase));
+
+                var logEvents = closeableLogSetup.getLogEvents();
+
+                assertFalse(logEvents.stream().anyMatch(s -> s.contains("mySecretPassword")));
+            }
+        }
+    }
 
     @Test
     void testMain_expectTopLevelHelp() throws Exception {
@@ -25,9 +45,8 @@ public class MetadataMigrationTest {
 
                 var logEvents = closeableLogSetup.getLogEvents();
 
-                assertThat(logEvents, hasSize(2));
-                assertThat(logEvents.get(0), containsString("Command line arguments"));
-                assertThat(logEvents.get(1), containsString("Usage: [options] [command] [commandOptions]"));
+                assertThat(logEvents, hasSize(1));
+                assertThat(logEvents.get(0), containsString("Usage: [options] [command] [commandOptions]"));
             }
         }
     }
@@ -44,9 +63,8 @@ public class MetadataMigrationTest {
 
                 var logEvents = closeableLogSetup.getLogEvents();
 
-                assertThat(logEvents, hasSize(2));
-                assertThat(logEvents.get(0), containsString("Command line arguments"));
-                assertThat(logEvents.get(1), containsString("Usage: " + testCase[0] + " [options]"));
+                assertThat(logEvents, hasSize(1));
+                assertThat(logEvents.get(0), containsString("Usage: " + testCase[0] + " [options]"));
             }
         }
     }


### PR DESCRIPTION
### Description

CreateSnapshot, DocumentsFromSnapshotMigration, and MetadataMigration printed args which could contain secret value password

* Category: Bug Fix
* Why these changes are required? Password could be printed in plaintext
* What is the old behavior before changes and new behavior after changes? Password could be printed in plaintext

### Issues Resolved
N/A

Is this a backport? If so, please add backport PR # and/or commits #

### Testing

### Check List
- [x] New functionality includes testing
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
