### PR TITLE
Add note about not supporting customer managed keys

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -25,4 +25,4 @@ The output tuples, available on the shared EFS volume via the Migration Console,
 If you use basic authorization credentials, ensure that access to your output tuples is protected similarly to the credentials themselves.
 
 ### Customer Managed Keys are not supported by the migration infrastructure
-We are able to migrate data to and from clusters with customer managed keys, but data in the intermediary stages (on Kafka, EFS volume, ephemeral storage on ECS) is stored with KMS managed keys.
+We are able to migrate data to and from clusters with customer managed keys, but data in the intermediary stages (on Kafka, EFS volume, ephemeral storage on ECS) is stored with AWS managed keys.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -28,4 +28,4 @@ If you use basic authorization credentials, ensure that access to your output tu
 Each of the AWS services that are interacting with data will encrypt all data being stored at rest. While the services themselves can support performing the encryption via a KMS Key, the CDK deployment option of Migration Assistant doesn't have the ability to set a customer key for any of those services. That will leave all of the data at rest encrypted, but not under the control of a customer's KMS Key. See the links below for more details on forthcoming support:
 
 https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html
-#1026
+[Issue #1026](https://github.com/opensearch-project/opensearch-migrations/issues/1026)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -25,4 +25,7 @@ The output tuples, available on the shared EFS volume via the Migration Console,
 If you use basic authorization credentials, ensure that access to your output tuples is protected similarly to the credentials themselves.
 
 ### Customer Managed Keys are not supported by the migration infrastructure
-We are able to migrate data to and from clusters with customer managed keys, but data in the intermediary stages (on Kafka, EFS volume, ephemeral storage on ECS) is stored with AWS managed keys.
+Each of the AWS services that are interacting with data will encrypt all data being stored at rest. While the services themselves can support performing the encryption via a KMS Key, the CDK deployment option of Migration Assistant doesn't have the ability to set a customer key for any of those services. That will leave all of the data at rest encrypted, but not under the control of a customer's KMS Key. See the links below for more details on forthcoming support:
+
+https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html
+#1026

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -23,3 +23,6 @@ If you are concerned about this scenario, we recommend fully mitigating it by pu
 The output tuples, available on the shared EFS volume via the Migration Console, contain the exact requests and responses received from both the source and target clusters with the headers and the body of the messages. The Authorization header is present on SigV4 signed requests and those using basic authorization, and with basic authorization credentials can be extracted from the header value. These values are often essential for debugging and so are not censored from the output.
 
 If you use basic authorization credentials, ensure that access to your output tuples is protected similarly to the credentials themselves.
+
+### Customer Managed Keys are not supported by the migration infrastructure
+We are able to migrate data to and from clusters with customer managed keys, but data in the intermediary stages (on Kafka, EFS volume, ephemeral storage on ECS) is stored with KMS managed keys.


### PR DESCRIPTION
### Description
It came up in PE review that we don't support customer managed keys within the migration infrastructure. Adding a note about it to the SECURITY.md caveats section.

### Issues Resolved
[List any issues this PR will resolve]

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]

### Check List
- [ ] New functionality includes testing
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
