### PR TITLE
Add option to take a snapshot of a managed service source cluster

### DIFF
--- a/deployment/cdk/opensearch-service-migration/cdk.context.json
+++ b/deployment/cdk/opensearch-service-migration/cdk.context.json
@@ -7,7 +7,7 @@
         "type": "none | basic | sigv4",
         "// basic auth documentation": "The next two lines are releavant for basic auth only",
         "username": "<USERNAME>",
-        "password_from_secret_arn": "<ARN_OF_SECRET_CONTAINING_PASSWORD>",
+        "passwordFromSecretArn": "<ARN_OF_SECRET_CONTAINING_PASSWORD>",
         "// sigv4 documentation": "The next two lines are releavant for sigv4 only",
         "region": "<REGION>",
         "serviceSigningName": "es | aoss"
@@ -19,7 +19,7 @@
         "type": "none | basic | sigv4",
         "// basic auth documentation": "The next two lines are releavant for basic auth only",
         "username": "<USERNAME>",
-        "password_from_secret_arn": "<ARN_OF_SECRET_CONTAINING_PASSWORD>",
+        "passwordFromSecretArn": "<ARN_OF_SECRET_CONTAINING_PASSWORD>",
         "// sigv4 documentation": "The next two lines are releavant for sigv4 only",
         "region": "<REGION>",
         "serviceSigningName": "es | aoss"

--- a/deployment/cdk/opensearch-service-migration/lib/common-utilities.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/common-utilities.ts
@@ -187,6 +187,31 @@ export function createDefaultECSTaskRole(scope: Construct, serviceName: string):
     return serviceTaskRole
 }
 
+export function createSnapshotOnAOSRole(scope: Construct, artifactS3Arn: string, migrationConsoleTaskRoleArn: string): Role {
+    const snapshotRole = new Role(scope, `SnapshotRole`, {
+        assumedBy: new ServicePrincipal('es.amazonaws.com'),
+        description: 'Role that grants OpenSearch Service permissions to access S3 to create snapshots',
+    });
+    snapshotRole.addToPolicy(new PolicyStatement({
+        effect: Effect.ALLOW,
+        actions: ['s3:ListBucket'],
+        resources: [artifactS3Arn],
+    }));
+
+    snapshotRole.addToPolicy(new PolicyStatement({
+        effect: Effect.ALLOW,
+        actions: ['s3:GetObject', 's3:PutObject', 's3:DeleteObject'],
+        resources: [`${artifactS3Arn}/*`],
+    }));
+
+    // The Migration Console Role needs to be able to pass the snapshot role
+    const requestingRole = Role.fromRoleArn(scope, 'RequestingRole', migrationConsoleTaskRoleArn);
+    snapshotRole.grantPassRole(requestingRole);
+
+    return snapshotRole
+}
+
+
 export function validateFargateCpuArch(cpuArch?: string): CpuArchitecture {
     const desiredArch = cpuArch ?? process.arch
     const desiredArchUpper = desiredArch.toUpperCase()
@@ -396,7 +421,7 @@ export function parseClusterDefinition(json: any): ClusterYaml {
     }
     const auth = parseAuth(json.auth)
     if (!auth) {
-        throw new Error(`Invalid auth type when parsing cluster definition: ${json.auth.type}`)
+        throw new Error(`Invalid auth type when parsing cluster definition: ${json.auth}`)
     }
     return new ClusterYaml({endpoint, version, auth})
 }

--- a/deployment/cdk/opensearch-service-migration/lib/common-utilities.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/common-utilities.ts
@@ -187,10 +187,12 @@ export function createDefaultECSTaskRole(scope: Construct, serviceName: string):
     return serviceTaskRole
 }
 
-export function createSnapshotOnAOSRole(scope: Construct, artifactS3Arn: string, migrationConsoleTaskRoleArn: string): Role {
+export function createSnapshotOnAOSRole(scope: Construct, artifactS3Arn: string, migrationConsoleTaskRoleArn: string,
+                                        region: string, stage: string, defaultDeployId: string): Role {
     const snapshotRole = new Role(scope, `SnapshotRole`, {
-        assumedBy: new ServicePrincipal('es.amazonaws.com'),
+        assumedBy: new ServicePrincipal('es.amazonaws.com'),  // Note that snapshots are not currently possible on AOSS
         description: 'Role that grants OpenSearch Service permissions to access S3 to create snapshots',
+        roleName: `OSMigrations-${stage}-${region}-${defaultDeployId}-SnapshotRole`
     });
     snapshotRole.addToPolicy(new PolicyStatement({
         effect: Effect.ALLOW,
@@ -421,7 +423,7 @@ export function parseClusterDefinition(json: any): ClusterYaml {
     }
     const auth = parseAuth(json.auth)
     if (!auth) {
-        throw new Error(`Invalid auth type when parsing cluster definition: ${json.auth}`)
+        throw new Error(`Invalid auth type when parsing cluster definition: ${json.auth.type}`)
     }
     return new ClusterYaml({endpoint, version, auth})
 }

--- a/deployment/cdk/opensearch-service-migration/lib/service-stacks/migration-console-stack.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/service-stacks/migration-console-stack.ts
@@ -328,8 +328,7 @@ export class MigrationConsoleStack extends MigrationServiceCore {
         });
 
         if (props.managedServiceSourceSnapshotEnabled) {
-            const consoleServiceRoleName = "migration-console-TaskRole";
-            const snapshotRole = createSnapshotOnAOSRole(this, artifactS3Arn, this.serviceTaskRole.roleArn);
+            const snapshotRole = createSnapshotOnAOSRole(this, artifactS3Arn, this.serviceTaskRole.roleArn, this.region, props.stage, props.defaultDeployId);
         }
     }
 

--- a/deployment/cdk/opensearch-service-migration/lib/service-stacks/migration-console-stack.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/service-stacks/migration-console-stack.ts
@@ -11,7 +11,8 @@ import {
     getSecretAccessPolicy,
     getMigrationStringParameterValue,
     hashStringSHA256,
-    MigrationSSMParameter
+    MigrationSSMParameter,
+    createSnapshotOnAOSRole
 } from "../common-utilities";
 import {StreamingSourceType} from "../streaming-source-type";
 import {LogGroup, RetentionDays} from "aws-cdk-lib/aws-logs";
@@ -33,6 +34,7 @@ export interface MigrationConsoleProps extends StackPropsExt {
     readonly servicesYaml: ServicesYaml,
     readonly otelCollectorEnabled?: boolean,
     readonly sourceCluster?: ClusterYaml,
+    readonly managedServiceSourceSnapshotEnabled?: boolean
 }
 
 export class MigrationConsoleStack extends MigrationServiceCore {
@@ -308,6 +310,7 @@ export class MigrationConsoleStack extends MigrationServiceCore {
                 parameter: MigrationSSMParameter.OSI_PIPELINE_LOG_GROUP_NAME,
             });
         }
+
         this.createService({
             serviceName: "migration-console",
             dockerDirectoryPath: join(__dirname, "../../../../../", "TrafficCapture/dockerSolution/src/main/docker/migrationConsole"),
@@ -324,6 +327,10 @@ export class MigrationConsoleStack extends MigrationServiceCore {
             ...props
         });
 
+        if (props.managedServiceSourceSnapshotEnabled) {
+            const consoleServiceRoleName = "migration-console-TaskRole";
+            const snapshotRole = createSnapshotOnAOSRole(this, artifactS3Arn, this.serviceTaskRole.roleArn);
+        }
     }
 
 }

--- a/deployment/cdk/opensearch-service-migration/options.md
+++ b/deployment/cdk/opensearch-service-migration/options.md
@@ -54,11 +54,12 @@ The optional component is:
 
 ### Reindex from Snapshot (RFS) Service Options
 
-| Name                              | Type    | Example                                                              | Description                                                                                                                                                                |
-| --------------------------------- | ------- | -------------------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| reindexFromSnapshotServiceEnabled | boolean | true                                                                 | Create resources for deploying and configuring the RFS ECS service                                                                                                         |
-| reindexFromSnapshotExtraArgs      | string  | "--target-aws-region us-east-1 --target-aws-service-signing-name es" | Extra arguments to provide to the Document Migration command with space separation. See [RFS Arguments](../../../DocumentsFromSnapshotMigration/README.md#Arguments). [^1] |
-| sourceClusterEndpoint             | string  | `"https://source-cluster.elb.us-east-1.endpoint.com"`                | The endpoint for the source cluster from which RFS will take a snapshot                                                                                                    |
+| Name                                | Type    | Example                                                              | Description                                                                                                                                                                |
+| ----------------------------------- | ------- | -------------------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| reindexFromSnapshotServiceEnabled   | boolean | true                                                                 | Create resources for deploying and configuring the RFS ECS service                                                                                                         |
+| reindexFromSnapshotExtraArgs        | string  | "--target-aws-region us-east-1 --target-aws-service-signing-name es" | Extra arguments to provide to the Document Migration command with space separation. See [RFS Arguments](../../../DocumentsFromSnapshotMigration/README.md#Arguments). [^1] |
+| sourceClusterEndpoint               | string  | `"https://source-cluster.elb.us-east-1.endpoint.com"`                | The endpoint for the source cluster from which RFS will take a snapshot                                                                                                    |
+| managedServiceSourceSnapshotEnabled | boolean | true                                                                 | Create the necessary roles and trust relationships to take a snapshot of a managed service source cluster. This is only compatible with SigV4 auth.                        |
 
 ### VPC Options
 


### PR DESCRIPTION
### Description
We discovered that our existing CDK is not sufficient for taking a snapshot of a managed service source cluster. A specific snapshot role must be created, and there needs to be a trust relationship between the console task role and this snapshot role that allows it to be passed.

With this PR, if `managedServiceSourceSnapshotEnabled` is added to the `cdk.context` as `true`, it sets up these roles and relationships.

In this PR, it **does not** handle adding the relevant role arn to the services.yaml and passing it through automatically.  That would be an excellent follow-up, but in this case I'm trying to focus on _unblocking_ the particularly time-confusing and messy parts instead of making this a fully supported experience.

One of the caveats is that, to pass in the snapshot role, the source cluster **must** use sigv4 auth. I added a check for this in the CDK.

Manually tested:

Before:
```
(.venv) bash-5.2# console snapshot create
2024-09-28 03:23:13,956 INFO o.o.m.u.ProcessHelpers [main] getNodeInstanceName()=ip-10-0-5-198.us-east-2.compute.internal
2024-09-28 03:23:14,679 INFO o.o.m.CreateSnapshot [main] Running CreateSnapshot with --snapshot-name rfs-snapshot --source-host https://vpc-cisco-or1-j5nojtdsafdmocqgnzmpjpcbwe.us-east-2.es.amazonaws.com --source-username admin --source-password Admin123! --otel-collector-endpoint http://localhost:4317 --s3-repo-uri s3://migration-artifacts-293444901541-new-cdk-us-east-2/rfs-snapshot-repo --s3-region us-east-2 --no-wait
2024-09-28 03:23:15,144 INFO o.o.m.b.w.SnapshotRunner [main] Attempting to initiate the snapshot...
2024-09-28 03:23:16,573 ERROR o.o.m.b.c.OpenSearchClient [reactor-http-nio-2] Could not register snapshot repo: _snapshot/migration_assistant_repo. Response Code: 401, Response Message: Unauthorized, Response Body: {"Message":"settings.role_arn is needed for snapshot registration."}
```

With this enabled:
```
(.venv) bash-5.2# console snapshot create --s3-role-arn arn:aws:iam::293444901541:role/OSMigrations-new-cdk-us-east-2-SnapshotRole53D7C789-18fLjvR4jHRc
2024-09-28 19:34:29,439 INFO o.o.m.u.ProcessHelpers [main] getNodeInstanceName()=ip-10-0-5-155.us-east-2.compute.internal
2024-09-28 19:34:30,381 INFO o.o.m.CreateSnapshot [main] Running CreateSnapshot with --snapshot-name rfs-snapshot --source-host https://vpc-demo-target-cluster-3v7rbwdjxvf6xaxmdxcswmrjgm.us-east-2.es.amazonaws.com --source-aws-service-signing-name es --source-aws-region us-east-2 --otel-collector-endpoint http://localhost:4317 --s3-repo-uri s3://migration-artifacts-293444901541-new-cdk-us-east-2/rfs-snapshot-repo --s3-region us-east-2 --no-wait --s3-role-arn arn:aws:iam::293444901541:role/OSMigrations-new-cdk-us-east-2-SnapshotRole53D7C789-18fLjvR4jHRc
2024-09-28 19:34:30,871 INFO o.o.m.b.w.SnapshotRunner [main] Attempting to initiate the snapshot...
2024-09-28 19:34:32,953 INFO o.o.m.b.c.SnapshotCreator [main] Snapshot repo registration successful
2024-09-28 19:34:33,040 INFO o.o.m.b.c.SnapshotCreator [main] Snapshot rfs-snapshot creation initiated
2024-09-28 19:34:33,040 INFO o.o.m.b.w.SnapshotRunner [main] Snapshot in progress...
Snapshot rfs-snapshot creation initiated successfully
```


### Issues Resolved
#2001

I also fix a dumb mistake I made in the sample `cdk.context.json` and make the logic around `targetVersion` vs `engineVersion` cleaner. It was still requiring an `engineVersion` in some cases where it really wasn't relevant.

### Testing
Manual.

### Check List
- [ ] New functionality includes testing
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
