### PR TITLE
?v -> ?v=true to workaround the sigv4 bug

### DIFF
--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/middleware/clusters.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/middleware/clusters.py
@@ -22,7 +22,7 @@ def call_api(cluster: Cluster, path: str, method=HttpMethod.GET, data=None, head
 def cat_indices(cluster: Cluster, refresh=False, as_json=False):
     if refresh:
         cluster.call_api('/_refresh')
-    as_json_suffix = "?format=json" if as_json else "?v"
+    as_json_suffix = "?format=json" if as_json else "?v=true"
     cat_indices_path = f"/_cat/indices/_all{as_json_suffix}"
     r = cluster.call_api(cat_indices_path)
     return r.json() if as_json else r.content


### PR DESCRIPTION
### Description
There's a bug in our sigv4 dependency for `requests` that breaks when a url has a query param with no value. So `?v` fails but `?v=true` succeeds.

### Issues Resolved
https://opensearch.atlassian.net/browse/MIGRATIONS-2023

### Testing
Manual

### Check List
- [ ] New functionality includes testing
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
