### PR TITLE
Optimize the regex parser for InvalidResponse

### DIFF
--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/common/InvalidResponse.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/common/InvalidResponse.java
@@ -17,7 +17,7 @@ import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class InvalidResponse extends RfsException {
-    private static final Pattern UNKNOWN_SETTING = Pattern.compile("unknown setting \\[(.+?)\\].+");
+    private static final Pattern UNKNOWN_SETTING = Pattern.compile("unknown setting \\[([a-zA-Z0-9_.-]+)\\].+");
     private static final ObjectMapper objectMapper = new ObjectMapper();
     private final transient HttpResponse response;
 


### PR DESCRIPTION
### Description
Rather than using a backtracking pattern which could have performance impact, switch to using explict character ranges which work for json path seperated with periods.

Mitigates sonar lint rule java:S5852 [1]

- [1] https://rules.sonarsource.com/java/RSPEC-5852/?search=Using%20slow%20regular%20expressions%20is%20security-sensitive

### Check List
- [ ] ~New functionality includes testing~
  - [X] All tests pass, including unit test, integration test and doctest
- [ ] ~New functionality has been documented~
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
