### PR TITLE
Apply dependency overrides to all dependency types

### DIFF
--- a/CreateSnapshot/build.gradle
+++ b/CreateSnapshot/build.gradle
@@ -9,8 +9,6 @@ java.sourceCompatibility = JavaVersion.VERSION_11
 java.targetCompatibility = JavaVersion.VERSION_11
 
 dependencies {
-    implementation project(":commonDependencyVersionConstraints")
-
     implementation project(':coreUtilities')
     implementation project(":RFS")
 

--- a/DocumentsFromSnapshotMigration/build.gradle
+++ b/DocumentsFromSnapshotMigration/build.gradle
@@ -23,7 +23,6 @@ class DockerServiceProps {
 }
 
 dependencies {
-    implementation project(":commonDependencyVersionConstraints")
     implementation platform('io.projectreactor:reactor-bom:2023.0.5')
     testImplementation platform('io.projectreactor:reactor-bom:2023.0.5')
 

--- a/MetadataMigration/build.gradle
+++ b/MetadataMigration/build.gradle
@@ -8,8 +8,6 @@ java.sourceCompatibility = JavaVersion.VERSION_11
 java.targetCompatibility = JavaVersion.VERSION_11
 
 dependencies {
-    implementation project(":commonDependencyVersionConstraints")
-
     implementation project(":coreUtilities")
     implementation project(":RFS")
     implementation project(':transformation')

--- a/RFS/build.gradle
+++ b/RFS/build.gradle
@@ -15,7 +15,6 @@ ext {
 }
 
 dependencies {
-    implementation project(":commonDependencyVersionConstraints")
     implementation project(':awsUtilities')
     implementation project(':coreUtilities')
     implementation project(':transformation')
@@ -75,7 +74,6 @@ dependencies {
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-core'
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-annotations'
 
-    testFixturesImplementation project(":commonDependencyVersionConstraints")
     testFixturesImplementation project(':transformation')
     testFixturesImplementation testFixtures(project(":coreUtilities"))
     testFixturesImplementation group: 'com.github.docker-java', name: 'docker-java'

--- a/TrafficCapture/captureKafkaOffloader/build.gradle
+++ b/TrafficCapture/captureKafkaOffloader/build.gradle
@@ -5,7 +5,6 @@ plugins {
 }
 
 dependencies {
-    api project(":commonDependencyVersionConstraints")
     implementation project(':TrafficCapture:captureOffloader')
     implementation project(':coreUtilities')
     implementation group: 'com.google.protobuf', name:'protobuf-java'

--- a/TrafficCapture/captureOffloader/build.gradle
+++ b/TrafficCapture/captureOffloader/build.gradle
@@ -16,7 +16,6 @@ sourceSets {
     }
 }
 dependencies {
-    api project(":commonDependencyVersionConstraints")
     api group: 'io.netty', name: 'netty-buffer'
 
     implementation project(':TrafficCapture:captureProtobufs')

--- a/TrafficCapture/captureProtobufs/build.gradle
+++ b/TrafficCapture/captureProtobufs/build.gradle
@@ -8,7 +8,6 @@ plugins {
 }
 
 dependencies {
-    api project(":commonDependencyVersionConstraints")
     api group: 'com.google.protobuf', name: 'protobuf-java'
 }
 

--- a/TrafficCapture/nettyWireLogging/build.gradle
+++ b/TrafficCapture/nettyWireLogging/build.gradle
@@ -8,8 +8,6 @@ plugins {
 }
 
 dependencies {
-    api project(":commonDependencyVersionConstraints")
-
     implementation project(':TrafficCapture:captureOffloader')
     implementation project(':coreUtilities')
     api            group: 'io.netty', name: 'netty-buffer'

--- a/TrafficCapture/trafficCaptureProxyServer/build.gradle
+++ b/TrafficCapture/trafficCaptureProxyServer/build.gradle
@@ -13,8 +13,6 @@ configurations {
 }
 
 dependencies {
-    implementation project(":commonDependencyVersionConstraints")
-
     def openSearch = '2.11.1'
     implementation "org.opensearch.plugin:opensearch-security:${openSearch}.0"
     implementation "org.opensearch:opensearch-common:${openSearch}"

--- a/TrafficCapture/trafficCaptureProxyServerTest/build.gradle
+++ b/TrafficCapture/trafficCaptureProxyServerTest/build.gradle
@@ -20,8 +20,6 @@ def calculateDockerHash = { projectName ->
 }
 
 dependencies {
-    api project(":commonDependencyVersionConstraints")
-
     implementation project(':TrafficCapture:trafficCaptureProxyServer')
     compileOnly 'org.projectlombok:lombok:1.18.28'
     annotationProcessor 'org.projectlombok:lombok:1.18.28'

--- a/TrafficCapture/trafficReplayer/build.gradle
+++ b/TrafficCapture/trafficReplayer/build.gradle
@@ -16,8 +16,6 @@ plugins {
 }
 
 dependencies {
-    implementation project(":commonDependencyVersionConstraints")
-
     implementation project(':TrafficCapture:captureProtobufs')
     implementation project(':coreUtilities')
     implementation project(':awsUtilities')

--- a/TrafficCapture/transformationPlugins/jsonMessageTransformers/jsonJoltMessageTransformer/build.gradle
+++ b/TrafficCapture/transformationPlugins/jsonMessageTransformers/jsonJoltMessageTransformer/build.gradle
@@ -9,7 +9,6 @@ plugins {
 }
 
 dependencies {
-    implementation project(":commonDependencyVersionConstraints")
     implementation project(':TrafficCapture:transformationPlugins:jsonMessageTransformers:jsonMessageTransformerInterface')
 
     implementation group: 'com.bazaarvoice.jolt', name: 'jolt-core'

--- a/TrafficCapture/transformationPlugins/jsonMessageTransformers/jsonMessageTransformerInterface/build.gradle
+++ b/TrafficCapture/transformationPlugins/jsonMessageTransformers/jsonMessageTransformerInterface/build.gradle
@@ -23,5 +23,4 @@ plugins {
 }
 
 dependencies {
-    api project(":commonDependencyVersionConstraints")
 }

--- a/awsUtilities/build.gradle
+++ b/awsUtilities/build.gradle
@@ -26,8 +26,6 @@ java.sourceCompatibility = JavaVersion.VERSION_11
 java.targetCompatibility = JavaVersion.VERSION_11
 
 dependencies {
-    api project(":commonDependencyVersionConstraints")
-
     implementation group: 'software.amazon.awssdk', name: 'arns'
     implementation group: 'software.amazon.awssdk', name: 'auth'
     implementation group: 'software.amazon.awssdk', name: 'sdk-core'

--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,20 @@ allprojects {
     }
 }
 
+subprojects { subproject ->
+    subproject.afterEvaluate {
+        if (subproject.plugins.hasPlugin('java') && subproject.name != 'commonDependencyVersionConstraints') {
+            subproject.dependencies {
+                implementation project(":commonDependencyVersionConstraints")
+                annotationProcessor project(":commonDependencyVersionConstraints")
+                if (subproject.plugins.hasPlugin('java-test-fixtures')) {
+                    testFixturesImplementation project(":commonDependencyVersionConstraints")
+                }
+            }
+        }
+    }
+}
+
 task buildDockerImages() {
     dependsOn(':TrafficCapture:dockerSolution:buildDockerImages')
     dependsOn(':DocumentsFromSnapshotMigration:buildDockerImages')

--- a/coreUtilities/build.gradle
+++ b/coreUtilities/build.gradle
@@ -27,8 +27,6 @@ java.sourceCompatibility = JavaVersion.VERSION_11
 java.targetCompatibility = JavaVersion.VERSION_11
 
 dependencies {
-    api project(":commonDependencyVersionConstraints")
-
     implementation group: "com.google.protobuf", name: "protobuf-java"
     implementation group: 'org.slf4j', name: 'slf4j-api'
 

--- a/dashboardsSanitizer/build.gradle
+++ b/dashboardsSanitizer/build.gradle
@@ -19,9 +19,6 @@ repositories {
 }
 
 dependencies {
-
-    implementation project(":commonDependencyVersionConstraints")
-
     implementation project(':coreUtilities')
     implementation project(":RFS")
 

--- a/testHelperFixtures/build.gradle
+++ b/testHelperFixtures/build.gradle
@@ -25,8 +25,6 @@ plugins {
 }
 
 dependencies {
-    api project(":commonDependencyVersionConstraints")
-
     testFixturesImplementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind'
     testFixturesImplementation group: 'com.google.guava', name: 'guava'
     testFixturesImplementation group: 'eu.rekawek.toxiproxy', name: 'toxiproxy-java'

--- a/transformation/build.gradle
+++ b/transformation/build.gradle
@@ -27,8 +27,6 @@ java.sourceCompatibility = JavaVersion.VERSION_11
 java.targetCompatibility = JavaVersion.VERSION_11
 
 dependencies {
-    api project(":commonDependencyVersionConstraints")
-
     implementation group: 'org.slf4j', name: 'slf4j-api'
 
     testImplementation group: 'org.apache.logging.log4j', name: 'log4j-api'


### PR DESCRIPTION
### Description
Apply dependency overrides to all dependency types
* Category: Fixes dependency versions across all compile types
* Why these changes are required? Protobuf wasn't using a consistent version 
* What is the old behavior before changes and new behavior after changes? Annotation processing depended on protobuf 2.19 instead of current 2.25

### Issues Resolved
[List any issues this PR will resolve]

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
GHA, verified dependency versions with `./gradlew <task>:dependencies`

### Check List
- [x] New functionality includes testing
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
