### PR TITLE
RFS Workers now use EBS to store/unpack the snapshot

### DIFF
--- a/deployment/cdk/opensearch-service-migration/cdk.context.json
+++ b/deployment/cdk/opensearch-service-migration/cdk.context.json
@@ -27,6 +27,7 @@
     },
     "vpcId": "<VPC_ID>",
     "reindexFromSnapshotServiceEnabled": true,
+    "reindexFromSnapshotMaxShardSizeGiB": 80,
     "trafficReplayerServiceEnabled": true
   }
 }

--- a/deployment/cdk/opensearch-service-migration/default-values.json
+++ b/deployment/cdk/opensearch-service-migration/default-values.json
@@ -4,5 +4,6 @@
   "migrationAssistanceEnabled": true,
   "migrationConsoleServiceEnabled": true,
   "trafficReplayerServiceEnabled": false,
-  "otelCollectorEnabled": true
+  "otelCollectorEnabled": true,
+  "reindexFromSnapshotMaxShardSizeGiB": 80
 }

--- a/deployment/cdk/opensearch-service-migration/default-values.json
+++ b/deployment/cdk/opensearch-service-migration/default-values.json
@@ -4,6 +4,5 @@
   "migrationAssistanceEnabled": true,
   "migrationConsoleServiceEnabled": true,
   "trafficReplayerServiceEnabled": false,
-  "otelCollectorEnabled": true,
-  "reindexFromSnapshotMaxShardSizeGiB": 80
+  "otelCollectorEnabled": true
 }

--- a/deployment/cdk/opensearch-service-migration/lib/network-stack.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/network-stack.ts
@@ -99,7 +99,8 @@ export class NetworkStack extends Stack {
         // General interface endpoints
         const interfaceEndpoints = [
             InterfaceVpcEndpointAwsService.CLOUDWATCH_LOGS, // Push Logs from tasks
-            InterfaceVpcEndpointAwsService.CLOUDWATCH_MONITORING, // Pull Metrics from Migration Console 
+            InterfaceVpcEndpointAwsService.CLOUDWATCH_MONITORING, // Pull Metrics from Migration Console
+            InterfaceVpcEndpointAwsService.EBS_DIRECT, // Enable EBS Volumes
             InterfaceVpcEndpointAwsService.ECR_DOCKER, // Pull Images on Startup
             InterfaceVpcEndpointAwsService.ECR, // List Images on Startup
             InterfaceVpcEndpointAwsService.ECS_AGENT, // Task Container Metrics

--- a/deployment/cdk/opensearch-service-migration/lib/network-stack.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/network-stack.ts
@@ -100,7 +100,6 @@ export class NetworkStack extends Stack {
         const interfaceEndpoints = [
             InterfaceVpcEndpointAwsService.CLOUDWATCH_LOGS, // Push Logs from tasks
             InterfaceVpcEndpointAwsService.CLOUDWATCH_MONITORING, // Pull Metrics from Migration Console
-            InterfaceVpcEndpointAwsService.EBS_DIRECT, // Enable EBS Volumes
             InterfaceVpcEndpointAwsService.ECR_DOCKER, // Pull Images on Startup
             InterfaceVpcEndpointAwsService.ECR, // List Images on Startup
             InterfaceVpcEndpointAwsService.ECS_AGENT, // Task Container Metrics

--- a/deployment/cdk/opensearch-service-migration/lib/service-stacks/migration-service-core.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/service-stacks/migration-service-core.ts
@@ -13,6 +13,7 @@ import {
     Volume,
     AwsLogDriverMode,
     ContainerDependencyCondition,
+    ServiceManagedVolume
 } from "aws-cdk-lib/aws-ecs";
 import {DockerImageAsset} from "aws-cdk-lib/aws-ecr-assets";
 import {Duration, RemovalPolicy, Stack} from "aws-cdk-lib";
@@ -185,6 +186,11 @@ export class MigrationServiceCore extends Stack {
             securityGroups: props.securityGroups,
             vpcSubnets: props.vpc.selectSubnets({subnetType: SubnetType.PRIVATE_WITH_EGRESS}),
         });
+
+        // Add any ServiceManagedVolumes to the service, if they exist
+        if (props.volumes) {
+            props.volumes.filter(vol => vol instanceof ServiceManagedVolume).forEach(vol => fargateService.addVolume(vol as ServiceManagedVolume));
+        }
 
         if (props.targetGroups) {
             props.targetGroups.filter(tg => tg !== undefined).forEach(tg => tg.addTarget(fargateService));

--- a/deployment/cdk/opensearch-service-migration/lib/service-stacks/reindex-from-snapshot-stack.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/service-stacks/reindex-from-snapshot-stack.ts
@@ -149,7 +149,7 @@ export class ReindexFromSnapshotStack extends MigrationServiceCore {
                 fileSystemType: FileSystemType.XFS,
                 tagSpecifications: [{
                     tags: {
-                        name: `rfs-snapshot-volume-${props.stage}`,
+                        Name: `rfs-snapshot-volume-${props.stage}`,
                     },
                     propagateTags: EbsPropagatedTagSource.SERVICE,
                 }],

--- a/deployment/cdk/opensearch-service-migration/lib/service-stacks/reindex-from-snapshot-stack.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/service-stacks/reindex-from-snapshot-stack.ts
@@ -1,6 +1,12 @@
 import {StackPropsExt} from "../stack-composer";
-import {IVpc, SecurityGroup} from "aws-cdk-lib/aws-ec2";
-import {CpuArchitecture} from "aws-cdk-lib/aws-ecs";
+import {Size} from "aws-cdk-lib/core";
+import {IVpc, SecurityGroup, EbsDeviceVolumeType} from "aws-cdk-lib/aws-ec2";
+import {
+    CpuArchitecture,
+    ServiceManagedVolume,
+    FileSystemType,
+    EbsPropagatedTagSource
+} from "aws-cdk-lib/aws-ecs";
 import {Construct} from "constructs";
 import {join} from "path";
 import {MigrationServiceCore} from "./migration-service-core";
@@ -24,7 +30,9 @@ export interface ReindexFromSnapshotProps extends StackPropsExt {
     readonly extraArgs?: string,
     readonly otelCollectorEnabled: boolean,
     readonly clusterAuthDetails: ClusterAuth
-    readonly sourceClusterVersion?: string
+    readonly sourceClusterVersion?: string,
+    readonly maxShardSizeGiB?: number
+
 }
 
 export class ReindexFromSnapshotStack extends MigrationServiceCore {
@@ -70,11 +78,12 @@ export class ReindexFromSnapshotStack extends MigrationServiceCore {
         const s3Uri = `s3://migration-artifacts-${this.account}-${props.stage}-${this.region}/rfs-snapshot-repo`;
         let command = "/rfs-app/runJavaWithClasspath.sh org.opensearch.migrations.RfsMigrateDocuments"
         const extraArgsDict = parseArgsToDict(props.extraArgs)
-        command = appendArgIfNotInExtraArgs(command, extraArgsDict, "--s3-local-dir", "/tmp/s3_files")
+        const storagePath = "/storage"
+        command = appendArgIfNotInExtraArgs(command, extraArgsDict, "--s3-local-dir", `"${storagePath}/s3_files"`)
         command = appendArgIfNotInExtraArgs(command, extraArgsDict, "--s3-repo-uri", `"${s3Uri}"`)
         command = appendArgIfNotInExtraArgs(command, extraArgsDict, "--s3-region", this.region)
         command = appendArgIfNotInExtraArgs(command, extraArgsDict, "--snapshot-name", "rfs-snapshot")
-        command = appendArgIfNotInExtraArgs(command, extraArgsDict, "--lucene-dir", "/lucene")
+        command = appendArgIfNotInExtraArgs(command, extraArgsDict, "--lucene-dir", `"${storagePath}/lucene"`)
         command = appendArgIfNotInExtraArgs(command, extraArgsDict, "--target-host", osClusterEndpoint)
         if (props.clusterAuthDetails.sigv4) {
             command = appendArgIfNotInExtraArgs(command, extraArgsDict, "--target-aws-service-signing-name", props.clusterAuthDetails.sigv4.serviceSigningName)
@@ -113,19 +122,53 @@ export class ReindexFromSnapshotStack extends MigrationServiceCore {
             servicePolicies.push(getSecretsPolicy);
         }
 
+        const volumes = [sharedLogFileSystem.asVolume()];
+        const mountPoints = [sharedLogFileSystem.asMountPoint()];
+
+        // Calculate the volume size based on the max shard size
+        // Have space for the snapshot and an unpacked copy, with buffer
+        const planningSize = props.maxShardSizeGiB ?? 80;
+        const volumeSize = Math.max(
+            Math.ceil(planningSize * 2 * 1.15),
+            125 // Minimum volume size for ST1
+        )
+
+        // Volume we'll use to download and unpack the snapshot
+        const snapshotVolume = new ServiceManagedVolume(this, 'SnapshotVolume', {
+            name: 'snapshot-volume',
+            managedEBSVolume: {
+                size: Size.gibibytes(volumeSize),
+                volumeType: EbsDeviceVolumeType.ST1,
+                fileSystemType: FileSystemType.XFS,
+                tagSpecifications: [{
+                    tags: {
+                    purpose: 'production',
+                    },
+                    propagateTags: EbsPropagatedTagSource.SERVICE,
+                }],
+            },
+        });
+
+        volumes.push(snapshotVolume);
+        mountPoints.push({
+            containerPath: storagePath,
+            readOnly: false,
+            sourceVolume: snapshotVolume.name,
+        });
+
         this.createService({
             serviceName: 'reindex-from-snapshot',
             taskInstanceCount: 0,
             dockerDirectoryPath: join(__dirname, "../../../../../", "DocumentsFromSnapshotMigration/docker"),
             dockerImageCommand: ['/bin/sh', '-c', "/rfs-app/entrypoint.sh"],
             securityGroups: securityGroups,
-            volumes: [sharedLogFileSystem.asVolume()],
-            mountPoints: [sharedLogFileSystem.asMountPoint()],
+            volumes: volumes,
+            mountPoints: mountPoints,
             taskRolePolicies: servicePolicies,
             cpuArchitecture: props.fargateCpuArch,
             taskCpuUnits: 2048,
             taskMemoryLimitMiB: 4096,
-            ephemeralStorageGiB: 200,
+            ephemeralStorageGiB: 60, // Use for the RFS Process; not the snapshot & lucene storage
             environment: {
                 "RFS_COMMAND": command,
                 "RFS_TARGET_USER": targetUser,

--- a/deployment/cdk/opensearch-service-migration/lib/stack-composer.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/stack-composer.ts
@@ -210,6 +210,7 @@ export class StackComposer {
         const otelCollectorEnabled = this.getContextForType('otelCollectorEnabled', 'boolean', defaultValues, contextJSON)
         const reindexFromSnapshotServiceEnabled = this.getContextForType('reindexFromSnapshotServiceEnabled', 'boolean', defaultValues, contextJSON)
         const reindexFromSnapshotExtraArgs = this.getContextForType('reindexFromSnapshotExtraArgs', 'string', defaultValues, contextJSON)
+        const reindexFromSnapshotMaxShardSizeGiB = this.getContextForType('reindexFromSnapshotMaxShardSizeGiB', 'number', defaultValues, contextJSON)
         const albAcmCertArn = this.getContextForType('albAcmCertArn', 'string', defaultValues, contextJSON);
         const managedServiceSourceSnapshotEnabled = this.getContextForType('managedServiceSourceSnapshotEnabled', 'boolean', defaultValues, contextJSON)
 
@@ -483,7 +484,8 @@ export class StackComposer {
                 otelCollectorEnabled: otelCollectorEnabled,
                 defaultDeployId: defaultDeployId,
                 fargateCpuArch: fargateCpuArch,
-                env: props.env
+                env: props.env,
+                maxShardSizeGiB: reindexFromSnapshotMaxShardSizeGiB
             })
             this.addDependentStacks(reindexFromSnapshotStack, [migrationStack, openSearchStack, osContainerStack])
             this.stacks.push(reindexFromSnapshotStack)

--- a/deployment/cdk/opensearch-service-migration/options.md
+++ b/deployment/cdk/opensearch-service-migration/options.md
@@ -60,6 +60,7 @@ The optional component is:
 | reindexFromSnapshotExtraArgs        | string  | "--target-aws-region us-east-1 --target-aws-service-signing-name es" | Extra arguments to provide to the Document Migration command with space separation. See [RFS Arguments](../../../DocumentsFromSnapshotMigration/README.md#Arguments). [^1] |
 | sourceClusterEndpoint               | string  | `"https://source-cluster.elb.us-east-1.endpoint.com"`                | The endpoint for the source cluster from which RFS will take a snapshot                                                                                                    |
 | managedServiceSourceSnapshotEnabled | boolean | true                                                                 | Create the necessary roles and trust relationships to take a snapshot of a managed service source cluster. This is only compatible with SigV4 auth.                        |
+| reindexFromSnapshotMaxShardSizeGiB                     | integer | 80                                                                   | OPTIONAL: The size, in whole GiB, of the largest shard you want to migrate across all indices; used to ensure we have enough disk space reserved to perform the migration.  Default: 80 GiB                                   |
 
 ### VPC Options
 

--- a/deployment/cdk/opensearch-service-migration/test/reindex-from-snapshot-stack.test.ts
+++ b/deployment/cdk/opensearch-service-migration/test/reindex-from-snapshot-stack.test.ts
@@ -119,6 +119,7 @@ describe('ReindexFromSnapshotStack Tests', () => {
               {
                 "Ref": "SsmParameterValuemigrationunittestdefaultosClusterEndpointC96584B6F00A464EAD1953AFF4B05118Parameter",
               },
+              " --max-shard-size-bytes 8589934592"
             ],
           ],
         }
@@ -186,7 +187,7 @@ describe('ReindexFromSnapshotStack Tests', () => {
               {
                 "Ref": "SsmParameterValuemigrationunittestdefaultosClusterEndpointC96584B6F00A464EAD1953AFF4B05118Parameter",
               },
-              " --target-aws-service-signing-name aoss --target-aws-region eu-west-1",
+              " --max-shard-size-bytes 8589934592 --target-aws-service-signing-name aoss --target-aws-region eu-west-1",
             ],
           ],
         }
@@ -275,7 +276,7 @@ describe('ReindexFromSnapshotStack Tests', () => {
               {
                 "Ref": "SsmParameterValuemigrationunittestdefaultosClusterEndpointC96584B6F00A464EAD1953AFF4B05118Parameter",
               },
-              " --custom-arg value --flag --snapshot-name \"custom-snapshot\""
+              " --max-shard-size-bytes 8589934592 --custom-arg value --flag --snapshot-name \"custom-snapshot\""
             ]
           ]
         }

--- a/deployment/cdk/opensearch-service-migration/test/reindex-from-snapshot-stack.test.ts
+++ b/deployment/cdk/opensearch-service-migration/test/reindex-from-snapshot-stack.test.ts
@@ -119,7 +119,7 @@ describe('ReindexFromSnapshotStack Tests', () => {
               {
                 "Ref": "SsmParameterValuemigrationunittestdefaultosClusterEndpointC96584B6F00A464EAD1953AFF4B05118Parameter",
               },
-              " --max-shard-size-bytes 8589934592"
+              " --max-shard-size-bytes 85899345920"
             ],
           ],
         }
@@ -187,7 +187,7 @@ describe('ReindexFromSnapshotStack Tests', () => {
               {
                 "Ref": "SsmParameterValuemigrationunittestdefaultosClusterEndpointC96584B6F00A464EAD1953AFF4B05118Parameter",
               },
-              " --max-shard-size-bytes 8589934592 --target-aws-service-signing-name aoss --target-aws-region eu-west-1",
+              " --max-shard-size-bytes 85899345920 --target-aws-service-signing-name aoss --target-aws-region eu-west-1",
             ],
           ],
         }
@@ -276,7 +276,7 @@ describe('ReindexFromSnapshotStack Tests', () => {
               {
                 "Ref": "SsmParameterValuemigrationunittestdefaultosClusterEndpointC96584B6F00A464EAD1953AFF4B05118Parameter",
               },
-              " --max-shard-size-bytes 8589934592 --custom-arg value --flag --snapshot-name \"custom-snapshot\""
+              " --max-shard-size-bytes 85899345920 --custom-arg value --flag --snapshot-name \"custom-snapshot\""
             ]
           ]
         }

--- a/deployment/cdk/opensearch-service-migration/test/reindex-from-snapshot-stack.test.ts
+++ b/deployment/cdk/opensearch-service-migration/test/reindex-from-snapshot-stack.test.ts
@@ -115,7 +115,7 @@ describe('ReindexFromSnapshotStack Tests', () => {
         Value: {
           "Fn::Join": [
             "",
-            [ "/rfs-app/runJavaWithClasspath.sh org.opensearch.migrations.RfsMigrateDocuments --s3-local-dir /storage/s3_files --s3-repo-uri \"s3://migration-artifacts-test-account-unit-test-us-east-1/rfs-snapshot-repo\" --s3-region us-east-1 --snapshot-name rfs-snapshot --lucene-dir /storage/lucene --target-host ",
+            [ "/rfs-app/runJavaWithClasspath.sh org.opensearch.migrations.RfsMigrateDocuments --s3-local-dir \"/storage/s3_files\" --s3-repo-uri \"s3://migration-artifacts-test-account-unit-test-us-east-1/rfs-snapshot-repo\" --s3-region us-east-1 --snapshot-name rfs-snapshot --lucene-dir \"/storage/lucene\" --target-host ",
               {
                 "Ref": "SsmParameterValuemigrationunittestdefaultosClusterEndpointC96584B6F00A464EAD1953AFF4B05118Parameter",
               },
@@ -182,7 +182,7 @@ describe('ReindexFromSnapshotStack Tests', () => {
         Value: {
           "Fn::Join": [
             "",
-            [ "/rfs-app/runJavaWithClasspath.sh org.opensearch.migrations.RfsMigrateDocuments --s3-local-dir /storage/s3_files --s3-repo-uri \"s3://migration-artifacts-test-account-unit-test-us-east-1/rfs-snapshot-repo\" --s3-region us-east-1 --snapshot-name rfs-snapshot --lucene-dir /storage/lucene --target-host ",
+            [ "/rfs-app/runJavaWithClasspath.sh org.opensearch.migrations.RfsMigrateDocuments --s3-local-dir \"/storage/s3_files\" --s3-repo-uri \"s3://migration-artifacts-test-account-unit-test-us-east-1/rfs-snapshot-repo\" --s3-region us-east-1 --snapshot-name rfs-snapshot --lucene-dir \"/storage/lucene\" --target-host ",
               {
                 "Ref": "SsmParameterValuemigrationunittestdefaultosClusterEndpointC96584B6F00A464EAD1953AFF4B05118Parameter",
               },
@@ -271,7 +271,7 @@ describe('ReindexFromSnapshotStack Tests', () => {
         Value: {
           "Fn::Join": [
             "",
-            [ "/rfs-app/runJavaWithClasspath.sh org.opensearch.migrations.RfsMigrateDocuments --s3-local-dir /storage/s3_files --s3-repo-uri \"s3://migration-artifacts-test-account-unit-test-us-east-1/rfs-snapshot-repo\" --s3-region us-east-1 --lucene-dir /storage/lucene --target-host ",
+            [ "/rfs-app/runJavaWithClasspath.sh org.opensearch.migrations.RfsMigrateDocuments --s3-local-dir \"/storage/s3_files\" --s3-repo-uri \"s3://migration-artifacts-test-account-unit-test-us-east-1/rfs-snapshot-repo\" --s3-region us-east-1 --lucene-dir \"/storage/lucene\" --target-host ",
               {
                 "Ref": "SsmParameterValuemigrationunittestdefaultosClusterEndpointC96584B6F00A464EAD1953AFF4B05118Parameter",
               },

--- a/deployment/cdk/opensearch-service-migration/test/reindex-from-snapshot-stack.test.ts
+++ b/deployment/cdk/opensearch-service-migration/test/reindex-from-snapshot-stack.test.ts
@@ -115,7 +115,7 @@ describe('ReindexFromSnapshotStack Tests', () => {
         Value: {
           "Fn::Join": [
             "",
-            [ "/rfs-app/runJavaWithClasspath.sh org.opensearch.migrations.RfsMigrateDocuments --s3-local-dir /tmp/s3_files --s3-repo-uri \"s3://migration-artifacts-test-account-unit-test-us-east-1/rfs-snapshot-repo\" --s3-region us-east-1 --snapshot-name rfs-snapshot --lucene-dir /lucene --target-host ",
+            [ "/rfs-app/runJavaWithClasspath.sh org.opensearch.migrations.RfsMigrateDocuments --s3-local-dir /storage/s3_files --s3-repo-uri \"s3://migration-artifacts-test-account-unit-test-us-east-1/rfs-snapshot-repo\" --s3-region us-east-1 --snapshot-name rfs-snapshot --lucene-dir /storage/lucene --target-host ",
               {
                 "Ref": "SsmParameterValuemigrationunittestdefaultosClusterEndpointC96584B6F00A464EAD1953AFF4B05118Parameter",
               },
@@ -182,7 +182,7 @@ describe('ReindexFromSnapshotStack Tests', () => {
         Value: {
           "Fn::Join": [
             "",
-            [ "/rfs-app/runJavaWithClasspath.sh org.opensearch.migrations.RfsMigrateDocuments --s3-local-dir /tmp/s3_files --s3-repo-uri \"s3://migration-artifacts-test-account-unit-test-us-east-1/rfs-snapshot-repo\" --s3-region us-east-1 --snapshot-name rfs-snapshot --lucene-dir /lucene --target-host ",
+            [ "/rfs-app/runJavaWithClasspath.sh org.opensearch.migrations.RfsMigrateDocuments --s3-local-dir /storage/s3_files --s3-repo-uri \"s3://migration-artifacts-test-account-unit-test-us-east-1/rfs-snapshot-repo\" --s3-region us-east-1 --snapshot-name rfs-snapshot --lucene-dir /storage/lucene --target-host ",
               {
                 "Ref": "SsmParameterValuemigrationunittestdefaultosClusterEndpointC96584B6F00A464EAD1953AFF4B05118Parameter",
               },
@@ -271,7 +271,7 @@ describe('ReindexFromSnapshotStack Tests', () => {
         Value: {
           "Fn::Join": [
             "",
-            [ "/rfs-app/runJavaWithClasspath.sh org.opensearch.migrations.RfsMigrateDocuments --s3-local-dir /tmp/s3_files --s3-repo-uri \"s3://migration-artifacts-test-account-unit-test-us-east-1/rfs-snapshot-repo\" --s3-region us-east-1 --lucene-dir /lucene --target-host ",
+            [ "/rfs-app/runJavaWithClasspath.sh org.opensearch.migrations.RfsMigrateDocuments --s3-local-dir /storage/s3_files --s3-repo-uri \"s3://migration-artifacts-test-account-unit-test-us-east-1/rfs-snapshot-repo\" --s3-region us-east-1 --lucene-dir /storage/lucene --target-host ",
               {
                 "Ref": "SsmParameterValuemigrationunittestdefaultosClusterEndpointC96584B6F00A464EAD1953AFF4B05118Parameter",
               },


### PR DESCRIPTION
### Description
* Updated the RFS Workers to use an EBS volume to store and unpack the snapshot.  Each worker gets a separate volume, which is provisioned on task launch.

### Issues Resolved
* https://opensearch.atlassian.net/browse/MIGRATIONS-1750

### Testing
* Tested by performing a small migration in AWS and confirming separate, correctly-size volumes were used for each task

```
(.venv) bash-5.2# console clusters cat-indices

SOURCE CLUSTER
health status index       uuid                   pri rep docs.count docs.deleted store.size pri.store.size
green  open   bwc_index_1 QYzCFpW9RTeZ9xW3ht5eTA   1   0          1            0      3.8kb          3.8kb
green  open   fwc_index_1 Axns2r74RCiDQYt6ewLAeQ   1   0          1            0      3.8kb          3.8kb

TARGET CLUSTER
health status index                     uuid                   pri rep docs.count docs.deleted store.size pri.store.size
green  open   .migrations_working_state BUg_NWvsSE-a8kbdnPN6_Q   1   1          3            0     47.1kb          6.8kb
green  open   bwc_index_1               NR4nYu4rSiyfLNqRr3UQWw   5   1          1            0     11.5kb          5.7kb
green  open   fwc_index_1               xsBlWTtLT5-SJUUni3kBog   1   0          1            0      3.8kb          3.8kb
```
<img width="1448" alt="Screenshot 2024-10-01 at 1 54 28 PM" src="https://github.com/user-attachments/assets/884e42a1-c787-46b7-9ade-1f4f9930a3ab">

<img width="1460" alt="Screenshot 2024-10-01 at 1 55 30 PM" src="https://github.com/user-attachments/assets/81a91165-7df8-454c-87e4-608d1a43a9fe">




### Check List
- [ ] New functionality includes testing
  - [X] All tests pass, including unit test, integration test and doctest
- [X] New functionality has been documented
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
