### PR TITLE
Add spotless formatting rules for json files

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,11 @@ spotless {
         indentWithSpaces()
         endWithNewline()
     }
+    json {
+        target 'deployment/cdk/opensearch-service-migration/*.json'
+        prettier()
+        endWithNewline()
+    }
 }
 
 subprojects {

--- a/deployment/cdk/opensearch-service-migration/cdk.json
+++ b/deployment/cdk/opensearch-service-migration/cdk.json
@@ -1,9 +1,7 @@
 {
   "app": "npx ts-node --prefer-ts-exts bin/app.ts",
   "watch": {
-    "include": [
-      "**"
-    ],
+    "include": ["**"],
     "exclude": [
       "README.md",
       "cdk*.json",
@@ -19,10 +17,7 @@
   "context": {
     "@aws-cdk/aws-lambda:recognizeLayerVersion": true,
     "@aws-cdk/core:checkSecretUsage": true,
-    "@aws-cdk/core:target-partitions": [
-      "aws",
-      "aws-cn"
-    ],
+    "@aws-cdk/core:target-partitions": ["aws", "aws-cn"],
     "@aws-cdk-containers/ecs-service-extensions:enableDefaultLogDriver": true,
     "@aws-cdk/aws-ec2:uniqueImdsv2TemplateName": true,
     "@aws-cdk/aws-ecs:arnFormatIncludesClusterName": true,

--- a/deployment/cdk/opensearch-service-migration/tsconfig.json
+++ b/deployment/cdk/opensearch-service-migration/tsconfig.json
@@ -3,9 +3,7 @@
     "outDir": "dist",
     "target": "ES2020",
     "module": "commonjs",
-    "lib": [
-      "es2020"
-    ],
+    "lib": ["es2020"],
     "resolveJsonModule": true,
     "declaration": true,
     "strict": true,
@@ -21,15 +19,7 @@
     "inlineSources": true,
     "experimentalDecorators": true,
     "strictPropertyInitialization": false,
-    "typeRoots": [
-      "./node_modules/@types"
-    ]
+    "typeRoots": ["./node_modules/@types"]
   },
-  "exclude": [
-    "node_modules",
-    "cdk.out",
-    "dist",
-    "test",
-    "bin"
-  ]
+  "exclude": ["node_modules", "cdk.out", "dist", "test", "bin"]
 }


### PR DESCRIPTION
### Description
This ensures that our json files are valid and follow common formatting conventions.

### Issues Resolved
- Related https://github.com/opensearch-project/opensearch-migrations/pull/1022

### Check List
- [X] New functionality includes testing
  - [X] All tests pass, including unit test, integration test and doctest
- [ ] ~New functionality has been documented~
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
