### PR TITLE
Add a script to determine the AWS resources used

### DIFF
--- a/deployment/cdk/opensearch-service-migration/.gitignore
+++ b/deployment/cdk/opensearch-service-migration/.gitignore
@@ -9,3 +9,4 @@ dist
 .cdk.staging
 cdk.out
 certs
+cdk-synth-output

--- a/deployment/cdk/opensearch-service-migration/aws-feature-usage.sh
+++ b/deployment/cdk/opensearch-service-migration/aws-feature-usage.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+set -e
+
+if [ -z "$1" ]; then
+    echo "Error: contextId is required. Please pass it as the first argument to the script."
+    echo "Usage: $0 <contextId>"
+    exit 1
+fi
+
+contextId="$1"
+
+output_dir="cdk-synth-output"
+rm -rf "$output_dir"
+mkdir -p "$output_dir"
+
+echo "Synthesizing all stacks..."
+raw_stacks=$(cdk list --ci --context contextId=$contextId)
+
+echo "$raw_stacks" | sed -E 's/ *\(.*\)//' | while read -r stack; do
+    echo "Synthesizing stack: $stack"
+    cdk synth $stack --ci --context contextId=$contextId > "$output_dir/$stack.yaml"
+done
+
+echo "Finding resource usage from synthesized stacks..."
+echo "-----------------------------------"
+echo "IAM Policy Actions:"
+
+grep -h -A 1000 "PolicyDocument:" "$output_dir"/*.yaml | \
+grep -E "Action:" -A 50 | \
+grep -E "^[ \t-]+[a-zA-Z0-9]+:[a-zA-Z0-9\*]+" | \
+grep -vE "^[ \t-]+(aws:|arn:)" | \
+sed -E 's/^[ \t-]+//' | \
+sort -u
+
+echo "-----------------------------------"
+echo "Resources Types:"
+
+grep -h -E " Type: AWS" "$output_dir"/*.yaml | \
+sed -E 's/^[ \t]*Type: //' | \
+sort -u

--- a/deployment/cdk/opensearch-service-migration/lib/network-stack.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/network-stack.ts
@@ -75,7 +75,6 @@ export class NetworkStack extends Stack {
                 onePerAz: true
             }).subnetIds
         }
-        console.info(`Detected VPC with ${vpc.privateSubnets.length} private subnets, ${vpc.publicSubnets.length} public subnets, and ${vpc.isolatedSubnets.length} isolated subnets`)
         if (uniqueAzPrivateSubnets.length < 2) {
             throw new Error(`Not enough AZs (${uniqueAzPrivateSubnets.length} unique AZs detected) used for private subnets to meet 2 or 3 AZ requirement`)
         }

--- a/deployment/cdk/opensearch-service-migration/lib/opensearch-domain-stack.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/opensearch-domain-stack.ts
@@ -108,9 +108,7 @@ export class OpenSearchDomainStack extends Stack {
       defaultDeployId: deployId,
       stage,
     });
-    if (domain.masterUserPassword && !adminUserSecret) {
-      console.log(`An OpenSearch domain fine-grained access control user was configured without an existing Secrets Manager secret, will not create SSM Parameter: /migration/${stage}/${deployId}/osUserAndSecret`)
-    } else if (domain.masterUserPassword && adminUserSecret) {
+    if (domain.masterUserPassword && adminUserSecret) {
       createMigrationStringParameter(this, `${adminUserName} ${adminUserSecret.secretArn}`, {
           parameter: MigrationSSMParameter.OS_USER_AND_SECRET_ARN,
           defaultDeployId: deployId,

--- a/deployment/cdk/opensearch-service-migration/lib/stack-composer.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/stack-composer.ts
@@ -144,10 +144,6 @@ export class StackComposer {
             throw new Error("Required context field 'contextId' not provided")
         }
         const contextJSON = this.parseContextBlock(scope, contextId)
-        console.log('Received following context block for deployment: ')
-        console.log(contextJSON)
-        console.log('End of context block.')
-
         const stage = this.getContextForType('stage', 'string', defaultValues, contextJSON)
 
         const domainName = this.getContextForType('domainName', 'string', defaultValues, contextJSON)
@@ -302,7 +298,6 @@ export class StackComposer {
         if (captureProxyServiceEnabled || captureProxyESServiceEnabled || trafficReplayerServiceEnabled || kafkaBrokerServiceEnabled) {
             streamingSourceType = determineStreamingSourceType(kafkaBrokerServiceEnabled)
         } else {
-            console.log("MSK is not enabled and will not be deployed.")
             streamingSourceType = StreamingSourceType.DISABLED
         }
 


### PR DESCRIPTION
### Description
To help customers determine what resources are used by the Migration Assistant when deployed adding a shell script that can be used on the bootstrap machine to identify what there deployment will require based on the synthesized stacks.

Example output:
```shell
./aws-feature-usage.sh default
Synthesizing all stacks...
Synthesizing stack: networkStack-default
Synthesizing stack: migrationInfraStack
Synthesizing stack: reindexFromSnapshotStack
Synthesizing stack: migration-console
Finding resource usage from synthesized stacks...
-----------------------------------
IAM Policy Actions:
cloudwatch:GetMetricData
cloudwatch:ListMetrics
ec2:DescribeRouteTables
ec2:DescribeSubnets
ecr:BatchCheckLayerAvailability
...
-----------------------------------
Resources Types:
AWS::CDK::Metadata
AWS::EC2::InternetGateway
AWS::EC2::Route
AWS::EC2::RouteTable
AWS::EC2::SecurityGroup
...
```

### Testing
Ran locally, manually

### Check List
- [ ] ~New functionality includes testing~
  - [ ] ~All tests pass, including unit test, integration test and doctest~
- [ ] ~New functionality has been documented~
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
