### PR TITLE
Increase the RFS default scale to 5

### DIFF
--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/backfill_rfs.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/backfill_rfs.py
@@ -92,7 +92,7 @@ class ECSRFSBackfill(RFSBackfill):
         super().__init__(config)
         self.client_options = client_options
         self.target_cluster = target_cluster
-        self.default_scale = self.config["reindex_from_snapshot"].get("scale", 1)
+        self.default_scale = self.config["reindex_from_snapshot"].get("scale", 5)
 
         self.ecs_config = self.config["reindex_from_snapshot"]["ecs"]
         self.ecs_client = ECSService(cluster_name=self.ecs_config["cluster_name"],


### PR DESCRIPTION
### Description
After starting backfill it appears to be slow because a single worker node needs to spin up and down to process the default index with 5 shards.  By increasing the default this should move at least an index at a time causing the overall process to move much faster.

### Issues Resolved
- To be created

### Testing
Not tested

### Check List
- [ ] ~New functionality includes testing~
  - [ ] ~All tests pass, including unit test, integration test and doctest~
- [ ] ~New functionality has been documented~
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
