### PR TITLE
Remove elasticsearch from default capture proxy base image

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -212,8 +212,8 @@ jobs:
           docker tag $image migrations/migration_console:latest
           docker tag $image migrations/reindex_from_snapshot:latest
           docker tag $image migrations/traffic_replayer:latest
-      - name: Run CDK Jest Tests
-        run: npm test
+      - name: Run CDK Jest Tests (using mocked images)
+        run: npm run test:withoutBuildImages
 
   link-checker:
     runs-on: ubuntu-latest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -200,6 +200,16 @@ jobs:
           node-version: ${{ env.node-version }}
       - name: Install NPM dependencies
         run: npm ci
+      - name: Mock Docker Images for CDK Tests
+        run: docker images &&  docker pull alpine && \
+          docker tag alpine migrations/capture_proxy:latest && \
+          docker tag alpine migrations/capture_proxy_es:latest && \
+          docker tag alpine opensearchproject/opensearch:2 && \
+          docker tag alpine migrations/elasticsearch_searchguard:latest && \
+          docker tag alpine docker.io/apache/kafka:3.7.0 && \
+          docker tag alpine migrations/migration_console:latest && \
+          docker tag alpine migrations/reindex_from_snapshot:latest && \
+          docker tag alpine migrations/traffic_replayer:latest
       - name: Run CDK Jest Tests
         run: npm test
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -201,15 +201,17 @@ jobs:
       - name: Install NPM dependencies
         run: npm ci
       - name: Mock Docker Images for CDK Tests
-        run: docker images &&  docker pull alpine && \
-          docker tag alpine migrations/capture_proxy:latest && \
-          docker tag alpine migrations/capture_proxy_es:latest && \
-          docker tag alpine opensearchproject/opensearch:2 && \
-          docker tag alpine migrations/elasticsearch_searchguard:latest && \
-          docker tag alpine docker.io/apache/kafka:3.7.0 && \
-          docker tag alpine migrations/migration_console:latest && \
-          docker tag alpine migrations/reindex_from_snapshot:latest && \
-          docker tag alpine migrations/traffic_replayer:latest
+        run: |
+          image=$(docker images --format '{{.Repository}}:{{.Tag}}' | head -n 1)
+          echo "Using image for mocked tags: $image"
+          docker tag $image migrations/capture_proxy:latest
+          docker tag $image migrations/capture_proxy_es:latest
+          docker tag $image opensearchproject/opensearch:2
+          docker tag $image migrations/elasticsearch_searchguard:latest
+          docker tag $image docker.io/apache/kafka:3.7.0
+          docker tag $image migrations/migration_console:latest
+          docker tag $image migrations/reindex_from_snapshot:latest
+          docker tag $image migrations/traffic_replayer:latest
       - name: Run CDK Jest Tests
         run: npm test
 

--- a/DocumentsFromSnapshotMigration/build.gradle
+++ b/DocumentsFromSnapshotMigration/build.gradle
@@ -144,6 +144,6 @@ tasks.named('composeUp') {
 }
 
 tasks.named('slowTest') {
-    dependsOn(':TrafficCapture:dockerSolution:buildDockerImage_elasticsearchTestConsole')
+    dependsOn(':TrafficCapture:dockerSolution:buildDockerImage_elasticsearch_client_test_console')
     testLogging.showStandardStreams = false
 }

--- a/TrafficCapture/dockerSolution/build.gradle
+++ b/TrafficCapture/dockerSolution/build.gradle
@@ -7,10 +7,6 @@ plugins {
 import org.opensearch.migrations.common.CommonUtils
 import com.bmuschko.gradle.docker.tasks.image.DockerBuildImage
 
-def calculateDockerHash = { projectName ->
-    CommonUtils.calculateDockerHash(project.fileTree("src/main/docker/${projectName}"))
-}
-
 dependencies {
     constraints {
         implementation('software.amazon.awssdk:secretsmanager:2.25.19') {
@@ -20,17 +16,16 @@ dependencies {
 }
 
 def dockerFilesForExternalServices = [
-        "elasticsearchWithSearchGuard": "elasticsearch_searchguard",
-        "captureProxyBase": "capture_proxy_base",
-        "elasticsearchTestConsole": "elasticsearch_client_test_console",
-        "migrationConsole": "migration_console",
-        "otelCollector": "otel_collector",
+        "elasticsearch_searchguard": "elasticsearchWithSearchGuard",
+        "capture_proxy_base": "captureProxyBase",
+        "elasticsearch_client_test_console": "elasticsearchTestConsole",
+        "migration_console": "migrationConsole",
+        "otel_collector": "otelCollector",
         "grafana": "grafana"
 ]
-
-dockerFilesForExternalServices.each { projectName, dockerImageName ->
+dockerFilesForExternalServices.each { dockerImageName, projectName ->
     def escapedProjectName = projectName;
-    task("buildDockerImage_${escapedProjectName}", type: DockerBuildImage) {
+    task("buildDockerImage_${dockerImageName}", type: DockerBuildImage) {
         if (escapedProjectName == "migrationConsole") {
             def libraries = [
                 project(":libraries:kafkaCommandLineFormatter")
@@ -52,28 +47,28 @@ dockerFilesForExternalServices.each { projectName, dockerImageName ->
     }
 }
 
-static def Sync getMigrationConsoleSyncTask(Project project, String dockerImageName, String escapedProjectName, List<Project> libraries, List<Project> applications) {
+static Sync getMigrationConsoleSyncTask(Project project, String dockerImageName, String escapedProjectName, List<Project> libraries, List<Project> applications) {
      // Create a single sync task to copy the required files
     def destDir = "build/docker/${dockerImageName}_${escapedProjectName}"
     def syncTask = project.tasks.create("syncArtifact_${dockerImageName}_${escapedProjectName}", Sync) {
         into destDir
         duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 
-        // Copy libraries
-        (libraries + applications).each { libProject ->
-            def applicationDestDir = "staging/${libProject.name}/"
-            from (libProject.configurations.findByName("runtimeClasspath").files) {
+        // Applications and Standalone Libraries both have libraries
+        (libraries + applications).each { lib ->
+            def applicationDestDir = "staging/${lib.name}/"
+            from (lib.configurations.findByName("runtimeClasspath").files) {
                 into "${applicationDestDir}/lib"
             }
-            from (libProject.tasks.getByName('jar')) {
+            from (lib.tasks.getByName('jar')) {
                 into "${applicationDestDir}/lib"
             }
         }
 
         // Copy applications
-        applications.each { appProject ->
-            def applicationDestDir = "staging/${appProject.name}/"
-            from (appProject.tasks.getByName('startScripts').outputs.files) {
+        applications.each { app ->
+            def applicationDestDir = "staging/${app.name}/"
+            from (app.tasks.getByName('startScripts').outputs.files) {
                 into "${applicationDestDir}/bin"
             }
         }
@@ -87,7 +82,7 @@ static def Sync getMigrationConsoleSyncTask(Project project, String dockerImageN
     syncTask.dependsOn assembleTasks
 
     // Migration Console base image is the test console
-    syncTask.dependsOn "buildDockerImage_elasticsearchTestConsole"
+    syncTask.dependsOn "buildDockerImage_elasticsearch_client_test_console"
 
     return syncTask
 }
@@ -97,14 +92,14 @@ def javaContainerServices = [
         "capture_proxy_es": ":TrafficCapture:trafficCaptureProxyServer",
         "traffic_replayer": ":TrafficCapture:trafficReplayer"
 ]
-def baseImageProjectOverrides = [
-        "capture_proxy": "captureProxyBase",
-        "capture_proxy_es": "elasticsearchWithSearchGuard",
+def baseImageOverrides = [
+        "capture_proxy": "capture_proxy_base",
+        "capture_proxy_es": "elasticsearch_searchguard",
 ]
 javaContainerServices.each { dockerImageName, projectName ->
     def artifactProject = project(projectName);
     CommonUtils.copyArtifactFromProjectToProjectsDockerStaging(project as Project, artifactProject, dockerImageName)
-    CommonUtils.createDockerfile(project, artifactProject, baseImageProjectOverrides[dockerImageName], dockerFilesForExternalServices, dockerImageName)
+    CommonUtils.createDockerfile(project, artifactProject, baseImageOverrides[dockerImageName], dockerFilesForExternalServices, dockerImageName)
 }
 
 javaContainerServices.forEach { dockerImageName, projectName ->
@@ -130,9 +125,9 @@ dockerCompose {
 }
 
 task buildDockerImages {
-    dependsOn buildDockerImage_elasticsearchWithSearchGuard
-    dependsOn buildDockerImage_migrationConsole
-    dependsOn buildDockerImage_otelCollector
+    dependsOn buildDockerImage_elasticsearch_searchguard
+    dependsOn buildDockerImage_migration_console
+    dependsOn buildDockerImage_otel_collector
     dependsOn buildDockerImage_grafana
     dependsOn buildDockerImage_traffic_replayer
     dependsOn buildDockerImage_capture_proxy

--- a/TrafficCapture/dockerSolution/build.gradle
+++ b/TrafficCapture/dockerSolution/build.gradle
@@ -11,10 +11,6 @@ def calculateDockerHash = { projectName ->
     CommonUtils.calculateDockerHash(project.fileTree("src/main/docker/${projectName}"))
 }
 
-clean.doFirst {
-    delete project.file("./src/main/docker/migrationConsole/build")
-}
-
 dependencies {
     constraints {
         implementation('software.amazon.awssdk:secretsmanager:2.25.19') {
@@ -25,89 +21,108 @@ dependencies {
 
 def dockerFilesForExternalServices = [
         "elasticsearchWithSearchGuard": "elasticsearch_searchguard",
+        "captureProxyBase": "capture_proxy_base",
         "elasticsearchTestConsole": "elasticsearch_client_test_console",
         "migrationConsole": "migration_console",
         "otelCollector": "otel_collector",
         "grafana": "grafana"
 ]
-// Create the static docker files that aren't hosting migrations java code from this repo
+
 dockerFilesForExternalServices.each { projectName, dockerImageName ->
     def escapedProjectName = projectName;
     task("buildDockerImage_${escapedProjectName}", type: DockerBuildImage) {
         if (escapedProjectName == "migrationConsole") {
-            def dependencies = []
-            dependencies += stageConsoleDependenciesFromLibraries(project as Project,
-                    List.of(project(":libraries:kafkaCommandLineFormatter")),
-                    projectName, "src/main/docker/${escapedProjectName}")
-            dependencies +=stageConsoleDependenciesFromApplications(project as Project,
-                    List.of(project(":CreateSnapshot"),
-                            project(":MetadataMigration"),
-                    ), projectName, "src/main/docker/${escapedProjectName}")
+            // Define lists of libraries and applications
+            def libraries = [
+                project(":libraries:kafkaCommandLineFormatter")
+            ]
 
+            def applications = [
+                project(":CreateSnapshot"),
+                project(":MetadataMigration")
+            ]
 
-            def parentCopyTask = project.tasks.create("copyArtifact_${projectName}")
-            dependencies.forEach { d -> parentCopyTask.dependsOn(d) }
+            // Create a single sync task to copy the required files
+            def destDir = "build/docker/${dockerImageName}_${escapedProjectName}"
+            def syncTask = project.tasks.create("syncArtifact_${dockerImageName}_${escapedProjectName}", Sync) {
+                into destDir
+                duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 
-            dependsOn "copyArtifact_${escapedProjectName}"
+                // Copy libraries
+                libraries.each { libProject ->
+                    def applicationDestDir = "staging/${libProject.name}/"
+                    from (libProject.configurations.findByName("runtimeClasspath").files) {
+                        into "${applicationDestDir}/lib"
+                    }
+                    from (libProject.tasks.getByName('jar')) {
+                        into "${applicationDestDir}/lib"
+                    }
+                }
+
+                // Copy applications
+                applications.each { appProject ->
+                    def applicationDestDir = "staging/${appProject.name}/"
+                    from (appProject.configurations.findByName("runtimeClasspath").files) {
+                        into "${applicationDestDir}/lib"
+                    }
+                    from (appProject.tasks.getByName('jar')) {
+                        into "${applicationDestDir}/lib"
+                    }
+                    from (appProject.tasks.getByName('startScripts').outputs.files) {
+                        into "${applicationDestDir}/bin"
+                    }
+                }
+
+                from "src/main/docker/${projectName}"
+            }
+
+            // Collect assemble tasks from libraries and applications
+            def assembleTasks = (libraries + applications).collect { it.tasks.named("assemble") }
+            // Ensure the sync task depends on the assemble tasks
+            syncTask.dependsOn(assembleTasks)
+
+            dependsOn syncTask
+            dependsOn assembleTasks
+            // Migration Console base image is the test console
             dependsOn "buildDockerImage_elasticsearchTestConsole"
+        } else {
+            // Sync the src into the build folder
+            def syncTask = project.tasks.create("syncArtifact_${dockerImageName}_${escapedProjectName}", Sync) {
+                from "src/main/docker/${projectName}"
+                into "build/docker/${dockerImageName}_${escapedProjectName}"
+                duplicatesStrategy = DuplicatesStrategy.FAIL
+            }
+
+            // Ensure the sync task depends on the build task
+            dependsOn syncTask
         }
         def hash = calculateDockerHash(projectName)
         images.add("migrations/${dockerImageName}:$hash")
         images.add("migrations/${dockerImageName}:latest")
-        inputDir = project.file("src/main/docker/${projectName}")
+        inputDir = project.file("build/docker/${dockerImageName}_${projectName}")
     }
-}
-
-
-static def List<Task> stageConsoleDependenciesFromLibraries(Project dockerBuildProject,
-                                                            List<Project> sourceArtifactProjects,
-                                                            String destProjectName, String destDir) {
-    return sourceArtifactProjects.collect { sourceArtifactProject ->
-        def applicationDestDir = "${destDir}/staging/${sourceArtifactProject.name}/";
-        def libCopyTask = dockerBuildProject.tasks.create("copyLibArtifacts_${destProjectName}_${sourceArtifactProject.name}", Sync) {
-            from { sourceArtifactProject.configurations.findByName("runtimeClasspath").files }
-            from { sourceArtifactProject.tasks.getByName('jar') }
-            into "${applicationDestDir}/lib"
-        }
-        libCopyTask.dependsOn(sourceArtifactProject.tasks.named("assemble"))
-        return libCopyTask
-    }
-}
-
-static def List<Task> stageConsoleDependenciesFromApplications(Project dockerBuildProject,
-                                                               List<Project> sourceArtifactProjects,
-                                                               String destProjectName, String destDir) {
-    def libDeps = stageConsoleDependenciesFromLibraries(dockerBuildProject, sourceArtifactProjects, destProjectName, destDir)
-    def appDeps = sourceArtifactProjects.collect { sourceArtifactProject ->
-        def applicationDestDir = "${destDir}/staging/${sourceArtifactProject.name}/";
-        def binCopyTask = dockerBuildProject.tasks.create("copyBinArtifacts_${destProjectName}_${sourceArtifactProject.name}", Sync) {
-            from { sourceArtifactProject.tasks.getByName('startScripts').outputs.files }
-            into "${applicationDestDir}/bin"
-        }
-        binCopyTask.dependsOn(sourceArtifactProject.tasks.named("assemble"))
-        return binCopyTask;
-    }
-    return libDeps + appDeps;
 }
 
 def javaContainerServices = [
-        ":TrafficCapture:trafficCaptureProxyServer": "capture_proxy",
-        ":TrafficCapture:trafficReplayer": "traffic_replayer"
+        "capture_proxy": ":TrafficCapture:trafficCaptureProxyServer",
+        "capture_proxy_es": ":TrafficCapture:trafficCaptureProxyServer",
+        "traffic_replayer": ":TrafficCapture:trafficReplayer"
 ]
 def baseImageProjectOverrides = [
-        "trafficCaptureProxyServer": "elasticsearchWithSearchGuard"
+        "capture_proxy": "captureProxyBase",
+        "capture_proxy_es": "elasticsearchWithSearchGuard",
 ]
-javaContainerServices.each { projectName, dockerImageName ->
+javaContainerServices.each { dockerImageName, projectName ->
     def artifactProject = project(projectName);
-    CommonUtils.copyArtifactFromProjectToProjectsDockerStaging(project as Project, artifactProject)
-    CommonUtils.createDockerfile(project, artifactProject, baseImageProjectOverrides, dockerFilesForExternalServices)
+    CommonUtils.copyArtifactFromProjectToProjectsDockerStaging(project as Project, artifactProject, dockerImageName)
+    CommonUtils.createDockerfile(project, artifactProject, baseImageProjectOverrides[dockerImageName], dockerFilesForExternalServices, dockerImageName)
 }
 
-javaContainerServices.forEach { projectName, dockerImageName ->
+javaContainerServices.forEach { dockerImageName, projectName ->
     def escapedProjectName = project(projectName).name;
-    def dockerBuildDir = "build/docker/${escapedProjectName}"
-    task "buildDockerImage_${escapedProjectName}"(type: DockerBuildImage) {
-        dependsOn "createDockerfile_${escapedProjectName}"
+    def dockerBuildDir = "build/docker/${dockerImageName}_${escapedProjectName}"
+    task "buildDockerImage_${dockerImageName}"(type: DockerBuildImage) {
+        dependsOn "createDockerfile_${dockerImageName}"
         inputDir = project.file("${dockerBuildDir}")
         images.add("migrations/${dockerImageName}:${version}")
         images.add("migrations/${dockerImageName}:latest")
@@ -130,9 +145,9 @@ task buildDockerImages {
     dependsOn buildDockerImage_migrationConsole
     dependsOn buildDockerImage_otelCollector
     dependsOn buildDockerImage_grafana
-
-    dependsOn buildDockerImage_trafficCaptureProxyServer
-    dependsOn buildDockerImage_trafficReplayer
+    dependsOn buildDockerImage_traffic_replayer
+    dependsOn buildDockerImage_capture_proxy
+    dependsOn buildDockerImage_capture_proxy_es
 }
 
 tasks.getByName('composeUp')

--- a/TrafficCapture/dockerSolution/build.gradle
+++ b/TrafficCapture/dockerSolution/build.gradle
@@ -54,7 +54,7 @@ static Sync getMigrationConsoleSyncTask(Project project, String dockerImageName,
         into destDir
         duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 
-        // Applications and Standalone Libraries both have libraries
+        // Applications and Standalone Libraries both have libraries, sync them
         (libraries + applications).each { lib ->
             def applicationDestDir = "staging/${lib.name}/"
             from (lib.configurations.findByName("runtimeClasspath").files) {
@@ -65,7 +65,7 @@ static Sync getMigrationConsoleSyncTask(Project project, String dockerImageName,
             }
         }
 
-        // Copy applications
+        // Sync application start scripts
         applications.each { app ->
             def applicationDestDir = "staging/${app.name}/"
             from (app.tasks.getByName('startScripts').outputs.files) {

--- a/TrafficCapture/dockerSolution/build.gradle
+++ b/TrafficCapture/dockerSolution/build.gradle
@@ -32,7 +32,6 @@ dockerFilesForExternalServices.each { projectName, dockerImageName ->
     def escapedProjectName = projectName;
     task("buildDockerImage_${escapedProjectName}", type: DockerBuildImage) {
         if (escapedProjectName == "migrationConsole") {
-            // Define lists of libraries and applications
             def libraries = [
                 project(":libraries:kafkaCommandLineFormatter")
             ]
@@ -41,66 +40,56 @@ dockerFilesForExternalServices.each { projectName, dockerImageName ->
                 project(":CreateSnapshot"),
                 project(":MetadataMigration")
             ]
-
-            // Create a single sync task to copy the required files
-            def destDir = "build/docker/${dockerImageName}_${escapedProjectName}"
-            def syncTask = project.tasks.create("syncArtifact_${dockerImageName}_${escapedProjectName}", Sync) {
-                into destDir
-                duplicatesStrategy = DuplicatesStrategy.EXCLUDE
-
-                // Copy libraries
-                libraries.each { libProject ->
-                    def applicationDestDir = "staging/${libProject.name}/"
-                    from (libProject.configurations.findByName("runtimeClasspath").files) {
-                        into "${applicationDestDir}/lib"
-                    }
-                    from (libProject.tasks.getByName('jar')) {
-                        into "${applicationDestDir}/lib"
-                    }
-                }
-
-                // Copy applications
-                applications.each { appProject ->
-                    def applicationDestDir = "staging/${appProject.name}/"
-                    from (appProject.configurations.findByName("runtimeClasspath").files) {
-                        into "${applicationDestDir}/lib"
-                    }
-                    from (appProject.tasks.getByName('jar')) {
-                        into "${applicationDestDir}/lib"
-                    }
-                    from (appProject.tasks.getByName('startScripts').outputs.files) {
-                        into "${applicationDestDir}/bin"
-                    }
-                }
-
-                from "src/main/docker/${projectName}"
-            }
-
-            // Collect assemble tasks from libraries and applications
-            def assembleTasks = (libraries + applications).collect { it.tasks.named("assemble") }
-            // Ensure the sync task depends on the assemble tasks
-            syncTask.dependsOn(assembleTasks)
-
+            def syncTask = getMigrationConsoleSyncTask(project, dockerImageName, escapedProjectName, libraries, applications)
             dependsOn syncTask
-            dependsOn assembleTasks
-            // Migration Console base image is the test console
-            dependsOn "buildDockerImage_elasticsearchTestConsole"
+            inputDir = syncTask.destinationDir
         } else {
-            // Sync the src into the build folder
-            def syncTask = project.tasks.create("syncArtifact_${dockerImageName}_${escapedProjectName}", Sync) {
-                from "src/main/docker/${projectName}"
-                into "build/docker/${dockerImageName}_${escapedProjectName}"
-                duplicatesStrategy = DuplicatesStrategy.FAIL
-            }
-
-            // Ensure the sync task depends on the build task
-            dependsOn syncTask
+            inputDir = project.file("src/main/docker/${escapedProjectName}")
         }
-        def hash = calculateDockerHash(projectName)
-        images.add("migrations/${dockerImageName}:$hash")
+        def hashNonce = CommonUtils.calculateDockerHash(project.fileTree(inputDir))
+        images.add("migrations/${dockerImageName}:$hashNonce")
         images.add("migrations/${dockerImageName}:latest")
-        inputDir = project.file("build/docker/${dockerImageName}_${projectName}")
     }
+}
+
+static def Sync getMigrationConsoleSyncTask(Project project, String dockerImageName, String escapedProjectName, List<Project> libraries, List<Project> applications) {
+     // Create a single sync task to copy the required files
+    def destDir = "build/docker/${dockerImageName}_${escapedProjectName}"
+    def syncTask = project.tasks.create("syncArtifact_${dockerImageName}_${escapedProjectName}", Sync) {
+        into destDir
+        duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+
+        // Copy libraries
+        (libraries + applications).each { libProject ->
+            def applicationDestDir = "staging/${libProject.name}/"
+            from (libProject.configurations.findByName("runtimeClasspath").files) {
+                into "${applicationDestDir}/lib"
+            }
+            from (libProject.tasks.getByName('jar')) {
+                into "${applicationDestDir}/lib"
+            }
+        }
+
+        // Copy applications
+        applications.each { appProject ->
+            def applicationDestDir = "staging/${appProject.name}/"
+            from (appProject.tasks.getByName('startScripts').outputs.files) {
+                into "${applicationDestDir}/bin"
+            }
+        }
+
+        from "src/main/docker/${escapedProjectName}"
+    }
+
+    // Collect assemble tasks from libraries and applications
+    def assembleTasks = (libraries + applications).collect { it.tasks.named("assemble") }
+    // Ensure the sync task depends on the assemble tasks
+    syncTask.dependsOn assembleTasks
+
+    // Migration Console base image is the test console
+    syncTask.dependsOn "buildDockerImage_elasticsearchTestConsole"
+
+    return syncTask
 }
 
 def javaContainerServices = [

--- a/TrafficCapture/dockerSolution/src/main/docker/captureProxyBase/Dockerfile
+++ b/TrafficCapture/dockerSolution/src/main/docker/captureProxyBase/Dockerfile
@@ -39,8 +39,7 @@ COPY --from=cert-builder /certs/esnode-key.pem $ES_HOME/config/esnode-key.pem
 RUN chown -R root:root $ES_HOME/
 
 # Update the default Java truststore to trust the root-ca
-RUN keytool -import -alias root-ca -keystore $JAVA_HOME/lib/security/cacerts -file $ES_HOME/config/root-ca.pem -storepass changeit -noprompt
-
+RUN keytool -import -alias root-ca -cacerts -file $ES_HOME/config/root-ca.pem -storepass changeit -noprompt
 # Set environment variables for Search Guard
 ENV SEARCHGUARD_CONFIG_DIR=$ES_HOME/config
 ENV SEARCHGUARD_CERTS_DIR=$ES_HOME/config

--- a/TrafficCapture/dockerSolution/src/main/docker/captureProxyBase/Dockerfile
+++ b/TrafficCapture/dockerSolution/src/main/docker/captureProxyBase/Dockerfile
@@ -48,11 +48,7 @@ ENV SEARCHGUARD_CERTS_DIR=$ES_HOME/config
 # The elasticsearch.yml and proxy_tls.yml files are configured to work seamlessly with the Search Guard plugin and TLS settings.
 
 # Add base elasticsearch.yml content
-RUN echo 'searchguard.ssl.transport.pemcert_filepath: esnode.pem' >> $ELASTIC_SEARCH_CONFIG_FILE && \
-    echo 'searchguard.ssl.transport.pemkey_filepath: esnode-key.pem' >> $ELASTIC_SEARCH_CONFIG_FILE && \
-    echo 'searchguard.ssl.transport.pemtrustedcas_filepath: root-ca.pem' >> $ELASTIC_SEARCH_CONFIG_FILE && \
-    echo 'searchguard.ssl.transport.enforce_hostname_verification: false' >> $ELASTIC_SEARCH_CONFIG_FILE && \
-    echo 'searchguard.ssl.http.enabled: true' >> $ELASTIC_SEARCH_CONFIG_FILE && \
+RUN echo 'searchguard.ssl.http.enabled: true' >> $ELASTIC_SEARCH_CONFIG_FILE && \
     echo 'searchguard.ssl.http.pemcert_filepath: esnode.pem' >> $ELASTIC_SEARCH_CONFIG_FILE && \
     echo 'searchguard.ssl.http.pemkey_filepath: esnode-key.pem' >> $ELASTIC_SEARCH_CONFIG_FILE && \
     echo 'searchguard.ssl.http.pemtrustedcas_filepath: root-ca.pem' >> $ELASTIC_SEARCH_CONFIG_FILE

--- a/TrafficCapture/dockerSolution/src/main/docker/captureProxyBase/Dockerfile
+++ b/TrafficCapture/dockerSolution/src/main/docker/captureProxyBase/Dockerfile
@@ -1,0 +1,79 @@
+# =======================
+# Stage 1: Certificate Generation
+# =======================
+FROM amazonlinux:2023 AS cert-builder
+
+# Install OpenSSL
+RUN yum update -y && \
+    yum install -y openssl && \
+    yum clean all
+
+# Generate self-signed certificates
+RUN mkdir -p /certs && \
+    openssl req -x509 -nodes -newkey rsa:4096 \
+    -keyout /certs/esnode-key.pem \
+    -out /certs/root-ca.pem \
+    -subj "/CN=localhost" \
+    -days 365 && \
+    openssl req -new -key /certs/esnode-key.pem -out /certs/esnode.csr -subj "/CN=localhost" && \
+    openssl x509 -req -in /certs/esnode.csr -CA /certs/root-ca.pem -CAkey /certs/esnode-key.pem -CAcreateserial -out /certs/esnode.pem -days 365 -sha256
+
+# =======================
+# Stage 2: Final Image
+# =======================
+FROM amazoncorretto:11-al2023-headless
+
+# Set environment variables
+ENV ES_HOME=/usr/share/elasticsearch
+RUN mkdir -p $ES_HOME
+ENV PATH=$ES_HOME/bin:$PATH
+ENV ELASTIC_SEARCH_CONFIG_FILE=$ES_HOME/config/elasticsearch.yml
+ENV PROXY_TLS_CONFIG_FILE=$ES_HOME/config/proxy_tls.yml
+
+# Copy certificates from builder stage
+USER root
+RUN mkdir -p $ES_HOME/certs
+COPY --from=cert-builder /certs/root-ca.pem $ES_HOME/config/root-ca.pem
+COPY --from=cert-builder /certs/esnode.pem $ES_HOME/config/esnode.pem
+COPY --from=cert-builder /certs/esnode-key.pem $ES_HOME/config/esnode-key.pem
+RUN chown -R root:root $ES_HOME/
+
+# Update the default Java truststore to trust the root-ca
+RUN keytool -import -alias root-ca -keystore $JAVA_HOME/lib/security/cacerts -file $ES_HOME/config/root-ca.pem -storepass changeit -noprompt
+
+# Set environment variables for Search Guard
+ENV SEARCHGUARD_CONFIG_DIR=$ES_HOME/config
+ENV SEARCHGUARD_CERTS_DIR=$ES_HOME/config
+
+# Note: The following configurations are added to ensure compatibility with the es-7.10-oss base image used in the Dockerfile.
+# The elasticsearch.yml and proxy_tls.yml files are configured to work seamlessly with the Search Guard plugin and TLS settings.
+
+# Add base elasticsearch.yml content
+RUN echo 'searchguard.ssl.transport.pemcert_filepath: esnode.pem' >> $ELASTIC_SEARCH_CONFIG_FILE && \
+    echo 'searchguard.ssl.transport.pemkey_filepath: esnode-key.pem' >> $ELASTIC_SEARCH_CONFIG_FILE && \
+    echo 'searchguard.ssl.transport.pemtrustedcas_filepath: root-ca.pem' >> $ELASTIC_SEARCH_CONFIG_FILE && \
+    echo 'searchguard.ssl.transport.enforce_hostname_verification: false' >> $ELASTIC_SEARCH_CONFIG_FILE && \
+    echo 'searchguard.ssl.http.enabled: true' >> $ELASTIC_SEARCH_CONFIG_FILE && \
+    echo 'searchguard.ssl.http.pemcert_filepath: esnode.pem' >> $ELASTIC_SEARCH_CONFIG_FILE && \
+    echo 'searchguard.ssl.http.pemkey_filepath: esnode-key.pem' >> $ELASTIC_SEARCH_CONFIG_FILE && \
+    echo 'searchguard.ssl.http.pemtrustedcas_filepath: root-ca.pem' >> $ELASTIC_SEARCH_CONFIG_FILE
+
+# Add base proxy_tls.yml content
+RUN echo 'plugins.security.ssl.http.enabled: true' >> $PROXY_TLS_CONFIG_FILE && \
+    echo 'plugins.security.ssl.http.pemcert_filepath: esnode.pem' >> $PROXY_TLS_CONFIG_FILE && \
+    echo 'plugins.security.ssl.http.pemkey_filepath: esnode-key.pem' >> $PROXY_TLS_CONFIG_FILE && \
+    echo 'plugins.security.ssl.http.pemtrustedcas_filepath: root-ca.pem' >> $PROXY_TLS_CONFIG_FILE && \
+    echo "plugins.security.ssl.http.enabled_protocols: ['TLSv1.2', 'TLSv1.3']" >> $PROXY_TLS_CONFIG_FILE
+
+
+# Set the right permissions and ownership for created files
+RUN chmod 644 $ELASTIC_SEARCH_CONFIG_FILE && \
+    chmod 644 $PROXY_TLS_CONFIG_FILE && \
+    chown root:root $ELASTIC_SEARCH_CONFIG_FILE && \
+    chown root:root $PROXY_TLS_CONFIG_FILE
+
+# Expose ports
+EXPOSE 9200
+
+# Set the entrypoint
+CMD ["tail", "-f", "/dev/null"]

--- a/TrafficCapture/dockerSolution/src/main/docker/captureProxyBase/Dockerfile
+++ b/TrafficCapture/dockerSolution/src/main/docker/captureProxyBase/Dockerfile
@@ -11,12 +11,12 @@ RUN yum update -y && \
 # Generate self-signed certificates
 RUN mkdir -p /certs && \
     openssl req -x509 -nodes -newkey rsa:4096 \
-    -keyout /certs/esnode-key.pem \
-    -out /certs/root-ca.pem \
+    -keyout /certs/key.pem \
+    -out /certs/ca.pem \
     -subj "/CN=localhost" \
-    -days 365 && \
-    openssl req -new -key /certs/esnode-key.pem -out /certs/esnode.csr -subj "/CN=localhost" && \
-    openssl x509 -req -in /certs/esnode.csr -CA /certs/root-ca.pem -CAkey /certs/esnode-key.pem -CAcreateserial -out /certs/esnode.pem -days 365 -sha256
+    -days 36500 && \
+    openssl req -new -key /certs/key.pem -out /certs/key.csr -subj "/CN=localhost" && \
+    openssl x509 -req -in /certs/key.csr -CA /certs/ca.pem -CAkey /certs/key.pem -CAcreateserial -out /certs/pub.pem -days 36500 -sha256
 
 # =======================
 # Stage 2: Final Image
@@ -24,50 +24,32 @@ RUN mkdir -p /certs && \
 FROM amazoncorretto:11-al2023-headless
 
 # Set environment variables
-ENV ES_HOME=/usr/share/elasticsearch
-RUN mkdir -p $ES_HOME
-ENV PATH=$ES_HOME/bin:$PATH
-ENV ELASTIC_SEARCH_CONFIG_FILE=$ES_HOME/config/elasticsearch.yml
-ENV PROXY_TLS_CONFIG_FILE=$ES_HOME/config/proxy_tls.yml
+ENV CONFIG_HOME=/usr/share/captureProxy/config
+ENV PROXY_TLS_CONFIG_FILE=$CONFIG_HOME/proxy_tls.yml
 
 # Copy certificates from builder stage
 USER root
-RUN mkdir -p $ES_HOME/certs
-COPY --from=cert-builder /certs/root-ca.pem $ES_HOME/config/root-ca.pem
-COPY --from=cert-builder /certs/esnode.pem $ES_HOME/config/esnode.pem
-COPY --from=cert-builder /certs/esnode-key.pem $ES_HOME/config/esnode-key.pem
-RUN chown -R root:root $ES_HOME/
+RUN mkdir -p $CONFIG_HOME/certs
+COPY --from=cert-builder /certs/ca.pem $CONFIG_HOME/ca.pem
+COPY --from=cert-builder /certs/pub.pem $CONFIG_HOME/pub.pem
+COPY --from=cert-builder /certs/key.pem $CONFIG_HOME/key.pem
+RUN chown -R root:root $CONFIG_HOME/
 
 # Update the default Java truststore to trust the root-ca
-RUN keytool -import -alias root-ca -cacerts -file $ES_HOME/config/root-ca.pem -storepass changeit -noprompt
-# Set environment variables for Search Guard
-ENV SEARCHGUARD_CONFIG_DIR=$ES_HOME/config
-ENV SEARCHGUARD_CERTS_DIR=$ES_HOME/config
+RUN keytool -import -alias root-ca -cacerts -file $CONFIG_HOME/ca.pem -storepass changeit -noprompt
 
-# Note: The following configurations are added to ensure compatibility with the es-7.10-oss base image used in the Dockerfile.
-# The elasticsearch.yml and proxy_tls.yml files are configured to work seamlessly with the Search Guard plugin and TLS settings.
-
-# Add base elasticsearch.yml content
-RUN echo 'searchguard.ssl.http.enabled: true' >> $ELASTIC_SEARCH_CONFIG_FILE && \
-    echo 'searchguard.ssl.http.pemcert_filepath: esnode.pem' >> $ELASTIC_SEARCH_CONFIG_FILE && \
-    echo 'searchguard.ssl.http.pemkey_filepath: esnode-key.pem' >> $ELASTIC_SEARCH_CONFIG_FILE && \
-    echo 'searchguard.ssl.http.pemtrustedcas_filepath: root-ca.pem' >> $ELASTIC_SEARCH_CONFIG_FILE
-
-# Add base proxy_tls.yml content
+# Note: The following configurations are added to ensure compatibility with the es-7.10-oss base image.
+# The proxy_tls.yml file are configured to work seamlessly with the Capture Proxy.
 RUN echo 'plugins.security.ssl.http.enabled: true' >> $PROXY_TLS_CONFIG_FILE && \
-    echo 'plugins.security.ssl.http.pemcert_filepath: esnode.pem' >> $PROXY_TLS_CONFIG_FILE && \
-    echo 'plugins.security.ssl.http.pemkey_filepath: esnode-key.pem' >> $PROXY_TLS_CONFIG_FILE && \
-    echo 'plugins.security.ssl.http.pemtrustedcas_filepath: root-ca.pem' >> $PROXY_TLS_CONFIG_FILE && \
+    echo 'plugins.security.ssl.http.pemcert_filepath: pub.pem' >> $PROXY_TLS_CONFIG_FILE && \
+    echo 'plugins.security.ssl.http.pemkey_filepath: key.pem' >> $PROXY_TLS_CONFIG_FILE && \
+    echo 'plugins.security.ssl.http.pemtrustedcas_filepath: ca.pem' >> $PROXY_TLS_CONFIG_FILE && \
     echo "plugins.security.ssl.http.enabled_protocols: ['TLSv1.2', 'TLSv1.3']" >> $PROXY_TLS_CONFIG_FILE
 
-
-# Set the right permissions and ownership for created files
-RUN chmod 644 $ELASTIC_SEARCH_CONFIG_FILE && \
-    chmod 644 $PROXY_TLS_CONFIG_FILE && \
-    chown root:root $ELASTIC_SEARCH_CONFIG_FILE && \
+RUN chmod 644 $PROXY_TLS_CONFIG_FILE && \
     chown root:root $PROXY_TLS_CONFIG_FILE
 
-# Expose ports
+# Default port
 EXPOSE 9200
 
 # Set the entrypoint

--- a/TrafficCapture/dockerSolution/src/main/docker/composeExtensions/proxy-multi.yml
+++ b/TrafficCapture/dockerSolution/src/main/docker/composeExtensions/proxy-multi.yml
@@ -2,7 +2,7 @@ version: '3.7'
 services:
 
   capture-proxy-es1:
-     image: 'migrations/capture_proxy:latest'
+     image: 'migrations/capture_proxy_es:latest'
      networks:
       - migrations
      ports:
@@ -22,7 +22,7 @@ services:
       - kafka
 
   capture-proxy-es2:
-    image: 'migrations/capture_proxy:latest'
+    image: 'migrations/capture_proxy_es:latest'
     networks:
       - migrations
     ports:

--- a/TrafficCapture/dockerSolution/src/main/docker/composeExtensions/proxy-single.yml
+++ b/TrafficCapture/dockerSolution/src/main/docker/composeExtensions/proxy-single.yml
@@ -4,7 +4,7 @@ services:
 
   # Run combined instance of Capture Proxy and Elasticsearch
 #  capture-proxy-es:
-#    image: 'migrations/capture_proxy:latest'
+#    image: 'migrations/capture_proxy_es:latest'
 #    networks:
 #      - migrations
 #    ports:

--- a/TrafficCapture/dockerSolution/src/main/docker/composeExtensions/proxy-single.yml
+++ b/TrafficCapture/dockerSolution/src/main/docker/composeExtensions/proxy-single.yml
@@ -25,7 +25,7 @@ services:
       - migrations
     ports:
       - "9200:9200"
-    command: /runJavaWithClasspath.sh org.opensearch.migrations.trafficcapture.proxyserver.CaptureProxy  --kafkaConnection kafka:9092 --destinationUri  https://elasticsearch:9200  --insecureDestination --listenPort 9200 --sslConfigFile /usr/share/elasticsearch/config/proxy_tls.yml --otelCollectorEndpoint http://otel-collector:4317
+    command: /runJavaWithClasspath.sh org.opensearch.migrations.trafficcapture.proxyserver.CaptureProxy  --kafkaConnection kafka:9092 --destinationUri  https://elasticsearch:9200  --insecureDestination --listenPort 9200 --sslConfigFile /usr/share/captureProxy/config/proxy_tls.yml --otelCollectorEndpoint http://otel-collector:4317
     depends_on:
       - kafka
       - elasticsearch

--- a/TrafficCapture/trafficCaptureProxyServerTest/build.gradle
+++ b/TrafficCapture/trafficCaptureProxyServerTest/build.gradle
@@ -43,12 +43,12 @@ configurations {
 
 
 def dockerFilesForExternalServices = [
-        "nginx": "nginx-perf-test-webserver"
+        "nginx_perf_test_webserver": "nginx"
 ]
 
 // Create the static docker files that aren't hosting migrations java code from this repo
-dockerFilesForExternalServices.each { projectName, dockerImageName ->
-    task("buildDockerImage_${projectName}", type: DockerBuildImage) {
+dockerFilesForExternalServices.each { dockerImageName, projectName ->
+    task("buildDockerImage_${dockerImageName}", type: DockerBuildImage) {
         def hash = calculateDockerHash(projectName)
         images.add("migrations/${dockerImageName}:$hash")
         images.add("migrations/${dockerImageName}:latest")
@@ -60,7 +60,7 @@ def javaContainerServices = [
         "jmeter": ":TrafficCapture:trafficCaptureProxyServerTest"
 ]
 def baseImageProjectOverrides = [
-        "nginx": "nginx-perf-test-webserver"
+        "nginx": "nginx_perf_test_webserver"
 ]
 
 def createContainerTasks = { dockerImageName, projectName ->
@@ -88,7 +88,7 @@ dockerCompose {
 
 task buildDockerImages {
     dependsOn ':TrafficCapture:dockerSolution:buildDockerImage_capture_proxy'
-    dependsOn buildDockerImage_nginx
+    dependsOn buildDockerImage_nginx_perf_test_webserver
     dependsOn buildDockerImage_jmeter
 }
 

--- a/TrafficCapture/trafficCaptureProxyServerTest/build.gradle
+++ b/TrafficCapture/trafficCaptureProxyServerTest/build.gradle
@@ -72,7 +72,7 @@ def createContainerTasks = { dockerImageName, projectName ->
 javaContainerServices.each(createContainerTasks)
 
 (javaContainerServices).forEach { dockerImageName, projectName ->
-def escapedProjectName = project(projectName).name;
+    def escapedProjectName = project(projectName).name;
     def dockerBuildDir = "build/docker/${dockerImageName}_${escapedProjectName}"
     task "buildDockerImage_${dockerImageName}"(type: DockerBuildImage) {
         dependsOn "createDockerfile_${dockerImageName}"

--- a/TrafficCapture/trafficCaptureProxyServerTest/build.gradle
+++ b/TrafficCapture/trafficCaptureProxyServerTest/build.gradle
@@ -57,41 +57,44 @@ dockerFilesForExternalServices.each { projectName, dockerImageName ->
 }
 
 def javaContainerServices = [
-        ":TrafficCapture:trafficCaptureProxyServerTest": "jmeter"
+        "jmeter": ":TrafficCapture:trafficCaptureProxyServerTest"
 ]
 def baseImageProjectOverrides = [
         "nginx": "nginx-perf-test-webserver"
 ]
 
-def createContainerTasks = { projectName, dockerImageName ->
+def createContainerTasks = { dockerImageName, projectName ->
     def sourceArtifactProject = project(projectName);
-    CommonUtils.copyArtifactFromProjectToProjectsDockerStaging(project, sourceArtifactProject)
-    CommonUtils.createDockerfile(project, sourceArtifactProject, baseImageProjectOverrides, dockerFilesForExternalServices)
+    CommonUtils.copyArtifactFromProjectToProjectsDockerStaging(project, sourceArtifactProject, dockerImageName)
+    CommonUtils.createDockerfile(project, sourceArtifactProject, baseImageProjectOverrides[dockerImageName], dockerFilesForExternalServices, dockerImageName)
 }
 
 javaContainerServices.each(createContainerTasks)
 
-(javaContainerServices).forEach { projectName, dockerImageName ->
-    def escapedProjectName = project(projectName).name;
-    def dockerBuildDir = "build/docker/${escapedProjectName}"
-    task "buildDockerImage_${escapedProjectName}"(type: DockerBuildImage) {
-        dependsOn "createDockerfile_${escapedProjectName}"
+(javaContainerServices).forEach { dockerImageName, projectName ->
+def escapedProjectName = project(projectName).name;
+    def dockerBuildDir = "build/docker/${dockerImageName}_${escapedProjectName}"
+    task "buildDockerImage_${dockerImageName}"(type: DockerBuildImage) {
+        dependsOn "createDockerfile_${dockerImageName}"
         inputDir = project.file("${dockerBuildDir}")
         images.add("migrations/${dockerImageName}:${version}")
         images.add("migrations/${dockerImageName}:latest")
     }
 }
 
-
-
 dockerCompose {
     useComposeFiles.add("src/main/docker/docker-compose.yml")
 }
 
 task buildDockerImages {
-    dependsOn(':TrafficCapture:dockerSolution:buildDockerImage_trafficCaptureProxyServer')
+    dependsOn ':TrafficCapture:dockerSolution:buildDockerImage_capture_proxy'
     dependsOn buildDockerImage_nginx
-    dependsOn buildDockerImage_trafficCaptureProxyServerTest
+    dependsOn buildDockerImage_jmeter
+}
+
+tasks.named('copyArtifact_jmeter') {
+    // Add dependency on inter-project dependencies from above dependencies
+    dependsOn ':TrafficCapture:trafficCaptureProxyServer:build'
 }
 
 tasks.getByName('composeUp')

--- a/TrafficCapture/trafficCaptureProxyServerTest/src/main/docker/docker-compose.yml
+++ b/TrafficCapture/trafficCaptureProxyServerTest/src/main/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.7'
 services:
   webserver:
-    image: 'migrations/nginx-perf-test-webserver:latest'
+    image: 'migrations/nginx_perf_test_webserver:latest'
     networks:
       - testing
     ports:

--- a/buildSrc/src/main/groovy/org/opensearch/migrations/common/CommonUtils.groovy
+++ b/buildSrc/src/main/groovy/org/opensearch/migrations/common/CommonUtils.groovy
@@ -20,10 +20,11 @@ class CommonUtils {
         return digest.digest().encodeHex().toString()
     }
 
-    static def copyArtifactFromProjectToProjectsDockerStaging(Project dockerBuildProject, Project project) {
-        def destBuildDir = "build/docker/${project.name}"
+    static def copyArtifactFromProjectToProjectsDockerStaging(Project dockerBuildProject, Project project,
+                                                              String dockerImageName) {
+        def destBuildDir = "build/docker/${dockerImageName}_${project.name}"
         def destDir = "${destBuildDir}/jars"
-        copyArtifactFromProjectToProjectsDockerStaging(dockerBuildProject, project, project.name, destDir)
+        copyArtifactFromProjectToProjectsDockerStaging(dockerBuildProject, project, dockerImageName, destDir)
     }
     static def copyArtifactFromProjectToProjectsDockerStaging(Project dockerBuildProject, Project sourceArtifactProject,
                                                               String destProjectName, String destDir) {
@@ -44,22 +45,24 @@ class CommonUtils {
     }
 
     static def createDockerfile(Project dockerBuildProject, Project sourceArtifactProject,
-                                Map<String, String> baseImageProjectOverrides,
-                                Map<String, String> dockerFilesForExternalServices) {
+                                String baseImageProjectOverride,
+                                Map<String, String> dockerFilesForExternalServices,
+                                String dockerImageName) {
         def projectName = sourceArtifactProject.name;
-        def dockerBuildDir = "build/docker/${projectName}"
-        dockerBuildProject.task("createDockerfile_${projectName}", type: Dockerfile) {
+        def dockerBuildDir = "build/docker/${dockerImageName}_${projectName}"
+        dockerBuildProject.task("createDockerfile_${dockerImageName}", type: Dockerfile) {
             destFile = dockerBuildProject.file("${dockerBuildDir}/Dockerfile")
-            dependsOn "copyArtifact_${projectName}"
-            def baseImageOverrideProjectName = baseImageProjectOverrides.get(projectName)
-            if (baseImageOverrideProjectName) {
-                def dependentDockerImageName = dockerFilesForExternalServices.get(baseImageOverrideProjectName)
+            dependsOn "copyArtifact_${dockerImageName}"
+            if (baseImageProjectOverride) {
+                def dependentDockerImageName = dockerFilesForExternalServices.get(baseImageProjectOverride)
                 def hashNonce = CommonUtils.calculateDockerHash(
-                        dockerBuildProject.fileTree("src/main/docker/${baseImageOverrideProjectName}"))
+                        dockerBuildProject.fileTree("src/main/docker/${baseImageProjectOverride}"))
                 from "migrations/${dependentDockerImageName}:${hashNonce}"
-                def dependencyName = "buildDockerImage_${baseImageOverrideProjectName}";
+                def dependencyName = "buildDockerImage_${baseImageProjectOverride}";
                 dependsOn dependencyName
-                runCommand("sed -i -e \"s|mirrorlist=|#mirrorlist=|g\" /etc/yum.repos.d/CentOS-* ;  sed -i -e \"s|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g\" /etc/yum.repos.d/CentOS-*")
+                if (baseImageProjectOverride.startsWith("elasticsearch")) {
+                    runCommand("sed -i -e \"s|mirrorlist=|#mirrorlist=|g\" /etc/yum.repos.d/CentOS-* ;  sed -i -e \"s|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g\" /etc/yum.repos.d/CentOS-*")
+                }
             } else {
                 from 'amazoncorretto:11-al2023-headless'
             }

--- a/deployment/cdk/opensearch-service-migration/cdk.context.json
+++ b/deployment/cdk/opensearch-service-migration/cdk.context.json
@@ -1,33 +1,31 @@
 {
   "default": {
-    "stage": "<STAGE>",
+    "stage": "test-stage",
     "targetCluster": {
-      "endpoint": "<TARGET_CLUSTER_ENDPOINT>",
+      "endpoint": "https://target-cluster.com:443",
       "auth": {
-        "type": "none | basic | sigv4",
-        "// basic auth documentation": "The next two lines are releavant for basic auth only",
-        "username": "<USERNAME>",
-        "passwordFromSecretArn": "<ARN_OF_SECRET_CONTAINING_PASSWORD>",
-        "// sigv4 documentation": "The next two lines are releavant for sigv4 only",
-        "region": "<REGION>",
-        "serviceSigningName": "es | aoss"
+        "type": "none"
       }
     },
     "sourceCluster": {
-      "endpoint": "<SOURCE_CLUSTER_ENDPOINT>",
+      "endpoint": "https://source-cluster.com:443",
       "auth": {
-        "type": "none | basic | sigv4",
-        "// basic auth documentation": "The next two lines are releavant for basic auth only",
-        "username": "<USERNAME>",
-        "passwordFromSecretArn": "<ARN_OF_SECRET_CONTAINING_PASSWORD>",
-        "// sigv4 documentation": "The next two lines are releavant for sigv4 only",
-        "region": "<REGION>",
-        "serviceSigningName": "es | aoss"
+        "type": "none"
       }
     },
-    "vpcId": "<VPC_ID>",
     "reindexFromSnapshotServiceEnabled": true,
     "reindexFromSnapshotMaxShardSizeGiB": 80,
-    "trafficReplayerServiceEnabled": true
-  }
+    "migrationAssistanceEnabled": true,
+    "migrationConsoleServiceEnabled": true,
+    "otelCollectorEnabled": true,
+    "targetClusterProxyServiceEnabled": true
+  },
+  "availability-zones:account=767398060394:region=us-east-1": [
+    "us-east-1a",
+    "us-east-1b",
+    "us-east-1c",
+    "us-east-1d",
+    "us-east-1e",
+    "us-east-1f"
+  ]
 }

--- a/deployment/cdk/opensearch-service-migration/cdk.context.json
+++ b/deployment/cdk/opensearch-service-migration/cdk.context.json
@@ -1,31 +1,33 @@
 {
   "default": {
-    "stage": "test-stage",
+    "stage": "<STAGE>",
     "targetCluster": {
-      "endpoint": "https://target-cluster.com:443",
+      "endpoint": "<TARGET_CLUSTER_ENDPOINT>",
       "auth": {
-        "type": "none"
+        "type": "none | basic | sigv4",
+        "// basic auth documentation": "The next two lines are releavant for basic auth only",
+        "username": "<USERNAME>",
+        "passwordFromSecretArn": "<ARN_OF_SECRET_CONTAINING_PASSWORD>",
+        "// sigv4 documentation": "The next two lines are releavant for sigv4 only",
+        "region": "<REGION>",
+        "serviceSigningName": "es | aoss"
       }
     },
     "sourceCluster": {
-      "endpoint": "https://source-cluster.com:443",
+      "endpoint": "<SOURCE_CLUSTER_ENDPOINT>",
       "auth": {
-        "type": "none"
+        "type": "none | basic | sigv4",
+        "// basic auth documentation": "The next two lines are releavant for basic auth only",
+        "username": "<USERNAME>",
+        "passwordFromSecretArn": "<ARN_OF_SECRET_CONTAINING_PASSWORD>",
+        "// sigv4 documentation": "The next two lines are releavant for sigv4 only",
+        "region": "<REGION>",
+        "serviceSigningName": "es | aoss"
       }
     },
+    "vpcId": "<VPC_ID>",
     "reindexFromSnapshotServiceEnabled": true,
     "reindexFromSnapshotMaxShardSizeGiB": 80,
-    "migrationAssistanceEnabled": true,
-    "migrationConsoleServiceEnabled": true,
-    "otelCollectorEnabled": true,
-    "targetClusterProxyServiceEnabled": true
-  },
-  "availability-zones:account=767398060394:region=us-east-1": [
-    "us-east-1a",
-    "us-east-1b",
-    "us-east-1c",
-    "us-east-1d",
-    "us-east-1e",
-    "us-east-1f"
-  ]
+    "trafficReplayerServiceEnabled": true
+  }
 }

--- a/deployment/cdk/opensearch-service-migration/lib/common-utilities.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/common-utilities.ts
@@ -15,9 +15,9 @@ export function getSecretAccessPolicy(secretArn: string): PolicyStatement {
         ]
     })
 }
-import * as fs from 'fs';
-import * as path from 'path';
-import * as os from 'os';
+import { mkdtempSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
 import { DockerImageAsset } from "aws-cdk-lib/aws-ecr-assets";
 
 export function appendArgIfNotInExtraArgs(
@@ -451,12 +451,12 @@ export function isRegionGovCloud(region: string): boolean {
  */
 export function makeDockerImageAsset(scope: Construct, serviceName: string, imageName: string): ContainerImage {
     const sanitizedImageName = imageName.replace(/[^a-zA-Z0-9-_]/g, '_');
-    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'docker-build-' + sanitizedImageName));
-    const dockerfilePath = path.join(tempDir, 'Dockerfile');
+    const tempDir = mkdtempSync(join(tmpdir(), 'docker-build-' + sanitizedImageName));
+    const dockerfilePath = join(tempDir, 'Dockerfile');
     const dockerfileContent = `
         FROM ${imageName}
     `;
-    fs.writeFileSync(dockerfilePath, dockerfileContent);
+    writeFileSync(dockerfilePath, dockerfileContent);
     const asset = new DockerImageAsset(scope, serviceName + 'Image', {
         directory: tempDir,
     });

--- a/deployment/cdk/opensearch-service-migration/lib/service-stacks/capture-proxy-es-stack.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/service-stacks/capture-proxy-es-stack.ts
@@ -81,7 +81,7 @@ export class CaptureProxyESStack extends MigrationServiceCore {
 
         this.createService({
             serviceName: "capture-proxy-es",
-            dockerImageRegistryName: "migrations/capture_proxy_es:latest",
+            dockerImageName: "migrations/capture_proxy_es:latest",
             dockerImageCommand: ['/bin/sh', '-c', command.concat(" & wait -n 1")],
             securityGroups: securityGroups,
             taskRolePolicies: servicePolicies,

--- a/deployment/cdk/opensearch-service-migration/lib/service-stacks/capture-proxy-es-stack.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/service-stacks/capture-proxy-es-stack.ts
@@ -67,7 +67,7 @@ export class CaptureProxyESStack extends MigrationServiceCore {
         const extraArgsDict = parseArgsToDict(props.extraArgs)
         command = appendArgIfNotInExtraArgs(command, extraArgsDict, "--destinationUri", "https://localhost:19200")
         command = appendArgIfNotInExtraArgs(command, extraArgsDict, "--insecureDestination")
-        command = appendArgIfNotInExtraArgs(command, extraArgsDict, "--sslConfigFile", "/usr/share/elasticsearch/config/proxy_tls.yml")
+        command = appendArgIfNotInExtraArgs(command, extraArgsDict, "--sslConfigFile", "/usr/share/captureProxy/config/proxy_tls.yml")
         if (props.streamingSourceType !== StreamingSourceType.DISABLED) {
             command = appendArgIfNotInExtraArgs(command, extraArgsDict, "--kafkaConnection", brokerEndpoints)
         }

--- a/deployment/cdk/opensearch-service-migration/lib/service-stacks/capture-proxy-es-stack.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/service-stacks/capture-proxy-es-stack.ts
@@ -81,7 +81,7 @@ export class CaptureProxyESStack extends MigrationServiceCore {
 
         this.createService({
             serviceName: "capture-proxy-es",
-            dockerDirectoryPath: join(__dirname, "../../../../../", "TrafficCapture/dockerSolution/build/docker/trafficCaptureProxyServer"),
+            dockerImageRegistryName: "migrations/capture_proxy_es:latest",
             dockerImageCommand: ['/bin/sh', '-c', command.concat(" & wait -n 1")],
             securityGroups: securityGroups,
             taskRolePolicies: servicePolicies,

--- a/deployment/cdk/opensearch-service-migration/lib/service-stacks/capture-proxy-stack.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/service-stacks/capture-proxy-stack.ts
@@ -114,11 +114,6 @@ export class CaptureProxyStack extends MigrationServiceCore {
 
         const servicePolicies = props.streamingSourceType === StreamingSourceType.AWS_MSK ? createMSKProducerIAMPolicies(this, this.partition, this.region, this.account, props.stage, props.defaultDeployId) : []
 
-        const brokerEndpoints = getMigrationStringParameterValue(this, {
-            ...props,
-            parameter: MigrationSSMParameter.KAFKA_BROKERS,
-        });
-
         const destinationEndpoint = getDestinationEndpoint(this, props.destinationConfig, props);
 
         let command = "/runJavaWithClasspath.sh org.opensearch.migrations.trafficcapture.proxyserver.CaptureProxy"
@@ -129,6 +124,10 @@ export class CaptureProxyStack extends MigrationServiceCore {
         command = appendArgIfNotInExtraArgs(command, extraArgsDict, "--listenPort", "9200")
         command = appendArgIfNotInExtraArgs(command, extraArgsDict, "--sslConfigFile", "/usr/share/elasticsearch/config/proxy_tls.yml")
         if (props.streamingSourceType !== StreamingSourceType.DISABLED) {
+            const brokerEndpoints = getMigrationStringParameterValue(this, {
+                ...props,
+                parameter: MigrationSSMParameter.KAFKA_BROKERS,
+            });
             command = appendArgIfNotInExtraArgs(command, extraArgsDict, "--kafkaConnection", brokerEndpoints)
         }
         if (props.streamingSourceType === StreamingSourceType.AWS_MSK) {

--- a/deployment/cdk/opensearch-service-migration/lib/service-stacks/capture-proxy-stack.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/service-stacks/capture-proxy-stack.ts
@@ -140,7 +140,7 @@ export class CaptureProxyStack extends MigrationServiceCore {
 
         this.createService({
             serviceName: serviceName,
-            dockerImageRegistryName: "migrations/capture_proxy:latest",
+            dockerImageName: "migrations/capture_proxy:latest",
             dockerImageCommand: ['/bin/sh', '-c', command],
             securityGroups: securityGroups,
             taskRolePolicies: servicePolicies,

--- a/deployment/cdk/opensearch-service-migration/lib/service-stacks/capture-proxy-stack.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/service-stacks/capture-proxy-stack.ts
@@ -122,7 +122,7 @@ export class CaptureProxyStack extends MigrationServiceCore {
         command = appendArgIfNotInExtraArgs(command, extraArgsDict, "--destinationUri", destinationEndpoint)
         command = appendArgIfNotInExtraArgs(command, extraArgsDict, "--insecureDestination")
         command = appendArgIfNotInExtraArgs(command, extraArgsDict, "--listenPort", "9200")
-        command = appendArgIfNotInExtraArgs(command, extraArgsDict, "--sslConfigFile", "/usr/share/elasticsearch/config/proxy_tls.yml")
+        command = appendArgIfNotInExtraArgs(command, extraArgsDict, "--sslConfigFile", "/usr/share/captureProxy/config/proxy_tls.yml")
         if (props.streamingSourceType !== StreamingSourceType.DISABLED) {
             const brokerEndpoints = getMigrationStringParameterValue(this, {
                 ...props,

--- a/deployment/cdk/opensearch-service-migration/lib/service-stacks/capture-proxy-stack.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/service-stacks/capture-proxy-stack.ts
@@ -141,7 +141,7 @@ export class CaptureProxyStack extends MigrationServiceCore {
 
         this.createService({
             serviceName: serviceName,
-            dockerDirectoryPath: join(__dirname, "../../../../../", "TrafficCapture/dockerSolution/build/docker/trafficCaptureProxyServer"),
+            dockerImageRegistryName: "migrations/capture_proxy:latest",
             dockerImageCommand: ['/bin/sh', '-c', command],
             securityGroups: securityGroups,
             taskRolePolicies: servicePolicies,

--- a/deployment/cdk/opensearch-service-migration/lib/service-stacks/elasticsearch-stack.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/service-stacks/elasticsearch-stack.ts
@@ -39,7 +39,7 @@ export class ElasticsearchStack extends MigrationServiceCore {
 
         this.createService({
             serviceName: "elasticsearch",
-            dockerImageRegistryName: "migrations/elasticsearch_searchguard:latest",
+            dockerImageName: "migrations/elasticsearch_searchguard:latest",
             securityGroups: securityGroups,
             portMappings: [servicePort],
             cpuArchitecture: props.fargateCpuArch,

--- a/deployment/cdk/opensearch-service-migration/lib/service-stacks/elasticsearch-stack.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/service-stacks/elasticsearch-stack.ts
@@ -39,7 +39,7 @@ export class ElasticsearchStack extends MigrationServiceCore {
 
         this.createService({
             serviceName: "elasticsearch",
-            dockerDirectoryPath: join(__dirname, "../../../../../", "TrafficCapture/dockerSolution/src/main/docker/elasticsearchWithSearchGuard"),
+            dockerImageRegistryName: "migrations/elasticsearch_searchguard:latest",
             securityGroups: securityGroups,
             portMappings: [servicePort],
             cpuArchitecture: props.fargateCpuArch,

--- a/deployment/cdk/opensearch-service-migration/lib/service-stacks/kafka-stack.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/service-stacks/kafka-stack.ts
@@ -42,7 +42,7 @@ export class KafkaStack extends MigrationServiceCore {
         });
         this.createService({
             serviceName: "kafka",
-            dockerImageRegistryName: "docker.io/apache/kafka:3.7.0",
+            dockerImageName: "docker.io/apache/kafka:3.7.0",
             securityGroups: securityGroups,
             // see https://github.com/apache/kafka/blob/3.7/docker/examples/jvm/single-node/plaintext/docker-compose.yml
             environment: {

--- a/deployment/cdk/opensearch-service-migration/lib/service-stacks/migration-console-stack.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/service-stacks/migration-console-stack.ts
@@ -313,7 +313,7 @@ export class MigrationConsoleStack extends MigrationServiceCore {
 
         this.createService({
             serviceName: "migration-console",
-            dockerImageRegistryName: "migrations/migration_console:latest",
+            dockerImageName: "migrations/migration_console:latest",
             securityGroups: securityGroups,
             portMappings: servicePortMappings,
             dockerImageCommand: imageCommand,

--- a/deployment/cdk/opensearch-service-migration/lib/service-stacks/migration-console-stack.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/service-stacks/migration-console-stack.ts
@@ -313,7 +313,7 @@ export class MigrationConsoleStack extends MigrationServiceCore {
 
         this.createService({
             serviceName: "migration-console",
-            dockerDirectoryPath: join(__dirname, "../../../../../", "TrafficCapture/dockerSolution/src/main/docker/migrationConsole"),
+            dockerImageRegistryName: "migrations/migration_console:latest",
             securityGroups: securityGroups,
             portMappings: servicePortMappings,
             dockerImageCommand: imageCommand,

--- a/deployment/cdk/opensearch-service-migration/lib/service-stacks/migration-service-core.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/service-stacks/migration-service-core.ts
@@ -30,9 +30,6 @@ export interface MigrationServiceCoreProps extends StackPropsExt {
     readonly cpuArchitecture: CpuArchitecture,
     readonly dockerImageRegistryName: string,
     readonly dockerImageCommand?: string[],
-    readonly dockerBuildArgs?: {
-        [key: string]: string
-    },
     readonly taskRolePolicies?: PolicyStatement[],
     readonly mountPoints?: MountPoint[],
     readonly volumes?: Volume[],

--- a/deployment/cdk/opensearch-service-migration/lib/service-stacks/migration-service-core.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/service-stacks/migration-service-core.ts
@@ -18,7 +18,7 @@ import {
 import {Duration, RemovalPolicy, Stack} from "aws-cdk-lib";
 import {LogGroup, RetentionDays} from "aws-cdk-lib/aws-logs";
 import {PolicyStatement, Role} from "aws-cdk-lib/aws-iam";
-import {createDefaultECSTaskRole, makeDockerImageAsset} from "../common-utilities";
+import {createDefaultECSTaskRole, makeLocalAssetContainerImage} from "../common-utilities";
 import {OtelCollectorSidecar} from "./migration-otel-collector-sidecar";
 import { IApplicationTargetGroup, INetworkTargetGroup } from "aws-cdk-lib/aws-elasticloadbalancingv2";
 
@@ -28,7 +28,7 @@ export interface MigrationServiceCoreProps extends StackPropsExt {
     readonly vpc: IVpc,
     readonly securityGroups: ISecurityGroup[],
     readonly cpuArchitecture: CpuArchitecture,
-    readonly dockerImageRegistryName: string,
+    readonly dockerImageName: string,
     readonly dockerImageCommand?: string[],
     readonly taskRolePolicies?: PolicyStatement[],
     readonly mountPoints?: MountPoint[],
@@ -76,7 +76,7 @@ export class MigrationServiceCore extends Stack {
             props.volumes.forEach(vol => serviceTaskDef.addVolume(vol))
         }
 
-        const serviceImage = makeDockerImageAsset(this, props.serviceName, props.dockerImageRegistryName)
+        const serviceImage = makeLocalAssetContainerImage(this, props.dockerImageName)
 
         const serviceLogGroup = new LogGroup(this, 'ServiceLogGroup',  {
             retention: RetentionDays.ONE_MONTH,

--- a/deployment/cdk/opensearch-service-migration/lib/service-stacks/opensearch-container-stack.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/service-stacks/opensearch-container-stack.ts
@@ -83,7 +83,7 @@ export class OpenSearchContainerStack extends MigrationServiceCore {
 
         this.createService({
             serviceName: dnsNameForContainer,
-            dockerImageRegistryName: "opensearchproject/opensearch:2",
+            dockerImageName: "opensearchproject/opensearch:2",
             securityGroups: securityGroups,
             environment: {
                 "cluster.name": "os-docker-cluster",

--- a/deployment/cdk/opensearch-service-migration/lib/service-stacks/reindex-from-snapshot-stack.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/service-stacks/reindex-from-snapshot-stack.ts
@@ -167,7 +167,7 @@ export class ReindexFromSnapshotStack extends MigrationServiceCore {
         this.createService({
             serviceName: 'reindex-from-snapshot',
             taskInstanceCount: 0,
-            dockerImageRegistryName: "migrations/reindex_from_snapshot:latest",
+            dockerImageName: "migrations/reindex_from_snapshot:latest",
             dockerImageCommand: ['/bin/sh', '-c', "/rfs-app/entrypoint.sh"],
             securityGroups: securityGroups,
             volumes: volumes,

--- a/deployment/cdk/opensearch-service-migration/lib/service-stacks/reindex-from-snapshot-stack.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/service-stacks/reindex-from-snapshot-stack.ts
@@ -167,7 +167,7 @@ export class ReindexFromSnapshotStack extends MigrationServiceCore {
         this.createService({
             serviceName: 'reindex-from-snapshot',
             taskInstanceCount: 0,
-            dockerDirectoryPath: join(__dirname, "../../../../../", "DocumentsFromSnapshotMigration/docker"),
+            dockerImageRegistryName: "migrations/reindex_from_snapshot:latest",
             dockerImageCommand: ['/bin/sh', '-c', "/rfs-app/entrypoint.sh"],
             securityGroups: securityGroups,
             volumes: volumes,

--- a/deployment/cdk/opensearch-service-migration/lib/service-stacks/traffic-replayer-stack.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/service-stacks/traffic-replayer-stack.ts
@@ -128,7 +128,7 @@ export class TrafficReplayerStack extends MigrationServiceCore {
         this.createService({
             serviceName: `traffic-replayer-${deployId}`,
             taskInstanceCount: 0,
-            dockerDirectoryPath: join(__dirname, "../../../../../", "TrafficCapture/dockerSolution/build/docker/trafficReplayer"),
+            dockerImageRegistryName: "migrations/traffic_replayer:latest",
             dockerImageCommand: ['/bin/sh', '-c', command],
             securityGroups: securityGroups,
             volumes: [sharedLogFileSystem.asVolume()],

--- a/deployment/cdk/opensearch-service-migration/lib/service-stacks/traffic-replayer-stack.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/service-stacks/traffic-replayer-stack.ts
@@ -128,7 +128,7 @@ export class TrafficReplayerStack extends MigrationServiceCore {
         this.createService({
             serviceName: `traffic-replayer-${deployId}`,
             taskInstanceCount: 0,
-            dockerImageRegistryName: "migrations/traffic_replayer:latest",
+            dockerImageName: "migrations/traffic_replayer:latest",
             dockerImageCommand: ['/bin/sh', '-c', command],
             securityGroups: securityGroups,
             volumes: [sharedLogFileSystem.asVolume()],

--- a/deployment/cdk/opensearch-service-migration/package.json
+++ b/deployment/cdk/opensearch-service-migration/package.json
@@ -36,7 +36,8 @@
   "scripts": {
     "build": "tsc",
     "watch": "tsc -w",
-    "test": "jest  --coverage",
+    "test": "./buildDockerImages.sh && npm run test:withoutBuildImages",
+    "test:withoutBuildImages": "jest  --coverage",
     "clean": "rm -rf dist",
     "release": "npm run build",
     "cdk": "cdk",

--- a/deployment/cdk/opensearch-service-migration/test/migration-console-stack.test.ts
+++ b/deployment/cdk/opensearch-service-migration/test/migration-console-stack.test.ts
@@ -5,7 +5,6 @@ import {ContainerImage} from "aws-cdk-lib/aws-ecs";
 import {describe, beforeEach, afterEach, test, expect, jest} from '@jest/globals';
 import {ReindexFromSnapshotStack} from "../lib";
 
-jest.mock('aws-cdk-lib/aws-ecr-assets');
 describe('Migration Console Stack Tests', () => {
     // Mock the implementation of fromDockerImageAsset before all tests
     beforeEach(() => {

--- a/deployment/cdk/opensearch-service-migration/test/migration-services-yaml.test.ts
+++ b/deployment/cdk/opensearch-service-migration/test/migration-services-yaml.test.ts
@@ -7,7 +7,6 @@ import {createStackComposer} from "./test-utils";
 import * as yaml from 'yaml';
 import {describe, afterEach, beforeEach, test, expect, jest} from '@jest/globals';
 
-jest.mock('aws-cdk-lib/aws-ecr-assets');
 describe('Migration Services YAML Tests', () => {
     beforeEach(() => {
         jest.spyOn(ContainerImage, 'fromDockerImageAsset').mockImplementation(() => ContainerImage.fromRegistry("ServiceImage"));

--- a/deployment/cdk/opensearch-service-migration/test/network-stack.test.ts
+++ b/deployment/cdk/opensearch-service-migration/test/network-stack.test.ts
@@ -7,7 +7,6 @@ import { describe, beforeEach, afterEach, test, expect, jest } from '@jest/globa
 import { GatewayVpcEndpointAwsService, InterfaceVpcEndpointAwsService } from "aws-cdk-lib/aws-ec2";
 import { Stack } from "aws-cdk-lib";
 
-jest.mock('aws-cdk-lib/aws-ecr-assets');
 
 function getExpectedEndpoints(networkStack: NetworkStack): (InterfaceVpcEndpointAwsService | GatewayVpcEndpointAwsService)[] {
     return [

--- a/deployment/cdk/opensearch-service-migration/test/opensearch-domain-stack.test.ts
+++ b/deployment/cdk/opensearch-service-migration/test/opensearch-domain-stack.test.ts
@@ -6,7 +6,6 @@ import { ClusterYaml } from '../lib/migration-services-yaml';
 import { ContainerImage } from "aws-cdk-lib/aws-ecs";
 import { describe, beforeEach, afterEach, test, expect, jest} from '@jest/globals';
 
-jest.mock('aws-cdk-lib/aws-ecr-assets');
 describe('OpenSearch Domain Stack Tests', () => {
   beforeEach(() => {
     jest.spyOn(ContainerImage, 'fromDockerImageAsset').mockImplementation(() => ContainerImage.fromRegistry("ServiceImage"));

--- a/deployment/cdk/opensearch-service-migration/test/reindex-from-snapshot-stack.test.ts
+++ b/deployment/cdk/opensearch-service-migration/test/reindex-from-snapshot-stack.test.ts
@@ -5,7 +5,6 @@ import { ReindexFromSnapshotStack } from '../lib/service-stacks/reindex-from-sna
 import { createStackComposer } from './test-utils';
 import { describe, beforeEach, afterEach, test, expect, jest } from '@jest/globals';
 
-jest.mock('aws-cdk-lib/aws-ecr-assets');
 
 describe('ReindexFromSnapshotStack Tests', () => {
   beforeEach(() => {

--- a/deployment/cdk/opensearch-service-migration/test/stack-composer-ordering.test.ts
+++ b/deployment/cdk/opensearch-service-migration/test/stack-composer-ordering.test.ts
@@ -11,7 +11,6 @@ import {OpenSearchContainerStack} from "../lib/service-stacks/opensearch-contain
 import {ReindexFromSnapshotStack} from "../lib/service-stacks/reindex-from-snapshot-stack";
 import {describe, beforeEach, afterEach, test, expect, jest} from '@jest/globals';
 
-jest.mock('aws-cdk-lib/aws-ecr-assets');
 describe('Stack Composer Ordering Tests', () => {
     beforeEach(() => {
         jest.spyOn(ContainerImage, 'fromDockerImageAsset').mockImplementation(() => ContainerImage.fromRegistry("ServiceImage"));

--- a/deployment/cdk/opensearch-service-migration/test/stack-composer.test.ts
+++ b/deployment/cdk/opensearch-service-migration/test/stack-composer.test.ts
@@ -7,7 +7,6 @@ import { KafkaStack } from "../lib";
 import { describe, beforeEach, afterEach, test, expect, jest } from '@jest/globals';
 import { ContainerImage } from "aws-cdk-lib/aws-ecs";
 
-jest.mock('aws-cdk-lib/aws-ecr-assets');
 describe('Stack Composer Tests', () => {
   beforeEach(() => {
     jest.spyOn(ContainerImage, 'fromDockerImageAsset').mockImplementation(() => ContainerImage.fromRegistry("ServiceImage"));


### PR DESCRIPTION
### Description
Currently, the capture proxy container image builds on the es base image. This is not needed for running the capture proxy independently. This change modifies this base image to use AL2023.

This change uses a multi-staged build to generate the certs with openssl without including it in the final image.

Other Changes:
 * Cleaned up how cdk references docker images (uses local tag instead of rebuilding from final build directory)
 * Cleaned up how migration console is being built, made more robust by using dedicated build directory instead of the source directory and fixed it erroneously being built
 * Fixed TrafficCaptureProxyServerTest dockerImageBuild by explicitly declaring dependencies 

___


* Category: Enhancement
* Why these changes are required? Increased security 
* What is the old behavior before changes and new behavior after changes? 

### Issues Resolved
https://opensearch.atlassian.net/browse/MIGRATIONS-2078

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
Local docker/gradle testing, cdk deploy in aws

```bash
akurait@80a9970d0850 opensearch-migrations % curl https://localhost:9200 --insecure -u admin:admin -v 
* Host localhost:9200 was resolved.
* IPv6: ::1
* IPv4: 127.0.0.1
*   Trying [::1]:9200...
* Connected to localhost (::1) port 9200
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
* (304) (IN), TLS handshake, Server hello (2):
* (304) (IN), TLS handshake, Unknown (8):
* (304) (IN), TLS handshake, Request CERT (13):
* (304) (IN), TLS handshake, Certificate (11):
* (304) (IN), TLS handshake, CERT verify (15):
* (304) (IN), TLS handshake, Finished (20):
* (304) (OUT), TLS handshake, Certificate (11):
* (304) (OUT), TLS handshake, Finished (20):
* SSL connection using TLSv1.3 / AEAD-AES256-GCM-SHA384 / [blank] / UNDEF
* ALPN: server did not agree on a protocol. Uses default.
* Server certificate:
*  subject: CN=localhost
*  start date: Oct 10 21:34:18 2024 GMT
*  expire date: Oct 10 21:34:18 2025 GMT
*  issuer: CN=localhost
*  SSL certificate verify result: self signed certificate (18), continuing anyway.
* using HTTP/1.x
* Server auth using Basic with user 'admin'
> GET / HTTP/1.1
> Host: localhost:9200
> Authorization: Basic YWRtaW46YWRtaW4=
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/1.1 200 OK
< content-type: application/json; charset=UTF-8
< content-length: 538
< 
{
  "name" : "10b92fdc2ca3",
  "cluster_name" : "docker-cluster",
  "cluster_uuid" : "0MZAhMQlQzejHWzug61-rA",
  "version" : {
    "number" : "7.10.2",
    "build_flavor" : "oss",
    "build_type" : "docker",
    "build_hash" : "747e1cc71def077253878a59143c1f785afa92b9",
    "build_date" : "2021-01-13T00:42:12.435326Z",
    "build_snapshot" : false,
    "lucene_version" : "8.7.0",
    "minimum_wire_compatibility_version" : "6.8.0",
    "minimum_index_compatibility_version" : "6.0.0-beta1"
  },
  "tagline" : "You Know, for Search"
}
* Connection #0 to host localhost left intact
```

### Check List
- [x] New functionality includes testing
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
