### PR TITLE
[CVE] Update snappy-java from 1.1.10.4 -> 1.1.10.6

### DIFF
--- a/commonDependencyVersionConstraints/build.gradle
+++ b/commonDependencyVersionConstraints/build.gradle
@@ -130,6 +130,7 @@ dependencies {
     implementation group: 'org.apache.tika', name: 'tika-core', version: '1.28.4'
     implementation group: 'com.jayway.jsonpath', name: 'json-path', version: '2.9.0'
     implementation group: 'dnsjava', name: 'dnsjava', version: '3.6.0'
+    implementation group: 'org.xerial.snappy', name: 'snappy-java', version: '1.1.10.6'
     api group: 'org.glassfish.jersey.core', name: 'jersey-common', version: '2.34'
     api group: 'org.apache.httpcomponents', 'name': 'httpclient', version: '4.5.13'
 


### PR DESCRIPTION
### Description
[CVE] Update snappy-java from 1.1.10.4 -> 1.1.10.6

See full list of CVEs on advisories for the 2.0.1 release [1].

- https://advisories.opensearch.org/vulnerabilities/OpenSearch%20Migrations/2.0.1

### Check List
- [ ] ~New functionality includes testing~
  - [ ] ~All tests pass, including unit test, integration test and doctest~
- [ ] ~New functionality has been documented~
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
