### PR TITLE
Replace requests-auth-aws-sigv4 with boto3 signing

### DIFF
--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/console_api/Pipfile.lock
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/console_api/Pipfile.lock
@@ -471,14 +471,6 @@
             "markers": "python_version >= '3.8'",
             "version": "==2.32.3"
         },
-        "requests-auth-aws-sigv4": {
-            "hashes": [
-                "sha256:1f6c7f63a0696a8f131a2ff21a544380f43c11f54d72600f6f2a1d402bd41d41",
-                "sha256:3d2a475cccbf85d4c93b8bd052d072e5c3f8e77022fd621b69a5b11ac2c139c8"
-            ],
-            "markers": "python_version >= '2.7'",
-            "version": "==0.7"
-        },
         "s3transfer": {
             "hashes": [
                 "sha256:0711534e9356d3cc692fdde846b4a1e4b0cb6519971860796e6bc4c7aea00ef6",

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/Pipfile
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/Pipfile
@@ -10,7 +10,6 @@ pyyaml = "*"
 Click = "*"
 cerberus = "*"
 awscli = "*"
-requests-auth-aws-sigv4 = ">=0.7"
 
 [dev-packages]
 pytest = "*"

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/Pipfile.lock
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "78bd6c8b8764c6d11ab77832542313282b29d29bcc577a23167049253fcc0f54"
+            "sha256": "732106b5c0463690ea660a9021d614109dc94fb9882d1474fbfef5f892fe6a8a"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -279,15 +279,6 @@
             "index": "pypi",
             "markers": "python_version >= '3.8'",
             "version": "==2.32.3"
-        },
-        "requests-auth-aws-sigv4": {
-            "hashes": [
-                "sha256:1f6c7f63a0696a8f131a2ff21a544380f43c11f54d72600f6f2a1d402bd41d41",
-                "sha256:3d2a475cccbf85d4c93b8bd052d072e5c3f8e77022fd621b69a5b11ac2c139c8"
-            ],
-            "index": "pypi",
-            "markers": "python_version >= '2.7'",
-            "version": "==0.7"
         },
         "rsa": {
             "hashes": [

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/cluster.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/cluster.py
@@ -8,11 +8,9 @@ from cerberus import Validator
 import requests
 import requests.auth
 from requests.auth import HTTPBasicAuth
-from requests_auth_aws_sigv4 import AWSSigV4
-
 from console_link.models.client_options import ClientOptions
 from console_link.models.schema_tools import contains_one_of
-from console_link.models.utils import create_boto3_client, append_user_agent_header_for_requests
+from console_link.models.utils import SigV4AuthPlugin, create_boto3_client, append_user_agent_header_for_requests
 
 requests.packages.urllib3.disable_warnings()  # ignore: type
 
@@ -136,8 +134,8 @@ class Cluster:
                 password
             )
         elif self.auth_type == AuthMethod.SIGV4:
-            sigv4_details = self._get_sigv4_details()
-            return AWSSigV4(sigv4_details[0], region=sigv4_details[1])
+            service_name, region_name = self._get_sigv4_details(force_region=True)
+            return SigV4AuthPlugin(service_name, region_name)
         elif self.auth_type is AuthMethod.NO_AUTH:
             return None
         raise NotImplementedError(f"Auth type {self.auth_type} not implemented")

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/setup.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/setup.py
@@ -5,8 +5,7 @@ setup(
     version="1.0.0",
     description="A Python module to create a console application from a Python script",
     packages=find_packages(exclude=("tests")),
-    install_requires=["requests", "boto3", "pyyaml", "Click", "cerberus",
-                      "requests-auth-aws-sigv4"],
+    install_requires=["requests", "boto3", "pyyaml", "Click", "cerberus"],
     entry_points={
         "console_scripts": [
             "console = console_link.cli:cli",

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/test_cluster.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/test_cluster.py
@@ -460,7 +460,8 @@ def test_sigv4_authentication_signature(requests_mock, method, endpoint, data, h
         # Verify that essential headers are included in SignedHeaders
         required_headers = ['host', 'x-amz-date', 'x-custom-header-1', 'x-custom-header-2']
         for header in required_headers:
-            assert header in signed_headers, f"Header '{header}' not found in SignedHeaders, actual headers: {signed_headers}"
+            assert header in signed_headers, f"Header '{header}' not found in SignedHeaders," + \
+                f" actual headers: {signed_headers}"
 
         # Check that the x-amz-date header is present
         amz_date_header = last_request.headers.get('x-amz-date')
@@ -484,7 +485,8 @@ def test_sigv4_authentication_signature(requests_mock, method, endpoint, data, h
             method=last_request.method,
             url=last_request.url,
             data=last_request.body,
-            headers={k: v for k, v in last_request.headers.items() if k.lower() not in requests.utils.default_headers().keys()}
+            headers={k: v for k, v in last_request.headers.items() if
+                     k.lower() not in requests.utils.default_headers().keys()}
         )
         # Sign the request
         SigV4Auth(credentials, service_name, region_name).add_auth(aws_request)

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/integ_test/Pipfile.lock
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/integ_test/Pipfile.lock
@@ -312,14 +312,6 @@
             "markers": "python_version >= '3.8'",
             "version": "==2.32.3"
         },
-        "requests-auth-aws-sigv4": {
-            "hashes": [
-                "sha256:1f6c7f63a0696a8f131a2ff21a544380f43c11f54d72600f6f2a1d402bd41d41",
-                "sha256:3d2a475cccbf85d4c93b8bd052d072e5c3f8e77022fd621b69a5b11ac2c139c8"
-            ],
-            "markers": "python_version >= '2.7'",
-            "version": "==0.7"
-        },
         "requests-aws4auth": {
             "hashes": [
                 "sha256:2969b5379ae6e60ee666638caf6cb94a32d67033f6bfcf0d50c95cd5474f2419",


### PR DESCRIPTION
### Description
Replace requests-auth-aws-sigv4 with boto3 signing
* Category: Bug fix
* Why these changes are required? better security with sigv4 by using trusted library and bug fixes
* What is the old behavior before changes and new behavior after changes? Some calls would fail that included `?v` or `*` in url

### Issues Resolved
[MIGRATIONS-2099](https://opensearch.atlassian.net/browse/MIGRATIONS-2099)

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
Added unit tests

Tested locally against an aws cluster with sigv4
```
(.venv) bash-5.2# console clusters clear-indices --cluster target --acknowledge-risk
Performing clear indices operation...
```
```
(.venv) bash-5.2# console clusters curl -XGET target_cluster /_cat/indices?v
health status index                     uuid                   pri rep docs.count docs.deleted store.size pri.store.size
green  open   .opensearch-observability pfTL2UhYS_WCRVfqJTx6Bg   1   2          0            0       624b           208b
green  open   .plugins-ml-config        4ox10VJMTFSXHTBERLp-Lg   1   1          1            0      7.8kb          3.9kb
green  open   .ql-datasources           iQ014_ShS4eYj9e-RSMZpg   1   2          0            0       624b           208b
green  open   .kibana_1                 OqJWIofcRUeXYvf8YDS0OA   1   2          1            0     15.6kb          5.2kb
```

### Check List
- [x] New functionality includes testing
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
