### PR TITLE
Remove unspecified dependencies in maven pom publishing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,21 @@ allprojects {
     }
 }
 
+// Define version properties
+ext {
+    // support -Dbuild.version, but include default
+    buildVersion = System.getProperty("build.version", "0.1.0")
+    // support -Dbuild.snapshot=false, but default to true
+    buildSnapshot = System.getProperty("build.snapshot", "true") == "true"
+    finalVersion = buildSnapshot ? "${buildVersion}-SNAPSHOT" : buildVersion
+}
+
+// Apply the version to all projects
+allprojects {
+    version = finalVersion
+    group = 'org.opensearch.migrations.trafficcapture' // Ensure groupId is consistent
+}
+
 subprojects { subproject ->
     subproject.afterEvaluate {
         if (subproject.plugins.hasPlugin('java') && subproject.name != 'commonDependencyVersionConstraints') {
@@ -157,6 +172,9 @@ subprojects {
                 mavenJava(MavenPublication) {
                     versionMapping {
                         allVariants {
+                            if (project.plugins.hasPlugin('java-test-fixtures')) {
+                                fromResolutionOf('testFixturesRuntimeClasspath')
+                            }
                             fromResolutionResult()
                         }
                     }
@@ -164,16 +182,6 @@ subprojects {
                     from components.java
                     artifact javadocJar
                     artifact sourcesJar
-
-                    group = 'org.opensearch.migrations.trafficcapture'
-
-                    // support -Dbuild.version, but include default
-                    version = System.getProperty("build.version", "0.1.0")
-
-                    // support -Dbuild.snapshot=false, but default to true
-                    if (System.getProperty("build.snapshot", "true") == "true") {
-                        version += "-SNAPSHOT"
-                    }
 
                     pom {
                         name = project.name
@@ -196,6 +204,24 @@ subprojects {
                             connection = "scm:git@github.com:opensearch-project/opensearch-migrations.git"
                             developerConnection = "scm:git@github.com:opensearch-project/opensearch-migrations.git"
                             url = "git@github.com:opensearch-project/opensearch-migrations.git"
+                        }
+                    }
+
+                    pom.withXml {
+                        def pomFile = asNode()
+
+                        // Find all dependencies in the POM file
+                        def dependencies = pomFile.dependencies.dependency
+
+                        // Iterate over each dependency and check if the version is missing
+                        dependencies.each { dependency ->
+                            def version = dependency.version.text()
+
+                            if (version == null || version.trim().isEmpty() || version.trim() == 'unspecified') {
+                                def groupId = dependency.groupId.text()
+                                def artifactId = dependency.artifactId.text()
+                                throw new GradleException("Dependency ${groupId}:${artifactId} is missing a version in the pom.xml")
+                            }
                         }
                     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,8 @@ ext {
 // Apply the version to all projects
 allprojects {
     version = finalVersion
-    group = 'org.opensearch.migrations.trafficcapture' // Ensure groupId is consistent
+    // This should eventually change, see https://opensearch.atlassian.net/browse/MIGRATIONS-2167
+    group = 'org.opensearch.migrations.trafficcapture'
 }
 
 subprojects { subproject ->
@@ -172,6 +173,9 @@ subprojects {
                 mavenJava(MavenPublication) {
                     versionMapping {
                         allVariants {
+                            // Test fixtures are published as a separate jar in maven
+                            // This ensures dependencies that are only declared in test
+                            // fixtures have a version number in the pom
                             if (project.plugins.hasPlugin('java-test-fixtures')) {
                                 fromResolutionOf('testFixturesRuntimeClasspath')
                             }


### PR DESCRIPTION
### Description
Remove unspecified dependencies in maven pom publishing

We were having one dependency that was unspecified opentelemetry-testing because it was only used in a testFixtures and wasn't in the resolution classpath. Fixed that and added a check before publishing that all versions are specified.

* Category: Bug Fix
* Why these changes are required? Usable Maven Pom files
* What is the old behavior before changes and new behavior after changes? opentelemetry-testing didn't include a version

### Issues Resolved
N/A

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
ran `./gradlew publishToMavenLocal`

### Check List
- [x] New functionality includes testing
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
