### PR TITLE
Fix numWorkItemsArePending bug

### DIFF
--- a/DocumentsFromSnapshotMigration/src/main/java/org/opensearch/migrations/RfsMigrateDocuments.java
+++ b/DocumentsFromSnapshotMigration/src/main/java/org/opensearch/migrations/RfsMigrateDocuments.java
@@ -303,7 +303,7 @@ public class RfsMigrateDocuments {
             scopedWorkCoordinator,
             rootDocumentContext
         );
-        if (!workCoordinator.workItemsArePending(
+        if (!workCoordinator.workItemsNotYetComplete(
             rootDocumentContext.getWorkCoordinationContext()::createItemsPendingContext
         )) {
             throw new NoWorkLeftException("No work items are pending/all work items have been processed.  Returning.");

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/workcoordination/IWorkCoordinator.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/workcoordination/IWorkCoordinator.java
@@ -103,7 +103,7 @@ public interface IWorkCoordinator extends AutoCloseable {
      * @throws IOException
      * @throws InterruptedException
      */
-    int numWorkItemsArePending(Supplier<IWorkCoordinationContexts.IPendingWorkItemsContext> contextSupplier)
+    int numWorkItemsNotYetComplete(Supplier<IWorkCoordinationContexts.IPendingWorkItemsContext> contextSupplier)
         throws IOException, InterruptedException;
 
     /**
@@ -111,7 +111,7 @@ public interface IWorkCoordinator extends AutoCloseable {
      * @throws IOException
      * @throws InterruptedException
      */
-    boolean workItemsArePending(Supplier<IWorkCoordinationContexts.IPendingWorkItemsContext> contextSupplier)
+    boolean workItemsNotYetComplete(Supplier<IWorkCoordinationContexts.IPendingWorkItemsContext> contextSupplier)
         throws IOException, InterruptedException;
 
     /**

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/workcoordination/OpenSearchWorkCoordinator.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/workcoordination/OpenSearchWorkCoordinator.java
@@ -435,7 +435,7 @@ public class OpenSearchWorkCoordinator implements IWorkCoordinator {
                         + " instead of 200"
                 );
             }
-            return resultHitsUpper.path("hits").size();
+            return resultHitsUpper.path("total").path("value").asInt();
         }
     }
 

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/workcoordination/OpenSearchWorkCoordinator.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/workcoordination/OpenSearchWorkCoordinator.java
@@ -416,10 +416,11 @@ public class OpenSearchWorkCoordinator implements IWorkCoordinator {
                 + "      }"
                 + "    ]"
                 + "  }"
-                + "}"
+                + "},"
+                + "\"size\": 1"
                 + "}";
 
-            var path = INDEX_NAME + "/_count";
+            var path = INDEX_NAME + "/_search";
             var response = httpClient.makeJsonRequest(AbstractedHttpClient.POST_METHOD, path, null, queryBody);
             var statusCode = response.getStatusCode();
             if (statusCode != 200) {
@@ -430,7 +431,7 @@ public class OpenSearchWorkCoordinator implements IWorkCoordinator {
                                 + " instead of 200"
                 );
             }
-            return objectMapper.readTree(response.getPayloadBytes()).path("count").asInt();
+            return objectMapper.readTree(response.getPayloadBytes()).path("hits").path("total").path("value").asInt();
         }
     }
 

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/workcoordination/OpenSearchWorkCoordinator.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/workcoordination/OpenSearchWorkCoordinator.java
@@ -397,7 +397,7 @@ public class OpenSearchWorkCoordinator implements IWorkCoordinator {
         }
     }
 
-    private int numWorkItemsArePendingInternal(
+    private int numWorkItemsNotYetCompleteInternal(
         Supplier<IWorkCoordinationContexts.IPendingWorkItemsContext> contextSupplier
     ) throws IOException, InterruptedException {
         try (var context = contextSupplier.get()) {
@@ -436,15 +436,15 @@ public class OpenSearchWorkCoordinator implements IWorkCoordinator {
     }
 
     @Override
-    public int numWorkItemsArePending(Supplier<IWorkCoordinationContexts.IPendingWorkItemsContext> contextSupplier)
+    public int numWorkItemsNotYetComplete(Supplier<IWorkCoordinationContexts.IPendingWorkItemsContext> contextSupplier)
         throws IOException, InterruptedException {
-        return numWorkItemsArePendingInternal(contextSupplier);
+        return numWorkItemsNotYetCompleteInternal(contextSupplier);
     }
 
     @Override
-    public boolean workItemsArePending(Supplier<IWorkCoordinationContexts.IPendingWorkItemsContext> contextSupplier)
+    public boolean workItemsNotYetComplete(Supplier<IWorkCoordinationContexts.IPendingWorkItemsContext> contextSupplier)
         throws IOException, InterruptedException {
-        return numWorkItemsArePendingInternal(contextSupplier) >= 1;
+        return numWorkItemsNotYetCompleteInternal(contextSupplier) >= 1;
     }
 
     enum UpdateResult {

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/workcoordination/OpenSearchWorkCoordinator.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/workcoordination/OpenSearchWorkCoordinator.java
@@ -417,8 +417,8 @@ public class OpenSearchWorkCoordinator implements IWorkCoordinator {
                 + "    ]"
                 + "  }"
                 + "},"
-                + "\"size\": 1"
-                + "}";
+                + "\"size\": 0" // This sets the number of items to include in the `hits.hits` array, but doesn't affect
+                + "}";          // the integer value in `hits.total.value`
 
             var path = INDEX_NAME + "/_search";
             var response = httpClient.makeJsonRequest(AbstractedHttpClient.POST_METHOD, path, null, queryBody);

--- a/RFS/src/test/java/org/opensearch/migrations/bulkload/workcoordination/WorkCoordinatorTest.java
+++ b/RFS/src/test/java/org/opensearch/migrations/bulkload/workcoordination/WorkCoordinatorTest.java
@@ -86,12 +86,12 @@ public class WorkCoordinatorTest {
         var testContext = WorkCoordinationTestContext.factory().withAllTracking();
         final var NUM_DOCS = 100;
         try (var workCoordinator = new OpenSearchWorkCoordinator(httpClientSupplier.get(), 3600, "docCreatorWorker")) {
-            Assertions.assertFalse(workCoordinator.workItemsArePending(testContext::createItemsPendingContext));
+            Assertions.assertFalse(workCoordinator.workItemsNotYetComplete(testContext::createItemsPendingContext));
             for (var i = 0; i < NUM_DOCS; ++i) {
                 final var docId = "R" + i;
                 workCoordinator.createUnassignedWorkItem(docId, testContext::createUnassignedWorkContext);
             }
-            Assertions.assertTrue(workCoordinator.workItemsArePending(testContext::createItemsPendingContext));
+            Assertions.assertTrue(workCoordinator.workItemsNotYetComplete(testContext::createItemsPendingContext));
         }
 
         final var seenWorkerItems = new ConcurrentHashMap<String, String>();
@@ -123,12 +123,12 @@ public class WorkCoordinatorTest {
         final var MAX_RUNS = 2;
         var executorService = Executors.newFixedThreadPool(NUM_DOCS);
         try (var workCoordinator = new OpenSearchWorkCoordinator(httpClientSupplier.get(), 3600, "docCreatorWorker")) {
-            Assertions.assertFalse(workCoordinator.workItemsArePending(testContext::createItemsPendingContext));
+            Assertions.assertFalse(workCoordinator.workItemsNotYetComplete(testContext::createItemsPendingContext));
             for (var i = 0; i < NUM_DOCS; ++i) {
                 final var docId = "R" + i;
                 workCoordinator.createUnassignedWorkItem(docId, testContext::createUnassignedWorkContext);
             }
-            Assertions.assertTrue(workCoordinator.workItemsArePending(testContext::createItemsPendingContext));
+            Assertions.assertTrue(workCoordinator.workItemsNotYetComplete(testContext::createItemsPendingContext));
         }
 
         for (int run = 0; run < MAX_RUNS; ++run) {
@@ -177,7 +177,7 @@ public class WorkCoordinatorTest {
             Thread.sleep(expiration.multipliedBy(2).toMillis());
         }
         try (var workCoordinator = new OpenSearchWorkCoordinator(httpClientSupplier.get(), 3600, "docCreatorWorker")) {
-            Assertions.assertFalse(workCoordinator.workItemsArePending(testContext::createItemsPendingContext));
+            Assertions.assertFalse(workCoordinator.workItemsNotYetComplete(testContext::createItemsPendingContext));
         }
         var metrics = testContext.inMemoryInstrumentationBundle.getFinishedMetrics();
         Assertions.assertNotEquals(0,


### PR DESCRIPTION
### Description
The `numWorkItemsArePending` function had a parameter for maximum results, but if that field was set to `-1` (intended to be no maximum), it just wasn't set in the API call, which actually meant that it defaulted to a max of 10.

There was also a note in the function about switching it to use `_count`, and that was an easy way to fix the bug. The max results param was no longer relevant, so I removed it.


### Issues Resolved
n/a

### Testing
This being broken was breaking a different test, so fixing it has made that test pass.

### Check List
- [ ] New functionality includes testing
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
