### PR TITLE
Generate two CFN templates for create VPC and import VPC for bootstrap

### DIFF
--- a/deployment/migration-assistant-solution/bin/app.ts
+++ b/deployment/migration-assistant-solution/bin/app.ts
@@ -33,12 +33,12 @@ const getProps = () => {
 const app = new App();
 const infraProps = getProps()
 
-new SolutionsInfrastructureStack(app, 'OSMigrations-Bootstrap-Import-VPC', {
+new SolutionsInfrastructureStack(app, 'Migration-Assistant-Infra-Import-VPC', {
   synthesizer: new DefaultStackSynthesizer(),
   createVPC: false,
   ...infraProps
 });
-new SolutionsInfrastructureStack(app, 'OSMigrations-Bootstrap-Create-VPC', {
+new SolutionsInfrastructureStack(app, 'Migration-Assistant-Infra-Create-VPC', {
   synthesizer: new DefaultStackSynthesizer(),
   createVPC: true,
   ...infraProps

--- a/deployment/migration-assistant-solution/bin/app.ts
+++ b/deployment/migration-assistant-solution/bin/app.ts
@@ -32,7 +32,14 @@ const getProps = () => {
 
 const app = new App();
 const infraProps = getProps()
-new SolutionsInfrastructureStack(app, 'OSMigrations-Bootstrap', {
+
+new SolutionsInfrastructureStack(app, 'OSMigrations-Bootstrap-Import-VPC', {
   synthesizer: new DefaultStackSynthesizer(),
+  createVPC: false,
+  ...infraProps
+});
+new SolutionsInfrastructureStack(app, 'OSMigrations-Bootstrap-Create-VPC', {
+  synthesizer: new DefaultStackSynthesizer(),
+  createVPC: true,
   ...infraProps
 });

--- a/deployment/migration-assistant-solution/lib/solutions-stack.ts
+++ b/deployment/migration-assistant-solution/lib/solutions-stack.ts
@@ -182,7 +182,7 @@ export class SolutionsInfrastructureStack extends Stack {
                 type: 'List<AWS::EC2::Subnet::Id>',
                 description: 'Private Subnet IDs in the selected VPC to use. Please provide exactly 2 or 3 subnets EACH in their own AZ. The subnets must have routes to a NAT gateway.'
             });
-            addParameterLabel(parameterLabels, privateSubnetIdsParameter, "Private Subnet Ids")
+            addParameterLabel(parameterLabels, privateSubnetIdsParameter, "Private Subnets")
             additionalParameters.push(vpcIdParameter.logicalId, availabilityZonesParameter.logicalId, privateSubnetIdsParameter.logicalId)
             vpc = importVPC(this, vpcIdParameter, availabilityZonesParameter, privateSubnetIdsParameter);
         }

--- a/deployment/migration-assistant-solution/lib/solutions-stack.ts
+++ b/deployment/migration-assistant-solution/lib/solutions-stack.ts
@@ -25,6 +25,10 @@ export interface SolutionsInfrastructureStackProps extends StackProps {
     readonly createVPC: boolean;
 }
 
+export interface ParameterLabel {
+    default: string;
+}
+
 export function applyAppRegistry(stack: Stack, stage: string, infraProps: SolutionsInfrastructureStackProps): string {
     const application = new Application(stack, "AppRegistry", {
         applicationName: Fn.join("-", [
@@ -63,7 +67,7 @@ export function applyAppRegistry(stack: Stack, stage: string, infraProps: Soluti
     return application.applicationArn
 }
 
-export function importVPCResources(stack: Stack, additionalParameters: String[], parameterLabels: {[id: string] : {}}) {
+export function importVPCResources(stack: Stack, additionalParameters: string[], parameterLabels: Record<string, ParameterLabel>) {
     const vpcIdParameter = new CfnParameter(stack, 'VPCId', {
         type: 'AWS::EC2::VPC::Id',
         description: 'Specify the VPC id to place Migration resources into'
@@ -115,8 +119,8 @@ export class SolutionsInfrastructureStack extends Stack {
             lazy: false,
         });
 
-        const additionalParameters: String[] = []
-        const parameterLabels: {[id: string] : {}} = {}
+        const additionalParameters: string[] = [];
+        const parameterLabels: Record<string, ParameterLabel> = {};
         const stageParameter = new CfnParameter(this, 'Stage', {
             type: 'String',
             description: 'Specify the stage identifier which will be used in naming resources, e.g. dev,gamma,wave1',

--- a/deployment/migration-assistant-solution/lib/solutions-stack.ts
+++ b/deployment/migration-assistant-solution/lib/solutions-stack.ts
@@ -170,7 +170,7 @@ export class SolutionsInfrastructureStack extends Stack {
                 type: 'AWS::EC2::VPC::Id',
                 description: 'Specify the VPC id to place Migration resources into'
             });
-            addParameterLabel(parameterLabels, vpcIdParameter, "VPC Id")
+            addParameterLabel(parameterLabels, vpcIdParameter, "VPC")
 
             const availabilityZonesParameter = new CfnParameter(this, 'VPCAvailabilityZones', {
                 type: 'List<AWS::EC2::AvailabilityZone::Name>',

--- a/deployment/migration-assistant-solution/lib/solutions-stack.ts
+++ b/deployment/migration-assistant-solution/lib/solutions-stack.ts
@@ -220,7 +220,7 @@ export class SolutionsInfrastructureStack extends Stack {
         }
 
         const parameterGroups = [];
-        if (importedVPCParameters) {
+        if (importedVPCParameters.length > 0) {
             parameterGroups.push({
                 Label: { default: "Imported VPC parameters" },
                 Parameters: importedVPCParameters

--- a/deployment/migration-assistant-solution/package.json
+++ b/deployment/migration-assistant-solution/package.json
@@ -12,7 +12,7 @@
     "watch": "tsc -w",
     "test": "npm run test:lint && npm run test:jest",
     "test:lint": "eslint .",
-    "test:jest": "jest",
+    "test:jest": "jest --coverage",
     "synth": "cdk synthesize --asset-metadata false --path-metadata false",
     "deploy": "cdk deploy --require-approval never"
   },

--- a/deployment/migration-assistant-solution/test/solutions-stack.test.ts
+++ b/deployment/migration-assistant-solution/test/solutions-stack.test.ts
@@ -4,15 +4,34 @@ import { App } from 'aws-cdk-lib';
 import { SolutionsInfrastructureStack } from '../lib/solutions-stack';
 
 describe('Solutions stack', () => {
-    test('EC2 bootstrap instance is created', () => {
+    test('Generate bootstrap stack with create VPC', () => {
         const app = new App();
         const stack = new SolutionsInfrastructureStack(app, 'TestBootstrapStack', {
             solutionId: 'SO0000',
             solutionName: 'test-solution',
             solutionVersion: '0.0.1',
-            codeBucket: 'test-bucket'
+            codeBucket: 'test-bucket',
+            createVPC: true
         });
         const template = Template.fromStack(stack);
+        template.resourceCountIs('AWS::EC2::VPC', 1)
+        template.resourceCountIs('AWS::ServiceCatalogAppRegistry::Application', 1)
+        template.hasResourceProperties('AWS::EC2::Instance', {
+            InstanceType: "t3.large"
+        });
+    });
+    test('Generate bootstrap stack with imported VPC', () => {
+        const app = new App();
+        const stack = new SolutionsInfrastructureStack(app, 'TestBootstrapStack', {
+            solutionId: 'SO0000',
+            solutionName: 'test-solution',
+            solutionVersion: '0.0.1',
+            codeBucket: 'test-bucket',
+            createVPC: false
+        });
+        const template = Template.fromStack(stack);
+        template.resourceCountIs('AWS::EC2::VPC', 0)
+        template.resourceCountIs('AWS::ServiceCatalogAppRegistry::Application', 1)
         template.hasResourceProperties('AWS::EC2::Instance', {
             InstanceType: "t3.large"
         });

--- a/deployment/migration-assistant-solution/test/solutions-stack.test.ts
+++ b/deployment/migration-assistant-solution/test/solutions-stack.test.ts
@@ -4,9 +4,9 @@ import { App } from 'aws-cdk-lib';
 import { SolutionsInfrastructureStack } from '../lib/solutions-stack';
 
 describe('Solutions stack', () => {
-    test('Generate bootstrap stack with create VPC', () => {
+    test('Generate migration assistant stack with create VPC', () => {
         const app = new App();
-        const stack = new SolutionsInfrastructureStack(app, 'TestBootstrapStack', {
+        const stack = new SolutionsInfrastructureStack(app, 'TestMigrationAssistantStack', {
             solutionId: 'SO0000',
             solutionName: 'test-solution',
             solutionVersion: '0.0.1',
@@ -20,9 +20,9 @@ describe('Solutions stack', () => {
             InstanceType: "t3.large"
         });
     });
-    test('Generate bootstrap stack with imported VPC', () => {
+    test('Generate migration assistant stack with imported VPC', () => {
         const app = new App();
-        const stack = new SolutionsInfrastructureStack(app, 'TestBootstrapStack', {
+        const stack = new SolutionsInfrastructureStack(app, 'TestMigrationAssistantStack', {
             solutionId: 'SO0000',
             solutionName: 'test-solution',
             solutionVersion: '0.0.1',


### PR DESCRIPTION
### Description
Changes functionality to generate two CFN templates for create VPC and import VPC for bootstrap. As well as introduces VPC Id and Subnet intake from CFN parameters that will later be used when deploying the Migration Assistant CDK

#### Import VPC v1
<img width="1242" alt="image" src="https://github.com/user-attachments/assets/95917f16-c6f5-4e47-bb99-6b3d9feb6df5">

#### Import VPC v2
<img width="1230" alt="image" src="https://github.com/user-attachments/assets/ed5a905a-925e-4d05-b55d-6dd7104c260b">


#### Create VPC
<img width="1225" alt="image" src="https://github.com/user-attachments/assets/2cede625-b3cb-4e4d-8ff1-ad38860eea7e">


### Issues Resolved
https://opensearch.atlassian.net/browse/MIGRATIONS-2166

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
Manual CFN deployment testing
CDK tests

### Check List
- [ ] New functionality includes testing
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
