### PR TITLE
Update test ES 6.8 to use es-oss image

### DIFF
--- a/RFS/src/testFixtures/java/org/opensearch/migrations/bulkload/framework/SearchClusterContainer.java
+++ b/RFS/src/testFixtures/java/org/opensearch/migrations/bulkload/framework/SearchClusterContainer.java
@@ -30,7 +30,7 @@ public class SearchClusterContainer extends GenericContainer<SearchClusterContai
         Version.fromString("ES 7.17.22")
     );
     public static final ContainerVersion ES_V6_8_23 = new ElasticsearchVersion(
-        "docker.elastic.co/elasticsearch/elasticsearch:6.8.23",
+        "docker.elastic.co/elasticsearch/elasticsearch-oss:6.8.23",
         Version.fromString("ES 6.8.23")
     );
 


### PR DESCRIPTION
### Description

I encountered startup issues running the ES 6.8 image on apple silicon due to x-pack-ml.

Fixed encountered metadata issue when only a single template exists in the cluster. 

* Category: Bug Fix
* Why these changes are required? We shouldn't depend on 6.8 x-pack in unit tests
* What is the old behavior before changes and new behavior after changes? Encountered failure `org.elasticsearch.bootstrap.StartupException: org.elasticsearch.bootstrap.BootstrapException: java.io.IOException: Cannot run program "/usr/share/elasticsearch/modules/x-pack-ml/platform/linux-x86_64/bin/controller": error=0, Failed to exec spawn helper: pid: 111, exit value: 1 at org.elasticsearch.bootstrap.Elasticsearch.init(Elasticsearch.java:163)` exiting container in test

### Issues Resolved
[MIGRATIONS-2202](https://opensearch.atlassian.net/browse/MIGRATIONS-2202)

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
Ran locally on M3 Pro

### Check List
- [x] New functionality includes testing
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
