### PR TITLE
Auto detect target cluster version

### DIFF
--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/common/OpenSearchClient.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/common/OpenSearchClient.java
@@ -13,6 +13,7 @@ import java.util.stream.Collectors;
 
 import org.opensearch.migrations.Flavor;
 import org.opensearch.migrations.Version;
+import org.opensearch.migrations.VersionMatchers;
 import org.opensearch.migrations.bulkload.common.http.ConnectionContext;
 import org.opensearch.migrations.bulkload.common.http.HttpResponse;
 import org.opensearch.migrations.bulkload.tracing.IRfsContexts;
@@ -20,7 +21,9 @@ import org.opensearch.migrations.parsing.BulkResponseParser;
 import org.opensearch.migrations.reindexer.FailedRequestsLogger;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import lombok.extern.slf4j.Slf4j;
 import reactor.core.publisher.Mono;
@@ -30,6 +33,13 @@ import reactor.util.retry.Retry;
 public class OpenSearchClient {
 
     protected static final ObjectMapper objectMapper = new ObjectMapper();
+
+    /** Amazon OpenSearch Serverless cluster don't have a version number, but
+     * its closely aligned with the latest open-source OpenSearch 2.X */
+    private static Version AMAZON_SERVERLESS_VERSION = Version.builder()
+        .flavor(Flavor.AMAZON_SERVERLESS_OPENSEARCH)
+        .major(2)
+        .build();
 
     private static final int DEFAULT_MAX_RETRY_ATTEMPTS = 3;
     private static final Duration DEFAULT_BACKOFF = Duration.ofSeconds(1);
@@ -69,23 +79,43 @@ public class OpenSearchClient {
     }
 
     public Version getClusterVersion() {
-        return client.getAsync("", null)
+        var versionFromRootApi = client.getAsync("", null)
             .flatMap(resp -> {
-                try {
-                    return Mono.just(versionFromResponse(resp));
-                } catch (Exception e) {
-                    return Mono.error(new OperationFailed(e.getMessage(), resp));
+                if (resp.statusCode == 200) {
+                    return versionFromResponse(resp);
                 }
+                // If the root API doesn't exist, the cluster is OpenSearch Serverless
+                if (resp.statusCode == 404) {
+                    return Mono.just(AMAZON_SERVERLESS_VERSION);
+                }
+                return Mono.error(new OperationFailed("Unexpected status code " + resp.statusCode, resp));
             })
             .doOnError(e -> log.error(e.getMessage()))
             .retryWhen(CHECK_IF_ITEM_EXISTS_RETRY_STRATEGY)
             .block();
+
+        // Compatibility mode is only enabled on OpenSearch clusters responding with the version of 7.10.2 
+        if (!VersionMatchers.isES_7_10.test(versionFromRootApi)) {
+            return versionFromRootApi;
+        }
+        return client.getAsync("_cluster/settings", null)
+            .flatMap(this::checkCompatibilityModeFromResponse)
+            .doOnError(e -> log.error(e.getMessage()))
+            .retryWhen(CHECK_IF_ITEM_EXISTS_RETRY_STRATEGY)
+            .flatMap(hasCompatibilityModeEnabled -> {
+                log.atInfo().setMessage("Checking CompatibilityMode, was enabled? {}").addArgument(hasCompatibilityModeEnabled).log();
+                if (!hasCompatibilityModeEnabled) {
+                    return Mono.just(versionFromRootApi);
+                }
+                return client.getAsync("_cat/plugins?format=json", null)
+                    .flatMap(this::getVersionFromPlugins)
+                    .doOnError(e -> log.error(e.getMessage()))
+                    .retryWhen(CHECK_IF_ITEM_EXISTS_RETRY_STRATEGY);
+            })
+            .block();        
     }
 
-    private Version versionFromResponse(HttpResponse resp) {
-        if (resp.statusCode != 200) {
-            throw new OperationFailed("Unexpected status code " + resp.statusCode, resp);
-        }
+    private Mono<Version> versionFromResponse(HttpResponse resp) {
         try {
             var body = objectMapper.readTree(resp.body);
             var versionNode = body.get("version");
@@ -99,15 +129,74 @@ public class OpenSearchClient {
 
             var distroNode = versionNode.get("distribution");
             if (distroNode != null && distroNode.asText().equalsIgnoreCase("opensearch")) {
-                versionBuilder.flavor(Flavor.OPENSEARCH);
+                versionBuilder.flavor(getLikelyOpenSearchFlavor());
             } else {
                 versionBuilder.flavor(Flavor.ELASTICSEARCH);
             }
-            return versionBuilder.build();
+            return Mono.just(versionBuilder.build());
         } catch (Exception e) {
             log.error("Unable to parse version from response", e);
-            throw new OperationFailed("Unable to parse version from response: " + e.getMessage(), resp);
+            return Mono.error(new OperationFailed("Unable to parse version from response: " + e.getMessage(), resp));
         }
+    }
+
+    Mono<Boolean> checkCompatibilityModeFromResponse(HttpResponse resp) {
+        if (resp.statusCode != 200) {
+            return Mono.error(new OperationFailed("Unexpected status code " + resp.statusCode, resp));
+        }
+        try {
+            var body = Optional.of(objectMapper.readTree(resp.body));
+            var persistentlyInCompatibilityMode = inCompatibilityMode(body.map(n -> n.get("persistent")));
+            var transientlyInCompatibilityMode = inCompatibilityMode(body.map(n -> n.get("transient")));
+            return Mono.just(persistentlyInCompatibilityMode || transientlyInCompatibilityMode);
+        } catch (Exception e) {
+            log.error("Unable to determine if the cluster is in compatibility mode", e);
+            return Mono.error(new OperationFailed("Unable to determine if the cluster is in compatibility mode from response: " + e.getMessage(), resp));
+        }
+    }
+    
+    private boolean inCompatibilityMode(Optional<JsonNode> node) {
+        return node.filter(n -> !n.isNull())
+            .map(n -> n.get("compatibility"))
+            .filter(n -> !n.isNull())
+            .map(n -> n.get("override_main_response_version"))
+            .filter(n -> !n.isNull())
+            .map(n -> n.asBoolean())
+            .orElse(false);
+    }
+
+    private Mono<Version> getVersionFromPlugins(HttpResponse resp) {
+        if (resp.statusCode != 200) {
+            return Mono.error(new OperationFailed("Unexpected status code " + resp.statusCode, resp));
+        }
+        try {
+            var body = (ArrayNode) objectMapper.readTree(resp.body);
+            var elemIterator = body.elements();
+            while (elemIterator.hasNext()) {
+                var current = elemIterator.next();
+                var isRepositoryS3 = Optional.ofNullable(current.get("component"))
+                    .filter(n -> !n.isNull())
+                    .map(n -> n.asText())
+                    .map(text -> "repository-s3".equals(text))
+                    .orElse(false);
+                if (isRepositoryS3) {
+                    return Optional.ofNullable(current.get("version"))
+                        .filter(n -> !n.isNull())
+                        .map(n -> n.asText())
+                        .map(text -> Version.fromString(getLikelyOpenSearchFlavor() + " " + text))
+                        .map(Mono::just)
+                        .orElseGet(() -> Mono.error(new OperationFailed("No version number found", resp)));
+                }
+            }
+        } catch (Exception e) {
+            log.error("Unable to determine if the cluster is in compatibility mode", e);
+            return Mono.error(new OperationFailed("Unable to determine if the cluster is in compatibility mode from response: " + e.getMessage(), resp));
+        }
+        return Mono.error(new OperationFailed("No version number found after scanning all installed plugins", resp));
+    }
+
+    private Flavor getLikelyOpenSearchFlavor() {
+        return client.getConnectionContext().isAwsSpecificAuthentication() ? Flavor.AMAZON_MANAGED_OPENSEARCH : Flavor.OPENSEARCH;
     }
 
     /*

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/common/RestClient.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/common/RestClient.java
@@ -30,6 +30,7 @@ import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
+import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import reactor.core.publisher.Mono;
 import reactor.netty.Connection;
@@ -41,6 +42,7 @@ import reactor.util.annotation.Nullable;
 
 @Slf4j
 public class RestClient {
+    @Getter
     private final ConnectionContext connectionContext;
     private final HttpClient client;
 

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/common/http/ConnectionContext.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/common/http/ConnectionContext.java
@@ -28,6 +28,7 @@ public class ConnectionContext {
     private final boolean insecure;
     private final RequestTransformer requestTransformer;
     private final boolean compressionSupported;
+    private final boolean awsSpecificAuthentication;
 
     private ConnectionContext(IParams params) {
         assert params.getHost() != null : "host is null";
@@ -61,6 +62,7 @@ public class ConnectionContext {
         if (basicAuthEnabled && sigv4Enabled) {
             throw new IllegalArgumentException("Cannot have both Basic Auth and SigV4 Auth enabled.");
         }
+        awsSpecificAuthentication = sigv4Enabled;
 
         if (basicAuthEnabled) {
             requestTransformer = new BasicAuthTransformer(params.getUsername(), params.getPassword());

--- a/RFS/src/test/java/org/opensearch/migrations/bulkload/common/OpenSearchClientTest.java
+++ b/RFS/src/test/java/org/opensearch/migrations/bulkload/common/OpenSearchClientTest.java
@@ -53,7 +53,28 @@ import static org.opensearch.migrations.bulkload.http.BulkRequestGenerator.itemE
 
 @ExtendWith(MockitoExtension.class)
 class OpenSearchClientTest {
-    private static final String PLUGINS_RESPONSE_OS_2_13_0 = "[{\"name\":\"74c8fa743d5e3626e3903c3b1d5450e0\",\"component\":\"performance-analyzer\",\"version\":\"x.x.x.x\"},{\"name\":\"74c8fa743d5e3626e3903c3b1d5450e0\",\"component\":\"repository-s3\",\"version\":\"2.13.0\"}]";
+    private static final String NODES_RESPONSE_OS_2_13_0 = "{\r\n" + //
+                "    \"_nodes\": {\r\n" + //
+                "        \"total\": 1,\r\n" + //
+                "        \"successful\": 1,\r\n" + //
+                "        \"failed\": 0\r\n" + //
+                "    },\r\n" + //
+                "    \"cluster_name\": \"336984078605:target-domain\",\r\n" + //
+                "    \"nodes\": {\r\n" + //
+                "        \"HDzrwdO8TneRQaxzx94uKA\": {\r\n" + //
+                "            \"name\": \"74c8fa743d5e3626e3903c3b1d5450e0\",\r\n" + //
+                "            \"version\": \"2.13.0\",\r\n" + //
+                "            \"build_type\": \"tar\",\r\n" + //
+                "            \"build_hash\": \"unknown\",\r\n" + //
+                "            \"roles\": [\r\n" + //
+                "                \"data\",\r\n" + //
+                "                \"ingest\",\r\n" + //
+                "                \"master\",\r\n" + //
+                "                \"remote_cluster_client\"\r\n" + //
+                "            ]\r\n" + //
+                "        }\r\n" + //
+                "    }\r\n" + //
+                "}";
     private static final String CLUSTER_SETTINGS_COMPATIBILITY_OVERRIDE_ENABLED = "{\"persistent\":{\"compatibility\":{\"override_main_response_version\":\"true\"}}}";
     private static final String CLUSTER_SETTINGS_COMPATIBILITY_OVERRIDE_DISABLED = "{\"persistent\":{\"compatibility\":{\"override_main_response_version\":\"false\"}}}";
     private static final String ROOT_RESPONSE_OS_1_0_0 = "{\"version\":{\"distribution\":\"opensearch\",\"number\":\"1.0.0\"}}";
@@ -169,14 +190,14 @@ class OpenSearchClientTest {
         when(connectionContext.isAwsSpecificAuthentication()).thenReturn(true);
         setupOkResponse(restClient, "", ROOT_RESPONSE_ES_7_10_2);
         setupOkResponse(restClient, "_cluster/settings", CLUSTER_SETTINGS_COMPATIBILITY_OVERRIDE_ENABLED);
-        setupOkResponse(restClient, "_cat/plugins?format=json", PLUGINS_RESPONSE_OS_2_13_0);
+        setupOkResponse(restClient, "_nodes/_all/nodes,version?format=json", NODES_RESPONSE_OS_2_13_0);
 
         var version = openSearchClient.getClusterVersion();
 
         assertThat(version, equalTo(Version.fromString("AOS 2.13.0")));
         verify(restClient).getAsync("", null);
         verify(restClient).getAsync("_cluster/settings", null);
-        verify(restClient).getAsync("_cat/plugins?format=json", null);
+        verify(restClient).getAsync("_nodes/_all/nodes,version?format=json", null);
     }
 
     @Test

--- a/transformation/src/main/java/org/opensearch/migrations/Flavor.java
+++ b/transformation/src/main/java/org/opensearch/migrations/Flavor.java
@@ -7,7 +7,20 @@ import lombok.RequiredArgsConstructor;
 @Getter
 public enum Flavor {
     ELASTICSEARCH("ES"),
-    OPENSEARCH("OS");
+    OPENSEARCH("OS"),
+    AMAZON_MANAGED_OPENSEARCH("AOS"),
+    AMAZON_SERVERLESS_OPENSEARCH("AOSS");
 
     final String shorthand;
+
+    public boolean isOpenSearch() {
+        switch (this) {
+            case OPENSEARCH:
+            case AMAZON_MANAGED_OPENSEARCH:
+            case AMAZON_SERVERLESS_OPENSEARCH:
+                return true;
+            default:
+                return false;
+        }
+    }
 }

--- a/transformation/src/main/java/org/opensearch/migrations/Version.java
+++ b/transformation/src/main/java/org/opensearch/migrations/Version.java
@@ -1,6 +1,7 @@
 package org.opensearch.migrations;
 
 import java.util.Arrays;
+import java.util.Comparator;
 
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
@@ -27,6 +28,7 @@ public class Version {
 
         var finalRemainingString = remainingString;
         var matchedFlavor = Arrays.stream(Flavor.values())
+            .sorted(Comparator.comparing((Flavor f) -> f.shorthand.length()).reversed())
             .filter(flavor -> finalRemainingString.startsWith(flavor.name().toLowerCase()) ||
                               finalRemainingString.startsWith(flavor.shorthand.toLowerCase()))
             .findFirst();

--- a/transformation/src/main/java/org/opensearch/migrations/VersionMatchers.java
+++ b/transformation/src/main/java/org/opensearch/migrations/VersionMatchers.java
@@ -8,17 +8,30 @@ import lombok.experimental.UtilityClass;
 public class VersionMatchers {
     public static final Predicate<Version> isES_6_X = VersionMatchers.matchesMajorVersion(Version.fromString("ES 6.8"));
     public static final Predicate<Version> isES_7_X = VersionMatchers.matchesMajorVersion(Version.fromString("ES 7.10"));
+    public static final Predicate<Version> isES_7_10 = VersionMatchers.matchesMinorVersion(Version.fromString("ES 7.10.2"));
     public static final Predicate<Version> equalOrGreaterThanES_7_10 = VersionMatchers.equalOrGreaterThanMinorVersion(Version.fromString("ES 7.10"));
 
     public static final Predicate<Version> isOS_1_X = VersionMatchers.matchesMajorVersion(Version.fromString("OS 1.0.0"));
     public static final Predicate<Version> isOS_2_X = VersionMatchers.matchesMajorVersion(Version.fromString("OS 2.0.0"));
+
+    private static Predicate<Flavor> compatibleFlavor(final Flavor flavor) {
+        return other -> {
+            if (other == null) {
+                return false;
+            }
+            if (other.isOpenSearch() && flavor.isOpenSearch()) {
+                return true;
+            }
+            return other == flavor;
+        };
+    }
 
     private static Predicate<Version> matchesMajorVersion(final Version version) {
         return other -> {
             if (other == null) {
                 return false;
             }
-            var flavorMatches = version.getFlavor() == other.getFlavor();
+            var flavorMatches = compatibleFlavor(other.getFlavor()).test(version.getFlavor());
             var majorVersionNumberMatches = version.getMajor() == other.getMajor();
 
             return flavorMatches && majorVersionNumberMatches;

--- a/transformation/src/test/java/org/opensearch/migrations/FlavorTest.java
+++ b/transformation/src/test/java/org/opensearch/migrations/FlavorTest.java
@@ -1,0 +1,33 @@
+package org.opensearch.migrations;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
+
+public class FlavorTest {
+    @Test
+    void testIsOpenSearch() {
+        var trueCases = List.of(Flavor.AMAZON_MANAGED_OPENSEARCH, Flavor.AMAZON_SERVERLESS_OPENSEARCH, Flavor.OPENSEARCH);
+        for (var testCase : trueCases) {
+            assertThat(testCase.isOpenSearch(), equalTo(true));
+        }
+
+        var falseCases = List.of(Flavor.ELASTICSEARCH);
+        for (var testCase : falseCases) {
+            assertThat(testCase.isOpenSearch(), equalTo(false));
+        }
+    }
+
+    @Test
+    void uniqueValues() {
+        // Make sure values in the flavor enum are never marked as equal to one another
+        var valuesInSet = new HashSet<>(Arrays.asList(Flavor.values()));
+        assertThat(valuesInSet, hasSize(Flavor.values().length));
+    }
+}

--- a/transformation/src/test/java/org/opensearch/migrations/VersionTest.java
+++ b/transformation/src/test/java/org/opensearch/migrations/VersionTest.java
@@ -38,4 +38,13 @@ public class VersionTest {
         assertThat(Version.fromString("OpenSearch 1.x"), equalTo(expected));
         assertThat(Version.fromString("OpenSearch  1"), equalTo(expected));
     }
+
+    @Test
+    void parseAllPossibleNames() throws ParseException {
+        for (var testCase : Flavor.values()) {
+            var expected = Version.builder().flavor(testCase).major(4).build();
+            assertThat(Version.fromString(testCase.shorthand + " 4.0.0") , equalTo(expected));
+            assertThat(Version.fromString(testCase.name() + " 4.0.0") , equalTo(expected));
+        }
+    }
 }


### PR DESCRIPTION
### Description
Adding automatic version detection that supports both flavors of the Amazon Managed OpenSearch and Serverless offerings.  Also detecting if combability mode has been enabled that will extract the version number from the `_cat/plugins` api, specifically looking at the `repository-s3` plugin.

### Issues Resolved
- Resolves https://opensearch.atlassian.net/browse/MIGRATIONS-2187

### Testing
Tested with both a managed and serverless cluster locally.

```
> ./gradlew MetadataMigration:run --args='evaluate --source-host https://search-target-domain-p5keoxlvhl5slkqgildik64mce.us-west-2.es.amazonaws.com/ --source-aws-region us-west-2 --source-aws-service-signing-name es --target-host https://vwpt0d13nhrsiinwng90.us-west-2.aoss.amazonaws.com/ --target-aws-region us-west-2 --target-aws-service-signing-name aoss'

> Task :MetadataMigration:run
Starting Metadata Evaluation
Clusters:
   Source:
      Remote Cluster: AMAZON_MANAGED_OPENSEARCH 2.13.0 ConnectionContext(uri=https://search-target-domain-p5keoxlvhl5slkqgildik64mce.us-west-2.es.amazonaws.com/, protocol=HTTPS, insecure=false, compressionSupported=false, awsSpecificAuthentication=true)

   Target:
      Remote Cluster: AMAZON_SERVERLESS_OPENSEARCH 2.0.0 ConnectionContext(uri=https://vwpt0d13nhrsiinwng90.us-west-2.aoss.amazonaws.com/, protocol=HTTPS, insecure=false, compressionSupported=false, awsSpecificAuthentication=true)
````


### Check List
- [X] New functionality includes testing
  - [X] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
