### PR TITLE
Generate and output sbom in GHA

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -51,27 +51,27 @@ jobs:
         run: |
           ./deployment/cdk/opensearch-service-migration/buildDockerImages.sh -Dbuild.snapshot=false -Dbuild.version=0.${{ steps.get_data.outputs.version }}
       - name: Generate SBOM for migration_console
-        uses: anchore/sbom-action@v0
+        uses: anchore/sbom-action@v0.17.7
         with:
           image: migrations/migration_console:latest
           artifact-name: opensearch-migrations-console-sbom.spdx.json
       - name: Generate SBOM for traffic_replayer
-        uses: anchore/sbom-action@v0
+        uses: anchore/sbom-action@v0.17.7
         with:
           image: migrations/traffic_replayer:latest
           artifact-name: opensearch-migrations-traffic-replayer-sbom.spdx.json
       - name: Generate SBOM for capture_proxy
-        uses: anchore/sbom-action@v0
+        uses: anchore/sbom-action@v0.17.7
         with:
           image: migrations/capture_proxy:latest
           artifact-name: opensearch-migrations-traffic-capture-proxy-sbom.spdx.json
       - name: Generate SBOM for reindex_from_snapshot
-        uses: anchore/sbom-action@v0
+        uses: anchore/sbom-action@v0.17.7
         with:
           image: migrations/reindex_from_snapshot:latest
           artifact-name: opensearch-migrations-reindex-from-snapshot-sbom.spdx.json
       - name: Generate SBOM for artifacts
-        uses: anchore/sbom-action@v0
+        uses: anchore/sbom-action@v0.17.7
         with:
           file: artifacts.tar.gz
           artifact-name: artifacts-sbom.spdx.json

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -49,7 +49,32 @@ jobs:
           ./gradlew publishMavenJavaPublicationToMavenRepository -Dbuild.snapshot=false -Dbuild.version=0.${{ steps.get_data.outputs.version }} && tar -C build -cvf traffic-capture-artifacts.tar.gz repository
       - name: Build Docker Images
         run: |
-          ./deployment/cdk/opensearch-service-migration/buildDockerImages.sh
+          ./deployment/cdk/opensearch-service-migration/buildDockerImages.sh -Dbuild.snapshot=false -Dbuild.version=0.${{ steps.get_data.outputs.version }}
+      - name: Generate SBOM for migration_console
+        uses: anchore/sbom-action@v0
+        with:
+          image: migrations/migration_console:latest
+          artifact-name: opensearch-migrations-console-sbom.spdx.json
+      - name: Generate SBOM for traffic_replayer
+        uses: anchore/sbom-action@v0
+        with:
+          image: migrations/traffic_replayer:latest
+          artifact-name: opensearch-migrations-traffic-replayer-sbom.spdx.json
+      - name: Generate SBOM for capture_proxy
+        uses: anchore/sbom-action@v0
+        with:
+          image: migrations/capture_proxy:latest
+          artifact-name: opensearch-migrations-traffic-capture-proxy-sbom.spdx.json
+      - name: Generate SBOM for reindex_from_snapshot
+        uses: anchore/sbom-action@v0
+        with:
+          image: migrations/reindex_from_snapshot:latest
+          artifact-name: opensearch-migrations-reindex-from-snapshot-sbom.spdx.json
+      - name: Generate SBOM for artifacts
+        uses: anchore/sbom-action@v0
+        with:
+          file: artifacts.tar.gz
+          artifact-name: artifacts-sbom.spdx.json
       - name: Tag Docker image
         run: |
           docker tag migrations/migration_console:latest opensearchstaging/opensearch-migrations-console:${{ steps.get_data.outputs.version }}
@@ -97,3 +122,4 @@ jobs:
           files: |
             artifacts.tar.gz
             traffic-capture-artifacts.tar.gz
+            **/*.spdx.json

--- a/DocumentsFromSnapshotMigration/docker/Dockerfile
+++ b/DocumentsFromSnapshotMigration/docker/Dockerfile
@@ -2,7 +2,9 @@
 FROM amazoncorretto:11-al2023-headless
 
 # Install the AWS CLI in the container
-RUN dnf update -y && dnf install -y aws-cli
+RUN dnf install -y aws-cli --setopt=install_weak_deps=False && \
+       dnf clean all && \
+       rm -rf /var/cache/dnf
 
 # Requires Gradle to genearte runtime jars initially
 COPY ./build/runtimeJars /rfs-app/jars

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/Dockerfile
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/Dockerfile
@@ -47,7 +47,10 @@ WORKDIR /root
 
 # Console setup bash completion and venv for interactive access
 RUN echo '. /.venv/bin/activate' >> /etc/profile.d/venv.sh
-RUN dnf install -y bash-completion
+RUN dnf install -y bash-completion --setopt=install_weak_deps=False && \
+        dnf clean all && \
+        rm -rf /var/cache/dnf
+
 RUN echo '. /etc/profile.d/bash_completion.sh' >> ~/.bashrc && \
     echo '. /etc/profile.d/venv.sh' >> ~/.bashrc && \
     echo 'echo Welcome to the Migration Assistant Console' >> ~/.bashrc

--- a/build.gradle
+++ b/build.gradle
@@ -22,11 +22,19 @@ ext {
     finalVersion = buildSnapshot ? "${buildVersion}-SNAPSHOT" : buildVersion
 }
 
-// Apply the version to all projects
 allprojects {
     version = finalVersion
     // This should eventually change, see https://opensearch.atlassian.net/browse/MIGRATIONS-2167
     group = 'org.opensearch.migrations.trafficcapture'
+    tasks.withType(Jar).tap {
+        configureEach {
+            manifest {
+                attributes(
+                        'SPDX-License-Identifier': 'Apache-2.0'
+                )
+            }
+        }
+    }
 }
 
 subprojects { subproject ->
@@ -160,8 +168,9 @@ subprojects {
     task sourcesJar(type: Jar) {
         archiveClassifier.set('sources')
         from sourceSets.main.allSource
-        duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+        duplicatesStrategy = DuplicatesStrategy.WARN
     }
+
     def excludedProjectPaths = [
             ':RFS',
             ':TrafficCapture',
@@ -246,7 +255,7 @@ subprojects {
 
     // Utility task to allow copying required libraries into a 'dependencies' folder for security scanning
     tasks.register('copyDependencies', Sync) {
-        duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+        duplicatesStrategy = DuplicatesStrategy.WARN
 
         from configurations.runtimeClasspath
         into "${buildDir}/dependencies"

--- a/deployment/cdk/opensearch-service-migration/buildDockerImages.sh
+++ b/deployment/cdk/opensearch-service-migration/buildDockerImages.sh
@@ -6,4 +6,4 @@ script_dir_abs_path=$(dirname "$script_abs_path")
 cd "$script_dir_abs_path" || exit
 
 cd ../../.. || exit
-./gradlew :buildDockerImages -x test
+./gradlew :buildDockerImages -x test "$@"


### PR DESCRIPTION
### Description
Use Syft action to generate and output sbom alongside published artifacts.
Added license identifier to created jars.

* Category: Enhancement
* Why these changes are required? Users expect software boms with artifacts
* What is the old behavior before changes and new behavior after changes?

### Issues Resolved

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
Tested with GHA, see https://github.com/opensearch-project/opensearch-migrations/actions/runs/11713035148?pr=1121

### Check List
- [ ] New functionality includes testing
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
