### PR TITLE
Metadata Support ES7+ Legacy Templates

### DIFF
--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/models/GlobalMetadata.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/models/GlobalMetadata.java
@@ -25,6 +25,10 @@ public interface GlobalMetadata {
 
     public ObjectNode getTemplates();
 
+    public ObjectNode getIndexTemplates();
+
+    public ObjectNode getComponentTemplates();
+
     /**
     * Defines the behavior required to read a snapshot's global metadata as JSON and convert it into a Data object
     */

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/transformers/Transformer_ES_7_10_OS_2_11.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/transformers/Transformer_ES_7_10_OS_2_11.java
@@ -24,12 +24,13 @@ public class Transformer_ES_7_10_OS_2_11 implements Transformer {
 
         // Transform the legacy templates
         if (root.get(TEMPLATES_KEY_STR) != null) {
-            ObjectNode templatesRoot = (ObjectNode) root.get(TEMPLATES_KEY_STR).deepCopy();
+            ObjectNode templatesRoot =  metaData.getTemplates().deepCopy();
             templatesRoot.fieldNames().forEachRemaining(templateName -> {
                 ObjectNode template = (ObjectNode) templatesRoot.get(templateName);
                 log.atInfo().setMessage("Transforming template: {}").addArgument(templateName).log();
                 log.atDebug().setMessage("Original template: {}").addArgument(template).log();
                 TransformFunctions.removeIntermediateIndexSettingsLevel(template); // run before fixNumberOfReplicas
+                TransformFunctions.removeIntermediateMappingsLevels(template);
                 TransformFunctions.fixReplicasForDimensionality(templatesRoot, awarenessAttributeDimensionality);
                 log.atDebug().setMessage("Transformed template: {}").addArgument(template).log();
                 templatesRoot.set(templateName, template);
@@ -39,8 +40,7 @@ public class Transformer_ES_7_10_OS_2_11 implements Transformer {
 
         // Transform the index templates
         if (root.get(INDEX_TEMPLATE_KEY_STR) != null) {
-            ObjectNode indexTemplatesRoot = (ObjectNode) root.get(INDEX_TEMPLATE_KEY_STR).deepCopy();
-            ObjectNode indexTemplateValuesRoot = (ObjectNode) indexTemplatesRoot.get(INDEX_TEMPLATE_KEY_STR);
+            ObjectNode indexTemplateValuesRoot = metaData.getIndexTemplates().deepCopy();
             indexTemplateValuesRoot.fieldNames().forEachRemaining(templateName -> {
                 ObjectNode template = (ObjectNode) indexTemplateValuesRoot.get(templateName);
                 ObjectNode templateSubRoot = (ObjectNode) template.get("template");
@@ -57,13 +57,12 @@ public class Transformer_ES_7_10_OS_2_11 implements Transformer {
                 log.atDebug().setMessage("Transformed index template: {}").addArgument(template).log();
                 indexTemplateValuesRoot.set(templateName, template);
             });
-            root.set(INDEX_TEMPLATE_KEY_STR, indexTemplatesRoot);
+            ((ObjectNode) root.get(INDEX_TEMPLATE_KEY_STR)).set(INDEX_TEMPLATE_KEY_STR, indexTemplateValuesRoot);
         }
 
         // Transform the component templates
         if (root.get(COMPONENT_TEMPLATE_KEY_STR) != null) {
-            ObjectNode componentTemplatesRoot = (ObjectNode) root.get(COMPONENT_TEMPLATE_KEY_STR).deepCopy();
-            ObjectNode componentTemplateValuesRoot = (ObjectNode) componentTemplatesRoot.get(COMPONENT_TEMPLATE_KEY_STR);
+            ObjectNode componentTemplateValuesRoot = metaData.getComponentTemplates().deepCopy();
             componentTemplateValuesRoot.fieldNames().forEachRemaining(templateName -> {
                 ObjectNode template = (ObjectNode) componentTemplateValuesRoot.get(templateName);
                 ObjectNode templateSubRoot = (ObjectNode) template.get("template");
@@ -78,7 +77,7 @@ public class Transformer_ES_7_10_OS_2_11 implements Transformer {
                 log.atDebug().setMessage("Transformed component template: {}").addArgument(template).log();
                 componentTemplateValuesRoot.set(templateName, template);
             });
-            root.set(COMPONENT_TEMPLATE_KEY_STR, componentTemplatesRoot);
+            ((ObjectNode) root.get(COMPONENT_TEMPLATE_KEY_STR)).set(COMPONENT_TEMPLATE_KEY_STR, componentTemplateValuesRoot);
         }
 
         return new GlobalMetadataData_OS_2_11(root);

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/version_es_6_8/GlobalMetadataData_ES_6_8.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/version_es_6_8/GlobalMetadataData_ES_6_8.java
@@ -19,4 +19,14 @@ public class GlobalMetadataData_ES_6_8 implements GlobalMetadata {
     public ObjectNode getTemplates() {
         return (ObjectNode) root.get("templates");
     }
+
+    @Override
+    public ObjectNode getIndexTemplates() {
+        return null;
+    }
+
+    @Override
+    public ObjectNode getComponentTemplates() {
+        return null;
+    }
 }

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/version_es_7_10/GlobalMetadataData_ES_7_10.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/version_es_7_10/GlobalMetadataData_ES_7_10.java
@@ -1,5 +1,7 @@
 package org.opensearch.migrations.bulkload.version_es_7_10;
 
+import java.util.Optional;
+
 import org.opensearch.migrations.bulkload.models.GlobalMetadata;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -17,7 +19,11 @@ public class GlobalMetadataData_ES_7_10 implements GlobalMetadata {
     }
 
     public ObjectNode getTemplates() {
-        return (ObjectNode) root.get("templates");
+        return Optional.ofNullable(root)
+                .map(node -> node.get("templates"))
+                .filter(ObjectNode.class::isInstance)
+                .map(ObjectNode.class::cast)
+                .orElse(null);
     }
 
     public ObjectNode getIndexTemplates() {

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/version_universal/RemoteMetadata.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/version_universal/RemoteMetadata.java
@@ -26,4 +26,22 @@ public class RemoteMetadata implements GlobalMetadata {
             .map(ObjectNode.class::cast)
             .orElse(null);
     }
+
+    @Override
+    public ObjectNode getIndexTemplates() {
+        return Optional.ofNullable(sourceData)
+                .map(node -> node.get("index_template"))
+                .map(node -> node.get("index_template"))
+                .filter(ObjectNode.class::isInstance)
+                .map(ObjectNode.class::cast)
+                .orElse(null);    }
+
+    @Override
+    public ObjectNode getComponentTemplates() {
+        return Optional.ofNullable(sourceData)
+                .map(node -> node.get("component_template"))
+                .map(node -> node.get("component_template"))
+                .filter(ObjectNode.class::isInstance)
+                .map(ObjectNode.class::cast)
+                .orElse(null);    }
 }

--- a/RFS/src/test/java/org/opensearch/migrations/bulkload/transformers/Transformer_ES_7_10_OS_2_11Test.java
+++ b/RFS/src/test/java/org/opensearch/migrations/bulkload/transformers/Transformer_ES_7_10_OS_2_11Test.java
@@ -31,7 +31,7 @@ public class Transformer_ES_7_10_OS_2_11Test {
         GlobalMetadata transformedGlobalMetadata = transformer.transformGlobalMetadata(globalMetadata);
         GlobalMetadataData_OS_2_11 finalMetadata = new GlobalMetadataData_OS_2_11(transformedGlobalMetadata.toObjectNode());
 
-        String expectedBwcTemplates = "{\"bwc_template\":{\"order\":0,\"index_patterns\":[\"bwc_index*\"],\"settings\":{\"number_of_shards\":\"1\",\"number_of_replicas\":\"0\"},\"mappings\":[{\"arbitrary_type\":{\"properties\":{\"title\":{\"type\":\"text\"},\"content\":{\"type\":\"text\"}}}}],\"aliases\":{\"bwc_alias\":{}}}}";
+        String expectedBwcTemplates = "{\"bwc_template\":{\"order\":0,\"index_patterns\":[\"bwc_index*\"],\"settings\":{\"number_of_shards\":\"1\",\"number_of_replicas\":\"0\"},\"mappings\":{\"properties\":{\"title\":{\"type\":\"text\"},\"content\":{\"type\":\"text\"}}},\"aliases\":{\"bwc_alias\":{}}}}";
         String expectedIndexTemplates = "{\"fwc_template\":{\"index_patterns\":[\"fwc_index*\"],\"template\":{\"aliases\":{\"fwc_alias\":{}}},\"composed_of\":[\"fwc_mappings\",\"fwc_settings\"]}}";
         String expectedComponentTemplates = "{\"fwc_settings\":{\"template\":{\"settings\":{\"index\":{\"number_of_shards\":\"1\",\"number_of_replicas\":\"0\"}}}},\"fwc_mappings\":{\"template\":{\"mappings\":{\"properties\":{\"title\":{\"type\":\"text\"},\"content\":{\"type\":\"text\"}}}}}}";
 


### PR DESCRIPTION
### Description
Currently, legacy templates (created with `_template`) were only supported on ES 6. Since the API is deprecated and not removed, customers still use this type of template for ES 7 and above and it should be supported and tested.

This change mirrors the existing transformation logic that is in Index processing and applying to Legacy templates for ES7. E.g.
```
 * Starting state:
 * {
 *   "mappings": [
 *     {
 *       "foo": {
 *         "properties": {
 *           "field1": { "type": "text" },
 *           "field2": { "type": "keyword" }
 *         }
 *       }
 *     }
 *   ]
 * }
 *
 * Ending state:
 * {
 *   "mappings": {
 *     "properties": {
 *       "field1": { "type": "text" },
 *       "field2": { "type": "keyword" },
 *     }
 *   }
 * }
```

* Category: Bug fix
* Why these changes are required? Legacy template support on ES7+
* What is the old behavior before changes and new behavior after changes? Legacy templates wouldn't work and parse correctly.

### Issues Resolved
[MIGRATIONS-2217](https://opensearch.atlassian.net/browse/MIGRATIONS-2217)

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
Added E2E tests across different criteria for legacy templates on all versions with snapshot and api retrieval

### Check List
- [x] New functionality includes testing
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
