### PR TITLE
Disable CodeCov as Required

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -73,7 +73,7 @@ jobs:
             token: ${{ secrets.CODECOV_TOKEN }}
             files: ./coverage.xml
             flags: python-test
-            fail_ci_if_error: true
+            fail_ci_if_error: false
 
   console-api-tests:
     runs-on: ubuntu-latest
@@ -100,7 +100,7 @@ jobs:
             token: ${{ secrets.CODECOV_TOKEN }}
             files: ./coverage.xml
             flags: python-test
-            fail_ci_if_error: true
+            fail_ci_if_error: false
 
 
   gradle-tests:
@@ -142,7 +142,7 @@ jobs:
             token: ${{ secrets.CODECOV_TOKEN }}
             files: ${{ github.workspace }}/build/reports/jacoco/mergedReport/jacocoMergedReport.xml
             flags: gradle-test
-            fail_ci_if_error: true
+            fail_ci_if_error: false
             disable_search: true
 
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -74,6 +74,9 @@ jobs:
 
   console-api-tests:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        iteration: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]
     defaults:
       run:
         working-directory: ./TrafficCapture/dockerSolution/src/main/docker/migrationConsole/console_api

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -63,17 +63,14 @@ jobs:
           pipenv install --deploy --dev
           pipenv run test
           pipenv run coverage xml
-      - name: Upload Coverage with retry
-        uses: Wandalen/wretry.action@v3.7.2
+      - name: Upload Coverage
+        uses: codecov/codecov-action@v4
         with:
-          attempt_limit: 5
-          attempt_delay: 2000
-          action: codecov/codecov-action@v4
-          with: |
-            token: ${{ secrets.CODECOV_TOKEN }}
-            files: ./coverage.xml
-            flags: python-test
-            fail_ci_if_error: false
+          verbose: true
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage.xml
+          flags: python-test
+          fail_ci_if_error: false
 
   console-api-tests:
     runs-on: ubuntu-latest
@@ -90,17 +87,14 @@ jobs:
           pipenv install --deploy --dev
           pipenv run coverage run --source='.' manage.py test console_api
           pipenv run coverage xml
-      - name: Upload Coverage with retry
-        uses: Wandalen/wretry.action@v3.7.2
+      - name: Upload Coverage
+        uses: codecov/codecov-action@v4
         with:
-          attempt_limit: 5
-          attempt_delay: 2000
-          action: codecov/codecov-action@v4
-          with: |
-            token: ${{ secrets.CODECOV_TOKEN }}
-            files: ./coverage.xml
-            flags: python-test
-            fail_ci_if_error: false
+          verbose: true
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage.xml
+          flags: python-test
+          fail_ci_if_error: true
 
 
   gradle-tests:
@@ -132,18 +126,15 @@ jobs:
           path: |
             **/build/reports/tests/
             **/reports/jacoco/mergedReport/
-      - name: Upload Coverage with retry
-        uses: Wandalen/wretry.action@v3.7.2
+      - name: Upload Coverage
+        uses: codecov/codecov-action@v4
         with:
-          attempt_limit: 5
-          attempt_delay: 2000
-          action: codecov/codecov-action@v4
-          with: |
-            token: ${{ secrets.CODECOV_TOKEN }}
-            files: ${{ github.workspace }}/build/reports/jacoco/mergedReport/jacocoMergedReport.xml
-            flags: gradle-test
-            fail_ci_if_error: false
-            disable_search: true
+          verbose: true
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false
+          files: ${{ github.workspace }}/build/reports/jacoco/mergedReport/jacocoMergedReport.xml
+          flags: gradle-test
+          disable_search: true
 
 
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -2,7 +2,8 @@ name: CI
 
 on:
   push:
-  pull_request:
+  pull_request_target:
+    types: [assigned, opened, synchronize, reopened]
 
 env:
   python-version: '3.11'

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -63,17 +63,14 @@ jobs:
           pipenv install --deploy --dev
           pipenv run test
           pipenv run coverage xml
-      - name: Upload Coverage with retry
-        uses: Wandalen/wretry.action@v3.7.2
+      - name: Upload Coverage
+        uses: codecov/codecov-action@v4
         with:
-          attempt_limit: 5
-          attempt_delay: 2000
-          action: codecov/codecov-action@v4
-          with: |
-            token: ${{ secrets.CODECOV_TOKEN }}
-            files: ./coverage.xml
-            flags: python-test
-            fail_ci_if_error: true
+          verbose: true
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage.xml
+          flags: python-test
+          fail_ci_if_error: false
 
   console-api-tests:
     runs-on: ubuntu-latest
@@ -90,17 +87,14 @@ jobs:
           pipenv install --deploy --dev
           pipenv run coverage run --source='.' manage.py test console_api
           pipenv run coverage xml
-      - name: Upload Coverage with retry
-        uses: Wandalen/wretry.action@v3.7.2
+      - name: Upload Coverage
+        uses: codecov/codecov-action@v4
         with:
-          attempt_limit: 5
-          attempt_delay: 2000
-          action: codecov/codecov-action@v4
-          with: |
-            token: ${{ secrets.CODECOV_TOKEN }}
-            files: ./coverage.xml
-            flags: python-test
-            fail_ci_if_error: true
+          verbose: true
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage.xml
+          flags: python-test
+          fail_ci_if_error: false
 
 
   gradle-tests:
@@ -132,18 +126,15 @@ jobs:
           path: |
             **/build/reports/tests/
             **/reports/jacoco/mergedReport/
-      - name: Upload Coverage with retry
-        uses: Wandalen/wretry.action@v3.7.2
+      - name: Upload Coverage
+        uses: codecov/codecov-action@v4
         with:
-          attempt_limit: 5
-          attempt_delay: 2000
-          action: codecov/codecov-action@v4
-          with: |
-            token: ${{ secrets.CODECOV_TOKEN }}
-            files: ${{ github.workspace }}/build/reports/jacoco/mergedReport/jacocoMergedReport.xml
-            flags: gradle-test
-            fail_ci_if_error: true
-            disable_search: true
+          verbose: true
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false
+          files: ${{ github.workspace }}/build/reports/jacoco/mergedReport/jacocoMergedReport.xml
+          flags: gradle-test
+          disable_search: true
 
 
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -89,6 +89,8 @@ jobs:
           pipenv run coverage xml
       - name: Upload Coverage
         uses: codecov/codecov-action@v4
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
           verbose: true
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -4,10 +4,23 @@ on:
   push:
   pull_request_target:
     types:
-      - opened
       - assigned
-      - synchronize
+      - unassigned
+      - labeled
+      - unlabeled
+      - opened
+      - edited
+      - closed
       - reopened
+      - synchronize
+      - converted_to_draft
+      - ready_for_review
+      - locked
+      - unlocked
+      - review_requested
+      - review_request_removed
+      - auto_merge_enabled
+      - auto_merge_disabled
 
 env:
   python-version: '3.11'

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -3,7 +3,11 @@ name: CI
 on:
   push:
   pull_request_target:
-    types: [assigned, opened, synchronize, reopened]
+    types:
+      - opened
+      - assigned
+      - synchronize
+      - reopened
 
 env:
   python-version: '3.11'

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -63,14 +63,17 @@ jobs:
           pipenv install --deploy --dev
           pipenv run test
           pipenv run coverage xml
-      - name: Upload Coverage
-        uses: codecov/codecov-action@v4
+      - name: Upload Coverage with retry
+        uses: Wandalen/wretry.action@v3.7.2
         with:
-          verbose: true
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: ./coverage.xml
-          flags: python-test
-          fail_ci_if_error: false
+          attempt_limit: 5
+          attempt_delay: 2000
+          action: codecov/codecov-action@v4
+          with: |
+            token: ${{ secrets.CODECOV_TOKEN }}
+            files: ./coverage.xml
+            flags: python-test
+            fail_ci_if_error: true
 
   console-api-tests:
     runs-on: ubuntu-latest
@@ -87,16 +90,17 @@ jobs:
           pipenv install --deploy --dev
           pipenv run coverage run --source='.' manage.py test console_api
           pipenv run coverage xml
-      - name: Upload Coverage
-        uses: codecov/codecov-action@v4
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      - name: Upload Coverage with retry
+        uses: Wandalen/wretry.action@v3.7.2
         with:
-          verbose: true
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: ./coverage.xml
-          flags: python-test
-          fail_ci_if_error: false
+          attempt_limit: 5
+          attempt_delay: 2000
+          action: codecov/codecov-action@v4
+          with: |
+            token: ${{ secrets.CODECOV_TOKEN }}
+            files: ./coverage.xml
+            flags: python-test
+            fail_ci_if_error: true
 
 
   gradle-tests:
@@ -128,15 +132,18 @@ jobs:
           path: |
             **/build/reports/tests/
             **/reports/jacoco/mergedReport/
-      - name: Upload Coverage
-        uses: codecov/codecov-action@v4
+      - name: Upload Coverage with retry
+        uses: Wandalen/wretry.action@v3.7.2
         with:
-          verbose: true
-          token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: false
-          files: ${{ github.workspace }}/build/reports/jacoco/mergedReport/jacocoMergedReport.xml
-          flags: gradle-test
-          disable_search: true
+          attempt_limit: 5
+          attempt_delay: 2000
+          action: codecov/codecov-action@v4
+          with: |
+            token: ${{ secrets.CODECOV_TOKEN }}
+            files: ${{ github.workspace }}/build/reports/jacoco/mergedReport/jacocoMergedReport.xml
+            flags: gradle-test
+            fail_ci_if_error: true
+            disable_search: true
 
 
 


### PR DESCRIPTION
### Description
Seeing token codecov failures, temporarily disabling ci failure.

See: https://github.com/opensearch-project/opensearch-migrations/actions/runs/11809477035/job/32899830385?pr=1130



### Check List
- [x] New functionality includes testing
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
