### PR TITLE
GHA trigger CI with pull_request_target for secrets access

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-  pull_request:
+  pull_request_target:
 
 env:
   python-version: '3.11'
@@ -63,20 +63,20 @@ jobs:
           pipenv install --deploy --dev
           pipenv run test
           pipenv run coverage xml
-      - name: Upload Coverage with retry
-        uses: Wandalen/wretry.action@v3.7.2
+      - name: Upload Coverage
+        uses: codecov/codecov-action@v4
         with:
-          attempt_limit: 5
-          attempt_delay: 2000
-          action: codecov/codecov-action@v4
-          with: |
-            token: ${{ secrets.CODECOV_TOKEN }}
-            files: ./coverage.xml
-            flags: python-test
-            fail_ci_if_error: true
+          verbose: true
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage.xml
+          flags: python-test
+          fail_ci_if_error: true
 
   console-api-tests:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        iteration: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]
     defaults:
       run:
         working-directory: ./TrafficCapture/dockerSolution/src/main/docker/migrationConsole/console_api
@@ -90,17 +90,14 @@ jobs:
           pipenv install --deploy --dev
           pipenv run coverage run --source='.' manage.py test console_api
           pipenv run coverage xml
-      - name: Upload Coverage with retry
-        uses: Wandalen/wretry.action@v3.7.2
+      - name: Upload Coverage
+        uses: codecov/codecov-action@v4
         with:
-          attempt_limit: 5
-          attempt_delay: 2000
-          action: codecov/codecov-action@v4
-          with: |
-            token: ${{ secrets.CODECOV_TOKEN }}
-            files: ./coverage.xml
-            flags: python-test
-            fail_ci_if_error: true
+          verbose: true
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage.xml
+          flags: python-test
+          fail_ci_if_error: true
 
 
   gradle-tests:
@@ -132,18 +129,15 @@ jobs:
           path: |
             **/build/reports/tests/
             **/reports/jacoco/mergedReport/
-      - name: Upload Coverage with retry
-        uses: Wandalen/wretry.action@v3.7.2
+      - name: Upload Coverage
+        uses: codecov/codecov-action@v4
         with:
-          attempt_limit: 5
-          attempt_delay: 2000
-          action: codecov/codecov-action@v4
-          with: |
-            token: ${{ secrets.CODECOV_TOKEN }}
-            files: ${{ github.workspace }}/build/reports/jacoco/mergedReport/jacocoMergedReport.xml
-            flags: gradle-test
-            fail_ci_if_error: true
-            disable_search: true
+          verbose: true
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: true
+          files: ${{ github.workspace }}/build/reports/jacoco/mergedReport/jacocoMergedReport.xml
+          flags: gradle-test
+          disable_search: true
 
 
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -74,9 +74,6 @@ jobs:
 
   console-api-tests:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        iteration: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]
     defaults:
       run:
         working-directory: ./TrafficCapture/dockerSolution/src/main/docker/migrationConsole/console_api

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -66,11 +66,11 @@ jobs:
       - name: Upload Coverage
         uses: codecov/codecov-action@v4
         with:
-          verbose: true
-          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: true
           files: ./coverage.xml
           flags: python-test
-          fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }}
+          verbose: true
 
   console-api-tests:
     runs-on: ubuntu-latest
@@ -90,11 +90,11 @@ jobs:
       - name: Upload Coverage
         uses: codecov/codecov-action@v4
         with:
-          verbose: true
-          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: true
           files: ./coverage.xml
           flags: python-test
-          fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }}
+          verbose: true
 
 
   gradle-tests:
@@ -129,13 +129,12 @@ jobs:
       - name: Upload Coverage
         uses: codecov/codecov-action@v4
         with:
-          verbose: true
-          token: ${{ secrets.CODECOV_TOKEN }}
+          disable_search: true
           fail_ci_if_error: true
           files: ${{ github.workspace }}/build/reports/jacoco/mergedReport/jacocoMergedReport.xml
           flags: gradle-test
-          disable_search: true
-
+          token: ${{ secrets.CODECOV_TOKEN }}
+          verbose: true
 
 
   python-e2e-tests:


### PR DESCRIPTION
### Description
Update pull request trigger to be "pull_request_target" which allows actions to access secrets needed for CODECOV_TOKEN.

Removed codecov retry since this was due to throttling when ran without tokens, the retry didn't help. Also added `verbose: true` to aid in any future debugging on codecov action.

See documentation: https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#workflows-in-forked-repositories

Note: This will make changes to GHA workflows slightly more complicated, the GHA on the PR will run with the upstream branch workflow definition when triggered on a PR from a forked repository (a security feature). Instead we can push updates to a branch to verify, or temporarily update pull_request_target -> pull_request in a staged commit which will run the forked actions without secrets.

### Testing
See GHA

Verified throttle limits aren't hit
* https://github.com/opensearch-project/opensearch-migrations/actions/runs/11810094397/job/32901507727

Verified PRs run with secrets:
* https://github.com/opensearch-project/opensearch-migrations/actions/runs/11810129776/job/32901596046?pr=1131

### Check List
- [x] New functionality includes testing
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
