### PR TITLE
Capture the created role arn for snapshotting into the AWS yaml parameter and pass it through the command line

### DIFF
--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/README.md
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/README.md
@@ -191,6 +191,7 @@ Exactly one of the following blocks must be present:
 - `s3`:
     - `repo_uri`: required, `s3://` path to where the snapshot repo exists or should be created (the bucket must already exist, and the repo needs to be configured on the source cluster)
     - `aws_region`: required, region for the s3 bucket
+    - `role`: optional, required for clusters managed by Amazon OpenSearch Service.  The IAM Role that is passed to the source cluster for the service to assume in order to work with the snapshot bucket.  
 
 - `fs`:
     - `repo_path`: required, path to where the repo exists or should be created on the filesystem (the repo needs to be configured on the source cluster).

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/snapshot.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/snapshot.py
@@ -23,6 +23,7 @@ SNAPSHOT_SCHEMA = {
                 'schema': {
                     'repo_uri': {'type': 'string', 'required': True},
                     'aws_region': {'type': 'string', 'required': True},
+                    'role': {'type': 'string', 'required': False}
                 }
             },
             'fs': {
@@ -109,6 +110,7 @@ class S3Snapshot(Snapshot):
         self.snapshot_name = config['snapshot_name']
         self.otel_endpoint = config.get("otel_endpoint", None)
         self.s3_repo_uri = config['s3']['repo_uri']
+        self.s3_role_arn = config['s3'].get('role')
         self.s3_region = config['s3']['aws_region']
 
     def create(self, *args, **kwargs) -> CommandResult:
@@ -131,6 +133,8 @@ class S3Snapshot(Snapshot):
             command_args["--no-wait"] = FlagOnlyArgument
         if max_snapshot_rate_mb_per_node is not None:
             command_args["--max-snapshot-rate-mb-per-node"] = max_snapshot_rate_mb_per_node
+        if self.s3_role_arn:
+            command_args["--s3-role-arn"] = self.s3_role_arn
         if extra_args:
             for arg in extra_args:
                 command_args[arg] = FlagOnlyArgument

--- a/deployment/cdk/opensearch-service-migration/lib/migration-services-yaml.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/migration-services-yaml.ts
@@ -83,6 +83,7 @@ export class FileSystemSnapshotYaml {
 export class S3SnapshotYaml {
     repo_uri = '';
     aws_region = '';
+    role? = '';
 }
 
 export class SnapshotYaml {

--- a/deployment/cdk/opensearch-service-migration/lib/service-stacks/migration-console-stack.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/service-stacks/migration-console-stack.ts
@@ -253,6 +253,35 @@ export class MigrationConsoleStack extends MigrationServiceCore {
             }
         }
 
+        const serviceTaskRole = new Role(this, 'MigrationServiceTaskRole', {
+            assumedBy: new ServicePrincipal('ecs-tasks.amazonaws.com'),
+            description: 'Role for Migration Console ECS Tasks',
+        });
+
+        const openSearchPolicy = createOpenSearchIAMAccessPolicy(this.partition, this.region, this.account)
+        const openSearchServerlessPolicy = createOpenSearchServerlessIAMAccessPolicy(this.partition, this.region, this.account)
+        let servicePolicies = [sharedLogFileSystem.asPolicyStatement(), openSearchPolicy, openSearchServerlessPolicy, ecsUpdateServicePolicy, clusterTasksPolicy,
+            listTasksPolicy, artifactS3PublishPolicy, describeVPCPolicy, getSSMParamsPolicy, getMetricsPolicy,
+            // only add secrets policies if they're non-null
+            ...(getTargetSecretsPolicy ? [getTargetSecretsPolicy] : []),
+            ...(getSourceSecretsPolicy ? [getSourceSecretsPolicy] : [])
+        ]
+
+        if (props.streamingSourceType === StreamingSourceType.AWS_MSK) {
+            const mskAdminPolicies = this.createMSKAdminIAMPolicies(props.stage, props.defaultDeployId)
+            servicePolicies = servicePolicies.concat(mskAdminPolicies)
+        }
+
+        if (props.managedServiceSourceSnapshotEnabled &&
+            servicesYaml.snapshot &&
+            servicesYaml.snapshot.s3) {
+            servicesYaml.snapshot.s3.role =
+                createSnapshotOnAOSRole(this, artifactS3Arn, serviceTaskRole.roleArn,
+                    this.region, props.stage, props.defaultDeployId)
+                    .roleArn;
+            // HOW DO I GET THIS servicesYaml into the parameter AND get the service created?
+        }
+
         const parameter = createMigrationStringParameter(this, servicesYaml.stringify(), {
             ...props,
             parameter: MigrationSSMParameter.SERVICES_YAML_FILE,
@@ -267,18 +296,6 @@ export class MigrationConsoleStack extends MigrationServiceCore {
             "SHARED_LOGS_DIR_PATH": `${sharedLogFileSystem.mountPointPath}/migration-console-${props.defaultDeployId}`,
         }
 
-        const openSearchPolicy = createOpenSearchIAMAccessPolicy(this.partition, this.region, this.account)
-        const openSearchServerlessPolicy = createOpenSearchServerlessIAMAccessPolicy(this.partition, this.region, this.account)
-        let servicePolicies = [sharedLogFileSystem.asPolicyStatement(), openSearchPolicy, openSearchServerlessPolicy, ecsUpdateServicePolicy, clusterTasksPolicy,
-            listTasksPolicy, artifactS3PublishPolicy, describeVPCPolicy, getSSMParamsPolicy, getMetricsPolicy,
-            // only add secrets policies if they're non-null
-            ...(getTargetSecretsPolicy ? [getTargetSecretsPolicy] : []),
-            ...(getSourceSecretsPolicy ? [getSourceSecretsPolicy] : [])
-        ]
-        if (props.streamingSourceType === StreamingSourceType.AWS_MSK) {
-            const mskAdminPolicies = this.createMSKAdminIAMPolicies(props.stage, props.defaultDeployId)
-            servicePolicies = servicePolicies.concat(mskAdminPolicies)
-        }
 
         if (props.migrationAPIEnabled) {
             servicePortMappings = [{
@@ -319,16 +336,13 @@ export class MigrationConsoleStack extends MigrationServiceCore {
             volumes: [sharedLogFileSystem.asVolume()],
             mountPoints: [sharedLogFileSystem.asMountPoint()],
             environment: environment,
+            taskRole: serviceTaskRole,
             taskRolePolicies: servicePolicies,
             cpuArchitecture: props.fargateCpuArch,
             taskCpuUnits: 1024,
             taskMemoryLimitMiB: 2048,
             ...props
         });
-
-        if (props.managedServiceSourceSnapshotEnabled) {
-            createSnapshotOnAOSRole(this, artifactS3Arn, this.serviceTaskRole.roleArn, this.region, props.stage, props.defaultDeployId);
-        }
     }
 
 }

--- a/deployment/cdk/opensearch-service-migration/lib/service-stacks/migration-console-stack.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/service-stacks/migration-console-stack.ts
@@ -279,7 +279,6 @@ export class MigrationConsoleStack extends MigrationServiceCore {
                 createSnapshotOnAOSRole(this, artifactS3Arn, serviceTaskRole.roleArn,
                     this.region, props.stage, props.defaultDeployId)
                     .roleArn;
-            // HOW DO I GET THIS servicesYaml into the parameter AND get the service created?
         }
 
         const parameter = createMigrationStringParameter(this, servicesYaml.stringify(), {

--- a/deployment/cdk/opensearch-service-migration/lib/service-stacks/migration-service-core.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/service-stacks/migration-service-core.ts
@@ -30,6 +30,7 @@ export interface MigrationServiceCoreProps extends StackPropsExt {
     readonly cpuArchitecture: CpuArchitecture,
     readonly dockerImageName: string,
     readonly dockerImageCommand?: string[],
+    readonly taskRole?: Role,
     readonly taskRolePolicies?: PolicyStatement[],
     readonly mountPoints?: MountPoint[],
     readonly volumes?: Volume[],
@@ -56,7 +57,7 @@ export class MigrationServiceCore extends Stack {
             vpc: props.vpc
         })
 
-        this.serviceTaskRole = createDefaultECSTaskRole(this, props.serviceName)
+        this.serviceTaskRole = props.taskRole ? props.taskRole : createDefaultECSTaskRole(this, props.serviceName)
         props.taskRolePolicies?.forEach(policy => this.serviceTaskRole.addToPolicy(policy))
 
         const serviceTaskDef = new FargateTaskDefinition(this, "ServiceTaskDef", {


### PR DESCRIPTION
### Description
Specifying 'managedServiceSourceSnapshotEnabled' in the cdk.context.json will now not just create the role for making a snapshot to s3, but it will add it to the services yaml file and the console will thread that through to the command line for snapshot create so that users don't have to.

* Category Enhancement

### Issues Resolved
https://opensearch.atlassian.net/browse/MIGRATIONS-2001

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
Manual deployments w/ and without the cdk.context.json value and w/ and w/out the value in migration_services.yaml

### Check List
- [ ] New functionality includes testing
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
