### PR TITLE
Split codecov upload to separate github actions workflow

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -242,7 +242,8 @@ jobs:
       - link-checker
       - node-tests
       - python-e2e-tests
-      - python-lint
+#      Temp disable linting from blocking
+#      - python-lint
       - style-check
     if: always()
     runs-on: ubuntu-latest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -133,7 +133,7 @@ jobs:
         with:
           if-no-files-found: error
           name: coverage-reports-gradle-tests
-          path: /**/jacocoMergedReport.xml
+          path: ./**/jacocoMergedReport.xml
 
 
   python-e2e-tests:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-  pull_request_target:
+  pull_request:
 
 env:
   python-version: '3.11'
@@ -42,17 +42,20 @@ jobs:
        run: |
         flake8 $(git ls-files '*.py')
 
-  python-tests:
+  console-python-tests:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         py-project:
-          - ./TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link
-          - ./TrafficCapture/dockerSolution/src/main/docker/migrationConsole/cluster_tools
+          - lib/console_link
+          - cluster_tools
+          - console_api
+    env:
+      WORKING_DIR: ./TrafficCapture/dockerSolution/src/main/docker/migrationConsole/${{ matrix.py-project }}
     defaults:
       run:
-        working-directory: ${{ matrix.py-project }}
+        working-directory: ${{ env.WORKING_DIR }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -63,38 +66,36 @@ jobs:
           pipenv install --deploy --dev
           pipenv run test
           pipenv run coverage xml
-      - name: Upload Coverage
-        uses: codecov/codecov-action@v4
+      - name: Get Sanitized Name
+        env:
+          PY_PROJECT: ${{ matrix.py-project }}
+        run: echo "SANITIZED_PY_PROJECT=${PY_PROJECT/\//-}" >> $GITHUB_ENV
+      - name: Upload Coverage Reports
+        uses: actions/upload-artifact@v4
         with:
-          fail_ci_if_error: true
-          files: ./coverage.xml
-          flags: python-test
-          token: ${{ secrets.CODECOV_TOKEN }}
-          verbose: true
+          if-no-files-found: error
+          name: coverage-reports-python-tests-${{ env.SANITIZED_PY_PROJECT }}
+          path: ${{ env.WORKING_DIR }}/coverage.xml
 
-  console-api-tests:
+  upload-codecov-info:
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ./TrafficCapture/dockerSolution/src/main/docker/migrationConsole/console_api
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - name: Create JSON Artifact
+        run: |
+          echo '{' > codecov_info.json
+          echo '  "pr_number": "${{ github.event.pull_request.number }}",' >> codecov_info.json
+          echo '  "commit": "${{ github.event.pull_request.head.sha || github.event.after || github.sha }}",' >> codecov_info.json
+          echo '  "branch": "${{ github.ref }}",' >> codecov_info.json
+          echo '  "commit_parent": "${{ github.event.pull_request.base.sha || github.event.before || github.base.sha }}",' >> codecov_info.json
+          echo '  "build_url": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}",' >> codecov_info.json
+          echo '  "build": "${{ github.run_id }}"' >> codecov_info.json
+          echo '}' >> codecov_info.json
+          echo "codecov_info.json created"
+      - name: Upload JSON Artifact
+        uses: actions/upload-artifact@v4
         with:
-          python-version: ${{ env.python-version }}
-      - run: |
-          python3 -m pip install --upgrade pipenv
-          pipenv install --deploy --dev
-          pipenv run coverage run --source='.' manage.py test console_api
-          pipenv run coverage xml
-      - name: Upload Coverage
-        uses: codecov/codecov-action@v4
-        with:
-          fail_ci_if_error: true
-          files: ./coverage.xml
-          flags: python-test
-          token: ${{ secrets.CODECOV_TOKEN }}
-          verbose: true
+          name: codecov-info
+          path: codecov_info.json
 
 
   gradle-tests:
@@ -122,19 +123,16 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: test-reports
+          name: test-reports-gradle-tests
           path: |
             **/build/reports/tests/
             **/reports/jacoco/mergedReport/
-      - name: Upload Coverage
-        uses: codecov/codecov-action@v4
+      - name: Upload Coverage Reports
+        uses: actions/upload-artifact@v4
         with:
-          disable_search: true
-          fail_ci_if_error: true
-          files: ${{ github.workspace }}/build/reports/jacoco/mergedReport/jacocoMergedReport.xml
-          flags: gradle-test
-          token: ${{ secrets.CODECOV_TOKEN }}
-          verbose: true
+          if-no-files-found: error
+          name: coverage-reports-gradle-tests
+          path: /**/jacocoMergedReport.xml
 
 
   python-e2e-tests:
@@ -236,15 +234,16 @@ jobs:
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
+
   all-ci-checks-pass:
     needs:
-      - style-check
-      - node-tests
+      - console-python-tests
       - gradle-tests
       - link-checker
+      - node-tests
       - python-e2e-tests
       - python-lint
-      - python-tests
+      - style-check
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -11,6 +11,27 @@ env:
   node-version: '18.x'
 
 jobs:
+  workflow-info:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create JSON Artifact
+        run: |
+          echo '{' > workflow-info.json
+          echo '  "pr_number": "${{ github.event.pull_request.number }}",' >> workflow-info.json
+          echo '  "commit": "${{ github.event.pull_request.head.sha || github.event.after || github.sha }}",' >> workflow-info.json
+          echo '  "branch": "${{ github.ref }}",' >> workflow-info.json
+          echo '  "commit_parent": "${{ github.event.pull_request.base.sha || github.event.before || github.base.sha }}",' >> workflow-info.json
+          echo '  "build_url": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}",' >> workflow-info.json
+          echo '  "build": "${{ github.run_id }}"' >> workflow-info.json
+          echo '}' >> workflow-info.json
+          echo "workflow-info.json created"
+      - name: Upload JSON Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: workflow-info
+          path: workflow-info.json
+
+
   style-check:
     runs-on: ubuntu-latest
     steps:
@@ -76,26 +97,6 @@ jobs:
           if-no-files-found: error
           name: coverage-reports-python-tests-${{ env.SANITIZED_PY_PROJECT }}
           path: ${{ env.WORKING_DIR }}/coverage.xml
-
-  upload-codecov-info:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Create JSON Artifact
-        run: |
-          echo '{' > codecov_info.json
-          echo '  "pr_number": "${{ github.event.pull_request.number }}",' >> codecov_info.json
-          echo '  "commit": "${{ github.event.pull_request.head.sha || github.event.after || github.sha }}",' >> codecov_info.json
-          echo '  "branch": "${{ github.ref }}",' >> codecov_info.json
-          echo '  "commit_parent": "${{ github.event.pull_request.base.sha || github.event.before || github.base.sha }}",' >> codecov_info.json
-          echo '  "build_url": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}",' >> codecov_info.json
-          echo '  "build": "${{ github.run_id }}"' >> codecov_info.json
-          echo '}' >> codecov_info.json
-          echo "codecov_info.json created"
-      - name: Upload JSON Artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: codecov-info
-          path: codecov_info.json
 
 
   gradle-tests:

--- a/.github/workflows/codecov-publish.yml
+++ b/.github/workflows/codecov-publish.yml
@@ -1,0 +1,56 @@
+name: Codecov Publish
+
+# Due to the behavior of workflow_run, changes to this file will
+# only be reflected once it is pushed up to the `default` (main) branch
+#
+# It is recommended to test changes to this file by pushing to the default branch
+# on a fork and evaluating the correctness of the action execution
+
+on:
+  workflow_run:
+    workflows: [CI]
+    types:
+      - completed
+
+jobs:
+  publish-codecov:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download CodeCov Info
+        uses: actions/download-artifact@v4
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          name: codecov-info
+          run-id: ${{ github.event.workflow_run.id }}
+      - name: Set Environment Variables from JSON
+        run: |
+          ls
+          # Read the JSON file and export each key-value pair as an environment variable
+          for key in $(jq -r 'keys[]' ./codecov_info.json); do
+            value=$(jq -r --arg key "$key" '.[$key]' ./codecov_info.json)
+            echo "codecov_info_$key=$value"
+            echo "codecov_info_$key=$value" >> $GITHUB_ENV
+          done
+      - name: Download Coverage Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path: ./coverage-reports
+          pattern: coverage-reports-*
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Upload coverage report
+        uses: codecov/codecov-action@v4
+        with:
+          fail_ci_if_error: true
+          files: /**/coverage-reports/**/*.*
+          flags: unittests
+          override_branch: ${{ env.codecov_info_branch }}
+          override_commit: ${{ env.codecov_info_commit }}
+          override_pr: ${{ env.codecov_info_pr_number }}
+          commit_parent: ${{ env.codecov_info_commit_parent }}
+          override_build_url: ${{ env.codecov_info_build_url }}
+          override_build:  ${{ env.codecov_info_build }}
+          token: ${{ secrets.CODECOV_TOKEN }}
+          verbose: true

--- a/.github/workflows/codecov-publish.yml
+++ b/.github/workflows/codecov-publish.yml
@@ -17,25 +17,23 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     steps:
-      - name: Download CodeCov Info
+      - name: Download Workflow Info
         uses: actions/download-artifact@v4
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          name: codecov-info
+          name: workflow-info
           run-id: ${{ github.event.workflow_run.id }}
       - name: Set Environment Variables from JSON
         run: |
           ls
           # Read the JSON file and export each key-value pair as an environment variable
-          for key in $(jq -r 'keys[]' ./codecov_info.json); do
-            value=$(jq -r --arg key "$key" '.[$key]' ./codecov_info.json)
-            echo "codecov_info_$key=$value"
-            echo "codecov_info_$key=$value" >> $GITHUB_ENV
+          for key in $(jq -r 'keys[]' ./workflow-info.json); do
+            value=$(jq -r --arg key "$key" '.[$key]' ./workflow-info.json)
+            echo "workflow-info_$key=$value"
+            echo "workflow-info_$key=$value" >> $GITHUB_ENV
           done
       - name: Download Coverage Artifacts
         uses: actions/download-artifact@v4
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
           path: ./coverage-reports
           pattern: coverage-reports-*
           run-id: ${{ github.event.workflow_run.id }}
@@ -46,11 +44,11 @@ jobs:
           fail_ci_if_error: true
           files: /**/coverage-reports/**/*.*
           flags: unittests
-          override_branch: ${{ env.codecov_info_branch }}
-          override_commit: ${{ env.codecov_info_commit }}
-          override_pr: ${{ env.codecov_info_pr_number }}
-          commit_parent: ${{ env.codecov_info_commit_parent }}
-          override_build_url: ${{ env.codecov_info_build_url }}
-          override_build:  ${{ env.codecov_info_build }}
+          override_branch: ${{ env.workflow-info_branch }}
+          override_commit: ${{ env.workflow-info_commit }}
+          override_pr: ${{ env.workflow-info_pr_number }}
+          commit_parent: ${{ env.workflow-info_commit_parent }}
+          override_build_url: ${{ env.workflow-info_build_url }}
+          override_build:  ${{ env.workflow-info_build }}
           token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/console_api/Pipfile
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/console_api/Pipfile
@@ -19,3 +19,7 @@ moto = {version = "*", extras = ["sts"]}
 
 [requires]
 python_version = "3.11"
+
+[scripts]
+test = "coverage run --source='.' manage.py test console_api"
+coverage = "coverage"


### PR DESCRIPTION
### Description
Split codecov upload to separate github actions workflow.

This enables making the CI workflow trigger on `pull_request` as it will not need secret access making modifications much easier.

* Category: Enhancement
* Why these changes are required? Changes to the CI workflow are common to unblock the pipeline and it can impede PRs to make it pull_request_target
* What is the old behavior before changes and new behavior after changes?

### Issues Resolved
[List any issues this PR will resolve]

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
Lots of testing on my fork with push, pr, and pr from a fork.
E.g.: https://github.com/AndreKurait/opensearch-migrations/pull/7

### Check List
- [x] New functionality includes testing
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
