### PR TITLE
Added initial CloudWatch Dashboard for RFS

### DIFF
--- a/deployment/cdk/opensearch-service-migration/lib/components/reindex-from-snapshot-dashboard.json
+++ b/deployment/cdk/opensearch-service-migration/lib/components/reindex-from-snapshot-dashboard.json
@@ -1,0 +1,292 @@
+{
+    "variables": [
+        {
+            "type": "property",
+            "property": "region",
+            "inputType": "input",
+            "id": "REGION",
+            "label": "Region",
+            "defaultValue": "us-east-1",
+            "visible": false
+        },
+        {
+            "type": "property",
+            "property": "DomainName",
+            "inputType": "input",
+            "id": "TC_DOMAIN_NAME",
+            "label": "Target Cluster Domain Name",
+            "defaultValue": "placeholder-name",
+            "visible": true
+        },
+        {
+            "type": "pattern",
+            "pattern": "MA_STAGE",
+            "inputType": "input",
+            "id": "MA_STAGE",
+            "label": "Migration Assistant Stage",
+            "defaultValue": "placeholder-stage",
+            "visible": false
+        },
+        {
+            "type": "pattern",
+            "pattern": "ACCOUNT_ID",
+            "inputType": "input",
+            "id": "ACCOUNT_ID",
+            "label": "ACCOUNT_ID",
+            "defaultValue": "ACCOUNT_ID",
+            "visible": false
+        }
+    ],
+    "widgets": [
+        {
+            "height": 1,
+            "width": 24,
+            "y": 0,
+            "x": 0,
+            "type": "text",
+            "properties": {
+                "markdown": "# Target Cluster\n",
+                "background": "transparent"
+            }
+        },
+        {
+            "height": 8,
+            "width": 12,
+            "y": 1,
+            "x": 0,
+            "type": "metric",
+            "properties": {
+                "view": "timeSeries",
+                "stacked": false,
+                "metrics": [
+                    [ { "expression": "METRICS()/1000", "id": "e1", "region": "REGION" } ],
+                    [ "AWS/ES", "IndexingRate", "DomainName", "TC_DOMAIN_NAME", "ClientId", "ACCOUNT_ID", { "region": "region", "label": "Document Ingested per 60 seconds - MIN: ${MIN}, MAX: ${MAX}, AVG: ${AVG}", "id": "m1", "visible": false } ]
+                ],
+                "region": "REGION",
+                "title": "Target Cluster Document Index Rate",
+                "yAxis": {
+                    "left": {
+                        "label": "Thousands",
+                        "showUnits": false
+                    }
+                },
+                "period": 60,
+                "stat": "Sum"
+            }
+        },
+        {
+            "height": 8,
+            "width": 12,
+            "y": 1,
+            "x": 12,
+            "type": "metric",
+            "properties": {
+                "metrics": [
+                    [ { "expression": "METRICS()/1000", "id": "e1", "region": "REGION" } ],
+                    [ "AWS/ES", "SearchableDocuments", "DomainName", "TC_DOMAIN_NAME", "ClientId", "ACCOUNT_ID", { "region": "REGION", "label": "SearchableDocuments - MIN: ${MIN}, MAX ${MAX}", "id": "m1", "visible": false } ]
+                ],
+                "view": "timeSeries",
+                "stacked": false,
+                "region": "REGION",
+                "title": "Target Cluster SearchableDocuments",
+                "period": 60,
+                "stat": "Average",
+                "yAxis": {
+                    "left": {
+                        "label": "Thousands",
+                        "showUnits": false
+                    }
+                }
+            }
+        },
+                {
+            "height": 8,
+            "width": 12,
+            "y": 9,
+            "x": 0,
+            "type": "metric",
+            "properties": {
+                "metrics": [
+                    [ "AWS/ES", "4xx", "DomainName", "TC_DOMAIN_NAME", "ClientId", "ACCOUNT_ID", { "region": "REGION", "label": "4xx - ${SUM}" } ],
+                    [ ".", "3xx", ".", ".", ".", ".", { "region": "REGION", "label": "3xx - ${SUM}" } ],
+                    [ ".", "2xx", ".", ".", ".", ".", { "region": "REGION", "label": "2xx - ${SUM}" } ],
+                    [ ".", "5xx", ".", ".", ".", ".", { "region": "REGION", "label": "5xx - ${SUM}" } ]
+                ],
+                "view": "timeSeries",
+                "stacked": false,
+                "region": "REGION",
+                "stat": "Sum",
+                "period": 300,
+                "title": "Target Cluster Status Codes (per 5 minutes)"
+            }
+        },
+        {
+            "height": 8,
+            "width": 12,
+            "y": 9,
+            "x": 12,
+            "type": "metric",
+            "properties": {
+                "metrics": [
+                    [ "AWS/ES", "CPUUtilization", "DomainName", "TC_DOMAIN_NAME", "ClientId", "ACCOUNT_ID", { "stat": "Minimum", "label": "Min Data Node CPU Utilization", "color": "#2ca02c", "region": "REGION" } ],
+                    [ "...", { "stat": "Maximum", "label": "Max Data Node CPU Utilization", "color": "#d62728", "region": "REGION" } ],
+                    [ "...", { "stat": "Average", "label": "Avg Data Node CPU Utilization", "color": "#1f77b4", "region": "REGION" } ],
+                    [ "AWS/ES", "MasterCPUUtilization", "DomainName", "TC_DOMAIN_NAME", "ClientId", "ACCOUNT_ID", { "stat": "Minimum", "label": "Min Master Node CPU Utilization", "color": "#98df8a", "region": "REGION" } ],
+                    [ "...", { "stat": "Maximum", "label": "Max Master Node CPU Utilization", "color": "#ff9896", "region": "REGION" } ],
+                    [ "...", { "stat": "Average", "label": "Avg Master Node CPU Utilization", "color": "#ff7f0e", "region": "REGION" } ]
+                ],
+                "view": "timeSeries",
+                "stacked": false,
+                "region": "REGION",
+                "title": "Target Cluster CPU Utilization by Node",
+                "period": 60,
+                "yAxis": {
+                    "left": {
+                        "label": "CPU Utilization (%)",
+                        "min": 0,
+                        "max": 100,
+                        "showUnits": false
+                    }
+                },
+                "legend": {
+                    "position": "bottom"
+                }
+            }
+        },
+        {
+            "height": 8,
+            "width": 12,
+            "y": 17,
+            "x": 0,
+            "type": "metric",
+            "properties": {
+                "metrics": [
+                    [ { "expression": "METRICS()/1000", "label": "", "id": "e1", "region": "REGION" } ],
+                    [ "AWS/ES", "ClusterUsedSpace", "DomainName", "TC_DOMAIN_NAME", "ClientId", "ACCOUNT_ID", { "id": "m1", "visible": false, "period": 60, "region": "REGION" } ]
+                ],
+                "view": "timeSeries",
+                "stacked": false,
+                "region": "REGION",
+                "title": "Target Cluster Used Space",
+                "period": 60,
+                "stat": "Average",
+                "yAxis": {
+                    "left": {
+                        "label": "GB",
+                        "showUnits": false
+                    }
+                }
+            }
+        },
+        {
+            "height": 8,
+            "width": 12,
+            "y": 17,
+            "x": 12,
+            "type": "metric",
+            "properties": {
+                "metrics": [
+                    [ "AWS/ES", "ThroughputThrottle", "DomainName", "TC_DOMAIN_NAME", "ClientId", "ACCOUNT_ID", { "id": "m1", "period": 60, "region": "REGION" } ],
+                    [ ".", "IopsThrottle", ".", ".", ".", ".", { "period": 60, "region": "REGION", "id": "m2" } ]
+                ],
+                "view": "timeSeries",
+                "stacked": false,
+                "region": "REGION",
+                "title": "Target Cluster EBS Throttling",
+                "period": 60,
+                "stat": "Average"
+            }
+        },
+        {
+            "height": 1,
+            "width": 24,
+            "y": 25,
+            "x": 0,
+            "type": "text",
+            "properties": {
+                "markdown": "# Reindex-From-Snapshot Workers",
+                "background": "transparent"
+            }
+        },
+        {
+            "height": 8,
+            "width": 12,
+            "y": 26,
+            "x": 0,
+            "type": "metric",
+            "properties": {
+                "metrics": [
+                    [ "OpenSearchMigrations", "bytesSent", "OTelLib", "documentMigration", { "region": "REGION", "label": "Bytes Sent - MIN - ${MIN}, MAX - ${MAX}, AVG - ${AVG}" } ]
+                ],
+                "period": 60,
+                "region": "REGION",
+                "stacked": false,
+                "title": "RFS Reindexing Traffic",
+                "view": "timeSeries",
+                "stat": "Sum",
+                "yAxis": {
+                    "left": {
+                        "label": "Bytes",
+                        "showUnits": false
+                    }
+                }
+            }
+        },
+        {
+            "height": 8,
+            "width": 12,
+            "y": 26,
+            "x": 12,
+            "type": "metric",
+            "properties": {
+                "metrics": [
+                    [ "AWS/ECS", "CPUUtilization", "ServiceName", "migration-MA_STAGE-reindex-from-snapshot", "ClusterName", "migration-MA_STAGE-ecs-cluster", { "region": "REGION", "label": "RFS Workers - MIN - ${MIN}, MAX - ${MAX}, AVG - ${AVG}" } ]
+                ],
+                "period": 60,
+                "region": "REGION",
+                "stacked": false,
+                "title": "RFS Workers Reporting in During Period",
+                "view": "timeSeries",
+                "stat": "SampleCount"
+            }
+        },
+        {
+            "height": 8,
+            "width": 12,
+            "y": 34,
+            "x": 0,
+            "type": "metric",
+            "properties": {
+                "metrics": [
+                    [ "AWS/ECS", "CPUUtilization", "ServiceName", "migration-MA_STAGE-reindex-from-snapshot", "ClusterName", "migration-MA_STAGE-ecs-cluster", { "stat": "Minimum", "region": "REGION", "color": "#2ca02c" } ],
+                    [ "...", { "stat": "Average", "region": "REGION", "color": "#1f77b4" } ],
+                    [ "...", { "stat": "Maximum", "region": "REGION", "color": "#d62728" } ]
+                ],
+                "period": 60,
+                "region": "REGION",
+                "stacked": false,
+                "title": "RFS CPU utilization",
+                "view": "timeSeries"
+            }
+        },
+        {
+            "height": 8,
+            "width": 12,
+            "y": 34,
+            "x": 12,
+            "type": "metric",
+            "properties": {
+                "metrics": [
+                    [ "AWS/ECS", "MemoryUtilization", "ServiceName", "migration-MA_STAGE-reindex-from-snapshot", "ClusterName", "migration-MA_STAGE-ecs-cluster", { "stat": "Minimum", "region": "REGION", "color": "#2ca02c" } ],
+                    [ "...", { "stat": "Average", "region": "REGION", "color": "#1f77b4" } ],
+                    [ "...", { "stat": "Maximum", "region": "REGION", "color": "#d62728" } ]
+                ],
+                "period": 60,
+                "region": "REGION",
+                "stacked": false,
+                "title": "RFS Memory utilization",
+                "view": "timeSeries"
+            }
+        }
+    ]
+}

--- a/deployment/cdk/opensearch-service-migration/lib/components/reindex-from-snapshot-dashboard.json
+++ b/deployment/cdk/opensearch-service-migration/lib/components/reindex-from-snapshot-dashboard.json
@@ -12,9 +12,11 @@
         {
             "type": "property",
             "property": "DomainName",
-            "inputType": "input",
+            "inputType": "select",
             "id": "TC_DOMAIN_NAME",
             "label": "Target Cluster Domain Name",
+            "search": "{AWS/ES,ClientId,DomainName} MetricName=\"CPUUtilization\"",
+            "populateFrom": "DomainName",
             "defaultValue": "placeholder-name",
             "visible": true
         },

--- a/deployment/cdk/opensearch-service-migration/lib/components/reindex-from-snapshot-dashboard.json
+++ b/deployment/cdk/opensearch-service-migration/lib/components/reindex-from-snapshot-dashboard.json
@@ -61,8 +61,8 @@
                 "view": "timeSeries",
                 "stacked": false,
                 "metrics": [
-                    [ { "expression": "METRICS()/1000", "id": "e1", "region": "REGION" } ],
-                    [ "AWS/ES", "IndexingRate", "DomainName", "TC_DOMAIN_NAME", "ClientId", "ACCOUNT_ID", { "region": "region", "label": "Document Ingested per 60 seconds - MIN: ${MIN}, MAX: ${MAX}, AVG: ${AVG}", "id": "m1", "visible": false } ]
+                    [ { "expression": "METRICS()/1000/PERIOD(m1)*60", "id": "e1", "region": "REGION" } ],
+                    [ "AWS/ES", "IndexingRate", "DomainName", "TC_DOMAIN_NAME", "ClientId", "ACCOUNT_ID", { "region": "region", "label": "Document Ingested (included replicas) - MIN: ${MIN}, MAX: ${MAX}, AVG: ${AVG}", "id": "m1", "visible": false } ]
                 ],
                 "region": "REGION",
                 "title": "Target Cluster Document Index Rate",
@@ -248,7 +248,7 @@
                 "period": 60,
                 "region": "REGION",
                 "stacked": false,
-                "title": "RFS Workers Reporting in During Period",
+                "title": "RFS Workers Reporting In",
                 "view": "timeSeries",
                 "stat": "SampleCount"
             }

--- a/deployment/cdk/opensearch-service-migration/lib/components/reindex-from-snapshot-dashboard.json
+++ b/deployment/cdk/opensearch-service-migration/lib/components/reindex-from-snapshot-dashboard.json
@@ -32,7 +32,7 @@
             "pattern": "ACCOUNT_ID",
             "inputType": "input",
             "id": "ACCOUNT_ID",
-            "label": "ACCOUNT_ID",
+            "label": "Account ID",
             "defaultValue": "ACCOUNT_ID",
             "visible": false
         }
@@ -99,7 +99,7 @@
                 }
             }
         },
-                {
+        {
             "height": 8,
             "width": 12,
             "y": 9,

--- a/deployment/cdk/opensearch-service-migration/lib/components/reindex-from-snapshot-dashboard.json
+++ b/deployment/cdk/opensearch-service-migration/lib/components/reindex-from-snapshot-dashboard.json
@@ -240,7 +240,8 @@
             "type": "metric",
             "properties": {
                 "metrics": [
-                    [ "AWS/ECS", "CPUUtilization", "ServiceName", "migration-MA_STAGE-reindex-from-snapshot", "ClusterName", "migration-MA_STAGE-ecs-cluster", { "region": "REGION", "label": "RFS Workers - MIN - ${MIN}, MAX - ${MAX}, AVG - ${AVG}" } ]
+                    [ { "expression": "METRICS()/PERIOD(m1)*60", "id" : "e1", "region": "REGION" } ],
+                    [ "AWS/ECS", "CPUUtilization", "ServiceName", "migration-MA_STAGE-reindex-from-snapshot", "ClusterName", "migration-MA_STAGE-ecs-cluster", { "region": "REGION", "label": "RFS Workers - MIN - ${MIN}, MAX - ${MAX}, AVG - ${AVG}", "id": "m1", "visible": false } ]
                 ],
                 "period": 60,
                 "region": "REGION",

--- a/deployment/cdk/opensearch-service-migration/lib/service-stacks/reindex-from-snapshot-stack.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/service-stacks/reindex-from-snapshot-stack.ts
@@ -25,29 +25,41 @@ import { CfnDashboard } from "aws-cdk-lib/aws-cloudwatch";
 import * as rfsDashboard from '../components/reindex-from-snapshot-dashboard.json';
 
 
-function setDefaultValueForVariable(variables: any[], variableName: string, defaultValue: string): any[] {
-    for (let i = 0; i < variables.length; i++) {
-        if (variables[i].id === variableName) {
-            variables[i].defaultValue = defaultValue;
-            console.log(`changing ${variables[i].defaultValue} to ${defaultValue}`)
-            break;
-        }
-    }
-    console.log(`returning ${JSON.stringify(variables)}`);
-    return variables;
-}
-function setAccountIdForDashboard(dashboardBody: any, account: string): any {
-    dashboardBody.variables = setDefaultValueForVariable(dashboardBody.variables, 'ACCOUNT_ID', account)
-    return dashboardBody;
-}
-function setRegionForDashboard(dashboardBody: any, region: string): any {
-    dashboardBody.variables = setDefaultValueForVariable(dashboardBody.variables, 'REGION', region)
-    return dashboardBody;
-}
-function setStageForDashboard(dashboardBody: any, stage: string): any {
-    dashboardBody.variables = setDefaultValueForVariable(dashboardBody.variables, 'MA_STAGE', stage)
-    return dashboardBody;
-}
+interface DashboardVariable {
+    id: string;
+    defaultValue: string;
+  }
+  
+  function setDefaultValueForVariable(variables: DashboardVariable[], variableName: string, defaultValue: string): DashboardVariable[] {
+      for (const variable of variables) {
+          if (variable.id === variableName) {
+              variable.defaultValue = defaultValue;
+              console.log(`changing ${variable.defaultValue} to ${defaultValue}`);
+              break;
+          }
+      }
+      console.log(`returning ${JSON.stringify(variables)}`);
+      return variables;
+  }
+  
+  interface DashboardBody {
+    variables: DashboardVariable[];
+  }
+  
+  function setAccountIdForDashboard(dashboardBody: DashboardBody, account: string): DashboardBody {
+      dashboardBody.variables = setDefaultValueForVariable(dashboardBody.variables, 'ACCOUNT_ID', account);
+      return dashboardBody;
+  }
+  
+  function setRegionForDashboard(dashboardBody: DashboardBody, region: string): DashboardBody {
+      dashboardBody.variables = setDefaultValueForVariable(dashboardBody.variables, 'REGION', region);
+      return dashboardBody;
+  }
+  
+  function setStageForDashboard(dashboardBody: DashboardBody, stage: string): DashboardBody {
+      dashboardBody.variables = setDefaultValueForVariable(dashboardBody.variables, 'MA_STAGE', stage);
+      return dashboardBody;
+  }
 
 export interface ReindexFromSnapshotProps extends StackPropsExt {
     readonly vpc: IVpc,

--- a/deployment/cdk/opensearch-service-migration/lib/service-stacks/reindex-from-snapshot-stack.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/service-stacks/reindex-from-snapshot-stack.ts
@@ -34,11 +34,9 @@ interface DashboardVariable {
       for (const variable of variables) {
           if (variable.id === variableName) {
               variable.defaultValue = defaultValue;
-              console.log(`changing ${variable.defaultValue} to ${defaultValue}`);
               break;
           }
       }
-      console.log(`returning ${JSON.stringify(variables)}`);
       return variables;
   }
   


### PR DESCRIPTION
### Description
* Added a CloudWatch Dashboard for RFS that gets created when the RFS feature is enabled
* The Target Cluster section relies on having metrics provided by an Amazon OpenSearch Service domain to populate.  Additionally, the user must supply the name of their domain in the Dashboard.
* One quirk is the mechanic we're using to represent how many "active" RFS Workers there are.  We don't have a good way to represent the number of \*desired\* workers in a steady-state sense, so what we do is effectively report how many RFS Workers were alive in a given period by counting the number of separate instances of a CPU metric for our ECS containers.  During steady-state operation, we'd expect the metric in that graph to resemble closely the user's desired worker count.  However, if the workers are dying frequently (such as if there's no work), then new workers will be constantly popping up, reporting in, and dying.  Each such worker adds a new entry to this sample count, and so the number skews higher than the desired number.

### Issues Resolved
* https://opensearch.atlassian.net/browse/MIGRATIONS-2132

### Testing
* Created the dashboard in my account and used to visualize a few simple migrations:

![Screenshot 2024-11-19 at 9 13 26 AM](https://github.com/user-attachments/assets/770f54b1-0638-40ba-9771-034adac272aa)

![Screenshot 2024-11-19 at 9 13 42 AM](https://github.com/user-attachments/assets/0e3becb7-54b6-428f-93e6-13856647cc8c)

### Check List
- [ ] New functionality includes testing
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
