### PR TITLE
Add metadata transformations with metadata tuples

### DIFF
--- a/MetadataMigration/build.gradle
+++ b/MetadataMigration/build.gradle
@@ -11,6 +11,7 @@ dependencies {
     implementation project(":coreUtilities")
     implementation project(":RFS")
     implementation project(':transformation')
+    implementation project(':transformation:transformationPlugins:jsonMessageTransformers:jsonMessageTransformerLoaders')
 
     implementation group: 'org.jcommander', name: 'jcommander'
     implementation group: 'org.slf4j', name: 'slf4j-api'

--- a/MetadataMigration/src/main/java/org/opensearch/migrations/MigrateOrEvaluateArgs.java
+++ b/MetadataMigration/src/main/java/org/opensearch/migrations/MigrateOrEvaluateArgs.java
@@ -56,7 +56,7 @@ public class MigrateOrEvaluateArgs {
     public Version sourceVersion = null;
 
     @ParametersDelegate
-    public MetadataTransformerParams metadataTransformationParams = new MetadataTransformerParams();
+    public TransformerParams metadataTransformationParams = new MetadataTransformerParams();
 
     @Getter
     public static class MetadataTransformerParams implements TransformerParams {

--- a/MetadataMigration/src/main/java/org/opensearch/migrations/MigrateOrEvaluateArgs.java
+++ b/MetadataMigration/src/main/java/org/opensearch/migrations/MigrateOrEvaluateArgs.java
@@ -4,9 +4,11 @@ package org.opensearch.migrations;
 
 import org.opensearch.migrations.bulkload.common.http.ConnectionContext;
 import org.opensearch.migrations.bulkload.models.DataFilterArgs;
+import org.opensearch.migrations.transform.TransformerParams;
 
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.ParametersDelegate;
+import lombok.Getter;
 
 public class MigrateOrEvaluateArgs {
     @Parameter(names = {"--help", "-h"}, help = true, description = "Displays information about how to use this tool")
@@ -52,4 +54,39 @@ public class MigrateOrEvaluateArgs {
 
     @Parameter(names = {"--source-version" }, description = "Version of the source cluster, for example: Elasticsearch 7.10 or OS 1.3.", converter = VersionConverter.class)
     public Version sourceVersion = null;
+
+    @ParametersDelegate
+    public MetadataTransformerParams metadataTransformationParams = new MetadataTransformerParams();
+
+    @Getter
+    public static class MetadataTransformerParams implements TransformerParams {
+        public String getTransformerConfigParameterArgPrefix() {
+            return "";
+        }
+        @Parameter(
+                required = false,
+                names = "--transformer-config-base64",
+                arity = 1,
+                description = "Configuration of metadata transformers.  The same contents as --transformer-config but " +
+                        "Base64 encoded so that the configuration is easier to pass as a command line parameter.")
+        private String transformerConfigEncoded;
+
+        @Parameter(
+                required = false,
+                names = "--transformer-config",
+                arity = 1,
+                description = "Configuration of metadata transformers.  Either as a string that identifies the "
+                        + "transformer that should be run (with default settings) or as json to specify options "
+                        + "as well as multiple transformers to run in sequence.  "
+                        + "For json, keys are the (simple) names of the loaded transformers and values are the "
+                        + "configuration passed to each of the transformers.")
+        private String transformerConfig;
+
+        @Parameter(
+                required = false,
+                names = "--transformer-config-file",
+                arity = 1,
+                description = "Path to the JSON configuration file of metadata transformers.")
+        private String transformerConfigFile;
+    }
 }

--- a/MetadataMigration/src/main/java/org/opensearch/migrations/commands/Evaluate.java
+++ b/MetadataMigration/src/main/java/org/opensearch/migrations/commands/Evaluate.java
@@ -2,7 +2,6 @@ package org.opensearch.migrations.commands;
 
 import org.opensearch.migrations.MigrateOrEvaluateArgs;
 import org.opensearch.migrations.MigrationMode;
-import org.opensearch.migrations.bulkload.transformers.CompositeTransformer;
 import org.opensearch.migrations.metadata.tracing.RootMetadataMigrationContext;
 
 import com.beust.jcommander.ParameterException;

--- a/MetadataMigration/src/main/java/org/opensearch/migrations/commands/Evaluate.java
+++ b/MetadataMigration/src/main/java/org/opensearch/migrations/commands/Evaluate.java
@@ -25,10 +25,7 @@ public class Evaluate extends MigratorEvaluatorBase {
             var clusters = createClusters();
             evaluateResult.clusters(clusters);
 
-            var transformer = new CompositeTransformer(
-                    getCustomTransformer(),
-                    selectTransformer(clusters)
-            );
+            var transformer = selectTransformer(clusters);
 
             var items = migrateAllItems(migrationMode, clusters, transformer, context);
             evaluateResult.items(items);

--- a/MetadataMigration/src/main/java/org/opensearch/migrations/commands/Evaluate.java
+++ b/MetadataMigration/src/main/java/org/opensearch/migrations/commands/Evaluate.java
@@ -2,6 +2,7 @@ package org.opensearch.migrations.commands;
 
 import org.opensearch.migrations.MigrateOrEvaluateArgs;
 import org.opensearch.migrations.MigrationMode;
+import org.opensearch.migrations.bulkload.transformers.CompositeTransformer;
 import org.opensearch.migrations.metadata.tracing.RootMetadataMigrationContext;
 
 import com.beust.jcommander.ParameterException;
@@ -24,7 +25,10 @@ public class Evaluate extends MigratorEvaluatorBase {
             var clusters = createClusters();
             evaluateResult.clusters(clusters);
 
-            var transformer = selectTransformer(clusters);
+            var transformer = new CompositeTransformer(
+                    getCustomTransformer(),
+                    selectTransformer(clusters)
+            );
 
             var items = migrateAllItems(migrationMode, clusters, transformer, context);
             evaluateResult.items(items);

--- a/MetadataMigration/src/main/java/org/opensearch/migrations/commands/Migrate.java
+++ b/MetadataMigration/src/main/java/org/opensearch/migrations/commands/Migrate.java
@@ -2,7 +2,6 @@ package org.opensearch.migrations.commands;
 
 import org.opensearch.migrations.MigrateOrEvaluateArgs;
 import org.opensearch.migrations.MigrationMode;
-import org.opensearch.migrations.bulkload.transformers.CompositeTransformer;
 import org.opensearch.migrations.metadata.tracing.RootMetadataMigrationContext;
 
 import com.beust.jcommander.ParameterException;

--- a/MetadataMigration/src/main/java/org/opensearch/migrations/commands/Migrate.java
+++ b/MetadataMigration/src/main/java/org/opensearch/migrations/commands/Migrate.java
@@ -25,10 +25,7 @@ public class Migrate extends MigratorEvaluatorBase {
             var clusters = createClusters();
             migrateResult.clusters(clusters);
 
-            var transformer = new CompositeTransformer(
-                    getCustomTransformer(),
-                    selectTransformer(clusters)
-            );
+            var transformer = selectTransformer(clusters);
 
             var items = migrateAllItems(migrationMode, clusters, transformer, context);
             migrateResult.items(items);

--- a/MetadataMigration/src/main/java/org/opensearch/migrations/commands/Migrate.java
+++ b/MetadataMigration/src/main/java/org/opensearch/migrations/commands/Migrate.java
@@ -2,6 +2,7 @@ package org.opensearch.migrations.commands;
 
 import org.opensearch.migrations.MigrateOrEvaluateArgs;
 import org.opensearch.migrations.MigrationMode;
+import org.opensearch.migrations.bulkload.transformers.CompositeTransformer;
 import org.opensearch.migrations.metadata.tracing.RootMetadataMigrationContext;
 
 import com.beust.jcommander.ParameterException;
@@ -24,7 +25,10 @@ public class Migrate extends MigratorEvaluatorBase {
             var clusters = createClusters();
             migrateResult.clusters(clusters);
 
-            var transformer = selectTransformer(clusters);
+            var transformer = new CompositeTransformer(
+                    getCustomTransformer(),
+                    selectTransformer(clusters)
+            );
 
             var items = migrateAllItems(migrationMode, clusters, transformer, context);
             migrateResult.items(items);

--- a/MetadataMigration/src/main/java/org/opensearch/migrations/commands/MigratorEvaluatorBase.java
+++ b/MetadataMigration/src/main/java/org/opensearch/migrations/commands/MigratorEvaluatorBase.java
@@ -7,6 +7,7 @@ import org.opensearch.migrations.MigrateOrEvaluateArgs;
 import org.opensearch.migrations.MigrationMode;
 import org.opensearch.migrations.bulkload.transformers.TransformFunctions;
 import org.opensearch.migrations.bulkload.transformers.Transformer;
+import org.opensearch.migrations.bulkload.transformers.TransformerToIJsonTransformerAdapter;
 import org.opensearch.migrations.bulkload.worker.IndexMetadataResults;
 import org.opensearch.migrations.bulkload.worker.IndexRunner;
 import org.opensearch.migrations.bulkload.worker.MetadataRunner;
@@ -17,12 +18,19 @@ import org.opensearch.migrations.cluster.ClusterProviderRegistry;
 import org.opensearch.migrations.metadata.CreationResult;
 import org.opensearch.migrations.metadata.GlobalMetadataCreatorResults;
 import org.opensearch.migrations.metadata.tracing.RootMetadataMigrationContext;
+import org.opensearch.migrations.transform.TransformationLoader;
+import org.opensearch.migrations.transform.TransformerConfigUtils;
 
 import lombok.extern.slf4j.Slf4j;
 
 /** Shared functionality between migration and evaluation commands */
 @Slf4j
 public abstract class MigratorEvaluatorBase {
+    public static final String NOOP_TRANSFORMATION_CONFIG = "[" +
+            "  {" +
+            "    \"NoopTransformerProvider\":\"\"" +
+            "  }" +
+            "]";
 
     static final int INVALID_PARAMETER_CODE = 999;
     static final int UNEXPECTED_FAILURE_CODE = 888;
@@ -45,13 +53,27 @@ public abstract class MigratorEvaluatorBase {
         return clusters.build();
     }
 
+    protected Transformer getCustomTransformer() {
+        var transformerConfig = TransformerConfigUtils.getTransformerConfig(arguments.metadataTransformationParams);
+        if (transformerConfig != null) {
+            log.atInfo().setMessage("Metadata Transformations config string: {}")
+                    .addArgument(transformerConfig).log();
+        } else {
+            log.atInfo().setMessage("Using Noop transformation config: {}")
+                    .addArgument(NOOP_TRANSFORMATION_CONFIG).log();
+            transformerConfig = NOOP_TRANSFORMATION_CONFIG;
+        }
+        var transformer =  new TransformationLoader().getTransformerFactoryLoader(transformerConfig);
+        return new TransformerToIJsonTransformerAdapter(transformer);
+    }
+
     protected Transformer selectTransformer(Clusters clusters) {
         var transformer = TransformFunctions.getTransformer(
             clusters.getSource().getVersion(),
             clusters.getTarget().getVersion(),
             arguments.minNumberOfReplicas
         );
-        log.info("Selected transformer " + transformer.toString());
+        log.atInfo().setMessage("Selected transformer: {}").addArgument(transformer).log();
         return transformer;
     }
 

--- a/MetadataMigration/src/main/resources/log4j2.properties
+++ b/MetadataMigration/src/main/resources/log4j2.properties
@@ -3,9 +3,59 @@ status = WARN
 property.logsDir = ${env:SHARED_LOGS_DIR_PATH:-./logs}
 property.failedLoggerFileNamePrefix = ${logsDir}/${hostName}/failedRequests/failedRequests
 property.metadataTuplesFileNamePrefix = ${logsDir}/${hostName}/metadataTuples/tuples
+property.runTime = ${date:yyyy-MM-dd_HH-mm-ss}
+property.metadataRunLoggerFileNamePrefix = ${logsDir}/${hostName}/metadata/metadata
 
-appenders = console, FailedRequests, MetadataRun, MetadataTuples
+appenders = console, MetadataTuples, FailedRequests, MetadataRun
 
+appender.console.type = Console
+appender.console.name = Console
+appender.console.target = SYSTEM_OUT
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = %m%n
+
+rootLogger.level = ERROR
+rootLogger.appenderRef.console.ref = MetadataRun
+
+# Metadata Migration
+logger.MetadataMigration.name = org.opensearch.migrations.MetadataMigration
+logger.MetadataMigration.level = info
+logger.MetadataMigration.additivity = false
+logger.MetadataMigration.appenderRef.stdout.ref = Console
+logger.MetadataMigration.appenderRef.MetadataRun.ref = MetadataRun
+
+# Metadata Tuples
+appender.MetadataTuples.type = RollingRandomAccessFile
+appender.MetadataTuples.name = MetadataTuples
+appender.MetadataTuples.fileName = ${metadataTuplesFileNamePrefix}.log
+appender.MetadataTuples.filePattern = ${metadataTuplesFileNamePrefix}_${runTime}-%i.log
+appender.MetadataTuples.layout.type = PatternLayout
+appender.MetadataTuples.layout.pattern = %m%n
+appender.MetadataTuples.policies.type = Policies
+appender.MetadataTuples.policies.startup.type = OnStartupTriggeringPolicy
+appender.MetadataTuples.policies.startup.minSize = 0
+appender.MetadataTuples.strategy.type = DefaultRolloverStrategy
+appender.MetadataTuples.immediateFlush = false
+
+logger.OutputTransformationJsonLogger.name = OutputTransformationJsonLogger
+logger.OutputTransformationJsonLogger.level = info
+logger.OutputTransformationJsonLogger.additivity = false
+logger.OutputTransformationJsonLogger.appenderRef.MetadataTuples.ref = MetadataTuples
+
+# MetadataRun Logs
+appender.MetadataRun.type = File
+appender.MetadataRun.name = MetadataRun
+appender.MetadataRun.fileName = ${metadataRunLoggerFileNamePrefix}${runTime}-%i.log
+appender.MetadataRun.layout.type = PatternLayout
+appender.MetadataRun.layout.pattern = %d{yyyy-MM-dd HH:mm:ss,SSS}{UTC} %p %c{1.} [%t] %m%n
+appender.MetadataRun.immediateFlush = false
+
+logger.MetadataLogger.name = MetadataLogger
+logger.MetadataLogger.level = debug
+logger.MetadataLogger.additivity = false
+logger.MetadataLogger.appenderRef.MetadataRun.ref = MetadataRun
+
+# Failed Requestss
 appender.FailedRequests.type = RollingRandomAccessFile
 appender.FailedRequests.name = FailedRequests
 appender.FailedRequests.fileName = ${failedLoggerFileNamePrefix}.log
@@ -22,50 +72,3 @@ logger.FailedRequestsLogger.name = FailedRequestsLogger
 logger.FailedRequestsLogger.level = info
 logger.FailedRequestsLogger.additivity = false
 logger.FailedRequestsLogger.appenderRef.FailedRequests.ref = FailedRequests
-
-property.runTime = ${date:yyyy-MM-dd_HH-mm-ss}
-property.metadataRunLoggerFileNamePrefix = ${logsDir}/${hostName}/metadata/metadata_
-
-appender.MetadataRun.type = File
-appender.MetadataRun.name = MetadataRun
-appender.MetadataRun.fileName = ${metadataRunLoggerFileNamePrefix}${runTime}.log
-appender.MetadataRun.layout.type = PatternLayout
-appender.MetadataRun.layout.pattern = %d{yyyy-MM-dd HH:mm:ss,SSS}{UTC} %p %c{1.} [%t] %m%n
-appender.MetadataRun.immediateFlush = true
-
-logger.MetadataLogger.name = MetadataLogger
-logger.MetadataLogger.level = debug
-logger.MetadataLogger.additivity = false
-logger.MetadataLogger.appenderRef.MetadataRun.ref = MetadataRun
-
-appender.console.type = Console
-appender.console.name = Console
-appender.console.target = SYSTEM_OUT
-appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = %m%n
-
-rootLogger.level = info
-rootLogger.appenderRef.console.ref = MetadataRun
-
-logger.MetadataMigration.name = org.opensearch.migrations.MetadataMigration
-logger.MetadataMigration.level = info
-logger.MetadataMigration.additivity = false
-logger.MetadataMigration.appenderRef.stdout.ref = Console
-logger.MetadataMigration.appenderRef.MetadataRun.ref = MetadataRun
-
-appender.MetadataTuples.type = RollingRandomAccessFile
-appender.MetadataTuples.name = MetadataTuples
-appender.MetadataTuples.fileName = ${metadataTuplesFileNamePrefix}.log
-appender.MetadataTuples.filePattern = ${metadataTuplesFileNamePrefix}-%d{yyyy-MM-dd-HH-mm}{UTC}-%i.log
-appender.MetadataTuples.layout.type = PatternLayout
-appender.MetadataTuples.layout.pattern = %m%n
-appender.MetadataTuples.policies.type = Policies
-appender.MetadataTuples.policies.size.type = SizeBasedTriggeringPolicy
-appender.MetadataTuples.policies.size.size = 10 MB
-appender.MetadataTuples.strategy.type = DefaultRolloverStrategy
-appender.MetadataTuples.immediateFlush = false
-
-logger.OutputTransformationJsonLogger.name = OutputTransformationJsonLogger
-logger.OutputTransformationJsonLogger.level = info
-logger.OutputTransformationJsonLogger.additivity = false
-logger.OutputTransformationJsonLogger.appenderRef.MetadataTuples.ref = MetadataTuples

--- a/MetadataMigration/src/main/resources/log4j2.properties
+++ b/MetadataMigration/src/main/resources/log4j2.properties
@@ -2,8 +2,9 @@ status = WARN
 
 property.logsDir = ${env:SHARED_LOGS_DIR_PATH:-./logs}
 property.failedLoggerFileNamePrefix = ${logsDir}/${hostName}/failedRequests/failedRequests
+property.metadataTuplesFileNamePrefix = ${logsDir}/${hostName}/metadataTuples/tuples
 
-appenders = console, FailedRequests, MetadataRun
+appenders = console, FailedRequests, MetadataRun, MetadataTuples
 
 appender.FailedRequests.type = RollingRandomAccessFile
 appender.FailedRequests.name = FailedRequests
@@ -51,3 +52,20 @@ logger.MetadataMigration.level = info
 logger.MetadataMigration.additivity = false
 logger.MetadataMigration.appenderRef.stdout.ref = Console
 logger.MetadataMigration.appenderRef.MetadataRun.ref = MetadataRun
+
+appender.MetadataTuples.type = RollingRandomAccessFile
+appender.MetadataTuples.name = MetadataTuples
+appender.MetadataTuples.fileName = ${metadataTuplesFileNamePrefix}.log
+appender.MetadataTuples.filePattern = ${metadataTuplesFileNamePrefix}-%d{yyyy-MM-dd-HH-mm}{UTC}-%i.log
+appender.MetadataTuples.layout.type = PatternLayout
+appender.MetadataTuples.layout.pattern = %m%n
+appender.MetadataTuples.policies.type = Policies
+appender.MetadataTuples.policies.size.type = SizeBasedTriggeringPolicy
+appender.MetadataTuples.policies.size.size = 10 MB
+appender.MetadataTuples.strategy.type = DefaultRolloverStrategy
+appender.MetadataTuples.immediateFlush = false
+
+logger.OutputTransformationJsonLogger.name = OutputTransformationJsonLogger
+logger.OutputTransformationJsonLogger.level = info
+logger.OutputTransformationJsonLogger.additivity = false
+logger.OutputTransformationJsonLogger.appenderRef.MetadataTuples.ref = MetadataTuples

--- a/MetadataMigration/src/test/java/org/opensearch/migrations/CustomTransformationTest.java
+++ b/MetadataMigration/src/test/java/org/opensearch/migrations/CustomTransformationTest.java
@@ -1,0 +1,281 @@
+package org.opensearch.migrations;
+
+import java.io.File;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Stream;
+
+import org.opensearch.migrations.bulkload.SupportedClusters;
+import org.opensearch.migrations.bulkload.common.FileSystemSnapshotCreator;
+import org.opensearch.migrations.bulkload.common.OpenSearchClient;
+import org.opensearch.migrations.bulkload.common.http.ConnectionContextTestParams;
+import org.opensearch.migrations.bulkload.framework.SearchClusterContainer;
+import org.opensearch.migrations.bulkload.http.ClusterOperations;
+import org.opensearch.migrations.bulkload.models.DataFilterArgs;
+import org.opensearch.migrations.bulkload.worker.SnapshotRunner;
+import org.opensearch.migrations.commands.MigrationItemResult;
+import org.opensearch.migrations.metadata.tracing.MetadataMigrationTestContext;
+import org.opensearch.migrations.snapshot.creation.tracing.SnapshotTestContext;
+import org.opensearch.migrations.transform.TransformerParams;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * Test class to verify custom transformations during metadata migrations.
+ */
+@Tag("isolatedTest")
+@Slf4j
+class CustomTransformationTest {
+
+    @TempDir
+    private File localDirectory;
+
+    private static Stream<Arguments> scenarios() {
+        // Define scenarios with different source and target cluster versions
+        return SupportedClusters.sources().stream()
+                .flatMap(sourceCluster ->
+                        SupportedClusters.targets().stream()
+                                .map(targetCluster -> Arguments.of(sourceCluster, targetCluster))
+                );
+    }
+
+    @ParameterizedTest(name = "Custom Transformation From {0} to {1}")
+    @MethodSource(value = "scenarios")
+    void customTransformationMetadataMigration(
+            SearchClusterContainer.ContainerVersion sourceVersion,
+            SearchClusterContainer.ContainerVersion targetVersion) {
+        try (
+                final var sourceCluster = new SearchClusterContainer(sourceVersion);
+                final var targetCluster = new SearchClusterContainer(targetVersion)
+        ) {
+            performCustomTransformationTest(sourceCluster, targetCluster);
+        }
+    }
+
+    @SneakyThrows
+    private void performCustomTransformationTest(
+            final SearchClusterContainer sourceCluster,
+            final SearchClusterContainer targetCluster
+    ) {
+        // Start both source and target clusters asynchronously
+        CompletableFuture.allOf(
+                CompletableFuture.runAsync(sourceCluster::start),
+                CompletableFuture.runAsync(targetCluster::start)
+        ).join();
+
+        var sourceOperations = new ClusterOperations(sourceCluster.getUrl());
+        var targetOperations = new ClusterOperations(targetCluster.getUrl());
+
+        // Test data
+        var originalIndexName = "test_index";
+        var transformedIndexName = "transformed_index";
+        var documentId = "1";
+        var documentContent = "{\"field\":\"value\"}";
+
+        // Create index and add a document on the source cluster
+        sourceOperations.createIndex(originalIndexName);
+        sourceOperations.createDocument(originalIndexName, documentId, documentContent);
+
+        // Create legacy template
+        var legacyTemplateName = "legacy_template";
+        var legacyTemplatePattern = "legacy_*";
+        sourceOperations.createLegacyTemplate(legacyTemplateName, legacyTemplatePattern);
+
+        // Create index template
+        var indexTemplateName = "index_template";
+        var indexTemplatePattern = "index*";
+
+        // Create component template
+        var componentTemplateName = "component_template";
+        var componentTemplateMode = "mode_value"; // Replace with actual mode if applicable
+        boolean newComponentCompatible = sourceCluster.getContainerVersion().getVersion().getMajor() >= 7;
+        if (newComponentCompatible) {
+            sourceOperations.createIndexTemplate(indexTemplateName, "dummy", indexTemplatePattern);
+
+            var componentTemplateAdditionalParam = "additional_param"; // Replace with actual param if applicable
+            sourceOperations.createComponentTemplate(componentTemplateName, indexTemplateName, componentTemplateAdditionalParam, "index*");
+        }
+
+        // Create index that matches the templates
+        var legacyIndexName = "legacy_index";
+        var indexIndexName = "index_index";
+        sourceOperations.createIndex(legacyIndexName);
+        sourceOperations.createIndex(indexIndexName);
+
+        // Define custom transformations for index, legacy, and component templates
+        String customTransformationJson = "[\n" +
+            "  {\n" +
+            "    \"JsonConditionalTransformerProvider\": [\n" +
+            "      {\"JsonJMESPathPredicateProvider\": { \"script\": \"name == 'test_index'\"}},\n" +
+            "      [\n" +
+            "        {\"JsonJoltTransformerProvider\": { \n" +
+            "          \"script\": {\n" +
+            "            \"operation\": \"modify-overwrite-beta\",\n" +
+            "            \"spec\": {\n" +
+            "              \"name\": \"transformed_index\"\n" +
+            "            }\n" +
+            "          } \n" +
+            "        }}\n" +
+            "      ]\n" +
+            "    ]\n" +
+            "  },\n" +
+            "  {\n" +
+            "    \"JsonConditionalTransformerProvider\": [\n" +
+            "      {\"JsonJMESPathPredicateProvider\": { \"script\": \"type == 'template' && name == 'legacy_template'\"}},\n" +
+            "      [\n" +
+            "        {\"JsonJoltTransformerProvider\": { \n" +
+            "          \"script\": {\n" +
+            "            \"operation\": \"modify-overwrite-beta\",\n" +
+            "            \"spec\": {\n" +
+            "              \"name\": \"transformed_legacy_template\"\n" +
+            "            }\n" +
+            "          } \n" +
+            "        }}\n" +
+            "      ]\n" +
+            "    ]\n" +
+            "  },\n" +
+            "  {\n" +
+            "    \"JsonConditionalTransformerProvider\": [\n" +
+            "      {\"JsonJMESPathPredicateProvider\": { \"script\": \"type == 'index_template' && name == 'index_template'\"}},\n" +
+            "      [\n" +
+            "        {\"JsonJoltTransformerProvider\": { \n" +
+            "          \"script\": {\n" +
+            "            \"operation\": \"modify-overwrite-beta\",\n" +
+            "            \"spec\": {\n" +
+            "              \"name\": \"transformed_index_template\",\n" +
+            "              \"body\": {\n" +
+            "                \"composed_of\": {\n" +
+            "                  \"[0]\": \"transformed_component_template\"\n" +
+            "                }\n" +
+            "              }\n" +
+            "            }\n" +
+            "          }\n" +
+            "        }}\n" +
+            "      ]\n" +
+            "    ]\n" +
+            "  },\n" +
+            "  {\n" +
+            "    \"JsonConditionalTransformerProvider\": [\n" +
+            "      {\"JsonJMESPathPredicateProvider\": { \"script\": \"type == 'component_template' && name == 'component_template'\"}},\n" +
+            "      [\n" +
+            "        {\"JsonJoltTransformerProvider\": { \n" +
+            "          \"script\": {\n" +
+            "            \"operation\": \"modify-overwrite-beta\",\n" +
+            "            \"spec\": {\n" +
+            "              \"name\": \"transformed_component_template\"\n" +
+            "            }\n" +
+            "          } \n" +
+            "        }}\n" +
+            "      ]\n" +
+            "    ]\n" +
+            "  }\n" +
+            "]";
+
+        var arguments = new MigrateOrEvaluateArgs();
+
+        // Use SnapshotImage as the transfer medium
+        var snapshotName = "custom_transformation_snap";
+        var snapshotContext = SnapshotTestContext.factory().noOtelTracking();
+        var sourceClient = new OpenSearchClient(ConnectionContextTestParams.builder()
+                .host(sourceCluster.getUrl())
+                .insecure(true)
+                .build()
+                .toConnectionContext());
+        var snapshotCreator = new FileSystemSnapshotCreator(
+                snapshotName,
+                sourceClient,
+                SearchClusterContainer.CLUSTER_SNAPSHOT_DIR,
+                List.of(),
+                snapshotContext.createSnapshotCreateContext()
+        );
+        SnapshotRunner.runAndWaitForCompletion(snapshotCreator);
+        sourceCluster.copySnapshotData(localDirectory.toString());
+        arguments.fileSystemRepoPath = localDirectory.getAbsolutePath();
+        arguments.snapshotName = snapshotName;
+        arguments.sourceVersion = sourceCluster.getContainerVersion().getVersion();
+
+        arguments.targetArgs.host = targetCluster.getUrl();
+
+        // Set up data filters to include only the test index and templates
+        var dataFilterArgs = new DataFilterArgs();
+        dataFilterArgs.indexAllowlist = List.of(originalIndexName, legacyIndexName, indexIndexName, transformedIndexName);
+        dataFilterArgs.indexTemplateAllowlist = List.of(indexTemplateName, legacyTemplateName, "transformed_legacy_template", "transformed_index_template");
+        dataFilterArgs.componentTemplateAllowlist = List.of(componentTemplateName, "transformed_component_template");
+        arguments.dataFilterArgs = dataFilterArgs;
+
+        // Specify the custom transformer configuration
+        arguments.metadataTransformationParams = TestTransformationParams.builder()
+                .transformerConfig(customTransformationJson)
+                .build();
+
+        // Execute the migration with the custom transformation
+        var metadataContext = MetadataMigrationTestContext.factory().noOtelTracking();
+        var metadata = new MetadataMigration();
+
+        MigrationItemResult result = metadata.migrate(arguments).execute(metadataContext);
+
+        // Verify the migration result
+        log.info(result.asCliOutput());
+        assertThat(result.getExitCode(), equalTo(0));
+
+        // Verify that the transformed index exists on the target cluster
+        var res = targetOperations.get("/" + transformedIndexName);
+        assertThat(res.getKey(), equalTo(200));
+        assertThat(res.getValue(), containsString(transformedIndexName));
+
+        // Verify that the original index does not exist on the target cluster
+        res = targetOperations.get("/" + originalIndexName);
+        assertThat(res.getKey(), equalTo(404));
+
+        // Verify that the transformed legacy template exists on the target cluster
+        res = targetOperations.get("/_template/transformed_legacy_template");
+        assertThat(res.getKey(), equalTo(200));
+        assertThat(res.getValue(), containsString("transformed_legacy_template"));
+
+        // Verify that the original legacy template does not exist on the target cluster
+        res = targetOperations.get("/_template/" + legacyTemplateName);
+        assertThat(res.getKey(), equalTo(404));
+
+        if (newComponentCompatible) {
+            // Verify that the transformed index template exists on the target cluster
+            res = targetOperations.get("/_index_template/transformed_index_template");
+            assertThat(res.getKey(), equalTo(200));
+            assertThat(res.getValue(), containsString("transformed_index_template"));
+
+            // Verify that the original index template does not exist on the target cluster
+            res = targetOperations.get("/_index_template/" + indexTemplateName);
+            assertThat(res.getKey(), equalTo(404));
+
+            // Verify that the transformed component template exists on the target cluster
+            res = targetOperations.get("/_component_template/transformed_component_template");
+            assertThat(res.getKey(), equalTo(200));
+            assertThat(res.getValue(), containsString("transformed_component_template"));
+
+            // Verify that the original component template does not exist on the target cluster
+            res = targetOperations.get("/_component_template/" + componentTemplateName);
+            assertThat(res.getKey(), equalTo(404));
+        }
+    }
+
+    @Data
+    @Builder
+    private static class TestTransformationParams implements TransformerParams {
+        @Builder.Default
+        private String transformerConfigParameterArgPrefix = "";
+        private String transformerConfigEncoded;
+        private String transformerConfig;
+        private String transformerConfigFile;
+    }
+}

--- a/MetadataMigration/src/test/java/org/opensearch/migrations/EndToEndTest.java
+++ b/MetadataMigration/src/test/java/org/opensearch/migrations/EndToEndTest.java
@@ -208,7 +208,8 @@ class EndToEndTest {
         var migratedItems = result.getItems();
         assertThat(getNames(getSuccessfulResults(migratedItems.getIndexTemplates())), containsInAnyOrder(testData.indexTemplateName));
         assertThat(getNames(getSuccessfulResults(migratedItems.getComponentTemplates())), equalTo(templateType.equals(TemplateType.IndexAndComponent) ? List.of(testData.compoTemplateName) : List.of()));
-        assertThat(getNames(getSuccessfulResults(migratedItems.getIndexes())), containsInAnyOrder(testData.blogIndexName, testData.movieIndexName, testData.indexThatAlreadyExists));
+        assertThat(getNames(getSuccessfulResults(migratedItems.getIndexes())), containsInAnyOrder(testData.blogIndexName, testData.movieIndexName));
+        assertThat(getNames(getFailedResultsByType(migratedItems.getIndexes(), CreationResult.CreationFailureType.ALREADY_EXISTS)), containsInAnyOrder(testData.indexThatAlreadyExists));
         assertThat(getNames(getSuccessfulResults(migratedItems.getAliases())), containsInAnyOrder(testData.aliasInTemplate, testData.aliasName));
 
     }
@@ -216,6 +217,12 @@ class EndToEndTest {
     private List<CreationResult> getSuccessfulResults(List<CreationResult> results) {
         return results.stream()
                 .filter(CreationResult::wasSuccessful)
+                .collect(Collectors.toList());
+    }
+
+    private List<CreationResult> getFailedResultsByType(List<CreationResult> results, CreationResult.CreationFailureType failureType) {
+        return results.stream()
+                .filter(r -> failureType.equals(r.getFailureType()))
                 .collect(Collectors.toList());
     }
 

--- a/MetadataMigration/src/test/java/org/opensearch/migrations/EndToEndTest.java
+++ b/MetadataMigration/src/test/java/org/opensearch/migrations/EndToEndTest.java
@@ -206,10 +206,17 @@ class EndToEndTest {
         assertThat(result.getExitCode(), equalTo(0));
 
         var migratedItems = result.getItems();
-        assertThat(getNames(migratedItems.getIndexTemplates()), containsInAnyOrder(testData.indexTemplateName));
-        assertThat(getNames(migratedItems.getComponentTemplates()), equalTo(templateType.equals(TemplateType.IndexAndComponent) ? List.of(testData.compoTemplateName) : List.of()));
-        assertThat(getNames(migratedItems.getIndexes()), containsInAnyOrder(testData.blogIndexName, testData.movieIndexName, testData.indexThatAlreadyExists));
-        assertThat(getNames(migratedItems.getAliases()), containsInAnyOrder(testData.aliasInTemplate, testData.aliasName));
+        assertThat(getNames(getSuccessfulResults(migratedItems.getIndexTemplates())), containsInAnyOrder(testData.indexTemplateName));
+        assertThat(getNames(getSuccessfulResults(migratedItems.getComponentTemplates())), equalTo(templateType.equals(TemplateType.IndexAndComponent) ? List.of(testData.compoTemplateName) : List.of()));
+        assertThat(getNames(getSuccessfulResults(migratedItems.getIndexes())), containsInAnyOrder(testData.blogIndexName, testData.movieIndexName, testData.indexThatAlreadyExists));
+        assertThat(getNames(getSuccessfulResults(migratedItems.getAliases())), containsInAnyOrder(testData.aliasInTemplate, testData.aliasName));
+
+    }
+
+    private List<CreationResult> getSuccessfulResults(List<CreationResult> results) {
+        return results.stream()
+                .filter(CreationResult::wasSuccessful)
+                .collect(Collectors.toList());
     }
 
     private List<String> getNames(List<CreationResult> items) {

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/models/ComponentTemplate.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/models/ComponentTemplate.java
@@ -1,0 +1,13 @@
+package org.opensearch.migrations.bulkload.models;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(force = true, access = AccessLevel.PRIVATE) // For Jackson
+public class ComponentTemplate extends MigrationItem {
+    public static final String TYPE = "component_template";
+    public ComponentTemplate(final String name, final ObjectNode body) {
+        super(TYPE, name, body);
+    }
+}

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/models/GlobalMetadata.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/models/GlobalMetadata.java
@@ -9,6 +9,7 @@ import org.opensearch.migrations.bulkload.common.ByteArrayIndexInput;
 import org.opensearch.migrations.bulkload.common.RfsException;
 import org.opensearch.migrations.bulkload.common.SnapshotRepo;
 
+import com.fasterxml.jackson.core.JsonPointer;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -21,18 +22,34 @@ public interface GlobalMetadata {
     * See: https://github.com/elastic/elasticsearch/blob/v7.10.2/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java#L1622
     * See: https://github.com/elastic/elasticsearch/blob/v6.8.23/server/src/main/java/org/elasticsearch/cluster/metadata/MetaData.java#L1214
     */
-    public ObjectNode toObjectNode();
+    ObjectNode toObjectNode();
 
-    public ObjectNode getTemplates();
+    JsonPointer getTemplatesPath();
 
-    public ObjectNode getIndexTemplates();
+    JsonPointer getIndexTemplatesPath();
 
-    public ObjectNode getComponentTemplates();
+    JsonPointer getComponentTemplatesPath();
+
+    default ObjectNode getTemplates() {
+        return getObjectNodeWithPath(getTemplatesPath());
+    }
+
+    default ObjectNode getIndexTemplates() {
+        return getObjectNodeWithPath(getIndexTemplatesPath());
+    }
+
+    default ObjectNode getComponentTemplates() {
+        return getObjectNodeWithPath(getComponentTemplatesPath());
+    }
+
+    default ObjectNode getObjectNodeWithPath(JsonPointer path) {
+        return toObjectNode().withObject(path, JsonNode.OverwriteMode.NULLS, false);
+    }
 
     /**
     * Defines the behavior required to read a snapshot's global metadata as JSON and convert it into a Data object
     */
-    public static interface Factory {
+    interface Factory {
         private JsonNode getJsonNode(
             SnapshotRepo.Provider repoDataProvider,
             String snapshotName,
@@ -73,22 +90,22 @@ public interface GlobalMetadata {
         }
 
         // Version-specific implementation
-        public GlobalMetadata fromJsonNode(JsonNode root);
+        GlobalMetadata fromJsonNode(JsonNode root);
 
         // Version-specific implementation
-        public SmileFactory getSmileFactory();
+        SmileFactory getSmileFactory();
 
         // Get the underlying SnapshotRepo Provider
-        public SnapshotRepo.Provider getRepoDataProvider();
+        SnapshotRepo.Provider getRepoDataProvider();
     }
 
-    public static class CantFindSnapshotInRepo extends RfsException {
+     class CantFindSnapshotInRepo extends RfsException {
         public CantFindSnapshotInRepo(String snapshotName) {
             super("Can't find snapshot in repo: " + snapshotName);
         }
     }
 
-    public static class CantReadGlobalMetadataFromSnapshot extends RfsException {
+    class CantReadGlobalMetadataFromSnapshot extends RfsException {
         public CantReadGlobalMetadataFromSnapshot(String snapshotName, Throwable cause) {
             super("Can't read the global metadata from snapshot: " + snapshotName, cause);
         }

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/models/Index.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/models/Index.java
@@ -1,0 +1,13 @@
+package org.opensearch.migrations.bulkload.models;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(force = true, access = AccessLevel.PRIVATE) // For Jackson
+public class Index extends MigrationItem {
+    public final static String TYPE = "index";
+    public Index(String name, ObjectNode body) {
+        super(TYPE, name, body);
+    }
+}

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/models/IndexMetadata.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/models/IndexMetadata.java
@@ -10,31 +10,33 @@ import org.opensearch.migrations.bulkload.common.RfsException;
 import org.opensearch.migrations.bulkload.common.SnapshotRepo;
 import org.opensearch.migrations.transformation.entity.Index;
 
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.smile.SmileFactory;
 import org.apache.lucene.codecs.CodecUtil;
 
-public interface IndexMetadata extends Index {
-
+// All subclasses need to be annotated with this
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, property = "type")
+public abstract class IndexMetadata implements Index {
     /*
     * Defines the behavior expected of an object that will surface the metadata of an index stored in a snapshot
     * See: https://github.com/elastic/elasticsearch/blob/v7.10.2/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java#L1475
     * See: https://github.com/elastic/elasticsearch/blob/v6.8.23/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetaData.java#L1284
     */
-    public JsonNode getAliases();
+    public abstract JsonNode getAliases();
 
-    public String getId();
+    public abstract String getId();
 
-    public JsonNode getMappings();
+    public abstract JsonNode getMappings();
 
-    public String getName();
+    public abstract String getName();
 
-    public int getNumberOfShards();
+    public abstract int getNumberOfShards();
 
-    public JsonNode getSettings();
+    public abstract JsonNode getSettings();
 
-    public IndexMetadata deepCopy();
+    public abstract IndexMetadata deepCopy();
 
     /**
     * Defines the behavior required to read a snapshot's index metadata as JSON and convert it into a Data object
@@ -71,15 +73,15 @@ public interface IndexMetadata extends Index {
         }
 
         // Version-specific implementation
-        public IndexMetadata fromJsonNode(JsonNode root, String indexId, String indexName);
+        IndexMetadata fromJsonNode(JsonNode root, String indexId, String indexName);
 
         // Version-specific implementation
-        public SmileFactory getSmileFactory();
+        SmileFactory getSmileFactory();
 
         // Version-specific implementation
-        public String getIndexFileId(String snapshotName, String indexName);
+        String getIndexFileId(String snapshotName, String indexName);
 
         // Get the underlying SnapshotRepo Provider
-        public SnapshotRepo.Provider getRepoDataProvider();
+        SnapshotRepo.Provider getRepoDataProvider();
     }
 }

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/models/IndexTemplate.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/models/IndexTemplate.java
@@ -1,0 +1,13 @@
+package org.opensearch.migrations.bulkload.models;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(force = true, access = AccessLevel.PRIVATE) // For Jackson
+public class IndexTemplate extends MigrationItem {
+    public static final String TYPE = "index_template";
+    public IndexTemplate(final String name, final ObjectNode body) {
+        super(TYPE, name, body);
+    }
+}

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/models/LegacyTemplate.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/models/LegacyTemplate.java
@@ -1,0 +1,13 @@
+package org.opensearch.migrations.bulkload.models;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(force = true, access = AccessLevel.PRIVATE) // For Jackson
+public class LegacyTemplate extends MigrationItem {
+    public final static String TYPE = "template";
+    public LegacyTemplate(final String name, final ObjectNode body) {
+        super(TYPE, name, body);
+    }
+}

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/models/MigrationItem.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/models/MigrationItem.java
@@ -1,0 +1,27 @@
+package org.opensearch.migrations.bulkload.models;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(force = true, access = AccessLevel.PROTECTED) // For Jackson
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+@JsonSubTypes({
+        @JsonSubTypes.Type(value = Index.class, name = Index.TYPE),
+        @JsonSubTypes.Type(value = LegacyTemplate.class, name = LegacyTemplate.TYPE),
+        @JsonSubTypes.Type(value = IndexTemplate.class, name = IndexTemplate.TYPE),
+        @JsonSubTypes.Type(value = ComponentTemplate.class, name = ComponentTemplate.TYPE)
+})
+public abstract class MigrationItem {
+    public final String type;
+    public final String name;
+    public final ObjectNode body;
+
+    public MigrationItem(final String type, final String name, final ObjectNode body) {
+        this.type = type;
+        this.name = name;
+        this.body = body;
+    }
+}

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/transformers/CompositeTransformer.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/transformers/CompositeTransformer.java
@@ -1,0 +1,28 @@
+package org.opensearch.migrations.bulkload.transformers;
+
+import org.opensearch.migrations.bulkload.models.GlobalMetadata;
+import org.opensearch.migrations.bulkload.models.IndexMetadata;
+
+public class CompositeTransformer implements Transformer {
+    private final Transformer[] transformers;
+
+    public CompositeTransformer(Transformer... transformers) {
+        this.transformers = transformers;
+    }
+
+    @Override
+    public GlobalMetadata transformGlobalMetadata(GlobalMetadata globalData) {
+        for (Transformer transformer : transformers) {
+            globalData = transformer.transformGlobalMetadata(globalData);
+        }
+        return globalData;
+    }
+
+    @Override
+    public IndexMetadata transformIndexMetadata(IndexMetadata indexData) {
+        for (Transformer transformer : transformers) {
+            indexData = transformer.transformIndexMetadata(indexData);
+        }
+        return indexData;
+    }
+}

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/transformers/TransformerToIJsonTransformerAdapter.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/transformers/TransformerToIJsonTransformerAdapter.java
@@ -1,0 +1,165 @@
+package org.opensearch.migrations.bulkload.transformers;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.opensearch.migrations.bulkload.models.ComponentTemplate;
+import org.opensearch.migrations.bulkload.models.GlobalMetadata;
+import org.opensearch.migrations.bulkload.models.IndexMetadata;
+import org.opensearch.migrations.bulkload.models.IndexTemplate;
+import org.opensearch.migrations.bulkload.models.LegacyTemplate;
+import org.opensearch.migrations.bulkload.models.MigrationItem;
+import org.opensearch.migrations.transform.IJsonTransformer;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import lombok.Lombok;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+@Slf4j
+public class TransformerToIJsonTransformerAdapter implements Transformer {
+    public static final String OUTPUT_TRANSFORMATION_JSON_LOGGER = "OutputTransformationJsonLogger";
+    private final static ObjectMapper MAPPER = new ObjectMapper();
+    private final IJsonTransformer transformer;
+    private final Logger transformerLogger;
+
+    public TransformerToIJsonTransformerAdapter(IJsonTransformer transformer, Logger transformerLogger) {
+        this.transformer = transformer;
+        this.transformerLogger = transformerLogger != null ? transformerLogger : LoggerFactory.getLogger(OUTPUT_TRANSFORMATION_JSON_LOGGER);
+    }
+
+    public TransformerToIJsonTransformerAdapter(IJsonTransformer transformer) {
+        this(transformer, LoggerFactory.getLogger(OUTPUT_TRANSFORMATION_JSON_LOGGER));
+    }
+
+    private void logTransformation(Map<String, Object> before, Map<String, Object> after) {
+        if (transformerLogger.isInfoEnabled()) {
+            try {
+                var transformationTuple = toTransformationMap(before, after);
+                var tupleString = MAPPER.writeValueAsString(transformationTuple);
+                transformerLogger.atInfo().setMessage("{}").addArgument(tupleString).log();
+            } catch (Exception e) {
+                log.atError().setCause(e).setMessage("Exception converting tuple to string").log();
+                transformerLogger.atInfo().setMessage("{ \"error\":\"{}\" }").addArgument(e::getMessage).log();
+                throw Lombok.sneakyThrow(e);
+            }
+        }
+    }
+
+    private Map<String, Object> toTransformationMap(Map<String, Object> before, Map<String, Object> after) {
+        var transformationMap = new LinkedHashMap<String, Object>();
+        transformationMap.put("before", before);
+        transformationMap.put("after", after);
+        return transformationMap;
+    }
+
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> objectNodeToMap(Object node) {
+        return (Map<String, Object>) MAPPER.convertValue(node, Map.class);
+    }
+
+    @SneakyThrows
+    private static String printMap(Map<String, Object> map) {
+        return MAPPER.writeValueAsString(map);
+    }
+
+    @SuppressWarnings("unchecked")
+    private MigrationItem transformMigrationItem(MigrationItem migrationItem) {
+        // Keep untouched original for logging
+        final Map<String, Object> originalMap = MAPPER.convertValue(migrationItem, Map.class);
+        var transformedMigrationItem = transformer.transformJson(MAPPER.convertValue(migrationItem, Map.class));
+        logTransformation(originalMap, transformedMigrationItem);
+        return MAPPER.convertValue(transformedMigrationItem, MigrationItem.class);
+    }
+
+    void updateTemplates(Collection<? extends MigrationItem> transformedItems, ObjectNode itemsRoot) {
+        itemsRoot.removeAll();
+        transformedItems.forEach(item ->
+                {
+                    log.atInfo().setMessage("Setting new item of type {}, name {}, body {}")
+                            .addArgument(item.type)
+                            .addArgument(item.name)
+                            .addArgument(item.body)
+                            .log();
+                    itemsRoot.set(item.name, item.body);
+                }
+        );
+    }
+
+    @Override
+    public GlobalMetadata transformGlobalMetadata(GlobalMetadata globalData) {
+        var inputJson = objectNodeToMap(globalData.toObjectNode());
+        log.atInfo().setMessage("BeforeJsonGlobal: {}").addArgument(() -> printMap(inputJson)).log();
+        var afterJson = transformer.transformJson(inputJson);
+        log.atInfo().setMessage("AfterJsonGlobal: {}").addArgument(() -> printMap(afterJson)).log();
+
+
+        final List<LegacyTemplate> legacyTemplates = new ArrayList<>();
+        globalData.getTemplates().fields().forEachRemaining(
+                entry -> legacyTemplates.add(new LegacyTemplate(entry.getKey(), (ObjectNode) entry.getValue()))
+        );
+        final List<IndexTemplate> indexTemplates = new ArrayList<>();
+        globalData.getIndexTemplates().fields().forEachRemaining(
+                entry -> indexTemplates.add(new IndexTemplate(entry.getKey(), (ObjectNode) entry.getValue()))
+        );
+        final List<ComponentTemplate> componentTemplates = new ArrayList<>();
+        globalData.getComponentTemplates().fields().forEachRemaining(
+                entry -> componentTemplates.add(new ComponentTemplate(entry.getKey(), (ObjectNode) entry.getValue()))
+        );
+
+        var transformedTemplates = Stream.concat(Stream.concat(
+                legacyTemplates.stream(),
+                indexTemplates.stream()),
+                componentTemplates.stream()
+                )
+                .map(this::transformMigrationItem).collect(Collectors.toList());
+
+        var transformedLegacy = transformedTemplates.stream().filter(
+                item -> item instanceof LegacyTemplate
+        )
+                .map(item -> (LegacyTemplate) item)
+                .collect(Collectors.toList());
+
+        var transformedIndex = transformedTemplates.stream().filter(
+                        item -> item instanceof IndexTemplate
+                )
+                .map(item -> (IndexTemplate) item)
+                .collect(Collectors.toList());
+
+        var transformedComponent = transformedTemplates.stream().filter(
+                        item -> item instanceof ComponentTemplate
+                )
+                .map(item -> (ComponentTemplate) item)
+                .collect(Collectors.toList());
+
+        assert transformedLegacy.size() + transformedIndex.size() + transformedComponent.size() == transformedTemplates.size();
+
+        updateTemplates(transformedLegacy, globalData.getTemplates());
+        updateTemplates(transformedIndex, globalData.getIndexTemplates());
+        updateTemplates(transformedComponent, globalData.getComponentTemplates());
+
+        log.atInfo().setMessage("GlobalOutput: {}").addArgument(() -> printMap(objectNodeToMap(globalData.toObjectNode()))).log();
+        return globalData;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public IndexMetadata transformIndexMetadata(IndexMetadata indexData) {
+        final Map<String, Object> originalInput = MAPPER.convertValue(indexData, Map.class);
+        final Map<String, Object> inputJson = MAPPER.convertValue(indexData, Map.class);
+        var afterJson = transformer.transformJson(inputJson);
+        logTransformation(originalInput, afterJson);
+        return MAPPER.convertValue(inputJson, IndexMetadata.class);
+    }
+
+}

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/version_es_6_8/GlobalMetadataData_ES_6_8.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/version_es_6_8/GlobalMetadataData_ES_6_8.java
@@ -2,6 +2,7 @@ package org.opensearch.migrations.bulkload.version_es_6_8;
 
 import org.opensearch.migrations.bulkload.models.GlobalMetadata;
 
+import com.fasterxml.jackson.core.JsonPointer;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
 public class GlobalMetadataData_ES_6_8 implements GlobalMetadata {
@@ -16,17 +17,18 @@ public class GlobalMetadataData_ES_6_8 implements GlobalMetadata {
         return root;
     }
 
-    public ObjectNode getTemplates() {
-        return (ObjectNode) root.get("templates");
+    @Override
+    public JsonPointer getTemplatesPath() {
+        return JsonPointer.compile("/templates");
     }
 
     @Override
-    public ObjectNode getIndexTemplates() {
-        return null;
+    public JsonPointer getIndexTemplatesPath() {
+        return JsonPointer.compile("/index_template");
     }
 
     @Override
-    public ObjectNode getComponentTemplates() {
-        return null;
+    public JsonPointer getComponentTemplatesPath() {
+        return JsonPointer.compile("/component_template");
     }
 }

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/version_es_6_8/IndexMetadataData_ES_6_8.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/version_es_6_8/IndexMetadataData_ES_6_8.java
@@ -3,18 +3,28 @@ package org.opensearch.migrations.bulkload.version_es_6_8;
 import org.opensearch.migrations.bulkload.models.IndexMetadata;
 import org.opensearch.migrations.bulkload.transformers.TransformFunctions;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
-public class IndexMetadataData_ES_6_8 implements IndexMetadata {
+@NoArgsConstructor(force = true) // For Jackson
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.NONE, getterVisibility = JsonAutoDetect.Visibility.NONE)
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, property = "type")
+public class IndexMetadataData_ES_6_8 extends IndexMetadata {
     @Getter
+    @JsonProperty("body")
     private final ObjectNode rawJson;
     private ObjectNode mappings;
     private ObjectNode settings;
     @Getter
+    @JsonProperty("id")
     private final String id;
     @Getter
+    @JsonProperty("name")
     private final String name;
 
     public IndexMetadataData_ES_6_8(ObjectNode root, String indexId, String indexName) {

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/version_es_7_10/GlobalMetadataData_ES_7_10.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/version_es_7_10/GlobalMetadataData_ES_7_10.java
@@ -1,10 +1,11 @@
 package org.opensearch.migrations.bulkload.version_es_7_10;
 
-import java.util.Optional;
 
 import org.opensearch.migrations.bulkload.models.GlobalMetadata;
 
+import com.fasterxml.jackson.core.JsonPointer;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+
 
 public class GlobalMetadataData_ES_7_10 implements GlobalMetadata {
     private final ObjectNode root;
@@ -18,19 +19,18 @@ public class GlobalMetadataData_ES_7_10 implements GlobalMetadata {
         return root;
     }
 
-    public ObjectNode getTemplates() {
-        return Optional.ofNullable(root)
-                .map(node -> node.get("templates"))
-                .filter(ObjectNode.class::isInstance)
-                .map(ObjectNode.class::cast)
-                .orElse(null);
+    @Override
+    public JsonPointer getTemplatesPath() {
+        return JsonPointer.compile("/templates");
     }
 
-    public ObjectNode getIndexTemplates() {
-        return (ObjectNode) root.get("index_template").get("index_template");
+    @Override
+    public JsonPointer getIndexTemplatesPath() {
+        return JsonPointer.compile("/index_template/index_template");
     }
 
-    public ObjectNode getComponentTemplates() {
-        return (ObjectNode) root.get("component_template").get("component_template");
+    @Override
+    public JsonPointer getComponentTemplatesPath() {
+        return JsonPointer.compile("/component_template/component_template");
     }
 }

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/version_es_7_10/IndexMetadataData_ES_7_10.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/version_es_7_10/IndexMetadataData_ES_7_10.java
@@ -3,17 +3,27 @@ package org.opensearch.migrations.bulkload.version_es_7_10;
 import org.opensearch.migrations.bulkload.models.IndexMetadata;
 import org.opensearch.migrations.bulkload.transformers.TransformFunctions;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
-public class IndexMetadataData_ES_7_10 implements IndexMetadata {
+@NoArgsConstructor(force = true) // For Jackson
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.NONE, getterVisibility = JsonAutoDetect.Visibility.NONE)
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, property = "type")
+public class IndexMetadataData_ES_7_10 extends IndexMetadata {
     @Getter
+    @JsonProperty("body")
     private final ObjectNode rawJson;
     private ObjectNode mappings;
     private ObjectNode settings;
     @Getter
+    @JsonProperty("id")
     private final String id;
     @Getter
+    @JsonProperty("name")
     private final String name;
 
     public IndexMetadataData_ES_7_10(ObjectNode root, String indexId, String indexName) {

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/version_os_2_11/GlobalMetadataData_OS_2_11.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/version_os_2_11/GlobalMetadataData_OS_2_11.java
@@ -2,6 +2,7 @@ package org.opensearch.migrations.bulkload.version_os_2_11;
 
 import org.opensearch.migrations.bulkload.models.GlobalMetadata;
 
+import com.fasterxml.jackson.core.JsonPointer;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
 public class GlobalMetadataData_OS_2_11 implements GlobalMetadata {
@@ -16,25 +17,18 @@ public class GlobalMetadataData_OS_2_11 implements GlobalMetadata {
         return root;
     }
 
-    public ObjectNode getTemplates() {
-        return (ObjectNode) root.get("templates");
+    @Override
+    public JsonPointer getTemplatesPath() {
+        return JsonPointer.compile("/templates");
     }
 
-    public ObjectNode getIndexTemplates() {
-        String indexTemplateKey = "index_template";
-        if (root.get(indexTemplateKey) != null) {
-            return (ObjectNode) root.get(indexTemplateKey).get(indexTemplateKey);
-        } else {
-            return null;
-        }
+    @Override
+    public JsonPointer getIndexTemplatesPath() {
+        return JsonPointer.compile("/index_template/index_template");
     }
 
-    public ObjectNode getComponentTemplates() {
-        String componentTemplateKey = "component_template";
-        if (root.get(componentTemplateKey) != null) {
-            return (ObjectNode) root.get(componentTemplateKey).get(componentTemplateKey);
-        } else {
-            return null;
-        }
+    @Override
+    public JsonPointer getComponentTemplatesPath() {
+        return JsonPointer.compile("/component_template/component_template");
     }
 }

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/version_os_2_11/IndexMetadataData_OS_2_11.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/version_os_2_11/IndexMetadataData_OS_2_11.java
@@ -2,11 +2,21 @@ package org.opensearch.migrations.bulkload.version_os_2_11;
 
 import org.opensearch.migrations.bulkload.models.IndexMetadata;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import lombok.NoArgsConstructor;
 
-public class IndexMetadataData_OS_2_11 implements IndexMetadata {
+@NoArgsConstructor(force = true) // For Jackson
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.NONE, getterVisibility = JsonAutoDetect.Visibility.NONE)
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, property = "type")
+public class IndexMetadataData_OS_2_11 extends IndexMetadata {
+    @JsonProperty("body")
     private ObjectNode root;
+    @JsonProperty("id")
     private String indexId;
+    @JsonProperty("name")
     private String indexName;
 
     public IndexMetadataData_OS_2_11(ObjectNode root, String indexId, String indexName) {

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/version_universal/RemoteMetadata.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/version_universal/RemoteMetadata.java
@@ -1,9 +1,8 @@
 package org.opensearch.migrations.bulkload.version_universal;
 
-import java.util.Optional;
-
 import org.opensearch.migrations.bulkload.models.GlobalMetadata;
 
+import com.fasterxml.jackson.core.JsonPointer;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import lombok.AllArgsConstructor;
 
@@ -18,30 +17,17 @@ public class RemoteMetadata implements GlobalMetadata {
     }
 
     @Override
-    public ObjectNode getTemplates() {
-        return Optional.ofNullable(sourceData)
-            .map(node -> node.get("templates"))
-            .map(node -> node.get("templates"))
-            .filter(ObjectNode.class::isInstance)
-            .map(ObjectNode.class::cast)
-            .orElse(null);
+    public JsonPointer getTemplatesPath() {
+        return JsonPointer.compile("/templates/templates");
     }
 
     @Override
-    public ObjectNode getIndexTemplates() {
-        return Optional.ofNullable(sourceData)
-                .map(node -> node.get("index_template"))
-                .map(node -> node.get("index_template"))
-                .filter(ObjectNode.class::isInstance)
-                .map(ObjectNode.class::cast)
-                .orElse(null);    }
+    public JsonPointer getIndexTemplatesPath() {
+        return JsonPointer.compile("/index_template/index_template");
+    }
 
     @Override
-    public ObjectNode getComponentTemplates() {
-        return Optional.ofNullable(sourceData)
-                .map(node -> node.get("component_template"))
-                .map(node -> node.get("component_template"))
-                .filter(ObjectNode.class::isInstance)
-                .map(ObjectNode.class::cast)
-                .orElse(null);    }
+    public JsonPointer getComponentTemplatesPath() {
+        return JsonPointer.compile("/component_template/component_template");
+    }
 }

--- a/RFS/src/main/java/org/opensearch/migrations/metadata/CreationResult.java
+++ b/RFS/src/main/java/org/opensearch/migrations/metadata/CreationResult.java
@@ -29,7 +29,8 @@ public class CreationResult implements Comparable<CreationResult>  {
     public static enum CreationFailureType {
         ALREADY_EXISTS(false, "already exists"),
         UNABLE_TO_TRANSFORM_FAILURE(true, "failed to transform to the target version"),
-        TARGET_CLUSTER_FAILURE(true, "failed on target cluster");
+        TARGET_CLUSTER_FAILURE(true, "failed on target cluster"),
+        SKIPPED_DUE_TO_FILTER(false, "skipped due to filter");
 
         private final boolean fatal;
         private final String message;

--- a/transformation/src/main/java/org/opensearch/migrations/transformation/JsonTransformerForDocumentTypeRemovalProvider.java
+++ b/transformation/src/main/java/org/opensearch/migrations/transformation/JsonTransformerForDocumentTypeRemovalProvider.java
@@ -18,7 +18,9 @@ public class JsonTransformerForDocumentTypeRemovalProvider implements IJsonTrans
         @Override
         @SuppressWarnings("unchecked")
         public Map<String, Object> transformJson(Map<String, Object> incomingJson) {
-            ((Map<String, Object>) incomingJson.get("index")).remove("_type");
+            if (incomingJson.containsKey("index")) {
+                ((Map<String, Object>) incomingJson.get("index")).remove("_type");
+            }
             return incomingJson;
         }
     }


### PR DESCRIPTION
### Description

Add metadata transformations with metadata tuples.

Adds SKIPPED migration failure type

* Category: New feature
* Why these changes are required? Users may require metadata transformations across versions, particularly to support multi-type indices.
* What is the old behavior before changes and new behavior after changes? No Metadata tuples, no shown output for skipped indexes/templates, no transformation support in metadata

### Issues Resolved

#1115 

https://opensearch.atlassian.net/browse/MIGRATIONS-2157

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
Unit tests added, aws testing for log format and location

### Check List
- [x] New functionality includes testing
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
