### PR TITLE
Hardcode AMIs for use in the bootstrap machine

### DIFF
--- a/deployment/migration-assistant-solution/README.md
+++ b/deployment/migration-assistant-solution/README.md
@@ -36,6 +36,10 @@ The full range of functionality offered by the migration assistant deployed thro
 
 This project is writen in TypeScript and uses the cloud developer tookit (CDK) to produce its build artifacts, cloud formation templates that can be used to deploy onto Amazon Web Services.
 
+### Hardcoded AMIs
+
+While using EC2 we have run into issues with AMI's being released that broken our functionality so we are hardcoding all AMIs to ensure the solution will work.  Setup your AWS credentials in the command line and run the script `create-ami-map.sh` in this directory to find the matching AMI in all regions, then update the map inside the solutions stack, [ref](./create-ami-map.sh).
+
 ### Quick Start Guide
 
 * Install Node 18+ & Npm 10+ https://docs.npmjs.com/downloading-and-installing-node-js-and-npm

--- a/deployment/migration-assistant-solution/create-ami-map.sh
+++ b/deployment/migration-assistant-solution/create-ami-map.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# AMI name to look up
+AMI_NAME="al2023-ami-2023.5.20241001.1-kernel-6.1-x86_64"
+OWNER="amazon"
+
+# Get the list of all available AWS regions
+REGIONS=$(aws ec2 describe-regions --query "Regions[].RegionName" --output text)
+
+declare -A amiMap
+
+echo "Looking up AMI IDs for '$AMI_NAME' owned by '$OWNER' in all regions..."
+
+for region in $REGIONS; do
+    echo "Searching in region: $region"
+    ami_id=$(aws ec2 describe-images \
+        --region $region \
+        --owners $OWNER \
+        --filters "Name=name,Values=$AMI_NAME" \
+        --query "Images[0].ImageId" \
+        --output text)
+    
+    if [ "$ami_id" != "None" ]; then
+        amiMap[$region]=$ami_id
+        echo "Found AMI ID: $ami_id in region $region"
+    else
+        echo "No AMI found in region $region"
+    fi
+done
+
+# Generate the AMI map as typescript
+echo ""
+echo "AMI Map:"
+echo "const amiMap = {"
+for region in "${!amiMap[@]}"; do
+    echo "  '$region': '${amiMap[$region]}',"
+done
+echo "};"

--- a/deployment/migration-assistant-solution/create-ami-map.sh
+++ b/deployment/migration-assistant-solution/create-ami-map.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # AMI name to look up
-AMI_NAME="al2023-ami-2023.5.20241001.1-kernel-6.1-x86_64"
+AMI_NAME="al2023-ami-2023.6.20241031.0-kernel-6.1-x86_64"
 OWNER="amazon"
 
 # Get the list of all available AWS regions

--- a/deployment/migration-assistant-solution/lib/solutions-stack.ts
+++ b/deployment/migration-assistant-solution/lib/solutions-stack.ts
@@ -203,28 +203,28 @@ export class SolutionsInfrastructureStack extends Stack {
 
         // Generated with ../create-ami-map.sh
         const amiMap: Record<string, string> =  {
-            'us-east-2': 'ami-09da212cf18033880',
-            'us-east-1': 'ami-0fff1b9a61dec8a5f',
-            'us-west-1': 'ami-09b2477d43bc5d0ac',
-            'us-west-2': 'ami-0d081196e3df05f4d',
-            'ca-central-1': 'ami-0d9c7bbbda4b78ffd',
-            'ap-south-1': 'ami-078264b8ba71bc45e',
-            'sa-east-1': 'ami-0fd8b11b89c97edaf',
-            'eu-north-1': 'ami-097c5c21a18dc59ea',
-            'ap-northeast-1': 'ami-0ef29ab52ff72213b',
-            'ap-northeast-2': 'ami-0e18fe6ecdad223e5',
-            'ap-northeast-3': 'ami-022b677fdccc634eb',
-            'eu-central-1': 'ami-0592c673f0b1e7665',
-            'eu-west-2': 'ami-0b4c7755cdf0d9219',
-            'eu-west-3': 'ami-0a3598a00eff32f66',
-            'eu-west-1': 'ami-054a53dca63de757b',
-            'ap-southeast-2': 'ami-0cf70e1d861e1dfb8',
-            'ap-southeast-1': 'ami-0ad522a4a529e7aa8',
+            'us-east-2': 'ami-0fae88c1e6794aa17',
+            'us-east-1': 'ami-063d43db0594b521b',
+            'us-west-1': 'ami-05c65d8bb2e35991a',
+            'us-west-2': 'ami-066a7fbea5161f451',
+            'ca-central-1': 'ami-0d13170a36bc1b384',
+            'ap-south-1': 'ami-08bf489a05e916bbd',
+            'sa-east-1': 'ami-065c72b3f381dab73',
+            'eu-north-1': 'ami-04b54ebf295fe01d7',
+            'ap-northeast-1': 'ami-08ce76bae392de7dc',
+            'ap-northeast-2': 'ami-03d31e4041396b53c',
+            'ap-northeast-3': 'ami-0403e868508046e73',
+            'eu-central-1': 'ami-0eddb4a4e7d846d6f',
+            'eu-west-2': 'ami-02f617729751b375a',
+            'eu-west-3': 'ami-0db5e28c1b3823bb7',
+            'eu-west-1': 'ami-03ca36368dbc9cfa1',
+            'ap-southeast-2': 'ami-037a2314eeca55594',
+            'ap-southeast-1': 'ami-08f49baa317796afd',
         };
 
         // Manually looked up with https://us-gov-east-1.console.amazonaws-us-gov.com/ec2/home?region=us-gov-east-1#AMICatalog:
-        amiMap['us-gov-west-1'] = 'ami-0c428177c69dbc6ff';
-        amiMap['us-gov-east-1'] = 'ami-0345e99d9ca0e18a1';
+        amiMap['us-gov-west-1'] = 'ami-0e46a6a8d36d6f1f2';
+        amiMap['us-gov-east-1'] = 'ami-0016d10ace091da71';
 
         new Instance(this, 'BootstrapEC2Instance', {
             vpc: vpc,

--- a/deployment/migration-assistant-solution/lib/solutions-stack.ts
+++ b/deployment/migration-assistant-solution/lib/solutions-stack.ts
@@ -222,6 +222,10 @@ export class SolutionsInfrastructureStack extends Stack {
             'ap-southeast-1': 'ami-0ad522a4a529e7aa8',
         };
 
+        // Manually looked up with https://us-gov-east-1.console.amazonaws-us-gov.com/ec2/home?region=us-gov-east-1#AMICatalog:
+        amiMap['us-gov-west-1'] = 'ami-0c428177c69dbc6ff';
+        amiMap['us-gov-east-1'] = 'ami-0345e99d9ca0e18a1';
+
         new Instance(this, 'BootstrapEC2Instance', {
             vpc: vpc,
             vpcSubnets: {

--- a/deployment/migration-assistant-solution/test/solutions-stack.test.ts
+++ b/deployment/migration-assistant-solution/test/solutions-stack.test.ts
@@ -11,7 +11,10 @@ describe('Solutions stack', () => {
             solutionName: 'test-solution',
             solutionVersion: '0.0.1',
             codeBucket: 'test-bucket',
-            createVPC: true
+            createVPC: true,
+            env: {
+                region: 'us-west-1'
+            }
         });
         const template = Template.fromStack(stack);
         template.resourceCountIs('AWS::EC2::VPC', 1)
@@ -27,7 +30,10 @@ describe('Solutions stack', () => {
             solutionName: 'test-solution',
             solutionVersion: '0.0.1',
             codeBucket: 'test-bucket',
-            createVPC: false
+            createVPC: false,
+            env: {
+                region: 'us-west-1'
+            }
         });
         const template = Template.fromStack(stack);
         template.resourceCountIs('AWS::EC2::VPC', 0)


### PR DESCRIPTION
### Description
With the current latest AL2023 image `al2023-ami-2023.6.20241111.0-kernel-6.1-x86_64` npm install hangs indefinitely.  We are switching back to an older version that works and providing a way to incrementally update to AMIs that we have tested.

### Issues Resolved
- initBootstrap.sh hangs on npm install tasks https://opensearch.atlassian.net/browse/MIGRATIONS-2227
- Related https://github.com/amazonlinux/amazon-linux-2023/issues/840

### Testing
Deployed the updated cloudformation manually and verified the build succeeds.

### Check List
- [ ] New functionality includes testing
  - [ ] All tests pass, including unit test, integration test and doctest
- [X] New functionality has been documented
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
