### PR TITLE
Add baseline sonarqube issue count

### DIFF
--- a/.github/workflows/sonar-qube.yml
+++ b/.github/workflows/sonar-qube.yml
@@ -77,11 +77,12 @@ jobs:
         done
 
         ISSUE_COUNT=$(jq '.issues | length' issues.json)
-        if [ "$ISSUE_COUNT" -gt 0 ]; then
-          echo "❌ Build failed: Found $ISSUE_COUNT issues."
+        BASELINE_ISSUE_COUNT=89 # Baseline issue count
+        if [ "$ISSUE_COUNT" -gt "$BASELINE_ISSUE_COUNT" ]; then
+          echo "❌ Build failed: Found $ISSUE_COUNT issues, which is more than the baseline of $BASELINE_ISSUE_COUNT."
           exit 1
         else
-          echo "✅ No issues found."
+          echo "✅ Build passed: Found $ISSUE_COUNT issues, which is within the baseline of $BASELINE_ISSUE_COUNT."
         fi
     - name: Upload SonarQube Artifacts
       if: always()


### PR DESCRIPTION
### Description

Add baseline sonarqube issue count of 89 so that commits that don't make it worse pass. As we resolve issues, we can reduce this number to avoid regressions. 

* Category: Test fix
* Why these changes are required? GHA should show as passing for commits that do not introduce issues
* What is the old behavior before changes and new behavior after changes? All commits and PRs showed failing sonarqube

### Issues Resolved
N/A

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
GHA

### Check List
- [x] New functionality includes testing
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
