### PR TITLE
More consistent index template allow list behavior

### DIFF
--- a/MetadataMigration/DEVELOPER_GUIDE.md
+++ b/MetadataMigration/DEVELOPER_GUIDE.md
@@ -71,7 +71,7 @@ If your target cluster has basic auth enabled on it, you can supply those creden
 
 ### Allowlisting the templates and indices to migrate
 
-By default, the tool has an empty allowlist for templates, meaning none will be migrated.  In contrast, the default allowlist for indices is open, meaning all non-system indices (those not prefixed with `.`) will be migrated.  You can tweak these allowlists with a comma-separated list of items you specifically with to migrate.  If you specify an custom allowlist for the templates or indices, the default allowlist is disregarded and **only** the items you have in your allowlist will be moved.
+By default, allowlist for indices and index templates is open, meaning all non-system indices (those not prefixed with `.`) will be migrated.  You can tweak these allowlists with a comma-separated list of items you specifically with to migrate.  If you specify an custom allowlist for the templates or indices, the default allowlist is disregarded and **only** the items you have in your allowlist will be moved.
 
 ```shell
 ./gradlew MetadataMigration:run --args='--snapshot-name reindex-from-snapshot --s3-local-dir /tmp/s3_files --s3-repo-uri s3://your-s3-uri --s3-region us-fake-1 --target-host http://hostname:9200 --index-allowlist Index1,.my_system_index,logs-2023 --index-template-allowlist logs_template --component-template-allowlist component2,component7'

--- a/MetadataMigration/src/test/java/org/opensearch/migrations/EndToEndTest.java
+++ b/MetadataMigration/src/test/java/org/opensearch/migrations/EndToEndTest.java
@@ -14,7 +14,6 @@ import org.opensearch.migrations.bulkload.common.http.ConnectionContextTestParam
 import org.opensearch.migrations.bulkload.framework.SearchClusterContainer;
 import org.opensearch.migrations.bulkload.framework.SearchClusterContainer.ContainerVersion;
 import org.opensearch.migrations.bulkload.http.ClusterOperations;
-import org.opensearch.migrations.bulkload.models.DataFilterArgs;
 import org.opensearch.migrations.bulkload.worker.SnapshotRunner;
 import org.opensearch.migrations.commands.MigrationItemResult;
 import org.opensearch.migrations.metadata.CreationResult;
@@ -162,12 +161,6 @@ class EndToEndTest {
         }
 
         arguments.targetArgs.host = targetCluster.getUrl();
-
-        var dataFilterArgs = new DataFilterArgs();
-        dataFilterArgs.indexAllowlist = List.of();
-        dataFilterArgs.componentTemplateAllowlist = List.of(testData.compoTemplateName);
-        dataFilterArgs.indexTemplateAllowlist = List.of(testData.indexTemplateName);
-        arguments.dataFilterArgs = dataFilterArgs;
 
         var targetClusterOperations = new ClusterOperations(targetCluster.getUrl());
         targetClusterOperations.createDocument(testData.indexThatAlreadyExists, "doc77", "{}");

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/common/FilterScheme.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/common/FilterScheme.java
@@ -1,26 +1,23 @@
 package org.opensearch.migrations.bulkload.common;
 
 import java.util.List;
-import java.util.function.BiConsumer;
 import java.util.function.Predicate;
 
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
 public class FilterScheme {
     private FilterScheme() {}
 
-    public static Predicate<SnapshotRepo.Index> filterIndicesByAllowList(
-        List<String> indexAllowlist,
-        BiConsumer<String, Boolean> indexNameAcceptanceObserver
-    ) {
-        return index -> {
+    public static Predicate<String> filterByAllowList(List<String> allowlist) {
+        return item -> {
             boolean accepted;
-            if (indexAllowlist.isEmpty()) {
-                accepted = !index.getName().startsWith(".");
+            // By default allow all items except 'system' items that start with a period
+            if (allowlist == null || allowlist.isEmpty()) {
+                accepted = !item.startsWith(".");
             } else {
-                accepted = indexAllowlist.contains(index.getName());
+                accepted = allowlist.contains(item);
             }
-
-            indexNameAcceptanceObserver.accept(index.getName(), accepted);
-
             return accepted;
         };
     }

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/models/DataFilterArgs.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/models/DataFilterArgs.java
@@ -11,11 +11,11 @@ public class DataFilterArgs {
 
     @Parameter(names = {
         "--index-template-allowlist" }, description = ("Optional.  List of index template names to migrate"
-            + " (e.g. 'posts_index_template1, posts_index_template2').  Default: empty list"), required = false)
+            + " (e.g. 'posts_index_template1, posts_index_template2').  Default: all non-system indices (e.g. those not starting with '.')"), required = false)
     public List<String> indexTemplateAllowlist = List.of();
 
     @Parameter(names = {
         "--component-template-allowlist" }, description = ("Optional. List of component template names to migrate"
-            + " (e.g. 'posts_template1, posts_template2').  Default: empty list"), required = false)
+            + " (e.g. 'posts_template1, posts_template2').  Default: all non-system indices (e.g. those not starting with '.')"), required = false)
     public List<String> componentTemplateAllowlist = List.of();
 }

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/version_os_2_11/GlobalMetadataCreator_OS_2_11.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/version_os_2_11/GlobalMetadataCreator_OS_2_11.java
@@ -1,12 +1,13 @@
 package org.opensearch.migrations.bulkload.version_os_2_11;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import org.opensearch.migrations.MigrationMode;
+import org.opensearch.migrations.bulkload.common.FilterScheme;
 import org.opensearch.migrations.bulkload.common.OpenSearchClient;
 import org.opensearch.migrations.bulkload.models.GlobalMetadata;
 import org.opensearch.migrations.metadata.CreationResult;
@@ -35,14 +36,13 @@ public class GlobalMetadataCreator_OS_2_11 implements GlobalMetadataCreator {
         log.info("Setting Global Metadata");
 
         var results = GlobalMetadataCreatorResults.builder();
-        GlobalMetadataData_OS_2_11 globalMetadata = new GlobalMetadataData_OS_2_11(root.toObjectNode());
-        results.legacyTemplates(createLegacyTemplates(globalMetadata, mode, context));
-        results.componentTemplates(createComponentTemplates(globalMetadata, mode, context));
-        results.indexTemplates(createIndexTemplates(globalMetadata, mode, context));
+        results.legacyTemplates(createLegacyTemplates(root, mode, context));
+        results.componentTemplates(createComponentTemplates(root, mode, context));
+        results.indexTemplates(createIndexTemplates(root, mode, context));
         return results.build();
     }
 
-    public List<CreationResult> createLegacyTemplates(GlobalMetadataData_OS_2_11 metadata, MigrationMode mode, IClusterMetadataContext context) {
+    public List<CreationResult> createLegacyTemplates(GlobalMetadata metadata, MigrationMode mode, IClusterMetadataContext context) {
         return createTemplates(
             metadata.getTemplates(),
             legacyTemplateAllowlist,
@@ -52,7 +52,7 @@ public class GlobalMetadataCreator_OS_2_11 implements GlobalMetadataCreator {
         );
     }
 
-    public List<CreationResult> createComponentTemplates(GlobalMetadataData_OS_2_11 metadata, MigrationMode mode, IClusterMetadataContext context) {
+    public List<CreationResult> createComponentTemplates(GlobalMetadata metadata, MigrationMode mode, IClusterMetadataContext context) {
         return createTemplates(
             metadata.getComponentTemplates(),
             componentTemplateAllowlist,
@@ -62,7 +62,7 @@ public class GlobalMetadataCreator_OS_2_11 implements GlobalMetadataCreator {
         );
     }
 
-    public List<CreationResult> createIndexTemplates(GlobalMetadataData_OS_2_11 metadata, MigrationMode mode, IClusterMetadataContext context) {
+    public List<CreationResult> createIndexTemplates(GlobalMetadata metadata, MigrationMode mode, IClusterMetadataContext context) {
         return createTemplates(
             metadata.getIndexTemplates(),
             indexTemplateAllowlist,
@@ -73,7 +73,7 @@ public class GlobalMetadataCreator_OS_2_11 implements GlobalMetadataCreator {
     }
 
     @AllArgsConstructor
-    private enum TemplateTypes {
+    enum TemplateTypes {
         INDEX_TEMPLATE(
             (targetClient, name, body, context) -> targetClient.createIndexTemplate(name, body, context.createMigrateTemplateContext()),
             (targetClient, name) -> targetClient.hasIndexTemplate(name)
@@ -118,34 +118,18 @@ public class GlobalMetadataCreator_OS_2_11 implements GlobalMetadataCreator {
             return List.of();
         }
 
-        if (templateAllowlist != null && templateAllowlist.isEmpty()) {
-            log.info("No {} in specified allowlist", templateType);
-            return List.of();
-        }
+        var templatesToCreate = getAllTemplates(templates, templateType);
 
-        var templatesToCreate = getTemplatesToCreate(templates, templateAllowlist, templateType);
-
-        return processTemplateCreation(templatesToCreate, templateType, mode, context);
+        return processTemplateCreation(templatesToCreate, templateType, templateAllowlist, mode, context);
     }
 
-    private Map<String, ObjectNode> getTemplatesToCreate(ObjectNode templates, List<String> templateAllowlist, TemplateTypes templateType) {
+    Map<String, ObjectNode> getAllTemplates(ObjectNode templates, TemplateTypes templateType) {
         var templatesToCreate = new HashMap<String, ObjectNode>();
 
-        if (templateAllowlist != null) {
-            for (String templateName : templateAllowlist) {
-                if (!templates.has(templateName) || templates.get(templateName) == null) {
-                    log.warn("{} not found: {}", templateType, templateName);
-                    continue;
-                }
-                ObjectNode settings = (ObjectNode) templates.get(templateName);
-                templatesToCreate.put(templateName, settings);
-            }
-        } else {
-            templates.fieldNames().forEachRemaining(templateName -> {
-                ObjectNode settings = (ObjectNode) templates.get(templateName);
-                templatesToCreate.put(templateName, settings);
-            });
-        }
+        templates.fieldNames().forEachRemaining(templateName -> {
+            ObjectNode settings = (ObjectNode) templates.get(templateName);
+            templatesToCreate.put(templateName, settings);
+        });
 
         return templatesToCreate;
     }
@@ -153,14 +137,22 @@ public class GlobalMetadataCreator_OS_2_11 implements GlobalMetadataCreator {
     private List<CreationResult> processTemplateCreation(
             Map<String, ObjectNode> templatesToCreate,
             TemplateTypes templateType,
+            List<String> templateAllowList,
             MigrationMode mode,
             IClusterMetadataContext context
         ) {
+        var skipCreation = FilterScheme.filterByAllowList(templateAllowList).negate();
 
-        List<CreationResult> templateList = new ArrayList<>();
-
-        templatesToCreate.forEach((templateName, templateBody) -> {
+        return templatesToCreate.entrySet().stream().map((kvp) -> {
+            var templateName = kvp.getKey();
+            var templateBody = kvp.getValue();
             var creationResult = CreationResult.builder().name(templateName);
+
+            if (skipCreation.test(templateName)) {
+                log.atInfo().setMessage("Template {} was skipped due to allow list filter {}").addArgument(templateName).addArgument(templateAllowList).log();
+                return creationResult.failureType(CreationFailureType.SKIPPED_DUE_TO_FILTER).build();
+            }
+
             log.info("Creating {}: {}", templateType, templateName);
             try {
                 if (mode == MigrationMode.SIMULATE) {
@@ -179,9 +171,7 @@ public class GlobalMetadataCreator_OS_2_11 implements GlobalMetadataCreator {
                 creationResult.failureType(CreationFailureType.TARGET_CLUSTER_FAILURE);
                 creationResult.exception(e);
             }
-            templateList.add(creationResult.build());
-        });
-
-        return templateList;
+            return creationResult.build();
+        }).collect(Collectors.toList());
     }
 }

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/worker/IndexRunner.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/worker/IndexRunner.java
@@ -1,8 +1,6 @@
 package org.opensearch.migrations.bulkload.worker;
 
 import java.util.List;
-import java.util.function.BiConsumer;
-import java.util.function.Predicate;
 
 import org.opensearch.migrations.MigrationMode;
 import org.opensearch.migrations.bulkload.common.FilterScheme;
@@ -29,52 +27,46 @@ public class IndexRunner {
 
     public IndexMetadataResults migrateIndices(MigrationMode mode, ICreateIndexContext context) {
         var repoDataProvider = metadataFactory.getRepoDataProvider();
-        BiConsumer<String, Boolean> logger = (indexName, accepted) -> {
-            if (Boolean.FALSE.equals(accepted)) {
-                log.atInfo().setMessage("Index {} rejected by allowlist").addArgument(indexName).log();
-            }
-        };
         var results = IndexMetadataResults.builder();
-
-        // Set results for filtered items
-        repoDataProvider.getIndicesInSnapshot(snapshotName)
-                .stream()
-                .filter(Predicate.not(FilterScheme.filterIndicesByAllowList(indexAllowlist, logger)))
-                .forEach(index -> results.index(CreationResult.builder()
-                        .name(index.getName())
-                        .failureType(CreationFailureType.SKIPPED_DUE_TO_FILTER)
-                        .build()));
-
+        var skipCreation = FilterScheme.filterByAllowList(indexAllowlist).negate();
 
         repoDataProvider.getIndicesInSnapshot(snapshotName)
             .stream()
-            .filter(FilterScheme.filterIndicesByAllowList(indexAllowlist, logger))
             .forEach(index -> {
-                var indexName = index.getName();
-                var originalIndexMetadata = metadataFactory.fromRepo(snapshotName, indexName);
-
-                CreationResult indexResult = null;
-                var indexMetadata = originalIndexMetadata.deepCopy();
-                try {
-                    indexMetadata = transformer.transformIndexMetadata(indexMetadata);
-                    indexResult = indexCreator.create(indexMetadata, mode, context);
-                } catch (Throwable t) {
-                    indexResult = CreationResult.builder()
-                        .name(indexName)
-                        .exception(new IndexTransformationException(indexName, t))
-                        .failureType(CreationFailureType.UNABLE_TO_TRANSFORM_FAILURE)
+                CreationResult creationResult;
+                if (skipCreation.test(index.getName())) {
+                    creationResult = CreationResult.builder()
+                        .name(index.getName())
+                        .failureType(CreationFailureType.SKIPPED_DUE_TO_FILTER)
                         .build();
+                } else {
+                    creationResult = createIndex(index.getName(), mode, context);
                 }
 
-                var finalResult = indexResult;
-                results.index(finalResult);
+                results.index(creationResult);
 
+                var indexMetadata = metadataFactory.fromRepo(snapshotName, index.getName());
                 indexMetadata.getAliases().fieldNames().forEachRemaining(alias -> {
                     var aliasResult = CreationResult.builder().name(alias);
-                    aliasResult.failureType(finalResult.getFailureType());
+                    aliasResult.failureType(creationResult.getFailureType());
                     results.alias(aliasResult.build());
                 });
             });
         return results.build();
     }
+
+    private CreationResult createIndex(String indexName, MigrationMode mode, ICreateIndexContext context) {
+        var originalIndexMetadata = metadataFactory.fromRepo(snapshotName, indexName);
+        var indexMetadata = originalIndexMetadata.deepCopy();
+        try {
+            indexMetadata = transformer.transformIndexMetadata(indexMetadata);
+            return indexCreator.create(indexMetadata, mode, context);
+        } catch (Throwable t) {
+            return CreationResult.builder()
+                .name(indexName)
+                .exception(new IndexTransformationException(indexName, t))
+                .failureType(CreationFailureType.UNABLE_TO_TRANSFORM_FAILURE)
+                .build();
+        }
+    } 
 }

--- a/RFS/src/test/java/org/opensearch/migrations/bulkload/common/FilterSchemeTest.java
+++ b/RFS/src/test/java/org/opensearch/migrations/bulkload/common/FilterSchemeTest.java
@@ -1,0 +1,46 @@
+package org.opensearch.migrations.bulkload.common;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class FilterSchemeTest {
+    @Test
+    void testFilterByAllowList_null() {
+        var filter = FilterScheme.filterByAllowList(null);
+
+        assertThat(filter.test("test"), equalTo(true));
+        assertThat(filter.test("test1"), equalTo(true));
+        assertThat(filter.test(".test"), equalTo(false));
+    }
+
+    @Test
+    void testFilterByAllowList_empty() {
+        var filter = FilterScheme.filterByAllowList(List.of());
+
+        assertThat(filter.test("test"), equalTo(true));
+        assertThat(filter.test("test1"), equalTo(true));
+        assertThat(filter.test(".test"), equalTo(false));
+    }
+
+    @Test
+    void testFilterByAllowList_matches() {
+        var filter = FilterScheme.filterByAllowList(List.of("test"));
+
+        assertThat(filter.test("test"), equalTo(true));
+        assertThat(filter.test("test1"), equalTo(false));
+        assertThat(filter.test(".test"), equalTo(false));
+    }
+
+    @Test
+    void testFilterByAllowList_matches_with_period() {
+        var filter = FilterScheme.filterByAllowList(List.of(".test"));
+
+        assertThat(filter.test("test"), equalTo(false));
+        assertThat(filter.test("test1"), equalTo(false));
+        assertThat(filter.test(".test"), equalTo(true));
+    }
+}

--- a/RFS/src/test/java/org/opensearch/migrations/bulkload/version_os_2_11/GlobalMetadataCreator_OS_2_11Test.java
+++ b/RFS/src/test/java/org/opensearch/migrations/bulkload/version_os_2_11/GlobalMetadataCreator_OS_2_11Test.java
@@ -1,0 +1,73 @@
+package org.opensearch.migrations.bulkload.version_os_2_11;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.opensearch.migrations.MigrationMode;
+import org.opensearch.migrations.bulkload.common.OpenSearchClient;
+import org.opensearch.migrations.bulkload.models.GlobalMetadata;
+import org.opensearch.migrations.bulkload.version_os_2_11.GlobalMetadataCreator_OS_2_11.TemplateTypes;
+import org.opensearch.migrations.metadata.CreationResult;
+import org.opensearch.migrations.metadata.CreationResult.CreationFailureType;
+import org.opensearch.migrations.metadata.tracing.IMetadataMigrationContexts.IClusterMetadataContext;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.opensearch.migrations.metadata.CreationResult.CreationFailureType.SKIPPED_DUE_TO_FILTER;
+
+@ExtendWith(MockitoExtension.class)
+public class GlobalMetadataCreator_OS_2_11Test {
+
+    @Mock
+    OpenSearchClient client;
+
+    @Mock
+    IClusterMetadataContext context;
+
+    @Test
+    void testCreate() {
+        var mapper = new ObjectMapper();
+        var obj = mapper.createObjectNode();
+        var filledOptional = Optional.of(obj);
+        doReturn(filledOptional).when(client).createComponentTemplate(any(), any(), any());
+        doReturn(filledOptional).when(client).createIndexTemplate(any(), any(), any());
+        doReturn(filledOptional).when(client).createLegacyTemplate(any(), any(), any());
+
+        var creator = spy(new GlobalMetadataCreator_OS_2_11(client, List.of("lit1"), List.of(), null));
+        doReturn(Map.of("lit1", obj, "lit2", obj, ".lits", obj)).when(creator).getAllTemplates(any(), eq(TemplateTypes.LEGACY_INDEX_TEMPLATE));
+        doReturn(Map.of("it1", obj, ".its", obj)).when(creator).getAllTemplates(any(), eq(TemplateTypes.INDEX_TEMPLATE));
+        doReturn(Map.of("ct1", obj, ".cts", obj)).when(creator).getAllTemplates(any(), eq(TemplateTypes.COMPONENT_TEMPLATE));
+
+        var globalMetadata = mock(GlobalMetadata.class);
+        doReturn(obj).when(globalMetadata).getComponentTemplates();
+        doReturn(obj).when(globalMetadata).getIndexTemplates();
+        doReturn(obj).when(globalMetadata).getTemplates();
+
+        var results = creator.create(globalMetadata, MigrationMode.PERFORM, context);
+        assertThat(results.fatalIssueCount(), equalTo(0L));
+        assertThat(results.getLegacyTemplates(), containsInAnyOrder(createSuccessResult("lit1"), createResult("lit2", SKIPPED_DUE_TO_FILTER), createResult(".lits", SKIPPED_DUE_TO_FILTER)));
+        assertThat(results.getComponentTemplates(), containsInAnyOrder(createResult("ct1", SKIPPED_DUE_TO_FILTER), createSuccessResult(".cts")));
+        assertThat(results.getIndexTemplates(), containsInAnyOrder(createResult("it1", SKIPPED_DUE_TO_FILTER), createSuccessResult(".its")));
+    }
+
+    private CreationResult createSuccessResult(String name) {
+        return createResult(name, null);
+    }
+
+    private CreationResult createResult(String name, CreationFailureType type) {
+        return CreationResult.builder().name(name).failureType(type).build();
+    }
+}


### PR DESCRIPTION
### Description
Index and index template matching behavior is filtered in the same way, so when no allow list is supplied all templates that do not start with '.' are included by default.

### Issues Resolved
- Metadata Migration should include templates by default https://opensearch.atlassian.net/browse/MIGRATIONS-2039

### Testing
Added new test cases, and removed hardcoded allow list behavior in the end to end test cases.

### Check List
- [X] New functionality includes testing
  - [X] All tests pass, including unit test, integration test and doctest
- [X] New functionality has been documented
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
