### PR TITLE
Flip the default should throw behavior for HttpJsonMessageWithFaultingPayload

### DIFF
--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/PayloadAccessFaultingMap.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/PayloadAccessFaultingMap.java
@@ -34,6 +34,7 @@ public class PayloadAccessFaultingMap extends AbstractMap<String, Object> {
     private boolean disableThrowingPayloadNotLoaded;
 
     public PayloadAccessFaultingMap(StrictCaseInsensitiveHttpHeadersMap headers) {
+        disableThrowingPayloadNotLoaded = true;
         underlyingMap = new TreeMap<>();
         isJson = Optional.ofNullable(headers.get("content-type"))
             .map(list -> list.stream().anyMatch(s -> s.startsWith("application/json")))

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/http/NettyDecodedHttpRequestPreliminaryTransformHandler.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/http/NettyDecodedHttpRequestPreliminaryTransformHandler.java
@@ -67,7 +67,9 @@ public class NettyDecodedHttpRequestPreliminaryTransformHandler<R> extends Chann
             IAuthTransformer authTransformer = requestPipelineOrchestrator.authTransfomerFactory.getAuthTransformer(
                 httpJsonMessage
             );
+            final var payloadMap = (PayloadAccessFaultingMap) httpJsonMessage.payload();
             try {
+                payloadMap.setDisableThrowingPayloadNotLoaded(false);
                 handlePayloadNeutralTransformationOrThrow(
                     ctx,
                     originalHttpJsonMessage,
@@ -86,6 +88,8 @@ public class NettyDecodedHttpRequestPreliminaryTransformHandler<R> extends Chann
                     getAuthTransformerAsStreamingTransformer(authTransformer)
                 );
                 ctx.fireChannelRead(handleAuthHeaders(httpJsonMessage, authTransformer));
+            } finally {
+                payloadMap.setDisableThrowingPayloadNotLoaded(true);
             }
         } else if (msg instanceof HttpContent) {
             ctx.fireChannelRead(msg);


### PR DESCRIPTION
Flip the default should throw behavior for HttpJsonMessageWithFaultingPayload to opt-in rather than opt-out.

HttpJsonMessageWithFaultingPayload throws by default - so it could be run even if it wasn't within a transform - like from within a LoggingHandler, which is what I was observing when I added some more logging.  The worst part was that it created other errors which then caused the message to be processed in a very different way.

### Description

* Category Bug fix
* Why these changes are required? When logging levels go up, the system behaves as if logging weren't enabled!
* What is the old behavior before changes and new behavior after changes?

### Issues Resolved
https://opensearch.atlassian.net/browse/MIGRATIONS-2242

### Testing
gradle/cicd

### Check List
- [ ] New functionality includes testing
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
