### PR TITLE
Fix bug handle empty mappings when removing mapping types

### DIFF
--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/transformers/Transformer_ES_6_8_to_OS_2_11.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/transformers/Transformer_ES_6_8_to_OS_2_11.java
@@ -38,8 +38,16 @@ public class Transformer_ES_6_8_to_OS_2_11 implements Transformer {
             templatesRoot.fields().forEachRemaining(template -> {
                 var templateCopy = (ObjectNode) template.getValue().deepCopy();
                 var indexTemplate = (Index) () -> templateCopy;
-                transformIndex(indexTemplate, IndexType.TEMPLATE);
-                templates.set(template.getKey(), indexTemplate.getRawJson());
+                try {
+                    transformIndex(indexTemplate, IndexType.TEMPLATE);
+                    templates.set(template.getKey(), indexTemplate.getRawJson());
+                }  catch (Exception e) {
+                    log.atError()
+                        .setMessage("Unable to transform object: {}")
+                        .addArgument(indexTemplate::getRawJson)
+                        .setCause(e)
+                        .log();
+                }
             });
             newRoot.set("templates", templates);
         }

--- a/transformation/src/main/java/org/opensearch/migrations/transformation/rules/IndexMappingTypeRemoval.java
+++ b/transformation/src/main/java/org/opensearch/migrations/transformation/rules/IndexMappingTypeRemoval.java
@@ -45,7 +45,7 @@ public class IndexMappingTypeRemoval implements TransformationRule<Index> {
     public CanApplyResult canApply(final Index index) {
         final var mappingNode = index.getRawJson().get(MAPPINGS_KEY);
 
-        if (mappingNode == null) {
+        if (mappingNode == null || mappingNode.size() == 0) {
             return CanApplyResult.NO;
         }
 

--- a/transformation/src/test/java/org/opensearch/migrations/transformation/rules/IndexMappingTypeRemovalTest.java
+++ b/transformation/src/test/java/org/opensearch/migrations/transformation/rules/IndexMappingTypeRemovalTest.java
@@ -121,6 +121,21 @@ public class IndexMappingTypeRemovalTest {
     }
 
     @Test
+    void testApplyTransformation_emptyMappingArray() {
+        // Setup
+        var originalJson = indexSettingJson("\"mappings\": [],");
+        var indexJson = originalJson.deepCopy();
+
+        // Action
+        var wasChanged = applyTransformation(indexJson);
+        assertThat(canApply(originalJson), equalTo(CanApplyResult.NO));
+
+        // Verification
+        assertThat(wasChanged, equalTo(false));
+        assertThat(indexJson.toPrettyString(), equalTo(originalJson.toPrettyString()));
+    }
+
+    @Test
     void testApplyTransformation_noMappingNode() {
         // Setup
         var originalJson = indexSettingJson("");


### PR DESCRIPTION
### Description
Fix bug handle empty mappings when removing mapping types

### Issues Resolved
- Resolves #1177

### Check List
- [X] New functionality includes testing
  - [X] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
