### PR TITLE
MIGRATIONS-2243 - Replace 'Shards' verbiage with 'Fragment' in console backfill status

### DIFF
--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/backfill_rfs.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/backfill_rfs.py
@@ -232,7 +232,7 @@ class ECSRFSBackfill(RFSBackfill):
             logger.warning(f"Unclaimed ({values['unclaimed']}) and in progress ({values['in progress']}) shards do not"
                            f" sum to the incomplete ({values['incomplete']}) shards." + disclaimer)
 
-        return "\n".join([f"Shards {key}: {value}" for key, value in values.items() if value is not None])
+        return "\n".join([f"Work items {key}: {value}" for key, value in values.items() if value is not None])
 
 
 def get_working_state_index_backup_path(archive_dir_path: str = None, archive_file_name: str = None) -> str:


### PR DESCRIPTION
### Description

The customer-facing issue [#1172](https://github.com/opensearch-project/opensearch-migrations/issues/1172) highlights confusion arising from the use of the term "shard" to describe both console backfill and console snapshot operations. The shard count in a snapshot does not necessarily match the shard count in a backfill. For instance, some indices (and their corresponding shards) may be excluded from the backill. To address this, we propose changing the terminology from "shards" to "worker items" for backfill operations. This change aligns with potential future updates where multiple worker items may be associated with a single shard.

* Category: Maintenance
* What is the old behavior before changes and new behavior after changes? `console backfill status --deep-check` displays items as "Work Items" instead of "Shards"

### Issues Resolved
https://opensearch.atlassian.net/browse/MIGRATIONS-2243

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]

### Check List
- [ ] New functionality includes testing
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
