### PR TITLE
Fix log message when unable to find a reference id for a document

### DIFF
--- a/DocumentsFromSnapshotMigration/src/test/java/org/opensearch/migrations/bulkload/PerformanceVerificationTest.java
+++ b/DocumentsFromSnapshotMigration/src/test/java/org/opensearch/migrations/bulkload/PerformanceVerificationTest.java
@@ -23,6 +23,7 @@ import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.store.ByteBuffersDirectory;
 import org.apache.lucene.util.BytesRef;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Mono;
@@ -36,6 +37,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @Slf4j
+@Disabled("https://opensearch.atlassian.net/browse/MIGRATIONS-2254")
 public class PerformanceVerificationTest {
 
     @Test


### PR DESCRIPTION
### Description
We were incorrectly reporting documents that were missing a reference id as an error message whereas this is on par with a missing source body at warning level.

Updated the error message to include slightly more context for troubleshooting.

- Lower logging level when there is no usable reference idenifiers
- Add the directory path in logging messages from troubleshooting
- Rename docId -> docSegId since it represents the position of the document as opposed to he other identifiers to improve readability

### Issues Resolved
- Resolves _Fix log message when unable to find a reference id for a document_ https://opensearch.atlassian.net/browse/MIGRATIONS-2252

### Testing
Locally examined the error messages

### Check List
- [ ] New functionality includes testing
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
