### PR TITLE
For backfill bulk items, don't transcribe the documents through jinjava but just have it pulled from the source doc.

### DIFF
--- a/transformation/transformationPlugins/jsonMessageTransformers/jsonTypeMappingsSanitizationTransformer/src/main/resources/jinjava/typeMappings/documentBackfillItems.j2
+++ b/transformation/transformationPlugins/jsonMessageTransformers/jsonTypeMappingsSanitizationTransformer/src/main/resources/jinjava/typeMappings/documentBackfillItems.j2
@@ -10,7 +10,7 @@
     {%- if target_index -%}
         {
           {{ rewrite_index_parameters(parameters, target_index) }},
-          "source": {{ source_document.source | tojson }}
+          "preserve": ["source"]
         }
     {%- endif -%}
 {%- else -%}


### PR DESCRIPTION
For backfill bulk items, don't transcribe the documents through jinjava but just have it pulled from the source doc.

### Description

* Category Performance enhancement
* Why these changes are required? To reduce wasted transcriptions and parses
* What is the old behavior before changes and new behavior after changes? Should be no semantic differences.

### Issues Resolved
No Jira

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
CICD tests

### Check List
- [ ] New functionality includes testing
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
