### PR TITLE
Fix display of `console replay status`

### DIFF
--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/middleware/replay.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/middleware/replay.py
@@ -40,7 +40,8 @@ def scale(replayer: Replayer, units: int, *args, **kwargs) -> CommandResult[str]
     return replayer.scale(units, *args, **kwargs)
 
 
-@handle_replay_errors()
+@handle_replay_errors(
+    on_success=lambda status: (ExitCode.SUCCESS, f"{status[0]}\n{status[1]}"))
 def status(replayer: Replayer, *args, **kwargs) -> CommandResult[str]:
     logger.info("Getting replayer status")
     return replayer.get_status(*args, **kwargs)


### PR DESCRIPTION
### Description
`console replay status` was printing poorly -- it showed the actual tuple being returned from the model function, e.g.:
```
(<ReplayStatus.STOPPED: 4>, 'Running=0\nPending=0\nDesired=0')
```

This PR is a very small change to fix that, so that it prints the same way as `console backfill status`. The middleware function for replayer status was just missing an `on_success` handler to deal with this case.

```
(.venv) bash-5.2# console backfill status
BackfillStatus.STOPPED
Running=0
Pending=0
Desired=0
(.venv) bash-5.2# console replay status
ReplayStatus.STOPPED
Running=0
Pending=0
Desired=0
```


### Issues Resolved
Bug discovered during demo prep

### Testing
Manual, see above.

### Check List
- [ ] New functionality includes testing
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
