### PR TITLE
Add robustness for missing TupleComponents

### DIFF
--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/tuple_reader.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/tuple_reader.py
@@ -191,7 +191,11 @@ def parse_tuple(line: str, line_no: int) -> dict:
         return initial_tuple
 
     for component in SINGLE_COMPONENTS:
-        tuple_component = TupleComponent(component, initial_tuple[component], line_no, is_bulk_path)
+        if component in initial_tuple:
+            tuple_component = TupleComponent(component, initial_tuple[component], line_no, is_bulk_path)
+        else:
+            logger.info(f"`{component}` was not present on line {line_no}. Skipping component.")
+            continue
 
         processed_tuple = tuple_component.b64decode().decode_utf8().parse_as_json()
         final_value = processed_tuple.final_value
@@ -201,6 +205,9 @@ def parse_tuple(line: str, line_no: int) -> dict:
             logger.error(processed_tuple.error)
 
     for component in LIST_COMPONENTS:
+        if component not in initial_tuple:
+            logger.info(f"`{component}` was not present on line {line_no}. Skipping component.")
+            continue
         for i, item in enumerate(initial_tuple[component]):
             tuple_component = TupleComponent(f"{component} item {i}", item, line_no, is_bulk_path)
 

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/data/valid_tuple_missing_component.json
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/data/valid_tuple_missing_component.json
@@ -1,0 +1,32 @@
+{
+  "sourceRequest": {
+    "Request-URI": "/_snapshot/migration_assistant_repo/rfs-snapshot",
+    "Method": "DELETE",
+    "HTTP-Version": "HTTP/1.1",
+    "payload": {
+      "inlinedTextBody": ""
+    }
+  },
+  "targetRequest": {
+    "Request-URI": "/_snapshot/migration_assistant_repo/rfs-snapshot",
+    "Method": "DELETE",
+    "payload": {
+      "inlinedTextBody": ""
+    }
+  },
+  "targetResponses": [
+    {
+      "Date": ["Tue, 10 Dec 2024 21:07:03 GMT"],
+      "Content-Type": ["application/json; charset=UTF-8"],
+      "Status-Code": 404,
+      "Reason-Phrase": "Not Found",
+      "response_time_ms": 49,
+      "payload": {
+        "inlinedJsonBody": {}
+      }
+    }
+  ],
+  "connectionId": "024ad2fffe460aed-00000007-00000ac1-61aca27669436ce2-fdb9a98a.1563",
+  "numRequests": 4,
+  "numErrors": 0
+}

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/test_tuple_reader.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/test_tuple_reader.py
@@ -15,6 +15,7 @@ VALID_TUPLE_PARSED = TEST_DATA_DIRECTORY / "valid_tuple_parsed.json"
 VALID_TUPLE_GZIPPED_CHUNKED = TEST_DATA_DIRECTORY / "valid_tuple_gzipped_and_chunked.json"
 VALID_TUPLE_GZIPPED_CHUNKED_PARSED = TEST_DATA_DIRECTORY / "valid_tuple_gzipped_and_chunked_parsed.json"
 INVALID_TUPLE = TEST_DATA_DIRECTORY / "invalid_tuple.json"
+VALID_TUPLE_MISSING_COMPONENT = TEST_DATA_DIRECTORY / "valid_tuple_missing_component.json"
 
 
 def test_get_element_with_regex_succeeds():
@@ -161,3 +162,14 @@ def test_parse_tuple_with_malformed_bodies(caplog):
     assert json.loads(tuple_) == parsed  # Values weren't changed if they couldn't be interpreted
     assert "Body value of sourceResponse on line 0 could not be decoded to utf-8" in caplog.text
     assert "Body value of targetResponses item 0 on line 0 should be a json, but could not be parsed" in caplog.text
+
+
+def test_parse_tuple_with_missing_component():
+    with open(VALID_TUPLE_MISSING_COMPONENT, 'r') as f:
+        tuple_ = f.read()
+
+    assert 'sourceResponse' not in json.loads(tuple_)
+    parsed = parse_tuple(tuple_, 0)
+
+    assert 'sourceResponse' not in parsed
+    assert json.loads(tuple_).keys() == parsed.keys()


### PR DESCRIPTION
### Description
While prepping for the demo today, we encountered a bug while checking the tuples. A tuple was throwing the following error (shown with a minimal-ish valid tuple):
```
(.venv) sh-5.2# echo '{"sourceRequest":{"Request-URI":"/_snapshot/migration_assistant_repo/rfs-snapshot","Method":"DELETE","HTTP-Version":"HTTP/1.1","payload":{"inlinedTextBody":""}},"targetRequest":{"Request-URI":"/_snapshot/migration_assistant_repo/rfs-snapshot","Method":"DELETE","payload":{"inlinedTextBody":""}},"targetResponses":[{"Date":["Tue, 10 Dec 2024 21:07:03 GMT"],"Content-Type":["application/json; charset=UTF-8"],"Status-Code":404,"Reason-Phrase":"Not Found","response_time_ms":49,"payload":{"inlinedJsonBody":{}}}],"connectionId":"024ad2fffe460aed-00000007-00000ac1-61aca27669436ce2-fdb9a98a.1563","numRequests":4,"numErrors":0}' | console tuples show
Traceback (most recent call last):
...
  File "/root/lib/console_link/console_link/middleware/tuples.py", line 10, in convert
    tuple_reader.transform_stream(inputfile, ouptutfile)
  File "/root/lib/console_link/console_link/models/tuple_reader.py", line 26, in transform_stream
    json.dump(next(transformer), outputfile)
              ^^^^^^^^^^^^^^^^^
  File "/root/lib/console_link/console_link/models/tuple_reader.py", line 34, in _transform_lines
    yield parse_tuple(line, i + 1)
          ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/lib/console_link/console_link/models/tuple_reader.py", line 194, in parse_tuple
    tuple_component = TupleComponent(component, initial_tuple[component], line_no, is_bulk_path)
                                                ~~~~~~~~~~~~~^^^^^^^^^^^
KeyError: 'sourceResponse'
```

This tuple is as-expected, except that it doesn't have a `sourceResponse` field, which is a valid state for a tuple. The correct behavior is to translate all the _present_ components of the tuple, but not to worry about the missing ones.

The fixed behavior (same tuple):
```
(.venv) sh-5.2# echo '{"sourceRequest":{"Request-URI":"/_snapshot/migration_assistant_repo/rfs-snapshot","Method":"DELETE","HTTP-Version":"HTTP/1.1","payload":{"inlinedTextBody":""}},"targetRequest":{"Request-URI":"/_snapshot/migration_assistant_repo/rfs-snapshot","Method":"DELETE","payload":{"inlinedTextBody":""}},"targetResponses":[{"Date":["Tue, 10 Dec 2024 21:07:03 GMT"],"Content-Type":["application/json; charset=UTF-8"],"Status-Code":404,"Reason-Phrase":"Not Found","response_time_ms":49,"payload":{"inlinedJsonBody":{}}}],"connectionId":"024ad2fffe460aed-00000007-00000ac1-61aca27669436ce2-fdb9a98a.1563","numRequests":4,"numErrors":0}' | console tuples show
{"sourceRequest": {"Request-URI": "/_snapshot/migration_assistant_repo/rfs-snapshot", "Method": "DELETE", "HTTP-Version": "HTTP/1.1", "payload": {"inlinedTextBody": ""}, "body": {}}, "targetRequest": {"Request-URI": "/_snapshot/migration_assistant_repo/rfs-snapshot", "Method": "DELETE", "payload": {"inlinedTextBody": ""}, "body": {}}, "targetResponses": [{"Date": ["Tue, 10 Dec 2024 21:07:03 GMT"], "Content-Type": ["application/json; charset=UTF-8"], "Status-Code": 404, "Reason-Phrase": "Not Found", "response_time_ms": 49, "payload": {"inlinedJsonBody": {}}, "body": {}}], "connectionId": "024ad2fffe460aed-00000007-00000ac1-61aca27669436ce2-fdb9a98a.1563", "numRequests": 4, "numErrors": 0}
```

I add a log message at info level, so a user can add `-v` to view these logs (and others), but they don't indicate an error and shouldn't be surfaced to most users.

### Issues Resolved

### Testing
Manual, working on a unit test.

### Check List
- [x] New functionality includes testing
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
