### PR TITLE
Enable MultiTypeMappingTransformationTest

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -111,44 +111,6 @@ jobs:
         with:
           gradle-version: ${{ env.gradle-version }}
           gradle-home-cache-cleanup: true
-      - name: Generate Cache Key from Dockerfiles
-        id: generate_cache_key
-        run: |
-          files=$(find . -type f \( -name 'docker-compose.yml' -o -name 'Dockerfile' \))
-          file_contents=$(cat $files)
-          key=$(echo "${file_contents}" | sha1sum | awk '{print $1}')
-          echo "key=${key}" >> "$GITHUB_OUTPUT"
-      - name: Cache Docker Images
-        uses: ScribeMD/docker-cache@0.5.0
-        with:
-          key: docker-${{ runner.os }}-${{ steps.generate_cache_key.outputs.key }}
-      - name: Pre pull images
-        run: |
-          pull_if_not_present() {
-            local image="$1"
-            if docker image inspect "$image" > /dev/null 2>&1; then
-              echo "Image '$image' already exists locally."
-            else
-              echo "Pulling image '$image'..."
-              docker pull "$image"
-            fi
-          }
-          images=(
-            "opensearchproject/opensearch:1.3.16"
-            "opensearchproject/opensearch:2.14.0"
-            "docker.elastic.co/elasticsearch/elasticsearch:7.17.22"
-            "docker.elastic.co/elasticsearch/elasticsearch-oss:7.10.2"
-            "docker.elastic.co/elasticsearch/elasticsearch-oss:6.8.23"
-            "docker.elastic.co/elasticsearch/elasticsearch:5.6.16"
-            "httpd:alpine"
-            "confluentinc/cp-kafka:7.5.0"
-            "ghcr.io/shopify/toxiproxy:latest"
-            "amazonlinux:2023"
-            "alpine:3.16"
-          )
-          for image in "${images[@]}"; do
-            pull_if_not_present "$image"
-          done
       - name: Run Gradle Build
         run: ./gradlew build -x test -x TrafficCapture:dockerSolution:build -x spotlessCheck --stacktrace
         env:

--- a/MetadataMigration/src/test/java/org/opensearch/migrations/BaseMigrationTest.java
+++ b/MetadataMigration/src/test/java/org/opensearch/migrations/BaseMigrationTest.java
@@ -1,6 +1,6 @@
 package org.opensearch.migrations;
 
-import java.io.File;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.io.TempDir;
 abstract class BaseMigrationTest {
 
     @TempDir
-    protected File localDirectory;
+    protected Path localDirectory;
 
     @Getter
     protected SearchClusterContainer sourceCluster;
@@ -83,7 +83,7 @@ abstract class BaseMigrationTest {
      */
     protected MigrateOrEvaluateArgs prepareSnapshotMigrationArgs(String snapshotName) {
         var arguments = new MigrateOrEvaluateArgs();
-        arguments.fileSystemRepoPath = localDirectory.getAbsolutePath();
+        arguments.fileSystemRepoPath = localDirectory.toString();
         arguments.snapshotName = snapshotName;
         arguments.sourceVersion = sourceCluster.getContainerVersion().getVersion();
         arguments.targetArgs.host = targetCluster.getUrl();

--- a/RFS/src/testFixtures/java/org/opensearch/migrations/bulkload/framework/SearchClusterContainer.java
+++ b/RFS/src/testFixtures/java/org/opensearch/migrations/bulkload/framework/SearchClusterContainer.java
@@ -14,6 +14,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.utility.DockerImageName;
+import org.testcontainers.utility.MountableFile;
 
 /**
  * Containerized version of Elasticsearch cluster
@@ -111,6 +112,16 @@ public class SearchClusterContainer extends GenericContainer<SearchClusterContai
             throw new RuntimeException(e);
         }
     }
+
+    public void putSnapshotData(final String directory) {
+        try {
+            this.copyFileToContainer(MountableFile.forHostPath(directory), CLUSTER_SNAPSHOT_DIR);
+            this.execInContainer("chown", "-R", "elasticsearch:elasticsearch", CLUSTER_SNAPSHOT_DIR);
+        } catch (final Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
 
     public void start() {
         log.info("Starting container version:" + containerVersion.version);


### PR DESCRIPTION
### Description
Enable MultiTypeMappingTransformationTest

Fixes issue in GHA by not depending on local mounts and instead copying the required files into the container.
Reverts docker caching recently added in gradle gha actions, will be addressed with [MIGRATIONS-2265](https://opensearch.atlassian.net/browse/MIGRATIONS-2265)

* Category: Test fix
* Why these changes are required? Ensure full coverage of tests in GHA
* What is the old behavior before changes and new behavior after changes? Test Disabled, now enabled

### Issues Resolved
No jira created

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
GHA, verified working locally too

### Check List
- [x] New functionality includes testing
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
