### PR TITLE
Update Issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE/BUG_TEMPLATE.md
@@ -1,0 +1,21 @@
+---
+name: 🐛 Bug Report
+about: Create a report to help us improve
+title: '[BUG]'
+labels: 'bug, untriaged'
+assignees: ''
+---
+### What is the bug?
+_A clear and concise description of the bug._
+
+### How can one reproduce the bug?
+_Steps to reproduce the behavior._
+
+### What is the expected behavior?
+_A clear and concise description of what you expected to happen._
+
+### What are your migration environments?
+_What version of Elasticsearch / Opensearch, what version of the Migration Assistant._
+
+### Do you have any additional context?
+_Add any other context about the problem, such as log files our console output._

--- a/.github/ISSUE_TEMPLATE/BUG_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE/BUG_TEMPLATE.md
@@ -8,14 +8,14 @@ assignees: ''
 ### What is the bug?
 _A clear and concise description of the bug._
 
+### What are your migration environments?
+_What versions of Elasticsearch / Opensearch, what version of the Migration Assistant._
+
 ### How can one reproduce the bug?
 _Steps to reproduce the behavior._
 
 ### What is the expected behavior?
 _A clear and concise description of what you expected to happen._
-
-### What are your migration environments?
-_What version of Elasticsearch / Opensearch, what version of the Migration Assistant._
 
 ### Do you have any additional context?
 _Add any other context about the problem, such as log files our console output._

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,22 +1,15 @@
 ### Description
-[Describe what this change achieves]
-* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)
-* Why these changes are required?
-* What is the old behavior before changes and new behavior after changes?
+<!-- Describe what this change achieves -->
 
 ### Issues Resolved
-[List any issues this PR will resolve]
-
-Is this a backport? If so, please add backport PR # and/or commits #
+<!-- List any GitHub or Jira issues this PR will resolve -->
 
 ### Testing
-[Please provide details of testing done: unit testing, integration testing and manual testing]
+<!-- Please provide details of testing done: unit testing, integration testing and manual testing -->
 
 ### Check List
 - [ ] New functionality includes testing
-  - [ ] All tests pass, including unit test, integration test and doctest
-- [ ] New functionality has been documented
-- [ ] Commits are signed per the DCO using --signoff
+- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.
 
 By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
 For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).


### PR DESCRIPTION
### Description
Reduce and clarify instructions on issues and pr templates

### Testing
- See updated Issue template, [link](https://github.com/peternied/opensearch-migrations/issues/new?assignees=&labels=bug%2C+untriaged&projects=&template=BUG_TEMPLATE.md&title=%5BBUG%5D).
- See updated PR template, [link](https://github.com/peternied/opensearch-migrations/compare/main...frontend-proto).

### Check List
- [ ] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
