### PR TITLE
Fix OSB on specific working workload commit

### DIFF
--- a/TrafficCapture/dockerSolution/src/main/docker/elasticsearchTestConsole/runTestBenchmarks.sh
+++ b/TrafficCapture/dockerSolution/src/main/docker/elasticsearchTestConsole/runTestBenchmarks.sh
@@ -86,6 +86,7 @@ set -o xtrace
 # Newer OSB Workload revisions fail with single node cluster that is persistently in yellow state
 # See https://github.com/opensearch-project/opensearch-migrations/pull/1202
 workload_revision="440ce4b1fc8832b6b7673bdcec948cce3ee87e7e"
+pipenv run opensearch-benchmark info --workload-revision=$workload_revision --workload=geonames
 
 echo "Running opensearch-benchmark workloads against ${endpoint}"
 echo "Running opensearch-benchmark w/ 'geonames' workload..." &&

--- a/TrafficCapture/dockerSolution/src/main/docker/elasticsearchTestConsole/runTestBenchmarks.sh
+++ b/TrafficCapture/dockerSolution/src/main/docker/elasticsearchTestConsole/runTestBenchmarks.sh
@@ -86,7 +86,6 @@ set -o xtrace
 # Newer OSB Workload revisions fail with single node cluster that is persistently in yellow state
 # See https://github.com/opensearch-project/opensearch-migrations/pull/1202
 workload_revision="440ce4b1fc8832b6b7673bdcec948cce3ee87e7e"
-pipenv run opensearch-benchmark info --workload-revision=$workload_revision --workload=geonames
 
 echo "Running opensearch-benchmark workloads against ${endpoint}"
 echo "Running opensearch-benchmark w/ 'geonames' workload..." &&

--- a/TrafficCapture/dockerSolution/src/main/docker/elasticsearchTestConsole/runTestBenchmarks.sh
+++ b/TrafficCapture/dockerSolution/src/main/docker/elasticsearchTestConsole/runTestBenchmarks.sh
@@ -83,12 +83,16 @@ client_options=$(IFS=,; echo "${options[*]}")
 
 set -o xtrace
 
+# Newer OSB Workload revisions fail with single node cluster that is persistently in yellow state
+# See https://github.com/opensearch-project/opensearch-migrations/pull/1202
+workload_revision="440ce4b1fc8832b6b7673bdcec948cce3ee87e7e"
+
 echo "Running opensearch-benchmark workloads against ${endpoint}"
 echo "Running opensearch-benchmark w/ 'geonames' workload..." &&
-pipenv run opensearch-benchmark execute-test --distribution-version=1.0.0 --target-host=$endpoint --workload=geonames --pipeline=benchmark-only --test-mode --kill-running-processes --workload-params "target_throughput:0.5,bulk_size:10,bulk_indexing_clients:1,search_clients:1"  --client-options=$client_options &&
+pipenv run opensearch-benchmark execute-test --distribution-version=1.0.0 --workload-revision=$workload_revision --target-host=$endpoint --workload=geonames --pipeline=benchmark-only --test-mode --kill-running-processes --workload-params "target_throughput:0.5,bulk_size:10,bulk_indexing_clients:1,search_clients:1"  --client-options=$client_options &&
 echo "Running opensearch-benchmark w/ 'http_logs' workload..." &&
-pipenv run opensearch-benchmark execute-test --distribution-version=1.0.0 --target-host=$endpoint --workload=http_logs --pipeline=benchmark-only --test-mode --kill-running-processes --workload-params "target_throughput:0.5,bulk_size:10,bulk_indexing_clients:1,search_clients:1" --client-options=$client_options &&
+pipenv run opensearch-benchmark execute-test --distribution-version=1.0.0 --workload-revision=$workload_revision --target-host=$endpoint --workload=http_logs --pipeline=benchmark-only --test-mode --kill-running-processes --workload-params "target_throughput:0.5,bulk_size:10,bulk_indexing_clients:1,search_clients:1" --client-options=$client_options &&
 echo "Running opensearch-benchmark w/ 'nested' workload..." &&
-pipenv run opensearch-benchmark execute-test --distribution-version=1.0.0 --target-host=$endpoint --workload=nested --pipeline=benchmark-only --test-mode --kill-running-processes --workload-params "target_throughput:0.5,bulk_size:10,bulk_indexing_clients:1,search_clients:1"  --client-options=$client_options &&
+pipenv run opensearch-benchmark execute-test --distribution-version=1.0.0 --workload-revision=$workload_revision --target-host=$endpoint --workload=nested --pipeline=benchmark-only --test-mode --kill-running-processes --workload-params "target_throughput:0.5,bulk_size:10,bulk_indexing_clients:1,search_clients:1"  --client-options=$client_options &&
 echo "Running opensearch-benchmark w/ 'nyc_taxis' workload..." &&
-pipenv run opensearch-benchmark execute-test --distribution-version=1.0.0 --target-host=$endpoint --workload=nyc_taxis --pipeline=benchmark-only --test-mode --kill-running-processes --workload-params "target_throughput:0.5,bulk_size:10,bulk_indexing_clients:1,search_clients:1"  --client-options=$client_options
+pipenv run opensearch-benchmark execute-test --distribution-version=1.0.0 --workload-revision=$workload_revision --target-host=$endpoint --workload=nyc_taxis --pipeline=benchmark-only --test-mode --kill-running-processes --workload-params "target_throughput:0.5,bulk_size:10,bulk_indexing_clients:1,search_clients:1"  --client-options=$client_options

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/cluster.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/cluster.py
@@ -190,10 +190,11 @@ class Cluster:
             raise NotImplementedError(f"Auth type {self.auth_type} is not currently support for executing "
                                       f"benchmark workloads")
         # Note -- we should censor the password when logging this command
-        workload_revision="440ce4b1fc8832b6b7673bdcec948cce3ee87e7e"
+        workload_revision = "440ce4b1fc8832b6b7673bdcec948cce3ee87e7e"
         logger.info(f"Running opensearch-benchmark with '{workload}' workload and revision '{workload_revision}'")
         command = (f"opensearch-benchmark execute-test --distribution-version=1.0.0 --target-host={self.endpoint} "
-                   f"--workload={workload} --workload-revision={workload_revision} --pipeline=benchmark-only --test-mode --kill-running-processes "
+                   f"--workload={workload} --workload-revision={workload_revision} --pipeline=benchmark-only "
+                   "--test-mode --kill-running-processes "
                    f"--workload-params={workload_params} --client-options={client_options}")
         # While a little wordier, this apprach prevents us from censoring the password if it appears in other contexts,
         # e.g. username:admin,password:admin.

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/cluster.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/cluster.py
@@ -190,9 +190,10 @@ class Cluster:
             raise NotImplementedError(f"Auth type {self.auth_type} is not currently support for executing "
                                       f"benchmark workloads")
         # Note -- we should censor the password when logging this command
-        logger.info(f"Running opensearch-benchmark with '{workload}' workload")
+        workload_revision="440ce4b1fc8832b6b7673bdcec948cce3ee87e7e"
+        logger.info(f"Running opensearch-benchmark with '{workload}' workload and revision '{workload_revision}'")
         command = (f"opensearch-benchmark execute-test --distribution-version=1.0.0 --target-host={self.endpoint} "
-                   f"--workload={workload} --pipeline=benchmark-only --test-mode --kill-running-processes "
+                   f"--workload={workload} --workload-revision={workload_revision} --pipeline=benchmark-only --test-mode --kill-running-processes "
                    f"--workload-params={workload_params} --client-options={client_options}")
         # While a little wordier, this apprach prevents us from censoring the password if it appears in other contexts,
         # e.g. username:admin,password:admin.

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/test_cluster.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/test_cluster.py
@@ -389,8 +389,10 @@ def test_run_benchmark_executes_correctly_no_auth(mocker):
     mock = mocker.patch("subprocess.run", autospec=True)
     workload = "nyctaxis"
     cluster.execute_benchmark_workload(workload=workload)
-    mock.assert_called_once_with("opensearch-benchmark execute-test --distribution-version=1.0.0 "
-                                 f"--target-host={cluster.endpoint} --workload={workload} --pipeline=benchmark-only"
+    mock.assert_called_once_with("opensearch-benchmark execute-test --distribution-version=1.0.0"
+                                 f" --target-host={cluster.endpoint} --workload={workload}"
+                                 f" --workload-revision=440ce4b1fc8832b6b7673bdcec948cce3ee87e7e"
+                                 " --pipeline=benchmark-only"
                                  " --test-mode --kill-running-processes --workload-params=target_throughput:0.5,"
                                  "bulk_size:10,bulk_indexing_clients:1,search_clients:1 "
                                  "--client-options=verify_certs:false", shell=True)
@@ -411,8 +413,10 @@ def test_run_benchmark_executes_correctly_basic_auth_and_https(mocker):
     mock = mocker.patch("subprocess.run", autospec=True)
     workload = "nyctaxis"
     cluster.execute_benchmark_workload(workload=workload)
-    mock.assert_called_once_with("opensearch-benchmark execute-test --distribution-version=1.0.0 "
-                                 f"--target-host={cluster.endpoint} --workload={workload} --pipeline=benchmark-only"
+    mock.assert_called_once_with("opensearch-benchmark execute-test --distribution-version=1.0.0"
+                                 f" --target-host={cluster.endpoint} --workload={workload}"
+                                 f" --workload-revision=440ce4b1fc8832b6b7673bdcec948cce3ee87e7e"
+                                 " --pipeline=benchmark-only"
                                  " --test-mode --kill-running-processes --workload-params=target_throughput:0.5,"
                                  "bulk_size:10,bulk_indexing_clients:1,search_clients:1 "
                                  "--client-options=verify_certs:false,use_ssl:true,"


### PR DESCRIPTION
### Description
In https://github.com/opensearch-project/opensearch-benchmark-workloads/pull/514 OSB added waiting for green for cluster operations. This commit fixes the workload on the prior commit since our use case uses a single node cluster that is always in yellow state. 

Fixed workload on commit:
https://github.com/opensearch-project/opensearch-benchmark-workloads/commit/440ce4b1fc8832b6b7673bdcec948cce3ee87e7e


### Issues Resolved
- https://opensearch.atlassian.net/browse/MIGRATIONS-2279

### Testing
See GHA

### Check List
- [ ] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
