### PR TITLE
Make sure that S3Uri are human readable when printed

### DIFF
--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/common/S3Uri.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/common/S3Uri.java
@@ -1,5 +1,8 @@
 package org.opensearch.migrations.bulkload.common;
 
+import lombok.ToString;
+
+@ToString
 public class S3Uri {
     public final String bucketName;
     public final String key;


### PR DESCRIPTION
### Description
When running metadata command part of the output shows the S3 uri and it was not human readable.

#### Example updated output
```
S3Uri(bucketName=bucket-name, key=, uri=s3://bucket-name)
S3Uri(bucketName=bucket-name, key=, uri=s3://bucket-name)
S3Uri(bucketName=bucket-name, key=with/suffix, uri=s3://bucket-name/with/suffix)
S3Uri(bucketName=bucket-name, key=with/suffix, uri=s3://bucket-name/with/suffix)
```

#### Example error case
```
Starting Metadata Evaluation
Clusters:
   Source:
      Snapshot: ELASTICSEARCH 7.10.0 S3Repo(s3RepoUri=org.opensearch.migrations.bulkload.common.S3Uri@639cb788)
```

### Issues Resolved
N/A

### Testing
N/A Simple UX change

### Check List
- [ ] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
