### PR TITLE
Modify transformationPlugins contract to return Object to support One to Many transformations

### DIFF
--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/common/BulkDocSection.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/common/BulkDocSection.java
@@ -75,7 +75,7 @@ public class BulkDocSection {
         }
     }
 
-    public static BulkDocSection fromMap(Map<String, Object> map) {
+    public static BulkDocSection fromMap(Object map) {
         BulkIndex bulkIndex = OBJECT_MAPPER.convertValue(map, BulkIndex.class);
         return new BulkDocSection(bulkIndex);
     }

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/common/DocumentReindexer.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/common/DocumentReindexer.java
@@ -1,7 +1,6 @@
 package org.opensearch.migrations.bulkload.common;
 
 import java.util.List;
-import java.util.Map;
 import java.util.UUID;
 import java.util.function.Predicate;
 
@@ -57,7 +56,7 @@ public class DocumentReindexer {
     BulkDocSection transformDocument(RfsLuceneDocument doc, String indexName) {
         var original = new BulkDocSection(doc.id, indexName, doc.type, doc.source, doc.routing);
         if (transformer != null) {
-            final Map<String,Object> transformedDoc = transformer.transformJson(original.toMap());
+            final Object transformedDoc = transformer.transformJson(original.toMap());
             return BulkDocSection.fromMap(transformedDoc);
         }
         return BulkDocSection.fromMap(original.toMap());

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/transformers/TransformerToIJsonTransformerAdapter.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/transformers/TransformerToIJsonTransformerAdapter.java
@@ -41,7 +41,7 @@ public class TransformerToIJsonTransformerAdapter implements Transformer {
         this(transformer, LoggerFactory.getLogger(OUTPUT_TRANSFORMATION_JSON_LOGGER));
     }
 
-    private void logTransformation(Map<String, Object> before, Map<String, Object> after) {
+    private void logTransformation(Map<String, Object> before, Object after) {
         if (transformerLogger.isInfoEnabled()) {
             try {
                 var transformationTuple = toTransformationMap(before, after);
@@ -55,7 +55,7 @@ public class TransformerToIJsonTransformerAdapter implements Transformer {
         }
     }
 
-    private Map<String, Object> toTransformationMap(Map<String, Object> before, Map<String, Object> after) {
+    private Map<String, Object> toTransformationMap(Map<String, Object> before, Object after) {
         var transformationMap = new LinkedHashMap<String, Object>();
         transformationMap.put("before", before);
         transformationMap.put("after", after);
@@ -69,7 +69,7 @@ public class TransformerToIJsonTransformerAdapter implements Transformer {
     }
 
     @SneakyThrows
-    private static String printMap(Map<String, Object> map) {
+    private static String printMap(Object map) {
         return MAPPER.writeValueAsString(map);
     }
 
@@ -77,7 +77,7 @@ public class TransformerToIJsonTransformerAdapter implements Transformer {
     private MigrationItem transformMigrationItem(MigrationItem migrationItem) {
         // Keep untouched original for logging
         final Map<String, Object> originalMap = MAPPER.convertValue(migrationItem, Map.class);
-        var transformedMigrationItem = transformer.transformJson(MAPPER.convertValue(migrationItem, Map.class));
+        Object transformedMigrationItem = transformer.transformJson(MAPPER.convertValue(migrationItem, Map.class));
         logTransformation(originalMap, transformedMigrationItem);
         return MAPPER.convertValue(transformedMigrationItem, MigrationItem.class);
     }
@@ -100,7 +100,7 @@ public class TransformerToIJsonTransformerAdapter implements Transformer {
     public GlobalMetadata transformGlobalMetadata(GlobalMetadata globalData) {
         var inputJson = objectNodeToMap(globalData.toObjectNode());
         log.atInfo().setMessage("BeforeJsonGlobal: {}").addArgument(() -> printMap(inputJson)).log();
-        var afterJson = transformer.transformJson(inputJson);
+        Object afterJson = transformer.transformJson(inputJson);
         log.atInfo().setMessage("AfterJsonGlobal: {}").addArgument(() -> printMap(afterJson)).log();
 
 
@@ -154,7 +154,7 @@ public class TransformerToIJsonTransformerAdapter implements Transformer {
     public IndexMetadata transformIndexMetadata(IndexMetadata indexData) {
         final Map<String, Object> originalInput = MAPPER.convertValue(indexData, Map.class);
         final Map<String, Object> inputJson = MAPPER.convertValue(indexData, Map.class);
-        var afterJson = transformer.transformJson(inputJson);
+        Object afterJson = transformer.transformJson(inputJson);
         logTransformation(originalInput, afterJson);
         return MAPPER.convertValue(inputJson, IndexMetadata.class);
     }

--- a/RFS/src/test/java/org/opensearch/migrations/bulkload/common/DocumentReindexerTest.java
+++ b/RFS/src/test/java/org/opensearch/migrations/bulkload/common/DocumentReindexerTest.java
@@ -125,7 +125,7 @@ class DocumentReindexerTest {
         // Set up the transformer that replaces the sourceDoc from the document
         var repalcedSourceDoc = Map.of("simpleKey", "simpleValue");
         IJsonTransformer transformer = originalJson -> {
-            originalJson.put("source", repalcedSourceDoc);
+            ((Map) originalJson).put("source", repalcedSourceDoc);
             return originalJson;
         };
         int numDocs = 5;

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/ResultsToLogsConsumer.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/ResultsToLogsConsumer.java
@@ -142,7 +142,7 @@ public class ResultsToLogsConsumer implements BiConsumer<SourceTargetCaptureTupl
         if (tupleLogger.isInfoEnabled()) {
             try {
                 var originalTuple = toJSONObject(tuple, parsedMessages);
-                var transformedTuple = tupleTransformer.transformJson(originalTuple);
+                Object transformedTuple = tupleTransformer.transformJson(originalTuple);
                 var tupleString = PLAIN_MAPPER.writeValueAsString(transformedTuple);
                 tupleLogger.atInfo().setMessage("{}").addArgument(tupleString).log();
             } catch (Exception e) {

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/http/NettyDecodedHttpRequestPreliminaryTransformHandler.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/http/NettyDecodedHttpRequestPreliminaryTransformHandler.java
@@ -117,10 +117,19 @@ public class NettyDecodedHttpRequestPreliminaryTransformHandler<R> extends Chann
 
         assert httpJsonMessage.containsKey("payload");
 
-        var returnedObject = transformer.transformJson(httpJsonMessage);
+        Object returnedObject = transformer.transformJson(httpJsonMessage);
+        if(!(returnedObject instanceof Map)) {
+            throw new TransformationException(
+                new IllegalArgumentException("Returned object from transformation not map, instead was "
+                    + returnedObject.getClass().getName())
+            );
+        }
+        @SuppressWarnings("unchecked")
+        var returnedObjectMap = (Map<String, ?>) returnedObject;
+
 
         if (returnedObject != httpJsonMessage) {
-            httpJsonMessage = new HttpJsonRequestWithFaultingPayload(returnedObject);
+            httpJsonMessage = new HttpJsonRequestWithFaultingPayload(returnedObjectMap);
         }
 
         if (originalHttpJsonMessage != httpJsonMessage) {

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/datahandlers/http/HttpJsonTransformingConsumerTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/datahandlers/http/HttpJsonTransformingConsumerTest.java
@@ -210,11 +210,11 @@ class HttpJsonTransformingConsumerTest extends InstrumentationTest {
         var testPacketCapture = new TestCapturePacketToHttpHandler(Duration.ofMillis(100), dummyAggregatedResponse);
         var complexTransformer = new JsonCompositeTransformer(new IJsonTransformer() {
             @Override
-            public Map<String, Object> transformJson(Map<String, Object> incomingJson) {
-                var payload = (Map) incomingJson.get("payload");
+            public Object transformJson(Object incomingJson) {
+                var payload = (Map) ((Map) incomingJson).get("payload");
                 Assertions.assertNull(payload.get(JsonKeysForHttpMessage.INLINED_NDJSON_BODIES_DOCUMENT_KEY));
                 Assertions.assertNull(payload.get(JsonKeysForHttpMessage.INLINED_JSON_BODY_DOCUMENT_KEY));
-                ((Map) incomingJson.get("headers"))
+                ((Map) ((Map) incomingJson).get("headers"))
                     .put("extraKey", "extraValue");
                 // just walk everything - that's enough to touch the payload and throw
                 walkMaps(incomingJson);
@@ -261,11 +261,11 @@ class HttpJsonTransformingConsumerTest extends InstrumentationTest {
         final var dummyAggregatedResponse = new AggregatedRawResponse(null, 19, Duration.ZERO, List.of(), null);
         var testPacketCapture = new TestCapturePacketToHttpHandler(Duration.ofMillis(100), dummyAggregatedResponse);
         var sizeCalculatingTransformer = new JsonCompositeTransformer(incomingJson -> {
-            var payload = (Map) incomingJson.get("payload");
+            var payload = (Map) ((Map) incomingJson).get("payload");
             Assertions.assertNull(payload.get(JsonKeysForHttpMessage.INLINED_JSON_BODY_DOCUMENT_KEY));
             Assertions.assertNull(payload.get(JsonKeysForHttpMessage.INLINED_BINARY_BODY_DOCUMENT_KEY));
             var list = (List) payload.get(JsonKeysForHttpMessage.INLINED_NDJSON_BODIES_DOCUMENT_KEY);
-            ((Map) incomingJson.get("headers"))
+            ((Map) ((Map) incomingJson).get("headers"))
                 .put("listSize", ""+list.size());
             return incomingJson;
         });
@@ -289,13 +289,13 @@ class HttpJsonTransformingConsumerTest extends InstrumentationTest {
         final var dummyAggregatedResponse = new AggregatedRawResponse(null, 19, Duration.ZERO, List.of(), null);
         var testPacketCapture = new TestCapturePacketToHttpHandler(Duration.ofMillis(100), dummyAggregatedResponse);
         var sizeCalculatingTransformer = new JsonCompositeTransformer(incomingJson -> {
-            var payload = (Map) incomingJson.get("payload");
+            var payload = (Map) ((Map) incomingJson).get("payload");
             Assertions.assertFalse(payload.containsKey(JsonKeysForHttpMessage.INLINED_JSON_BODY_DOCUMENT_KEY));
             Assertions.assertFalse(payload.containsKey(JsonKeysForHttpMessage.INLINED_BINARY_BODY_DOCUMENT_KEY));
             Assertions.assertNotNull(payload.get(JsonKeysForHttpMessage.INLINED_TEXT_BODY_DOCUMENT_KEY));
             var list = (List) payload.get(JsonKeysForHttpMessage.INLINED_NDJSON_BODIES_DOCUMENT_KEY);
             var leftoverString = (String) payload.get(JsonKeysForHttpMessage.INLINED_TEXT_BODY_DOCUMENT_KEY);
-            var headers = (Map<String,Object>) incomingJson.get("headers");
+            var headers = (Map<String,Object>) ((Map<String,Object>) incomingJson).get("headers");
             headers.put("listSize", "" + list.size());
             headers.put("leftover", "" + leftoverString.getBytes(StandardCharsets.UTF_8).length);
             return incomingJson;

--- a/transformation/src/main/java/org/opensearch/migrations/transformation/JsonTransformerForDocumentTypeRemovalProvider.java
+++ b/transformation/src/main/java/org/opensearch/migrations/transformation/JsonTransformerForDocumentTypeRemovalProvider.java
@@ -17,9 +17,11 @@ public class JsonTransformerForDocumentTypeRemovalProvider implements IJsonTrans
     private static class Transformer implements IJsonTransformer {
         @Override
         @SuppressWarnings("unchecked")
-        public Map<String, Object> transformJson(Map<String, Object> incomingJson) {
-            if (incomingJson.containsKey("index")) {
-                ((Map<String, Object>) incomingJson.get("index")).remove("_type");
+        public Object transformJson(Object incomingJson) {
+            @SuppressWarnings("unchecked")
+            var incomingJsonMap = ((Map<String, Object>) incomingJson);
+            if (incomingJsonMap.containsKey("index")) {
+                ((Map<String, Object>) ((Map<String, Object>) incomingJson).get("index")).remove("_type");
             }
             return incomingJson;
         }

--- a/transformation/transformationPlugins/jsonMessageTransformers/jsonJMESPathMessageTransformer/src/main/java/org/opensearch/migrations/transform/JsonJMESPathPredicate.java
+++ b/transformation/transformationPlugins/jsonMessageTransformers/jsonJMESPathMessageTransformer/src/main/java/org/opensearch/migrations/transform/JsonJMESPathPredicate.java
@@ -1,6 +1,5 @@
 package org.opensearch.migrations.transform;
 
-import java.util.Map;
 
 import io.burt.jmespath.BaseRuntime;
 import io.burt.jmespath.Expression;
@@ -16,7 +15,7 @@ public class JsonJMESPathPredicate implements IJsonPredicate {
     }
 
     @Override
-    public boolean test(Map<String, Object> incomingJson) {
+    public boolean test(Object incomingJson) {
         var output = expression.search(incomingJson);
         log.atDebug().setMessage("output={}").addArgument(output).log();
         return (Boolean) output;

--- a/transformation/transformationPlugins/jsonMessageTransformers/jsonJMESPathMessageTransformer/src/main/java/org/opensearch/migrations/transform/JsonJMESPathTransformer.java
+++ b/transformation/transformationPlugins/jsonMessageTransformers/jsonJMESPathMessageTransformer/src/main/java/org/opensearch/migrations/transform/JsonJMESPathTransformer.java
@@ -16,7 +16,7 @@ public class JsonJMESPathTransformer implements IJsonTransformer {
     }
 
     @Override
-    public Map<String, Object> transformJson(Map<String, Object> incomingJson) {
+    public Object transformJson(Object incomingJson) {
         var output = expression.search(incomingJson);
         log.info("output=" + output);
         return (Map<String, Object>) output;

--- a/transformation/transformationPlugins/jsonMessageTransformers/jsonJMESPathMessageTransformerProvider/src/test/java/org/opensearch/migrations/replay/JsonJMESPathTransformerProviderTest.java
+++ b/transformation/transformationPlugins/jsonMessageTransformers/jsonJMESPathMessageTransformerProvider/src/test/java/org/opensearch/migrations/replay/JsonJMESPathTransformerProviderTest.java
@@ -77,7 +77,7 @@ class JsonJMESPathTransformerProviderTest {
         var documentJson = parseStringAsJson(mapper, TEST_INPUT_REQUEST);
         var transformer = new JsonJMESPathTransformerProvider().createTransformer(Map.of(
             "script",  EXCISE_TYPE_EXPRESSION_STRING));
-        var transformedDocument = transformer.transformJson(documentJson);
+        Object transformedDocument = transformer.transformJson(documentJson);
         var outputStr = emitJson(mapper, transformedDocument);
 
         final String TEST_OUTPUT_REQUEST = "{\n"

--- a/transformation/transformationPlugins/jsonMessageTransformers/jsonJinjavaTransformer/src/main/java/org/opensearch/migrations/transform/PreservesProcessor.java
+++ b/transformation/transformationPlugins/jsonMessageTransformers/jsonJinjavaTransformer/src/main/java/org/opensearch/migrations/transform/PreservesProcessor.java
@@ -31,7 +31,7 @@ public class PreservesProcessor {
     }
 
     private static void copyValues(Map<String, Object> source, Map<String, Object> target,
-                            String directiveKey, boolean forced) {
+                                   String directiveKey, boolean forced) {
         Object directive = target.remove(directiveKey);
         if (directive == null) {
             return;

--- a/transformation/transformationPlugins/jsonMessageTransformers/jsonJinjavaTransformer/src/test/java/org/opensearch/migrations/transform/FeatureMaskingTest.java
+++ b/transformation/transformationPlugins/jsonMessageTransformers/jsonJinjavaTransformer/src/test/java/org/opensearch/migrations/transform/FeatureMaskingTest.java
@@ -13,7 +13,7 @@ import org.testcontainers.shaded.com.fasterxml.jackson.databind.ObjectMapper;
 @Slf4j
 public class FeatureMaskingTest {
     private static final ObjectMapper objectMapper = new ObjectMapper();
-    public Map<String, Object> transformForMask(Map<String, Object> incomingFlags) throws IOException {
+    public Object transformForMask(Map<String, Object> incomingFlags) throws IOException {
         var incomingFlagStr = objectMapper.writeValueAsString(incomingFlags);
         log.atInfo().setMessage("incoming map as string: {}").addArgument(incomingFlagStr).log();
         var flags = FeatureFlags.parseJson(incomingFlagStr);
@@ -39,44 +39,44 @@ public class FeatureMaskingTest {
     public void testFalseFlag() throws Exception {
         Assertions.assertEquals(
             "false,false,false,false",
-            transformForMask(Map.of("testFlag", false)).get("enabledFlags"));
+            ((Map) transformForMask(Map.of("testFlag", false))).get("enabledFlags"));
     }
 
     @Test
     public void testTrueFlag() throws Exception {
         Assertions.assertEquals(
             "true,false,false,false",
-            transformForMask(Map.of("testFlag", true)).get("enabledFlags"));
+            ((Map) transformForMask(Map.of("testFlag", true))).get("enabledFlags"));
     }
 
     @Test
     public void testLongerFalseFlag() throws Exception {
         Assertions.assertEquals(
             "false,false,false,false",
-            transformForMask(Map.of("testFlag", false)).get("enabledFlags"));
+            ((Map) transformForMask(Map.of("testFlag", false))).get("enabledFlags"));
     }
 
     @Test
     public void testLongerTrueFlag() throws Exception {
         Assertions.assertEquals(
             "true,false,false,false",
-            transformForMask(Map.of(
+            ((Map) transformForMask(Map.of(
                 "testFlag", Map.of("notPresent", false))
-            ).get("enabledFlags"));
+            )).get("enabledFlags"));
     }
 
     @Test
     public void testImplicitTrueFlag() throws Exception {
         Assertions.assertEquals(
             "true,true,false,false",
-            transformForMask(Map.of(
+            ((Map) transformForMask(Map.of(
                 "testFlag", Map.of("t1", true))
-            ).get("enabledFlags"));
+            )).get("enabledFlags"));
     }
 
     @Test
     public void testNullFeatures() throws Exception {
         Assertions.assertEquals(
-            "true,true,true,true", transformForMask(null).get("enabledFlags"));
+            "true,true,true,true", ((Map) transformForMask(null)).get("enabledFlags"));
     }
 }

--- a/transformation/transformationPlugins/jsonMessageTransformers/jsonJinjavaTransformer/src/test/java/org/opensearch/migrations/transform/JinjavaTransformerTest.java
+++ b/transformation/transformationPlugins/jsonMessageTransformers/jsonJinjavaTransformer/src/test/java/org/opensearch/migrations/transform/JinjavaTransformerTest.java
@@ -87,7 +87,7 @@ class JinjavaTransformerTest {
             new JinjavaConfig(null,
                 Map.of("hello", "{%- macro hello() -%} hi {%- endmacro -%}\n")));
 
-        var resultObj = indexTypeMappingRewriter.transformJson(OBJECT_MAPPER.readValue(testString, Map.class));
+        Object resultObj = indexTypeMappingRewriter.transformJson(OBJECT_MAPPER.readValue(testString, Map.class));
         Assertions.assertEquals(JsonNormalizer.fromString(testString.replace("indexA/type2/", "indexA_2/_doc/")),
             JsonNormalizer.fromObject(resultObj));
     }
@@ -101,7 +101,7 @@ class JinjavaTransformerTest {
             new JinjavaConfig(null,
                 Map.of("hello", "{%- macro hello() -%}{\"hi\": \"world\"}{%- endmacro -%}\n")));
 
-        var resultObj = indexTypeMappingRewriter.transformJson(Map.of());
+        Object resultObj = indexTypeMappingRewriter.transformJson(Map.of());
         var resultStr = OBJECT_MAPPER.writeValueAsString(resultObj);
         Assertions.assertEquals("{\"hi\":\"world\"}", resultStr);
     }
@@ -121,7 +121,7 @@ class JinjavaTransformerTest {
                 new JinjavaConfig(null,
                     Map.of("hello", "{%- macro hello() -%}{\"hi\": \"world\"}{%- endmacro -%}\n")));
 
-            var resultObj = indexTypeMappingRewriter.transformJson(Map.of());
+            Object resultObj = indexTypeMappingRewriter.transformJson(Map.of());
             var resultStr = OBJECT_MAPPER.writeValueAsString(resultObj);
             Assertions.assertEquals("{}", resultStr);
 

--- a/transformation/transformationPlugins/jsonMessageTransformers/jsonJinjavaTransformer/src/test/java/org/opensearch/migrations/transform/RouteTest.java
+++ b/transformation/transformationPlugins/jsonMessageTransformers/jsonJinjavaTransformer/src/test/java/org/opensearch/migrations/transform/RouteTest.java
@@ -14,7 +14,7 @@ import org.junit.jupiter.api.Test;
 public class RouteTest {
     private static final ObjectMapper objectMapper = new ObjectMapper();
 
-    public Map<String, Object> doRouting(Map<String, Object> flags, Map<String, Object> inputDoc) {
+    public Object doRouting(Map<String, Object> flags, Map<String, Object> inputDoc) {
         log.atInfo().setMessage("parsed flags: {}").addArgument(flags).log();
         final var template = "" +
             "{%- macro doDefault(ignored_input) -%}" +
@@ -65,16 +65,16 @@ public class RouteTest {
                 "data2"
             ));
         {
-            var resultMap = doRouting(null, docA);
+            var resultMap = (Map) doRouting(null, docA);
             Assertions.assertEquals(1, resultMap.size());
             Assertions.assertEquals("_and more!", resultMap.get("matchedVal"));
         }
         {
-            var resultMap = doRouting(flagAOff, docA);
+            var resultMap = (Map) doRouting(flagAOff, docA);
             Assertions.assertTrue(resultMap.isEmpty());
         }
         {
-            var resultMap = doRouting(flagAOff, docB);
+            var resultMap = (Map) doRouting(flagAOff, docB);
             Assertions.assertEquals("{\"label\":\"B-hive\",\"stuff\":[\"data2\",\"data1\"]}",
                 objectMapper.writeValueAsString(new TreeMap<>(resultMap)));
         }

--- a/transformation/transformationPlugins/jsonMessageTransformers/jsonJinjavaTransformerProvider/src/test/java/org/opensearch/migrations/replay/JinjavaTransformerProviderTest.java
+++ b/transformation/transformationPlugins/jsonMessageTransformers/jsonJinjavaTransformerProvider/src/test/java/org/opensearch/migrations/replay/JinjavaTransformerProviderTest.java
@@ -77,7 +77,7 @@ class JinjavaTransformerProviderTest {
         var documentJson = parseStringAsJson(mapper, TEST_INPUT_REQUEST);
         var transformer = new JsonJinjavaTransformerProvider().createTransformer(Map.of(
             "template",  EXCISE_TYPE_EXPRESSION_STRING));
-        var transformedDocument = transformer.transformJson(documentJson);
+        Object transformedDocument = transformer.transformJson(documentJson);
         var outputStr = emitJson(mapper, transformedDocument);
 
         final String TEST_OUTPUT_REQUEST = "{\n"

--- a/transformation/transformationPlugins/jsonMessageTransformers/jsonJoltMessageTransformer/src/main/java/org/opensearch/migrations/transform/JsonJoltTransformer.java
+++ b/transformation/transformationPlugins/jsonMessageTransformers/jsonJoltMessageTransformer/src/main/java/org/opensearch/migrations/transform/JsonJoltTransformer.java
@@ -18,7 +18,7 @@ public class JsonJoltTransformer implements IJsonTransformer {
     }
 
     @Override
-    public Map<String, Object> transformJson(Map<String, Object> incomingJson) {
+    public Object transformJson(Object incomingJson) {
         return (Map<String, Object>) this.spec.transform(incomingJson);
     }
 }

--- a/transformation/transformationPlugins/jsonMessageTransformers/jsonMessageTransformerInterface/src/main/java/org/opensearch/migrations/transform/IJsonPredicate.java
+++ b/transformation/transformationPlugins/jsonMessageTransformers/jsonMessageTransformerInterface/src/main/java/org/opensearch/migrations/transform/IJsonPredicate.java
@@ -1,7 +1,6 @@
 package org.opensearch.migrations.transform;
 
-import java.util.Map;
 import java.util.function.Predicate;
 
-public interface IJsonPredicate extends Predicate<Map<String, Object>> {
+public interface IJsonPredicate extends Predicate<Object> {
 }

--- a/transformation/transformationPlugins/jsonMessageTransformers/jsonMessageTransformerInterface/src/main/java/org/opensearch/migrations/transform/IJsonTransformer.java
+++ b/transformation/transformationPlugins/jsonMessageTransformers/jsonMessageTransformerInterface/src/main/java/org/opensearch/migrations/transform/IJsonTransformer.java
@@ -1,11 +1,9 @@
 package org.opensearch.migrations.transform;
 
-import java.util.Map;
-
 /**
  * This is a simple interface to convert a JSON object (String, Map, or Array) into another
  * JSON object.  Any changes to datastructures, nesting, order, etc should be intentional.
  */
 public interface IJsonTransformer {
-    Map<String, Object> transformJson(Map<String, Object> incomingJson);
+    Object transformJson(Object incomingJson);
 }

--- a/transformation/transformationPlugins/jsonMessageTransformers/jsonMessageTransformerInterface/src/main/java/org/opensearch/migrations/transform/JsonCompositeTransformer.java
+++ b/transformation/transformationPlugins/jsonMessageTransformers/jsonMessageTransformerInterface/src/main/java/org/opensearch/migrations/transform/JsonCompositeTransformer.java
@@ -1,7 +1,6 @@
 package org.opensearch.migrations.transform;
 
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 
 public class JsonCompositeTransformer implements IJsonTransformer {
@@ -12,8 +11,8 @@ public class JsonCompositeTransformer implements IJsonTransformer {
     }
 
     @Override
-    public Map<String, Object> transformJson(Map<String, Object> incomingJson) {
-        var lastOutput = new AtomicReference<>(incomingJson);
+    public Object transformJson(Object incomingJson) {
+        AtomicReference<Object> lastOutput = new AtomicReference<>(incomingJson);
         jsonTransformerList.forEach(t -> lastOutput.set(t.transformJson(lastOutput.get())));
         return lastOutput.get();
     }

--- a/transformation/transformationPlugins/jsonMessageTransformers/jsonMessageTransformerInterface/src/main/java/org/opensearch/migrations/transform/JsonConditionalTransformer.java
+++ b/transformation/transformationPlugins/jsonMessageTransformers/jsonMessageTransformerInterface/src/main/java/org/opensearch/migrations/transform/JsonConditionalTransformer.java
@@ -1,7 +1,5 @@
 package org.opensearch.migrations.transform;
 
-import java.util.Map;
-
 public class JsonConditionalTransformer implements IJsonTransformer {
     IJsonPredicate jsonPredicate;
     IJsonTransformer jsonTransformer;
@@ -12,7 +10,7 @@ public class JsonConditionalTransformer implements IJsonTransformer {
     }
 
     @Override
-    public Map<String, Object> transformJson(Map<String, Object> incomingJson) {
+    public Object transformJson(Object incomingJson) {
         if (jsonPredicate.test(incomingJson)) {
             return jsonTransformer.transformJson(incomingJson);
         }

--- a/transformation/transformationPlugins/jsonMessageTransformers/jsonMessageTransformerInterface/src/main/java/org/opensearch/migrations/transform/NoopTransformerProvider.java
+++ b/transformation/transformationPlugins/jsonMessageTransformers/jsonMessageTransformerInterface/src/main/java/org/opensearch/migrations/transform/NoopTransformerProvider.java
@@ -1,11 +1,9 @@
 package org.opensearch.migrations.transform;
 
-import java.util.Map;
-
 public class NoopTransformerProvider implements IJsonTransformerProvider {
     private static class NoopTransformer implements IJsonTransformer {
         @Override
-        public Map<String, Object> transformJson(Map<String, Object> incomingJson) {
+        public Object transformJson(Object incomingJson) {
             return incomingJson;
         }
     }

--- a/transformation/transformationPlugins/jsonMessageTransformers/jsonMessageTransformerLoaders/src/main/java/org/opensearch/migrations/transform/TransformationLoader.java
+++ b/transformation/transformationPlugins/jsonMessageTransformers/jsonMessageTransformerLoaders/src/main/java/org/opensearch/migrations/transform/TransformationLoader.java
@@ -125,8 +125,9 @@ public class TransformationLoader {
         private final String userAgent;
 
         @Override
-        public Map<String, Object> transformJson(Map<String, Object> incomingJson) {
-            var headers = (Map<String, Object>) incomingJson.get(JsonKeysForHttpMessage.HEADERS_KEY);
+        public Object transformJson(Object incomingJson) {
+            @SuppressWarnings("unchecked")
+            var headers = (Map<String, Object>) ((Map<String, Object>) incomingJson).get(JsonKeysForHttpMessage.HEADERS_KEY);
             var oldVal = headers.get(USER_AGENT);
             if (oldVal != null) {
                 if (oldVal instanceof List) {
@@ -146,8 +147,9 @@ public class TransformationLoader {
         private final String newHostName;
 
         @Override
-        public Map<String, Object> transformJson(Map<String, Object> incomingJson) {
-            var headers = (Map<String, Object>) incomingJson.get(JsonKeysForHttpMessage.HEADERS_KEY);
+        public Object transformJson(Object incomingJson) {
+            @SuppressWarnings("unchecked")
+            var headers = (Map<String, Object>) ((Map<String, Object>) incomingJson).get(JsonKeysForHttpMessage.HEADERS_KEY);
             if (headers != null) {
                 headers.replace("host", newHostName);
             } else {

--- a/transformation/transformationPlugins/jsonMessageTransformers/jsonMessageTransformerLoaders/src/test/java/org/opensearch/migrations/transform/replay/JsonTransformerTest.java
+++ b/transformation/transformationPlugins/jsonMessageTransformers/jsonMessageTransformerLoaders/src/test/java/org/opensearch/migrations/transform/replay/JsonTransformerTest.java
@@ -54,7 +54,7 @@ class JsonTransformerTest {
         var transformer = JsonJoltTransformer.newBuilder()
                 .addCannedOperation(JsonJoltTransformBuilder.CANNED_OPERATION.PASS_THRU)
                 .build();
-        var transformedDocument = transformer.transformJson(documentJson);
+        Object transformedDocument = transformer.transformJson(documentJson);
         var finalOutputStr = emitJson(transformedDocument);
 
         Assertions.assertEquals(TEST_DOCUMENT, finalOutputStr);
@@ -65,7 +65,7 @@ class JsonTransformerTest {
         var testResourceName = "parsed/post_formUrlEncoded_withFixedLength.json";
         final var documentJson = parseSampleRequestFromResource(testResourceName);
         var transformer = JsonJoltTransformer.newBuilder().addHostSwitchOperation(DUMMY_HOSTNAME_TEST_STRING).build();
-        var transformedDocument = transformer.transformJson(documentJson);
+        Object transformedDocument = transformer.transformJson(documentJson);
         String transformedJsonOutputStr = emitJson(transformedDocument);
         log.atInfo().setMessage("transformed json document: {}").addArgument(transformedJsonOutputStr).log();
         Assertions.assertTrue(transformedJsonOutputStr.contains(DUMMY_HOSTNAME_TEST_STRING));
@@ -123,7 +123,7 @@ class JsonTransformerTest {
         public void testSimpleTransformJMES() throws JsonProcessingException {
             var documentJson = parseStringAsJson(mapper, TEST_INPUT_REQUEST);
             var transformer = new JsonJMESPathTransformer(new JcfRuntime(), EXCISE_TYPE_EXPRESSION_STRING);
-            var transformedDocument = transformer.transformJson(documentJson);
+            Object transformedDocument = transformer.transformJson(documentJson);
             var outputStr = emitJson(mapper, transformedDocument);
 
             final String TEST_OUTPUT_REQUEST = "{\n"

--- a/transformation/transformationPlugins/jsonMessageTransformers/jsonMessageTransformerLoaders/src/test/java/org/opensearch/migrations/transform/replay/MultipleJMESPathScriptsTest.java
+++ b/transformation/transformationPlugins/jsonMessageTransformers/jsonMessageTransformerLoaders/src/test/java/org/opensearch/migrations/transform/replay/MultipleJMESPathScriptsTest.java
@@ -30,7 +30,7 @@ public class MultipleJMESPathScriptsTest {
             aggregateScriptString
         );
         var origDoc = JsonTransformerTest.parseStringAsJson(mapper, JsonTransformerTest.TEST_INPUT_REQUEST);
-        var newDoc = toNewHostTransformer.transformJson(origDoc);
+        Object newDoc = toNewHostTransformer.transformJson(origDoc);
 
         final String TEST_OUTPUT_REQUEST = "{\n"
             + "    \"method\": \"PUT\",\n"

--- a/transformation/transformationPlugins/jsonMessageTransformers/jsonMessageTransformerLoaders/src/test/java/org/opensearch/migrations/transform/replay/MultipleJoltScriptsTest.java
+++ b/transformation/transformationPlugins/jsonMessageTransformers/jsonMessageTransformerLoaders/src/test/java/org/opensearch/migrations/transform/replay/MultipleJoltScriptsTest.java
@@ -29,9 +29,9 @@ public class MultipleJoltScriptsTest {
         );
         var origDocStr = SampleContents.loadSampleJsonRequestAsString();
         var origDoc = parseAsMap(origDocStr);
-        var newDoc = toNewHostTransformer.transformJson(origDoc);
-        Assertions.assertEquals("testhostname", ((Map) newDoc.get(JsonKeysForHttpMessage.HEADERS_KEY)).get("host"));
-        Assertions.assertEquals("gzip", ((Map) newDoc.get(JsonKeysForHttpMessage.HEADERS_KEY)).get("content-encoding"));
+        Object newDoc = toNewHostTransformer.transformJson(origDoc);
+        Assertions.assertEquals("testhostname", ((Map) ((Map) newDoc).get(JsonKeysForHttpMessage.HEADERS_KEY)).get("host"));
+        Assertions.assertEquals("gzip", ((Map) ((Map) newDoc).get(JsonKeysForHttpMessage.HEADERS_KEY)).get("content-encoding"));
     }
 
     @Test
@@ -53,9 +53,9 @@ public class MultipleJoltScriptsTest {
         );
         var origDocStr = SampleContents.loadSampleJsonRequestAsString();
         var origDoc = parseAsMap(origDocStr);
-        var newDoc = toNewHostTransformer.transformJson(origDoc);
-        Assertions.assertEquals("testhostname", ((Map) newDoc.get(JsonKeysForHttpMessage.HEADERS_KEY)).get("host"));
-        var headers = (Map) newDoc.get(JsonKeysForHttpMessage.HEADERS_KEY);
+        Object newDoc = toNewHostTransformer.transformJson(origDoc);
+        Assertions.assertEquals("testhostname", ((Map) ((Map) newDoc).get(JsonKeysForHttpMessage.HEADERS_KEY)).get("host"));
+        var headers = (Map) ((Map) newDoc).get(JsonKeysForHttpMessage.HEADERS_KEY);
         Assertions.assertEquals("gzip", headers.get("content-encoding"));
         Assertions.assertEquals("newValue", headers.get("newHeader"));
     }
@@ -136,14 +136,14 @@ public class MultipleJoltScriptsTest {
             "}";
         var expectedDocStr = "{\"method\":\"PUT\",\"protocol\":\"HTTP/1.0\",\"URI\":\"/oldStyleIndex/moreStuff\",\"headers\":{\"host\":\"testhostname\"},\"payload\":{\"inlinedJsonBody\":{\"top\":{\"properties\":{\"field1\":{\"type\":\"text\"},\"field2\":{\"type\":\"keyword\"}}}}}}";
         var origDoc = parseAsMap(origDocStr);
-        var newDoc = excisingTransformer.transformJson(origDoc);
+        Object newDoc = excisingTransformer.transformJson(origDoc);
         var newAsStr = mapper.writeValueAsString(newDoc);
         Assertions.assertEquals(expectedDocStr, newAsStr);
 
-        var secondPassDoc = excisingTransformer.transformJson(newDoc);
+        Object secondPassDoc = excisingTransformer.transformJson(newDoc);
         var secondPassDocAsStr = mapper.writeValueAsString(secondPassDoc);
         Assertions.assertEquals(expectedDocStr, secondPassDocAsStr);
 
-        Assertions.assertEquals("testhostname", ((Map) newDoc.get(JsonKeysForHttpMessage.HEADERS_KEY)).get("host"));
+        Assertions.assertEquals("testhostname", ((Map) ((Map) newDoc).get(JsonKeysForHttpMessage.HEADERS_KEY)).get("host"));
     }
 }

--- a/transformation/transformationPlugins/jsonMessageTransformers/jsonMessageTransformerLoaders/src/test/java/org/opensearch/migrations/transform/replay/TransformationLoaderTest.java
+++ b/transformation/transformationPlugins/jsonMessageTransformers/jsonMessageTransformerLoaders/src/test/java/org/opensearch/migrations/transform/replay/TransformationLoaderTest.java
@@ -23,9 +23,9 @@ public class TransformationLoaderTest {
         var toOldHostTransformer = new TransformationLoader().getTransformerFactoryLoaderWithNewHostName("localhost");
         var origDoc = parseAsMap(SampleContents.loadSampleJsonRequestAsString());
         var origDocStr = mapper.writeValueAsString(origDoc);
-        var outputWithNewHostname = toNewHostTransformer.transformJson(origDoc);
+        Object outputWithNewHostname = toNewHostTransformer.transformJson(origDoc);
         var docWithNewHostnameStr = mapper.writeValueAsString(outputWithNewHostname);
-        var outputWithOldHostname = toOldHostTransformer.transformJson(outputWithNewHostname);
+        Object outputWithOldHostname = toOldHostTransformer.transformJson(outputWithNewHostname);
         var docWithOldHostnameStr = mapper.writeValueAsString(outputWithOldHostname);
         Assertions.assertEquals(origDocStr, docWithOldHostnameStr);
         Assertions.assertNotEquals(origDocStr, docWithNewHostnameStr);
@@ -39,7 +39,7 @@ public class TransformationLoaderTest {
             "NoopTransformerProvider"
         );
         var origDoc = parseAsMap(SampleContents.loadSampleJsonRequestAsString());
-        var output = noopTransformer.transformJson(origDoc);
+        Object output = noopTransformer.transformJson(origDoc);
         Assertions.assertEquals(mapper.writeValueAsString(origDoc), mapper.writeValueAsString(output));
     }
 
@@ -72,13 +72,14 @@ public class TransformationLoaderTest {
         + "}\n";
 
     @Test
+    @SuppressWarnings("unchecked")
     public void testUserAgentAppends() throws Exception {
         var userAgentTransformer = new TransformationLoader().getTransformerFactoryLoader("localhost", "tester", null);
 
         var origDoc = parseAsMap(TEST_INPUT_REQUEST);
-        var pass1 = userAgentTransformer.transformJson(origDoc);
-        var pass2 = userAgentTransformer.transformJson(pass1);
-        var finalUserAgentInHeaders = ((Map<String, Object>) pass2.get("headers")).get("user-agent");
+        Object pass1 = userAgentTransformer.transformJson(origDoc);
+        Object pass2 = userAgentTransformer.transformJson(pass1);
+        var finalUserAgentInHeaders = ((Map<String, Object>) ((Map<String, Object>) pass2).get("headers")).get("user-agent");
         Assertions.assertEquals("tester; tester", finalUserAgentInHeaders);
     }
 }

--- a/transformation/transformationPlugins/jsonMessageTransformers/jsonTypeMappingsSanitizationTransformer/src/main/java/org/opensearch/migrations/transform/TypeMappingsSanitizationTransformer.java
+++ b/transformation/transformationPlugins/jsonMessageTransformers/jsonTypeMappingsSanitizationTransformer/src/main/java/org/opensearch/migrations/transform/TypeMappingsSanitizationTransformer.java
@@ -5,7 +5,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.function.UnaryOperator;
+import java.util.function.Function;
 
 import org.opensearch.migrations.transform.jinjava.JinjavaConfig;
 import org.opensearch.migrations.transform.typemappings.SourceProperties;
@@ -37,7 +37,7 @@ public class TypeMappingsSanitizationTransformer extends JinjavaTransformer {
             Optional.ofNullable(jinjavaSettings).orElse(new JinjavaConfig()));
     }
 
-    private static UnaryOperator<Map<String, Object>>
+    private static Function<Object, Map<String, Object>>
     makeSourceWrapperFunction(SourceProperties sourceProperties,
                               Map<String, Object> featureFlagsIncoming,
                               Map<String, Map<String, String>> indexMappingsIncoming,

--- a/transformation/transformationPlugins/jsonMessageTransformers/jsonTypeMappingsSanitizationTransformer/src/test/java/org/opensearch/migrations/transform/TypeMappingsSanitizationCreateIndexTest.java
+++ b/transformation/transformationPlugins/jsonMessageTransformers/jsonTypeMappingsSanitizationTransformer/src/test/java/org/opensearch/migrations/transform/TypeMappingsSanitizationCreateIndexTest.java
@@ -138,7 +138,7 @@ public class TypeMappingsSanitizationCreateIndexTest {
             "  }\n" +
             "}";
         var indexTypeMappingRewriter = makeIndexTypeMappingRewriter();
-        var resultObj = indexTypeMappingRewriter.transformJson(OBJECT_MAPPER.readValue(testString, LinkedHashMap.class));
+        Object resultObj = indexTypeMappingRewriter.transformJson(OBJECT_MAPPER.readValue(testString, LinkedHashMap.class));
         Assertions.assertEquals(JsonNormalizer.fromString(testString), JsonNormalizer.fromObject(resultObj));
     }
 
@@ -161,7 +161,7 @@ public class TypeMappingsSanitizationCreateIndexTest {
             "  }\n" +
             "}";
         var indexTypeMappingRewriter = makeIndexTypeMappingRewriter();
-        var resultObj = indexTypeMappingRewriter.transformJson(OBJECT_MAPPER.readValue(testString, LinkedHashMap.class));
+        Object resultObj = indexTypeMappingRewriter.transformJson(OBJECT_MAPPER.readValue(testString, LinkedHashMap.class));
         Assertions.assertEquals(JsonNormalizer.fromString(testString), JsonNormalizer.fromObject(resultObj));
     }
 

--- a/transformation/transformationPlugins/jsonMessageTransformers/jsonTypeMappingsSanitizationTransformer/src/test/java/org/opensearch/migrations/transform/TypeMappingsSanitizationDocBackfillTest.java
+++ b/transformation/transformationPlugins/jsonMessageTransformers/jsonTypeMappingsSanitizationTransformer/src/test/java/org/opensearch/migrations/transform/TypeMappingsSanitizationDocBackfillTest.java
@@ -28,7 +28,7 @@ public class TypeMappingsSanitizationDocBackfillTest {
 
 
         var indexTypeMappingRewriter = new TypeMappingsSanitizationTransformer(null, null);
-        var resultObj = indexTypeMappingRewriter.transformJson(OBJECT_MAPPER.readValue(testString, LinkedHashMap.class));
+        Object resultObj = indexTypeMappingRewriter.transformJson(OBJECT_MAPPER.readValue(testString, LinkedHashMap.class));
         log.atInfo().setMessage("resultStr = {}").addArgument(() -> {
             try {
                 return OBJECT_MAPPER.writeValueAsString(resultObj);

--- a/transformation/transformationPlugins/jsonMessageTransformers/jsonTypeMappingsSanitizationTransformer/src/test/java/org/opensearch/migrations/transform/TypeMappingsSanitizationTransformerBulkTest.java
+++ b/transformation/transformationPlugins/jsonMessageTransformers/jsonTypeMappingsSanitizationTransformer/src/test/java/org/opensearch/migrations/transform/TypeMappingsSanitizationTransformerBulkTest.java
@@ -111,7 +111,7 @@ public class TypeMappingsSanitizationTransformerBulkTest {
                 "}";
 
 
-        var resultObj = indexTypeMappingRewriter.transformJson(OBJECT_MAPPER.readValue(testString, LinkedHashMap.class));
+        Object resultObj = indexTypeMappingRewriter.transformJson(OBJECT_MAPPER.readValue(testString, LinkedHashMap.class));
         log.atInfo().setMessage("resultStr = {}").addArgument(() -> {
             try {
                 return OBJECT_MAPPER.writeValueAsString(resultObj);

--- a/transformation/transformationPlugins/jsonMessageTransformers/jsonTypeMappingsSanitizationTransformerProvider/src/test/java/org/opensearch/migrations/replay/TypeMappingsSanitizationProviderTest.java
+++ b/transformation/transformationPlugins/jsonMessageTransformers/jsonTypeMappingsSanitizationTransformerProvider/src/test/java/org/opensearch/migrations/replay/TypeMappingsSanitizationProviderTest.java
@@ -73,12 +73,12 @@ public class TypeMappingsSanitizationProviderTest {
         Map<String, Object> inputMap = OBJECT_MAPPER.readValue(TEST_INPUT_REQUEST, new TypeReference<>() {
         });
         {
-            var transformedDocument = provider.createTransformer(config).transformJson(inputMap);
+            Object transformedDocument = provider.createTransformer(config).transformJson(inputMap);
             Assertions.assertEquals(JsonNormalizer.fromString(EXPECTED),
                 JsonNormalizer.fromObject(transformedDocument));
         }
         {
-            var resultFromNullConfig = provider.createTransformer(null).transformJson(inputMap);
+            Object resultFromNullConfig = provider.createTransformer(null).transformJson(inputMap);
             Assertions.assertEquals(
                 JsonNormalizer.fromString(
                     EXPECTED.replace(
@@ -97,7 +97,7 @@ public class TypeMappingsSanitizationProviderTest {
                     Map.of("major",  (Object) 6,
                         "minor", (Object) 10)));
         var transformer = new TypeMappingSanitizationTransformerProvider().createTransformer(fullTransformerConfig);
-        var resultObj = transformer.transformJson(OBJECT_MAPPER.readValue(testString, LinkedHashMap.class));
+        Object resultObj = transformer.transformJson(OBJECT_MAPPER.readValue(testString, LinkedHashMap.class));
         Assertions.assertEquals(JsonNormalizer.fromString(testString), JsonNormalizer.fromObject(resultObj));
     }
 
@@ -110,7 +110,7 @@ public class TypeMappingsSanitizationProviderTest {
                         "minor", (Object) 10)),
                 "regex_index_mappings", List.of(List.of("", "", "")));
         var transformer = new TypeMappingSanitizationTransformerProvider().createTransformer(fullTransformerConfig);
-        var resultObj = transformer.transformJson(OBJECT_MAPPER.readValue(testString, LinkedHashMap.class));
+        Object resultObj = transformer.transformJson(OBJECT_MAPPER.readValue(testString, LinkedHashMap.class));
         Assertions.assertEquals(JsonNormalizer.fromString(testString), JsonNormalizer.fromObject(resultObj));
     }
 


### PR DESCRIPTION
### Description
Modify transformationPlugins contract to return Object to support One to Many transformations.

Initial step in plugin framework, applications (RFS, Metadata, Replayer) still need to be updated to support

### Issues Resolved
<!-- List any GitHub or Jira issues this PR will resolve -->

### Testing
<!-- Please provide details of testing done: unit testing, integration testing and manual testing -->

### Check List
- [ ] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
