### PR TITLE
Mark largeSourceDoc as slowTest for memory control

### DIFF
--- a/RFS/src/test/java/org/opensearch/migrations/bulkload/common/BulkDocSectionTest.java
+++ b/RFS/src/test/java/org/opensearch/migrations/bulkload/common/BulkDocSectionTest.java
@@ -9,6 +9,7 @@ import java.util.stream.Stream;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -141,6 +142,7 @@ class BulkDocSectionTest {
     }
 
     @Test
+    @Tag("longTest") // Mark as long test to control memory usage during parallel execution
     void testLargeSourceDoc() throws JsonProcessingException {
         var writer = new ObjectMapper();
         // Generate a 25MB source document


### PR DESCRIPTION
### Description
Mark largeSourceDoc as slowTest for memory control

### Issues Resolved
Fixes error encountered during GHA run
```
Caused by: java.lang.OutOfMemoryError: Java heap space
...
at com.fasterxml.jackson.databind.ObjectMapper.writeValueAsString(ObjectMapper.java:4039)
at org.opensearch.migrations.bulkload.common.BulkDocSectionTest.testLargeSourceDoc(BulkDocSectionTest.java:193)
...
```
[Source](https://scans.gradle.com/s/qr5ozgp4hjs6e/tests/task/:RFS:test/details/(N%2FA)/Gradle%20Test%20Executor%2043?expanded-stacktrace=WyIwLTEiXQ&top-execution=1)


### Testing
GHA

### Check List
- [ ] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
