### PR TITLE
[Solutions CDK] Remove bootstrap version CFN parameter

### DIFF
--- a/deployment/migration-assistant-solution/bin/app.ts
+++ b/deployment/migration-assistant-solution/bin/app.ts
@@ -35,12 +35,16 @@ const getProps = () => {
 const app = new App();
 const infraProps = getProps()
 new SolutionsInfrastructureStack(app, "Migration-Assistant-Infra-Import-VPC", {
-  synthesizer: new DefaultStackSynthesizer(),
+  synthesizer: new DefaultStackSynthesizer({
+    generateBootstrapVersionRule: false
+  }),
   createVPC: false,
   ...infraProps
 });
 new SolutionsInfrastructureStack(app, "Migration-Assistant-Infra-Create-VPC", {
-  synthesizer: new DefaultStackSynthesizer(),
+  synthesizer: new DefaultStackSynthesizer({
+    generateBootstrapVersionRule: false
+  }),
   createVPC: true,
   ...infraProps
 });


### PR DESCRIPTION
### Description
Removes this confusing CDK `BootstrapVersion` parameter that isn't necessary for our CFN deployments through the AWS console: 
<img width="1189" alt="image" src="https://github.com/user-attachments/assets/9776ed37-d73b-4cb5-ba64-2c035db5584a" />


### Issues Resolved
N/A

### Testing
CDK unit tests

### Check List
- [X] New functionality includes testing
- [N/A] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
