### PR TITLE
Update console_link logic on clearing snapshots with missing repo

### DIFF
--- a/.github/workflows/full_pr_e2e_test.yml
+++ b/.github/workflows/full_pr_e2e_test.yml
@@ -15,8 +15,11 @@ permissions:
   contents: read # to fetch code (actions/checkout)
 
 jobs:
-  full-es68-e2e-aws-test:
+  e2e-tests:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        job-name: [full-es68source-e2e-test, rfs-default-e2e-test]
     steps:
       - name: Sanitize branch and repo names
         env:
@@ -34,6 +37,6 @@ jobs:
         uses: lewijacn/jenkins-trigger@1.0.4
         with:
           jenkins_url: "https://migrations.ci.opensearch.org"
-          job_name: "full-es68source-e2e-test"
+          job_name: "${{ matrix.job-name }}"
           api_token: "${{ secrets.JENKINS_MIGRATIONS_GENERIC_WEBHOOK_TOKEN }}"
           job_params: "GIT_REPO_URL=${{ steps.sanitize-input.outputs.pr_repo_url }},GIT_BRANCH=${{ steps.sanitize-input.outputs.branch_name }}"

--- a/.github/workflows/full_pr_e2e_test.yml
+++ b/.github/workflows/full_pr_e2e_test.yml
@@ -15,11 +15,8 @@ permissions:
   contents: read # to fetch code (actions/checkout)
 
 jobs:
-  e2e-tests:
+  full-es68-e2e-aws-test:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        job-name: [full-es68source-e2e-test, rfs-default-e2e-test]
     steps:
       - name: Sanitize branch and repo names
         env:
@@ -37,6 +34,6 @@ jobs:
         uses: lewijacn/jenkins-trigger@1.0.4
         with:
           jenkins_url: "https://migrations.ci.opensearch.org"
-          job_name: "${{ matrix.job-name }}"
+          job_name: "full-es68source-e2e-test"
           api_token: "${{ secrets.JENKINS_MIGRATIONS_GENERIC_WEBHOOK_TOKEN }}"
           job_params: "GIT_REPO_URL=${{ steps.sanitize-input.outputs.pr_repo_url }},GIT_BRANCH=${{ steps.sanitize-input.outputs.branch_name }}"

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/test_clusters_middleware.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/test_clusters_middleware.py
@@ -1,0 +1,68 @@
+import pytest
+from unittest.mock import MagicMock
+from console_link.middleware.clusters import clear_snapshots
+from console_link.models.cluster import Cluster
+import requests
+import logging
+
+
+# Helper to mock HTTPError with response
+def create_http_error_mock(status_code, json_data):
+    response_mock = MagicMock()
+    response_mock.status_code = status_code
+    response_mock.json.return_value = json_data
+    return requests.exceptions.HTTPError(response=response_mock)
+
+
+@pytest.fixture
+def mock_cluster_with_missing_repo(mocker):
+    cluster = MagicMock(spec=Cluster)
+    # Simulate repository missing exception
+    error_mock = create_http_error_mock(
+        status_code=404,
+        json_data={
+            'error': {
+                'type': 'repository_missing_exception',
+                'reason': '[migration_assistant_repo] missing'
+            }
+        }
+    )
+    mocker.patch.object(cluster, 'call_api', side_effect=error_mock)
+    return cluster
+
+
+@pytest.fixture
+def mock_cluster_with_snapshots(mocker):
+    cluster = MagicMock(spec=Cluster)
+    # Mock the response for listing snapshots
+    mock_response = MagicMock()
+    mock_response.json.return_value = {
+        'snapshots': [
+            {'snapshot': 'snapshot_1'},
+            {'snapshot': 'snapshot_2'}
+        ]
+    }
+    mock_response.status_code = 200
+
+    def mock_call_api(path, *args, **kwargs):
+        if "_all" in path:
+            return mock_response
+        elif "snapshot_1" in path or "snapshot_2" in path:
+            return MagicMock()  # Simulate successful deletion
+        raise ValueError(f"Unexpected path: {path}")
+
+    mocker.patch.object(cluster, 'call_api', side_effect=mock_call_api)
+    return cluster
+
+
+def test_clear_snapshots_repository_missing(mock_cluster_with_missing_repo, caplog):
+    with caplog.at_level(logging.INFO, logger='console_link.middleware.clusters'):
+        clear_snapshots(mock_cluster_with_missing_repo, 'migration_assistant_repo')
+        assert "Repository 'migration_assistant_repo' is missing. Skipping snapshot clearing." in caplog.text
+
+
+def test_clear_snapshots_success(mock_cluster_with_snapshots, caplog):
+    with caplog.at_level(logging.INFO, logger='console_link.middleware.clusters'):
+        clear_snapshots(mock_cluster_with_snapshots, 'migration_assistant_repo')
+        assert "Deleted snapshot: snapshot_1 from repository 'migration_assistant_repo'." in caplog.text
+        assert "Deleted snapshot: snapshot_2 from repository 'migration_assistant_repo'." in caplog.text


### PR DESCRIPTION
### Description
Update console_link logic on clearing snapshots with missing repo

Fixes [error](https://migrations.ci.opensearch.org/job/rfs-default-e2e-test/2992/console)

```
[31m[1mERROR   [0m console_link.middleware.clusters:clusters.py:101 Error clearing snapshots from repository 'migration_assistant_repo': 404 Client Error: Not Found for url: [https://vpc-os-cluster-rfs-integ1-gqpxocxdv5z7hnfmjpvtekpvsy.us-east-1.es.amazonaws.com:443/_snapshot/migration_assistant_repo/_all](https://vpc-os-cluster-rfs-integ1-gqpxocxdv5z7hnfmjpvtekpvsy.us-east-1.es.amazonaws.com/_snapshot/migration_assistant_repo/_all)
```

Updates GHA to run with both 7.10 and 6.8 tests (will apply after pr is merged)

### Issues Resolved
N/A

### Testing
Added unit test

### Check List
- [x] New functionality includes testing
- [N/A] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
