### PR TITLE
Metadata add 1:many custom transformations

### DIFF
--- a/MetadataMigration/src/main/java/org/opensearch/migrations/commands/MigratorEvaluatorBase.java
+++ b/MetadataMigration/src/main/java/org/opensearch/migrations/commands/MigratorEvaluatorBase.java
@@ -5,7 +5,7 @@ import java.util.List;
 
 import org.opensearch.migrations.MigrateOrEvaluateArgs;
 import org.opensearch.migrations.MigrationMode;
-import org.opensearch.migrations.bulkload.transformers.CompositeTransformer;
+import org.opensearch.migrations.bulkload.transformers.FanOutCompositeTransformer;
 import org.opensearch.migrations.bulkload.transformers.TransformFunctions;
 import org.opensearch.migrations.bulkload.transformers.Transformer;
 import org.opensearch.migrations.bulkload.transformers.TransformerToIJsonTransformerAdapter;
@@ -76,7 +76,7 @@ public abstract class MigratorEvaluatorBase {
             arguments.metadataTransformationParams
         );
         var customTransformer = getCustomTransformer();
-        var compositeTransformer = new CompositeTransformer(customTransformer, versionTransformer);
+        var compositeTransformer = new FanOutCompositeTransformer(customTransformer, versionTransformer);
         log.atInfo().setMessage("Selected transformer: {}").addArgument(compositeTransformer).log();
         return compositeTransformer;
     }

--- a/MetadataMigration/src/test/java/org/opensearch/migrations/MultiTypeMappingTransformationTest.java
+++ b/MetadataMigration/src/test/java/org/opensearch/migrations/MultiTypeMappingTransformationTest.java
@@ -81,6 +81,7 @@ class MultiTypeMappingTransformationTest extends BaseMigrationTest {
             var dataFilterArgs = new DataFilterArgs();
             dataFilterArgs.indexAllowlist = List.of(originalIndexName);
             arguments.dataFilterArgs = dataFilterArgs;
+            arguments.sourceVersion = upgradedSourceCluster.getContainerVersion().getVersion();
 
             // Use union method for multi-type mappings
             arguments.metadataTransformationParams.multiTypeResolutionBehavior = IndexMappingTypeRemoval.MultiTypeResolutionBehavior.UNION;

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/transformers/Transformer.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/transformers/Transformer.java
@@ -1,5 +1,7 @@
 package org.opensearch.migrations.bulkload.transformers;
 
+import java.util.List;
+
 import org.opensearch.migrations.bulkload.models.GlobalMetadata;
 import org.opensearch.migrations.bulkload.models.IndexMetadata;
 
@@ -16,5 +18,5 @@ public interface Transformer {
     /**
      * Takes the raw JSON representing the Index Metadata of one version and returns a new, transformed copy of the JSON
      */
-    public IndexMetadata transformIndexMetadata(IndexMetadata indexData);
+    public List<IndexMetadata> transformIndexMetadata(IndexMetadata indexData);
 }

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/transformers/TransformerToIJsonTransformerAdapter.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/transformers/TransformerToIJsonTransformerAdapter.java
@@ -109,10 +109,8 @@ public class TransformerToIJsonTransformerAdapter implements Transformer {
 
     @Override
     public GlobalMetadata transformGlobalMetadata(GlobalMetadata globalData) {
-        var inputJson = objectNodeToMap(globalData.toObjectNode());
-        log.atInfo().setMessage("BeforeJsonGlobal: {}").addArgument(() -> printMap(inputJson)).log();
-        Object afterJson = transformer.transformJson(inputJson);
-        log.atInfo().setMessage("AfterJsonGlobal: {}").addArgument(() -> printMap(afterJson)).log();
+        log.atInfo().setMessage("BeforeJsonGlobal: {}")
+            .addArgument(() -> printMap(objectNodeToMap(globalData.toObjectNode()))).log();
 
         final List<LegacyTemplate> legacyTemplates = new ArrayList<>();
         globalData.getTemplates().fields().forEachRemaining(
@@ -150,13 +148,12 @@ public class TransformerToIJsonTransformerAdapter implements Transformer {
                 .map(ComponentTemplate.class::cast)
                 .collect(Collectors.toList());
 
-        assert transformedLegacy.size() + transformedIndex.size() + transformedComponent.size() == transformedTemplates.size();
-
         updateTemplates(transformedLegacy, globalData.getTemplates());
         updateTemplates(transformedIndex, globalData.getIndexTemplates());
         updateTemplates(transformedComponent, globalData.getComponentTemplates());
 
-        log.atInfo().setMessage("GlobalOutput: {}").addArgument(() -> printMap(objectNodeToMap(globalData.toObjectNode()))).log();
+        log.atInfo().setMessage("AfterJsonGlobal: {}")
+            .addArgument(() -> printMap(objectNodeToMap(globalData.toObjectNode()))).log();
         return globalData;
     }
 

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/transformers/Transformer_ES_6_8_to_OS_2_11.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/transformers/Transformer_ES_6_8_to_OS_2_11.java
@@ -85,10 +85,10 @@ public class Transformer_ES_6_8_to_OS_2_11 implements Transformer {
     }
 
     @Override
-    public IndexMetadata transformIndexMetadata(IndexMetadata index) {
+    public List<IndexMetadata> transformIndexMetadata(IndexMetadata index) {
         var copy = index.deepCopy();
         transformIndex(copy, IndexType.CONCRETE);
-        return new IndexMetadataData_OS_2_11(copy.getRawJson(), copy.getId(), copy.getName());
+        return List.of(new IndexMetadataData_OS_2_11(copy.getRawJson(), copy.getId(), copy.getName()));
     }
 
     private void transformIndex(Index index, IndexType type) {

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/transformers/Transformer_ES_7_10_OS_2_11.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/transformers/Transformer_ES_7_10_OS_2_11.java
@@ -1,5 +1,7 @@
 package org.opensearch.migrations.bulkload.transformers;
 
+import java.util.List;
+
 import org.opensearch.migrations.bulkload.models.GlobalMetadata;
 import org.opensearch.migrations.bulkload.models.IndexMetadata;
 import org.opensearch.migrations.bulkload.version_os_2_11.GlobalMetadataData_OS_2_11;
@@ -84,7 +86,7 @@ public class Transformer_ES_7_10_OS_2_11 implements Transformer {
     }
 
     @Override
-    public IndexMetadata transformIndexMetadata(IndexMetadata indexData) {
+    public List<IndexMetadata> transformIndexMetadata(IndexMetadata indexData) {
         log.atDebug().setMessage("Original Object: {}").addArgument(indexData::getRawJson).log();
         var copy = indexData.deepCopy();
         var newRoot = copy.getRawJson();
@@ -96,6 +98,6 @@ public class Transformer_ES_7_10_OS_2_11 implements Transformer {
         TransformFunctions.fixReplicasForDimensionality(newRoot, awarenessAttributeDimensionality);
 
         log.atDebug().setMessage("Transformed Object: {}").addArgument(newRoot).log();
-        return copy;
+        return List.of(copy);
     }
 }

--- a/RFS/src/test/java/org/opensearch/migrations/bulkload/common/http/FanOutCompositeTransformerTest.java
+++ b/RFS/src/test/java/org/opensearch/migrations/bulkload/common/http/FanOutCompositeTransformerTest.java
@@ -11,7 +11,7 @@ import reactor.test.StepVerifier;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
-public class CompositeTransformerTest {
+public class FanOutCompositeTransformerTest {
 
     @Test
     public void testCompositeTransformer() {

--- a/RFS/src/test/java/org/opensearch/migrations/bulkload/transformers/Transformer_ES_7_10_OS_2_11Test.java
+++ b/RFS/src/test/java/org/opensearch/migrations/bulkload/transformers/Transformer_ES_7_10_OS_2_11Test.java
@@ -51,19 +51,19 @@ public class Transformer_ES_7_10_OS_2_11Test {
         Transformer_ES_7_10_OS_2_11 transformer = new Transformer_ES_7_10_OS_2_11(2);
 
         IndexMetadata indexMetadataBwc = sourceResourceProvider.getIndexMetadata().fromRepo(snapshot.name, "bwc_index_1");
-        IndexMetadata transformedIndexBwc = transformer.transformIndexMetadata(indexMetadataBwc);
+        IndexMetadata transformedIndexBwc = transformer.transformIndexMetadata(indexMetadataBwc).get(0);
         IndexMetadataData_OS_2_11 finalIndexBwc =new IndexMetadataData_OS_2_11(transformedIndexBwc.getRawJson(), transformedIndexBwc.getId(), transformedIndexBwc.getName());
 
         IndexMetadata indexMetadataFwc = sourceResourceProvider.getIndexMetadata().fromRepo(snapshot.name, "fwc_index_1");
-        IndexMetadata transformedIndexFwc = transformer.transformIndexMetadata(indexMetadataFwc);
+        IndexMetadata transformedIndexFwc = transformer.transformIndexMetadata(indexMetadataFwc).get(0);
         IndexMetadataData_OS_2_11 finalIndexFwc =new IndexMetadataData_OS_2_11(transformedIndexFwc.getRawJson(), transformedIndexFwc.getId(), transformedIndexFwc.getName());
 
         IndexMetadata indexMetadataNoMappingNoDocs = sourceResourceProvider.getIndexMetadata().fromRepo(snapshot.name, "no_mappings_no_docs");
-        IndexMetadata transformedIndexNoMappingNoDocs = transformer.transformIndexMetadata(indexMetadataNoMappingNoDocs);
+        IndexMetadata transformedIndexNoMappingNoDocs = transformer.transformIndexMetadata(indexMetadataNoMappingNoDocs).get(0);
         IndexMetadataData_OS_2_11 finalIndexNoMappingNoDocs = new IndexMetadataData_OS_2_11(transformedIndexNoMappingNoDocs.getRawJson(), transformedIndexNoMappingNoDocs.getId(), transformedIndexNoMappingNoDocs.getName());
 
         IndexMetadata indexMetadataEmptyMappingNoDocs = sourceResourceProvider.getIndexMetadata().fromRepo(snapshot.name, "empty_mappings_no_docs");
-        IndexMetadata transformedIndexEmptyMappingNoDocs = transformer.transformIndexMetadata(indexMetadataEmptyMappingNoDocs);
+        IndexMetadata transformedIndexEmptyMappingNoDocs = transformer.transformIndexMetadata(indexMetadataEmptyMappingNoDocs).get(0);
         IndexMetadataData_OS_2_11 finalIndexEmptyMappingNoDocs = new IndexMetadataData_OS_2_11(transformedIndexEmptyMappingNoDocs.getRawJson(), transformedIndexEmptyMappingNoDocs.getId(), transformedIndexEmptyMappingNoDocs.getName());
 
         String expectedIndexBwc = "{\"version\":3,\"mapping_version\":1,\"settings_version\":1,\"aliases_version\":1,\"routing_num_shards\":1024,\"state\":\"open\",\"settings\":{\"creation_date\":\"1727459371883\",\"number_of_replicas\":1,\"number_of_shards\":\"1\",\"provided_name\":\"bwc_index_1\",\"uuid\":\"tBmFXxGhTeiDlznQiKfNCA\",\"version\":{\"created\":\"7100299\"}},\"mappings\":{\"properties\":{\"content\":{\"type\":\"text\"},\"title\":{\"type\":\"text\"}}},\"aliases\":{\"bwc_alias\":{}},\"primary_terms\":[1],\"in_sync_allocations\":{\"0\":[\"jSYEePXYTka3EJ0vvdPGJA\"]},\"rollover_info\":{},\"system\":false}";

--- a/transformation/src/main/java/org/opensearch/migrations/transformation/rules/IndexMappingTypeRemoval.java
+++ b/transformation/src/main/java/org/opensearch/migrations/transformation/rules/IndexMappingTypeRemoval.java
@@ -1,7 +1,6 @@
 package org.opensearch.migrations.transformation.rules;
 
 import org.opensearch.migrations.transformation.CanApplyResult;
-import org.opensearch.migrations.transformation.CanApplyResult.Unsupported;
 import org.opensearch.migrations.transformation.TransformationRule;
 import org.opensearch.migrations.transformation.entity.Index;
 
@@ -77,10 +76,10 @@ public class IndexMappingTypeRemoval implements TransformationRule<Index> {
         // 2. <pre>{"mappings": [{ "foo": {...}, "bar": {...}  }]}</pre>
         if (mappingNode.isArray() && (mappingNode.size() > 1 || mappingNode.get(0).size() > 1)) {
             if (MultiTypeResolutionBehavior.NONE.equals(multiTypeResolutionBehavior)) {
-                return new Unsupported("No multi type resolution behavior declared, specify --multi-type-behavior to process");
+                throw new IllegalArgumentException("No multi type resolution behavior declared, specify --multi-type-behavior to process");
             }
             if (MultiTypeResolutionBehavior.SPLIT.equals(multiTypeResolutionBehavior)) {
-                return new Unsupported("Split on multiple mapping types is not supported");
+                throw new IllegalArgumentException("Split on multiple mapping types is not supported");
             }
             // Support UNION
         }

--- a/transformation/src/test/java/org/opensearch/migrations/transformation/rules/IndexMappingTypeRemovalTest.java
+++ b/transformation/src/test/java/org/opensearch/migrations/transformation/rules/IndexMappingTypeRemovalTest.java
@@ -4,7 +4,6 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 
 import org.opensearch.migrations.transformation.CanApplyResult;
-import org.opensearch.migrations.transformation.CanApplyResult.Unsupported;
 import org.opensearch.migrations.transformation.entity.Index;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -15,7 +14,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.Mockito;
 
-import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -240,14 +238,11 @@ public class IndexMappingTypeRemovalTest {
 
         var behavior = IndexMappingTypeRemoval.MultiTypeResolutionBehavior.valueOf(resolutionBehavior);
 
-        // Action
-        var wasChanged = applyTransformation(behavior, indexJson);
-        var canApply = canApply(behavior, originalJson);
-        assertThat(canApply, instanceOf(Unsupported.class));
-        assertThat(((Unsupported) canApply).getReason(), equalTo(expectedReason));
+        // Action & Assertion
+        var exception = assertThrows(IllegalArgumentException.class, () -> canApply(behavior, originalJson));
+        assertThat(exception.getMessage(), equalTo(expectedReason));
 
         // Verification
-        assertThat(wasChanged, equalTo(false));
         assertThat(originalJson.toPrettyString(), equalTo(indexJson.toPrettyString()));
     }
 
@@ -263,14 +258,11 @@ public class IndexMappingTypeRemovalTest {
         var indexJson = originalJson.deepCopy();
         var behavior = IndexMappingTypeRemoval.MultiTypeResolutionBehavior.valueOf(resolutionBehavior);
 
-        // Action
-        var wasChanged = applyTransformation(behavior, indexJson);
-        var canApply = canApply(behavior, originalJson);
-        assertThat(canApply, instanceOf(Unsupported.class));
-        assertThat(((Unsupported) canApply).getReason(), equalTo(expectedReason));
+        // Action & Assertion
+        var exception = assertThrows(IllegalArgumentException.class, () -> canApply(behavior, originalJson));
+        assertThat(exception.getMessage(), equalTo(expectedReason));
 
         // Verification
-        assertThat(wasChanged, equalTo(false));
         assertThat(originalJson.toPrettyString(), equalTo(indexJson.toPrettyString()));
     }
 


### PR DESCRIPTION
### Description
<!-- Describe what this change achieves -->

1. Updates MetadataMigration to receive and handle List returned by IJsonTransformer, this adds support for 1:many custom transforms (e.g. multi type index split)
     * Note: A future change will add support for built in transform to handle the split case.
2. Updates the TypeSanitization built in transformer to throw an error when encountering multi type index and behavior is not set to Union. (Previous behavior was to return Unsupported which would ignore the transformation which would result in an error during cluster put) 

### Issues Resolved
<!-- List any GitHub or Jira issues this PR will resolve -->
[MIGRATIONS-2271](https://opensearch.atlassian.net/browse/MIGRATIONS-2271)

### Testing
Existing code paths tested by existing tests.

1:Many transformations will be tested during a followup PR which adds multi type split as a provided javascript transform.

### Check List
- [ ] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
