### PR TITLE
Added version-specific OpenSearchWorkCoordinators

### DIFF
--- a/.github/workflows/sonar-qube.yml
+++ b/.github/workflows/sonar-qube.yml
@@ -86,7 +86,7 @@ jobs:
         fi
     - name: Upload SonarQube Artifacts
       if: always()
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: sonar-reports
         path: issues.json

--- a/DocumentsFromSnapshotMigration/src/test/java/org/opensearch/migrations/bulkload/EndToEndTest.java
+++ b/DocumentsFromSnapshotMigration/src/test/java/org/opensearch/migrations/bulkload/EndToEndTest.java
@@ -140,6 +140,7 @@ public class EndToEndTest extends SourceTestBase {
                         clockJitter,
                         testDocMigrationContext,
                         sourceCluster.getContainerVersion().getVersion(),
+                        targetCluster.getContainerVersion().getVersion(),
                         false
                     )
                 )
@@ -178,5 +179,30 @@ public class EndToEndTest extends SourceTestBase {
             Assertions.assertEquals("1", routing);
         }
     }
+
+    // private static Stream<Arguments> scenarios_experimental() {
+    //     var scenarios = Stream.<Arguments>builder();
+
+    //     for (var sourceCluster : SupportedClusters.sources()) {
+    //         for (var targetCluster : SupportedClusters.targets_experimental()) {
+    //             scenarios.add(Arguments.of(sourceCluster, targetCluster));
+    //         }
+    //     }
+
+    //     return scenarios.build();
+    // }
+
+    // @ParameterizedTest(name = "Source {0} to Target {1}")
+    // @MethodSource(value = "scenarios_experimental")
+    // public void migrationDocumentsExperimental(
+    //     final SearchClusterContainer.ContainerVersion sourceVersion,
+    //     final SearchClusterContainer.ContainerVersion targetVersion) throws Exception {
+    //     try (
+    //         final var sourceCluster = new SearchClusterContainer(sourceVersion);
+    //         final var targetCluster = new SearchClusterContainer(targetVersion)
+    //     ) {
+    //         migrationDocumentsWithClusters(sourceCluster, targetCluster);
+    //     }
+    // }
 
 }

--- a/DocumentsFromSnapshotMigration/src/test/java/org/opensearch/migrations/bulkload/EndToEndTest.java
+++ b/DocumentsFromSnapshotMigration/src/test/java/org/opensearch/migrations/bulkload/EndToEndTest.java
@@ -179,30 +179,5 @@ public class EndToEndTest extends SourceTestBase {
             Assertions.assertEquals("1", routing);
         }
     }
-
-    // private static Stream<Arguments> scenarios_experimental() {
-    //     var scenarios = Stream.<Arguments>builder();
-
-    //     for (var sourceCluster : SupportedClusters.sources()) {
-    //         for (var targetCluster : SupportedClusters.targets_experimental()) {
-    //             scenarios.add(Arguments.of(sourceCluster, targetCluster));
-    //         }
-    //     }
-
-    //     return scenarios.build();
-    // }
-
-    // @ParameterizedTest(name = "Source {0} to Target {1}")
-    // @MethodSource(value = "scenarios_experimental")
-    // public void migrationDocumentsExperimental(
-    //     final SearchClusterContainer.ContainerVersion sourceVersion,
-    //     final SearchClusterContainer.ContainerVersion targetVersion) throws Exception {
-    //     try (
-    //         final var sourceCluster = new SearchClusterContainer(sourceVersion);
-    //         final var targetCluster = new SearchClusterContainer(targetVersion)
-    //     ) {
-    //         migrationDocumentsWithClusters(sourceCluster, targetCluster);
-    //     }
-    // }
-
+    
 }

--- a/DocumentsFromSnapshotMigration/src/test/java/org/opensearch/migrations/bulkload/ParallelDocumentMigrationsTest.java
+++ b/DocumentsFromSnapshotMigration/src/test/java/org/opensearch/migrations/bulkload/ParallelDocumentMigrationsTest.java
@@ -103,6 +103,7 @@ public class ParallelDocumentMigrationsTest extends SourceTestBase {
                                 clockJitter,
                                 testDocMigrationContext,
                                 sourceVersion.getVersion(),
+                                targetVersion.getVersion(),
                                 compressionEnabled
                             ),
                             executorService

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/version_os_2_11/OpenSearchWorkCoordinator_OS_2_11.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/version_os_2_11/OpenSearchWorkCoordinator_OS_2_11.java
@@ -1,0 +1,90 @@
+package org.opensearch.migrations.bulkload.version_os_2_11;
+
+import java.time.Clock;
+import java.util.function.Consumer;
+
+import org.opensearch.migrations.bulkload.workcoordination.AbstractedHttpClient;
+import org.opensearch.migrations.bulkload.workcoordination.OpenSearchWorkCoordinator;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+public class OpenSearchWorkCoordinator_OS_2_11 extends OpenSearchWorkCoordinator {    
+        public OpenSearchWorkCoordinator_OS_2_11(
+            AbstractedHttpClient httpClient,
+            long tolerableClientServerClockDifferenceSeconds,
+            String workerId
+        ) {
+            super(httpClient, tolerableClientServerClockDifferenceSeconds, workerId);
+        }
+
+        public OpenSearchWorkCoordinator_OS_2_11(
+                AbstractedHttpClient httpClient,
+                long tolerableClientServerClockDifferenceSeconds,
+                String workerId,
+                Clock clock
+        ) {
+            super(httpClient, tolerableClientServerClockDifferenceSeconds, workerId, clock);
+        }
+
+
+        public OpenSearchWorkCoordinator_OS_2_11(
+            AbstractedHttpClient httpClient,
+            long tolerableClientServerClockDifferenceSeconds,
+            String workerId,
+            Clock clock,
+            Consumer<WorkItemAndDuration> workItemConsumer
+        ) {
+            super(httpClient, tolerableClientServerClockDifferenceSeconds, workerId, clock, workItemConsumer);
+        }
+
+        protected String getCoordinationIndexSettingsBody(){
+            return "{\n"
+            + "  \"settings\": {\n"
+            + "   \"index\": {"
+            + "    \"number_of_shards\": 1,\n"
+            + "    \"number_of_replicas\": 1\n"
+            + "   }\n"
+            + "  },\n"
+            + "  \"mappings\": {\n"
+            + "    \"properties\": {\n"
+            + "      \"" + EXPIRATION_FIELD_NAME + "\": {\n"
+            + "        \"type\": \"long\"\n"
+            + "      },\n"
+            + "      \"" + COMPLETED_AT_FIELD_NAME + "\": {\n"
+            + "        \"type\": \"long\"\n"
+            + "      },\n"
+            + "      \"leaseHolderId\": {\n"
+            + "        \"type\": \"keyword\",\n"
+            + "        \"norms\": false\n"
+            + "      },\n"
+            + "      \"status\": {\n"
+            + "        \"type\": \"keyword\",\n"
+            + "        \"norms\": false\n"
+            + "      },\n"
+            + "     \"" + SUCCESSOR_ITEMS_FIELD_NAME + "\": {\n"
+            + "       \"type\": \"keyword\",\n"
+            + "        \"norms\": false\n"
+            + "      }\n"
+            + "    }\n"
+            + "  }\n"
+            + "}\n";
+        }
+
+        protected String getPathForUpdates(String workItemId) {
+            return INDEX_NAME + "/_update/" + workItemId;
+        }
+
+        protected String getPathForGets(String workItemId) {
+            return INDEX_NAME + "/_doc/" + workItemId;
+        }
+
+        protected String getPathForSearches() {
+            return INDEX_NAME + "/_search";
+        }
+
+        protected int getTotalHitsFromSearchResponse(JsonNode searchResponse) {
+            return searchResponse.path("hits").path("total").path("value").asInt();
+        }
+
+
+}

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/workcoordination/OpenSearchWorkCoordinator.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/workcoordination/OpenSearchWorkCoordinator.java
@@ -31,7 +31,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public abstract class OpenSearchWorkCoordinator implements IWorkCoordinator {
-    // Create a stable logger that descendants can use, and we can predictable read from in tests
+    // Create a stable logger that descendants can use, and we can predictably read from in tests
     protected static final Logger log = LoggerFactory.getLogger(OpenSearchWorkCoordinator.class);
 
     public static final String INDEX_NAME = ".migrations_working_state";

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/workcoordination/WorkCoordinatorFactory.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/workcoordination/WorkCoordinatorFactory.java
@@ -1,0 +1,58 @@
+package org.opensearch.migrations.bulkload.workcoordination;
+
+import java.time.Clock;
+import java.util.function.Consumer;
+
+import org.opensearch.migrations.Version;
+import org.opensearch.migrations.VersionMatchers;
+import org.opensearch.migrations.bulkload.version_os_2_11.OpenSearchWorkCoordinator_OS_2_11;
+import org.opensearch.migrations.bulkload.workcoordination.IWorkCoordinator.WorkItemAndDuration;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@RequiredArgsConstructor
+@Slf4j
+public class WorkCoordinatorFactory {
+    private final Version version;
+
+    public OpenSearchWorkCoordinator get(
+            AbstractedHttpClient httpClient,
+            long tolerableClientServerClockDifferenceSeconds,
+            String workerId
+        ) {
+        if (VersionMatchers.isOS_1_X.test(version) || VersionMatchers.isOS_2_X.test(version)) {
+            return new OpenSearchWorkCoordinator_OS_2_11(httpClient, tolerableClientServerClockDifferenceSeconds, workerId);
+        } else {
+            throw new IllegalArgumentException("Unsupported version: " + version);
+        }
+    }
+
+    public OpenSearchWorkCoordinator get(
+            AbstractedHttpClient httpClient,
+            long tolerableClientServerClockDifferenceSeconds,
+            String workerId,
+            Clock clock
+        ) {
+        if (VersionMatchers.isOS_1_X.test(version) || VersionMatchers.isOS_2_X.test(version)) {
+            return new OpenSearchWorkCoordinator_OS_2_11(httpClient, tolerableClientServerClockDifferenceSeconds, workerId, clock);
+        } else {
+            throw new IllegalArgumentException("Unsupported version: " + version);
+        }
+    }
+    
+    public OpenSearchWorkCoordinator get(
+            AbstractedHttpClient httpClient,
+            long tolerableClientServerClockDifferenceSeconds,
+            String workerId,
+            Clock clock,
+            Consumer<WorkItemAndDuration> workItemConsumer
+        ) {
+        if (VersionMatchers.isOS_1_X.test(version) || VersionMatchers.isOS_2_X.test(version)) {
+            return new OpenSearchWorkCoordinator_OS_2_11(httpClient, tolerableClientServerClockDifferenceSeconds, workerId, clock, workItemConsumer);
+        } else {
+            throw new IllegalArgumentException("Unsupported version: " + version);
+        }
+    }
+    
+}

--- a/RFS/src/test/java/org/opensearch/migrations/bulkload/workcoordination/OpenSearchWorkCoodinatorTest.java
+++ b/RFS/src/test/java/org/opensearch/migrations/bulkload/workcoordination/OpenSearchWorkCoodinatorTest.java
@@ -3,11 +3,15 @@ package org.opensearch.migrations.bulkload.workcoordination;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.AbstractMap;
+import java.util.List;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.opensearch.migrations.Version;
+import org.opensearch.migrations.bulkload.SupportedClusters;
+import org.opensearch.migrations.bulkload.framework.SearchClusterContainer.ContainerVersion;
 import org.opensearch.migrations.bulkload.workcoordination.OpenSearchWorkCoordinator.DocumentModificationResult;
 import org.opensearch.migrations.testutils.CloseableLogSetup;
 
@@ -15,7 +19,6 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -26,6 +29,11 @@ import org.testcontainers.shaded.com.fasterxml.jackson.databind.ObjectMapper;
 class OpenSearchWorkCoodinatorTest {
 
     public static final String THROTTLE_RESULT_VALUE = "slow your roll, dude";
+    public static final List<Version> testedVersions = SupportedClusters.targets().stream().map(ContainerVersion::getVersion).collect(Collectors.toList());
+
+    static Stream<Arguments> provideTestedVersions() {
+        return testedVersions.stream().map(Arguments::of);
+    }
 
     @AllArgsConstructor
     public static class MockHttpClient implements AbstractedHttpClient {
@@ -55,7 +63,7 @@ class OpenSearchWorkCoodinatorTest {
     }
 
     static Stream<Arguments> provideGetResultTestArgs() {
-        return Stream.of(
+        List<Arguments> staticArguments = List.of(
             Arguments.of(DocumentModificationResult.IGNORED,
                 "{\"" + OpenSearchWorkCoordinator.RESULT_OPENSSEARCH_FIELD_NAME + "\": \"noop\"}"
             ),
@@ -66,22 +74,30 @@ class OpenSearchWorkCoodinatorTest {
                 "{\"" + OpenSearchWorkCoordinator.RESULT_OPENSSEARCH_FIELD_NAME + "\": \""+ OpenSearchWorkCoordinator.UPDATED_COUNT_FIELD_NAME +"\"}"
             )
         );
+
+        return testedVersions.stream()
+            .flatMap(version -> staticArguments.stream()
+                .map(staticArg -> Arguments.of(version, staticArg.get()[0], staticArg.get()[1]))
+            );
     }
 
     @ParameterizedTest
     @MethodSource("provideGetResultTestArgs")
-    public void testWhenGetResult(DocumentModificationResult expectedResult, String responsePayload) throws Exception {
+    public void testWhenGetResult(Version version, DocumentModificationResult expectedResult, String responsePayload) throws Exception {
+        var factory = new WorkCoordinatorFactory(version);
         var response = new TestResponse(200, "ok", responsePayload);
-        try (var workCoordinator = new OpenSearchWorkCoordinator(new MockHttpClient(response), 2, "testWorker")) {
+        try (var workCoordinator = factory.get(new MockHttpClient(response), 2, "testWorker")) {
             var result = workCoordinator.getResult(response);
             Assertions.assertEquals(expectedResult, result);
         }
     }
 
-    @Test
-    public void testWhenGetResultAndConflictThenIgnored() throws Exception {
+    @ParameterizedTest
+    @MethodSource("provideTestedVersions")
+    public void testWhenGetResultAndConflictThenIgnored(Version version) throws Exception {
+        var factory = new WorkCoordinatorFactory(version);
         var response = new TestResponse(409, "conflict", "");
-        try (var workCoordinator = new OpenSearchWorkCoordinator(new MockHttpClient(response), 2, "testWorker")) {
+        try (var workCoordinator = factory.get(new MockHttpClient(response), 2, "testWorker")) {
             var result = workCoordinator.getResult(response);
             Assertions.assertEquals(DocumentModificationResult.IGNORED, result);
         }
@@ -92,37 +108,45 @@ class OpenSearchWorkCoodinatorTest {
         return new TestResponse(429, "THROTTLED", new ObjectMapper().writeValueAsString(resultJson));
     }
 
-    @Test
-    public void testWhenGetResultAndErrorThenLogged() throws Exception {
+    @ParameterizedTest
+    @MethodSource("provideTestedVersions")
+    public void testWhenGetResultAndErrorThenLogged(Version version) throws Exception {
+        var factory = new WorkCoordinatorFactory(version);
         var response = getThrottleResponse();
         MockHttpClient client = new MockHttpClient(response);
 
-        try (var workCoordinator = new OpenSearchWorkCoordinator(client, 2, "testWorker");
-             var closeableLogSetup = new CloseableLogSetup(workCoordinator.getClass().getName()))
+        try (var workCoordinator = factory.get(client, 2, "testWorker");
+             var closeableLogSetup = new CloseableLogSetup(workCoordinator.getLoggerName()))
         {
+            log.atInfo().log(workCoordinator.getClass().getName());
             Assertions.assertThrows(IllegalArgumentException.class, () -> workCoordinator.getResult(response));
             log.atDebug().setMessage("Logged events: {}").addArgument(closeableLogSetup::getLogEvents).log();
             Assertions.assertTrue(closeableLogSetup.getLogEvents().stream().anyMatch(e -> e.contains(THROTTLE_RESULT_VALUE)));
         }
     }
 
-    private static final AtomicInteger nonce = new AtomicInteger();
-
     static Stream<Arguments> makeConsumers() {
         var workItem = new IWorkCoordinator.WorkItemAndDuration.WorkItem("item", 0, 0).toString();
-        return Stream.<Function<IWorkCoordinator, Exception>>of(
+
+
+        var functions = List.<Function<IWorkCoordinator, Exception>>of(
             wc -> Assertions.assertThrows(Exception.class,
                 () -> wc.createUnassignedWorkItem(workItem, () -> null)),
             wc -> Assertions.assertThrows(Exception.class,
-                () -> wc.createOrUpdateLeaseForWorkItem(workItem, Duration.ZERO, () -> null)))
-            .map(Arguments::of);
+                () -> wc.createOrUpdateLeaseForWorkItem(workItem, Duration.ZERO, () -> null))
+        );
+    
+        return testedVersions.stream()
+            .flatMap(version -> functions.stream()
+                .map(function -> Arguments.of(version, function)));
     }
 
     @ParameterizedTest(name = "{index}")
     @MethodSource("makeConsumers")
-    public void testWhenInvokedWithHttpErrorThenLogged(Function<IWorkCoordinator, Exception> worker) throws Exception {
-        try (var workCoordinator = new OpenSearchWorkCoordinator(new MockHttpClient(getThrottleResponse()), 2, "t");
-             var closeableLogSetup = new CloseableLogSetup(workCoordinator.getClass().getName()))
+    public void testWhenInvokedWithHttpErrorThenLogged(Version version, Function<IWorkCoordinator, Exception> worker) throws Exception {
+        var factory = new WorkCoordinatorFactory(version);
+        try (var workCoordinator = factory.get(new MockHttpClient(getThrottleResponse()), 2, "t");
+             var closeableLogSetup = new CloseableLogSetup(workCoordinator.getLoggerName()))
         {
             worker.apply(workCoordinator);
             log.atDebug().setMessage("Logged events: {}").addArgument(()->closeableLogSetup.getLogEvents()).log();

--- a/RFS/src/test/java/org/opensearch/migrations/bulkload/workcoordination/WorkCoordinatorErrantAcquisitonsRetryTest.java
+++ b/RFS/src/test/java/org/opensearch/migrations/bulkload/workcoordination/WorkCoordinatorErrantAcquisitonsRetryTest.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
+import org.opensearch.migrations.Version;
 import org.opensearch.migrations.bulkload.common.http.ConnectionContextTestParams;
 import org.opensearch.migrations.testutils.HttpRequest;
 import org.opensearch.migrations.testutils.SimpleHttpResponse;
@@ -23,6 +24,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.slf4j.MDC;
 
 public class WorkCoordinatorErrantAcquisitonsRetryTest {
+    private static final WorkCoordinatorFactory factory = new WorkCoordinatorFactory(Version.fromString("OS 2.11"));
 
     private static final String UPDATE_BY_QUERY_RESPONSE_BODY = "" +
         "{\n" +
@@ -121,7 +123,7 @@ public class WorkCoordinatorErrantAcquisitonsRetryTest {
                 .toConnectionContext());
             var startingLeaseDuration = Duration.ofSeconds(1);
             var rootContext = WorkCoordinationTestContext.factory().withAllTracking();
-            try (var workCoordinator = new OpenSearchWorkCoordinator(client, 2, TEST_WORKER_ID)) {
+            try (var workCoordinator = factory.get(client, 2, TEST_WORKER_ID)) {
                 var e = Assertions.assertThrows(OpenSearchWorkCoordinator.RetriesExceededException.class,
                     () -> workCoordinator.acquireNextWorkItem(startingLeaseDuration, rootContext::createAcquireNextItemContext));
                 validate(pathToCounts, exceptionClassToTest, e);
@@ -156,7 +158,7 @@ public class WorkCoordinatorErrantAcquisitonsRetryTest {
                 .toConnectionContext());
             var startingLeaseDuration = Duration.ofSeconds(1);
             var rootContext = WorkCoordinationTestContext.factory().withAllTracking();
-            try (var wc = new OpenSearchWorkCoordinator(client, 2, TEST_WORKER_ID)) {
+            try (var wc = factory.get(client, 2, TEST_WORKER_ID)) {
                 var e1 = Assertions.assertThrows(OpenSearchWorkCoordinator.RetriesExceededException.class,
                     () -> wc.acquireNextWorkItem(startingLeaseDuration, rootContext::createAcquireNextItemContext));
                 validate(pathToCounts, OpenSearchWorkCoordinator.MalformedAssignedWorkDocumentException.class, e1);

--- a/RFS/src/testFixtures/java/org/opensearch/migrations/bulkload/SupportedClusters.java
+++ b/RFS/src/testFixtures/java/org/opensearch/migrations/bulkload/SupportedClusters.java
@@ -28,17 +28,4 @@ public class SupportedClusters {
             SearchClusterContainer.OS_V2_14_0
         );
     }
-
-    public static List<ContainerVersion> targets_experimental() {
-        return List.of(
-            SearchClusterContainer.ES_V6_8_23
-        );
-    }
-
-    public static List<ContainerVersion> targets_all() {
-        List<ContainerVersion> all_targets = List.of();
-        all_targets.addAll(targets());
-        all_targets.addAll(targets_experimental());
-        return all_targets;
-    }
 }

--- a/RFS/src/testFixtures/java/org/opensearch/migrations/bulkload/SupportedClusters.java
+++ b/RFS/src/testFixtures/java/org/opensearch/migrations/bulkload/SupportedClusters.java
@@ -28,4 +28,17 @@ public class SupportedClusters {
             SearchClusterContainer.OS_V2_14_0
         );
     }
+
+    public static List<ContainerVersion> targets_experimental() {
+        return List.of(
+            SearchClusterContainer.ES_V6_8_23
+        );
+    }
+
+    public static List<ContainerVersion> targets_all() {
+        List<ContainerVersion> all_targets = List.of();
+        all_targets.addAll(targets());
+        all_targets.addAll(targets_experimental());
+        return all_targets;
+    }
 }


### PR DESCRIPTION
### Description
* Checkpoint.  This PR updates the RFS code to use a version-specific OpenSearchWorkCoordinator.  Currently, there's only one supported version (OS 2), which presents the existing behavior.  E.g. there's no functional changes in this PR, it just sets up the plumbing to add Coordinators for new versions (like ES 6.8).

### Issues Resolved
* https://opensearch.atlassian.net/browse/MIGRATIONS-2285

### Testing
Ran the unit tests

### Check List
- [X] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
