### PR TITLE
Fix broken sonarqube upload

### DIFF
--- a/.github/workflows/sonar-qube.yml
+++ b/.github/workflows/sonar-qube.yml
@@ -86,7 +86,7 @@ jobs:
         fi
     - name: Upload SonarQube Artifacts
       if: always()
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: sonar-reports
         path: issues.json


### PR DESCRIPTION
### Description
We were using a deprecated versino of the upload-artifact, switched from v3 -> v4.

### Issues Resolved
- Sonarqube github action is broken https://opensearch.atlassian.net/browse/MIGRATIONS-2313 

### Testing
PR Check will confirm this is working correctly.

### Check List
- [ ] ~New functionality includes testing~
- [ ] ~Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
