### PR TITLE
[Console Library] Allow console library completion everywhere

### DIFF
--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/Dockerfile
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/Dockerfile
@@ -61,10 +61,9 @@ RUN echo '. /etc/profile.d/bash_completion.sh' >> ~/.bashrc && \
     echo '. /etc/profile.d/venv.sh' >> ~/.bashrc && \
     echo 'echo Welcome to the Migration Assistant Console' >> ~/.bashrc && \
     echo 'eval "$(register-python-argcomplete cluster_tools)"' >> ~/.bashrc && \
-    echo 'PS1="(\t) \[\e[92m\]migration-console \[\e[0m\](\w) -> "' >> ~/.bashrc && \
-    source /.venv/bin/activate && \
-    console --config-file=/root/lib/console_link/services.yaml completion bash > /usr/share/bash-completion/completions/console
-
+    echo 'source /.venv/bin/activate' >> ~/.bashrc && \
+    echo 'console --config-file=/root/lib/console_link/services.yaml completion bash > /usr/share/bash-completion/completions/console' >> ~/.bashrc && \
+    echo 'PS1="(\t) \[\e[92m\]migration-console \[\e[0m\](\w) -> "' >> ~/.bashrc
 # Set ENV to control startup script in /bin/sh mode
 ENV ENV=/root/.bashrc
 

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/Dockerfile
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/Dockerfile
@@ -61,7 +61,9 @@ RUN echo '. /etc/profile.d/bash_completion.sh' >> ~/.bashrc && \
     echo '. /etc/profile.d/venv.sh' >> ~/.bashrc && \
     echo 'echo Welcome to the Migration Assistant Console' >> ~/.bashrc && \
     echo 'eval "$(register-python-argcomplete cluster_tools)"' >> ~/.bashrc && \
-    echo 'PS1="(\t) \[\e[92m\]migration-console \[\e[0m\](\w) -> "' >> ~/.bashrc
+    echo 'PS1="(\t) \[\e[92m\]migration-console \[\e[0m\](\w) -> "' >> ~/.bashrc && \
+    source /.venv/bin/activate && \
+    console --config-file=/root/lib/console_link/services.yaml completion bash > /usr/share/bash-completion/completions/console
 
 # Set ENV to control startup script in /bin/sh mode
 ENV ENV=/root/.bashrc

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/services.yaml
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/services.yaml
@@ -1,3 +1,4 @@
+# These are default values for a local environment and should be changed for a cloud deployment
 source_cluster:
   endpoint: "https://capture-proxy:9200"
   allow_insecure: true

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/loadServicesFromParameterStore.sh
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/loadServicesFromParameterStore.sh
@@ -2,8 +2,6 @@
 
 set -eou pipefail
 
-source /.venv/bin/activate
-
 # Check if the environment variable MIGRATION_SERVICES_YAML_PARAMETER is set
 if [ -z "${MIGRATION_SERVICES_YAML_PARAMETER+x}" ]; then
   echo "Environment variable MIGRATION_SERVICES_YAML_PARAMETER is not set. Exiting successfully and "
@@ -32,7 +30,3 @@ if [ $? -ne 0 ]; then
   exit 1
 fi
 echo "Parameter value successfully written to $OUTPUT_FILE"
-
-# Generate bash completion script
-console completion bash > /usr/share/bash-completion/completions/console
-echo "Bash completion for console command has been set up and enabled."


### PR DESCRIPTION
### Description
Removes requirement that migrations `services.yaml` has to be loaded in from environment in order to get console library bash completion

### Issues Resolved
https://opensearch.atlassian.net/browse/MIGRATIONS-2236

### Testing
Local testing

### Check List
- [ ] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
