### PR TITLE
Update maintainer list to add Jugal

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # This should match the owning team set up in https://github.com/orgs/opensearch-project/teams
-*   @AndreKurait @chelma @gregschohn @lewijacn @mikaylathompson @peternied @sumobrian
+*   @AndreKurait @chelma @gregschohn @lewijacn @mikaylathompson @peternied @sumobrian @jugal-chauhan

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -13,6 +13,7 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Brian Presley      | [sumobrian](https://github.com/sumobrian)             | Amazon      |
 | Andre Kurait       | [andrekurait](https://github.com/AndreKurait)         | Amazon      |
 | Peter Nied         | [peternied](https://github.com/peternied)             | Amazon      |
+| Jugal Chauhan      | [jugal-chauhan](https://github.com/jugal-chauhan)     | Amazon      |
 
 
 ## Emeritus


### PR DESCRIPTION
### Description
This PR adds Jugal to the list of Maintainers. It also allows Jugal to gain membership access to this opensearch project.

### Issues Resolved
N/A

### Testing
N/A

### Check List
- [x] New functionality includes testing
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
