### PR TITLE
Sonarqube Fix - Ensure optional is present before `get`

### DIFF
--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/common/OpenSearchClientFactory.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/common/OpenSearchClientFactory.java
@@ -191,9 +191,7 @@ public class OpenSearchClientFactory {
 
             if (foundVersions.isEmpty()) {
                 return Mono.error(new OpenSearchClient.OperationFailed("Unable to find any version numbers", resp));
-            }
-
-            if (foundVersions.size() == 1) {
+            } else if (foundVersions.size() == 1) {
                 return Mono.just(foundVersions.stream().findFirst().get());
             }
 

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/common/OpenSearchClientFactory.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/common/OpenSearchClientFactory.java
@@ -46,7 +46,7 @@ public class OpenSearchClientFactory {
             return clientClass.getConstructor(ConnectionContext.class, Version.class)
                     .newInstance(connectionContext, version);
         } catch (NoSuchMethodException | InstantiationException | IllegalAccessException | InvocationTargetException e) {
-            throw new RuntimeException("Failed to instantiate OpenSearchClient", e);
+            throw new ClientInstantiationException("Failed to instantiate OpenSearchClient", e);
         }
     }
 
@@ -59,7 +59,7 @@ public class OpenSearchClientFactory {
             return clientClass.getConstructor(RestClient.class, FailedRequestsLogger.class, Version.class)
                     .newInstance(restClient, failedRequestsLogger, version);
         } catch (NoSuchMethodException | InstantiationException | IllegalAccessException | InvocationTargetException e) {
-            throw new RuntimeException("Failed to instantiate OpenSearchClient", e);
+            throw new ClientInstantiationException("Failed to instantiate OpenSearchClient", e);
         }
     }
 
@@ -207,5 +207,10 @@ public class OpenSearchClientFactory {
         return client.getConnectionContext().isAwsSpecificAuthentication() ? Flavor.AMAZON_MANAGED_OPENSEARCH : Flavor.OPENSEARCH;
     }
 
+    public static class ClientInstantiationException extends RuntimeException {
+        public ClientInstantiationException(String message, Exception cause) {
+            super(message, cause);
+        }
+    }
 
 }


### PR DESCRIPTION
### Description
[Sonarqube Fix](https://sonarqube.tools.solutions.aws.dev/project/issues?resolved=false&inNewCodePeriod=true&types=BUG&id=opensearch-migrations-aws-solutions%3Amainline&open=AZRnPZIntC8JI7w--v8d) for `Call "Optional#isPresent()" or "!Optional#isEmpty()" before accessing the value.` issue. The `isEmpty` check was already happening, but it wasn't explicitly linked with the `get`. I think this should solve the issue.

### Issues Resolved

### Testing

### Check List
- [ ] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
