### PR TITLE
Fix upload SBOM to release artifacts

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -54,27 +54,27 @@ jobs:
         uses: anchore/sbom-action@v0.17.7
         with:
           image: migrations/migration_console:latest
-          artifact-name: opensearch-migrations-console-sbom.spdx.json
+          output-file: opensearch-migrations-console-sbom.spdx.json
       - name: Generate SBOM for traffic_replayer
         uses: anchore/sbom-action@v0.17.7
         with:
           image: migrations/traffic_replayer:latest
-          artifact-name: opensearch-migrations-traffic-replayer-sbom.spdx.json
+          output-file: opensearch-migrations-traffic-replayer-sbom.spdx.json
       - name: Generate SBOM for capture_proxy
         uses: anchore/sbom-action@v0.17.7
         with:
           image: migrations/capture_proxy:latest
-          artifact-name: opensearch-migrations-traffic-capture-proxy-sbom.spdx.json
+          output-file: opensearch-migrations-traffic-capture-proxy-sbom.spdx.json
       - name: Generate SBOM for reindex_from_snapshot
         uses: anchore/sbom-action@v0.17.7
         with:
           image: migrations/reindex_from_snapshot:latest
-          artifact-name: opensearch-migrations-reindex-from-snapshot-sbom.spdx.json
+          output-file: opensearch-migrations-reindex-from-snapshot-sbom.spdx.json
       - name: Generate SBOM for artifacts
         uses: anchore/sbom-action@v0.17.7
         with:
           file: artifacts.tar.gz
-          artifact-name: artifacts-sbom.spdx.json
+          output-file: artifacts-sbom.spdx.json
       - name: Tag Docker image
         run: |
           docker tag migrations/migration_console:latest opensearchstaging/opensearch-migrations-console:${{ steps.get_data.outputs.version }}


### PR DESCRIPTION
### Description
Upload SBOM to release

### Issues Resolved
Currently SBOM are published to release run artifacts, but not release https://github.com/opensearch-project/opensearch-migrations/actions/runs/12717975529

### Testing
Verified on my fork using a modified version of the [workflow](https://github.com/AndreKurait/opensearch-migrations/actions/runs/12837665875/workflow)
 https://github.com/AndreKurait/opensearch-migrations/actions/runs/12837665875/job/35802627618
### Check List
- [ ] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
