### PR TITLE
Correctly read compatibility mode from cluster settings when it was unset

### DIFF
--- a/CreateSnapshot/src/test/java/org/opensearch/migrations/TestCreateSnapshot.java
+++ b/CreateSnapshot/src/test/java/org/opensearch/migrations/TestCreateSnapshot.java
@@ -64,7 +64,7 @@ public class TestCreateSnapshot {
                 fl -> {
                     if (Objects.equals(fl.uri(), "/")) {
                         return new SimpleHttpResponse(ROOT_RESPONSE_HEADERS, ROOT_RESPONSE_ES_7_10_2, "OK", 200);
-                    } else if (Objects.equals(fl.uri(), "/_cluster/settings")) {
+                    } else if (Objects.equals(fl.uri(), "/_cluster/settings?include_defaults=true")) {
                         return new SimpleHttpResponse(CLUSTER_SETTINGS_COMPATIBILITY_HEADERS, CLUSTER_SETTINGS_COMPATIBILITY_OVERRIDE_DISABLED,
                                 "OK", 200);
                     }
@@ -136,7 +136,7 @@ public class TestCreateSnapshot {
                 fl -> {
                     if (Objects.equals(fl.uri(), "/")) {
                         return new SimpleHttpResponse(ROOT_RESPONSE_HEADERS, ROOT_RESPONSE_ES_7_10_2, "OK", 200);
-                    } else if (Objects.equals(fl.uri(), "/_cluster/settings")) {
+                    } else if (Objects.equals(fl.uri(), "/_cluster/settings?include_defaults=true")) {
                         return new SimpleHttpResponse(CLUSTER_SETTINGS_COMPATIBILITY_HEADERS, CLUSTER_SETTINGS_COMPATIBILITY_OVERRIDE_DISABLED,
                                 "OK", 200);
                     } else if (fl.uri().equals("/_snapshot/migration_assistant_repo/" + snapshotName)) {

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/common/OpenSearchClientFactory.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/common/OpenSearchClientFactory.java
@@ -100,7 +100,7 @@ public class OpenSearchClientFactory {
         if (!VersionMatchers.isES_7_10.test(versionFromRootApi)) {
             return versionFromRootApi;
         }
-        return client.getAsync("_cluster/settings", null)
+        return client.getAsync("_cluster/settings?include_defaults=true", null)
                 .flatMap(this::checkCompatibilityModeFromResponse)
                 .doOnError(e -> log.error(e.getMessage()))
                 .retryWhen(OpenSearchClient.CHECK_IF_ITEM_EXISTS_RETRY_STRATEGY)

--- a/RFS/src/test/java/org/opensearch/migrations/bulkload/common/OpenSearchClientFactoryTest.java
+++ b/RFS/src/test/java/org/opensearch/migrations/bulkload/common/OpenSearchClientFactoryTest.java
@@ -86,13 +86,13 @@ class OpenSearchClientFactoryTest {
     @Test
     void testGetClusterVersion_ES_7_10() {
         setupOkResponse(restClient, "", ROOT_RESPONSE_ES_7_10_2);
-        setupOkResponse(restClient, "_cluster/settings", CLUSTER_SETTINGS_COMPATIBILITY_OVERRIDE_DISABLED);
+        setupOkResponse(restClient, "_cluster/settings?include_defaults=true", CLUSTER_SETTINGS_COMPATIBILITY_OVERRIDE_DISABLED);
 
         var version = openSearchClientFactory.getClusterVersion();
 
         assertThat(version, equalTo(Version.fromString("ES 7.10.2")));
         verify(restClient).getAsync("", null);
-        verify(restClient).getAsync("_cluster/settings", null);
+        verify(restClient).getAsync("_cluster/settings?include_defaults=true", null);
         verifyNoMoreInteractions(restClient);
     }
 
@@ -100,21 +100,21 @@ class OpenSearchClientFactoryTest {
     void testGetClusterVersion_OS_CompatibilityModeEnabled() {
         when(connectionContext.isAwsSpecificAuthentication()).thenReturn(true);
         setupOkResponse(restClient, "", ROOT_RESPONSE_ES_7_10_2);
-        setupOkResponse(restClient, "_cluster/settings", CLUSTER_SETTINGS_COMPATIBILITY_OVERRIDE_ENABLED);
+        setupOkResponse(restClient, "_cluster/settings?include_defaults=true", CLUSTER_SETTINGS_COMPATIBILITY_OVERRIDE_ENABLED);
         setupOkResponse(restClient, "_nodes/_all/nodes,version?format=json", NODES_RESPONSE_OS_2_13_0);
 
         var version = openSearchClientFactory.getClusterVersion();
 
         assertThat(version, equalTo(Version.fromString("AOS 2.13.0")));
         verify(restClient).getAsync("", null);
-        verify(restClient).getAsync("_cluster/settings", null);
+        verify(restClient).getAsync("_cluster/settings?include_defaults=true", null);
         verify(restClient).getAsync("_nodes/_all/nodes,version?format=json", null);
     }
 
     @Test
     void testGetClusterVersion_OS_CompatibilityModeDisableEnabled() {
         setupOkResponse(restClient, "", ROOT_RESPONSE_OS_1_0_0);
-        setupOkResponse(restClient, "_cluster/settings", CLUSTER_SETTINGS_COMPATIBILITY_OVERRIDE_DISABLED);
+        setupOkResponse(restClient, "_cluster/settings?include_defaults=true", CLUSTER_SETTINGS_COMPATIBILITY_OVERRIDE_DISABLED);
 
         var version = openSearchClientFactory.getClusterVersion();
 
@@ -129,13 +129,13 @@ class OpenSearchClientFactoryTest {
         setupOkResponse(restClient, "", ROOT_RESPONSE_ES_7_10_2);
 
         var versionResponse = new HttpResponse(403, "Forbidden", Map.of(), "");
-        when(restClient.getAsync("_cluster/settings", null)).thenReturn(Mono.just(versionResponse));
+        when(restClient.getAsync("_cluster/settings?include_defaults=true", null)).thenReturn(Mono.just(versionResponse));
 
         var version = openSearchClientFactory.getClusterVersion();
 
         assertThat(version, equalTo(Version.fromString("ES 7.10.2")));
         verify(restClient).getAsync("", null);
-        verify(restClient).getAsync("_cluster/settings", null);
+        verify(restClient).getAsync("_cluster/settings?include_defaults=true", null);
         verifyNoMoreInteractions(restClient);
     }
 


### PR DESCRIPTION
### Description
This change updates the `_cluster/settings` API call in the OpenSearchClient to include default settings. The modification ensures that the compatibility mode check accurately reflects the current cluster state, even when the setting is at its default value. This addresses an issue where the compatibility mode value could remain `true` even after being disabled via the Migration Console.

Specifically, this change:

- Updates the `getClusterVersion()` method in OpenSearchClient.java to use `_cluster/settings?include_defaults=true`.
- Modifies corresponding test cases in OpenSearchClientTest.java to reflect this change.

By including default settings in the API call, we can correctly interpret the compatibility mode status in both scenarios.

### Issues Resolved
This PR addresses the issue described in [MIGRATIONS-2325](https://opensearch.atlassian.net/browse/MIGRATIONS-2325), where the compatibility mode status was not accurately detected when set to its default value.

### Testing
Updated unit tests in OpenSearchClientTest.java to cover the modified API call.
Ran the following test suites, all of which completed successfully:

- `./gradlew :RFS:test`
- `./gradlew :RFS:isolatedTest`
- `./gradlew :RFS:slowTest`
- `./gradlew test `

### Check List
- [x] New functionality includes testing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
