### PR TITLE
Update Jenkins job to require maintainer trigger

### DIFF
--- a/.github/workflows/full_pr_e2e_test.yml
+++ b/.github/workflows/full_pr_e2e_test.yml
@@ -25,16 +25,16 @@ jobs:
           GITHUB_ACTOR: ${{ github.actor }}
         run: |
           echo "Checking if $GITHUB_ACTOR is a maintainer..."
-          
+
           # Query the API to get the actor's permissions
           permission=$(curl -s -H "Authorization: Bearer $GITHUB_TOKEN" \
             -H "Accept: application/vnd.github.v3+json" \
             "${{ github.api_url }}/repos/${{ github.repository }}/collaborators/${GITHUB_ACTOR}/permission" \
             | jq -r '.permission')
-  
+
           echo "Actor permissions: $permission"
           echo "actor_permission=$permission" >> $GITHUB_ENV
-  
+
           # Fail if the actor is not a maintainer
           if [ "$permission" != "admin" ] && [ "$permission" != "write" ]; then
             echo "::error::This workflow can only be triggered by a maintainer."

--- a/.github/workflows/full_pr_e2e_test.yml
+++ b/.github/workflows/full_pr_e2e_test.yml
@@ -18,7 +18,7 @@ jobs:
   full-es68-e2e-aws-test:
     runs-on: ubuntu-latest
     steps:
-      - name: Validate Actor is a Maintainer
+      - name: Check Github Actor is a Maintainer
         id: check-maintainer
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/full_pr_e2e_test.yml
+++ b/.github/workflows/full_pr_e2e_test.yml
@@ -18,6 +18,28 @@ jobs:
   full-es68-e2e-aws-test:
     runs-on: ubuntu-latest
     steps:
+      - name: Validate Actor is a Maintainer
+        id: check-maintainer
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_ACTOR: ${{ github.actor }}
+        run: |
+          echo "Checking if $GITHUB_ACTOR is a maintainer..."
+          
+          # Query the API to get the actor's permissions
+          permission=$(curl -s -H "Authorization: Bearer $GITHUB_TOKEN" \
+            -H "Accept: application/vnd.github.v3+json" \
+            "${{ github.api_url }}/repos/${{ github.repository }}/collaborators/${GITHUB_ACTOR}/permission" \
+            | jq -r '.permission')
+  
+          echo "Actor permissions: $permission"
+          echo "actor_permission=$permission" >> $GITHUB_ENV
+  
+          # Fail if the actor is not a maintainer
+          if [ "$permission" != "admin" ] && [ "$permission" != "write" ]; then
+            echo "::error::This workflow can only be triggered by a maintainer."
+            exit 1
+          fi
       - name: Sanitize branch and repo names
         env:
           BRANCH_NAME: ${{ github.event.pull_request.head.ref || github.ref_name }}
@@ -31,6 +53,7 @@ jobs:
           echo "branch_name=$clean_branch_name" >> $GITHUB_OUTPUT
           echo "pr_repo_url=$clean_repo_url" >> $GITHUB_OUTPUT
       - name: Jenkins Job Trigger and Monitor
+        if: env.actor_permission == 'admin' || env.actor_permission == 'write'
         uses: lewijacn/jenkins-trigger@1.0.4
         with:
           jenkins_url: "https://migrations.ci.opensearch.org"


### PR DESCRIPTION
### Description
Require maintainer trigger on Jenkins jobs

`pull_request_target` events are special: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository

With changes...

When a maintainer creates a PR, pushes a change, or retries the Jenkins action on their own PR, the action will execute as normal:
<img width="634" alt="image" src="https://github.com/user-attachments/assets/6f57039c-4344-49b7-80bb-b08b43082c3a" />

However, when a non-maintainer performs any action that would trigger the Jenkins action (same as list above), the action will fail early with error message:
<img width="666" alt="image" src="https://github.com/user-attachments/assets/482a0e11-3fd3-4ed7-b31f-165789eff11e" />


### Issues Resolved
N/A

### Testing
Personal fork testing

### Check List
- [ ] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
