### PR TITLE
Add 6.8 source to lease expiration test

### DIFF
--- a/DocumentsFromSnapshotMigration/src/test/java/org/opensearch/migrations/bulkload/LeaseExpirationTest.java
+++ b/DocumentsFromSnapshotMigration/src/test/java/org/opensearch/migrations/bulkload/LeaseExpirationTest.java
@@ -6,8 +6,13 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
+import java.util.stream.Stream;
 
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.opensearch.migrations.CreateSnapshot;
+import org.opensearch.migrations.DataGenerator;
+import org.opensearch.migrations.DataGeneratorArgs;
 import org.opensearch.migrations.bulkload.common.OpenSearchClientFactory;
 import org.opensearch.migrations.bulkload.common.http.ConnectionContextTestParams;
 import org.opensearch.migrations.bulkload.framework.SearchClusterContainer;
@@ -35,9 +40,18 @@ public class LeaseExpirationTest extends SourceTestBase {
 
     public static final String TARGET_DOCKER_HOSTNAME = "target";
 
-    @ParameterizedTest
-    @ValueSource(booleans = {true, false})
-    public void testProcessExitsAsExpected(boolean forceMoreSegments) {
+    private static Stream<Arguments> testParameters() {
+        List<Boolean> forceMoreSegmentsValues = List.of(false, true);
+        List<SearchClusterContainer.ContainerVersion> sourceClusterVersions = List.of(SearchClusterContainer.ES_V6_8_23, SearchClusterContainer.ES_V7_10_2);
+
+        return forceMoreSegmentsValues.stream()
+                .flatMap(force -> sourceClusterVersions.stream()
+                        .map(version -> Arguments.of(force, version)));
+    }
+
+    @ParameterizedTest(name = "forceMoreSegments={0}, sourceClusterVersion={1}")
+    @MethodSource("testParameters")
+    public void testProcessExitsAsExpected(boolean forceMoreSegments, SearchClusterContainer.ContainerVersion sourceClusterVersion) {
         // Sending 5 docs per request with 4 requests concurrently with each taking 0.250 second is 80 docs/sec
         // will process 9680 docs in 121 seconds. With 40s lease duration, expect to be finished in 4 leases.
         // This is ensured with the toxiproxy settings, the migration should not be able to be completed
@@ -50,8 +64,8 @@ public class LeaseExpirationTest extends SourceTestBase {
         int continueExitCode = 2;
         int finalExitCodePerShard = 0;
         runTestProcessWithCheckpoint(continueExitCode, (migrationProcessesPerShard - 1) * shards,
-                finalExitCodePerShard, shards, shards, indexDocCount, forceMoreSegments,
-            d -> runProcessAgainstToxicTarget(d.tempDirSnapshot, d.tempDirLucene, d.proxyContainer
+                finalExitCodePerShard, shards, shards, indexDocCount, forceMoreSegments, sourceClusterVersion,
+            d -> runProcessAgainstToxicTarget(d.tempDirSnapshot, d.tempDirLucene, d.proxyContainer, sourceClusterVersion
             ));
     }
 
@@ -59,7 +73,7 @@ public class LeaseExpirationTest extends SourceTestBase {
     private void runTestProcessWithCheckpoint(int expectedInitialExitCode, int expectedInitialExitCodeCount,
                                               int expectedEventualExitCode, int expectedEventualExitCodeCount,
                                               int shards, int indexDocCount,
-                                              boolean forceMoreSegments,
+                                              boolean forceMoreSegments, SearchClusterContainer.ContainerVersion sourceClusterVersion,
                                               Function<RunData, Integer> processRunner) {
         final var testSnapshotContext = SnapshotTestContext.factory().noOtelTracking();
 
@@ -67,7 +81,7 @@ public class LeaseExpirationTest extends SourceTestBase {
         var tempDirLucene = Files.createTempDirectory("opensearchMigrationReindexFromSnapshot_test_lucene");
 
         try (
-            var esSourceContainer = new SearchClusterContainer(SearchClusterContainer.ES_V7_10_2)
+            var esSourceContainer = new SearchClusterContainer(sourceClusterVersion)
                     .withAccessToHost(true);
             var network = Network.newNetwork();
             var osTargetContainer = new SearchClusterContainer(SearchClusterContainer.OS_V2_14_0)
@@ -84,13 +98,14 @@ public class LeaseExpirationTest extends SourceTestBase {
             proxyContainer.start("target", 9200);
 
             // Populate the source cluster with data
-            var client = new OpenSearchClientFactory(ConnectionContextTestParams.builder()
-                .host(esSourceContainer.getUrl())
-                .build()
-                .toConnectionContext()
-            ).determineVersionAndCreate();
+            var clientFactory = new OpenSearchClientFactory(ConnectionContextTestParams.builder()
+                    .host(esSourceContainer.getUrl())
+                    .build()
+                    .toConnectionContext());
+            var client = clientFactory.determineVersionAndCreate();
             var generator = new WorkloadGenerator(client);
             var workloadOptions = new WorkloadOptions();
+
 
             var sourceClusterOperations = new ClusterOperations(esSourceContainer.getUrl());
 
@@ -177,7 +192,8 @@ public class LeaseExpirationTest extends SourceTestBase {
     private static int runProcessAgainstToxicTarget(
         Path tempDirSnapshot,
         Path tempDirLucene,
-        ToxiProxyWrapper proxyContainer
+        ToxiProxyWrapper proxyContainer,
+        SearchClusterContainer.ContainerVersion sourceClusterVersion
     ) {
         String targetAddress = proxyContainer.getProxyUriAsString();
         var tp = proxyContainer.getProxy();
@@ -189,7 +205,8 @@ public class LeaseExpirationTest extends SourceTestBase {
         String[] additionalArgs = {
             "--documents-per-bulk-request", "5",
             "--max-connections", "4",
-            "--initial-lease-duration", "PT40s"
+            "--initial-lease-duration", "PT40s",
+            "--source-version", sourceClusterVersion.getVersion().toString()
         };
 
         ProcessBuilder processBuilder = setupProcess(

--- a/DocumentsFromSnapshotMigration/src/test/java/org/opensearch/migrations/bulkload/LeaseExpirationTest.java
+++ b/DocumentsFromSnapshotMigration/src/test/java/org/opensearch/migrations/bulkload/LeaseExpirationTest.java
@@ -8,11 +8,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
 import org.opensearch.migrations.CreateSnapshot;
-import org.opensearch.migrations.DataGenerator;
-import org.opensearch.migrations.DataGeneratorArgs;
 import org.opensearch.migrations.bulkload.common.OpenSearchClientFactory;
 import org.opensearch.migrations.bulkload.common.http.ConnectionContextTestParams;
 import org.opensearch.migrations.bulkload.framework.SearchClusterContainer;
@@ -31,7 +27,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.testcontainers.containers.Network;
 
 @Tag("longTest")

--- a/DocumentsFromSnapshotMigration/src/test/java/org/opensearch/migrations/bulkload/SourceTestBase.java
+++ b/DocumentsFromSnapshotMigration/src/test/java/org/opensearch/migrations/bulkload/SourceTestBase.java
@@ -358,14 +358,16 @@ public class SourceTestBase {
             "--target-host",
             targetAddress,
             "--index-allowlist",
-            "geonames",
-            "--source-version",
-            "ES_7_10"
+            "geonames"
         ));
 
         if (additionalArgs != null && additionalArgs.length > 0) {
             argsList.addAll(Arrays.asList(additionalArgs));
+            if (!argsList.contains("--source-version")) {
+                argsList.addAll(Arrays.asList("--source-version", "ES_7_10"));
+            }
         }
+
 
         log.atInfo().setMessage("Running RfsMigrateDocuments with args: {}")
             .addArgument(() -> argsList.toString())


### PR DESCRIPTION
### Description
Add a 6.8 source cluster to the automated Lease Expiration tests that validate sub-shard RFS behavior.

### Issues Resolved
https://opensearch.atlassian.net/browse/MIGRATIONS-2297

### Testing
This is an updated test.

### Check List
- [x] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
