### PR TITLE
Allow Maintainer/Non-Maintainer environments

### DIFF
--- a/.github/workflows/full_pr_e2e_test.yml
+++ b/.github/workflows/full_pr_e2e_test.yml
@@ -15,31 +15,14 @@ permissions:
   contents: read # to fetch code (actions/checkout)
 
 jobs:
+  get-require-approval:
+    uses: ./.github/workflows/require-approval.yml
+
   full-es68-e2e-aws-test:
+    needs: [get-require-approval]
+    environment: ${{ needs.get-require-approval.outputs.is-require-approval }}
     runs-on: ubuntu-latest
     steps:
-      - name: Check Github Actor is a Maintainer
-        id: check-maintainer
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_ACTOR: ${{ github.actor }}
-        run: |
-          echo "Checking if $GITHUB_ACTOR is a maintainer..."
-
-          # Query the API to get the actor's permissions
-          permission=$(curl -s -H "Authorization: Bearer $GITHUB_TOKEN" \
-            -H "Accept: application/vnd.github.v3+json" \
-            "${{ github.api_url }}/repos/${{ github.repository }}/collaborators/${GITHUB_ACTOR}/permission" \
-            | jq -r '.permission')
-
-          echo "Actor permissions: $permission"
-          echo "actor_permission=$permission" >> $GITHUB_ENV
-
-          # Fail if the actor is not a maintainer
-          if [ "$permission" != "admin" ] && [ "$permission" != "write" ]; then
-            echo "::error::This workflow can only be triggered by a maintainer."
-            exit 1
-          fi
       - name: Sanitize branch and repo names
         env:
           BRANCH_NAME: ${{ github.event.pull_request.head.ref || github.ref_name }}

--- a/.github/workflows/require-approval.yml
+++ b/.github/workflows/require-approval.yml
@@ -1,0 +1,46 @@
+---
+name: Check if the workflow requires approval
+on:
+  workflow_call:
+    outputs:
+      is-require-approval:
+        description: The CI image version for Linux build
+        value: ${{ jobs.require-approval.outputs.output-is-require-approval }}
+
+jobs:
+  require-approval:
+    runs-on: ubuntu-latest
+    outputs:
+      output-is-require-approval: ${{ steps.step-is-require-approval.outputs.is-require-approval }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+      - name: Get CodeOwner List
+        id: step-is-require-approval
+        run: |
+          github_event=${{ github.event_name }}
+          author=${{ github.event.pull_request.user.login }}
+
+          if [[ "$github_event" == "push" ]]; then
+            echo "Push event does not need approval."
+            echo "is-require-approval=migrations-cicd" >> $GITHUB_OUTPUT
+          else
+            # Handle Pull Request events
+
+            # Check if the PR is triggered by known helper bots
+            if [[ "$author" == "dependabot[bot]" || "$author" == "mend-for-github-com[bot]" ]]; then
+              echo "PR triggered by known helper bot. No approval needed."
+              echo "is-require-approval=migrations-cicd" >> $GITHUB_OUTPUT
+            else
+              # Check if the author is in the approvers list
+              approvers=$(cat .github/CODEOWNERS | grep @ | tr -d '* ' | sed 's/@/,/g' | sed 's/,//1')
+              if [[ "$approvers" =~ "$author" ]]; then
+                echo "$author is in the approval list."
+                echo "is-require-approval=migrations-cicd" >> $GITHUB_OUTPUT
+              else
+                echo "$author is not in the approval list."
+                echo "is-require-approval=migrations-cicd-require-approval" >> $GITHUB_OUTPUT
+              fi
+            fi
+          fi


### PR DESCRIPTION
### Description
Goal of this change is to introduce a pattern for allowing some GitHub actions to wait on maintainer approval (or automatically for maintainers) before executing, specifically `pull_request_target` actions

More details here: https://github.com/opensearch-project/.github/issues/275

### Issues Resolved
https://opensearch.atlassian.net/browse/MIGRATIONS-2357

### Testing
Fork testing WIP

### Check List
- [ ] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
