### PR TITLE
Fix RFS argument parsing error caused by floating point precision in maxShardSizeBytes

### DIFF
--- a/deployment/cdk/opensearch-service-migration/lib/service-stacks/reindex-from-snapshot-stack.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/service-stacks/reindex-from-snapshot-stack.ts
@@ -125,7 +125,7 @@ export class ReindexFromSnapshotStack extends MigrationServiceCore {
         command = appendArgIfNotInExtraArgs(command, extraArgsDict, "--snapshot-name", "rfs-snapshot")
         command = appendArgIfNotInExtraArgs(command, extraArgsDict, "--lucene-dir", `"${storagePath}/lucene"`)
         command = appendArgIfNotInExtraArgs(command, extraArgsDict, "--target-host", osClusterEndpoint)
-        command = appendArgIfNotInExtraArgs(command, extraArgsDict, "--max-shard-size-bytes", `${maxShardSizeBytes}`)
+        command = appendArgIfNotInExtraArgs(command, extraArgsDict, "--max-shard-size-bytes", `${Math.ceil(maxShardSizeBytes)}`)
         command = appendArgIfNotInExtraArgs(command, extraArgsDict, "--max-connections", props.reindexFromSnapshotWorkerSize === "maximum" ? "100" : "10")
         if (props.reindexFromSnapshotWorkerSize === "maximum") {
             command = appendArgIfNotInExtraArgs(command, extraArgsDict, "--target-compression")

--- a/deployment/cdk/opensearch-service-migration/test/reindex-from-snapshot-stack.test.ts
+++ b/deployment/cdk/opensearch-service-migration/test/reindex-from-snapshot-stack.test.ts
@@ -448,6 +448,77 @@ describe('ReindexFromSnapshotStack Tests', () => {
     expect(volumeCapture.asArray().length).toBe(1);
   });
 
+  test('ReindexFromSnapshotStack uses ceiling of maxShardSizeBytes calculation', () => {
+    const contextOptions = {
+      vpcEnabled: true,
+      reindexFromSnapshotServiceEnabled: true,
+      stage: 'unit-test',
+      sourceCluster: {
+        "endpoint": "https://test-cluster",
+        "auth": {"type": "none"},
+        "version": "ES_7.10"
+      },
+      targetCluster: {
+        "endpoint": "https://target-cluster",
+        "auth": {"type": "sigv4", "region": "eu-west-1", "serviceSigningName": "aoss"}
+      },
+      migrationAssistanceEnabled: true,
+      reindexFromSnapshotMaxShardSizeGiB: 1.000001
+    };
+
+
+    const stacks = createStackComposer(contextOptions);
+    const reindexStack = stacks.stacks.find(s => s instanceof ReindexFromSnapshotStack) as ReindexFromSnapshotStack;
+    expect(reindexStack).toBeDefined();
+    const template = Template.fromStack(reindexStack);
+
+    const taskDefinitionCapture = new Capture();
+    template.hasResourceProperties('AWS::ECS::TaskDefinition', {
+      ContainerDefinitions: taskDefinitionCapture,
+    });
+
+    const containerDefinitions = taskDefinitionCapture.asArray();
+    expect(containerDefinitions.length).toBe(1);
+    expect(containerDefinitions[0].Command).toEqual([
+      '/bin/sh',
+      '-c',
+      '/rfs-app/entrypoint.sh'
+    ]);
+    expect(containerDefinitions[0].Environment).toEqual([
+      {
+        Name: 'RFS_COMMAND',
+        Value: {
+          "Fn::Join": [
+            "",
+            [ "/rfs-app/runJavaWithClasspath.sh org.opensearch.migrations.RfsMigrateDocuments --s3-local-dir \"/storage/s3_files\" --s3-repo-uri \"s3://migration-artifacts-test-account-unit-test-us-east-1/rfs-snapshot-repo\" --s3-region us-east-1 --snapshot-name rfs-snapshot --lucene-dir \"/storage/lucene\" --target-host ",
+              {
+                "Ref": "SsmParameterValuemigrationunittestdefaultosClusterEndpointC96584B6F00A464EAD1953AFF4B05118Parameter",
+              },
+              " --max-shard-size-bytes 1181117188 --max-connections 10 --target-aws-service-signing-name aoss --target-aws-region eu-west-1 --source-version \"ES_7.10\"",
+            ],
+          ],
+        }
+      },
+      {
+        Name: 'RFS_TARGET_USER',
+        Value: ''
+      },
+      {
+        Name: 'RFS_TARGET_PASSWORD',
+        Value: ''
+      },
+      {
+        Name: 'RFS_TARGET_PASSWORD_ARN',
+        Value: ''
+      },
+      {
+        Name: 'SHARED_LOGS_DIR_PATH',
+        Value: '/shared-logs-output/reindex-from-snapshot-default'
+      }
+    ]);
+  });
+
+
   test('ReindexFromSnapshotStack throws error for large shard size in GovCloud', () => {
     const contextOptions = {
       vpcEnabled: true,


### PR DESCRIPTION
### Description
Fix RFS argument parsing error caused by floating point precision in maxShardSizeBytes.
Does not occur for default 80, but showed up when using `900` on release 2.1.3.
Confirmed behavior with unit test and added fix.

### Issues Resolved

```
2025-01-21 23:56:22,983 INFO o.o.m.RfsMigrateDocuments [main] Starting RfsMigrateDocuments with workerId =ip-10-0-149-200.ec2.internal Exception in thread "main" com.beust.jcommander.ParameterException: "--max-shard-size-bytes": couldn't convert "1063004405760.0001" to a long at com.beust.jcommander.converters.LongConverter.convert(LongConverter.java:38) at com.beust.jcommander.converters.LongConverter.convert(LongConverter.java:28) at com.beust.jcommander.JCommander.convertValue(JCommander.java:1443) at com.beust.jcommander.ParameterDescription.addValue(ParameterDescription.java:258) at com.beust.jcommander.JCommander.processFixedArity(JCommander.java:987) at com.beust.jcommander.JCommander.processFixedArity(JCommander.java:968) at com.beust.jcommander.JCommander.parseValues(JCommander.java:788) at com.beust.jcommander.JCommander.parse(JCommander.java:373) at com.beust.jcommander.JCommander.parse(JCommander.java:352) at org.opensearch.migrations.RfsMigrateDocuments.main(RfsMigrateDocuments.java:246) |  
```

### Testing
Added unit tests

### Check List
- [x] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
