### PR TITLE
[In Progress] Enable 6.8 as a target cluster

### DIFF
--- a/DocumentsFromSnapshotMigration/src/test/java/org/opensearch/migrations/bulkload/EndToEndTest.java
+++ b/DocumentsFromSnapshotMigration/src/test/java/org/opensearch/migrations/bulkload/EndToEndTest.java
@@ -43,6 +43,7 @@ public class EndToEndTest extends SourceTestBase {
                 scenarios.add(Arguments.of(sourceCluster, targetCluster));
             }
         }
+        scenarios.add(Arguments.of(SearchClusterContainer.ES_V6_8_23, SearchClusterContainer.ES_V6_8_23));
 
         return scenarios.build();
     }

--- a/MetadataMigration/src/main/java/org/opensearch/migrations/cli/Items.java
+++ b/MetadataMigration/src/main/java/org/opensearch/migrations/cli/Items.java
@@ -1,6 +1,7 @@
 package org.opensearch.migrations.cli;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import org.opensearch.migrations.metadata.CreationResult;
@@ -94,7 +95,9 @@ public class Items {
             .append(result.getFailureType().getMessage());
 
         if (result.getFailureType().isFatal()) {
-            sb.append(": " + result.getException().getMessage());
+            sb.append(": " + Optional.ofNullable(result.getException()).map(Exception::getMessage).orElse("")
+
+            );
         }
 
         return sb.toString();

--- a/MetadataMigration/src/test/java/org/opensearch/migrations/EndToEndTest.java
+++ b/MetadataMigration/src/test/java/org/opensearch/migrations/EndToEndTest.java
@@ -34,9 +34,14 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 @Tag("isolatedTest")
 @Slf4j
 class EndToEndTest extends BaseMigrationTest {
-
     private static Stream<Arguments> scenarios() {
-        return SupportedClusters.sources().stream()
+        Stream<Arguments> target_6_8_case = Stream.of(Arguments.of(
+                SearchClusterContainer.ES_V6_8_23,
+                SearchClusterContainer.ES_V6_8_23,
+                TransferMedium.SnapshotImage,
+                List.of(TemplateType.Legacy)
+        ));
+        Stream<Arguments> fullScenarios = SupportedClusters.sources().stream()
             .flatMap(sourceCluster -> {
                 // Determine applicable template types based on source version
                 List<TemplateType> templateTypes = Stream.concat(
@@ -55,6 +60,8 @@ class EndToEndTest extends BaseMigrationTest {
                             templateTypes)))
                     .collect(Collectors.toList()).stream();
             });
+
+        return Stream.concat(target_6_8_case, fullScenarios);
     }
 
     @ParameterizedTest(name = "From version {0} to version {1}, Medium {2}, Command {3}, Template Type {4}")

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/transformers/TransformFunctions.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/transformers/TransformFunctions.java
@@ -34,6 +34,9 @@ public class TransformFunctions {
                 return new Transformer_ES_7_10_OS_2_11(dimensionality);
             }
         }
+        if (VersionMatchers.isES_6_X.test(sourceVersion) && VersionMatchers.isES_6_X.test(targetVersion)) {
+            return new Transformer_NoOp();
+        }
 
         throw new IllegalArgumentException("Unsupported transformation requested");
     }

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/transformers/Transformer_NoOp.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/transformers/Transformer_NoOp.java
@@ -1,9 +1,9 @@
 package org.opensearch.migrations.bulkload.transformers;
 
+import java.util.List;
+
 import org.opensearch.migrations.bulkload.models.GlobalMetadata;
 import org.opensearch.migrations.bulkload.models.IndexMetadata;
-
-import java.util.List;
 
 public class Transformer_NoOp implements Transformer {
 

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/transformers/Transformer_NoOp.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/transformers/Transformer_NoOp.java
@@ -1,0 +1,19 @@
+package org.opensearch.migrations.bulkload.transformers;
+
+import org.opensearch.migrations.bulkload.models.GlobalMetadata;
+import org.opensearch.migrations.bulkload.models.IndexMetadata;
+
+import java.util.List;
+
+public class Transformer_NoOp implements Transformer {
+
+    @Override
+    public GlobalMetadata transformGlobalMetadata(GlobalMetadata globalData) {
+        return globalData;
+    }
+
+    @Override
+    public List<IndexMetadata> transformIndexMetadata(IndexMetadata indexData) {
+        return List.of(indexData);
+    }
+}

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/version_es_6_8/OpenSearchWorkCoordinator_ES_6_8.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/version_es_6_8/OpenSearchWorkCoordinator_ES_6_8.java
@@ -1,8 +1,10 @@
 package org.opensearch.migrations.bulkload.version_es_6_8;
 import java.time.Clock;
 import java.util.function.Consumer;
+
 import org.opensearch.migrations.bulkload.workcoordination.AbstractedHttpClient;
 import org.opensearch.migrations.bulkload.workcoordination.OpenSearchWorkCoordinator;
+
 import com.fasterxml.jackson.databind.JsonNode;
 
 public class OpenSearchWorkCoordinator_ES_6_8 extends OpenSearchWorkCoordinator {    

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/version_es_6_8/OpenSearchWorkCoordinator_ES_6_8.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/version_es_6_8/OpenSearchWorkCoordinator_ES_6_8.java
@@ -1,0 +1,84 @@
+package org.opensearch.migrations.bulkload.version_es_6_8;
+import java.time.Clock;
+import java.util.function.Consumer;
+import org.opensearch.migrations.bulkload.workcoordination.AbstractedHttpClient;
+import org.opensearch.migrations.bulkload.workcoordination.OpenSearchWorkCoordinator;
+import com.fasterxml.jackson.databind.JsonNode;
+
+public class OpenSearchWorkCoordinator_ES_6_8 extends OpenSearchWorkCoordinator {    
+        public OpenSearchWorkCoordinator_ES_6_8(
+            AbstractedHttpClient httpClient,
+            long tolerableClientServerClockDifferenceSeconds,
+            String workerId
+        ) {
+            super(httpClient, tolerableClientServerClockDifferenceSeconds, workerId);
+        }
+        public OpenSearchWorkCoordinator_ES_6_8(
+                AbstractedHttpClient httpClient,
+                long tolerableClientServerClockDifferenceSeconds,
+                String workerId,
+                Clock clock
+        ) {
+            super(httpClient, tolerableClientServerClockDifferenceSeconds, workerId, clock);
+        }
+
+        public OpenSearchWorkCoordinator_ES_6_8(
+            AbstractedHttpClient httpClient,
+            long tolerableClientServerClockDifferenceSeconds,
+            String workerId,
+            Clock clock,
+            Consumer<WorkItemAndDuration> workItemConsumer
+        ) {
+            super(httpClient, tolerableClientServerClockDifferenceSeconds, workerId, clock, workItemConsumer);
+        }
+
+        protected String getCoordinationIndexSettingsBody(){
+            return "{\n"
+            + "  \"settings\": {\n"
+            + "   \"index\": {"
+            + "    \"number_of_shards\": 1,\n"
+            + "    \"number_of_replicas\": 1\n"
+            + "   }\n"
+            + "  },\n"
+            + "  \"mappings\": {\n"
+            + "    \"doc\": {\n"
+            + "      \"properties\": {\n"
+            + "        \"" + EXPIRATION_FIELD_NAME + "\": {\n"
+            + "          \"type\": \"long\"\n"
+            + "        },\n"
+            + "        \"" + COMPLETED_AT_FIELD_NAME + "\": {\n"
+            + "          \"type\": \"long\"\n"
+            + "        },\n"
+            + "        \"leaseHolderId\": {\n"
+            + "          \"type\": \"keyword\",\n"
+            + "          \"norms\": false\n"
+            + "        },\n"
+            + "        \"status\": {\n"
+            + "          \"type\": \"keyword\",\n"
+            + "        \"norms\": false\n"
+            + "        },\n"
+            + "       \"" + SUCCESSOR_ITEMS_FIELD_NAME + "\": {\n"
+            + "         \"type\": \"keyword\",\n"
+            + "          \"norms\": false\n"
+            + "        }\n"
+            + "      }\n"
+            + "    }\n"
+            + "  }\n"
+            + "}\n";
+        }
+        protected String getPathForUpdates(String workItemId) {
+            return INDEX_NAME + "/doc/" + workItemId + "/_update";
+        }
+
+        protected String getPathForGets(String workItemId) {
+            return INDEX_NAME + "/doc/" + workItemId;
+        }
+
+        protected String getPathForSearches() {
+            return INDEX_NAME + "/doc/_search";
+        }
+
+        protected int getTotalHitsFromSearchResponse(JsonNode searchResponse) {
+            return searchResponse.path("hits").path("total").intValue();
+        }
+}

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/version_es_6_8/OpenSearchWorkCoordinator_ES_6_8.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/version_es_6_8/OpenSearchWorkCoordinator_ES_6_8.java
@@ -72,6 +72,8 @@ public class OpenSearchWorkCoordinator_ES_6_8 extends OpenSearchWorkCoordinator 
             return INDEX_NAME + "/doc/" + workItemId + "/_update";
         }
 
+        protected String getPathForSingleDocumentUpdateByQuery() { return INDEX_NAME + "/_update_by_query?refresh=true&size=1"; }
+
         protected String getPathForGets(String workItemId) {
             return INDEX_NAME + "/doc/" + workItemId;
         }

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/version_es_6_8/RemoteWriter_OS_6_8.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/version_es_6_8/RemoteWriter_OS_6_8.java
@@ -1,0 +1,98 @@
+package org.opensearch.migrations.bulkload.version_es_6_8;
+
+import lombok.extern.slf4j.Slf4j;
+import org.opensearch.migrations.Version;
+import org.opensearch.migrations.VersionMatchers;
+import org.opensearch.migrations.bulkload.common.OpenSearchClient;
+import org.opensearch.migrations.bulkload.common.OpenSearchClientFactory;
+import org.opensearch.migrations.bulkload.common.http.ConnectionContext;
+import org.opensearch.migrations.bulkload.models.DataFilterArgs;
+import org.opensearch.migrations.bulkload.version_os_2_11.GlobalMetadataCreator_OS_2_11;
+import org.opensearch.migrations.bulkload.version_os_2_11.IndexCreator_OS_2_11;
+import org.opensearch.migrations.cluster.ClusterWriter;
+import org.opensearch.migrations.cluster.RemoteCluster;
+import org.opensearch.migrations.metadata.GlobalMetadataCreator;
+import org.opensearch.migrations.metadata.IndexCreator;
+
+@Slf4j
+public class RemoteWriter_OS_6_8 implements RemoteCluster, ClusterWriter {
+    private Version version;
+    private OpenSearchClient client;
+    private ConnectionContext connection;
+    private DataFilterArgs dataFilterArgs;
+
+    @Override
+    public boolean compatibleWith(Version version) {
+        return VersionMatchers.isES_6_X.test(version);
+    }
+
+    @Override
+    public ClusterWriter initialize(Version versionOverride) {
+        if (versionOverride != null) {
+            log.warn("Overriding version for cluster, " + versionOverride);
+            this.version = versionOverride;
+        }
+        return this;
+    }
+
+    @Override
+    public ClusterWriter initialize(DataFilterArgs dataFilterArgs) {
+        this.dataFilterArgs = dataFilterArgs;
+        return this;
+    }
+
+    @Override
+    public RemoteCluster initialize(ConnectionContext connection) {
+        this.connection = connection;
+        return this;
+    }
+
+    @Override
+    public GlobalMetadataCreator getGlobalMetadataCreator() {
+        return new GlobalMetadataCreator_OS_2_11( // TODO
+            getClient(),
+            getDataFilterArgs().indexTemplateAllowlist,
+            getDataFilterArgs().componentTemplateAllowlist,
+            getDataFilterArgs().indexTemplateAllowlist);
+    }
+
+    @Override
+    public IndexCreator getIndexCreator() {
+        return new IndexCreator_OS_2_11(getClient());
+    } // TODO
+
+    @Override
+    public Version getVersion() {
+        if (version == null) {
+            version = getClient().getClusterVersion();
+        }
+        return version;
+    }
+
+    public String toString() {
+        // These values could be null, don't want to crash during toString
+        return String.format("Remote Cluster: %s %s", version, connection);
+    }
+
+    private OpenSearchClient getClient() {
+        if (client == null) {
+            var clientFactory = new OpenSearchClientFactory(getConnection());
+            client = clientFactory.determineVersionAndCreate();
+        }
+        return client;
+    }
+
+    private ConnectionContext getConnection() {
+        if (connection == null) {
+            throw new UnsupportedOperationException("initialize(...) must be called");
+        }
+        return connection;
+    }
+
+    private DataFilterArgs getDataFilterArgs() {
+        if (dataFilterArgs == null) {
+            throw new UnsupportedOperationException("initialize(...) must be called");
+        }
+        return dataFilterArgs;
+    } 
+}

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/version_es_6_8/RemoteWriter_OS_6_8.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/version_es_6_8/RemoteWriter_OS_6_8.java
@@ -1,6 +1,5 @@
 package org.opensearch.migrations.bulkload.version_es_6_8;
 
-import lombok.extern.slf4j.Slf4j;
 import org.opensearch.migrations.Version;
 import org.opensearch.migrations.VersionMatchers;
 import org.opensearch.migrations.bulkload.common.OpenSearchClient;
@@ -13,6 +12,8 @@ import org.opensearch.migrations.cluster.ClusterWriter;
 import org.opensearch.migrations.cluster.RemoteCluster;
 import org.opensearch.migrations.metadata.GlobalMetadataCreator;
 import org.opensearch.migrations.metadata.IndexCreator;
+
+import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class RemoteWriter_OS_6_8 implements RemoteCluster, ClusterWriter {

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/version_os_2_11/OpenSearchWorkCoordinator_OS_2_11.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/version_os_2_11/OpenSearchWorkCoordinator_OS_2_11.java
@@ -74,6 +74,8 @@ public class OpenSearchWorkCoordinator_OS_2_11 extends OpenSearchWorkCoordinator
             return INDEX_NAME + "/_update/" + workItemId;
         }
 
+        protected String getPathForSingleDocumentUpdateByQuery() { return INDEX_NAME + "/_update_by_query?refresh=true&max_docs=1"; }
+
         protected String getPathForGets(String workItemId) {
             return INDEX_NAME + "/_doc/" + workItemId;
         }

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/workcoordination/OpenSearchWorkCoordinator.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/workcoordination/OpenSearchWorkCoordinator.java
@@ -205,6 +205,8 @@ public abstract class OpenSearchWorkCoordinator implements IWorkCoordinator {
 
     protected abstract String getPathForUpdates(String workItemId);
 
+    protected abstract String getPathForSingleDocumentUpdateByQuery();
+
     protected abstract String getPathForGets(String workItemId);
 
     protected abstract String getPathForSearches();
@@ -516,8 +518,9 @@ public abstract class OpenSearchWorkCoordinator implements IWorkCoordinator {
             var totalHits = getTotalHitsFromSearchResponse(payload);
             // In the case where totalHits is 0, we need to be particularly sure that we're not missing data. The `relation`
             // for the total must be `eq` or we need to throw an error because it's not safe to rely on this data.
+            // ES 6.8 does not include the `relation` field, so we assume it's `eq`.
             var relationValue = payload.path("hits").path("total").path("relation").textValue();
-            if (totalHits == 0 && relationValue != null && relationValue.equals("eq")) {
+            if (totalHits == 0 && relationValue != null && !relationValue.equals("eq")) {
                 throw new IllegalStateException("Querying for notYetCompleted work returned 0 hits with an unexpected total relation.");
             }
             return totalHits;
@@ -601,7 +604,7 @@ public abstract class OpenSearchWorkCoordinator implements IWorkCoordinator {
 
         var response = httpClient.makeJsonRequest(
             AbstractedHttpClient.POST_METHOD,
-            INDEX_NAME + "/_update_by_query?refresh=true&size=1",
+            getPathForSingleDocumentUpdateByQuery(),
             null,
             body
         );
@@ -660,19 +663,18 @@ public abstract class OpenSearchWorkCoordinator implements IWorkCoordinator {
             throw new AssignedWorkDocumentNotFoundException(response);
         }
 
-        final var resultHitsUpper = objectMapper.readTree(response.getPayloadBytes()).path("hits");
-        if (resultHitsUpper.isMissingNode()) {
+        final var results = objectMapper.readTree(response.getPayloadBytes());
+        if (results.path("hits").isMissingNode()) {
             log.warn("Couldn't find the top level 'hits' field, returning no work item");
             throw new AssignedWorkDocumentNotFoundException(response);
         }
-//        final var numDocs = resultHitsUpper.path("total").path("value").longValue();
-        final var numDocs = resultHitsUpper.path("total").longValue();
+        final var numDocs = getTotalHitsFromSearchResponse(results);
         if (numDocs == 0) {
             throw new AssignedWorkDocumentNotFoundException(response);
         } else if (numDocs != 1) {
             throw new MalformedAssignedWorkDocumentException(response);
         }
-        var resultHitInner = resultHitsUpper.path("hits").path(0);
+        var resultHitInner = results.path("hits").path("hits").path(0);
         var expiration = resultHitInner.path(SOURCE_FIELD_NAME).path(EXPIRATION_FIELD_NAME).longValue();
         if (expiration == 0) {
             log.atWarn().setMessage("Expiration wasn't found or wasn't set to > 0 for response: {}")

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/workcoordination/WorkCoordinatorFactory.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/workcoordination/WorkCoordinatorFactory.java
@@ -5,6 +5,7 @@ import java.util.function.Consumer;
 
 import org.opensearch.migrations.Version;
 import org.opensearch.migrations.VersionMatchers;
+import org.opensearch.migrations.bulkload.version_es_6_8.OpenSearchWorkCoordinator_ES_6_8;
 import org.opensearch.migrations.bulkload.version_os_2_11.OpenSearchWorkCoordinator_OS_2_11;
 import org.opensearch.migrations.bulkload.workcoordination.IWorkCoordinator.WorkItemAndDuration;
 
@@ -23,6 +24,8 @@ public class WorkCoordinatorFactory {
         ) {
         if (VersionMatchers.isOS_1_X.test(version) || VersionMatchers.isOS_2_X.test(version)) {
             return new OpenSearchWorkCoordinator_OS_2_11(httpClient, tolerableClientServerClockDifferenceSeconds, workerId);
+        } else if (VersionMatchers.isES_6_X.test(version)) {
+            return new OpenSearchWorkCoordinator_ES_6_8(httpClient, tolerableClientServerClockDifferenceSeconds, workerId);
         } else {
             throw new IllegalArgumentException("Unsupported version: " + version);
         }
@@ -36,6 +39,8 @@ public class WorkCoordinatorFactory {
         ) {
         if (VersionMatchers.isOS_1_X.test(version) || VersionMatchers.isOS_2_X.test(version)) {
             return new OpenSearchWorkCoordinator_OS_2_11(httpClient, tolerableClientServerClockDifferenceSeconds, workerId, clock);
+        } else if (VersionMatchers.isES_6_X.test(version)) {
+            return new OpenSearchWorkCoordinator_ES_6_8(httpClient, tolerableClientServerClockDifferenceSeconds, workerId, clock);
         } else {
             throw new IllegalArgumentException("Unsupported version: " + version);
         }
@@ -50,6 +55,8 @@ public class WorkCoordinatorFactory {
         ) {
         if (VersionMatchers.isOS_1_X.test(version) || VersionMatchers.isOS_2_X.test(version)) {
             return new OpenSearchWorkCoordinator_OS_2_11(httpClient, tolerableClientServerClockDifferenceSeconds, workerId, clock, workItemConsumer);
+        } else if (VersionMatchers.isES_6_X.test(version)) {
+            return new OpenSearchWorkCoordinator_ES_6_8(httpClient, tolerableClientServerClockDifferenceSeconds, workerId, clock, workItemConsumer);
         } else {
             throw new IllegalArgumentException("Unsupported version: " + version);
         }

--- a/RFS/src/main/java/org/opensearch/migrations/cluster/ClusterProviderRegistry.java
+++ b/RFS/src/main/java/org/opensearch/migrations/cluster/ClusterProviderRegistry.java
@@ -9,6 +9,7 @@ import org.opensearch.migrations.bulkload.common.OpenSearchClientFactory;
 import org.opensearch.migrations.bulkload.common.SourceRepo;
 import org.opensearch.migrations.bulkload.common.http.ConnectionContext;
 import org.opensearch.migrations.bulkload.models.DataFilterArgs;
+import org.opensearch.migrations.bulkload.version_es_6_8.RemoteWriter_OS_6_8;
 import org.opensearch.migrations.bulkload.version_es_6_8.SnapshotReader_ES_6_8;
 import org.opensearch.migrations.bulkload.version_es_7_10.SnapshotReader_ES_7_10;
 import org.opensearch.migrations.bulkload.version_os_2_11.RemoteWriter_OS_2_11;
@@ -27,6 +28,7 @@ public class ClusterProviderRegistry {
             new SnapshotReader_ES_6_8(),
             new SnapshotReader_ES_7_10(),
             new RemoteWriter_OS_2_11(),
+            new RemoteWriter_OS_6_8(),
             new RemoteReader()
         );
     }

--- a/RFS/src/test/java/org/opensearch/migrations/bulkload/workcoordination/OpenSearchWorkCoodinatorTest.java
+++ b/RFS/src/test/java/org/opensearch/migrations/bulkload/workcoordination/OpenSearchWorkCoodinatorTest.java
@@ -11,6 +11,7 @@ import java.util.stream.Stream;
 
 import org.opensearch.migrations.Version;
 import org.opensearch.migrations.bulkload.SupportedClusters;
+import org.opensearch.migrations.bulkload.framework.SearchClusterContainer;
 import org.opensearch.migrations.bulkload.framework.SearchClusterContainer.ContainerVersion;
 import org.opensearch.migrations.bulkload.workcoordination.OpenSearchWorkCoordinator.DocumentModificationResult;
 import org.opensearch.migrations.testutils.CloseableLogSetup;
@@ -29,10 +30,10 @@ import org.testcontainers.shaded.com.fasterxml.jackson.databind.ObjectMapper;
 class OpenSearchWorkCoodinatorTest {
 
     public static final String THROTTLE_RESULT_VALUE = "slow your roll, dude";
-    public static final List<Version> testedVersions = SupportedClusters.targets().stream().map(ContainerVersion::getVersion).collect(Collectors.toList());
+    public static List<Version> testedVersions = SupportedClusters.targets().stream().map(ContainerVersion::getVersion).collect(Collectors.toList());
 
     static Stream<Arguments> provideTestedVersions() {
-        return testedVersions.stream().map(Arguments::of);
+        return Stream.concat(testedVersions.stream(), Stream.of(Version.fromString("ES 6.8"))).map(Arguments::of);
     }
 
     @AllArgsConstructor

--- a/RFS/src/test/java/org/opensearch/migrations/bulkload/workcoordination/OpenSearchWorkCoodinatorTest.java
+++ b/RFS/src/test/java/org/opensearch/migrations/bulkload/workcoordination/OpenSearchWorkCoodinatorTest.java
@@ -11,7 +11,6 @@ import java.util.stream.Stream;
 
 import org.opensearch.migrations.Version;
 import org.opensearch.migrations.bulkload.SupportedClusters;
-import org.opensearch.migrations.bulkload.framework.SearchClusterContainer;
 import org.opensearch.migrations.bulkload.framework.SearchClusterContainer.ContainerVersion;
 import org.opensearch.migrations.bulkload.workcoordination.OpenSearchWorkCoordinator.DocumentModificationResult;
 import org.opensearch.migrations.testutils.CloseableLogSetup;


### PR DESCRIPTION
### Description
Done:
- all necessary tests (mostly end-to-end) are set up and include the 6.8->6.8 scenario
- WorkCoordinator_6.8 is incorporated from Chris's branch https://github.com/chelma/opensearch-migrations/commit/f49242286b8377c89e63c4e7920756b2afabe178#diff-270487df7701832570a726b2b887c35fa4c8e8f94cfe742d12f37f78e7a8e002
- Metadata-related 6.8 functions are mostly in place
- NoopTransformer in place

Todo:
- figure out why metadata tests aren't working (claims that indices aren't created on target cluster -- I think they are, but aren't being found)
- figure out why doc migration tests aren't working (`Expected ExpectedMigrationWorkTerminationException to be thrown, but nothing was thrown`)

### Issues Resolved
<!-- List any GitHub or Jira issues this PR will resolve -->

### Testing
<!-- Please provide details of testing done: unit testing, integration testing and manual testing -->

### Check List
- [ ] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
