### PR TITLE
Improve spotless speed

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -86,24 +86,32 @@ task buildDockerImages() {
     dependsOn(':DocumentsFromSnapshotMigration:buildDockerImages')
 }
 
+def commonExclusions = ['**/build/**', '**/node_modules/**', '**/opensearch-cluster-cdk/**', '**/cdk.out/**']
 spotless {
     format 'misc', {
-        target '**/*.gradle', '.gitattributes', '.gitignore'
-        targetExclude '**/build/**'
+        target fileTree('.') {
+            include '**/*.gradle', '.gitattributes', '.gitignore'
+            exclude commonExclusions
+        }
         trimTrailingWhitespace()
         indentWithSpaces()
         endWithNewline()
 
     }
     yaml {
-        target '**/*.yml'
-        targetExclude '**/node_modules/**', '**/opensearch-cluster-cdk/**', '**/cdk.out/**'
+        target fileTree('.') {
+            include '**/*.yml'
+            exclude commonExclusions
+        }
         trimTrailingWhitespace()
         indentWithSpaces()
         endWithNewline()
     }
     json {
-        target 'deployment/cdk/opensearch-service-migration/*.json'
+        target fileTree('.') {
+            include '*.json'
+            exclude commonExclusions
+        }
         prettier()
         endWithNewline()
     }


### PR DESCRIPTION
### Description
When passed target/exclude spotless is doing its own file scan, instead of being able to build off of gradle's internal scan - gradle has a really fast implementation and in fully supports gradle's caching interface.

Anecdotally on my machine `./gradlew spotlessApply` went from 10s -> 4s and when up-to-date takes ~2s.

### Issues Resolved
- Resolves https://opensearch.atlassian.net/browse/MIGRATIONS-2229

### Testing
Local task checking

### Check List
- [ ] ~New functionality includes testing~
- [ ] ~Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
