### PR TITLE
Refactor Segment Sorting into lucene version agnostic way

### DIFF
--- a/DocumentsFromSnapshotMigration/src/test/java/org/opensearch/migrations/bulkload/LeaseExpirationTest.java
+++ b/DocumentsFromSnapshotMigration/src/test/java/org/opensearch/migrations/bulkload/LeaseExpirationTest.java
@@ -48,7 +48,7 @@ public class LeaseExpirationTest extends SourceTestBase {
 
     @ParameterizedTest(name = "forceMoreSegments={0}, sourceClusterVersion={1}")
     @MethodSource("testParameters")
-    public void testProcessExitsAsExpected(boolean forceMoreSegments) {
+    public void testProcessExitsAsExpected(boolean forceMoreSegments, SearchClusterContainer.ContainerVersion sourceClusterVersion) {
         // Sending 10 docs per request with 2 requests concurrently with each taking 1 second is 40 docs/sec
         // will process 1640 docs in 21 seconds. With 10s lease duration, expect to be finished in 3 leases.
         // This is ensured with the toxiproxy settings, the migration should not be able to be completed

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/common/DocumentReindexer.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/common/DocumentReindexer.java
@@ -66,7 +66,7 @@ public class DocumentReindexer {
      */
     Mono<WorkItemCursor> sendBulkRequest(UUID batchId, List<RfsDocument> docsBatch, String indexName, IDocumentReindexContext context, Scheduler scheduler) {
         var lastDoc = docsBatch.get(docsBatch.size() - 1);
-        log.atInfo().setMessage("Last doc is: Source Index " + indexName + "Shard " + " Lucene Doc Number " + lastDoc.luceneDocNumber).log();
+        log.atInfo().setMessage("Last doc is: Source Index " + indexName + " Lucene Doc Number " + lastDoc.luceneDocNumber).log();
 
         List<BulkDocSection> bulkDocSections = docsBatch.stream()
                 .map(rfsDocument -> rfsDocument.document)

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/common/LuceneDocumentsReader.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/common/LuceneDocumentsReader.java
@@ -267,7 +267,7 @@ public class LuceneDocumentsReader {
 
         // Start at
         int startDocIdInSegment = Math.max(docStartingId - segmentDocBase, 0);
-        int numDocsToProcessInSegment = segmentReader.maxDoc() - startDocIdInSegment;
+        int numDocsToProcessInSegment = segmentReader.numDocs() - startDocIdInSegment;
 
         // For any errors, we want to log the segment reader debug info so we can see which segment is causing the issue.
         // This allows us to pass the supplier to getDocument without having to recompute the debug info
@@ -277,7 +277,7 @@ public class LuceneDocumentsReader {
             s == null ? segmentReader.toString() : s
         );
 
-        log.atInfo().setMessage("For segment: {}, migrating from doc: {}. Will process {} docs in segment.")
+        log.atDebug().setMessage("For segment: {}, migrating from doc: {}. Will process {} docs in segment.")
                 .addArgument(readerAndBase.reader)
                 .addArgument(startDocIdInSegment)
                 .addArgument(numDocsToProcessInSegment)

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/common/LuceneDocumentsReader.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/common/LuceneDocumentsReader.java
@@ -150,12 +150,8 @@ public class LuceneDocumentsReader {
             // If both LeafReaders are SegmentReaders, sort on segment info name.
             // Name is the "Unique segment name in the directory" which is always present on a SegmentInfo
             if (leafReader1 instanceof SegmentReader && leafReader2 instanceof SegmentReader) {
-                SegmentCommitInfo segmentInfo1 = ((SegmentReader) leafReader1).getSegmentInfo();
-                SegmentCommitInfo segmentInfo2 = ((SegmentReader) leafReader2).getSegmentInfo();
-
-                var segmentName1 = segmentInfo1.info.name;
-                var segmentName2 = segmentInfo2.info.name;
-
+                var segmentName1 = ((SegmentReader) leafReader1).getSegmentName();
+                var segmentName2 = ((SegmentReader) leafReader2).getSegmentName();
                 return segmentName1.compareTo(segmentName2);
             }
             // Otherwise, keep initial sort


### PR DESCRIPTION
### Description
Refactor Segment Sorting into lucene version agnostic way.

Required for compatibility with lucene  < 9

### Issues Resolved

### Testing
Existing subshard tests verify segments are sorted correctly.

### Check List
- [x] New functionality includes testing
- [] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
