### PR TITLE
[Bug] Jenkins Replayer test needs updated transformation arg name

### DIFF
--- a/vars/trafficReplayDefaultE2ETest.groovy
+++ b/vars/trafficReplayDefaultE2ETest.groovy
@@ -56,7 +56,7 @@ def call(Map config = [:]) {
         "domainRemovalPolicy": "DESTROY",
         "artifactBucketRemovalPolicy": "DESTROY",
         "trafficReplayerServiceEnabled": true,
-        "trafficReplayerExtraArgs": "--speedup-factor 10.0 --transformer-config-base64 $transformersConfigArg",
+        "trafficReplayerExtraArgs": "--speedup-factor 10.0 --transformer-config-encoded $transformersConfigArg",
         "reindexFromSnapshotServiceEnabled": true,
         "sourceClusterEndpoint": "<SOURCE_CLUSTER_ENDPOINT>",
         "migrationConsoleEnableOSI": true,


### PR DESCRIPTION
### Description
See title

```
[INFO ] 2025-01-31 12:28:28,702788 [main] TrafficReplayer - Starting Traffic Replayer with id=ip-12-0-2-118.ec2.internal
Only one main parameter allowed but found several: "https://<target-cluster>:443" and "--transformer-config-base64"
```
I removed target cluster endpoint here

### Issues Resolved
N/A

### Testing
Jenkins testing

### Check List
- [ ] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
