### PR TITLE
Add retry for worker coordination

### DIFF
--- a/DocumentsFromSnapshotMigration/src/test/java/org/opensearch/migrations/bulkload/ParallelDocumentMigrationsTest.java
+++ b/DocumentsFromSnapshotMigration/src/test/java/org/opensearch/migrations/bulkload/ParallelDocumentMigrationsTest.java
@@ -197,7 +197,7 @@ public class ParallelDocumentMigrationsTest extends SourceTestBase {
         long numItemsAssigned = getMetricValueOrZero(workMetrics, "nextWorkAssignedCount");
         Assertions.assertEquals(numItemsAssigned, shardCount);
         long numCompleted = getMetricValueOrZero(workMetrics, "completeWorkCount");
-        Assertions.assertEquals(numCompleted, shardCount + 1);
+        Assertions.assertEquals(shardCount + 1, numCompleted);
     }
 
 }

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/common/RestClient.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/common/RestClient.java
@@ -98,6 +98,7 @@ public class RestClient {
         this.client = httpClient
             .secure(sslProvider)
             .baseUrl(connectionContext.getUri().toString())
+            .disableRetry(false) // Enable one retry on connection reset with no delay
             .keepAlive(true);
     }
 

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/workcoordination/OpenSearchWorkCoordinator.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/workcoordination/OpenSearchWorkCoordinator.java
@@ -424,6 +424,18 @@ public class OpenSearchWorkCoordinator implements IWorkCoordinator {
     public void completeWorkItem(
         String workItemId,
         Supplier<IWorkCoordinationContexts.ICompleteWorkItemContext> contextSupplier
+    ) throws InterruptedException {
+            retryWithExponentialBackoff(
+                () -> completeWorkItemWithoutRetry(workItemId, contextSupplier),
+                MAX_MARK_AS_COMPLETED_RETRIES,
+                CREATE_SUCCESSOR_WORK_ITEMS_RETRY_BASE_MS,
+                ignored -> {}
+            );
+    }
+
+    private void completeWorkItemWithoutRetry(
+        String workItemId,
+        Supplier<IWorkCoordinationContexts.ICompleteWorkItemContext> contextSupplier
     ) throws IOException, InterruptedException {
         try (var ctx = contextSupplier.get()) {
             final var markWorkAsCompleteBodyTemplate = "{\n"
@@ -868,7 +880,7 @@ public class OpenSearchWorkCoordinator implements IWorkCoordinator {
                     e -> ctx.addTraceException(e, true)
             );
             retryWithExponentialBackoff(
-                    () -> completeWorkItem(workItemId, ctx::getCompleteWorkItemContext),
+                    () -> completeWorkItemWithoutRetry(workItemId, ctx::getCompleteWorkItemContext),
                     MAX_MARK_AS_COMPLETED_RETRIES,
                     CREATE_SUCCESSOR_WORK_ITEMS_RETRY_BASE_MS,
                     e -> ctx.addTraceException(e, true)
@@ -944,27 +956,53 @@ public class OpenSearchWorkCoordinator implements IWorkCoordinator {
 
         try (var context = contextSupplier.get()) {
             for (var attempt = 1; ; ++attempt) {
-                var suppliedVal = supplier.get();
-                var transformedVal = transformer.apply(suppliedVal);
-                if (test.test(suppliedVal, transformedVal)) {
-                    return transformedVal;
-                } else {
-                    log.atWarn().setMessage("Retrying {} because the predicate failed for: ({},{})")
-                        .addArgument(labelThatShouldBeAContext)
-                        .addArgument(suppliedVal)
-                        .addArgument(transformedVal)
-                        .log();
-                    if (attempt >= maxTries) {
-                        context.recordFailure();
-                        throw new MaxTriesExceededException(suppliedVal, transformedVal);
-                    } else {
-                        context.recordRetry();
+                T suppliedVal = null;
+                U transformedVal = null;
+                Exception exception = null;
+                try {
+                    suppliedVal = supplier.get();
+                    transformedVal = transformer.apply(suppliedVal);
+                    if (test.test(suppliedVal, transformedVal)) {
+                        return transformedVal;
                     }
-                    Thread.sleep(sleepMillis);
-                    sleepMillis *= 2;
+                } catch (Exception e) {
+                    exception = e;
                 }
+
+                if (attempt >= maxTries) {
+                    logFailure(labelThatShouldBeAContext, attempt, suppliedVal, transformedVal, exception);
+                    context.recordFailure();
+                    throw new MaxTriesExceededException(suppliedVal, transformedVal);
+                } else {
+                    context.recordRetry();
+                    logRetry(labelThatShouldBeAContext, attempt, suppliedVal, transformedVal, exception);
+                }
+                Thread.sleep(sleepMillis);
+                sleepMillis *= 2;
             }
         }
+    }
+
+    private static <T, U> void logRetry(String contextLabel, int attempt, T suppliedVal, U transformedVal, Exception e) {
+        log.atWarn()
+            .setMessage("Retrying {} (Attempt {}) for: ({}, {})")
+            .addArgument(contextLabel)
+            .addArgument(attempt)
+            .addArgument(suppliedVal)
+            .addArgument(transformedVal)
+            .setCause(e)
+            .log();
+    }
+
+    private static <T, U> void logFailure(String contextLabel, int attempt, T suppliedVal, U transformedVal, Exception e) {
+        log.atError()
+            .setMessage("Failing {}. Ran out of retries after attempt {} for ({}, {})")
+            .addArgument(contextLabel)
+            .addArgument(attempt)
+            .addArgument(suppliedVal)
+            .addArgument(transformedVal)
+            .setCause(e)
+            .log();
     }
 
     private void refresh(Supplier<IWorkCoordinationContexts.IRefreshContext> contextSupplier) throws IOException,


### PR DESCRIPTION
### Description
Worker Coordination does not retry on connection timeout. Observed with target self-managed cluster behind NLB (no ALB)
```
2025-02-05 09:08:26,485 INFO o.o.m.b.w.DocumentsRunner [reactor-http-epoll-4] Reindexing completed for Index REDACTED Shard 0 2025-02-05 09:08:26,485 INFO o.o.m.b.w.DocumentsRunner [main] Docs migrated 
2025-02-05 09:08:26,610 WARN r.n.h.c.HttpClientConnect [reactor-http-epoll-3] [2346c986-71, L:/10.0.154.183:34540 - R:REDACTED/REDACTED:443] The connection observed an error, the request cannot be retried as the headers/body were sent io.netty.channel.unix.Errors$NativeIoException: recvAddress(..) failed: Connection reset by peer
```

### Issues Resolved
[MIGRATIONS-2387](https://opensearch.atlassian.net/browse/MIGRATIONS-2387)

### Testing
Existing test suite, will later add more failure case testing

### Check List
- [ ] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
