### PR TITLE
Fix spotless configuration cache issue by updating to version 7.0.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -94,7 +94,7 @@ spotless {
             exclude commonExclusions
         }
         trimTrailingWhitespace()
-        indentWithSpaces()
+        leadingTabsToSpaces()
         endWithNewline()
 
     }
@@ -104,7 +104,7 @@ spotless {
             exclude commonExclusions
         }
         trimTrailingWhitespace()
-        indentWithSpaces()
+        leadingTabsToSpaces()
         endWithNewline()
     }
     json {
@@ -142,7 +142,7 @@ subprojects {
                     'org.opensearch',
                     '',
                     '\\#')
-            indentWithSpaces()
+            leadingTabsToSpaces()
             endWithNewline()
             removeUnusedImports()
         }

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
 //    Observing higher memory usage with task-tree plugin. Disabling except if needed
 //    id "com.dorongold.task-tree" version "2.1.1"
-    id "com.diffplug.spotless" version '6.25.0'
+    id "com.diffplug.spotless" version '7.0.2'
     id 'io.freefair.lombok' version '8.12' apply false
     id 'jacoco'
     id 'me.champeau.jmh' version '0.7.2' apply false

--- a/vars/defaultIntegPipeline.groovy
+++ b/vars/defaultIntegPipeline.groovy
@@ -105,8 +105,6 @@ def call(Map config = [:]) {
                             if (config.buildStep) {
                                 config.buildStep()
                             } else {
-                                // Needed due to https://github.com/diffplug/spotless/issues/987
-                                sh 'sudo --preserve-env rm -rf .gradle/configuration-cache'
                                 sh 'sudo --preserve-env ./gradlew clean build --no-daemon'
                             }
                         }

--- a/vars/defaultIntegPipeline.groovy
+++ b/vars/defaultIntegPipeline.groovy
@@ -105,6 +105,8 @@ def call(Map config = [:]) {
                             if (config.buildStep) {
                                 config.buildStep()
                             } else {
+                                // Needed due to https://github.com/diffplug/spotless/issues/987
+                                sh 'sudo --preserve-env rm -rf .gradle/configuration-cache'
                                 sh 'sudo --preserve-env ./gradlew clean build --no-daemon'
                             }
                         }


### PR DESCRIPTION
### Description
Fix spotless configuration cache issue with 8.12 since https://github.com/opensearch-project/opensearch-migrations/pull/1256:
```
> Error while evaluating property 'lineEndingsPolicy' of task ':TrafficCapture:trafficCaptureProxyServer:spotlessJava'.
   > Spotless JVM-local cache is stale. Regenerate the cache with
       rm -rf .gradle/configuration-cache
     To make this workaround obsolete, please upvote https://github.com/diffplug/spotless/issues/987
```
By updating to Spotless 7.0.0+

Also fix
```
'indentWithSpaces' is deprecated, use 'leadingTabsToSpaces' in your gradle build script instead.
```

### Issues Resolved
[MIGRATIONS-2386](https://opensearch.atlassian.net/browse/MIGRATIONS-2386)

### Testing
Ran jenkins with it in GHA

### Check List
- [x] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
