### PR TITLE
Revert "Upgrade gradle to 8.12.1 (#1256)"

### DIFF
--- a/CreateSnapshot/build.gradle
+++ b/CreateSnapshot/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'application'
     id 'java'
-    id 'io.freefair.lombok'
+    id 'io.freefair.lombok' version '8.6'
     id 'org.opensearch.migrations.java-application-conventions'
 }
 
@@ -22,5 +22,5 @@ dependencies {
 }
 
 application {
-    mainClass.set('org.opensearch.migrations.CreateSnapshot')
+    mainClassName = 'org.opensearch.migrations.CreateSnapshot'
 }

--- a/DataGenerator/build.gradle
+++ b/DataGenerator/build.gradle
@@ -33,5 +33,5 @@ dependencies {
 }
 
 application {
-    mainClass.set('org.opensearch.migrations.DataGenerator')
+    mainClassName = 'org.opensearch.migrations.DataGenerator'
 }

--- a/DocumentsFromSnapshotMigration/build.gradle
+++ b/DocumentsFromSnapshotMigration/build.gradle
@@ -1,8 +1,8 @@
 plugins {
     id 'application'
     id 'java'
-    id 'io.freefair.lombok'
-    id 'com.avast.gradle.docker-compose'
+    id 'io.freefair.lombok' version '8.6'
+    id "com.avast.gradle.docker-compose" version "0.17.4"
     id 'com.bmuschko.docker-remote-api'
 }
 
@@ -65,13 +65,12 @@ dependencies {
 }
 
 application {
-    mainClass.set('org.opensearch.migrations.RfsMigrateDocuments')
+    mainClassName = 'org.opensearch.migrations.RfsMigrateDocuments'
 }
 
 // Cleanup additional docker build directory
-def dockerBuildDir = file("./docker/build")
 clean.doFirst {
-    delete dockerBuildDir
+    delete project.file("./docker/build")
 }
 
 task copyDockerRuntimeJars (type: Sync) {
@@ -116,9 +115,9 @@ for (dockerService in dockerServices) {
         inputDir = project.file(dockerService.inputDir)
         // platform.set("linux/amd64")
         buildArgs = dockerService.buildArgs
-        images.add("migrations/${dockerService.dockerImageName}:${hash}".toString())
-        images.add("migrations/${dockerService.dockerImageName}:${version}".toString())
-        images.add("migrations/${dockerService.dockerImageName}:latest".toString())
+        images.add("migrations/${dockerService.dockerImageName}:${hash}")
+        images.add("migrations/${dockerService.dockerImageName}:${version}")
+        images.add("migrations/${dockerService.dockerImageName}:latest")
     }
 }
 

--- a/MetadataMigration/build.gradle
+++ b/MetadataMigration/build.gradle
@@ -30,5 +30,5 @@ dependencies {
 }
 
 application {
-    mainClass.set('org.opensearch.migrations.MetadataMigration')
+    mainClassName = 'org.opensearch.migrations.MetadataMigration'
 }

--- a/RFS/build.gradle
+++ b/RFS/build.gradle
@@ -4,7 +4,7 @@ plugins {
     id 'io.freefair.lombok'
     id 'java-test-fixtures'
     id 'me.champeau.jmh'
-    id 'com.gradleup.shadow'
+    id 'com.github.johnrengelman.shadow'
 }
 
 ext {

--- a/TrafficCapture/captureProtobufs/build.gradle
+++ b/TrafficCapture/captureProtobufs/build.gradle
@@ -4,7 +4,7 @@
 
 plugins {
     id 'org.opensearch.migrations.java-library-conventions'
-    id 'com.google.protobuf'
+    id 'com.google.protobuf' version "0.9.2"
 }
 
 dependencies {

--- a/TrafficCapture/dockerSolution/build.gradle
+++ b/TrafficCapture/dockerSolution/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'org.opensearch.migrations.java-library-conventions'
-    id "com.avast.gradle.docker-compose"
+    id "com.avast.gradle.docker-compose" version "0.17.4"
     id 'com.bmuschko.docker-remote-api'
 }
 
@@ -43,8 +43,8 @@ dockerFilesForExternalServices.each { dockerImageName, projectName ->
             inputDir = project.file("src/main/docker/${escapedProjectName}")
         }
         def hashNonce = CommonUtils.calculateDockerHash(project.fileTree(inputDir))
-        images.add("migrations/${dockerImageName}:${hashNonce}".toString())
-        images.add("migrations/${dockerImageName}:latest".toString())
+        images.add("migrations/${dockerImageName}:$hashNonce")
+        images.add("migrations/${dockerImageName}:latest")
     }
 }
 
@@ -58,14 +58,10 @@ static Sync getMigrationConsoleSyncTask(Project project, String dockerImageName,
         // Applications and Standalone Libraries both have libraries, sync them
         (libraries + applications).each { lib ->
             def applicationDestDir = "staging/${lib.name}/"
-
-            // Ensure dependencies are resolved within the correct project context
-            project.evaluationDependsOn(lib.path)
-
-            from (lib.files { lib.configurations.runtimeClasspath }) {
+            from (lib.configurations.findByName("runtimeClasspath").files) {
                 into "${applicationDestDir}/lib"
             }
-            from (lib.tasks.named('jar')) {
+            from (lib.tasks.getByName('jar')) {
                 into "${applicationDestDir}/lib"
             }
         }
@@ -73,7 +69,7 @@ static Sync getMigrationConsoleSyncTask(Project project, String dockerImageName,
         // Sync application start scripts
         applications.each { app ->
             def applicationDestDir = "staging/${app.name}/"
-            from (app.tasks.named('startScripts').get().outputs.files) {
+            from (app.tasks.getByName('startScripts').outputs.files) {
                 into "${applicationDestDir}/bin"
             }
         }
@@ -113,8 +109,8 @@ javaContainerServices.forEach { dockerImageName, projectName ->
     task "buildDockerImage_${dockerImageName}"(type: DockerBuildImage) {
         dependsOn "createDockerfile_${dockerImageName}"
         inputDir = project.file("${dockerBuildDir}")
-        images.add("migrations/${dockerImageName}:${version}".toString())
-        images.add("migrations/${dockerImageName}:latest".toString())
+        images.add("migrations/${dockerImageName}:${version}")
+        images.add("migrations/${dockerImageName}:latest")
     }
 }
 

--- a/TrafficCapture/trafficCaptureProxyServer/build.gradle
+++ b/TrafficCapture/trafficCaptureProxyServer/build.gradle
@@ -66,108 +66,89 @@ application {
     mainClass = 'org.opensearch.migrations.trafficcapture.proxyserver.CaptureProxy'
 }
 
-import org.gradle.api.DefaultTask
-import org.gradle.api.tasks.InputFiles
-import org.gradle.api.tasks.TaskAction
-import groovy.io.FileType
-import java.util.zip.ZipInputStream
+tasks.register("verifyCompatibilityWithJDK11") {
+    group = "verification"
+    description = "Verify Java major versions of compiled classes and dependencies for compatibility with JDK 11."
 
-// Custom task type
-class VerifyCompatibilityWithJDK11Task extends DefaultTask {
-    @InputFiles
-    File compiledClassesDir = new File("${project.buildDir}/classes/java/main")
+    // Declare task inputs
+    inputs.files(fileTree("${buildDir}/classes/java/main")).withPropertyName("compiledClasses")
+    inputs.files(configurations.compileClasspath).withPropertyName("compileClasspath")
+    inputs.files(configurations.runtimeClasspath).withPropertyName("runtimeClasspath")
 
-    @InputFiles
-    FileTree compileClasspath = project.configurations.compileClasspath.asFileTree
+    // Declare outputs (optional if no files are written, just up-to-date checking)
+    outputs.upToDateWhen { true }
 
-    @InputFiles
-    FileTree runtimeClasspath = project.configurations.runtimeClasspath.asFileTree
+    doLast {
+        // Task implementation logic
+        def isCompatible = true
+        def analyzedFiles = [] // To avoid duplicate processing
 
-    @Internal
-    boolean isCompatible = true
-
-    @Internal
-    HashSet analyzedFiles = new HashSet<File>()
-
-    int getMajorVersion(InputStream inputStream) {
-        // Skip first 6 bytes (magic and minor version)
-        inputStream.skip(6)
-        int majorVersion = (inputStream.read() << 8) | inputStream.read()
-        inputStream.close()
-        return majorVersion
-    }
-
-    void processClassFile(InputStream inputStream, String name, String source) {
-        int majorVersion = getMajorVersion(inputStream)
-        if (majorVersion > 55) {
-            isCompatible = false
-            println "Incompatible class file in ${source}: ${name} (Java major version ${majorVersion})"
+        def getMajorVersion = { InputStream inputStream ->
+            inputStream.skip(6)
+            def majorVersion = inputStream.read() << 8 | inputStream.read()
+            inputStream.close()
+            return majorVersion
         }
-    }
 
-    void analyzeCompiledClasses() {
-        if (compiledClassesDir.exists()) {
-            println "Analyzing compiled classes in ${compiledClassesDir}..."
-            compiledClassesDir.eachFileRecurse(FileType.FILES) { File file ->
-                if (file.name.endsWith('.class')) {
-                    file.withInputStream { InputStream inputStream ->
-                        processClassFile(inputStream, file.name, compiledClassesDir.toString())
+        def processClassFile = { InputStream inputStream, String name, String source ->
+            def majorVersion = getMajorVersion(inputStream)
+            if (majorVersion > 55) {
+                isCompatible = false
+                println "Incompatible class file in ${source}: ${name} (Java major version ${majorVersion})"
+            }
+        }
+
+        def analyzeCompiledClasses = {
+            def outputDir = file("${buildDir}/classes/java/main")
+            if (outputDir.exists()) {
+                println "Analyzing compiled classes in ${outputDir}..."
+                fileTree(dir: outputDir, include: '**/*.class').forEach { classFile ->
+                    classFile.withInputStream { inputStream ->
+                        processClassFile(inputStream, classFile.name, outputDir.toString())
                     }
                 }
+            } else {
+                println "No compiled classes found in ${outputDir}."
             }
-        } else {
-            println "No compiled classes found in ${compiledClassesDir}."
         }
-    }
 
-    void analyzeDependencies(FileTree classpathFiles) {
-        println "\nAnalyzing dependencies..."
-        classpathFiles.files.each { File dependency ->
-            if (dependency.name.endsWith(".jar") && !analyzedFiles.contains(dependency)) {
-                analyzedFiles.add(dependency)
-                def zipStream = new ZipInputStream(new FileInputStream(dependency))
-                def entry
-                while ((entry = zipStream.nextEntry) != null) {
-                    if (entry.name.endsWith(".class")) {
-                        // If this is a multi-release jar entry and its version is above 11, skip it.
-                        if (entry.name.startsWith("META-INF/versions/")) {
-                            def parts = entry.name.split("/")
-                            if (parts.size() >= 3 && parts[2].isInteger()) {
-                                def versionNumber = parts[2].toInteger()
+        def analyzeDependencies = { configuration ->
+            println "\nAnalyzing ${configuration.name} dependencies..."
+            configuration.files.each { dependency ->
+                if (dependency.name.endsWith(".jar") && !analyzedFiles.contains(dependency)) {
+                    analyzedFiles.add(dependency)
+                    def zipStream = new java.util.zip.ZipInputStream(new FileInputStream(dependency))
+                    def entry
+                    while ((entry = zipStream.nextEntry) != null) {
+                        if (entry.name.endsWith(".class")) {
+                            if (entry.name.startsWith("META-INF/versions/")) {
+                                def versionDir = entry.name.split("/")[2]
+                                def versionNumber = versionDir.isInteger() ? versionDir.toInteger() : 0
                                 if (versionNumber > 11) {
                                     continue
                                 }
                             }
-                        }
-                        // Copy the entry contents to a temporary file and process it.
-                        File tempFile = File.createTempFile("class", ".tmp")
-                        tempFile.deleteOnExit()
-                        tempFile.withOutputStream { os -> os << zipStream }
-                        tempFile.withInputStream { InputStream inputStream ->
-                            processClassFile(inputStream, entry.name, dependency.name)
+                            def tempFile = File.createTempFile("class", ".tmp")
+                            tempFile.deleteOnExit()
+                            tempFile.withOutputStream { it << zipStream }
+                            tempFile.withInputStream { inputStream ->
+                                processClassFile(inputStream, entry.name, dependency.name)
+                            }
                         }
                     }
+                    zipStream.close()
                 }
-                zipStream.close()
             }
         }
-    }
 
-    @TaskAction
-    void verify() {
         analyzeCompiledClasses()
-        analyzeDependencies(compileClasspath)
-        analyzeDependencies(runtimeClasspath)
+        analyzeDependencies(configurations.compileClasspath)
+        analyzeDependencies(configurations.runtimeClasspath)
 
         if (!isCompatible) {
             throw new GradleException("Incompatible class files detected! Ensure all classes are compatible with JDK 11 (major version ≤ 55).")
         }
     }
-}
-
-tasks.register("verifyCompatibilityWithJDK11", VerifyCompatibilityWithJDK11Task) {
-    group = "verification"
-    description = "Verify Java major versions of compiled classes and dependencies for compatibility with JDK 11."
     dependsOn tasks.named("assemble")
 }
 

--- a/TrafficCapture/trafficCaptureProxyServerTest/build.gradle
+++ b/TrafficCapture/trafficCaptureProxyServerTest/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'org.opensearch.migrations.java-library-conventions'
-    id "com.avast.gradle.docker-compose"
+    id "com.avast.gradle.docker-compose" version "0.17.4"
     //The 'com.bmushcko.docker-remote-api' line IS required (due to the remaining DockerBuildImage tasks) but W/O
     // a specified version. The version is managed within the buildSrc/build.gradle file.
     id 'com.bmuschko.docker-remote-api'
@@ -50,8 +50,8 @@ def dockerFilesForExternalServices = [
 dockerFilesForExternalServices.each { dockerImageName, projectName ->
     task("buildDockerImage_${dockerImageName}", type: DockerBuildImage) {
         def hash = calculateDockerHash(projectName)
-        images.add("migrations/${dockerImageName}:${hash}".toString())
-        images.add("migrations/${dockerImageName}:latest".toString())
+        images.add("migrations/${dockerImageName}:$hash")
+        images.add("migrations/${dockerImageName}:latest")
         inputDir = project.file("src/main/docker/${projectName}")
     }
 }
@@ -77,8 +77,8 @@ javaContainerServices.each(createContainerTasks)
     task "buildDockerImage_${dockerImageName}"(type: DockerBuildImage) {
         dependsOn "createDockerfile_${dockerImageName}"
         inputDir = project.file("${dockerBuildDir}")
-        images.add("migrations/${dockerImageName}:${version}".toString())
-        images.add("migrations/${dockerImageName}:latest".toString())
+        images.add("migrations/${dockerImageName}:${version}")
+        images.add("migrations/${dockerImageName}:latest")
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -2,12 +2,10 @@ plugins {
 //    Observing higher memory usage with task-tree plugin. Disabling except if needed
 //    id "com.dorongold.task-tree" version "2.1.1"
     id "com.diffplug.spotless" version '7.0.2'
-    id 'io.freefair.lombok' version '8.12' apply false
+    id 'io.freefair.lombok' version '8.6' apply false
     id 'jacoco'
+    id 'com.github.johnrengelman.shadow' version '8.1.1' apply false
     id 'me.champeau.jmh' version '0.7.2' apply false
-    id 'com.gradleup.shadow' version '8.3.5' apply false
-    id 'com.avast.gradle.docker-compose' version "0.17.12" apply false
-    id 'com.google.protobuf' version "0.9.4" apply false
 }
 
 allprojects {
@@ -24,24 +22,26 @@ ext.captureProxyDependencies = []
 gradle.projectsEvaluated {
     def captureProxyProject = rootProject.project(":TrafficCapture:trafficCaptureProxyServer")
     captureProxyDependencies = captureProxyProject.configurations.collectMany { configuration ->
-        configuration.dependencies.findAll { it instanceof ProjectDependency }.collect { it.path }
+        configuration.dependencies.findAll { it instanceof ProjectDependency }.collect { it.dependencyProject.path }
     }
     // Add the TrafficCaptureProxyServer project itself
     captureProxyDependencies << captureProxyProject.path
 }
 
 // Modify sourceCompatibility during the execution phase
-gradle.taskGraph.whenReady {
+gradle.taskGraph.whenReady { taskGraph ->
     allprojects {
         tasks.withType(JavaCompile).configureEach {
-            def jvmVersion = (project.path in rootProject.captureProxyDependencies) ? JavaVersion.VERSION_11 : JavaVersion.VERSION_17
-            sourceCompatibility = jvmVersion
-            targetCompatibility = jvmVersion
+            if (project.path in rootProject.captureProxyDependencies) {
+                sourceCompatibility = JavaVersion.VERSION_11
+                targetCompatibility = JavaVersion.VERSION_11
+            } else {
+                sourceCompatibility = JavaVersion.VERSION_17
+                targetCompatibility = JavaVersion.VERSION_17
+            }
         }
     }
 }
-
-
 
 // Define version properties
 ext {
@@ -153,11 +153,11 @@ subprojects {
         dependsOn project.javadoc
 
         testLogging {
-            events = ["passed", "skipped", "failed"]
-            exceptionFormat = "full"
-            showExceptions = true
-            showCauses = true
-            showStackTraces = true
+            events "passed", "skipped", "failed"
+            exceptionFormat "full"
+            showExceptions true
+            showCauses true
+            showStackTraces true
         }
         maxParallelForks = gradle.startParameter.maxWorkerCount
 
@@ -291,7 +291,7 @@ subprojects {
             repositories {
                 maven { url = "${rootProject.buildDir}/repository"}
                 maven {
-                    url = "https://aws.oss.sonatype.org/content/repositories/snapshots"
+                    url "https://aws.oss.sonatype.org/content/repositories/snapshots"
                     name = 'staging'
                 }
             }
@@ -312,9 +312,9 @@ subprojects {
         classDirectories.from = files(subprojects.collect { it.sourceSets.main.output.classesDirs })
         reports {
             xml.required = true
-            xml.outputLocation = file("${buildDir}/reports/jacoco/test/jacocoTestReport.xml")
+            xml.destination file("${buildDir}/reports/jacoco/test/jacocoTestReport.xml")
             html.required = true
-            html.outputLocation = file("${buildDir}/reports/jacoco/test/html")
+            html.destination file("${buildDir}/reports/jacoco/test/html")
         }
     }
 }
@@ -364,9 +364,9 @@ task mergeJacocoReports(type: JacocoReport) {
 
     reports {
         xml.required = true
-        xml.outputLocation = file("${buildDir}/reports/jacoco/mergedReport/jacocoMergedReport.xml")
+        xml.destination = file("${buildDir}/reports/jacoco/mergedReport/jacocoMergedReport.xml")
         html.required = true
-        html.outputLocation = file("${buildDir}/reports/jacoco/mergedReport/html")
+        html.destination = file("${buildDir}/reports/jacoco/mergedReport/html")
     }
 }
 

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -14,7 +14,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.bmuschko:gradle-docker-plugin:9.4.0'
+    implementation 'com.bmuschko:gradle-docker-plugin:9.3.1'
 }
 
 tasks.withType(Tar){

--- a/dashboardsSanitizer/build.gradle
+++ b/dashboardsSanitizer/build.gradle
@@ -27,5 +27,5 @@ dependencies {
 }
 
 application {
-    mainClass.set('org.opensearch.migrations.dashboards.SanitizerCli')
+    mainClassName = 'org.opensearch.migrations.dashboards.SanitizerCli'
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.2-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This reverts commit dc5dced034f5008a9886072032aa08d220264b07.

### Description
Reverts the gradle upgrade to 8.12.1 (#1256) because it causes issues with the dependency pom.xml file during the release workflow (see: https://github.com/opensearch-project/opensearch-migrations/actions/runs/13168301259/job/36753514331).

### Issues Resolved


### Testing


### Check List
- [ ] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
