### PR TITLE
Lock sonarqube version to pre-25.2

### DIFF
--- a/.github/workflows/sonar-qube.yml
+++ b/.github/workflows/sonar-qube.yml
@@ -15,7 +15,11 @@ jobs:
 
     services:
       sonarqube:
-        image: sonarqube:community
+        # sonarqube disabled the `password` option in 25.2.0. This is the last release of the
+        # `community` tag that supports this option, which we're using as a short-term solution
+        # while we support the `token` parameter.credentials:
+        # https://opensearch.atlassian.net/browse/MIGRATIONS-2389
+        image: sonarqube@sha256:47e573f85879254dafd7be9845f750155f33de8a6f33542015c31ce050917059
         ports:
           - 9000:9000
         options: >-


### PR DESCRIPTION
### Description
[In version 25.2.0, Sonarqube removed support of the `password` option](https://sonarsource.atlassian.net/issues/?jql=fixVersion%20%3D%2016130%20AND%20issuetype%20%21%3D%20Task%20ORDER%20BY%20status%20DESC%2C%20created%20ASC%20), which we are using. We should move to using the `token` option, but in the meantime this freezes us to the docker image before that change so that we can continue to get sonarqube data while fix this. 

### Issues Resolved
https://opensearch.atlassian.net/browse/MIGRATIONS-2389

### Testing

### Check List
- [ ] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
