### PR TITLE
Update netty to 4.1.118.Final

### DIFF
--- a/commonDependencyVersionConstraints/build.gradle
+++ b/commonDependencyVersionConstraints/build.gradle
@@ -9,7 +9,7 @@ ext {
 dependencies {
 
   constraints {
-    def netty = '4.1.115.Final'
+    def netty = '4.1.118.Final'
     api group: 'io.netty', name: 'netty-buffer', version: netty
     api group: 'io.netty', name: 'netty-codec-http', version: netty
     api group: 'io.netty', name: 'netty-handler', version: netty


### PR DESCRIPTION
### Description
Updates netty to the latest stable release, 4.1.118.Final

### Issues Resolved


### Testing
All tests pass locally.

### Check List
- [ ] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
