### PR TITLE
Update groovy to version 3.23

### DIFF
--- a/jenkinsTests/build.gradle
+++ b/jenkinsTests/build.gradle
@@ -17,7 +17,7 @@ sourceSets {
 }
 
 dependencies {
-    implementation 'org.codehaus.groovy:groovy-all:3.0.20'
+    implementation 'org.codehaus.groovy:groovy-all:3.0.23'
     testImplementation 'com.lesfurets:jenkins-pipeline-unit:1.23'
     testImplementation platform('org.junit:junit-bom:5.10.2')
     testImplementation 'org.junit.jupiter:junit-jupiter'


### PR DESCRIPTION
### Description
Update groovy to version 3.23, which includes an update for its dependency, testng, to 7.5.1, which resolves a CVE.

### Issues Resolved

### Testing
Automated tests passing

### Check List
- [ ] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
