### PR TITLE
Update xstream to 1.4.21

### DIFF
--- a/TrafficCapture/trafficCaptureProxyServerTest/build.gradle
+++ b/TrafficCapture/trafficCaptureProxyServerTest/build.gradle
@@ -30,6 +30,8 @@ dependencies {
     implementation group: 'org.apache.jmeter', name: 'ApacheJMeter_http', withoutBom
     implementation group: 'org.apache.jmeter', name: 'ApacheJMeter_config', withoutBom
     implementation group: 'org.jcommander', name: 'jcommander'
+
+    implementation group: 'com.thoughtworks.xstream', name: 'xstream', version: '1.4.21'
 }
 
 CommonConfigurations.applyCommonConfigurations(project)

--- a/commonDependencyVersionConstraints/build.gradle
+++ b/commonDependencyVersionConstraints/build.gradle
@@ -137,6 +137,7 @@ dependencies {
     implementation group: 'com.jayway.jsonpath', name: 'json-path', version: '2.9.0'
     implementation group: 'dnsjava', name: 'dnsjava', version: '3.6.0'
     implementation group: 'org.xerial.snappy', name: 'snappy-java', version: '1.1.10.6'
+    implementation group: 'com.thoughtworks.xstream', name: 'xstream', version: '1.4.21'
     api group: 'org.glassfish.jersey.core', name: 'jersey-common', version: '2.34'
     api group: 'org.apache.httpcomponents', 'name': 'httpclient', version: '4.5.13'
 

--- a/commonDependencyVersionConstraints/build.gradle
+++ b/commonDependencyVersionConstraints/build.gradle
@@ -137,7 +137,6 @@ dependencies {
     implementation group: 'com.jayway.jsonpath', name: 'json-path', version: '2.9.0'
     implementation group: 'dnsjava', name: 'dnsjava', version: '3.6.0'
     implementation group: 'org.xerial.snappy', name: 'snappy-java', version: '1.1.10.6'
-    implementation group: 'com.thoughtworks.xstream', name: 'xstream', version: '1.4.21'
     api group: 'org.glassfish.jersey.core', name: 'jersey-common', version: '2.34'
     api group: 'org.apache.httpcomponents', 'name': 'httpclient', version: '4.5.13'
 


### PR DESCRIPTION
### Description
Updates xstream, which is a dependency of Apache JMeter to version 1.4.21, which handles a CVE.

### Issues Resolved

### Testing
Automated tests

### Check List
- [ ] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
