### PR TITLE
Update json-smart to 2.5.1

### DIFF
--- a/commonDependencyVersionConstraints/build.gradle
+++ b/commonDependencyVersionConstraints/build.gradle
@@ -128,7 +128,7 @@ dependencies {
     // ************************************************************
     // The following constraints are for mitigating transitive CVEs
     // ************************************************************
-    implementation group: 'net.minidev', name: 'json-smart', version: '2.4.9'
+    implementation group: 'net.minidev', name: 'json-smart', version: '2.5.1'
     implementation group: 'xalan', name: 'xalan', version: '2.7.3'
     implementation group: 'com.thoughtworks.xstream', name: 'xstream', version: '1.4.21'
     implementation group: 'commons-net', name: 'commons-net', version: '3.9.0'


### PR DESCRIPTION
### Description
We already had a pinned version of this dependency but are updating to handle a CVE that occurs in 2.5.0 and below.

### Issues Resolved


### Testing
Automated tests pass

### Check List
- [ ] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
