### PR TITLE
Increase the timeout for initBootstrap in the solution-cfn-create-vpc pipeline from 25 to 30 min

### DIFF
--- a/test/awsRunInitBootstrap.sh
+++ b/test/awsRunInitBootstrap.sh
@@ -53,7 +53,7 @@ execute_command_and_wait_for_result() {
   fi
   sleep 5
   command_status=$(aws ssm get-command-invocation --command-id "$command_id" --instance-id "$instance_id" --output text --query 'Status')
-  max_attempts=25
+  max_attempts=30
   attempt_count=0
   while [ "$command_status" != "Success" ] && [ "$command_status" != "Failed" ] && [ "$command_status" != "TimedOut" ]
   do


### PR DESCRIPTION
### Description
This pipeline https://migrations.ci.opensearch.org/job/solutions-cfn-create-vpc-test/ has been timing out at the init bootstrap step. This PR gives it an extra 5 minutes to complete. We don't have much control over speeding up this process.

### Issues Resolved


### Testing


### Check List
- [ ] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
