### PR TITLE
Make HasLineCount test work on non-linux environments

### DIFF
--- a/testHelperFixtures/src/testFixtures/java/org/opensearch/migrations/matchers/HasLineCount.java
+++ b/testHelperFixtures/src/testFixtures/java/org/opensearch/migrations/matchers/HasLineCount.java
@@ -24,7 +24,7 @@ public class HasLineCount extends TypeSafeMatcher<String> {
     }
 
     private int newlineCount(String item) {
-        return item == null ? 0 : item.split("\n").length;
+        return item == null ? 0 : item.split(System.lineSeparator()).length;
     }
 
     public static HasLineCount hasLineCount(int n) {


### PR DESCRIPTION
### Description
Fixed the test assertion that was hard coded to look for `\n` character instead of system line ending.

### Testing
Ran test on windows machine, previously it failed now it passes.  I'm refraining from adding additional CI checks for windows development, as this project _could_ run on windows hosts, I don't think that is a priority for this project and the associated overhead.

### Check List
- [ ] ~New functionality includes testing~
- [ ] ~Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
