### PR TITLE
Make sure sanitizer test ignores whitespace

### DIFF
--- a/dashboardsSanitizer/src/test/java/org/opensearch/migrations/dashboards/SanitizerTest.java
+++ b/dashboardsSanitizer/src/test/java/org/opensearch/migrations/dashboards/SanitizerTest.java
@@ -21,11 +21,11 @@ class SanitizerTest {
         final Sanitizer sanitizer = Sanitizer.getInstance();
         
         // When calling sanitize
-        final String sanitizedString = sanitizer.sanitize(jsonString);
+        final var sanitized = objectMapper.readTree(sanitizer.sanitize(jsonString));
         
-        // Then the sanitized string should be the same as the input string - but it needs to be a one line string
-        final String expectedString = objectMapper.writeValueAsString(objectMapper.readTree(jsonString));
-        assertEquals(expectedString, sanitizedString);
+        // Then the sanitized string should be the same as the input
+        final var expected = objectMapper.readTree(jsonString);
+        assertEquals(expected, sanitized);
     }
 
     @Test


### PR DESCRIPTION
### Description
Make sure sanitizer test ignores whitespace

On windows machines the line-ending behavior can cause output to include a trailing new-line that causes incorrect test failures.

### Issues
- Related #1296 

### Testing
Ran test on windows machine, previously it failed now it passes.

### Check List
- [ ] ~New functionality includes testing~
- [ ] ~Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
