### PR TITLE
[K8s] Enable E2E Local Testing with Kubernetes

### DIFF
--- a/DocumentsFromSnapshotMigration/docker/entrypoint.sh
+++ b/DocumentsFromSnapshotMigration/docker/entrypoint.sh
@@ -4,7 +4,7 @@
 set -e
 
 # Print our ENV variables
-if [[ $RFS_COMMAND != *"--target-password"* ]]; then
+if [[ $RFS_COMMAND != *"--target-password"* && $RFS_COMMAND != *"--targetPassword"* ]]; then
     echo "RFS_COMMAND: $RFS_COMMAND"
 else
     echo "RFS Target Cluster password found in RFS_COMMAND; skipping logging of the value"
@@ -15,7 +15,7 @@ echo "RFS_TARGET_PASSWORD: <redacted>"
 echo "RFS_TARGET_PASSWORD_ARN: $RFS_TARGET_PASSWORD_ARN"
 
 # Check if the RFS Command already contains a username; only do special work if it does not
-if [[ $RFS_COMMAND != *"--target-username"* ]]; then
+if [[ $RFS_COMMAND != *"--target-username"* && $RFS_COMMAND != *"--targetUsername"* ]]; then
     if [[ -n "$RFS_TARGET_USER" ]]; then
         echo "Using username from ENV variable RFS_TARGET_USER.  Updating RFS Command with username."
         RFS_COMMAND="$RFS_COMMAND --target-username \"$RFS_TARGET_USER\""
@@ -23,7 +23,7 @@ if [[ $RFS_COMMAND != *"--target-username"* ]]; then
 fi
 
 # Check if the RFS Command already contains a password; only do special work if it does not
-if [[ $RFS_COMMAND != *"--target-password"* ]]; then
+if [[ $RFS_COMMAND != *"--target-password"* && $RFS_COMMAND != *"--targetPassword"* ]]; then
     PASSWORD_TO_USE=""
 
     # Check if the password is available in plaintext; if, use it.  Otherwise, retrieve it from AWS Secrets Manager
@@ -43,20 +43,20 @@ if [[ $RFS_COMMAND != *"--target-password"* ]]; then
     fi
 fi
 
-# Extract the value passed after --s3-local-dir
-S3_LOCAL_DIR=$(echo "$RFS_COMMAND" | sed -n 's/.*--s3-local-dir\s\+\("[^"]\+"\|[^ ]\+\).*/\1/p' | tr -d '"')
-# Extract the value passed after --lucene-dir
-LUCENE_DIR=$(echo "$RFS_COMMAND"  | sed -n 's/.*--lucene-dir\s\+\("[^"]\+"\|[^ ]\+\).*/\1/p' | tr -d '"')
+# Extract the value passed after --s3-local-dir or --s3LocalDir
+S3_LOCAL_DIR=$(echo "$RFS_COMMAND" | sed -n 's/.*--\(s3-local-dir\|s3LocalDir\)\s\+\("[^"]\+"\|[^ ]\+\).*/\2/p' | tr -d '"')
+# Extract the value passed after --lucene-dir or --luceneDir
+LUCENE_DIR=$(echo "$RFS_COMMAND"  | sed -n 's/.*--\(lucene-dir\|luceneDir\)\s\+\("[^"]\+"\|[^ ]\+\).*/\2/p' | tr -d '"')
 if [[ -n "$S3_LOCAL_DIR" ]]; then
     echo "Will delete S3 local directory between runs: $S3_LOCAL_DIR"
 else
-    echo "--s3-local-dir argument not found in RFS_COMMAND. Will not delete S3 local directory between runs."
+    echo "--s3-local-dir or --s3LocalDir argument not found in RFS_COMMAND. Will not delete S3 local directory between runs."
 fi
 
 if [[ -n "$LUCENE_DIR" ]]; then
     echo "Will delete lucene local directory between runs: $LUCENE_DIR"
 else
-    echo "--lucene-dir argument not found in RFS_COMMAND. This is required."
+    echo "--lucene-dir or --luceneDir argument not found in RFS_COMMAND. This is required."
     exit 1
 fi
 

--- a/TrafficCapture/dockerSolution/build.gradle
+++ b/TrafficCapture/dockerSolution/build.gradle
@@ -15,6 +15,53 @@ dependencies {
     }
 }
 
+static def isMinikubeRunning() {
+    try {
+        def status = "minikube status".execute().text
+        return status.contains("Running")
+    } catch (Exception ignored) {
+        return false
+    }
+}
+def syncToMinikube = isMinikubeRunning()
+def buildImageInMinikube(String imageName, String dockerBuildDir) {
+    println "Building image inside Minikube Docker environment"
+
+    // Set the Docker environment to Minikube's
+    def minikubeCommand = "eval \$(minikube docker-env) && docker build -t ${imageName} ${dockerBuildDir}"
+    try {
+        //def process = minikubeCommand.execute()
+        def process = ["bash", "-c", minikubeCommand].execute()
+        process.in.eachLine { println it }
+        process.err.eachLine { System.err.println it }
+        process.waitFor()
+
+        if (process.exitValue() != 0) {
+            throw new GradleException("Failed to build Docker image inside Minikube")
+        }
+    } catch (Exception e) {
+        println("Error executing command ${minikubeCommand} with error: ${e.message}")
+    }
+
+    // Optionally, you can output the result of the build to confirm the success
+    println "Image ${imageName} built in Minikube"
+}
+//def loadImageToMinikube(String imageName, String dockerBuildDir) {
+//    def error = ""
+//    def minikubeCommand = ""
+//    try {
+//        minikubeCommand = "eval $(minikube docker-env) && docker build -t ${imageName} ${dockerBuildDir}"
+//        def process = minikubeCommand.execute()
+//        process.waitFor()
+//        error = process.errorStream.text  // capture stderr
+//        if (error) {
+//            println("Error with command '${minikubeCommand}': ${error}")
+//        }
+//    } catch (Exception e) {
+//        println("Error executing command ${minikubeCommand} with error: ${e.message}")
+//    }
+//}
+
 def dockerFilesForExternalServices = [
         "elasticsearch_searchguard": "elasticsearchWithSearchGuard",
         "capture_proxy_base": "captureProxyBase",
@@ -108,9 +155,12 @@ javaContainerServices.forEach { dockerImageName, projectName ->
     def dockerBuildDir = "build/docker/${dockerImageName}_${escapedProjectName}"
     task "buildDockerImage_${dockerImageName}"(type: DockerBuildImage) {
         dependsOn "createDockerfile_${dockerImageName}"
-        inputDir = project.file("${dockerBuildDir}")
+        def dockerDir = project.file("${dockerBuildDir}")
+        inputDir = dockerDir
+        def latestImage = "migrations/${dockerImageName}:latest"
         images.add("migrations/${dockerImageName}:${version}")
         images.add("migrations/${dockerImageName}:latest")
+        //buildImageInMinikube(latestImage, dockerDir.absolutePath)
     }
 }
 

--- a/TrafficCapture/dockerSolution/build.gradle
+++ b/TrafficCapture/dockerSolution/build.gradle
@@ -15,53 +15,6 @@ dependencies {
     }
 }
 
-static def isMinikubeRunning() {
-    try {
-        def status = "minikube status".execute().text
-        return status.contains("Running")
-    } catch (Exception ignored) {
-        return false
-    }
-}
-def syncToMinikube = isMinikubeRunning()
-def buildImageInMinikube(String imageName, String dockerBuildDir) {
-    println "Building image inside Minikube Docker environment"
-
-    // Set the Docker environment to Minikube's
-    def minikubeCommand = "eval \$(minikube docker-env) && docker build -t ${imageName} ${dockerBuildDir}"
-    try {
-        //def process = minikubeCommand.execute()
-        def process = ["bash", "-c", minikubeCommand].execute()
-        process.in.eachLine { println it }
-        process.err.eachLine { System.err.println it }
-        process.waitFor()
-
-        if (process.exitValue() != 0) {
-            throw new GradleException("Failed to build Docker image inside Minikube")
-        }
-    } catch (Exception e) {
-        println("Error executing command ${minikubeCommand} with error: ${e.message}")
-    }
-
-    // Optionally, you can output the result of the build to confirm the success
-    println "Image ${imageName} built in Minikube"
-}
-//def loadImageToMinikube(String imageName, String dockerBuildDir) {
-//    def error = ""
-//    def minikubeCommand = ""
-//    try {
-//        minikubeCommand = "eval $(minikube docker-env) && docker build -t ${imageName} ${dockerBuildDir}"
-//        def process = minikubeCommand.execute()
-//        process.waitFor()
-//        error = process.errorStream.text  // capture stderr
-//        if (error) {
-//            println("Error with command '${minikubeCommand}': ${error}")
-//        }
-//    } catch (Exception e) {
-//        println("Error executing command ${minikubeCommand} with error: ${e.message}")
-//    }
-//}
-
 def dockerFilesForExternalServices = [
         "elasticsearch_searchguard": "elasticsearchWithSearchGuard",
         "capture_proxy_base": "captureProxyBase",
@@ -155,12 +108,9 @@ javaContainerServices.forEach { dockerImageName, projectName ->
     def dockerBuildDir = "build/docker/${dockerImageName}_${escapedProjectName}"
     task "buildDockerImage_${dockerImageName}"(type: DockerBuildImage) {
         dependsOn "createDockerfile_${dockerImageName}"
-        def dockerDir = project.file("${dockerBuildDir}")
-        inputDir = dockerDir
-        def latestImage = "migrations/${dockerImageName}:latest"
+        inputDir = project.file("${dockerBuildDir}")
         images.add("migrations/${dockerImageName}:${version}")
         images.add("migrations/${dockerImageName}:latest")
-        //buildImageInMinikube(latestImage, dockerDir.absolutePath)
     }
 }
 

--- a/TrafficCapture/dockerSolution/src/main/docker/elasticsearchTestConsole/Dockerfile
+++ b/TrafficCapture/dockerSolution/src/main/docker/elasticsearchTestConsole/Dockerfile
@@ -18,6 +18,7 @@ RUN dnf install -y --setopt=install_weak_deps=False \
         make \
         openssl-devel \
         pkg-config \
+        procps-ng \
         python3.11 \
         python3.11-devel \
         python3.11-pip \
@@ -27,7 +28,6 @@ RUN dnf install -y --setopt=install_weak_deps=False \
         vim \
         wget \
         zlib-devel \
-        procps-ng \
         && \
     dnf clean all && \
     rm -rf /var/cache/dnf

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/Dockerfile
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/Dockerfile
@@ -5,18 +5,35 @@ ENV WORKON_HOME=/
 ENV PIPENV_CUSTOM_VENV_NAME=.venv
 ENV PIPENV_DEFAULT_PYTHON_VERSION=3.11
 ENV PIPENV_MAX_DEPTH=1
+ARG HELM_VERSION="3.14.0"
+ARG KUBECTL_VERSION="1.32.1"
 
 RUN mkdir -p /root/kafka-tools/aws
 
 WORKDIR /root/kafka-tools
 # Get kafka distribution and unpack to 'kafka'
+#RUN curl --retry 5 --retry-delay 5 --retry-connrefused -fSL https://archive.apache.org/dist/kafka/3.6.0/kafka_2.13-3.6.0.tgz -o /tmp/kafka.tgz \
+#    && tar -xzf /tmp/kafka.tgz -C /root/kafka-tools --strip-components=1 \
+#    && rm -f /tmp/kafka.tgz
 ADD https://archive.apache.org/dist/kafka/3.6.0/kafka_2.13-3.6.0.tgz /root/kafka-tools/
 RUN tar --transform='s!^[^/]*!kafka!' -xzf kafka_2.13-3.6.0.tgz && \
     rm kafka_2.13-3.6.0.tgz
 
 ADD https://github.com/aws/aws-msk-iam-auth/releases/download/v2.0.3/aws-msk-iam-auth-2.0.3-all.jar kafka/libs/msk-iam-auth.jar
-WORKDIR /root
 
+# Add kubectl and Helm distributions
+RUN mkdir -p /tmp/k8s
+WORKDIR /tmp/k8s
+ADD https://dl.k8s.io/release/v${KUBECTL_VERSION}/bin/linux/arm64/kubectl .
+RUN install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl && \
+    kubectl completion bash > /etc/bash_completion.d/kubectl
+ADD https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz .
+RUN tar -zxvf helm-v${HELM_VERSION}-linux-amd64.tar.gz && \
+    mv linux-amd64/helm /usr/local/bin/ &&  \
+    helm completion bash > /etc/bash_completion.d/helm && \
+    rm -rf /tmp/k8s
+
+WORKDIR /root
 # Add Traffic Replayer jars for running KafkaPrinter from this container
 COPY staging/kafkaCommandLineFormatter/lib /root/kafka-tools/
 ENV CLASSPATH=/root/kafka-tools/kafkaCommandLineFormatter.jar

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/Dockerfile
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/Dockerfile
@@ -15,11 +15,11 @@ WORKDIR /root/kafka-tools
 #RUN curl --retry 5 --retry-delay 5 --retry-connrefused -fSL https://archive.apache.org/dist/kafka/3.6.0/kafka_2.13-3.6.0.tgz -o /tmp/kafka.tgz \
 #    && tar -xzf /tmp/kafka.tgz -C /root/kafka-tools --strip-components=1 \
 #    && rm -f /tmp/kafka.tgz
-ADD https://archive.apache.org/dist/kafka/3.6.0/kafka_2.13-3.6.0.tgz /root/kafka-tools/
-RUN tar --transform='s!^[^/]*!kafka!' -xzf kafka_2.13-3.6.0.tgz && \
-    rm kafka_2.13-3.6.0.tgz
+#ADD https://archive.apache.org/dist/kafka/3.6.0/kafka_2.13-3.6.0.tgz /root/kafka-tools/
+#RUN tar --transform='s!^[^/]*!kafka!' -xzf kafka_2.13-3.6.0.tgz && \
+#    rm kafka_2.13-3.6.0.tgz
 
-ADD https://github.com/aws/aws-msk-iam-auth/releases/download/v2.0.3/aws-msk-iam-auth-2.0.3-all.jar kafka/libs/msk-iam-auth.jar
+#ADD https://github.com/aws/aws-msk-iam-auth/releases/download/v2.0.3/aws-msk-iam-auth-2.0.3-all.jar kafka/libs/msk-iam-auth.jar
 
 # Add kubectl and Helm distributions
 RUN mkdir -p /tmp/k8s

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/Dockerfile
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/Dockerfile
@@ -1,3 +1,34 @@
+FROM migrations/elasticsearch_client_test_console:latest AS migration-console-base
+
+RUN ARCH=$(uname -m | sed 's/x86_64/amd64/; s/aarch64/arm64/') && \
+    if [ "$ARCH" != "amd64" ] && [ "$ARCH" != "arm64" ]; then \
+        echo "Unsupported architecture: $ARCH" && exit 1; \
+    fi && \
+    echo "Using architecture: $ARCH" && \
+    echo $ARCH > /arch.env
+
+ARG HELM_VERSION="3.14.0"
+ARG KUBECTL_VERSION="1.32.1"
+
+# Get kafka distribution and unpack to 'kafka'
+RUN mkdir -p /root/kafka-tools/kafka && \
+    curl --retry 5 --retry-delay 5 --retry-connrefused -fSL https://archive.apache.org/dist/kafka/3.6.0/kafka_2.13-3.6.0.tgz -o /tmp/kafka.tgz && \
+    tar -xzf /tmp/kafka.tgz -C /root/kafka-tools/kafka --strip-components=1 && \
+    rm -f /tmp/kafka.tgz
+RUN mkdir -p /root/kafka-tools/aws && \
+    curl --retry 5 --retry-delay 5 --retry-connrefused -fSL https://github.com/aws/aws-msk-iam-auth/releases/download/v2.0.3/aws-msk-iam-auth-2.0.3-all.jar -o /root/kafka-tools/kafka/libs/msk-iam-auth.jar
+
+# Get kubectl and Helm distributions
+RUN ARCH=$(cat /arch.env) && \
+    mkdir -p /k8s/bin && \
+    curl --retry 5 --retry-delay 5 --retry-connrefused -fSL "https://dl.k8s.io/release/v${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl" -o /k8s/bin/kubectl && \
+    chmod +x /k8s/bin/kubectl
+
+RUN ARCH=$(cat /arch.env) && \
+    curl --retry 5 --retry-delay 5 --retry-connrefused -fSL "https://get.helm.sh/helm-v${HELM_VERSION}-linux-${ARCH}.tar.gz" | tar -xz && \
+    mv linux-${ARCH}/helm /k8s/bin/
+
+
 FROM migrations/elasticsearch_client_test_console:latest
 
 # Define the virtual environment path
@@ -5,33 +36,12 @@ ENV WORKON_HOME=/
 ENV PIPENV_CUSTOM_VENV_NAME=.venv
 ENV PIPENV_DEFAULT_PYTHON_VERSION=3.11
 ENV PIPENV_MAX_DEPTH=1
-ARG HELM_VERSION="3.14.0"
-ARG KUBECTL_VERSION="1.32.1"
 
-RUN mkdir -p /root/kafka-tools/aws
+COPY --from=migration-console-base /root/kafka-tools /root/kafka-tools
+COPY --from=migration-console-base /k8s/bin/ /usr/local/bin
 
-WORKDIR /root/kafka-tools
-# Get kafka distribution and unpack to 'kafka'
-#RUN curl --retry 5 --retry-delay 5 --retry-connrefused -fSL https://archive.apache.org/dist/kafka/3.6.0/kafka_2.13-3.6.0.tgz -o /tmp/kafka.tgz \
-#    && tar -xzf /tmp/kafka.tgz -C /root/kafka-tools --strip-components=1 \
-#    && rm -f /tmp/kafka.tgz
-#ADD https://archive.apache.org/dist/kafka/3.6.0/kafka_2.13-3.6.0.tgz /root/kafka-tools/
-#RUN tar --transform='s!^[^/]*!kafka!' -xzf kafka_2.13-3.6.0.tgz && \
-#    rm kafka_2.13-3.6.0.tgz
-
-#ADD https://github.com/aws/aws-msk-iam-auth/releases/download/v2.0.3/aws-msk-iam-auth-2.0.3-all.jar kafka/libs/msk-iam-auth.jar
-
-# Add kubectl and Helm distributions
-RUN mkdir -p /tmp/k8s
-WORKDIR /tmp/k8s
-ADD https://dl.k8s.io/release/v${KUBECTL_VERSION}/bin/linux/arm64/kubectl .
-RUN install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl && \
-    kubectl completion bash > /etc/bash_completion.d/kubectl
-ADD https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz .
-RUN tar -zxvf helm-v${HELM_VERSION}-linux-amd64.tar.gz && \
-    mv linux-amd64/helm /usr/local/bin/ &&  \
-    helm completion bash > /etc/bash_completion.d/helm && \
-    rm -rf /tmp/k8s
+RUN kubectl completion bash > /etc/bash_completion.d/kubectl && \
+    helm completion bash > /etc/bash_completion.d/helm
 
 WORKDIR /root
 # Add Traffic Replayer jars for running KafkaPrinter from this container

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/README.md
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/README.md
@@ -130,8 +130,12 @@ OpenSearch Ingestion Pipeline (OSI).
 
 #### Reindex From Snapshot
 
-Depending on the purpose/deployment strategy, RFS can be used in Docker or on AWS in an Elastic Container Service (ECS) deployment.
-Most of the parameters for these two are the same, with some additional ones specific to the deployment.
+Depending on the purpose/deployment strategy, RFS can be used in various environments, including:
+1. Docker container environment, e.g. Docker compose setup
+2. AWS in an Elastic Container Service (ECS) deployment
+3. Kubernetes environment, e.g. Minikube environment
+
+Most of the parameters for these options are the same, with some additional ones specific to the deployment.
 
 - `reindex_from_snapshot`
     - `snapshot_repo`: optional, path to the snapshot repo. If not provided, ???
@@ -147,8 +151,11 @@ There is also a block that specifies the deployment type. Exactly one of the fol
     - `cluster_name`: required, name of the ECS cluster containing the RFS service
     - `service_name`: required, name of the ECS service for RFS
     - `aws_region`:  optional. if not provided, the usual rules are followed for determining aws region. (`AWS_DEFAULT_REGION`, `~/.aws/config`, etc.)
+- `k8s`:
+  - `namespace`: required, name of the Kubernetes namespace the RFS deployment is in
+  - `deployment_name`: required, name of the RFS deployment within the Kubernetes cluster
 
-Both of the following are valid RFS backfill specifications:
+All the following are valid RFS backfill specifications:
 
 ```yaml
 backfill:
@@ -166,6 +173,14 @@ backfill:
             cluster_name: migration-aws-integ-ecs-cluster
             service_name: migration-aws-integ-reindex-from-snapshot
             aws-region: us-east-1
+```
+
+```yaml
+backfill:
+  reindex_from_snapshot:
+    k8s:
+      namespace: "ma"
+      deployment_name: "ma-backfill"
 ```
 
 #### OpenSearch Ingestion
@@ -225,6 +240,10 @@ Exactly one of the following blocks must be present:
     - `cluster_name`: required, name of the ECS cluster containing the replayer service
     - `service_name`: required, name of the ECS replayer service
     - `aws_region`:  optional. if not provided, the usual rules are followed for determining aws region. (`AWS_DEFAULT_REGION`, `~/.aws/config`, etc.)
+  
+- `k8s`:
+  - `namespace`: required, name of the Kubernetes namespace the Replayer deployment is in
+  - `deployment_name`: required, name of the Replayer deployment within the Kubernetes cluster
 
 ### Kafka
 

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/cli.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/cli.py
@@ -251,20 +251,22 @@ def delete_snapshot_cmd(ctx, acknowledge_risk: bool):
     click.echo(result.value)
 
 
-@snapshot_group.command(name="delete-repo")
+@snapshot_group.command(name="unregister-repo")
 @click.option("--acknowledge-risk", is_flag=True, show_default=True, default=False,
               help="Flag to acknowledge risk and skip confirmation")
 @click.pass_obj
 def delete_snapshot_repo_cmd(ctx, acknowledge_risk: bool):
-    """Delete the snapshot repository"""
+    """Remove the snapshot repository"""
     if not acknowledge_risk:
-        confirmed = click.confirm('If you proceed with deleting the snapshot repository, the cluster will delete all '
-                                  'underlying local and remote files associated with the snapshot repository and its '
-                                  'underlying snapshots. Are you sure you want to continue?')
+        confirmed = click.confirm('If you proceed with unregistering the snapshot repository, the cluster will '
+                                  'deregister the existing snapshot repository but will not perform cleanup of existing '
+                                  'snapshot files that may exist. To remove the existing snapshot files '
+                                  '"console snapshot delete" must be used while this repository still exists. '
+                                  'Are you sure you want to continue?')
         if not confirmed:
-            click.echo("Aborting the command to delete snapshot repository.")
+            click.echo("Aborting the command to remove snapshot repository.")
             return
-    logger.info("Deleting snapshot repository")
+    logger.info("Removing snapshot repository")
     result = snapshot_.delete_snapshot_repo(ctx.env.snapshot)
     click.echo(result.value)
 

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/cli.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/cli.py
@@ -259,8 +259,8 @@ def delete_snapshot_repo_cmd(ctx, acknowledge_risk: bool):
     """Remove the snapshot repository"""
     if not acknowledge_risk:
         confirmed = click.confirm('If you proceed with unregistering the snapshot repository, the cluster will '
-                                  'deregister the existing snapshot repository but will not perform cleanup of existing '
-                                  'snapshot files that may exist. To remove the existing snapshot files '
+                                  'deregister the existing snapshot repository but will not perform cleanup of '
+                                  'existing snapshot files that may exist. To remove the existing snapshot files '
                                   '"console snapshot delete" must be used while this repository still exists. '
                                   'Are you sure you want to continue?')
         if not confirmed:

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/cli.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/cli.py
@@ -250,6 +250,24 @@ def delete_snapshot_cmd(ctx, acknowledge_risk: bool):
     result = snapshot_.delete(ctx.env.snapshot)
     click.echo(result.value)
 
+
+@snapshot_group.command(name="delete-repo")
+@click.option("--acknowledge-risk", is_flag=True, show_default=True, default=False,
+              help="Flag to acknowledge risk and skip confirmation")
+@click.pass_obj
+def delete_snapshot_repo_cmd(ctx, acknowledge_risk: bool):
+    """Delete the snapshot repository"""
+    if not acknowledge_risk:
+        confirmed = click.confirm('If you proceed with deleting the snapshot repository, the cluster will delete all '
+                                  'underlying local and remote files associated with the snapshot repository and its '
+                                  'underlying snapshots. Are you sure you want to continue?')
+        if not confirmed:
+            click.echo("Aborting the command to delete snapshot repository.")
+            return
+    logger.info("Deleting snapshot repository")
+    result = snapshot_.delete_snapshot_repo(ctx.env.snapshot)
+    click.echo(result.value)
+
 # ##################### BACKFILL ###################
 
 # As we add other forms of backfill migrations, we should incorporate a way to dynamically allow different sets of

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/cli.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/cli.py
@@ -255,7 +255,7 @@ def delete_snapshot_cmd(ctx, acknowledge_risk: bool):
 @click.option("--acknowledge-risk", is_flag=True, show_default=True, default=False,
               help="Flag to acknowledge risk and skip confirmation")
 @click.pass_obj
-def delete_snapshot_repo_cmd(ctx, acknowledge_risk: bool):
+def unregister_snapshot_repo_cmd(ctx, acknowledge_risk: bool):
     """Remove the snapshot repository"""
     if not acknowledge_risk:
         confirmed = click.confirm('If you proceed with unregistering the snapshot repository, the cluster will '

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/middleware/snapshot.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/middleware/snapshot.py
@@ -35,5 +35,3 @@ def delete_snapshot_repo(snapshot: Snapshot, *args, **kwargs) -> CommandResult:
     except Exception as e:
         logger.error(f"Failure running delete snapshot repo: {e}")
         return CommandResult(success=False, value=f"Failure running delete snapshot repo: {e}")
-
-

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/middleware/snapshot.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/middleware/snapshot.py
@@ -26,3 +26,14 @@ def delete(snapshot: Snapshot, *args, **kwargs) -> CommandResult:
     except Exception as e:
         logger.error(f"Failure running delete snapshot: {e}")
         return CommandResult(success=False, value=f"Failure running delete snapshot: {e}")
+
+
+def delete_snapshot_repo(snapshot: Snapshot, *args, **kwargs) -> CommandResult:
+    logger.info(f"Deleting snapshot repo with {args=} and {kwargs=}")
+    try:
+        return CommandResult(success=True, value=snapshot.delete_snapshot_repo(*args, **kwargs))
+    except Exception as e:
+        logger.error(f"Failure running delete snapshot repo: {e}")
+        return CommandResult(success=False, value=f"Failure running delete snapshot repo: {e}")
+
+

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/backfill_rfs.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/backfill_rfs.py
@@ -154,7 +154,7 @@ class K8sRFSBackfill(RFSBackfill):
                                archive_file_name=archive_file_name)
 
     def get_status(self, deep_check: bool, *args, **kwargs) -> CommandResult:
-        logger.info(f"Getting status of RFS backfill")
+        logger.info("Getting status of RFS backfill")
         deployment_status = self.kubectl_runner.retrieve_deployment_status()
         if not deployment_status:
             return CommandResult(False, "Failed to get deployment status for RFS backfill")
@@ -286,7 +286,10 @@ def get_detailed_status(target_cluster: Cluster) -> Optional[str]:
     return "\n".join([f"Work items {key}: {value}" for key, value in values.items() if value is not None])
 
 
-def perform_archive(target_cluster: Cluster, deployment_status: DeploymentStatus, archive_dir_path: str = None, archive_file_name: str = None) -> CommandResult:
+def perform_archive(target_cluster: Cluster,
+                    deployment_status: DeploymentStatus,
+                    archive_dir_path: str = None,
+                    archive_file_name: str = None) -> CommandResult:
     logger.info("Confirming there are no currently in-progress workers")
     if deployment_status.running > 0 or deployment_status.pending > 0 or deployment_status.desired > 0:
         return CommandResult(False, RfsWorkersInProgress())

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/backfill_rfs.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/backfill_rfs.py
@@ -11,6 +11,7 @@ from console_link.models.client_options import ClientOptions
 from console_link.models.cluster import Cluster, HttpMethod
 from console_link.models.schema_tools import contains_one_of
 from console_link.models.command_result import CommandResult
+from console_link.models.kubectl_runner import DeploymentStatus, KubectlRunner
 from console_link.models.ecs_service import ECSService
 
 from cerberus import Validator
@@ -39,17 +40,26 @@ ECS_RFS_SCHEMA = {
     }
 }
 
+K8S_RFS_SCHEMA = {
+    "type": "dict",
+    "schema": {
+        "namespace": {"type": "string", "required": True},
+        "deployment_name": {"type": "string", "required": True}
+    }
+}
+
 RFS_BACKFILL_SCHEMA = {
     "reindex_from_snapshot": {
         "type": "dict",
         "schema": {
             "docker": DOCKER_RFS_SCHEMA,
             "ecs": ECS_RFS_SCHEMA,
+            "k8s": K8S_RFS_SCHEMA,
             "snapshot_name": {"type": "string", "required": False},
             "snapshot_repo": {"type": "string", "required": False},
             "scale": {"type": "integer", "required": False, "min": 1}
         },
-        "check_with": contains_one_of({'docker', 'ecs'}),
+        "check_with": contains_one_of({'docker', 'ecs', 'k8s'}),
     }
 }
 
@@ -107,6 +117,55 @@ class WorkingIndexDoesntExist(Exception):
         super().__init__(f"The working state index '{index_name}' does not exist")
 
 
+class K8sRFSBackfill(RFSBackfill):
+    def __init__(self, config: Dict, target_cluster: Cluster, client_options: Optional[ClientOptions] = None) -> None:
+        super().__init__(config)
+        self.client_options = client_options
+        self.target_cluster = target_cluster
+        self.default_scale = self.config["reindex_from_snapshot"].get("scale", 5)
+
+        self.k8s_config = self.config["reindex_from_snapshot"]["k8s"]
+        self.namespace = self.k8s_config["namespace"]
+        self.deployment_name = self.k8s_config["deployment_name"]
+        self.kubectl_runner = KubectlRunner(namespace=self.namespace, deployment_name=self.deployment_name)
+
+    def start(self, *args, **kwargs) -> CommandResult:
+        logger.info(f"Starting RFS backfill by setting desired count to {self.default_scale} instances")
+        return self.kubectl_runner.perform_scale_command(replicas=self.default_scale)
+
+    def pause(self, *args, **kwargs) -> CommandResult:
+        logger.info("Pausing RFS backfill by setting desired count to 0 instances")
+        return self.kubectl_runner.perform_scale_command(replicas=0)
+
+    def stop(self, *args, **kwargs) -> CommandResult:
+        logger.info("Stopping RFS backfill by setting desired count to 0 instances")
+        return self.kubectl_runner.perform_scale_command(replicas=0)
+
+    def scale(self, units: int, *args, **kwargs) -> CommandResult:
+        logger.info(f"Scaling RFS backfill by setting desired count to {units} instances")
+        return self.kubectl_runner.perform_scale_command(replicas=units)
+
+    def archive(self, *args, archive_dir_path: str = None, archive_file_name: str = None, **kwargs) -> CommandResult:
+        logger.info("Confirming there are no currently in-progress workers")
+        deployment_status = self.kubectl_runner.retrieve_deployment_status()
+        return perform_archive(target_cluster=self.target_cluster,
+                               deployment_status=deployment_status,
+                               archive_dir_path=archive_dir_path,
+                               archive_file_name=archive_file_name)
+
+    def get_status(self, *args, **kwargs) -> CommandResult:
+        logger.info(f"Getting status of RFS backfill")
+        deployment_status = self.kubectl_runner.retrieve_deployment_status()
+        if not deployment_status:
+            return CommandResult(False, "Failed to get deployment status for RFS backfill")
+        status_str = str(deployment_status)
+        if deployment_status.running > 0:
+            return CommandResult(True, (BackfillStatus.RUNNING, status_str))
+        if deployment_status.desired > 0:
+            return CommandResult(True, (BackfillStatus.STARTING, status_str))
+        return CommandResult(True, (BackfillStatus.STOPPED, status_str))
+
+
 class ECSRFSBackfill(RFSBackfill):
     def __init__(self, config: Dict, target_cluster: Cluster, client_options: Optional[ClientOptions] = None) -> None:
         super().__init__(config)
@@ -139,27 +198,10 @@ class ECSRFSBackfill(RFSBackfill):
     def archive(self, *args, archive_dir_path: str = None, archive_file_name: str = None, **kwargs) -> CommandResult:
         logger.info("Confirming there are no currently in-progress workers")
         status = self.ecs_client.get_instance_statuses()
-        if status.running > 0 or status.pending > 0 or status.desired > 0:
-            return CommandResult(False, RfsWorkersInProgress())
-        
-        try:
-            backup_path = get_working_state_index_backup_path(archive_dir_path, archive_file_name)
-            logger.info(f"Backing up working state index to {backup_path}")
-            backup_working_state_index(self.target_cluster, WORKING_STATE_INDEX, backup_path)
-            logger.info("Working state index backed up successful")
-
-            logger.info("Cleaning up working state index on target cluster")
-            self.target_cluster.call_api(
-                f"/{WORKING_STATE_INDEX}",
-                method=HttpMethod.DELETE,
-                params={"ignore_unavailable": "true"}
-            )
-            logger.info("Working state index cleaned up successful")
-            return CommandResult(True, backup_path)
-        except requests.HTTPError as e:
-            if e.response.status_code == 404:
-                return CommandResult(False, WorkingIndexDoesntExist(WORKING_STATE_INDEX))
-            return CommandResult(False, e)
+        return perform_archive(target_cluster=self.target_cluster,
+                               deployment_status=status,
+                               archive_dir_path=archive_dir_path,
+                               archive_file_name=archive_file_name)
 
     def get_status(self, deep_check: bool, *args, **kwargs) -> CommandResult:
         logger.info(f"Getting status of RFS backfill, with {deep_check=}")
@@ -233,6 +275,31 @@ class ECSRFSBackfill(RFSBackfill):
                            f" sum to the incomplete ({values['incomplete']}) shards." + disclaimer)
 
         return "\n".join([f"Work items {key}: {value}" for key, value in values.items() if value is not None])
+
+
+def perform_archive(target_cluster: Cluster, deployment_status: DeploymentStatus, archive_dir_path: str = None, archive_file_name: str = None) -> CommandResult:
+    logger.info("Confirming there are no currently in-progress workers")
+    if deployment_status.running > 0 or deployment_status.pending > 0 or deployment_status.desired > 0:
+        return CommandResult(False, RfsWorkersInProgress())
+
+    try:
+        backup_path = get_working_state_index_backup_path(archive_dir_path, archive_file_name)
+        logger.info(f"Backing up working state index to {backup_path}")
+        backup_working_state_index(target_cluster, WORKING_STATE_INDEX, backup_path)
+        logger.info("Working state index backed up successful")
+
+        logger.info("Cleaning up working state index on target cluster")
+        target_cluster.call_api(
+            f"/{WORKING_STATE_INDEX}",
+            method=HttpMethod.DELETE,
+            params={"ignore_unavailable": "true"}
+        )
+        logger.info("Working state index cleaned up successful")
+        return CommandResult(True, backup_path)
+    except requests.HTTPError as e:
+        if e.response.status_code == 404:
+            return CommandResult(False, WorkingIndexDoesntExist(WORKING_STATE_INDEX))
+        return CommandResult(False, e)
 
 
 def get_working_state_index_backup_path(archive_dir_path: str = None, archive_file_name: str = None) -> str:

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/backfill_rfs.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/backfill_rfs.py
@@ -169,7 +169,7 @@ class K8sRFSBackfill(RFSBackfill):
                 status_str += f"\n{shard_status}"
         if deployment_status.running > 0:
             return CommandResult(True, (BackfillStatus.RUNNING, status_str))
-        if deployment_status.desired > 0:
+        if deployment_status.pending > 0:
             return CommandResult(True, (BackfillStatus.STARTING, status_str))
         return CommandResult(True, (BackfillStatus.STOPPED, status_str))
 

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/command_result.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/command_result.py
@@ -1,3 +1,4 @@
+from subprocess import CompletedProcess
 from typing import Generic, TypeVar
 from dataclasses import dataclass
 
@@ -8,6 +9,7 @@ T = TypeVar('T')
 class CommandResult(Generic[T]):
     success: bool
     value: T | Exception | None
+    output: CompletedProcess | None = None
 
     def display(self) -> str:
         if self.value:

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/command_runner.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/command_runner.py
@@ -1,10 +1,10 @@
 import subprocess
 import os
 import logging
+import sys
 from typing import Any, Dict, List, Optional
 
 from console_link.models.command_result import CommandResult
-
 
 logger = logging.getLogger(__name__)
 
@@ -27,10 +27,10 @@ class CommandRunner:
         self.run_as_detached = run_as_detatched
         self.log_file = log_file
 
-    def run(self) -> CommandResult:
+    def run(self, print_to_console=True) -> CommandResult:
         if self.run_as_detached:
             return self._run_as_detached_process(self.log_file)
-        return self._run_as_synchronous_process()
+        return self._run_as_synchronous_process(print_to_console=print_to_console)
 
     def sanitized_command(self) -> List[str]:
         if not self.sensitive_fields:
@@ -44,11 +44,16 @@ class CommandRunner:
                     display_command[field_index + 1] = "*" * 8
         return display_command
 
-    def _run_as_synchronous_process(self) -> CommandResult:
+    def _run_as_synchronous_process(self, print_to_console: bool) -> CommandResult:
         try:
             # Pass None to stdout and stderr to not capture output and show in terminal
-            subprocess.run(self.command, stdout=None, stderr=None, text=True, check=True)
-            return CommandResult(success=True, value="Command executed successfully")
+            # output = subprocess.run(self.command, stdout=None, stderr=None, capture_output=True, text=True, check=True)
+            # return CommandResult(success=True, value="Command executed successfully", output=output)
+            cmd_output = subprocess.run(self.command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, check=True)
+            if print_to_console:
+                sys.stdout.write(cmd_output.stdout)
+                sys.stderr.write(cmd_output.stderr)
+            return CommandResult(success=True, value="Command executed successfully", output=cmd_output)
         except subprocess.CalledProcessError as e:
             raise CommandRunnerError(e.returncode, self.sanitized_command(), e.stderr, self)
 

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/command_runner.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/command_runner.py
@@ -46,10 +46,11 @@ class CommandRunner:
 
     def _run_as_synchronous_process(self, print_to_console: bool) -> CommandResult:
         try:
-            # Pass None to stdout and stderr to not capture output and show in terminal
-            # output = subprocess.run(self.command, stdout=None, stderr=None, capture_output=True, text=True, check=True)
-            # return CommandResult(success=True, value="Command executed successfully", output=output)
-            cmd_output = subprocess.run(self.command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, check=True)
+            cmd_output = subprocess.run(self.command,
+                                        stdout=subprocess.PIPE,
+                                        stderr=subprocess.PIPE,
+                                        text=True,
+                                        check=True)
             if print_to_console:
                 sys.stdout.write(cmd_output.stdout)
                 sys.stderr.write(cmd_output.stderr)

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/command_runner.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/command_runner.py
@@ -52,8 +52,10 @@ class CommandRunner:
                                         text=True,
                                         check=True)
             if print_to_console:
-                sys.stdout.write(cmd_output.stdout)
-                sys.stderr.write(cmd_output.stderr)
+                if cmd_output.stdout:
+                    sys.stdout.write(cmd_output.stdout)
+                if cmd_output.stderr:
+                    sys.stderr.write(cmd_output.stderr)
             return CommandResult(success=True, value="Command executed successfully", output=cmd_output)
         except subprocess.CalledProcessError as e:
             raise CommandRunnerError(e.returncode, self.sanitized_command(), e.stderr, self)

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/ecs_service.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/ecs_service.py
@@ -1,19 +1,10 @@
 import logging
-from typing import NamedTuple, Optional
+from typing import Optional
 
 from console_link.models.command_result import CommandResult
-from console_link.models.utils import AWSAPIError, raise_for_aws_api_error, create_boto3_client
+from console_link.models.utils import AWSAPIError, DeploymentStatus, raise_for_aws_api_error, create_boto3_client
 
 logger = logging.getLogger(__name__)
-
-
-class InstanceStatuses(NamedTuple):
-    running: int = 0
-    pending: int = 0
-    desired: int = 0
-
-    def __str__(self):
-        return f"Running={self.running}\nPending={self.pending}\nDesired={self.desired}"
 
 
 class ECSService:
@@ -47,7 +38,7 @@ class ECSService:
         return CommandResult(True, f"Service {self.service_name} set to {desired_count} desired count."
                              f" Currently {running_count} running and {pending_count} pending.")
 
-    def get_instance_statuses(self) -> Optional[InstanceStatuses]:
+    def get_instance_statuses(self) -> Optional[DeploymentStatus]:
         logger.info(f"Getting instance statuses for service {self.service_name}")
         response = self.client.describe_services(
             cluster=self.cluster_name,
@@ -60,7 +51,7 @@ class ECSService:
             return None
 
         service = response["services"][0]
-        return InstanceStatuses(
+        return DeploymentStatus(
             running=service["runningCount"],
             pending=service["pendingCount"],
             desired=service["desiredCount"]

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/factories.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/factories.py
@@ -3,10 +3,11 @@ from typing import Dict, Optional
 
 from console_link.models.client_options import ClientOptions
 from console_link.models.replayer_docker import DockerReplayer
+from console_link.models.replayer_k8s import K8sReplayer
 from console_link.models.metrics_source import CloudwatchMetricsSource, PrometheusMetricsSource
 from console_link.models.backfill_base import Backfill
 from console_link.models.backfill_osi import OpenSearchIngestionBackfill
-from console_link.models.backfill_rfs import DockerRFSBackfill, ECSRFSBackfill
+from console_link.models.backfill_rfs import DockerRFSBackfill, ECSRFSBackfill, K8sRFSBackfill
 from console_link.models.cluster import Cluster
 from console_link.models.kafka import MSK, StandardKafka
 from console_link.models.replayer_ecs import ECSReplayer
@@ -61,6 +62,8 @@ def get_replayer(config: Dict, client_options: Optional[ClientOptions] = None):
         return ECSReplayer(config=config, client_options=client_options)
     if 'docker' in config:
         return DockerReplayer(config)
+    if 'k8s' in config:
+        return K8sReplayer(config=config, client_options=client_options)
     logger.error(f"An unsupported replayer type was provided: {config.keys()}")
     raise UnsupportedReplayerError(next(iter(config.keys())))
 
@@ -98,6 +101,11 @@ def get_backfill(config: Dict, source_cluster: Optional[Cluster], target_cluster
         elif 'ecs' in config[BackfillType.reindex_from_snapshot.name]:
             logger.debug("Creating ECS RFS backfill instance")
             return ECSRFSBackfill(config=config,
+                                  target_cluster=target_cluster,
+                                  client_options=client_options)
+        elif 'k8s' in config[BackfillType.reindex_from_snapshot.name]:
+            logger.debug("Creating K8s RFS backfill instance")
+            return K8sRFSBackfill(config=config,
                                   target_cluster=target_cluster,
                                   client_options=client_options)
 

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/kubectl_runner.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/kubectl_runner.py
@@ -1,0 +1,58 @@
+import json
+import logging
+
+from typing import Optional
+
+from console_link.models.command_result import CommandResult
+from console_link.models.command_runner import CommandRunner,CommandRunnerError,FlagOnlyArgument
+from console_link.models.utils import DeploymentStatus
+
+logger = logging.getLogger(__name__)
+
+
+class KubectlRunner:
+    def __init__(self, namespace: str, deployment_name: str):
+        self.namespace = namespace
+        self.deployment_name = deployment_name
+
+    def perform_scale_command(self, replicas: int) -> CommandResult:
+        command = "kubectl"
+        args = {
+            "-n": f"{self.namespace}",
+            "scale": FlagOnlyArgument,
+            "deployment": f"{self.deployment_name}",
+            "--replicas": f"{replicas}"
+        }
+        command_runner = CommandRunner(command_root=command, command_args=args)
+        try:
+            command_runner.run(print_to_console=False)
+            return CommandResult(True, f"The {self.deployment_name} deployment has been set to {replicas} desired count.")
+        except CommandRunnerError as e:
+            logger.error(f"Performing kubectl command to set replica count failed: {e}")
+            return CommandResult(success=False, value=f"Kubernetes command failed: {e}")
+
+    def retrieve_deployment_status(self) -> Optional[DeploymentStatus]:
+        command = "kubectl"
+        args = {
+            "-n": f"{self.namespace}",
+            "get": FlagOnlyArgument,
+            "deployment": FlagOnlyArgument,
+            self.deployment_name: FlagOnlyArgument,
+            "-o": "json"
+        }
+        command_runner = CommandRunner(command_root=command, command_args=args)
+        try:
+            cmd_result = command_runner.run(print_to_console=False)
+            json_output = json.loads(cmd_result.output.stdout)
+            desired = int(json_output["spec"]["replicas"])
+            running = int(json_output["status"].get("readyReplicas", "0"))
+            pending = (desired - running) if desired > running else 0
+            return DeploymentStatus(
+                running=running,
+                pending=pending,
+                desired=desired
+            )
+        except Exception as e:
+            logger.error(f"Performing kubectl command to get deployment status failed: {e}")
+            return None
+

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/kubectl_runner.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/kubectl_runner.py
@@ -4,7 +4,7 @@ import logging
 from typing import Optional
 
 from console_link.models.command_result import CommandResult
-from console_link.models.command_runner import CommandRunner,CommandRunnerError,FlagOnlyArgument
+from console_link.models.command_runner import CommandRunner, CommandRunnerError, FlagOnlyArgument
 from console_link.models.utils import DeploymentStatus
 
 logger = logging.getLogger(__name__)
@@ -26,7 +26,8 @@ class KubectlRunner:
         command_runner = CommandRunner(command_root=command, command_args=args)
         try:
             command_runner.run(print_to_console=False)
-            return CommandResult(True, f"The {self.deployment_name} deployment has been set to {replicas} desired count.")
+            return CommandResult(True, f"The {self.deployment_name} deployment has been set "
+                                       f"to {replicas} desired count.")
         except CommandRunnerError as e:
             logger.error(f"Performing kubectl command to set replica count failed: {e}")
             return CommandResult(success=False, value=f"Kubernetes command failed: {e}")
@@ -55,4 +56,3 @@ class KubectlRunner:
         except Exception as e:
             logger.error(f"Performing kubectl command to get deployment status failed: {e}")
             return None
-

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/replayer_base.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/replayer_base.py
@@ -24,15 +24,24 @@ ECS_REPLAY_SCHEMA = {
     }
 }
 
+K8S_REPLAY_SCHEMA = {
+    "type": "dict",
+    "schema": {
+        "namespace": {"type": "string", "required": True},
+        "deployment_name": {"type": "string", "required": True}
+    }
+}
+
 SCHEMA = {
     "replay": {
         "type": "dict",
         "schema": {
             "docker": DOCKER_REPLAY_SCHEMA,
             "ecs": ECS_REPLAY_SCHEMA,
+            "k8s": K8S_REPLAY_SCHEMA,
             "scale": {"type": "integer", "required": False, "min": 1}
         },
-        "check_with": contains_one_of({"docker", "ecs"})
+        "check_with": contains_one_of({"docker", "ecs", "k8s"})
     }
 }
 

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/replayer_k8s.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/replayer_k8s.py
@@ -1,0 +1,45 @@
+from typing import Dict, Optional
+from console_link.models.client_options import ClientOptions
+from console_link.models.command_result import CommandResult
+from console_link.models.kubectl_runner import DeploymentStatus, KubectlRunner
+from console_link.models.replayer_base import Replayer, ReplayStatus
+
+import json
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class K8sReplayer(Replayer):
+    def __init__(self, config: Dict, client_options: Optional[ClientOptions] = None) -> None:
+        super().__init__(config)
+        self.client_options = client_options
+        self.k8s_config = self.config["k8s"]
+        self.namespace = self.k8s_config["namespace"]
+        self.deployment_name = self.k8s_config["deployment_name"]
+        self.kubectl_runner = KubectlRunner(namespace=self.namespace, deployment_name=self.deployment_name)
+
+    def start(self, *args, **kwargs) -> CommandResult:
+        logger.info(f"Starting K8s replayer by setting desired count to {self.default_scale} instances")
+        return self.kubectl_runner.perform_scale_command(replicas=self.default_scale)
+
+    def stop(self, *args, **kwargs) -> CommandResult:
+        logger.info("Stopping K8s replayer by setting desired count to 0 instances")
+        return self.kubectl_runner.perform_scale_command(replicas=0)
+
+    def get_status(self, *args, **kwargs) -> CommandResult:
+        logger.info("Getting status of K8s replayer")
+        deployment_status = self.kubectl_runner.retrieve_deployment_status()
+        if not deployment_status:
+            return CommandResult(False, "Failed to get deployment status for Replayer")
+        status_str = str(deployment_status)
+        if deployment_status.running > 0:
+            return CommandResult(True, (ReplayStatus.RUNNING, status_str))
+        if deployment_status.desired > 0:
+            return CommandResult(True, (ReplayStatus.STARTING, status_str))
+        return CommandResult(True, (ReplayStatus.STOPPED, status_str))
+
+
+    def scale(self, units: int, *args, **kwargs) -> CommandResult:
+        logger.info(f"Scaling K8s replayer by setting desired count to {units} instances")
+        return self.kubectl_runner.perform_scale_command(replicas=units)

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/replayer_k8s.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/replayer_k8s.py
@@ -1,10 +1,9 @@
 from typing import Dict, Optional
 from console_link.models.client_options import ClientOptions
 from console_link.models.command_result import CommandResult
-from console_link.models.kubectl_runner import DeploymentStatus, KubectlRunner
+from console_link.models.kubectl_runner import KubectlRunner
 from console_link.models.replayer_base import Replayer, ReplayStatus
 
-import json
 import logging
 
 logger = logging.getLogger(__name__)
@@ -38,7 +37,6 @@ class K8sReplayer(Replayer):
         if deployment_status.desired > 0:
             return CommandResult(True, (ReplayStatus.STARTING, status_str))
         return CommandResult(True, (ReplayStatus.STOPPED, status_str))
-
 
     def scale(self, units: int, *args, **kwargs) -> CommandResult:
         logger.info(f"Scaling K8s replayer by setting desired count to {units} instances")

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/utils.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/utils.py
@@ -1,6 +1,6 @@
 from botocore import config
 from enum import Enum
-from typing import Dict, Optional
+from typing import Dict, NamedTuple, Optional
 from datetime import datetime
 import boto3
 import requests.utils
@@ -10,6 +10,15 @@ from requests.models import PreparedRequest
 
 
 from console_link.models.client_options import ClientOptions
+
+
+class DeploymentStatus(NamedTuple):
+    running: int = 0
+    pending: int = 0
+    desired: int = 0
+
+    def __str__(self):
+        return f"Running={self.running}\nPending={self.pending}\nDesired={self.desired}"
 
 
 class AWSAPIError(Exception):

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/data/kubectl_describe_deployment_output.json
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/data/kubectl_describe_deployment_output.json
@@ -1,0 +1,274 @@
+{
+  "apiVersion": "apps/v1",
+  "kind": "Deployment",
+  "metadata": {
+    "annotations": {
+      "deployment.kubernetes.io/revision": "1",
+      "meta.helm.sh/release-name": "ma",
+      "meta.helm.sh/release-namespace": "ma"
+    },
+    "creationTimestamp": "2025-02-17T21:27:22Z",
+    "generation": 2,
+    "labels": {
+      "app.kubernetes.io/managed-by": "Helm"
+    },
+    "name": "ma-replayer",
+    "namespace": "ma",
+    "resourceVersion": "160936",
+    "uid": "c1ee2ce4-9245-4380-bc67-317d3d1d12b3"
+  },
+  "spec": {
+    "progressDeadlineSeconds": 600,
+    "replicas": 1,
+    "revisionHistoryLimit": 10,
+    "selector": {
+      "matchLabels": {
+        "app": "ma-replayer"
+      }
+    },
+    "strategy": {
+      "rollingUpdate": {
+        "maxSurge": "25%",
+        "maxUnavailable": "25%"
+      },
+      "type": "RollingUpdate"
+    },
+    "template": {
+      "metadata": {
+        "creationTimestamp": null,
+        "labels": {
+          "app": "ma-replayer",
+          "env": "v1"
+        }
+      },
+      "spec": {
+        "containers": [
+          {
+            "command": [
+              "/bin/sh",
+              "-c",
+              "echo cat /shared/vars.sh...\ncat /shared/vars.sh\nsource /shared/vars.sh\n# Remove leading or trailing space in args file\nsed -i 's/^[ \\t]*//;s/[ \\t]*$//' /shared/args.txt\nreadarray -t arg_array \u003c /shared/args.txt\necho \"Using args from file: ${arg_array[@]}\"\nexec /runJavaWithClasspath.sh org.opensearch.migrations.replay.TrafficReplayer \"${arg_array[@]}\"\n"
+            ],
+            "image": "migrations/traffic_replayer:latest",
+            "imagePullPolicy": "IfNotPresent",
+            "name": "replayer",
+            "resources": {},
+            "terminationMessagePath": "/dev/termination-log",
+            "terminationMessagePolicy": "File",
+            "volumeMounts": [
+              {
+                "mountPath": "/shared",
+                "name": "env-vars"
+              }
+            ]
+          }
+        ],
+        "dnsPolicy": "ClusterFirst",
+        "initContainers": [
+          {
+            "command": [
+              "/bin/sh",
+              "-c",
+              "\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\nset -e\nif [ -z \"$AUTH_HEADER_VALUE\" ]; then\n  export AUTH_HEADER_VALUE=\"$AUTH_HEADER_VALUE_DEFAULT\"\nfi\nif [ -z \"$INSECURE\" ]; then\n  export INSECURE=\"$INSECURE_DEFAULT\"\nfi\nif [ -z \"$KAFKA_TRAFFIC_BROKERS\" ]; then\n  export KAFKA_TRAFFIC_BROKERS=\"$KAFKA_TRAFFIC_BROKERS_DEFAULT\"\nfi\nif [ -z \"$KAFKA_TRAFFIC_GROUP_ID\" ]; then\n  export KAFKA_TRAFFIC_GROUP_ID=\"$KAFKA_TRAFFIC_GROUP_ID_DEFAULT\"\nfi\nif [ -z \"$KAFKA_TRAFFIC_TOPIC\" ]; then\n  export KAFKA_TRAFFIC_TOPIC=\"$KAFKA_TRAFFIC_TOPIC_DEFAULT\"\nfi\nif [ -z \"$SPEEDUP_FACTOR\" ]; then\n  export SPEEDUP_FACTOR=\"$SPEEDUP_FACTOR_DEFAULT\"\nfi\nif [ -z \"$TARGET_URI\" ]; then\n  export TARGET_URI=\"$TARGET_URI_DEFAULT\"\nfi\nif [ -n \"$AUTH_HEADER_VALUE\" ]; then\n  export ARGS=\"$ARGS  --authHeaderValue  $AUTH_HEADER_VALUE\"\n  echo \" --authHeaderValue \n$AUTH_HEADER_VALUE\" \u003e\u003e /shared/args.txt\nfi\nif [ \"$INSECURE\" = \"true\" ] || [ \"$INSECURE\" = \"1\" ]; then\n  export ARGS=\"$ARGS  --insecure \"\n  echo \" --insecure \" \u003e\u003e /shared/args.txt\nfi\nif [ -n \"$KAFKA_TRAFFIC_BROKERS\" ]; then\n  export ARGS=\"$ARGS  --kafkaTrafficBrokers  $KAFKA_TRAFFIC_BROKERS\"\n  echo \" --kafkaTrafficBrokers \n$KAFKA_TRAFFIC_BROKERS\" \u003e\u003e /shared/args.txt\nfi\nif [ -n \"$KAFKA_TRAFFIC_GROUP_ID\" ]; then\n  export ARGS=\"$ARGS  --kafkaTrafficGroupId  $KAFKA_TRAFFIC_GROUP_ID\"\n  echo \" --kafkaTrafficGroupId \n$KAFKA_TRAFFIC_GROUP_ID\" \u003e\u003e /shared/args.txt\nfi\nif [ -n \"$KAFKA_TRAFFIC_TOPIC\" ]; then\n  export ARGS=\"$ARGS  --kafkaTrafficTopic  $KAFKA_TRAFFIC_TOPIC\"\n  echo \" --kafkaTrafficTopic \n$KAFKA_TRAFFIC_TOPIC\" \u003e\u003e /shared/args.txt\nfi\nif [ -n \"$SPEEDUP_FACTOR\" ]; then\n  export ARGS=\"$ARGS  --speedupFactor  $SPEEDUP_FACTOR\"\n  echo \" --speedupFactor \n$SPEEDUP_FACTOR\" \u003e\u003e /shared/args.txt\nfi\nprintf \"$TARGET_URI\n$(cat /shared/args.txt)\" \u003e \"/shared/args.txt\"\nexport ARGS=\" $TARGET_URI $ARGS\"\n/.venv/bin/python print_env_vars_as_exports.py \u003e /shared/vars.sh\n"
+            ],
+            "env": [
+              {
+                "name": "AUTH_HEADER_VALUE_DEFAULT",
+                "valueFrom": {
+                  "configMapKeyRef": {
+                    "key": "basicAuthHeader",
+                    "name": "target-cluster-default"
+                  }
+                }
+              },
+              {
+                "name": "AUTH_HEADER_VALUE",
+                "valueFrom": {
+                  "configMapKeyRef": {
+                    "key": "basicAuthHeader",
+                    "name": "target-cluster",
+                    "optional": true
+                  }
+                }
+              },
+              {
+                "name": "INSECURE_DEFAULT",
+                "valueFrom": {
+                  "configMapKeyRef": {
+                    "key": "allowInsecure",
+                    "name": "target-cluster-default"
+                  }
+                }
+              },
+              {
+                "name": "INSECURE",
+                "valueFrom": {
+                  "configMapKeyRef": {
+                    "key": "allowInsecure",
+                    "name": "target-cluster",
+                    "optional": true
+                  }
+                }
+              },
+              {
+                "name": "KAFKA_TRAFFIC_BROKERS_DEFAULT",
+                "valueFrom": {
+                  "configMapKeyRef": {
+                    "key": "brokers",
+                    "name": "kafka-brokers-default"
+                  }
+                }
+              },
+              {
+                "name": "KAFKA_TRAFFIC_BROKERS",
+                "valueFrom": {
+                  "configMapKeyRef": {
+                    "key": "brokers",
+                    "name": "kafka-brokers",
+                    "optional": true
+                  }
+                }
+              },
+              {
+                "name": "KAFKA_TRAFFIC_GROUP_ID_DEFAULT",
+                "valueFrom": {
+                  "configMapKeyRef": {
+                    "key": "value",
+                    "name": "ma-replayer-kafka-traffic-group-id-default"
+                  }
+                }
+              },
+              {
+                "name": "KAFKA_TRAFFIC_GROUP_ID",
+                "valueFrom": {
+                  "configMapKeyRef": {
+                    "key": "value",
+                    "name": "ma-replayer-kafka-traffic-group-id",
+                    "optional": true
+                  }
+                }
+              },
+              {
+                "name": "KAFKA_TRAFFIC_TOPIC_DEFAULT",
+                "valueFrom": {
+                  "configMapKeyRef": {
+                    "key": "value",
+                    "name": "ma-replayer-kafka-traffic-topic-default"
+                  }
+                }
+              },
+              {
+                "name": "KAFKA_TRAFFIC_TOPIC",
+                "valueFrom": {
+                  "configMapKeyRef": {
+                    "key": "value",
+                    "name": "ma-replayer-kafka-traffic-topic",
+                    "optional": true
+                  }
+                }
+              },
+              {
+                "name": "SPEEDUP_FACTOR_DEFAULT",
+                "valueFrom": {
+                  "configMapKeyRef": {
+                    "key": "value",
+                    "name": "ma-replayer-speedup-factor-default"
+                  }
+                }
+              },
+              {
+                "name": "SPEEDUP_FACTOR",
+                "valueFrom": {
+                  "configMapKeyRef": {
+                    "key": "value",
+                    "name": "ma-replayer-speedup-factor",
+                    "optional": true
+                  }
+                }
+              },
+              {
+                "name": "TARGET_URI_DEFAULT",
+                "valueFrom": {
+                  "configMapKeyRef": {
+                    "key": "endpoint",
+                    "name": "target-cluster-default"
+                  }
+                }
+              },
+              {
+                "name": "TARGET_URI",
+                "valueFrom": {
+                  "configMapKeyRef": {
+                    "key": "endpoint",
+                    "name": "target-cluster",
+                    "optional": true
+                  }
+                }
+              }
+            ],
+            "image": "migrations/k8s_config_map_util_scripts",
+            "imagePullPolicy": "IfNotPresent",
+            "name": "arg-prep",
+            "resources": {},
+            "terminationMessagePath": "/dev/termination-log",
+            "terminationMessagePolicy": "File",
+            "volumeMounts": [
+              {
+                "mountPath": "/shared",
+                "name": "env-vars"
+              }
+            ]
+          },
+          {
+            "command": [
+              "sh",
+              "-c",
+              "until kubectl wait --for=condition=Ready kafka/captured-traffic -n ma --timeout=10s; do echo waiting for kafka cluster is ready; sleep 1; done"
+            ],
+            "image": "bitnami/kubectl:latest",
+            "imagePullPolicy": "Always",
+            "name": "wait-for-kafka",
+            "resources": {},
+            "terminationMessagePath": "/dev/termination-log",
+            "terminationMessagePolicy": "File"
+          }
+        ],
+        "restartPolicy": "Always",
+        "schedulerName": "default-scheduler",
+        "securityContext": {},
+        "terminationGracePeriodSeconds": 30,
+        "volumes": [
+          {
+            "emptyDir": {},
+            "name": "env-vars"
+          }
+        ]
+      }
+    }
+  },
+  "status": {
+    "availableReplicas": 1,
+    "conditions": [
+      {
+        "lastTransitionTime": "2025-02-17T21:27:22Z",
+        "lastUpdateTime": "2025-02-17T21:27:22Z",
+        "message": "ReplicaSet \"ma-replayer-68f4c8475b\" has successfully progressed.",
+        "reason": "NewReplicaSetAvailable",
+        "status": "True",
+        "type": "Progressing"
+      },
+      {
+        "lastTransitionTime": "2025-02-17T21:30:13Z",
+        "lastUpdateTime": "2025-02-17T21:30:13Z",
+        "message": "Deployment has minimum availability.",
+        "reason": "MinimumReplicasAvailable",
+        "status": "True",
+        "type": "Available"
+      }
+    ],
+    "observedGeneration": 2,
+    "readyReplicas": 1,
+    "replicas": 1,
+    "updatedReplicas": 1
+  }
+}

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/test_backfill.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/test_backfill.py
@@ -12,8 +12,9 @@ from console_link.models.backfill_base import Backfill, BackfillStatus
 from console_link.models.backfill_osi import OpenSearchIngestionBackfill
 from console_link.models.backfill_rfs import (DockerRFSBackfill, ECSRFSBackfill, RfsWorkersInProgress,
                                               WorkingIndexDoesntExist)
-from console_link.models.ecs_service import ECSService, InstanceStatuses
+from console_link.models.ecs_service import ECSService
 from console_link.models.factories import UnsupportedBackfillTypeError, get_backfill
+from console_link.models.utils import DeploymentStatus
 from tests.utils import create_valid_cluster
 
 TEST_DATA_DIRECTORY = pathlib.Path(__file__).parent / "data"
@@ -210,7 +211,7 @@ def test_ecs_rfs_backfill_scale_sets_ecs_desired_count(ecs_rfs_backfill, mocker)
 
 
 def test_ecs_rfs_backfill_status_gets_ecs_instance_statuses(ecs_rfs_backfill, mocker):
-    mocked_instance_status = InstanceStatuses(
+    mocked_instance_status = DeploymentStatus(
         desired=3,
         running=1,
         pending=2
@@ -225,7 +226,7 @@ def test_ecs_rfs_backfill_status_gets_ecs_instance_statuses(ecs_rfs_backfill, mo
 
 
 def test_ecs_rfs_calculates_backfill_status_from_ecs_instance_statuses_stopped(ecs_rfs_backfill, mocker):
-    mocked_stopped_status = InstanceStatuses(
+    mocked_stopped_status = DeploymentStatus(
         desired=8,
         running=0,
         pending=0
@@ -240,7 +241,7 @@ def test_ecs_rfs_calculates_backfill_status_from_ecs_instance_statuses_stopped(e
 
 
 def test_ecs_rfs_calculates_backfill_status_from_ecs_instance_statuses_starting(ecs_rfs_backfill, mocker):
-    mocked_starting_status = InstanceStatuses(
+    mocked_starting_status = DeploymentStatus(
         desired=8,
         running=0,
         pending=6
@@ -255,7 +256,7 @@ def test_ecs_rfs_calculates_backfill_status_from_ecs_instance_statuses_starting(
 
 
 def test_ecs_rfs_calculates_backfill_status_from_ecs_instance_statuses_running(ecs_rfs_backfill, mocker):
-    mocked_running_status = InstanceStatuses(
+    mocked_running_status = DeploymentStatus(
         desired=1,
         running=3,
         pending=1
@@ -271,7 +272,7 @@ def test_ecs_rfs_calculates_backfill_status_from_ecs_instance_statuses_running(e
 
 def test_ecs_rfs_get_status_deep_check(ecs_rfs_backfill, mocker):
     target = create_valid_cluster()
-    mocked_instance_status = InstanceStatuses(
+    mocked_instance_status = DeploymentStatus(
         desired=1,
         running=1,
         pending=0
@@ -295,7 +296,7 @@ def test_ecs_rfs_get_status_deep_check(ecs_rfs_backfill, mocker):
 
 
 def test_ecs_rfs_deep_status_check_failure(ecs_rfs_backfill, mocker, caplog):
-    mocked_instance_status = InstanceStatuses(
+    mocked_instance_status = DeploymentStatus(
         desired=1,
         running=1,
         pending=0
@@ -312,7 +313,7 @@ def test_ecs_rfs_deep_status_check_failure(ecs_rfs_backfill, mocker, caplog):
 
 
 def test_ecs_rfs_backfill_archive_as_expected(ecs_rfs_backfill, mocker, tmpdir):
-    mocked_instance_status = InstanceStatuses(
+    mocked_instance_status = DeploymentStatus(
         desired=0,
         running=0,
         pending=0
@@ -340,7 +341,7 @@ def test_ecs_rfs_backfill_archive_as_expected(ecs_rfs_backfill, mocker, tmpdir):
 
 
 def test_ecs_rfs_backfill_archive_no_index_as_expected(ecs_rfs_backfill, mocker, tmpdir):
-    mocked_instance_status = InstanceStatuses(
+    mocked_instance_status = DeploymentStatus(
         desired=0,
         running=0,
         pending=0
@@ -361,7 +362,7 @@ def test_ecs_rfs_backfill_archive_no_index_as_expected(ecs_rfs_backfill, mocker,
 
 
 def test_ecs_rfs_backfill_archive_errors_if_in_progress(ecs_rfs_backfill, mocker):
-    mocked_instance_status = InstanceStatuses(
+    mocked_instance_status = DeploymentStatus(
         desired=3,
         running=1,
         pending=2

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/test_backfill_rfs_k8s.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/test_backfill_rfs_k8s.py
@@ -1,0 +1,244 @@
+import json
+import os
+import pathlib
+from unittest.mock import ANY
+
+import pytest
+import requests
+import requests_mock
+
+from console_link.models.cluster import Cluster, HttpMethod
+from console_link.models.backfill_base import Backfill, BackfillStatus
+from console_link.models.backfill_rfs import (K8sRFSBackfill, RfsWorkersInProgress, WorkingIndexDoesntExist)
+from console_link.models.factories import get_backfill
+from console_link.models.kubectl_runner import KubectlRunner
+
+from console_link.models.utils import DeploymentStatus
+from tests.utils import create_valid_cluster
+
+
+TEST_DATA_DIRECTORY = pathlib.Path(__file__).parent / "data"
+
+
+@pytest.fixture
+def k8s_rfs_backfill():
+    k8s_rfs_config = {
+        "reindex_from_snapshot": {
+            "k8s": {
+                "namespace": "ma",
+                "deployment_name": "ma-reindex-from-snapshot"
+            }
+        }
+    }
+    return get_backfill(k8s_rfs_config, None, target_cluster=create_valid_cluster())
+
+
+def test_get_backfill_valid_k8s_rfs(k8s_rfs_backfill):
+    assert isinstance(k8s_rfs_backfill, K8sRFSBackfill)
+    assert isinstance(k8s_rfs_backfill, Backfill)
+
+
+def test_k8s_rfs_backfill_start_sets_desired_count(k8s_rfs_backfill, mocker):
+    assert k8s_rfs_backfill.default_scale == 5
+    mock = mocker.patch.object(KubectlRunner, 'perform_scale_command', autospec=True)
+    k8s_rfs_backfill.start()
+
+    assert isinstance(k8s_rfs_backfill, K8sRFSBackfill)
+    mock.assert_called_once_with(k8s_rfs_backfill.kubectl_runner, 5)
+
+
+def test_k8s_rfs_backfill_pause_sets_desired_count(k8s_rfs_backfill, mocker):
+    assert k8s_rfs_backfill.default_scale == 5
+    mock = mocker.patch.object(KubectlRunner, 'perform_scale_command', autospec=True)
+    k8s_rfs_backfill.pause()
+
+    assert isinstance(k8s_rfs_backfill, K8sRFSBackfill)
+    mock.assert_called_once_with(k8s_rfs_backfill.kubectl_runner, 0)
+
+
+def test_k8s_rfs_backfill_stop_sets_desired_count(k8s_rfs_backfill, mocker):
+    assert k8s_rfs_backfill.default_scale == 5
+    mock = mocker.patch.object(KubectlRunner, 'perform_scale_command', autospec=True)
+    k8s_rfs_backfill.stop()
+
+    assert isinstance(k8s_rfs_backfill, K8sRFSBackfill)
+    mock.assert_called_once_with(k8s_rfs_backfill.kubectl_runner, 0)
+
+
+def test_k8s_rfs_backfill_scale_sets_desired_count(k8s_rfs_backfill, mocker):
+    mock = mocker.patch.object(KubectlRunner, 'perform_scale_command', autospec=True)
+    k8s_rfs_backfill.scale(3)
+
+    assert isinstance(k8s_rfs_backfill, K8sRFSBackfill)
+    mock.assert_called_once_with(k8s_rfs_backfill.kubectl_runner, 3)
+
+
+def test_k8s_rfs_backfill_status_gets_deployment_status(k8s_rfs_backfill, mocker):
+    mocked_instance_status = DeploymentStatus(
+        desired=3,
+        running=1,
+        pending=2
+    )
+    mock = mocker.patch.object(KubectlRunner, 'retrieve_deployment_status', autospec=True,
+                               return_value=mocked_instance_status)
+    value = k8s_rfs_backfill.get_status(deep_check=False)
+
+    mock.assert_called_once_with(k8s_rfs_backfill.kubectl_runner)
+    assert value.success
+    assert BackfillStatus.RUNNING == value.value[0]
+    assert str(mocked_instance_status) == value.value[1]
+
+
+def test_k8s_rfs_calculates_backfill_status_from_deployment_status_stopped(k8s_rfs_backfill, mocker):
+    mocked_stopped_status = DeploymentStatus(
+        desired=8,
+        running=0,
+        pending=0
+    )
+    mock = mocker.patch.object(KubectlRunner, 'retrieve_deployment_status', autospec=True,
+                               return_value=mocked_stopped_status)
+    value = k8s_rfs_backfill.get_status(deep_check=False)
+
+    mock.assert_called_once_with(k8s_rfs_backfill.kubectl_runner)
+    assert value.success
+    assert BackfillStatus.STOPPED == value.value[0]
+    assert str(mocked_stopped_status) == value.value[1]
+
+
+def test_k8s_rfs_calculates_backfill_status_from_deployment_status_starting(k8s_rfs_backfill, mocker):
+    mocked_starting_status = DeploymentStatus(
+        desired=8,
+        running=0,
+        pending=6
+    )
+    mock = mocker.patch.object(KubectlRunner, 'retrieve_deployment_status', autospec=True,
+                               return_value=mocked_starting_status)
+    value = k8s_rfs_backfill.get_status(deep_check=False)
+
+    mock.assert_called_once_with(k8s_rfs_backfill.kubectl_runner)
+    assert value.success
+    assert BackfillStatus.STARTING == value.value[0]
+    assert str(mocked_starting_status) == value.value[1]
+
+
+def test_k8s_rfs_calculates_backfill_status_from_deployment_status_running(k8s_rfs_backfill, mocker):
+    mocked_running_status = DeploymentStatus(
+        desired=1,
+        running=3,
+        pending=1
+    )
+    mock = mocker.patch.object(KubectlRunner, 'retrieve_deployment_status', autospec=True,
+                               return_value=mocked_running_status)
+    value = k8s_rfs_backfill.get_status(deep_check=False)
+
+    mock.assert_called_once_with(k8s_rfs_backfill.kubectl_runner)
+    assert value.success
+    assert BackfillStatus.RUNNING == value.value[0]
+    assert str(mocked_running_status) == value.value[1]
+
+
+def test_k8s_rfs_get_status_deep_check(k8s_rfs_backfill, mocker):
+    target = create_valid_cluster()
+    mocked_instance_status = DeploymentStatus(
+        desired=1,
+        running=1,
+        pending=0
+    )
+    mock = mocker.patch.object(KubectlRunner, 'retrieve_deployment_status', autospec=True,
+                               return_value=mocked_instance_status)
+    with open(TEST_DATA_DIRECTORY / "migrations_working_state_search.json") as f:
+        data = json.load(f)
+        total_shards = data['hits']['total']['value']
+    with requests_mock.Mocker() as rm:
+        rm.get(f"{target.endpoint}/.migrations_working_state", status_code=200)
+        rm.get(f"{target.endpoint}/.migrations_working_state/_search",
+               status_code=200,
+               json=data)
+        value = k8s_rfs_backfill.get_status(deep_check=True)
+
+    mock.assert_called_once_with(k8s_rfs_backfill.kubectl_runner)
+    assert value.success
+    assert BackfillStatus.RUNNING == value.value[0]
+    assert str(mocked_instance_status) in value.value[1]
+    assert str(total_shards) in value.value[1]
+
+
+def test_k8s_rfs_deep_status_check_failure(k8s_rfs_backfill, mocker, caplog):
+    mocked_instance_status = DeploymentStatus(
+        desired=1,
+        running=1,
+        pending=0
+    )
+    mock_k8s = mocker.patch.object(KubectlRunner, 'retrieve_deployment_status', autospec=True,
+                                   return_value=mocked_instance_status)
+    mock_api = mocker.patch.object(Cluster, 'call_api', side_effect=requests.exceptions.RequestException())
+    result = k8s_rfs_backfill.get_status(deep_check=True)
+    assert "Working state index does not yet exist" in caplog.text
+    mock_k8s.assert_called_once()
+    mock_api.assert_called_once()
+    assert result.success
+    assert result.value[0] == BackfillStatus.RUNNING
+
+
+def test_k8s_rfs_backfill_archive_as_expected(k8s_rfs_backfill, mocker, tmpdir):
+    mocked_instance_status = DeploymentStatus(
+        desired=0,
+        running=0,
+        pending=0
+    )
+    mocker.patch.object(KubectlRunner, 'retrieve_deployment_status', autospec=True, return_value=mocked_instance_status)
+
+    mocked_docs = [{"id": {"key": "value"}}]
+    mocker.patch.object(Cluster, 'fetch_all_documents', autospec=True, return_value=mocked_docs)
+
+    mock_api = mocker.patch.object(Cluster, 'call_api', autospec=True, return_value=requests.Response())
+
+    result = k8s_rfs_backfill.archive(archive_dir_path=tmpdir.strpath, archive_file_name="backup.json")
+
+    assert result.success
+    expected_path = os.path.join(tmpdir.strpath, "backup.json")
+    assert result.value == expected_path
+    assert os.path.exists(expected_path)
+    with open(expected_path, "r") as f:
+        assert json.load(f) == mocked_docs
+
+    mock_api.assert_called_once_with(
+        ANY, "/.migrations_working_state", method=HttpMethod.DELETE,
+        params={"ignore_unavailable": "true"}
+    )
+
+
+def test_k8s_rfs_backfill_archive_no_index_as_expected(k8s_rfs_backfill, mocker, tmpdir):
+    mocked_instance_status = DeploymentStatus(
+        desired=0,
+        running=0,
+        pending=0
+    )
+    mocker.patch.object(KubectlRunner, 'retrieve_deployment_status', autospec=True, return_value=mocked_instance_status)
+
+    response_404 = requests.Response()
+    response_404.status_code = 404
+    mocker.patch.object(
+        Cluster, 'fetch_all_documents', autospec=True,
+        side_effect=requests.HTTPError(response=response_404, request=requests.Request())
+    )
+
+    result = k8s_rfs_backfill.archive()
+
+    assert not result.success
+    assert isinstance(result.value, WorkingIndexDoesntExist)
+
+
+def test_k8s_rfs_backfill_archive_errors_if_in_progress(k8s_rfs_backfill, mocker):
+    mocked_instance_status = DeploymentStatus(
+        desired=3,
+        running=1,
+        pending=2
+    )
+    mock = mocker.patch.object(KubectlRunner, 'retrieve_deployment_status', autospec=True,
+                               return_value=mocked_instance_status)
+    result = k8s_rfs_backfill.archive()
+
+    mock.assert_called_once_with(k8s_rfs_backfill.kubectl_runner)
+    assert not result.success
+    assert isinstance(result.value, RfsWorkersInProgress)

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/test_cli.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/test_cli.py
@@ -13,10 +13,11 @@ from console_link.environment import Environment
 from console_link.models.backfill_rfs import ECSRFSBackfill, RfsWorkersInProgress, WorkingIndexDoesntExist
 from console_link.models.cluster import Cluster, HttpMethod
 from console_link.models.command_result import CommandResult
-from console_link.models.ecs_service import ECSService, InstanceStatuses
+from console_link.models.ecs_service import ECSService
 from console_link.models.kafka import StandardKafka
 from console_link.models.metrics_source import Component
 from console_link.models.replayer_ecs import ECSReplayer
+from console_link.models.utils import DeploymentStatus
 
 TEST_DATA_DIRECTORY = pathlib.Path(__file__).parent / "data"
 VALID_SERVICES_YAML = TEST_DATA_DIRECTORY / "services.yaml"
@@ -527,7 +528,7 @@ def test_cli_backfill_scale_with_no_units_fails(runner, mocker):
 
 
 def test_get_backfill_status_no_deep_check(runner, mocker):
-    mocked_running_status = InstanceStatuses(
+    mocked_running_status = DeploymentStatus(
         desired=1,
         running=3,
         pending=1
@@ -547,7 +548,7 @@ def test_get_backfill_status_no_deep_check(runner, mocker):
 
 
 def test_get_backfill_status_with_deep_check(runner, mocker):
-    mocked_running_status = InstanceStatuses(
+    mocked_running_status = DeploymentStatus(
         desired=1,
         running=3,
         pending=1

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/test_cli.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/test_cli.py
@@ -2,11 +2,10 @@ import json
 import pathlib
 import os
 import time
-
 import pytest
 import requests_mock
 from click.testing import CliRunner
-from types import SimpleNamespace
+from subprocess import CompletedProcess
 
 import console_link.middleware as middleware
 from console_link.cli import cli
@@ -460,7 +459,7 @@ def test_cli_snapshot_unregister_repo_without_acknowledgement_doesnt_run(runner,
                            catch_exceptions=True)
     assert result.exit_code == 0
 
-    # Ensure the mocks were called
+    # Ensure the mocks were not called
     mock.assert_not_called()
 
 
@@ -665,7 +664,7 @@ def test_cli_metadata_when_not_defined(runner, source_cluster_only_yaml_path):
 
 
 def test_cli_metadata_migrate(runner, mocker):
-    mock_subprocess_result = SimpleNamespace(stdout="Command successful", stderr=None)
+    mock_subprocess_result = CompletedProcess(args=[], returncode=0, stdout="Command successful", stderr=None)
     mock = mocker.patch("subprocess.run", return_value=mock_subprocess_result)
     result = runner.invoke(cli, ['--config-file', str(VALID_SERVICES_YAML), 'metadata', 'migrate'],
                            catch_exceptions=True)
@@ -674,7 +673,7 @@ def test_cli_metadata_migrate(runner, mocker):
 
 
 def test_cli_metadata_evaluate(runner, mocker):
-    mock_subprocess_result = SimpleNamespace(stdout="Command successful", stderr=None)
+    mock_subprocess_result = CompletedProcess(args=[], returncode=0, stdout="Command successful", stderr=None)
     mock = mocker.patch("subprocess.run", return_value=mock_subprocess_result)
     result = runner.invoke(cli, ['--config-file', str(VALID_SERVICES_YAML), 'metadata', 'evaluate'],
                            catch_exceptions=True)

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/test_cli.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/test_cli.py
@@ -434,6 +434,36 @@ def test_cli_snapshot_delete_without_acknowledgement_doesnt_run(runner, mocker):
     mock.assert_not_called()
 
 
+def test_cli_snapshot_unregister_repo_with_acknowledgement(runner, mocker):
+    mock = mocker.patch.object(Cluster, 'call_api', autospec=True)
+    mock.return_value.text = "Successfully deleted"
+
+    # Test snapshot status
+    result = runner.invoke(cli, ['--config-file',
+                                 str(VALID_SERVICES_YAML),
+                                 'snapshot',
+                                 'unregister-repo',
+                                 '--acknowledge-risk'],
+                           catch_exceptions=True)
+    assert result.exit_code == 0
+
+    # Ensure the mocks were called
+    mock.assert_called_once()
+
+
+def test_cli_snapshot_unregister_repo_without_acknowledgement_doesnt_run(runner, mocker):
+    mock = mocker.patch.object(Cluster, 'call_api', autospec=True)
+    mock.return_value.text = "Successfully deleted"
+
+    # Test snapshot status
+    result = runner.invoke(cli, ['--config-file', str(VALID_SERVICES_YAML), 'snapshot', 'unregister-repo'], input="n",
+                           catch_exceptions=True)
+    assert result.exit_code == 0
+
+    # Ensure the mocks were called
+    mock.assert_not_called()
+
+
 def test_cli_with_backfill_describe(runner, mocker):
     mock = mocker.patch('console_link.middleware.backfill.describe')
     result = runner.invoke(cli, ['--config-file', str(VALID_SERVICES_YAML), 'backfill', 'describe'],

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/test_command_runner.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/test_command_runner.py
@@ -1,8 +1,6 @@
 import pytest
 import subprocess
 
-from types import SimpleNamespace
-
 from console_link.models.command_runner import CommandRunner, CommandRunnerError, FlagOnlyArgument
 
 
@@ -65,7 +63,7 @@ def test_command_runner_sanitizing_a_flag_field_is_a_noop():
 def test_command_runner_prints_output_as_run_default(capsys, mocker):
     mock_stdout = "Found 5 directories"
     mock_stderr = "Unknown file path"
-    mock_subprocess_result = SimpleNamespace(stdout=mock_stdout, stderr=mock_stderr)
+    mock_subprocess_result = subprocess.CompletedProcess(args=[], returncode=0, stdout=mock_stdout, stderr=mock_stderr)
     runner = CommandRunner("ls", {})
     mocker.patch("subprocess.run", return_value=mock_subprocess_result)
     runner.run()
@@ -78,7 +76,7 @@ def test_command_runner_prints_output_as_run_default(capsys, mocker):
 def test_command_runner_prints_nothing_when_output_disabled(capsys, mocker):
     mock_stdout = "Found 5 directories"
     mock_stderr = "Unknown file path"
-    mock_subprocess_result = SimpleNamespace(stdout=mock_stdout, stderr=mock_stderr)
+    mock_subprocess_result = subprocess.CompletedProcess(args=[], returncode=0, stdout=mock_stdout, stderr=mock_stderr)
     runner = CommandRunner("ls", {})
     mocker.patch("subprocess.run", return_value=mock_subprocess_result)
     runner.run(print_to_console=False)
@@ -89,7 +87,7 @@ def test_command_runner_prints_nothing_when_output_disabled(capsys, mocker):
 
 
 def test_command_runner_handles_no_output(capsys, mocker):
-    mock_subprocess_result = SimpleNamespace(stdout=None, stderr=None)
+    mock_subprocess_result = subprocess.CompletedProcess(args=[], returncode=0, stdout=None, stderr=None)
     runner = CommandRunner("ls", {})
     mocker.patch("subprocess.run", return_value=mock_subprocess_result)
     runner.run()

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/test_command_runner.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/test_command_runner.py
@@ -1,7 +1,9 @@
+import pytest
 import subprocess
 
+from types import SimpleNamespace
+
 from console_link.models.command_runner import CommandRunner, CommandRunnerError, FlagOnlyArgument
-import pytest
 
 
 def test_command_runner_builds_command_without_args():
@@ -58,3 +60,40 @@ def test_command_runner_sanitizing_a_flag_field_is_a_noop():
     }, sensitive_fields=["--use-password"])
     assert runner.command == ["command", "--username", "admin", "--use-password"]
     assert runner.sanitized_command() == ["command", "--username", "admin", "--use-password"]
+
+
+def test_command_runner_prints_output_as_run_default(capsys, mocker):
+    mock_stdout = "Found 5 directories"
+    mock_stderr = "Unknown file path"
+    mock_subprocess_result = SimpleNamespace(stdout=mock_stdout, stderr=mock_stderr)
+    runner = CommandRunner("ls", {})
+    mocker.patch("subprocess.run", return_value=mock_subprocess_result)
+    runner.run()
+    # Capture stdout/stderr output
+    captured = capsys.readouterr()
+    assert captured.out == mock_stdout
+    assert captured.err == mock_stderr
+
+
+def test_command_runner_prints_nothing_when_output_disabled(capsys, mocker):
+    mock_stdout = "Found 5 directories"
+    mock_stderr = "Unknown file path"
+    mock_subprocess_result = SimpleNamespace(stdout=mock_stdout, stderr=mock_stderr)
+    runner = CommandRunner("ls", {})
+    mocker.patch("subprocess.run", return_value=mock_subprocess_result)
+    runner.run(print_to_console=False)
+    # Capture stdout/stderr output
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == ""
+
+
+def test_command_runner_handles_no_output(capsys, mocker):
+    mock_subprocess_result = SimpleNamespace(stdout=None, stderr=None)
+    runner = CommandRunner("ls", {})
+    mocker.patch("subprocess.run", return_value=mock_subprocess_result)
+    runner.run()
+    # Capture stdout/stderr output
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == ""

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/test_ecs.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/test_ecs.py
@@ -5,8 +5,8 @@ import botocore.session
 import pytest
 from botocore.stub import Stubber
 
-from console_link.models.ecs_service import ECSService, InstanceStatuses
-from console_link.models.utils import AWSAPIError
+from console_link.models.ecs_service import ECSService
+from console_link.models.utils import AWSAPIError, DeploymentStatus
 
 TEST_DATA_DIRECTORY = pathlib.Path(__file__).parent / "data"
 AWS_REGION = "us-east-1"
@@ -64,7 +64,7 @@ def test_ecs_get_instance_statues(ecs_stubber, ecs_service):
         ecs_stubber.add_response("describe_services", service_response=data)
     ecs_stubber.activate()
 
-    expected = InstanceStatuses(desired=5, pending=2, running=1)
+    expected = DeploymentStatus(desired=5, pending=2, running=1)
 
     ecs_service.client = ecs_stubber.client
     result = ecs_service.get_instance_statuses()

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/test_kubectl_runner.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/test_kubectl_runner.py
@@ -1,0 +1,94 @@
+import pathlib
+import subprocess
+
+from types import SimpleNamespace
+
+from console_link.models.command_result import CommandResult
+from console_link.models.kubectl_runner import KubectlRunner
+from console_link.models.utils import DeploymentStatus
+
+TEST_DATA_DIRECTORY = pathlib.Path(__file__).parent / "data"
+
+TEST_NAMESPACE = "test"
+TEST_DEPLOYMENT_NAME = "ma-test-deployment"
+
+
+def test_kubectl_runner_perform_scale(mocker):
+    kubectl_runner = KubectlRunner(TEST_NAMESPACE, TEST_DEPLOYMENT_NAME)
+
+    mock = mocker.patch("subprocess.run")
+
+    desired_count = 0
+    cmd_result: CommandResult = kubectl_runner.perform_scale_command(desired_count)
+
+    mock.assert_called_once_with([
+        'kubectl',
+        "-n", TEST_NAMESPACE,
+        "scale",
+        "deployment",
+        TEST_DEPLOYMENT_NAME,
+        "--replicas", str(desired_count),
+    ], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, check=True)
+
+    assert cmd_result.success is True
+
+
+def test_kubectl_runner_perform_scale_command_error(mocker):
+    kubectl_runner = KubectlRunner(TEST_NAMESPACE, TEST_DEPLOYMENT_NAME)
+
+    mock = mocker.patch("subprocess.run", side_effect=subprocess.CalledProcessError(cmd="Test command", returncode=1))
+
+    desired_count = 0
+    cmd_result: CommandResult = kubectl_runner.perform_scale_command(desired_count)
+
+    mock.assert_called_once_with([
+        'kubectl',
+        "-n", TEST_NAMESPACE,
+        "scale",
+        "deployment",
+        TEST_DEPLOYMENT_NAME,
+        "--replicas", str(desired_count),
+    ], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, check=True)
+
+    assert cmd_result.success is False
+
+
+def test_kubectl_retrieve_deployment_status(mocker):
+    kubectl_runner = KubectlRunner(TEST_NAMESPACE, TEST_DEPLOYMENT_NAME)
+    with open(TEST_DATA_DIRECTORY / "kubectl_describe_deployment_output.json") as f:
+        json_output = f.read()
+    mock_subprocess_result = SimpleNamespace(stdout=json_output, stderr=None)
+    mock = mocker.patch("subprocess.run", return_value=mock_subprocess_result)
+
+    deployment_status = kubectl_runner.retrieve_deployment_status()
+
+    mock.assert_called_once_with([
+        'kubectl',
+        "-n", TEST_NAMESPACE,
+        "get",
+        "deployment",
+        TEST_DEPLOYMENT_NAME,
+        "-o", "json",
+    ], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, check=True)
+
+    assert deployment_status == DeploymentStatus(running=1, pending=0, desired=1)
+
+
+def test_kubectl_retrieve_deployment_status_improper_json(mocker):
+    kubectl_runner = KubectlRunner(TEST_NAMESPACE, TEST_DEPLOYMENT_NAME)
+    json_output = "{\"spec\": []}"
+    mock_subprocess_result = SimpleNamespace(stdout=json_output, stderr=None)
+    mock = mocker.patch("subprocess.run", return_value=mock_subprocess_result)
+
+    deployment_status = kubectl_runner.retrieve_deployment_status()
+
+    mock.assert_called_once_with([
+        'kubectl',
+        "-n", TEST_NAMESPACE,
+        "get",
+        "deployment",
+        TEST_DEPLOYMENT_NAME,
+        "-o", "json",
+    ], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, check=True)
+
+    assert deployment_status is None

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/test_kubectl_runner.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/test_kubectl_runner.py
@@ -1,8 +1,6 @@
 import pathlib
 import subprocess
 
-from types import SimpleNamespace
-
 from console_link.models.command_result import CommandResult
 from console_link.models.kubectl_runner import KubectlRunner
 from console_link.models.utils import DeploymentStatus
@@ -57,7 +55,7 @@ def test_kubectl_retrieve_deployment_status(mocker):
     kubectl_runner = KubectlRunner(TEST_NAMESPACE, TEST_DEPLOYMENT_NAME)
     with open(TEST_DATA_DIRECTORY / "kubectl_describe_deployment_output.json") as f:
         json_output = f.read()
-    mock_subprocess_result = SimpleNamespace(stdout=json_output, stderr=None)
+    mock_subprocess_result = subprocess.CompletedProcess(args=[], returncode=0, stdout=json_output, stderr=None)
     mock = mocker.patch("subprocess.run", return_value=mock_subprocess_result)
 
     deployment_status = kubectl_runner.retrieve_deployment_status()
@@ -77,7 +75,7 @@ def test_kubectl_retrieve_deployment_status(mocker):
 def test_kubectl_retrieve_deployment_status_improper_json(mocker):
     kubectl_runner = KubectlRunner(TEST_NAMESPACE, TEST_DEPLOYMENT_NAME)
     json_output = "{\"spec\": []}"
-    mock_subprocess_result = SimpleNamespace(stdout=json_output, stderr=None)
+    mock_subprocess_result = subprocess.CompletedProcess(args=[], returncode=0, stdout=json_output, stderr=None)
     mock = mocker.patch("subprocess.run", return_value=mock_subprocess_result)
 
     deployment_status = kubectl_runner.retrieve_deployment_status()

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/test_metadata.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/test_metadata.py
@@ -1,4 +1,5 @@
 import pytest
+import subprocess
 
 from console_link.models.cluster import AuthMethod
 from console_link.models.metadata import Metadata
@@ -157,6 +158,8 @@ def test_full_config_with_version_includes_version_string_in_subprocess(s3_snaps
     metadata = Metadata(config, create_valid_cluster(), s3_snapshot)
 
     mock = mocker.patch("subprocess.run")
+    mocker.patch("sys.stdout.write")
+    mocker.patch("sys.stderr.write")
     metadata.migrate()
 
     mock.assert_called_once()
@@ -181,6 +184,8 @@ def test_metadata_with_s3_snapshot_makes_correct_subprocess_call(mocker):
     metadata = Metadata(config, target, None)
 
     mock = mocker.patch("subprocess.run")
+    mocker.patch("sys.stdout.write")
+    mocker.patch("sys.stderr.write")
     metadata.migrate()
 
     mock.assert_called_once_with([
@@ -194,7 +199,7 @@ def test_metadata_with_s3_snapshot_makes_correct_subprocess_call(mocker):
         "--s3-repo-uri", config["from_snapshot"]["s3"]["repo_uri"],
         "--s3-region", config["from_snapshot"]["s3"]["aws_region"],
         "--target-insecure",
-    ], stdout=None, stderr=None, text=True, check=True
+    ], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, check=True
     )
 
 
@@ -212,6 +217,8 @@ def test_metadata_with_fs_snapshot_makes_correct_subprocess_call(mocker):
     metadata = Metadata(config, target, None)
 
     mock = mocker.patch("subprocess.run")
+    mocker.patch("sys.stdout.write")
+    mocker.patch("sys.stderr.write")
     metadata.migrate()
 
     mock.assert_called_once_with([
@@ -223,7 +230,7 @@ def test_metadata_with_fs_snapshot_makes_correct_subprocess_call(mocker):
         "--min-replicas", '0',
         "--file-system-repo-path", config["from_snapshot"]["fs"]["repo_path"],
         "--target-insecure",
-    ], stdout=None, stderr=None, text=True, check=True)
+    ], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, check=True)
 
 
 def test_metadata_with_min_replicas_makes_correct_subprocess_call(mocker):
@@ -240,6 +247,8 @@ def test_metadata_with_min_replicas_makes_correct_subprocess_call(mocker):
     metadata = Metadata(config, target, None)
 
     mock = mocker.patch("subprocess.run")
+    mocker.patch("sys.stdout.write")
+    mocker.patch("sys.stderr.write")
     metadata.migrate()
 
     mock.assert_called_once_with([
@@ -250,7 +259,7 @@ def test_metadata_with_min_replicas_makes_correct_subprocess_call(mocker):
         "--min-replicas", '2',
         "--file-system-repo-path", config["from_snapshot"]["fs"]["repo_path"],
         '--target-insecure'
-    ], stdout=None, stderr=None, text=True, check=True
+    ], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, check=True
     )
 
 
@@ -271,6 +280,8 @@ def test_metadata_with_allowlists_makes_correct_subprocess_call(mocker):
     metadata = Metadata(config, target, None)
 
     mock = mocker.patch("subprocess.run")
+    mocker.patch("sys.stdout.write")
+    mocker.patch("sys.stderr.write")
     metadata.migrate()
 
     mock.assert_called_once_with([
@@ -285,7 +296,7 @@ def test_metadata_with_allowlists_makes_correct_subprocess_call(mocker):
         "--index-allowlist", "index1,index2",
         "--index-template-allowlist", "index_template1,index_template2",
         "--component-template-allowlist", "component_template1,component_template2",
-    ], stdout=None, stderr=None, text=True, check=True
+    ], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, check=True
     )
 
 
@@ -304,6 +315,8 @@ def test_metadata_with_target_config_auth_makes_correct_subprocess_call(mocker):
     metadata = Metadata(config, target, None)
 
     mock = mocker.patch("subprocess.run")
+    mocker.patch("sys.stdout.write")
+    mocker.patch("sys.stderr.write")
     metadata.migrate()
 
     mock.assert_called_once_with([
@@ -318,7 +331,7 @@ def test_metadata_with_target_config_auth_makes_correct_subprocess_call(mocker):
         "--target-username", target.auth_details.get("username"),
         "--target-password", target.get_basic_auth_password(),
         "--target-insecure",
-    ], stdout=None, stderr=None, text=True, check=True
+    ], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, check=True
     )
 
 
@@ -340,6 +353,8 @@ def test_metadata_with_target_sigv4_makes_correct_subprocess_call(mocker):
     metadata = Metadata(config, target, None)
 
     mock = mocker.patch("subprocess.run")
+    mocker.patch("sys.stdout.write")
+    mocker.patch("sys.stderr.write")
     metadata.migrate()
 
     mock.assert_called_once_with([
@@ -354,7 +369,7 @@ def test_metadata_with_target_sigv4_makes_correct_subprocess_call(mocker):
         "--target-aws-service-signing-name", service_name,
         "--target-aws-region", signing_region,
         "--target-insecure",
-    ], stdout=None, stderr=None, text=True, check=True
+    ], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, check=True
     )
 
 
@@ -371,6 +386,8 @@ def test_metadata_init_with_minimal_config_and_extra_args(mocker):
     metadata = Metadata(config, create_valid_cluster(), None)
 
     mock = mocker.patch("subprocess.run")
+    mocker.patch("sys.stdout.write")
+    mocker.patch("sys.stderr.write")
     metadata.evaluate(extra_args=[
         "--foo", "bar",  # Pair of command and value
         "--flag",  # Flag with no value afterward
@@ -395,4 +412,4 @@ def test_metadata_init_with_minimal_config_and_extra_args(mocker):
         '--foo', 'bar',
         '--flag',
         '--bar', 'baz'
-    ], stdout=None, stderr=None, text=True, check=True)
+    ], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, check=True)

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/test_replay.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/test_replay.py
@@ -7,25 +7,77 @@ import yaml
 import console_link.middleware.replay as replay_
 from console_link.models.ecs_service import ECSService
 from console_link.models.factories import UnsupportedReplayerError, get_replayer
+from console_link.models.kubectl_runner import KubectlRunner
 from console_link.models.replayer_base import Replayer
 from console_link.models.replayer_ecs import ECSReplayer
+from console_link.models.replayer_k8s import K8sReplayer
 from console_link.models.replayer_docker import DockerReplayer
 
 TEST_DATA_DIRECTORY = pathlib.Path(__file__).parent / "data"
 AWS_REGION = "us-east-1"
 
 
-def test_get_replayer_valid_ecs():
-    ecs_config = {
+@pytest.fixture
+def docker_replayer():
+    config = {
+        "docker": {}
+    }
+    return get_replayer(config)
+
+
+@pytest.fixture
+def ecs_replayer():
+    config = {
         "ecs": {
             "cluster_name": "migration-aws-integ-ecs-cluster",
             "service_name": "migration-aws-integ-traffic-replayer-default"
         },
         "scale": 3
     }
-    replayer = get_replayer(ecs_config)
-    assert isinstance(replayer, ECSReplayer)
-    assert isinstance(replayer, Replayer)
+    return get_replayer(config)
+
+
+@pytest.fixture
+def k8s_replayer():
+    config = {
+        "k8s": {
+            "namespace": "ma",
+            "deployment_name": "ma-replayer"
+        },
+        "scale": 3
+    }
+    return get_replayer(config)
+
+
+def _mock_ecs_set_desired_count(mocker):
+    return mocker.patch.object(ECSService, 'set_desired_count', autospec=True)
+
+
+def _mock_ecs_validate_desired_count(mock, replayer, expected_count):
+    mock.assert_called_once_with(replayer.ecs_client, expected_count)
+
+
+def _mock_k8s_set_desired_count(mocker):
+    return mocker.patch.object(KubectlRunner, 'perform_scale_command', autospec=True)
+
+
+def _mock_k8s_validate_desired_count(mock, replayer, expected_count):
+    mock.assert_called_once_with(replayer.kubectl_runner, expected_count)
+
+
+def test_get_replayer_valid_docker(docker_replayer):
+    assert isinstance(docker_replayer, DockerReplayer)
+    assert isinstance(docker_replayer, Replayer)
+
+
+def test_get_replayer_valid_ecs(ecs_replayer):
+    assert isinstance(ecs_replayer, ECSReplayer)
+    assert isinstance(ecs_replayer, Replayer)
+
+
+def test_get_replayer_valid_k8s(k8s_replayer):
+    assert isinstance(k8s_replayer, K8sReplayer)
+    assert isinstance(k8s_replayer, Replayer)
 
 
 def test_cant_instantiate_with_multiple_types():
@@ -44,89 +96,6 @@ def test_cant_instantiate_with_multiple_types():
     assert "More than one value is present" in str(excinfo.value.args[1]['replay'][0])
 
 
-def test_replayer_start_sets_ecs_desired_count(mocker):
-    config = {
-        "ecs": {
-            "cluster_name": "migration-aws-integ-ecs-cluster",
-            "service_name": "migration-aws-integ-traffic-replayer-default"
-        },
-        "scale": 3
-    }
-    replayer = get_replayer(config)
-    mock = mocker.patch.object(ECSService, 'set_desired_count', autospec=True)
-    replayer.start()
-
-    assert isinstance(replayer, ECSReplayer)
-    mock.assert_called_once_with(replayer.ecs_client, config["scale"])
-
-
-def test_replayer_stop_sets_ecs_desired_count(mocker):
-    config = {
-        "ecs": {
-            "cluster_name": "migration-aws-integ-ecs-cluster",
-            "service_name": "migration-aws-integ-traffic-replayer-default"
-        },
-        "scale": 3
-    }
-    replayer = get_replayer(config)
-    mock = mocker.patch.object(ECSService, 'set_desired_count', autospec=True)
-    replayer.stop()
-
-    assert isinstance(replayer, ECSReplayer)
-    mock.assert_called_once_with(replayer.ecs_client, 0)
-
-
-def test_replayer_scale_sets_ecs_desired_count(mocker):
-    config = {
-        "ecs": {
-            "cluster_name": "migration-aws-integ-ecs-cluster",
-            "service_name": "migration-aws-integ-traffic-replayer-default"
-        }
-    }
-    replayer = get_replayer(config)
-    mock = mocker.patch.object(ECSService, 'set_desired_count', autospec=True)
-    replayer.scale(5)
-
-    assert isinstance(replayer, ECSReplayer)
-    mock.assert_called_once_with(replayer.ecs_client, 5)
-
-
-def test_replayer_describe_no_json():
-    config = {
-        "ecs": {
-            "cluster_name": "migration-aws-integ-ecs-cluster",
-            "service_name": "migration-aws-integ-traffic-replayer-default"
-        },
-        "scale": 3
-    }
-    replayer = get_replayer(config)
-    success, output = replay_.describe(replayer, as_json=False)
-    assert success
-    assert output == yaml.safe_dump(config)
-
-
-def test_replayer_describe_as_json():
-    config = {
-        "ecs": {
-            "cluster_name": "migration-aws-integ-ecs-cluster",
-            "service_name": "migration-aws-integ-traffic-replayer-default"
-        },
-        "scale": 3
-    }
-    replayer = get_replayer(config)
-    success, output = replay_.describe(replayer, as_json=True)
-    assert success
-    assert json.loads(output) == config
-
-
-def test_get_docker_replayer():
-    config = {
-        "docker": None
-    }
-    replayer = get_replayer(config)
-    assert isinstance(replayer, DockerReplayer)
-
-
 def test_nonexistent_replayer_type():
     config = {
         "new_replayer_type": {
@@ -136,3 +105,73 @@ def test_nonexistent_replayer_type():
     with pytest.raises(UnsupportedReplayerError) as exc_info:
         get_replayer(config)
     assert 'new_replayer_type' in exc_info.value.args
+
+
+@pytest.mark.parametrize(
+    "replayer_fixture, mock_desired_count, validate_desired_count",
+    [
+        ('ecs_replayer', _mock_ecs_set_desired_count, _mock_ecs_validate_desired_count),
+        ('k8s_replayer', _mock_k8s_set_desired_count, _mock_k8s_validate_desired_count),
+    ]
+)
+def test_replayer_start_sets_desired_count(request,
+                                           replayer_fixture,
+                                           mock_desired_count,
+                                           validate_desired_count,
+                                           mocker):
+    replayer = request.getfixturevalue(replayer_fixture)
+    mock = mock_desired_count(mocker)
+    replayer.start()
+    validate_desired_count(mock, replayer, replayer.config["scale"])
+
+
+@pytest.mark.parametrize(
+    "replayer_fixture, mock_desired_count, validate_desired_count",
+    [
+        ('ecs_replayer', _mock_ecs_set_desired_count, _mock_ecs_validate_desired_count),
+        ('k8s_replayer', _mock_k8s_set_desired_count, _mock_k8s_validate_desired_count),
+    ]
+)
+def test_replayer_stop_sets_desired_count(request,
+                                          replayer_fixture,
+                                          mock_desired_count,
+                                          validate_desired_count,
+                                          mocker):
+    replayer = request.getfixturevalue(replayer_fixture)
+    mock = mock_desired_count(mocker)
+    replayer.stop()
+    validate_desired_count(mock, replayer, 0)
+
+
+@pytest.mark.parametrize(
+    "replayer_fixture, mock_desired_count, validate_desired_count",
+    [
+        ('ecs_replayer', _mock_ecs_set_desired_count, _mock_ecs_validate_desired_count),
+        ('k8s_replayer', _mock_k8s_set_desired_count, _mock_k8s_validate_desired_count),
+    ]
+)
+def test_replayer_scale_sets_desired_count(request,
+                                           replayer_fixture,
+                                           mock_desired_count,
+                                           validate_desired_count,
+                                           mocker):
+    replayer = request.getfixturevalue(replayer_fixture)
+    mock = mock_desired_count(mocker)
+    replayer.scale(5)
+    validate_desired_count(mock, replayer, 5)
+
+
+@pytest.mark.parametrize("replayer_fixture", ['ecs_replayer', 'k8s_replayer'])
+def test_replayer_describe_no_json(request, replayer_fixture):
+    replayer = request.getfixturevalue(replayer_fixture)
+    success, output = replay_.describe(replayer, as_json=False)
+    assert success
+    assert output == yaml.safe_dump(replayer.config)
+
+
+@pytest.mark.parametrize("replayer_fixture", ['ecs_replayer', 'k8s_replayer'])
+def test_replayer_describe_as_json(request, replayer_fixture):
+    replayer = request.getfixturevalue(replayer_fixture)
+    success, output = replay_.describe(replayer, as_json=True)
+    assert success
+    assert json.loads(output) == replayer.config

--- a/deployment/k8s/README.md
+++ b/deployment/k8s/README.md
@@ -19,7 +19,7 @@ Follow instructions [here](https://docs.docker.com/engine/install/) to set up Do
 
 We test our solution with minikube and are beginning to test Amazon EKS.  See below for more information to set these up.
 
-## Local Kubernetes Cluster
+## Setup local Kubernetes Cluster
 Creating a local Kubernetes cluster is useful for testing and developing a given deployment. There are a few different tools for running a Kubernetes cluster locally. This documentation focuses on using [Minikube](https://github.com/kubernetes/minikube) to run the local Kubernetes cluster.
 
 ### Install Minikube

--- a/deployment/k8s/charts/aggregates/migrationAssistant/values.yaml
+++ b/deployment/k8s/charts/aggregates/migrationAssistant/values.yaml
@@ -16,8 +16,17 @@ shared-configs:
     sourceCluster:
       allowRuntimeOverride: true
       object:
-        endpoint: "http://sourcecluster.example.com:9200"
+        endpoint: "http://elasticsearch-master:9200"
         allowInsecure: true
+    targetCluster:
+      allowRuntimeOverride: true
+      object:
+        endpoint: "https://opensearch-cluster-master:9200"
+        allowInsecure: true
+        basicAuthUsername: "admin"
+        basicAuthPassword: "myStrongPassword123!"
+        # Should be in sync with above username/password
+        basicAuthHeader: "Basic YWRtaW46bXlTdHJvbmdQYXNzd29yZDEyMyE="
     kafkaBrokers:
       allowRuntimeOverride: false
       object:
@@ -54,20 +63,42 @@ bulk-document-loader:
       value: rfs-snapshot
       allowRuntimeOverride: true
     targetHost:
-      source: parameterConfig
-      value: https://opensearch-cluster-master:9200
-      allowRuntimeOverride: true
+      source: otherConfig
+      configMapName: "target-cluster"
+      configMapKey: "endpoint"
+    targetInsecure:
+      source: otherConfig
+      configMapName: "target-cluster"
+      configMapKey: "allowInsecure"
+      parameterType: booleanFlag
+    targetUsername:
+      source: otherConfig
+      configMapName: "target-cluster"
+      configMapKey: "basicAuthUsername"
+    targetPassword:
+      source: otherConfig
+      configMapName: "target-cluster"
+      configMapKey: "basicAuthPassword"
 
 replayer:
   parameters:
-    targetUri:
-      source: parameterConfig
-      value: https://opensearch-cluster-master.mcc:9200/
-      allowRuntimeOverride: true
     kafkaTrafficBrokers:
       source: otherConfig  # eventually this will become a list from a shared config
       configMapName: "kafka-brokers"
       configMapKey: "brokers"
+    targetUri:
+      source: otherConfig
+      configMapName: "target-cluster"
+      configMapKey: "endpoint"
+    insecure:
+      source: otherConfig
+      configMapName: "target-cluster"
+      configMapKey: "allowInsecure"
+      parameterType: booleanFlag
+    authHeaderValue:
+      source: otherConfig
+      configMapName: "target-cluster"
+      configMapKey: "basicAuthHeader"
 
 captured-traffic-kafka-cluster:
   environment: test

--- a/deployment/k8s/charts/aggregates/mockCustomerClusters/Chart.lock
+++ b/deployment/k8s/charts/aggregates/mockCustomerClusters/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
-- name: elasticsearch
-  repository: https://helm.elastic.co
-  version: 8.5.1
 - name: capture-proxy
   repository: file://../../components/captureProxy
   version: 0.1.0
+- name: elasticsearch
+  repository: https://helm.elastic.co
+  version: 8.5.1
 - name: opensearch
   repository: https://opensearch-project.github.io/helm-charts/
   version: 2.23.1
-digest: sha256:9b3812d61b38a98c97adfbd7afe6cc27a73615ca3b3f792c8d64847fc50c5600
-generated: "2024-12-28T10:22:08.454087-05:00"
+digest: sha256:21f1fee499ee5a8a42f073cbaa21cc731d5e859edd587d869d736f50da01bf43
+generated: "2025-02-10T13:54:29.806432-06:00"

--- a/deployment/k8s/charts/components/bulkLoad/Chart.lock
+++ b/deployment/k8s/charts/components/bulkLoad/Chart.lock
@@ -2,11 +2,8 @@ dependencies:
 - name: helm-common
   repository: file://../../sharedResources/helmCommon
   version: 0.1.0
-- name: snapshot-volume
-  repository: file://../../sharedResources/snapshotVolume
-  version: 0.1.0
 - name: logs-volume
   repository: file://../../sharedResources/logsVolume
   version: 0.1.0
-digest: sha256:4f480eb9ba10ee779064919444e65e9adcab54916ba47962ca784738be1c803e
-generated: "2024-12-28T10:22:19.870333-05:00"
+digest: sha256:5e118d521e5fe18deb458491cbeedae908bd27ded08b0d16f867968c0c591c28
+generated: "2025-01-29T17:20:16.376823-06:00"

--- a/deployment/k8s/charts/components/bulkLoad/templates/deployment.yaml
+++ b/deployment/k8s/charts/components/bulkLoad/templates/deployment.yaml
@@ -29,11 +29,7 @@ spec:
             - |
               echo `cat /shared/vars.sh`
               source /shared/vars.sh
-              {{/* Replace '|' with a space. This replacing only gets us back to our original state, it would only allow
-              strings with spaces as arguments if we were to provide the args directrly to the java app in an array
-              like in other services  */}}
-              clean_args=$(echo "$ARGS" | sed 's/|/ /g')
-              export RFS_COMMAND="/rfs-app/runJavaWithClasspath.sh org.opensearch.migrations.RfsMigrateDocuments $clean_args"
+              export RFS_COMMAND="/rfs-app/runJavaWithClasspath.sh org.opensearch.migrations.RfsMigrateDocuments $ARGS"
               exec /rfs-app/entrypoint.sh
           volumeMounts:
             - name: {{ $envMountName }}

--- a/deployment/k8s/charts/components/bulkLoad/templates/deployment.yaml
+++ b/deployment/k8s/charts/components/bulkLoad/templates/deployment.yaml
@@ -11,8 +11,6 @@ spec:
       app: {{ include "generic.fullname" . }}
   template:
     metadata:
-      annotations:
-        rollme: {{ randAlphaNum 5 | quote }}
       labels:
         app: {{ include "generic.fullname" . }}
         env: v1
@@ -31,7 +29,12 @@ spec:
             - |
               echo `cat /shared/vars.sh`
               source /shared/vars.sh
-              exec /rfs-app/runJavaWithClasspath.sh org.opensearch.migrations.RfsMigrateDocuments $ARGS
+              {{/* Replace '|' with a space. This replacing only gets us back to our original state, it would only allow
+              strings with spaces as arguments if we were to provide the args directrly to the java app in an array
+              like in other services  */}}
+              clean_args=$(echo "$ARGS" | sed 's/|/ /g')
+              export RFS_COMMAND="/rfs-app/runJavaWithClasspath.sh org.opensearch.migrations.RfsMigrateDocuments $clean_args"
+              exec /rfs-app/entrypoint.sh
           volumeMounts:
             - name: {{ $envMountName }}
               mountPath: /shared

--- a/deployment/k8s/charts/components/captureProxy/templates/deployment.yaml
+++ b/deployment/k8s/charts/components/captureProxy/templates/deployment.yaml
@@ -32,12 +32,11 @@ spec:
             - "-c"
             - |
               source /shared/vars.sh
-              args_array=($ARGS)
-              {{/* Loop through the array and replace '|' with a space */}}
-              for i in "${!args_array[@]}"; do
-                args_array[$i]="${args_array[$i]//|/ }"
-              done
-              exec /runJavaWithClasspath.sh org.opensearch.migrations.trafficcapture.proxyserver.CaptureProxy "${args_array[@]}"
+              # Remove leading or trailing space in args file
+              sed -i 's/^[ \t]*//;s/[ \t]*$//' /shared/args.txt
+              readarray -t arg_array < /shared/args.txt
+              echo "Using args from file: ${arg_array[@]}"
+              exec /runJavaWithClasspath.sh org.opensearch.migrations.trafficcapture.proxyserver.CaptureProxy "${arg_array[@]}"
           ports:
             - containerPort: 9200
           volumeMounts:

--- a/deployment/k8s/charts/components/captureProxy/templates/deployment.yaml
+++ b/deployment/k8s/charts/components/captureProxy/templates/deployment.yaml
@@ -10,8 +10,6 @@ spec:
       app: {{ include "generic.fullname" . }}
   template:
     metadata:
-      annotations:
-        rollme: {{ randAlphaNum 5 | quote }}
       labels:
         app: {{ include "generic.fullname" . }}
         env: v1
@@ -34,7 +32,12 @@ spec:
             - "-c"
             - |
               source /shared/vars.sh
-              exec /runJavaWithClasspath.sh org.opensearch.migrations.trafficcapture.proxyserver.CaptureProxy $ARGS
+              args_array=($ARGS)
+              {{/* Loop through the array and replace '|' with a space */}}
+              for i in "${!args_array[@]}"; do
+                args_array[$i]="${args_array[$i]//|/ }"
+              done
+              exec /runJavaWithClasspath.sh org.opensearch.migrations.trafficcapture.proxyserver.CaptureProxy "${args_array[@]}"
           ports:
             - containerPort: 9200
           volumeMounts:

--- a/deployment/k8s/charts/components/migrationConsole/migration_services.yaml
+++ b/deployment/k8s/charts/components/migrationConsole/migration_services.yaml
@@ -1,5 +1,5 @@
 source_cluster:
-  endpoint: "http://elasticsearch:9200"
+  endpoint: "http://elasticsearch-master:9200"
   allow_insecure: true
   version: "7.10.2"
   no_auth:
@@ -14,9 +14,13 @@ metrics_source:
     endpoint: "http://prometheus:9090"
 backfill:
   reindex_from_snapshot:
-    docker:
+    k8s:
+      namespace: "ma"
+      deployment_name: "ma-bulk-document-loader"
 replay:
-  docker:
+  k8s:
+    namespace: "ma"
+    deployment_name: "ma-replayer"
 snapshot:
   snapshot_name: "rfs-snapshot"
   fs:

--- a/deployment/k8s/charts/components/migrationConsole/templates/deployment.yaml
+++ b/deployment/k8s/charts/components/migrationConsole/templates/deployment.yaml
@@ -13,13 +13,11 @@ spec:
       app: {{ include "generic.fullname" . }}
   template:
     metadata:
-      annotations:
-        rollme: {{ randAlphaNum 5 | quote }}
       labels:
         app: {{ include "generic.fullname" . }}
         env: v1
     spec:
-      serviceAccountName: configmap-watcher
+      serviceAccountName: migration-console-access-role
       initContainers:
         {{- include "generic.setupEnvLoadInitContainer" (merge (dict
            "MountName" $envVarMountName
@@ -49,6 +47,9 @@ spec:
               mountPath: /shared
             - name: services-yaml
               mountPath: /etc/migration_services.yaml
+{{/*              Enable if developing the console library */}}
+{{/*            - name: local-console-link*/}}
+{{/*              mountPath: /root/lib/console_link*/}}
             {{- if $snapshotVolumeEnabled }}
             - name: snapshot-volume
               mountPath: /snapshot
@@ -62,6 +63,10 @@ spec:
           hostPath:
             path: /opensearch-migrations/deployment/k8s/charts/components/migrationConsole/migration_services.yaml
             type: File
+{{/*        - name: local-console-link*/}}
+{{/*          hostPath:*/}}
+{{/*            path: /opensearch-migrations/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link*/}}
+{{/*            type: Directory*/}}
         {{- if $sharedLogsVolumeEnabled  }}
         - name: shared-logs
           persistentVolumeClaim:

--- a/deployment/k8s/charts/components/migrationConsole/templates/rbac.yaml
+++ b/deployment/k8s/charts/components/migrationConsole/templates/rbac.yaml
@@ -2,27 +2,33 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: configmap-watcher
+  name: migration-console-access-role
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: configmap-watcher
+  name: migration-console-access-role
 rules:
-  - apiGroups: [""]
-    resources: ["configmaps"]
-    verbs: ["get", "watch", "list"]
+  - apiGroups: [ "" ]
+    resources: ["secrets"]
+    verbs: ["list"]
+  - apiGroups: [ "" ]
+    resources: ["configmaps", "persistentvolumeclaims", "pods", "pods/log"]
+    verbs: ["get", "watch", "list", "create", "update", "patch", "delete", "deletecollection"]
+  - apiGroups: [ "apps" ]
+    resources: ["deployments", "deployments/scale"]
+    verbs: ["get", "watch", "list", "create", "update", "patch", "delete", "deletecollection"]
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: configmap-watcher
+  name: migration-console-access-role
 subjects:
   - kind: ServiceAccount
-    name: configmap-watcher
+    name: migration-console-access-role
 roleRef:
   kind: Role
-  name: configmap-watcher
+  name: migration-console-access-role
   apiGroup: rbac.authorization.k8s.io

--- a/deployment/k8s/charts/components/replayer/templates/deployment.yaml
+++ b/deployment/k8s/charts/components/replayer/templates/deployment.yaml
@@ -4,14 +4,12 @@ kind: Deployment
 metadata:
   name: {{ include "generic.fullname" . }}
 spec:
-  replicas: 1
+  replicas: 0
   selector:
     matchLabels:
       app: {{ include "generic.fullname" . }}
   template:
     metadata:
-      annotations:
-        rollme: {{ randAlphaNum 5 | quote }}
       labels:
         app: {{ include "generic.fullname" . }}
         env: v1
@@ -36,7 +34,12 @@ spec:
               echo cat /shared/vars.sh...
               cat /shared/vars.sh
               source /shared/vars.sh
-              exec /runJavaWithClasspath.sh org.opensearch.migrations.replay.TrafficReplayer $ARGS
+              args_array=($ARGS)
+              {{/* Loop through the array and replace '|' with a space */}}
+              for i in "${!args_array[@]}"; do
+                args_array[$i]="${args_array[$i]//|/ }"
+              done
+              exec /runJavaWithClasspath.sh org.opensearch.migrations.replay.TrafficReplayer "${args_array[@]}"
           volumeMounts:
             - name: {{ $envMountName }}
               mountPath: /shared

--- a/deployment/k8s/charts/components/replayer/templates/deployment.yaml
+++ b/deployment/k8s/charts/components/replayer/templates/deployment.yaml
@@ -34,12 +34,11 @@ spec:
               echo cat /shared/vars.sh...
               cat /shared/vars.sh
               source /shared/vars.sh
-              args_array=($ARGS)
-              {{/* Loop through the array and replace '|' with a space */}}
-              for i in "${!args_array[@]}"; do
-                args_array[$i]="${args_array[$i]//|/ }"
-              done
-              exec /runJavaWithClasspath.sh org.opensearch.migrations.replay.TrafficReplayer "${args_array[@]}"
+              # Remove leading or trailing space in args file
+              sed -i 's/^[ \t]*//;s/[ \t]*$//' /shared/args.txt
+              readarray -t arg_array < /shared/args.txt
+              echo "Using args from file: ${arg_array[@]}"
+              exec /runJavaWithClasspath.sh org.opensearch.migrations.replay.TrafficReplayer "${arg_array[@]}"
           volumeMounts:
             - name: {{ $envMountName }}
               mountPath: /shared

--- a/deployment/k8s/charts/sharedResources/helmCommon/templates/initContainerToLoadEnvScript/_buildArgsFromEnvVarParameters.tpl
+++ b/deployment/k8s/charts/sharedResources/helmCommon/templates/initContainerToLoadEnvScript/_buildArgsFromEnvVarParameters.tpl
@@ -36,7 +36,8 @@
         {{- else -}}
             {{- if not (eq "" $formattedKeyFlagName) -}}
                 {{- $lines = append $lines (printf "if [ -n \"$%s\" ]; then" $envVarName) -}}
-                {{- $lines = append $lines (printf "  export %s=\"$%s %s $%s\"" $argsName $argsName $formattedKeyFlagName $envVarName) -}}
+                {{- $lines = append $lines (printf "  cleanString=$(echo \"$%s\" | sed 's/ /|/g')" $envVarName) -}}
+                {{- $lines = append $lines (printf "  export %s=\"$%s %s $cleanString\"" $argsName $argsName $formattedKeyFlagName) -}}
                 {{- $lines = append $lines (printf "fi") -}}
             {{- end -}}
         {{- end -}}

--- a/deployment/k8s/minikubeLocal.sh
+++ b/deployment/k8s/minikubeLocal.sh
@@ -12,10 +12,10 @@ kill_minikube_processes() {
   if [ -n "$mount_process_id" ]; then
     kill "$mount_process_id"
   fi
-  tunnel_process_id=$(pgrep -f "minikube tunnel")
-  if [ -n "$tunnel_process_id" ]; then
-    kill "$tunnel_process_id"
-  fi
+  #tunnel_process_id=$(pgrep -f "minikube tunnel")
+  #if [ -n "$tunnel_process_id" ]; then
+  #  kill "$tunnel_process_id"
+  #fi
 }
 
 start() {
@@ -24,7 +24,7 @@ start() {
 
   minikube start
   minikube mount .:/opensearch-migrations > /dev/null 2>&1 &
-  minikube tunnel > /dev/null 2>&1 &
+  #minikube tunnel > /dev/null 2>&1 &
 }
 
 pause() {

--- a/deployment/k8s/quickstart.md
+++ b/deployment/k8s/quickstart.md
@@ -1,0 +1,231 @@
+# 🚀 Quickstart Guide - Migration Assistant
+
+Get started quickly by testing out the Migration Assistant solution in a local Kubernetes cluster while utilizing test Elasticsearch and OpenSearch clusters and the same Helm charts that can be deployed to the cloud
+
+
+
+## What you'll need
+
+### 🔹 Install kubectl (Kubernetes CLI)
+
+`kubectl` is the primary command-line tool for managing and interacting with your Kubernetes cluster. Follow the official installation guide [here](https://kubernetes.io/docs/tasks/tools/).
+
+Kubectl autocompletion is also recommended [here](https://kubernetes.io/docs/reference/kubectl/generated/kubectl_completion/)
+
+✅ Verify install
+
+```shell
+kubectl version
+```
+
+
+### 🔹 Install Helm (Kubernetes Package Manager)
+
+Helm simplifies application deployment on Kubernetes by managing charts which are essentially pre-configured application definitions. Install Helm by following the instructions [here](https://helm.sh/docs/intro/install/).
+
+Helm autocompletion is also recommended [here](https://helm.sh/docs/helm/helm_completion_bash/)
+
+✅ Verify install
+
+```shell
+helm version
+```
+
+
+### 🔹 Install Docker
+
+Docker is essential for building container images and running a local Kubernetes cluster in this setup. Follow the setup guide [here](https://docs.docker.com/engine/install/).
+
+✅ Verify install
+
+```shell
+docker version
+```
+
+
+### 🔹 Install Minikube
+
+Minikube will be used as the local Kubernetes cluster for this deployment, follow the official installation instructions [here](https://minikube.sigs.k8s.io/docs/start/?arch=%2Fmacos%2Farm64%2Fstable%2Fbinary+download).
+
+✅ Verify install
+
+```shell
+minikube version
+```
+
+
+## Start your local Kubernetes cluster
+
+To get started we will utilize Minikube as our local Kubernetes environment. It will function very similarly to other Kubernetes environments like EKS in AWS.  We should first move to the K8s directory for the remainder of the commands
+
+```shell
+cd deployment/k8s
+```
+
+The following wrapper script command will start Minikube, which will create a minikube container in Docker within which the Kubernetes environment will live.
+
+```shell
+./minikubeLocal.sh --start
+```
+
+
+## Build the Docker images
+
+Since we are building from source here, we will need to build the necessary Docker images for the Migration Assistant that our K8s containers will utilize. An important point to note is that Minikube will use its own Docker registry separate from that of your local machine, this means it will have its own set of images separate from that of your local.
+
+```shell
+./buildDockerImagesMini.sh
+```
+
+If you are ever curious what images are in your Minikube environment the following command will list the images:
+
+```shell
+minikube image ls
+```
+
+
+
+## Update Helm Chart dependencies
+
+As you can see from the charts/ directory for our various component and aggregate charts, Helm will package and place its dependent charts in this directory. The following helper script will go through each of our charts and perform the helm dependency update  command so that the required dependencies are in place to deploy the desired charts
+
+```shell
+./update_deps.sh
+```
+
+
+## Deploy the Migration Assistant Helm chart
+
+This will deploy our main Migration Assistant Helm chart which will create the needed resources to perform the Migration Assistant suite of migration tooling
+
+```shell
+helm install ma -n ma charts/aggregates/migrationAssistant --create-namespace
+```
+
+To see all helm deployments for this namespace
+
+```shell
+helm -n ma list
+```
+
+To view the pods that were created and are initializing
+
+```shell
+kubectl -n ma get pods
+```
+
+
+## Deploy test clusters with Helm chart
+
+Next to simulate an actual migration environment we should create both a source cluster and target cluster that we will migrate data between . The below chart will create an Elasticsearch 7.10 source cluster and an OpenSearch 2.16 target cluster, but could be supplied different values to customize the source and target versions or settings by modifying the /charts/aggregates/mockCustomerClusters/values.yaml . We don’t need to wait for the Migration Assistant pods to finish initializing before deploying our test clusters with the below command.
+
+```shell
+helm install mcc -n ma charts/aggregates/mockCustomerClusters
+```
+
+
+## Access the Migration Console
+
+Open a shell to the Migration Console pod
+
+```shell
+kubectl -n ma exec --stdin --tty ma-migration-console-<pod_id> -- /bin/bash
+```
+
+The `<id>` here can easily be replaced with autocomplete or retrieved from the pod name when executing:
+
+```shell
+kubectl -n ma get pods
+```
+
+
+## Ingest test data into source cluster
+
+From the Migration Console this could be done with the default OpenSearch Benchmark workloads
+
+```shell
+console clusters run-test-benchmarks
+```
+
+Or by manually ingesting data
+
+```shell
+console clusters curl source_cluster -XPUT /my-test-index/_doc/1 -H "Content-Type: application/json" -d '{"message": "Hello, world!"}'
+```
+
+The current indices and documents for both clusters can then be viewed with
+
+```shell
+console clusters cat-indices
+```
+
+## Create a Snapshot
+
+Before performing a Metadata or Backfill migration, we should first create a snapshot of our source cluster which will be utilized by both migrations and remove any need for these migrations to send traffic to the source cluster
+
+```shell
+console snapshot create
+```
+
+The status of the snapshot being created can be viewed with
+
+```shell
+console snapshot status
+```
+
+
+## Perform Metadata Migration
+
+Often as an initial migration, we can perform a Metadata migration to migrate metadata, such as index settings, to the target cluster
+
+```shell
+console metadata migrate
+```
+
+The migrated index metadata can then be viewed with
+
+```shell
+console clusters cat-indices
+```
+
+
+## Perform Backfill Migration
+
+Once ready, the backfill migration can be triggered to start
+
+```shell
+console backfill start
+```
+
+As the backfill migration is in progress, we can check the documents being migrated to the target cluster
+
+```shell
+console clusters cat-indices --refresh
+```
+
+Once the backfill migration is completed, we can stop the backfill process
+
+```shell
+console backfill stop
+```
+
+
+## Cleanup
+
+After exiting the Migration Console
+
+```shell
+migration-console (~) -> exit
+```
+
+To remove both our Migration Assistant and Test Clusters Helm deployments:
+
+```shell
+helm uninstall -n ma ma mcc
+```
+
+To remove the Minikube container:
+
+```shell
+./minikubeLocal.sh --delete
+```

--- a/deployment/k8s/update_deps.sh
+++ b/deployment/k8s/update_deps.sh
@@ -2,6 +2,7 @@
 
 START_TIME=$(date +%s)
 
+helm dependency update charts/sharedResources/baseKafkaCluster
 helm dependency update charts/components/bulkLoad
 helm dependency update charts/components/captureProxy
 helm dependency update charts/components/migrationConsole

--- a/deployment/k8s/update_deps.sh
+++ b/deployment/k8s/update_deps.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+START_TIME=$(date +%s)
+
+helm dependency update charts/components/bulkLoad
+helm dependency update charts/components/captureProxy
+helm dependency update charts/components/migrationConsole
+helm dependency update charts/components/replayer
+
+helm dependency update charts/aggregates/migrationAssistant
+helm dependency update charts/aggregates/mockCustomerClusters
+
+END_TIME=$(date +%s)
+EXECUTION_TIME=$((END_TIME - START_TIME))
+
+echo "Execution Time: $EXECUTION_TIME seconds"

--- a/vars/README.md
+++ b/vars/README.md
@@ -1,3 +1,5 @@
 ### Migrations Jenkins Shared Library
 
-This directory represents the migrations shared library for Jenkins and contains relevant groovy files.**Note**: This directory must be named 'vars' and located at the root of the repo in order to allow dynamically loading in this library.
+This directory represents the migrations shared library for Jenkins and contains relevant groovy files.
+
+**Note**: This directory must be named 'vars' and located at the root of the repo in order to allow dynamically loading in this library.


### PR DESCRIPTION
### Description
This PR accomplishes several items to make performing our E2E python tests locally possible with a local K8s environment.

* Add Console Library support for performing RFS Backfill with a K8s setup
* Add Console Library support for performing Live Capture Replay with a K8s setup
* Adds basic status functionality to existing File System Snapshot implementation in Console Library
* Adds support for deleting the snapshot repository with the Console Library for outlier cases where this repository has got to a bad state and snapshot delete isn't sufficient
* Provide K8s support for arguments containing spaces being provided such as auth header for the Traffic Replayer
* Make minor modifications to allow Capture and Replay to be functional from a local K8s environment 
* Adds `quickstart.md` file for users looking to dive in quickly and test the Migration Assistant

### Issues Resolved
https://opensearch.atlassian.net/browse/MIGRATIONS-2390
https://opensearch.atlassian.net/browse/MIGRATIONS-2347

### Testing
Unit testing through Console Library
Manual local deployment testing

### Check List
- [ ] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
