### PR TITLE
Fix race condition causing failed request replay

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -101,6 +101,10 @@ jobs:
 
   gradle-tests:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        host: [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20]
+      fail-fast: false
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
@@ -115,12 +119,10 @@ jobs:
         run: ./gradlew build :TrafficCapture:dockerSolution:buildDockerImage_elasticsearch_client_test_console -x test -x spotlessCheck --stacktrace
         env:
           OS_MIGRATIONS_GRADLE_SCAN_TOS_AGREE_AND_ENABLED: ''
-
       - name: Run Tests with Coverage
         run: ./gradlew mergeJacocoReports -x spotlessCheck --stacktrace
         env:
           OS_MIGRATIONS_GRADLE_SCAN_TOS_AGREE_AND_ENABLED: ''
-
       - name: Detect Memory Dumps
         if: failure()
         run: |
@@ -130,19 +132,17 @@ jobs:
             echo "To download and inspect these files, navigate to 'Actions' -> 'Artifacts'."
             echo "::endgroup::"
           fi
-
       - name: Upload memory dump
         if: failure()
         uses: actions/upload-artifact@v4
         with:
           if-no-files-found: ignore
-          name: memory-dumps
+          name: memory-dumps-${{ matrix.host }}
           path: ./**/*.hprof
-
       - uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: test-reports-gradle-tests
+          name: test-reports-gradle-tests-host-${{ matrix.host }}
           path: |
             **/build/reports/tests/
             **/reports/jacoco/mergedReport/
@@ -150,9 +150,8 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           if-no-files-found: error
-          name: coverage-reports-gradle-tests
+          name: coverage-reports-gradle-tests-host-${{ matrix.host }}
           path: ./**/jacocoMergedReport.xml
-
 
   python-e2e-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -101,10 +101,6 @@ jobs:
 
   gradle-tests:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        host: [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20]
-      fail-fast: false
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
@@ -119,10 +115,12 @@ jobs:
         run: ./gradlew build :TrafficCapture:dockerSolution:buildDockerImage_elasticsearch_client_test_console -x test -x spotlessCheck --stacktrace
         env:
           OS_MIGRATIONS_GRADLE_SCAN_TOS_AGREE_AND_ENABLED: ''
+
       - name: Run Tests with Coverage
         run: ./gradlew mergeJacocoReports -x spotlessCheck --stacktrace
         env:
           OS_MIGRATIONS_GRADLE_SCAN_TOS_AGREE_AND_ENABLED: ''
+
       - name: Detect Memory Dumps
         if: failure()
         run: |
@@ -132,17 +130,19 @@ jobs:
             echo "To download and inspect these files, navigate to 'Actions' -> 'Artifacts'."
             echo "::endgroup::"
           fi
+
       - name: Upload memory dump
         if: failure()
         uses: actions/upload-artifact@v4
         with:
           if-no-files-found: ignore
-          name: memory-dumps-${{ matrix.host }}
+          name: memory-dumps
           path: ./**/*.hprof
+
       - uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: test-reports-gradle-tests-host-${{ matrix.host }}
+          name: test-reports-gradle-tests
           path: |
             **/build/reports/tests/
             **/reports/jacoco/mergedReport/
@@ -150,8 +150,9 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           if-no-files-found: error
-          name: coverage-reports-gradle-tests-host-${{ matrix.host }}
+          name: coverage-reports-gradle-tests
           path: ./**/jacocoMergedReport.xml
+
 
   python-e2e-tests:
     runs-on: ubuntu-latest

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/NettyPacketToHttpConsumer.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/NettyPacketToHttpConsumer.java
@@ -105,12 +105,12 @@ public class NettyPacketToHttpConsumer implements IPacketFinalizingConsumer<Aggr
         Duration readTimeoutDuration
     ) {
         this.replaySession = replaySession;
+        this.readTimeoutDuration = readTimeoutDuration;
+        this.responseBuilder = AggregatedRawResponse.builder(Instant.now());
         var parentContext = ctx.createTargetRequestContext();
         this.setCurrentMessageContext(parentContext.createHttpSendingContext());
-        responseBuilder = AggregatedRawResponse.builder(Instant.now());
         log.atDebug().setMessage("C'tor: incoming session={}").addArgument(replaySession).log();
         this.activeChannelFuture = activateLiveChannel();
-        this.readTimeoutDuration = readTimeoutDuration;
     }
 
     private TrackedFuture<String, Void> activateLiveChannel() {
@@ -382,6 +382,7 @@ public class NettyPacketToHttpConsumer implements IPacketFinalizingConsumer<Aggr
                     .setMessage("{} outbound channel was not set up successfully, NOT writing bytes hash={}")
                     .addArgument(() -> httpContext().getReplayerRequestKey())
                     .addArgument(() -> System.identityHashCode(packetData))
+                    .setCause(channelException)
                     .log();
                 if (channel != null) {
                     channel.close();

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/datahandlers/NettyPacketToHttpConsumerTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/datahandlers/NettyPacketToHttpConsumerTest.java
@@ -201,7 +201,7 @@ public class NettyPacketToHttpConsumerTest extends InstrumentationTest {
             useTls,
             withServerReadTimeout,
             RESPONSE_TIMEOUT_FOR_HUNG_TEST,
-            RESPONSE_TIMEOUT_FOR_HUNG_TEST.plus(Duration.ofMillis(250))
+            RESPONSE_TIMEOUT_FOR_HUNG_TEST.plus(Duration.ofMillis(1000))
         );
     }
 


### PR DESCRIPTION
### Description
Fix race condition where `readTimeoutMillis` may be accessed before it is set. This is because it was being used in an asynchronous callback setup in activateLiveChannel though initialized right afterwards.

Observed in [gha run](https://scans.gradle.com/s/jdpvxlyrg7sss/tests/task/:TrafficCapture:trafficReplayer:slowTest/details/org.opensearch.migrations.replay.datahandlers.NettyPacketToHttpConsumerTest/testThatPeerResetTriggersFinalizeFuture(boolean%2C%20boolean)%5B1%5D?top-execution=1)

```
java.util.concurrent.CompletionException: java.lang.NullPointerException: Cannot invoke "java.time.Duration.toMillis()" because "this.readTimeoutDuration" is null |  
...
  | at org.opensearch.migrations.replay.datahandlers.NettyPacketToHttpConsumer.lambda$activateLiveChannel$3(NettyPacketToHttpConsumer.java:124) ~[trafficReplayer-0.1.0-SNAPSHOT.jar:?] |  
  | at org.opensearch.migrations.utils.TrackedFuture.lambda$thenCompose$7(TrackedFuture.java:165) ~[coreUtilities-0.1.0-SNAPSHOT.jar:?] |  
  | at java.base/java.util.concurrent.CompletableFuture.uniComposeStage(CompletableFuture.java:1187) ~[?:?] |  
  | at java.base/java.util.concurrent.CompletableFuture.thenCompose(CompletableFuture.java:2309) ~[?:?] |  
  | at org.opensearch.migrations.utils.TrackedFuture.thenCompose(TrackedFuture.java:164) ~[coreUtilities-0.1.0-SNAPSHOT.jar:?] |  
  | at org.opensearch.migrations.replay.datahandlers.NettyPacketToHttpConsumer.activateLiveChannel(NettyPacketToHttpConsumer.java:120) ~[trafficReplayer-0.1.0-SNAPSHOT.jar:?] |  
  | at org.opensearch.migrations.replay.datahandlers.NettyPacketToHttpConsumer.<init>(NettyPacketToHttpConsumer.java:112) ~[trafficReplayer-0.1.0-SNAPSHOT.jar:?]
...
```

Modified `RESPONSE_TIMEOUT_FOR_HUNG_TEST.plus(Duration.ofMillis(1000))` to fix cases where resource contention caused test `testThatPeerResetTriggersFinalizeFuture` to fail intermittently.

### Issues Resolved

[MIGRATIONS-2412](https://opensearch.atlassian.net/browse/MIGRATIONS-2412)

### Testing
Ran GHA 20x which consistently reproduced the issue, moving around the initialization resolved the issue, results can be found [here](https://github.com/opensearch-project/opensearch-migrations/actions/runs/13467149087)

### Check List
- [x] New functionality includes testing
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
