### PR TITLE
Parallel gradle gha

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -323,6 +323,7 @@ jobs:
     needs:
       - console-python-tests
       - gradle-tests
+      - jacoco-aggregate
       - link-checker
       - node-tests
       - python-e2e-tests

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -159,7 +159,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          if-no-files-found: ignore
+          if-no-files-found: warn
           name: memory-dumps-gradle-tests-${{ steps.sanitize-name.outputs.sanitized_name }}
           path: ./**/*.hprof
 
@@ -167,7 +167,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          if-no-files-found: ignore # Needed for subprojects that don't have tests
+          if-no-files-found: error
           name: test-reports-gradle-tests-${{ steps.sanitize-name.outputs.sanitized_name }}
           path: |
             **/build/reports/tests/
@@ -176,7 +176,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          if-no-files-found: ignore # Needed for subprojects that don't have tests
+          if-no-files-found: error
           name: coverage-exec-artifacts-gradle-tests-${{ steps.sanitize-name.outputs.sanitized_name }}
           path: |
             **/build/jacoco/*.exec
@@ -201,7 +201,7 @@ jobs:
           pattern: coverage-exec-artifacts-gradle-tests-*
 
       - name: Create .exec directory
-        run: rm -rf build/jacoco && mkdir -p build/jacoco
+        run: rm -rf build/jacocoMerged && mkdir -p build/jacocoMerged
 
       - name: Move .exec files for aggregation
         run: |
@@ -214,7 +214,7 @@ jobs:
             find "$artifact_dir" -name "*.exec" -exec sh -c '
               src="$1"
               filename=$(basename "$src")
-              dest="build/jacoco/'"$subproject"'_$filename"
+              dest="build/jacocoMerged/'"$subproject"'_$filename"
               cp "$src" "$dest"
               echo "Copied $src to $dest"
             ' sh {} \;
@@ -222,7 +222,7 @@ jobs:
 
           # List all the .exec files copied
           echo "All copied .exec files:"
-          find build/jacoco -type f -name "*.exec" | sort
+          find build/jacocoMerged -type f -name "*.exec" | sort
 
       - name: Generate aggregate JaCoCo report
         run: ./gradlew jacocoAggregateReport -x spotlessCheck
@@ -232,9 +232,10 @@ jobs:
       - name: Upload Aggregate JaCoCo report
         uses: actions/upload-artifact@v4
         with:
+          if-no-files-found: error
           name: coverage-reports-gradle-tests-aggregate
           path: |
-            build/reports/jacoco/jacocoAggregateReport/jacocoAggregateReport.xml
+            **/jacocoMergedReport.xml
 
   python-e2e-tests:
     runs-on: ubuntu-latest
@@ -283,6 +284,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
+          if-no-files-found: error
           name: e2e-test-logs
           path: |
             logs/docker

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -117,7 +117,7 @@ jobs:
           reports=$(./gradlew tasks --all | grep jacocoTestReport | awk -F' - ' '{print $1}' | sed 's/:jacocoTestReport//' | sort -u)
           matrix=$(echo "$reports" | grep . | jq -R -s -c 'split("\n")[:-1] | {include: map({subproject: .})}')
           echo "Matrix is: $matrix"
-          echo "::set-output name=matrix::$matrix"
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
 
   gradle-tests:
     needs:
@@ -139,7 +139,7 @@ jobs:
         id: sanitize-name
         run: |
           sanitized_name=$(echo "${{ matrix.subproject }}" | sed 's/[^a-zA-Z0-9]/_/g')
-          echo "::set-output name=sanitized_name::$sanitized_name"
+          echo "sanitized_name=$sanitized_name" >> "$GITHUB_OUTPUT"
       - name: Run tests for ${{ matrix.subproject }}
         run: ./gradlew :${{ matrix.subproject }}:jacocoTestReport -x spotlessCheck --stacktrace
         env:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -51,17 +51,17 @@ jobs:
   python-lint:
     runs-on: ubuntu-latest
     steps:
-     - uses: actions/checkout@v4
-     - uses: actions/setup-python@v5
-       with:
-         python-version: ${{ env.python-version }}
-     - name: Install dependencies
-       run: |
-        python3 -m pip install --upgrade pip
-        python3 -m pip install flake8
-     - name: Analysing the code with flake8
-       run: |
-        flake8 $(git ls-files '*.py')
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.python-version }}
+      - name: Install dependencies
+        run: |
+          python3 -m pip install --upgrade pip
+          python3 -m pip install flake8
+      - name: Analysing the code with flake8
+        run: |
+          flake8 $(git ls-files '*.py')
 
   console-python-tests:
     runs-on: ubuntu-latest
@@ -119,14 +119,15 @@ jobs:
         run: |
           matrix=$(./gradlew listTestTasksAsJson --quiet | jq -c)
           echo "Matrix is: $matrix"
-          echo "matrix={\"include\": $(echo $matrix)}" >> "$GITHUB_OUTPUT"
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
 
   gradle-tests:
     needs:
       - generate-project-test-matrix
     runs-on: ubuntu-latest
     strategy:
-      matrix: ${{ fromJson(needs.generate-project-test-matrix.outputs.matrix) }}
+      matrix:
+        task: ${{ fromJson(needs.generate-project-test-matrix.outputs.matrix) }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
@@ -140,10 +141,10 @@ jobs:
       - name: Sanitize task name
         id: sanitize-name
         run: |
-          sanitized_name=$(echo "${{ matrix }}" | sed 's/[^a-zA-Z0-9]/_/g')
+          sanitized_name=$(echo "${{ matrix.task }}" | sed 's/[^a-zA-Z0-9]/_/g')
           echo "sanitized_name=$sanitized_name" >> "$GITHUB_OUTPUT"
-      - name: Run Gradle task ${{ matrix }}
-        run: ./gradlew ${{ matrix }} -x spotlessCheck --stacktrace
+      - name: Run Gradle task ${{ matrix.task }}
+        run: ./gradlew ${{ matrix.task }} -x spotlessCheck --stacktrace
         env:
           OS_MIGRATIONS_GRADLE_SCAN_TOS_AGREE_AND_ENABLED: ''
       - name: Detect Memory Dumps
@@ -163,8 +164,8 @@ jobs:
           name: memory-dumps-gradle-tests-${{ steps.sanitize-name.outputs.sanitized_name }}
           path: ./**/*.hprof
 
-      - name: Upload test reports for ${{ matrix }}
-        if: always() && contains(matrix, 'jacoco')
+      - name: Upload test reports for ${{ matrix.task }}
+        if: always() && contains(matrix.task, 'jacoco')
         uses: actions/upload-artifact@v4
         with:
           if-no-files-found: error
@@ -172,8 +173,8 @@ jobs:
           path: |
             **/build/reports/tests/
 
-      - name: Publish Jacoco report artifact for ${{ matrix }}
-        if: always() && contains(matrix, 'jacoco')
+      - name: Publish Jacoco report artifact for ${{ matrix.task }}
+        if: always() && contains(matrix.task, 'jacoco')
         uses: actions/upload-artifact@v4
         with:
           if-no-files-found: error
@@ -182,7 +183,7 @@ jobs:
             **/build/jacoco/*.exec
 
   jacoco-aggregate:
-    needs: [gradle-tests]
+    needs: [ gradle-tests ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -98,9 +98,33 @@ jobs:
           name: coverage-reports-python-tests-${{ env.SANITIZED_PY_PROJECT }}
           path: ${{ env.WORKING_DIR }}/coverage.xml
 
+  generate-project-test-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          java-version: ${{ env.java-version }}
+          distribution: "corretto"
+      - uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: ${{ env.gradle-version }}
+      - name: Generate matrix for jacocoTestReport jobs
+        id: set-matrix
+        run: |
+          reports=$(./gradlew tasks --all | grep jacocoTestReport | awk -F' - ' '{print $1}' | sed 's/:jacocoTestReport//' | sort -u)
+          matrix=$(echo "$reports" | grep . | jq -R -s -c 'split("\n")[:-1] | {include: map({subproject: .})}')
+          echo "Matrix is: $matrix"
+          echo "::set-output name=matrix::$matrix"
 
   gradle-tests:
+    needs:
+      - generate-project-test-matrix
     runs-on: ubuntu-latest
+    strategy:
+      matrix: ${{ fromJson(needs.generate-project-test-matrix.outputs.matrix) }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
@@ -111,13 +135,13 @@ jobs:
         with:
           gradle-version: ${{ env.gradle-version }}
           gradle-home-cache-cleanup: true
-      - name: Run Gradle Build
-        run: ./gradlew build :TrafficCapture:dockerSolution:buildDockerImage_elasticsearch_client_test_console -x test -x spotlessCheck --stacktrace
-        env:
-          OS_MIGRATIONS_GRADLE_SCAN_TOS_AGREE_AND_ENABLED: ''
-
-      - name: Run Tests with Coverage
-        run: ./gradlew mergeJacocoReports -x spotlessCheck --stacktrace
+      - name: Sanitize subproject name
+        id: sanitize-name
+        run: |
+          sanitized_name=$(echo "${{ matrix.subproject }}" | sed 's/[^a-zA-Z0-9]/_/g')
+          echo "::set-output name=sanitized_name::$sanitized_name"
+      - name: Run tests for ${{ matrix.subproject }}
+        run: ./gradlew :${{ matrix.subproject }}:jacocoTestReport -x spotlessCheck --stacktrace
         env:
           OS_MIGRATIONS_GRADLE_SCAN_TOS_AGREE_AND_ENABLED: ''
 
@@ -136,23 +160,81 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           if-no-files-found: ignore
-          name: memory-dumps
+          name: memory-dumps-gradle-tests-${{ steps.sanitize-name.outputs.sanitized_name }}
           path: ./**/*.hprof
 
-      - uses: actions/upload-artifact@v4
+      - name: Upload test reports for ${{ matrix.subproject }}
+        uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: test-reports-gradle-tests
+          if-no-files-found: ignore # Needed for subprojects that don't have tests
+          name: test-reports-gradle-tests-${{ steps.sanitize-name.outputs.sanitized_name }}
           path: |
             **/build/reports/tests/
-            **/reports/jacoco/mergedReport/
-      - name: Upload Coverage Reports
+
+      - name: Publish jacoco report artifact for ${{ matrix.subproject }}
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          if-no-files-found: ignore # Needed for subprojects that don't have tests
+          name: coverage-exec-artifacts-gradle-tests-${{ steps.sanitize-name.outputs.sanitized_name }}
+          path: |
+            **/build/jacoco/*.exec
+
+  jacoco-aggregate:
+    needs: [gradle-tests]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          java-version: ${{ env.java-version }}
+          distribution: 'corretto'
+      - uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: ${{ env.gradle-version }}
+
+      - name: Download all JaCoCo .exec files
+        uses: actions/download-artifact@v4
+        with:
+          path: jacoco-artifacts
+          pattern: coverage-exec-artifacts-gradle-tests-*
+
+      - name: Create .exec directory
+        run: rm -rf build/jacoco && mkdir -p build/jacoco
+
+      - name: Move .exec files for aggregation
+        run: |
+          # Find and copy .exec files while renaming them to include their subproject name
+          for artifact_dir in jacoco-artifacts/coverage-exec-artifacts-gradle-tests-*; do
+            # Extract the subproject name from the directory
+            subproject=$(basename "$artifact_dir" | sed 's/coverage-exec-artifacts-gradle-tests-//')
+
+            # Find and copy each .exec file with a unique name
+            find "$artifact_dir" -name "*.exec" -exec sh -c '
+              src="$1"
+              filename=$(basename "$src")
+              dest="build/jacoco/'"$subproject"'_$filename"
+              cp "$src" "$dest"
+              echo "Copied $src to $dest"
+            ' sh {} \;
+          done
+
+          # List all the .exec files copied
+          echo "All copied .exec files:"
+          find build/jacoco -type f -name "*.exec" | sort
+
+      - name: Generate aggregate JaCoCo report
+        run: ./gradlew jacocoAggregateReport -x spotlessCheck
+        env:
+          OS_MIGRATIONS_GRADLE_SCAN_TOS_AGREE_AND_ENABLED: ''
+
+      - name: Upload Aggregate JaCoCo report
         uses: actions/upload-artifact@v4
         with:
-          if-no-files-found: error
-          name: coverage-reports-gradle-tests
-          path: ./**/jacocoMergedReport.xml
-
+          name: coverage-reports-gradle-tests-aggregate
+          path: |
+            build/reports/jacoco/jacocoAggregateReport/jacocoAggregateReport.xml
 
   python-e2e-tests:
     runs-on: ubuntu-latest
@@ -167,7 +249,7 @@ jobs:
           gradle-version: ${{ env.gradle-version }}
       - uses: actions/setup-python@v5
         with:
-         python-version: ${{ env.python-version }}
+          python-version: ${{ env.python-version }}
       - name: Generate Cache Key from Dockerfiles
         id: generate_cache_key
         run: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -194,35 +194,15 @@ jobs:
         with:
           gradle-version: ${{ env.gradle-version }}
 
-      - name: Download all JaCoCo .exec files
-        uses: actions/download-artifact@v4
-        with:
-          path: jacoco-artifacts
-          pattern: coverage-exec-artifacts-gradle-tests-*
-
-      - name: Create .exec directory
+      - name: Create clean .exec directory
         run: rm -rf build/jacocoMerged && mkdir -p build/jacocoMerged
 
-      - name: Move .exec files for aggregation
-        run: |
-          # Find and copy .exec files while renaming them to include their subproject name
-          for artifact_dir in jacoco-artifacts/coverage-exec-artifacts-gradle-tests-*; do
-            # Extract the subproject name from the directory
-            subproject=$(basename "$artifact_dir" | sed 's/coverage-exec-artifacts-gradle-tests-//')
-
-            # Find and copy each .exec file with a unique name
-            find "$artifact_dir" -name "*.exec" -exec sh -c '
-              src="$1"
-              filename=$(basename "$src")
-              dest="build/jacocoMerged/'"$subproject"'_$filename"
-              cp "$src" "$dest"
-              echo "Copied $src to $dest"
-            ' sh {} \;
-          done
-
-          # List all the .exec files copied
-          echo "All copied .exec files:"
-          find build/jacocoMerged -type f -name "*.exec" | sort
+      - name: Download all JaCoCo .exec files into directory expected by jacocoAggregateReport
+        uses: actions/download-artifact@v4
+        with:
+          path: build/jacocoMerged
+          pattern: coverage-exec-artifacts-gradle-tests-*
+          merge-multiple: true
 
       - name: Generate aggregate JaCoCo report
         run: ./gradlew jacocoAggregateReport -x spotlessCheck

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -104,20 +104,22 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - uses: actions/checkout@v4
+
       - uses: actions/setup-java@v4
         with:
           java-version: ${{ env.java-version }}
           distribution: "corretto"
+
       - uses: gradle/actions/setup-gradle@v4
         with:
           gradle-version: ${{ env.gradle-version }}
-      - name: Generate matrix for jacocoTestReport jobs
+
+      - name: Generate matrix for test jobs
         id: set-matrix
         run: |
-          reports=$(./gradlew tasks --all | grep jacocoTestReport | awk -F' - ' '{print $1}' | sed 's/:jacocoTestReport//' | sort -u)
-          matrix=$(echo "$reports" | grep . | jq -R -s -c 'split("\n")[:-1] | {include: map({subproject: .})}')
+          matrix=$(./gradlew listTestTasksAsJson --quiet | jq -c)
           echo "Matrix is: $matrix"
-          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+          echo "matrix={\"include\": $(echo $matrix)}" >> "$GITHUB_OUTPUT"
 
   gradle-tests:
     needs:
@@ -135,16 +137,15 @@ jobs:
         with:
           gradle-version: ${{ env.gradle-version }}
           gradle-home-cache-cleanup: true
-      - name: Sanitize subproject name
+      - name: Sanitize task name
         id: sanitize-name
         run: |
-          sanitized_name=$(echo "${{ matrix.subproject }}" | sed 's/[^a-zA-Z0-9]/_/g')
+          sanitized_name=$(echo "${{ matrix }}" | sed 's/[^a-zA-Z0-9]/_/g')
           echo "sanitized_name=$sanitized_name" >> "$GITHUB_OUTPUT"
-      - name: Run tests for ${{ matrix.subproject }}
-        run: ./gradlew :${{ matrix.subproject }}:jacocoTestReport -x spotlessCheck --stacktrace
+      - name: Run Gradle task ${{ matrix }}
+        run: ./gradlew ${{ matrix }} -x spotlessCheck --stacktrace
         env:
           OS_MIGRATIONS_GRADLE_SCAN_TOS_AGREE_AND_ENABLED: ''
-
       - name: Detect Memory Dumps
         if: failure()
         run: |
@@ -154,7 +155,6 @@ jobs:
             echo "To download and inspect these files, navigate to 'Actions' -> 'Artifacts'."
             echo "::endgroup::"
           fi
-
       - name: Upload memory dump
         if: failure()
         uses: actions/upload-artifact@v4
@@ -163,18 +163,18 @@ jobs:
           name: memory-dumps-gradle-tests-${{ steps.sanitize-name.outputs.sanitized_name }}
           path: ./**/*.hprof
 
-      - name: Upload test reports for ${{ matrix.subproject }}
+      - name: Upload test reports for ${{ matrix }}
+        if: always() && contains(matrix, 'jacoco')
         uses: actions/upload-artifact@v4
-        if: always()
         with:
           if-no-files-found: error
           name: test-reports-gradle-tests-${{ steps.sanitize-name.outputs.sanitized_name }}
           path: |
             **/build/reports/tests/
 
-      - name: Publish jacoco report artifact for ${{ matrix.subproject }}
+      - name: Publish Jacoco report artifact for ${{ matrix }}
+        if: always() && contains(matrix, 'jacoco')
         uses: actions/upload-artifact@v4
-        if: always()
         with:
           if-no-files-found: error
           name: coverage-exec-artifacts-gradle-tests-${{ steps.sanitize-name.outputs.sanitized_name }}

--- a/TrafficCapture/build.gradle
+++ b/TrafficCapture/build.gradle
@@ -43,13 +43,13 @@ allprojects {
 }
 
 subprojects {
-    tasks.named('test', Test) {
+    tasks.matching { it.name == 'test' && it instanceof Test }.configureEach {
         // Memory leak tests are adding too much execution time on `test` in TrafficCapture
         // Disabling and will test in `slowTest`
-        it.systemProperty 'disableMemoryLeakTests', 'true'
+        systemProperty 'disableMemoryLeakTests', 'true'
     }
 
-    tasks.named('slowTest', Test) {
+    tasks.matching { it.name == 'slowTest' && it instanceof Test }.configureEach {
         useJUnitPlatform {
             includeTags = []
             excludeTags = ['isolatedTest']

--- a/build.gradle
+++ b/build.gradle
@@ -309,38 +309,19 @@ subprojects {
     jacocoTestReport {
         dependsOn = project.tasks.withType(Test).matching { it.jacoco && it.jacoco.enabled }
         executionData.from = project.tasks.withType(Test).matching { it.jacoco && it.jacoco.enabled }.collect { it.jacoco.destinationFile }
-        classDirectories.setFrom(
-                files(allprojects.collect { project ->
-                    project.sourceSets.main.output.classesDirs.filter { dir ->
-                        !dir.path.contains('captureProtobufs') &&
-                                !dir.path.contains('trafficCaptureProxyServerTest')
-                    }
-                })
-        )
-
-        sourceDirectories.setFrom(
-                files(allprojects.collect { project ->
-                    project.sourceSets.main.allSource.srcDirs
-                })
-        )
-
         reports {
             xml.required = true
-            xml.destination file("${buildDir}/reports/jacoco/test/jacocoTestReport.xml")
-            html.required = true
-            html.destination file("${buildDir}/reports/jacoco/test/html")
         }
     }
 }
 
-// Aggregate JaCoCo report task for all subprojects
 tasks.register('jacocoAggregateReport', JacocoReport) {
     group = 'Verification'
-    description = 'Generates an aggregate report from exec files in build/jacoco/*.exec over the whole project'
+    description = 'Generates an aggregate report from exec files in build/jacocoMerged/*.exec over the whole project'
 
-    // Find all .exec files
+    // Find all merged .exec files
     executionData.setFrom(fileTree(dir: "${buildDir}", includes: [
-            "jacoco/*.exec"
+            "jacocoMerged/*.exec"
     ]))
 
     // Get all subprojects with Java plugin
@@ -363,12 +344,11 @@ tasks.register('jacocoAggregateReport', JacocoReport) {
             })
     )
 
-
     reports {
         xml.required = true
-        xml.destination file("${buildDir}/reports/jacoco/jacocoAggregateReport/jacocoAggregateReport.xml")
+        xml.destination file("${buildDir}/reports/jacoco/mergedReport/jacocoMergedReport.xml")
         html.required = true
-        html.destination file("${buildDir}/reports/jacoco/jacocoAggregateReport/html")
+        html.destination file("${buildDir}/reports/jacoco/mergedReport/html")
     }
 }
 
@@ -402,25 +382,34 @@ gradle.projectsEvaluated {
     }
 }
 
-task mergeJacocoReports(type: JacocoReport) {
+task mergeJacocoReports {
     def jacocoReportTasks = subprojects.collect { it.tasks.withType(JacocoReport).matching { it.name == "jacocoTestReport" } }.flatten()
     dependsOn jacocoReportTasks
 
-    additionalSourceDirs.setFrom(files(jacocoReportTasks.collect { it.additionalSourceDirs }.flatten()))
-    sourceDirectories.setFrom(files(jacocoReportTasks.collect { it.sourceDirectories }.flatten()))
-    classDirectories.setFrom(files(subprojects.collect { subproject ->
-        subproject.sourceSets.main.output.classesDirs.filter { dir ->
-            !dir.path.contains('captureProtobufs') && !dir.path.contains('trafficCaptureProxyServerTest')
-        }
-    }))
-    executionData.setFrom(files(jacocoReportTasks.collect { it.executionData }.flatten()))
+    // Create a Sync task to collect all exec files
+    def syncJacocoExecFiles = tasks.create("syncJacocoExecFiles", Sync) {
+        from jacocoReportTasks.collect { it.executionData }
+        into "${buildDir}/jacocoMerged/"
+        duplicatesStrategy = DuplicatesStrategy.FAIL
 
-    reports {
-        xml.required = true
-        xml.destination = file("${buildDir}/reports/jacoco/mergedReport/jacocoMergedReport.xml")
-        html.required = true
-        html.destination = file("${buildDir}/reports/jacoco/mergedReport/html")
+        // Ensure unique names by including project path
+        eachFile { fileCopyDetails ->
+            // Get the project from the file path
+            def projectPath = jacocoReportTasks.find { task ->
+                task.executionData.files.contains(fileCopyDetails.file)
+            }?.project?.path?.replaceAll('[^a-zA-Z0-9]', '_') ?: 'unknown'
+
+            // Set a unique name with project identifier
+            fileCopyDetails.name = "${projectPath}_${fileCopyDetails.name}"
+        }
     }
+
+    // Make sure sync task runs after all report tasks
+    syncJacocoExecFiles.mustRunAfter jacocoReportTasks
+    dependsOn syncJacocoExecFiles
+
+    // Finalize with jacocoAggregateReport
+    finalizedBy jacocoAggregateReport
 }
 
 task listPublishedArtifacts {

--- a/build.gradle
+++ b/build.gradle
@@ -309,13 +309,66 @@ subprojects {
     jacocoTestReport {
         dependsOn = project.tasks.withType(Test).matching { it.jacoco && it.jacoco.enabled }
         executionData.from = project.tasks.withType(Test).matching { it.jacoco && it.jacoco.enabled }.collect { it.jacoco.destinationFile }
-        classDirectories.from = files(subprojects.collect { it.sourceSets.main.output.classesDirs })
+        classDirectories.setFrom(
+                files(allprojects.collect { project ->
+                    project.sourceSets.main.output.classesDirs.filter { dir ->
+                        !dir.path.contains('captureProtobufs') &&
+                                !dir.path.contains('trafficCaptureProxyServerTest')
+                    }
+                })
+        )
+
+        sourceDirectories.setFrom(
+                files(allprojects.collect { project ->
+                    project.sourceSets.main.allSource.srcDirs
+                })
+        )
+
         reports {
             xml.required = true
             xml.destination file("${buildDir}/reports/jacoco/test/jacocoTestReport.xml")
             html.required = true
             html.destination file("${buildDir}/reports/jacoco/test/html")
         }
+    }
+}
+
+// Aggregate JaCoCo report task for all subprojects
+tasks.register('jacocoAggregateReport', JacocoReport) {
+    group = 'Verification'
+    description = 'Generates an aggregate report from exec files in build/jacoco/*.exec over the whole project'
+
+    // Find all .exec files
+    executionData.setFrom(fileTree(dir: "${buildDir}", includes: [
+            "jacoco/*.exec"
+    ]))
+
+    // Get all subprojects with Java plugin
+    def javaProjects = subprojects.findAll { it.plugins.hasPlugin('java') }
+
+    // Collect all class directories from Java subprojects
+    classDirectories.setFrom(
+            files(javaProjects.collect { project ->
+                project.sourceSets.main.output.classesDirs.filter { dir ->
+                    !dir.path.contains('captureProtobufs') &&
+                            !dir.path.contains('trafficCaptureProxyServerTest')
+                }
+            })
+    )
+
+    // Collect all source directories from Java subprojects
+    sourceDirectories.setFrom(
+            files(javaProjects.collect { project ->
+                project.sourceSets.main.allSource.srcDirs
+            })
+    )
+
+
+    reports {
+        xml.required = true
+        xml.destination file("${buildDir}/reports/jacoco/jacocoAggregateReport/jacocoAggregateReport.xml")
+        html.required = true
+        html.destination file("${buildDir}/reports/jacoco/jacocoAggregateReport/html")
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -173,7 +173,10 @@ subprojects {
         systemProperty 'log4j2.contextSelector', 'org.apache.logging.log4j.core.selector.BasicContextSelector'
         // Verify assertions in tests
         jvmArgs = ['-ea', '-XX:+HeapDumpOnOutOfMemoryError']
-        jacoco.enabled = true
+        jacoco {
+            enabled = true
+            destinationFile = layout.buildDirectory.file("jacoco/${project.path.replace(':', '-')}-${project.name}-${name}.exec").get().asFile
+        }
     }
 
     // Mutually exclusive tests to avoid duplication
@@ -321,7 +324,7 @@ tasks.register('jacocoAggregateReport', JacocoReport) {
 
     // Find all merged .exec files
     executionData.setFrom(fileTree(dir: "${buildDir}", includes: [
-            "jacocoMerged/*.exec"
+            "jacocoMerged/**/*.exec"
     ]))
 
     // Get all subprojects with Java plugin
@@ -391,17 +394,6 @@ task mergeJacocoReports {
         from jacocoReportTasks.collect { it.executionData }
         into "${buildDir}/jacocoMerged/"
         duplicatesStrategy = DuplicatesStrategy.FAIL
-
-        // Ensure unique names by including project path
-        eachFile { fileCopyDetails ->
-            // Get the project from the file path
-            def projectPath = jacocoReportTasks.find { task ->
-                task.executionData.files.contains(fileCopyDetails.file)
-            }?.project?.path?.replaceAll('[^a-zA-Z0-9]', '_') ?: 'unknown'
-
-            // Set a unique name with project identifier
-            fileCopyDetails.name = "${projectPath}_${fileCopyDetails.name}"
-        }
     }
 
     // Make sure sync task runs after all report tasks

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,5 @@
+import groovy.json.JsonOutput
+
 plugins {
 //    Observing higher memory usage with task-tree plugin. Disabling except if needed
 //    id "com.dorongold.task-tree" version "2.1.1"
@@ -151,61 +153,69 @@ subprojects {
     tasks.withType(Test) {
         // Getting javadoc to compile is part of the test suite to ensure we are able to publish our artifacts
         dependsOn project.javadoc
-
-        testLogging {
-            events "passed", "skipped", "failed"
-            exceptionFormat "full"
-            showExceptions true
-            showCauses true
-            showStackTraces true
-        }
-        maxParallelForks = gradle.startParameter.maxWorkerCount
-
-        // Provide way to exclude particular tests from CLI
-        // e.g. ../gradlew test -PexcludeTests=**/KafkaProtobufConsumerLongTermTest*
-        if (project.hasProperty('excludeTests')) {
-            exclude project.property('excludeTests')
-        }
-
-        useJUnitPlatform()
-        //  Disable parallel test execution, see MIGRATIONS-1666
-        systemProperty 'junit.jupiter.execution.parallel.enabled', 'false'
-        systemProperty 'log4j2.contextSelector', 'org.apache.logging.log4j.core.selector.BasicContextSelector'
-        // Verify assertions in tests
-        jvmArgs = ['-ea', '-XX:+HeapDumpOnOutOfMemoryError']
-        jacoco {
-            enabled = true
-            destinationFile = layout.buildDirectory.file("jacoco/${project.path.replace(':', '-')}-${project.name}-${name}.exec").get().asFile
-        }
     }
+    if (!sourceSets.test.allSource.files.isEmpty()) {
+        tasks.withType(Test) {
+            testLogging {
+                events "passed", "skipped", "failed"
+                exceptionFormat "full"
+                showExceptions true
+                showCauses true
+                showStackTraces true
+            }
+            maxParallelForks = gradle.startParameter.maxWorkerCount
 
-    // Mutually exclusive tests to avoid duplication
-    tasks.named('test') {
-        systemProperty 'migrationLogLevel', 'TRACE'
-        useJUnitPlatform {
-            excludeTags('longTest', 'isolatedTest')
+            // Provide way to exclude particular tests from CLI
+            // e.g. ../gradlew test -PexcludeTests=**/KafkaProtobufConsumerLongTermTest*
+            if (project.hasProperty('excludeTests')) {
+                exclude project.property('excludeTests')
+            }
+
+            useJUnitPlatform()
+            //  Disable parallel test execution, see MIGRATIONS-1666
+            systemProperty 'junit.jupiter.execution.parallel.enabled', 'false'
+            systemProperty 'log4j2.contextSelector', 'org.apache.logging.log4j.core.selector.BasicContextSelector'
+            // Verify assertions in tests
+            jvmArgs = ['-ea', '-XX:+HeapDumpOnOutOfMemoryError']
+            jacoco {
+                enabled = true
+                destinationFile = layout.buildDirectory.file("jacoco/${project.path.replace(':', '-')}-${project.name}-${name}.exec").get().asFile
+            }
         }
-    }
-
-    tasks.register('slowTest', Test) {
-        systemProperty 'migrationLogLevel', 'DEBUG'
-        useJUnitPlatform {
-            includeTags 'longTest'
-            excludeTags 'isolatedTest'
+        // Mutually exclusive tests to avoid duplication
+        tasks.named('test') {
+            systemProperty 'migrationLogLevel', 'TRACE'
+            useJUnitPlatform {
+                excludeTags('longTest', 'isolatedTest')
+            }
         }
-    }
 
-    tasks.register('isolatedTest', Test) {
-        maxParallelForks = 1
-        useJUnitPlatform {
-            includeTags 'isolatedTest'
+        tasks.register('slowTest', Test) {
+            systemProperty 'migrationLogLevel', 'DEBUG'
+            useJUnitPlatform {
+                includeTags 'longTest'
+                excludeTags 'isolatedTest'
+            }
         }
-    }
 
-    tasks.register('fullTest') {
-        dependsOn test
-        dependsOn slowTest
-        dependsOn isolatedTest
+        tasks.register('isolatedTest', Test) {
+            maxParallelForks = 1
+            useJUnitPlatform {
+                includeTags 'isolatedTest'
+            }
+        }
+
+        tasks.register('fullTest') {
+            dependsOn test
+            dependsOn slowTest
+            dependsOn isolatedTest
+        }
+    } else {
+        tasks.withType(Test) {
+            jacoco {
+                enabled = false
+            }
+        }
     }
 
     task javadocJar(type: Jar, dependsOn: javadoc) {
@@ -309,9 +319,10 @@ subprojects {
         into "${buildDir}/dependencies"
     }
 
+    def testsWithJacoco = project.tasks.withType(Test).matching { it.jacoco && it.jacoco.enabled }
     jacocoTestReport {
-        dependsOn = project.tasks.withType(Test).matching { it.jacoco && it.jacoco.enabled }
-        executionData.from = project.tasks.withType(Test).matching { it.jacoco && it.jacoco.enabled }.collect { it.jacoco.destinationFile }
+        dependsOn = testsWithJacoco
+        executionData.from testsWithJacoco*.jacoco.destinationFile
         reports {
             xml.required = true
         }
@@ -416,5 +427,32 @@ task listPublishedArtifacts {
                 }
             }
         }
+    }
+}
+
+tasks.register("listTestTasksAsJson") {
+    doLast {
+        def testTasks = []
+
+        subprojects.each { subproject ->
+            def projectPath = subproject.path
+
+            // Collect test tasks without JaCoCo enabled
+            subproject.tasks.withType(Test).findAll {
+                !(it.extensions.findByType(JacocoTaskExtension)?.enabled ?: false)
+            }.each {
+                testTasks << "${projectPath}:${it.name}"
+            }
+
+            // Add jacocoTestReport if any test task has JaCoCo enabled
+            if (subproject.tasks.withType(Test).any {
+                it.extensions.findByType(JacocoTaskExtension)?.enabled ?: false
+            }) {
+                testTasks << "${projectPath}:jacocoTestReport"
+            }
+        }
+
+        // Print as a clean JSON list
+        println JsonOutput.prettyPrint(JsonOutput.toJson(testTasks))
     }
 }

--- a/jenkinsTests/src/test/groovy/JenkinsPipelineTestRunner.groovy
+++ b/jenkinsTests/src/test/groovy/JenkinsPipelineTestRunner.groovy
@@ -1,9 +1,7 @@
 import com.lesfurets.jenkins.unit.BasePipelineTest
-import com.lesfurets.jenkins.unit.PipelineTestHelper
-import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.Assertions
 
 class JenkinsPipelineTestRunner extends BasePipelineTest {
     def script
@@ -14,9 +12,11 @@ class JenkinsPipelineTestRunner extends BasePipelineTest {
     }
 
     void setProjectDir() {
-        String dir = System.getProperty('projectDir')
+        // When run from base project, projectDir is set, else navigate up parent
+        String dir = System.getProperty('projectDir',
+                new File(System.getProperty('user.dir')).getParent())
         // Store current directory
-        originalDir = new File(System.getProperty("projectDir"))
+        originalDir = new File(dir)
 
         // Change to project root directory
         var testRoot = new File(dir, "vars").absolutePath


### PR DESCRIPTION
### Description
We currently have one GHA run for all the gradle tests, this can make runs take >40 minutes when a change impacts multiple parts of the project (e.g. transformations).

This change splits up this execution over parallel jobs while retaining existing functionality with codecov etc.

This achieves this by aggregating the jacoco and non-jacoco test tasks in order to enforce jacoco artifact upload on those tasks while executing all test tasks.

### Issues Resolved
[MIGRATIONS-2411](https://opensearch.atlassian.net/browse/MIGRATIONS-2411)

### Testing
See GHA and Codecov stats

### Check List
- [x] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
