### PR TITLE
Update regexIndexMappings to regexMappings with map structure

### DIFF
--- a/transformation/transformationPlugins/jsonMessageTransformers/jsonTypeMappingsSanitizationTransformer/README.md
+++ b/transformation/transformationPlugins/jsonMessageTransformers/jsonTypeMappingsSanitizationTransformer/README.md
@@ -129,8 +129,16 @@ When the regex pattern isn't defined the following pattern is used to map each t
 index, preserving all data and its separation:
 ```
 [
-  ["(.+)", "_doc", "$1"],
-  ["(.+)", "(.+)", "$1_$2"]
+  {
+    "sourceIndexPattern": "(.+)",
+    "sourceTypePattern": "_doc",
+    "targetIndexPattern": "$1"
+  },
+  {
+    "sourceIndexPattern": "(.+)",
+    "sourceTypePattern": "(.+)",
+    "targetIndexPattern": "$1_$2"
+  }
 ]
 ```
 
@@ -141,7 +149,11 @@ The following sample shows how indices that start with 'time-' will be migrated 
 already matched will be dropped.
 ```
 [
-  ["time-(.*)", "(cpu)", "time-$1-$2"]
+  {
+    "sourceIndexPattern": "time-(.*)",
+    "sourceTypePattern": "(cpu)",
+    "targetIndexPattern": "time-$1-$2"
+  }
 ]
 ```
 
@@ -149,8 +161,16 @@ The following example preserves all other non-matched items,
 merging all types into a single index with the same name as the source index.
 ```
 [
-  ["time-(.+)", "(cpu)", "time-$1-$2"],
-  ["(.+)", ".+", "$1"]
+  {
+    "sourceIndexPattern": "time-(.+)",
+    "sourceTypePattern": "(cpu)",
+    "targetIndexPattern": "time-$1-$2"
+  },
+  {
+    "sourceIndexPattern": "(.+)",
+    "sourceTypePattern": ".+",
+    "targetIndexPattern": "$1"
+  }
 ]
 ```
 
@@ -159,13 +179,12 @@ Though note that anything matched by the static maps shown above will block any 
 
 | Regex Entry                                                                | Source Index | Source Type | Target Index      | PUT Doc URL                    | Bulk Index Command                                             |
 |----------------------------------------------------------------------------|-------------|-------------|-------------------|--------------------------------|----------------------------------------------------------------|
-| `[["time-(.*)", "(cpu)", "time-$1-$2"]]`                                   | time-nov11  | cpu         | time-nov11-cpu    | /time-nov11-cpu/_doc/doc512    | `{"index": {"_index": "time-nov11-cpu", "_id": "doc512" }}`    |
-| `[["time-(.*)", "(cpu)", "time-$1-$2"]]`                                   | logs        | access      | [DELETED]         | [DELETED]                      | [DELETED]                                                      |
-| `[["time-(.*)", "(cpu)", "time-$1-$2"],`<br/>` ["(.*)", "(.*)", "$1-$2"]]` | logs        | access      | logs_access       | /logs_access/_doc/doc513       | `{"index": {"_index": "logs_access", "_id": "doc513" }}`       |
-| `[["time-(.*)", "(cpu)", "time-$1-$2"],`<br/>`[["(.*)", ".*", "$1"]]`      | everything  | widgets     | everything        | /everything/_doc/doc514        | `{"index": {"_index": "everything", "_id": "doc514" }}`        |
-| `[["time-(.*)", "(cpu)", "time-$1-$2"],`<br/>`[["(.*)", ".*", "$1"]]`      | everything  | sprockets   | everything        | /everything/_doc/doc515        | `{"index": {"_index": "everything", "_id": "doc515" }}`        |
-| `[["time-(.*)", "(.*)-(cpu)", "$2-$3-$1"]]`                                | time-nov11  | host123-cpu | host123-cpu-nov11 | /host123-cpu-nov11/_doc/doc512 | `{"index": {"_index": "host123-cpu-nov11", "_id": "doc512" }}` |
-| `[["(.*)", ".*", "$1"]]`                                                   | metadata    | users       | metadata          | /metadata/_doc/doc516          | `{"index": {"_index": "metadata", "_id": "doc516" }}`          |
-| `[[".*", ".*", "leftovers"]]`                                              | logs        | access      | leftovers         | /leftovers/_doc/doc517         | `{"index": {"_index": "leftovers", "_id": "doc517" }}`         |
-| `[[".*", ".*", "leftovers"]]`                                              | permissions | access      | leftovers         | /leftovers/_doc/doc517         | `{"index": {"_index": "leftovers", "_id": "doc517" }}`         |
-
+| `[{"sourceIndexPattern": "(.+)", "sourceTypePattern": "_doc", "targetIndexPattern": "$1"}]`                                   | time-nov11  | cpu         | time-nov11-cpu    | /time-nov11-cpu/_doc/doc512    | `{"index": {"_index": "time-nov11-cpu", "_id": "doc512" }}`    |
+| `[{"sourceIndexPattern": "(.+)", "sourceTypePattern": "_doc", "targetIndexPattern": "$1"}]`                                   | logs        | access      | [DELETED]         | [DELETED]                      | [DELETED]                                                      |
+| `[{"sourceIndexPattern": "(.+)", "sourceTypePattern": "_doc", "targetIndexPattern": "$1"},`<br/>`{"sourceIndexPattern": "(.*)", "sourceTypePattern": "(.*)", "targetIndexPattern": "$1-$2"}]` | logs        | access      | logs_access       | /logs_access/_doc/doc513       | `{"index": {"_index": "logs_access", "_id": "doc513" }}`       |
+| `[{"sourceIndexPattern": "time-(.*)", "sourceTypePattern": "(cpu)", "targetIndexPattern": "time-$1-$2"},`<br/>`{"sourceIndexPattern": "(.*)", "sourceTypePattern": ".*", "targetIndexPattern": "$1"}]`      | everything  | widgets     | everything        | /everything/_doc/doc514        | `{"index": {"_index": "everything", "_id": "doc514" }}`        |
+| `[{"sourceIndexPattern": "time-(.*)", "sourceTypePattern": "(cpu)", "targetIndexPattern": "time-$1-$2"},`<br/>`{"sourceIndexPattern": "(.*)", "sourceTypePattern": ".*", "targetIndexPattern": "$1"}]`      | everything  | sprockets   | everything        | /everything/_doc/doc515        | `{"index": {"_index": "everything", "_id": "doc515" }}`        |
+| `[{"sourceIndexPattern": "(.*)", "sourceTypePattern": "(.*)-(cpu)", "targetIndexPattern": "$2-$3-$1"}]`                                | time-nov11  | host123-cpu | host123-cpu-nov11 | /host123-cpu-nov11/_doc/doc512 | `{"index": {"_index": "host123-cpu-nov11", "_id": "doc512" }}` |
+| `[{"sourceIndexPattern": "(.*)", "sourceTypePattern": ".*", "targetIndexPattern": "$1"}]`                                                   | metadata    | users       | metadata          | /metadata/_doc/doc516          | `{"index": {"_index": "metadata", "_id": "doc516" }}`          |
+| `[{"sourceIndexPattern": ".*", "sourceTypePattern": ".*", "targetIndexPattern": "leftovers"}]`                                              | logs        | access      | leftovers         | /leftovers/_doc/doc517         | `{"index": {"_index": "leftovers", "_id": "doc517" }}`         |
+| `[{"sourceIndexPattern": ".*", "sourceTypePattern": ".*", "targetIndexPattern": "leftovers"}]`                                              | permissions | access      | leftovers         | /leftovers/_doc/doc517         | `{"index": {"_index": "leftovers", "_id": "doc517" }}`         |

--- a/transformation/transformationPlugins/jsonMessageTransformers/jsonTypeMappingsSanitizationTransformer/src/main/resources/js/typeMappingsSanitizer.js
+++ b/transformation/transformationPlugins/jsonMessageTransformers/jsonTypeMappingsSanitizationTransformer/src/main/resources/js/typeMappingsSanitizer.js
@@ -40,24 +40,24 @@ function route(input, fieldToMatch, featureFlags, defaultAction, routes) {
     return defaultAction(input);
 }
 
-function convertSourceIndexToTargetViaRegex(sourceIndex, sourceType, regexIndexMappings) {
+function convertSourceIndexToTargetViaRegex(sourceIndex, sourceType, regexMappings) {
     const conjoinedSource = `${sourceIndex}/${sourceType}`;
-    for (const [idxRegex, typeRegex, targetIdxPattern] of regexIndexMappings) {
-        // Add start (^) and end ($) anchors to the regex to ensure it matches the entire string
-        const conjoinedRegexString = `^${idxRegex}/${typeRegex}$`;
+    for (const { sourceIndexPattern, sourceTypePattern, targetIndexPattern } of regexMappings) {
+        // Add start (^) and end ($) anchors to ensure the entire string is matched
+        const conjoinedRegexString = `^${sourceIndexPattern}/${sourceTypePattern}$`;
         const conjoinedRegex = new RegExp(conjoinedRegexString);
         if (conjoinedRegex.test(conjoinedSource)) {
-            return conjoinedSource.replace(conjoinedRegex, targetIdxPattern);
+            return conjoinedSource.replace(conjoinedRegex, targetIndexPattern);
         }
     }
     return null;
 }
 
-function convertSourceIndexToTarget(sourceIndex, sourceType, indexMappings, regexIndexMappings) {
+function convertSourceIndexToTarget(sourceIndex, sourceType, indexMappings, regexMappings) {
     if (indexMappings[sourceIndex]) {
         return indexMappings[sourceIndex][sourceType];
     }
-    return convertSourceIndexToTargetViaRegex(sourceIndex, sourceType, regexIndexMappings);
+    return convertSourceIndexToTargetViaRegex(sourceIndex, sourceType, regexMappings);
 }
 
 function makeNoopRequest() {
@@ -73,7 +73,7 @@ function rewriteDocRequest(match, inputMap) {
         match[1],
         match[2],
         inputMap.index_mappings,
-        inputMap.regex_index_mappings
+        inputMap.regex_mappings
     );
 
     if (!targetIndex) return makeNoopRequest();
@@ -110,7 +110,7 @@ function rewriteBulk(match, context) {
             commandParameters._index,
             typeName,
             context.index_mappings,
-            context.regex_index_mappings
+            context.regex_mappings
         );
 
         // If no valid target index, skip.
@@ -230,7 +230,7 @@ function rewriteCreateIndex(match, inputMap) {
     const sourceIndex = match[1].replace(new RegExp("[?].*"), ""); // remove the query string that could be after
     const types = Object.keys(mappings);
     const sourceTypeToTargetIndicesMap = new Map(types
-        .map(type => [type, convertSourceIndexToTarget(sourceIndex, type, inputMap.index_mappings, inputMap.regex_index_mappings)])
+        .map(type => [type, convertSourceIndexToTarget(sourceIndex, type, inputMap.index_mappings, inputMap.regex_mappings)])
         .filter(([, targetIndex]) => targetIndex) // Keep only entries with valid target indices
     );
     return createIndexAsUnionedExcise(sourceTypeToTargetIndicesMap, inputMap);
@@ -257,7 +257,7 @@ function processMetadataRequest(document, context) {
             document.name,
             typeName,
             context.index_mappings,
-            context.regex_index_mappings
+            context.regex_mappings
         );
 
         if (targetIndex) {
@@ -277,7 +277,7 @@ function processMetadataRequest(document, context) {
             document.name,
             type,
             context.index_mappings,
-            context.regex_index_mappings
+            context.regex_mappings
         );
         
         if(targetIndex) {
@@ -305,7 +305,7 @@ function routeHttpRequest(source_document, context) {
     const documentAndContext = {
         request: source_document,
         index_mappings: context.index_mappings,
-        regex_index_mappings: context.regex_index_mappings,
+        regex_mappings: context.regex_mappings,
         properties: context.source_properties
     };
     return route(
@@ -331,7 +331,7 @@ function processBulkIndex(docBackfillPair, context) {
         sourceIndexName,
         typeName,
         context.index_mappings,
-        context.regex_index_mappings
+        context.regex_mappings
     );
 
     if (!targetIndex) return [];

--- a/transformation/transformationPlugins/jsonMessageTransformers/jsonTypeMappingsSanitizationTransformer/src/test/java/org/opensearch/migrations/transform/TypeMappingsSanitizationCreateIndexTest.java
+++ b/transformation/transformationPlugins/jsonMessageTransformers/jsonTypeMappingsSanitizationTransformer/src/test/java/org/opensearch/migrations/transform/TypeMappingsSanitizationCreateIndexTest.java
@@ -29,10 +29,15 @@ public class TypeMappingsSanitizationCreateIndexTest {
             "socialTypes", Map.of(
                 "tweet", "communal",
                 "user", "communal"));
-        var regexIndexMappings = List.of(
-            List.of("time-(.*)", "(.*)", "time-$1-$2"));
+        var regexMappings = List.of(
+                Map.of(
+                        "sourceIndexPattern","time-(.*)",
+                        "sourceTypePattern", "(.*)",
+                        "targetIndexPattern", "time-$1-$2"
+                )
+        );
         var sourceProperties = new SourceProperties("ES", new SourceProperties.Version(5, 8));
-        return new TypeMappingsSanitizationTransformer(indexMappings, regexIndexMappings, sourceProperties, null);
+        return new TypeMappingsSanitizationTransformer(indexMappings, regexMappings, sourceProperties, null);
     }
 
     private static String makeMultiTypePutIndexRequest(String indexName, Boolean includeTypeName) {

--- a/transformation/transformationPlugins/jsonMessageTransformers/jsonTypeMappingsSanitizationTransformer/src/test/java/org/opensearch/migrations/transform/TypeMappingsSanitizationDocBackfillTest.java
+++ b/transformation/transformationPlugins/jsonMessageTransformers/jsonTypeMappingsSanitizationTransformer/src/test/java/org/opensearch/migrations/transform/TypeMappingsSanitizationDocBackfillTest.java
@@ -2,6 +2,7 @@ package org.opensearch.migrations.transform;
 
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.opensearch.migrations.testutils.JsonNormalizer;
 import org.opensearch.migrations.transform.typemappings.SourceProperties;
@@ -51,8 +52,16 @@ public class TypeMappingsSanitizationDocBackfillTest {
 
         try (var indexTypeMappingRewriter = new TypeMappingsSanitizationTransformer(null,
             List.of(
-                List.of("(test_e2e_0001_.*)", ".*", "$1_transformed"),
-                List.of("(.*)", "(.*)", "$1")
+                    Map.of(
+                            "sourceIndexPattern","(test_e2e_0001_.*)",
+                            "sourceTypePattern", ".*",
+                            "targetIndexPattern", "$1_transformed"
+                    ),
+                    Map.of(
+                            "sourceIndexPattern","(.*)",
+                            "sourceTypePattern", "(.*)",
+                            "targetIndexPattern", "$1"
+                    )
             ),
             new SourceProperties("ES", new SourceProperties.Version(6, 8)), null)) {
             var docObj = OBJECT_MAPPER.readValue(testString, LinkedHashMap.class);
@@ -76,8 +85,16 @@ public class TypeMappingsSanitizationDocBackfillTest {
 
         try (var indexTypeMappingRewriter = new TypeMappingsSanitizationTransformer(null,
             List.of(
-                List.of("(test_e2e_0001_.*)", "_doc", "$1_transformed"),
-                List.of("(.*)", "(.*)", "$1")
+                    Map.of(
+                            "sourceIndexPattern","(test_e2e_0001_.*)",
+                            "sourceTypePattern", ".*",
+                            "targetIndexPattern", "$1_transformed"
+                    ),
+                    Map.of(
+                            "sourceIndexPattern","(.*)",
+                            "sourceTypePattern", "(.*)",
+                            "targetIndexPattern", "$1"
+                    )
             ),
             new SourceProperties("ES", new SourceProperties.Version(6, 8)), null)) {
             var docObj = OBJECT_MAPPER.readValue(testString, LinkedHashMap.class);

--- a/transformation/transformationPlugins/jsonMessageTransformers/jsonTypeMappingsSanitizationTransformer/src/test/java/org/opensearch/migrations/transform/TypeMappingsSanitizationMetadataTest.java
+++ b/transformation/transformationPlugins/jsonMessageTransformers/jsonTypeMappingsSanitizationTransformer/src/test/java/org/opensearch/migrations/transform/TypeMappingsSanitizationMetadataTest.java
@@ -22,8 +22,14 @@ public class TypeMappingsSanitizationMetadataTest {
                 "keep", Map.of("_doc", "keep")
         );
         var sourceProperties = new SourceProperties("ES", new SourceProperties.Version(6, 8));
-        var regexIndexMappings = List.of(List.of("time-(.*)", "(.*)", "time-$1-$2"));
-        return new TypeMappingsSanitizationTransformer(indexMappings, regexIndexMappings, sourceProperties, null);
+        var regexMappings = List.of(
+                Map.of(
+                        "sourceIndexPattern","time-(.*)",
+                        "sourceTypePattern", "(.*)",
+                        "targetIndexPattern", "time-$1-$2"
+                )
+        );
+        return new TypeMappingsSanitizationTransformer(indexMappings, regexMappings, sourceProperties, null);
     }
 
     private static String makeMetadataRequest(String indexName, String type1, String type2) {

--- a/transformation/transformationPlugins/jsonMessageTransformers/jsonTypeMappingsSanitizationTransformer/src/test/java/org/opensearch/migrations/transform/TypeMappingsSanitizationTransformerBulkTest.java
+++ b/transformation/transformationPlugins/jsonMessageTransformers/jsonTypeMappingsSanitizationTransformer/src/test/java/org/opensearch/migrations/transform/TypeMappingsSanitizationTransformerBulkTest.java
@@ -32,12 +32,20 @@ public class TypeMappingsSanitizationTransformerBulkTest {
                 "type2", "indexb"),
             "indexc", Map.of(
                 "type2", "indexc"));
-        var regexIndexMappings = List.of(
-            List.of("time-(.*)", "(.*)", "time-$1-$2"),
-            List.of("(.*)", "_doc", "$1")
+        var regexMappings = List.of(
+                Map.of(
+                        "sourceIndexPattern","time-(.*)",
+                        "sourceTypePattern", "(.*)",
+                        "targetIndexPattern", "time-$1-$2"
+                ),
+                Map.of(
+                        "sourceIndexPattern","(.*)",
+                        "sourceTypePattern", "_doc",
+                        "targetIndexPattern", "$1"
+                )
             );
         var sourceProperties = new SourceProperties("ES", new SourceProperties.Version(7, 10));
-        indexTypeMappingRewriter = new TypeMappingsSanitizationTransformer(indexMappings, regexIndexMappings, sourceProperties, null);
+        indexTypeMappingRewriter = new TypeMappingsSanitizationTransformer(indexMappings, regexMappings, sourceProperties, null);
     }
 
     @AfterAll

--- a/transformation/transformationPlugins/jsonMessageTransformers/jsonTypeMappingsSanitizationTransformer/src/test/java/org/opensearch/migrations/transform/TypeMappingsSanitizationTransformerTest.java
+++ b/transformation/transformationPlugins/jsonMessageTransformers/jsonTypeMappingsSanitizationTransformer/src/test/java/org/opensearch/migrations/transform/TypeMappingsSanitizationTransformerTest.java
@@ -35,10 +35,15 @@ class TypeMappingsSanitizationTransformerTest {
             "socialTypes", Map.of(
                 "tweet", "communal",
                 "user", "communal"));
-        var regexIndexMappings = List.of(
-            List.of("time-(.*)", "(.*)", "time-$1-$2"));
+        var regexMappings = List.of(
+                Map.of(
+                        "sourceIndexPattern","time-(.*)",
+                        "sourceTypePattern", "(.*)",
+                        "targetIndexPattern", "time-$1-$2"
+                )
+        );
         var sourceProperties = new SourceProperties("ES", new SourceProperties.Version(7, 10));
-        indexTypeMappingRewriter = new TypeMappingsSanitizationTransformer(indexMappings, regexIndexMappings, sourceProperties, null);
+        indexTypeMappingRewriter = new TypeMappingsSanitizationTransformer(indexMappings, regexMappings, sourceProperties, null);
     }
 
     @AfterAll

--- a/transformation/transformationPlugins/jsonMessageTransformers/jsonTypeMappingsSanitizationTransformerProvider/README.md
+++ b/transformation/transformationPlugins/jsonMessageTransformers/jsonTypeMappingsSanitizationTransformerProvider/README.md
@@ -6,15 +6,15 @@ for specifics of how rules are evaluated.
 This package loads a [Type Mappings Sanitization Transformer](../jsonTypeMappingsSanitizationTransformer/src/main/java/org/opensearch/migrations/transform/TypeMappingsSanitizationTransformer.java)
 for that appropriate application variant (currently only for the REPLAYER) along with the configuration passed into
 the provider.  This [Provider](./src/main/java/org/opensearch/migrations/transform/TypeMappingSanitizationTransformerProvider.java)
-pulls the values for keys `featureFlags`, `staticMappings`, and `regexIndexMappings` from the incoming configuration map
+pulls the values for keys `featureFlags`, `sourceProperties`, `staticMappings`, and `regexMappings` from the incoming configuration map
 object so that the Type Mappings Sanitization Transformer can adjust requests for specific type mappings into the 
 appropriate target index.  
 
 The following example will load a Transformer to rewrite types as per the static mappings shown in the second key-value
-(staticMappings), or if not present, will then default to the mappings in regexIndexMappings.  Note that regexIndexMappings will
-only be checked if there are no entries in staticMappings.  
+(staticMappings), or if not present, will then default to the mappings in regexMappings.  Note that regexMappings will
+only be checked if there are no entries in staticMappings for a given index.  
 staticMappings index names (top-level key) and keys to their children maps will be evaluated literally, not as patterns.  
-Patterns are ONLY supported via regexIndexMappings.
+Patterns are ONLY supported via regexMappings.
 
 ```
 {
@@ -31,8 +31,13 @@ Patterns are ONLY supported via regexIndexMappings.
             "type2": "indexC"
         }
     },
-    "regexIndexMappings": [
-        [ "(time*)", "(type*)", "\\1_And_\\2" ]
-    ]
+    "regexMappings": [
+    {
+          "sourceIndexPattern": "(time.*)",
+          "sourceTypePattern": "(.*)",
+          "targetIndexPattern": "$1_And_$2"
+    }
+    ],
+    
 }
 ```

--- a/transformation/transformationPlugins/jsonMessageTransformers/jsonTypeMappingsSanitizationTransformerProvider/src/main/java/org/opensearch/migrations/transform/TypeMappingSanitizationTransformerProvider.java
+++ b/transformation/transformationPlugins/jsonMessageTransformers/jsonTypeMappingsSanitizationTransformerProvider/src/main/java/org/opensearch/migrations/transform/TypeMappingSanitizationTransformerProvider.java
@@ -15,7 +15,7 @@ public class TypeMappingSanitizationTransformerProvider extends JsonJSTransforme
 
     public static final String FEATURE_FLAGS = "featureFlags";
     public static final String STATIC_MAPPINGS = "staticMappings";
-    public static final String REGEX_INDEX_MAPPINGS = "regexIndexMappings";
+    public static final String REGEX_MAPPINGS = "regexMappings";
     public static final String SOURCE_PROPERTIES_KEY = "sourceProperties";
 
     private static final ObjectMapper MAPPER = new ObjectMapper();
@@ -31,7 +31,7 @@ public class TypeMappingSanitizationTransformerProvider extends JsonJSTransforme
 
             return new TypeMappingsSanitizationTransformer(
                 (Map<String, Map<String, String>>) config.get(STATIC_MAPPINGS),
-                (List<List<String>>) config.get(REGEX_INDEX_MAPPINGS),
+                (List<Map<String, String>>) config.get(REGEX_MAPPINGS),
                 Optional.ofNullable(config.get(SOURCE_PROPERTIES_KEY)).map(m ->
                     MAPPER.convertValue(m, SourceProperties.class)).orElse(null),
                 (Map<String, Object>) config.get(FEATURE_FLAGS));
@@ -46,10 +46,10 @@ public class TypeMappingSanitizationTransformerProvider extends JsonJSTransforme
         return this.getClass().getName() + " " +
             "expects the incoming configuration to be a Map<String, Object>, " +
             "with values (some optional) '" +
-            String.join("', '", STATIC_MAPPINGS,REGEX_INDEX_MAPPINGS,FEATURE_FLAGS,SOURCE_PROPERTIES_KEY) + "'.  " +
+            String.join("', '", STATIC_MAPPINGS,REGEX_MAPPINGS,FEATURE_FLAGS,SOURCE_PROPERTIES_KEY) + "'.  " +
             "The value of " + STATIC_MAPPINGS + " should be a two-level map where the top-level key is the name " +
             "of a source index and that key's dictionary maps each sub-type to a specific target index.  " +
-            REGEX_INDEX_MAPPINGS + " (List<[List<String>>]) matches index names and sub-types to a target pattern.  " +
+            REGEX_MAPPINGS + " (List<[Map<String, String>]) matches index names and sub-types to a target pattern.  " +
             FEATURE_FLAGS + " is a map of feature flags that may alter the behavior of the transformation." +
             SOURCE_PROPERTIES_KEY + " (required) is a nested map of the source cluster version e.g. " +
             "{\"version\":{\"major\":7,\"minor\":10}}.";

--- a/transformation/transformationPlugins/jsonMessageTransformers/jsonTypeMappingsSanitizationTransformerProvider/src/test/java/org/opensearch/migrations/replay/TypeMappingsSanitizationProviderTest.java
+++ b/transformation/transformationPlugins/jsonMessageTransformers/jsonTypeMappingsSanitizationTransformerProvider/src/test/java/org/opensearch/migrations/replay/TypeMappingsSanitizationProviderTest.java
@@ -34,9 +34,15 @@ public class TypeMappingsSanitizationProviderTest {
                     "type2", "indexb"),
                 "indexc", Map.of(
                     "type2", "indexc")),
-            "regexIndexMappings", List.of(
-                    List.of("(time.*)", "(type.*)", "$1_And_$2"),
-                    List.of("(.*)", "(.*)", "$1") // Type Union
+            "regexMappings", List.of(
+                    Map.of(
+                        "sourceIndexPattern", "(time.*)",
+                        "sourceTypePattern", "(type.*)",
+                        "targetIndexPattern", "$1_And_$2"),
+                    Map.of(
+                        "sourceIndexPattern", "(.*)",
+                        "sourceTypePattern", "(.*)",
+                        "targetIndexPattern", "$1") // Type Union
                 ),
             "sourceProperties", Map.of(
                 "version", Map.of(
@@ -94,7 +100,10 @@ public class TypeMappingsSanitizationProviderTest {
                 Map.of("version",
                     Map.of("major",  (Object) 6,
                         "minor", (Object) 10)),
-                "regexIndexMappings", List.of(List.of("(.*)", "(.*)", "$1")));
+                "regexMappings", List.of(Map.of(
+                        "sourceIndexPattern", "(.*)",
+                        "sourceTypePattern", "(.*)",
+                        "targetIndexPattern", "$1")));
         try (var transformer = new TypeMappingSanitizationTransformerProvider().createTransformer(fullTransformerConfig)) {
             var resultObj = transformer.transformJson(OBJECT_MAPPER.readValue(testString, LinkedHashMap.class));
             Assertions.assertEquals(JsonNormalizer.fromString(testString), JsonNormalizer.fromObject(resultObj));
@@ -108,7 +117,10 @@ public class TypeMappingsSanitizationProviderTest {
             Map.of("sourceProperties", Map.of("version",
                     Map.of("major",  (Object) 5,
                         "minor", (Object) 10)),
-                "regexIndexMappings", List.of(List.of("(.*)", ".*", "$1")));
+                "regexMappings", List.of(Map.of(
+                        "sourceIndexPattern", "(.*)",
+                        "sourceTypePattern", "(.*)",
+                        "targetIndexPattern", "$1")));
         try (var transformer = new TypeMappingSanitizationTransformerProvider().createTransformer(fullTransformerConfig)) {
             var resultObj = transformer.transformJson(OBJECT_MAPPER.readValue(testString, LinkedHashMap.class));
             Assertions.assertEquals(JsonNormalizer.fromString(testString), JsonNormalizer.fromObject(resultObj));

--- a/vars/fullES68SourceE2ETest.groovy
+++ b/vars/fullES68SourceE2ETest.groovy
@@ -9,11 +9,18 @@ def call(Map config = [:]) {
     def rfsJsonTransformations = [
         [
                 TypeMappingSanitizationTransformerProvider: [
-                        regexIndexMappings: [
-                                ["(test_e2e_0001_.*)", ".*", "\$1_transformed"], // Expected Transform
-                                ["(.*)", "(.*)", "\$1"] // Type Union otherwise
+                        regexMappings: [
+                                [
+                                        "sourceIndexPattern": "(test_e2e_0001_.*)",
+                                        "sourceTypePattern": ".*",
+                                        "targetIndexPattern": "\$1_transformed"
+                                ],
+                                [
+                                        "sourceIndexPattern": "(.*)",
+                                        "sourceTypePattern": "(.*)",
+                                        "targetIndexPattern": "\$1"
+                                ]
                         ],
-
                         sourceProperties: [
                                 version: [
                                         major: 6,


### PR DESCRIPTION
### Description
Update regexIndexMappings to regexMappings with map structure

From 
```
 "regexIndexMappings": [
        [
          "(.*)",
          ".*",
          "$1"
        ]
      ]
```
to
```
"regexMappings": [
        {
          "sourceIndexPattern": "(.*)",
          "sourceTypePattern": ".*",
          "targetIndexPattern": "$1"
        }
]
```
### Issues Resolved
[MIGRATIONS-2407](https://opensearch.atlassian.net/browse/MIGRATIONS-2407)

### Testing
See GHA and 6.8 test

### Check List
- [x] New functionality includes testing
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.
Updated in https://github.com/opensearch-project/documentation-website/pull/9164/files

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
