### PR TITLE
Update Sigv4 and ALB according to Opensearch logic

### DIFF
--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/utils.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/utils.py
@@ -7,6 +7,7 @@ import requests.utils
 from botocore.auth import SigV4Auth
 from botocore.awsrequest import AWSRequest
 from requests.models import PreparedRequest
+from urllib.parse import urlparse
 
 
 from console_link.models.client_options import ClientOptions
@@ -84,6 +85,11 @@ class SigV4AuthPlugin(requests.auth.AuthBase):
         # Exclude signing headers that may change after signing
         default_headers = requests.utils.default_headers()
         excluded_headers = default_headers.keys()
+
+        # Opensearch has unique port signing behavior where it cannot be in the signature
+        # Thus adding a custom Host header streamline auth edge cases
+        r.headers['Host'] = urlparse(r.url).hostname
+
         filtered_headers = {k: v for k, v in r.headers.items() if k.lower() not in excluded_headers}
         aws_request = AWSRequest(method=r.method, url=r.url, data=r.body, headers=filtered_headers)
         signer = SigV4Auth(self.credentials, self.service, self.region)

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/test_cluster.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/test_cluster.py
@@ -333,7 +333,7 @@ def test_valid_cluster_api_call_with_secrets_auth(requests_mock, aws_credentials
 
 def test_valid_cluster_api_call_with_sigv4_auth(requests_mock, aws_credentials):
     valid_with_sigv4 = {
-        "endpoint": "https://opensearchtarget:9200",
+        "endpoint": "https://test.opensearchtarget.com:9200",
         "allow_insecure": True,
         "sigv4": {
             "region": "us-east-2",
@@ -358,6 +358,8 @@ def test_valid_cluster_api_call_with_sigv4_auth(requests_mock, aws_credentials):
         assert "Signature=" in auth_header
         assert "es" in auth_header
         assert "us-east-2" in auth_header
+        host_header = requests_mock.last_request.headers['Host']
+        assert "test.opensearchtarget.com" == host_header
 
 
 def test_call_api_via_middleware(requests_mock):

--- a/deployment/cdk/opensearch-service-migration/lib/network-stack.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/network-stack.ts
@@ -225,15 +225,15 @@ export class NetworkStack extends Stack {
 
             // Setup ALB weighted listener when both source and target proxies are enabled
             if (this.albSourceProxyTG && this.albTargetProxyTG) {
-                const albMigrationListener = this.createSecureListener('ALBMigrationListener', 9200, alb, cert);
+                const albMigrationListener = this.createSecureListener('ALBMigrationListener', 443, alb, cert);
                 albMigrationListener.addAction("default", {
                     action: ListenerAction.weightedForward([
                         {targetGroup: this.albSourceProxyTG, weight: 1},
                         {targetGroup: this.albTargetProxyTG, weight: 0}
                     ])
                 });
-                createALBListenerUrlParameter(9200, MigrationSSMParameter.MIGRATION_LISTENER_URL);
-                createALBListenerUrlParameterAlias(9200, MigrationSSMParameter.MIGRATION_LISTENER_URL_ALIAS);
+                createALBListenerUrlParameter(443, MigrationSSMParameter.MIGRATION_LISTENER_URL);
+                createALBListenerUrlParameterAlias(443, MigrationSSMParameter.MIGRATION_LISTENER_URL_ALIAS);
             }
         }
 

--- a/docs/ClientTrafficSwinging.md
+++ b/docs/ClientTrafficSwinging.md
@@ -22,11 +22,11 @@ Our ALB is set up to route traffic to these main services:
 
 2. **Target Cluster Proxy** (Port 9202): This service forwards requests to the new cluster we're migrating to, acting as an intermediary between the ALB and the target cluster.
 
-3. **Weighted Proxy** (Port 9200): This forwards requests to either the Capture Proxy or Target Cluster Proxy based on configuration, see [Weighted Proxy](#weighted-proxy)
+3. **Weighted Proxy** (Port 443): This forwards requests to either the Capture Proxy or Target Cluster Proxy based on configuration, see [Weighted Proxy](#weighted-proxy)
 
 ## Weighted Proxy
 
-A key feature of our ALB is its ability to distribute traffic between the old and new systems. This is accomplished using the weighted listener on port `9200`:
+A key feature of our ALB is its ability to distribute traffic between the old and new systems. This is accomplished using the weighted listener on port `443`:
 
 - The ALB can direct a portion or all of the requests to either the Capture Proxy or Target Cluster Proxy.
 - We can adjust the traffic distribution between each system, allowing for a gradual transition.
@@ -57,7 +57,7 @@ Using this ALB setup offers several advantages:
 5. **Smoke Testing**: Ports 9201 and 9202 can be used for preliminary testing before shifting client traffic:
    - Port 9201 (Capture Proxy): Test requests can be sent here to confirm that the source cluster is still accessible and functioning correctly through the ALB.
    - Port 9202 (Target Cluster Proxy): Send test requests to this port to verify that the new target cluster is properly set up and responding as expected.
-   - By testing both ports, we can ensure that both the old and new systems are working correctly before gradually shifting real client traffic using the weighted routing on port 9200.
+   - By testing both ports, we can ensure that both the old and new systems are working correctly before gradually shifting real client traffic using the weighted routing on port `443`.
 
    This smoke testing process allows us to:
    - Verify the ALB configuration is correct for both source and target clusters.
@@ -78,7 +78,7 @@ graph TD
     subgraph MigrationAssistantInfrastructure
         ALB[Application Load Balancer]
         subgraph ALB
-            L1[Weighted Listener :9200]
+            L1[Weighted Listener :443]
             L2[Source Listener :9201]
             L3[Target Listener :9202]
         end


### PR DESCRIPTION
### Description
Opensearch Managed Service for Sigv4 auth requires the sigv4 signature to not have a port specified, this complicates adding the capture proxy between the service if the listener is on a non-443 port.

For the Migration Console, we will update our cluster sigv4 logic to exclude the port on the host prior to signing.
For the ALB, we will move the standard weighted listener to the 443 port instead of the current 9200 one.

### Issues Resolved
https://opensearch.atlassian.net/browse/MIGRATIONS-2421

### Testing
Verified with the migration console that sigv4 works with a vpc cluster on port 9201 (the capture proxy direct listener)

### Check List
- [x] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
