### PR TITLE
[Bug] Fix metadata output with console library

### DIFF
--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/command_runner.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/command_runner.py
@@ -27,10 +27,10 @@ class CommandRunner:
         self.run_as_detached = run_as_detatched
         self.log_file = log_file
 
-    def run(self, print_to_console=True) -> CommandResult:
+    def run(self, print_to_console=True, print_on_error=False) -> CommandResult:
         if self.run_as_detached:
             return self._run_as_detached_process(self.log_file)
-        return self._run_as_synchronous_process(print_to_console=print_to_console)
+        return self._run_as_synchronous_process(print_to_console=print_to_console, print_on_error=print_on_error)
 
     def sanitized_command(self) -> List[str]:
         if not self.sensitive_fields:
@@ -44,21 +44,28 @@ class CommandRunner:
                     display_command[field_index + 1] = "*" * 8
         return display_command
 
-    def _run_as_synchronous_process(self, print_to_console: bool) -> CommandResult:
+    def print_output_if_enabled(self, holder, should_print):
+        if holder.stdout:
+            if should_print:
+                sys.stdout.write(holder.stdout)
+            logger.info(f"\nSTDOUT:\n{holder.stdout}")
+        if holder.stderr:
+            if should_print:
+                sys.stderr.write(holder.stderr)
+            logger.info(f"\nSTDERR:\n{holder.stderr}")
+
+    def _run_as_synchronous_process(self, print_to_console: bool, print_on_error: bool) -> CommandResult:
         try:
             cmd_output = subprocess.run(self.command,
                                         stdout=subprocess.PIPE,
                                         stderr=subprocess.PIPE,
                                         text=True,
                                         check=True)
-            if print_to_console:
-                if cmd_output.stdout:
-                    sys.stdout.write(cmd_output.stdout)
-                if cmd_output.stderr:
-                    sys.stderr.write(cmd_output.stderr)
+            self.print_output_if_enabled(holder=cmd_output, should_print=print_to_console)
             return CommandResult(success=True, value="Command executed successfully", output=cmd_output)
         except subprocess.CalledProcessError as e:
-            raise CommandRunnerError(e.returncode, self.sanitized_command(), e.stderr, self)
+            self.print_output_if_enabled(holder=e, should_print=print_on_error)
+            raise CommandRunnerError(e.returncode, self.sanitized_command(), e.stdout, e.stderr)
 
     def _run_as_detached_process(self, log_file: str) -> CommandResult:
         try:
@@ -70,9 +77,13 @@ class CommandRunner:
                 return CommandResult(success=True, value=f"Process started with PID {process.pid}\n"
                                      f"Logs are being written to {log_file}")
         except subprocess.CalledProcessError as e:
-            raise CommandRunnerError(e.returncode, self.sanitized_command(), e.stderr, self)
+            raise CommandRunnerError(e.returncode, self.sanitized_command(), e.stdout, e.stderr)
 
 
 class CommandRunnerError(subprocess.CalledProcessError):
     def __init__(self, returncode, cmd, output=None, stderr=None):
         super().__init__(returncode, cmd, output=output, stderr=stderr)
+
+    def __str__(self):
+        return (f"Command [{' '.join(self.cmd)}] failed with exit code {self.returncode}. For more verbose output, "
+                f"repeat the console command with '-v', for example 'console -v snapshot create'")

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/command_runner.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/command_runner.py
@@ -50,7 +50,7 @@ class CommandRunner:
                 sys.stdout.write(holder.stdout)
             log_message_out = f"\nSTDOUT ({' '.join(self.command)}):\n{holder.stdout}"
             if is_error:
-                logger.warning(log_message_out)
+                logger.info(log_message_out)
             else:
                 logger.debug(log_message_out)
         if holder.stderr:
@@ -58,7 +58,7 @@ class CommandRunner:
                 sys.stderr.write(holder.stderr)
             log_message_err = f"\nSTDERR ({' '.join(self.command)}):\n{holder.stderr}"
             if is_error:
-                logger.warning(log_message_err)
+                logger.info(log_message_err)
             else:
                 logger.debug(log_message_err)
 

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/metadata.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/metadata.py
@@ -238,7 +238,7 @@ class Metadata:
                                        sensitive_fields=["--target-password"])
         logger.info(f"Migrating metadata with command: {' '.join(command_runner.sanitized_command())}")
         try:
-            return command_runner.run()
+            return command_runner.run(print_on_error=True)
         except CommandRunnerError as e:
-            logger.error(f"Metadata migration failed: {e}")
+            logger.debug(f"Metadata migration failed: {e}")
             return CommandResult(success=False, value=f"Metadata migration failed: {e}")

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/snapshot.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/snapshot.py
@@ -151,7 +151,7 @@ class S3Snapshot(Snapshot):
             return CommandResult(success=True,
                                  value=f"Snapshot {self.config['snapshot_name']} creation initiated successfully")
         except CommandRunnerError as e:
-            logger.error(f"Failed to create snapshot: {str(e)}")
+            logger.debug(f"Failed to create snapshot: {str(e)}")
             return CommandResult(success=False, value=f"Failed to create snapshot: {str(e)}")
 
     def status(self, *args, deep_check=False, **kwargs) -> CommandResult:
@@ -196,7 +196,7 @@ class FileSystemSnapshot(Snapshot):
             return CommandResult(success=True,
                                  value=f"Snapshot {self.config['snapshot_name']} creation initiated successfully")
         except CommandRunnerError as e:
-            logger.error(f"Failed to create snapshot: {str(e)}")
+            logger.debug(f"Failed to create snapshot: {str(e)}")
             return CommandResult(success=False, value=f"Failed to create snapshot: {str(e)}")
 
     def status(self, *args, deep_check=False, **kwargs) -> CommandResult:

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/test_command_runner.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/test_command_runner.py
@@ -95,3 +95,43 @@ def test_command_runner_handles_no_output(capsys, mocker):
     captured = capsys.readouterr()
     assert captured.out == ""
     assert captured.err == ""
+
+
+def test_command_runner_prints_nothing_on_error_when_disabled(capsys, mocker):
+    mock_stdout = "Found 5 directories"
+    mock_stderr = "Unknown file path"
+    runner = CommandRunner("ls", {})
+    mocker.patch("subprocess.run", side_effect=subprocess.CalledProcessError(returncode=1, cmd=["ls"],
+                                                                             output=mock_stdout, stderr=mock_stderr))
+    with pytest.raises(CommandRunnerError):
+        runner.run(print_on_error=False)
+    # Capture stdout/stderr output
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == ""
+
+
+def test_command_runner_prints_output_on_error_when_enabled(capsys, mocker):
+    mock_stdout = "Found 5 directories"
+    mock_stderr = "Unknown file path"
+    runner = CommandRunner("ls", {})
+    mocker.patch("subprocess.run", side_effect=subprocess.CalledProcessError(returncode=1, cmd=["ls"],
+                                                                             output=mock_stdout, stderr=mock_stderr))
+    with pytest.raises(CommandRunnerError):
+        runner.run(print_on_error=True)
+    # Capture stdout/stderr output
+    captured = capsys.readouterr()
+    assert captured.out == mock_stdout
+    assert captured.err == mock_stderr
+
+
+def test_command_runner_handles_no_output_on_error(capsys, mocker):
+    runner = CommandRunner("ls", {})
+    mocker.patch("subprocess.run", side_effect=subprocess.CalledProcessError(returncode=1, cmd=["ls"],
+                                                                             output=None, stderr=None))
+    with pytest.raises(CommandRunnerError):
+        runner.run(print_on_error=True)
+    # Capture stdout/stderr output
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == ""

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/test_snapshot.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/test_snapshot.py
@@ -409,7 +409,7 @@ def test_snapshot_delete_repo(request, snapshot_fixture):
 @pytest.mark.parametrize("snapshot_fixture", ['s3_snapshot', 'fs_snapshot'])
 def test_snapshot_create_catches_error(mocker, request, snapshot_fixture):
     snapshot = request.getfixturevalue(snapshot_fixture)
-    fake_command = "/root/createSnapshot/bin/CreateSnapshot --snapshot_name=reindex_from_snapshot"
+    fake_command = ["/root/createSnapshot/bin/CreateSnapshot", "--snapshot_name=reindex_from_snapshot"]
     mock = mocker.patch.object(CommandRunner, 'run', cmd="abc", autospec=True,
                                side_effect=CommandRunnerError(2, cmd=fake_command, output="Snapshot failure"))
 
@@ -417,7 +417,8 @@ def test_snapshot_create_catches_error(mocker, request, snapshot_fixture):
 
     mock.assert_called_once()
     assert not result.success
-    assert fake_command in result.value
+    for element in fake_command:
+        assert element in result.value
 
 
 def test_get_snapshot_repository_via_delete(s3_snapshot):


### PR DESCRIPTION
### Description
This modifies recent changes around printing output with the `command_runner` in the console library to allow printing output on commands that fail (which is very helpful for metadata commands) as well as always logging output regardless of success or failure

There is a decision here to not print failed command output to the console as a default, as I have found cases like snapshot create produce several stack traces on failure which we likely don't want to put in front of a user as a default, but give the option to explore this with the `-v` flag

### Issues Resolved
N/A

### Testing
Local testing

### Check List
- [ ] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
