### PR TITLE
Implement replayer support for /<index>/_bulk in type mapping sanitization transformer

### DIFF
--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/TypeMappingTransformationTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/TypeMappingTransformationTest.java
@@ -1,0 +1,111 @@
+package org.opensearch.migrations.replay;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import org.opensearch.migrations.replay.datahandlers.PayloadAccessFaultingMap;
+import org.opensearch.migrations.replay.datahandlers.http.HttpJsonRequestWithFaultingPayload;
+import org.opensearch.migrations.replay.datahandlers.http.StrictCaseInsensitiveHttpHeadersMap;
+import org.opensearch.migrations.transform.JsonKeysForHttpMessage;
+import org.opensearch.migrations.transform.TransformationLoader;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class TypeMappingTransformationTest {
+
+    /**
+     * Provides test cases for bulk transformation.
+     *
+     * Each argument consists of:
+     * - inputPath: the original HTTP path (determines the match length)
+     * - expectedUri: the expected transformed URI after removing defaults and applying conversion
+     * - expectedFirstIndex: the expected _index value in the first NDJSON command after transformation
+     *
+     * Cases:
+     * 1. No default index in URI: inputPath="/_bulk"
+     * 2. Default index provided: inputPath="/btc-rfs/_bulk"
+     * 3. Default index and type provided: inputPath="/btc-rfs/sometype/_bulk"
+     */
+    static Stream<Arguments> bulkTransformationTestCases() {
+        return Stream.of(
+                Arguments.of("/_bulk", "/_bulk", "btc-rfs_transformed"),
+                Arguments.of("/btc-rfs/_bulk", "/btc-rfs_transformed/_bulk", "btc-rfs_transformed"),
+                Arguments.of("/btc-rfs/sometype/_bulk", "/btc-rfs_transformed-sometype/_bulk", "btc-rfs_transformed-sometype")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("bulkTransformationTestCases")
+    public void testBulkTransformation(String inputPath, String expectedUri, String expectedFirstIndex) {
+        // Setup HTTP message with given inputPath.
+        // The path drives the defaultSourceIndex and defaultType for the transformation.
+        var headers = new StrictCaseInsensitiveHttpHeadersMap();
+        headers.put("content-type", List.of("application/json"));
+        var httpMessage = new HttpJsonRequestWithFaultingPayload(headers);
+        httpMessage.setPayloadFaultMap(new PayloadAccessFaultingMap(headers));
+        httpMessage.setPath(inputPath);
+        httpMessage.setMethod("POST");
+
+        // Prepare a sample NDJSON payload.
+        // The first command is the index command with _index "btc-rfs"
+        // which should be transformed to "btc-rfs_transformed" per the regex mapping.
+        List<Map<String, Object>> dataList = new ArrayList<>();
+
+        Map<String, Object> indexCommand = new HashMap<>();
+        indexCommand.put("index", Map.of("_id", "sampleId", "_index", "btc-rfs"));
+        dataList.add(indexCommand);
+
+        // Add a dummy document (transaction) which remains unchanged.
+        Map<String, Object> transactionDoc = new HashMap<>();
+        transactionDoc.put("dummyField", "dummyValue");
+        dataList.add(transactionDoc);
+
+        httpMessage.payload().put(JsonKeysForHttpMessage.INLINED_NDJSON_BODIES_DOCUMENT_KEY, dataList);
+
+        // Create transformer with configuration.
+        // The regex mapping converts any index starting with "btc" to have a "_transformed" suffix.
+        var transformer = new TransformationLoader().getTransformerFactoryLoader(
+                null,
+                null,
+                "[{ \"TypeMappingSanitizationTransformerProvider\": { " +
+                        "  \"sourceProperties\": { " +
+                        "    \"version\": { " +
+                        "      \"major\": 7, " +
+                        "      \"minor\": 10 " +
+                        "    } " +
+                        "  }, " +
+                        "  \"regexMappings\": [ " +
+                        "    { " +
+                        "      \"sourceIndexPattern\": \"(btc.*)\", " +
+                        "      \"sourceTypePattern\":  \"(sometype)\", " +
+                        "      \"targetIndexPattern\": \"$1_transformed-$2\" " +
+                        "    }, " +
+                        "    { " +
+                        "      \"sourceIndexPattern\": \"(btc.*)\", " +
+                        "      \"sourceTypePattern\":  \"_doc\", " +
+                        "      \"targetIndexPattern\": \"$1_transformed\" " +
+                        "    } " +
+                        "  ] " +
+                        "} }] "
+        );
+
+        // Transform the HTTP message
+        var rval = (Map<String, Object>) transformer.transformJson(httpMessage);
+
+        // Extract the transformed URI and the first NDJSON command's _index value.
+        var transformedPayload = (Map<String, Object>) rval.get(JsonKeysForHttpMessage.PAYLOAD_KEY);
+        var ndjsonList = (List<Map<String, Map<String, Object>>>) transformedPayload.get(JsonKeysForHttpMessage.INLINED_NDJSON_BODIES_DOCUMENT_KEY);
+        String firstTargetIndex = (String) ndjsonList.get(0).get("index").get("_index");
+        String transformedPath = (String) rval.get(JsonKeysForHttpMessage.URI_KEY);
+
+        // Validate that the transformed URI and first index match the expected values.
+        Assertions.assertEquals(expectedUri, transformedPath);
+        Assertions.assertEquals(expectedFirstIndex, firstTargetIndex);
+    }
+}

--- a/transformation/transformationPlugins/jsonMessageTransformers/jsonTypeMappingsSanitizationTransformer/src/main/resources/js/typeMappingsSanitizer.js
+++ b/transformation/transformationPlugins/jsonMessageTransformers/jsonTypeMappingsSanitizationTransformer/src/main/resources/js/typeMappingsSanitizer.js
@@ -81,10 +81,11 @@ function rewriteDocRequest(match, inputMap) {
     return inputMap.request;
 }
 
-function retargetCommandParameters(parameters, targetIndex) {
-    parameters._index = targetIndex;
-    delete parameters._type;
-    return parameters;
+function retargetCommandParameters({ _type, ...remainingParameters }, targetIndex) {
+    return {
+        ...remainingParameters,
+        _index: targetIndex
+    };
 }
 
 function rewriteBulk(match, context) {
@@ -92,10 +93,34 @@ function rewriteBulk(match, context) {
     const newLines = [];
     let ndi = 0;
 
+    let defaultSourceIndex = null;
+    let defaultType = "_doc";
+    if (match.length === 3) {
+        // Case: /{index}/{type}/_bulk
+        defaultSourceIndex = match[1];
+        defaultType = match[2];
+    } else if (match.length === 2) {
+        // Case: /{index}/_bulk (default type _doc)
+        defaultSourceIndex = match[1];
+    }
+
+    if (defaultSourceIndex) {
+        let defaultTargetIndex = convertSourceIndexToTarget(defaultSourceIndex,
+            defaultType,
+            context.index_mappings,
+            context.regex_mappings);
+        const patternToReplace = /^.*\/(.*\/)?_bulk/;
+        // Replace the pattern in the URI with the converted target index, if available.
+        // If no valid conversion is found, remove the source index/type segment and default to '/_bulk'.
+        context.request.URI = defaultTargetIndex
+            ? context.request.URI.replace(patternToReplace, `/${defaultTargetIndex}/_bulk`)
+            : context.request.URI.replace(patternToReplace, "/_bulk");
+    }
+
     while (ndi < lines.length) {
         const command = lines[ndi++];
         const commandType = Object.keys(command)[0];
-        const commandParameters = command[commandType] || {};
+        let commandParameters = command[commandType] || {};
 
         // Next line is doc if it's not a 'delete' command.
         let doc = null;
@@ -103,11 +128,14 @@ function rewriteBulk(match, context) {
             doc = lines[ndi++];
         }
 
-        const typeName = commandParameters._type ?? "_doc";
+        // Use command index or default source index if available
+        const sourceIndex = commandParameters._index || defaultSourceIndex;
+        // Use provided _type if exists, otherwise use the defaultType
+        const typeName = commandParameters._type ?? defaultType;
 
         // Convert source index to target index.
         const targetIndex = convertSourceIndexToTarget(
-            commandParameters._index,
+            sourceIndex,
             typeName,
             context.index_mappings,
             context.regex_mappings
@@ -117,8 +145,11 @@ function rewriteBulk(match, context) {
         if (!targetIndex) {
             continue;
         }
-        retargetCommandParameters(commandParameters, targetIndex);
-        newLines.push(command);
+
+        // Update command parameters and ensure they're correctly inserted
+        commandParameters = retargetCommandParameters(commandParameters, targetIndex);
+        const updatedCommand = { [commandType]: commandParameters };
+        newLines.push(updatedCommand);
         if (doc) newLines.push(doc);
 
     }
@@ -240,6 +271,8 @@ const PUT_POST_DOC_REGEX = /(?:PUT|POST) \/([^\/]*)\/([^\/]*)\/(.*)/;
 const GET_DOC_REGEX = /GET \/(?!\.{1,2}(?:\/|$))([^-_+][^A-Z\\/*?\"<>|,# ]*)\/(?!\.{1,2}(?:\/|$))([^-_+][^A-Z\\/*?\"<>|,# ]*)\/([^\/]+)$/;
 const BULK_REQUEST_REGEX = /(?:PUT|POST) \/_bulk/;
 const CREATE_INDEX_REGEX = /(?:PUT|POST) \/([^\/]*)/;
+const INDEX_BULK_REQUEST_REGEX = /(?:PUT|POST) \/([^\/]+)\/_bulk/;
+const INDEX_TYPE_BULK_REQUEST_REGEX = /(?:PUT|POST) \/([^\/]+)\/([^\/]+)\/_bulk/;
 
 function processMetadataRequest(document, context) {
     let mappings = document?.body?.mappings;
@@ -325,15 +358,18 @@ function routeHttpRequest(source_document, context) {
         regex_mappings: context.regex_mappings,
         properties: context.source_properties
     };
+    console.log("Route test on" + methodAndUri)
     return route(
         documentAndContext,
         methodAndUri,
         context.flags,
         () => (source_document),
         [
+            [INDEX_TYPE_BULK_REQUEST_REGEX, rewriteBulk, 'rewrite_bulk'],
+            [INDEX_BULK_REQUEST_REGEX, rewriteBulk, 'rewrite_bulk'],
+            [BULK_REQUEST_REGEX, rewriteBulk, 'rewrite_bulk'],
             [PUT_POST_DOC_REGEX, rewriteDocRequest, 'rewrite_add_request_to_strip_types'],
             [GET_DOC_REGEX, rewriteDocRequest, 'rewrite_get_request_to_strip_types'],
-            [BULK_REQUEST_REGEX, rewriteBulk, 'rewrite_bulk'],
             [CREATE_INDEX_REGEX, rewriteCreateIndex, 'rewrite_create_index']
         ]
     );

--- a/transformation/transformationPlugins/jsonMessageTransformers/jsonTypeMappingsSanitizationTransformer/src/main/resources/js/typeMappingsSanitizer.js
+++ b/transformation/transformationPlugins/jsonMessageTransformers/jsonTypeMappingsSanitizationTransformer/src/main/resources/js/typeMappingsSanitizer.js
@@ -267,12 +267,12 @@ function rewriteCreateIndex(match, inputMap) {
 }
 
 // Define regex patterns as constants
-const PUT_POST_DOC_REGEX = /(?:PUT|POST) \/([^\/]*)\/([^\/]*)\/(.*)/;
-const GET_DOC_REGEX = /GET \/(?!\.{1,2}(?:\/|$))([^-_+][^A-Z\\/*?\"<>|,# ]*)\/(?!\.{1,2}(?:\/|$))([^-_+][^A-Z\\/*?\"<>|,# ]*)\/([^\/]+)$/;
+const PUT_POST_DOC_REGEX = /(?:PUT|POST) \/([^/]*)\/([^/]*)\/(.*)/;
+const GET_DOC_REGEX = /GET \/(?!\.{1,2}(?:\/|$))([^-_+][^A-Z/*?"<>|,# ]*)\/(?!\.{1,2}(?:\/|$))([^-_+][^A-Z/*?"<>|,# ]*)\/([^/]+)$/;
 const BULK_REQUEST_REGEX = /(?:PUT|POST) \/_bulk/;
-const CREATE_INDEX_REGEX = /(?:PUT|POST) \/([^\/]*)/;
-const INDEX_BULK_REQUEST_REGEX = /(?:PUT|POST) \/([^\/]+)\/_bulk/;
-const INDEX_TYPE_BULK_REQUEST_REGEX = /(?:PUT|POST) \/([^\/]+)\/([^\/]+)\/_bulk/;
+const CREATE_INDEX_REGEX = /(?:PUT|POST) \/([^/]*)/;
+const INDEX_BULK_REQUEST_REGEX = /(?:PUT|POST) \/([^/]+)\/_bulk/;
+const INDEX_TYPE_BULK_REQUEST_REGEX = /(?:PUT|POST) \/([^/]+)\/([^/]+)\/_bulk/;
 
 function processMetadataRequest(document, context) {
     let mappings = document?.body?.mappings;
@@ -358,7 +358,6 @@ function routeHttpRequest(source_document, context) {
         regex_mappings: context.regex_mappings,
         properties: context.source_properties
     };
-    console.log("Route test on" + methodAndUri)
     return route(
         documentAndContext,
         methodAndUri,


### PR DESCRIPTION
### Description
Implement replayer support for `/<index>/_bulk` and `/<index>/<type>/_bulk` in type mapping sanitization transformer

Users can run bulk requests with either `/_bulk` or `/index/_bulk`, `/<index>/<type>/_bulk` but our Type Mappings Sanitization transformer only works for /_bulk.  This task should work for when the index is specified.  When multiple types/indices are used, it should change the URI to use the more general /_bulk format.

### Issues Resolved
[MIGRATIONS-2268](https://opensearch.atlassian.net/browse/MIGRATIONS-2268)

### Testing
Unit tests added

### Check List
- [x] New functionality includes testing
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.
https://github.com/opensearch-project/documentation-website/pull/9363

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
