### PR TITLE
Update sonarqube threshold to 44

### DIFF
--- a/.github/workflows/sonar-qube.yml
+++ b/.github/workflows/sonar-qube.yml
@@ -92,7 +92,7 @@ jobs:
         done
 
         ISSUE_COUNT=$(jq '.issues | length' issues.json)
-        BASELINE_ISSUE_COUNT=43 # Baseline issue count
+        BASELINE_ISSUE_COUNT=44 # Baseline issue count
         if [ "$ISSUE_COUNT" -gt "$BASELINE_ISSUE_COUNT" ]; then
           echo "❌ Build failed: Found $ISSUE_COUNT issues, which is more than the baseline of $BASELINE_ISSUE_COUNT."
           exit 1


### PR DESCRIPTION
### Description
Update sonarqube threshold to 44, which reflects the current count

### Issues Resolved
N/A

### Testing
GHA

### Check List
- [ ] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
