### PR TITLE
Add usage warning for creating snapshot on Amazon Managed OpenSearch

### DIFF
--- a/CreateSnapshot/README.md
+++ b/CreateSnapshot/README.md
@@ -26,7 +26,7 @@ In order for this succeed, you'll need to make sure:
 * The S3 URI currently exists, and is in the region you specify
 * There are no other snapshots present in that S3 URI
 
-If your source cluster is OpenSearch 1.x, you may also need to:
+If your source cluster uses AWS SIGv4 Authentication, you may also need to:
 * Pass args `--source-aws-service-signing-name es` and `--source-aws-region` parameters to correctly sign your AWS SIGV4 requests
 * Configure and pass `--s3-role-arn` to register your S3 repository (see [AWS OpenSearch Managed Domains Snapshots Guide](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/managedomains-snapshots.html))
 

--- a/CreateSnapshot/README.md
+++ b/CreateSnapshot/README.md
@@ -26,6 +26,14 @@ In order for this succeed, you'll need to make sure:
 * The S3 URI currently exists, and is in the region you specify
 * There are no other snapshots present in that S3 URI
 
+If your source cluster is OpenSearch 1.x, you may also need to:
+* Pass args `--source-aws-service-signing-name es` and `--source-aws-region` parameters to correctly sign your AWS SIGV4 requests
+* Configure and pass `--s3-role-arn` to register your S3 repository (see [AWS OpenSearch Managed Domains Snapshots Guide](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/managedomains-snapshots.html))
+
+```shell
+./gradlew CreateSnapshot:run --args='--snapshot-name reindex-from-snapshot --s3-repo-uri s3://your-s3-uri --s3-region us-fake-1 --s3-role-arn arn:aws:iam::123456789012:role/your-role --source-aws-region us-fake-1 --source-aws-service-signing-name es --source-host https://hostname.us-fake-1.es.amazonaws.com'
+```
+
 ### On-Disk Snapshot
 
 From the root directory of the repo, run a CLI command like so:


### PR DESCRIPTION
### Description

Add details of command usage required when creating snapshots on Managed OpenSearch 1.x source clusters. Had to pass in a few extra arguments after auth failed from ["anonymous not authorized" errors](https://repost.aws/knowledge-center/anonymous-not-authorized-opensearch).

This docs update might be too small to want to commit, but given that the compatibility guide mentions OpenSearch 1.3.x -> 2.14 [is supported](https://github.com/opensearch-project/opensearch-migrations/blob/0b868bd042bd1c67d2153624aae4068966003420/README.md?plain=1#L55) I thought it could be useful for future users.

**Context**: I'm evaluating whether my team can use OpenSearch Migrations to migrate our 1.x clusters. Adding my learnings from trying to step through the guide in a test environment.


### Issues Resolved

n/a

### Testing

Manual testing:
1. Created S3 role / bucket following guide: https://docs.aws.amazon.com/opensearch-service/latest/developerguide/managedomains-snapshots.html
2. Successfully running snapshots in test environment running OpenSearch 1.3.x

```
o.o.m.b.w.SnapshotRunner [main] Attempting to initiate the snapshot...
2025-03-10 06:35:59,698 INFO o.o.m.b.c.SnapshotCreator [main] Snapshot repo registration successful
2025-03-10 06:36:00,059 INFO o.o.m.b.c.SnapshotCreator [main] Snapshot reindex-from-snapshot creation initiated
2025-03-10 06:36:00,059 INFO o.o.m.b.w.SnapshotRunner [main] Snapshot in progress...
2025-03-10 06:36:00,188 INFO o.o.m.b.w.SnapshotRunner [main] Snapshot not finished yet; sleeping for 1000ms...
2025-03-10 06:36:01,340 INFO o.o.m.b.w.SnapshotRunner [main] Snapshot not finished yet; sleeping for 1000ms...
2025-03-10 06:36:02,423 INFO o.o.m.b.w.SnapshotRunner [main] Snapshot not finished yet; sleeping for 1000ms...
```

### Check List
- [x] New functionality includes testing (no new functionality added)
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable. (is this applicable?)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
