### PR TITLE
[Bug] Check that SSM is ready on EC2 instance in Jenkins pipeline

### DIFF
--- a/test/awsRunInitBootstrap.sh
+++ b/test/awsRunInitBootstrap.sh
@@ -92,7 +92,41 @@ get_instance_id() {
   echo "$instance_id"
 }
 
+check_ssm_ready() {
+    local instance_id="$1"
+    local timeout="${2:-60}"   # default 60 seconds
+    local interval="${3:-5}"   # default 5 seconds
+    local elapsed=0
+    local ssm_status
+
+    echo "Checking for SSM registration of instance ${instance_id}..."
+
+    while [ $elapsed -lt $timeout ]; do
+        # Using the --filters parameter to retrieve info for the specific instance ID.
+        # If the instance is not registered, the returned InstanceInformationList will be empty.
+        ssm_status=$(aws ssm describe-instance-information \
+            --filters "Key=InstanceIds,Values=${instance_id}" \
+            --query "InstanceInformationList[0].PingStatus" --output text)
+
+        if [ -z "$ssm_status" ] || [ "$ssm_status" = "None" ]; then
+            echo "Instance ${instance_id} is not currently registered with SSM."
+        elif [ "$ssm_status" != "Online" ]; then
+            echo "Instance ${instance_id} SSM PingStatus is not Online. Current status: ${ssm_status}"
+        else
+            echo "Instance ${instance_id} is ready (running and SSM PingStatus is Online)."
+            return 0
+        fi
+
+        sleep "$interval"
+        elapsed=$((elapsed + interval))
+    done
+
+    echo "Instance ${instance_id} was not ready for SSM after ${timeout} seconds."
+    exit 1
+}
+
 instance_id=$(get_instance_id)
+check_ssm_ready "$instance_id"
 init_command="cd /opensearch-migrations && ./initBootstrap.sh"
 verify_command="cdk --version && docker --version && java --version && python3 --version"
 if [ "$WORKFLOW" = "ALL" ]; then

--- a/test/awsRunInitBootstrap.sh
+++ b/test/awsRunInitBootstrap.sh
@@ -102,8 +102,6 @@ check_ssm_ready() {
     echo "Checking for SSM registration of instance ${instance_id}..."
 
     while [ $elapsed -lt $timeout ]; do
-        # Using the --filters parameter to retrieve info for the specific instance ID.
-        # If the instance is not registered, the returned InstanceInformationList will be empty.
         ssm_status=$(aws ssm describe-instance-information \
             --filters "Key=InstanceIds,Values=${instance_id}" \
             --query "InstanceInformationList[0].PingStatus" --output text)


### PR DESCRIPTION
### Description
More details in issue, this change should ensure an EC2 instance is ready to execute an SSM command before we send it one

### Issues Resolved
https://opensearch.atlassian.net/browse/MIGRATIONS-2432

### Testing
Manual and Jenkins testing

### Check List
- [ ] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).