### PR TITLE
Update most tests to use OS_LATEST image, currently 2.19.1

### DIFF
--- a/DataGenerator/src/test/java/org/opensearch/migrations/DataGeneratorEndToEnd.java
+++ b/DataGenerator/src/test/java/org/opensearch/migrations/DataGeneratorEndToEnd.java
@@ -24,8 +24,8 @@ import static org.hamcrest.Matchers.hasEntry;
 class DataGeneratorEndToEnd {
 
     @Test
-    void generateData_OS_2_14() throws Exception {
-        try (var targetCluster = new SearchClusterContainer(SearchClusterContainer.OS_V2_14_0)) {
+    void generateData_OS_2_X() throws Exception {
+        try (var targetCluster = new SearchClusterContainer(SearchClusterContainer.OS_LATEST)) {
             generateData(targetCluster);
         }
     }

--- a/DocumentsFromSnapshotMigration/src/test/java/org/opensearch/migrations/bulkload/CustomRfsTransformationTest.java
+++ b/DocumentsFromSnapshotMigration/src/test/java/org/opensearch/migrations/bulkload/CustomRfsTransformationTest.java
@@ -94,7 +94,7 @@ public class CustomRfsTransformationTest extends SourceTestBase {
             var esSourceContainer = new SearchClusterContainer(SearchClusterContainer.ES_V7_10_2)
                     .withAccessToHost(true);
             var network = Network.newNetwork();
-            var osTargetContainer = new SearchClusterContainer(SearchClusterContainer.OS_V2_14_0)
+            var osTargetContainer = new SearchClusterContainer(SearchClusterContainer.OS_LATEST)
                     .withAccessToHost(true)
                     .withNetwork(network)
                     .withNetworkAliases(TARGET_DOCKER_HOSTNAME);

--- a/DocumentsFromSnapshotMigration/src/test/java/org/opensearch/migrations/bulkload/LeaseExpirationTest.java
+++ b/DocumentsFromSnapshotMigration/src/test/java/org/opensearch/migrations/bulkload/LeaseExpirationTest.java
@@ -83,7 +83,7 @@ public class LeaseExpirationTest extends SourceTestBase {
             var esSourceContainer = new SearchClusterContainer(sourceClusterVersion)
                     .withAccessToHost(true);
             var network = Network.newNetwork();
-            var osTargetContainer = new SearchClusterContainer(SearchClusterContainer.OS_V2_14_0)
+            var osTargetContainer = new SearchClusterContainer(SearchClusterContainer.OS_LATEST)
                     .withAccessToHost(true)
                     .withNetwork(network)
                     .withNetworkAliases(TARGET_DOCKER_HOSTNAME);

--- a/DocumentsFromSnapshotMigration/src/test/java/org/opensearch/migrations/bulkload/ParallelDocumentMigrationsTest.java
+++ b/DocumentsFromSnapshotMigration/src/test/java/org/opensearch/migrations/bulkload/ParallelDocumentMigrationsTest.java
@@ -38,7 +38,7 @@ public class ParallelDocumentMigrationsTest extends SourceTestBase {
     public static Stream<Arguments> makeDocumentMigrationArgs() {
         var numWorkersList = List.of(1, 3, 40);
         return numWorkersList.stream()
-            .map(numWorkers -> Arguments.of(numWorkers, SearchClusterContainer.OS_V2_14_0)
+            .map(numWorkers -> Arguments.of(numWorkers, SearchClusterContainer.OS_LATEST)
             );
     }
 

--- a/DocumentsFromSnapshotMigration/src/test/java/org/opensearch/migrations/bulkload/ProcessLifecycleTest.java
+++ b/DocumentsFromSnapshotMigration/src/test/java/org/opensearch/migrations/bulkload/ProcessLifecycleTest.java
@@ -107,7 +107,7 @@ public class ProcessLifecycleTest extends SourceTestBase {
     private void testProcess(int expectedExitCode, Function<RunData, Integer> processRunner) {
         final var testSnapshotContext = SnapshotTestContext.factory().noOtelTracking();
 
-        var targetImageName = SearchClusterContainer.OS_V2_14_0.getImageName();
+        var targetImageName = SearchClusterContainer.OS_LATEST.getImageName();
 
         var tempDirSnapshot = Files.createTempDirectory("opensearchMigrationReindexFromSnapshot_test_snapshot");
         var tempDirLucene = Files.createTempDirectory("opensearchMigrationReindexFromSnapshot_test_lucene");

--- a/MetadataMigration/src/test/java/org/opensearch/migrations/MultiTypeMappingTransformationTest.java
+++ b/MetadataMigration/src/test/java/org/opensearch/migrations/MultiTypeMappingTransformationTest.java
@@ -48,7 +48,7 @@ class MultiTypeMappingTransformationTest extends BaseMigrationTest {
 
         try (
             final var upgradedSourceCluster = new SearchClusterContainer(SearchClusterContainer.ES_V6_8_23);
-            final var targetCluster = new SearchClusterContainer(SearchClusterContainer.OS_V2_14_0)
+            final var targetCluster = new SearchClusterContainer(SearchClusterContainer.OS_LATEST)
         ) {
             this.sourceCluster = upgradedSourceCluster;
             this.targetCluster = targetCluster;
@@ -83,7 +83,7 @@ class MultiTypeMappingTransformationTest extends BaseMigrationTest {
     public void multiTypeTransformationTest_union_5_6() {
         try (
             final var indexCreatedCluster = new SearchClusterContainer(SearchClusterContainer.ES_V5_6_16);
-            final var targetCluster = new SearchClusterContainer(SearchClusterContainer.OS_V2_14_0)
+            final var targetCluster = new SearchClusterContainer(SearchClusterContainer.OS_LATEST)
         ) {
             indexCreatedCluster.start();
 

--- a/RFS/src/testFixtures/java/org/opensearch/migrations/bulkload/SupportedClusters.java
+++ b/RFS/src/testFixtures/java/org/opensearch/migrations/bulkload/SupportedClusters.java
@@ -26,7 +26,7 @@ public class SupportedClusters {
     public static List<ContainerVersion> targets() {
         return List.of(
             SearchClusterContainer.OS_V1_3_16,
-            SearchClusterContainer.OS_V2_14_0
+            SearchClusterContainer.OS_V2_19_1
         );
     }
 }

--- a/RFS/src/testFixtures/java/org/opensearch/migrations/bulkload/framework/SearchClusterContainer.java
+++ b/RFS/src/testFixtures/java/org/opensearch/migrations/bulkload/framework/SearchClusterContainer.java
@@ -70,6 +70,7 @@ public class SearchClusterContainer extends GenericContainer<SearchClusterContai
             new ImmutableMap.Builder<String, String>().putAll(BASE.getEnvVariables())
                 .put("plugins.security.disabled", "true")
                 .put("OPENSEARCH_INITIAL_ADMIN_PASSWORD", "SecurityIsDisabled123$%^")
+                .put("search.insights.top_queries.exporter.type", "debug")
                 .build()
         );
 

--- a/RFS/src/testFixtures/java/org/opensearch/migrations/bulkload/framework/SearchClusterContainer.java
+++ b/RFS/src/testFixtures/java/org/opensearch/migrations/bulkload/framework/SearchClusterContainer.java
@@ -49,6 +49,11 @@ public class SearchClusterContainer extends GenericContainer<SearchClusterContai
         "opensearchproject/opensearch:2.14.0",
         Version.fromString("OS 2.14.0")
     );
+    public static final ContainerVersion OS_V2_19_1 = new OpenSearchVersion(
+        "opensearchproject/opensearch:2.19.1",
+        Version.fromString("OS 2.19.1")
+    );
+    public static final ContainerVersion OS_LATEST = OS_V2_19_1;
 
     private enum INITIALIZATION_FLAVOR {
         BASE(Map.of("discovery.type", "single-node",

--- a/RFS/src/testFixtures/java/org/opensearch/migrations/bulkload/framework/SearchClusterContainer.java
+++ b/RFS/src/testFixtures/java/org/opensearch/migrations/bulkload/framework/SearchClusterContainer.java
@@ -5,6 +5,7 @@ import java.time.Duration;
 import java.util.Map;
 
 import org.opensearch.migrations.Version;
+import org.opensearch.migrations.VersionMatchers;
 
 import com.google.common.collect.ImmutableMap;
 import lombok.EqualsAndHashCode;
@@ -68,6 +69,11 @@ public class SearchClusterContainer extends GenericContainer<SearchClusterContai
                 .build()),
         OPENSEARCH(
             new ImmutableMap.Builder<String, String>().putAll(BASE.getEnvVariables())
+                .put("plugins.security.disabled", "true")
+                .put("OPENSEARCH_INITIAL_ADMIN_PASSWORD", "SecurityIsDisabled123$%^")
+                .build()),
+        OPENSEARCH_2_19(
+        new ImmutableMap.Builder<String, String>().putAll(BASE.getEnvVariables())
                 .put("plugins.security.disabled", "true")
                 .put("OPENSEARCH_INITIAL_ADMIN_PASSWORD", "SecurityIsDisabled123$%^")
                 .put("search.insights.top_queries.exporter.type", "debug")
@@ -178,7 +184,7 @@ public class SearchClusterContainer extends GenericContainer<SearchClusterContai
 
     public static class OpenSearchVersion extends ContainerVersion {
         public OpenSearchVersion(String imageName, Version version) {
-            super(imageName, version, INITIALIZATION_FLAVOR.OPENSEARCH);
+            super(imageName, version, VersionMatchers.isOS_2_19.test(version) ? INITIALIZATION_FLAVOR.OPENSEARCH_2_19 : INITIALIZATION_FLAVOR.OPENSEARCH);
         }
     }
 }

--- a/transformation/src/main/java/org/opensearch/migrations/VersionMatchers.java
+++ b/transformation/src/main/java/org/opensearch/migrations/VersionMatchers.java
@@ -14,6 +14,7 @@ public class VersionMatchers {
 
     public static final Predicate<Version> isOS_1_X = VersionMatchers.matchesMajorVersion(Version.fromString("OS 1.0.0"));
     public static final Predicate<Version> isOS_2_X = VersionMatchers.matchesMajorVersion(Version.fromString("OS 2.0.0"));
+    public static final Predicate<Version> isOS_2_19 = VersionMatchers.matchesMinorVersion(Version.fromString("OS 2.19.1"));
 
     private static Predicate<Flavor> compatibleFlavor(final Flavor flavor) {
         return other -> {


### PR DESCRIPTION
### Description
The documentation, as of #1336, refers to migrating to 2.19. This PR updates our tests to use the 2.19.1 image.

Because it's kind of silly to have to go change our code in N places every time we are testing against a new version, I also added an `OS_LATEST` alias so that as we add a new image, we only have to add its image info and update the alias in one file, and we'll automatically test against it in most places.

I did _not_ change our `SupportedCluster` matrix to use `OS_LATEST` because I think that's a helpful spot to be very explicit about exactly what we test against. Open to feedback if others disagree.

### Issues Resolved
https://opensearch.atlassian.net/browse/MIGRATIONS-2430

### Testing
Primarily a test-related change.

### Check List
- [ ] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
