### PR TITLE
Loosen capture proxy healthcheck error codes

### DIFF
--- a/deployment/cdk/opensearch-service-migration/lib/network-stack.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/network-stack.ts
@@ -306,9 +306,10 @@ export class NetworkStack extends Stack {
             protocolVersion: ApplicationProtocolVersion.HTTP1,
             port: containerPort,
             vpc: vpc,
+            // Cluster may reject requests with no authentication
             healthCheck: {
                 path: "/",
-                healthyHttpCodes: "200,401"
+                healthyHttpCodes: "200-499"
             }
         });
     }


### PR DESCRIPTION
### Description
Loosen capture proxy healthcheck error codes

Customers may get 403 due to sigv4 requirements on their cluster.

### Issues Resolved

### Testing

### Check List
- [ ] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
