### PR TITLE
Minor improvements to Solutions CFN naming and CIDR range

### DIFF
--- a/deployment/migration-assistant-solution/lib/solutions-stack.ts
+++ b/deployment/migration-assistant-solution/lib/solutions-stack.ts
@@ -198,11 +198,6 @@ export class SolutionsInfrastructureStack extends Stack {
                 Tags.of(subnet)
                     .add("Name", `migration-assistant-private-subnet-${index + 1}-${stageParameter.valueAsString}`);
             });
-            // No isolated subnets should be generated, including as a guardrail
-            vpc.isolatedSubnets.forEach((subnet, index) => {
-                Tags.of(subnet)
-                    .add("Name", `migration-assistant-isolated-subnet-${index + 1}-${stageParameter.valueAsString}`);
-            });
 
             // S3 used for storage and retrieval of snapshot data for backfills
             new GatewayVpcEndpoint(this, 'S3VpcEndpoint', {

--- a/deployment/migration-assistant-solution/lib/solutions-stack.ts
+++ b/deployment/migration-assistant-solution/lib/solutions-stack.ts
@@ -24,9 +24,10 @@ import {
     InstanceType,
     InterfaceVpcEndpoint,
     InterfaceVpcEndpointAwsService,
+    IpAddresses,
     IpProtocol,
     SecurityGroup,
-    Vpc
+    Vpc, SubnetType
 } from "aws-cdk-lib/aws-ec2";
 import {CfnDocument} from "aws-cdk-lib/aws-ssm";
 import {Application, AttributeGroup} from "@aws-cdk/aws-servicecatalogappregistry-alpha";
@@ -182,7 +183,10 @@ export class SolutionsInfrastructureStack extends Stack {
         let vpc: IVpc;
         if (props.createVPC) {
             vpc = new Vpc(this, 'Vpc', {
-                ipProtocol: IpProtocol.DUAL_STACK
+                // Using 10.212 to avoid default VPC range conflicts with VPC peering
+                ipAddresses: IpAddresses.cidr('10.212.0.0/16'),
+                ipProtocol: IpProtocol.DUAL_STACK,
+                vpcName: `migration-assistant-vpc-${stackMarker}`,
             });
             // S3 used for storage and retrieval of snapshot data for backfills
             new GatewayVpcEndpoint(this, 'S3VpcEndpoint', {

--- a/deployment/migration-assistant-solution/lib/solutions-stack.ts
+++ b/deployment/migration-assistant-solution/lib/solutions-stack.ts
@@ -192,16 +192,16 @@ export class SolutionsInfrastructureStack extends Stack {
 
             vpc.publicSubnets.forEach((subnet, index) => {
                 Tags.of(subnet)
-                    .add("Name", `migration-assistant-${stageParameter.valueAsString}-public-subnet-${index + 1}`);
+                    .add("Name", `migration-assistant-public-subnet-${index + 1}-${stageParameter.valueAsString}`);
             });
             vpc.privateSubnets.forEach((subnet, index) => {
                 Tags.of(subnet)
-                    .add("Name", `migration-assistant-${stageParameter.valueAsString}-private-subnet-${index + 1}`);
+                    .add("Name", `migration-assistant-private-subnet-${index + 1}-${stageParameter.valueAsString}`);
             });
             // No isolated subnets should be generated, including as a guardrail
             vpc.isolatedSubnets.forEach((subnet, index) => {
                 Tags.of(subnet)
-                    .add("Name", `migration-assistant-${stageParameter.valueAsString}-isolated-subnet-${index + 1}`);
+                    .add("Name", `migration-assistant-isolated-subnet-${index + 1}-${stageParameter.valueAsString}`);
             });
 
             // S3 used for storage and retrieval of snapshot data for backfills

--- a/deployment/migration-assistant-solution/test/solutions-stack.test.ts
+++ b/deployment/migration-assistant-solution/test/solutions-stack.test.ts
@@ -1,5 +1,5 @@
 import { describe, test } from '@jest/globals';
-import { Template } from 'aws-cdk-lib/assertions';
+import {Template} from 'aws-cdk-lib/assertions';
 import { App } from 'aws-cdk-lib';
 import { SolutionsInfrastructureStack } from '../lib/solutions-stack';
 
@@ -20,7 +20,9 @@ describe('Solutions stack', () => {
         const template = Template.fromStack(stack);
         verifyResources(template, {
             vpcCount: 1,
-            vpcEndpointCount: 5
+            vpcEndpointCount: 5,
+            subnetCount: 4,
+            natGatewayCount: 2
         });
     });
 
@@ -34,7 +36,9 @@ describe('Solutions stack', () => {
         const template = Template.fromStack(stack);
         verifyResources(template, {
             vpcCount: 1,
-            vpcEndpointCount: 5
+            vpcEndpointCount: 5,
+            subnetCount: 4,
+            natGatewayCount: 2
         });
     });
 
@@ -46,13 +50,19 @@ describe('Solutions stack', () => {
         const template = Template.fromStack(stack);
         verifyResources(template, {
             vpcCount: 0,
-            vpcEndpointCount: 0
+            vpcEndpointCount: 0,
+            subnetCount: 0,
+            natGatewayCount: 0
         });
     });
 
-    function verifyResources(template: Template, props: { vpcCount: number, vpcEndpointCount: number }) {
+    function verifyResources(template: Template, props: { vpcCount: number, vpcEndpointCount: number,
+        subnetCount: number, natGatewayCount: number }) {
+
         template.resourceCountIs('AWS::EC2::VPC', props.vpcCount);
         template.resourceCountIs('AWS::EC2::VPCEndpoint', props.vpcEndpointCount);
+        template.resourceCountIs('AWS::EC2::Subnet', props.subnetCount);
+        template.resourceCountIs('AWS::EC2::NatGateway', props.natGatewayCount);
         template.resourceCountIs('AWS::ServiceCatalogAppRegistry::Application', 1);
         template.hasResourceProperties('AWS::EC2::Instance', {
             InstanceType: "t3.large"


### PR DESCRIPTION
### Description
This change accomplishes the following:
* Use a different CIDR range for VPC than default to avoid IP conflicts with VPC peering
* Include stage in VPC and subnet names

### Issues Resolved
N/A

### Testing
Cloud deployment testing: https://migrations.ci.opensearch.org/job/solutions-cfn-create-vpc-test/2701/console

### Check List
- [ ] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
