### PR TITLE
Report newest issues first on sonarqube PR annotations

### DIFF
--- a/.github/workflows/sonar-qube.yml
+++ b/.github/workflows/sonar-qube.yml
@@ -81,8 +81,8 @@ jobs:
         jq -r '.issues[] | "File: \(.component):\(.line), Rule: \(.rule), Message: \(.message)"' issues.json | sort
         echo "::endgroup::"
 
-        # Annotate issue on the PR
-        jq -c '.issues[]' issues.json | while read -r issue; do
+        # Annotate issue on the PR with newest first
+        jq -c '.issues | sort_by(.creationDate) | reverse | .[]' issues.json | while read -r issue; do
           FILE=$(echo "$issue" | jq -r '.component | split(":")[1]')
           LINE=$(echo "$issue" | jq -r '.line')
           MESSAGE=$(echo "$issue" | jq -r '.message')


### PR DESCRIPTION
### Description
When annotations are put on pull requests they are limited to the first 10 items reported, by ordering the issues reported from Sonarqube it would be sure to notify PR creator of issues they are introducing in the current PR, or more recent additions.

### Testing
Verified the workflow result

### Check List
- [ ] ~New functionality includes testing~
- [ ] ~Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
