### PR TITLE
Bug fixes and E2E test update for handling ES 5.x default metadata

### DIFF
--- a/MetadataMigration/src/test/java/org/opensearch/migrations/EndToEndTest.java
+++ b/MetadataMigration/src/test/java/org/opensearch/migrations/EndToEndTest.java
@@ -142,7 +142,7 @@ class EndToEndTest extends BaseMigrationTest {
         arguments.metadataTransformationParams.multiTypeResolutionBehavior = MultiTypeResolutionBehavior.UNION;
 
         // Set up data filters for ES 7.17 as we do not currently have transformations in place to support breaking
-        // changes from default templates and settings here
+        // changes from default templates and settings here: https://opensearch.atlassian.net/browse/MIGRATIONS-2447
         if (sourceCluster.getContainerVersion().getVersion().equals(Version.fromString("ES 7.17.22"))) {
             var dataFilterArgs = new DataFilterArgs();
             dataFilterArgs.indexAllowlist = Stream.concat(testData.blogIndexNames.stream(),

--- a/MetadataMigration/src/test/java/org/opensearch/migrations/EndToEndTest.java
+++ b/MetadataMigration/src/test/java/org/opensearch/migrations/EndToEndTest.java
@@ -27,7 +27,7 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.hasItems;
 
 /**
  * Tests focused on setting up whole source clusters, performing a migration, and validation on the target cluster.
@@ -141,13 +141,16 @@ class EndToEndTest extends BaseMigrationTest {
         }
         arguments.metadataTransformationParams.multiTypeResolutionBehavior = MultiTypeResolutionBehavior.UNION;
 
-        // Set up data filters
-        var dataFilterArgs = new DataFilterArgs();
-        dataFilterArgs.indexAllowlist = Stream.concat(testData.blogIndexNames.stream(),
-            Stream.of(testData.movieIndexName, testData.indexThatAlreadyExists)).collect(Collectors.toList());
-        dataFilterArgs.componentTemplateAllowlist = testData.componentTemplateNames;
-        dataFilterArgs.indexTemplateAllowlist = testData.templateNames;
-        arguments.dataFilterArgs = dataFilterArgs;
+        // Set up data filters for ES 7.17 as we do not currently have transformations in place to support breaking
+        // changes from default templates and settings here
+        if (sourceCluster.getContainerVersion().getVersion().equals(Version.fromString("ES 7.17.22"))) {
+            var dataFilterArgs = new DataFilterArgs();
+            dataFilterArgs.indexAllowlist = Stream.concat(testData.blogIndexNames.stream(),
+                    Stream.of(testData.movieIndexName, testData.indexThatAlreadyExists)).collect(Collectors.toList());
+            dataFilterArgs.componentTemplateAllowlist = testData.componentTemplateNames;
+            dataFilterArgs.indexTemplateAllowlist = testData.templateNames;
+            arguments.dataFilterArgs = dataFilterArgs;
+        }
 
         targetOperations.createDocument(testData.indexThatAlreadyExists, "doc77", "{}");
 
@@ -179,17 +182,17 @@ class EndToEndTest extends BaseMigrationTest {
 
         var migratedItems = result.getItems();
         assertThat(getNames(getSuccessfulResults(migratedItems.getIndexTemplates())),
-            containsInAnyOrder(testData.templateNames.toArray(new String[0])));
+            hasItems(testData.templateNames.toArray(new String[0])));
         assertThat(getNames(getSuccessfulResults(migratedItems.getComponentTemplates())),
-            containsInAnyOrder(testData.componentTemplateNames.toArray(new String[0])));
+            hasItems(testData.componentTemplateNames.toArray(new String[0])));
         assertThat(getNames(getSuccessfulResults(migratedItems.getIndexes())),
-            containsInAnyOrder(Stream.concat(testData.blogIndexNames.stream(),
-                Stream.of(testData.movieIndexName)).toArray()));
+            hasItems(Stream.concat(testData.blogIndexNames.stream(),
+                Stream.of(testData.movieIndexName)).toArray(String[]::new)));
         assertThat(getNames(getFailedResultsByType(migratedItems.getIndexes(),
                 CreationResult.CreationFailureType.ALREADY_EXISTS)),
-            containsInAnyOrder(testData.indexThatAlreadyExists));
+            hasItems(testData.indexThatAlreadyExists));
         assertThat(getNames(getSuccessfulResults(migratedItems.getAliases())),
-            containsInAnyOrder(testData.aliasNames.toArray(new String[0])));
+            hasItems(testData.aliasNames.toArray(new String[0])));
     }
 
     private List<CreationResult> getSuccessfulResults(List<CreationResult> results) {

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/common/ObjectNodeUtils.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/common/ObjectNodeUtils.java
@@ -1,0 +1,26 @@
+package org.opensearch.migrations.bulkload.common;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+public class ObjectNodeUtils {
+
+    public static void removeFieldsByPath(ObjectNode node, String path) {
+        var pathParts = path.split("\\.");
+
+        if (pathParts.length == 1) {
+            node.remove(pathParts[0]);
+            return;
+        }
+
+        var currentNode = node;
+        for (int i = 0; i < pathParts.length - 1; i++) {
+            var nextNode = currentNode.get(pathParts[i]);
+            if (nextNode != null && nextNode.isObject()) {
+                currentNode = (ObjectNode) nextNode;
+            } else {
+                return;
+            }
+        }
+        currentNode.remove(pathParts[pathParts.length - 1]);
+    }
+}

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/version_os_2_11/GlobalMetadataCreator_OS_2_11.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/version_os_2_11/GlobalMetadataCreator_OS_2_11.java
@@ -8,7 +8,6 @@ import java.util.stream.Collectors;
 
 import org.opensearch.migrations.MigrationMode;
 import org.opensearch.migrations.bulkload.common.FilterScheme;
-import org.opensearch.migrations.bulkload.common.ObjectNodeUtils;
 import org.opensearch.migrations.bulkload.common.OpenSearchClient;
 import org.opensearch.migrations.bulkload.models.GlobalMetadata;
 import org.opensearch.migrations.metadata.CreationResult;
@@ -16,6 +15,7 @@ import org.opensearch.migrations.metadata.CreationResult.CreationFailureType;
 import org.opensearch.migrations.metadata.GlobalMetadataCreator;
 import org.opensearch.migrations.metadata.GlobalMetadataCreatorResults;
 import org.opensearch.migrations.metadata.tracing.IMetadataMigrationContexts.IClusterMetadataContext;
+import org.opensearch.migrations.parsing.ObjectNodeUtils;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import lombok.AllArgsConstructor;

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/version_os_2_11/GlobalMetadataCreator_OS_2_11.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/version_os_2_11/GlobalMetadataCreator_OS_2_11.java
@@ -8,6 +8,7 @@ import java.util.stream.Collectors;
 
 import org.opensearch.migrations.MigrationMode;
 import org.opensearch.migrations.bulkload.common.FilterScheme;
+import org.opensearch.migrations.bulkload.common.ObjectNodeUtils;
 import org.opensearch.migrations.bulkload.common.OpenSearchClient;
 import org.opensearch.migrations.bulkload.models.GlobalMetadata;
 import org.opensearch.migrations.metadata.CreationResult;
@@ -146,6 +147,12 @@ public class GlobalMetadataCreator_OS_2_11 implements GlobalMetadataCreator {
         return templatesToCreate.entrySet().stream().map(kvp -> {
             var templateName = kvp.getKey();
             var templateBody = kvp.getValue();
+
+            String[] problemSettings = { "settings.mapping.single_type", "settings.mapper.dynamic" };
+            for (var field : problemSettings) {
+                ObjectNodeUtils.removeFieldsByPath(templateBody, field);
+            }
+
             var creationResult = CreationResult.builder().name(templateName);
 
             if (skipCreation.test(templateName)) {

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/version_os_2_11/IndexCreator_OS_2_11.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/version_os_2_11/IndexCreator_OS_2_11.java
@@ -2,9 +2,9 @@ package org.opensearch.migrations.bulkload.version_os_2_11;
 
 import org.opensearch.migrations.MigrationMode;
 import org.opensearch.migrations.bulkload.common.InvalidResponse;
+import org.opensearch.migrations.bulkload.common.ObjectNodeUtils;
 import org.opensearch.migrations.bulkload.common.OpenSearchClient;
 import org.opensearch.migrations.bulkload.models.IndexMetadata;
-import org.opensearch.migrations.bulkload.common.ObjectNodeUtils;
 import org.opensearch.migrations.metadata.CreationResult;
 import org.opensearch.migrations.metadata.CreationResult.CreationFailureType;
 import org.opensearch.migrations.metadata.CreationResult.CreationResultBuilder;

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/version_os_2_11/IndexCreator_OS_2_11.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/version_os_2_11/IndexCreator_OS_2_11.java
@@ -2,7 +2,6 @@ package org.opensearch.migrations.bulkload.version_os_2_11;
 
 import org.opensearch.migrations.MigrationMode;
 import org.opensearch.migrations.bulkload.common.InvalidResponse;
-import org.opensearch.migrations.bulkload.common.ObjectNodeUtils;
 import org.opensearch.migrations.bulkload.common.OpenSearchClient;
 import org.opensearch.migrations.bulkload.models.IndexMetadata;
 import org.opensearch.migrations.metadata.CreationResult;
@@ -10,6 +9,7 @@ import org.opensearch.migrations.metadata.CreationResult.CreationFailureType;
 import org.opensearch.migrations.metadata.CreationResult.CreationResultBuilder;
 import org.opensearch.migrations.metadata.IndexCreator;
 import org.opensearch.migrations.metadata.tracing.IMetadataMigrationContexts.ICreateIndexContext;
+import org.opensearch.migrations.parsing.ObjectNodeUtils;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;

--- a/RFS/src/main/java/org/opensearch/migrations/parsing/ObjectNodeUtils.java
+++ b/RFS/src/main/java/org/opensearch/migrations/parsing/ObjectNodeUtils.java
@@ -1,4 +1,4 @@
-package org.opensearch.migrations.bulkload.common;
+package org.opensearch.migrations.parsing;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
 

--- a/RFS/src/test/java/org/opensearch/migrations/parsing/ObjectNodeUtilsTest.java
+++ b/RFS/src/test/java/org/opensearch/migrations/parsing/ObjectNodeUtilsTest.java
@@ -1,0 +1,118 @@
+package org.opensearch.migrations.parsing;
+
+import java.util.*;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class ObjectNodeUtilsTest {
+
+    // Recursively collects and returns all field names
+    private Set<String> collectAllFields(JsonNode node, String prefix) {
+        Set<String> fields = new HashSet<>();
+        if (node.isObject()) {
+            Iterator<Map.Entry<String, JsonNode>> iter = node.fields();
+            while (iter.hasNext()) {
+                Map.Entry<String, JsonNode> entry = iter.next();
+                // Create a fully qualified field name
+                String qualifiedName = prefix.isEmpty() ? entry.getKey() : prefix + "." + entry.getKey();
+                fields.add(qualifiedName);
+                fields.addAll(collectAllFields(entry.getValue(), qualifiedName));
+            }
+        } else if (node.isArray()) {
+            for (JsonNode element : node) {
+                fields.addAll(collectAllFields(element, prefix));
+            }
+        }
+        return fields;
+    }
+
+    @Test
+    void testRemoveFieldsByPath_topLevelField() {
+
+        ObjectMapper mapper = new ObjectMapper();
+        ObjectNode node = mapper.createObjectNode();
+        String fieldToRemove = "name";
+        String fieldToRemain = "age";
+        node.put(fieldToRemove, "testUser");
+        node.put(fieldToRemain, 25);
+
+        // Define expected fields
+        Set<String> expectedFields = new HashSet<>(List.of(fieldToRemain));
+
+        ObjectNodeUtils.removeFieldsByPath(node, fieldToRemove);
+
+        // Collect actual field names from the node
+        Set<String> actualFields = collectAllFields(node, "");
+
+        assertThat(expectedFields, equalTo(actualFields));
+    }
+
+    @Test
+    void testRemoveFieldsByPath_topLevelFieldThatDNE() {
+
+        ObjectMapper mapper = new ObjectMapper();
+        ObjectNode node = mapper.createObjectNode();
+        String nonExistentFieldToRemove = "unknown";
+        String fieldToRemain = "age";
+        node.put(fieldToRemain, 25);
+
+        // Define expected fields
+        Set<String> expectedFields = new HashSet<>(List.of(fieldToRemain));
+
+        ObjectNodeUtils.removeFieldsByPath(node, nonExistentFieldToRemove);
+
+        // Collect actual field names from the node
+        Set<String> actualFields = collectAllFields(node, "");
+
+        assertThat(expectedFields, equalTo(actualFields));
+    }
+
+    @Test
+    void testRemoveFieldsByPath_nestedFieldThatDNE() {
+
+        ObjectMapper mapper = new ObjectMapper();
+        ObjectNode node = mapper.createObjectNode();
+        String fieldToRemain = "age";
+        node.put(fieldToRemain, 25);
+
+        // Define expected fields
+        Set<String> expectedFields = new HashSet<>(List.of(fieldToRemain));
+
+        ObjectNodeUtils.removeFieldsByPath(node, "setting.unknown");
+
+        // Collect actual field names from the node
+        Set<String> actualFields = collectAllFields(node, "");
+
+        assertThat(expectedFields, equalTo(actualFields));
+    }
+
+    @Test
+    void testRemoveFieldsByPath_nestedField() {
+
+        ObjectMapper mapper = new ObjectMapper();
+        ObjectNode node = mapper.createObjectNode();
+        node.put("age", 25);
+
+        ObjectNode address = mapper.createObjectNode();
+        address.put("city", "New York");
+        address.put("zip", "10001");
+        node.set("address", address);
+
+        // Define expected fields
+        Set<String> expectedFields = new HashSet<>(List.of("age", "address", "address.city"));
+
+        ObjectNodeUtils.removeFieldsByPath(node, "address.zip");
+
+        // Collect actual field names from the node
+        Set<String> actualFields = collectAllFields(node, "");
+
+        assertThat(expectedFields, equalTo(actualFields));
+    }
+
+}


### PR DESCRIPTION
### Description
Bug fixes and E2E test update for handling ES 5.x default metadata

### Issues Resolved
https://opensearch.atlassian.net/browse/MIGRATIONS-2433

### Testing
Python E2E testing and Java E2E tests

### Check List
- [ ] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
