### PR TITLE
Add weekly dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,42 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/deployment/migration-assistant-solution"
+    schedule:
+      interval: "weekly"
+    groups:
+      migration-assistant-npm:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "npm"
+    directory: "/deployment/cdk/opensearch-service-migration"
+    schedule:
+      interval: "weekly"
+    groups:
+      opensearch-cdk-npm:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      gradle-all:
+        patterns:
+          - "*"
+    ignore:
+      - dependency-name: "org.opensearch:*"
+      - dependency-name: "org.opensearch.plugin:*"
+      - dependency-name: "org.apache.lucene:*"
+      - dependency-name: "io.opentelemetry.semconv:*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions-all:
+        patterns:
+          - "*"


### PR DESCRIPTION
### Description
Every week will make a consolidated PR for our major dependency areas for npm, gradle, and github actions.

### Issues Resolved
- Resolves [MIGRATIONS-2448 | Enable dependabot for dependencies](https://opensearch.atlassian.net/browse/MIGRATIONS-2448)

### Testing
Its running on [my fork](https://github.com/peternied/opensearch-migrations/pulls/app%2Fdependabot), now the only changes needed to get outstanding PRs merged is fixes due to incoming library changes.

### Check List
- [ ] New functionality includes testing
- [ ] ~Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
