### PR TITLE
[Sonarqube] Close localJsonTransformer resources when PacketToTransformingHttpHandlerFactory is closed

### DIFF
--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/PacketToTransformingHttpHandlerFactory.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/PacketToTransformingHttpHandlerFactory.java
@@ -1,5 +1,7 @@
 package org.opensearch.migrations.replay;
 
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
 
 import org.opensearch.migrations.replay.datahandlers.IPacketFinalizingConsumer;
@@ -15,11 +17,12 @@ import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class PacketToTransformingHttpHandlerFactory
-    implements
-        PacketConsumerFactory<TransformedOutputAndResult<ByteBufList>> {
+    implements PacketConsumerFactory<TransformedOutputAndResult<ByteBufList>>, AutoCloseable {
 
     // Using ThreadLocal to ensure thread safety with the json transformers which will be reused
     private final ThreadLocal<IJsonTransformer> localJsonTransformer;
+    private final Set<AutoCloseable> closeableResources = ConcurrentHashMap.newKeySet();
+
     // The authTransformerFactory is ThreadSafe and getAuthTransformer will be called for every request
     private final IAuthTransformerFactory authTransformerFactory;
 
@@ -42,5 +45,13 @@ public class PacketToTransformingHttpHandlerFactory
             new TransformedPacketReceiver(),
             httpTransactionContext
         );
+    }
+
+    @Override
+    public void close() throws Exception {
+        for (AutoCloseable resource : closeableResources) {
+            resource.close();
+        }
+        localJsonTransformer.remove();
     }
 }


### PR DESCRIPTION
### Description
Close localJsonTransformer resources when PacketToTransformingHttpHandlerFactory is closed

Call "remove()" on "localJsonTransformer".
"ThreadLocal" variables should be cleaned up when no longer used java:S5164

Fixes 
### Issues Resolved
<!-- List any GitHub or Jira issues this PR will resolve -->

### Testing
<!-- Please provide details of testing done: unit testing, integration testing and manual testing -->

### Check List
- [x] New functionality includes testing
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
