### PR TITLE
Fix RFS Shutdown logic during exception cases and set kafka tests as isolated

### DIFF
--- a/DocumentsFromSnapshotMigration/src/main/java/org/opensearch/migrations/RfsMigrateDocuments.java
+++ b/DocumentsFromSnapshotMigration/src/main/java/org/opensearch/migrations/RfsMigrateDocuments.java
@@ -429,37 +429,48 @@ public class RfsMigrateDocuments {
         log.atWarn().setMessage("Terminating RfsMigrateDocuments because the lease has expired for {}")
                 .addArgument(workItemId)
                 .log();
-        if (progressCursorRef.get() != null) {
-            log.atWarn().setMessage("Progress cursor set, cancelling active doc migration").log();
-            cancellationRunnable.run();
-            // Get a new progressCursor after cancellation for most up-to-date checkpoint
-            var progressCursor = progressCursorRef.get();
-            log.atWarn().setMessage("Progress cursor: {}")
-                    .addArgument(progressCursor).log();
-            var workItemAndDuration = workItemRef.get();
-            if (workItemAndDuration == null) {
-                throw new IllegalStateException("Unexpected state with progressCursor set without a" +
-                        "work item");
+        try {
+            if (progressCursorRef.get() != null) {
+                log.atWarn().setMessage("Progress cursor set, cancelling active doc migration").log();
+                cancellationRunnable.run();
+                // Get a new progressCursor after cancellation for most up-to-date checkpoint
+                var progressCursor = progressCursorRef.get();
+                log.atWarn().setMessage("Progress cursor: {}")
+                        .addArgument(progressCursor).log();
+                var workItemAndDuration = workItemRef.get();
+                if (workItemAndDuration == null) {
+                    throw new IllegalStateException("Unexpected state with progressCursor set without a" +
+                            "work item");
+                }
+                log.atWarn().setMessage("Work Item and Duration: {}").addArgument(workItemAndDuration)
+                        .log();
+                log.atWarn().setMessage("Work Item: {}").addArgument(workItemAndDuration.getWorkItem())
+                        .log();
+                var successorWorkItemIds = getSuccessorWorkItemIds(workItemAndDuration, progressCursor);
+                if (successorWorkItemIds.size() == 1 && workItemId.equals(successorWorkItemIds.get(0))) {
+                    log.atWarn().setMessage("No real progress was made for work item: {}. Will retry with larger timeout").addArgument(workItemId).log();
+                } else {
+                    log.atWarn().setMessage("Successor Work Ids: {}").addArgument(String.join(", ", successorWorkItemIds))
+                            .log();
+                    var successorNextAcquisitionLeaseExponent = getSuccessorNextAcquisitionLeaseExponent(workItemTimeProvider, initialLeaseDuration, workItemAndDuration.getLeaseExpirationTime());
+                    coordinator.createSuccessorWorkItemsAndMarkComplete(
+                            workItemId,
+                            successorWorkItemIds,
+                            successorNextAcquisitionLeaseExponent,
+                            contextSupplier
+                    );
+                }
+            } else {
+                log.atWarn().setMessage("No progress cursor to create successor work items from. This can happen when" +
+                        "downloading and unpacking shard takes longer than the lease").log();
+                log.atWarn().setMessage("Skipping creation of successor work item to retry the existing one with more time")
+                        .log();
             }
-            log.atWarn().setMessage("Work Item and Duration: {}").addArgument(workItemAndDuration)
-                    .log();
-            log.atWarn().setMessage("Work Item: {}").addArgument(workItemAndDuration.getWorkItem())
-                    .log();
-            var successorWorkItemIds = getSuccessorWorkItemIds(workItemAndDuration, progressCursor);
-            log.atWarn().setMessage("Successor Work Ids: {}").addArgument(String.join(", ", successorWorkItemIds))
-                    .log();
-            var successorNextAcquisitionLeaseExponent = getSuccessorNextAcquisitionLeaseExponent(workItemTimeProvider, initialLeaseDuration, workItemAndDuration.getLeaseExpirationTime());
-            coordinator.createSuccessorWorkItemsAndMarkComplete(
-                workItemId,
-                successorWorkItemIds,
-                successorNextAcquisitionLeaseExponent,
-                contextSupplier
-            );
-        } else {
-            log.atWarn().setMessage("No progress cursor to create successor work items from. This can happen when" +
-                    "downloading and unpacking shard takes longer than the lease").log();
-            log.atWarn().setMessage("Skipping creation of successor work item to retry the existing one with more time")
-                    .log();
+        } catch (Exception e) {
+            log.atError().setMessage("Exception during exit on lease timeout, clean shutdown failed")
+                    .setCause(e).log();
+            cleanShutdownCompleted.set(false);
+            System.exit(PROCESS_TIMED_OUT_EXIT_CODE);
         }
         cleanShutdownCompleted.set(true);
         System.exit(PROCESS_TIMED_OUT_EXIT_CODE);

--- a/DocumentsFromSnapshotMigration/src/test/java/org/opensearch/migrations/bulkload/SourceTestBase.java
+++ b/DocumentsFromSnapshotMigration/src/test/java/org/opensearch/migrations/bulkload/SourceTestBase.java
@@ -76,6 +76,8 @@ public class SourceTestBase {
 
     @NotNull
     protected static Process runAndMonitorProcess(ProcessBuilder processBuilder) throws IOException {
+        processBuilder.redirectErrorStream(true);
+        processBuilder.redirectOutput(ProcessBuilder.Redirect.PIPE);
         var process = processBuilder.start();
 
         log.atInfo().setMessage("Process started with ID: {}").addArgument(() -> process.toHandle().pid()).log();

--- a/TrafficCapture/trafficCaptureProxyServer/src/test/java/org/opensearch/migrations/trafficcapture/proxyserver/testcontainers/CaptureProxyContainer.java
+++ b/TrafficCapture/trafficCaptureProxyServer/src/test/java/org/opensearch/migrations/trafficcapture/proxyserver/testcontainers/CaptureProxyContainer.java
@@ -16,9 +16,9 @@ import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.testcontainers.containers.Container;
 import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.containers.KafkaContainer;
 import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
 import org.testcontainers.containers.wait.strategy.WaitStrategyTarget;
+import org.testcontainers.kafka.ConfluentKafkaContainer;
 import org.testcontainers.lifecycle.Startable;
 
 @Slf4j
@@ -47,7 +47,7 @@ public class CaptureProxyContainer extends GenericContainer implements AutoClose
         this(() -> destinationUri, () -> kafkaUri);
     }
 
-    public CaptureProxyContainer(final Container<?> destination, final KafkaContainer kafka) {
+    public CaptureProxyContainer(final Container<?> destination, final ConfluentKafkaContainer kafka) {
         this(() -> getUriFromContainer(destination), () -> getUriFromContainer(kafka));
     }
 

--- a/TrafficCapture/trafficCaptureProxyServer/src/test/java/org/opensearch/migrations/trafficcapture/proxyserver/testcontainers/KafkaContainerTestBase.java
+++ b/TrafficCapture/trafficCaptureProxyServer/src/test/java/org/opensearch/migrations/trafficcapture/proxyserver/testcontainers/KafkaContainerTestBase.java
@@ -2,13 +2,14 @@ package org.opensearch.migrations.trafficcapture.proxyserver.testcontainers;
 
 import org.opensearch.migrations.testutils.SharedDockerImageNames;
 
-import org.testcontainers.containers.KafkaContainer;
+import org.testcontainers.kafka.ConfluentKafkaContainer;
 
-public class KafkaContainerTestBase extends TestContainerTestBase<KafkaContainer> {
 
-    private static final KafkaContainer kafka = new KafkaContainer(SharedDockerImageNames.KAFKA);
+public class KafkaContainerTestBase extends TestContainerTestBase<ConfluentKafkaContainer> {
 
-    public KafkaContainer getContainer() {
+    private static final ConfluentKafkaContainer kafka = new ConfluentKafkaContainer(SharedDockerImageNames.KAFKA);
+
+    public ConfluentKafkaContainer getContainer() {
         return kafka;
     }
 }

--- a/TrafficCapture/trafficCaptureProxyServer/src/test/java/org/opensearch/migrations/trafficcapture/proxyserver/testcontainers/annotations/TestContainerTest.java
+++ b/TrafficCapture/trafficCaptureProxyServer/src/test/java/org/opensearch/migrations/trafficcapture/proxyserver/testcontainers/annotations/TestContainerTest.java
@@ -12,7 +12,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 @Inherited
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.TYPE })
-@Tag("longTest")
+@Tag("isolatedTest")
 @Testcontainers(disabledWithoutDocker = true, parallel = true)
 public @interface TestContainerTest {
 }

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/e2etests/KafkaRestartingTrafficReplayerTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/e2etests/KafkaRestartingTrafficReplayerTest.java
@@ -40,14 +40,14 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.parallel.ResourceLock;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
-import org.testcontainers.containers.KafkaContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.kafka.ConfluentKafkaContainer;
 
 @Slf4j
 @Testcontainers(disabledWithoutDocker = true)
 @WrapWithNettyLeakDetection(disableLeakChecks = true)
-@Tag("requiresDocker")
+@Tag("isolatedTest")
 public class KafkaRestartingTrafficReplayerTest extends InstrumentationTest {
     public static final int INITIAL_STOP_REPLAYER_REQUEST_COUNT = 1;
     public static final String TEST_GROUP_CONSUMER_ID = "TEST_GROUP_CONSUMER_ID";
@@ -64,7 +64,7 @@ public class KafkaRestartingTrafficReplayerTest extends InstrumentationTest {
     @Container
     // see
     // https://docs.confluent.io/platform/current/installation/versions-interoperability.html#cp-and-apache-kafka-compatibility
-    private final KafkaContainer embeddedKafkaBroker = new KafkaContainer(SharedDockerImageNames.KAFKA);
+    private final ConfluentKafkaContainer embeddedKafkaBroker = new ConfluentKafkaContainer(SharedDockerImageNames.KAFKA);
 
     private static class CounterLimitedReceiverFactory implements Supplier<Consumer<SourceTargetCaptureTuple>> {
         AtomicInteger nextStopPointRef = new AtomicInteger(INITIAL_STOP_REPLAYER_REQUEST_COUNT);
@@ -87,7 +87,6 @@ public class KafkaRestartingTrafficReplayerTest extends InstrumentationTest {
 
     @ParameterizedTest
     @CsvSource(value = { "3,false", "-1,false", "3,true", "-1,true", })
-    @Tag("longTest")
     @ResourceLock("TrafficReplayerRunner")
     public void fullTest(int testSize, boolean randomize) throws Throwable {
         var random = new Random(1);

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/kafka/KafkaCommitsWorkBetweenLongPollsTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/kafka/KafkaCommitsWorkBetweenLongPollsTest.java
@@ -18,13 +18,13 @@ import org.apache.kafka.clients.producer.Producer;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.testcontainers.containers.KafkaContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.kafka.ConfluentKafkaContainer;
 
 @Slf4j
 @Testcontainers(disabledWithoutDocker = true)
-@Tag("requiresDocker")
+@Tag("isolatedTest")
 public class KafkaCommitsWorkBetweenLongPollsTest extends InstrumentationTest {
     private static final long DEFAULT_POLL_INTERVAL_MS = 1000;
     private static final int NUM_RUNS = 5;
@@ -32,7 +32,7 @@ public class KafkaCommitsWorkBetweenLongPollsTest extends InstrumentationTest {
     @Container
     // see
     // https://docs.confluent.io/platform/current/installation/versions-interoperability.html#cp-and-apache-kafka-compatibility
-    private final KafkaContainer embeddedKafkaBroker = new KafkaContainer(SharedDockerImageNames.KAFKA);
+    private final ConfluentKafkaContainer embeddedKafkaBroker = new ConfluentKafkaContainer(SharedDockerImageNames.KAFKA);
 
     @SneakyThrows
     private KafkaConsumer<String, byte[]> buildKafkaConsumer() {
@@ -49,7 +49,6 @@ public class KafkaCommitsWorkBetweenLongPollsTest extends InstrumentationTest {
     }
 
     @Test
-    @Tag("longTest")
     public void testThatCommitsAndReadsKeepWorking() throws Exception {
         var kafkaSource = new KafkaTrafficCaptureSource(
             rootContext,

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/kafka/KafkaKeepAliveTests.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/kafka/KafkaKeepAliveTests.java
@@ -24,13 +24,13 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.testcontainers.containers.KafkaContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.kafka.ConfluentKafkaContainer;
 
 @Slf4j
 @Testcontainers(disabledWithoutDocker = true)
-@Tag("requiresDocker")
+@Tag("isolatedTest")
 public class KafkaKeepAliveTests extends InstrumentationTest {
     public static final String TEST_GROUP_CONSUMER_ID = "TEST_GROUP_CONSUMER_ID";
     public static final String HEARTBEAT_INTERVAL_MS_KEY = "heartbeat.interval.ms";
@@ -47,7 +47,7 @@ public class KafkaKeepAliveTests extends InstrumentationTest {
     @Container
     // see
     // https://docs.confluent.io/platform/current/installation/versions-interoperability.html#cp-and-apache-kafka-compatibility
-    private final KafkaContainer embeddedKafkaBroker = new KafkaContainer(SharedDockerImageNames.KAFKA);
+    private final ConfluentKafkaContainer embeddedKafkaBroker = new ConfluentKafkaContainer(SharedDockerImageNames.KAFKA);
 
     private KafkaTrafficCaptureSource kafkaSource;
 
@@ -90,7 +90,6 @@ public class KafkaKeepAliveTests extends InstrumentationTest {
     }
 
     @Test
-    @Tag("longTest")
     public void testTimeoutsDontOccurForSlowPolls() throws Exception {
         var pollIntervalMs = Optional.ofNullable(kafkaProperties.get(KafkaTrafficCaptureSource.MAX_POLL_INTERVAL_KEY))
             .map(s -> Integer.valueOf((String) s))
@@ -118,7 +117,6 @@ public class KafkaKeepAliveTests extends InstrumentationTest {
     }
 
     @Test
-    @Tag("longTest")
     public void testBlockedReadsAndBrokenCommitsDontCauseReordering() throws Exception {
         for (int i = 0; i < 2; ++i) {
             KafkaTestUtils.produceKafkaRecord(testTopicName, kafkaProducer, 1 + i, sendCompleteCount).get();

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/kafka/KafkaTrafficCaptureSourceLongTermTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/kafka/KafkaTrafficCaptureSourceLongTermTest.java
@@ -14,13 +14,13 @@ import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.testcontainers.containers.KafkaContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.kafka.ConfluentKafkaContainer;
 
 @Slf4j
 @Testcontainers(disabledWithoutDocker = true)
-@Tag("requiresDocker")
+@Tag("isolatedTest")
 public class KafkaTrafficCaptureSourceLongTermTest extends InstrumentationTest {
 
     public static final int TEST_RECORD_COUNT = 10;
@@ -30,7 +30,7 @@ public class KafkaTrafficCaptureSourceLongTermTest extends InstrumentationTest {
     @Container
     // see
     // https://docs.confluent.io/platform/current/installation/versions-interoperability.html#cp-and-apache-kafka-compatibility
-    private final KafkaContainer embeddedKafkaBroker = new KafkaContainer(SharedDockerImageNames.KAFKA);
+    private final ConfluentKafkaContainer embeddedKafkaBroker = new ConfluentKafkaContainer(SharedDockerImageNames.KAFKA);
 
     @Test
     @Tag("isolatedTest")

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/kafka/KafkaTrafficCaptureSourceTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/kafka/KafkaTrafficCaptureSourceTest.java
@@ -39,7 +39,7 @@ class KafkaTrafficCaptureSourceTest extends InstrumentationTest {
     public static final int NUM_READ_ITEMS_BOUND = 1000;
     public static final String TEST_TOPIC_NAME = "TEST_TOPIC_NAME";
 
-    private static final Duration TEST_TIMEOUT = Duration.ofSeconds(5);
+    private static final Duration TEST_TIMEOUT = Duration.ofSeconds(30);
 
     @Test
     public void testRecordToString() {


### PR DESCRIPTION
### Description
Fix RFS Shutdown logic during exception cases

Set kafka tests as isolated

Remove deprecated usage of KafkaContainer in favor of ConfluentKafkaContainer

### Issues Resolved
[MIGRATIONS-2461](https://opensearch.atlassian.net/browse/MIGRATIONS-2461)
[MIGRATIONS-2460](https://opensearch.atlassian.net/browse/MIGRATIONS-2460)

### Testing
GHA

### Check List
- [x] New functionality includes testing
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
