### PR TITLE
Improve test reliability

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -143,7 +143,7 @@ jobs:
           gradle-version: ${{ env.gradle-version }}
           gradle-home-cache-cleanup: true
       - name: Run Gradle tests with striping
-        run: gradle allTests -Dtest.striping.total=${{ env.gradle-test-parallelization }} -Dtest.striping.index=${{ matrix.index }} -x spotlessCheck --stacktrace --continue
+        run: gradle allTests --max-workers 3 -Dtest.striping.total=${{ env.gradle-test-parallelization }} -Dtest.striping.index=${{ matrix.index }} -x spotlessCheck --stacktrace --continue
         env:
           OS_MIGRATIONS_GRADLE_SCAN_TOS_AGREE_AND_ENABLED: ''
       - name: Detect Memory Dumps

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -149,7 +149,7 @@ jobs:
           --max-workers $MAX_WORKERS \
           -Dtest.striping.total=${{ env.gradle-test-parallelization }} \
           -Dtest.striping.index=${{ matrix.index }} \
-          -x spotlessCheck --stacktrace --continue --rerun-tasks
+          -x spotlessCheck --stacktrace --continue
         env:
           OS_MIGRATIONS_GRADLE_SCAN_TOS_AGREE_AND_ENABLED: ''
       - name: Detect Memory Dumps

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -143,7 +143,11 @@ jobs:
           gradle-version: ${{ env.gradle-version }}
           gradle-home-cache-cleanup: true
       - name: Run Gradle tests with striping
-        run: gradle allTests --max-workers 3 -Dtest.striping.total=${{ env.gradle-test-parallelization }} -Dtest.striping.index=${{ matrix.index }} -x spotlessCheck --stacktrace --continue
+        run: |
+          gradle allTests \
+          -Dtest.striping.total=${{ env.gradle-test-parallelization }} \
+          -Dtest.striping.index=${{ matrix.index }} \
+          -x spotlessCheck --stacktrace --continue --rerun-tasks
         env:
           OS_MIGRATIONS_GRADLE_SCAN_TOS_AGREE_AND_ENABLED: ''
       - name: Detect Memory Dumps

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -144,7 +144,9 @@ jobs:
           gradle-home-cache-cleanup: true
       - name: Run Gradle tests with striping
         run: |
+          MAX_WORKERS=$(( $(nproc) - 1 ))
           gradle allTests \
+          --max-workers $MAX_WORKERS \
           -Dtest.striping.total=${{ env.gradle-test-parallelization }} \
           -Dtest.striping.index=${{ matrix.index }} \
           -x spotlessCheck --stacktrace --continue --rerun-tasks

--- a/TrafficCapture/dockerSolution/src/main/docker/elasticsearchTestConsole/Dockerfile
+++ b/TrafficCapture/dockerSolution/src/main/docker/elasticsearchTestConsole/Dockerfile
@@ -3,14 +3,42 @@ FROM amazonlinux:2023
 ENV PIP_ROOT_USER_ACTION ignore
 ENV LANG C.UTF-8
 
+# Install HDF5 from source for Opensearch Benchmark compatibility with ARM
+ENV HDF5_VERSION 1.14.4
+RUN dnf install -y --setopt=install_weak_deps=False \
+      curl-minimal \
+      tar \
+      gzip \
+      clang \
+      glibc-devel \
+      zlib-devel \
+      && \
+    dnf clean all && \
+    rm -rf /var/cache/dnf
+
+RUN mkdir /tmp/hdf5 && \
+    curl -L https://github.com/HDFGroup/hdf5/archive/refs/tags/hdf5_${HDF5_VERSION}.tar.gz \
+     | tar -xz -C /tmp/hdf5 --strip-components=1
+
+ENV CC clang
+ENV CXX clang++
+ENV CFLAGS  "-w"
+WORKDIR /tmp/hdf5
+RUN ./configure --prefix=/usr/local \
+      --disable-tests  \
+      --disable-tools  \
+      --disable-fortran \
+      --disable-static \
+      && \
+    make -j$(nproc) && \
+    make install && \
+    rm -rf /tmp/hdf5
+ENV HDF5_DIR=/usr/local
+
 # procps-ng used for enabling 'watch' command on console
 RUN dnf install -y --setopt=install_weak_deps=False \
-        curl-minimal \
         diffutils \
-        gcc \
-        gcc-c++\
         git \
-        glibc-devel \
         hostname \
         java-17-amazon-corretto \
         jq \
@@ -23,26 +51,12 @@ RUN dnf install -y --setopt=install_weak_deps=False \
         python3.11-devel \
         python3.11-pip \
         python3.11-wheel \
-        tar \
         unzip \
         vim \
         wget \
-        zlib-devel \
         && \
     dnf clean all && \
     rm -rf /var/cache/dnf
-
-# Install HDF5 from source for Opensearch Benchmark compatibility with ARM
-ARG HDF5_VERSION=1.14.4
-ADD https://github.com/HDFGroup/hdf5/archive/refs/tags/hdf5_${HDF5_VERSION}.tar.gz /tmp/hdf5.tar.gz
-RUN mkdir /tmp/hdf5 && \
-    tar -xzf /tmp/hdf5.tar.gz -C /tmp/hdf5 --strip-components=1 && \
-    rm /tmp/hdf5.tar.gz
-WORKDIR /tmp/hdf5
-RUN CFLAGS="-w" ./configure --prefix=/usr/local --disable-tests --disable-tools && \
-    make -j$(nproc) && \
-    make install && \
-    rm -rf /tmp/hdf5
 
 # Define the virtual environment path to use for all pipenv runs
 ENV WORKON_HOME=/
@@ -57,7 +71,7 @@ RUN python3.11 -m venv .venv
 WORKDIR /root
 COPY Pipfile .
 COPY Pipfile.lock .
-RUN HDF5_DIR=/usr/local pipenv install --deploy
+RUN pipenv install --deploy
 
 COPY *.sh /root/
 COPY *.py /root/

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/datahandlers/NettyPacketToHttpConsumerTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/datahandlers/NettyPacketToHttpConsumerTest.java
@@ -449,8 +449,9 @@ public class NettyPacketToHttpConsumerTest extends InstrumentationTest {
     @ParameterizedTest
     @Tag("longTest")
     @CsvSource({ "false", "true" })
+    @WrapWithNettyLeakDetection(repetitions = 2)
     public void testTimeBetweenRequestsLongerThanResponseTimeout(boolean useTls) throws Exception {
-        var responseTimeout = Duration.ofMillis(100);
+        var responseTimeout = Duration.ofSeconds(1);
         var timeBetweenRequests = responseTimeout.plus(Duration.ofMillis(10));
         log.atInfo().setMessage("Running testTimeBetweenRequestsLongerThanResponseTimeout with responseTimeout {}" +
                 " and timeBetweenRequests {}")

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/datahandlers/NettyPacketToHttpConsumerTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/datahandlers/NettyPacketToHttpConsumerTest.java
@@ -210,7 +210,7 @@ public class NettyPacketToHttpConsumerTest extends InstrumentationTest {
     @Tag("longTest")
     @WrapWithNettyLeakDetection(repetitions = 1)
     public void testThatWithBigResponseReadTimeoutResponseWouldHang(boolean useTls) throws Exception {
-        testPeerResets(useTls, false, Duration.ofSeconds(30), Duration.ofSeconds(5));
+        testPeerResets(useTls, false, REGULAR_RESPONSE_TIMEOUT, Duration.ofSeconds(5));
     }
 
     private void testPeerResets(
@@ -439,7 +439,7 @@ public class NettyPacketToHttpConsumerTest extends InstrumentationTest {
                 Instant.now(),
                 Instant.now(),
                 () -> Stream.of(EXPECTED_REQUEST_STRING.getBytes(StandardCharsets.UTF_8)));
-            var maxTimeToWaitForTimeoutOrResponse = Duration.ofSeconds(30);
+            var maxTimeToWaitForTimeoutOrResponse = REGULAR_RESPONSE_TIMEOUT;
             var aggregatedResponse = requestFinishFuture.get(maxTimeToWaitForTimeoutOrResponse);
             log.atInfo().setMessage("RequestFinishFuture finished").log();
             Assertions.assertInstanceOf(ReadTimeoutException.class, aggregatedResponse.getError());
@@ -499,7 +499,7 @@ public class NettyPacketToHttpConsumerTest extends InstrumentationTest {
                     Instant.now(),
                     Instant.now(),
                     () -> Stream.of(EXPECTED_REQUEST_STRING.getBytes(StandardCharsets.UTF_8)));
-                var maxTimeToWaitForTimeoutOrResponse = Duration.ofSeconds(10);
+                var maxTimeToWaitForTimeoutOrResponse = REGULAR_RESPONSE_TIMEOUT;
                 var aggregatedResponse = requestFinishFuture.get(maxTimeToWaitForTimeoutOrResponse);
                 log.atInfo().setMessage("RequestFinishFuture finished for request {}").addArgument(i).log();
                 Assertions.assertNull(aggregatedResponse.getError());


### PR DESCRIPTION
### Description
Improve test reliability, increasing timeout of kafka tests and preventing overloading gha by running with one less gradle worker than cpu cores.

~30 second improvement going from # CPU Cores workers to # CPU Cores - 1 workers.
~30 second improvement going from GCC to clang compiler with some build exclusions

### Issues Resolved

### Testing
See GHA

### Check List
- [x] New functionality includes testing
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
