### PR TITLE
[RFS] Support for client-cert authentication

### DIFF
--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/common/http/FileTlsCredentialsProvider.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/common/http/FileTlsCredentialsProvider.java
@@ -1,0 +1,52 @@
+package org.opensearch.migrations.bulkload.common.http;
+
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.InputStream;
+import java.nio.file.Path;
+
+public class FileTlsCredentialsProvider implements TlsCredentialsProvider {
+    private final Path caCert;
+    private final Path clientCert;
+    private final Path clientCertKey;
+
+    public FileTlsCredentialsProvider(Path caCert, Path clientCert, Path clientCertKey) {
+        this.caCert = caCert;
+        this.clientCert = clientCert;
+        this.clientCertKey = clientCertKey;
+    }
+
+    public InputStream getCaCertInputStream() {
+        return openStream(caCert);
+    }
+
+    public InputStream getClientCertInputStream() {
+        return openStream(clientCert);
+    }
+
+    public InputStream getClientCertKeyInputStream() {
+        return openStream(clientCertKey);
+    }
+
+    public boolean hasClientCredentials() {
+        return clientCert != null && clientCertKey != null;
+    }
+
+    public boolean hasCACredentials() {
+        return caCert != null;
+    }
+
+    private InputStream openStream(Path path) {
+        try {
+            return new FileInputStream(path.toFile());
+        } catch (FileNotFoundException e) {
+            throw new TlsCredentialLoadingException("Failed to load " + path, e);
+        }
+    }
+
+    public static class TlsCredentialLoadingException extends RuntimeException {
+        public TlsCredentialLoadingException(String message, Throwable cause) {
+            super(message, cause);
+        }
+    }
+}

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/common/http/TlsCredentialsProvider.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/common/http/TlsCredentialsProvider.java
@@ -1,0 +1,11 @@
+package org.opensearch.migrations.bulkload.common.http;
+
+import java.io.InputStream;
+
+public interface TlsCredentialsProvider {
+    InputStream getCaCertInputStream();
+    InputStream getClientCertInputStream();
+    InputStream getClientCertKeyInputStream();
+    boolean hasClientCredentials();
+    boolean hasCACredentials();
+}

--- a/RFS/src/test/java/org/opensearch/migrations/bulkload/common/RestClientTest.java
+++ b/RFS/src/test/java/org/opensearch/migrations/bulkload/common/RestClientTest.java
@@ -1,5 +1,9 @@
 package org.opensearch.migrations.bulkload.common;
 
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLException;
+import javax.net.ssl.SSLHandshakeException;
+
 import java.nio.charset.StandardCharsets;
 import java.util.Comparator;
 import java.util.List;
@@ -7,15 +11,22 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.opensearch.migrations.bulkload.common.http.ConnectionContextTestParams;
+import org.opensearch.migrations.bulkload.common.http.TestTlsCredentialsProvider;
+import org.opensearch.migrations.bulkload.common.http.TestTlsUtils;
 import org.opensearch.migrations.bulkload.tracing.RfsContexts;
 import org.opensearch.migrations.snapshot.creation.tracing.SnapshotTestContext;
 import org.opensearch.migrations.testutils.HttpRequest;
 import org.opensearch.migrations.testutils.SimpleHttpResponse;
 import org.opensearch.migrations.testutils.SimpleNettyHttpServer;
 
+import io.netty.handler.ssl.ClientAuth;
+import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslContextBuilder;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import reactor.netty.http.client.HttpClient;
 import reactor.netty.resources.ConnectionProvider;
@@ -28,10 +39,22 @@ class RestClientTest {
     private static final int READ_RESPONSE_SIZE = 66;
     private static final int READ_TOTAL_SIZE = READ_RESPONSE_SIZE + READ_RESPONSE_SIZE;
 
+    private static TestTlsUtils.CertificateBundle caCertBundle;
+    private static TestTlsUtils.CertificateBundle serverCertBundle;
+    private static TestTlsUtils.CertificateBundle clientCertBundle;
+
     private static HttpClient makeSingleConnectionHttpClient() {
         var provider = ConnectionProvider.builder("singleConnection").maxConnections(1).build();
         return HttpClient.create(provider);
     }
+
+     @BeforeAll
+    static void setupCertificates() throws Exception {
+        caCertBundle = TestTlsUtils.generateCaCertificate();
+        serverCertBundle = TestTlsUtils.generateServerCertificate(caCertBundle);
+        clientCertBundle = TestTlsUtils.generateClientCertificate(caCertBundle);
+    }
+
 
     @Test
     public void testGetEmitsInstrumentation() throws Exception {
@@ -124,6 +147,94 @@ class RestClientTest {
                 new long[] { bytesSent, bytesRead },
                 Matchers.equalTo(expectedBytes)
             );
+        }
+    }
+
+    @Test
+    public void testMutualTlsSuccess() throws Exception {
+        SslContext serverSslContext = SslContextBuilder
+                .forServer(serverCertBundle.getCertificateInputStream(),
+                    serverCertBundle.getPrivateKeyInputStream())
+                .trustManager(caCertBundle.getCertificateInputStream())
+                .clientAuth(ClientAuth.REQUIRE)
+                .build();
+
+        SimpleNettyHttpServer.SSLEngineSupplier engineSupplier = (allocator) -> {
+            SSLEngine engine = serverSslContext.newEngine(allocator);
+            engine.setUseClientMode(false);
+            return engine;
+        };
+
+        try (var testServer = SimpleNettyHttpServer.makeServer(
+                engineSupplier,
+                null,
+                this::makeResponseContext)) {
+
+            var params = ConnectionContextTestParams.builder()
+                    .host("https://localhost:" + testServer.port)
+                    .insecure(false)
+                    .build();
+
+            var connCtx = params.toConnectionContext();
+            connCtx.setTlsCredentialsProvider(
+                new TestTlsCredentialsProvider(caCertBundle, clientCertBundle)
+            );
+
+            var restClient = new RestClient(connCtx);
+
+            var response = restClient.get("/", null);
+
+            Assertions.assertEquals(200, response.statusCode);
+            Assertions.assertEquals("Hi", response.body);
+        }
+    }
+
+    @Test
+    public void testMutualTlsFailsWithoutClientCert() throws Exception {
+        SslContext serverSslContext = SslContextBuilder
+                .forServer(serverCertBundle.getCertificateInputStream(),
+                    serverCertBundle.getPrivateKeyInputStream())
+                .trustManager(caCertBundle.getCertificateInputStream())
+                .clientAuth(ClientAuth.REQUIRE)
+                .build();
+
+        SimpleNettyHttpServer.SSLEngineSupplier engineSupplier = (allocator) -> {
+            SSLEngine engine = serverSslContext.newEngine(allocator);
+            engine.setUseClientMode(false);
+            return engine;
+        };
+
+        try (var testServer = SimpleNettyHttpServer.makeServer(
+                engineSupplier,
+                null,
+                this::makeResponseContext)) {
+
+            var params = ConnectionContextTestParams.builder()
+                    .host("https://localhost:" + testServer.port)
+                    .insecure(false)
+                    .build();
+
+            // Set the TLS credentials provider directly with only CA cert
+            var connCtx = params.toConnectionContext();
+            connCtx.setTlsCredentialsProvider(
+                new TestTlsCredentialsProvider(caCertBundle, null)
+            );
+
+            var restClient = new RestClient(params.toConnectionContext());
+
+            // 1) Capture the top-level exception (ReactiveException)
+            Exception ex = Assertions.assertThrows(Exception.class, () -> restClient.get("/", null));
+
+            // 2) Unwrap the cause chain
+            Throwable cause = ex.getCause();
+            while (cause != null && !(cause instanceof SSLException)) {
+                cause = cause.getCause();
+            }
+
+            // 3) Now check cause is the type we want
+            Assertions.assertNotNull(cause, "Expected an SSLException somewhere in the cause chain");
+            Assertions.assertTrue(cause instanceof SSLHandshakeException,
+                    "Expected an SSLHandshakeException but got " + cause.getClass());
         }
     }
 

--- a/RFS/src/testFixtures/java/org/opensearch/migrations/bulkload/common/http/ConnectionContextTestParams.java
+++ b/RFS/src/testFixtures/java/org/opensearch/migrations/bulkload/common/http/ConnectionContextTestParams.java
@@ -1,5 +1,7 @@
 package org.opensearch.migrations.bulkload.common.http;
 
+import java.nio.file.Path;
+
 import lombok.Builder;
 import lombok.Getter;
 
@@ -14,4 +16,8 @@ public class ConnectionContextTestParams implements ConnectionContext.IParams {
     @Builder.Default
     private boolean insecure = true;
     private boolean compressionEnabled;
+
+    private Path caCert;
+    private Path clientCert;
+    private Path clientCertKey;
 }

--- a/RFS/src/testFixtures/java/org/opensearch/migrations/bulkload/common/http/TestTlsCredentialsProvider.java
+++ b/RFS/src/testFixtures/java/org/opensearch/migrations/bulkload/common/http/TestTlsCredentialsProvider.java
@@ -1,0 +1,40 @@
+package org.opensearch.migrations.bulkload.common.http;
+
+import java.io.InputStream;
+
+public class TestTlsCredentialsProvider implements TlsCredentialsProvider {
+    private final TestTlsUtils.CertificateBundle caCertBundle;
+    private final TestTlsUtils.CertificateBundle clientCertBundle;
+
+    public TestTlsCredentialsProvider(
+            TestTlsUtils.CertificateBundle caCertBundle,
+            TestTlsUtils.CertificateBundle clientCertBundle) {
+        this.caCertBundle = caCertBundle;
+        this.clientCertBundle = clientCertBundle;
+    }
+
+    @Override
+    public InputStream getCaCertInputStream() {
+        return caCertBundle != null ? caCertBundle.getCertificateInputStream() : null;
+    }
+
+    @Override
+    public InputStream getClientCertInputStream() {
+        return clientCertBundle != null ? clientCertBundle.getCertificateInputStream() : null;
+    }
+
+    @Override
+    public InputStream getClientCertKeyInputStream() {
+        return clientCertBundle != null ? clientCertBundle.getPrivateKeyInputStream() : null;
+    }
+
+    @Override
+    public boolean hasClientCredentials() {
+        return clientCertBundle != null;
+    }
+
+    @Override
+    public boolean hasCACredentials() {
+        return caCertBundle != null;
+    }
+}

--- a/RFS/src/testFixtures/java/org/opensearch/migrations/bulkload/common/http/TestTlsUtils.java
+++ b/RFS/src/testFixtures/java/org/opensearch/migrations/bulkload/common/http/TestTlsUtils.java
@@ -1,0 +1,124 @@
+package org.opensearch.migrations.bulkload.common.http;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.io.StringWriter;
+import java.math.BigInteger;
+import java.security.*;
+import java.security.cert.X509Certificate;
+import java.time.Instant;
+import java.util.Date;
+
+import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.asn1.x509.BasicConstraints;
+import org.bouncycastle.asn1.x509.Extension;
+import org.bouncycastle.asn1.x509.KeyUsage;
+import org.bouncycastle.cert.X509v3CertificateBuilder;
+import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
+import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.openssl.jcajce.JcaPEMWriter;
+import org.bouncycastle.operator.ContentSigner;
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
+
+public class TestTlsUtils {
+
+    static {
+        Security.addProvider(new BouncyCastleProvider());
+    }
+
+    public static class CertificateBundle {
+        public final X509Certificate certificate;
+        public final PrivateKey privateKey;
+        public final String pemCertificate;
+        public final String pemPrivateKey;
+
+        public CertificateBundle(X509Certificate cert, PrivateKey key) throws Exception {
+            this.certificate = cert;
+            this.privateKey = key;
+            this.pemCertificate = toPEM(cert);
+            this.pemPrivateKey = toPEM(key);
+        }
+
+        public InputStream getCertificateInputStream() {
+            return new ByteArrayInputStream(pemCertificate.getBytes());
+        }
+
+        public InputStream getPrivateKeyInputStream() {
+            return new ByteArrayInputStream(pemPrivateKey.getBytes());
+        }
+
+        private static String toPEM(Object obj) throws Exception {
+            try (StringWriter sw = new StringWriter(); JcaPEMWriter writer = new JcaPEMWriter(sw)) {
+                writer.writeObject(obj);
+                writer.flush();
+                return sw.toString();
+            }
+        }
+    }
+
+    public static CertificateBundle generateCaCertificate() throws Exception {
+        KeyPair caKeyPair = generateKeyPair();
+        X500Name subject = new X500Name("CN=Test CA");
+        X509v3CertificateBuilder builder = createCertBuilder(subject, subject, caKeyPair.getPublic());
+
+        builder.addExtension(Extension.basicConstraints, true, new BasicConstraints(true));
+        builder.addExtension(Extension.keyUsage, true, new KeyUsage(KeyUsage.keyCertSign | KeyUsage.cRLSign));
+
+        X509Certificate cert = signCertificate(builder, caKeyPair.getPrivate());
+        return new CertificateBundle(cert, caKeyPair.getPrivate());
+    }
+
+    public static CertificateBundle generateServerCertificate(CertificateBundle ca) throws Exception {
+        return generateSignedCertificate("CN=localhost", ca, false);
+    }
+
+    public static CertificateBundle generateClientCertificate(CertificateBundle ca) throws Exception {
+        return generateSignedCertificate("CN=client", ca, false);
+    }
+
+    private static CertificateBundle generateSignedCertificate(String subjectDn, CertificateBundle ca, boolean isCa)
+            throws Exception {
+        KeyPair keyPair = generateKeyPair();
+        X500Name subject = new X500Name(subjectDn);
+        X500Name issuer = new X500Name(ca.certificate.getSubjectX500Principal().getName());
+
+        X509v3CertificateBuilder builder = createCertBuilder(issuer, subject, keyPair.getPublic());
+
+        if (isCa) {
+            builder.addExtension(Extension.basicConstraints, true, new BasicConstraints(true));
+            builder.addExtension(Extension.keyUsage, true, new KeyUsage(KeyUsage.keyCertSign | KeyUsage.cRLSign));
+        } else {
+            builder.addExtension(Extension.basicConstraints, false, new BasicConstraints(false));
+            builder.addExtension(Extension.keyUsage, true,
+                    new KeyUsage(KeyUsage.digitalSignature | KeyUsage.keyEncipherment));
+        }
+
+        X509Certificate cert = signCertificate(builder, ca.privateKey);
+        return new CertificateBundle(cert, keyPair.getPrivate());
+    }
+
+    private static X509v3CertificateBuilder createCertBuilder(X500Name issuer, X500Name subject, PublicKey pubKey) {
+        Instant now = Instant.now();
+        return new JcaX509v3CertificateBuilder(
+                issuer,
+                BigInteger.valueOf(now.toEpochMilli()),
+                Date.from(now),
+                Date.from(now.plusSeconds(365 * 24 * 60 * 60)),
+                subject,
+                pubKey
+        );
+    }
+
+    private static X509Certificate signCertificate(X509v3CertificateBuilder builder, PrivateKey signerKey)
+            throws Exception {
+        ContentSigner signer = new JcaContentSignerBuilder("SHA256WithRSA").build(signerKey);
+        return new JcaX509CertificateConverter().getCertificate(builder.build(signer));
+    }
+
+    private static KeyPair generateKeyPair() throws NoSuchAlgorithmException {
+        KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA");
+        generator.initialize(2048);
+        return generator.generateKeyPair();
+    }
+}


### PR DESCRIPTION
### Description

Adds support for optional client-cert based authentication

### Issues Resolved
https://github.com/opensearch-project/opensearch-migrations/issues/1397

### Testing
1. Added tests for RestClient with dummy certs created (steps followed are included in test-sources/inventory.md)
2. Manually tested against actual clusters with security-plugin client cert auth enabled.

### Check List
- [x] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
