### PR TITLE
Disable trafficReplayerServiceEnabled by default with comments on enabling services

### DIFF
--- a/deployment/cdk/opensearch-service-migration/cdk.context.json
+++ b/deployment/cdk/opensearch-service-migration/cdk.context.json
@@ -29,6 +29,16 @@
     "vpcId": "<VPC_ID>",
     "reindexFromSnapshotServiceEnabled": true,
     "reindexFromSnapshotMaxShardSizeGiB": 80,
-    "trafficReplayerServiceEnabled": true
+
+    "// settingsForCaptureAndReplay": "Enable the below services for live traffic capture and replay",
+    "trafficReplayerServiceEnabled": false,
+
+    "// help trafficReplayerExtraArgs": "Increase speedup factor in order replay requests at a faster rate to catchup",
+    "trafficReplayerExtraArgs": "--speedup-factor 1.5",
+
+    "// help capture/target proxy pt. 1 of 2": "captureProxyService and targetClusterProxyService require networking access configured to successfully deploy,",
+    "// help capture/target proxy pt. 2 of 2": "consider deploying without first and enabling after ensuring cluster networking access on the migration console",
+    "captureProxyServiceEnabled": false,
+    "targetClusterProxyServiceEnabled": false
   }
 }


### PR DESCRIPTION
### Description
Disable trafficReplayerServiceEnabled by default with comments on enabling capture and replay

For most customers, including those using capture and replay, it benefits them to deploy Migration Assistant without C&R enabled and to enable deploying the services after basic connectivity and auth is ensured for a faster and successful deployment with easier troubleshooting.

### Issues Resolved
N/A

### Testing
<!-- Please provide details of testing done: unit testing, integration testing and manual testing -->

### Check List
- [x] New functionality includes testing
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
