### PR TITLE
Fix soft delete behavior with ES 6 and above

### DIFF
--- a/DocumentsFromSnapshotMigration/src/test/java/org/opensearch/migrations/bulkload/EndToEndTest.java
+++ b/DocumentsFromSnapshotMigration/src/test/java/org/opensearch/migrations/bulkload/EndToEndTest.java
@@ -3,7 +3,6 @@ package org.opensearch.migrations.bulkload;
 import java.io.File;
 import java.util.List;
 import java.util.Random;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
 
@@ -28,6 +27,7 @@ import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.testcontainers.lifecycle.Startables;
 
 
 @Tag("isolatedTest")
@@ -44,7 +44,7 @@ public class EndToEndTest extends SourceTestBase {
     @MethodSource(value = "scenarios")
     public void migrationDocuments(
         final SearchClusterContainer.ContainerVersion sourceVersion,
-        final SearchClusterContainer.ContainerVersion targetVersion) throws Exception {
+        final SearchClusterContainer.ContainerVersion targetVersion) {
         try (
             final var sourceCluster = new SearchClusterContainer(sourceVersion);
             final var targetCluster = new SearchClusterContainer(targetVersion)
@@ -62,13 +62,8 @@ public class EndToEndTest extends SourceTestBase {
         final var testDocMigrationContext = DocumentMigrationTestContext.factory().noOtelTracking();
 
         try {
-
             // === ACTION: Set up the source/target clusters ===
-            var bothClustersStarted = CompletableFuture.allOf(
-                CompletableFuture.runAsync(() -> sourceCluster.start()),
-                CompletableFuture.runAsync(() -> targetCluster.start())
-            );
-            bothClustersStarted.join();
+            Startables.deepStart(sourceCluster, targetCluster).join();
 
             var indexName = "blog_2023";
             var numberOfShards = 3;
@@ -77,13 +72,16 @@ public class EndToEndTest extends SourceTestBase {
 
             // Number of default shards is different across different versions on ES/OS.
             // So we explicitly set it.
+            var sourceVersion = sourceCluster.getContainerVersion().getVersion();
             String body = String.format(
                 "{" +
                 "  \"settings\": {" +
-                "    \"index\": {" +
-                "      \"number_of_shards\": %d," +
-                "      \"number_of_replicas\": 0" +
-                "    }" +
+                "    \"number_of_shards\": %d," +
+                "    \"number_of_replicas\": 0," +
+                (VersionMatchers.isBelowES_6_X.test(sourceVersion)
+                        ? ""
+                        : "    \"index.soft_deletes.enabled\": true,") +
+                "    \"refresh_interval\": -1" +
                 "  }" +
                 "}",
                 numberOfShards
@@ -96,6 +94,15 @@ public class EndToEndTest extends SourceTestBase {
             sourceClusterOperations.createDocument(indexName, "223", "{\"author\":\"Tobias Funke\", \"category\": \"cooking\"}", "1", null);
             sourceClusterOperations.createDocument(indexName, "224", "{\"author\":\"Tobias Funke\", \"category\": \"cooking\"}", "1", null);
             sourceClusterOperations.createDocument(indexName, "225", "{\"author\":\"Tobias Funke\", \"category\": \"tech\"}", "2", null);
+
+
+            // To create deleted docs in a segment that persists on the snapshot, refresh, then create two docs on a shard, then after a refresh, delete one.
+            sourceClusterOperations.post("/" + indexName + "/_refresh", null);
+            sourceClusterOperations.createDocument(indexName, "toBeDeleted", "{\"author\":\"Tobias Funke\", \"category\": \"cooking\"}", "1", null);
+            sourceClusterOperations.createDocument(indexName, "remaining", "{\"author\":\"Tobias Funke\", \"category\": \"tech\"}", "1", null);
+            sourceClusterOperations.post("/" + indexName + "/_refresh", null);
+            sourceClusterOperations.deleteDocument(indexName, "toBeDeleted" , "1", null);
+            sourceClusterOperations.post("/" + indexName + "/_refresh", null);
 
             // === ACTION: Take a snapshot ===
             var snapshotName = "my_snap";

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/lucene/SegmentNameSorter.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/lucene/SegmentNameSorter.java
@@ -30,7 +30,7 @@ class SegmentNameSorter implements Comparator<LuceneLeafReader> {
             };
             log.atWarn().setMessage("Unexpected equality during leafReader sorting, expected sort to yield no equality " +
                     "to ensure consistent segment ordering. This may cause missing documents if both segments" +
-                    "contains docs. LeafReader1DebugInfo: {} \nLeafReader2DebugInfo: {}")
+                    "contains docs. \nLeafReader1DebugInfo: {} \nLeafReader2DebugInfo: {}")
                     .addArgument(getLeafReaderDebugInfo.apply(leafReader1))
                     .addArgument(getLeafReaderDebugInfo.apply(leafReader2))
                     .log();

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/lucene/version_6/LeafReader6.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/lucene/version_6/LeafReader6.java
@@ -1,13 +1,11 @@
 package org.opensearch.migrations.bulkload.lucene.version_6;
 
 import java.io.IOException;
-import java.util.Optional;
 
 import org.opensearch.migrations.bulkload.lucene.LuceneLeafReader;
 
 import lombok.AllArgsConstructor;
 import shadow.lucene6.org.apache.lucene.index.LeafReader;
-import shadow.lucene6.org.apache.lucene.index.SegmentCommitInfo;
 import shadow.lucene6.org.apache.lucene.index.SegmentReader;
 
 @AllArgsConstructor
@@ -31,24 +29,22 @@ public class LeafReader6 implements LuceneLeafReader {
         return wrapped.getContext().toString();
     }
 
-    private Optional<SegmentReader> getSegmentReader() {
+    private SegmentReader getSegmentReader() {
         if (wrapped instanceof SegmentReader) {
-            return Optional.of(((SegmentReader)wrapped));
+            return (SegmentReader) wrapped;
         }
-        return Optional.empty();
+        throw new IllegalStateException("Expected SegmentReader but got " + wrapped.getClass());
     }
 
     public String getSegmentName() { 
         return getSegmentReader()
-            .map(SegmentReader::getSegmentName)
-            .orElse(null);
+            .getSegmentName();
     }
 
     public String getSegmentInfoString() {
         return getSegmentReader()
-            .map(SegmentReader::getSegmentInfo)
-            .map(SegmentCommitInfo::toString)
-            .orElse(null);
+            .getSegmentInfo()
+            .toString();
     }
 
     public String toString() {

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/lucene/version_7/LeafReader7.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/lucene/version_7/LeafReader7.java
@@ -1,13 +1,12 @@
 package org.opensearch.migrations.bulkload.lucene.version_7;
 
 import java.io.IOException;
-import java.util.Optional;
 
 import org.opensearch.migrations.bulkload.lucene.LuceneLeafReader;
 
 import lombok.AllArgsConstructor;
+import shadow.lucene7.org.apache.lucene.index.FilterCodecReader;
 import shadow.lucene7.org.apache.lucene.index.LeafReader;
-import shadow.lucene7.org.apache.lucene.index.SegmentCommitInfo;
 import shadow.lucene7.org.apache.lucene.index.SegmentReader;
 
 @AllArgsConstructor
@@ -31,24 +30,27 @@ public class LeafReader7 implements LuceneLeafReader {
         return wrapped.getContext().toString();
     }
 
-    private Optional<SegmentReader> getSegmentReader() {
-        if (wrapped instanceof SegmentReader) {
-            return Optional.of(((SegmentReader)wrapped));
+    private SegmentReader getSegmentReader() {
+        var reader = wrapped;
+        if (reader instanceof FilterCodecReader) {
+            return (SegmentReader) ((FilterCodecReader) reader).getDelegate();
         }
-        return Optional.empty();
+        if (reader instanceof SegmentReader) {
+            return (SegmentReader) reader;
+        }
+        throw new IllegalStateException("Expected to extract SegmentReader but got " +
+                reader.getClass() + " from " + wrapped.getClass());
     }
 
     public String getSegmentName() { 
         return getSegmentReader()
-            .map(SegmentReader::getSegmentName)
-            .orElse(null);
+            .getSegmentName();
     }
 
     public String getSegmentInfoString() {
         return getSegmentReader()
-            .map(SegmentReader::getSegmentInfo)
-            .map(SegmentCommitInfo::toString)
-            .orElse(null);
+            .getSegmentInfo()
+            .toString();
     }
 
     public String toString() {

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/version_es_6_8/ElasticsearchConstants_ES_6_8.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/version_es_6_8/ElasticsearchConstants_ES_6_8.java
@@ -30,9 +30,11 @@ public class ElasticsearchConstants_ES_6_8 {
         SMILE_FACTORY.disable(JsonGenerator.Feature.AUTO_CLOSE_JSON_CONTENT);
         SMILE_FACTORY.disable(JsonParser.Feature.STRICT_DUPLICATE_DETECTION);
 
-        // Soft Deletes were added in 7.0
-        SOFT_DELETES_FIELD = "";
-        SOFT_DELETES_POSSIBLE = false;
+        // Soft deletes were added in 6.5
+        // Taken from:
+        // https://github.com/elastic/elasticsearch/blob/v6.8.23/server/src/main/java/org/elasticsearch/common/lucene/Lucene.java#L117
+        SOFT_DELETES_FIELD = "__soft_deletes";
+        SOFT_DELETES_POSSIBLE = true;
     }
 
 }

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/version_es_7_10/ElasticsearchConstants_ES_7_10.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/version_es_7_10/ElasticsearchConstants_ES_7_10.java
@@ -32,8 +32,6 @@ public class ElasticsearchConstants_ES_7_10 {
         // Taken from:
         // https://github.com/elastic/elasticsearch/blob/v7.10.2/server/src/main/java/org/elasticsearch/common/lucene/Lucene.java#L110
         SOFT_DELETES_FIELD = "__soft_deletes";
-
-        // Soft Deletes were added in 7.0
         SOFT_DELETES_POSSIBLE = true;
     }
 

--- a/RFS/src/testFixtures/java/org/opensearch/migrations/bulkload/http/ClusterOperations.java
+++ b/RFS/src/testFixtures/java/org/opensearch/migrations/bulkload/http/ClusterOperations.java
@@ -72,14 +72,17 @@ public class ClusterOperations {
         createDocument(index, docId, body, null, null);
     }
 
-    @SneakyThrows
-    public void createDocument(final String index, final String docId, final String body, String routing, String type) {
+    public void createDocument(final String index, final String docId, final String body, final String routing, final String type) {
         var response = put("/" + index + "/" + docTypePathOrDefault(type) + docId + "?routing=" + routing, body);
         assertThat(response.getValue(), response.getKey(), anyOf(equalTo(201), equalTo(200)));
     }
 
-    public void deleteDocument(final String index, final String docId, final String type) throws IOException {
-        var response = delete("/" + index + "/" + docTypePathOrDefault(type) + docId);
+    public void deleteDocument(final String index, final String docId, final String type) {
+        deleteDocument(index, docId, null, type);
+    }
+
+    public void deleteDocument(final String index, final String docId, final String routing, final String type) {
+        var response = delete("/" + index + "/" + docTypePathOrDefault(type) + docId + "?routing=" + routing);
         assertThat(response.getKey(), equalTo(200));
     }
 

--- a/transformation/src/main/java/org/opensearch/migrations/VersionMatchers.java
+++ b/transformation/src/main/java/org/opensearch/migrations/VersionMatchers.java
@@ -17,6 +17,15 @@ public class VersionMatchers {
     public static final Predicate<Version> isOS_2_X = VersionMatchers.matchesMajorVersion(Version.fromString("OS 2.0.0"));
     public static final Predicate<Version> isOS_2_19 = VersionMatchers.matchesMinorVersion(Version.fromString("OS 2.19.1"));
 
+    public static final Predicate<Version> isBelowES_2_X = belowMajorVersion(Version.fromString("ES 2.0"));
+    public static final Predicate<Version> isBelowES_5_X = belowMajorVersion(Version.fromString("ES 5.0"));
+    public static final Predicate<Version> isBelowES_6_X = belowMajorVersion(Version.fromString("ES 6.0"));
+    public static final Predicate<Version> isBelowES_7_X = belowMajorVersion(Version.fromString("ES 7.0"));
+    public static final Predicate<Version> isBelowOS_1_X = belowMajorVersion(Version.fromString("ES 8.0"))
+            .and(equalOrGreaterThanMinorVersion(Version.fromString("ES 7.10.3")).negate());
+    public static final Predicate<Version> isBelowOS_2_X = isBelowOS_1_X.or(belowMajorVersion(Version.fromString("OS 2.0")));
+    public static final Predicate<Version> isBelowOS_3_X = isBelowOS_1_X.or(belowMajorVersion(Version.fromString("OS 3.0")));
+
     private static Predicate<Flavor> compatibleFlavor(final Flavor flavor) {
         return other -> {
             if (other == null) {
@@ -52,4 +61,22 @@ public class VersionMatchers {
             .and(other2 -> version.getMinor() <= other2.getMinor())
             .test(other);
     }
-}
+
+    /**
+     * Returns a predicate that checks if a given version is of the same flavor as the provided threshold version
+     * and has a major version number that is lower than the threshold's major version.
+     * This method ensures that only versions with a matching flavor are compared, thereby excluding incompatible OS or ES versions.
+     *
+     * @param version The threshold version used for comparison.
+     * @return A predicate that returns {@code true} if the tested version's major version is less than the threshold and the flavors match.
+     */
+    private static Predicate<Version> belowMajorVersion(final Version version) {
+        return other -> {
+            if (other == null) {
+                return false;
+            }
+            var flavorMatches = compatibleFlavor(other.getFlavor()).test(version.getFlavor());
+            var isLowerMajorVersion = other.getMajor() < version.getMajor();
+            return flavorMatches && isLowerMajorVersion;
+        };
+    }}


### PR DESCRIPTION
### Description
This fixes the segmentName null issue mentioned here - https://github.com/opensearch-project/opensearch-migrations/issues/1405 by unwrapping the inner SegmentReader when there is a FilterCodecReader wrapper.

Refer to [SoftDeletesDirectoryReaderWrapper](https://github.com/apache/lucene/blob/main/lucene/core/src/java/org/apache/lucene/index/SoftDeletesDirectoryReaderWrapper.java#L130-L153) for more details on wrapping behavior.

Previous logic, assumed soft deletes were added in ES 6 when they were actually added in ES 6.5 as an opt-in feature. This miss meant we were previously recreating soft-deleted docs on the target (target could contain more docs than valid docs on the source)

Previous testing on soft deletes either did not successfully create snapshots with soft deletes, or did not create snapshots with soft deletes and more than 1 segment on an index.

### Issues Resolved
#1405 

### Testing
Added unit tests that created indices with soft deletes  

### Check List
- [x] New functionality includes testing
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
