### PR TITLE
Fixes #1417: RFS Handling of docs with fields over 20M characters in length

### DIFF
--- a/DocumentsFromSnapshotMigration/src/test/java/org/opensearch/migrations/bulkload/EndToEndTest.java
+++ b/DocumentsFromSnapshotMigration/src/test/java/org/opensearch/migrations/bulkload/EndToEndTest.java
@@ -89,7 +89,12 @@ public class EndToEndTest extends SourceTestBase {
             sourceClusterOperations.createIndex(indexName, body);
             targetClusterOperations.createIndex(indexName, body);
 
+            // === ACTION: Create two large documents (40MB each) ===
+            String largeDoc = generateLargeDocJson(40);
+            sourceClusterOperations.createDocument(indexName, "large1", largeDoc, "3", null);
+            sourceClusterOperations.createDocument(indexName, "large2", largeDoc, "3", null);
 
+            // === ACTION: Create some searchable documents ===
             sourceClusterOperations.createDocument(indexName, "222", "{\"author\":\"Tobias Funke\"}");
             sourceClusterOperations.createDocument(indexName, "223", "{\"author\":\"Tobias Funke\", \"category\": \"cooking\"}", "1", null);
             sourceClusterOperations.createDocument(indexName, "224", "{\"author\":\"Tobias Funke\", \"category\": \"cooking\"}", "1", null);
@@ -157,6 +162,19 @@ public class EndToEndTest extends SourceTestBase {
         } finally {
             deleteTree(localDirectory.toPath());
         }
+    }
+
+    private String generateLargeDocJson(int sizeInMB) {
+        // Calculate the number of characters needed (1 char = 1 byte)
+        int numChars = sizeInMB * 1024 * 1024;
+        Random random = new Random(1); // fixed seed for reproducibility
+        StringBuilder sb = new StringBuilder(numChars);
+        String characters = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+        for (int i = 0; i < numChars; i++) {
+            sb.append(characters.charAt(random.nextInt(characters.length())));
+        }
+        String timestamp = java.time.Instant.now().toString();
+        return "{\"timestamp\":\"" + timestamp + "\", \"large_field\":\"" + sb + "\"}";
     }
 
     private void checkDocsWithRouting(

--- a/DocumentsFromSnapshotMigration/src/test/java/org/opensearch/migrations/bulkload/SourceTestBase.java
+++ b/DocumentsFromSnapshotMigration/src/test/java/org/opensearch/migrations/bulkload/SourceTestBase.java
@@ -70,7 +70,7 @@ import static org.opensearch.migrations.bulkload.CustomRfsTransformationTest.SNA
 
 @Slf4j
 public class SourceTestBase {
-    public static final int MAX_SHARD_SIZE_BYTES = 64 * 1024 * 1024;
+    public static final long MAX_SHARD_SIZE_BYTES = 1024 * 1024 * 1024L; // 1 GB
     public static final String SOURCE_SERVER_ALIAS = "source";
     public static final long TOLERABLE_CLIENT_SERVER_CLOCK_DIFFERENCE_SECONDS = 3600;
 

--- a/RFS/src/testFixtures/java/org/opensearch/migrations/bulkload/http/ClusterOperations.java
+++ b/RFS/src/testFixtures/java/org/opensearch/migrations/bulkload/http/ClusterOperations.java
@@ -126,17 +126,27 @@ public class ClusterOperations {
         }
         try (var response = httpClient.execute(postRequest)) {
             var responseBody = EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
-            log.atInfo()
-                .setMessage("{} {}\n{}\nResponse: {}\n{}")
-                .addArgument("POST")
-                .addArgument(path)
-                .addArgument(body)
-                .addArgument(response.getCode())
-                .addArgument(responseBody)
-                .log();
+            logHttpRequestResponse("POST", path, response.getCode(), responseBody, null);
             return Map.entry(response.getCode(), responseBody);
         }
     }
+
+    private static String truncate(String input, int maxLength) {
+        return input != null && input.length() > maxLength ? input.substring(0, maxLength) + "..." : input;
+    }
+
+    private static void logHttpRequestResponse(
+            String method, String path, int statusCode, String responseBody, String body) {
+        log.atInfo()
+                .setMessage("{} {}\n{}\nResponse: {}\n{}")
+                .addArgument(method)
+                .addArgument(path)
+                .addArgument(() -> body != null ? truncate(body, 1000) : "")
+                .addArgument(statusCode)
+                .addArgument(() -> truncate(responseBody, 1000))
+                .log();
+    }
+
 
     @SneakyThrows
     public Map.Entry<Integer, String> put(final String path, final String body) {
@@ -147,14 +157,7 @@ public class ClusterOperations {
         }
         try (var response = httpClient.execute(putRequest)) {
             var responseBody = EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
-            log.atInfo()
-                .setMessage("{} {}\n{}\nResponse: {}\n{}")
-                .addArgument("PUT")
-                .addArgument(path)
-                .addArgument(body)
-                .addArgument(response.getCode())
-                .addArgument(responseBody)
-                .log();
+            logHttpRequestResponse("PUT", path, response.getCode(), responseBody, body);
             return Map.entry(response.getCode(), responseBody);
         }
     }
@@ -165,13 +168,7 @@ public class ClusterOperations {
 
         try (var response = httpClient.execute(getRequest)) {
             var responseBody = EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
-            log.atInfo()
-                .setMessage("{} {}\nResponse: {}\n{}")
-                .addArgument("GET")
-                .addArgument(path)
-                .addArgument(response.getCode())
-                .addArgument(responseBody)
-                .log();
+            logHttpRequestResponse("GET", path, response.getCode(), responseBody, null);
             return Map.entry(response.getCode(), responseBody);
         }
     }
@@ -182,13 +179,7 @@ public class ClusterOperations {
 
         try (var response = httpClient.execute(request)) {
             var responseBody = EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
-            log.atInfo()
-                .setMessage("{} {}\nResponse: {}\n{}")
-                .addArgument("DELETE")
-                .addArgument(path)
-                .addArgument(response.getCode())
-                .addArgument(responseBody)
-                .log();
+            logHttpRequestResponse("DELETE", path, response.getCode(), responseBody, null);
             return Map.entry(response.getCode(), responseBody);
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -208,7 +208,7 @@ subprojects {
 
             systemProperty 'junit.jupiter.extensions.autodetection.enabled', true
             // Verify assertions in tests
-            jvmArgs = ['-ea', '-XX:+HeapDumpOnOutOfMemoryError']
+            jvmArgs += ['-ea', '-XX:+HeapDumpOnOutOfMemoryError', '-Xmx2g']
             systemProperty "junit.jupiter.execution.timeout.default", "5m"
             jacoco {
                 enabled = true


### PR DESCRIPTION
### Description
Fixes #1417: RFS Handling of docs with fields over 20M characters in length

Existing behavior threw error
```
 "ERROR o.o.m.b.w.DocumentsRunner [DocumentBatchReindexer-1] Error prevented some batches from being processed 
org.opensearch.migrations.bulkload.common.BulkDocSection$DeserializationException: Failed to parse source doc: String 
value length (20054016) exceeds the maximum allowed (20000000, from `StreamReadConstraints.getMaxStringLength()`) 
at org.opensearch.migrations.bulkload.common.BulkDocSection.parseSource(BulkDocSection.java:71)"
```

### Issues Resolved
- Resolves #1417
- Resolves [MIGRATIONS-2469](https://opensearch.atlassian.net/browse/MIGRATIONS-2469)

### Testing
Added unit test

### Check List
- [x] New functionality includes testing
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
