### PR TITLE
[CVE] Bump commons-io from 2.13.0 -> 2.18.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -125,6 +125,7 @@ subprojects {
             force "org.bouncycastle:bcprov-jdk18on:${libs.versions.bouncycastle.get()}"
             force 'com.jayway.jsonpath:json-path:2.9.0'
             force 'com.thoughtworks.xstream:xstream:1.4.21'
+            force "commons-io:commons-io:2.18.0"
             force 'commons-net:commons-net:3.11.1'
             force 'dnsjava:dnsjava:3.6.3'
             force 'net.minidev:json-smart:2.5.2'


### PR DESCRIPTION
### Description
[CVE] Bump commons-io from 2.13.0 -> 2.18.0

### Issues Resolved
- Resolves CVE-2024-47554


### Check List
- [ ] ~New functionality includes testing~
- [ ] ~Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
