### PR TITLE
BYOS - Bring Your Own Snapshot for CDK

### DIFF
--- a/deployment/cdk/opensearch-service-migration/lib/common-utilities.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/common-utilities.ts
@@ -468,11 +468,11 @@ export function parseClusterDefinition(json: any): ClusterYaml {
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function parseSnapshotDefinition(json: any): SnapshotYaml {
-    const snapshotName = json.snapshot_name
-    const s3Region = json.s3_region
-    const s3Uri = json.s3_uri
+    const snapshotName = json.snapshotName
+    const s3Region = json.s3Region
+    const s3Uri = json.s3Uri
     if (!snapshotName || !s3Region || !s3Uri) {
-        throw new Error('Missing at least one of the required snapshot fields: snapshot_name, s3_region, s3_uri');
+        throw new Error('Missing at least one of the required snapshot fields: snapshotName, s3Region, s3Uri');
     }
     const snapshotYaml = new SnapshotYaml()
     snapshotYaml.snapshot_name = snapshotName

--- a/deployment/cdk/opensearch-service-migration/lib/common-utilities.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/common-utilities.ts
@@ -4,7 +4,7 @@ import {ContainerImage, CpuArchitecture} from "aws-cdk-lib/aws-ecs";
 import {RemovalPolicy, Stack} from "aws-cdk-lib";
 import { IStringParameter, StringParameter } from "aws-cdk-lib/aws-ssm";
 import * as forge from 'node-forge';
-import { ClusterYaml } from "./migration-services-yaml";
+import {ClusterYaml, SnapshotYaml} from "./migration-services-yaml";
 import { CdkLogger } from "./cdk-logger";
 import { mkdtempSync, writeFileSync } from 'fs';
 import { join } from 'path';
@@ -464,6 +464,20 @@ export function parseClusterDefinition(json: any): ClusterYaml {
         throw new Error(`Invalid auth type when parsing cluster definition: ${json.auth.type}`)
     }
     return new ClusterYaml({endpoint, version, auth})
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function parseSnapshotDefinition(json: any): SnapshotYaml {
+    const snapshotName = json.snapshot_name
+    const s3Region = json.s3_region
+    const s3Uri = json.s3_uri
+    if (!snapshotName || !s3Region || !s3Uri) {
+        throw new Error('Missing at least one of the required snapshot fields: snapshot_name, s3_region, s3_uri');
+    }
+    const snapshotYaml = new SnapshotYaml()
+    snapshotYaml.snapshot_name = snapshotName
+    snapshotYaml.s3 = {repo_uri: s3Uri, aws_region: s3Region}
+    return snapshotYaml
 }
 
 export function isStackInGovCloud(stack: Stack): boolean {

--- a/deployment/cdk/opensearch-service-migration/lib/migration-assistance-stack.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/migration-assistance-stack.ts
@@ -38,6 +38,7 @@ export interface MigrationStackProps extends StackPropsExt {
 
 export class MigrationAssistanceStack extends Stack {
     kafkaYaml: KafkaYaml;
+    artifactBucketName: string;
 
     // This function exists to overcome the limitation on the vpc.selectSubnets() call which requires the subnet
     // type to be provided or else an empty list will be returned if public subnets are provided, thus this function
@@ -216,8 +217,9 @@ export class MigrationAssistanceStack extends Stack {
             parameter: MigrationSSMParameter.SERVICE_SECURITY_GROUP_ID
         });
 
+        this.artifactBucketName = `migration-artifacts-${this.account}-${props.stage}-${this.region}`
         const artifactBucket = new Bucket(this, 'migrationArtifactsS3', {
-            bucketName: `migration-artifacts-${this.account}-${props.stage}-${this.region}`,
+            bucketName: this.artifactBucketName,
             encryption: BucketEncryption.S3_MANAGED,
             enforceSSL: true,
             removalPolicy: bucketRemovalPolicy,

--- a/deployment/cdk/opensearch-service-migration/lib/migration-services-yaml.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/migration-services-yaml.ts
@@ -92,6 +92,12 @@ export class SnapshotYaml {
     s3?: S3SnapshotYaml;
     fs?: FileSystemSnapshotYaml;
 
+    // constructor({snapshot_name, otel_endpoint, s3} : {snapshot_name: string, otel_endpoint: string, s3: S3SnapshotYaml}) {
+    //     this.snapshot_name = snapshot_name;
+    //     this.otel_endpoint = otel_endpoint;
+    //     this.s3 = s3;
+    // }
+
     toDict() {
         return {
             snapshot_name: this.snapshot_name,

--- a/deployment/cdk/opensearch-service-migration/lib/migration-services-yaml.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/migration-services-yaml.ts
@@ -92,12 +92,6 @@ export class SnapshotYaml {
     s3?: S3SnapshotYaml;
     fs?: FileSystemSnapshotYaml;
 
-    // constructor({snapshot_name, otel_endpoint, s3} : {snapshot_name: string, otel_endpoint: string, s3: S3SnapshotYaml}) {
-    //     this.snapshot_name = snapshot_name;
-    //     this.otel_endpoint = otel_endpoint;
-    //     this.s3 = s3;
-    // }
-
     toDict() {
         return {
             snapshot_name: this.snapshot_name,

--- a/deployment/cdk/opensearch-service-migration/lib/service-stacks/migration-console-stack.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/service-stacks/migration-console-stack.ts
@@ -194,10 +194,9 @@ export class MigrationConsoleStack extends MigrationServiceCore {
             ...props,
             parameter: MigrationSSMParameter.ARTIFACT_S3_ARN,
         });
-        const artifactS3AnyObjectPath = `${artifactS3Arn}/*`;
-        const artifactS3PublishPolicy = new PolicyStatement({
+        const s3AccessPolicy = new PolicyStatement({
             effect: Effect.ALLOW,
-            resources: [artifactS3Arn, artifactS3AnyObjectPath],
+            resources: ["*"],
             actions: [
                 "s3:*"
             ]
@@ -261,7 +260,7 @@ export class MigrationConsoleStack extends MigrationServiceCore {
         const openSearchPolicy = createOpenSearchIAMAccessPolicy(this.partition, this.region, this.account)
         const openSearchServerlessPolicy = createOpenSearchServerlessIAMAccessPolicy(this.partition, this.region, this.account)
         let servicePolicies = [sharedLogFileSystem.asPolicyStatement(), openSearchPolicy, openSearchServerlessPolicy, ecsUpdateServicePolicy, clusterTasksPolicy,
-            listTasksPolicy, artifactS3PublishPolicy, describeVPCPolicy, getSSMParamsPolicy, getMetricsPolicy,
+            listTasksPolicy, s3AccessPolicy, describeVPCPolicy, getSSMParamsPolicy, getMetricsPolicy,
             // only add secrets policies if they're non-null
             ...(getTargetSecretsPolicy ? [getTargetSecretsPolicy] : []),
             ...(getSourceSecretsPolicy ? [getSourceSecretsPolicy] : [])

--- a/deployment/cdk/opensearch-service-migration/lib/stack-composer.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/stack-composer.ts
@@ -140,7 +140,8 @@ export class StackComposer {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const defaultValues: Record<string, any> = defaultValuesJson
         if (!props.env?.region || !props.env?.account) {
-            throw new Error('Missing at least one of required fields [region, account] in props.env');
+            throw new Error('Missing at least one of required fields [region, account] in props.env. ' +
+                'Has AWS been configured for this environment?');
         }
         const account = props.env.account
         const region = props.env.region
@@ -385,6 +386,10 @@ export class StackComposer {
         const existingSnapshotDefinition = this.getContextForType('snapshot', 'object', defaultValues, contextJSON)
         let snapshotYaml
         if (existingSnapshotDefinition) {
+            if(!sourceCluster?.version) {
+                throw new Error("The `sourceCluster` object must be provided with a `version` field when using an external snapshot to ensure proper parsing of " +
+                    "the snapshot based on cluster version. See options.md for more details.")
+            }
             snapshotYaml = parseSnapshotDefinition(existingSnapshotDefinition)
         } else {
             snapshotYaml = new SnapshotYaml();

--- a/deployment/cdk/opensearch-service-migration/lib/stack-composer.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/stack-composer.ts
@@ -139,11 +139,10 @@ export class StackComposer {
 
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const defaultValues: Record<string, any> = defaultValuesJson
-        if (!props.env?.region || !props.env?.account) {
-            throw new Error('Missing at least one of required fields [region, account] in props.env. ' +
+        if (!props.env?.region) {
+            throw new Error('Missing at least one of required fields [region] in props.env. ' +
                 'Has AWS been configured for this environment?');
         }
-        const account = props.env.account
         const region = props.env.region
         const defaultDeployId = 'default'
 
@@ -394,8 +393,6 @@ export class StackComposer {
         } else {
             snapshotYaml = new SnapshotYaml();
             snapshotYaml.snapshot_name = "rfs-snapshot"
-            const s3Uri = `s3://migration-artifacts-${account}-${stage}-${region}/rfs-snapshot-repo`;
-            snapshotYaml.s3 = {repo_uri: s3Uri, aws_region: region};
         }
         servicesYaml.snapshot = snapshotYaml
 
@@ -467,6 +464,12 @@ export class StackComposer {
             this.addDependentStacks(migrationStack, [networkStack])
             this.stacks.push(migrationStack)
             servicesYaml.kafka = migrationStack.kafkaYaml;
+            if (!existingSnapshotDefinition) {
+                snapshotYaml.s3 = {
+                    repo_uri: `s3://${migrationStack.artifactBucketName}/rfs-snapshot-repo`,
+                    aws_region: region
+                };
+            }
         }
 
         let osContainerStack

--- a/deployment/cdk/opensearch-service-migration/options.md
+++ b/deployment/cdk/opensearch-service-migration/options.md
@@ -49,6 +49,22 @@ In all other cases, the required components of each cluster object are:
     3. Basic auth with plaintext password (only supported for the source cluster and not recommended): `{"type": "basic", "username": "admin", "password": "admin123"}`
     4. Basic auth with password in secrets manager (recommended): `{"type": "basic", "username": "admin", "passwordFromSecretArn": "arn:aws:secretsmanager:us-east-1:12345678912:secret:master-user-os-pass-123abc"}`
 
+### Snapshot Definition Options
+
+| Name     | Type   | Example                                                                                                                          | Description                                                                                        |
+|----------|--------|----------------------------------------------------------------------------------------------------------------------------------|:---------------------------------------------------------------------------------------------------|
+| snapshot | object | {"snapshotName": "test-snapshot", "s3Uri": "s3://snapshot-bucket-123456789012-us-east-2/snapshot-repo", "s3Region": "us-east-2"} | A json object for defining the details of an existing S3 snapshot. See below for detailed options. |
+
+#### Structure of the snapshot object
+
+A snapshot should only be configured when the user has an existing snapshot they want to utilize for performing an RFS backfill or Metadata migration instead of creating a snapshot with the Migration Assistant.
+
+In such case, the required fields in the snapshot object are:
+
+- `snapshotName` -- the name of the existing snapshot that was created
+- `s3Uri` -- the `s3://` URI path to where the snapshot repo exists in the given S3 bucket
+- `s3Region` -- the region where the S3 bucket is located
+
 ### Reindex from Snapshot (RFS) Service Options
 
 | Name                                | Type    | Example                                                              | Description                                                                                                                                                                                                                                                                          |

--- a/deployment/cdk/opensearch-service-migration/test/reindex-from-snapshot-stack.test.ts
+++ b/deployment/cdk/opensearch-service-migration/test/reindex-from-snapshot-stack.test.ts
@@ -236,11 +236,6 @@ describe('ReindexFromSnapshotStack Tests', () => {
 
     expect(reindexStack.rfsBackfillYaml.ecs.cluster_name).toBe('migration-unit-test-ecs-cluster');
     expect(reindexStack.rfsBackfillYaml.ecs.service_name).toBe('migration-unit-test-reindex-from-snapshot');
-    expect(reindexStack.rfsSnapshotYaml.s3).toEqual({
-      repo_uri: expect.stringMatching(/s3:\/\/migration-artifacts-.*-unit-test-.*/),
-      aws_region: expect.any(String),
-    });
-    expect(reindexStack.rfsSnapshotYaml.snapshot_name).toBe('rfs-snapshot');
   });
 
   test('ReindexFromSnapshotStack correctly overrides with extraArgs', () => {

--- a/deployment/cdk/opensearch-service-migration/test/reindex-from-snapshot-stack.test.ts
+++ b/deployment/cdk/opensearch-service-migration/test/reindex-from-snapshot-stack.test.ts
@@ -217,6 +217,80 @@ describe('ReindexFromSnapshotStack Tests', () => {
     ]);
   });
 
+  test('ReindexFromSnapshotStack sets correct RFS command from custom SnapshotYaml', () => {
+    const contextOptions = {
+      vpcEnabled: true,
+      sourceCluster: {
+        "endpoint": "https://test-cluster",
+        "auth": {"type": "none"},
+        "version": "ES_7.10"
+      },
+      snapshot: {
+        "snapshotName": "test-snapshot",
+        "s3Uri": "s3://snapshot-bucket-123456789012-us-east-2/snapshot-repo",
+        "s3Region": "us-east-2"
+      },
+      reindexFromSnapshotServiceEnabled: true,
+      stage: 'unit-test',
+      migrationAssistanceEnabled: true,
+      fineGrainedManagerUserName: "test-user",
+      fineGrainedManagerUserSecretManagerKeyARN: "arn:aws:secretsmanager:us-east-1:123456789012:secret:test-secret",
+      nodeToNodeEncryptionEnabled: true,
+      encryptionAtRestEnabled: true,
+      enforceHTTPS: true
+    };
+
+    const stacks = createStackComposer(contextOptions);
+    const reindexStack = stacks.stacks.find(s => s instanceof ReindexFromSnapshotStack) as ReindexFromSnapshotStack;
+    expect(reindexStack).toBeDefined();
+    const template = Template.fromStack(reindexStack);
+
+    const taskDefinitionCapture = new Capture();
+    template.hasResourceProperties('AWS::ECS::TaskDefinition', {
+      ContainerDefinitions: taskDefinitionCapture,
+    });
+
+    const containerDefinitions = taskDefinitionCapture.asArray();
+    expect(containerDefinitions.length).toBe(1);
+    expect(containerDefinitions[0].Command).toEqual([
+      '/bin/sh',
+      '-c',
+      '/rfs-app/entrypoint.sh'
+    ]);
+    expect(containerDefinitions[0].Environment).toEqual([
+      {
+        Name: 'RFS_COMMAND',
+        Value: {
+          "Fn::Join": [
+            "",
+            [ "/rfs-app/runJavaWithClasspath.sh org.opensearch.migrations.RfsMigrateDocuments --s3-local-dir \"/storage/s3_files\" --s3-repo-uri \"s3://snapshot-bucket-123456789012-us-east-2/snapshot-repo\" --s3-region us-east-2 --snapshot-name test-snapshot --lucene-dir \"/storage/lucene\" --target-host ",
+              {
+                "Ref": "SsmParameterValuemigrationunittestdefaultosClusterEndpointC96584B6F00A464EAD1953AFF4B05118Parameter",
+              },
+              " --max-shard-size-bytes 94489280512 --max-connections 10 --source-version \"ES_7.10\""
+            ],
+          ],
+        }
+      },
+      {
+        Name: 'RFS_TARGET_USER',
+        Value: 'test-user'
+      },
+      {
+        Name: 'RFS_TARGET_PASSWORD',
+        Value: ''
+      },
+      {
+        Name: 'RFS_TARGET_PASSWORD_ARN',
+        Value: 'arn:aws:secretsmanager:us-east-1:123456789012:secret:test-secret'
+      },
+      {
+        Name: 'SHARED_LOGS_DIR_PATH',
+        Value: '/shared-logs-output/reindex-from-snapshot-default'
+      }
+    ]);
+  });
+
   test('ReindexFromSnapshotStack sets correct YAML configurations', () => {
     const contextOptions = {
       vpcEnabled: true,


### PR DESCRIPTION
### Description
This change introduces the ability to specify an existing snapshot with CDK and have that be utilized by downstream services such as RFS and the Migration Console

Sample CDK context option:
```
{
    "snapshot": {
        "snapshotName": "test-snapshot",
        "s3Uri": "s3://snapshot-bucket-123456789012-us-east-2/snapshot-repo",
        "s3Region": "us-east-2"
    }
}
```
~Still verifying this works on a deployed environment and seeing if any issues exist to use this cross-region or cross-account as well as adding official documentation~

Documentation PR to review here: https://github.com/opensearch-project/documentation-website/pull/9573

### Issues Resolved
https://opensearch.atlassian.net/browse/MIGRATIONS-2219

### Testing
CDK tests

### Check List
- [x] New functionality includes testing
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
