### PR TITLE
Remove system.exit usage in components

### DIFF
--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/e2etests/KafkaRestartingTrafficReplayerTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/e2etests/KafkaRestartingTrafficReplayerTest.java
@@ -2,7 +2,6 @@ package org.opensearch.migrations.replay.e2etests;
 
 import java.time.Duration;
 import java.time.Instant;
-import java.util.List;
 import java.util.Properties;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -13,12 +12,9 @@ import java.util.stream.Stream;
 
 import org.opensearch.migrations.replay.SourceTargetCaptureTuple;
 import org.opensearch.migrations.replay.TestHttpServerContext;
-import org.opensearch.migrations.replay.V0_1TrafficCaptureSource;
 import org.opensearch.migrations.replay.kafka.KafkaTestUtils;
 import org.opensearch.migrations.replay.kafka.KafkaTrafficCaptureSource;
 import org.opensearch.migrations.replay.traffic.generator.ExhaustiveTrafficStreamGenerator;
-import org.opensearch.migrations.replay.traffic.source.ISimpleTrafficCaptureSource;
-import org.opensearch.migrations.replay.traffic.source.ITrafficStreamWithKey;
 import org.opensearch.migrations.testutils.SharedDockerImageNames;
 import org.opensearch.migrations.testutils.SimpleNettyHttpServer;
 import org.opensearch.migrations.testutils.WrapWithNettyLeakDetection;
@@ -28,7 +24,6 @@ import org.opensearch.migrations.trafficcapture.protos.TrafficStream;
 import org.opensearch.migrations.trafficcapture.protos.TrafficStreamUtils;
 
 import com.google.common.collect.Streams;
-import lombok.Lombok;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
@@ -185,6 +180,7 @@ public class KafkaRestartingTrafficReplayerTest extends InstrumentationTest {
         }
     }
 
+    @SuppressWarnings({ "unchecked", "rawtypes" })
     Producer<String, byte[]> buildKafkaProducer() {
         var kafkaProps = new Properties();
         kafkaProps.put(
@@ -206,48 +202,7 @@ public class KafkaRestartingTrafficReplayerTest extends InstrumentationTest {
             return new KafkaProducer(kafkaProps);
         } catch (Exception e) {
             log.atError().setCause(e).log();
-            System.exit(1);
             throw e;
         }
     }
-
-    private Supplier<ISimpleTrafficCaptureSource> loadStreamsToKafkaFromCompressedFile(
-        TestContext rootCtx,
-        KafkaConsumer<String, byte[]> kafkaConsumer,
-        String filename,
-        int recordCount
-    ) throws Exception {
-        var kafkaProducer = buildKafkaProducer();
-        loadStreamsAsynchronouslyWithCloseableResource(
-            kafkaConsumer,
-            new V0_1TrafficCaptureSource(rootCtx, filename),
-            originalTrafficSource -> {
-                try {
-                    for (int i = 0; i < recordCount; ++i) {
-                        List<ITrafficStreamWithKey> chunks = null;
-                        chunks = originalTrafficSource.readNextTrafficStreamChunk(rootCtx::createReadChunkContext)
-                            .get();
-                        for (int j = 0; j < chunks.size(); ++j) {
-                            KafkaTestUtils.writeTrafficStreamRecord(
-                                kafkaProducer,
-                                chunks.get(j).getStream(),
-                                TEST_TOPIC_NAME,
-                                "KEY_" + i + "_" + j
-                            );
-                            Thread.sleep(PRODUCER_SLEEP_INTERVAL_MS);
-                        }
-                    }
-                } catch (Exception e) {
-                    throw Lombok.sneakyThrow(e);
-                }
-            }
-        );
-        return () -> new KafkaTrafficCaptureSource(
-            rootCtx,
-            kafkaConsumer,
-            TEST_TOPIC_NAME,
-            Duration.ofMillis(DEFAULT_POLL_INTERVAL_MS)
-        );
-    }
-
 }

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/kafka/KafkaTestUtils.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/kafka/KafkaTestUtils.java
@@ -51,7 +51,6 @@ public class KafkaTestUtils {
             return new KafkaProducer(kafkaProps);
         } catch (Exception e) {
             log.atError().setCause(e).log();
-            System.exit(1);
             throw e;
         }
     }

--- a/transformation/transformationPlugins/jsonMessageTransformers/jsonMessageTransformerLoaders/src/main/java/org/opensearch/migrations/transform/TransformerConfigUtils.java
+++ b/transformation/transformationPlugins/jsonMessageTransformers/jsonMessageTransformerLoaders/src/main/java/org/opensearch/migrations/transform/TransformerConfigUtils.java
@@ -18,20 +18,19 @@ public final class TransformerConfigUtils {
                 isConfigured(params.getTransformerConfigEncoded()) +
                 isConfigured(params.getTransformerConfig());
         if (configuredCount > 1) {
-            System.err.println("Specify only one of " +
+            throw new TooManyTransformationConfigSourcesException("Specify only one of " +
                     "--" + params.getTransformerConfigParameterArgPrefix() + "-transformer-config-base64" + ", " +
                     "--" + params.getTransformerConfigParameterArgPrefix() + "-transformer-config" + ", or " +
                     "--" + params.getTransformerConfigParameterArgPrefix() + "-transformer-config-file" +
                     ". Both Kebab case and lower Camel case are supported.");
-            System.exit(4);
         }
 
         if (params.getTransformerConfigFile() != null && !params.getTransformerConfigFile().isBlank()) {
+            var configFile = Paths.get(params.getTransformerConfigFile());
             try {
-                return Files.readString(Paths.get(params.getTransformerConfigFile()), StandardCharsets.UTF_8);
+                return Files.readString(configFile, StandardCharsets.UTF_8);
             } catch (IOException e) {
-                System.err.println("Error reading transformer configuration file: " + e.getMessage());
-                System.exit(5);
+                throw new UnableToReadTransformationConfigException(configFile.toString(), e);
             }
         }
 
@@ -46,4 +45,15 @@ public final class TransformerConfigUtils {
         return null;
     }
 
+    public static class TooManyTransformationConfigSourcesException extends RuntimeException {
+        public TooManyTransformationConfigSourcesException(final String msg) {
+            super(msg);
+        }
+    }
+
+    public static class UnableToReadTransformationConfigException extends RuntimeException {
+        public UnableToReadTransformationConfigException(final String filePath, final Throwable cause) {
+            super("Unable to read transformation config: " + filePath, cause);
+        }
+    }
 }


### PR DESCRIPTION
### Description
While running a RFS test case with a bad transformation config the container went down without clear signals to the problem, it took many attempts to discover. Adding new exception to allow for callers to manage failures.

Also removed a couple other suspect System.exit() use cases where exception throwing should be sufficient.

### Issues Resolved
- Related https://github.com/opensearch-project/opensearch-migrations/pull/1438

### Check List
- [ ] ~New functionality includes testing~
- [ ] ~Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
