### PR TITLE
Use LocalThread for ResultsToLogsConsumer transformations

### DIFF
--- a/RFS/src/test/java/org/opensearch/migrations/bulkload/common/DocumentReindexerTest.java
+++ b/RFS/src/test/java/org/opensearch/migrations/bulkload/common/DocumentReindexerTest.java
@@ -51,7 +51,7 @@ class DocumentReindexerTest {
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
-        documentReindexer = new DocumentReindexer(mockClient, MAX_DOCS_PER_BULK, MAX_BYTES_PER_BULK_REQUEST, MAX_CONCURRENT_REQUESTS, () -> null);
+        documentReindexer = new DocumentReindexer(mockClient, MAX_DOCS_PER_BULK, MAX_BYTES_PER_BULK_REQUEST, MAX_CONCURRENT_REQUESTS, null);
         when(mockContext.createBulkRequest()).thenReturn(mock(IRfsContexts.IRequestContext.class));
     }
 
@@ -236,7 +236,7 @@ class DocumentReindexerTest {
     void reindex_shouldRespectMaxConcurrentRequests() {
         int numDocs = 100;
         int maxConcurrentRequests = 5;
-        DocumentReindexer concurrentReindexer = new DocumentReindexer(mockClient, 1, MAX_BYTES_PER_BULK_REQUEST, maxConcurrentRequests, () -> null);
+        DocumentReindexer concurrentReindexer = new DocumentReindexer(mockClient, 1, MAX_BYTES_PER_BULK_REQUEST, maxConcurrentRequests, null);
 
         Flux<RfsLuceneDocument> documentStream = Flux.range(1, numDocs).map(i -> createTestDocument(i));
 

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/TrafficReplayer.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/TrafficReplayer.java
@@ -437,9 +437,9 @@ public class TrafficReplayer {
             }, ACTIVE_WORK_MONITOR_CADENCE_MS, ACTIVE_WORK_MONITOR_CADENCE_MS, TimeUnit.MILLISECONDS);
 
             setupShutdownHookForReplayer(tr);
-
-            var tupleWriter = new TupleParserChainConsumer(new ResultsToLogsConsumer(null, null,
-                () -> transformationLoader.getTransformerFactoryLoader(tupleTransformerConfig)));
+            var resultsToLogsConsumer = new ResultsToLogsConsumer(null, null,
+                    () -> transformationLoader.getTransformerFactoryLoader(tupleTransformerConfig));
+            var tupleWriter = new TupleParserChainConsumer(resultsToLogsConsumer);
             tr.setupRunAndWaitForReplayWithShutdownChecks(
                 Duration.ofSeconds(params.observedPacketConnectionTimeout),
                 serverTimeout,

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/TrafficReplayer.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/TrafficReplayer.java
@@ -437,8 +437,9 @@ public class TrafficReplayer {
             }, ACTIVE_WORK_MONITOR_CADENCE_MS, ACTIVE_WORK_MONITOR_CADENCE_MS, TimeUnit.MILLISECONDS);
 
             setupShutdownHookForReplayer(tr);
+
             var tupleWriter = new TupleParserChainConsumer(new ResultsToLogsConsumer(null, null,
-                new TransformationLoader().getTransformerFactoryLoader(tupleTransformerConfig)));
+                () -> transformationLoader.getTransformerFactoryLoader(tupleTransformerConfig)));
             tr.setupRunAndWaitForReplayWithShutdownChecks(
                 Duration.ofSeconds(params.observedPacketConnectionTimeout),
                 serverTimeout,

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/ResultsToLogsConsumerTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/ResultsToLogsConsumerTest.java
@@ -338,7 +338,7 @@ class ResultsToLogsConsumerTest extends InstrumentationTest {
                 targetResponses,
                 null
             );
-            var streamConsumer = new ResultsToLogsConsumer(closeableLogSetup.getTestLogger(), null, transformer);
+            var streamConsumer = new ResultsToLogsConsumer(closeableLogSetup.getTestLogger(), null, () -> transformer);
             var consumer = new TupleParserChainConsumer(streamConsumer);
             consumer.accept(tuple);
             Assertions.assertEquals(1, closeableLogSetup.getLogEvents().size());

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/ResultsToLogsConsumerTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/ResultsToLogsConsumerTest.java
@@ -309,6 +309,10 @@ class ResultsToLogsConsumerTest extends InstrumentationTest {
     }
 
     private void testOutputterForRequest(String requestResourceName, String expected, IJsonTransformer transformer) throws IOException {
+        testOutputterForRequestWithTransformerSupplier(requestResourceName, expected, transformer != null ? () -> transformer : null);
+    }
+
+    private void testOutputterForRequestWithTransformerSupplier(String requestResourceName, String expected, java.util.function.Supplier<IJsonTransformer> transformerSupplier) throws IOException {
         var trafficStreamKey = PojoTrafficStreamKeyAndContext.build(
             NODE_ID,
             "c",
@@ -338,7 +342,7 @@ class ResultsToLogsConsumerTest extends InstrumentationTest {
                 targetResponses,
                 null
             );
-            var streamConsumer = new ResultsToLogsConsumer(closeableLogSetup.getTestLogger(), null, () -> transformer);
+            var streamConsumer = new ResultsToLogsConsumer(closeableLogSetup.getTestLogger(), null, transformerSupplier);
             var consumer = new TupleParserChainConsumer(streamConsumer);
             consumer.accept(tuple);
             Assertions.assertEquals(1, closeableLogSetup.getLogEvents().size());

--- a/transformation/transformationPlugins/jsonMessageTransformers/jsonMessageTransformerInterface/build.gradle
+++ b/transformation/transformationPlugins/jsonMessageTransformers/jsonMessageTransformerInterface/build.gradle
@@ -16,4 +16,5 @@ plugins {
 }
 
 dependencies {
+    implementation libs.slf4j.api
 }

--- a/transformation/transformationPlugins/jsonMessageTransformers/jsonMessageTransformerInterface/src/main/java/org/opensearch/migrations/transform/ThreadSafeTransformerWrapper.java
+++ b/transformation/transformationPlugins/jsonMessageTransformers/jsonMessageTransformerInterface/src/main/java/org/opensearch/migrations/transform/ThreadSafeTransformerWrapper.java
@@ -62,6 +62,7 @@ public class ThreadSafeTransformerWrapper implements IJsonTransformer {
         var transformer = threadLocalHolder.get();
         if (transformer != null) {
             transformer.close();
+            threadLocalHolder.remove();
         }
     }
 

--- a/transformation/transformationPlugins/jsonMessageTransformers/jsonMessageTransformerInterface/src/main/java/org/opensearch/migrations/transform/ThreadSafeTransformerWrapper.java
+++ b/transformation/transformationPlugins/jsonMessageTransformers/jsonMessageTransformerInterface/src/main/java/org/opensearch/migrations/transform/ThreadSafeTransformerWrapper.java
@@ -1,0 +1,131 @@
+package org.opensearch.migrations.transform;
+
+import java.lang.ref.Cleaner;
+import java.util.function.Supplier;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * A thread-safe wrapper around {@link IJsonTransformer} that ensures each thread
+ * has its own transformer instance via {@link ThreadLocal}.
+ * <p>
+ * This design is useful when the transformer is stateful or not thread-safe.
+ * Each thread gets a lazily-initialized transformer from the provided supplier.
+ *
+ * <h2>Resource Management</h2>
+ * The wrapper implements {@link AutoCloseable}, and callers are expected to invoke
+ * {@link #close()} when a thread is finished using its transformer. This ensures
+ * deterministic release of resources and avoids memory leaks in thread pools.
+ *
+ * <h2>Cleaner Integration</h2>
+ * As a fallback, this class also registers each transformer with a shared {@link java.lang.ref.Cleaner}.
+ * If a thread dies or the transformer becomes unreachable without an explicit {@link #close()} call,
+ * the cleaner will invoke a cleanup task to call {@link IJsonTransformer#close()}.
+ *
+ * <h2>Thread-local semantics</h2>
+ * Calling {@link #close()} only affects the transformer instance associated with the
+ * current thread. It does not close transformers used by other threads.
+ */
+@Slf4j
+public class ThreadSafeTransformerWrapper implements IJsonTransformer {
+
+    public static final Cleaner FALLBACK_CLEANER = Cleaner.create();
+
+    /** Thread-local holding per-thread transformer wrappers */
+    private final ThreadLocal<CloseTrackingTransformer> threadLocalHolder;
+
+    /**
+     * Constructs a new thread-safe transformer wrapper using the given supplier.
+     *
+     * @param transformerSupplier Supplier that produces a new {@link IJsonTransformer} for each thread.
+     */
+    public ThreadSafeTransformerWrapper(Supplier<IJsonTransformer> transformerSupplier) {
+        this.threadLocalHolder = ThreadLocal.withInitial(() -> {
+            var trackingTransformer = new CloseTrackingTransformer(transformerSupplier.get());
+            // Register the tracking wrapper with the Cleaner. The cleaner will call cleanup() when the ThreadSafeTransformerWrapper is garbage collected
+            FALLBACK_CLEANER.register(this, trackingTransformer::cleanup);
+            return trackingTransformer;
+        });
+    }
+
+    @Override
+    public Object transformJson(Object input) {
+        return threadLocalHolder.get().transformJson(input);
+    }
+
+    /**
+     * Manually closes the transformer associated with the current thread.
+     * This must be called prior to any calling thread being shutdown.
+     */
+    @Override
+    public void close() {
+        var transformer = threadLocalHolder.get();
+        if (transformer != null) {
+            transformer.close();
+        }
+    }
+
+    /**
+     * A close-tracking wrapper around an {@code IJsonTransformer} that monitors whether it has been closed.
+     */
+    private static class CloseTrackingTransformer implements IJsonTransformer {
+        private final IJsonTransformer delegate;
+        // Volatile flag for thread-safe check of the closed state.
+        private volatile boolean closed = false;
+
+        CloseTrackingTransformer(IJsonTransformer delegate) {
+            this.delegate = delegate;
+        }
+
+        /**
+         * Invoked by the Cleaner if the transformer is garbage-collected without an explicit close().
+         * This checks whether close() was already called, and if not, performs cleanup.
+         */
+        private void cleanup() {
+            if (!closed) {
+                log.atWarn()
+                    .setMessage("Fallback cleaner used to cleanup transformer {}. Explicit close() was not called.")
+                    .addArgument(delegate)
+                    .log();
+                try {
+                    delegate.close();
+                } catch (Exception e) {
+                    log.atError()
+                        .setMessage("Exception during fallback cleaning of transformer {}.")
+                        .addArgument(delegate)
+                        .setCause(e)
+                        .log();
+                }
+                closed = true;
+            }
+        }
+
+        @Override
+        public Object transformJson(Object input) {
+            if (closed) {
+                throw new IllegalStateException("Transformer is closed");
+            }
+            return delegate.transformJson(input);
+        }
+
+        /**
+         * Explicitly closes the transformer, deregisters the cleaner, and marks the instance as closed.
+         */
+        @Override
+        public synchronized void close() {
+            if (!closed) {
+                try {
+                    delegate.close();
+                } catch (Exception e) {
+                    log.atError()
+                        .setMessage("Failed to close transformer {}.")
+                        .addArgument(delegate)
+                        .setCause(e)
+                        .log();
+                } finally {
+                    closed = true;
+                }
+            }
+        }
+    }
+}

--- a/transformation/transformationPlugins/jsonMessageTransformers/jsonMessageTransformerInterface/src/test/java/org/opensearch/migrations/transform/ThreadSafeTransformerWrapperTest.java
+++ b/transformation/transformationPlugins/jsonMessageTransformers/jsonMessageTransformerInterface/src/test/java/org/opensearch/migrations/transform/ThreadSafeTransformerWrapperTest.java
@@ -1,0 +1,134 @@
+package org.opensearch.migrations.transform;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class ThreadSafeTransformerWrapperTest {
+
+    // Dummy implementation for testing transformation and closure behavior.
+    static class TestJsonTransformer implements IJsonTransformer {
+        private boolean closed = false;
+
+        @Override
+        public Object transformJson(Object input) {
+            // Simple transformation: convert String input to upper case.
+            if (input instanceof String) {
+                return ((String) input).toUpperCase();
+            }
+            return input;
+        }
+
+        @Override
+        public void close() {
+            closed = true;
+        }
+
+        public boolean isClosed() {
+            return closed;
+        }
+    }
+
+    // Test that transformJson correctly transforms input.
+    @Test
+    public void testTransformJson() {
+        Supplier<IJsonTransformer> supplier = TestJsonTransformer::new;
+        ThreadSafeTransformerWrapper wrapper = new ThreadSafeTransformerWrapper(supplier);
+        String input = "test";
+        Object result = wrapper.transformJson(input);
+        Assertions.assertEquals("TEST", result, "The transformer should convert input to upper case.");
+    }
+
+    // Test that calling close() properly triggers the underlying transformer's close() method.
+    @Test
+    public void testCloseCallsUnderlyingClose() {
+        TestJsonTransformer transformer = new TestJsonTransformer();
+        // For simplicity, always return the same transformer instance.
+        ThreadSafeTransformerWrapper wrapper = new ThreadSafeTransformerWrapper(() -> transformer);
+        // Initialize thread-local transformer instance.
+        wrapper.transformJson("dummy");
+        wrapper.close();
+        Assertions.assertTrue(transformer.isClosed(), "Underlying transformer should be marked as closed.");
+    }
+
+    // Test that each thread gets its own transformer by counting the total close() calls.
+    @Test
+    public void testThreadLocalTransformer() throws InterruptedException {
+        AtomicInteger closeCount = new AtomicInteger(0);
+        // Counting transformer: increments count when close() is invoked.
+        class CountingTransformer implements IJsonTransformer {
+            @Override
+            public Object transformJson(Object input) {
+                if (input instanceof String) {
+                    return ((String) input).toUpperCase();
+                }
+                return input;
+            }
+            @Override
+            public void close() {
+                closeCount.incrementAndGet();
+            }
+        }
+
+        ThreadSafeTransformerWrapper wrapper = new ThreadSafeTransformerWrapper(CountingTransformer::new);
+        // Use transformer in main thread.
+        wrapper.transformJson("foo");
+        wrapper.close();  // Expected to increment count to 1.
+
+        // Use transformer in a new thread.
+        Thread thread = new Thread(() -> {
+            wrapper.transformJson("bar");
+            wrapper.close();  // Expected to increment count to 2.
+        });
+        thread.start();
+        thread.join();
+
+        Assertions.assertEquals(2, closeCount.get(), "Each thread should have its own transformer and call close once.");
+    }
+
+    static class CloseLatchTransformer implements IJsonTransformer {
+        private final CountDownLatch latch;
+
+        CloseLatchTransformer(CountDownLatch latch) {
+            this.latch = latch;
+        }
+
+        @Override
+        public Object transformJson(Object input) {
+            return input;
+        }
+
+        @Override
+        public void close() {
+            latch.countDown();
+        }
+    }
+
+    @Test
+    public void testCleanerBehaviorWithLatch() throws InterruptedException {
+        // Latch to wait for the cleanup (close()) to be called.
+        CountDownLatch latch = new CountDownLatch(1);
+
+        Supplier<IJsonTransformer> transformerSupplier = () -> new CloseLatchTransformer(latch);
+
+        // Create and start a new thread that uses the transformer without explicitly calling close()
+        Thread thread = new Thread(() -> {
+            ThreadSafeTransformerWrapper wrapper = new ThreadSafeTransformerWrapper(transformerSupplier);
+            // Initialize thread-local transformer instance.
+            wrapper.transformJson("test");
+        });
+        thread.start();
+        thread.join();
+
+        // Force garbage collection to make thread-local data unreachable.
+        System.gc();
+
+        boolean closedByCleaner = latch.await(5, TimeUnit.SECONDS);
+
+        Assertions.assertTrue(closedByCleaner, "Cleaner should have closed the transformer within 5 seconds.");
+    }
+}


### PR DESCRIPTION
### Description
Fixes `java.lang.IllegalStateException: Multi threaded access requested by thread Thread[targetConnectionPool-4-2,5,main] but is not allowed for language(s) js.` caused in ResultsToLogsConsumer with non thread safe transformations.

### Issues Resolved

### Testing

### Check List
- [ ] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
