### PR TITLE
Remove RFS from excluded maven publishing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -265,7 +265,6 @@ subprojects {
     }
 
     def excludedProjectPaths = [
-            ':RFS',
             ':TrafficCapture',
             ':TrafficCapture:dockerSolution',
     ]


### PR DESCRIPTION
### Description
Remove RFS from excluded maven publishing

### Issues Resolved
<!-- List any GitHub or Jira issues this PR will resolve -->

### Testing
GHA runs through publish prereqs for a package https://github.com/opensearch-project/opensearch-migrations/actions/runs/14499105148/job/40674222682?pr=1451

### Check List
- [x] New functionality includes testing
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
