### PR TITLE
Update docker cache to AndreKurait/docker-cache@0.6.0

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -157,7 +157,7 @@ jobs:
           gradle-version: ${{ env.gradle-version }}
           gradle-home-cache-cleanup: true
       - name: Restore Docker Cache
-        uses: ScribeMD/docker-cache@0.5.0
+        uses: AndreKurait/docker-cache@0.6.0
         with:
           key: docker-${{ runner.os }}-${{ needs.generate-cache-key.outputs.docker_cache_key }}
           # Delegate cache saving to python-e2e-tests
@@ -260,7 +260,7 @@ jobs:
         with:
           python-version: ${{ env.python-version }}
       - name: Cache Docker Images
-        uses: ScribeMD/docker-cache@0.5.0
+        uses: AndreKurait/docker-cache@0.6.0
         with:
           key: docker-${{ runner.os }}-${{ needs.generate-cache-key.outputs.docker_cache_key }}
           # Only save cache on push events


### PR DESCRIPTION
### Description
Updates docker cache action to `AndreKurait/docker-cache@0.6.0` which provides an update for v4 of the underlying action cache

Fixes:
Failed to save: Unable to reserve cache with key docker-Linux-ae4aa90a40aa7d4bb6f161c37c0add12a35d0b4b, another job may be creating this cache. More details: This legacy service is shutting down, effective April 15, 2025. Migrate to the new service ASAP. For more information: https://gh.io/gha-cache-sunset

### Issues Resolved


### Testing
Test on GHA on my fork https://github.com/AndreKurait/opensearch-migrations/actions/runs/14503181939/job/40687342804

### Check List
- [x] New functionality includes testing
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
