### PR TITLE
[Console Lib] Support http head requests

### DIFF
--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/cluster.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/cluster.py
@@ -18,7 +18,7 @@ requests.packages.urllib3.disable_warnings()  # ignore: type
 logger = logging.getLogger(__name__)
 
 AuthMethod = Enum("AuthMethod", ["NO_AUTH", "BASIC_AUTH", "SIGV4"])
-HttpMethod = Enum("HttpMethod", ["GET", "POST", "PUT", "DELETE"])
+HttpMethod = Enum("HttpMethod", ["GET", "POST", "PUT", "DELETE", "HEAD"])
 
 
 NO_AUTH_SCHEMA = {

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/test_cli.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/test_cli.py
@@ -305,6 +305,20 @@ def test_cli_cluster_run_curl_multiple_headers(runner, mocker):
     assert result.exit_code == 0
 
 
+def test_cli_cluster_run_curl_head_method(runner, mocker):
+    middleware_mock = mocker.spy(middleware.clusters, 'call_api')
+    model_mock = mocker.patch.object(Cluster, 'call_api', autospec=True)
+    result = runner.invoke(cli, ['--config-file', str(VALID_SERVICES_YAML), 'clusters', 'curl',
+                                 'target_cluster', '/', '-X', 'HEAD'],
+                           catch_exceptions=True)
+    middleware_mock.assert_called_once()
+    model_mock.assert_called_once()
+    assert model_mock.call_args.kwargs == {'path': '/', 'method': HttpMethod.HEAD,
+                                           'data': None, 'headers': {}, 'timeout': None,
+                                           'session': None, 'raise_error': False}
+    assert result.exit_code == 0
+
+
 def test_cli_cluster_clear_indices(runner, mocker):
     mock = mocker.patch('console_link.middleware.clusters.clear_indices')
     result = runner.invoke(cli,

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/test_cluster.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/test_cluster.py
@@ -545,3 +545,11 @@ def test_sigv4_authentication_signature(requests_mock, method, endpoint, data, h
         new_signature = new_signature_match.group(1)
 
         assert original_signature == new_signature, "Signatures do not match"
+
+
+def test_call_api_with_head_method(requests_mock):
+    cluster = create_valid_cluster(auth_type=AuthMethod.NO_AUTH)
+    requests_mock.head(f"{cluster.endpoint}/test_api")
+
+    response = clusters_.call_api(cluster, '/test_api', HttpMethod.HEAD)
+    assert response.status_code == 200


### PR DESCRIPTION
### Description
@AndreKurait reported that `console clusters curl` throws `Error: Invalid value for '-X' / '--request': 'HEAD' is not one of 'GET', 'POST', 'PUT', 'DELETE'` for an attempted HEAD request.

This adds it as a valid HTTP method and verifies that.

### Issues Resolved
n/a

### Testing
Added two unit tests to verify behavior at the cluster model and the CLI level.

### Check List
- [x] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
