### PR TITLE
Expand suppression rules in the capture proxy

### DIFF
--- a/TrafficCapture/nettyWireLogging/src/main/java/org/opensearch/migrations/trafficcapture/netty/HeaderValueFilteringCapturePredicate.java
+++ b/TrafficCapture/nettyWireLogging/src/main/java/org/opensearch/migrations/trafficcapture/netty/HeaderValueFilteringCapturePredicate.java
@@ -2,31 +2,63 @@ package org.opensearch.migrations.trafficcapture.netty;
 
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Supplier;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import io.netty.handler.codec.http.HttpRequest;
+import lombok.Builder;
 
 public class HeaderValueFilteringCapturePredicate extends RequestCapturePredicate {
+    private final Pattern method;
+    private final Pattern path;
+    private final Pattern protocol;
+    private final Pattern firstLinePattern;
     private final Map<String, Pattern> headerToPredicateRegexMap;
 
-    public HeaderValueFilteringCapturePredicate(Map<String, String> suppressCaptureHeaderPairs) {
-        super(
-            new PassThruHttpHeaders.HttpHeadersToPreserve(suppressCaptureHeaderPairs.keySet().toArray(String[]::new))
-        );
-        headerToPredicateRegexMap = suppressCaptureHeaderPairs.entrySet()
-            .stream()
-            .collect(Collectors.toMap(Map.Entry::getKey, kvp -> Pattern.compile(kvp.getValue())));
+    @Builder
+    public HeaderValueFilteringCapturePredicate(String methodPattern,
+                                                String pathPattern,
+                                                String protocolPattern,
+                                                String firstLinePattern,
+                                                Map<String, String> suppressCaptureHeaderPairs) {
+        super(new PassThruHttpHeaders.HttpHeadersToPreserve(
+            Optional.ofNullable(suppressCaptureHeaderPairs)
+                .map(m->m.keySet().toArray(String[]::new))
+                .orElse(null)
+            ));
+        this.method               = methodPattern == null   ? null : Pattern.compile(methodPattern);
+        this.path                 = pathPattern == null     ? null : Pattern.compile(pathPattern);
+        this.protocol             = protocolPattern == null ? null : Pattern.compile(protocolPattern);
+        this.firstLinePattern     = firstLinePattern == null ? null : Pattern.compile(firstLinePattern);
+        headerToPredicateRegexMap = suppressCaptureHeaderPairs == null ? null :
+            suppressCaptureHeaderPairs.entrySet().stream()
+                .collect(Collectors.toMap(Map.Entry::getKey, kvp -> Pattern.compile(kvp.getValue())));
     }
 
     @Override
     public CaptureDirective apply(HttpRequest request) {
-        return headerToPredicateRegexMap.entrySet()
-            .stream()
-            .anyMatch(
-                kvp -> Optional.ofNullable(request.headers().get(kvp.getKey()))
-                    .map(v -> kvp.getValue().matcher(v).matches())
-                    .orElse(false)
-            ) ? CaptureDirective.DROP : CaptureDirective.CAPTURE;
+        return
+            patternMatches(method,           () -> request.method().name()) ||
+            patternMatches(path,             request::uri) ||
+            patternMatches(protocol,         () -> request.protocolVersion().text()) ||
+            patternMatches(firstLinePattern, () -> request.method().name()+" "+request.uri()) ||
+            headersMatch(request) ?
+                CaptureDirective.DROP : CaptureDirective.CAPTURE;
+    }
+
+    private static boolean patternMatches(Pattern pattern, Supplier<String> stringGetter) {
+        return Optional.ofNullable(pattern).map(p->p.matcher(stringGetter.get()).matches()).orElse(false);
+    }
+
+    private boolean headersMatch(HttpRequest request) {
+        return Optional.ofNullable(headerToPredicateRegexMap).map(m->m.entrySet()
+                .stream()
+                .anyMatch(
+                    kvp -> Optional.ofNullable(request.headers().get(kvp.getKey()))
+                        .map(v -> kvp.getValue().matcher(v).matches())
+                        .orElse(false)
+                ))
+            .orElse(false);
     }
 }

--- a/TrafficCapture/nettyWireLogging/src/main/java/org/opensearch/migrations/trafficcapture/netty/PassThruHttpHeaders.java
+++ b/TrafficCapture/nettyWireLogging/src/main/java/org/opensearch/migrations/trafficcapture/netty/PassThruHttpHeaders.java
@@ -1,6 +1,7 @@
 package org.opensearch.migrations.trafficcapture.netty;
 
 import java.util.Arrays;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 import io.netty.handler.codec.http.DefaultHttpHeaders;
@@ -26,7 +27,7 @@ public class PassThruHttpHeaders extends DefaultHttpHeaders {
                     HttpHeaderNames.CONTENT_TRANSFER_ENCODING.toString(),
                     HttpHeaderNames.TRAILER.toString()
                 ),
-                Arrays.stream(extraHeaderNames)
+                Optional.ofNullable(extraHeaderNames).stream().flatMap(Arrays::stream)
             ).forEach(h -> caseInsensitiveHeadersMap.add(h, ""));
         }
     }

--- a/TrafficCapture/nettyWireLogging/src/test/java/org/opensearch/migrations/trafficcapture/netty/ConditionallyReliableLoggingHttpHandlerTest.java
+++ b/TrafficCapture/nettyWireLogging/src/test/java/org/opensearch/migrations/trafficcapture/netty/ConditionallyReliableLoggingHttpHandlerTest.java
@@ -147,7 +147,9 @@ public class ConditionallyReliableLoggingHttpHandlerTest {
             var streamMgr = new TestStreamManager();
             var offloader = new StreamChannelConnectionCaptureSerializer("Test", "connection", streamMgr);
 
-            var headerCapturePredicate = new HeaderValueFilteringCapturePredicate(Map.of("user-Agent", "uploader"));
+
+            var headerCapturePredicate = HeaderValueFilteringCapturePredicate.builder()
+                .suppressCaptureHeaderPairs(Map.of("user-Agent", "uploader")).build();
             EmbeddedChannel channel = new EmbeddedChannel(
                 new ConditionallyReliableLoggingHttpHandler(
                     rootInstrumenter,
@@ -185,7 +187,8 @@ public class ConditionallyReliableLoggingHttpHandlerTest {
             var streamMgr = new TestStreamManager();
             var offloader = new StreamChannelConnectionCaptureSerializer("Test", "connection", streamMgr);
 
-            var headerCapturePredicate = new HeaderValueFilteringCapturePredicate(Map.of("user-Agent", ".*uploader.*"));
+            var headerCapturePredicate = HeaderValueFilteringCapturePredicate.builder()
+                .suppressCaptureHeaderPairs(Map.of("user-Agent", ".*uploader.*")).build();
             EmbeddedChannel channel = new EmbeddedChannel(
                 new ConditionallyReliableLoggingHttpHandler(
                     rootInstrumenter,

--- a/TrafficCapture/nettyWireLogging/src/test/java/org/opensearch/migrations/trafficcapture/netty/HeaderValueFilteringCapturePredicateTest.java
+++ b/TrafficCapture/nettyWireLogging/src/test/java/org/opensearch/migrations/trafficcapture/netty/HeaderValueFilteringCapturePredicateTest.java
@@ -1,0 +1,49 @@
+package org.opensearch.migrations.trafficcapture.netty;
+
+import java.util.function.Consumer;
+
+import io.netty.handler.codec.http.DefaultHttpHeaders;
+import io.netty.handler.codec.http.DefaultHttpRequest;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpVersion;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class HeaderValueFilteringCapturePredicateTest {
+    @Test
+    public void suppresses() {
+        var req = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/thing1/andThenSome", new DefaultHttpHeaders());
+        Assertions.assertEquals(RequestCapturePredicate.CaptureDirective.DROP,
+            build(b->b.methodPattern("GET")).apply(req));
+        Assertions.assertEquals(RequestCapturePredicate.CaptureDirective.CAPTURE,
+            build(b->b.methodPattern("POST")).apply(req));
+
+        Assertions.assertEquals(RequestCapturePredicate.CaptureDirective.DROP,
+            build(b->b.pathPattern("/.*")).apply(req));
+        Assertions.assertEquals(RequestCapturePredicate.CaptureDirective.DROP,
+            build(b->b.pathPattern("/thing1/.*")).apply(req));
+        Assertions.assertEquals(RequestCapturePredicate.CaptureDirective.CAPTURE,
+            build(b->b.pathPattern("/_cat")).apply(req));
+
+        Assertions.assertEquals(RequestCapturePredicate.CaptureDirective.DROP,
+            build(b->b.protocolPattern("HTTP/1\\.0")).apply(
+                new DefaultHttpRequest(HttpVersion.HTTP_1_0, HttpMethod.GET, "/", new DefaultHttpHeaders())
+            ));
+        Assertions.assertEquals(RequestCapturePredicate.CaptureDirective.CAPTURE,
+            build(b->b.protocolPattern("HTTP/1.0")).apply(req));
+
+        Assertions.assertEquals(RequestCapturePredicate.CaptureDirective.DROP,
+            build(b->b.firstLinePattern("GET /thing.*")).apply(req));
+        Assertions.assertEquals(RequestCapturePredicate.CaptureDirective.CAPTURE,
+            build(b->b.firstLinePattern("POST /thing/.*")).apply(req));
+    }
+
+    private static HeaderValueFilteringCapturePredicate
+    build(Consumer<HeaderValueFilteringCapturePredicate.HeaderValueFilteringCapturePredicateBuilder> filler) {
+        var b = HeaderValueFilteringCapturePredicate.builder();
+        filler.accept(b);
+        return b.build();
+    }
+}

--- a/TrafficCapture/trafficCaptureProxyServer/src/main/java/org/opensearch/migrations/trafficcapture/proxyserver/CaptureProxy.java
+++ b/TrafficCapture/trafficCaptureProxyServer/src/main/java/org/opensearch/migrations/trafficcapture/proxyserver/CaptureProxy.java
@@ -172,6 +172,29 @@ public class CaptureProxy {
                 + "pattern.  When the incoming request has a header that matches the regex, it will be passed "
                 + "through to the service but will NOT be captured.  E.g. user-agent 'healthcheck'.")
         public List<String> suppressCaptureHeaderPairs = new ArrayList<>();
+        @Parameter(required = false,
+            names = "--suppressCaptureForMethod",
+            arity = 1,
+            description = "The regex pattern to test against the METHOD value of the incoming HTTP request.  "
+                + "When the incoming request has the method that matches the regex, it will be passed "
+                + "through to the service but will NOT be captured.  " +
+                "E.g. 'GET' to ignore capturing all non-mutating traffic.")
+        public String suppressMethod;
+        @Parameter(required = false,
+            names = "--suppressCaptureForUriPath",
+            description = "The regex pattern to test against the PATH value of the incoming HTTP request.  "
+                + "When the incoming request has a path that matches the regex, it will be passed "
+                + "through to the service but will NOT be captured.  " +
+                "E.g. '/_cat/*' to ignore capturing all non-mutating traffic.")
+        public String suppressUriPath;
+        @Parameter(required = false,
+            names = "--suppressCaptureForUriPath",
+            description = "The regex pattern to test against the first line of the incoming HTTP request.  "
+                + "When the incoming request has a METHOD and PATH that matches the regex, it will be passed "
+                + "through to the service but will NOT be captured.  " +
+                "E.g. '(.* /ephemeral/*|GET /_cat/.*)' to ignore capturing all traffic for '/ephemeral' AND " +
+                "all GET requests to /_cat/.*")
+        public String suppressStartLine;
     }
 
     static Parameters parseArgs(String[] args) {
@@ -408,9 +431,13 @@ public class CaptureProxy {
                     throw Lombok.sneakyThrow(e);
                 }
             }).orElse(null);
-            var headerCapturePredicate = new HeaderValueFilteringCapturePredicate(
-                convertPairListToMap(params.suppressCaptureHeaderPairs)
-            );
+            var headerCapturePredicate = HeaderValueFilteringCapturePredicate.builder()
+                .methodPattern(params.suppressMethod)
+                .pathPattern(params.suppressUriPath)
+                .firstLinePattern(params.suppressStartLine)
+                .protocolPattern("HTTP/2.*")
+                .suppressCaptureHeaderPairs(convertPairListToMap(params.suppressCaptureHeaderPairs))
+                .build();
             var proxyChannelInitializer =
                 buildProxyChannelInitializer(ctx, backsideConnectionPool, sslEngineSupplier, headerCapturePredicate,
                     params.headerOverrides, getConnectionCaptureFactory(params, ctx));


### PR DESCRIPTION
### Description

Expand suppression rules in the capture proxy to include matching the method, uri, and any combination of those (first line).

Protocol== HTTP/2.* will also be suppressed, but that isn't a command line option for the proxy, all of the other ones are. If ANY of those MATCH, then the request is NOT captured, that's the reason that firstline is its own option.

### Issues Resolved

### Testing


### Check List
- [ ] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
