### PR TITLE
Refactor hard-coded snapshot repo name to be provided

### DIFF
--- a/CreateSnapshot/src/main/java/org/opensearch/migrations/CreateSnapshot.java
+++ b/CreateSnapshot/src/main/java/org/opensearch/migrations/CreateSnapshot.java
@@ -41,6 +41,12 @@ public class CreateSnapshot {
         public String snapshotName;
 
         @Parameter(
+                names = { "--snapshot-repo-name" },
+                required = true,
+                description = "The name of the snapshot repository")
+        public String snapshotRepoName;
+
+        @Parameter(
                 names = {"--file-system-repo-path" },
                 required = false,
                 description = "The full path to the snapshot repo on the file system.")
@@ -141,6 +147,7 @@ public class CreateSnapshot {
         if (arguments.fileSystemRepoPath != null) {
             snapshotCreator = new FileSystemSnapshotCreator(
                     arguments.snapshotName,
+                    arguments.snapshotRepoName,
                     client,
                     arguments.fileSystemRepoPath,
                     arguments.indexAllowlist,
@@ -149,6 +156,7 @@ public class CreateSnapshot {
         } else {
             snapshotCreator = new S3SnapshotCreator(
                 arguments.snapshotName,
+                arguments.snapshotRepoName,
                 client,
                 arguments.s3RepoUri,
                 arguments.s3Region,

--- a/DocumentsFromSnapshotMigration/src/test/java/org/opensearch/migrations/bulkload/EndToEndTest.java
+++ b/DocumentsFromSnapshotMigration/src/test/java/org/opensearch/migrations/bulkload/EndToEndTest.java
@@ -111,6 +111,7 @@ public class EndToEndTest extends SourceTestBase {
 
             // === ACTION: Take a snapshot ===
             var snapshotName = "my_snap";
+            var snapshotRepoName = "my_snap_repo";
             var sourceClientFactory = new OpenSearchClientFactory(ConnectionContextTestParams.builder()
                     .host(sourceCluster.getUrl())
                     .insecure(true)
@@ -119,6 +120,7 @@ public class EndToEndTest extends SourceTestBase {
             var sourceClient = sourceClientFactory.determineVersionAndCreate();
             var snapshotCreator = new FileSystemSnapshotCreator(
                 snapshotName,
+                snapshotRepoName,
                 sourceClient,
                 SearchClusterContainer.CLUSTER_SNAPSHOT_DIR,
                 List.of(),

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/common/FileSystemSnapshotCreator.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/common/FileSystemSnapshotCreator.java
@@ -14,12 +14,13 @@ public class FileSystemSnapshotCreator extends SnapshotCreator {
 
     public FileSystemSnapshotCreator(
         String snapshotName,
+        String snapshotRepoName,
         OpenSearchClient client,
         String snapshotRepoDirectoryPath,
         List<String> indexAllowlist,
         IRfsContexts.ICreateSnapshotContext context
     ) {
-        super(snapshotName, indexAllowlist, client, context);
+        super(snapshotName, snapshotRepoName, indexAllowlist, client, context);
         this.snapshotRepoDirectoryPath = snapshotRepoDirectoryPath;
     }
 

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/common/S3SnapshotCreator.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/common/S3SnapshotCreator.java
@@ -17,17 +17,19 @@ public class S3SnapshotCreator extends SnapshotCreator {
 
     public S3SnapshotCreator(
         String snapshotName,
+        String snapshotRepoName,
         OpenSearchClient client,
         String s3Uri,
         String s3Region,
         List<String> indexAllowlist,
         IRfsContexts.ICreateSnapshotContext context
     ) {
-        this(snapshotName, client, s3Uri, s3Region, indexAllowlist, null, null, context);
+        this(snapshotName, snapshotRepoName, client, s3Uri, s3Region, indexAllowlist, null, null, context);
     }
 
     public S3SnapshotCreator(
         String snapshotName,
+        String snapshotRepoName,
         OpenSearchClient client,
         String s3Uri,
         String s3Region,
@@ -36,7 +38,7 @@ public class S3SnapshotCreator extends SnapshotCreator {
         String snapshotRoleArn,
         IRfsContexts.ICreateSnapshotContext context
     ) {
-        super(snapshotName, indexAllowlist, client, context);
+        super(snapshotName, snapshotRepoName, indexAllowlist, client, context);
         this.s3Uri = s3Uri;
         this.s3Region = s3Region;
         this.maxSnapshotRateMBPerNode = maxSnapshotRateMBPerNode;

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/README.md
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/README.md
@@ -75,6 +75,7 @@ replay:
     service-name: "migrations-dev-replayer-service"
 snapshot:
   snapshot_name: "snapshot_2023_01_01"
+  snapshot_repo_name: "my-snapshot-repo"
   s3:
       repo_uri: "s3://my-snapshot-bucket"
       aws_region: "us-east-2"
@@ -200,6 +201,7 @@ backfill:
 The snapshot configuration specifies a local filesystem or an s3 snapshot that will be created by the `snapshot create` command, and (if not overridden) used as the source for the `metadata migrate` command. In a docker migration, it may also be used as the source for backfill via reindex-from-snapshot. If metadata migration and reindex-from-snapshot are not being used, this block is optional.
 
 - `snapshot_name`: required, name of the snapshot
+- `snapshot_repo_name`: optional, name of the snapshot repository
 
 Exactly one of the following blocks must be present:
 

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/cli.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/cli.py
@@ -276,7 +276,6 @@ def unregister_snapshot_repo_cmd(ctx, acknowledge_risk: bool):
         if not confirmed:
             click.echo("Aborting the command to remove snapshot repository.")
             return
-    #_external_snapshots_check(ctx.env.snapshot)
     logger.info("Removing snapshot repository")
     result = snapshot_.delete_snapshot_repo(ctx.env.snapshot)
     click.echo(result.value)

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/cli.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/cli.py
@@ -15,7 +15,7 @@ import console_link.middleware.tuples as tuples_
 
 from console_link.models.cluster import HttpMethod
 from console_link.models.backfill_rfs import RfsWorkersInProgress, WorkingIndexDoesntExist
-from console_link.models.utils import ExitCode
+from console_link.models.utils import DEFAULT_SNAPSHOT_REPO_NAME, ExitCode
 from console_link.environment import Environment
 from console_link.models.metrics_source import Component, MetricStatistic
 from click.shell_completion import get_completion_class
@@ -201,6 +201,13 @@ def cluster_curl_cmd(ctx, cluster, path, request, header, data, json_data):
 # ##################### SNAPSHOT ###################
 
 
+def _external_snapshots_check(snapshot):
+    if snapshot.snapshot_repo_name != DEFAULT_SNAPSHOT_REPO_NAME:
+        logger.warning(f"External snapshot detected, normally snapshot commands are not necessary for external "
+                       f"snapshots. The snapshot repository: '{snapshot.snapshot_repo_name}' must belong to "
+                       f"the source cluster as snapshot commands will perform requests to the source cluster")
+
+
 @cli.group(name="snapshot",
            help="Commands to create and check status of snapshots of the source cluster.")
 @click.pass_obj
@@ -208,6 +215,9 @@ def snapshot_group(ctx):
     """All actions related to snapshot creation"""
     if ctx.env.snapshot is None:
         raise click.UsageError("Snapshot is not set")
+    if ctx.env.source_cluster is None:
+        raise click.UsageError("Snapshot commands require a source cluster to be defined")
+    _external_snapshots_check(ctx.env.snapshot)
 
 
 @snapshot_group.command(name="create", context_settings=dict(ignore_unknown_options=True))
@@ -266,6 +276,7 @@ def unregister_snapshot_repo_cmd(ctx, acknowledge_risk: bool):
         if not confirmed:
             click.echo("Aborting the command to remove snapshot repository.")
             return
+    #_external_snapshots_check(ctx.env.snapshot)
     logger.info("Removing snapshot repository")
     result = snapshot_.delete_snapshot_repo(ctx.env.snapshot)
     click.echo(result.value)

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/middleware/clusters.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/middleware/clusters.py
@@ -1,7 +1,7 @@
 from console_link.models.cluster import Cluster, HttpMethod
+from console_link.models.snapshot import Snapshot
 from dataclasses import dataclass
 import logging
-from requests.exceptions import HTTPError
 
 logger = logging.getLogger(__name__)
 
@@ -66,72 +66,8 @@ def clear_indices(cluster: Cluster):
         return f"Error encountered when clearing indices: {e}"
 
 
-def clear_cluster(cluster: Cluster):
+def clear_cluster(cluster: Cluster, snapshot: Snapshot = None):
     clear_indices(cluster)
-    clear_snapshots(cluster, 'migration_assistant_repo')
-    delete_repo(cluster, 'migration_assistant_repo')
-
-
-def clear_snapshots(cluster: Cluster, repository: str) -> None:
-    logger.info(f"Clearing snapshots from repository '{repository}'")
-    """
-    Clears all snapshots from the specified repository.
-
-    :param cluster: Cluster object to interact with the Elasticsearch cluster.
-    :param repository: Name of the snapshot repository to clear snapshots from.
-    :raises Exception: For general errors during snapshot clearing, except when the repository is missing.
-    """
-    try:
-        # List all snapshots in the repository
-        snapshots_path = f"/_snapshot/{repository}/_all"
-        response = call_api(cluster, snapshots_path, raise_error=True)
-        logger.debug(f"Raw response: {response.json()}")
-        snapshots = response.json().get("snapshots", [])
-        logger.info(f"Found {len(snapshots)} snapshots in repository '{repository}'.")
-
-        if not snapshots:
-            logger.info(f"No snapshots found in repository '{repository}'.")
-            return
-
-        # Delete each snapshot
-        for snapshot in snapshots:
-            snapshot_name = snapshot["snapshot"]
-            delete_path = f"/_snapshot/{repository}/{snapshot_name}"
-            call_api(cluster, delete_path, method=HttpMethod.DELETE, raise_error=True)
-            logger.info(f"Deleted snapshot: {snapshot_name} from repository '{repository}'.")
-
-    except Exception as e:
-        # Handle 404 errors specifically for missing repository
-        if isinstance(e, HTTPError) and e.response.status_code == 404:
-            error_details = e.response.json().get('error', {})
-            if error_details.get('type') == 'repository_missing_exception':
-                logger.info(f"Repository '{repository}' is missing. Skipping snapshot clearing.")
-                return
-        # Re-raise other errors
-        logger.error(f"Error clearing snapshots from repository '{repository}': {e}")
-        raise e
-
-
-def delete_repo(cluster: Cluster, repository: str) -> None:
-    logger.info(f"Deleting repository '{repository}'")
-    """
-    Delete repository. Should be empty before execution.
-
-    :param cluster: Cluster object to interact with the Elasticsearch cluster.
-    :param repository: Name of the snapshot repository to delete.
-    :raises Exception: For general errors during repository deleting, except when the repository is missing.
-    """
-    try:
-        delete_path = f"/_snapshot/{repository}"
-        call_api(cluster, delete_path, method=HttpMethod.DELETE, raise_error=True)
-        logger.info(f"Deleted repository: {repository}.")
-    except Exception as e:
-        # Handle 404 errors specifically for missing repository
-        if isinstance(e, HTTPError) and e.response.status_code == 404:
-            error_details = e.response.json().get('error', {})
-            if error_details.get('type') == 'repository_missing_exception':
-                logger.info(f"Repository '{repository}' is missing. Skipping delete.")
-                return
-        # Re-raise other errors
-        logger.error(f"Error deleting repository '{repository}': {e}")
-        raise e
+    if snapshot:
+        snapshot.delete_all_snapshots()
+        snapshot.delete_snapshot_repo()

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/snapshot.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/snapshot.py
@@ -2,7 +2,7 @@ import datetime
 import logging
 from abc import ABC, abstractmethod
 from requests.exceptions import HTTPError
-from typing import Dict, Optional
+from typing import Dict
 
 from cerberus import Validator
 from console_link.models.cluster import AuthMethod, Cluster, HttpMethod

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/snapshot.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/snapshot.py
@@ -9,6 +9,8 @@ from console_link.models.cluster import AuthMethod, Cluster, HttpMethod
 from console_link.models.command_result import CommandResult
 from console_link.models.command_runner import CommandRunner, CommandRunnerError, FlagOnlyArgument
 from console_link.models.schema_tools import contains_one_of
+from console_link.models.utils import DEFAULT_SNAPSHOT_REPO_NAME
+
 
 logger = logging.getLogger(__name__)
 
@@ -51,7 +53,7 @@ class Snapshot(ABC):
         if not v.validate({'snapshot': config}):
             raise ValueError("Invalid config file for snapshot", v.errors)
         self.snapshot_name = config['snapshot_name']
-        self.snapshot_repo_name = config.get("snapshot_repo_name", "migration_assistant_repo")
+        self.snapshot_repo_name = config.get("snapshot_repo_name", DEFAULT_SNAPSHOT_REPO_NAME)
         self.otel_endpoint = config.get("otel_endpoint", None)
 
     @abstractmethod

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/utils.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/utils.py
@@ -13,6 +13,9 @@ from urllib.parse import urlparse
 from console_link.models.client_options import ClientOptions
 
 
+DEFAULT_SNAPSHOT_REPO_NAME = "migration_assistant_repo"
+
+
 class DeploymentStatus(NamedTuple):
     running: int = 0
     pending: int = 0

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/services.yaml
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/services.yaml
@@ -21,6 +21,7 @@ replay:
   docker:
 snapshot:
   snapshot_name: "snapshot_2023_01_01"
+  snapshot_repo_name: "migration_assistant_repo"
   fs:
     repo_path: "/snapshot/test-console"
   otel_endpoint: "http://otel-collector:4317"

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/test_cli.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/test_cli.py
@@ -116,6 +116,30 @@ snapshot:
     assert result.exit_code == 1
     assert isinstance(result.exception, SystemExit)
 
+
+def test_cli_snapshot_when_source_cluster_not_defined_raises_error(runner, tmp_path):
+    no_source_cluster_with_snapshot = """
+target_cluster:
+  endpoint: "https://opensearchtarget:9200"
+  allow_insecure: true
+  basic_auth:
+    username: "admin"
+    password: "myStrongPassword123!"
+snapshot:
+  snapshot_name: "test_snapshot"
+  fs:
+    repo_path: "/snapshot/test-console"
+  otel_endpoint: "http://otel-collector:4317"
+  """
+    yaml_path = tmp_path / "services.yaml"
+    with open(yaml_path, 'w') as f:
+        f.write(no_source_cluster_with_snapshot)
+
+    result = runner.invoke(cli, ['--config-file', str(yaml_path), 'snapshot', 'create'],
+                           catch_exceptions=True)
+    assert result.exit_code == 2
+    assert "Snapshot commands require a source cluster to be defined" in result.output
+
 # The following tests are mostly smoke-tests with a goal of covering every CLI command and option.
 # They generally mock functions either at the logic or the model layer, though occasionally going all the way to
 # an external endpoint call.

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/test_metadata.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/test_metadata.py
@@ -395,8 +395,6 @@ def test_metadata_init_with_minimal_config_and_extra_args(mocker):
         "bazzy"  # Lone value, will be ignored
     ])
 
-    print(mock.call_args_list)
-
     mock.assert_called_once_with([
         '/root/metadataMigration/bin/MetadataMigration',
         "evaluate",

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/test_snapshot.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/test_snapshot.py
@@ -62,8 +62,10 @@ def test_snapshot_status(request, snapshot_fixture):
     assert isinstance(result, CommandResult)
     assert result.success
     assert result.value == "SUCCESS"
-    source_cluster.call_api.assert_called_once_with(f"/_snapshot/migration_assistant_repo/{snapshot.snapshot_name}",
-                                                    HttpMethod.GET)
+    source_cluster.call_api.assert_called_once_with(
+        f"/_snapshot/{snapshot.snapshot_repo_name}/{snapshot.snapshot_name}",
+        HttpMethod.GET
+    )
 
 
 @pytest.mark.parametrize("snapshot_fixture", ['s3_snapshot', 'fs_snapshot'])
@@ -120,8 +122,10 @@ def test_snapshot_status_full(request, snapshot_fixture):
 
     assert "N/A" not in result.value
 
-    source_cluster.call_api.assert_called_with(f"/_snapshot/migration_assistant_repo/{snapshot.snapshot_name}/_status",
-                                               HttpMethod.GET)
+    source_cluster.call_api.assert_called_with(
+        f"/_snapshot/{snapshot.snapshot_repo_name}/{snapshot.snapshot_name}/_status",
+        HttpMethod.GET
+    )
 
 
 def test_s3_snapshot_init_succeeds():
@@ -432,7 +436,7 @@ def test_snapshot_delete(request, snapshot_fixture):
     source_cluster = snapshot.source_cluster
     snapshot.delete()
     source_cluster.call_api.assert_called_once()
-    source_cluster.call_api.assert_called_with(f"/_snapshot/migration_assistant_repo/{snapshot.snapshot_name}",
+    source_cluster.call_api.assert_called_with(f"/_snapshot/{snapshot.snapshot_repo_name}/{snapshot.snapshot_name}",
                                                HttpMethod.DELETE)
 
 
@@ -445,8 +449,8 @@ def test_snapshot_delete_all_snapshots(request, snapshot_fixture):
     snapshot.delete_all_snapshots()
     source_cluster.call_api.assert_called()
     source_cluster.call_api.assert_has_calls([
-        mock.call('/_snapshot/migration_assistant_repo/_all', raise_error=True),
-        mock.call('/_snapshot/migration_assistant_repo/test_snapshot', HttpMethod.DELETE),
+        mock.call(f'/_snapshot/{snapshot.snapshot_repo_name}/_all', raise_error=True),
+        mock.call(f'/_snapshot/{snapshot.snapshot_repo_name}/test_snapshot', HttpMethod.DELETE),
     ])
 
 
@@ -456,7 +460,7 @@ def test_snapshot_delete_repo(request, snapshot_fixture):
     source_cluster = snapshot.source_cluster
     snapshot.delete_snapshot_repo()
     source_cluster.call_api.assert_called_once()
-    source_cluster.call_api.assert_called_with("/_snapshot/migration_assistant_repo",
+    source_cluster.call_api.assert_called_with(f"/_snapshot/{snapshot.snapshot_repo_name}",
                                                method=HttpMethod.DELETE,
                                                raise_error=True)
 

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/test_snapshot_cleanup.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/test_snapshot_cleanup.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock
 
 from console_link.models.cluster import Cluster
 from console_link.models.snapshot import S3Snapshot
+from console_link.models.utils import DEFAULT_SNAPSHOT_REPO_NAME
 import requests
 import logging
 
@@ -24,7 +25,7 @@ def mock_cluster_with_missing_repo(mocker):
         json_data={
             'error': {
                 'type': 'repository_missing_exception',
-                'reason': '[migration_assistant_repo] missing'
+                'reason': f'[{DEFAULT_SNAPSHOT_REPO_NAME}] missing'
             }
         }
     )
@@ -88,5 +89,5 @@ def test_delete_all_snapshots_success(mock_cluster_with_snapshots, caplog):
     snapshot = S3Snapshot(config=config["snapshot"], source_cluster=mock_cluster_with_snapshots)
     with caplog.at_level(logging.INFO, logger='console_link.models.snapshot'):
         snapshot.delete_all_snapshots(cluster=mock_cluster_with_snapshots, repository=snapshot.snapshot_repo_name)
-        assert "Deleted snapshot: snapshot_1 from repository 'migration_assistant_repo'." in caplog.text
-        assert "Deleted snapshot: snapshot_2 from repository 'migration_assistant_repo'." in caplog.text
+        assert f"Deleted snapshot: snapshot_1 from repository '{snapshot.snapshot_repo_name}'." in caplog.text
+        assert f"Deleted snapshot: snapshot_2 from repository '{snapshot.snapshot_repo_name}'." in caplog.text

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/test_snapshot_cleanup.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/test_snapshot_cleanup.py
@@ -56,12 +56,12 @@ def mock_cluster_with_snapshots(mocker):
     return cluster
 
 
-
 def test_delete_all_snapshots_repository_missing(mock_cluster_with_missing_repo, caplog):
     config = {
         "snapshot": {
             "otel_endpoint": "http://otel:1111",
             "snapshot_name": "reindex_from_snapshot",
+            "snapshot_repo_name": "test-repo",
             "s3": {
                 "repo_uri": "s3://my-bucket",
                 "aws_region": "us-east-1"
@@ -71,7 +71,7 @@ def test_delete_all_snapshots_repository_missing(mock_cluster_with_missing_repo,
     snapshot = S3Snapshot(config=config["snapshot"], source_cluster=mock_cluster_with_missing_repo)
     with caplog.at_level(logging.INFO, logger='console_link.models.snapshot'):
         snapshot.delete_all_snapshots(cluster=mock_cluster_with_missing_repo, repository=snapshot.snapshot_repo_name)
-        assert "Repository 'migration_assistant_repo' is missing. Skipping snapshot clearing." in caplog.text
+        assert "Repository 'test-repo' is missing. Skipping snapshot clearing." in caplog.text
 
 
 def test_delete_all_snapshots_success(mock_cluster_with_snapshots, caplog):

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/test_source_cluster_multiversion.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/test_source_cluster_multiversion.py
@@ -9,6 +9,7 @@ import pytest
 
 from console_link.environment import Environment
 from console_link.models.cluster import Cluster, HttpMethod
+from console_link.models.utils import DEFAULT_SNAPSHOT_REPO_NAME
 from tests.search_containers import SearchContainer, Version, CLUSTER_SNAPSHOT_DIR
 import console_link.middleware.clusters as clusters_
 import console_link.middleware.snapshot as snapshot_
@@ -46,10 +47,10 @@ def seed_data_with_types(cluster: Cluster, doc_count):
 
 def setup_snapshot_repo_and_snapshot(cluster: Cluster):
     # Register repo
-    cluster.call_api("/_snapshot/migration_assistant_repo", HttpMethod.PUT,
+    cluster.call_api(f"/_snapshot/{DEFAULT_SNAPSHOT_REPO_NAME}", HttpMethod.PUT,
                      data=json.dumps({"type": "fs", "settings": {"location": CLUSTER_SNAPSHOT_DIR}}),
                      headers={"Content-Type": "application/json"})
-    cluster.call_api(f"/_snapshot/migration_assistant_repo/{SNAPSHOT_NAME}", HttpMethod.POST)
+    cluster.call_api(f"/_snapshot/{DEFAULT_SNAPSHOT_REPO_NAME}/{SNAPSHOT_NAME}", HttpMethod.POST)
 
 
 @pytest.fixture()

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/integ_test/integ_test/backfill_tests.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/integ_test/integ_test/backfill_tests.py
@@ -7,6 +7,7 @@ from console_link.models.cluster import Cluster
 from console_link.models.backfill_base import Backfill
 from console_link.models.command_result import CommandResult
 from console_link.models.metadata import Metadata
+from console_link.models.snapshot import Snapshot
 from console_link.cli import Context
 from .common_utils import EXPECTED_BENCHMARK_DOCS
 from .default_operations import DefaultOperationsLibrary
@@ -15,7 +16,7 @@ logger = logging.getLogger(__name__)
 ops = DefaultOperationsLibrary()
 
 
-def preload_data(source_cluster: Cluster, target_cluster: Cluster):
+def preload_data(source_cluster: Cluster, target_cluster: Cluster, snapshot: Snapshot):
     # Confirm source and target connection
     source_con_result: ConnectionResult = connection_check(source_cluster)
     assert source_con_result.connection_established is True
@@ -23,7 +24,7 @@ def preload_data(source_cluster: Cluster, target_cluster: Cluster):
     assert target_con_result.connection_established is True
 
     # Clear all data from clusters
-    clear_cluster(source_cluster)
+    clear_cluster(source_cluster, snapshot)
     clear_cluster(target_cluster)
 
     # Preload data that test cases will verify is migrated
@@ -45,7 +46,8 @@ def setup_backfill(request):
     pytest.console_env = Context(config_path).env
     pytest.unique_id = unique_id
     preload_data(source_cluster=pytest.console_env.source_cluster,
-                 target_cluster=pytest.console_env.target_cluster)
+                 target_cluster=pytest.console_env.target_cluster,
+                 snapshot=pytest.console_env.snapshot)
     backfill: Backfill = pytest.console_env.backfill
     assert backfill is not None
     metadata: Metadata = pytest.console_env.metadata

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/integ_test/integ_test/full_tests.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/integ_test/integ_test/full_tests.py
@@ -50,6 +50,8 @@ def initialize(request):
     replayer: Replayer = pytest.console_env.replay
     assert replayer is not None
     kafka: Kafka = pytest.console_env.kafka
+    snapshot: Snapshot = pytest.console_env.snapshot
+    assert snapshot is not None
 
     # Confirm source and target connection
     source_con_result: ConnectionResult = connection_check(source_cluster)
@@ -58,7 +60,7 @@ def initialize(request):
     assert target_con_result.connection_established is True
 
     # Clear Cluster
-    clear_cluster(source_cluster)
+    clear_cluster(source_cluster, snapshot)
     clear_cluster(target_cluster)
 
     # Delete existing Kafka topic to clear records

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/integ_test/integ_test/ma_workflow_test.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/integ_test/integ_test/ma_workflow_test.py
@@ -21,6 +21,7 @@ def setup_and_teardown(request, test_cases: List[MATestBase]):
     test_case = test_cases[0]
     source_cluster = test_case.source_cluster
     target_cluster = test_case.target_cluster
+    snapshot = test_case.snapshot
     source_con_result: ConnectionResult = connection_check(source_cluster)
     assert source_con_result.connection_established is True
     target_con_result: ConnectionResult = connection_check(target_cluster)
@@ -35,7 +36,7 @@ def setup_and_teardown(request, test_cases: List[MATestBase]):
         logger.info("No transformation files detected to cleanup")
 
     # Clear cluster data
-    clear_cluster(source_cluster)
+    clear_cluster(source_cluster, snapshot)
     clear_indices(target_cluster)
     test_case.target_operations.clear_index_templates(cluster=target_cluster)
 

--- a/deployment/cdk/opensearch-service-migration/lib/common-utilities.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/common-utilities.ts
@@ -469,18 +469,16 @@ export function parseClusterDefinition(json: any): ClusterYaml {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function parseSnapshotDefinition(json: any): SnapshotYaml {
     const snapshotName = json.snapshotName
+    const snapshotRepoName = json.snapshotRepoName
     const s3Region = json.s3Region
     const s3Uri = json.s3Uri
-    if (!snapshotName || !s3Region || !s3Uri) {
-        throw new Error('Missing at least one of the required snapshot fields: snapshotName, s3Region, s3Uri');
+    if (!snapshotName || !snapshotRepoName || !s3Region || !s3Uri) {
+        throw new Error('Missing at least one of the required snapshot fields: snapshotName, snapshotRepoName, s3Region, s3Uri');
     }
-    const snapshotRepoName = json.snapshotRepoName
     const snapshotYaml = new SnapshotYaml()
     snapshotYaml.snapshot_name = snapshotName
+    snapshotYaml.snapshot_repo_name = snapshotRepoName
     snapshotYaml.s3 = {repo_uri: s3Uri, aws_region: s3Region}
-    if (snapshotRepoName) {
-        snapshotYaml.snapshot_repo_name = snapshotRepoName
-    }
     return snapshotYaml
 }
 

--- a/deployment/cdk/opensearch-service-migration/lib/common-utilities.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/common-utilities.ts
@@ -474,9 +474,13 @@ export function parseSnapshotDefinition(json: any): SnapshotYaml {
     if (!snapshotName || !s3Region || !s3Uri) {
         throw new Error('Missing at least one of the required snapshot fields: snapshotName, s3Region, s3Uri');
     }
+    const snapshotRepoName = json.snapshotRepoName
     const snapshotYaml = new SnapshotYaml()
     snapshotYaml.snapshot_name = snapshotName
     snapshotYaml.s3 = {repo_uri: s3Uri, aws_region: s3Region}
+    if (snapshotRepoName) {
+        snapshotYaml.snapshot_repo_name = snapshotRepoName
+    }
     return snapshotYaml
 }
 

--- a/deployment/cdk/opensearch-service-migration/lib/migration-services-yaml.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/migration-services-yaml.ts
@@ -89,6 +89,7 @@ export class S3SnapshotYaml {
 export class SnapshotYaml {
     snapshot_name = '';
     otel_endpoint = '';
+    snapshot_repo_name? = '';
     s3?: S3SnapshotYaml;
     fs?: FileSystemSnapshotYaml;
 
@@ -96,6 +97,8 @@ export class SnapshotYaml {
         return {
             snapshot_name: this.snapshot_name,
             otel_endpoint: this.otel_endpoint,
+            // TODO check this is valid
+            snapshot_repo_name: this.snapshot_repo_name,
             // This conditinally includes the s3 and fs parameters if they're defined,
             // but does not add the keys otherwise
             ...(this.s3 && { s3: this.s3 }),

--- a/deployment/cdk/opensearch-service-migration/lib/migration-services-yaml.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/migration-services-yaml.ts
@@ -89,7 +89,7 @@ export class S3SnapshotYaml {
 export class SnapshotYaml {
     snapshot_name = '';
     otel_endpoint = '';
-    snapshot_repo_name? = '';
+    snapshot_repo_name = '';
     s3?: S3SnapshotYaml;
     fs?: FileSystemSnapshotYaml;
 
@@ -97,7 +97,6 @@ export class SnapshotYaml {
         return {
             snapshot_name: this.snapshot_name,
             otel_endpoint: this.otel_endpoint,
-            // TODO check this is valid
             snapshot_repo_name: this.snapshot_repo_name,
             // This conditinally includes the s3 and fs parameters if they're defined,
             // but does not add the keys otherwise

--- a/deployment/cdk/opensearch-service-migration/lib/stack-composer.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/stack-composer.ts
@@ -393,6 +393,7 @@ export class StackComposer {
         } else {
             snapshotYaml = new SnapshotYaml();
             snapshotYaml.snapshot_name = "rfs-snapshot"
+            snapshotYaml.snapshot_repo_name = "migration_assistant_repo"
         }
         servicesYaml.snapshot = snapshotYaml
 

--- a/deployment/cdk/opensearch-service-migration/options.md
+++ b/deployment/cdk/opensearch-service-migration/options.md
@@ -51,9 +51,9 @@ In all other cases, the required components of each cluster object are:
 
 ### Snapshot Definition Options
 
-| Name     | Type   | Example                                                                                                                          | Description                                                                                        |
-|----------|--------|----------------------------------------------------------------------------------------------------------------------------------|:---------------------------------------------------------------------------------------------------|
-| snapshot | object | {"snapshotName": "test-snapshot", "s3Uri": "s3://snapshot-bucket-123456789012-us-east-2/snapshot-repo", "s3Region": "us-east-2"} | A json object for defining the details of an existing S3 snapshot. See below for detailed options. |
+| Name     | Type   | Example                                                                                                                                                                    | Description                                                                                        |
+|----------|--------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:---------------------------------------------------------------------------------------------------|
+| snapshot | object | {"snapshotName": "test-snapshot", "snapshotRepoName": "test-snapshot-repo", "s3Uri": "s3://snapshot-bucket-123456789012-us-east-2/snapshot-repo", "s3Region": "us-east-2"} | A json object for defining the details of an existing S3 snapshot. See below for detailed options. |
 
 #### Structure of the snapshot object
 
@@ -62,6 +62,7 @@ A snapshot should only be configured when the user has an existing snapshot they
 In such case, the required fields in the snapshot object are:
 
 - `snapshotName` -- the name of the existing snapshot that was created
+- `snapshotRepoName` -- the name of the existing snapshot repository that contains the given `snapshotName`
 - `s3Uri` -- the `s3://` URI path to where the snapshot repo exists in the given S3 bucket
 - `s3Region` -- the region where the S3 bucket is located
 

--- a/deployment/cdk/opensearch-service-migration/test/reindex-from-snapshot-stack.test.ts
+++ b/deployment/cdk/opensearch-service-migration/test/reindex-from-snapshot-stack.test.ts
@@ -227,6 +227,7 @@ describe('ReindexFromSnapshotStack Tests', () => {
       },
       snapshot: {
         "snapshotName": "test-snapshot",
+        "snapshotRepoName": "test-repo",
         "s3Uri": "s3://snapshot-bucket-123456789012-us-east-2/snapshot-repo",
         "s3Region": "us-east-2"
       },


### PR DESCRIPTION
### Description
This change refactors out the hardcoded snapshot repository name found in several places in our code base and allows passing this name. This allows our migration console to be more customizable when it comes to creating a snapshot or performing operations such as checking the status of an external snapshot.

Also included is some refactoring of some disjoint snapshot logic in the console library to be contained within the snapshot class

- Documentation site update: https://github.com/opensearch-project/documentation-website/pull/9721

### ~~TODO:~~
~~Test with BYOS in cloud~~
~~Fix gradle tests~~
~~Update to documentation website~~

### Issues Resolved
https://opensearch.atlassian.net/browse/MIGRATIONS-2471

### Testing
Unit tests, cloud testing

### Check List
- [x] New functionality includes testing
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
