### PR TITLE
Metadata better handle null exception messages

### DIFF
--- a/MetadataMigration/src/main/java/org/opensearch/migrations/cli/Items.java
+++ b/MetadataMigration/src/main/java/org/opensearch/migrations/cli/Items.java
@@ -85,7 +85,10 @@ public class Items {
         }
     }
 
-    private String failureMessage(CreationResult result){
+    private String failureMessage(CreationResult result) {
+        if (result.getFailureType() == null) {
+            return "";
+        }
         var sb = new StringBuilder()
             .append(result.getFailureType().isFatal() ? "ERROR" : "WARN")
             .append(" - ")
@@ -93,8 +96,12 @@ public class Items {
             .append(" ")
             .append(result.getFailureType().getMessage());
 
-        if (result.getFailureType().isFatal()) {
-            sb.append(": " + result.getException().getMessage());
+        if (result.getFailureType().isFatal() && result.getException() != null) {
+            // There might not be an message in the exception, if so fallback to the toString of the exception.  
+            var exceptionDetail = result.getException().getMessage() != null
+                ? result.getException().getMessage()
+                : result.getException().toString();
+            sb.append(": " + exceptionDetail);
         }
 
         return sb.toString();


### PR DESCRIPTION
### Description
It was possible to have a null exception or a null message that would case error printing to thrown an exception - and not have context on what the source of the failure was.  Fixing an issue reported by a customer.

### Check List
- [X] New functionality includes testing
- [ ] ~Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
