### PR TITLE
Update capture-replay-dashboard with rename

### DIFF
--- a/deployment/cdk/opensearch-service-migration/lib/components/capture-replay-dashboard.json
+++ b/deployment/cdk/opensearch-service-migration/lib/components/capture-replay-dashboard.json
@@ -27,108 +27,37 @@
             "x": 0,
             "type": "text",
             "properties": {
-                "markdown": "# Traffic Capture",
+                "markdown": "# Bytes",
                 "background": "transparent"
             }
         },
         {
-            "height": 10,
-            "width": 12,
+            "height": 6,
+            "width": 11,
             "y": 1,
             "x": 0,
             "type": "metric",
             "properties": {
                 "metrics": [
-                    [ "OpenSearchMigrations", "bytesWrittenToTarget", "OTelLib", "replayer", { "region": "REGION", "id": "m1", "label": "Replayed on T" } ],
-                    [ ".", "bytesRead", ".", "captureProxy", { "label": "Captured from S", "region": "REGION", "id": "m2" } ]
+                    [ "OpenSearchMigrations", "bytesRead", "OTelLib", "captureProxy", { "label": "Response Bytes", "region": "REGION", "id": "c1", "visible": false } ],
+                    [ ".", "bytesWritten", ".", ".", { "label": "Request Bytes", "region": "REGION", "id": "c2", "visible": false } ],
+                    [ { "expression": "(c1 + c2) / 1048576 / PERIOD(c1)", "label": "Proxy", "id": "e1", "region": "REGION", "color": "#7f7f7f" } ],
+                    [ { "expression": "SEARCH('{AWS/Kafka,\"Broker ID\",\"Cluster Name\",Topic} Topic=\"logging-traffic-topic\" MetricName=\"BytesInPerSec\" \"Cluster Name\"=\"migration-msk-cluster-MA_STAGE\"', 'Average', 60)", "id": "k1", "region": "REGION", "visible": false, "label": "Kafka Bytes In Per Second", "period": 60 } ],
+                    [ { "expression": "SUM(k1) / 1048576", "label": "Kafka", "id": "k2", "region": "REGION" } ],
+                    [ { "expression": "SEARCH('{AWS/ApplicationELB,LoadBalancer} app/MigrationAssistant-MA_STAGE MetricName=\"ProcessedBytes\"', 'Sum', 60)", "id": "b2", "period": 60, "region": "REGION", "visible": false, "label": "ALB Bytes per Period" } ],
+                    [ { "expression": "SUM(b2)/1048576 / PERIOD(c1)", "label": "ALB", "id": "e2", "region": "REGION" } ]
                 ],
                 "view": "timeSeries",
                 "stacked": false,
                 "region": "REGION",
                 "stat": "Sum",
                 "period": 60,
-                "title": "Captured vs Replayed Bytes",
+                "title": "Proxy Traffic as observed by various sources (MBps)",
                 "yAxis": {
                     "left": {
-                        "label": "Bytes"
-                    }
-                }
-            }
-        },
-        {
-            "height": 5,
-            "width": 12,
-            "y": 1,
-            "x": 12,
-            "type": "metric",
-            "properties": {
-                "metrics": [
-                    [ "OpenSearchMigrations", "activeTargetConnections", "OTelLib", "replayer" ],
-                    [ "OpenSearchMigrations", "connectionsOpened", "OTelLib", "replayer" ],
-                    [ "OpenSearchMigrations", "connectionsClosedCount", "OTelLib", "replayer" ]
-                ],
-                "sparkline": true,
-                "view": "singleValue",
-                "region": "REGION",
-                "stat": "Sum",
-                "period": 60,
-                "title": "Active Replayer Connections",
-                "liveData": true
-            }
-        },
-        {
-            "height": 5,
-            "width": 12,
-            "y": 6,
-            "x": 12,
-            "type": "metric",
-            "properties": {
-                "metrics": [
-                    [ "OpenSearchMigrations", "activeConnection", "OTelLib", "captureProxy" ],
-                    [ "OpenSearchMigrations", "gatheringRequestCount", "OTelLib", "captureProxy" ],
-                    [ "OpenSearchMigrations", "gatheringResponseCount", "OTelLib", "captureProxy" ]
-                ],
-                "sparkline": true,
-                "view": "singleValue",
-                "region": "REGION",
-                "stat": "Sum",
-                "period": 60,
-                "title": "Active Capture Proxy Connections",
-                "liveData": true
-            }
-        },
-        {
-            "height": 1,
-            "width": 24,
-            "y": 11,
-            "x": 0,
-            "type": "text",
-            "properties": {
-                "markdown": "# Error Analysis",
-                "background": "transparent"
-            }
-        },
-        {
-            "height": 9,
-            "width": 12,
-            "y": 12,
-            "x": 0,
-            "type": "metric",
-            "properties": {
-                "metrics": [
-                    [ "OpenSearchMigrations", "removed", "OTelLib", "captureProxy", { "label": "Removed Connections", "color": "#ff7f0e", "region": "REGION" } ],
-                    [ ".", "unregistered", ".", ".", { "label": "Unregistered Connections", "color": "#2ca02c", "region": "REGION", "visible": false } ],
-                    [ ".", "gatheringRequestCount", ".", ".", { "label": "Total Requests", "yAxis": "right", "region": "REGION", "color": "#1f77b4" } ]
-                ],
-                "view": "timeSeries",
-                "stacked": false,
-                "region": "REGION",
-                "stat": "Sum",
-                "period": 60,
-                "title": "CaptureProxy Connections",
-                "yAxis": {
-                    "left": {
-                        "label": "Request Count"
+                        "min": 0,
+                        "label": "MBps",
+                        "showUnits": false
                     }
                 }
             }
@@ -136,7 +65,7 @@
         {
             "height": 1,
             "width": 24,
-            "y": 21,
+            "y": 28,
             "x": 0,
             "type": "text",
             "properties": {
@@ -145,85 +74,44 @@
             }
         },
         {
-            "height": 10,
-            "width": 12,
-            "y": 22,
+            "height": 6,
+            "width": 24,
+            "y": 29,
             "x": 0,
             "type": "metric",
             "properties": {
                 "metrics": [
-                    [ "OpenSearchMigrations", "kafkaCommitCount", "OTelLib", "replayer" ],
-                    [ ".", "kafkaCommitDuration", ".", ".", { "stat": "Average" } ],
-                    [ "AWS/Kafka", "MessagesInPerSec", "Cluster Name", "migration-msk-cluster-MA_STAGE", "Broker ID", "1" ],
-                    [ "...", "2" ]
+                    [ { "expression": "IF(m2 > 0, 1, 0)", "label": "CommitsObserved", "id": "e1", "region": "REGION", "period": 300 } ],
+                    [ "OpenSearchMigrations", "kafkaCommitCount", "OTelLib", "replayer", { "id": "m2", "region": "REGION", "visible": false } ]
                 ],
+                "sparkline": true,
                 "view": "timeSeries",
-                "stacked": false,
-                "title": "Kafka Message Commit Rate",
                 "region": "REGION",
-                "stat": "Average",
-                "period": 60,
-                "setPeriodToTimeRange": true
+                "period": 300,
+                "stat": "Sum",
+                "title": "Replayer Kafka Healthy",
+                "stacked": false,
+                "liveData": false,
+                "yAxis": {
+                    "left": {
+                        "label": "Count",
+                        "min": 0,
+                        "showUnits": false
+                    }
+                }
             }
         },
         {
-            "height": 10,
-            "width": 7,
-            "y": 22,
+            "height": 6,
+            "width": 12,
+            "y": 36,
             "x": 12,
             "type": "metric",
             "properties": {
                 "metrics": [
-                    [ "OpenSearchMigrations", "kafkaCommitCount", "OTelLib", "replayer", { "id": "m2" } ],
-                    [ ".", "kafkaRecordsRead", ".", ".", { "id": "m3" } ]
-                ],
-                "sparkline": true,
-                "view": "singleValue",
-                "region": "REGION",
-                "period": 60,
-                "stat": "Sum",
-                "title": "Kafka-Replayer Monitor"
-            }
-        },
-        {
-            "height": 10,
-            "width": 5,
-            "y": 22,
-            "x": 19,
-            "type": "metric",
-            "properties": {
-                "metrics": [
-                    [ "OpenSearchMigrations", "kafkaCommitCount", "OTelLib", "captureProxy", { "id": "m1" } ]
-                ],
-                "sparkline": true,
-                "view": "singleValue",
-                "region": "REGION",
-                "period": 60,
-                "stat": "Sum",
-                "title": "Kafka-CaptureProxy Monitor"
-            }
-        },
-        {
-            "height": 1,
-            "width": 24,
-            "y": 32,
-            "x": 0,
-            "type": "text",
-            "properties": {
-                "markdown": "# Replayer Performance"
-            }
-        },
-        {
-            "height": 9,
-            "width": 12,
-            "y": 33,
-            "x": 0,
-            "type": "metric",
-            "properties": {
-                "metrics": [
-                    [ "AWS/ECS", "MemoryUtilization", "ServiceName", "migration-MA_STAGE-traffic-replayer-default", "ClusterName", "migration-MA_STAGE-ecs-cluster", { "stat": "Minimum", "label": "Memory Min" } ],
-                    [ ".", ".", ".", ".", ".", ".", { "stat": "Maximum", "label": "Memory Max" } ],
-                    [ ".", ".", ".", ".", ".", ".", { "stat": "Average", "label": "Memory Avg" } ]
+                    [ "AWS/ECS", "MemoryUtilization", "ServiceName", "migration-MA_STAGE-traffic-replayer-default", "ClusterName", "migration-MA_STAGE-ecs-cluster", { "stat": "Minimum", "label": "Memory Min", "region": "${REGION}" } ],
+                    [ "...", { "stat": "Maximum", "label": "Memory Max", "region": "${REGION}" } ],
+                    [ "...", { "stat": "Average", "label": "Memory Avg", "region": "${REGION}" } ]
                 ],
                 "view": "timeSeries",
                 "stacked": false,
@@ -232,22 +120,26 @@
                 "period": 60,
                 "yAxis": {
                     "left": {
-                        "label": "Memory %"
+                        "label": "Utilization",
+                        "min": 0,
+                        "max": 100,
+                        "showUnits": true
                     }
-                }
+                },
+                "setPeriodToTimeRange": true
             }
         },
         {
-            "height": 9,
+            "height": 6,
             "width": 12,
-            "y": 33,
-            "x": 12,
+            "y": 36,
+            "x": 0,
             "type": "metric",
             "properties": {
                 "metrics": [
-                    [ "AWS/ECS", "CPUUtilization", "ServiceName", "migration-MA_STAGE-traffic-replayer-default", "ClusterName", "migration-MA_STAGE-ecs-cluster", { "stat": "Minimum", "label": "CPU Min" } ],
-                    [ ".", ".", ".", ".", ".", ".", { "stat": "Maximum", "label": "CPU Max" } ],
-                    [ ".", ".", ".", ".", ".", ".", { "stat": "Average", "label": "CPU Avg" } ]
+                    [ "AWS/ECS", "CPUUtilization", "ServiceName", "migration-MA_STAGE-traffic-replayer-default", "ClusterName", "migration-MA_STAGE-ecs-cluster", { "stat": "Minimum", "label": "CPU Min", "region": "REGION" } ],
+                    [ "...", { "stat": "Maximum", "label": "CPU Max", "region": "REGION" } ],
+                    [ "...", { "stat": "Average", "label": "CPU Avg", "region": "REGION" } ]
                 ],
                 "view": "timeSeries",
                 "stacked": false,
@@ -257,77 +149,249 @@
                 "period": 60,
                 "yAxis": {
                     "left": {
-                        "label": "CPU Utilization %"
+                        "label": "Utilization",
+                        "min": 0,
+                        "max": 100
                     }
-                }
+                },
+                "liveData": true
             }
         },
         {
-            "height": 8,
+            "height": 6,
             "width": 12,
             "y": 42,
             "x": 0,
             "type": "metric",
             "properties": {
                 "metrics": [
-                    [ "OpenSearchMigrations", "transformedJsonSucceeded", "OTelLib", "replayer", { "label": "JSON Transformations Succeeded" } ],
-                    [ ".", "transformedTextSucceeded", ".", ".", { "label": "Text Transformations Succeeded" } ]
-                ],
-                "view": "singleValue",
-                "stacked": false,
-                "title": "Transformation Success Counts",
-                "region": "REGION",
-                "stat": "Sum",
-                "period": 60,
-                "sparkline": true,
-                "singleValueFullPrecision": true
-            }
-        },
-        {
-            "height": 8,
-            "width": 12,
-            "y": 42,
-            "x": 12,
-            "type": "metric",
-            "properties": {
-                "metrics": [
-                    [ { "expression": "m1/1000000", "label": "Source/Target Request Lag (sec)", "region": "REGION", "stat": "Average", "period": 60, "id": "m3" } ],
-                    [ "OpenSearchMigrations", "lagBetweenSourceAndTargetRequests", "OTelLib", "replayer", { "id": "m1", "visible": false, "region": "REGION" } ],
-                    [ { "expression": "m2/1000000", "label": "Schedule Lag (sec)", "region": "REGION", "stat": "Average", "period": 60, "id": "m4" } ],
-                    [ "OpenSearchMigrations", "scheduleLag", "OTelLib", "replayer", { "id": "m2", "visible": false, "region": "REGION" } ]
+                    [ "OpenSearchMigrations", "lagBetweenSourceAndTargetRequests", "OTelLib", "replayer", { "id": "m1", "region": "REGION", "stat": "Minimum", "visible": false, "label": "Min", "color": "#9edae5" } ],
+                    [ "...", { "id": "m4", "region": "REGION", "visible": false, "label": "Avg", "color": "#dbdb8d" } ],
+                    [ "...", { "id": "m5", "region": "REGION", "label": "Max", "stat": "Maximum", "visible": false, "color": "#c7c7c7" } ],
+                    [ { "expression": "FLOOR(METRICS()/1000)/60", "label": "Replay Lag", "id": "e2", "region": "REGION", "color": "#9edae5", "period": 300 } ]
                 ],
                 "view": "timeSeries",
                 "title": "Replayer Performance Analysis",
                 "region": "REGION",
                 "yAxis": {
                     "left": {
-                        "label": "Lag (seconds)"
+                        "label": "Lag (minutes)",
+                        "showUnits": false
                     }
                 },
                 "stat": "Average",
-                "period": 60
+                "period": 300,
+                "liveData": true
             }
         },
         {
-            "height": 9,
+            "height": 7,
+            "width": 24,
+            "y": 14,
+            "x": 0,
+            "type": "metric",
+            "properties": {
+                "metrics": [
+                    [ { "expression": "SEARCH('{OpenSearchMigrations,OTelLib,method,sourceStatusCode,statusCodesMatch,targetStatusCode} statusCodesMatch=\"true\"', 'Sum', 60)", "id": "e2", "period": 60, "region": "REGION", "label": "" } ]
+                ],
+                "sparkline": true,
+                "view": "timeSeries",
+                "region": "REGION",
+                "period": 60,
+                "stat": "Sum",
+                "title": "Replayer Status Code Matches ",
+                "setPeriodToTimeRange": true,
+                "stacked": false,
+                "liveData": true,
+                "yAxis": {
+                    "left": {
+                        "label": "Requests",
+                        "min": 0,
+                        "showUnits": false
+                    }
+                }
+            }
+        },
+        {
+            "height": 6,
             "width": 12,
-            "y": 12,
+            "y": 42,
             "x": 12,
             "type": "metric",
             "properties": {
-                "sparkline": true,
                 "metrics": [
-                    [ "OpenSearchMigrations", "tupleComparison", "method", "PUT", "OTelLib", "replayer", { "label": "Replayer total PUTs" } ],
-                    [ "...", "GET", ".", ".", { "label": "Replayer total GETs" } ],
-                    [ "...", "sourceStatusCode", "400", ".", ".", { "label": "Total mismatches" } ],
-                    [ ".", ".", "targetStatusCode", "200", "method", "PUT", "sourceStatusCode", "200", "OTelLib", "replayer", "statusCodesMatch", "false", { "label": "Replayer PUT mismatch" } ],
-                    [ "...", "GET", ".", "400", ".", ".", ".", ".", { "label": "Replayer GET mismatch" } ]
+                    [ { "expression": "FLOOR(m1_avg/1000)", "label": "Lag (sec) - Avg", "id": "m3_avg", "visible": false, "region": "REGION", "stat": "Average", "period": 300 } ],
+                    [ { "expression": "IF(DIFF_TIME(m3_avg) > PERIOD(m3_avg), 0/0, -1*RATE(m3_avg)+1)", "label": "Speedup Factor - Avg", "id": "m4_avg", "region": "REGION", "stat": "Average", "period": 300 } ],
+                    [ "OpenSearchMigrations", "lagBetweenSourceAndTargetRequests", "OTelLib", "replayer", { "id": "m1_avg", "region": "REGION", "visible": false } ],
+                    [ { "expression": "FLOOR(m1_min/1000)", "label": "Lag (sec) - Min", "id": "m3_min", "visible": false, "region": "REGION", "stat": "Average", "period": 300 } ],
+                    [ { "expression": "IF(DIFF_TIME(m3_min) > PERIOD(m3_min), 0/0, -1*RATE(m3_min)+1)", "label": "Speedup Factor - Min", "id": "m4_min", "region": "REGION", "stat": "Average", "period": 300 } ],
+                    [ "OpenSearchMigrations", "lagBetweenSourceAndTargetRequests", "OTelLib", "replayer", { "id": "m1_min", "region": "REGION", "visible": false, "stat": "Minimum" } ],
+                    [ { "expression": "FLOOR(m1_max/1000)", "label": "Lag (sec) - Max", "id": "m3_max", "visible": false, "region": "REGION", "stat": "Average", "period": 300 } ],
+                    [ { "expression": "IF(DIFF_TIME(m3_max) > PERIOD(m3_max), 0/0, -1*RATE(m3_max)+1)", "label": "Speedup Factor - Max", "id": "m4_max", "region": "REGION", "stat": "Average", "period": 300, "visible": false } ],
+                    [ "OpenSearchMigrations", "lagBetweenSourceAndTargetRequests", "OTelLib", "replayer", { "id": "m1_max", "region": "REGION", "visible": false, "stat": "Maximum" } ]
+                ],
+                "view": "timeSeries",
+                "title": "Actual Speedup Factor",
+                "region": "REGION",
+                "yAxis": {
+                    "left": {
+                        "label": "Speedup Factor",
+                        "min": 0,
+                        "showUnits": false
+                    }
+                },
+                "stat": "Average",
+                "period": 300
+            }
+        },
+        {
+            "height": 6,
+            "width": 13,
+            "y": 1,
+            "x": 11,
+            "type": "metric",
+            "properties": {
+                "metrics": [
+                    [ "OpenSearchMigrations", "bytesReadFromTarget", "OTelLib", "replayer", { "label": "Response Bytes", "region": "REGION", "id": "c1", "visible": false } ],
+                    [ ".", "bytesWrittenToTarget", ".", ".", { "label": "Request Bytes", "region": "REGION", "id": "c2", "visible": false } ],
+                    [ { "expression": "(c1 + c2) / (1024*1024) / PERIOD(c2)", "label": "Total", "id": "e1", "region": "REGION" } ],
+                    [ { "expression": "(c2) / (1024*1024) / PERIOD(c2)", "label": "Request", "id": "e2", "region": "REGION" } ],
+                    [ { "expression": "(c1)/ (1024*1024) / PERIOD(c1)", "label": "Response", "id": "e3", "region": "REGION" } ]
+                ],
+                "view": "timeSeries",
+                "stacked": false,
+                "region": "REGION",
+                "stat": "Sum",
+                "period": 60,
+                "title": "Replayer Throughput (MBps)",
+                "yAxis": {
+                    "left": {
+                        "min": 0,
+                        "label": "MBps",
+                        "showUnits": false
+                    }
+                }
+            }
+        },
+        {
+            "height": 7,
+            "width": 24,
+            "y": 21,
+            "x": 0,
+            "type": "metric",
+            "properties": {
+                "metrics": [
+                    [ { "expression": "SEARCH('{OpenSearchMigrations,OTelLib,method,sourceStatusCode,statusCodesMatch,targetStatusCode} statusCodesMatch=\"false\"', 'Sum', 300)", "id": "e2", "period": 300, "region": "REGION" } ]
+                ],
+                "sparkline": true,
+                "view": "timeSeries",
+                "region": "REGION",
+                "period": 300,
+                "stat": "Sum",
+                "title": "Replayer Status Code Mismatches",
+                "setPeriodToTimeRange": true,
+                "liveData": true,
+                "labels": {
+                    "visible": true
+                },
+                "yAxis": {
+                    "left": {
+                        "label": "Requests",
+                        "min": 0,
+                        "showUnits": false
+                    }
+                },
+                "stacked": false
+            }
+        },
+        {
+            "height": 1,
+            "width": 24,
+            "y": 13,
+            "x": 0,
+            "type": "text",
+            "properties": {
+                "markdown": "# Replay Status Code Analysis",
+                "background": "transparent"
+            }
+        },
+        {
+            "height": 1,
+            "width": 24,
+            "y": 35,
+            "x": 0,
+            "type": "text",
+            "properties": {
+                "markdown": "# Additional Replay Metrics",
+                "background": "transparent"
+            }
+        },
+        {
+            "height": 6,
+            "width": 12,
+            "y": 48,
+            "x": 0,
+            "type": "metric",
+            "properties": {
+                "metrics": [
+                    [ { "expression": "lag_avg_ms/1000", "label": "Expression3", "id": "e3", "region": "REGION", "stat": "Average", "period": 300, "visible": false } ],
+                    [ "OpenSearchMigrations", "lagBetweenSourceAndTargetRequests", "OTelLib", "replayer", { "id": "lag_avg_ms", "region": "REGION", "visible": false, "label": "lag_avg_ms" } ],
+                    [ { "expression": "lag_avg_ms/1000", "label": "lag_avg_sec", "id": "lag_avg_sec", "region": "REGION", "stat": "Average", "period": 300, "visible": false } ],
+                    [ { "expression": "FLOOR(lag_avg_sec/60/5 + 0.5)*60*5", "label": "lag_avg_sec_cleaned", "id": "lag_avg_sec_cleaned", "visible": false, "region": "REGION", "stat": "Average", "period": 300 } ],
+                    [ { "expression": "lag_avg_sec/3600", "label": "lag_avg_hr", "id": "lag_avg_hr", "visible": false, "region": "REGION", "stat": "Average", "period": 300 } ],
+                    [ { "expression": "-1*RATE(lag_avg_sec_cleaned)+1", "label": "Speedup Factor", "id": "speedup", "region": "REGION", "stat": "Average", "period": 300, "visible": false } ],
+                    [ { "expression": "IF(DIFF_TIME(speedup) > PERIOD(speedup), 0/0, speedup)", "label": "Speedup Factor (cleaned)", "id": "speedup_cleaned", "region": "REGION", "period": 300, "visible": false } ],
+                    [ { "expression": "lag_avg_hr/(speedup_cleaned-1)", "label": "catchup_hours", "id": "catchup_hours", "region": "REGION", "period": 300 } ]
                 ],
                 "view": "singleValue",
-                "region": "us-west-1",
-                "period": 60,
+                "title": "Time to catchup in hours",
+                "region": "REGION",
+                "yAxis": {
+                    "left": {
+                        "label": "Speedup Factor",
+                        "min": 0,
+                        "showUnits": false
+                    }
+                },
+                "stat": "Average",
+                "period": 300,
+                "setPeriodToTimeRange": false,
+                "singleValueFullPrecision": false,
+                "sparkline": true,
+                "stacked": true,
+                "liveData": false
+            }
+        },
+        {
+            "height": 6,
+            "width": 24,
+            "y": 7,
+            "x": 0,
+            "type": "metric",
+            "properties": {
+                "metrics": [
+                    [ "OpenSearchMigrations", "bytesReadFromTarget", "OTelLib", "replayer", { "label": "Response Bytes", "region": "REGION", "id": "r1", "visible": false } ],
+                    [ ".", "bytesWrittenToTarget", ".", ".", { "label": "Request Bytes", "region": "REGION", "id": "r2", "visible": false } ],
+                    [ { "expression": "(r1 + r2) / (1024*1024) / PERIOD(r2)", "label": "Replayer", "id": "e1", "region": "REGION" } ],
+                    [ { "expression": "(r2) / (1024*1024) / PERIOD(r2)", "label": "Request", "id": "e2", "region": "REGION", "visible": false } ],
+                    [ { "expression": "(r1)/ (1024*1024) / PERIOD(r1)", "label": "Response", "id": "e3", "region": "REGION", "visible": false } ],
+                    [ "OpenSearchMigrations", "bytesRead", "OTelLib", "captureProxy", { "label": "Response Bytes", "region": "REGION", "id": "c1", "visible": false } ],
+                    [ ".", "bytesWritten", ".", ".", { "label": "Request Bytes", "region": "REGION", "id": "c2", "visible": false } ],
+                    [ { "expression": "(c1 + c2) / 1048576 / PERIOD(c1)", "label": "Proxy", "id": "e4", "region": "REGION" } ]
+                ],
+                "view": "timeSeries",
+                "stacked": false,
+                "region": "REGION",
                 "stat": "Sum",
-                "title": "Replayer StatusCode Mismatches"
+                "period": 60,
+                "title": "Capture and Replay Bytes (MBps)",
+                "yAxis": {
+                    "left": {
+                        "min": 0,
+                        "label": "MBps",
+                        "showUnits": false
+                    }
+                }
             }
         }
     ]

--- a/deployment/cdk/opensearch-service-migration/lib/constructs/migration-dashboard.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/constructs/migration-dashboard.ts
@@ -11,7 +11,7 @@ interface DashboardBody {
 }
 
 export interface MigrationDashboardProps {
-    readonly dashboardName: string;
+    readonly dashboardQualifier: string;
     readonly stage: string;
     readonly account: string;
     readonly region: string;
@@ -19,12 +19,13 @@ export interface MigrationDashboardProps {
 }
 
 export class MigrationDashboard extends Construct {
-    constructor(scope: Construct, id: string, props: MigrationDashboardProps) {
-        super(scope, id);
+    constructor(scope: Construct, props: MigrationDashboardProps) {
+        const dashboardName = `MigrationAssistant_${props.dashboardQualifier}_${props.stage}_${props.region}`
+        super(scope, dashboardName);
 
         const dashboard = this.setDashboardVariables(props.dashboardJson, props);
-        new CfnDashboard(this, 'Dashboard', {
-            dashboardName: props.dashboardName,
+        new CfnDashboard(this, dashboardName, {
+            dashboardName: dashboardName,
             dashboardBody: JSON.stringify(dashboard)
         });
     }

--- a/deployment/cdk/opensearch-service-migration/lib/service-stacks/reindex-from-snapshot-stack.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/service-stacks/reindex-from-snapshot-stack.ts
@@ -208,8 +208,8 @@ export class ReindexFromSnapshotStack extends MigrationServiceCore {
             ...props
         });
 
-        new MigrationDashboard(this, 'RFSDashboard', {
-            dashboardName: `MigrationAssistant_ReindexFromSnapshot_Dashboard_${props.stage}`,
+        new MigrationDashboard(this, {
+            dashboardQualifier: `Backfill_Summary`,
             stage: props.stage,
             account: this.account,
             region: this.region,

--- a/deployment/cdk/opensearch-service-migration/lib/service-stacks/traffic-replayer-stack.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/service-stacks/traffic-replayer-stack.ts
@@ -148,8 +148,8 @@ export class TrafficReplayerStack extends MigrationServiceCore {
         this.replayerYaml.ecs.cluster_name = `migration-${props.stage}-ecs-cluster`;
         this.replayerYaml.ecs.service_name = `migration-${props.stage}-traffic-replayer-${deployId}`;
 
-        new MigrationDashboard(this, 'CnRDashboard', {
-            dashboardName: `MigrationAssistant_CaptureAndReplay_Dashboard_${props.stage}`,
+        new MigrationDashboard(this, {
+            dashboardQualifier: `LiveCaptureReplay_Summary`,
             stage: props.stage,
             account: this.account,
             region: this.region,


### PR DESCRIPTION
### Description
Dashboards cannot share the same name across all regions in an account. This change fixes deployment failures when the same stage name is used across regions along with adding simplification to the capture and replay dashboard, primarily fixing metric discovery with SEARCH, adding calculations for speedup observed and catchup time, and removing metrics that were unclear or added confusion.

### Issues Resolved

[MIGRATIONS-1608](https://opensearch.atlassian.net/issues/MIGRATIONS-1608)

### Testing
Jenkins run to verify successful deployment along with verifying json in AWS under a migration

### Check List
- [x] New functionality includes testing
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
