### PR TITLE
Move TrafficSummary to debug logging

### DIFF
--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/TrafficReplayerCore.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/TrafficReplayerCore.java
@@ -366,7 +366,7 @@ public abstract class TrafficReplayerCore extends RequestTransformerAndSender<Tr
                         .collect(Collectors.joining(";"))
                 )
                     .filter(s -> !s.isEmpty())
-                    .ifPresent(s -> log.atInfo().setMessage("TrafficStream Summary: {{}}").addArgument(s).log());
+                    .ifPresent(s -> log.atDebug().setMessage("TrafficStream Summary: {{}}").addArgument(s).log());
             }
             trafficStreams.forEach(trafficToHttpTransactionAccumulator::accept);
         }

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/TrafficReplayerCore.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/TrafficReplayerCore.java
@@ -359,7 +359,7 @@ public abstract class TrafficReplayerCore extends RequestTransformerAndSender<Tr
                     throw ex.getCause();
                 }
             }
-            if (log.isInfoEnabled()) {
+            if (log.isDebugEnabled()) {
                 Optional.of(
                     trafficStreams.stream()
                         .map(ts -> TrafficStreamUtils.summarizeTrafficStream(ts.getStream()))


### PR DESCRIPTION
### Description
TrafficStream Summary was noisy, especially for numerous packets for large requests. Reducing log level

### Issues Resolved
<!-- List any GitHub or Jira issues this PR will resolve -->

### Testing
<!-- Please provide details of testing done: unit testing, integration testing and manual testing -->

### Check List
- [ ] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
