### PR TITLE
Remove Amazon OpenSearch Service references from Migration Assistant Image Readmes

### DIFF
--- a/docs/imageOverviews/opensearch-migrations-console.md
+++ b/docs/imageOverviews/opensearch-migrations-console.md
@@ -2,17 +2,17 @@
 
 - **Maintained by:** [OpenSearch team](https://github.com/opensearch-project)
 - **Need help?** Ask questions and discuss on our [community forum](https://forum.opensearch.org/tag/migration)
-- **Need to file issues?** Use our [issue tracker](https://github.com/opensearch-project/opensearch-migrations/issues) to report problems with Migration Assistant for Amazon OpenSearch or the Docker images
+- **Need to file issues?** Use our [issue tracker](https://github.com/opensearch-project/opensearch-migrations/issues) to report problems with Migration Assistant for OpenSearch or the Docker images
 
-## What is the Migration Assistant for Amazon OpenSearch?
+## What is the Migration Assistant for OpenSearch?
 
-The Migration Assistant for Amazon OpenSearch is a tool that simplifies the migration of data from Elasticsearch to OpenSearch. It provides a comprehensive solution for migrating historical and/or live data.
+The Migration Assistant for OpenSearch is a tool that simplifies the migration of data from Elasticsearch to OpenSearch. It provides a comprehensive solution for migrating historical and/or live data.
 
-Learn more about the Migration Assistant for Amazon OpenSearch in the [Amazon Solutions page](https://aws.amazon.com/solutions/implementations/migration-assistant-for-amazon-opensearch-service/).
+Learn more at the documentation for the [Migration Assistant for OpenSearch](https://docs.opensearch.org/docs/latest/migration-assistant).
 
 ## What is OpenSearch Migrations Console?
 
-The OpenSearch Migrations Console is the central control plane for the Migration Assistant for Amazon OpenSearch. It orchestrates and manages the migration process by coordinating various components in the migration pipeline, providing users with a unified interface to interact with all aspects of the migration.
+The OpenSearch Migrations Console is the central control plane for the Migration Assistant for OpenSearch. It orchestrates and manages the migration process by coordinating various components in the migration pipeline, providing users with a unified interface to interact with all aspects of the migration.
 
 ## How to Pull This Image
 

--- a/docs/imageOverviews/opensearch-migrations-reindex-from-snapshot.md
+++ b/docs/imageOverviews/opensearch-migrations-reindex-from-snapshot.md
@@ -2,17 +2,17 @@
 
 - **Maintained by:** [OpenSearch team](https://github.com/opensearch-project)
 - **Need help?** Ask questions and discuss on our [community forum](https://forum.opensearch.org/tag/migration)
-- **Need to file issues?** Use our [issue tracker](https://github.com/opensearch-project/opensearch-migrations/issues) to report problems with Migration Assistant for Amazon OpenSearch or the Docker images
+- **Need to file issues?** Use our [issue tracker](https://github.com/opensearch-project/opensearch-migrations/issues) to report problems with Migration Assistant for OpenSearch or the Docker images
 
-## What is the Migration Assistant for Amazon OpenSearch?
+## What is the Migration Assistant for OpenSearch?
 
-The Migration Assistant for Amazon OpenSearch is a tool that simplifies the migration of data from Elasticsearch to OpenSearch. It provides a comprehensive solution for migrating historical and/or live data.
+The Migration Assistant for OpenSearch is a tool that simplifies the migration of data from Elasticsearch to OpenSearch. It provides a comprehensive solution for migrating historical and/or live data.
 
-Learn more about the Migration Assistant for Amazon OpenSearch in the [Amazon Solutions page](https://aws.amazon.com/solutions/implementations/migration-assistant-for-amazon-opensearch-service/).
+Learn more at the documentation for the [Migration Assistant for OpenSearch](https://docs.opensearch.org/docs/latest/migration-assistant).
 
 ## What is OpenSearch Migrations Reindex-from-Snapshot?
 
-The OpenSearch Migrations Reindex-from-Snapshot is the component of the Migration Assistant for Amazon OpenSearch that reads an Elasticsearch snapshot, extracts the source docs, and reindexes it into a target cluster.
+The OpenSearch Migrations Reindex-from-Snapshot is the component of the Migration Assistant for OpenSearch that reads an Elasticsearch snapshot, extracts the source docs, and reindexes it into a target cluster.
 
 ## How to Pull This Image
 
@@ -26,7 +26,7 @@ See [ECR](https://gallery.ecr.aws/opensearchproject/opensearch-migrations-reinde
 
 ## How to Use This Image
 
-OpenSearch Migration Reindex-from-Snapshot is a component of the Migration Assistant for Amazon OpenSearch. We recommend following the instructions in the [wiki documentation](https://github.com/opensearch-project/opensearch-migrations/wiki) to get started.
+OpenSearch Migration Reindex-from-Snapshot is a component of the Migration Assistant for OpenSearch. We recommend following the instructions in the [wiki documentation](https://github.com/opensearch-project/opensearch-migrations/wiki) to get started.
 
 ## Licensing
 

--- a/docs/imageOverviews/opensearch-migrations-traffic-capture-proxy.md
+++ b/docs/imageOverviews/opensearch-migrations-traffic-capture-proxy.md
@@ -2,17 +2,17 @@
 
 - **Maintained by:** [OpenSearch team](https://github.com/opensearch-project)
 - **Need help?** Ask questions and discuss on our [community forum](https://forum.opensearch.org/tag/migration)
-- **Need to file issues?** Use our [issue tracker](https://github.com/opensearch-project/opensearch-migrations/issues) to report problems with Migration Assistant for Amazon OpenSearch or the Docker images
+- **Need to file issues?** Use our [issue tracker](https://github.com/opensearch-project/opensearch-migrations/issues) to report problems with Migration Assistant for OpenSearch or the Docker images
 
-## What is the Migration Assistant for Amazon OpenSearch?
+## What is the Migration Assistant for OpenSearch?
 
-The Migration Assistant for Amazon OpenSearch is a tool that simplifies the migration of data from Elasticsearch to OpenSearch. It provides a comprehensive solution for migrating historical and/or live data.
+The Migration Assistant for OpenSearch is a tool that simplifies the migration of data from Elasticsearch to OpenSearch. It provides a comprehensive solution for migrating historical and/or live data.
 
-Learn more about the Migration Assistant for Amazon OpenSearch in the [Amazon Solutions page](https://aws.amazon.com/solutions/implementations/migration-assistant-for-amazon-opensearch-service/).
+Learn more at the documentation for the [Migration Assistant for OpenSearch](https://docs.opensearch.org/docs/latest/migration-assistant).
 
 ## What is OpenSearch Migrations Traffic Capture Proxy?
 
-The OpenSearch Migrations Traffic Capture Proxy is the component of the Migration Assistant for Amazon OpenSearch that captures traffic infront of a source server into a Kafka topic.
+The OpenSearch Migrations Traffic Capture Proxy is the component of the Migration Assistant for OpenSearch that captures traffic infront of a source server into a Kafka topic.
 
 ## How to Pull This Image
 
@@ -26,7 +26,7 @@ See [ECR](https://gallery.ecr.aws/opensearchproject/opensearch-migrations-traffi
 
 ## How to Use This Image
 
-OpenSearch Migrations Traffic Capture Proxy is a component of the Migration Assistant for Amazon OpenSearch. We recommend following the instructions in the [wiki documentation](https://github.com/opensearch-project/opensearch-migrations/wiki) to get started.
+OpenSearch Migrations Traffic Capture Proxy is a component of the Migration Assistant for OpenSearch. We recommend following the instructions in the [wiki documentation](https://github.com/opensearch-project/opensearch-migrations/wiki) to get started.
 
 ## Licensing
 

--- a/docs/imageOverviews/opensearch-migrations-traffic-replayer.md
+++ b/docs/imageOverviews/opensearch-migrations-traffic-replayer.md
@@ -2,17 +2,17 @@
 
 - **Maintained by:** [OpenSearch team](https://github.com/opensearch-project)
 - **Need help?** Ask questions and discuss on our [community forum](https://forum.opensearch.org/tag/migration)
-- **Need to file issues?** Use our [issue tracker](https://github.com/opensearch-project/opensearch-migrations/issues) to report problems with Migration Assistant for Amazon OpenSearch or the Docker images
+- **Need to file issues?** Use our [issue tracker](https://github.com/opensearch-project/opensearch-migrations/issues) to report problems with Migration Assistant for OpenSearch or the Docker images
 
-## What is the Migration Assistant for Amazon OpenSearch?
+## What is the Migration Assistant for OpenSearch?
 
-The Migration Assistant for Amazon OpenSearch is a tool that simplifies the migration of data from Elasticsearch to OpenSearch. It provides a comprehensive solution for migrating historical and/or live data.
+The Migration Assistant for OpenSearch is a tool that simplifies the migration of data from Elasticsearch to OpenSearch. It provides a comprehensive solution for migrating historical and/or live data.
 
-Learn more about the Migration Assistant for Amazon OpenSearch in the [Amazon Solutions page](https://aws.amazon.com/solutions/implementations/migration-assistant-for-amazon-opensearch-service/).
+Learn more at the documentation for the [Migration Assistant for OpenSearch](https://docs.opensearch.org/docs/latest/migration-assistant).
 
 ## What is OpenSearch Migrations Traffic Replayer?
 
-The OpenSearch Migrations Traffic Replayer is the component of the Migration Assistant for Amazon OpenSearch that replays captured traffic from a Kafka topic into a target OpenSearch cluster.
+The OpenSearch Migrations Traffic Replayer is the component of the Migration Assistant for OpenSearch that replays captured traffic from a Kafka topic into a target OpenSearch cluster.
 
 ## How to Pull This Image
 
@@ -26,7 +26,7 @@ See [ECR](https://gallery.ecr.aws/opensearchproject/opensearch-migrations-traffi
 
 ## How to Use This Image
 
-OpenSearch Migrations Traffic Replayer is a component of the Migration Assistant for Amazon OpenSearch. We recommend following the instructions in the [wiki documentation](https://github.com/opensearch-project/opensearch-migrations/wiki) to get started.
+OpenSearch Migrations Traffic Replayer is a component of the Migration Assistant for OpenSearch. We recommend following the instructions in the [wiki documentation](https://github.com/opensearch-project/opensearch-migrations/wiki) to get started.
 
 ## Licensing
 


### PR DESCRIPTION
### Description
Remove Amazon OpenSearch Service references from Migration Assistant Image Readmes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).