### PR TITLE
Only update netty for patch version changes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,6 +31,10 @@ updates:
       - dependency-name: "org.opensearch.plugin:*"
       - dependency-name: "org.apache.lucene:*"
       - dependency-name: "io.opentelemetry.semconv:*"
+      - dependency-name: "io.netty:*"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
### Description
Only update netty for patch version changes

### Issues
- Related https://github.com/opensearch-project/opensearch-migrations/pull/1502 was cut attempting to move to netty 4.2

### Check List
- [ ] ~New functionality includes testing~
- [ ] ~Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
