### PR TITLE
Add parameter to loosen strict version requirements for Metadata and RFS

### DIFF
--- a/DocumentsFromSnapshotMigration/src/main/java/org/opensearch/migrations/RfsMigrateDocuments.java
+++ b/DocumentsFromSnapshotMigration/src/main/java/org/opensearch/migrations/RfsMigrateDocuments.java
@@ -185,6 +185,9 @@ public class RfsMigrateDocuments {
 
         @ParametersDelegate
         private DocParams docTransformationParams = new DocParams();
+
+        @ParametersDelegate
+        private VersionStrictness versionStrictness = new VersionStrictness();
     }
 
     @Getter
@@ -355,7 +358,7 @@ public class RfsMigrateDocuments {
             }
             var repoAccessor = new DefaultSourceRepoAccessor(sourceRepo);
 
-            var sourceResourceProvider = ClusterProviderRegistry.getSnapshotReader(arguments.sourceVersion, sourceRepo);
+            var sourceResourceProvider = ClusterProviderRegistry.getSnapshotReader(arguments.sourceVersion, sourceRepo, arguments.versionStrictness.allowLooseVersionMatches);
 
             var unpackerFactory = new SnapshotShardUnpacker.Factory(
                 repoAccessor,

--- a/DocumentsFromSnapshotMigration/src/test/java/org/opensearch/migrations/bulkload/EndToEndTest.java
+++ b/DocumentsFromSnapshotMigration/src/test/java/org/opensearch/migrations/bulkload/EndToEndTest.java
@@ -6,6 +6,7 @@ import java.util.Random;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
 
+import org.opensearch.migrations.UnboundVersionMatchers;
 import org.opensearch.migrations.VersionMatchers;
 import org.opensearch.migrations.bulkload.common.FileSystemRepo;
 import org.opensearch.migrations.bulkload.common.FileSystemSnapshotCreator;
@@ -77,7 +78,7 @@ public class EndToEndTest extends SourceTestBase {
                 "  \"settings\": {" +
                 "    \"number_of_shards\": %d," +
                 "    \"number_of_replicas\": 0," +
-                (VersionMatchers.isBelowES_6_X.test(sourceVersion)
+                (UnboundVersionMatchers.isBelowES_6_X.test(sourceVersion)
                         ? ""
                         : "    \"index.soft_deletes.enabled\": true,") +
                 "    \"refresh_interval\": -1" +

--- a/DocumentsFromSnapshotMigration/src/test/java/org/opensearch/migrations/bulkload/SourceTestBase.java
+++ b/DocumentsFromSnapshotMigration/src/test/java/org/opensearch/migrations/bulkload/SourceTestBase.java
@@ -253,7 +253,7 @@ public class SourceTestBase {
                 return d;
             };
 
-            var sourceResourceProvider = ClusterProviderRegistry.getSnapshotReader(sourceVersion, sourceRepo);
+            var sourceResourceProvider = ClusterProviderRegistry.getSnapshotReader(sourceVersion, sourceRepo, false);
 
             DefaultSourceRepoAccessor repoAccessor = new DefaultSourceRepoAccessor(sourceRepo);
             SnapshotShardUnpacker.Factory unpackerFactory = new SnapshotShardUnpacker.Factory(

--- a/MetadataMigration/src/main/java/org/opensearch/migrations/MigrateOrEvaluateArgs.java
+++ b/MetadataMigration/src/main/java/org/opensearch/migrations/MigrateOrEvaluateArgs.java
@@ -67,6 +67,9 @@ public class MigrateOrEvaluateArgs {
     @ParametersDelegate
     public TransformerParams metadataCustomTransformationParams = new MetadataCustomTransformationParams();
 
+    @ParametersDelegate
+    public VersionStrictness versionStrictness = new VersionStrictness();
+
     @Getter
     public static class MetadataTransformationParams implements MetadataTransformerParams {
         @Parameter(names = {"--multi-type-behavior"}, description = "Define behavior for resolving multi type mappings.")

--- a/MetadataMigration/src/main/java/org/opensearch/migrations/cli/ClusterReaderExtractor.java
+++ b/MetadataMigration/src/main/java/org/opensearch/migrations/cli/ClusterReaderExtractor.java
@@ -47,10 +47,10 @@ public class ClusterReaderExtractor {
     }
 
     ClusterReader getRemoteReader(ConnectionContext connection) {
-        return ClusterProviderRegistry.getRemoteReader(connection);
+        return ClusterProviderRegistry.getRemoteReader(connection, arguments.versionStrictness.allowLooseVersionMatches);
     }
 
     ClusterReader getSnapshotReader(Version sourceVersion, SourceRepo repo) {
-        return ClusterProviderRegistry.getSnapshotReader(sourceVersion, repo);
+        return ClusterProviderRegistry.getSnapshotReader(sourceVersion, repo, arguments.versionStrictness.allowLooseVersionMatches);
     }
 }

--- a/MetadataMigration/src/main/java/org/opensearch/migrations/commands/Evaluate.java
+++ b/MetadataMigration/src/main/java/org/opensearch/migrations/commands/Evaluate.java
@@ -1,5 +1,7 @@
 package org.opensearch.migrations.commands;
 
+import java.util.Optional;
+
 import org.opensearch.migrations.MigrateOrEvaluateArgs;
 import org.opensearch.migrations.MigrationMode;
 import org.opensearch.migrations.metadata.tracing.RootMetadataMigrationContext;
@@ -36,9 +38,10 @@ public class Evaluate extends MigratorEvaluatorBase {
                 .build();
         } catch (Throwable e) {
             log.atError().setCause(e).setMessage("Unexpected failure").log();
+            var causeMessage = Optional.of(e).map(Throwable::getCause).map(Throwable::getMessage).orElse(null);
             evaluateResult
                 .exitCode(UNEXPECTED_FAILURE_CODE)
-                .errorMessage("Unexpected failure: " + e.getMessage())
+                .errorMessage("Unexpected failure: " + e.getMessage() + (causeMessage == null ? "" : ", inner cause: " + causeMessage))
                 .build();
         }
 

--- a/MetadataMigration/src/main/resources/log4j2.properties
+++ b/MetadataMigration/src/main/resources/log4j2.properties
@@ -1,4 +1,4 @@
-status = WARN
+status = INFO
 
 property.logsDir = ${env:SHARED_LOGS_DIR_PATH:-./logs}
 property.failedLoggerFileNamePrefix = ${logsDir}/${hostName}/failedRequests/failedRequests

--- a/MetadataMigration/src/main/resources/log4j2.properties
+++ b/MetadataMigration/src/main/resources/log4j2.properties
@@ -14,7 +14,7 @@ appender.console.target = SYSTEM_OUT
 appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = %m%n
 
-rootLogger.level = ERROR
+rootLogger.level = INFO
 rootLogger.appenderRef.console.ref = MetadataRun
 
 # Metadata Migration

--- a/RFS/src/main/java/org/opensearch/migrations/VersionStrictness.java
+++ b/RFS/src/main/java/org/opensearch/migrations/VersionStrictness.java
@@ -1,0 +1,17 @@
+package org.opensearch.migrations;
+
+import com.beust.jcommander.Parameter;
+import lombok.Getter;
+
+@Getter
+public class VersionStrictness {
+    public static final String ALLOW_LOOSE_VERSION_MATCHING_PARAM_KEY = "--allow-loose-version-matching";
+
+    public static final String REMEDIATION_MESSAGE = "There was a problem matching versions, this might be worked around by adding '"
+        + ALLOW_LOOSE_VERSION_MATCHING_PARAM_KEY + "' to the command line arguments";
+
+    @Parameter(names = { ALLOW_LOOSE_VERSION_MATCHING_PARAM_KEY }, description = "Allow loose version matching for cluster version types that are"
+        + " not officially supported. By default this is disabled.")
+    public boolean allowLooseVersionMatches = false;
+
+}

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/common/OpenSearchClientFactory.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/common/OpenSearchClientFactory.java
@@ -6,6 +6,7 @@ import java.util.HashSet;
 import java.util.Optional;
 
 import org.opensearch.migrations.Flavor;
+import org.opensearch.migrations.UnboundVersionMatchers;
 import org.opensearch.migrations.Version;
 import org.opensearch.migrations.VersionMatchers;
 import org.opensearch.migrations.bulkload.common.http.ConnectionContext;
@@ -65,11 +66,11 @@ public class OpenSearchClientFactory {
     }
 
     private Class<? extends OpenSearchClient> getOpenSearchClientClass(Version version) {
-        if (VersionMatchers.anyOS.or(VersionMatchers.isES_7_X).or(VersionMatchers.isES_8_X).test(version)) {
+        if (UnboundVersionMatchers.anyOS.or(UnboundVersionMatchers.isGreaterOrEqualES_7_X).test(version)) {
             return OpenSearchClient_OS_2_11.class;
         } else if (VersionMatchers.isES_6_X.test(version)) {
             return OpenSearchClient_ES_6_8.class;
-        } else if (VersionMatchers.isES_5_X.test(version)) {
+        } else if (UnboundVersionMatchers.isBelowES_6_X.test(version)) {
             return OpenSearchClient_ES_5_6.class;
         }
         throw new IllegalArgumentException("Unsupported version: " + version);

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/transformers/TransformFunctions.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/transformers/TransformFunctions.java
@@ -1,8 +1,5 @@
 package org.opensearch.migrations.bulkload.transformers;
 
-import org.opensearch.migrations.Version;
-import org.opensearch.migrations.VersionMatchers;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -16,29 +13,6 @@ public class TransformFunctions {
     public static final String INDEX_KEY_STR = "index";
 
     private TransformFunctions() {}
-
-    public static Transformer getTransformer(
-        Version sourceVersion,
-        Version targetVersion,
-        int awarenessAttributes,
-        MetadataTransformerParams metadataTransformerParams
-    ) {
-        if (VersionMatchers.anyOS.test(targetVersion)) {
-            if (VersionMatchers.isES_5_X.test(sourceVersion)) {
-                return new Transformer_ES_5_6_to_OS_2_11(awarenessAttributes, metadataTransformerParams);
-            }
-            if (VersionMatchers.isES_6_X.test(sourceVersion)) {
-                return new Transformer_ES_6_8_to_OS_2_11(awarenessAttributes, metadataTransformerParams);
-            }
-            if (VersionMatchers.equalOrGreaterThanES_7_10.test(sourceVersion)) {
-                return new Transformer_ES_7_10_OS_2_11(awarenessAttributes);
-            }
-            if (VersionMatchers.anyOS.test(sourceVersion)) {
-                return new Transformer_ES_7_10_OS_2_11(awarenessAttributes);
-            }
-        }
-        throw new IllegalArgumentException("Unsupported transformation requested for " + sourceVersion + " to " + targetVersion);
-    }
 
     /* Turn dotted index settings into a tree, will start like:
      * {"index.number_of_replicas":"1","index.number_of_shards":"5","index.version.created":"6082499"}

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/transformers/TransformerMapper.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/transformers/TransformerMapper.java
@@ -1,0 +1,67 @@
+package org.opensearch.migrations.bulkload.transformers;
+
+import org.opensearch.migrations.UnboundVersionMatchers;
+import org.opensearch.migrations.Version;
+import org.opensearch.migrations.VersionMatchers;
+import org.opensearch.migrations.VersionStrictness;
+
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@AllArgsConstructor
+public class TransformerMapper {
+    private final Version sourceVersion;
+    private final Version targetVersion;
+
+    public Transformer getTransformer(
+        int awarenessAttributes,
+        MetadataTransformerParams metadataTransformerParams,
+        boolean allowLooseMatches
+    ) {
+        if (allowLooseMatches) {
+            log.atInfo()
+                .setMessage("Allowing loose version matching, attempting to find matching transformer from {} to {}")
+                .addArgument(sourceVersion)
+                .addArgument(targetVersion)
+                .log();
+
+            return looseTransformerMapping(awarenessAttributes, metadataTransformerParams);
+        }
+
+        return strictTransformerMapping(awarenessAttributes, metadataTransformerParams);
+    }
+
+    private Transformer strictTransformerMapping(int awarenessAttributes, MetadataTransformerParams metadataTransformerParams) {
+        if (VersionMatchers.anyOS.test(targetVersion)) {
+            if (VersionMatchers.isES_5_X.test(sourceVersion)) {
+                return new Transformer_ES_5_6_to_OS_2_11(awarenessAttributes, metadataTransformerParams);
+            }
+            if (VersionMatchers.isES_6_X.test(sourceVersion)) {
+                return new Transformer_ES_6_8_to_OS_2_11(awarenessAttributes, metadataTransformerParams);
+            }
+            if (VersionMatchers.equalOrGreaterThanES_7_10.test(sourceVersion)) {
+                return new Transformer_ES_7_10_OS_2_11(awarenessAttributes);
+            }
+            if (VersionMatchers.anyOS.test(sourceVersion)) {
+                return new Transformer_ES_7_10_OS_2_11(awarenessAttributes);
+            }
+        }
+        throw new IllegalArgumentException("Unsupported transformation requested for " + sourceVersion + " to " + targetVersion + "." + VersionStrictness.REMEDIATION_MESSAGE);
+    }
+
+    private Transformer looseTransformerMapping(int awarenessAttributes, MetadataTransformerParams metadataTransformerParams) {
+        if (UnboundVersionMatchers.anyOS.or(UnboundVersionMatchers.isGreaterOrEqualES_6_X).test(targetVersion)) {
+            if (UnboundVersionMatchers.isBelowES_6_X.test(sourceVersion)) {
+                return new Transformer_ES_5_6_to_OS_2_11(awarenessAttributes, metadataTransformerParams);
+            }
+            if (VersionMatchers.isES_6_X.test(sourceVersion)) {
+                return new Transformer_ES_6_8_to_OS_2_11(awarenessAttributes, metadataTransformerParams);
+            }
+            if (UnboundVersionMatchers.anyES.or(UnboundVersionMatchers.anyOS).test(sourceVersion)) {
+                return new Transformer_ES_7_10_OS_2_11(awarenessAttributes);
+            }
+        }
+        throw new IllegalArgumentException("Unsupported transformation requested for " + sourceVersion + " to " + targetVersion + ".");
+    }
+}

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/version_es_6_8/RemoteWriter_ES_6_8.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/version_es_6_8/RemoteWriter_ES_6_8.java
@@ -16,7 +16,7 @@ import org.opensearch.migrations.metadata.IndexCreator;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
-public class RemoteWriter_OS_6_8 implements RemoteCluster, ClusterWriter {
+public class RemoteWriter_ES_6_8 implements RemoteCluster, ClusterWriter {
     private Version version;
     private OpenSearchClient client;
     private ConnectionContext connection;
@@ -25,6 +25,11 @@ public class RemoteWriter_OS_6_8 implements RemoteCluster, ClusterWriter {
     @Override
     public boolean compatibleWith(Version version) {
         return VersionMatchers.isES_6_X.test(version);
+    }
+
+    @Override
+    public boolean looseCompatibleWith(Version version) {
+        return this.compatibleWith(version);
     }
 
     @Override

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/version_es_6_8/SnapshotReader_ES_6_8.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/version_es_6_8/SnapshotReader_ES_6_8.java
@@ -1,5 +1,6 @@
 package org.opensearch.migrations.bulkload.version_es_6_8;
 
+import org.opensearch.migrations.UnboundVersionMatchers;
 import org.opensearch.migrations.Version;
 import org.opensearch.migrations.VersionMatchers;
 import org.opensearch.migrations.bulkload.common.SnapshotRepo;
@@ -18,6 +19,13 @@ public class SnapshotReader_ES_6_8 implements ClusterSnapshotReader {
     public boolean compatibleWith(Version version) {
         return VersionMatchers.isES_6_X
             .or(VersionMatchers.isES_5_X)
+            .test(version);
+    }
+
+    @Override
+    public boolean looseCompatibleWith(Version version) {
+        return UnboundVersionMatchers.isBelowES_6_X
+            .or(VersionMatchers.isES_6_X)
             .test(version);
     }
 

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/version_es_7_10/SnapshotReader_ES_7_10.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/version_es_7_10/SnapshotReader_ES_7_10.java
@@ -1,5 +1,6 @@
 package org.opensearch.migrations.bulkload.version_es_7_10;
 
+import org.opensearch.migrations.UnboundVersionMatchers;
 import org.opensearch.migrations.Version;
 import org.opensearch.migrations.VersionMatchers;
 import org.opensearch.migrations.bulkload.common.SnapshotRepo;
@@ -20,6 +21,13 @@ public class SnapshotReader_ES_7_10 implements ClusterSnapshotReader {
             .or(VersionMatchers.isES_8_X)
             .or(VersionMatchers.isOS_1_X)
             .or(VersionMatchers.isOS_2_X)
+            .test(version);
+    }
+
+    @Override
+    public boolean looseCompatibleWith(Version version) {
+        return UnboundVersionMatchers.isGreaterOrEqualES_7_X
+            .or(UnboundVersionMatchers.anyOS)
             .test(version);
     }
 

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/version_os_2_11/RemoteWriter_OS_2_11.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/version_os_2_11/RemoteWriter_OS_2_11.java
@@ -1,6 +1,7 @@
 package org.opensearch.migrations.bulkload.version_os_2_11;
 
 import org.opensearch.migrations.AwarenessAttributeSettings;
+import org.opensearch.migrations.UnboundVersionMatchers;
 import org.opensearch.migrations.Version;
 import org.opensearch.migrations.VersionMatchers;
 import org.opensearch.migrations.bulkload.common.OpenSearchClient;
@@ -24,6 +25,12 @@ public class RemoteWriter_OS_2_11 implements RemoteCluster, ClusterWriter {
     @Override
     public boolean compatibleWith(Version version) {
         return VersionMatchers.anyOS
+            .test(version);
+    }
+
+    @Override
+    public boolean looseCompatibleWith(Version version) {
+        return UnboundVersionMatchers.anyOS
             .test(version);
     }
 

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/version_universal/RemoteReader.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/version_universal/RemoteReader.java
@@ -1,5 +1,6 @@
 package org.opensearch.migrations.bulkload.version_universal;
 
+import org.opensearch.migrations.UnboundVersionMatchers;
 import org.opensearch.migrations.Version;
 import org.opensearch.migrations.VersionMatchers;
 import org.opensearch.migrations.bulkload.common.OpenSearchClientFactory;
@@ -21,6 +22,13 @@ public class RemoteReader implements RemoteCluster, ClusterReader {
             .or(VersionMatchers.isES_7_X)
             .or(VersionMatchers.isES_5_X)
             .or(VersionMatchers.anyOS)
+            .test(version);
+    }
+
+    @Override
+    public boolean looseCompatibleWith(Version version) {
+        return UnboundVersionMatchers.anyES
+            .or(UnboundVersionMatchers.anyOS)
             .test(version);
     }
 
@@ -57,7 +65,7 @@ public class RemoteReader implements RemoteCluster, ClusterReader {
 
     private RemoteReaderClient getClient() {
         if (client == null) {
-            if (VersionMatchers.isES_6_X.or(VersionMatchers.isES_5_X).test(getVersion())) {
+            if (UnboundVersionMatchers.isBelowES_7_X.test(getVersion())) {
                 client = new RemoteReaderClient_ES_6_8(getConnection());
             } else {
                 client = new RemoteReaderClient(getConnection());

--- a/RFS/src/main/java/org/opensearch/migrations/cluster/ClusterProviderRegistry.java
+++ b/RFS/src/main/java/org/opensearch/migrations/cluster/ClusterProviderRegistry.java
@@ -5,11 +5,12 @@ import java.util.Optional;
 import java.util.stream.Stream;
 
 import org.opensearch.migrations.Version;
+import org.opensearch.migrations.VersionStrictness;
 import org.opensearch.migrations.bulkload.common.OpenSearchClientFactory;
 import org.opensearch.migrations.bulkload.common.SourceRepo;
 import org.opensearch.migrations.bulkload.common.http.ConnectionContext;
 import org.opensearch.migrations.bulkload.models.DataFilterArgs;
-import org.opensearch.migrations.bulkload.version_es_6_8.RemoteWriter_OS_6_8;
+import org.opensearch.migrations.bulkload.version_es_6_8.RemoteWriter_ES_6_8;
 import org.opensearch.migrations.bulkload.version_es_6_8.SnapshotReader_ES_6_8;
 import org.opensearch.migrations.bulkload.version_es_7_10.SnapshotReader_ES_7_10;
 import org.opensearch.migrations.bulkload.version_os_2_11.RemoteWriter_OS_2_11;
@@ -28,7 +29,7 @@ public class ClusterProviderRegistry {
             new SnapshotReader_ES_6_8(),
             new SnapshotReader_ES_7_10(),
             new RemoteWriter_OS_2_11(),
-            new RemoteWriter_OS_6_8(),
+            new RemoteWriter_ES_6_8(),
             new RemoteReader()
         );
     }
@@ -39,15 +40,21 @@ public class ClusterProviderRegistry {
      * @param repo The source repo that contains of the snapshot
      * @return The snapshot resource provider
      */
-    public ClusterSnapshotReader getSnapshotReader(Version version, SourceRepo repo) {
+    public ClusterSnapshotReader getSnapshotReader(Version version, SourceRepo repo, boolean looseMatch) {
         var snapshotProvider = getProviders()
             .stream()
-            .filter(p -> p.compatibleWith(version))
+            .filter(p -> looseMatch ? p.looseCompatibleWith(version) : p.compatibleWith(version))
             .filter(ClusterSnapshotReader.class::isInstance)
             .map(ClusterSnapshotReader.class::cast)
             .map(p -> p.initialize(version))
             .findFirst()
-            .orElseThrow(() -> new UnsupportedVersionException("No snapshot provider found for version: " + version));
+            .orElseThrow(() -> {
+                var message = "No snapshot provider found for version: " + version;
+                if (!looseMatch) {
+                    message = message + " " + VersionStrictness.REMEDIATION_MESSAGE;
+                }
+                return new UnsupportedVersionException(message);
+            });
 
         snapshotProvider.initialize(repo);
         log.info("Found snapshot resource reader for version: " + version);
@@ -59,17 +66,23 @@ public class ClusterProviderRegistry {
      * @param connection The connection context for the cluster
      * @return The remote resource provider
      */
-    public ClusterReader getRemoteReader(ConnectionContext connection) {
+    public ClusterReader getRemoteReader(ConnectionContext connection, boolean looseMatch) {
         var clientFactory = new OpenSearchClientFactory(connection);
         var client = clientFactory.determineVersionAndCreate();
         var version = client.getClusterVersion();
 
         var remoteProvider = getRemoteProviders(connection)
-            .filter(p -> p.compatibleWith(version))
+            .filter(p -> looseMatch ? p.looseCompatibleWith(version) : p.compatibleWith(version))
             .filter(ClusterReader.class::isInstance)
             .map(ClusterReader.class::cast)
             .findFirst()
-            .orElseThrow(() -> new UnsupportedVersionException("Unable to find compatible reader for " + connection + ", " + version));
+            .orElseThrow(() -> {
+                var message = "Unable to find compatible reader for " + connection + ", " + version;
+                if (!looseMatch) {
+                    message = message + " " + VersionStrictness.REMEDIATION_MESSAGE;
+                }
+                return new UnsupportedVersionException(message);
+            });
 
         log.info("Found remote reader for version: " + version);
         return remoteProvider;
@@ -80,18 +93,24 @@ public class ClusterProviderRegistry {
      * @param connection The connection context for the cluster
      * @return The remote resource creator
      */
-    public ClusterWriter getRemoteWriter(ConnectionContext connection, Version versionOverride, DataFilterArgs dataFilterArgs) {
+    public ClusterWriter getRemoteWriter(ConnectionContext connection, Version versionOverride, DataFilterArgs dataFilterArgs, boolean looseMatch) {
         var version = Optional.ofNullable(versionOverride)
             .orElseGet(() -> new OpenSearchClientFactory(connection).getClusterVersion());
 
         var remoteProvider = getRemoteProviders(connection)
-            .filter(p -> p.compatibleWith(version))
+            .filter(p -> looseMatch ? p.looseCompatibleWith(version) : p.compatibleWith(version))
             .filter(ClusterWriter.class::isInstance)
             .map(ClusterWriter.class::cast)
             .map(p -> p.initialize(versionOverride))
             .map(p -> p.initialize(dataFilterArgs))
             .findFirst()
-            .orElseThrow(() -> new UnsupportedVersionException("Unable to find compatible writer for " + connection + ", " + version));
+            .orElseThrow(() -> {
+                var message = "Unable to find compatible writer for " + connection + ", " + version;
+                if (!looseMatch) {
+                    message = message + " " + VersionStrictness.REMEDIATION_MESSAGE;
+                }
+                return new UnsupportedVersionException(message);
+            });
 
         log.info("Found remote writer for version: " + version);
         return remoteProvider;

--- a/RFS/src/main/java/org/opensearch/migrations/cluster/VersionSpecificCluster.java
+++ b/RFS/src/main/java/org/opensearch/migrations/cluster/VersionSpecificCluster.java
@@ -8,6 +8,9 @@ public interface VersionSpecificCluster {
     /** Can this version be used with the cluster */
     boolean compatibleWith(Version version);
 
+    /** Can this version be used with the cluster after user selects loose compatibility */
+    boolean looseCompatibleWith(Version version);
+
     /** Gets the detected version of the cluster */
     Version getVersion();
 }

--- a/RFS/src/test/java/org/opensearch/migrations/bulkload/common/LuceneDocumentsReaderTest.java
+++ b/RFS/src/test/java/org/opensearch/migrations/bulkload/common/LuceneDocumentsReaderTest.java
@@ -86,7 +86,7 @@ public class LuceneDocumentsReaderTest {
     @MethodSource("provideSnapshots")
     public void ReadDocuments_AsExpected(TestResources.Snapshot snapshot, Version version) {
         final var repo = new FileSystemRepo(snapshot.dir);
-        var sourceResourceProvider = ClusterProviderRegistry.getSnapshotReader(version, repo);
+        var sourceResourceProvider = ClusterProviderRegistry.getSnapshotReader(version, repo, false);
         DefaultSourceRepoAccessor repoAccessor = new DefaultSourceRepoAccessor(repo);
 
         final ShardMetadata shardMetadata = sourceResourceProvider.getShardMetadata().fromRepo(snapshot.name, "test_updates_deletes", 0);
@@ -149,7 +149,7 @@ public class LuceneDocumentsReaderTest {
         Version version = Version.fromString("ES 6.8");
 
         final var repo = new FileSystemRepo(snapshot.dir);
-        var sourceResourceProvider = ClusterProviderRegistry.getSnapshotReader(version, repo);
+        var sourceResourceProvider = ClusterProviderRegistry.getSnapshotReader(version, repo, false);
         DefaultSourceRepoAccessor repoAccessor = new DefaultSourceRepoAccessor(repo);
 
         final ShardMetadata shardMetadata = sourceResourceProvider.getShardMetadata().fromRepo(snapshot.name, "test_updates_deletes", 0);
@@ -302,7 +302,7 @@ public class LuceneDocumentsReaderTest {
         List<Integer> documentStartingIndices = List.of(0, 2, 5);
 
         final var repo = new FileSystemRepo(snapshot.dir);
-        var sourceResourceProvider = ClusterProviderRegistry.getSnapshotReader(version, repo);
+        var sourceResourceProvider = ClusterProviderRegistry.getSnapshotReader(version, repo, false);
         DefaultSourceRepoAccessor repoAccessor = new DefaultSourceRepoAccessor(repo);
 
         final ShardMetadata shardMetadata = sourceResourceProvider.getShardMetadata().fromRepo(snapshot.name, "test_updates_deletes", 0);
@@ -339,7 +339,7 @@ public class LuceneDocumentsReaderTest {
                 List.of("unchangeddoc"));
 
         final var repo = new FileSystemRepo(snapshot.dir);
-        var sourceResourceProvider = ClusterProviderRegistry.getSnapshotReader(version, repo);
+        var sourceResourceProvider = ClusterProviderRegistry.getSnapshotReader(version, repo, false);
         DefaultSourceRepoAccessor repoAccessor = new DefaultSourceRepoAccessor(repo);
 
         final ShardMetadata shardMetadata = sourceResourceProvider.getShardMetadata().fromRepo(snapshot.name, "test_updates_deletes", 0);

--- a/RFS/src/test/java/org/opensearch/migrations/bulkload/transformers/TransformerMapperTest.java
+++ b/RFS/src/test/java/org/opensearch/migrations/bulkload/transformers/TransformerMapperTest.java
@@ -1,0 +1,55 @@
+package org.opensearch.migrations.bulkload.transformers;
+
+import org.opensearch.migrations.Version;
+import org.opensearch.migrations.VersionStrictness;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+
+
+public class TransformerMapperTest {
+
+    @Test
+    void testGetTransformer_strict_found() {
+        var params = mock(MetadataTransformerParams.class);
+        var mapper = new TransformerMapper(Version.fromString("ES 5.0"), Version.fromString("OS 3"));
+
+        var transformer = mapper.getTransformer(0, params, false);
+        assertThat(transformer, notNullValue());
+        assertThat(transformer, instanceOf(Transformer_ES_5_6_to_OS_2_11.class));
+    }
+
+    @Test
+    void testGetTransformer_strict_notFound() {
+        var mapper = new TransformerMapper(Version.fromString("ES 1.0"), Version.fromString("OS 999"));
+
+        var exception = assertThrows(IllegalArgumentException.class, () -> mapper.getTransformer(0, null, false));
+        assertThat(exception.getMessage(), containsString(VersionStrictness.REMEDIATION_MESSAGE));
+    }
+
+    @Test
+    void testGetTransformer_loose_found() {
+        var params = mock(MetadataTransformerParams.class);
+        var mapper = new TransformerMapper(Version.fromString("ES 1.0"), Version.fromString("OS 999"));
+
+        var transformer = mapper.getTransformer(0, params, true);
+        assertThat(transformer, notNullValue());
+        assertThat(transformer, instanceOf(Transformer_ES_5_6_to_OS_2_11.class));
+    }
+
+    @Test
+    void testGetTransformer_loose_notFound() {
+        var mapper = new TransformerMapper(Version.fromString("OS 1.0"), Version.fromString("ES 2"));
+
+        var exception = assertThrows(IllegalArgumentException.class, () -> mapper.getTransformer(0, null, true));
+
+        assertThat(exception.getMessage(), not(containsString(VersionStrictness.REMEDIATION_MESSAGE)));
+    }
+}

--- a/RFS/src/test/java/org/opensearch/migrations/bulkload/transformers/Transformer_ES_7_10_OS_2_11Test.java
+++ b/RFS/src/test/java/org/opensearch/migrations/bulkload/transformers/Transformer_ES_7_10_OS_2_11Test.java
@@ -23,7 +23,7 @@ public class Transformer_ES_7_10_OS_2_11Test {
         Version version = Version.fromString("ES 7.10");
 
         final var repo = new FileSystemRepo(snapshot.dir);
-        var sourceResourceProvider = ClusterProviderRegistry.getSnapshotReader(version, repo);
+        var sourceResourceProvider = ClusterProviderRegistry.getSnapshotReader(version, repo, false);
 
         Transformer_ES_7_10_OS_2_11 transformer = new Transformer_ES_7_10_OS_2_11(2);
 
@@ -46,7 +46,7 @@ public class Transformer_ES_7_10_OS_2_11Test {
         Version version = Version.fromString("ES 7.10");
 
         final var repo = new FileSystemRepo(snapshot.dir);
-        var sourceResourceProvider = ClusterProviderRegistry.getSnapshotReader(version, repo);
+        var sourceResourceProvider = ClusterProviderRegistry.getSnapshotReader(version, repo, false);
 
         Transformer_ES_7_10_OS_2_11 transformer = new Transformer_ES_7_10_OS_2_11(2);
 

--- a/transformation/src/main/java/org/opensearch/migrations/UnboundVersionMatchers.java
+++ b/transformation/src/main/java/org/opensearch/migrations/UnboundVersionMatchers.java
@@ -1,0 +1,39 @@
+package org.opensearch.migrations;
+
+import java.util.function.Predicate;
+
+import lombok.experimental.UtilityClass;
+
+/** Only use after loose version checking is enabled by a user */
+@UtilityClass
+public class UnboundVersionMatchers {
+
+    public static final Predicate<Version> anyES = VersionMatchers.matchesFlavor(Version.fromString("ES 1.0.0"));
+    public static final Predicate<Version> isBelowES_6_X = belowMajorVersion(Version.fromString("ES 6.0.0"));
+    public static final Predicate<Version> isBelowES_7_X = belowMajorVersion(Version.fromString("ES 7.0.0"));
+    public static final Predicate<Version> isGreaterOrEqualES_6_X = greaterOrEqualMajorVersion(Version.fromString("ES 6.0.0"));
+    public static final Predicate<Version> isGreaterOrEqualES_7_X = greaterOrEqualMajorVersion(Version.fromString("ES 7.0.0"));
+    public static final Predicate<Version> anyOS = VersionMatchers.matchesFlavor(Version.fromString("OS 1.0.0"));
+
+    static Predicate<Version> belowMajorVersion(final Version version) {
+        return other -> {
+            if (other == null) {
+                return false;
+            }
+            var flavorMatches = VersionMatchers.matchesFlavor(other).test(version);
+            var isLowerMajorVersion = other.getMajor() < version.getMajor();
+            return flavorMatches && isLowerMajorVersion;
+        };
+    }
+
+    static Predicate<Version> greaterOrEqualMajorVersion(final Version version) {
+        return other -> {
+            if (other == null) {
+                return false;
+            }
+            var flavorMatches = VersionMatchers.matchesFlavor(other).test(version);
+            var isLowerMajorVersion = other.getMajor() >= version.getMajor();
+            return flavorMatches && isLowerMajorVersion;
+        };
+    }
+}

--- a/transformation/src/main/java/org/opensearch/migrations/Version.java
+++ b/transformation/src/main/java/org/opensearch/migrations/Version.java
@@ -6,6 +6,7 @@ import java.util.Comparator;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
@@ -13,6 +14,7 @@ import lombok.RequiredArgsConstructor;
 @Builder
 @EqualsAndHashCode
 public class Version {
+    @NonNull
     private final Flavor flavor;
     private final int major;
     private final int minor;

--- a/transformation/src/main/java/org/opensearch/migrations/VersionMatchers.java
+++ b/transformation/src/main/java/org/opensearch/migrations/VersionMatchers.java
@@ -20,59 +20,39 @@ public class VersionMatchers {
     public static final Predicate<Version> isOS_2_19_OrGreater = VersionMatchers.equalOrGreaterThanMinorVersion(Version.fromString("OS 2.19.0"))
                                                                     .or(VersionMatchers.isOS_3_X);
     public static final Predicate<Version> anyOS = VersionMatchers.isOS_1_X.or(VersionMatchers.isOS_2_X).or(VersionMatchers.isOS_3_X);
-    public static final Predicate<Version> isBelowES_6_X = belowMajorVersion(Version.fromString("ES 6.0"));
 
-    private static Predicate<Flavor> compatibleFlavor(final Flavor flavor) {
+    static Predicate<Version> matchesFlavor(final Version version) {
         return other -> {
             if (other == null) {
                 return false;
             }
-            if (other.isOpenSearch() && flavor.isOpenSearch()) {
+            if (other.getFlavor().isOpenSearch() && version.getFlavor().isOpenSearch()) {
                 return true;
             }
-            return other == flavor;
+            return other.getFlavor() == version.getFlavor();
         };
     }
-
-    private static Predicate<Version> matchesMajorVersion(final Version version) {
+    
+    static Predicate<Version> matchesMajorVersion(final Version version) {
         return other -> {
             if (other == null) {
                 return false;
             }
-            var flavorMatches = compatibleFlavor(other.getFlavor()).test(version.getFlavor());
+            var flavorMatches = matchesFlavor(other).test(version);
             var majorVersionNumberMatches = version.getMajor() == other.getMajor();
             return flavorMatches && majorVersionNumberMatches;
         };
     }
 
-    private static Predicate<Version> matchesMinorVersion(final Version version) {
+    static Predicate<Version> matchesMinorVersion(final Version version) {
         return other -> matchesMajorVersion(version)
             .and(other2 -> version.getMinor() == other2.getMinor())
             .test(other);
     }
 
-    private static Predicate<Version> equalOrGreaterThanMinorVersion(final Version version) {
+    static Predicate<Version> equalOrGreaterThanMinorVersion(final Version version) {
         return other -> matchesMajorVersion(version)
             .and(other2 -> version.getMinor() <= other2.getMinor())
             .test(other);
-    }
-
-    /**
-     * Returns a predicate that checks if a given version is of the same flavor as the provided threshold version
-     * and has a major version number that is lower than the threshold's major version.
-     * This method ensures that only versions with a matching flavor are compared, thereby excluding incompatible OS or ES versions.
-     *
-     * @param version The threshold version used for comparison.
-     * @return A predicate that returns {@code true} if the tested version's major version is less than the threshold and the flavors match.
-     */
-    private static Predicate<Version> belowMajorVersion(final Version version) {
-        return other -> {
-            if (other == null) {
-                return false;
-            }
-            var flavorMatches = compatibleFlavor(other.getFlavor()).test(version.getFlavor());
-            var isLowerMajorVersion = other.getMajor() < version.getMajor();
-            return flavorMatches && isLowerMajorVersion;
-        };
     }
 }

--- a/transformation/src/test/java/org/opensearch/migrations/UnboundVersionMatchersTest.java
+++ b/transformation/src/test/java/org/opensearch/migrations/UnboundVersionMatchersTest.java
@@ -1,0 +1,71 @@
+package org.opensearch.migrations;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import static org.opensearch.migrations.VersionMatchersTest.testPredicate;
+
+public class UnboundVersionMatchersTest {
+
+    @Test
+    void testAnyOS() {
+        testPredicate(
+            UnboundVersionMatchers.anyOS,
+            "anyOs",
+            List.of("OS 0.0", "OS 1.3", "OS 4", "OS 999.10"),
+            List.of("ES 6.8", "ES 6.8.23", "ES 6.9", "ES 2.1")
+        );
+    }
+
+    @Test
+    void testAnyES() {
+        testPredicate(
+            UnboundVersionMatchers.anyES,
+            "anyES",
+            List.of("ES 6.8", "ES 6.8.23", "ES 6.9", "ES 2.1", "ES 9999"),
+            List.of("OS 0.0", "OS 1.3", "OS 4", "OS 999.10")
+        );
+    }
+
+    @Test
+    void testIsBelowES_6_X() {
+        testPredicate(
+            UnboundVersionMatchers.isBelowES_6_X,
+            "isBelowES_6_X",
+            List.of("ES 5.9999.9999", "ES 4.8.23", "ES 0.0", "ES 2.1"),
+            List.of("ES 6", "ES 10", "OS 0.0", "OS 1.3", "OS 4", "OS 999.10")
+        );
+    }
+
+    @Test
+    void testIsBelowES_7_X() {
+        testPredicate(
+            UnboundVersionMatchers.isBelowES_7_X,
+            "isBelowES_7_X",
+            List.of("ES 6.9999.9999", "ES 4.8.23", "ES 0.0", "ES 2.1"),
+            List.of("ES 7", "ES 10", "OS 0.0", "OS 1.3", "OS 4", "OS 999.10")
+        );
+    }
+
+    @Test
+    void testIsGreaterOrEqualES_6_X() {
+        testPredicate(
+            UnboundVersionMatchers.isGreaterOrEqualES_6_X,
+            "isGreaterOrEqualES_6_X",
+            List.of("ES 6.0", "ES 7", "ES 10"),
+            List.of("ES 5.9999.9999", "ES 4.8.23", "ES 0.0", "ES 2.1", "OS 0.0", "OS 1.3", "OS 4", "OS 999.10")
+        );
+    }
+
+    @Test
+    void testIsGreaterOrEqualES_7_X() {
+        testPredicate(
+            UnboundVersionMatchers.isGreaterOrEqualES_7_X,
+            "isGreaterOrEqualES_7_X",
+            List.of("ES 7.0", "ES 7", "ES 10"),
+            List.of("ES 6.0", "ES 5.9999.9999", "ES 4.8.23", "ES 0.0", "ES 2.1", "OS 0.0", "OS 1.3", "OS 4", "OS 999.10")
+        );
+    }
+
+}

--- a/transformation/src/test/java/org/opensearch/migrations/VersionMatchersTest.java
+++ b/transformation/src/test/java/org/opensearch/migrations/VersionMatchersTest.java
@@ -10,7 +10,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 public class VersionMatchersTest {
 
-    private void testPredicate(Predicate<Version> predicate, String matcherName, List<String> expectMatches, List<String> expectDoesNotMatch) {
+    static void testPredicate(Predicate<Version> predicate, String matcherName, List<String> expectMatches, List<String> expectDoesNotMatch) {
         expectMatches.forEach(v -> {
             assertThat(v + " should be matched by " + matcherName, predicate.test(Version.fromString(v)), equalTo(true));
         });


### PR DESCRIPTION
### Description
We've had issues where customers have tried to use our tooling on their cluster configuration and it was slightly outside the support ranges for both Metadata and RFS scenarios.  This allows customers to use a command line parameter to loosen the requirements.  

### Testing
Added unit test cases for the new scenario, by default none of the existing tests use `loose version mode` since we don't officially support testing of these versions.

#### New behavior on failure

```
~/git/opensearch-migrations$ ./gradlew MetadataMigration:run --args='evaluate --snapshot-name reindex-from-snapshot --s3-local-dir /tmp/s3_files --s3-repo-uri s3://your-s3-uri --s3-region us-fake-1 --target-host http://hostname:9200 --target-username <user> --target-password <pass> --source-version ES_21_2_1'
...
Starting Metadata Evaluation
Results:
   Issue(s) detected
Issues:
   Unexpected failure: No snapshot provider found for version: ELASTICSEARCH 21.2.1 There was a problem matching versions, this might be worked around by adding '--allow-loose-version-matching' to the command line arguments
...
```

#### After passing new parameter to loosen the version check (exception was expected)
```
~/git/opensearch-migrations$ ./gradlew MetadataMigration:run --args='evaluate --snapshot-name reindex-from-snapshot --s3-local-dir /tmp/s3_files --s3-repo-uri s3://your-s3-uri --s3-region us-fake-1 --target-host http://hostname:9200 --target-username <user> --target-password <pass> --source-version ES_21_2_1 --allow-loose-version-matching'
...
Starting Metadata Evaluation
Results:
   Issue(s) detected
Issues:
   Unexpected failure: Retries exhausted: 3/3, inner cause: Failed to resolve 'hostname' [A(1)]
```

### Check List
- [X] New functionality includes testing
- [ ] ~Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
