### PR TITLE
ES 8x specific test coverage for metadata and backfill using k8s

### DIFF
--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/integ_test/integ_test/default_operations.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/integ_test/integ_test/default_operations.py
@@ -201,6 +201,48 @@ class DefaultOperationsLibrary:
         return {
             "NoopTransformerProvider": ""
         }
-    
+
     def run_test_benchmarks(self, cluster: Cluster):
         run_test_benchmarks(cluster=cluster)
+
+    def disable_bloom(self, cluster: Cluster, index_name: str):
+        """
+        Disable bloom_filter_for_id_field for a given index (ES 8.x specific).
+        """
+        path = f"/{index_name}/_settings"
+        headers = {'Content-Type': 'application/json'}
+        payload = {
+            "index": {
+                "bloom_filter_for_id_field": {
+                    "enabled": False
+                }
+            }
+        }
+
+        response = execute_api_call(
+            cluster=cluster,
+            method=HttpMethod.PUT,
+            path=path,
+            headers=headers,
+            data=json.dumps(payload),
+            expected_status_code=200
+        )
+
+        logger.info(f"Successfully disabled bloom filter on index: {index_name}. Response: {response}")
+
+    def refresh(self, cluster: Cluster, index_name: str):
+        """
+        Refresh the index to make recent changes (like settings updates) visible to search.
+        """
+        path = f"/{index_name}/_refresh"
+        headers = {'Content-Type': 'application/json'}
+
+        response = execute_api_call(
+            cluster=cluster,
+            method=HttpMethod.POST,
+            path=path,
+            headers=headers,
+            expected_status_code=200
+        )
+
+        logger.info(f"Successfully refreshed index: {index_name}. Response: {response}")

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/integ_test/integ_test/test_cases/backfill_tests.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/integ_test/integ_test/test_cases/backfill_tests.py
@@ -26,7 +26,7 @@ full_indices = {
     "logs-181998": {"count": "1000"},
     "logs-201998": {"count": "1000"},
     "logs-191998": {"count": "1000"},
-    "sonested": {"count": "1000"},
+    "sonested": {"count": "2977"},
     "nyc_taxis": {"count": "1000"}
 }
 
@@ -72,4 +72,147 @@ class Test0006OpenSearchBenchmarkBackfill(MATestBase):
                                                       expected_index_details=full_indices,
                                                       delay=5,
                                                       max_attempts=30)
+        return super().backfill_wait_for_stop()
+
+
+class Test0007EndToEndTestForES8WithOSBenchmarks(MATestBase):
+    def __init__(self, console_config_path: str, console_link_env: Environment, unique_id: str):
+        allow_combinations = [
+            (ElasticsearchV8_X, OpensearchV2_X)
+        ]
+        run_isolated = True
+        description = "For ES 8x, run OpenSearch Benchmark tests and then runs metadata and backfill."
+        super().__init__(console_config_path=console_config_path,
+                         console_link_env=console_link_env,
+                         unique_id=unique_id,
+                         description=description,
+                         allow_source_target_combinations=allow_combinations,
+                         migrations_required=[MigrationType.BACKFILL, MigrationType.METADATA],
+                         run_isolated=run_isolated)
+        self.transform_config_file = "/shared-logs-output/test-transformations/transformation.json"
+    
+    def test_before(self):
+        # Ingest OSBenchmarks data into source cluster
+        self.source_operations.run_test_benchmarks(cluster=self.source_cluster)
+
+        # Disable bloom filter for each index in benchmarks
+        # and refresh indexes
+        for index_name in empty_indices:
+            self.source_operations.disable_bloom(cluster=self.source_cluster, index_name=index_name)
+            self.source_operations.refresh(cluster=self.source_cluster, index_name=index_name)
+
+        # Use no-op transformer
+        noop_transform = self.source_operations.get_noop_transformation()
+        self.source_operations.create_transformation_json_file(
+            transform_config_data=[noop_transform],
+            file_path_to_create=self.transform_config_file
+        )
+
+    def metadata_migrate(self):
+        comma_separated_indices = ",".join(full_indices.keys())
+        metadata_result: CommandResult = self.metadata.migrate(
+            extra_args=[
+                "--transformer-config-file", self.transform_config_file,
+                "--index-allowlist", comma_separated_indices,
+                "--component-template-allowlist", "none",
+                "--index-template-allowlist", "none"
+            ]
+        )
+        assert metadata_result.success
+
+    def metadata_after(self):
+        self.target_operations.check_doc_counts_match(
+            cluster=self.target_cluster,
+            expected_index_details=empty_indices,
+            delay=3,
+            max_attempts=20
+        )
+
+    def backfill_wait_for_stop(self):
+        self.target_operations.check_doc_counts_match(
+            cluster=self.target_cluster,
+            expected_index_details=full_indices,
+            delay=5,
+            max_attempts=30
+        )
+        return super().backfill_wait_for_stop()
+
+
+class Test0008EndToEndTestForES8WithSimpleDocs(MATestBase):
+    def __init__(self, console_config_path: str, console_link_env: Environment, unique_id: str):
+        allow_combinations = [
+            (ElasticsearchV8_X, OpensearchV2_X)
+        ]
+        run_isolated = True
+        description = "For ES 8x test using 2 simple docs in 1 index to perform metadata and backfill."
+        super().__init__(console_config_path=console_config_path,
+                         console_link_env=console_link_env,
+                         unique_id=unique_id,
+                         description=description,
+                         allow_source_target_combinations=allow_combinations,
+                         migrations_required=[MigrationType.BACKFILL, MigrationType.METADATA],
+                         run_isolated=run_isolated)
+        self.transform_config_file = "/shared-logs-output/test-transformations/transformation.json"
+        self.index_name = f"test_0010_{self.unique_id}"
+        self.doc_id1 = "test_1000_doc"
+        self.doc_id2 = "test_2000_doc"
+
+    def test_before(self):
+        # Create a single index
+        self.source_operations.create_index(cluster=self.source_cluster, index_name=self.index_name)
+        self.source_operations.disable_bloom(cluster=self.source_cluster, index_name=self.index_name)
+        self.source_operations.refresh(cluster=self.source_cluster, index_name=self.index_name)
+        self.source_operations.get_index(cluster=self.source_cluster, index_name=self.index_name)
+
+        # Create a single document
+        self.source_operations.create_document(
+            cluster=self.source_cluster,
+            index_name=self.index_name,
+            doc_id=self.doc_id1
+        )
+        self.source_operations.get_document(
+            cluster=self.source_cluster,
+            index_name=self.index_name,
+            doc_id=self.doc_id1
+        )
+
+        # Create a single document
+        self.source_operations.create_document(
+            cluster=self.source_cluster,
+            index_name=self.index_name,
+            doc_id=self.doc_id2
+        )
+        self.source_operations.get_document(
+            cluster=self.source_cluster,
+            index_name=self.index_name,
+            doc_id=self.doc_id2
+        )
+
+        # Use no-op transformer
+        noop_transform = self.source_operations.get_noop_transformation()
+        self.source_operations.create_transformation_json_file(
+            transform_config_data=[noop_transform],
+            file_path_to_create=self.transform_config_file
+        )
+
+    def metadata_migrate(self):
+        metadata_result: CommandResult = self.metadata.migrate(
+            extra_args=[
+                "--transformer-config-file", self.transform_config_file,
+                "--index-allowlist", self.index_name,
+                "--component-template-allowlist", "none",
+                "--index-template-allowlist", "none"
+            ]
+        )
+        assert metadata_result.success
+
+    def metadata_after(self):
+        self.target_operations.get_index(
+            cluster=self.target_cluster,
+            index_name=self.index_name,
+            max_attempts=5,
+            delay=2.0
+        )
+
+    def backfill_wait_for_stop(self):
         return super().backfill_wait_for_stop()

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/integ_test/integ_test/test_cases/ma_test_base.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/integ_test/integ_test/test_cases/ma_test_base.py
@@ -92,7 +92,7 @@ class MATestBase:
     def backfill_start(self):
         if MigrationType.BACKFILL in self.migrations_required:
             # Flip this bool to only use one worker otherwise use the default worker count (5), useful for debugging
-            single_worker_mode = False
+            single_worker_mode = True
             if not single_worker_mode:
                 backfill_start_result: CommandResult = self.backfill.start()
                 assert backfill_start_result.success


### PR DESCRIPTION
### Description
This PR brings in 2 test cases for ES 8x as a source. One where we create a basic index and ingest 2 documents in it, and second to utilize the opensearch-benchmarks workload along with verification.

- Test0007EndToEndTestForES8WithOSBenchmarks
- Test0008EndToEndTestForES8WithSimpleDocs

The 0008 test is currently passing for ES 8x as a source, whereas the 0007 test will fail on the `nyc_taxis` workload as we require a Codec to handle the ZSTD compression. Hence creating this as a draft PR as of now.

### Issues Resolved
[MIGRATIONS-2529](https://opensearch.atlassian.net/browse/MIGRATIONS-2529)

### Steps to execute tests

From deployment/k8s
- `./minikubeLocal.sh --start`
- `./ buildDockerImagesMini.sh`
Then from libraries/testAutomation, perform
- `pipenv run app --source-version=ES_8.x --target-version=OS_2.x --test-ids=0007`
- pipenv run app --source-version=ES_8.x --target-version=OS_2.x --test-ids=0008`

### Check List
- [ ] New functionality includes testing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
