### PR TITLE
Register SPI stub class and add codec for zstd

### DIFF
--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/lucene/version_9/ForgivingStoredFieldsFormat.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/lucene/version_9/ForgivingStoredFieldsFormat.java
@@ -1,0 +1,32 @@
+package org.opensearch.migrations.bulkload.lucene.version_9;
+
+import java.io.IOException;
+
+import shadow.lucene9.org.apache.lucene.codecs.StoredFieldsFormat;
+import shadow.lucene9.org.apache.lucene.codecs.StoredFieldsReader;
+import shadow.lucene9.org.apache.lucene.codecs.StoredFieldsWriter;
+import shadow.lucene9.org.apache.lucene.codecs.lucene90.Lucene90StoredFieldsFormat;
+import shadow.lucene9.org.apache.lucene.codecs.lucene90.Lucene90StoredFieldsFormat.Mode;
+import shadow.lucene9.org.apache.lucene.index.FieldInfos;
+import shadow.lucene9.org.apache.lucene.index.SegmentInfo;
+import shadow.lucene9.org.apache.lucene.store.Directory;
+import shadow.lucene9.org.apache.lucene.store.IOContext;
+
+public class ForgivingStoredFieldsFormat extends StoredFieldsFormat {
+
+    @Override
+    public StoredFieldsReader fieldsReader(Directory directory, SegmentInfo si, FieldInfos fn, IOContext context)
+            throws IOException {
+        if (si.getAttribute("Lucene90StoredFieldsFormat.mode") == null) {
+            System.out.println(">>>>> Injecting missing mode BEST_SPEED into segment info");
+            si.putAttribute("Lucene90StoredFieldsFormat.mode", "BEST_SPEED");
+        }
+        return new Lucene90StoredFieldsFormat(Mode.BEST_SPEED).fieldsReader(directory, si, fn, context);
+    }
+
+    @Override
+    public StoredFieldsWriter fieldsWriter(Directory directory, SegmentInfo si, IOContext context)
+            throws IOException {
+        return new Lucene90StoredFieldsFormat(Mode.BEST_SPEED).fieldsWriter(directory, si, context);
+    }
+}

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/lucene/version_9/IgnoreBloomFilter.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/lucene/version_9/IgnoreBloomFilter.java
@@ -1,0 +1,54 @@
+package org.opensearch.migrations.bulkload.lucene.version_9;
+
+import java.io.IOException;
+import java.util.Iterator;
+
+import shadow.lucene9.org.apache.lucene.codecs.FieldsConsumer;
+import shadow.lucene9.org.apache.lucene.codecs.FieldsProducer;
+import shadow.lucene9.org.apache.lucene.codecs.PostingsFormat;
+import shadow.lucene9.org.apache.lucene.index.SegmentReadState;
+import shadow.lucene9.org.apache.lucene.index.SegmentWriteState;
+import shadow.lucene9.org.apache.lucene.index.Terms;
+import shadow.lucene9.org.apache.lucene.store.Directory;
+
+/**
+ * PostingsFormat fallback for Elasticsearch 8.7+ segment formats.
+ *
+ * <p>This class provides a dummy implementation for "ES87BloomFilter" to avoid runtime
+ * errors when Lucene 9 attempts to load this postings format from snapshot-based
+ * segment metadata during document migration.</p>
+ *
+ * <p>Registered via Lucene's SPI to allow dynamic loading based on PostingsFormat name
+ * stored in segment metadata.</p>
+ *
+ * <p><b>NOTE:</b> This class is intentionally limited to fallback behavior and not meant
+ * to parse actual ES 8.x Lucene segments.</p>
+ */
+public class IgnoreBloomFilter extends PostingsFormat{
+
+    public IgnoreBloomFilter() {
+        super("ES87BloomFilter");
+        System.out.println(">>>>> Loading stub IgnoreBloomFilter class");
+    }
+
+    public FieldsConsumer fieldsConsumer(SegmentWriteState state) throws IOException {
+        throw new UnsupportedOperationException("ES87BloomFilter is read-only fallback");
+    }
+
+    @Override
+    public FieldsProducer fieldsProducer(SegmentReadState state) throws IOException {
+        return new FieldsProducer() {
+            @Override public void close() {}
+            @Override public void checkIntegrity() {}
+            @Override public Iterator<String> iterator() {
+                return java.util.Collections.emptyIterator();
+            }
+            @Override public Terms terms(String field) {
+                return null;
+            }
+            @Override public int size() {
+                return 0;
+            }
+        };
+    }
+}

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/lucene/version_9/IgnoreElasticsearch816Codec
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/lucene/version_9/IgnoreElasticsearch816Codec
@@ -1,0 +1,36 @@
+package org.opensearch.migrations.bulkload.lucene.version_9;
+
+import shadow.lucene9.org.apache.lucene.codecs.*;
+
+/**
+ * Codec fallback for Elasticsearch 8.16+ segment formats.
+ *
+ * <p>This class provides a dummy implementation for "Elasticsearch816" to avoid runtime
+ * errors when Lucene 9 attempts to load this postings format from snapshot-based
+ * segment metadata during document migration.</p>
+ *
+ * <p>Registered via Lucene's SPI to allow dynamic loading based on Codec name
+ * stored in segment metadata.</p>
+ *
+ * <p><b>NOTE:</b> This class is intentionally limited to fallback behavior and not meant
+ * to parse actual ES 8.x Lucene segments.</p>
+ */
+public class IgnoreElasticsearch816Codec extends Codec {
+
+    public IgnoreElasticsearch816Codec() {
+        super("Elasticsearch816");
+        System.out.println(">>>>> Loaded stub Codec for Elasticsearch816");
+    }
+
+    @Override public PostingsFormat postingsFormat() { return Codec.forName("Lucene912").postingsFormat(); }
+    @Override public DocValuesFormat docValuesFormat() { return Codec.forName("Lucene912").docValuesFormat(); }
+    @Override public StoredFieldsFormat storedFieldsFormat() { return new ForgivingStoredFieldsFormat(); }
+    @Override public TermVectorsFormat termVectorsFormat() { return Codec.forName("Lucene912").termVectorsFormat(); }
+    @Override public FieldInfosFormat fieldInfosFormat() { return Codec.forName("Lucene912").fieldInfosFormat(); }
+    @Override public SegmentInfoFormat segmentInfoFormat() { return Codec.forName("Lucene912").segmentInfoFormat(); }
+    @Override public NormsFormat normsFormat() { return Codec.forName("Lucene912").normsFormat(); }
+    @Override public LiveDocsFormat liveDocsFormat() { return Codec.forName("Lucene912").liveDocsFormat(); }
+    @Override public CompoundFormat compoundFormat() { return Codec.forName("Lucene912").compoundFormat(); }
+    @Override public PointsFormat pointsFormat() { return Codec.forName("Lucene912").pointsFormat(); }
+    @Override public KnnVectorsFormat knnVectorsFormat() { return Codec.forName("Lucene912").knnVectorsFormat(); }
+}

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/lucene/version_9/IgnorePsmPostings.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/lucene/version_9/IgnorePsmPostings.java
@@ -59,6 +59,7 @@ public class IgnorePsmPostings extends PostingsFormat {
 
     public IgnorePsmPostings() {
         super("ES812Postings");
+        System.out.println(">>>>> Loading stub IgnorePsmPostings class");
     }
 
     public FieldsConsumer fieldsConsumer(SegmentWriteState state) throws IOException {

--- a/RFS/src/main/resources/META-INF/services/shadow.lucene9.org.apache.lucene.codecs.Codec
+++ b/RFS/src/main/resources/META-INF/services/shadow.lucene9.org.apache.lucene.codecs.Codec
@@ -1,0 +1,1 @@
+org.opensearch.migrations.bulkload.lucene.version_9.IgnoreElasticsearch816Codec

--- a/RFS/src/main/resources/META-INF/services/shadow.lucene9.org.apache.lucene.codecs.PostingsFormat
+++ b/RFS/src/main/resources/META-INF/services/shadow.lucene9.org.apache.lucene.codecs.PostingsFormat
@@ -1,1 +1,2 @@
 org.opensearch.migrations.bulkload.lucene.version_9.IgnorePsmPostings
+org.opensearch.migrations.bulkload.lucene.version_9.IgnoreBloomFilter


### PR DESCRIPTION
### Description
This PR brings in the No-Op implement for ignoring Bloom Filters and to skip the Elasticsearch816 Codec required due to certain default index settings in ES 8x. It also focuses on adding in any new Codec into our Lucene9 Readers to successfully read ZSTD compressed lucene segments.

### Issues Resolved
[MIGRATIONS-2536](https://opensearch.atlassian.net/browse/MIGRATIONS-2536)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
