### PR TITLE
Metadata make sure all errors are counted and reported

### DIFF
--- a/MetadataMigration/src/main/java/org/opensearch/migrations/cli/Items.java
+++ b/MetadataMigration/src/main/java/org/opensearch/migrations/cli/Items.java
@@ -1,7 +1,9 @@
 package org.opensearch.migrations.cli;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -34,16 +36,13 @@ public class Items {
         if (failureMessage != null) {
             errors.add(failureMessage);
         }
-        Stream.concat(
-            Stream.concat(
-                Stream.concat(
-                    indexTemplates.stream(),
-                    componentTemplates.stream()),
-                indexes.stream()),
-            aliases.stream()
-        ).filter(result -> result.getFailureType() != null && result.getFailureType().isFatal())
-        .map(this::failureMessage)
-        .forEach(errors::add);
+
+        Stream.of(indexTemplates, componentTemplates, indexes, aliases)
+            .filter(Objects::nonNull)
+            .flatMap(Collection::stream)
+            .filter(result -> result.getFailureType() != null && result.getFailureType().isFatal())
+            .map(this::failureMessage)
+            .forEach(errors::add);
 
         return errors;
     }

--- a/MetadataMigration/src/main/java/org/opensearch/migrations/cli/Items.java
+++ b/MetadataMigration/src/main/java/org/opensearch/migrations/cli/Items.java
@@ -1,7 +1,9 @@
 package org.opensearch.migrations.cli;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.opensearch.migrations.metadata.CreationResult;
 
@@ -26,6 +28,25 @@ public class Items {
     @NonNull
     private final List<CreationResult> aliases;
     private final String failureMessage;
+
+    public List<String> getAllErrors() {
+        var errors = new ArrayList<String>();
+        if (failureMessage != null) {
+            errors.add(failureMessage);
+        }
+        Stream.concat(
+            Stream.concat(
+                Stream.concat(
+                    indexTemplates.stream(),
+                    componentTemplates.stream()),
+                indexes.stream()),
+            aliases.stream()
+        ).filter(result -> result.getFailureType() != null && result.getFailureType().isFatal())
+        .map(this::failureMessage)
+        .forEach(errors::add);
+
+        return errors;
+    }
 
     public String asCliOutput() {
         var sb = new StringBuilder();

--- a/MetadataMigration/src/main/java/org/opensearch/migrations/commands/EvaluateResult.java
+++ b/MetadataMigration/src/main/java/org/opensearch/migrations/commands/EvaluateResult.java
@@ -18,7 +18,6 @@ public class EvaluateResult implements MigrationItemResult {
 
     @Override
     public int getExitCode() {
-        System.out.println("Bye!!");
         return Math.max(exitCode, collectErrors().size());
     }
 }

--- a/MetadataMigration/src/main/java/org/opensearch/migrations/commands/EvaluateResult.java
+++ b/MetadataMigration/src/main/java/org/opensearch/migrations/commands/EvaluateResult.java
@@ -7,10 +7,18 @@ import lombok.Builder;
 import lombok.Getter;
 
 @Builder
-@Getter
 public class EvaluateResult implements MigrationItemResult {
+    @Getter
     private final Clusters clusters;
+    @Getter
     private final Items items;
+    @Getter
     private final String errorMessage;
     private final int exitCode;
+
+    @Override
+    public int getExitCode() {
+        System.out.println("Bye!!");
+        return Math.max(exitCode, collectErrors().size());
+    }
 }

--- a/MetadataMigration/src/main/java/org/opensearch/migrations/commands/MigrateResult.java
+++ b/MetadataMigration/src/main/java/org/opensearch/migrations/commands/MigrateResult.java
@@ -7,10 +7,17 @@ import lombok.Builder;
 import lombok.Getter;
 
 @Builder
-@Getter
 public class MigrateResult implements MigrationItemResult {
+    @Getter
     private final Clusters clusters;
+    @Getter
     private final Items items;
+    @Getter
     private final String errorMessage;
     private final int exitCode;
+
+    public int getExitCode() {
+        System.out.println("Hello!");
+        return Math.max(exitCode, collectErrors().size());
+    }
 }

--- a/MetadataMigration/src/main/java/org/opensearch/migrations/commands/MigrationItemResult.java
+++ b/MetadataMigration/src/main/java/org/opensearch/migrations/commands/MigrationItemResult.java
@@ -16,14 +16,16 @@ public interface MigrationItemResult extends Result {
 
     default List<String> collectErrors() {
         var errors = new ArrayList<String>();
-        if (getClusters().getSource() == null) {
+        if (getClusters() == null || getClusters().getSource() == null) {
             errors.add("No source was defined");
         }
-        if (getClusters().getTarget() == null) {
+        if (getClusters() == null || getClusters().getTarget() == null) {
             errors.add("No target was defined");
         }
 
-        errors.addAll(getItems().getAllErrors());
+        if (getItems() != null) {
+            errors.addAll(getItems().getAllErrors());
+        }
         return errors;
     }
 

--- a/MetadataMigration/src/main/java/org/opensearch/migrations/commands/MigrationItemResult.java
+++ b/MetadataMigration/src/main/java/org/opensearch/migrations/commands/MigrationItemResult.java
@@ -1,5 +1,8 @@
 package org.opensearch.migrations.commands;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.opensearch.migrations.cli.Clusters;
 import org.opensearch.migrations.cli.Format;
 import org.opensearch.migrations.cli.Items;
@@ -11,6 +14,19 @@ public interface MigrationItemResult extends Result {
     Clusters getClusters();
     Items getItems();
 
+    default List<String> collectErrors() {
+        var errors = new ArrayList<String>();
+        if (getClusters().getSource() == null) {
+            errors.add("No source was defined");
+        }
+        if (getClusters().getTarget() == null) {
+            errors.add("No target was defined");
+        }
+
+        errors.addAll(getItems().getAllErrors());
+        return errors;
+    }
+
     default String asCliOutput() {
         var sb = new StringBuilder();
         if (getClusters() != null) {
@@ -20,10 +36,16 @@ public interface MigrationItemResult extends Result {
             sb.append(getItems().asCliOutput() + System.lineSeparator());
         }
         sb.append("Results:" + System.lineSeparator());
-        if (Strings.isNotBlank(getErrorMessage())) {
+        var innerErrors = collectErrors();
+        if (Strings.isNotBlank(getErrorMessage()) || !innerErrors.isEmpty()) {
             sb.append(Format.indentToLevel(1) + "Issue(s) detected" + System.lineSeparator());
             sb.append("Issues:" + System.lineSeparator());
-            sb.append(Format.indentToLevel(1) + getErrorMessage() + System.lineSeparator());
+            if (Strings.isNotBlank(getErrorMessage())) {
+                sb.append(Format.indentToLevel(1) + getErrorMessage() + System.lineSeparator());
+            }
+            if (!innerErrors.isEmpty()) {
+                innerErrors.forEach(err -> sb.append(Format.indentToLevel(1) + err + System.lineSeparator()));
+            }
         } else {
             sb.append(Format.indentToLevel(1) + getExitCode() + " issue(s) detected" + System.lineSeparator());
         }

--- a/MetadataMigration/src/test/java/org/opensearch/migrations/commands/MigrationItemResultTest.java
+++ b/MetadataMigration/src/test/java/org/opensearch/migrations/commands/MigrationItemResultTest.java
@@ -2,19 +2,21 @@ package org.opensearch.migrations.commands;
 
 import org.opensearch.migrations.cli.Clusters;
 import org.opensearch.migrations.cli.Items;
-
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.withSettings;
 
 public class MigrationItemResultTest {
     @Test
     void testAsString_fullResults_withMessage() {
-        var clusters = mock(Clusters.class);
+        var clusters = mock(Clusters.class, withSettings().defaultAnswer(RETURNS_DEEP_STUBS));
         var items = mock(Items.class);
         var testObject = EvaluateResult.builder()
             .clusters(clusters)
@@ -28,13 +30,16 @@ public class MigrationItemResultTest {
         assertThat(result, containsString("Issues:"));
 
         verify(clusters).asCliOutput();
+        verify(clusters).getSource();
+        verify(clusters).getTarget();
         verify(items).asCliOutput();
+        verify(items, times(1)).getAllErrors();
         verifyNoMoreInteractions(items, clusters);
     }
 
     @Test
     void testAsString_fullResults_withNoMessage() {
-        var clusters = mock(Clusters.class);
+        var clusters = mock(Clusters.class, withSettings().defaultAnswer(RETURNS_DEEP_STUBS));
         var items = mock(Items.class);
         var testObject = EvaluateResult.builder()
             .clusters(clusters)
@@ -44,14 +49,14 @@ public class MigrationItemResultTest {
 
         var result = testObject.asCliOutput();
         assertThat(result, containsString("10 issue(s) detected"));
-        verify(clusters).asCliOutput();
         verify(items).asCliOutput();
-        verifyNoMoreInteractions(items, clusters);
+        verify(items, times(2)).getAllErrors();
+        verifyNoMoreInteractions(items);
     }
 
     @Test
     void testAsString_noItems() {
-        var clusters = mock(Clusters.class);
+        var clusters = mock(Clusters.class, withSettings().defaultAnswer(RETURNS_DEEP_STUBS));
         var testObject = EvaluateResult.builder()
             .clusters(clusters)
             .exitCode(0)
@@ -59,8 +64,6 @@ public class MigrationItemResultTest {
 
         var result = testObject.asCliOutput();
         assertThat(result, containsString("0 issue(s) detected"));
-        verify(clusters).asCliOutput();
-        verifyNoMoreInteractions(clusters);
     }
 
     @Test
@@ -70,6 +73,7 @@ public class MigrationItemResultTest {
             .build();
 
         var result = testObject.asCliOutput();
-        assertThat(result, containsString("0 issue(s) detected"));
+        assertThat(result, containsString(  "No source was defined"));
+        assertThat(result, containsString(  "No target was defined"));
     }
 }

--- a/MetadataMigration/src/test/java/org/opensearch/migrations/commands/MigrationItemResultTest.java
+++ b/MetadataMigration/src/test/java/org/opensearch/migrations/commands/MigrationItemResultTest.java
@@ -2,6 +2,7 @@ package org.opensearch.migrations.commands;
 
 import org.opensearch.migrations.cli.Clusters;
 import org.opensearch.migrations.cli.Items;
+
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.containsString;


### PR DESCRIPTION
### Description
When troubleshooting another issue saw a scenario where there were
errors in the metadata output, but nothing was reported at the bottom of
the report, fixed how this is calculated to include any fatal issues.

### Issues Resolved
#### Prev
```
   Indexes:
      blog_index_2023, blog_indexandcomponent_2023, blog_legacy_2023, movies_2023
      ERROR - myindexv4 failed on target cluster: Create object failed for myindexv4 [...]
      WARN - already-exists already exists

   Aliases:
      alias_component, alias_index, alias_legacy, movies-alias


Results:
   0 issue(s) detected
```

#### Updated
```
   Indexes:
      blog_index_2023, blog_indexandcomponent_2023, blog_legacy_2023, movies_2023
      ERROR - myindexv4 failed on target cluster: Create object failed for myindexv4...
      WARN - already-exists already exists

   Aliases:
      alias_component, alias_index, alias_legacy, movies-alias


Results:
   Issue(s) detected
Issues:
      ERROR - myindexv4 failed on target cluster: Create object failed for myindexv4 [...]
```
Also the process exits with the correct non-zero error code whoops!

### Testing
Updated unit tests
### Check List
- [X] New functionality includes testing
- [X] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
