### PR TITLE
Fix mergeJacocoReports after gradle refactor to correctly run all tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -500,18 +500,18 @@ tasks.register('mergeJacocoReports') {
     }
 }
 
-task listPublishedArtifacts {
-    doLast {
-        subprojects.each { proj ->
-            def publishingExtension = proj.extensions.findByType(PublishingExtension)
-            if (publishingExtension) {
-                publishingExtension.publications.each { publication ->
-                    if (publication instanceof MavenPublication) {
-                        println "${publication.groupId}.${publication.artifactId}"
-                    }
-                }
-            }
+def publishedArtifacts = []
+subprojects.each { proj ->
+    def publishingExtension = proj.extensions.findByType(PublishingExtension)
+    if (publishingExtension) {
+        publishingExtension.publications.withType(MavenPublication).all { publication ->
+            publishedArtifacts << "${publication.groupId}.${publication.artifactId}"
         }
+    }
+}
+tasks.register('listPublishedArtifacts') {
+    doLast {
+        publishedArtifacts.each { println it }
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -453,40 +453,6 @@ gradle.projectsEvaluated {
     }
 }
 
-task mergeJacocoReports {
-    def jacocoReportTasks = subprojects.collect { it.tasks.withType(JacocoReport).matching { it.name == "jacocoTestReport" } }.flatten()
-    dependsOn jacocoReportTasks
-
-    // Create a Sync task to collect all exec files
-    def syncJacocoExecFiles = tasks.create("syncJacocoExecFiles", Sync) {
-        from jacocoReportTasks.collect { it.executionData }
-        into "${buildDir}/jacocoMerged/"
-        duplicatesStrategy = DuplicatesStrategy.FAIL
-    }
-
-    // Make sure sync task runs after all report tasks
-    syncJacocoExecFiles.mustRunAfter jacocoReportTasks
-    dependsOn syncJacocoExecFiles
-
-    // Finalize with jacocoAggregateReport
-    finalizedBy jacocoAggregateReport
-}
-
-task listPublishedArtifacts {
-    doLast {
-        subprojects.each { proj ->
-            def publishingExtension = proj.extensions.findByType(PublishingExtension)
-            if (publishingExtension) {
-                publishingExtension.publications.each { publication ->
-                    if (publication instanceof MavenPublication) {
-                        println "${publication.groupId}.${publication.artifactId}"
-                    }
-                }
-            }
-        }
-    }
-}
-
 // Define a provider for test tasks list
 def testTasksProvider = provider {
     def testTasks = []
@@ -508,6 +474,45 @@ def testTasksProvider = provider {
         }
     }
     return testTasks
+}
+
+tasks.register('mergeJacocoReports') {
+    def jacocoReportTasks = testTasksProvider.get()
+    dependsOn jacocoReportTasks
+    // Assertion: fail if no Jacoco report tasks are found
+    if (jacocoReportTasks.isEmpty()) {
+        throw new GradleException("No jacocoTestReport tasks found in subprojects.")
+    }
+    doLast {
+        // Create a Sync task to collect all exec files
+        def syncJacocoExecFiles = tasks.register("syncJacocoExecFiles", Sync) {
+            from jacocoReportTasks.collect { it.executionData }
+            into "${buildDir}/jacocoMerged/"
+            duplicatesStrategy = DuplicatesStrategy.FAIL
+        }
+
+        // Make sure sync task runs after all report tasks
+        syncJacocoExecFiles.mustRunAfter jacocoReportTasks
+        dependsOn syncJacocoExecFiles
+
+        // Finalize with jacocoAggregateReport
+        finalizedBy jacocoAggregateReport
+    }
+}
+
+task listPublishedArtifacts {
+    doLast {
+        subprojects.each { proj ->
+            def publishingExtension = proj.extensions.findByType(PublishingExtension)
+            if (publishingExtension) {
+                publishingExtension.publications.each { publication ->
+                    if (publication instanceof MavenPublication) {
+                        println "${publication.groupId}.${publication.artifactId}"
+                    }
+                }
+            }
+        }
+    }
 }
 
 tasks.register("listTestTasksAsJson") {


### PR DESCRIPTION
### Description
Fix mergeJacocoReports after gradle refactor to correctly run all tests.
Fixes `listPublishedArtifacts` to correctly list the artifacts.

### Issues Resolved
`mergeJacocoReports` not correctly resolving the test tasks

### Testing
Local run

```
➜  opensearch-migrations git:(CodeCov) ✗ ./gradlew listPublishedArtifacts
Calculating task graph as configuration cache cannot be reused because file 'build.gradle' has changed.
adding task named 'test' = task ':transformation:standardJavascriptTransforms:test'

> Task :listPublishedArtifacts
org.opensearch.migrations.trafficcapture.awsUtilities
org.opensearch.migrations.trafficcapture.coreUtilities
org.opensearch.migrations.trafficcapture.CreateSnapshot
org.opensearch.migrations.trafficcapture.dashboardsSanitizer
org.opensearch.migrations.trafficcapture.DataGenerator
org.opensearch.migrations.trafficcapture.DocumentsFromSnapshotMigration
org.opensearch.migrations.trafficcapture.jenkinsTests
org.opensearch.migrations.trafficcapture.MetadataMigration
org.opensearch.migrations.trafficcapture.RFS
org.opensearch.migrations.trafficcapture.testHelperFixtures
org.opensearch.migrations.trafficcapture.captureKafkaOffloader
org.opensearch.migrations.trafficcapture.captureOffloader
org.opensearch.migrations.trafficcapture.captureProtobufs
org.opensearch.migrations.trafficcapture.nettyWireLogging
org.opensearch.migrations.trafficcapture.trafficCaptureProxyServer
org.opensearch.migrations.trafficcapture.trafficCaptureProxyServerTest
org.opensearch.migrations.trafficcapture.trafficReplayer
org.opensearch.migrations.trafficcapture.transformation
org.opensearch.migrations.trafficcapture.kafkaCommandLineFormatter
org.opensearch.migrations.trafficcapture.kafkaUtils
org.opensearch.migrations.trafficcapture.jsonJMESPathMessageTransformer
org.opensearch.migrations.trafficcapture.jsonJMESPathMessageTransformerProvider
org.opensearch.migrations.trafficcapture.jsonJoltMessageTransformer
org.opensearch.migrations.trafficcapture.jsonJoltMessageTransformerProvider
org.opensearch.migrations.trafficcapture.jsonJSTransformer
org.opensearch.migrations.trafficcapture.jsonJSTransformerProvider
org.opensearch.migrations.trafficcapture.jsonMessageTransformerInterface
org.opensearch.migrations.trafficcapture.jsonMessageTransformerLoaders
org.opensearch.migrations.trafficcapture.jsonTypeMappingsSanitizationTransformer
org.opensearch.migrations.trafficcapture.jsonTypeMappingsSanitizationTransformerProvider

[Incubating] Problems report is available at: file:///Users/akurait/workplace/opensearch-migrations/build/reports/problems/problems-report.html

Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

For more on this, please refer to https://docs.gradle.org/8.12.1/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.

BUILD SUCCESSFUL in 1s
9 actionable tasks: 1 executed, 8 up-to-date
Configuration cache entry stored.
```

### Check List
- [x] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
