### PR TITLE
Fix the jacocoMergeReports task so that it works with gradle caching.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -453,50 +453,54 @@ gradle.projectsEvaluated {
     }
 }
 
-// Define a provider for test tasks list
-def testTasksProvider = provider {
-    def testTasks = []
+def jacocoExecFilesProvider = provider {
+    def execFiles = []
     rootProject.subprojects.each { subproject ->
-        def projectPath = subproject.path
-
         subproject.tasks.withType(Test).configureEach { testTask ->
             def jacocoExtension = testTask.extensions.findByType(JacocoTaskExtension)
-            if (!(jacocoExtension?.enabled ?: false)) {
-                testTasks << "${projectPath}:${testTask.name}"
+            if (jacocoExtension?.enabled) {
+                execFiles << jacocoExtension.destinationFile
             }
         }
+    }
+    return execFiles
+}
 
-        if (subproject.tasks.withType(Test).any { testTask ->
+def jacocoTestTasksProvider = provider {
+    def testTasks = []
+    rootProject.subprojects.each { subproject ->
+        subproject.tasks.withType(Test).configureEach { testTask ->
             def jacocoExtension = testTask.extensions.findByType(JacocoTaskExtension)
-            jacocoExtension?.enabled ?: false
-        }) {
-            testTasks << "${projectPath}:jacocoTestReport"
+            if (jacocoExtension?.enabled) {
+                testTasks << testTask
+            }
+        }
+        // Add jacocoTestReport tasks if they exist
+        if (subproject.tasks.findByName('jacocoTestReport')) {
+            testTasks << subproject.tasks.jacocoTestReport
         }
     }
     return testTasks
 }
 
+def syncJacocoExecFiles = tasks.register("syncJacocoExecFiles", Sync) {
+    duplicatesStrategy = DuplicatesStrategy.FAIL
+    into layout.buildDirectory.dir("jacocoMerged")
+
+    from jacocoExecFilesProvider
+    dependsOn jacocoTestTasksProvider
+}
+
 tasks.register('mergeJacocoReports') {
-    def jacocoReportTasks = testTasksProvider.get()
-    dependsOn jacocoReportTasks
-    // Assertion: fail if no Jacoco report tasks are found
-    if (jacocoReportTasks.isEmpty()) {
-        throw new GradleException("No jacocoTestReport tasks found in subprojects.")
-    }
+    dependsOn syncJacocoExecFiles
+    finalizedBy jacocoAggregateReport
+
     doLast {
-        // Create a Sync task to collect all exec files
-        def syncJacocoExecFiles = tasks.register("syncJacocoExecFiles", Sync) {
-            from jacocoReportTasks.collect { it.executionData }
-            into "${buildDir}/jacocoMerged/"
-            duplicatesStrategy = DuplicatesStrategy.FAIL
+        def execFiles = jacocoExecFilesProvider.get()
+        if (execFiles.isEmpty()) {
+            throw new GradleException("No Jacoco exec files found in subprojects.")
         }
-
-        // Make sure sync task runs after all report tasks
-        syncJacocoExecFiles.mustRunAfter jacocoReportTasks
-        dependsOn syncJacocoExecFiles
-
-        // Finalize with jacocoAggregateReport
-        finalizedBy jacocoAggregateReport
+        println "Merged ${execFiles.size()} Jacoco execution files"
     }
 }
 


### PR DESCRIPTION
### Description
Fix the jacocoMergeReports task so that it works with gradle caching.

### Issues Resolved
No Jira

### Testing
Tweaked the build.gradle file test definitions as below and ran ./gradlew jacocoMergeReports and confirmed that I had a full report in build/reports/jacoco/mergedReport/html/index.html that showed 66% coverage (I wasn't running all of the tests).

```
            // Mutually exclusive tests to avoid duplication
            tasks.named('test') {
                systemProperty 'migrationLogLevel', 'TRACE'
                useJUnitPlatform {
                    excludeTags('longTest', 'isolatedTest')
                }
            }

            tasks.register('slowTest', Test) {
                systemProperty 'migrationLogLevel', 'DEBUG'
                useJUnitPlatform {
                    excludeTags 'longTest'
                    excludeTags 'isolatedTest'
                }
            }

            tasks.register('isolatedTest', Test) {
                maxParallelForks = 1
                useJUnitPlatform {
                    excludeTags 'longTest'
                    excludeTags 'isolatedTest'
                }
            }

            tasks.register('fullTest') {
                dependsOn test
                dependsOn slowTest
                dependsOn isolatedTest
            }
```


### Check List
- [ ] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
