### PR TITLE
Add experimental path for EKS solutions deployments

### DIFF
--- a/deployment/migration-assistant-solution/bin/app.ts
+++ b/deployment/migration-assistant-solution/bin/app.ts
@@ -4,7 +4,7 @@ import { SolutionsInfrastructureStack } from '../lib/solutions-stack';
 import {SolutionsInfrastructureEKSStack} from "../lib/solutions-stack-eks";
 
 const getProps = () => {
-  const { CODE_BUCKET, SOLUTION_NAME, CODE_VERSION, STACK_NAME_SUFFIX, EKS_ENABLED } = process.env;
+  const { CODE_BUCKET, SOLUTION_NAME, CODE_VERSION, STACK_NAME_SUFFIX } = process.env;
   if (typeof CODE_BUCKET !== 'string' || CODE_BUCKET.trim() === '') {
     console.warn(`Missing environment variable CODE_BUCKET, using a default value`);
   }
@@ -15,12 +15,6 @@ const getProps = () => {
 
   if (typeof CODE_VERSION !== 'string' || CODE_VERSION.trim() === '') {
     console.warn(`Missing environment variable CODE_VERSION, using a default value`);
-  }
-
-  let eksEnabled = false
-  if (typeof EKS_ENABLED === 'string' && EKS_ENABLED.trim() === 'true') {
-    eksEnabled = true
-    console.warn(`The environment variable EKS_ENABLED=true has been provided, will only create the EKS solutions stack`);
   }
 
   const codeBucket = CODE_BUCKET ?? "Unknown";
@@ -35,34 +29,30 @@ const getProps = () => {
     solutionId,
     solutionName,
     description,
-    stackNameSuffix,
-    eksEnabled
+    stackNameSuffix
   };
 };
 
 const app = new App();
 const infraProps = getProps()
-if (!infraProps.eksEnabled) {
-  new SolutionsInfrastructureStack(app, "Migration-Assistant-Infra-Import-VPC", {
-    synthesizer: new DefaultStackSynthesizer({
-      generateBootstrapVersionRule: false
-    }),
-    createVPC: false,
-    ...infraProps
-  });
-  new SolutionsInfrastructureStack(app, "Migration-Assistant-Infra-Create-VPC", {
-    synthesizer: new DefaultStackSynthesizer({
-      generateBootstrapVersionRule: false
-    }),
-    createVPC: true,
-    ...infraProps
-  });
-} else {
-  new SolutionsInfrastructureEKSStack(app, "Migration-Assistant-Infra-Create-VPC", {
-    synthesizer: new DefaultStackSynthesizer({
-      generateBootstrapVersionRule: false
-    }),
-    createVPC: true,
-    ...infraProps
-  });
-}
+new SolutionsInfrastructureStack(app, "Migration-Assistant-Infra-Import-VPC", {
+  synthesizer: new DefaultStackSynthesizer({
+    generateBootstrapVersionRule: false
+  }),
+  createVPC: false,
+  ...infraProps
+});
+new SolutionsInfrastructureStack(app, "Migration-Assistant-Infra-Create-VPC", {
+  synthesizer: new DefaultStackSynthesizer({
+    generateBootstrapVersionRule: false
+  }),
+  createVPC: true,
+  ...infraProps
+});
+new SolutionsInfrastructureEKSStack(app, "Migration-Assistant-Infra-Create-VPC-v3", {
+  synthesizer: new DefaultStackSynthesizer({
+    generateBootstrapVersionRule: false
+  }),
+  createVPC: true,
+  ...infraProps
+});

--- a/deployment/migration-assistant-solution/lib/common-utils.ts
+++ b/deployment/migration-assistant-solution/lib/common-utils.ts
@@ -1,0 +1,64 @@
+import {Aws, CfnParameter, Fn, Stack, Tags} from "aws-cdk-lib";
+import {Application, AttributeGroup} from "@aws-cdk/aws-servicecatalogappregistry-alpha";
+import {SolutionsInfrastructureStackProps} from "./solutions-stack";
+import {InterfaceVpcEndpointAwsService} from "aws-cdk-lib/aws-ec2";
+
+export interface ParameterLabel {
+    default: string;
+}
+
+export function applyAppRegistry(stack: Stack, stage: string, infraProps: SolutionsInfrastructureStackProps): string {
+    const application = new Application(stack, "AppRegistry", {
+        applicationName: Fn.join("-", [
+            infraProps.solutionName,
+            Aws.REGION,
+            Aws.ACCOUNT_ID,
+            stage
+        ]),
+        description: `Service Catalog application to track and manage all your resources for the solution ${infraProps.solutionName}`,
+    });
+    application.associateApplicationWithStack(stack);
+    Tags.of(application).add("Solutions:SolutionID", infraProps.solutionId);
+    Tags.of(application).add("Solutions:SolutionName", infraProps.solutionName);
+    Tags.of(application).add("Solutions:SolutionVersion", infraProps.solutionVersion);
+    Tags.of(application).add("Solutions:ApplicationType", "AWS-Solutions");
+
+    const attributeGroup = new AttributeGroup(
+        stack,
+        "DefaultApplicationAttributes",
+        {
+            attributeGroupName: Fn.join("-", [
+                Aws.REGION,
+                stage,
+                "attributes"
+            ]),
+            description: "Attribute group for solution information",
+            attributes: {
+                applicationType: "AWS-Solutions",
+                version: infraProps.solutionVersion,
+                solutionID: infraProps.solutionId,
+                solutionName: infraProps.solutionName,
+            },
+        }
+    );
+    attributeGroup.associateWith(application)
+    return application.applicationArn
+}
+
+export function addParameterLabel(labels: Record<string, ParameterLabel>, parameter: CfnParameter, labelName: string) {
+    labels[parameter.logicalId] = {"default": labelName}
+}
+
+export function generateExportString(exports:  Record<string, string>): string {
+    return Object.entries(exports)
+        .map(([key, value]) => `export ${key}=${value}`)
+        .join("; ");
+}
+
+export function getVpcEndpointForEFS(stack: Stack): InterfaceVpcEndpointAwsService {
+    const isGovRegion = stack.region?.startsWith('us-gov-')
+    if (isGovRegion) {
+        return InterfaceVpcEndpointAwsService.ELASTIC_FILESYSTEM_FIPS;
+    }
+    return InterfaceVpcEndpointAwsService.ELASTIC_FILESYSTEM;
+}

--- a/deployment/migration-assistant-solution/lib/eks-infra.ts
+++ b/deployment/migration-assistant-solution/lib/eks-infra.ts
@@ -1,0 +1,205 @@
+import {Construct} from 'constructs';
+import {CfnCluster, CfnPodIdentityAssociation} from 'aws-cdk-lib/aws-eks';
+import {IVpc, Port, SecurityGroup} from 'aws-cdk-lib/aws-ec2';
+import {
+    CfnPolicy,
+    CfnRole,
+    Effect,
+    ManagedPolicy,
+    PolicyStatement,
+    Role,
+    ServicePrincipal,
+} from "aws-cdk-lib/aws-iam";
+import {RemovalPolicy, Tags} from "aws-cdk-lib";
+import {Repository} from "aws-cdk-lib/aws-ecr";
+
+
+export interface EKSInfraProps {
+    vpc: IVpc;
+    clusterName: string;
+    ecrRepoName: string;
+    stackName: string;
+    namespace?: string;
+    serviceAccountName?: string;
+}
+
+export class EKSInfra extends Construct {
+    public readonly cluster: CfnCluster;
+    public readonly ecrRepo: Repository;
+
+    constructor(scope: Construct, id: string, props: EKSInfraProps) {
+        super(scope, id);
+
+        const namespace = props.namespace ?? 'ma';
+        const serviceAccountName = props.serviceAccountName ?? 'migrations-sa';
+
+        const migrationSecurityGroup = new SecurityGroup(this, 'MigrationsSecurityGroup', {
+            vpc: props.vpc,
+            allowAllOutbound: true,
+            allowAllIpv6Outbound: true,
+        })
+        migrationSecurityGroup.addIngressRule(migrationSecurityGroup, Port.allTraffic());
+
+        this.ecrRepo = new Repository(this, 'MigrationsECRRepository', {
+            repositoryName: props.ecrRepoName,
+            removalPolicy: RemovalPolicy.DESTROY,
+            emptyOnDelete: true
+        });
+
+        const clusterRole = new Role(this, 'MigrationsEKSClusterRole', {
+            assumedBy: new ServicePrincipal('eks.amazonaws.com'),
+            managedPolicies: [
+                ManagedPolicy.fromAwsManagedPolicyName('AmazonEKSClusterPolicy'),
+                ManagedPolicy.fromAwsManagedPolicyName('AmazonEKSBlockStoragePolicy'),
+                ManagedPolicy.fromAwsManagedPolicyName('AmazonEKSComputePolicy'),
+                ManagedPolicy.fromAwsManagedPolicyName('AmazonEKSLoadBalancingPolicy'),
+                ManagedPolicy.fromAwsManagedPolicyName('AmazonEKSNetworkingPolicy'),
+            ],
+        });
+        clusterRole.assumeRolePolicy?.addStatements(
+            new PolicyStatement({
+                effect: Effect.ALLOW,
+                principals: [new ServicePrincipal('eks.amazonaws.com')],
+                actions: ['sts:AssumeRole', 'sts:TagSession']
+            }),
+        );
+
+        const ec2NodeRole = new Role(this, 'MigrationsEKSEC2NodeRole', {
+            assumedBy: new ServicePrincipal('ec2.amazonaws.com'),
+            managedPolicies: [
+                ManagedPolicy.fromAwsManagedPolicyName('AmazonEKSWorkerNodePolicy'),
+                ManagedPolicy.fromAwsManagedPolicyName('AmazonEC2ContainerRegistryReadOnly'),
+                ManagedPolicy.fromAwsManagedPolicyName('AmazonEKS_CNI_Policy'),
+            ],
+        });
+
+        const subnetIds = []
+        for (const subnet of props.vpc.privateSubnets) {
+            Tags.of(subnet).add(`kubernetes.io/cluster/${props.clusterName}`, 'shared');
+            Tags.of(subnet).add('kubernetes.io/role/internal-elb', '1');
+            subnetIds.push(subnet.subnetId)
+        }
+        this.cluster = new CfnCluster(this, 'MigrationsEKSCluster', {
+            name: props.clusterName,
+            version: '1.32',
+            roleArn: clusterRole.roleArn,
+            resourcesVpcConfig: {
+                subnetIds: subnetIds,
+                endpointPrivateAccess: true,
+                endpointPublicAccess: true,
+                securityGroupIds: [migrationSecurityGroup.securityGroupId]
+            },
+            accessConfig: {
+                authenticationMode: 'API',
+            },
+            computeConfig: {
+                enabled: true,
+                nodeRoleArn: ec2NodeRole.roleArn,
+                nodePools: ["general-purpose", "system"]
+            },
+            storageConfig: {
+                blockStorage: {
+                    enabled: true
+                }
+            },
+            kubernetesNetworkConfig: {
+                elasticLoadBalancing: {
+                    enabled: true
+                }
+            }
+        });
+        migrationSecurityGroup.addIngressRule(
+            SecurityGroup.fromSecurityGroupId(this, "MigrationsEKSClusterDefaultSG", this.cluster.attrClusterSecurityGroupId),
+            Port.allTraffic()
+        );
+
+        const podIdentityRole = new CfnRole(this, 'MigrationsPodIdentityRole', {
+            roleName: `${props.clusterName}-migrations-role`,
+            assumeRolePolicyDocument: {
+                Version: '2012-10-17',
+                Statement: [
+                    {
+                        Effect: 'Allow',
+                        Principal: {
+                            Service: 'pods.eks.amazonaws.com',
+                        },
+                        Action: [
+                            "sts:AssumeRole",
+                            "sts:TagSession"
+                        ]
+                    },
+                ],
+            },
+            managedPolicyArns: [
+                ManagedPolicy.fromAwsManagedPolicyName('AmazonEC2ContainerRegistryFullAccess').managedPolicyArn,
+            ],
+            description: 'Migrations IAM role assumed by pods via EKS Pod Identity',
+        });
+
+        new CfnPolicy(this, 'MigrationsPodIdentityPolicy', {
+            policyName: 'MigrationsPodPolicy',
+            roles: [podIdentityRole.ref],
+            policyDocument: {
+                Version: '2012-10-17',
+                Statement: [
+                    {
+                        Effect: 'Allow',
+                        Action: [
+                            'ecr:GetAuthorizationToken',
+                            'ecr:BatchGetImage',
+                            'ecr:GetDownloadUrlForLayer',
+                            'ecr:DescribeRepositories',
+                            'ecr:BatchCheckLayerAvailability',
+                            'ecr:CompleteLayerUpload',
+                            'ecr:InitiateLayerUpload',
+                            'ecr:PutImage',
+                            'ecr:UploadLayerPart',
+                        ],
+                        Resource: '*',
+                    },
+                    {
+                        Effect: 'Allow',
+                        Action: [
+                            'elasticfilesystem:ClientMount',
+                            'elasticfilesystem:ClientWrite',
+                        ],
+                        Resource: '*',
+                    },
+                    {
+                        Effect: 'Allow',
+                        Action: ['es:ESHttp*', 'aoss:APIAccessAll'],
+                        Resource: '*',
+                    },
+                    {
+                        Effect: 'Allow',
+                        Action: [
+                            'secretsmanager:GetSecretValue',
+                            'secretsmanager:DescribeSecret',
+                            'secretsmanager:ListSecrets'
+                        ],
+                        Resource: '*',
+                    },
+                    {
+                        Effect: 'Allow',
+                        Action: [
+                            's3:GetObject',
+                            's3:PutObject',
+                            's3:ListBucket',
+                            's3:DeleteObject'
+                        ],
+                        Resource: '*',
+                    },
+                ],
+            },
+        });
+
+        const podIdentityAssociation = new CfnPodIdentityAssociation(this, 'MigrationsPodIdentityAssociation', {
+            clusterName: props.clusterName,
+            namespace: namespace,
+            serviceAccount: serviceAccountName,
+            roleArn: podIdentityRole.attrArn,
+        });
+        podIdentityAssociation.node.addDependency(this.cluster)
+
+    }
+}

--- a/deployment/migration-assistant-solution/lib/eks-infra.ts
+++ b/deployment/migration-assistant-solution/lib/eks-infra.ts
@@ -80,6 +80,9 @@ export class EKSInfra extends Construct {
         this.cluster = new CfnCluster(this, 'MigrationsEKSCluster', {
             name: props.clusterName,
             version: '1.32',
+            upgradePolicy: {
+                supportType: 'STANDARD'
+            },
             roleArn: clusterRole.roleArn,
             resourcesVpcConfig: {
                 subnetIds: subnetIds,

--- a/deployment/migration-assistant-solution/lib/solutions-stack-eks.ts
+++ b/deployment/migration-assistant-solution/lib/solutions-stack-eks.ts
@@ -1,0 +1,236 @@
+import {
+    Aws,
+    CfnMapping, CfnOutput,
+    CfnParameter,
+    Fn,
+    Stack,
+    StackProps,
+    Tags
+} from 'aws-cdk-lib';
+import {Construct} from 'constructs';
+import {
+    GatewayVpcEndpoint,
+    GatewayVpcEndpointAwsService,
+    IVpc,
+    InterfaceVpcEndpoint,
+    InterfaceVpcEndpointAwsService,
+    IpAddresses,
+    IpProtocol,
+    Vpc
+} from "aws-cdk-lib/aws-ec2";
+import {Application, AttributeGroup} from "@aws-cdk/aws-servicecatalogappregistry-alpha";
+import {EKSInfra} from "./eks-infra";
+
+export interface SolutionsInfrastructureStackEKSProps extends StackProps {
+    readonly solutionId: string;
+    readonly solutionName: string;
+    readonly solutionVersion: string;
+    readonly codeBucket: string;
+    readonly createVPC: boolean;
+    readonly stackNameSuffix?: string;
+}
+
+interface ParameterLabel {
+    default: string;
+}
+
+function applyAppRegistry(stack: Stack, stage: string, infraProps: SolutionsInfrastructureStackEKSProps): string {
+    const application = new Application(stack, "AppRegistry", {
+        applicationName: Fn.join("-", [
+            infraProps.solutionName,
+            Aws.REGION,
+            Aws.ACCOUNT_ID,
+            stage
+        ]),
+        description: `Service Catalog application to track and manage all your resources for the solution ${infraProps.solutionName}`,
+    });
+    application.associateApplicationWithStack(stack);
+    Tags.of(application).add("Solutions:SolutionID", infraProps.solutionId);
+    Tags.of(application).add("Solutions:SolutionName", infraProps.solutionName);
+    Tags.of(application).add("Solutions:SolutionVersion", infraProps.solutionVersion);
+    Tags.of(application).add("Solutions:ApplicationType", "AWS-Solutions");
+
+    const attributeGroup = new AttributeGroup(
+        stack,
+        "DefaultApplicationAttributes",
+        {
+            attributeGroupName: Fn.join("-", [
+                Aws.REGION,
+                stage,
+                "attributes"
+            ]),
+            description: "Attribute group for solution information",
+            attributes: {
+                applicationType: "AWS-Solutions",
+                version: infraProps.solutionVersion,
+                solutionID: infraProps.solutionId,
+                solutionName: infraProps.solutionName,
+            },
+        }
+    );
+    attributeGroup.associateWith(application)
+    return application.applicationArn
+}
+
+function addParameterLabel(labels: Record<string, ParameterLabel>, parameter: CfnParameter, labelName: string) {
+    labels[parameter.logicalId] = {"default": labelName}
+}
+
+function importVPC(stack: Stack, vpdIdParameter: CfnParameter, privateSubnetIdsParameter: CfnParameter): IVpc {
+    // TODO add support for import VPC scenario with VPC validations
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const privateSubnetIds = privateSubnetIdsParameter.valueAsList
+    return Vpc.fromLookup(stack, 'ImportedVPC', {
+        vpcId: vpdIdParameter.valueAsString,
+    });
+}
+
+function generateExportString(exports:  Record<string, string>): string {
+    return Object.entries(exports)
+        .map(([key, value]) => `export ${key}=${value}`)
+        .join("; ");
+}
+
+function getVpcEndpointForEFS(stack: Stack): InterfaceVpcEndpointAwsService {
+    const isGovRegion = stack.region?.startsWith('us-gov-')
+    if (isGovRegion) {
+        return InterfaceVpcEndpointAwsService.ELASTIC_FILESYSTEM_FIPS;
+    }
+    return InterfaceVpcEndpointAwsService.ELASTIC_FILESYSTEM;
+}
+
+export class SolutionsInfrastructureEKSStack extends Stack {
+
+    constructor(scope: Construct, id: string, props: SolutionsInfrastructureStackEKSProps) {
+        const finalId = props.stackNameSuffix ? `${id}-${props.stackNameSuffix}` : id
+        super(scope, finalId, props);
+        this.templateOptions.templateFormatVersion = '2010-09-09';
+        new CfnMapping(this, 'Solution', {
+            mapping: {
+                Config: {
+                    CodeVersion: props.solutionVersion,
+                    KeyPrefix: `${props.solutionName}/${props.solutionVersion}`,
+                    S3Bucket: props.codeBucket,
+                    SendAnonymousUsage: 'No',
+                    SolutionId: props.solutionId
+                }
+            },
+            lazy: false,
+        });
+
+        const importedVPCParameters: string[] = [];
+        const additionalParameters: string[] = [];
+        const parameterLabels: Record<string, ParameterLabel> = {};
+        const stageParameter = new CfnParameter(this, 'Stage', {
+            type: 'String',
+            description: 'Specify the stage identifier which will be used in naming resources, e.g. dev,gamma,wave1',
+            default: 'dev',
+        });
+        additionalParameters.push(stageParameter.logicalId)
+
+        const stackMarker = `${stageParameter.valueAsString}-${Aws.REGION}`;
+        const appRegistryAppARN = applyAppRegistry(this, stackMarker, props)
+
+        const solutionsUserAgent = `AwsSolution/${props.solutionId}/${props.solutionVersion}`
+
+        let vpc: IVpc;
+        if (props.createVPC) {
+            vpc = new Vpc(this, `Vpc`, {
+                // Using 10.212.0.0/16 to avoid default VPC CIDR range conflicts when using VPC peering
+                ipAddresses: IpAddresses.cidr('10.212.0.0/16'),
+                ipProtocol: IpProtocol.DUAL_STACK,
+                vpcName: `migration-assistant-vpc-${stageParameter.valueAsString}`,
+                maxAzs: 2
+            });
+
+            vpc.publicSubnets.forEach((subnet, index) => {
+                Tags.of(subnet)
+                    .add("Name", `migration-assistant-public-subnet-${index + 1}-${stageParameter.valueAsString}`);
+            });
+            vpc.privateSubnets.forEach((subnet, index) => {
+                Tags.of(subnet)
+                    .add("Name", `migration-assistant-private-subnet-${index + 1}-${stageParameter.valueAsString}`);
+            });
+
+            // S3 used for storage and retrieval of snapshot data for backfills
+            new GatewayVpcEndpoint(this, 'S3VpcEndpoint', {
+                service: GatewayVpcEndpointAwsService.S3,
+                vpc: vpc,
+            });
+
+            const serviceEndpoints = [
+                // Logs and disk usage scales based on total data transfer
+                InterfaceVpcEndpointAwsService.CLOUDWATCH_LOGS,
+                getVpcEndpointForEFS(this),
+
+                // Elastic container registry is used for all images in the solution
+                InterfaceVpcEndpointAwsService.ECR,
+                InterfaceVpcEndpointAwsService.ECR_DOCKER,
+            ];
+
+            serviceEndpoints.forEach(service => {
+                new InterfaceVpcEndpoint(this, `${service.shortName}VpcEndpoint`, {
+                    service,
+                    vpc: vpc,
+                });
+            })
+        }
+        else {
+            const vpcIdParameter = new CfnParameter(this, 'VPCId', {
+                type: 'AWS::EC2::VPC::Id',
+                description: 'Select a VPC, we recommend choosing the VPC of the target cluster.'
+            });
+            addParameterLabel(parameterLabels, vpcIdParameter, "VPC")
+
+            const privateSubnetIdsParameter = new CfnParameter(this, 'VPCPrivateSubnetIds', {
+                type: 'List<AWS::EC2::Subnet::Id>',
+                description: 'Select Private Subnets in the selected VPC. Please provide two subnets at least, corresponding with the availability zones selected previously.'
+            });
+            addParameterLabel(parameterLabels, privateSubnetIdsParameter, "Private Subnets")
+            importedVPCParameters.push(vpcIdParameter.logicalId, privateSubnetIdsParameter.logicalId)
+            vpc = importVPC(this, vpcIdParameter, privateSubnetIdsParameter);
+        }
+
+        const eksClusterName = `migration-eks-cluster-${stackMarker}`
+        const eksInfra = new EKSInfra(this, 'EKSInfra', {
+            vpc,
+            clusterName: eksClusterName,
+            stackName: Fn.ref('AWS::StackName'),
+            ecrRepoName: `migration-ecr-${stackMarker}`
+        });
+
+        const exportString = generateExportString({
+            "MIGRATIONS_APP_REGISTRY_ARN": appRegistryAppARN,
+            "MIGRATIONS_USER_AGENT": solutionsUserAgent,
+            "MIGRATIONS_EKS_CLUSTER_NAME": eksClusterName,
+            "MIGRATIONS_ECR_REGISTRY": `${eksInfra.ecrRepo.registryUri}/${eksInfra.ecrRepo.repositoryName}`,
+            "AWS_CFN_REGION": this.region,
+            "VPC_ID": vpc.vpcId,
+            "STAGE": stageParameter.valueAsString
+        })
+        new CfnOutput(this, 'MigrationsExportString', {
+            value: exportString,
+            description: 'Export string for Migration resources created from this deployment',
+            exportName: 'MigrationsExportString',
+        });
+
+        const parameterGroups = [];
+        if (importedVPCParameters.length > 0) {
+            parameterGroups.push({
+                Label: { default: "Imported VPC parameters" },
+                Parameters: importedVPCParameters
+            });
+        }
+        parameterGroups.push({
+            Label: { default: "Additional parameters" },
+            Parameters: additionalParameters
+        });
+
+        this.templateOptions.metadata = {
+            'AWS::CloudFormation::Interface': {
+                ParameterGroups: parameterGroups,
+                ParameterLabels: parameterLabels
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Description
This change adds an additional experimental template for our solutions CDK to generate a CFN stack that utilizes an EKS cluster. I expect this to change a good bit as we discover more about how we should configure EKS and what additional resources we actually need there, but should provide developers of this feature a good starting point.

The template can be generated with the following command:
```
cdk synth "Migration-Assistant-Infra-Create-VPC-v3"
```

### Issues Resolved
https://opensearch.atlassian.net/browse/MIGRATIONS-2474

### Testing
AWS deployment of template

### Check List
- [ ] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
