### PR TITLE
[Transformations] Add a 'template' for metadata updater function

### DIFF
--- a/transformation/standardJavascriptTransforms/src/metadataUpdater.js
+++ b/transformation/standardJavascriptTransforms/src/metadataUpdater.js
@@ -1,0 +1,38 @@
+function applyRules(node, rules) {
+  if (Array.isArray(node)) {
+    node.forEach((child) => applyRules(child, rules));
+  } else if (node && typeof node === "object") {
+    for (const { when, set, remove = [] } of rules) {
+      const matches = Object.entries(when).every(([k, v]) => node[k] === v);
+      if (matches) {
+        // apply the rule
+        Object.assign(node, set);
+        remove.forEach((key) => delete node[key]);
+      }
+    }
+    // recurse
+    Object.values(node).forEach((child) => applyRules(child, rules));
+  }
+}
+
+function main(context) {
+  if (!context.rules) {
+    throw Error(
+      "Expected rules to be defined in the context.  Example: " +
+        JSON.stringify(
+          { rules: [{ when: { type: "foo" }, set: { type: "bar" } }] },
+          null,
+          2
+        )
+    );
+  }
+
+  return (doc) => {
+    if (doc && doc.type && doc.name && doc.body) {
+      applyRules(doc.body, context.rules);
+    }
+    return doc;
+  };
+}
+
+module.exports = { main };

--- a/transformation/standardJavascriptTransforms/src/metadataUpdater.js
+++ b/transformation/standardJavascriptTransforms/src/metadataUpdater.js
@@ -1,14 +1,33 @@
+function applyRulesToMap(when, set, remove, map) {
+  const matches = Object.entries(when).every(([k, v]) => map.get(k) === v);
+  if (matches) {
+    Object.entries(set).every(([k, v]) => map.set(k, v));
+    remove.forEach((key) => map.delete(key));
+  }
+}
+
+function applyRulesToObject(when, set, remove, obj) {
+  const matches = Object.entries(when).every(([k, v]) => obj[k] === v);
+  if (matches) {
+    Object.assign(obj, set);
+    remove.forEach((key) => delete obj[key]);
+  }
+}
+
 function applyRules(node, rules) {
   if (Array.isArray(node)) {
     node.forEach((child) => applyRules(child, rules));
+  } else if (node instanceof Map) {
+    for (const { when, set, remove = [] } of rules) {
+      applyRulesToMap(when, set, remove, node);
+    }
+    // recurse
+    for (const child of node.values()) {
+      applyRules(child, rules);
+    }
   } else if (node && typeof node === "object") {
     for (const { when, set, remove = [] } of rules) {
-      const matches = Object.entries(when).every(([k, v]) => node[k] === v);
-      if (matches) {
-        // apply the rule
-        Object.assign(node, set);
-        remove.forEach((key) => delete node[key]);
-      }
+      applyRulesToObject(when, set, remove, node);
     }
     // recurse
     Object.values(node).forEach((child) => applyRules(child, rules));

--- a/transformation/standardJavascriptTransforms/test/metadataUpdater.test.js
+++ b/transformation/standardJavascriptTransforms/test/metadataUpdater.test.js
@@ -1,0 +1,172 @@
+const { main } = require("../src/metadataUpdater.js");
+
+let templateDescription = {
+  template: {
+    mappings: {
+      properties: {
+        timestamp: {
+          type: "date",
+        },
+        ecs: {
+          properties: {
+            version: {
+              ignore_above: 1024,
+              type: "keyword",
+            },
+          },
+        },
+        data_stream: {
+          properties: {
+            namespace: {
+              type: "constant_keyword",
+            },
+            dataset: {
+              type: "constant_keyword",
+            },
+          },
+        },
+        host: {
+          type: "object",
+        },
+      },
+    },
+  },
+  version: 1,
+  _meta: {
+    managed: true,
+    description: "general mapping conventions for data streams",
+  },
+};
+
+let indexDescription = {
+  mappings: [
+    {
+      _doc: {
+        dynamic: "strict",
+        properties: {
+          all_modifiers: {
+            type: "flattened",
+          },
+          creator: {
+            properties: {
+              alias: {
+                type: "keyword",
+                index: false,
+              },
+              avatar_url: {
+                properties: {
+                  web: {
+                    type: "text",
+                    index: false,
+                    fields: {
+                      keyword: {
+                        type: "keyword",
+                        ignore_above: 2048,
+                      },
+                    },
+                  },
+                },
+              },
+              email: {
+                type: "text",
+                fields: {
+                  keyword: {
+                    type: "keyword",
+                    ignore_above: 256,
+                  },
+                },
+              },
+              name: {
+                type: "text",
+                fields: {
+                  keyword: {
+                    type: "keyword",
+                    ignore_above: 256,
+                  },
+                },
+              },
+              profile_link: {
+                type: "flattened",
+                index: false,
+              },
+              uuid: {
+                type: "text",
+                fields: {
+                  keyword: {
+                    type: "keyword",
+                    ignore_above: 256,
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  ],
+};
+
+const flattenToFlatObjectConfig = {
+  rules: [{
+    when: { type: "flattened" },
+    set: { type: "flat_object" },
+    remove: ["index"],
+  }]
+};
+
+const constantKeywordToKeywordConfig = {
+  rules: [{
+    when: { type: "constant_keyword" },
+    set: { type: "keyword" },
+  }]
+};
+
+const multipleCriteriaConfig = {
+    rules: [{
+        when: { type: "keyword", ignore_above: 2048 },
+        set: { type: "keyword", ignore_above: 999 },
+      }]
+}
+
+function wrapAsDoc(obj) {
+    return { type: "index", name: "doc_name", body: clone(obj) };
+}
+
+function clone(obj) {
+  return JSON.parse(JSON.stringify(obj));
+}
+
+describe("TypeMappingsSanitizer", () => {
+  test("null context throws", () => {
+    expect(() => main(null)).toThrow();
+  });
+
+  test("Non conforming doc is ignored", () => {
+    const original = clone(templateDescription);
+    const instance = main(constantKeywordToKeywordConfig);
+    const result = instance(templateDescription);
+    expect(result).toStrictEqual(original);
+  });
+
+  test("Constant_keywords are replaced", () => {
+    const instance = main(constantKeywordToKeywordConfig);
+    const result = instance(wrapAsDoc(templateDescription)).body;
+
+    expect(result).not.toStrictEqual(templateDescription);
+  });
+
+  test("Flattened are replaced", () => {
+    const updaterInstance = main(flattenToFlatObjectConfig);
+    const result = updaterInstance(wrapAsDoc(indexDescription)).body;
+    expect(result).not.toStrictEqual(indexDescription);
+  });
+
+  test("Multiple criteria are matched", () => {
+    const updaterInstance = main(multipleCriteriaConfig);
+    const result = updaterInstance(wrapAsDoc(indexDescription)).body
+    expect(result).not.toStrictEqual(indexDescription);
+    const resultAsString = JSON.stringify(result, null, 2);
+    expect(resultAsString).toEqual(expect.not.stringContaining("2048"));
+    expect(resultAsString).toEqual(expect.stringContaining("999"));
+  })
+});

--- a/transformation/standardJavascriptTransforms/test/metadataUpdater.test.js
+++ b/transformation/standardJavascriptTransforms/test/metadataUpdater.test.js
@@ -156,20 +156,20 @@ describe("Metadata Updater", () => {
 
   test("Constant_keywords are replaced", () => {
     const instance = main(constantKeywordToKeywordConfig);
-    const result = instance(wrapAsDoc(templateDescription)).body;
+    const result = instance(wrapAsDoc(clone(templateDescription))).body;
 
     expect(result).not.toStrictEqual(templateDescription);
   });
 
   test("Flattened are replaced", () => {
-    const updaterInstance = main(flattenToFlatObjectConfig);
-    const result = updaterInstance(wrapAsDoc(indexDescription)).body;
+    const instance = main(flattenToFlatObjectConfig);
+    const result = instance(wrapAsDoc(clone(indexDescription))).body;
     expect(result).not.toStrictEqual(indexDescription);
   });
 
   test("Multiple criteria are matched", () => {
-    const updaterInstance = main(multipleCriteriaConfig);
-    const result = updaterInstance(wrapAsDoc(indexDescription)).body;
+    const instance = main(multipleCriteriaConfig);
+    const result = instance(wrapAsDoc(clone(indexDescription))).body;
     expect(result).not.toStrictEqual(indexDescription);
     const resultAsString = JSON.stringify(result, null, 2);
     expect(resultAsString).toEqual(expect.not.stringContaining("2048"));

--- a/transformation/transformationPlugins/jsonMessageTransformers/jsonJSTransformerProvider/build.gradle
+++ b/transformation/transformationPlugins/jsonMessageTransformers/jsonJSTransformerProvider/build.gradle
@@ -9,8 +9,14 @@ dependencies {
 
     implementation libs.jackson.core
     implementation libs.jackson.databind
-}
 
-tasks.named('test') {
-    useJUnitPlatform()
+    testImplementation testFixtures(project(path: ':testHelperFixtures'))
+    testImplementation testFixtures(project(path: ':TrafficCapture:trafficReplayer'))
+
+    testImplementation libs.junit.jupiter.api
+    testImplementation libs.junit.jupiter.params
+    testImplementation libs.slf4j.api
+    testImplementation libs.hamcrest
+    testRuntimeOnly libs.junit.jupiter.engine
+
 }

--- a/transformation/transformationPlugins/jsonMessageTransformers/jsonJSTransformerProvider/src/main/java/org/opensearch/migrations/transform/JsonJSTransformerProvider.java
+++ b/transformation/transformationPlugins/jsonMessageTransformers/jsonJSTransformerProvider/src/main/java/org/opensearch/migrations/transform/JsonJSTransformerProvider.java
@@ -1,6 +1,11 @@
 package org.opensearch.migrations.transform;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -9,7 +14,8 @@ import lombok.SneakyThrows;
 
 public class JsonJSTransformerProvider implements IJsonTransformerProvider {
 
-    public static final String INITIALIZATION_SCRIPT_KEY = "initializationScript";
+    public static final String SCRIPT_FILE_KEY = "initializationScriptFile";
+    public static final String INLINE_SCRIPT_KEY = "initializationScript";
     public static final String BINDINGS_OBJECT = "bindingsObject";
 
     /**
@@ -31,7 +37,7 @@ public class JsonJSTransformerProvider implements IJsonTransformerProvider {
         var config = (Map<String, Object>) jsonConfig;
         for (String key : requiredKeys) {
             if (!config.containsKey(key)) {
-                throw new IllegalArgumentException("Configuration missing required key: " + key + "."
+                throw new IllegalArgumentException("Configuration missing required key: " + key + ". "
                 + getConfigUsageStr());
             }
         }
@@ -46,32 +52,55 @@ public class JsonJSTransformerProvider implements IJsonTransformerProvider {
      */
     protected String getConfigUsageStr() {
         return this.getClass().getName() + " expects the incoming configuration to be a Map<String, Object>, " +
-            "with keys: " + INITIALIZATION_SCRIPT_KEY + ", " + BINDINGS_OBJECT + "." +
-            INITIALIZATION_SCRIPT_KEY + " is a string consisting of Javascript which may define functions and ends in an evaluation that returns" +
-            " a main function which takes in the " + BINDINGS_OBJECT + " and returns a transform function which takes in a json object and returns the transformed object." +
+            "with keys: " + INLINE_SCRIPT_KEY + " or " + SCRIPT_FILE_KEY + ", " + BINDINGS_OBJECT + ".\n" +
+            SCRIPT_FILE_KEY + " is a string pointing to a full file path to a JavaScript file to load. \n" +
+            INLINE_SCRIPT_KEY + " is a string consisting of Javascript which may define functions and ends in an evaluation that returns" +
+            " a main function which takes in the " + BINDINGS_OBJECT + " and returns a transform function which takes in a json object and returns the transformed object.\n" +
             BINDINGS_OBJECT + " is a value which can be deserialized with Jackson ObjectMapper into a Map, List, Array," +
             " or primitive type/wrapper and when passed as an argument into " +
-            "the function returned by the " + INITIALIZATION_SCRIPT_KEY + " will give the transform function.";
+            "the function returned by the " + INLINE_SCRIPT_KEY + " will give the transform function.";
     }
 
     @SneakyThrows
     @Override
     public IJsonTransformer createTransformer(Object jsonConfig) {
-        var requiredKeys = new String[]{INITIALIZATION_SCRIPT_KEY, BINDINGS_OBJECT};
+        var exclusiveScriptParameters = List.of(SCRIPT_FILE_KEY, INLINE_SCRIPT_KEY)
+            .stream()
+            .map(key -> "\"" + key + "\"")
+            .collect(Collectors.joining(","));
+        var requiredKeys = new String[]{BINDINGS_OBJECT};
         var config = validateAndExtractConfig(jsonConfig, requiredKeys);
 
-        String script = (String) config.get(INITIALIZATION_SCRIPT_KEY);
+        String script = null;
+
+        var scriptFile = (String) config.getOrDefault(SCRIPT_FILE_KEY, null);
+        if (scriptFile != null) {
+            try {
+                script = Files.readString(Path.of(scriptFile));
+            } catch (IOException ioe) {
+                throw new IllegalArgumentException("Failed to load script file '" + scriptFile + "'. " + getConfigUsageStr(), ioe);
+            }
+        }
+
+        var inlineScript = (String) config.getOrDefault(INLINE_SCRIPT_KEY, null);
+        if (inlineScript != null) {
+            if (scriptFile != null) {
+                throw new IllegalArgumentException("Unable to use both parameters at the same time, {" + exclusiveScriptParameters + "}. " + getConfigUsageStr());
+            }
+            script = inlineScript;
+        }
+
         Object bindingsObject;
-        ObjectMapper objectMapper = new ObjectMapper();
+        var objectMapper = new ObjectMapper();
         try {
             String bindingsObjectString = (String) config.get(BINDINGS_OBJECT);
             bindingsObject = objectMapper.readValue(bindingsObjectString, new TypeReference<>() {});
-        } catch (JsonProcessingException e) {
-            throw new IllegalArgumentException("Failed to parse the bindingsObject." + getConfigUsageStr(), e);
+        } catch (ClassCastException | JsonProcessingException e) {
+            throw new IllegalArgumentException("Failed to parse the bindingsObject. " + getConfigUsageStr(), e);
         }
 
         if (script == null) {
-            throw new IllegalArgumentException(INITIALIZATION_SCRIPT_KEY + " must be provided." + getConfigUsageStr());
+            throw new IllegalArgumentException(" One of {" + exclusiveScriptParameters + "} must be provided. " + getConfigUsageStr());
         }
 
         return new JavascriptTransformer(script, bindingsObject);

--- a/transformation/transformationPlugins/jsonMessageTransformers/jsonJSTransformerProvider/src/test/java/org/opensearch/migrations/transform/JsonJSTransformerProviderTest.java
+++ b/transformation/transformationPlugins/jsonMessageTransformers/jsonJSTransformerProvider/src/test/java/org/opensearch/migrations/transform/JsonJSTransformerProviderTest.java
@@ -1,0 +1,124 @@
+package org.opensearch.migrations.transform;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class JsonJSTransformerProviderTest {
+    private static final String SIMPLE_JS_TRANSFORM = "\n" + //
+            "function main(context) {\n" + //
+            "  return (document) => {\n" + //
+            "    document.set(\"modified\", true);\n" + //
+            "    return document;\n" + //
+            "  };\n" + //
+            "}\n" + //
+            "(() => main)();";
+    private static final Map<String, String> TEST_DOC = Map.of(
+            "name", "test-doc",
+            "type", "document");
+
+    private File tempScriptFile;
+    private JsonJSTransformerProvider provider;
+
+    @BeforeEach
+    public void before() throws Exception {
+        tempScriptFile = File.createTempFile("json-js-transformation-provider", ".js");
+        provider = new JsonJSTransformerProvider();
+    }
+
+    @AfterEach
+    public void after() {
+        tempScriptFile.delete();
+    }
+
+    @Test
+    public void testCreateTransformer_scriptFile() throws Exception {
+        Files.writeString(tempScriptFile.toPath(), SIMPLE_JS_TRANSFORM);
+
+        var config = Map.of(
+                "bindingsObject", "{}",
+                "initializationScriptFile", tempScriptFile.getAbsolutePath());
+        var transformer = provider.createTransformer(config);
+        var result = (Map) transformer.transformJson(new HashMap<>(TEST_DOC));
+
+        assertThat(result.getOrDefault("modified", null), equalTo(true));
+        assertThat(result.size(), equalTo(TEST_DOC.size() + 1));
+    }
+
+    @Test
+    public void testCreateTransformer_inlineScript() throws Exception {
+        var config = Map.of(
+                "bindingsObject", "{}",
+                "initializationScript", SIMPLE_JS_TRANSFORM);
+        var transformer = provider.createTransformer(config);
+        var result = (Map) transformer.transformJson(new HashMap<>(TEST_DOC));
+
+        assertThat(result.getOrDefault("modified", null), equalTo(true));
+        assertThat(result.size(), equalTo(TEST_DOC.size() + 1));
+    }
+
+    @Test
+    public void testCreateTransformer_invalidScript() throws Exception {
+        var config = Map.of(
+                "bindingsObject", "{}",
+                "initializationScript", "");
+        var exception = assertThrows(UnsupportedOperationException.class, () -> provider.createTransformer(config));
+        assertThat(exception.getMessage(), containsString("Unsupported operation Value.execute(Object...)"));
+    }
+
+    @Test
+    public void testCreateTransformer_missingBindings() throws Exception {
+        var config = Map.of(
+                "initializationScript", "");
+        var exception = assertThrows(IllegalArgumentException.class, () -> provider.createTransformer(config));
+        assertThat(exception.getMessage(), containsString("Configuration missing required key: bindingsObject."));
+    }
+
+    @Test
+    public void testCreateTransformer_invalidBindings() throws Exception {
+        var config = Map.of(
+                "bindingsObject", Map.of(),
+                "initializationScript", "");
+        var exception = assertThrows(IllegalArgumentException.class, () -> provider.createTransformer(config));
+        assertThat(exception.getMessage(), containsString("Failed to parse the bindingsObject."));
+    }
+
+    @Test
+    public void testCreateTransformer_missingScript() throws Exception {
+        var config = Map.of(
+                "bindingsObject", "{}");
+        var exception = assertThrows(IllegalArgumentException.class, () -> provider.createTransformer(config));
+        assertThat(exception.getMessage(),
+                containsString("One of {\"initializationScriptFile\",\"initializationScript\"} must be provided."));
+    }
+
+    @Test
+    public void testCreateTransformer_tooManyScriptSources() throws Exception {
+        var config = Map.of(
+                "bindingsObject", "{}",
+                "initializationScript", "",
+                "initializationScriptFile", tempScriptFile.getAbsolutePath());
+        var exception = assertThrows(IllegalArgumentException.class, () -> provider.createTransformer(config));
+        assertThat(exception.getMessage(), containsString(
+                "Unable to use both parameters at the same time, {\"initializationScriptFile\",\"initializationScript\"}. "));
+    }
+
+    @Test
+    public void testCreateTransformer_invalidFilePath() throws Exception {
+        var config = Map.of(
+                "bindingsObject", "{}",
+                "initializationScriptFile", "");
+        var exception = assertThrows(IllegalArgumentException.class, () -> provider.createTransformer(config));
+        assertThat(exception.getMessage(), containsString("Failed to load script file ''."));
+    }
+}


### PR DESCRIPTION
### Description
Adding a JavaScript transformation example that can be iterated on by customer to handle mapping type conversions.  So long as this looks like a good foundation I'll adapt it to a simplified version that I'll post on the documentation website.

Can be used with string -> text, flattened -> flat_object, constant_keyword -> keyword fields as quick examples.

I'd expect the version that is posted into the documentation site to look something like the following:

```javascript
function main(context) {
  /* Define rules here */
  const rules = [{
    when: { type: "string" }, /* Match all the key/value pairs here */
    set: { type: "text" }, /* Replace them with these key/value pairs */
  }, {
    when: { type: "flattened" }, /* Match all the key/value pairs here */
    set: { type: "flat_object" }, /* Replace them with these key/value pairs */
    remove: ["index"], /* Any sibling keys that should be removed */
  }];

  function applyRulesToMap(when, set, remove, map) {
    const matches = Object.entries(when).every(([k, v]) => map.get(k) === v);
    if (matches) {
      Object.entries(set).every(([k, v]) => map.set(k, v));
      remove.forEach((key) => map.delete(key));
    }
  }

  function applyRulesToObject(when, set, remove, obj) {
    const matches = Object.entries(when).every(([k, v]) => obj[k] === v);
    if (matches) {
      Object.assign(obj, set);
      remove.forEach((key) => delete obj[key]);
    }
  }

  function applyRules(node, rules) {
    if (Array.isArray(node)) {
      node.forEach((child) => applyRules(child, rules));
    } else if (node instanceof Map) {
      for (const { when, set, remove = [] } of rules) {
        applyRulesToMap(when, set, remove, node);
      }
      // recurse
      for (const child of node.values()) {
        applyRules(child, rules);
      }
    } else if (node && typeof node === "object") {
      for (const { when, set, remove = [] } of rules) {
        applyRulesToObject(when, set, remove, node);
      }
      // recurse
      Object.values(node).forEach((child) => applyRules(child, rules));
    }
  }

  return (doc) => {
    if (doc && doc.type && doc.name && doc.body) {
      applyRules(doc.body, context.rules);
    }
    return doc;
  };
}
(() => main)();
```



### Issues Resolved
- Resolves

### Testing
Added new JavaScript tests that verify the new 

### Check List
- [X] New functionality includes testing
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.
    https://github.com/opensearch-project/documentation-website/pull/10010

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
