### PR TITLE
10%+ speed improvement all gradle-tests legs

### DIFF
--- a/DocumentsFromSnapshotMigration/build.gradle
+++ b/DocumentsFromSnapshotMigration/build.gradle
@@ -141,6 +141,5 @@ tasks.named('composeUp') {
 }
 
 tasks.named('slowTest') {
-    dependsOn(':TrafficCapture:dockerSolution:buildDockerImage_elasticsearch_client_test_console')
     testLogging.showStandardStreams = false
 }


### PR DESCRIPTION
### Description
We were building docker images for a container that used to be used, but has been phased out.

### Testing
Verified the GHA results against a standard run, seeing ~2 mins less build time on the first 10 jobs I checked.

### Check List
- [ ] ~New functionality includes testing~
- [ ] ~Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
