### PR TITLE
Increase capture proxy cpu and memory to 2vCPU/4GB

### DIFF
--- a/deployment/cdk/opensearch-service-migration/lib/service-stacks/capture-proxy-stack.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/service-stacks/capture-proxy-stack.ts
@@ -146,8 +146,8 @@ export class CaptureProxyStack extends MigrationServiceCore {
             taskRolePolicies: servicePolicies,
             portMappings: [servicePort],
             cpuArchitecture: props.fargateCpuArch,
-            taskCpuUnits: 512,
-            taskMemoryLimitMiB: 2048,
+            taskCpuUnits: 2048,
+            taskMemoryLimitMiB: 4096,
             ...props
         });
     }


### PR DESCRIPTION
### Description
Increase capture proxy cpu and memory to 2vCPU/4GB which was shown to have lower more consistent latency addition versus the existing configuration even in low throughput scenarios.

Existing configuration had 15-30ms latency addition while new configuration had 5-10ms impact on client traffic after switchover.

### Issues Resolved
N/A

### Testing
Tested in AWS

### Check List
- [ ] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
