### PR TITLE
Add qualifier as default dimension for cloudwatch metrics retrieval

### DIFF
--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/metrics_source.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/metrics_source.py
@@ -33,6 +33,10 @@ CLOUDWATCH_SCHEMA = {
             "type": "string",
             "required": False,
         },
+        "qualifier": {
+            "type": "string",
+            "required": True,
+        },
     },
     "nullable": True
 }
@@ -118,6 +122,9 @@ class CloudwatchMetricsSource(MetricsSource):
         self.aws_region = None
         if type(config["cloudwatch"]) is dict and "aws_region" in config["cloudwatch"]:
             self.aws_region = config["cloudwatch"]["aws_region"]
+        if type(config["cloudwatch"]) is dict and "qualifier" in config["cloudwatch"]:
+            self.qualifier = config["cloudwatch"]["qualifier"]
+
         self.client = create_boto3_client(aws_service_name="cloudwatch", region=self.aws_region,
                                           client_options=self.client_options)
 
@@ -154,6 +161,7 @@ class CloudwatchMetricsSource(MetricsSource):
                     f"{start_time=}, {period_in_seconds=}, {end_time=}, {dimensions=}")
 
         aws_dimensions = [{"Name": "OTelLib", "Value": component.value}]
+        aws_dimensions += [{"Name": "qualifier", "Value": self.qualifier}]
         if dimensions:
             aws_dimensions += [{"Name": k, "Value": v} for k, v in dimensions.items()]
         logger.debug(f"AWS Dimensions set to: {aws_dimensions}")

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/test_metrics_source.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/test_metrics_source.py
@@ -19,6 +19,7 @@ from console_link.models.utils import AWSAPIError
 TEST_DATA_DIRECTORY = pathlib.Path(__file__).parent / "data"
 AWS_REGION = "us-east-1"
 USER_AGENT_EXTRA = "test-agent-v1.0"
+STAGE = "test"
 
 mock_metrics_list = {'captureProxy': ['kafkaCommitCount', 'captureConnectionDuration'],
                      'replayer': ['kafkaCommitCount']}
@@ -56,7 +57,8 @@ def cw_ms():
     return CloudwatchMetricsSource(
         config={
             "cloudwatch": {
-                "aws_region": AWS_REGION
+                "aws_region": AWS_REGION,
+                "qualifier": STAGE
             }
         },
         client_options=ClientOptions(config={"user_agent_extra": USER_AGENT_EXTRA})
@@ -66,7 +68,8 @@ def cw_ms():
 def test_get_metrics_source():
     cw_config = {
         "cloudwatch": {
-            "aws_region": AWS_REGION
+            "aws_region": AWS_REGION,
+            "qualifier": STAGE
         }
     }
     cw_metrics_source = get_metrics_source(cw_config)

--- a/deployment/cdk/opensearch-service-migration/lib/migration-services-yaml.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/migration-services-yaml.ts
@@ -24,7 +24,10 @@ export class ClusterYaml {
 }
 
 export class MetricsSourceYaml {
-    cloudwatch? : object | null = null;
+    cloudwatch?: {
+        aws_region?: string
+        qualifier: string;
+    } | null = null;
 }
 
 export class ECSService {

--- a/deployment/cdk/opensearch-service-migration/lib/service-stacks/migration-console-stack.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/service-stacks/migration-console-stack.ts
@@ -251,6 +251,11 @@ export class MigrationConsoleStack extends MigrationServiceCore {
             if (servicesYaml.snapshot) {
                 servicesYaml.snapshot.otel_endpoint = otelSidecarEndpoint;
             }
+            if (servicesYaml.metrics_source?.cloudwatch !== undefined) {
+                servicesYaml.metrics_source.cloudwatch = {
+                    ...servicesYaml.metrics_source.cloudwatch,
+                    qualifier : props.stage };
+            }
         }
 
         const serviceTaskRole = new Role(this, 'MigrationServiceTaskRole', {


### PR DESCRIPTION
### Description
Add qualifier as default dimension for cloudwatch metrics retrieval

### Issues Resolved
https://opensearch.atlassian.net/browse/MIGRATIONS-2512

### Testing
Adhoc test with jenkins job that was previously failing
<img width="1254" alt="image" src="https://github.com/user-attachments/assets/2a9340a6-bfdc-4f2d-bcd3-e04053cfc678" />

### Check List
- [ ] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
