### PR TITLE
Add ES 7.7, 7.8, and 7.9 as extended supported sources

### DIFF
--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/transformers/TransformerMapper.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/transformers/TransformerMapper.java
@@ -40,8 +40,11 @@ public class TransformerMapper {
             if (VersionMatchers.isES_6_X.test(sourceVersion)) {
                 return new Transformer_ES_6_8_to_OS_2_11(awarenessAttributes, metadataTransformerParams);
             }
-            if (VersionMatchers.isES_7_0_to_7_9.test(sourceVersion)) {
+            if (VersionMatchers.isES_7_0_to_7_8.test(sourceVersion)) {
                 return new Transformer_ES_6_8_to_OS_2_11(awarenessAttributes, metadataTransformerParams);
+            }
+            if (VersionMatchers.isES_7_9_X.test(sourceVersion)) {
+                return new Transformer_ES_7_10_OS_2_11(awarenessAttributes);
             }
             if (VersionMatchers.equalOrGreaterThanES_7_10.test(sourceVersion)) {
                 return new Transformer_ES_7_10_OS_2_11(awarenessAttributes);

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/version_es_6_8/SnapshotReader_ES_6_8.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/version_es_6_8/SnapshotReader_ES_6_8.java
@@ -19,7 +19,7 @@ public class SnapshotReader_ES_6_8 implements ClusterSnapshotReader {
     public boolean compatibleWith(Version version) {
         return VersionMatchers.isES_6_X
             .or(VersionMatchers.isES_5_X)
-            .or(VersionMatchers.isES_7_0_to_7_9)
+            .or(VersionMatchers.isES_7_0_to_7_8)
             .test(version);
     }
 
@@ -27,7 +27,7 @@ public class SnapshotReader_ES_6_8 implements ClusterSnapshotReader {
     public boolean looseCompatibleWith(Version version) {
         return UnboundVersionMatchers.isBelowES_6_X
             .or(VersionMatchers.isES_6_X)
-            .or(VersionMatchers.isES_7_0_to_7_9)
+            .or(VersionMatchers.isES_7_0_to_7_8)
             .test(version);
     }
 

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/version_es_6_8/SnapshotRepoData_ES_6_8.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/version_es_6_8/SnapshotRepoData_ES_6_8.java
@@ -10,12 +10,14 @@ import org.opensearch.migrations.bulkload.common.SnapshotRepo;
 import org.opensearch.migrations.bulkload.common.SnapshotRepo.CantParseRepoFile;
 import org.opensearch.migrations.bulkload.common.SourceRepo;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class SnapshotRepoData_ES_6_8 {
 
     public static SnapshotRepoData_ES_6_8 fromRepoFile(Path filePath) {
@@ -50,6 +52,7 @@ public class SnapshotRepoData_ES_6_8 {
     @Getter
     @AllArgsConstructor
     @NoArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
     public static class Snapshot implements SnapshotRepo.Snapshot {
         private String name;
         private String uuid;
@@ -64,6 +67,7 @@ public class SnapshotRepoData_ES_6_8 {
     @Getter
     @AllArgsConstructor
     @NoArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
     public static class RawIndex {
         private String id;
         private List<String> snapshots;

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/version_es_7_10/SnapshotReader_ES_7_10.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/version_es_7_10/SnapshotReader_ES_7_10.java
@@ -17,7 +17,8 @@ public class SnapshotReader_ES_7_10 implements ClusterSnapshotReader {
 
     @Override
     public boolean compatibleWith(Version version) {
-        return VersionMatchers.equalOrGreaterThanES_7_10
+        return VersionMatchers.isES_7_9_X
+            .or(VersionMatchers.equalOrGreaterThanES_7_10)
             .or(VersionMatchers.isES_8_X)
             .or(VersionMatchers.isOS_1_X)
             .or(VersionMatchers.isOS_2_X)
@@ -26,7 +27,8 @@ public class SnapshotReader_ES_7_10 implements ClusterSnapshotReader {
 
     @Override
     public boolean looseCompatibleWith(Version version) {
-        return UnboundVersionMatchers.isGreaterOrEqualES_7_10
+        return VersionMatchers.isES_7_9_X
+            .or(UnboundVersionMatchers.isGreaterOrEqualES_7_10)
             .or(UnboundVersionMatchers.anyOS)
             .test(version);
     }

--- a/RFS/src/testFixtures/java/org/opensearch/migrations/bulkload/SupportedClusters.java
+++ b/RFS/src/testFixtures/java/org/opensearch/migrations/bulkload/SupportedClusters.java
@@ -30,6 +30,9 @@ public class SupportedClusters {
 
     public static List<ContainerVersion> extendedSources() {
         return List.of(
+                SearchClusterContainer.ES_V7_9,
+                SearchClusterContainer.ES_V7_8,
+                SearchClusterContainer.ES_V7_7,
                 SearchClusterContainer.ES_V7_4,
                 SearchClusterContainer.ES_V7_1
         );

--- a/RFS/src/testFixtures/java/org/opensearch/migrations/bulkload/framework/SearchClusterContainer.java
+++ b/RFS/src/testFixtures/java/org/opensearch/migrations/bulkload/framework/SearchClusterContainer.java
@@ -33,6 +33,18 @@ public class SearchClusterContainer extends GenericContainer<SearchClusterContai
         "docker.elastic.co/elasticsearch/elasticsearch:8.17.5",
         Version.fromString("ES 8.17.5")
     );
+    public static final ContainerVersion ES_V7_9 = new ElasticsearchOssVersion(
+            "docker.elastic.co/elasticsearch/elasticsearch-oss:7.9.3",
+            Version.fromString("ES 7.9.3")
+    );
+    public static final ContainerVersion ES_V7_8 = new ElasticsearchOssVersion(
+            "docker.elastic.co/elasticsearch/elasticsearch-oss:7.8.1",
+            Version.fromString("ES 7.8.1")
+    );
+    public static final ContainerVersion ES_V7_7 = new ElasticsearchOssVersion(
+            "docker.elastic.co/elasticsearch/elasticsearch-oss:7.7.1",
+            Version.fromString("ES 7.7.1")
+    );
     public static final ContainerVersion ES_V7_4 = new ElasticsearchOssVersion(
             "docker.elastic.co/elasticsearch/elasticsearch-oss:7.4.2",
             Version.fromString("ES 7.4.2")

--- a/transformation/src/main/java/org/opensearch/migrations/VersionMatchers.java
+++ b/transformation/src/main/java/org/opensearch/migrations/VersionMatchers.java
@@ -12,8 +12,9 @@ public class VersionMatchers {
     public static final Predicate<Version> isES_7_X = VersionMatchers.matchesMajorVersion(Version.fromString("ES 7.10"));
     public static final Predicate<Version> isES_7_10 = VersionMatchers.matchesMinorVersion(Version.fromString("ES 7.10.2"));
     public static final Predicate<Version> isES_8_X = VersionMatchers.matchesMajorVersion(Version.fromString("ES 8.17"));
-    public static final Predicate<Version> isES_7_0_to_7_9 = VersionMatchers.equalOrGreaterThanMinorVersion(Version.fromString("ES 7.0"))
-                                                                .and(VersionMatchers.equalOrLessThanMinorVersion(Version.fromString("ES 7.9")));
+    public static final Predicate<Version> isES_7_0_to_7_8 = VersionMatchers.equalOrGreaterThanMinorVersion(Version.fromString("ES 7.0"))
+                                                                .and(VersionMatchers.equalOrLessThanMinorVersion(Version.fromString("ES 7.8")));
+    public static final Predicate<Version> isES_7_9_X = VersionMatchers.matchesMinorVersion(Version.fromString("ES 7.9.0"));
     public static final Predicate<Version> equalOrGreaterThanES_7_10 = VersionMatchers.equalOrGreaterThanMinorVersion(Version.fromString("ES 7.10"));
 
     public static final Predicate<Version> isOS_1_X = VersionMatchers.matchesMajorVersion(Version.fromString("OS 1.0.0"));


### PR DESCRIPTION
### Description
This PR extends support for Elasticsearch 7.7, 7.8, and 7.9 as source clusters for migration assistant, using the existing SnapshotReader for ES 6.8 and ES 7.10. These versions are now officially supported as extended sources when migrating to OpenSearch (target OS 3.0 or AOS target OS 2.19).

Code changes include:
- Created new predicate `isES_7_9_X` for matching ES 7.9.x specifically
- Added new transformer mapping for `isES_7_9_X` as it relies on `SnapshotReader_ES_7_10`
- Modified `SnapshotReader_ES_7_10` to treat ES 7.9.x as strictly and loosely compatible
- Updated `SnapshotReader_ES_6_8` to ignore unknown fields in repo metadata (via `@JsonIgnoreProperties`) to safely handle additional fields introduced in ES 7.7 and 7.8
- Modified `isES_7_0_to_7_9` to `isES_7_0_to_7_8`

### Issues Resolved
[MIGRATIONS-2554](https://opensearch.atlassian.net/browse/MIGRATIONS-2554)

### Testing
- `./gradlew :MetadataMigration:isolatedTest --tests "*EndToEndTest"`
- `./gradlew :DocumentsFromSnapshotMigration:isolatedTest --tests "*EndToEndTest"`

### Check List
- [ ] New functionality includes testing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
