### PR TITLE
Fix TrafficReplayer behavior with HEAD and CONNECT method requests.

### DIFF
--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/HttpByteBufFormatter.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/HttpByteBufFormatter.java
@@ -258,8 +258,8 @@ public class HttpByteBufFormatter {
         try {
             byteBufStream.forEachOrdered(b -> channel.writeInbound(b.retainedDuplicate()));
             T output = channel.readInbound();
-            if (output == null) {
-                log.debug("HTTP message was not processed after decoding all bytes." +
+            if (output == null && HttpMessageType.RESPONSE.equals(msgType)) {
+                log.debug("HTTP response was not processed after decoding all bytes." +
                         "Manually writing empty last content to the channel to signal end of stream." +
                         "This will happen for HEAD and CONNECT responses since we" +
                         "are not decoding the request in the same channel.");

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/HttpByteBufFormatter.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/HttpByteBufFormatter.java
@@ -259,10 +259,12 @@ public class HttpByteBufFormatter {
             byteBufStream.forEachOrdered(b -> channel.writeInbound(b.retainedDuplicate()));
             T output = channel.readInbound();
             if (output == null && HttpMessageType.RESPONSE.equals(msgType)) {
-                log.debug("HTTP response was not processed after decoding all bytes." +
-                        "Manually writing empty last content to the channel to signal end of stream." +
-                        "This will happen for HEAD and CONNECT responses since we" +
-                        "are not decoding the request in the same channel.");
+                log.atDebug().setMessage( () ->
+                        "HTTP response was not processed after decoding all bytes. " +
+                        "Manually writing empty last content to the channel to signal" +
+                        " end of stream to channel handlers." +
+                        "This will happen HEAD and CONNECT responses or if a server " +
+                        "sends a malformed or incomplete response.").log();
                 channel.writeInbound(LastHttpContent.EMPTY_LAST_CONTENT);
                 output = channel.readInbound();
             }

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/HttpByteBufFormatter.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/HttpByteBufFormatter.java
@@ -25,13 +25,13 @@ import io.netty.handler.codec.http.DefaultFullHttpRequest;
 import io.netty.handler.codec.http.DefaultFullHttpResponse;
 import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.FullHttpResponse;
-import io.netty.handler.codec.http.HttpClientCodec;
 import io.netty.handler.codec.http.HttpContent;
 import io.netty.handler.codec.http.HttpContentDecompressor;
 import io.netty.handler.codec.http.HttpMessage;
 import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpRequestDecoder;
 import io.netty.handler.codec.http.HttpResponse;
-import io.netty.handler.codec.http.HttpServerCodec;
+import io.netty.handler.codec.http.HttpResponseDecoder;
 import io.netty.handler.codec.http.LastHttpContent;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
@@ -249,7 +249,7 @@ public class HttpByteBufFormatter {
                                                    Stream<ByteBuf> byteBufStream,
                                                    ChannelHandler... handlers) {
         EmbeddedChannel channel = new EmbeddedChannel(
-            msgType == HttpMessageType.REQUEST ? new HttpServerCodec() : new HttpClientCodec(),
+            msgType == HttpMessageType.REQUEST ? new HttpRequestDecoder() : new HttpResponseDecoder(),
             new HttpContentDecompressor()
         );
         for (var h : handlers) {
@@ -257,7 +257,17 @@ public class HttpByteBufFormatter {
         }
         try {
             byteBufStream.forEachOrdered(b -> channel.writeInbound(b.retainedDuplicate()));
-            return channel.readInbound();
+            T output = channel.readInbound();
+            if (output == null) {
+                log.debug("HTTP message was not processed after decoding all bytes." +
+                        "Manually writing empty last content to the channel to signal end of stream." +
+                        "This will happen for HEAD and CONNECT responses since we" +
+                        "are not decoding the request in the same channel.");
+                channel.writeInbound(LastHttpContent.EMPTY_LAST_CONTENT);
+                output = channel.readInbound();
+            }
+            channel.checkException();
+            return output;
         } finally {
             channel.finishAndReleaseAll();
         }

--- a/TrafficCapture/trafficReplayer/src/test/resources/requests/raw/head_withAuthHeader.txt
+++ b/TrafficCapture/trafficReplayer/src/test/resources/requests/raw/head_withAuthHeader.txt
@@ -1,0 +1,4 @@
+HEAD /test HTTP/1.1
+Host: foo.example
+auTHorization: Basic YWRtaW46YWRtaW4=
+


### PR DESCRIPTION
### Description
TrafficReplayer's HttpByteBufFormatter, used for tuples, decodes the request and response in separate Embedded Channels. This limits the ability for the decoder to detect rfc9112 6.3.1-2 behavior where responses from HEAD and CONNECT requests are terminated after the headers ignoring content-length fields.

We now achieve correct behavior for these requests by writing a LastHttpContent.EMPTY_LAST_CONTENT in the channel if the output was empty after the entire request/response was sent. This triggers the end of the message and output is written.

This change converts from using HttpClientCodec to HttpResponseDecoder for initial response decoding and HttpServerCodec to HttpRequestDecoder for request decoding to simplify the decoding and make clearer the responsibilities. HttpClientCodec misleadingly handled this case for HEAD and CONNECT requests as it seeks to maintain state for these responses, but to do so, it requires the request be sent through the outbound of the channel. Doing this would add unnecessary complexity to couple the request and response decoding for the HttpByteBufFormatter especially in cases of multiple responses during retrys where we would need to decode a single request several times to maintain this state for each of the response parsing.

### Issues Resolved
[MIGRATIONS-2560](https://opensearch.atlassian.net/browse/MIGRATIONS-2560)

### Testing
Unit testing

### Check List
- [x] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
