### PR TITLE
Add exclusion list for known default/plugin ES index templates and indices

### DIFF
--- a/MetadataMigration/src/test/java/org/opensearch/migrations/EndToEndTest.java
+++ b/MetadataMigration/src/test/java/org/opensearch/migrations/EndToEndTest.java
@@ -9,7 +9,6 @@ import java.util.stream.Stream;
 
 import org.opensearch.migrations.bulkload.SupportedClusters;
 import org.opensearch.migrations.bulkload.framework.SearchClusterContainer;
-import org.opensearch.migrations.bulkload.models.DataFilterArgs;
 import org.opensearch.migrations.commands.MigrationItemResult;
 import org.opensearch.migrations.metadata.CreationResult;
 import org.opensearch.migrations.snapshot.creation.tracing.SnapshotTestContext;
@@ -182,17 +181,6 @@ class EndToEndTest extends BaseMigrationTest {
         }
 
         arguments.metadataTransformationParams.multiTypeResolutionBehavior = MultiTypeResolutionBehavior.UNION;
-
-        // Set up data filters for ES 7.17 as we do not currently have transformations in place to support breaking
-        // changes from default templates and settings here: https://opensearch.atlassian.net/browse/MIGRATIONS-2447
-        if (UnboundVersionMatchers.isGreaterOrEqualES_7_X.test(sourceCluster.getContainerVersion().getVersion())) {
-            var dataFilterArgs = new DataFilterArgs();
-            dataFilterArgs.indexAllowlist = Stream.concat(testData.blogIndexNames.stream(),
-                    Stream.of(testData.movieIndexName, testData.indexThatAlreadyExists)).collect(Collectors.toList());
-            dataFilterArgs.componentTemplateAllowlist = testData.componentTemplateNames;
-            dataFilterArgs.indexTemplateAllowlist = testData.templateNames;
-            arguments.dataFilterArgs = dataFilterArgs;
-        }
 
         targetOperations.createDocument(testData.indexThatAlreadyExists, "doc77", "{}");
 

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/common/FilterScheme.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/common/FilterScheme.java
@@ -1,21 +1,66 @@
 package org.opensearch.migrations.bulkload.common;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.function.Predicate;
 
 public class FilterScheme {
     private FilterScheme() {}
 
+    private static final List<String> EXCLUDED_PREFIXES = Arrays.asList(
+            ".",
+            "apm-",
+            "apm@",
+            "behavioral_analytics-",
+            "data-streams-",
+            "data-streams@",
+            "ecs@",
+            "elastic-connectors-",
+            "ilm-history-",
+            "logs-",
+            "metrics-",
+            "profiling-",
+            "synthetics-",
+            "traces-"
+    );
+
+    private static final List<String> EXCLUDED_SUFFIXES = Arrays.asList(
+            "@settings",
+            "@mappings",
+            "@tsdb-settings"
+        );
+
+    private static final List<String> EXCLUDED_NAMES = Arrays.asList(
+            "elastic-connectors",
+            "ilm-history",
+            "logs",
+            "metrics",
+            "profiling",
+            "search-acl-filter",
+            "synthetics"
+    );
+
     public static Predicate<String> filterByAllowList(List<String> allowlist) {
         return item -> {
-            boolean accepted;
-            // By default allow all items except 'system' items that start with a period
             if (allowlist == null || allowlist.isEmpty()) {
-                accepted = !item.startsWith(".");
+                return !isExcluded(item);
             } else {
-                accepted = allowlist.contains(item);
+                return allowlist.contains(item);
             }
-            return accepted;
         };
+    }
+
+    private static boolean isExcluded(String item) {
+        for (String prefix : EXCLUDED_PREFIXES) {
+            if (item.startsWith(prefix)) {
+                return true;
+            }
+        }
+        for (String suffix : EXCLUDED_SUFFIXES) {
+            if (item.endsWith(suffix)) {
+                return true;
+            }
+        }
+        return EXCLUDED_NAMES.contains(item);
     }
 }

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/common/FilterScheme.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/common/FilterScheme.java
@@ -17,16 +17,15 @@ public class FilterScheme {
             "ecs@",
             "elastic-connectors-",
             "ilm-history-",
-            "logs-",
-            "metrics-",
             "profiling-",
-            "synthetics-",
-            "traces-"
+            "synthetics-"
     );
 
     private static final List<String> EXCLUDED_SUFFIXES = Arrays.asList(
-            "@settings",
+            "@ilm",
             "@mappings",
+            "@settings",
+            "@template",
             "@tsdb-settings"
         );
 
@@ -34,10 +33,20 @@ public class FilterScheme {
             "elastic-connectors",
             "ilm-history",
             "logs",
+            "logs-mappings",
+            "logs-settings",
+            "logs-tsdb-settings",
             "metrics",
+            "metrics-mappings",
+            "metrics-settings",
+            "metrics-tsdb-settings",
             "profiling",
             "search-acl-filter",
-            "synthetics"
+            "synthetics",
+            "traces",
+            "traces-mappings",
+            "traces-settings",
+            "traces-tsdb-settings"
     );
 
     public static Predicate<String> filterByAllowList(List<String> allowlist) {

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/models/DataFilterArgs.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/models/DataFilterArgs.java
@@ -6,16 +6,16 @@ import com.beust.jcommander.Parameter;
 
 public class DataFilterArgs {
     @Parameter(names = { "--index-allowlist" }, description = ("Optional.  List of index names to migrate"
-        + " (e.g. 'logs_2024_01, logs_2024_02').  Default: all non-system indices (e.g. those not starting with '.')"), required = false)
+        + " (e.g. 'logs_2024_01, logs_2024_02').  Default: all non-system indices (e.g. those not starting with '.', created by plugins)"), required = false)
     public List<String> indexAllowlist = List.of();
 
     @Parameter(names = {
         "--index-template-allowlist" }, description = ("Optional.  List of index template names to migrate"
-            + " (e.g. 'posts_index_template1, posts_index_template2').  Default: all non-system indices (e.g. those not starting with '.')"), required = false)
+            + " (e.g. 'posts_index_template1, posts_index_template2').  Default: all non-system indices (e.g. those not starting with '.', created by plugins)"), required = false)
     public List<String> indexTemplateAllowlist = List.of();
 
     @Parameter(names = {
         "--component-template-allowlist" }, description = ("Optional. List of component template names to migrate"
-            + " (e.g. 'posts_template1, posts_template2').  Default: all non-system indices (e.g. those not starting with '.')"), required = false)
+            + " (e.g. 'posts_template1, posts_template2').  Default: all non-system indices (e.g. those not starting with '.', created by plugins)"), required = false)
     public List<String> componentTemplateAllowlist = List.of();
 }

--- a/RFS/src/test/java/org/opensearch/migrations/bulkload/common/FilterSchemeTest.java
+++ b/RFS/src/test/java/org/opensearch/migrations/bulkload/common/FilterSchemeTest.java
@@ -9,6 +9,42 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 public class FilterSchemeTest {
     @Test
+    void testExcludedByPrefix() {
+        var filter = FilterScheme.filterByAllowList(null);
+        
+        // Should be excluded due to prefix
+        assertThat(filter.test("logs-test"), equalTo(false));
+        assertThat(filter.test(".hidden"), equalTo(false));
+        
+        // Should not be excluded (no matching prefix)
+        assertThat(filter.test("myindex"), equalTo(true));
+    }
+    
+    @Test
+    void testExcludedBySuffix() {
+        var filter = FilterScheme.filterByAllowList(null);
+        
+        // Should be excluded due to suffix
+        assertThat(filter.test("index@settings"), equalTo(false));
+        assertThat(filter.test("test@mappings"), equalTo(false));
+        
+        // Should not be excluded (no matching suffix)
+        assertThat(filter.test("settings"), equalTo(true));
+    }
+    
+    @Test
+    void testExcludedByExactName() {
+        var filter = FilterScheme.filterByAllowList(null);
+        
+        // Should be excluded due to exact name match
+        assertThat(filter.test("logs"), equalTo(false));
+        assertThat(filter.test("metrics"), equalTo(false));
+        
+        // Should not be excluded (no exact name match)
+        assertThat(filter.test("metrics_custom"), equalTo(true));
+    }
+    
+    @Test
     void testFilterByAllowList_null() {
         var filter = FilterScheme.filterByAllowList(null);
 

--- a/RFS/src/test/java/org/opensearch/migrations/bulkload/common/FilterSchemeTest.java
+++ b/RFS/src/test/java/org/opensearch/migrations/bulkload/common/FilterSchemeTest.java
@@ -13,11 +13,13 @@ public class FilterSchemeTest {
         var filter = FilterScheme.filterByAllowList(null);
         
         // Should be excluded due to prefix
-        assertThat(filter.test("logs-test"), equalTo(false));
+        assertThat(filter.test("apm-test"), equalTo(false));
         assertThat(filter.test(".hidden"), equalTo(false));
         
         // Should not be excluded (no matching prefix)
         assertThat(filter.test("myindex"), equalTo(true));
+        assertThat(filter.test("logs-2024"), equalTo(true));
+        assertThat(filter.test("metrics-2024"), equalTo(true));
     }
     
     @Test


### PR DESCRIPTION
### Description
Add exclusion list for known default/plugin ES index templates and indices.
Several system/plugin indicies do not follow the `.` prefix convention. This extends the default allowlist based on known defaults.

These indexes are either transient (cluster logs), or relate to plugins that are not compatible with Opensearch as they are.

### Issues Resolved
https://opensearch.atlassian.net/browse/MIGRATIONS-2447

### Testing
Unit Tests

### Check List
- [x] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).