### PR TITLE
Extend Migration Assistant iam permissions to allow access to cross account/region domain/collection/pipeline

### DIFF
--- a/deployment/cdk/opensearch-service-migration/lib/common-utilities.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/common-utilities.ts
@@ -71,20 +71,22 @@ export function parseArgsToDict(argString: string | undefined): Record<string, s
     return args;
 }
 
-export function createOpenSearchIAMAccessPolicy(partition: string, region: string, accountId: string): PolicyStatement {
+export function createAllAccessOpenSearchIAMAccessPolicy(): PolicyStatement {
+    // Allow all access to opensearch domains in any account/region
     return new PolicyStatement({
         effect: Effect.ALLOW,
-        resources: [`arn:${partition}:es:${region}:${accountId}:domain/*`],
+        resources: ["*"],
         actions: [
             "es:ESHttp*"
         ]
     })
 }
 
-export function createOpenSearchServerlessIAMAccessPolicy(partition: string, region: string, accountId: string): PolicyStatement {
+export function createAllAccessOpenSearchServerlessIAMAccessPolicy(): PolicyStatement {
+    // Allow all access to collections in any account/region
     return new PolicyStatement({
         effect: Effect.ALLOW,
-        resources: [`arn:${partition}:aoss:${region}:${accountId}:collection/*`],
+        resources: ["*"],
         actions: [
             "aoss:APIAccessAll"
         ]

--- a/deployment/cdk/opensearch-service-migration/lib/service-stacks/migration-console-stack.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/service-stacks/migration-console-stack.ts
@@ -6,8 +6,8 @@ import {Construct} from "constructs";
 import {Effect, PolicyStatement, Role, ServicePrincipal} from "aws-cdk-lib/aws-iam";
 import {
     createMigrationStringParameter,
-    createOpenSearchIAMAccessPolicy,
-    createOpenSearchServerlessIAMAccessPolicy,
+    createAllAccessOpenSearchIAMAccessPolicy,
+    createAllAccessOpenSearchServerlessIAMAccessPolicy,
     getSecretAccessPolicy,
     getMigrationStringParameterValue,
     hashStringSHA256,
@@ -86,7 +86,7 @@ export class MigrationConsoleStack extends MigrationServiceCore {
             assumedBy: new ServicePrincipal('osis-pipelines.amazonaws.com'),
             description: 'OpenSearch Ingestion Pipeline role for OpenSearch Migrations'
         });
-        // Add policy to allow access to Opensearch domains
+        // Add policy to allow access to Opensearch domains in same account/region
         osiPipelineRole.addToPolicy(new PolicyStatement({
             effect: Effect.ALLOW,
             actions: ["es:DescribeDomain", "es:ESHttp*"],
@@ -102,10 +102,10 @@ export class MigrationConsoleStack extends MigrationServiceCore {
     }
 
     createOpenSearchIngestionManagementPolicy(pipelineRoleArn: string): PolicyStatement[] {
-        const allMigrationPipelineArn = `arn:${this.partition}:osis:${this.region}:${this.account}:pipeline/*`
+        // Allow all access for pipelines in other accounts or regions
         const osiManagementPolicy = new PolicyStatement({
             effect: Effect.ALLOW,
-            resources: [allMigrationPipelineArn],
+            resources: ["*"],
             actions: [
                 "osis:*"
             ]
@@ -263,8 +263,8 @@ export class MigrationConsoleStack extends MigrationServiceCore {
             description: 'Role for Migration Console ECS Tasks',
         });
 
-        const openSearchPolicy = createOpenSearchIAMAccessPolicy(this.partition, this.region, this.account)
-        const openSearchServerlessPolicy = createOpenSearchServerlessIAMAccessPolicy(this.partition, this.region, this.account)
+        const openSearchPolicy = createAllAccessOpenSearchIAMAccessPolicy()
+        const openSearchServerlessPolicy = createAllAccessOpenSearchServerlessIAMAccessPolicy()
         let servicePolicies = [sharedLogFileSystem.asPolicyStatement(), openSearchPolicy, openSearchServerlessPolicy, ecsUpdateServicePolicy, clusterTasksPolicy,
             listTasksPolicy, s3AccessPolicy, describeVPCPolicy, getSSMParamsPolicy, getMetricsPolicy,
             // only add secrets policies if they're non-null

--- a/deployment/cdk/opensearch-service-migration/lib/service-stacks/reindex-from-snapshot-stack.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/service-stacks/reindex-from-snapshot-stack.ts
@@ -13,8 +13,8 @@ import {MigrationServiceCore} from "./migration-service-core";
 import {Effect, PolicyStatement} from "aws-cdk-lib/aws-iam";
 import {
     MigrationSSMParameter,
-    createOpenSearchIAMAccessPolicy,
-    createOpenSearchServerlessIAMAccessPolicy,
+    createAllAccessOpenSearchIAMAccessPolicy,
+    createAllAccessOpenSearchServerlessIAMAccessPolicy,
     getSecretAccessPolicy,
     getMigrationStringParameterValue,
     ClusterAuth, parseArgsToDict, appendArgIfNotInExtraArgs, isStackInGovCloud
@@ -115,8 +115,8 @@ export class ReindexFromSnapshotStack extends MigrationServiceCore {
         command = props.extraArgs?.trim() ? command.concat(` ${props.extraArgs?.trim()}`) : command
 
         const sharedLogFileSystem = new SharedLogFileSystem(this, props.stage, props.defaultDeployId);
-        const openSearchPolicy = createOpenSearchIAMAccessPolicy(this.partition, this.region, this.account);
-        const openSearchServerlessPolicy = createOpenSearchServerlessIAMAccessPolicy(this.partition, this.region, this.account);
+        const openSearchPolicy = createAllAccessOpenSearchIAMAccessPolicy();
+        const openSearchServerlessPolicy = createAllAccessOpenSearchServerlessIAMAccessPolicy();
         const servicePolicies = [sharedLogFileSystem.asPolicyStatement(), s3AccessPolicy, openSearchPolicy, openSearchServerlessPolicy];
 
         const getSecretsPolicy = props.clusterAuthDetails.basicAuth?.password_from_secret_arn ?

--- a/deployment/cdk/opensearch-service-migration/lib/service-stacks/traffic-replayer-stack.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/service-stacks/traffic-replayer-stack.ts
@@ -9,8 +9,8 @@ import {
     ClusterAuth,
     MigrationSSMParameter,
     createMSKConsumerIAMPolicies,
-    createOpenSearchIAMAccessPolicy,
-    createOpenSearchServerlessIAMAccessPolicy,
+    createAllAccessOpenSearchIAMAccessPolicy,
+    createAllAccessOpenSearchServerlessIAMAccessPolicy,
     getMigrationStringParameterValue, appendArgIfNotInExtraArgs, parseArgsToDict
 } from "../common-utilities";
 import {StreamingSourceType} from "../streaming-source-type";
@@ -65,8 +65,8 @@ export class TrafficReplayerStack extends MigrationServiceCore {
                 "secretsmanager:DescribeSecret"
             ]
         })
-        const openSearchPolicy = createOpenSearchIAMAccessPolicy(this.partition, this.region, this.account)
-        const openSearchServerlessPolicy = createOpenSearchServerlessIAMAccessPolicy(this.partition, this.region, this.account)
+        const openSearchPolicy = createAllAccessOpenSearchIAMAccessPolicy()
+        const openSearchServerlessPolicy = createAllAccessOpenSearchServerlessIAMAccessPolicy()
         let servicePolicies = [sharedLogFileSystem.asPolicyStatement(), secretAccessPolicy, openSearchPolicy, openSearchServerlessPolicy]
         if (props.streamingSourceType === StreamingSourceType.AWS_MSK) {
             const mskConsumerPolicies = createMSKConsumerIAMPolicies(this, this.partition, this.region, this.account, props.stage, props.defaultDeployId)


### PR DESCRIPTION
### Description
Customers are currently getting stuck with cross region/account migrations in part due to restrictive iam role permissions deployed by MA which restrict api calls only to clusters in the same region and account MA is deployed in. 

This change broadens resource policy in MA iam permissions to "*" for these resources customers bring in. Access will be controlled at the Resource level (e.g. opensearch access policy/FGAC) instead of customers having to self manage these and the role permissions.

### Issues Resolved
[MIGRATIONS-2603](https://opensearch.atlassian.net/browse/MIGRATIONS-2603)

### Testing
Unit/integ tests validate synthesis and existing permissions. Known behavior change for cross region/account access

### Check List
- [x] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
