### PR TITLE
symlink vi to vim int the migration console image

### DIFF
--- a/TrafficCapture/dockerSolution/src/main/docker/elasticsearchTestConsole/Dockerfile
+++ b/TrafficCapture/dockerSolution/src/main/docker/elasticsearchTestConsole/Dockerfile
@@ -78,5 +78,6 @@ COPY *.py /root/
 
 RUN chmod ug+x /root/*.sh
 RUN chmod ug+x /root/*.py
+RUN ln -s  `which vim` /usr/local/bin/vi
 
 CMD tail -f /dev/null


### PR DESCRIPTION
### Description
symlink vi to vim int the migration console image

### Issues Resolved
https://opensearch.atlassian.net/browse/MIGRATIONS-2599

### Testing
docker... composeUp...
```
 % docker exec -i -t $(docker ps -aqf "ancestor=migrations/migration_console:latest") bash
Welcome to the Migration Assistant Console
(13:27:56) migration-console (~) -> vi
```
```
~                                                                
~                                                                
~                       VIM - Vi IMproved                        
~                                                                
~                       version 9.1.1202                         
~                   by Bram Moolenaar et al.                     
~         Modified by <amazon-linux-engine@amazon.com>           
~          Vim is open source and freely distributable           
~
...
```

### Check List
- [ ] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
