### PR TITLE
Move standardJavascriptTransforms to compileOnly dependency for POM resolution

### DIFF
--- a/transformation/transformationPlugins/jsonMessageTransformers/jsonJSTransformer/build.gradle
+++ b/transformation/transformationPlugins/jsonMessageTransformers/jsonJSTransformer/build.gradle
@@ -24,7 +24,7 @@ dependencies {
     testImplementation libs.junit.jupiter.params
     testImplementation libs.slf4j.api
     testRuntimeOnly libs.junit.jupiter.engine
-    implementation project(path: ':transformation:standardJavascriptTransforms', configuration: 'jsResources')
+    compileOnly project(path: ':transformation:standardJavascriptTransforms', configuration: 'jsResources')
 }
 
 


### PR DESCRIPTION
### Description
Move standardJavascriptTransforms to compileOnly dependency to fix POM resolution as the artifacts are included in artifacts but not published independently to maven

### Issues Resolved
Fixes POM associated with current maven output https://central.sonatype.com/artifact/org.opensearch.migrations.trafficcapture/jsonJSTransformer/dependents which currently includes standardJavascriptTransforms which is an unpublished package


### Testing
Verified locally with `./gradlew publishToMavenLocal`

### Check List
- [ ] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
