### PR TITLE
Upload aggregated code coverage data

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -243,6 +243,7 @@ jobs:
           name: coverage-reports-gradle-tests-aggregate
           path: |
             **/jacocoMergedReport.xml
+            **mergedReport/html/*
 
   python-e2e-tests:
     needs: [ generate-cache-key ]

--- a/build.gradle
+++ b/build.gradle
@@ -420,6 +420,26 @@ tasks.register('jacocoAggregateReport', JacocoReport) {
         html.required = true
         html.destination file("${buildDir}/reports/jacoco/mergedReport/html")
     }
+
+    doLast {
+        File xmlFile = reports.xml.outputLocation.get().asFile
+        // Doctype's are not allowed by the XmlParser, so remove them
+        String xmlText = xmlFile.text.replaceAll(/(?m)<!DOCTYPE[^>]*>/, "")
+        def reportXml = new XmlParser().parseText(xmlText)
+
+        logger.lifecycle("=== Code Coverage Summary ===")
+        reportXml.counter.each { c ->
+        int missed  = c.@missed  as int
+        int covered = c.@covered as int
+        int total   = missed + covered
+        double percent  = total ? (covered / total * 100) : 0
+        // Looks like: "LINE       : 85.4% (123/144)"
+        logger.lifecycle(String.format(
+            "%-12s : %6.1f%% (%d/%d)",
+            c.@type, percent, covered, total
+        ))
+        }
+    }
 }
 
 gradle.projectsEvaluated {
@@ -497,6 +517,15 @@ def syncJacocoExecFiles = tasks.register("syncJacocoExecFiles", Sync) {
 
     from jacocoExecFilesProvider
     dependsOn jacocoTestTasksProvider
+}
+
+tasks.register('gatherJacocoExecForMerging', Copy) {
+    description = 'Local troubleshooting, gathers coverage all exec files in build/jacocoMerged/*.exec into to be consumed by jacocoAggregateReport'
+
+    from subprojects.collect { proj ->
+        fileTree(dir: proj.buildDir, include: 'jacoco/*.exec')
+    }
+    into "$buildDir/jacocoMerged"
 }
 
 tasks.register('mergeJacocoReports') {


### PR DESCRIPTION
### Description
The aggregate coverage data job was not producing human readable arifacts, updating it to include the full html report for the project.  Also included a small test output during the execution of the GitHub Action that can be quickly eyeballed.  Curious how we'd want to update the presentation of this information - once that is better refined I'll move out of draft.

```
...
> Task :jacocoAggregateReport
=== Code Coverage Summary ===
INSTRUCTION  :   67.0% (38837/57988)
BRANCH       :   59.8% (2121/3546)
LINE         :   68.8% (9265/13473)
COMPLEXITY   :   60.5% (3288/5434)
METHOD       :   69.9% (2550/3647)
CLASS        :   79.6% (558/701)

...
```

### Issues Resolved
- Resolves [MIGRATIONS-2548 | Produce code coverage report on pull request/push](https://opensearch.atlassian.net/browse/MIGRATIONS-2548)

### Testing
Tested locally, will confirm with this pull request check results.

### Check List
- [ ] ~New functionality includes testing~
- [ ] ~Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
