### PR TITLE
Update maven publishing workflow to accommodate nexus EOL

### DIFF
--- a/jenkins/release.jenkinsFile
+++ b/jenkins/release.jenkinsFile
@@ -1,4 +1,4 @@
-lib = library(identifier: 'jenkins@5.9.1', retriever: modernSCM([
+lib = library(identifier: 'jenkins@10.0.0', retriever: modernSCM([
     $class: 'GitSCMSource',
     remote: 'https://github.com/opensearch-project/opensearch-build-libraries.git',
 ]))


### PR DESCRIPTION
### Description
Maven central recently announced the end of life for publishing artifacts via nexus portal. As a part of the migration https://central.sonatype.org/pages/ossrh-eol/#process-to-migrate we made some changes to accommodate the new endpoints. See related [PR](https://github.com/opensearch-project/opensearch-build-libraries/pull/716/files#diff-4a19239627cfa172fa2404fa4a2feb02d26c4e26e1b2125e657d9f48ce4941ed)

This PR accommodates the change to successfully publish artifacts to maven central in future releases. 

### Issues Resolved
- part of https://github.com/opensearch-project/opensearch-build/issues/5552

### Testing
<!-- Please provide details of testing done: unit testing, integration testing and manual testing -->

### Check List
- [ ] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
