### PR TITLE
Add ignore support for ES8 KnnVectorsFormat

### DIFF
--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/lucene/version_9/FallbackLuceneComponents.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/lucene/version_9/FallbackLuceneComponents.java
@@ -4,7 +4,12 @@ import java.util.Collections;
 import java.util.Iterator;
 
 import shadow.lucene9.org.apache.lucene.codecs.FieldsProducer;
+import shadow.lucene9.org.apache.lucene.codecs.KnnVectorsReader;
+import shadow.lucene9.org.apache.lucene.index.ByteVectorValues;
+import shadow.lucene9.org.apache.lucene.index.FloatVectorValues;
 import shadow.lucene9.org.apache.lucene.index.Terms;
+import shadow.lucene9.org.apache.lucene.search.KnnCollector;
+import shadow.lucene9.org.apache.lucene.util.Bits;
 
 /**
  * Shared fallback implementations for Lucene codecs used in no-op PostingsFormat stubs.
@@ -15,6 +20,42 @@ public class FallbackLuceneComponents {
     private FallbackLuceneComponents() {
         // Utility class
     }
+
+    public static final KnnVectorsReader EMPTY_VECTORS_READER = new KnnVectorsReader() {
+
+        @Override
+        public long ramBytesUsed() {
+            return 0;
+        }
+
+        @Override
+        public void close() {
+        }
+
+        @Override
+        public void checkIntegrity() {
+        }
+
+        @Override
+        public FloatVectorValues getFloatVectorValues(String s) {
+            throw new UnsupportedOperationException("Should never be called");
+        }
+
+        @Override
+        public ByteVectorValues getByteVectorValues(String s) {
+            throw new UnsupportedOperationException("Should never be called");
+        }
+
+        @Override
+        public void search(String s, float[] floats, KnnCollector knnCollector, Bits bits) {
+            throw new UnsupportedOperationException("Should never be called");
+        }
+
+        @Override
+        public void search(String s, byte[] bytes, KnnCollector knnCollector, Bits bits) {
+            throw new UnsupportedOperationException("Should never be called");
+        }
+    };
 
     public static final FieldsProducer EMPTY_FIELDS_PRODUCER = new FieldsProducer() {
         @Override

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/lucene/version_9/FallbackLuceneComponents.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/lucene/version_9/FallbackLuceneComponents.java
@@ -30,10 +30,12 @@ public class FallbackLuceneComponents {
 
         @Override
         public void close() {
+            // No resources to close in this fallback implementation
         }
 
         @Override
         public void checkIntegrity() {
+            // Integrity check is skipped in this fallback stub
         }
 
         @Override

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/lucene/version_9/IgnoreVectorsFormat.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/lucene/version_9/IgnoreVectorsFormat.java
@@ -1,0 +1,27 @@
+package org.opensearch.migrations.bulkload.lucene.version_9;
+
+import shadow.lucene9.org.apache.lucene.codecs.KnnVectorsFormat;
+import shadow.lucene9.org.apache.lucene.codecs.KnnVectorsReader;
+import shadow.lucene9.org.apache.lucene.codecs.KnnVectorsWriter;
+import shadow.lucene9.org.apache.lucene.index.SegmentReadState;
+import shadow.lucene9.org.apache.lucene.index.SegmentWriteState;
+
+/**
+ * PostingsFormat fallback for Elasticsearch 8.14+ vector formats.
+ */
+public class IgnoreVectorsFormat extends KnnVectorsFormat {
+
+    public IgnoreVectorsFormat() {
+        super("ES814HnswScalarQuantizedVesctorsFormat");
+    }
+
+    @Override
+    public KnnVectorsWriter fieldsWriter(SegmentWriteState ignored) {
+        throw new UnsupportedOperationException("IgnoreVectorsFormat is read-only fallback");
+    }
+
+    @Override
+    public KnnVectorsReader fieldsReader(SegmentReadState ignored) {
+        return FallbackLuceneComponents.EMPTY_VECTORS_READER;
+    }
+}

--- a/RFS/src/main/resources/META-INF/services/shadow.lucene9.org.apache.lucene.codecs.KnnVectorsFormat
+++ b/RFS/src/main/resources/META-INF/services/shadow.lucene9.org.apache.lucene.codecs.KnnVectorsFormat
@@ -1,0 +1,1 @@
+org.opensearch.migrations.bulkload.lucene.version_9.IgnoreVectorsFormat


### PR DESCRIPTION
### Description
Add ignore support for ES8 KnnVectorsFormat.

Fixes previous error migrating documents with `dense_vector` fields
```
java.lang.IllegalArgumentException: An SPI class of type shadow.lucene9.org.apache.lucene.codecs.KnnVectorsFormat with name 'ES814HnswScalarQuantizedVectorsFormat' does not exist.  You need to add the corresponding JAR file supporting this SPI to your classpath.  The current classpath supports the following names: [Lucene90HnswVectorsFormat, Lucene91HnswVectorsFormat, lucene92HnswVectorsFormat, Lucene94HnswVectorsFormat, Lucene95HnswVectorsFormat, Lucene99HnswVectorsFormat, Lucene99HnswScalarQuantizedVectorsFormat, Lucene99ScalarQuantizedVectorsFormat
```

### Issues Resolved
https://opensearch.atlassian.net/browse/MIGRATIONS-2645

### Testing
Manual testing through unit test performed to validate ES8 -> OS2 with `dense_vector` showed failing prior to this change and passing afterwards.

### Check List
- [ ] ~New functionality includes testing~ Testing to be performed with followup https://opensearch.atlassian.net/browse/MIGRATIONS-2646
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
