### PR TITLE
Update cdk.context.json with default vpcAZCount

### DIFF
--- a/deployment/cdk/opensearch-service-migration/cdk.context.json
+++ b/deployment/cdk/opensearch-service-migration/cdk.context.json
@@ -34,6 +34,9 @@
       "maxCapacity": 16384
     },
     "vpcId": "<VPC_ID>",
+    "// help vpcAZCount": "AZ Count should match upstream service/NLB AZ count or cross-zone load balancing should be enabled",
+    "vpcAZCount": 2,
+
     "reindexFromSnapshotServiceEnabled": true,
     "reindexFromSnapshotMaxShardSizeGiB": 80,
 

--- a/deployment/cdk/opensearch-service-migration/cdk.context.json
+++ b/deployment/cdk/opensearch-service-migration/cdk.context.json
@@ -34,7 +34,7 @@
       "maxCapacity": 16384
     },
     "vpcId": "<VPC_ID>",
-    "// help vpcAZCount": "AZ Count should match upstream service/NLB AZ count or cross-zone load balancing should be enabled",
+    "// help vpcAZCount": "For deployments using the capture-proxy, this AZ count should match the source cluster AZ count.",
     "vpcAZCount": 2,
 
     "reindexFromSnapshotServiceEnabled": true,


### PR DESCRIPTION
### Description
We had a customer with 1/3 of requests through the capture proxy was failing. Turns out they had 3 AZ on their NLB with cross zone load balancing turned off, and 2 AZ deployed on MA (by default) causing all requests through the 3rd AZ to fail.

### Issues Resolved
https://opensearch.atlassian.net/browse/MIGRATIONS-2647

### Testing
Existing feature

### Check List
- [ ] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
