### PR TITLE
Fix typo in ES814HnswScalarQuantizedVectorsFormat

### DIFF
--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/lucene/version_9/IgnoreVectorsFormat.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/lucene/version_9/IgnoreVectorsFormat.java
@@ -12,7 +12,7 @@ import shadow.lucene9.org.apache.lucene.index.SegmentWriteState;
 public class IgnoreVectorsFormat extends KnnVectorsFormat {
 
     public IgnoreVectorsFormat() {
-        super("ES814HnswScalarQuantizedVesctorsFormat");
+        super("ES814HnswScalarQuantizedVectorsFormat");
     }
 
     @Override


### PR DESCRIPTION
### Description
Fix spi loading for ES814HnswScalarQuantizedVectorsFormat

### Testing
Testing done previously, typo introduced after testing
 
### Check List
- [ ] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
