### PR TITLE
Set maven auto-publish to false

### DIFF
--- a/jenkins/release.jenkinsFile
+++ b/jenkins/release.jenkinsFile
@@ -80,7 +80,7 @@ pipeline {
                         publishToMaven(
                             signingArtifactsPath: "$WORKSPACE/repository/",
                             mavenArtifactsPath: "$WORKSPACE/repository/",
-                            autoPublish: true
+                            autoPublish: false
                         )
 
                         def sourceRegistry = "opensearchstaging"


### PR DESCRIPTION
### Description
Maven auto-publication is failing since the migration. We are following up with sonatype for the same. 
Since there are multiple steps after maven publication as well, setting this to false in order to proceed with next steps.
Please add a comment after the release and I'll take care of publishing the already staged artifacts manually to maven central. 

### Issues Resolved
<!-- List any GitHub or Jira issues this PR will resolve -->

### Testing
<!-- Please provide details of testing done: unit testing, integration testing and manual testing -->

### Check List
- [ ] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
