### PR TITLE
Metadata cleaner clusters and items

### DIFF
--- a/MetadataMigration/src/main/java/org/opensearch/migrations/cli/Clusters.java
+++ b/MetadataMigration/src/main/java/org/opensearch/migrations/cli/Clusters.java
@@ -1,7 +1,9 @@
 package org.opensearch.migrations.cli;
 
 import org.opensearch.migrations.cluster.ClusterReader;
+import org.opensearch.migrations.cluster.ClusterSnapshotReader;
 import org.opensearch.migrations.cluster.ClusterWriter;
+import org.opensearch.migrations.cluster.RemoteCluster;
 
 import lombok.Builder;
 import lombok.Getter;
@@ -19,12 +21,25 @@ public class Clusters {
         sb.append("Clusters:" + System.lineSeparator());
         if (getSource() != null) {
             sb.append(Format.indentToLevel(1) + "Source:" + System.lineSeparator());
-            sb.append(Format.indentToLevel(2) + getSource() + System.lineSeparator());
+            sb.append(Format.indentToLevel(2) + "Type: " + getSource().getTypeName() + " (" + getSource().getVersion() + ")" + System.lineSeparator());
+            if (getSource() instanceof ClusterSnapshotReader) {
+                var reader = (ClusterSnapshotReader) getSource();
+                sb.append(Format.indentToLevel(2) + "Repository: " + reader.getSourceRepo().getRepoRootDir() + System.lineSeparator());
+            }
+            // TODO: Refactor into the readers themselves
             sb.append(System.lineSeparator());
         }
         if (getTarget() != null) {
             sb.append(Format.indentToLevel(1) + "Target:" + System.lineSeparator());
-            sb.append(Format.indentToLevel(2) + getTarget() + System.lineSeparator());
+            sb.append(Format.indentToLevel(2) + "Type: " + getTarget().getTypeName() + " (" + getTarget().getVersion() + ")" + System.lineSeparator());
+            if (getTarget() instanceof RemoteCluster) {
+                var connection = ((RemoteCluster) getTarget()).getConnection();
+                sb.append(Format.indentToLevel(2) + "URI: " + connection.getUri() + System.lineSeparator());
+                sb.append(Format.indentToLevel(2) + "Protocol: " + connection.getProtocol() + System.lineSeparator());
+                sb.append(Format.indentToLevel(2) + "TLS Verification: " + !connection.isInsecure() + System.lineSeparator());
+                sb.append(Format.indentToLevel(2) + "Aws Auth: " + connection.isAwsSpecificAuthentication() + System.lineSeparator());
+            }
+            // TODO: Refactor into the writers themselves
             sb.append(System.lineSeparator());
         }
         return sb.toString();

--- a/MetadataMigration/src/main/java/org/opensearch/migrations/cli/Items.java
+++ b/MetadataMigration/src/main/java/org/opensearch/migrations/cli/Items.java
@@ -72,7 +72,7 @@ public class Items {
             sb.append(Format.indentToLevel(2))
                 .append(NONE_FOUND_MARKER)
                 .append(System.lineSeparator());
-          } else {
+        } else {
             appendItems(sb, items);
             appendFailures(sb, items);
         }
@@ -83,12 +83,16 @@ public class Items {
         var successfulItems = items.stream()
             .filter(r -> r.wasSuccessful())
             .map(r -> r.getName())
+            .sorted()
             .collect(Collectors.toList());
 
         if (!successfulItems.isEmpty()) {
-            sb.append(Format.indentToLevel(2))
-                .append(getPrintableList(successfulItems))
+            successfulItems.forEach(item -> {
+                sb.append(Format.indentToLevel(2))
+                .append("- ")
+                .append(item)
                 .append(System.lineSeparator());
+            });
         }
     }
 

--- a/MetadataMigration/src/test/java/org/opensearch/migrations/EndToEndTest.java
+++ b/MetadataMigration/src/test/java/org/opensearch/migrations/EndToEndTest.java
@@ -57,7 +57,7 @@ class EndToEndTest extends BaseMigrationTest {
                 return Arrays.stream(TransferMedium.values())
                     .map(medium -> Arguments.of(pair.source(), pair.target(), medium, templateTypes))
                         .toList().stream();
-            });
+            }).limit(2);
     }
 
     @ParameterizedTest(name = "From version {0} to version {1}, Medium {2}, Command {3}, Template Type {4}")

--- a/MetadataMigration/src/test/java/org/opensearch/migrations/EndToEndTest.java
+++ b/MetadataMigration/src/test/java/org/opensearch/migrations/EndToEndTest.java
@@ -57,7 +57,7 @@ class EndToEndTest extends BaseMigrationTest {
                 return Arrays.stream(TransferMedium.values())
                     .map(medium -> Arguments.of(pair.source(), pair.target(), medium, templateTypes))
                         .toList().stream();
-            }).limit(2);
+            });
     }
 
     @ParameterizedTest(name = "From version {0} to version {1}, Medium {2}, Command {3}, Template Type {4}")

--- a/MetadataMigration/src/test/java/org/opensearch/migrations/cli/ClustersTest.java
+++ b/MetadataMigration/src/test/java/org/opensearch/migrations/cli/ClustersTest.java
@@ -1,6 +1,16 @@
 package org.opensearch.migrations.cli;
 
+import java.nio.file.Path;
+
+import org.opensearch.migrations.Version;
+import org.opensearch.migrations.bulkload.common.FileSystemRepo;
+import org.opensearch.migrations.bulkload.common.S3Repo;
+import org.opensearch.migrations.bulkload.common.S3Uri;
+import org.opensearch.migrations.bulkload.common.http.ConnectionContext;
+import org.opensearch.migrations.bulkload.version_os_2_11.RemoteWriter_OS_2_11;
+import org.opensearch.migrations.bulkload.version_universal.RemoteReader;
 import org.opensearch.migrations.cluster.ClusterReader;
+import org.opensearch.migrations.cluster.ClusterSnapshotReader;
 import org.opensearch.migrations.cluster.ClusterWriter;
 
 import org.junit.jupiter.api.Test;
@@ -9,6 +19,7 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import static org.opensearch.migrations.matchers.HasLineCount.hasLineCount;
 
 public class ClustersTest {
@@ -25,31 +36,99 @@ public class ClustersTest {
     }
 
     @Test
-    void testAsString_withSource() {
+    void testAsString_withS3Source() {
         var clusters = Clusters.builder()
-            .source(mock(ClusterReader.class))
+            .source(mockS3SnapshotReaderOS78())
             .build();
 
         var result = clusters.asCliOutput();
 
         assertThat(result, containsString("Clusters:"));
         assertThat(result, containsString("Source:"));
+        assertThat(result, containsString("Type: MockS3SnapshotReader (OPENSEARCH 78.0.0)"));
+        assertThat(result, containsString("S3 repository: s3://s3.aws.com/repo"));
         assertThat(result, not(containsString("Target:")));
-        assertThat(result, hasLineCount(3));
+        assertThat(result, hasLineCount(4));
     }
 
     @Test
-    void testAsString_withSourceAndTarget() {
+    void testAsString_withLocalSource() {
         var clusters = Clusters.builder()
-            .source(mock(ClusterReader.class))
-            .target(mock(ClusterWriter.class))
+            .source(mockLocalSnapshotReaderOS87())
             .build();
 
         var result = clusters.asCliOutput();
 
         assertThat(result, containsString("Clusters:"));
         assertThat(result, containsString("Source:"));
+        assertThat(result, containsString("Type: MockSnapshotReader (OPENSEARCH 87.0.0)"));
+        assertThat(result, containsString("Local repository: /tmp/snapshots"));
+        assertThat(result, not(containsString("Target:")));
+        assertThat(result, hasLineCount(4));
+    }
+
+
+    @Test
+    void testAsString_withRemoteSourceAndTarget() {
+        var clusters = Clusters.builder()
+            .source(mockRemoteReaderOS54())
+            .target(mockRemoteWriterOS2000())
+            .build();
+
+        var result = clusters.asCliOutput();
+
+        assertThat(result, containsString("Clusters:"));
+        assertThat(result, containsString("Source:"));
+        assertThat(result, containsString("Source:"));
+        assertThat(result, containsString("Type: MockRemoteReader (OPENSEARCH 54.0.0)"));
+        assertThat(result, containsString("Uri: http://remote.source"));
+        assertThat(result, containsString("TLS Verification: Disabled"));
         assertThat(result, containsString("Target:"));
-        assertThat(result, hasLineCount(6));
+        assertThat(result, containsString("Type: MockClusterWriter (OPENSEARCH 2000.0.0)"));
+        assertThat(result, containsString("Uri: http://remote.target"));
+        assertThat(result, containsString("TLS Verification: Enabled"));
+        assertThat(result, hasLineCount(12));
+    }
+
+    private ClusterReader mockS3SnapshotReaderOS78() {
+        var clusterReader = mock(ClusterSnapshotReader.class);
+        when(clusterReader.getFriendlyTypeName()).thenReturn("MockS3SnapshotReader");
+        when(clusterReader.getVersion()).thenReturn(Version.fromString("OS 78.0"));
+        var s3Repo = mock(S3Repo.class);
+        when(s3Repo.getS3RepoUri()).thenReturn(new S3Uri("s3://s3.aws.com/repo"));
+        when(clusterReader.getSourceRepo()).thenReturn(s3Repo);
+        return clusterReader;
+    }
+
+    private ClusterReader mockLocalSnapshotReaderOS87() {
+        var clusterReader = mock(ClusterSnapshotReader.class);
+        when(clusterReader.getFriendlyTypeName()).thenReturn("MockSnapshotReader");
+        when(clusterReader.getVersion()).thenReturn(Version.fromString("OS 87.0"));
+        var fileRepo = mock(FileSystemRepo.class);
+        when(fileRepo.getRepoRootDir()).thenReturn(Path.of("/tmp/snapshots"));
+        when(clusterReader.getSourceRepo()).thenReturn(fileRepo);
+        return clusterReader;
+    }
+
+    private ClusterReader mockRemoteReaderOS54() {
+        var clusterReader = mock(RemoteReader.class);
+        when(clusterReader.getFriendlyTypeName()).thenReturn("MockRemoteReader");
+        when(clusterReader.getVersion()).thenReturn(Version.fromString("OS 54.0"));
+        var targetArgs = new ConnectionContext.SourceArgs();
+        targetArgs.host = "http://remote.source";
+        targetArgs.insecure = false;
+        when(clusterReader.getConnection()).thenReturn(targetArgs.toConnectionContext());
+        return clusterReader;
+    }
+
+    private ClusterWriter mockRemoteWriterOS2000() {
+        var clusterWriter = mock(RemoteWriter_OS_2_11.class);
+        when(clusterWriter.getFriendlyTypeName()).thenReturn("MockClusterWriter");
+        when(clusterWriter.getVersion()).thenReturn(Version.fromString("OS 2000"));
+        var targetArgs = new ConnectionContext.TargetArgs();
+        targetArgs.host = "http://remote.target";
+        targetArgs.insecure = true;
+        when(clusterWriter.getConnection()).thenReturn(targetArgs.toConnectionContext());
+        return clusterWriter;
     }
 }

--- a/MetadataMigration/src/test/java/org/opensearch/migrations/cli/ItemsTest.java
+++ b/MetadataMigration/src/test/java/org/opensearch/migrations/cli/ItemsTest.java
@@ -9,6 +9,7 @@ import org.opensearch.migrations.metadata.CreationResult.CreationFailureType;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.text.StringContainsInOrder.stringContainsInOrder;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.opensearch.migrations.matchers.ContainsStringCount.containsStringCount;
@@ -57,17 +58,13 @@ public class ItemsTest {
 
         assertThat(result, containsString("Migrated Items:"));
         assertThat(result, containsString("Index Templates:"));
-        assertThat(result, containsString("it1"));
-        assertThat(result, containsString("it2"));
+        assertThat(result, stringContainsInOrder("it1", "it2"));
         assertThat(result, containsString("Component Templates:"));
-        assertThat(result, containsString("ct1"));
-        assertThat(result, containsString("ct2"));
+        assertThat(result, stringContainsInOrder("ct1", "ct2"));
         assertThat(result, containsString("Indexes:"));
-        assertThat(result, containsString("i1"));
-        assertThat(result, containsString("i2"));
+        assertThat(result, stringContainsInOrder("i1", "i2"));
         assertThat(result, containsString("Aliases:"));
-        assertThat(result, containsString("a1"));
-        assertThat(result, containsString("a2"));
+        assertThat(result, stringContainsInOrder("a1", "a2"));
         assertThat(result, containsStringCount(Items.NONE_FOUND_MARKER, 0));
         assertThat(result, hasLineCount(16));
     }
@@ -110,11 +107,7 @@ public class ItemsTest {
 
         assertThat(result, containsString("Migrated Items:"));
         assertThat(result, containsString("Index Templates:"));
-        assertThat(result, containsString("- i1\n"));
-        assertThat(result, containsString("- i2"));
-        assertThat(result, containsString("- i3"));
-        assertThat(result, containsString("- i4"));
-        assertThat(result, containsString("- i5"));
+        assertThat(result, stringContainsInOrder("i1", "i2", "i3", "i4","i5"));
         assertThat(result, containsString("Component Templates:"));
         assertThat(result, containsString("Indexes:"));
         assertThat(result, containsString("Aliases:"));
@@ -136,12 +129,9 @@ public class ItemsTest {
             .build();
 
         var result = items.asCliOutput();
-        assertThat(result, containsString("i1"));
-        assertThat(result, containsString("i2"));
-        assertThat(result, containsString("i3"));
+        assertThat(result, stringContainsInOrder("i1", "i2", "i3"));
         assertThat("Results with no errors do not print exception info", result, not(containsString("exception-without-failure-type")));
-        assertThat(result, containsString("i4 failed on target cluster"));
-        assertThat(result, containsString("i5 failed on target cluster: re1"));        
+        assertThat(result, stringContainsInOrder("i4 failed on target cluster", "i5 failed on target cluster: re1"));
         assertThat("Expect an exception's toString() if there was no message in the exception", result, containsString("i6 failed on target cluster: java.lang.RuntimeException"));
         assertThat(result, hasLineCount(18));
     }

--- a/MetadataMigration/src/test/java/org/opensearch/migrations/cli/ItemsTest.java
+++ b/MetadataMigration/src/test/java/org/opensearch/migrations/cli/ItemsTest.java
@@ -57,15 +57,19 @@ public class ItemsTest {
 
         assertThat(result, containsString("Migrated Items:"));
         assertThat(result, containsString("Index Templates:"));
-        assertThat(result, containsString("it1, it2"));
+        assertThat(result, containsString("it1"));
+        assertThat(result, containsString("it2"));
         assertThat(result, containsString("Component Templates:"));
-        assertThat(result, containsString("ct1, ct2"));
+        assertThat(result, containsString("ct1"));
+        assertThat(result, containsString("ct2"));
         assertThat(result, containsString("Indexes:"));
-        assertThat(result, containsString("i1, i2"));
+        assertThat(result, containsString("i1"));
+        assertThat(result, containsString("i2"));
         assertThat(result, containsString("Aliases:"));
-        assertThat(result, containsString("a1, a2"));
+        assertThat(result, containsString("a1"));
+        assertThat(result, containsString("a2"));
         assertThat(result, containsStringCount(Items.NONE_FOUND_MARKER, 0));
-        assertThat(result, hasLineCount(12));
+        assertThat(result, hasLineCount(16));
     }
 
     @Test
@@ -106,12 +110,16 @@ public class ItemsTest {
 
         assertThat(result, containsString("Migrated Items:"));
         assertThat(result, containsString("Index Templates:"));
-        assertThat(result, containsString("i1, i2, i3, i4, i5"));
+        assertThat(result, containsString("- i1\n"));
+        assertThat(result, containsString("- i2"));
+        assertThat(result, containsString("- i3"));
+        assertThat(result, containsString("- i4"));
+        assertThat(result, containsString("- i5"));
         assertThat(result, containsString("Component Templates:"));
         assertThat(result, containsString("Indexes:"));
         assertThat(result, containsString("Aliases:"));
         assertThat(result, containsStringCount(Items.NONE_FOUND_MARKER, 3));
-        assertThat(result, hasLineCount(12));
+        assertThat(result, hasLineCount(16));
     }
 
     @Test
@@ -135,7 +143,7 @@ public class ItemsTest {
         assertThat(result, containsString("i4 failed on target cluster"));
         assertThat(result, containsString("i5 failed on target cluster: re1"));        
         assertThat("Expect an exception's toString() if there was no message in the exception", result, containsString("i6 failed on target cluster: java.lang.RuntimeException"));
-        assertThat(result, hasLineCount(15));
+        assertThat(result, hasLineCount(18));
     }
 
     private ItemsBuilder createEmptyItemsBuilder() {

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/common/S3Repo.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/common/S3Repo.java
@@ -9,6 +9,7 @@ import java.util.Optional;
 
 import org.opensearch.migrations.bulkload.models.ShardMetadata;
 
+import lombok.Getter;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
@@ -33,6 +34,7 @@ public class S3Repo implements SourceRepo {
     public static final String INDICES_PREFIX_STR = "indices/";
 
     private final Path s3LocalDir;
+    @Getter
     @ToString.Include
     private final S3Uri s3RepoUri;
     private final String s3Region;

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/common/http/ConnectionContext.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/common/http/ConnectionContext.java
@@ -4,6 +4,8 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.time.Clock;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.ParametersDelegate;
@@ -92,6 +94,18 @@ public class ConnectionContext {
                 params.getClientCert(),
                 params.getClientCertKey());
         }
+    }
+
+    // Used for presentation to user facing output
+    public Map<String, String> toUserFacingData() {
+        var dataBuilder = new LinkedHashMap<String, String>();
+        dataBuilder.put("Uri", getUri().toString());
+        dataBuilder.put("Protocol", getProtocol().toString());
+        dataBuilder.put("TLS Verification", isInsecure() ? "Enabled" : "Disabled");
+        if (awsSpecificAuthentication) {
+            dataBuilder.put("AWS Auth", "Enabled");
+        }
+        return dataBuilder;
     }
 
     /**

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/version_es_5_4/SnapshotReader_ES_5_4.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/version_es_5_4/SnapshotReader_ES_5_4.java
@@ -13,9 +13,12 @@ import org.opensearch.migrations.bulkload.version_es_6_8.IndexMetadataFactory_ES
 import org.opensearch.migrations.bulkload.version_es_6_8.ShardMetadataFactory_ES_6_8;
 import org.opensearch.migrations.cluster.ClusterSnapshotReader;
 
+import lombok.Getter;
+
 public class SnapshotReader_ES_5_4 implements ClusterSnapshotReader {
 
     private Version version;
+    @Getter
     private SourceRepo sourceRepo;
 
     @Override

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/version_es_6_8/RemoteWriter_ES_6_8.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/version_es_6_8/RemoteWriter_ES_6_8.java
@@ -108,7 +108,7 @@ public class RemoteWriter_ES_6_8 implements RemoteCluster, ClusterWriter {
     }
 
     @Override
-    public String getTypeName() {
+    public String getFriendlyTypeName() {
         return "Remote Cluster";
     }
 

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/version_es_6_8/RemoteWriter_ES_6_8.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/version_es_6_8/RemoteWriter_ES_6_8.java
@@ -93,7 +93,7 @@ public class RemoteWriter_ES_6_8 implements RemoteCluster, ClusterWriter {
         return client;
     }
 
-    private ConnectionContext getConnection() {
+    public ConnectionContext getConnection() {
         if (connection == null) {
             throw new UnsupportedOperationException("initialize(...) must be called");
         }
@@ -105,5 +105,11 @@ public class RemoteWriter_ES_6_8 implements RemoteCluster, ClusterWriter {
             throw new UnsupportedOperationException("initialize(...) must be called");
         }
         return dataFilterArgs;
-    } 
+    }
+
+    @Override
+    public String getTypeName() {
+        return "Remote Cluster";
+    }
+
 }

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/version_es_6_8/SnapshotReader_ES_6_8.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/version_es_6_8/SnapshotReader_ES_6_8.java
@@ -9,9 +9,12 @@ import org.opensearch.migrations.bulkload.models.IndexMetadata;
 import org.opensearch.migrations.bulkload.models.ShardMetadata;
 import org.opensearch.migrations.cluster.ClusterSnapshotReader;
 
+import lombok.Getter;
+
 public class SnapshotReader_ES_6_8 implements ClusterSnapshotReader {
 
     private Version version;
+    @Getter
     private SourceRepo sourceRepo;
 
     @Override

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/version_es_7_10/SnapshotReader_ES_7_10.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/version_es_7_10/SnapshotReader_ES_7_10.java
@@ -10,9 +10,12 @@ import org.opensearch.migrations.bulkload.models.IndexMetadata;
 import org.opensearch.migrations.bulkload.models.ShardMetadata;
 import org.opensearch.migrations.cluster.ClusterSnapshotReader;
 
+import lombok.Getter;
+
 public class SnapshotReader_ES_7_10 implements ClusterSnapshotReader {
 
     private Version version;
+    @Getter
     private SourceRepo sourceRepo;
 
     @Override

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/version_os_2_11/RemoteWriter_OS_2_11.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/version_os_2_11/RemoteWriter_OS_2_11.java
@@ -110,7 +110,7 @@ public class RemoteWriter_OS_2_11 implements RemoteCluster, ClusterWriter {
         return dataFilterArgs;
     }
 
-    public String getTypeName() {
+    public String getFriendlyTypeName() {
         return "Remote Cluster";
     }
 }

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/version_os_2_11/RemoteWriter_OS_2_11.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/version_os_2_11/RemoteWriter_OS_2_11.java
@@ -110,6 +110,7 @@ public class RemoteWriter_OS_2_11 implements RemoteCluster, ClusterWriter {
         return dataFilterArgs;
     }
 
+    @Override
     public String getFriendlyTypeName() {
         return "Remote Cluster";
     }

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/version_os_2_11/RemoteWriter_OS_2_11.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/version_os_2_11/RemoteWriter_OS_2_11.java
@@ -96,7 +96,7 @@ public class RemoteWriter_OS_2_11 implements RemoteCluster, ClusterWriter {
         return client;
     }
 
-    private ConnectionContext getConnection() {
+    public ConnectionContext getConnection() {
         if (connection == null) {
             throw new UnsupportedOperationException("initialize(...) must be called");
         }
@@ -108,5 +108,9 @@ public class RemoteWriter_OS_2_11 implements RemoteCluster, ClusterWriter {
             throw new UnsupportedOperationException("initialize(...) must be called");
         }
         return dataFilterArgs;
-    } 
+    }
+
+    public String getTypeName() {
+        return "Remote Cluster";
+    }
 }

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/version_universal/RemoteReader.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/version_universal/RemoteReader.java
@@ -75,10 +75,16 @@ public class RemoteReader implements RemoteCluster, ClusterReader {
         return client;
     }
 
-    private ConnectionContext getConnection() {
+    public ConnectionContext getConnection() {
         if (connection == null) {
             throw new UnsupportedOperationException("initialize(...) must be called");
         }
         return connection;
     }
+
+    @Override
+    public String getTypeName() {
+        return "Remote Cluster";
+    }
+
 }

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/version_universal/RemoteReader.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/version_universal/RemoteReader.java
@@ -83,7 +83,7 @@ public class RemoteReader implements RemoteCluster, ClusterReader {
     }
 
     @Override
-    public String getTypeName() {
+    public String getFriendlyTypeName() {
         return "Remote Cluster";
     }
 

--- a/RFS/src/main/java/org/opensearch/migrations/cluster/ClusterReader.java
+++ b/RFS/src/main/java/org/opensearch/migrations/cluster/ClusterReader.java
@@ -12,5 +12,6 @@ public interface ClusterReader extends VersionSpecificCluster {
     /** Reads the index metadata of the cluster */
     IndexMetadata.Factory getIndexMetadata();
 
-    String getTypeName();
+    /** Get the type of reader that is user facing */
+    String getFriendlyTypeName();
 }

--- a/RFS/src/main/java/org/opensearch/migrations/cluster/ClusterReader.java
+++ b/RFS/src/main/java/org/opensearch/migrations/cluster/ClusterReader.java
@@ -11,4 +11,6 @@ public interface ClusterReader extends VersionSpecificCluster {
 
     /** Reads the index metadata of the cluster */
     IndexMetadata.Factory getIndexMetadata();
+
+    String getTypeName();
 }

--- a/RFS/src/main/java/org/opensearch/migrations/cluster/ClusterSnapshotReader.java
+++ b/RFS/src/main/java/org/opensearch/migrations/cluster/ClusterSnapshotReader.java
@@ -29,7 +29,7 @@ public interface ClusterSnapshotReader extends ClusterReader {
     SourceRepo getSourceRepo();
 
     @Override
-    default String getTypeName() {
+    default String getFriendlyTypeName() {
         return "Snapshot";
     }
 }

--- a/RFS/src/main/java/org/opensearch/migrations/cluster/ClusterSnapshotReader.java
+++ b/RFS/src/main/java/org/opensearch/migrations/cluster/ClusterSnapshotReader.java
@@ -24,4 +24,12 @@ public interface ClusterSnapshotReader extends ClusterReader {
 
     /** gets the soft deletes can field data */
     String getSoftDeletesFieldData();
+
+    /** Get the source repo for the snapshot */
+    SourceRepo getSourceRepo();
+
+    @Override
+    default String getTypeName() {
+        return "Snapshot";
+    }
 }

--- a/RFS/src/main/java/org/opensearch/migrations/cluster/ClusterWriter.java
+++ b/RFS/src/main/java/org/opensearch/migrations/cluster/ClusterWriter.java
@@ -24,4 +24,5 @@ public interface ClusterWriter extends VersionSpecificCluster {
     /** Gets the awareness attribute settings of the cluster */
     AwarenessAttributeSettings getAwarenessAttributeSettings();
 
+    String getTypeName();
 }

--- a/RFS/src/main/java/org/opensearch/migrations/cluster/ClusterWriter.java
+++ b/RFS/src/main/java/org/opensearch/migrations/cluster/ClusterWriter.java
@@ -24,5 +24,5 @@ public interface ClusterWriter extends VersionSpecificCluster {
     /** Gets the awareness attribute settings of the cluster */
     AwarenessAttributeSettings getAwarenessAttributeSettings();
 
-    String getTypeName();
+    String getFriendlyTypeName();
 }

--- a/RFS/src/main/java/org/opensearch/migrations/cluster/ClusterWriter.java
+++ b/RFS/src/main/java/org/opensearch/migrations/cluster/ClusterWriter.java
@@ -24,5 +24,6 @@ public interface ClusterWriter extends VersionSpecificCluster {
     /** Gets the awareness attribute settings of the cluster */
     AwarenessAttributeSettings getAwarenessAttributeSettings();
 
+    /** Get the type of reader that is user facing */
     String getFriendlyTypeName();
 }

--- a/RFS/src/main/java/org/opensearch/migrations/cluster/RemoteCluster.java
+++ b/RFS/src/main/java/org/opensearch/migrations/cluster/RemoteCluster.java
@@ -7,4 +7,6 @@ public interface RemoteCluster extends VersionSpecificCluster {
 
     /** Remote clusters are communicated with via a connection */
     RemoteCluster initialize(ConnectionContext connection);
+
+    ConnectionContext getConnection();
 }


### PR DESCRIPTION
### Description
This makes the user facing output on the metadata tool much easier to read for customers, targeting the cluster and items sections.

#### Clusters After:
```
Clusters:
  Source:
    Type: Snapshot (Elasticsearch 8.17.0)
    Repository: s3://otc-dash-test-team-bucket

  Target:
    Type: Remote Cluster (OpenSearch 2.19.0)
    URI: https://aos-05a19f075882-r7cfrx5sdnuxzvqhaiv77tufye.us-west-2.es.amazonaws.com
    Protocol: HTTPS
    TLS Verification: Enabled
```

#### Clusters Before:

```
Clusters:   Source:      Snapshot: ELASTICSEARCH 8.17.0 S3Repo(s3RepoUri=S3Uri(bucketName=otc-dash-test-team-bucket, key=, uri=s3://otc-dash-test-team-bucket))

   Target:      Remote Cluster: OPENSEARCH 2.19.0 ConnectionContext(uri=https://aos-05a19f075882-r7cfrx5sdnuxzvqhaiv77tufye.us-west-2.es.amazonaws.com:443, protocol=HTTPS, insecure=false,compressionSupported=false, awsSpecificAuthentication=false, tlsCredentialsProvider=null)
```

#### Items After:
```
  Indexes:
    - dfb_personal_index_team_16496179_v1
    - dfb_shared_index_team_16496179_v1
    - messages_dfb_shared_index_team_16496179_v1
    - messages_dfb_shared_index_team_16496179_v2
```

#### Items Before:
```
   Indexes:
      dfb_personal_index_team_16496179_v1, dfb_shared_index_team_16496179_v1, messages_dfb_shared_index_team_16496179_v1, messages_dfb_shared_index_team_16496179_v2
```


### Issues Resolved
- Resolves [[MIGRATIONS-2633 | Make metadata results cleaner to read on their own lines]](https://opensearch.atlassian.net/browse/MIGRATIONS-2633)

### Check List
- [X] New functionality includes testing
- [ ] ~Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
