### PR TITLE
Reduce redundant information and include easier to read details in test logs

### DIFF
--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/cluster.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/cluster.py
@@ -191,7 +191,6 @@ class Cluster:
         # Extract query parameters from kwargs
         params = kwargs.get('params', {})
 
-        logger.info(f"Performing request: {method.name} {self.endpoint}{path}")
         r = session.request(
             method.name,
             f"{self.endpoint}{path}",
@@ -202,7 +201,7 @@ class Cluster:
             headers=request_headers,
             timeout=timeout
         )
-        logger.info(f"Received response: {r.status_code} {method.name} {self.endpoint}{path} - {r.text[:1000]}")
+        logger.info(f"call_api request {method.name} {self.endpoint}{path}, response: {r.status_code} {r.text[:1000]}")
         if raise_error:
             r.raise_for_status()
         return r

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/replayer_k8s.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/replayer_k8s.py
@@ -27,8 +27,8 @@ class K8sReplayer(Replayer):
         return self.kubectl_runner.perform_scale_command(replicas=0)
 
     def get_status(self, *args, **kwargs) -> CommandResult:
-        logger.info("Getting status of K8s replayer")
         deployment_status = self.kubectl_runner.retrieve_deployment_status()
+        logger.info(f"Get status K8s replayer: {deployment_status}")
         if not deployment_status:
             return CommandResult(False, "Failed to get deployment status for Replayer")
         status_str = str(deployment_status)


### PR DESCRIPTION
### Description
Reduce redundant information and include easier to read details in test logs.  Following up from a previous PR.

### Issues Resolved
- Related https://github.com/opensearch-project/opensearch-migrations/pull/1656

### Testing
- [ ] Verified test output from this elasticsearch-5x-k8s-local-test PR check.

### Check List
- [ ] ~New functionality includes testing~
- [ ] ~Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
