### PR TITLE
Add back in target cluster property to backfill dashboard, this was m…

### DIFF
--- a/deployment/cdk/opensearch-service-migration/lib/components/reindex-from-snapshot-dashboard.json
+++ b/deployment/cdk/opensearch-service-migration/lib/components/reindex-from-snapshot-dashboard.json
@@ -10,6 +10,17 @@
             "visible": false
         },
         {
+            "type": "property",
+            "property": "DomainName",
+            "inputType": "select",
+            "id": "TC_DOMAIN_NAME",
+            "label": "Target Cluster Domain Name",
+            "search": "{AWS/ES,ClientId,DomainName} MetricName=\"CPUUtilization\"",
+            "populateFrom": "DomainName",
+            "defaultValue": "placeholder-name",
+            "visible": true
+        },
+        {
             "type": "pattern",
             "pattern": "MA_STAGE",
             "inputType": "input",


### PR DESCRIPTION
### Description
Add back in target cluster property to backfill dashboard, this was mistakenly removed in an earlier revision

### Issues Resolved
N/A

### Testing
Added in exact code from git history

### Check List
- [ ] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
