### PR TITLE
Add metrics-elastic_agent prefix to default list of excluded templates

### DIFF
--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/common/FilterScheme.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/common/FilterScheme.java
@@ -17,6 +17,7 @@ public class FilterScheme {
             "ecs@",
             "elastic-connectors-",
             "ilm-history-",
+            "metrics-elastic_agent",
             "profiling-",
             "synthetics-"
     );

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/common/FilterScheme.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/common/FilterScheme.java
@@ -19,7 +19,11 @@ public class FilterScheme {
             "elastic_agent.",
             "ilm-history-",
             "logs-elastic_agent",
+            "logs-index_pattern",
+            "metricbeat-",
             "metrics-elastic_agent",
+            "metrics-endpoint.",
+            "metrics-index_pattern",
             "profiling-",
             "synthetics-"
     );
@@ -27,6 +31,7 @@ public class FilterScheme {
     private static final List<String> EXCLUDED_SUFFIXES = Arrays.asList(
             "@ilm",
             "@mappings",
+            "@package",
             "@settings",
             "@template",
             "@tsdb-settings"

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/common/FilterScheme.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/common/FilterScheme.java
@@ -16,7 +16,9 @@ public class FilterScheme {
             "data-streams@",
             "ecs@",
             "elastic-connectors-",
+            "elastic_agent.",
             "ilm-history-",
+            "logs-elastic_agent",
             "metrics-elastic_agent",
             "profiling-",
             "synthetics-"


### PR DESCRIPTION
### Description
Fixes error during metadata on ES 8

```
   ERROR - metrics-elastic_agent.apm_server failed on target cluster: Create object failed for _index_template/metrics-elastic_agent.apm_server
```

### Issues Resolved
N/A

### Testing
N/A

### Check List
- [ ] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
