### PR TITLE
Add support for ES 8 ZSTD Compression

### DIFF
--- a/DocumentsFromSnapshotMigration/src/test/java/org/opensearch/migrations/bulkload/EndToEndCompressionTest.java
+++ b/DocumentsFromSnapshotMigration/src/test/java/org/opensearch/migrations/bulkload/EndToEndCompressionTest.java
@@ -48,7 +48,7 @@ public class EndToEndCompressionTest extends SourceTestBase {
 
                             // TODO: Enable below tests once zstd and zstd_no_dict are supported on OS 2
                             // Add zstd and zstd_no_dict if OS version >= 2.9.0
-                            if (VersionMatchers.isOS_2_9_OrGreater.test(source.getVersion())) {
+                            if (VersionMatchers.equalOrGreaterThanOS_2_9.test(source.getVersion())) {
                                 log.atInfo().setMessage("Skipping OS 2 test with ZSTD since unsupported")
                                         .log();
 //                        args.add(Arguments.of(source, target, "zstd"));

--- a/DocumentsFromSnapshotMigration/src/test/java/org/opensearch/migrations/bulkload/EndToEndCompressionTest.java
+++ b/DocumentsFromSnapshotMigration/src/test/java/org/opensearch/migrations/bulkload/EndToEndCompressionTest.java
@@ -1,0 +1,163 @@
+package org.opensearch.migrations.bulkload;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Stream;
+
+import org.opensearch.migrations.VersionMatchers;
+import org.opensearch.migrations.bulkload.common.FileSystemRepo;
+import org.opensearch.migrations.bulkload.common.FileSystemSnapshotCreator;
+import org.opensearch.migrations.bulkload.common.OpenSearchClientFactory;
+import org.opensearch.migrations.bulkload.common.http.ConnectionContextTestParams;
+import org.opensearch.migrations.bulkload.framework.SearchClusterContainer;
+import org.opensearch.migrations.bulkload.http.ClusterOperations;
+import org.opensearch.migrations.bulkload.worker.SnapshotRunner;
+import org.opensearch.migrations.reindexer.tracing.DocumentMigrationTestContext;
+import org.opensearch.migrations.snapshot.creation.tracing.SnapshotTestContext;
+
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.testcontainers.lifecycle.Startables;
+
+@Tag("isolatedTest")
+@Slf4j
+public class EndToEndCompressionTest extends SourceTestBase {
+    @TempDir
+    private File localDirectory;
+
+    private static Stream<Arguments> scenarios() {
+        var target = SearchClusterContainer.OS_LATEST;
+        return
+                SupportedClusters.supportedSources(true).stream()
+                        .flatMap(source -> {
+                            List<Arguments> args = new ArrayList<>();
+
+                            // Add best_compression if supported
+                            if (!VersionMatchers.isES_1_X.test(source.getVersion())) {
+                                args.add(Arguments.of(source, target, "best_compression"));
+                            }
+
+                            // TODO: Enable below tests once zstd and zstd_no_dict are supported on OS 2
+                            // Add zstd and zstd_no_dict if OS version >= 2.9.0
+                            if (VersionMatchers.isOS_2_9_OrGreater.test(source.getVersion())) {
+                                log.atInfo().setMessage("Skipping OS 2 test with ZSTD since unsupported")
+                                        .log();
+//                        args.add(Arguments.of(source, target, "zstd"));
+//                        args.add(Arguments.of(source, target, "zstd_no_dict"));
+                            }
+                            return args.stream();
+                        });
+    }
+
+    @ParameterizedTest(name = "Source {0} to Target {1} using codec {2}")
+    @MethodSource("scenarios")
+    public void migrationDocuments(
+            final SearchClusterContainer.ContainerVersion sourceVersion,
+            final SearchClusterContainer.ContainerVersion targetVersion,
+            final String codec) {
+        try (
+                final var sourceCluster = new SearchClusterContainer(sourceVersion);
+                final var targetCluster = new SearchClusterContainer(targetVersion)
+        ) {
+            migrationDocumentsWithClusters(sourceCluster, targetCluster, codec);
+        }
+    }
+
+    @SneakyThrows
+    private void migrationDocumentsWithClusters(
+            final SearchClusterContainer sourceCluster,
+            final SearchClusterContainer targetCluster,
+            final String codec
+    ) {
+        final var snapshotContext = SnapshotTestContext.factory().noOtelTracking();
+        final var testDocMigrationContext = DocumentMigrationTestContext.factory().noOtelTracking();
+
+        try {
+            // === ACTION: Set up the source/target clusters ===
+            Startables.deepStart(sourceCluster, targetCluster).join();
+
+            var indexName = "compressed_index";
+            var numberOfShards = 1;
+            var sourceClusterOperations = new ClusterOperations(sourceCluster);
+            var targetClusterOperations = new ClusterOperations(targetCluster);
+
+            String body = String.format(
+                    "{" +
+                            "  \"settings\": {" +
+                            "    \"number_of_shards\": %d," +
+                            "    \"number_of_replicas\": 0," +
+                            "    \"codec\": \"%s\"," +
+                            "    \"refresh_interval\": -1" +
+                            "  }" +
+                            "}",
+                    numberOfShards,
+                    codec
+            );
+            sourceClusterOperations.createIndex(indexName, body);
+            targetClusterOperations.createIndex(indexName, body);
+
+            sourceClusterOperations.createDocument(indexName, "222", "{\"score\": 42}");
+            sourceClusterOperations.get("/_refresh");
+
+            // === ACTION: Take a snapshot ===
+            var snapshotName = "my_snap";
+            var snapshotRepoName = "my_snap_repo";
+            var sourceClientFactory = new OpenSearchClientFactory(ConnectionContextTestParams.builder()
+                    .host(sourceCluster.getUrl())
+                    .insecure(true)
+                    .build()
+                    .toConnectionContext());
+            var sourceClient = sourceClientFactory.determineVersionAndCreate();
+            var snapshotCreator = new FileSystemSnapshotCreator(
+                    snapshotName,
+                    snapshotRepoName,
+                    sourceClient,
+                    SearchClusterContainer.CLUSTER_SNAPSHOT_DIR,
+                    List.of(),
+                    snapshotContext.createSnapshotCreateContext()
+            );
+            SnapshotRunner.runAndWaitForCompletion(snapshotCreator);
+            sourceCluster.copySnapshotData(localDirectory.toString());
+            var sourceRepo = new FileSystemRepo(localDirectory.toPath());
+
+            // === ACTION: Migrate the documents ===
+            var runCounter = new AtomicInteger();
+            var clockJitter = new Random(1);
+
+            var transformationConfig = VersionMatchers.isES_5_X.or(VersionMatchers.isES_6_X)
+                    .test(targetCluster.getContainerVersion().getVersion()) ?
+                    "[{\"NoopTransformerProvider\":{}}]" // skip transformations including doc type removal
+                    : null;
+
+            // ExpectedMigrationWorkTerminationException is thrown on completion.
+            var expectedTerminationException = waitForRfsCompletion(() -> migrateDocumentsSequentially(
+                    sourceRepo,
+                    snapshotName,
+                    List.of(),
+                    targetCluster,
+                    runCounter,
+                    clockJitter,
+                    testDocMigrationContext,
+                    sourceCluster.getContainerVersion().getVersion(),
+                    targetCluster.getContainerVersion().getVersion(),
+                    transformationConfig
+            ));
+
+            Assertions.assertEquals(numberOfShards + 1, expectedTerminationException.numRuns);
+
+            // Check that the docs were migrated
+            checkClusterMigrationOnFinished(sourceCluster, targetCluster, testDocMigrationContext);
+        } finally {
+            deleteTree(localDirectory.toPath());
+        }
+    }
+}

--- a/RFS/build.gradle
+++ b/RFS/build.gradle
@@ -77,6 +77,8 @@ dependencies {
     implementation libs.netty.codec.http
     implementation libs.httpclient5
 
+    implementation libs.zstd.jni
+
     implementation libs.slf4j.api
 
     lucene5 libs.lucene.v5.core

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/lucene/version_9/ES8CompatibleZstdNoDictCompressionMode.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/lucene/version_9/ES8CompatibleZstdNoDictCompressionMode.java
@@ -1,0 +1,73 @@
+package org.opensearch.migrations.bulkload.lucene.version_9;
+
+import java.io.IOException;
+
+import com.github.luben.zstd.Zstd;
+import shadow.lucene9.org.apache.lucene.codecs.compressing.CompressionMode;
+import shadow.lucene9.org.apache.lucene.codecs.compressing.Compressor;
+import shadow.lucene9.org.apache.lucene.codecs.compressing.Decompressor;
+import shadow.lucene9.org.apache.lucene.store.DataInput;
+import shadow.lucene9.org.apache.lucene.util.ArrayUtil;
+import shadow.lucene9.org.apache.lucene.util.BytesRef;
+
+/** ZSTD Compression Mode (decompression only, no dictionary support). */
+public class ES8CompatibleZstdNoDictCompressionMode extends CompressionMode {
+
+    @Override
+    public Compressor newCompressor() {
+        throw new UnsupportedOperationException("Compression not supported");
+    }
+
+    @Override
+    public Decompressor newDecompressor() {
+        return new ZstdDecompressor();
+    }
+
+    private static final class ZstdDecompressor extends Decompressor {
+        private byte[] compressed;
+        public ZstdDecompressor() {
+            compressed = BytesRef.EMPTY_BYTES;
+        }
+
+        public ZstdDecompressor(ZstdDecompressor original) {
+            this.compressed = original.compressed.clone();
+        }
+
+        @Override
+        public void decompress(DataInput in, int originalLength, int offset, int length, BytesRef bytes) throws IOException {
+            assert offset + length <= originalLength : "buffer read size must be within limit";
+
+            if (length == 0) {
+                bytes.length = 0;
+                return;
+            }
+
+            // Read all remaining compressed bytes assuming the entire input is one Zstd frame
+            final int remaining = in.readVInt();
+            compressed = ArrayUtil.growNoCopy(compressed, remaining); // allocate enough buffer
+            in.readBytes(compressed, 0, remaining); // read the Zstd frame(s)
+
+            // Prepare output buffer
+            bytes.bytes = ArrayUtil.grow(bytes.bytes, originalLength);
+            bytes.offset = 0;
+
+            int decompressedSize = (int) Zstd.decompressByteArray(
+                    bytes.bytes, 0, originalLength,
+                    compressed, 0, remaining
+            );
+
+            if (decompressedSize != originalLength) {
+                throw new IOException("Decompressed size mismatch: expected " + originalLength + " but got " + decompressedSize);
+            }
+
+            bytes.offset = offset;
+            bytes.length = length;
+
+            assert bytes.isValid() : "decompression output is corrupted.";
+        }
+
+        public Decompressor clone() {
+            return new ZstdDecompressor(this);
+        }
+    }
+}

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/lucene/version_9/Elasticsearch814ZstdFieldsFormat.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/lucene/version_9/Elasticsearch814ZstdFieldsFormat.java
@@ -13,7 +13,7 @@ import shadow.lucene9.org.apache.lucene.store.Directory;
 import shadow.lucene9.org.apache.lucene.store.IOContext;
 
 @NoArgsConstructor
-public class Elasticsearch8CompatibleFieldsFormat extends StoredFieldsFormat {
+public class Elasticsearch814ZstdFieldsFormat extends StoredFieldsFormat {
     public static final String MODE_KEY = "Zstd814StoredFieldsFormat.mode";
 
     public StoredFieldsReader fieldsReader(Directory directory, SegmentInfo si, FieldInfos fn, IOContext context) throws IOException {

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/lucene/version_9/Elasticsearch816CodecFallback.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/lucene/version_9/Elasticsearch816CodecFallback.java
@@ -35,7 +35,7 @@ public class Elasticsearch816CodecFallback extends Codec {
 
     @Override
     public StoredFieldsFormat storedFieldsFormat() {
-        return Codec.forName(BASE_CODEC_NAME).storedFieldsFormat();
+        return new Elasticsearch8CompatibleFieldsFormat();
     }
 
     @Override

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/lucene/version_9/Elasticsearch816CodecFallback.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/lucene/version_9/Elasticsearch816CodecFallback.java
@@ -35,7 +35,7 @@ public class Elasticsearch816CodecFallback extends Codec {
 
     @Override
     public StoredFieldsFormat storedFieldsFormat() {
-        return new Elasticsearch8CompatibleFieldsFormat();
+        return new Elasticsearch814ZstdFieldsFormat();
     }
 
     @Override

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/lucene/version_9/Elasticsearch8CompatibleFieldsFormat.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/lucene/version_9/Elasticsearch8CompatibleFieldsFormat.java
@@ -1,0 +1,44 @@
+package org.opensearch.migrations.bulkload.lucene.version_9;
+
+import java.io.IOException;
+
+import lombok.NoArgsConstructor;
+import shadow.lucene9.org.apache.lucene.codecs.StoredFieldsFormat;
+import shadow.lucene9.org.apache.lucene.codecs.StoredFieldsReader;
+import shadow.lucene9.org.apache.lucene.codecs.StoredFieldsWriter;
+import shadow.lucene9.org.apache.lucene.codecs.lucene90.compressing.Lucene90CompressingStoredFieldsFormat;
+import shadow.lucene9.org.apache.lucene.index.FieldInfos;
+import shadow.lucene9.org.apache.lucene.index.SegmentInfo;
+import shadow.lucene9.org.apache.lucene.store.Directory;
+import shadow.lucene9.org.apache.lucene.store.IOContext;
+
+@NoArgsConstructor
+public class Elasticsearch8CompatibleFieldsFormat extends StoredFieldsFormat {
+    public static final String MODE_KEY = "Zstd814StoredFieldsFormat.mode";
+
+    public StoredFieldsReader fieldsReader(Directory directory, SegmentInfo si, FieldInfos fn, IOContext context) throws IOException {
+        String value = si.getAttribute(MODE_KEY);
+        if (value == null) {
+            throw new IllegalStateException("missing value for " + MODE_KEY + " for segment: " + si.name);
+        } else {
+            Mode mode = Mode.valueOf(value);
+            return this.impl(mode).fieldsReader(directory, si, fn, context);
+        }
+    }
+
+    public StoredFieldsWriter fieldsWriter(Directory directory, SegmentInfo si, IOContext context) throws IOException {
+        throw new UnsupportedOperationException("Elasticsearch8CompatibleFieldsFormat does not support writing stored fields");
+    }
+
+    StoredFieldsFormat impl(Mode mode) {
+        if (Mode.BEST_COMPRESSION.equals(mode)) {
+            // Arbitrary values, kept lucene defaults
+            return new Lucene90CompressingStoredFieldsFormat("ZstdStoredFields814", new ES8CompatibleZstdNoDictCompressionMode(), 491520, 4096, 10);
+        }
+        throw new AssertionError();
+    }
+
+    public enum Mode {
+        BEST_COMPRESSION;
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -42,6 +42,7 @@ semver4j = "6.0.0"
 slf4j = "2.0.17"
 testcontainers = "1.21.3"
 toxiproxy = "2.1.7"
+zstd-jni = "1.5.7-4"
 
 [libraries]
 aws-arns = { module = "software.amazon.awssdk:arns", version.ref = "aws-sdk" }
@@ -158,6 +159,8 @@ testcontainers-opensearch = {module = "org.opensearch:opensearch-testcontainers"
 testcontainers-toxiproxy = {module = "org.testcontainers:toxiproxy", version.ref = "testcontainers" }
 
 toxiproxy = {module = "eu.rekawek.toxiproxy:toxiproxy-java", version.ref = "toxiproxy" }
+
+zstd-jni = {module = "com.github.luben:zstd-jni", version.ref = "zstd-jni" }
 
 # List all boms here with prefix boms- to force platforms across all projects
 boms-aws-sdk          = { module = "software.amazon.awssdk:bom", version.ref = "aws-sdk" }

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -62,7 +62,7 @@ sonar.sourceEncoding=UTF-8
 sonar.issue.ignore.multicriteria = \
   p1, \
   ts1, ts2, ts3, ts4, ts5, ts6, ts7, ts8, ts9, ts10, ts11, \
-  j1, j2, j3, j4, j5, j6, j7, j8, j9, j10, j11, j12, j13, j14, \
+  j1, j2, j3, j4, j5, j6, j7, j8, j9, j10, j11, j12, j13, j14, j15 \
   autoclose1, autoclose2, \
   comp1, comp2, comp3, comp4, \
   loop1, loop2, loop3, loop4, loop5, loop6, loop7, \
@@ -184,7 +184,9 @@ sonar.issue.ignore.multicriteria.j13.resourceKey = **/*.java
 sonar.issue.ignore.multicriteria.j14.ruleKey = java:S6241
 sonar.issue.ignore.multicriteria.j14.resourceKey = **/*.java
 
-
+# Ignore use of clone when extending class
+sonar.issue.ignore.multicriteria.j15.ruleKey = java:S2975
+sonar.issue.ignore.multicriteria.j15.resourceKey = **/ES8CompatibleZstdNoDictCompressionMode.java
 
 # "Use try-with-resources or close this"
 # We use AutoCloseable for tracing contexts so that we can properly record spans

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -62,7 +62,7 @@ sonar.sourceEncoding=UTF-8
 sonar.issue.ignore.multicriteria = \
   p1, \
   ts1, ts2, ts3, ts4, ts5, ts6, ts7, ts8, ts9, ts10, ts11, \
-  j1, j2, j3, j4, j5, j6, j7, j8, j9, j10, j11, j12, j13, j14, j15, \
+  j1, j2, j3, j4, j5, j6, j7, j8, j9, j10, j11, j12, j13, j14, j15, j16, \
   autoclose1, autoclose2, \
   comp1, comp2, comp3, comp4, \
   loop1, loop2, loop3, loop4, loop5, loop6, loop7, \
@@ -184,9 +184,11 @@ sonar.issue.ignore.multicriteria.j13.resourceKey = **/*.java
 sonar.issue.ignore.multicriteria.j14.ruleKey = java:S6241
 sonar.issue.ignore.multicriteria.j14.resourceKey = **/*.java
 
-# Ignore use of clone when extending class
+# Ignore use of clone when extending interface that requires it
 sonar.issue.ignore.multicriteria.j15.ruleKey = java:S2975
 sonar.issue.ignore.multicriteria.j15.resourceKey = **/*CompressionMode.java
+sonar.issue.ignore.multicriteria.j16.ruleKey = java:S1182
+sonar.issue.ignore.multicriteria.j16.resourceKey = **/*CompressionMode.java
 
 # "Use try-with-resources or close this"
 # We use AutoCloseable for tracing contexts so that we can properly record spans

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -62,7 +62,7 @@ sonar.sourceEncoding=UTF-8
 sonar.issue.ignore.multicriteria = \
   p1, \
   ts1, ts2, ts3, ts4, ts5, ts6, ts7, ts8, ts9, ts10, ts11, \
-  j1, j2, j3, j4, j5, j6, j7, j8, j9, j10, j11, j12, j13, j14, j15 \
+  j1, j2, j3, j4, j5, j6, j7, j8, j9, j10, j11, j12, j13, j14, j15, \
   autoclose1, autoclose2, \
   comp1, comp2, comp3, comp4, \
   loop1, loop2, loop3, loop4, loop5, loop6, loop7, \
@@ -178,7 +178,7 @@ sonar.issue.ignore.multicriteria.j12.resourceKey = **/*.java
 
 # Ignore Set the credentials provider explicitly on this builder, false positive.
 sonar.issue.ignore.multicriteria.j13.ruleKey = java:S6242
-sonar.issue.ignore.multicriteria.j13.resourceKey = **/*.java 
+sonar.issue.ignore.multicriteria.j13.resourceKey = **/*.java
 
 # Ignore Set the region explicitly on this builder, false positive.
 sonar.issue.ignore.multicriteria.j14.ruleKey = java:S6241
@@ -186,7 +186,7 @@ sonar.issue.ignore.multicriteria.j14.resourceKey = **/*.java
 
 # Ignore use of clone when extending class
 sonar.issue.ignore.multicriteria.j15.ruleKey = java:S2975
-sonar.issue.ignore.multicriteria.j15.resourceKey = **/ES8CompatibleZstdNoDictCompressionMode.java
+sonar.issue.ignore.multicriteria.j15.resourceKey = **/*CompressionMode.java
 
 # "Use try-with-resources or close this"
 # We use AutoCloseable for tracing contexts so that we can properly record spans

--- a/transformation/src/main/java/org/opensearch/migrations/VersionMatchers.java
+++ b/transformation/src/main/java/org/opensearch/migrations/VersionMatchers.java
@@ -31,6 +31,8 @@ public class VersionMatchers {
     public static final Predicate<Version> isOS_3_X = VersionMatchers.matchesMajorVersion(Version.fromString("OS 3.0.0"));
     public static final Predicate<Version> isOS_2_19_OrGreater = VersionMatchers.equalOrGreaterThanMinorVersion(Version.fromString("OS 2.19.0"))
                                                                     .or(VersionMatchers.isOS_3_X);
+    public static final Predicate<Version> isOS_2_9_OrGreater = VersionMatchers.equalOrGreaterThanMinorVersion(Version.fromString("OS 2.9.0"))
+            .or(VersionMatchers.isOS_3_X);
     public static final Predicate<Version> anyOS = VersionMatchers.isOS_1_X.or(VersionMatchers.isOS_2_X).or(VersionMatchers.isOS_3_X);
 
     static Predicate<Version> matchesFlavor(final Version version) {

--- a/transformation/src/main/java/org/opensearch/migrations/VersionMatchers.java
+++ b/transformation/src/main/java/org/opensearch/migrations/VersionMatchers.java
@@ -31,7 +31,7 @@ public class VersionMatchers {
     public static final Predicate<Version> isOS_3_X = VersionMatchers.matchesMajorVersion(Version.fromString("OS 3.0.0"));
     public static final Predicate<Version> isOS_2_19_OrGreater = VersionMatchers.equalOrGreaterThanMinorVersion(Version.fromString("OS 2.19.0"))
                                                                     .or(VersionMatchers.isOS_3_X);
-    public static final Predicate<Version> isOS_2_9_OrGreater = VersionMatchers.equalOrGreaterThanMinorVersion(Version.fromString("OS 2.9.0"))
+    public static final Predicate<Version> equalOrGreaterThanOS_2_9 = VersionMatchers.equalOrGreaterThanMinorVersion(Version.fromString("OS 2.9.0"))
             .or(VersionMatchers.isOS_3_X);
     public static final Predicate<Version> anyOS = VersionMatchers.isOS_1_X.or(VersionMatchers.isOS_2_X).or(VersionMatchers.isOS_3_X);
 


### PR DESCRIPTION
### Description
Add RFS support for ES 8 ZSTD Compression, along with tests against other versions "best_compression".

**Note, RFS still does not support ZSTD in OS 2.9+**

Note: We're not using https://github.com/opensearch-project/custom-codecs/blob/main/src/main/java/org/opensearch/index/codec/customcodecs/ZstdNoDictCompressionMode.java because based on snapshot data, it does not appear ES8 uses "subblocks" strategy as OS does, though its likely we can leverage the library for the OS2 extra compression schema support

### Issues Resolved
[MIGRATIONS-2536](https://opensearch.atlassian.net/browse/MIGRATIONS-2536)

### Testing
Unit testing

### Check List
- [x] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
