### PR TITLE
Fix pace-assignment syntax deprecation for gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -84,7 +84,8 @@ def commonExclusions = ['**/build/**',
                         '**/opensearch-cluster-cdk/**',
                         '**/cdk.out/**',
                         '**/transformation/standardJavascriptTransforms/node_modules/**',
-                        '**/frontend/**']
+                        '**/frontend/**',
+                        '**/.venv/**']
 spotless {
     format 'misc', {
         target fileTree('.') {
@@ -94,7 +95,6 @@ spotless {
         trimTrailingWhitespace()
         leadingTabsToSpaces()
         endWithNewline()
-
     }
     yaml {
         target fileTree('.') {
@@ -164,11 +164,11 @@ subprojects {
         if (!sourceSets.test.allSource.files.isEmpty()) {
             tasks.withType(Test) {
                 testLogging {
-                    events "passed", "skipped", "failed"
-                    exceptionFormat "full"
-                    showExceptions true
-                    showCauses true
-                    showStackTraces true
+                    events = ["passed", "skipped", "failed"]
+                    exceptionFormat = "full"
+                    showExceptions = true
+                    showCauses = true
+                    showStackTraces = true
                 }
                 maxParallelForks = gradle.startParameter.maxWorkerCount
 

--- a/jenkinsTests/build.gradle
+++ b/jenkinsTests/build.gradle
@@ -5,7 +5,7 @@ plugins {
 
 repositories {
     mavenCentral()
-    maven { url 'https://repo.jenkins-ci.org/releases/' }
+    maven { url = 'https://repo.jenkins-ci.org/releases/' }
 }
 
 sourceSets {


### PR DESCRIPTION
### Description
The gradle 9 configuration cache system reports an error on these types of assignments because it will be deprecated in gradle 10, updating these impacted areas proactively and to reduce the noise when troubleshooting configuration cache issues.

### Issues Resolved
- N/A

### Testing
Tested locally by running `./gradlew help --configuration-cache --configuration-cache-problems=warn`

### Check List
- [ ] ~New functionality includes testing~
- [ ] ~Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
