### PR TITLE
[Bug] Provide earlier cleanup of additional git files

### DIFF
--- a/vars/cleanupDeployment.groovy
+++ b/vars/cleanupDeployment.groovy
@@ -20,9 +20,14 @@ def call(Map config = [:]) {
             stage('Checkout') {
                 steps {
                     script {
+                        // If in an existing git repository, remove any additional files in git tree that are not listed in .gitignore
+                        if (sh(script: 'git rev-parse --git-dir > /dev/null 2>&1', returnStatus: true) == 0) {
+                            echo 'Cleaning any existing git files in workspace'
+                            sh 'sudo --preserve-env git clean -fd'
+                        } else {
+                            echo 'No git project detected, this is likely an initial run of this pipeline on the worker'
+                        }
                         git branch: "${params.GIT_BRANCH}", url: "${params.GIT_REPO_URL}"
-                        // Remove any additional files in git tree that are not listed in .gitignore
-                        sh 'sudo --preserve-env git clean -fd'
                     }
                 }
             }

--- a/vars/defaultIntegPipeline.groovy
+++ b/vars/defaultIntegPipeline.groovy
@@ -62,9 +62,14 @@ def call(Map config = [:]) {
                         if (config.checkoutStep) {
                             config.checkoutStep()
                         } else {
+                            // If in an existing git repository, remove any additional files in git tree that are not listed in .gitignore
+                            if (sh(script: 'git rev-parse --git-dir > /dev/null 2>&1', returnStatus: true) == 0) {
+                                echo 'Cleaning any existing git files in workspace'
+                                sh 'sudo --preserve-env git clean -fd'
+                            } else {
+                                echo 'No git project detected, this is likely an initial run of this pipeline on the worker'
+                            }
                             git branch: "${params.GIT_BRANCH}", url: "${params.GIT_REPO_URL}"
-                            // Remove any additional files in git tree that are not listed in .gitignore
-                            sh 'sudo --preserve-env git clean -fd'
                         }
                     }
                 }

--- a/vars/k8sLocalDeployment.groovy
+++ b/vars/k8sLocalDeployment.groovy
@@ -41,9 +41,14 @@ def call(Map config = [:]) {
             stage('Checkout') {
                 steps {
                     script {
+                        // If in an existing git repository, remove any additional files in git tree that are not listed in .gitignore
+                        if (sh(script: 'git rev-parse --git-dir > /dev/null 2>&1', returnStatus: true) == 0) {
+                            echo 'Cleaning any existing git files in workspace'
+                            sh 'sudo --preserve-env git clean -fd'
+                        } else {
+                            echo 'No git project detected, this is likely an initial run of this pipeline on the worker'
+                        }
                         git branch: "${params.GIT_BRANCH}", url: "${params.GIT_REPO_URL}"
-                        // Remove any additional files in git tree that are not listed in .gitignore
-                        sh 'sudo --preserve-env git clean -fd'
                     }
                 }
             }

--- a/vars/solutionsCFNTest.groovy
+++ b/vars/solutionsCFNTest.groovy
@@ -20,9 +20,14 @@ def call(Map config = [:]) {
             stage('Checkout') {
                 steps {
                     script {
+                        // If in an existing git repository, remove any additional files in git tree that are not listed in .gitignore
+                        if (sh(script: 'git rev-parse --git-dir > /dev/null 2>&1', returnStatus: true) == 0) {
+                            echo 'Cleaning any existing git files in workspace'
+                            sh 'sudo --preserve-env git clean -fd'
+                        } else {
+                            echo 'No git project detected, this is likely an initial run of this pipeline on the worker'
+                        }
                         git branch: "${params.GIT_BRANCH}", url: "${params.GIT_REPO_URL}"
-                        // Remove any additional files in git tree that are not listed in .gitignore
-                        sh 'sudo --preserve-env git clean -fd'
                     }
                 }
             }


### PR DESCRIPTION
### Description
Building off https://github.com/opensearch-project/opensearch-migrations/pull/1690, we should try to cleanup before checking out directory to prevent issues like: 
```
stderr: error: unable to unlink old 'frontend/src/generated/api/client.gen.ts': Permission denied
error: unable to unlink old 'frontend/src/generated/api/client/client.ts': Permission denied
error: unable to unlink old 'frontend/src/generated/api/client/index.ts': Permission denied
```

### Issues Resolved
N/A

### Testing
Jenkins testing

### Check List
- [ ] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
