### PR TITLE
Add support for completion codec available in ES 5/6/7

### DIFF
--- a/DocumentsFromSnapshotMigration/src/test/java/org/opensearch/migrations/bulkload/CompletionCodecTest.java
+++ b/DocumentsFromSnapshotMigration/src/test/java/org/opensearch/migrations/bulkload/CompletionCodecTest.java
@@ -1,0 +1,162 @@
+package org.opensearch.migrations.bulkload;
+
+import java.io.File;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Stream;
+
+import org.opensearch.migrations.VersionMatchers;
+import org.opensearch.migrations.bulkload.common.FileSystemRepo;
+import org.opensearch.migrations.bulkload.common.FileSystemSnapshotCreator;
+import org.opensearch.migrations.bulkload.common.OpenSearchClientFactory;
+import org.opensearch.migrations.bulkload.common.http.ConnectionContextTestParams;
+import org.opensearch.migrations.bulkload.framework.SearchClusterContainer;
+import org.opensearch.migrations.bulkload.http.ClusterOperations;
+import org.opensearch.migrations.bulkload.worker.SnapshotRunner;
+import org.opensearch.migrations.reindexer.tracing.DocumentMigrationTestContext;
+import org.opensearch.migrations.snapshot.creation.tracing.SnapshotTestContext;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.testcontainers.lifecycle.Startables;
+
+@Slf4j
+@Tag("isolatedTest")
+public class CompletionCodecTest extends SourceTestBase {
+    @TempDir
+    private File localDirectory;
+
+    private static Stream<Arguments> completionFieldScenario() {
+        return Stream.of(
+                Arguments.of(SearchClusterContainer.ES_V7_17, SearchClusterContainer.OS_V1_3_16),
+                Arguments.of(SearchClusterContainer.ES_V7_17, SearchClusterContainer.OS_V2_19_1),
+                Arguments.of(SearchClusterContainer.ES_V7_17, SearchClusterContainer.OS_V3_0_0),
+                Arguments.of(SearchClusterContainer.ES_V6_8_23, SearchClusterContainer.OS_V1_3_16),
+                Arguments.of(SearchClusterContainer.ES_V6_8_23, SearchClusterContainer.OS_V2_19_1),
+                Arguments.of(SearchClusterContainer.ES_V6_8_23, SearchClusterContainer.OS_V3_0_0),
+                Arguments.of(SearchClusterContainer.ES_V5_6_16, SearchClusterContainer.OS_V1_3_16),
+                Arguments.of(SearchClusterContainer.ES_V5_6_16, SearchClusterContainer.OS_V2_19_1),
+                Arguments.of(SearchClusterContainer.ES_V5_6_16, SearchClusterContainer.OS_V3_0_0)
+        );
+    }
+
+    @ParameterizedTest(name = "Completion Field: Source {0} to Target {1}")
+    @MethodSource("completionFieldScenario")
+    public void completionFieldMigrationTest(
+            final SearchClusterContainer.ContainerVersion sourceVersion,
+            final SearchClusterContainer.ContainerVersion targetVersion
+    ) {
+        try (
+                final var sourceCluster = new SearchClusterContainer(sourceVersion);
+                final var targetCluster = new SearchClusterContainer(targetVersion)
+        ) {
+            migrationDocumentsWithClusters(sourceCluster, targetCluster);
+        }
+    }
+
+    @SneakyThrows
+    private void migrationDocumentsWithClusters(
+            final SearchClusterContainer sourceCluster,
+            final SearchClusterContainer targetCluster
+    ) {
+        final var snapshotContext = SnapshotTestContext.factory().noOtelTracking();
+        final var testDocMigrationContext = DocumentMigrationTestContext.factory().noOtelTracking();
+
+        try {
+            // === ACTION: Set up the source/target clusters ===
+            Startables.deepStart(sourceCluster, targetCluster).join();
+            var sourceClusterOperations = new ClusterOperations(sourceCluster);
+            var targetClusterOperations = new ClusterOperations(targetCluster);
+
+            // Number of default shards is different across different versions on ES/OS.
+            // So we explicitly set it.
+            var numberOfShards = 3;
+
+            var sourceVersion = sourceCluster.getContainerVersion().getVersion();
+            boolean supportsSoftDeletes = VersionMatchers.equalOrGreaterThanES_6_5.test(sourceVersion);
+
+            // === Create index with completion field ===
+            String specialIndexName = "completion_index";
+            sourceClusterOperations.createIndexWithCompletionField(specialIndexName, numberOfShards);
+
+            // Insert a single document into it
+            String completionDoc =
+                "{" +
+                "    \"completion\": \"openai\" " +
+                "}";
+            String docType = sourceClusterOperations.defaultDocType();
+            sourceClusterOperations.createDocument(specialIndexName, "1", completionDoc, null, docType);
+
+            // Perform a refresh
+            sourceClusterOperations.post("/_refresh", null);
+
+            // === ACTION: Take a snapshot ===
+            var snapshotName = "my_snap";
+            var snapshotRepoName = "my_snap_repo";
+            var sourceClientFactory = new OpenSearchClientFactory(ConnectionContextTestParams.builder()
+                    .host(sourceCluster.getUrl())
+                    .insecure(true)
+                    .build()
+                    .toConnectionContext());
+            var sourceClient = sourceClientFactory.determineVersionAndCreate();
+            var snapshotCreator = new FileSystemSnapshotCreator(
+                    snapshotName,
+                    snapshotRepoName,
+                    sourceClient,
+                    SearchClusterContainer.CLUSTER_SNAPSHOT_DIR,
+                    List.of(),
+                    snapshotContext.createSnapshotCreateContext()
+            );
+            SnapshotRunner.runAndWaitForCompletion(snapshotCreator);
+            sourceCluster.copySnapshotData(localDirectory.toString());
+            var sourceRepo = new FileSystemRepo(localDirectory.toPath());
+
+            // === ACTION: Migrate the documents ===
+            var runCounter = new AtomicInteger();
+            var clockJitter = new Random(1);
+
+            var transformationConfig = VersionMatchers.isES_5_X.or(VersionMatchers.isES_6_X)
+                    .test(targetCluster.getContainerVersion().getVersion()) ?
+                    "[{\"NoopTransformerProvider\":{}}]" // skip transformations including doc type removal
+                    : null;
+
+            // ExpectedMigrationWorkTerminationException is thrown on completion.
+            var expectedTerminationException = waitForRfsCompletion(() -> migrateDocumentsSequentially(
+                    sourceRepo,
+                    snapshotName,
+                    List.of(),
+                    targetCluster,
+                    runCounter,
+                    clockJitter,
+                    testDocMigrationContext,
+                    sourceCluster.getContainerVersion().getVersion(),
+                    targetCluster.getContainerVersion().getVersion(),
+                    transformationConfig
+            ));
+
+            Assertions.assertEquals(numberOfShards + 1, expectedTerminationException.numRuns);
+
+            // Check that the docs were migrated
+            checkClusterMigrationOnFinished(sourceCluster, targetCluster, testDocMigrationContext);
+
+            // === Validate completion field doc migrated to target ===
+            var res = targetClusterOperations.get("/completion_index/_doc/1");
+            System.out.println("Completion doc in target: " + res.getValue());
+
+            JsonNode doc = new com.fasterxml.jackson.databind.ObjectMapper().readTree(res.getValue());
+            JsonNode sourceNode = doc.path("_source").path("completion");
+
+            Assertions.assertTrue(sourceNode.isTextual() || sourceNode.isArray(), "Expected 'completion' field to be present and textual or array");
+        } finally {
+            deleteTree(localDirectory.toPath());
+        }
+    }
+}

--- a/RFS/build.gradle
+++ b/RFS/build.gradle
@@ -81,16 +81,20 @@ dependencies {
 
     lucene5 libs.lucene.v5.core
     lucene5 libs.lucene.v5.backward.codecs
+    lucene5 libs.lucene.v5.suggest
 
     lucene6 libs.lucene.v6.core
     lucene6 libs.lucene.v6.backward.codecs
+    lucene6 libs.lucene.v6.suggest
 
     lucene7 libs.lucene.v7.core
     lucene7 libs.lucene.v7.backward.codecs
+    lucene7 libs.lucene.v7.suggest
 
     lucene9 libs.lucene.v9.core
     lucene9 libs.lucene.v9.analysis.common
     lucene9 libs.lucene.v9.backward.codecs
+    lucene9 libs.lucene.v9.suggest
 
     implementation shadowLucene5.outputs.files
     implementation shadowLucene6.outputs.files

--- a/RFS/src/testFixtures/java/org/opensearch/migrations/bulkload/http/ClusterOperations.java
+++ b/RFS/src/testFixtures/java/org/opensearch/migrations/bulkload/http/ClusterOperations.java
@@ -140,6 +140,63 @@ public class ClusterOperations {
     }
 
     @SneakyThrows
+    public void createIndexWithCompletionField(String indexName, int numberOfShards) {
+        boolean useTypedMappings = UnboundVersionMatchers.isBelowES_8_X.test(clusterVersion);
+        boolean needsTypeNameParam = (VersionMatchers.equalOrGreaterThanES_6_7
+                .or(VersionMatchers.isES_7_X))
+                .test(clusterVersion);
+
+        boolean supportsSoftDeletes = VersionMatchers.equalOrGreaterThanES_6_5.test(clusterVersion);
+        String typeName = defaultDocType();
+
+        String mappingsSection = useTypedMappings
+            ? String.format(
+            "{\n" +
+            "  \"%s\": {\n" +
+            "    \"properties\": {\n" +
+            "      \"completion\": {\n" +
+            "        \"type\": \"completion\",\n" +
+            "        \"analyzer\": \"simple\",\n" +
+            "        \"preserve_separators\": true,\n" +
+            "        \"preserve_position_increments\": true,\n" +
+            "        \"max_input_length\": 50\n" +
+            "      }\n" +
+            "    }\n" +
+            "  }\n" +
+            "}", typeName)
+            : "{\n" +
+            "  \"properties\": {\n" +
+            "    \"completion\": {\n" +
+            "      \"type\": \"completion\",\n" +
+            "      \"analyzer\": \"simple\",\n" +
+            "      \"preserve_separators\": true,\n" +
+            "      \"preserve_position_increments\": true,\n" +
+            "      \"max_input_length\": 50\n" +
+            "    }\n" +
+            "  }\n" +
+            "}";
+
+        String body = String.format(
+            "{\n" +
+                    "  \"settings\": {\n" +
+                    "    \"number_of_shards\": %d,\n" +
+                    "    \"number_of_replicas\": 0,%s\n" +
+                    "    \"refresh_interval\": -1\n" +
+                    "  },\n" +
+                    "  \"mappings\": %s\n" +
+                    "}",
+            numberOfShards,
+            supportsSoftDeletes ? "\n    \"index.soft_deletes.enabled\": true," : "",
+            mappingsSection
+        );
+
+        String path = "/"+indexName + (needsTypeNameParam ? "?include_type_name=true" : "");
+        var response = put(path, body);
+
+        assertThat("Failed to create index with completion field", response.getKey(), equalTo(200));
+    }
+
+    @SneakyThrows
     public Map.Entry<Integer, String> post(final String path, final String body) {
         final var postRequest = new HttpPost(clusterUrl + path);
         if (body != null) {
@@ -381,7 +438,7 @@ public class ClusterOperations {
         assertThat(response.getKey(), equalTo(200));
     }
 
-    private String defaultDocType() {
+    public String defaultDocType() {
         if (UnboundVersionMatchers.isBelowES_6_X
             .or(VersionMatchers.equalOrBetween_ES_6_0_and_6_1)
             .test(clusterVersion)) {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -114,13 +114,17 @@ lombok = { module = "org.projectlombok:lombok", version.ref = "lombok" }
 
 lucene-v5-backward-codecs = { module = "org.apache.lucene:lucene-backward-codecs", version.ref = "lucene5" }
 lucene-v5-core = { module = "org.apache.lucene:lucene-core", version.ref = "lucene5" }
+lucene-v5-suggest = { module = "org.apache.lucene:lucene-suggest", version.ref = "lucene5" }
 lucene-v6-backward-codecs = { module = "org.apache.lucene:lucene-backward-codecs", version.ref = "lucene6" }
 lucene-v6-core = { module = "org.apache.lucene:lucene-core", version.ref = "lucene6" }
+lucene-v6-suggest = { module = "org.apache.lucene:lucene-suggest", version.ref = "lucene6" }
 lucene-v7-backward-codecs = { module = "org.apache.lucene:lucene-backward-codecs", version.ref = "lucene7" }
 lucene-v7-core = { module = "org.apache.lucene:lucene-core", version.ref = "lucene7" }
+lucene-v7-suggest = { module = "org.apache.lucene:lucene-suggest", version.ref = "lucene7" }
 lucene-v9-analysis-common = { module = "org.apache.lucene:lucene-analysis-common", version.ref = "lucene9" }
 lucene-v9-backward-codecs = { module = "org.apache.lucene:lucene-backward-codecs", version.ref = "lucene9" }
 lucene-v9-core = { module = "org.apache.lucene:lucene-core", version.ref = "lucene9" }
+lucene-v9-suggest = { module = "org.apache.lucene:lucene-suggest", version.ref = "lucene9" }
 
 mockito-core = { module = "org.mockito:mockito-core", version.ref = "mockito" }
 mockito-junit-jupiter = { module = "org.mockito:mockito-junit-jupiter", version.ref = "mockito" }


### PR DESCRIPTION
### Description
This PR address a recent issue discovered due to missing Codec.

Code changes include:
- Adding lucene-suggest as a runtime dependency to the Lucene 9/7/6/5 shadow jar
- Introduced createIndexWithCompletionField() in ClusterOperations to create a completion field index with correct mappings/settings across ES versions.
- Added CompletionCodecTest to validate document migration involving completion fields from ES 5.6, 6.8, and 7.17 to OS targets.

### Issues Resolved
[Github Issue](https://github.com/opensearch-project/opensearch-migrations/issues/1684)
[MIGRATIONS-2654](https://opensearch.atlassian.net/browse/MIGRATIONS-2654)

### Testing
CompletionCodecTest has been added and used to validate

### Check List
- [ ] New functionality includes testing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
