### PR TITLE
Print Migration Assistant version on Migration Console

### DIFF
--- a/DocumentsFromSnapshotMigration/build.gradle
+++ b/DocumentsFromSnapshotMigration/build.gradle
@@ -63,6 +63,9 @@ application {
     mainClass.set('org.opensearch.migrations.RfsMigrateDocuments')
 }
 
+// Register copy version file task
+CommonUtils.copyVersionFileToDockerStaging(project, "reindexFromSnapshot", "docker/build")
+
 // Cleanup additional docker build directory
 def dockerBuildDir = file("./docker/build")
 clean.doFirst {
@@ -87,7 +90,7 @@ DockerServiceProps[] dockerServices = [
         new DockerServiceProps([projectName:"reindexFromSnapshot",
                                 dockerImageName:"reindex_from_snapshot",
                                 inputDir:"./docker",
-                                taskDependencies:["copyDockerRuntimeJars"]]),
+                                taskDependencies:["copyDockerRuntimeJars", "copyVersionFile_reindexFromSnapshot"]]),
         new DockerServiceProps([projectName:"emptyElasticsearchSource_5_6",
                                 dockerImageName:"empty_elasticsearch_source_5_6",
                                 inputDir:"./docker/TestSource_ES_5_6"]),

--- a/DocumentsFromSnapshotMigration/docker/Dockerfile
+++ b/DocumentsFromSnapshotMigration/docker/Dockerfile
@@ -8,6 +8,7 @@ RUN dnf install -y procps && \
 
 # Requires Gradle to genearte runtime jars initially
 COPY ./build/runtimeJars /rfs-app/jars
+COPY ./build/VERSION /rfs-app/VERSION
 WORKDIR /rfs-app
 RUN printf "#!/bin/sh\nexec java -XX:MaxRAMPercentage=80.0 -cp /rfs-app/jars/*:. \"\$@\" " > /rfs-app/runJavaWithClasspath.sh
 RUN chmod +x /rfs-app/runJavaWithClasspath.sh

--- a/TrafficCapture/dockerSolution/build.gradle
+++ b/TrafficCapture/dockerSolution/build.gradle
@@ -75,6 +75,9 @@ static Sync getMigrationConsoleSyncTask(Project project, String dockerImageName,
             }
         }
 
+        // Sync VERSION file
+        from (project.rootProject.layout.projectDirectory.file("VERSION"))
+
         from "src/main/docker/${projectName}"
     }
 

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/Dockerfile
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/Dockerfile
@@ -77,6 +77,8 @@ RUN chmod ug+x /root/loadServicesFromParameterStore.sh
 COPY start-console.sh /root/
 RUN chmod +x /root/start-console.sh
 
+COPY VERSION /root/VERSION
+
 WORKDIR /root
 COPY lib /root/lib
 WORKDIR /root/lib/console_link

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/api/system.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/api/system.py
@@ -4,6 +4,8 @@ from pydantic import BaseModel
 from typing import Callable, Dict
 import os
 
+from console_link.models.container_utils import get_version_str
+
 system_router = APIRouter(
     prefix="/system",
     tags=["system"],
@@ -22,6 +24,10 @@ class HealthStatus(str, Enum):
 class HealthApiResponse(BaseModel):
     checks: Dict[str, str]
     status: HealthStatus
+
+
+class VersionApiResponse(BaseModel):
+    version: str
 
 
 def check_shared_logs_config() -> str:
@@ -49,3 +55,9 @@ def health():
     if status != HealthStatus.ok:
         raise HTTPException(status_code=503, detail=results)
     return HealthApiResponse(checks=results, status=status)
+
+
+@system_router.get("/version", response_model=VersionApiResponse)
+def version():
+    version_str = get_version_str()
+    return VersionApiResponse(version=version_str)

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/cli.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/cli.py
@@ -38,7 +38,7 @@ class Context(object):
         self.json = False
 
 
-@click.group()
+@click.group(invoke_without_command=True)
 @click.option("--config-file", default="/config/migration_services.yaml", help="Path to config file")
 @click.option("--json", is_flag=True)
 @click.option('-v', '--verbose', count=True, help="Verbosity level. Default is warn, -v is info, -vv is debug.")
@@ -48,6 +48,13 @@ def cli(ctx, config_file, json, verbose, version):
     if version:
         click.echo(get_version_str())
         ctx.exit(0)
+
+    # Enforce command required unless --version was passed
+    if ctx.invoked_subcommand is None:
+        click.echo("Error: Missing command.", err=True)
+        click.echo(cli.get_help(ctx))
+        ctx.exit(2)
+
     logging.basicConfig(level=logging.WARN - (10 * verbose))
     logger.info(f"Logging set to {logging.getLevelName(logger.getEffectiveLevel())}")
     ctx.obj = Context(config_file)

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/cli.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/cli.py
@@ -13,6 +13,7 @@ import console_link.middleware.replay as replay_
 import console_link.middleware.kafka as kafka_
 import console_link.middleware.tuples as tuples_
 
+from console_link.models.container_utils import get_version_str
 from console_link.models.cluster import HttpMethod
 from console_link.models.backfill_rfs import RfsWorkersInProgress, WorkingIndexDoesntExist
 from console_link.models.utils import DEFAULT_SNAPSHOT_REPO_NAME, ExitCode
@@ -41,8 +42,12 @@ class Context(object):
 @click.option("--config-file", default="/config/migration_services.yaml", help="Path to config file")
 @click.option("--json", is_flag=True)
 @click.option('-v', '--verbose', count=True, help="Verbosity level. Default is warn, -v is info, -vv is debug.")
+@click.option("--version", is_flag=True, is_eager=True, help="Show the Migration Assistant version.")
 @click.pass_context
-def cli(ctx, config_file, json, verbose):
+def cli(ctx, config_file, json, verbose, version):
+    if version:
+        click.echo(get_version_str())
+        ctx.exit(0)
     logging.basicConfig(level=logging.WARN - (10 * verbose))
     logger.info(f"Logging set to {logging.getLevelName(logger.getEffectiveLevel())}")
     ctx.obj = Context(config_file)

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/container_utils.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/container_utils.py
@@ -1,0 +1,25 @@
+import logging
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+VERSION_PREFIX = "Migration Assistant"
+
+
+def get_version_str() -> str:
+    version_file = Path.home() / "VERSION"
+    version = "unknown"
+    if version_file.exists():
+        try:
+            version_line = next(
+                (line.strip() for line in version_file.read_text().splitlines() if line.strip()), None
+            )
+            if version_line:
+                version = version_line
+            else:
+                logger.info("VERSION file is empty at ~/VERSION")
+        except Exception as e:
+            logger.info(f"Failed to read ~/VERSION file: {e}")
+    else:
+        logger.info("VERSION file not found at ~/VERSION")
+
+    return f"{VERSION_PREFIX} {version}"

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/test_cli.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/test_cli.py
@@ -183,6 +183,18 @@ def test_cli_cluster_connection_check(runner, mocker):
     api_mock.assert_called()
 
 
+def test_cli_version_check(runner, mocker):
+    result = runner.invoke(cli, ["--version"], catch_exceptions=True)
+    assert result.exit_code == 0
+    assert "Migration Assistant" in result.output
+
+
+def test_missing_command(runner, mocker):
+    result = runner.invoke(cli, [], catch_exceptions=True)
+    assert result.exit_code == 2
+    assert "Error: Missing command" in result.output
+
+
 def test_cli_cluster_cat_indices_and_connection_check_with_one_cluster(runner, mocker,
                                                                        target_cluster_only_yaml_path,
                                                                        source_cluster_only_yaml_path):

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/test_container_utils.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/test_container_utils.py
@@ -1,0 +1,53 @@
+import pytest
+from unittest.mock import patch
+
+from console_link.models.container_utils import get_version_str, VERSION_PREFIX
+
+
+@pytest.fixture
+def fake_home(tmp_path):
+    """Temporarily override Path.home() to point to a temp dir"""
+    with patch("pathlib.Path.home", return_value=tmp_path):
+        yield tmp_path
+
+
+def test_version_file_present_and_valid(fake_home):
+    version_path = fake_home / "VERSION"
+    version_path.write_text("1.2.3\n")
+
+    assert get_version_str() == f"{VERSION_PREFIX} 1.2.3"
+
+
+def test_version_file_present_and_valid_no_new_line(fake_home):
+    version_path = fake_home / "VERSION"
+    version_path.write_text("1.2.3")
+
+    assert get_version_str() == f"{VERSION_PREFIX} 1.2.3"
+
+
+def test_version_file_empty(fake_home, caplog):
+    version_path = fake_home / "VERSION"
+    version_path.write_text("\n\n")
+
+    with caplog.at_level("INFO"):
+        result = get_version_str()
+        assert result == f"{VERSION_PREFIX} unknown"
+        assert "VERSION file is empty" in caplog.text
+
+
+def test_version_file_missing(fake_home, caplog):
+    with caplog.at_level("INFO"):
+        result = get_version_str()
+        assert result == f"{VERSION_PREFIX} unknown"
+        assert "VERSION file not found" in caplog.text
+
+
+def test_version_file_unreadable(fake_home, caplog):
+    version_path = fake_home / "VERSION"
+    version_path.write_text("1.2.3")
+    version_path.chmod(0)  # Remove all permissions
+
+    with caplog.at_level("INFO"):
+        result = get_version_str()
+        assert result == f"{VERSION_PREFIX} unknown"
+        assert "Failed to read" in caplog.text

--- a/buildImages/build.gradle
+++ b/buildImages/build.gradle
@@ -25,6 +25,9 @@ def jibProjects = [
                 baseImageTag  : "17-al2023-headless",
                 imageName     : "traffic_replayer",
                 imageTag      : "latest",
+                requiredDependencies: [
+                    ":TrafficCapture:trafficReplayer": ["copyVersionFile_traffic_replayer"]
+                ]
         ],
         "TrafficCapture:trafficCaptureProxyServer": [
                 baseImageRegistryEndpoint: rootProject.ext.registryEndpoint,
@@ -33,7 +36,10 @@ def jibProjects = [
                 baseImageTag   : "latest",
                 imageName      : "capture_proxy",
                 imageTag       : "latest",
-                requiredDependencies: ["buildKit_captureProxyBase"]
+                requiredDependencies: [
+                    "": ["buildKit_captureProxyBase"],
+                    ":TrafficCapture:trafficCaptureProxyServer": ["copyVersionFile_capture_proxy"]
+                ]
         ]
 ]
 
@@ -58,7 +64,8 @@ def buildKitProjects = [
                 imageName:  "reindex_from_snapshot",
                 imageTag:   "latest",
                 requiredDependencies: [
-                        ":DocumentsFromSnapshotMigration:copyDockerRuntimeJars"
+                        ":DocumentsFromSnapshotMigration:copyDockerRuntimeJars",
+                        ":DocumentsFromSnapshotMigration:copyVersionFile_reindexFromSnapshot"
                 ]
         ],
         [

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -6,5 +6,7 @@ COPY out /usr/share/nginx/html
 # overwrite default Nginx config
 COPY nginx.conf /etc/nginx/conf.d/default.conf
 
+COPY build/VERSION /VERSION
+
 EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/build.gradle
+++ b/frontend/build.gradle
@@ -33,6 +33,9 @@ def buildOutputs = [
     'out'
 ]
 
+// Register copy version file task
+CommonUtils.copyVersionFileToDockerStaging(project, "frontend", "build/")
+
 tasks.register('buildFrontend', NpmTask) {
     dependsOn 'npmInstall'
     args = ['run', 'build']
@@ -52,6 +55,7 @@ tasks.register('cleanFrontend', Delete) {
 
 tasks.register('buildDockerImage', DockerBuildImage) {
     dependsOn 'buildFrontend'
+    dependsOn 'copyVersionFile_frontend'
     inputs.files fileTree(dir: '.', include: buildInputs, exclude: buildExclusions)
     outputs.file(imageIdFile)
 


### PR DESCRIPTION
### Description
This achieves two things:
1. Add VERSION file to all images to give traceability of version for built image
2. Allow the console link library to print the version of the Migration Assistant

```
(19:59:50) migration-console (~) -> console --version
Migration Assistant 2.4.7
```

### Issues Resolved
https://opensearch.atlassian.net/browse/MIGRATIONS-2612

### Testing
Python tests and gradle build testing

### Check List
- [ ] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
