### PR TITLE
Attempt to fix exceptions by using bounded executor and prestarting executor service

### DIFF
--- a/DocumentsFromSnapshotMigration/src/test/resources/log4j2.properties
+++ b/DocumentsFromSnapshotMigration/src/test/resources/log4j2.properties
@@ -27,7 +27,7 @@ appender.console.type = Console
 appender.console.name = Console
 appender.console.target = SYSTEM_OUT
 appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss,SSS}{UTC} %p %c{1.} [%t] %m%n
+appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss,SSS}{UTC} [%thread] %-5level %logger{36} - %msg%n%ex{full}
 
 rootLogger.level = info
 rootLogger.appenderRef.console.ref = Console


### PR DESCRIPTION
### Description
Fixes scheduling deadlock and Scheduler Unavailable Exception.

There were two observed failure methods, one was a seemingly "paused" runtime and the second was a rejection with "Scheduler unavailable". 

Deadlock / "paused" processing:
    * Previously, the final subscription scheduler on RFS was a `Schedulers.newSingle` thread pool. This would be used for all the flux actions that didn't have a subscription tied to it (e.g. lucene segment sorting/binary search, transformation thread creation, etc.). In some rare cases within the integration junit tests, we observed a deadlock where we may have seen an exception and/or no work getting done. This is because this final scheduler became blocked on some action in the chain, and since it was single threaded, it held there indefinitely leaving other parts of the chain in an incomplete state.

Scheduler Unavailable:
    * We observed `ReactorRejectedExecutionException: Scheduler unavailable` that went away if pre-initializing the executor service.

This changes the final scheduler to the shared bounded elastic scheduler and addresses the Scheduler unavailable with initializing the executor.

Prior Exception:
```
2025-07-31 01:12:03,136 INFO o.o.m.b.w.DocumentsRunner [Test worker] Waiting on latch for index=blog_2023, shard=2...
2025-07-31 01:12:03,152 INFO o.o.m.b.l.LuceneReader [workFinishScheduler-13] 5 documents in 2 leaves found in the current Lucene index
2025-07-31 01:12:03,152 INFO o.o.m.b.w.DocumentsRunner [workFinishScheduler-13] Subscribed to docMigrationCursors for index=blog_2023, shard=2
Exception in thread "DocumentBulkAggregator-1" reactor.core.Exceptions$ReactorRejectedExecutionException: Scheduler unavailable
	at reactor.core.Exceptions.failWithRejected(Exceptions.java:285)
	at reactor.core.publisher.Operators.onRejectedExecution(Operators.java:1076)
	at reactor.core.publisher.FluxSubscribeOn$SubscribeOnSubscriber.requestUpstream(FluxSubscribeOn.java:142)
	at reactor.core.publisher.FluxSubscribeOn$SubscribeOnSubscriber.request(FluxSubscribeOn.java:175)
	at reactor.core.publisher.FluxDoFinally$DoFinallySubscriber.request(FluxDoFinally.java:140)
	at reactor.core.publisher.FluxUsing$UsingSubscriber.request(FluxUsing.java:170)
	at reactor.core.publisher.FluxPublishOn$PublishOnSubscriber.runAsync(FluxPublishOn.java:453)
	at reactor.core.publisher.FluxPublishOn$PublishOnSubscriber.run(FluxPublishOn.java:533)
	at reactor.core.scheduler.WorkerTask.call(WorkerTask.java:84)
	at reactor.core.scheduler.WorkerTask.call(WorkerTask.java:37)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at org.opensearch.migrations.bulkload.common.DocumentReindexer.lambda$reindex$1(DocumentReindexer.java:57)
	at java.base/java.lang.Thread.run(Thread.java:840)
Caused by: java.util.concurrent.RejectedExecutionException: Task java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask@5c23eb24[Not completed, task = reactor.core.scheduler.WorkerTask@581c64ff] rejected from BoundedScheduledExecutorService{IDLE, queued=0/unbounded, completed=4}
	at java.base/java.util.concurrent.ThreadPoolExecutor$AbortPolicy.rejectedExecution(ThreadPoolExecutor.java:2065)
	at java.base/java.util.concurrent.ThreadPoolExecutor.reject(ThreadPoolExecutor.java:833)
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor.delayedExecute(ScheduledThreadPoolExecutor.java:340)
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor.schedule(ScheduledThreadPoolExecutor.java:579)
	at reactor.core.scheduler.BoundedElasticScheduler$BoundedScheduledExecutorService.schedule(BoundedElasticScheduler.java:948)
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor.submit(ScheduledThreadPoolExecutor.java:731)
	at reactor.core.scheduler.BoundedElasticScheduler$BoundedScheduledExecutorService.submit(BoundedElasticScheduler.java:1024)
	at reactor.core.scheduler.Schedulers.workerSchedule(Schedulers.java:1445)
	at reactor.core.scheduler.ExecutorServiceWorker.schedule(ExecutorServiceWorker.java:50)
	at reactor.core.publisher.FluxSubscribeOn$SubscribeOnSubscriber.requestUpstream(FluxSubscribeOn.java:135)
	... 12 more
```

### Issues Resolved
<!-- List any GitHub or Jira issues this PR will resolve -->

### Testing
Run 1: https://github.com/opensearch-project/opensearch-migrations/actions/runs/16659592503/attempts/1?pr=1721
Run 2: https://github.com/opensearch-project/opensearch-migrations/actions/runs/16659592503/attempts/2?pr=1721
Run 3: https://github.com/opensearch-project/opensearch-migrations/actions/runs/16659592503/attempts/3?pr=1721
~Run 4: https://github.com/opensearch-project/opensearch-migrations/actions/runs/16659592503/attempts/4?pr=1721~ FAILED

### Check List
- [ ] New functionality includes testing
     - Unclear how to repro this in a unit test. I've opened up an issue on reactor's side for this
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
