### PR TITLE
Add automatic flattened to flat_object transformation

### DIFF
--- a/MetadataMigration/src/main/java/org/opensearch/migrations/MetadataTransformationRegistry.java
+++ b/MetadataMigration/src/main/java/org/opensearch/migrations/MetadataTransformationRegistry.java
@@ -1,6 +1,7 @@
 package org.opensearch.migrations;
 
 import java.util.List;
+import java.util.function.BiPredicate;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
@@ -35,55 +36,93 @@ public class MetadataTransformationRegistry {
     private static final List<TransformerConfigs> BAKED_IN_TRANSFORMER_CONFIGS = List.of(
         TransformerConfigs.builder()
             .filename("js/es-string-text-keyword-metadata.js")
-            .isRelevantForSourceVersion(UnboundVersionMatchers.isBelowES_6_X)
+            .isRelevantForVersions(andSourceTargetVersionPredicate(
+                UnboundVersionMatchers.isBelowES_6_X,
+                UnboundVersionMatchers.isBelowES_5_X.negate()
+            ))
             .transformerInfo(Transformers.TransformerInfo.builder()
                 .name("Field Data Type Deprecation - string")
-                .descriptionLine("Convert mapping type string to text/keyword based on field data mappings")
+                .descriptionLine("Convert field data type string to text/keyword")
                 .build())
             .build(),
         TransformerConfigs.builder()
             .filename("js/es-vector-knn-metadata.js")
-            .isRelevantForSourceVersion(UnboundVersionMatchers.isGreaterOrEqualES_7_X)
+            .isRelevantForVersions(andSourceTargetVersionPredicate(
+                    UnboundVersionMatchers.isGreaterOrEqualES_7_X,
+                    UnboundVersionMatchers.anyOS
+            ))
             .transformerInfo(Transformers.TransformerInfo.builder()
                 .name("dense_vector to knn_vector")
-                .descriptionLine("Convert mapping type dense_vector to OpenSearch knn_vector")
+                .descriptionLine("Convert field data type dense_vector to OpenSearch knn_vector")
+                .build())
+            .build(),
+        TransformerConfigs.builder()
+            .filename("js/metadataUpdater.js")
+            .context(
+                "{" +
+                "  \"rules\": [" +
+                "    {" +
+                "      \"when\": { \"type\": \"flattened\" }," +
+                "      \"set\": { \"type\": \"flat_object\" }," +
+                "      \"remove\": [\"index\"]" +
+                "    }" +
+                "  ]" +
+                "}")
+            .isRelevantForVersions(andSourceTargetVersionPredicate(
+                UnboundVersionMatchers.isGreaterOrEqualES_7_3,
+                UnboundVersionMatchers.equalOrGreaterThanOS_2_7
+            ))
+            .transformerInfo(Transformers.TransformerInfo.builder()
+                .name("flattened to flat_object")
+                .descriptionLine("Convert field data type flattened to OpenSearch flat_object")
                 .build())
             .build()
     );
 
+    private static BiPredicate<Version, Version> andSourceTargetVersionPredicate(
+        Predicate<Version> sourcePredicate,
+        Predicate<Version> targetPredicate
+    ) {
+        return (source, target) -> sourcePredicate.test(source) && targetPredicate.test(target);
+    }
 
     @Getter
     @Builder
     private static class TransformerConfigs {
         @NonNull private Transformers.TransformerInfo transformerInfo;
         @NonNull private String filename;
-        @NonNull private Predicate<Version> isRelevantForSourceVersion;
+        private String context;
+        @NonNull private BiPredicate<Version, Version> isRelevantForVersions;
     }
 
-    public static Transformers getCustomTransformationBySourceVersion(Version sourceVersion) {
+    public static Transformers getCustomTransformationByClusterVersions(Version sourceVersion, Version targetVersion) {
         var transformersBuilder = Transformers.builder();
         var bakedInTransformers = BAKED_IN_TRANSFORMER_CONFIGS
             .stream().filter(config ->
-                config.getIsRelevantForSourceVersion().test(sourceVersion))
+                config.isRelevantForVersions.test(sourceVersion, targetVersion))
             .toList();
         transformersBuilder.transformerInfos(bakedInTransformers.stream().map(TransformerConfigs::getTransformerInfo).collect(Collectors.toList()));
-        var config = getAggregateJSTransformer(bakedInTransformers.stream().map(TransformerConfigs::getFilename).toList());
+        var config = getAggregateJSTransformer(bakedInTransformers);
         logTransformerConfig("Default breaking changes transform config", config);
         transformersBuilder.transformer(configToTransformer(config));
         return transformersBuilder.build();
     }
 
-    private static String getAggregateJSTransformer(List<String> jsFilenames) {
-        return jsFilenames.isEmpty() ? NOOP_TRANSFORMATION_CONFIG :
-            jsFilenames.stream()
-                .map(filename ->
-                    "{" +
-                        "  \"JsonJSTransformerProvider\":{" +
-                        "    \"initializationResourcePath\":\"" + filename + "\"," +
-                        "    \"bindingsObject\":\"{}\"" +
-                        "  }" +
-                        "}")
+    private static String getAggregateJSTransformer(List<TransformerConfigs> transformerConfigs) {
+        return transformerConfigs.isEmpty() ? NOOP_TRANSFORMATION_CONFIG :
+            transformerConfigs.stream()
+                .map((config) -> getJSTransform(config.getFilename(), config.getContext()))
                 .collect(Collectors.joining(",", "[", "]"));
+    }
+
+    private static String getJSTransform(String filename, String context) {
+        var bindings = context == null ? "{}" : context.replace("\"", "\\\"");
+        return  "{" +
+            "  \"JsonJSTransformerProvider\":{" +
+            "    \"initializationResourcePath\":\"" + filename + "\"," +
+            "    \"bindingsObject\": \"" + bindings + "\"" +
+            "  }" +
+            "}";
     }
 
     public static Transformer configToTransformer(String config) {

--- a/MetadataMigration/src/main/java/org/opensearch/migrations/MetadataTransformationRegistry.java
+++ b/MetadataMigration/src/main/java/org/opensearch/migrations/MetadataTransformationRegistry.java
@@ -111,7 +111,7 @@ public class MetadataTransformationRegistry {
     private static String getAggregateJSTransformer(List<TransformerConfigs> transformerConfigs) {
         return transformerConfigs.isEmpty() ? NOOP_TRANSFORMATION_CONFIG :
             transformerConfigs.stream()
-                .map((config) -> getJSTransform(config.getFilename(), config.getContext()))
+                .map(config -> getJSTransform(config.getFilename(), config.getContext()))
                 .collect(Collectors.joining(",", "[", "]"));
     }
 

--- a/MetadataMigration/src/main/java/org/opensearch/migrations/commands/MigratorEvaluatorBase.java
+++ b/MetadataMigration/src/main/java/org/opensearch/migrations/commands/MigratorEvaluatorBase.java
@@ -52,8 +52,8 @@ public abstract class MigratorEvaluatorBase {
         return clusters.build();
     }
 
-    protected Transformers getCustomTransformer(Version sourceVersion) {
-        var versionSpecificCustomTransforms = MetadataTransformationRegistry.getCustomTransformationBySourceVersion(sourceVersion);
+    protected Transformers getCustomTransformer(Version sourceVersion, Version targetVersion) {
+        var versionSpecificCustomTransforms = MetadataTransformationRegistry.getCustomTransformationByClusterVersions(sourceVersion, targetVersion);
         var transformerConfig = TransformerConfigUtils.getTransformerConfig(arguments.metadataCustomTransformationParams);
         if (transformerConfig != null) {
             MetadataTransformationRegistry.logTransformerConfig("User supplied custom transform", transformerConfig);
@@ -82,7 +82,7 @@ public abstract class MigratorEvaluatorBase {
                 arguments.metadataTransformationParams,
                 allowLooseVersionMatches
         );
-        var customTransformer = getCustomTransformer(clusters.getSource().getVersion());
+        var customTransformer = getCustomTransformer(clusters.getSource().getVersion(), clusters.getTarget().getVersion());
         log.atInfo().setMessage("Selected transformer composite: custom = {}, version = {}")
                 .addArgument(customTransformer.getClass().getSimpleName())
                 .addArgument(versionTransformer.getClass().getSimpleName())

--- a/MetadataMigration/src/test/java/org/opensearch/migrations/ES7FlattenedMappingsTransformationTest.java
+++ b/MetadataMigration/src/test/java/org/opensearch/migrations/ES7FlattenedMappingsTransformationTest.java
@@ -9,6 +9,7 @@ import org.opensearch.migrations.snapshot.creation.tracing.SnapshotTestContext;
 
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -78,8 +79,11 @@ class ES7FlattenedMappingsTransformationTest extends BaseMigrationTest {
         log.info(result.asCliOutput());
         assertThat(result.getExitCode(), equalTo(0));
 
-        assertThat(result.getTransformations().getTransformerInfos().size(), equalTo(3));
-        assertThat(result.getTransformations().getTransformerInfos().get(1).getName(), equalTo("flattened to flat_object"));
+        var transformation = result.getTransformations().getTransformerInfos().stream()
+            .filter(t -> t.getName().contains("flattened"))
+            .findAny();
+        Assertions.assertTrue(transformation.isPresent());
+        Assertions.assertEquals("flattened to flat_object", transformation.get().getName());
 
         // Verify that the transformed index exists on the target cluster
         var res = targetOperations.get("/" + indexName);

--- a/MetadataMigration/src/test/java/org/opensearch/migrations/ES7FlattenedMappingsTransformationTest.java
+++ b/MetadataMigration/src/test/java/org/opensearch/migrations/ES7FlattenedMappingsTransformationTest.java
@@ -1,0 +1,91 @@
+package org.opensearch.migrations;
+
+import java.io.File;
+import java.util.stream.Stream;
+
+import org.opensearch.migrations.bulkload.framework.SearchClusterContainer;
+import org.opensearch.migrations.commands.MigrationItemResult;
+import org.opensearch.migrations.snapshot.creation.tracing.SnapshotTestContext;
+
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+
+@Tag("isolatedTest")
+@Slf4j
+class ES7FlattenedMappingsTransformationTest extends BaseMigrationTest {
+    @TempDir
+    protected File localDirectory;
+
+    private static Stream<Arguments> scenarios() {
+        var source = SearchClusterContainer.ES_V7_17;
+        var target = SearchClusterContainer.OS_LATEST;
+        return Stream.of(Arguments.of(source, target));
+    }
+
+    @ParameterizedTest(name = "Custom Transformation From {0} to {1}")
+    @MethodSource(value = "scenarios")
+    void customTransformationMetadataMigration(
+            SearchClusterContainer.ContainerVersion sourceVersion,
+            SearchClusterContainer.ContainerVersion targetVersion) {
+        try (
+                final var sourceCluster = new SearchClusterContainer(sourceVersion);
+                final var targetCluster = new SearchClusterContainer(targetVersion)
+        ) {
+            this.sourceCluster = sourceCluster;
+            this.targetCluster = targetCluster;
+            performCustomTransformationTest();
+        }
+    }
+
+    @SneakyThrows
+    private void performCustomTransformationTest() {
+        startClusters();
+
+        String requestBody = "{\n" +
+            "  \"mappings\": {\n" +
+            "    \"dynamic\": \"strict\",\n" +
+            "    \"properties\": {\n" +
+            "      \"flattened_data\": {\n" +
+            "        \"type\": \"flattened\"," +
+            "        \"index\": false" +
+            "      }\n" +
+            "    }\n" +
+            "  }\n" +
+            "}";
+        var indexName = "flattened";
+        sourceOperations.createIndex(indexName, requestBody);
+
+        var snapshotName = "custom_transformation_snap";
+        var testSnapshotContext = SnapshotTestContext.factory().noOtelTracking();
+        createSnapshot(sourceCluster, snapshotName, testSnapshotContext);
+        sourceCluster.copySnapshotData(localDirectory.toString());
+        var arguments = prepareSnapshotMigrationArgs(snapshotName, localDirectory.toString());
+
+        // Execute migration
+        MigrationItemResult result = executeMigration(arguments, MetadataCommands.MIGRATE);
+
+        // Verify the migration result
+        log.info(result.asCliOutput());
+        assertThat(result.getExitCode(), equalTo(0));
+
+        assertThat(result.getTransformations().getTransformerInfos().size(), equalTo(3));
+        assertThat(result.getTransformations().getTransformerInfos().get(1).getName(), equalTo("flattened to flat_object"));
+
+        // Verify that the transformed index exists on the target cluster
+        var res = targetOperations.get("/" + indexName);
+        assertThat(res.getKey(), equalTo(200));
+        assertThat(res.getValue(), containsString(indexName));
+        assertThat(res.getValue(), containsString("flat_object"));
+
+    }
+}

--- a/MetadataMigration/src/test/java/org/opensearch/migrations/ES8VectorFieldMappingsTransformationTest.java
+++ b/MetadataMigration/src/test/java/org/opensearch/migrations/ES8VectorFieldMappingsTransformationTest.java
@@ -9,6 +9,7 @@ import org.opensearch.migrations.snapshot.creation.tracing.SnapshotTestContext;
 
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -101,8 +102,11 @@ class ES8VectorFieldMappingsTransformationTest extends BaseMigrationTest {
         log.info(result.asCliOutput());
         assertThat(result.getExitCode(), equalTo(0));
 
-        assertThat(result.getTransformations().getTransformerInfos().size(), equalTo(2));
-        assertThat(result.getTransformations().getTransformerInfos().get(0).getName(), equalTo("dense_vector to knn_vector"));
+        var vectorTransformation = result.getTransformations().getTransformerInfos().stream()
+            .filter(t -> t.getName().contains("dense_vector"))
+            .findAny();
+        Assertions.assertTrue(vectorTransformation.isPresent());
+        Assertions.assertEquals("dense_vector to knn_vector", vectorTransformation.get().getName());
 
         // Verify that the transformed index exists on the target cluster
         var res = targetOperations.get("/" + indexName);

--- a/transformation/src/main/java/org/opensearch/migrations/UnboundVersionMatchers.java
+++ b/transformation/src/main/java/org/opensearch/migrations/UnboundVersionMatchers.java
@@ -16,8 +16,12 @@ public class UnboundVersionMatchers {
     public static final Predicate<Version> isBelowES_8_X = belowMajorVersion(Version.fromString("ES 8.0.0"));
     public static final Predicate<Version> isGreaterOrEqualES_6_X = greaterOrEqualMajorVersion(Version.fromString("ES 6.0.0"));
     public static final Predicate<Version> isGreaterOrEqualES_7_X = greaterOrEqualMajorVersion(Version.fromString("ES 7.0.0"));
+    public static final Predicate<Version> isGreaterOrEqualES_7_3 = greaterOrEqualMajorVersion(Version.fromString("ES 7.3.0"));
     public static final Predicate<Version> isGreaterOrEqualES_7_10 = greaterOrEqualMajorVersion(Version.fromString("ES 7.10.0"));
     public static final Predicate<Version> anyOS = VersionMatchers.matchesFlavor(Version.fromString("OS 1.0.0"));
+    public static final Predicate<Version> isGreaterOrEqualOS_3_x = greaterOrEqualMajorVersion(Version.fromString("OS 3.0.0"));
+    public static final Predicate<Version> equalOrGreaterThanOS_2_7 = VersionMatchers.equalOrGreaterThanMinorVersion(Version.fromString("OS 2.7.0"))
+        .or(isGreaterOrEqualOS_3_x);
 
     static Predicate<Version> belowMajorVersion(final Version version) {
         return other -> {

--- a/transformation/standardJavascriptTransforms/src/metadataUpdater.js
+++ b/transformation/standardJavascriptTransforms/src/metadataUpdater.js
@@ -18,7 +18,10 @@ function applyRules(node, rules) {
   if (Array.isArray(node)) {
     node.forEach((child) => applyRules(child, rules));
   } else if (node instanceof Map) {
-    for (const { when, set, remove = [] } of rules) {
+    for (const rule of rules) {
+      let when = rule.get("when");
+      let set = rule.get("set");
+      let remove = rule.get("remove") || [];
       applyRulesToMap(when, set, remove, node);
     }
     // recurse
@@ -35,7 +38,7 @@ function applyRules(node, rules) {
 }
 
 function main(context) {
-  if (!context.rules) {
+  if (!context.rules && !context.get("rules")) {
     throw Error(
       "Expected rules to be defined in the context.  Example: " +
         JSON.stringify(
@@ -44,6 +47,15 @@ function main(context) {
           2
         )
     );
+  }
+
+  if (context instanceof Map) {
+    return (doc) => {
+      if (doc && doc.type && doc.name && doc.body) {
+        applyRules(doc.body, context.get("rules"));
+      }
+      return doc;
+    };
   }
 
   return (doc) => {

--- a/transformation/standardJavascriptTransforms/src/metadataUpdater.js
+++ b/transformation/standardJavascriptTransforms/src/metadataUpdater.js
@@ -1,7 +1,7 @@
 function applyRulesToMap(when, set, remove, map) {
-  const matches = Object.entries(when).every(([k, v]) => map.get(k) === v);
+  const matches = [...when.entries()].every( ([k, v]) => map.get(k) === v);
   if (matches) {
-    Object.entries(set).every(([k, v]) => map.set(k, v));
+    [...set.entries()].every(([k, v]) => map.set(k, v));
     remove.forEach((key) => map.delete(key));
   }
 }

--- a/transformation/standardJavascriptTransforms/test/metadataUpdater.test.js
+++ b/transformation/standardJavascriptTransforms/test/metadataUpdater.test.js
@@ -192,7 +192,16 @@ describe("Metadata updater internals", () => {
   });
 
   test("Decomposes Maps", () => {
-    const updaterInstance = main(simpleConfig);
+    let simpleConfigMap = new Map([
+        [
+        "rules", Array.of(new Map( [
+            ["when", new Map([["a", 1]])],
+          ["set", new Map([["a", 2]])],
+          ["remove", Array.of("c")]
+      ]))]]
+    );
+
+    const updaterInstance = main(simpleConfigMap);
 
     const testObj = new Map([
       ["a", 1],


### PR DESCRIPTION
### Description
Add support to automatically resolve breaking change during ES 7.3+ to OS 2.7+ migrations by migrating `flattened` data type to flat_object https://docs.opensearch.org/latest/field-types/supported-field-types/flat-object/

### Issues Resolved
<!-- List any GitHub or Jira issues this PR will resolve -->

### Testing
Added test

### Check List
- [x] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
