### PR TITLE
Support automatic recovery during latch await interruption

### DIFF
--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/worker/DocumentsRunner.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/worker/DocumentsRunner.java
@@ -132,6 +132,7 @@ public class DocumentsRunner {
             // Clear any interrupt for next iteration of while loop
             boolean wasInterrupted = Thread.interrupted();
             assert wasInterrupted : "Expected thread interrupted if looping over latch.await()";
+            log.info("Retrying latch.await() after thread interruption.");
         }
 
     }


### PR DESCRIPTION
### Description
Support automatic recovery during latch await interruption

### Issues Resolved
https://opensearch.atlassian.net/browse/MIGRATIONS-2648
### Testing
<!-- Please provide details of testing done: unit testing, integration testing and manual testing -->

### Check List
- [ ] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
