### PR TITLE
Remove problematic `console --version` python test

### DIFF
--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/test_container_utils.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/test_container_utils.py
@@ -40,14 +40,3 @@ def test_version_file_missing(fake_home, caplog):
         result = get_version_str()
         assert result == f"{VERSION_PREFIX} unknown"
         assert "VERSION file not found" in caplog.text
-
-
-def test_version_file_unreadable(fake_home, caplog):
-    version_path = fake_home / "VERSION"
-    version_path.write_text("1.2.3")
-    version_path.chmod(0)  # Remove all permissions
-
-    with caplog.at_level("INFO"):
-        result = get_version_str()
-        assert result == f"{VERSION_PREFIX} unknown"
-        assert "Failed to read" in caplog.text


### PR DESCRIPTION
### Description
Remove recently added `console --version` test which can cause issues when ran in environments with different permission models

### Issues Resolved
N/A

### Testing
N/A

### Check List
- [ ] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
