### PR TITLE
Set request timeout and shorten connection timeout for rest client

### DIFF
--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/common/RestClient.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/common/RestClient.java
@@ -6,6 +6,7 @@ import javax.net.ssl.SSLParameters;
 
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -24,6 +25,7 @@ import org.opensearch.migrations.bulkload.tracing.IRfsContexts;
 
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelOption;
 import io.netty.channel.ChannelPipeline;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpHeaders;
@@ -49,6 +51,13 @@ public class RestClient {
 
     public static final String READ_METERING_HANDLER_NAME = "REST_CLIENT_READ_METERING_HANDLER";
     public static final String WRITE_METERING_HANDLER_NAME = "REST_CLIENT_WRITE_METERING_HANDLER";
+
+    // This allows us to control the max "staleness" that a request header/body may have been constructed versus sent
+    // This is important for worker coordination (upper bound on valid request of 15 seconds)
+    // and to a lesser degree SigV4 signed requests.
+    private static final Duration DEFAULT_CONNECT_TIMEOUT = Duration.ofSeconds(5);
+    // Longer than the default OpenSearch request timeout of 1 minute
+    private static final Duration DEFAULT_REQUEST_TIMEOUT = Duration.ofSeconds(65);
 
     private static final String USER_AGENT_HEADER_NAME = HttpHeaderNames.USER_AGENT.toString();
     private static final String CONTENT_TYPE_HEADER_NAME = HttpHeaderNames.CONTENT_TYPE.toString();
@@ -92,6 +101,8 @@ public class RestClient {
             .secure(sslProvider)
             .baseUrl(connectionContext.getUri().toString())
             .disableRetry(false) // Enable one retry on connection reset with no delay
+            .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, (int) DEFAULT_CONNECT_TIMEOUT.toMillis())
+            .responseTimeout(DEFAULT_REQUEST_TIMEOUT)
             .keepAlive(true);
     }
 


### PR DESCRIPTION
### Description

Reduce default RestClient connection and request timeout

We have seen some worker coordination client/server time out of sync. Upon investigation
this could occur during connection timeout issues since a reqeust could be delayed to be sent
until after a connection timesout (prior default 30s) which would cause a clock skew exception 
with the current value of 15 seconds. This change sets the value to 5 and further failure will delegate to 
the retry logic surrounding a call which would be able to reconstruct the request as needed.


Set request timeout and shorten connection timeout for rest client.
Prior default connection timeout is 30 seconds and prior to this PR there is no request timeout.
 
### Issues Resolved
<!-- List any GitHub or Jira issues this PR will resolve -->

### Testing
<!-- Please provide details of testing done: unit testing, integration testing and manual testing -->

### Check List
- [ ] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
