### PR TITLE
Remove duplicated ES 1.7.6 version from test suites

### DIFF
--- a/RFS/src/testFixtures/java/org/opensearch/migrations/bulkload/SupportedClusters.java
+++ b/RFS/src/testFixtures/java/org/opensearch/migrations/bulkload/SupportedClusters.java
@@ -61,8 +61,7 @@ public class SupportedClusters {
                 SearchClusterContainer.ES_V2_1,
                 SearchClusterContainer.ES_V2_0,
                 SearchClusterContainer.ES_V1_6,
-                SearchClusterContainer.ES_V1_5,
-                SearchClusterContainer.ES_V1_0
+                SearchClusterContainer.ES_V1_5
         );
     }
 

--- a/RFS/src/testFixtures/java/org/opensearch/migrations/bulkload/framework/SearchClusterContainer.java
+++ b/RFS/src/testFixtures/java/org/opensearch/migrations/bulkload/framework/SearchClusterContainer.java
@@ -115,7 +115,6 @@ public class SearchClusterContainer extends GenericContainer<SearchClusterContai
     public static final ContainerVersion ES_V1_7_6 = OlderElasticsearchVersion.fromTag("1.7.6");
     public static final ContainerVersion ES_V1_6 = OlderElasticsearchVersion.fromTag("1.6.2");
     public static final ContainerVersion ES_V1_5 = OlderElasticsearchVersion.fromTag("1.5.2");
-    public static final ContainerVersion ES_V1_0 = OlderElasticsearchVersion.fromTag("1");
 
     public static final ContainerVersion OS_V1_3_16 = OpenSearchVersion.fromTag("1.3.16");
     public static final ContainerVersion OS_V2_19_1 = OpenSearchVersion.fromTag("2.19.1");


### PR DESCRIPTION
### Description
From recent discussions, the docker container associated with our `SearchClusterContainer.ES_V1_0` had a simple docker image URL `elasticsearch:1`. Upon looking further, this version appeared to be a duplicate image of `SearchClusterContainer.ES_V1_7_6` which corresponds to docker image URL `elasticsearch:1.7.6`.

The duplicated docker image url also does not follow the consistent format of `<major>.<minor>.<patch>`. The best action here is to drop it from all of our testing scenarios.

### Issues Updated
[MIGRATIONS-2673](https://opensearch.atlassian.net/browse/MIGRATIONS-2673)
- this task now also includes the addition of ES 1.0.0

### Testing
This duplication was also confirmed when a simple `GET call` on `elasticsearch:1` resulted in 
```
...
"version" : {
    "number" : "1.7.6",
    ...
```

### Check List
- [x] New functionality includes testing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
