### PR TITLE
Bump com.gradleup.shadow from 8.3.8 -> 9.0.1

### DIFF
--- a/RFS/build.gradle
+++ b/RFS/build.gradle
@@ -16,6 +16,11 @@ configurations {
     lucene6
     lucene7
     lucene9
+    
+    all {
+        // Exclude problematic GraalVM js-community dependency
+        exclude group: 'org.graalvm.js', module: 'js-community'
+    }
 }
 
 task shadowLucene5(type: com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar) {

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
     id "com.diffplug.spotless" version '7.2.1'
     id 'io.freefair.lombok' version '8.14' apply false
     id 'me.champeau.jmh' version '0.7.3' apply false
-    id 'com.gradleup.shadow' version '8.3.8' apply false
+    id 'com.gradleup.shadow' version '9.0.1' apply false
     id 'com.avast.gradle.docker-compose' version "0.17.12" apply false
     id 'com.google.protobuf' version "0.9.5" apply false
     id 'com.google.cloud.tools.jib' version '3.4.5' apply false


### PR DESCRIPTION
### Description
Bump com.gradleup.shadow from 8.3.8 -> 9.0.1

### Check List
- [ ] ~New functionality includes testing~
- [ ] ~Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
