### PR TITLE
Add a check to the frontend to make sure that generated files are tracked or fails the build

### DIFF
--- a/frontend/build.gradle
+++ b/frontend/build.gradle
@@ -73,6 +73,19 @@ tasks.register('lintFrontend', NpmTask) {
     inputs.files fileTree(dir: '.', include: buildInputs, exclude: buildExclusions)
 }
 
+tasks.register('checkGeneratedFilesTracked', Exec) {
+    dependsOn 'buildFrontend'
+    group = 'check'
+    description = 'Verifies there are no untracked files in src/generated directory'
+    workingDir = project.projectDir
+    
+    // Using System.out and System.err is compatible with configuration cache
+    standardOutput = System.out
+    errorOutput = System.err
+    
+    commandLine 'bash', '-c', 'untrackedFiles=$(git ls-files --others --exclude-standard src/generated); if [ -n "$untrackedFiles" ]; then echo "Error: Untracked files found in src/generated:"; echo "$untrackedFiles"; exit 1; else echo "All generated files are tracked by git"; fi'
+}
+
 tasks.register('cleanFrontend', Delete) {
     delete buildOutputs
 }
@@ -104,4 +117,5 @@ The following is a list of npm commands to execute:
 
 assemble.dependsOn 'buildFrontend'
 check.dependsOn 'lintFrontend'
+check.dependsOn 'checkGeneratedFilesTracked'
 clean.dependsOn 'cleanFrontend'


### PR DESCRIPTION
### Description
Add a check to the frontend to make sure that generated files are tracked or fails the build

### Check List
- [X] New functionality includes testing
- [ ] ~Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
