### PR TITLE
feat(migration-assistant-solution/idmsv2): add IDMSv2 to instance launch template

### DIFF
--- a/deployment/migration-assistant-solution/lib/solutions-stack.ts
+++ b/deployment/migration-assistant-solution/lib/solutions-stack.ts
@@ -267,6 +267,7 @@ export class SolutionsInfrastructureStack extends Stack {
             initOptions: {
                 printLog: true,
             },
+            requireImdsv2: true,
             securityGroup
         });
 

--- a/deployment/migration-assistant-solution/test/solutions-stack.test.ts
+++ b/deployment/migration-assistant-solution/test/solutions-stack.test.ts
@@ -9,7 +9,7 @@ describe('Solutions stack', () => {
         solutionName: 'test-solution',
         solutionVersion: '0.0.1',
         codeBucket: 'test-bucket',
-        createVPC: true, 
+        createVPC: true,
         env: {
             region: 'us-west-1'
         }
@@ -66,6 +66,13 @@ describe('Solutions stack', () => {
         template.resourceCountIs('AWS::ServiceCatalogAppRegistry::Application', 1);
         template.hasResourceProperties('AWS::EC2::Instance', {
             InstanceType: "t3.large"
+        });
+        template.hasResourceProperties('AWS::EC2::LaunchTemplate', {
+            LaunchTemplateData: {
+                MetadataOptions: {
+                    HttpTokens: "required"
+                }
+            }
         });
     }
 });


### PR DESCRIPTION
IDMSv1 has been optional and sort of deprecated, while V2 is recommended.

This change adds IDMSv2 support via enforced tokens.

- Setting `requireImdsv2: true` in the `Instance` construct
- Yielding `AWS::EC2::LaunchTemplate` object to have `LaunchTemplateData/MetadataOptions/HttpTokens = required`
   at the generated Cloudformation Template output.

> P.S: Also added a relevant test to check existence of this property in the synthesised output.

### Description
<!-- Describe what this change achieves -->

### Issues Resolved
<!-- List any GitHub or Jira issues this PR will resolve -->

### Testing
<!-- Please provide details of testing done: unit testing, integration testing and manual testing -->

### Check List
- [x] New functionality includes testing
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
