### PR TITLE
Ignore dependabot upgrades for `com.gradleup.shadow`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,6 +33,7 @@ updates:
       - dependency-name: "org.apache.lucene:*"
       - dependency-name: "io.opentelemetry.semconv:*"
       - dependency-name: "io.netty:*"
+      - dependency-name: "com.gradleup.shadow:*"
       - dependency-name: "org.apache.commons:commons-compress"
         update-types:
           - "version-update:semver-major"


### PR DESCRIPTION
### Description
We are seeing errors with the latest version of the shadow build plugin we are using, see more details on the following PR.
- https://github.com/opensearch-project/opensearch-migrations/pull/1755

### Check List
- [ ] ~New functionality includes testing~
- [ ] ~Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
