### PR TITLE
[Bug] Update k8s pipelines to have consistent repo and branch default

### DIFF
--- a/jenkins/migrationIntegPipelines/elasticsearch5xK8sLocalTestCover.groovy
+++ b/jenkins/migrationIntegPipelines/elasticsearch5xK8sLocalTestCover.groovy
@@ -6,8 +6,5 @@ library identifier: "migrations-lib@${gitBranch}", retriever: modernSCM(
          remote: "${gitUrl}"])
 
 // Shared library function (location from root: vars/elasticsearch5xK8sLocalTest.groovy)
-elasticsearch5xK8sLocalTest(
-        gitUrl: gitUrl,
-        gitBranch: gitBranch
-)
+elasticsearch5xK8sLocalTest()
 

--- a/jenkins/migrationIntegPipelines/elasticsearch8xK8sLocalTestCover.groovy
+++ b/jenkins/migrationIntegPipelines/elasticsearch8xK8sLocalTestCover.groovy
@@ -6,7 +6,4 @@ library identifier: "migrations-lib@${gitBranch}", retriever: modernSCM(
          remote: "${gitUrl}"])
 
 // Shared library function (location from root: vars/elasticsearch8xK8sLocalTest.groovy)
-elasticsearch8xK8sLocalTest(
-    gitUrl: gitUrl,
-    gitBranch: gitBranch
-)
+elasticsearch8xK8sLocalTest()

--- a/vars/elasticsearch5xK8sLocalTest.groovy
+++ b/vars/elasticsearch5xK8sLocalTest.groovy
@@ -1,7 +1,5 @@
 def call(Map config = [:]) {
     k8sLocalDeployment(
-            gitUrl: config.gitUrl,
-            gitBranch: config.gitBranch,
             jobName: 'elasticsearch-5x-k8s-local-test',
             sourceVersion: 'ES_5.6',
             targetVersion: 'OS_2.19',

--- a/vars/elasticsearch8xK8sLocalTest.groovy
+++ b/vars/elasticsearch8xK8sLocalTest.groovy
@@ -1,9 +1,7 @@
 def call(Map config = [:]) {
     k8sLocalDeployment(
-            gitUrl: config.gitUrl,
-            gitBranch: config.gitBranch,
             jobName: 'elasticsearch-8x-k8s-local-test',
             sourceVersion: 'ES_8.x',
-            targetVersion: 'OS_2.x'
+            targetVersion: 'OS_2.19'
     )
 }

--- a/vars/k8sLocalDeployment.groovy
+++ b/vars/k8sLocalDeployment.groovy
@@ -15,8 +15,8 @@ def call(Map config = [:]) {
         agent { label config.workerAgent ?: 'Jenkins-Default-Agent-X64-C5xlarge-Single-Host' }
 
         parameters {
-            string(name: 'GIT_REPO_URL', defaultValue: "${gitDefaultUrl}", description: 'Git repository url')
-            string(name: 'GIT_BRANCH', defaultValue: "${gitDefaultBranch}", description: 'Git branch to use for repository')
+            string(name: 'GIT_REPO_URL', defaultValue: 'https://github.com/opensearch-project/opensearch-migrations.git', description: 'Git repository url')
+            string(name: 'GIT_BRANCH', defaultValue: 'main', description: 'Git branch to use for repository')
         }
 
         options {


### PR DESCRIPTION
### Description
Currently k8s Jenkins pipeline will set default repo url and branch to the latest run executed which will provide inconsistent hourly runs. This may not have been happening before as we have only recently started skipping the default checkout.

### Issues Resolved
N/A

### Testing
Jenkins testing

### Check List
- [ ] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
