### PR TITLE
Improve Developer UX with Argo Integration Tests

### DIFF
--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/cluster.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/cluster.py
@@ -111,6 +111,7 @@ class Cluster:
         if not v.validate({'cluster': config}):
             raise ValueError("Invalid config file for cluster", v.errors)
 
+        self.config = config
         self.endpoint = config["endpoint"]
         self.version = config.get("version", None)
         self.allow_insecure = config.get("allow_insecure", False) if self.endpoint.startswith(

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/cluster.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/cluster.py
@@ -97,6 +97,7 @@ class Cluster:
     An elasticcsearch or opensearch cluster.
     """
 
+    config: Dict
     endpoint: str = ""
     version: Optional[str] = None
     aws_secret_arn: Optional[str] = None

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/integ_test/integ_test/conftest.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/integ_test/integ_test/conftest.py
@@ -35,6 +35,8 @@ def pytest_addoption(parser):
     parser.addoption("--target_version", action="store", default=None)
     parser.addoption("--keep_workflows", action="store_true", default=False,
                      help="If set, will not delete Argo workflows created by tests")
+    parser.addoption("--reuse_clusters", action="store_true", default=False,
+                     help="If set, will reuse source and target clusters if they already exist")
     parser.addoption("--config_file_path", action="store", default="/config/migration_services.yaml",
                      help="Path to config file for console library")
     parser.addoption("--source_proxy_alb_endpoint", action="store", default=None,
@@ -58,6 +60,7 @@ def pytest_generate_tests(metafunc):
     if metafunc.function.__name__ == "test_migration_assistant_workflow":
         source_version = metafunc.config.getoption("source_version")
         target_version = metafunc.config.getoption("target_version")
+        reuse_clusters = metafunc.config.getoption("reuse_clusters")
         if not source_version or not target_version:
             raise ValueError("The migration_assistant_workflow test requires both a '--source_version' "
                              "and '--target_version' parameter")
@@ -65,7 +68,8 @@ def pytest_generate_tests(metafunc):
         metafunc.config.test_summary["source_version"] = source_version
         metafunc.config.test_summary["target_version"] = target_version
         test_ids_list = metafunc.config.getoption("test_ids")
-        test_cases_param = _generate_test_cases(source_version, target_version, unique_id, test_ids_list)
+        test_cases_param = _generate_test_cases(source_version, target_version, unique_id, test_ids_list,
+                                                reuse_clusters)
         metafunc.parametrize("test_case", test_cases_param)
 
 
@@ -79,14 +83,15 @@ def _filter_test_cases(test_ids_list: List[str]) -> List:
     return filtered_cases
 
 
-def _generate_test_cases(source_version: str, target_version: str, unique_id: str, test_ids_list: List[str]):
+def _generate_test_cases(source_version: str, target_version: str, unique_id: str, test_ids_list: List[str],
+                         reuse_clusters: bool):
     test_cases_to_run = []
     unsupported_test_cases = []
     cases = _filter_test_cases(test_ids_list)
     for test_case in cases:
         try:
             valid_case: MATestBase = test_case(source_version=source_version, target_version=target_version,
-                                               unique_id=unique_id)
+                                               unique_id=unique_id, reuse_clusters=reuse_clusters)
             test_cases_to_run.append(valid_case)
         except ClusterVersionCombinationUnsupported:
             unsupported_test_cases.append(test_case)

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/integ_test/integ_test/ma_workflow_test.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/integ_test/integ_test/ma_workflow_test.py
@@ -40,10 +40,17 @@ def test_migration_assistant_workflow(record_data, test_case: MATestBase):
     #breakpoint()
 
     test_case.test_before()
+    test_case.import_existing_clusters()
+    test_case.prepare_workflow_snapshot_and_migration_config()
     test_case.prepare_workflow_parameters()
+    # For imported clusters, we should load test data before the workflow starts as we will not
+    # set up clusters and suspend
+    if test_case.imported_clusters:
+        test_case.prepare_clusters()
     test_case.workflow_start()
     test_case.workflow_setup_clusters()
-    test_case.prepare_clusters()
+    if not test_case.imported_clusters:
+        test_case.prepare_clusters()
     test_case.workflow_perform_migrations()
     test_case.display_final_cluster_state()
     test_case.verify_clusters()

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/integ_test/integ_test/test_cases/backfill_tests.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/integ_test/integ_test/test_cases/backfill_tests.py
@@ -1,5 +1,5 @@
 import logging
-from ..cluster_version import ElasticsearchV5_X, ElasticsearchV8_X, OpensearchV2_X
+from ..cluster_version import ElasticsearchV5_X, ElasticsearchV7_X, ElasticsearchV8_X, OpensearchV1_X, OpensearchV2_X
 from .ma_argo_test_base import MATestBase, MigrationType
 
 logger = logging.getLogger(__name__)
@@ -20,7 +20,11 @@ full_indices = {
 class Test0006OpenSearchBenchmarkBackfill(MATestBase):
     def __init__(self, source_version: str, target_version: str, unique_id: str, reuse_clusters: bool):
         allow_combinations = [
+            (ElasticsearchV5_X, OpensearchV1_X),
             (ElasticsearchV5_X, OpensearchV2_X),
+            (ElasticsearchV7_X, OpensearchV1_X),
+            (ElasticsearchV7_X, OpensearchV2_X),
+            (ElasticsearchV8_X, OpensearchV1_X),
             (ElasticsearchV8_X, OpensearchV2_X),
         ]
         description = "Run OpenSearch Benchmark tests and then runs metadata and backfill."

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/integ_test/integ_test/test_cases/backfill_tests.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/integ_test/integ_test/test_cases/backfill_tests.py
@@ -1,6 +1,6 @@
 import logging
 from ..cluster_version import ElasticsearchV5_X, ElasticsearchV7_X, ElasticsearchV8_X, OpensearchV1_X, OpensearchV2_X
-from .ma_argo_test_base import MATestBase, MigrationType
+from .ma_argo_test_base import MATestBase, MigrationType, MATestUserArguments
 
 logger = logging.getLogger(__name__)
 full_indices = {
@@ -18,7 +18,7 @@ full_indices = {
 
 
 class Test0006OpenSearchBenchmarkBackfill(MATestBase):
-    def __init__(self, source_version: str, target_version: str, unique_id: str, reuse_clusters: bool):
+    def __init__(self, user_args: MATestUserArguments):
         allow_combinations = [
             (ElasticsearchV5_X, OpensearchV1_X),
             (ElasticsearchV5_X, OpensearchV2_X),
@@ -28,11 +28,8 @@ class Test0006OpenSearchBenchmarkBackfill(MATestBase):
             (ElasticsearchV8_X, OpensearchV2_X),
         ]
         description = "Run OpenSearch Benchmark tests and then runs metadata and backfill."
-        super().__init__(source_version=source_version,
-                         target_version=target_version,
-                         unique_id=unique_id,
+        super().__init__(user_args=user_args,
                          description=description,
-                         reuse_clusters=reuse_clusters,
                          allow_source_target_combinations=allow_combinations,
                          migrations_required=[MigrationType.BACKFILL, MigrationType.METADATA])
 

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/integ_test/integ_test/test_cases/backfill_tests.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/integ_test/integ_test/test_cases/backfill_tests.py
@@ -18,7 +18,7 @@ full_indices = {
 
 
 class Test0006OpenSearchBenchmarkBackfill(MATestBase):
-    def __init__(self, source_version: str, target_version: str, unique_id: str):
+    def __init__(self, source_version: str, target_version: str, unique_id: str, reuse_clusters: bool):
         allow_combinations = [
             (ElasticsearchV5_X, OpensearchV2_X),
             (ElasticsearchV8_X, OpensearchV2_X),
@@ -28,6 +28,7 @@ class Test0006OpenSearchBenchmarkBackfill(MATestBase):
                          target_version=target_version,
                          unique_id=unique_id,
                          description=description,
+                         reuse_clusters=reuse_clusters,
                          allow_source_target_combinations=allow_combinations,
                          migrations_required=[MigrationType.BACKFILL, MigrationType.METADATA])
 

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/integ_test/integ_test/test_cases/basic_tests.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/integ_test/integ_test/test_cases/basic_tests.py
@@ -1,5 +1,5 @@
 import logging
-from ..cluster_version import ElasticsearchV5_X, OpensearchV2_X
+from ..cluster_version import ElasticsearchV5_X, ElasticsearchV7_X, OpensearchV1_X, OpensearchV2_X
 from .ma_argo_test_base import MATestBase, MigrationType
 
 logger = logging.getLogger(__name__)
@@ -9,7 +9,10 @@ logger = logging.getLogger(__name__)
 class Test0001SingleDocumentBackfill(MATestBase):
     def __init__(self, source_version: str, target_version: str, unique_id: str, reuse_clusters: bool):
         allow_combinations = [
+            (ElasticsearchV5_X, OpensearchV1_X),
             (ElasticsearchV5_X, OpensearchV2_X),
+            (ElasticsearchV7_X, OpensearchV1_X),
+            (ElasticsearchV7_X, OpensearchV2_X),
         ]
         migrations_required = [MigrationType.BACKFILL]
         description = "Performs backfill migration for a single document."

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/integ_test/integ_test/test_cases/basic_tests.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/integ_test/integ_test/test_cases/basic_tests.py
@@ -7,7 +7,7 @@ logger = logging.getLogger(__name__)
 
 # This test case is subject to removal, as its value looks limited
 class Test0001SingleDocumentBackfill(MATestBase):
-    def __init__(self, source_version: str, target_version: str, unique_id: str):
+    def __init__(self, source_version: str, target_version: str, unique_id: str, reuse_clusters: bool):
         allow_combinations = [
             (ElasticsearchV5_X, OpensearchV2_X),
         ]
@@ -17,6 +17,7 @@ class Test0001SingleDocumentBackfill(MATestBase):
                          target_version=target_version,
                          unique_id=unique_id,
                          description=description,
+                         reuse_clusters=reuse_clusters,
                          migrations_required=migrations_required,
                          allow_source_target_combinations=allow_combinations)
         self.index_name = f"test_0001_{self.unique_id}"

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/integ_test/integ_test/test_cases/basic_tests.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/integ_test/integ_test/test_cases/basic_tests.py
@@ -1,13 +1,13 @@
 import logging
 from ..cluster_version import ElasticsearchV5_X, ElasticsearchV7_X, OpensearchV1_X, OpensearchV2_X
-from .ma_argo_test_base import MATestBase, MigrationType
+from .ma_argo_test_base import MATestBase, MigrationType, MATestUserArguments
 
 logger = logging.getLogger(__name__)
 
 
 # This test case is subject to removal, as its value looks limited
 class Test0001SingleDocumentBackfill(MATestBase):
-    def __init__(self, source_version: str, target_version: str, unique_id: str, reuse_clusters: bool):
+    def __init__(self, user_args: MATestUserArguments):
         allow_combinations = [
             (ElasticsearchV5_X, OpensearchV1_X),
             (ElasticsearchV5_X, OpensearchV2_X),
@@ -16,11 +16,8 @@ class Test0001SingleDocumentBackfill(MATestBase):
         ]
         migrations_required = [MigrationType.BACKFILL]
         description = "Performs backfill migration for a single document."
-        super().__init__(source_version=source_version,
-                         target_version=target_version,
-                         unique_id=unique_id,
+        super().__init__(user_args=user_args,
                          description=description,
-                         reuse_clusters=reuse_clusters,
                          migrations_required=migrations_required,
                          allow_source_target_combinations=allow_combinations)
         self.index_name = f"test_0001_{self.unique_id}"

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/integ_test/integ_test/test_cases/ma_argo_test_base.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/integ_test/integ_test/test_cases/ma_argo_test_base.py
@@ -2,7 +2,6 @@ from enum import Enum
 import logging
 import json
 
-from ..common_utils import check_ma_system_health
 from ..cluster_version import ClusterVersion, is_incoming_version_supported
 from ..operations_library_factory import get_operations_library_by_version
 
@@ -27,7 +26,7 @@ class MATestBase:
                  reuse_clusters=False, migrations_required=None, allow_source_target_combinations=None):
         self.allow_source_target_combinations = allow_source_target_combinations or []
         self.description = description
-        self.reuse_clusters=reuse_clusters
+        self.reuse_clusters = reuse_clusters
         self.migrations_required = migrations_required if migrations_required else [MigrationType.METADATA,
                                                                                     MigrationType.BACKFILL]
         self.source_version = ClusterVersion(version_str=source_version)
@@ -93,7 +92,6 @@ class MATestBase:
                 clear_indices(target_cluster)
                 self.target_operations.clear_index_templates(cluster=target_cluster)
 
-
     def prepare_workflow_snapshot_and_migration_config(self):
         snapshot_and_migration_configs = [{
             "migrations": [{
@@ -150,7 +148,6 @@ class MATestBase:
         else:
             self.argo_service.resume_workflow(workflow_name=self.workflow_name)
             self.argo_service.wait_for_suspend(workflow_name=self.workflow_name, timeout_seconds=timeout_seconds)
-
 
     def display_final_cluster_state(self):
         source_response = cat_indices(cluster=self.source_cluster).decode("utf-8")

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/integ_test/integ_test/test_cases/ma_argo_test_base.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/integ_test/integ_test/test_cases/ma_argo_test_base.py
@@ -2,21 +2,16 @@ from enum import Enum
 import logging
 import json
 
-#from ..common_utils import check_ma_system_health
+from ..common_utils import check_ma_system_health
 from ..cluster_version import ClusterVersion, is_incoming_version_supported
 from ..operations_library_factory import get_operations_library_by_version
 
 from console_link.models.argo_service import ArgoService
-from console_link.middleware.clusters import cat_indices
+from console_link.middleware.clusters import cat_indices, connection_check, clear_indices, ConnectionResult
 
 logger = logging.getLogger(__name__)
 
 MigrationType = Enum("MigrationType", ["METADATA", "BACKFILL", "CAPTURE_AND_REPLAY"])
-
-ARGO_CLUSTER_TEMPLATES = [
-    "elasticsearch-5-6-single-node",
-    "opensearch-2-19-single-node"
-]
 
 
 class ClusterVersionCombinationUnsupported(Exception):
@@ -29,9 +24,10 @@ class ClusterVersionCombinationUnsupported(Exception):
 
 class MATestBase:
     def __init__(self, source_version: str, target_version: str, unique_id: str, description: str,
-                 migrations_required=None, allow_source_target_combinations=None):
+                 reuse_clusters=False, migrations_required=None, allow_source_target_combinations=None):
         self.allow_source_target_combinations = allow_source_target_combinations or []
         self.description = description
+        self.reuse_clusters=reuse_clusters
         self.migrations_required = migrations_required if migrations_required else [MigrationType.METADATA,
                                                                                     MigrationType.BACKFILL]
         self.source_version = ClusterVersion(version_str=source_version)
@@ -40,6 +36,7 @@ class MATestBase:
         self.workflow_name = None
         self.source_cluster = None
         self.target_cluster = None
+        self.imported_clusters = False
 
         supported_combo = False
         for (allowed_source, allowed_target) in allow_source_target_combinations:
@@ -56,17 +53,10 @@ class MATestBase:
         self.target_argo_cluster_template = (f"{self.target_version.full_cluster_type}-"
                                              f"{self.target_version.major_version}-"
                                              f"{self.target_version.minor_version}-single-node")
-        if self.source_argo_cluster_template not in ARGO_CLUSTER_TEMPLATES:
-            raise ValueError(f"The provided source version: {source_version} does not match any of the "
-                             f"currently allowed Argo cluster templates: {ARGO_CLUSTER_TEMPLATES}")
-        if self.target_argo_cluster_template not in ARGO_CLUSTER_TEMPLATES:
-            raise ValueError(f"The provided target version: {target_version} does not match any of the "
-                             f"currently allowed Argo cluster templates: {ARGO_CLUSTER_TEMPLATES}")
 
-        self.parameters = {
-            "source-cluster-template": self.source_argo_cluster_template,
-            "target-cluster-template": self.target_argo_cluster_template
-        }
+        self.parameters = {}
+        self.workflow_template = "full-migration-with-clusters"
+        self.workflow_snapshot_and_migration_config = None
         self.source_operations = get_operations_library_by_version(self.source_version)
         self.target_operations = get_operations_library_by_version(self.target_version)
         self.unique_id = unique_id
@@ -75,11 +65,36 @@ class MATestBase:
         return f"<{self.__class__.__name__}(source={self.source_version},target={self.target_version})>"
 
     def test_before(self):
-        # TODO This should be enabled once the console API is enabled for this chart
         #check_ma_system_health()
         pass
 
-    def prepare_workflow_parameters(self):
+    def import_existing_clusters(self):
+        if self.reuse_clusters:
+            source_cluster = self.argo_service.get_cluster_from_configmap(f"source-"
+                                                                          f"{self.source_version.full_cluster_type}-"
+                                                                          f"{self.source_version.major_version}-"
+                                                                          f"{self.source_version.minor_version}")
+            target_cluster = self.argo_service.get_cluster_from_configmap(f"target-"
+                                                                          f"{self.target_version.full_cluster_type}-"
+                                                                          f"{self.target_version.major_version}-"
+                                                                          f"{self.target_version.minor_version}")
+            if not source_cluster or not target_cluster:
+                logger.info("Unable to locate an existing source and/or target cluster. Proceeding with creating these "
+                            "clusters as part of workflow, and skipping their deletion for reuse")
+            else:
+                self.imported_clusters = True
+                self.source_cluster = source_cluster
+                self.target_cluster = target_cluster
+                source_con_result: ConnectionResult = connection_check(source_cluster)
+                assert source_con_result.connection_established is True
+                target_con_result: ConnectionResult = connection_check(target_cluster)
+                assert target_con_result.connection_established is True
+                clear_indices(source_cluster)
+                clear_indices(target_cluster)
+                self.target_operations.clear_index_templates(cluster=target_cluster)
+
+
+    def prepare_workflow_snapshot_and_migration_config(self):
         snapshot_and_migration_configs = [{
             "migrations": [{
                 "metadata": {
@@ -90,14 +105,28 @@ class MATestBase:
                 }]
             }]
         }]
-        snapshot_and_migration_configs_str = json.dumps(
-            snapshot_and_migration_configs,
-            separators=(',', ':')
-        )
-        self.parameters["snapshot-and-migration-configs"] = snapshot_and_migration_configs_str
+        self.workflow_snapshot_and_migration_config = snapshot_and_migration_configs
+
+    def prepare_workflow_parameters(self):
+        # For existing clusters
+        if self.imported_clusters:
+            self.workflow_template = "full-migration"
+            source_migration_configs = [
+                {
+                    "source": self.source_cluster.config,
+                    "snapshot-and-migration-configs": self.workflow_snapshot_and_migration_config
+                }
+            ]
+            self.parameters["source-migration-configs"] = source_migration_configs
+            self.parameters["targets"] = json.dumps([self.target_cluster.config], separators=(',', ':'))
+        else:
+            self.parameters["snapshot-and-migration-configs"] = self.workflow_snapshot_and_migration_config
+            self.parameters["source-cluster-template"] = self.source_argo_cluster_template
+            self.parameters["target-cluster-template"] = self.target_argo_cluster_template
+            self.parameters["skip-cleanup"] = "true" if self.reuse_clusters else "false"
 
     def workflow_start(self):
-        start_result = self.argo_service.start_workflow(workflow_template_name="full-migration-with-clusters",
+        start_result = self.argo_service.start_workflow(workflow_template_name=self.workflow_template,
                                                         parameters=self.parameters)
         assert start_result.success is True
         self.workflow_name = start_result.value
@@ -105,9 +134,10 @@ class MATestBase:
     def workflow_setup_clusters(self):
         if not self.workflow_name:
             raise ValueError("Workflow name is not available, workflow may not have been started")
-        self.argo_service.wait_for_suspend(workflow_name=self.workflow_name, timeout_seconds=180)
-        self.source_cluster = self.argo_service.get_source_cluster_from_workflow(workflow_name=self.workflow_name)
-        self.target_cluster = self.argo_service.get_target_cluster_from_workflow(workflow_name=self.workflow_name)
+        if not self.imported_clusters:
+            self.argo_service.wait_for_suspend(workflow_name=self.workflow_name, timeout_seconds=180)
+            self.source_cluster = self.argo_service.get_source_cluster_from_workflow(workflow_name=self.workflow_name)
+            self.target_cluster = self.argo_service.get_target_cluster_from_workflow(workflow_name=self.workflow_name)
 
     def prepare_clusters(self):
         pass
@@ -115,12 +145,17 @@ class MATestBase:
     def workflow_perform_migrations(self, timeout_seconds: int = 180):
         if not self.workflow_name:
             raise ValueError("Workflow name is not available, workflow may not have been started")
-        self.argo_service.resume_workflow(workflow_name=self.workflow_name)
-        self.argo_service.wait_for_suspend(workflow_name=self.workflow_name, timeout_seconds=timeout_seconds)
+        if self.imported_clusters:
+            self.argo_service.wait_for_ending_phase(workflow_name=self.workflow_name, timeout_seconds=timeout_seconds)
+        else:
+            self.argo_service.resume_workflow(workflow_name=self.workflow_name)
+            self.argo_service.wait_for_suspend(workflow_name=self.workflow_name, timeout_seconds=timeout_seconds)
+
 
     def display_final_cluster_state(self):
         source_response = cat_indices(cluster=self.source_cluster).decode("utf-8")
         target_response = cat_indices(cluster=self.target_cluster).decode("utf-8")
+        logger.info("Printing document counts for source and target clusters:")
         print("SOURCE CLUSTER")
         print(source_response)
         print("TARGET CLUSTER")
@@ -132,8 +167,9 @@ class MATestBase:
     def workflow_finish(self):
         if not self.workflow_name:
             raise ValueError("Workflow name is not available, workflow may not have been started")
-        self.argo_service.resume_workflow(workflow_name=self.workflow_name)
-        self.argo_service.wait_for_ending_phase(workflow_name=self.workflow_name)
+        if not self.imported_clusters:
+            self.argo_service.resume_workflow(workflow_name=self.workflow_name)
+            self.argo_service.wait_for_ending_phase(workflow_name=self.workflow_name)
 
     def test_after(self):
         status_result = self.argo_service.get_workflow_status(workflow_name=self.workflow_name)

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/integ_test/integ_test/test_cases/ma_argo_test_base.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/integ_test/integ_test/test_cases/ma_argo_test_base.py
@@ -21,16 +21,24 @@ class ClusterVersionCombinationUnsupported(Exception):
         super().__init__(self.message)
 
 
+class MATestUserArguments:
+    def __init__(self, source_version: str, target_version: str, unique_id: str, reuse_clusters: bool):
+        self.source_version = source_version
+        self.target_version = target_version
+        self.unique_id = unique_id
+        self.reuse_clusters = reuse_clusters
+
+
 class MATestBase:
-    def __init__(self, source_version: str, target_version: str, unique_id: str, description: str,
-                 reuse_clusters=False, migrations_required=None, allow_source_target_combinations=None):
+    def __init__(self, user_args: MATestUserArguments, description: str, migrations_required=None,
+                 allow_source_target_combinations=None):
         self.allow_source_target_combinations = allow_source_target_combinations or []
         self.description = description
-        self.reuse_clusters = reuse_clusters
+        self.reuse_clusters = user_args.reuse_clusters
         self.migrations_required = migrations_required if migrations_required else [MigrationType.METADATA,
                                                                                     MigrationType.BACKFILL]
-        self.source_version = ClusterVersion(version_str=source_version)
-        self.target_version = ClusterVersion(version_str=target_version)
+        self.source_version = ClusterVersion(version_str=user_args.source_version)
+        self.target_version = ClusterVersion(version_str=user_args.target_version)
         self.argo_service = ArgoService()
         self.workflow_name = None
         self.source_cluster = None
@@ -58,7 +66,7 @@ class MATestBase:
         self.workflow_snapshot_and_migration_config = None
         self.source_operations = get_operations_library_by_version(self.source_version)
         self.target_operations = get_operations_library_by_version(self.target_version)
-        self.unique_id = unique_id
+        self.unique_id = user_args.unique_id
 
     def __repr__(self):
         return f"<{self.__class__.__name__}(source={self.source_version},target={self.target_version})>"

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/integ_test/integ_test/test_cases/multi_type_tests.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/integ_test/integ_test/test_cases/multi_type_tests.py
@@ -8,7 +8,7 @@ logger = logging.getLogger(__name__)
 
 
 class Test0004MultiTypeUnionMigration(MATestBase):
-    def __init__(self, source_version: str, target_version: str, unique_id: str):
+    def __init__(self, source_version: str, target_version: str, unique_id: str, reuse_clusters: bool):
         allow_combinations = [
             (ElasticsearchV5_X, OpensearchV1_X),
             (ElasticsearchV5_X, OpensearchV2_X),
@@ -18,6 +18,7 @@ class Test0004MultiTypeUnionMigration(MATestBase):
                          target_version=target_version,
                          unique_id=unique_id,
                          description=description,
+                         reuse_clusters=reuse_clusters,
                          allow_source_target_combinations=allow_combinations)
         self.index_name = f"test_0004_{self.unique_id}"
         self.doc_id1 = "test_0004_1"
@@ -37,7 +38,7 @@ class Test0004MultiTypeUnionMigration(MATestBase):
             'published_date': '2025-03-11T14:00:00Z'
         }
 
-    def prepare_workflow_parameters(self):
+    def prepare_workflow_snapshot_and_migration_config(self):
         union_transform = self.source_operations.get_type_mapping_union_transformation(
             multi_type_index_name=self.index_name,
             doc_type_1=self.doc_type1,
@@ -56,11 +57,7 @@ class Test0004MultiTypeUnionMigration(MATestBase):
                 }]
             }]
         }]
-        snapshot_and_migration_configs_str = json.dumps(
-            snapshot_and_migration_configs,
-            separators=(',', ':')
-        )
-        self.parameters["snapshot-and-migration-configs"] = snapshot_and_migration_configs_str
+        self.workflow_snapshot_and_migration_config = snapshot_and_migration_configs
 
     def prepare_clusters(self):
         # Create two documents each with a different type mapping for the same index
@@ -86,7 +83,7 @@ class Test0004MultiTypeUnionMigration(MATestBase):
 
 
 class Test0005MultiTypeSplitMigration(MATestBase):
-    def __init__(self, source_version: str, target_version: str, unique_id: str):
+    def __init__(self, source_version: str, target_version: str, unique_id: str, reuse_clusters: bool):
         allow_combinations = [
             (ElasticsearchV5_X, OpensearchV1_X),
             (ElasticsearchV5_X, OpensearchV2_X),
@@ -96,6 +93,7 @@ class Test0005MultiTypeSplitMigration(MATestBase):
                          target_version=target_version,
                          unique_id=unique_id,
                          description=description,
+                         reuse_clusters=reuse_clusters,
                          allow_source_target_combinations=allow_combinations)
         self.index_name = f"test_0005_{self.unique_id}"
         self.split_index_name1 = f"test_0005_split_1_{self.unique_id}"
@@ -117,7 +115,7 @@ class Test0005MultiTypeSplitMigration(MATestBase):
             'published_date': '2025-03-11T14:00:00Z'
         }
 
-    def prepare_workflow_parameters(self):
+    def prepare_workflow_snapshot_and_migration_config(self):
         split_transform = self.source_operations.get_type_mapping_split_transformation(
             multi_type_index_name=self.index_name,
             doc_type_1=self.doc_type1,
@@ -138,11 +136,7 @@ class Test0005MultiTypeSplitMigration(MATestBase):
                 }]
             }]
         }]
-        snapshot_and_migration_configs_str = json.dumps(
-            snapshot_and_migration_configs,
-            separators=(',', ':')
-        )
-        self.parameters["snapshot-and-migration-configs"] = snapshot_and_migration_configs_str
+        self.workflow_snapshot_and_migration_config = snapshot_and_migration_configs
 
     def prepare_clusters(self):
         # Create two documents each with a different type mapping for the same index

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/integ_test/integ_test/test_cases/multi_type_tests.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/integ_test/integ_test/test_cases/multi_type_tests.py
@@ -1,23 +1,20 @@
 import logging
 from ..common_utils import convert_to_b64
 from ..cluster_version import ElasticsearchV5_X, OpensearchV1_X, OpensearchV2_X
-from .ma_argo_test_base import MATestBase
+from .ma_argo_test_base import MATestBase, MATestUserArguments
 
 logger = logging.getLogger(__name__)
 
 
 class Test0004MultiTypeUnionMigration(MATestBase):
-    def __init__(self, source_version: str, target_version: str, unique_id: str, reuse_clusters: bool):
+    def __init__(self, user_args: MATestUserArguments):
         allow_combinations = [
             (ElasticsearchV5_X, OpensearchV1_X),
             (ElasticsearchV5_X, OpensearchV2_X),
         ]
         description = "Performs metadata and backfill migrations with a multi-type union transformation."
-        super().__init__(source_version=source_version,
-                         target_version=target_version,
-                         unique_id=unique_id,
+        super().__init__(user_args=user_args,
                          description=description,
-                         reuse_clusters=reuse_clusters,
                          allow_source_target_combinations=allow_combinations)
         self.index_name = f"test_0004_{self.unique_id}"
         self.doc_id1 = "test_0004_1"
@@ -82,17 +79,14 @@ class Test0004MultiTypeUnionMigration(MATestBase):
 
 
 class Test0005MultiTypeSplitMigration(MATestBase):
-    def __init__(self, source_version: str, target_version: str, unique_id: str, reuse_clusters: bool):
+    def __init__(self, user_args: MATestUserArguments):
         allow_combinations = [
             (ElasticsearchV5_X, OpensearchV1_X),
             (ElasticsearchV5_X, OpensearchV2_X),
         ]
         description = "Performs metadata and backfill migrations with a multi-type split transformation."
-        super().__init__(source_version=source_version,
-                         target_version=target_version,
-                         unique_id=unique_id,
+        super().__init__(user_args=user_args,
                          description=description,
-                         reuse_clusters=reuse_clusters,
                          allow_source_target_combinations=allow_combinations)
         self.index_name = f"test_0005_{self.unique_id}"
         self.split_index_name1 = f"test_0005_split_1_{self.unique_id}"

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/integ_test/integ_test/test_cases/multi_type_tests.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/integ_test/integ_test/test_cases/multi_type_tests.py
@@ -1,4 +1,3 @@
-import json
 import logging
 from ..common_utils import convert_to_b64
 from ..cluster_version import ElasticsearchV5_X, OpensearchV1_X, OpensearchV2_X

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/workflows/createClusterWorkflow.yaml
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/workflows/createClusterWorkflow.yaml
@@ -1,0 +1,14 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: create-cluster-
+spec:
+  workflowTemplateRef:
+    name: cluster-templates
+  entrypoint: elasticsearch-7-10-single-node
+  arguments:
+    parameters:
+      - name: cluster-name
+        value: "source-elasticsearch-7-10-test-cluster"
+      - name: namespace
+        value: "ma"

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/workflows/createFullMigrationWithClustersWorkflow.yaml
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/workflows/createFullMigrationWithClustersWorkflow.yaml
@@ -25,3 +25,5 @@ spec:
       - name: replayer-config
         value: |
           {"batchSize": 1000, "concurrency": 4}
+      - name: skip-cleanup
+        value: "false"

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/workflows/templates/clusterTemplates.yaml
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/workflows/templates/clusterTemplates.yaml
@@ -100,6 +100,199 @@ spec:
             valueFrom:
               path: /tmp/cluster-config.json
 
+    # Elasticsearch 7.10 Single Node Template
+    - name: elasticsearch-7-10-single-node
+      inputs:
+        parameters:
+          - name: cluster-name
+          - name: namespace
+      container:
+        image: dtzar/helm-kubectl:latest
+        command: [sh, -c]
+        args:
+          - |
+            # Add Elasticsearch Helm repository
+            helm repo add elastic https://helm.elastic.co
+            helm repo update
+            
+            cat > /tmp/elasticsearch.yml << EOF
+            network.host: 0.0.0.0
+            discovery.type: single-node
+            EOF
+            
+            cat > /tmp/es-values.yaml << 'EOF'
+            fullnameOverride: {{inputs.parameters.cluster-name}}
+            image: "docker.elastic.co/elasticsearch/elasticsearch-oss"
+            imageTag: "7.10.2"
+            antiAffinity: "soft"
+            esJavaOpts: "-Xmx128m -Xms128m"
+            protocol: "http"
+            replicas: 1
+            createCert: false
+            clusterHealthCheckParams: "wait_for_status=yellow&timeout=3s"
+            readinessProbe:
+              failureThreshold: 5
+              successThreshold: 2
+            extraEnvs:
+              - name: node.roles
+                value: "master,data,ingest"
+              - name: "cluster.initial_master_nodes"
+                value: ""
+              - name: "AWS_REGION"
+                value: "us-east-2"
+            
+              
+            persistence:
+              enabled: false
+            
+            extraInitContainers:
+              - name: install-s3-plugin
+                image: docker.elastic.co/elasticsearch/elasticsearch-oss:7.10.2
+                command: ["sh", "-c", "bin/elasticsearch-plugin install --batch repository-s3"]
+                volumeMounts:
+                  - name: plugins
+                    mountPath: /usr/share/elasticsearch/plugins
+              - name: inject-aws-creds
+                image: docker.elastic.co/elasticsearch/elasticsearch-oss:7.10.2
+                command:
+                  - sh
+                  - -c
+                  - |
+                    set -e
+                    echo "Creating Elasticsearch keystore and adding AWS credentials"
+                    echo 'y' | bin/elasticsearch-keystore create
+                    echo "test" | bin/elasticsearch-keystore add --stdin s3.client.default.access_key --force
+                    echo "test" | bin/elasticsearch-keystore add --stdin s3.client.default.secret_key --force
+                    # Copy keystore to shared volume location
+                    cp /usr/share/elasticsearch/config/elasticsearch.keystore /shared/elasticsearch.keystore
+                    echo "Keystore created and saved to shared volume"
+                volumeMounts:
+                  - name: elasticsearch-keystore
+                    mountPath: /shared
+                    
+            
+            extraVolumes:
+              - name: plugins
+                emptyDir: {}
+              - name: elasticsearch-keystore
+                emptyDir: {}
+            
+            extraVolumeMounts:
+              - name: plugins
+                mountPath: /usr/share/elasticsearch/plugins
+              - name: elasticsearch-keystore
+                mountPath: /usr/share/elasticsearch/config/elasticsearch.keystore
+                subPath: elasticsearch.keystore
+            EOF
+            
+            helm install {{inputs.parameters.cluster-name}} elastic/elasticsearch \
+              --version 8.5.1 \
+              --namespace {{inputs.parameters.namespace}} \
+              --values /tmp/es-values.yaml \
+              --set-file esConfig."elasticsearch\.yml"=/tmp/elasticsearch.yml
+            
+            # Generate cluster configuration output
+            cat > /tmp/cluster-config.json << EOF
+            {
+              "endpoint": "http://{{inputs.parameters.cluster-name}}:9200",
+              "allow_insecure": true,
+              "no_auth": null,
+              "version": "ES_7.10"
+            }
+            EOF
+
+            kubectl create configmap {{inputs.parameters.cluster-name}}-migration-config \
+              --from-file=cluster-config=/tmp/cluster-config.json \
+              --namespace {{inputs.parameters.namespace}}
+            
+            echo "Elasticsearch 7.10 cluster"
+            echo "Cluster config:"
+            cat /tmp/cluster-config.json
+      outputs:
+        parameters:
+          - name: cluster-config
+            valueFrom:
+              path: /tmp/cluster-config.json
+
+    # OpenSearch 1.3 Single Node Template
+    - name: opensearch-1-3-single-node
+      inputs:
+        parameters:
+          - name: cluster-name
+          - name: namespace
+      container:
+        image: dtzar/helm-kubectl:latest
+        command: [sh, -c]
+        args:
+          - |
+            # Add OpenSearch Helm repository
+            helm repo add opensearch https://opensearch-project.github.io/helm-charts/
+            helm repo update
+            
+            # Create OpenSearch configuration
+            cat > /tmp/opensearch.yml << EOF
+            cluster.name: {{inputs.parameters.cluster-name}}
+            network.host: 0.0.0.0
+            discovery.type: single-node
+            EOF
+            
+            # Create OpenSearch values file
+            cat > /tmp/opensearch-values.yaml << 'EOF'
+            fullnameOverride: {{inputs.parameters.cluster-name}}
+            nodeGroup: ""
+            image:
+              repository: "opensearchproject/opensearch"
+              tag: "1.3.20"
+            singleNode: true
+            replicas: 1
+            resources:
+              requests:
+                cpu: "500m"
+                memory: "1Gi"
+              limits:
+                cpu: "1000m"
+                memory: "2Gi"
+            persistence:
+              enabled: false
+            opensearchJavaOpts: "-Xmx1g -Xms1g"
+            plugins:
+              enabled: true
+              installList:
+                - "repository-s3"
+            EOF
+            
+            # Install OpenSearch 1.3
+            helm install {{inputs.parameters.cluster-name}} opensearch/opensearch \
+              --namespace {{inputs.parameters.namespace}} \
+              --values /tmp/opensearch-values.yaml \
+              --set-file config."opensearch\.yml"=/tmp/opensearch.yml
+            
+            # Generate cluster configuration output
+            cat > /tmp/cluster-config.json << EOF
+            {
+              "endpoint": "https://{{inputs.parameters.cluster-name}}:9200",
+              "allow_insecure": true,
+              "version": "OS_1.3",
+              "basic_auth": {
+                "username": "admin",
+                "password": "admin"
+              }
+            }
+            EOF
+
+            kubectl create configmap {{inputs.parameters.cluster-name}}-migration-config \
+              --from-file=cluster-config=/tmp/cluster-config.json \
+              --namespace {{inputs.parameters.namespace}}
+            
+            echo "OpenSearch 1.3 cluster created successfully"
+            echo "Cluster config:"
+            cat /tmp/cluster-config.json
+      outputs:
+        parameters:
+          - name: cluster-config
+            valueFrom:
+              path: /tmp/cluster-config.json
+
     # OpenSearch 2.19 Single Node Template
     - name: opensearch-2-19-single-node
       inputs:

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/workflows/templates/clusterTemplates.yaml
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/workflows/templates/clusterTemplates.yaml
@@ -13,7 +13,7 @@ spec:
           - name: cluster-name
           - name: namespace
       container:
-        image: alpine/helm:latest
+        image: dtzar/helm-kubectl:latest
         command: [sh, -c]
         args:
           - |
@@ -86,6 +86,10 @@ spec:
               "version": "ES_5.6"
             }
             EOF
+
+            kubectl create configmap {{inputs.parameters.cluster-name}}-migration-config \
+              --from-file=cluster-config=/tmp/cluster-config.json \
+              --namespace {{inputs.parameters.namespace}}
             
             echo "Elasticsearch 5.6.16 cluster"
             echo "Cluster config:"
@@ -103,7 +107,7 @@ spec:
           - name: cluster-name
           - name: namespace
       container:
-        image: alpine/helm:latest
+        image: dtzar/helm-kubectl:latest
         command: [sh, -c]
         args:
           - |
@@ -164,6 +168,10 @@ spec:
               }
             }
             EOF
+
+            kubectl create configmap {{inputs.parameters.cluster-name}}-migration-config \
+              --from-file=cluster-config=/tmp/cluster-config.json \
+              --namespace {{inputs.parameters.namespace}}
             
             echo "OpenSearch 2.19.1 cluster created successfully"
             echo "Cluster config:"

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/workflows/templates/clusterTemplates.yaml
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/workflows/templates/clusterTemplates.yaml
@@ -37,7 +37,7 @@ spec:
             image: "docker.elastic.co/elasticsearch/elasticsearch"
             imageTag: "5.6.16"
             antiAffinity: "soft"
-            esJavaOpts: "-Xmx128m -Xms128m"
+            esJavaOpts: "-Xmx512m -Xms512m"
             protocol: "http"
             replicas: 1
             createCert: false
@@ -125,7 +125,7 @@ spec:
             image: "docker.elastic.co/elasticsearch/elasticsearch-oss"
             imageTag: "7.10.2"
             antiAffinity: "soft"
-            esJavaOpts: "-Xmx128m -Xms128m"
+            esJavaOpts: "-Xmx512m -Xms512m"
             protocol: "http"
             replicas: 1
             createCert: false

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/workflows/templates/fullMigration.yaml
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/workflows/templates/fullMigration.yaml
@@ -469,15 +469,16 @@ spec:
                   value: "{{=fromJSON(inputs.parameters['image-config'])['etcd-utils']['image']}}"
                 - name: etcd-utils-pull-policy
                   value: "{{=fromJSON(inputs.parameters['image-config'])['etcd-utils']['pull-policy']}}"
-        - - name: run-replayer-for-target
-            template: run-replayer-for-target
-            when: "{{steps.target-backfill-complete-check.outputs.parameters.should-finalize}} == true"
-            arguments:
-              parameters:
-                - name: target-config
-                  value: "{{inputs.parameters.target-config}}"
-                - name: image-config
-                  value: "{{inputs.parameters.image-config}}"
+        # Enable once Replay support has been added
+        # - - name: run-replayer-for-target
+        #     template: run-replayer-for-target
+        #     when: "{{steps.target-backfill-complete-check.outputs.parameters.should-finalize}} == true"
+        #     arguments:
+        #       parameters:
+        #         - name: target-config
+        #           value: "{{inputs.parameters.target-config}}"
+        #         - name: image-config
+        #           value: "{{inputs.parameters.image-config}}"
 
     # This is where we'd start running live-replay
     - name: run-replayer-for-target

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/workflows/templates/fullMigration.yaml
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/workflows/templates/fullMigration.yaml
@@ -469,7 +469,7 @@ spec:
                   value: "{{=fromJSON(inputs.parameters['image-config'])['etcd-utils']['image']}}"
                 - name: etcd-utils-pull-policy
                   value: "{{=fromJSON(inputs.parameters['image-config'])['etcd-utils']['pull-policy']}}"
-        # Enable once Replay support has been added
+        # Enable once Capture and Replay support has been added: https://opensearch.atlassian.net/browse/MIGRATIONS-2607
         # - - name: run-replayer-for-target
         #     template: run-replayer-for-target
         #     when: "{{steps.target-backfill-complete-check.outputs.parameters.should-finalize}} == true"
@@ -480,7 +480,6 @@ spec:
         #         - name: image-config
         #           value: "{{inputs.parameters.image-config}}"
 
-    # This is where we'd start running live-replay
     - name: run-replayer-for-target
       inputs:
         parameters:

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/workflows/templates/fullMigrationWithClusters.yaml
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/workflows/templates/fullMigrationWithClusters.yaml
@@ -4,7 +4,7 @@ metadata:
   name: full-migration-with-clusters
 spec:
   serviceAccountName: argo-workflow-executor
-  onExit: cleanup-all-clusters
+  onExit: conditional-cleanup
   entrypoint: main
   parallelism: 100
 
@@ -31,6 +31,8 @@ spec:
       - name: replayer-config
         value: |
           {"batchSize": 1000, "concurrency": 4}
+      - name: skip-cleanup
+        value: "false"
       # Any references to workflow.parameters must come from top level workflow
       - name: etcd-endpoints
         value: "http://etcd.ma.svc.cluster.local:2379"
@@ -124,7 +126,6 @@ spec:
                 - name: targets
                   value: "{{steps.generate-migration-configs.outputs.parameters.targets}}"
         
-        # Pause for integration test migration verification
         - - name: pause-for-migration-verification
             template: suspend-step
 
@@ -211,13 +212,20 @@ spec:
                 '[' + inputs.parameters['target-config'] + ']'
       steps: [[]]  # no-op
 
-    # Cleanup template that always runs on exit (success or failure)
+    - name: conditional-cleanup
+      steps:
+        - - name: check-cleanup-needed
+            template: cleanup-all-clusters
+            when: "{{workflow.parameters.skip-cleanup}} != true"
+
     - name: cleanup-all-clusters
       container:
-        image: alpine/helm:latest
+        image: dtzar/helm-kubectl:latest
         command: [sh, -c]
         args:
           - |
+            echo "Starting cluster cleanup process..."
+            
             # Regenerate the same cluster names using workflow UID and template names
             SUFFIX=$(echo "{{workflow.uid}}" | cut -c1-8)
             
@@ -236,6 +244,9 @@ spec:
             helm uninstall ${SOURCE_CLUSTER_NAME} \
               --namespace {{workflow.parameters.cluster-namespace}} \
               --ignore-not-found || true
+
+            echo "Removing source cluster configmap"
+            kubectl delete configmap ${SOURCE_CLUSTER_NAME}-migration-config
             
             # Cleanup target cluster  
             echo "Uninstalling target cluster: ${TARGET_CLUSTER_NAME}"
@@ -243,4 +254,7 @@ spec:
               --namespace {{workflow.parameters.cluster-namespace}} \
               --ignore-not-found || true
             
-            echo "Cluster cleanup completed"
+            echo "Removing target cluster configmap"
+            kubectl delete configmap ${TARGET_CLUSTER_NAME}-migration-config
+            
+            echo "Cluster cleanup completed successfully"

--- a/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/templates/resources/migrationConsole.yaml
+++ b/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/templates/resources/migrationConsole.yaml
@@ -70,7 +70,7 @@ spec:
     {{- if .Values.developerModeEnabled }}
               source /.venv/bin/activate && pipenv install -e ~/lib/console_link
     {{- end }}
-              tail -f /dev/null
+              /root/start-console.sh
           volumeMounts:
     {{- if $sharedLogsVolumeEnabled }}
             - name: shared-logs

--- a/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/values.yaml
+++ b/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/values.yaml
@@ -54,6 +54,7 @@ aws:
   account: "123456789012"
 
 stageName: dev
+developerModeEnabled: false
 
 defaultBucketConfiguration:
   create: true

--- a/libraries/testAutomation/README.md
+++ b/libraries/testAutomation/README.md
@@ -17,10 +17,15 @@ pipenv run app
 
 Or alternatively specific versions for the source and target cluster can be specified, which will result in executing tests against this specific version combination:
 ```shell
-pipenv run app --source-version=ES_8.x --target-version=OS_2.x
+pipenv run app --source-version=ES_5.6 --target-version=OS_2.19
 ```
 
 Or to execute a specific test
 ```shell
 pipenv run app --test-ids=0004
+```
+
+For development testing, it is often convenient to reuse an existing set of clusters and keep the Migration Assistant helm chart installed between executions. The `--dev` flag is an aggregate flag that achieves this by enabling the following flags `[--skip-delete, --reuse-clusters, --keep-workflows, --developer-mode]`. This command can then be run repeatedly for faster executions.
+```shell
+pipenv run app --dev --source-version=ES_5.6 --target-version=OS_2.19 --test-ids=0001
 ```

--- a/libraries/testAutomation/testAutomation/k8s_service.py
+++ b/libraries/testAutomation/testAutomation/k8s_service.py
@@ -4,9 +4,10 @@ from kubernetes import client, config, stream
 from kubernetes.client import V1Pod
 from kubernetes.stream.ws_client import WSClient
 import logging
+import shlex
 import subprocess
 import time
-from typing import List
+from typing import Dict, List
 
 logging.basicConfig(format='%(asctime)s [%(levelname)s] %(message)s', level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -181,7 +182,7 @@ class K8sService:
         return self.run_command(command)
 
     def helm_install(self, chart_path: str, release_name: str,
-                     values_file: str = None) -> CompletedProcess | bool:
+                     values_file: str = None, values: Dict[str, str] = None) -> CompletedProcess | bool:
         helm_release_exists = self.check_helm_release_exists(release_name=release_name)
         if helm_release_exists:
             logger.info(f"Helm release {release_name} already exists, skipping install")
@@ -190,6 +191,9 @@ class K8sService:
         command = ["helm", "install", release_name, chart_path, "-n", self.namespace, "--create-namespace"]
         if values_file:
             command.extend(["-f", values_file])
+        if values:
+            for key, value in values.items():
+                command.extend(["--set", f"{key}={shlex.quote(str(value))}"])
         return self.run_command(command)
 
     def helm_uninstall(self, release_name: str) -> CompletedProcess | bool:
@@ -200,3 +204,60 @@ class K8sService:
 
         logger.info(f"Uninstalling {release_name}...")
         return self.run_command(["helm", "uninstall", release_name, "-n", self.namespace])
+
+    def get_helm_installations(self) -> List[str]:
+        target_namespace = self.namespace
+        # Use helm list with short output format to get just the release names
+        command = ["helm", "list", "-n", target_namespace, "--short"]
+        
+        try:
+            result = self.run_command(command)
+            if result and result.stdout:
+                # Split the output by lines and filter out empty lines
+                release_names = [line.strip() for line in result.stdout.strip().split('\n') if line.strip()]
+                logger.info(f"Found {len(release_names)} helm installations in "
+                            f"namespace '{target_namespace}': {release_names}")
+                return release_names
+            else:
+                logger.info(f"No helm installations found in namespace '{target_namespace}'")
+                return []
+        except subprocess.CalledProcessError as e:
+            logger.error(f"Failed to list helm installations in namespace '{target_namespace}': {e.stderr}")
+            raise HelmCommandFailed(f"Helm list command failed: {e.stderr}")
+
+    def get_configmaps(self) -> List[str]:
+        target_namespace = self.namespace
+        # Use kubectl get configmaps to get just the ConfigMap names
+        command = ["kubectl", "get", "configmaps", "-n", target_namespace, "--no-headers", "-o",
+                   "custom-columns=:metadata.name"]
+        
+        try:
+            result = self.run_command(command)
+            if result and result.stdout:
+                # Split the output by lines and filter out empty lines
+                configmap_names = [line.strip() for line in result.stdout.strip().split('\n') if line.strip()]
+                logger.info(f"Found {len(configmap_names)} ConfigMaps in "
+                            f"namespace '{target_namespace}': {configmap_names}")
+                return configmap_names
+            else:
+                logger.info(f"No ConfigMaps found in namespace '{target_namespace}'")
+                return []
+        except subprocess.CalledProcessError as e:
+            logger.error(f"Failed to list ConfigMaps in namespace '{target_namespace}': {e.stderr}")
+            raise subprocess.CalledProcessError(e.returncode, e.cmd, e.stderr)
+
+    def delete_configmap(self, configmap_name: str) -> CompletedProcess | bool:
+        target_namespace = self.namespace
+        
+        # Check if ConfigMap exists first
+        check_command = ["kubectl", "get", "configmap", configmap_name, "-n", target_namespace, "--ignore-not-found"]
+        check_result = self.run_command(check_command, ignore_errors=True)
+        
+        if not check_result or not check_result.stdout.strip():
+            logger.info(f"ConfigMap '{configmap_name}' doesn't exist in namespace '{target_namespace}', "
+                        f"skipping delete")
+            return True
+        
+        logger.info(f"Deleting ConfigMap '{configmap_name}' from namespace '{target_namespace}'...")
+        delete_command = ["kubectl", "delete", "configmap", configmap_name, "-n", target_namespace]
+        return self.run_command(delete_command)

--- a/libraries/testAutomation/testAutomation/test_runner.py
+++ b/libraries/testAutomation/testAutomation/test_runner.py
@@ -14,8 +14,8 @@ from typing import List, Optional, Tuple
 logging.basicConfig(format='%(asctime)s [%(levelname)s] %(message)s', level=logging.INFO)
 logger = logging.getLogger(__name__)
 
-VALID_SOURCE_VERSIONS = ["ES_5.6"]
-VALID_TARGET_VERSIONS = ["OS_2.19"]
+VALID_SOURCE_VERSIONS = ["ES_5.6", "ES_7.10"]
+VALID_TARGET_VERSIONS = ["OS_1.3", "OS_2.19"]
 MA_RELEASE_NAME = "ma"
 
 


### PR DESCRIPTION
### Description
Focus of this change was adding the ability to reuse clusters in the Argo integ test suite that is triggered by the testAutomation library. I went through a few iterations of adding this functionality with the least complexity. I am not pleased with some of the conditional logic the `MATestBase` currently has but preferred this for the time being after seeing some of the complexity/difficulty of trying to weave this conditional logic into the workflow file itself (I'm hopeful the Typescript DSL would make this much easier). A next iteration here could benefit from having a workflow step that calls some python logic to see if a cluster exists or otherwise creates the cluster, and always outputs the config to make things simpler.

As noted in the README, a command like the following, could be used when developing to reuse clusters across multiple executions
```shell
pipenv run app --dev --source-version=ES_5.6 --target-version=OS_2.19 --test-ids=0001
```

Additional changes this PR adds
* Modifies Argo Helm chart to enable the API server for the migration console
* Adds ability to enable migration console developer mode automatically when running testAutomation
* Adds ES_7.10 as another source for the integ tests
* Adds OS_1.3 as another target for the integ tests

### Issues Resolved
https://opensearch.atlassian.net/browse/MIGRATIONS-2687

### Testing
Local deployment and integration test runs

### Check List
- [ ] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
