### PR TITLE
Support longer boostraps in jenkins before failing

### DIFF
--- a/test/awsRunInitBootstrap.sh
+++ b/test/awsRunInitBootstrap.sh
@@ -162,7 +162,7 @@ instance_id=$(get_instance_id)
 check_ssm_ready "$instance_id"
 init_command="cd /opensearch-migrations && ./initBootstrap.sh"
 verify_command="cdk --version && docker --version && java --version && python3 --version"
-init_command_timeout="2100" # 35 minutes
+init_command_timeout="3300" # 50 minutes
 verify_command_timeout="300" # 5 minutes
 if [ "$WORKFLOW" = "ALL" ]; then
   execute_command_and_wait_for_result "$init_command" "$instance_id" "$init_command_timeout"


### PR DESCRIPTION
### Description
Fix some timeouts observed by increasing the overall timeout to 2 hours
https://migrations.ci.opensearch.org/job/solutions-cfn-create-vpc-test/6855/
