### PR TITLE
Update java-common-conventions to override versions on all classpaths…

### DIFF
--- a/buildSrc/src/main/groovy/org.opensearch.migrations.java-common-conventions.gradle
+++ b/buildSrc/src/main/groovy/org.opensearch.migrations.java-common-conventions.gradle
@@ -21,21 +21,24 @@ configurations.configureEach {
     resolutionStrategy.preferProjectModules()
 }
 
+// Extend resolvable *classpath* configs (excluding lucene ones)
 configurations {
-    // private bucket for BOMs / constraints
     enforcedAlignment {
         canBeResolved = false
         canBeConsumed = false
         visible = false
     }
-    // make classpaths inherit it (compile, runtime, tests, fixtures if used)
-    compileClasspath.extendsFrom(enforcedAlignment)
-    runtimeClasspath.extendsFrom(enforcedAlignment)
-    testCompileClasspath.extendsFrom(enforcedAlignment)
-    testRuntimeClasspath.extendsFrom(enforcedAlignment)
-    testFixturesCompileClasspath.extendsFrom(enforcedAlignment)
-    testFixturesRuntimeClasspath.extendsFrom(enforcedAlignment)
-    annotationProcessor.extendsFrom(enforcedAlignment)
+
+    configureEach {
+        if (
+            name != "enforcedAlignment" &&
+            canBeResolved && !canBeConsumed &&
+            (name.toLowerCase().endsWith("classpath") || name == "annotationProcessor") &&
+            !name.toLowerCase().contains("lucene")
+        ) {
+            extendsFrom(enforcedAlignment)
+        }
+    }
 }
 
 dependencies {


### PR DESCRIPTION
… including jmhCompileClasspath which was missing before.

Verified with before and after of ./gradlew :RFS:dependencyInsight   --configuration jmhCompileClasspath   --dependency io.netty:netty-codec-http2

### Check List
- [ ] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
