### PR TITLE
Update Capture Proxy to OS 2.19.3 for security plugin usage

### DIFF
--- a/TrafficCapture/trafficCaptureProxyServer/build.gradle
+++ b/TrafficCapture/trafficCaptureProxyServer/build.gradle
@@ -14,7 +14,7 @@ configurations {
 }
 
 dependencies {
-    def openSearch = '2.11.1'
+    def openSearch = '2.19.3'
     implementation "org.opensearch.plugin:opensearch-security:${openSearch}.0"
     implementation "org.opensearch:opensearch-common:${openSearch}"
     implementation "org.opensearch:opensearch-core:${openSearch}"

--- a/TrafficCapture/trafficCaptureProxyServer/build.gradle
+++ b/TrafficCapture/trafficCaptureProxyServer/build.gradle
@@ -24,6 +24,7 @@ dependencies {
         include "*.jar"
         exclude "slf*.jar"
         exclude "netty*.jar"
+        exclude "google-java-format-*.jar"
     })
 
     implementation project(':TrafficCapture:captureOffloader')


### PR DESCRIPTION
### Description
Update Capture Proxy to OS 2.19.3 for security plugin usage for CVE GHSA-2rjv-cv85-xhgm (though this is unimpacting on Capture Proxy)

### Issues Resolved
<!-- List any GitHub or Jira issues this PR will resolve -->

### Testing
GHA

### Check List
- [x] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
