### PR TITLE
Replace OpenSearch version 2.11 with latest 2.19 

### DIFF
--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/cluster_tools/tests/conftest.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/cluster_tools/tests/conftest.py
@@ -27,7 +27,7 @@ def wait_for_opensearch(url, max_retries=30, retry_interval=2):
 
 def create_opensearch_container():
     """Create and start an OpenSearch container."""
-    container = OpenSearchContainer("opensearchproject/opensearch:2.11.0")
+    container = OpenSearchContainer("opensearchproject/opensearch:2.19.1")
     container.with_env("discovery.type", "single-node")
     container.start()
 

--- a/test/README.md
+++ b/test/README.md
@@ -44,7 +44,7 @@ Migration Context File
   "rfs-backfill": {
     "stage": "<STAGE>",
     "vpcId": "<VPC_ID>",
-    "engineVersion": "OS_2.11",
+    "engineVersion": "OS_2.19",
     "domainName": "os-cluster-<STAGE>",
     "dataNodeCount": 2,
     "openAccessPolicyEnabled": true,

--- a/test/defaultMigrationContext.json
+++ b/test/defaultMigrationContext.json
@@ -2,7 +2,7 @@
   "migration-default": {
     "stage": "<STAGE>",
     "vpcId": "<VPC_ID>",
-    "engineVersion": "OS_2.11",
+    "engineVersion": "OS_2.19",
     "domainName": "os-cluster-<STAGE>",
     "dataNodeCount": 2,
     "openAccessPolicyEnabled": true,

--- a/vars/fullES68SourceE2ETest.groovy
+++ b/vars/fullES68SourceE2ETest.groovy
@@ -59,7 +59,7 @@ def call(Map config = [:]) {
           "full-migration": {
             "stage": "<STAGE>",
             "vpcId": "<VPC_ID>",
-            "engineVersion": "OS_2.11",
+            "engineVersion": "OS_2.19",
             "domainName": "os-cluster-<STAGE>",
             "dataNodeCount": 2,
             "openAccessPolicyEnabled": true,

--- a/vars/rfsDefaultE2ETest.groovy
+++ b/vars/rfsDefaultE2ETest.groovy
@@ -29,7 +29,7 @@ def call(Map config = [:]) {
           "migration-rfs": {
             "stage": "<STAGE>",
             "vpcId": "<VPC_ID>",
-            "engineVersion": "OS_2.11",
+            "engineVersion": "OS_2.19",
             "domainName": "os-cluster-<STAGE>",
             "dataNodeCount": 2,
             "openAccessPolicyEnabled": true,

--- a/vars/trafficReplayDefaultE2ETest.groovy
+++ b/vars/trafficReplayDefaultE2ETest.groovy
@@ -49,7 +49,7 @@ def call(Map config = [:]) {
       "migration-default": {
         "stage": "<STAGE>",
         "vpcId": "<VPC_ID>",
-        "engineVersion": "OS_2.11",
+        "engineVersion": "OS_2.19",
         "domainName": "os-cluster-<STAGE>",
         "dataNodeCount": 2,
         "openAccessPolicyEnabled": true,


### PR DESCRIPTION
### Description
This fix replaces all usages of OS_2.11 with OS_2.19.
The developer pipeline is failing because it cannot find OS_2.11 image. A new update was recently merged in to register all images into our ECR, this update uses OS_2.19 since it is the latest os2x available.

### Issues Resolved
No issue


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
