### PR TITLE
Update Kafka version to 3.9.1

### DIFF
--- a/TrafficCapture/captureKafkaOffloader/README.md
+++ b/TrafficCapture/captureKafkaOffloader/README.md
@@ -38,8 +38,8 @@ Resources for making testing/development easier
 For quick startup of Kafka, you can run it inside a docker container.  Pull the Apache Kafka image and run it.
 
 ```
-docker pull apache/kafka:3.7.0
-docker run -p 9092:9092 apache/kafka:3.7.0
+docker pull apache/kafka:3.9.1
+docker run -p 9092:9092 apache/kafka:3.9.1
 ```
 
 More information can be found at https://kafka.apache.org/quickstart, including commands to test and query a running

--- a/TrafficCapture/dockerSolution/src/main/docker/docker-compose.yml
+++ b/TrafficCapture/dockerSolution/src/main/docker/docker-compose.yml
@@ -43,7 +43,7 @@ services:
       - prometheus
 
   kafka:
-    image: apache/kafka:3.7.0
+    image: apache/kafka:3.9.1
     networks:
       - migrations
     ports:

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/Dockerfile
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/Dockerfile
@@ -17,7 +17,7 @@ ARG KAFKA_VERSION="3.9.1"
 RUN mkdir -p /root/kafka-tools/kafka && \
     url_cdn="https://dlcdn.apache.org/kafka/${KAFKA_VERSION}/kafka_2.13-${KAFKA_VERSION}.tgz" && \
     url_archive="https://archive.apache.org/dist/kafka/${KAFKA_VERSION}/kafka_2.13-${KAFKA_VERSION}.tgz" && \
-    curl --retry 5 --retry-delay 5 --retry-connrefused -fSL "$url_cdn" -o /tmp/kafka.tgz || curl  --retry 5 --retry-delay 5 --retry-connrefused -fSL "$url_archive" -o /tmp/kafka.tgz && \
+    curl --retry 2 --retry-delay 5 --retry-connrefused -fSL "$url_cdn" -o /tmp/kafka.tgz || curl  --retry 5 --retry-delay 5 --retry-connrefused -fSL "$url_archive" -o /tmp/kafka.tgz && \
     tar -xzf /tmp/kafka.tgz -C /root/kafka-tools/kafka --strip-components=1 && \
     rm -f /tmp/kafka.tgz
 RUN mkdir -p /root/kafka-tools/aws && \

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/Dockerfile
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/Dockerfile
@@ -11,10 +11,13 @@ RUN ARCH=$(uname -m | sed 's/x86_64/amd64/; s/aarch64/arm64/') && \
 
 ARG HELM_VERSION="3.14.0"
 ARG KUBECTL_VERSION="1.32.1"
+ARG KAFKA_VERSION="3.9.1"
 
 # Get kafka distribution and unpack to 'kafka'
 RUN mkdir -p /root/kafka-tools/kafka && \
-    curl --retry 5 --retry-delay 5 --retry-connrefused -fSL https://archive.apache.org/dist/kafka/3.6.0/kafka_2.13-3.6.0.tgz -o /tmp/kafka.tgz && \
+    url_cdn="https://dlcdn.apache.org/kafka/${KAFKA_VERSION}/kafka_2.13-${KAFKA_VERSION}.tgz" && \
+    url_archive="https://archive.apache.org/dist/kafka/${KAFKA_VERSION}/kafka_2.13-${KAFKA_VERSION}.tgz" && \
+    curl --retry 5 --retry-delay 5 --retry-connrefused -fSL "$url_cdn" -o /tmp/kafka.tgz || curl  --retry 5 --retry-delay 5 --retry-connrefused -fSL "$url_archive" -o /tmp/kafka.tgz && \
     tar -xzf /tmp/kafka.tgz -C /root/kafka-tools/kafka --strip-components=1 && \
     rm -f /tmp/kafka.tgz
 RUN mkdir -p /root/kafka-tools/aws && \

--- a/deployment/cdk/opensearch-service-migration/lib/migration-assistance-stack.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/migration-assistance-stack.ts
@@ -69,7 +69,7 @@ export class MigrationAssistanceStack extends Stack {
 
         const mskCluster = new MSKCluster(this, 'mskCluster', {
             clusterName: `migration-msk-cluster-${props.stage}`,
-            kafkaVersion: KafkaVersion.V3_6_0,
+            kafkaVersion: KafkaVersion.V3_9_X,
             numberOfBrokerNodes: brokerNodesPerAZ,
             vpc: props.vpcDetails.vpc,
             vpcSubnets: props.vpcDetails.subnetSelection,

--- a/deployment/cdk/opensearch-service-migration/lib/service-stacks/kafka-stack.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/service-stacks/kafka-stack.ts
@@ -43,7 +43,7 @@ export class KafkaStack extends MigrationServiceCore {
         });
         this.createService({
             serviceName: "kafka",
-            dockerImageName: "docker.io/apache/kafka:3.7.0",
+            dockerImageName: "docker.io/apache/kafka:3.9.1",
             securityGroups: securityGroups,
             // see https://github.com/apache/kafka/blob/3.7/docker/examples/jvm/single-node/plaintext/docker-compose.yml
             environment: {

--- a/deployment/cdk/opensearch-service-migration/package-lock.json
+++ b/deployment/cdk/opensearch-service-migration/package-lock.json
@@ -20,7 +20,7 @@
         "yaml": "^2.8.1"
       },
       "devDependencies": {
-        "@aws-cdk/aws-msk-alpha": "2.186.0-alpha.0",
+        "@aws-cdk/aws-msk-alpha": "2.213.0-alpha.0",
         "@aws-cdk/aws-servicecatalogappregistry-alpha": "2.186.0-alpha.0",
         "@eslint/js": "^9.34.0",
         "@types/eslint__js": "^9.14.0",
@@ -75,15 +75,16 @@
       "license": "Apache-2.0"
     },
     "node_modules/@aws-cdk/aws-msk-alpha": {
-      "version": "2.186.0-alpha.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-msk-alpha/-/aws-msk-alpha-2.186.0-alpha.0.tgz",
-      "integrity": "sha512-IJ947zX6fYN3tLGTXB7a7ZTWlj+64jPf3llONQeM4iA6XmEH78wcKjSMPcAKohVIqMzOGGyYyR000e1+TNGTvA==",
+      "version": "2.213.0-alpha.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-msk-alpha/-/aws-msk-alpha-2.213.0-alpha.0.tgz",
+      "integrity": "sha512-AcB7vWXW+gVIi7keT4BbEXK548BYhhAMz6/mCHNdV0bIc2bUUfVPtzmjtx6Lq3C7YCw/w9hpvqQCIKj3n6wLwg==",
       "dev": true,
+      "license": "Apache-2.0",
       "engines": {
-        "node": ">= 14.15.0"
+        "node": ">= 18.0.0"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.186.0",
+        "aws-cdk-lib": "^2.213.0",
         "constructs": "^10.0.0"
       }
     },

--- a/deployment/cdk/opensearch-service-migration/package.json
+++ b/deployment/cdk/opensearch-service-migration/package.json
@@ -46,7 +46,7 @@
   },
   "devDependencies": {
     "@aws-cdk/aws-servicecatalogappregistry-alpha": "2.186.0-alpha.0",
-    "@aws-cdk/aws-msk-alpha": "2.186.0-alpha.0",
+    "@aws-cdk/aws-msk-alpha": "2.213.0-alpha.0",
     "@eslint/js": "^9.34.0",
     "@types/eslint__js": "^9.14.0",
     "@types/jest": "^30.0.0",

--- a/deployment/cdk/opensearch-service-migration/test/jest.setup.ts
+++ b/deployment/cdk/opensearch-service-migration/test/jest.setup.ts
@@ -4,7 +4,7 @@ jest.mock('child_process', () => {
 
   // Define the list of expected Docker images as per CI.yml
   const expectedDockerImages = [
-    'docker.io/apache/kafka:3.7.0',
+    'docker.io/apache/kafka:3.9.1',
     'migrations/capture_proxy_es:latest',
     'migrations/capture_proxy:latest',
     'migrations/elasticsearch_searchguard:latest',


### PR DESCRIPTION
### Description
This updates the Kafka version used across the project to `3.9.1`. The MSK instance in CDK is changed to `3_9_X` and the kafka clients are already on `4.0.0` and did not need update. By using a newer non-archived version of Kafka we can also utilize the CDN for the kafka distribution download in the Migration Console. Since this version could also later be added to the archived versions, there is a fallback URL to use the archive if the CDN endpoint is not available.

### Issues Resolved
<!-- List any GitHub or Jira issues this PR will resolve -->

### Testing
<!-- Please provide details of testing done: unit testing, integration testing and manual testing -->

### Check List
- [ ] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
