### PR TITLE
[Bug] Wire source version through metadata config when source is disabled

### DIFF
--- a/deployment/cdk/opensearch-service-migration/lib/service-stacks/migration-console-stack.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/service-stacks/migration-console-stack.ts
@@ -28,6 +28,7 @@ export interface MigrationConsoleProps extends StackPropsExt {
     readonly fargateCpuArch: CpuArchitecture,
     readonly targetGroups?: ELBTargetGroup[],
     readonly servicesYaml: ServicesYaml,
+    readonly sourceClusterVersion?: string,
     readonly otelCollectorEnabled?: boolean,
     readonly managedServiceSourceSnapshotEnabled?: boolean
 }
@@ -188,7 +189,7 @@ export class MigrationConsoleStack extends MigrationServiceCore {
 
         // Upload the services.yaml file to Parameter Store
         servicesYaml.metadata_migration = new MetadataMigrationYaml();
-        servicesYaml.metadata_migration.source_cluster_version = props.servicesYaml.source_cluster?.version
+        servicesYaml.metadata_migration.source_cluster_version = props.servicesYaml.source_cluster?.version ?? props.sourceClusterVersion
         if (props.otelCollectorEnabled) {
             const otelSidecarEndpoint = OtelCollectorSidecar.getOtelLocalhostEndpoint();
             if (servicesYaml.metadata_migration) {

--- a/deployment/cdk/opensearch-service-migration/lib/stack-composer.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/stack-composer.ts
@@ -585,6 +585,7 @@ export class StackComposer {
                 vpcDetails: networkStack.vpcDetails,
                 streamingSourceType: streamingSourceType,
                 servicesYaml: servicesYaml,
+                sourceClusterVersion: sourceClusterField?.version,
                 stackName: `OSMigrations-${stage}-${region}-MigrationConsole`,
                 description: "This stack contains resources for the Migration Console ECS service",
                 stage: stage,

--- a/deployment/cdk/opensearch-service-migration/test/migration-services-yaml.test.ts
+++ b/deployment/cdk/opensearch-service-migration/test/migration-services-yaml.test.ts
@@ -391,7 +391,7 @@ describe('Migration Services YAML Tests', () => {
         const parsedFromYaml = yaml.parse(yamlFileContents);
 
         expect(parsedFromYaml.metadata_migration).toBeDefined();
-        expect(parsedFromYaml.metadata_migration.source_cluster_version).toBeDefined();
+        expect(parsedFromYaml.metadata_migration.source_cluster_version).toBe("ES_7.10")
 
         expect(parsedFromYaml.target_cluster).toBeDefined();
         expect(parsedFromYaml.target_cluster.basic_auth).toBeDefined();

--- a/deployment/cdk/opensearch-service-migration/test/migration-services-yaml.test.ts
+++ b/deployment/cdk/opensearch-service-migration/test/migration-services-yaml.test.ts
@@ -350,4 +350,61 @@ describe('Migration Services YAML Tests', () => {
         expect(Object.keys(parsedFromYaml).length).toEqual(expectedFields.length)
         expect(new Set(Object.keys(parsedFromYaml))).toEqual(new Set(expectedFields))
     });
+
+    test('Test that services yaml includes source version in metadata when source cluster is disabled', () => {
+        const contextOptions = {
+            vpcEnabled: true,
+            migrationAssistanceEnabled: true,
+            migrationConsoleServiceEnabled: true,
+            sourceCluster: {
+                "version": "ES_7.10",
+                "disabled": true
+            },
+            targetCluster: {
+                "endpoint": "https://target-cluster",
+                "auth": {
+                    "type": "basic",
+                    "userSecretArn": "arn:aws:secretsmanager:us-east-1:12345678912:secret:master-user-os-pass-123abc",
+                }
+            },
+            reindexFromSnapshotServiceEnabled: true,
+            trafficReplayerServiceEnabled: true,
+        }
+
+        const stacks = createStackComposer(contextOptions)
+
+        const migrationConsoleStack: MigrationConsoleStack = (stacks.stacks.filter((s) => s instanceof MigrationConsoleStack)[0]) as MigrationConsoleStack
+        const migrationConsoleStackTemplate = Template.fromStack(migrationConsoleStack)
+
+        const valueCapture = new Capture();
+        migrationConsoleStackTemplate.hasResourceProperties("AWS::SSM::Parameter", {
+            Type: "String",
+            Name: Match.stringLikeRegexp("/migration/.*/.*/servicesYamlFile"),
+            Value: valueCapture,
+        });
+        const value = valueCapture.asObject()
+        expect(value).toBeDefined();
+        expect(value['Fn::Join']).toBeInstanceOf(Array);
+        expect(value['Fn::Join'][1]).toBeInstanceOf(Array)
+        // join the strings together to get the yaml file contents
+        const yamlFileContents = value['Fn::Join'][1].join('')
+        const parsedFromYaml = yaml.parse(yamlFileContents);
+
+        expect(parsedFromYaml.metadata_migration).toBeDefined();
+        expect(parsedFromYaml.metadata_migration.source_cluster_version).toBeDefined();
+
+        expect(parsedFromYaml.target_cluster).toBeDefined();
+        expect(parsedFromYaml.target_cluster.basic_auth).toBeDefined();
+        expect(parsedFromYaml.target_cluster.basic_auth.user_secret_arn).toBe(contextOptions.targetCluster.auth.userSecretArn);
+
+        expect(parsedFromYaml.metrics_source).toBeDefined();
+        expect(parsedFromYaml.metrics_source.cloudwatch).toBeDefined();
+
+        expect(parsedFromYaml.kafka).toBeDefined();
+
+        // Validates that the file has the expected fields
+        const expectedFields = ['target_cluster', 'metrics_source', 'backfill', 'snapshot', 'metadata_migration', 'replay', 'kafka'];
+        expect(Object.keys(parsedFromYaml).length).toEqual(expectedFields.length)
+        expect(new Set(Object.keys(parsedFromYaml))).toEqual(new Set(expectedFields))
+    });
 });


### PR DESCRIPTION
### Description
Ensures that when a source cluster is disabled in CDK, we still wire the version provided through the metadata block in the migration services yaml. Longer term we may want to look at aligning the differing models between handling a disabled source cluster in CDK versus the services yaml.

### Issues Resolved
N/A

### Testing
Jest testing

### Check List
- [ ] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
