### PR TITLE
Increase default JVM heap size for `cluster_tools` OS test container

### DIFF
--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/cluster_tools/tests/conftest.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/cluster_tools/tests/conftest.py
@@ -29,6 +29,7 @@ def create_opensearch_container():
     """Create and start an OpenSearch container."""
     container = OpenSearchContainer("opensearchproject/opensearch:2.19.1")
     container.with_env("discovery.type", "single-node")
+    container.with_env("OPENSEARCH_JAVA_OPTS", "-Xms2g -Xmx2g")
     container.start()
 
     url = f"http://{container.get_container_host_ip()}:{container.get_exposed_port(9200)}"


### PR DESCRIPTION
### Description
Seeing occasional flaky test from `cluster_tools` which seems related to our default `1g` heap setting
```
INFO     cluster_tools.tools.migrate_document:migrate_document.py:72 Original document size: 34603175 bytes
INFO     cluster_tools.tools.migrate_document:migrate_document.py:108 Fields to chunk: ['content']
INFO     cluster_tools.tools.migrate_document:migrate_document.py:128 Creating initial document in target cluster (size: 167 bytes)
INFO     console_link.models.cluster:cluster.py:207 call_api request PUT http://localhost:32777/test-migration-index/_doc/test-doc-1-large, response: 201 {"_index":"test-migration-index","_id":"test-doc-1-large","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":0,"_primary_term":1}
INFO     cluster_tools.tools.migrate_document:migrate_document.py:148 Updating field 'content' in 4 chunks
INFO     cluster_tools.tools.migrate_document:migrate_document.py:151 Sending chunk 1/4 for field 'content' (9437184 characters)
INFO     console_link.models.cluster:cluster.py:207 call_api request POST http://localhost:32777/test-migration-index/_update/test-doc-1-large, response: 200 {"_index":"test-migration-index","_id":"test-doc-1-large","_version":2,"result":"updated","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":1,"_primary_term":1}
INFO     cluster_tools.tools.migrate_document:migrate_document.py:151 Sending chunk 2/4 for field 'content' (9437184 characters)
INFO     console_link.models.cluster:cluster.py:207 call_api request POST http://localhost:32777/test-migration-index/_update/test-doc-1-large, response: 200 {"_index":"test-migration-index","_id":"test-doc-1-large","_version":3,"result":"updated","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":2,"_primary_term":1}
INFO     cluster_tools.tools.migrate_document:migrate_document.py:151 Sending chunk 3/4 for field 'content' (9437184 characters)
INFO     console_link.models.cluster:cluster.py:207 call_api request POST http://localhost:32777/test-migration-index/_update/test-doc-1-large, response: 200 {"_index":"test-migration-index","_id":"test-doc-1-large","_version":4,"result":"updated","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":3,"_primary_term":1}
INFO     cluster_tools.tools.migrate_document:migrate_document.py:151 Sending chunk 4/4 for field 'content' (3145728 characters)
INFO     console_link.models.cluster:cluster.py:207 call_api request POST http://localhost:32777/test-migration-index/_update/test-doc-1-large, response: 429 {"error":{"root_cause":[{"type":"circuit_breaking_exception","reason":"[parent] Data too large, data for [<http_request>] would be [1071225640/1021.6mb], which is larger than the limit of [1020054732/972.7mb], real usage: [1064304640/1015mb], new bytes reserved: [6921000/6.6mb], usages [request=0/0b, fielddata=197/197b, in_flight_requests=6921000/6.6mb]","bytes_wanted":1071225640,"bytes_limit":1020054732,"durability":"TRANSIENT"}],"type":"circuit_breaking_exception","reason":"[parent] Data too large, data for [<http_request>] would be [1071225640/1021.6mb], which is larger than the limit of [1020054732/972.7mb], real usage: [1064304640/1015mb], new bytes reserved: [6921000/6.6mb], usages [request=0/0b, fielddata=197/197b, in_flight_requests=6921000/6.6mb]","bytes_wanted":1071225640,"bytes_limit":1020054732,"durability":"TRANSIENT"},"status":429}
ERROR    cluster_tools.tools.migrate_document:migrate_document.py:259 Document migration failed: 429 Client Error: Too Many Requests for url: http://localhost:32777/test-migration-index/_update/test-doc-1-large
```

### Issues Resolved
N/A

### Testing
Local testing

### Check List
- [ ] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
