### PR TITLE
[Bug] Fix for RFS source cluster version on disabled sources

### DIFF
--- a/deployment/cdk/opensearch-service-migration/lib/service-stacks/migration-console-stack.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/service-stacks/migration-console-stack.ts
@@ -189,7 +189,7 @@ export class MigrationConsoleStack extends MigrationServiceCore {
 
         // Upload the services.yaml file to Parameter Store
         servicesYaml.metadata_migration = new MetadataMigrationYaml();
-        servicesYaml.metadata_migration.source_cluster_version = props.servicesYaml.source_cluster?.version ?? props.sourceClusterVersion
+        servicesYaml.metadata_migration.source_cluster_version = props.sourceClusterVersion
         if (props.otelCollectorEnabled) {
             const otelSidecarEndpoint = OtelCollectorSidecar.getOtelLocalhostEndpoint();
             if (servicesYaml.metadata_migration) {

--- a/deployment/cdk/opensearch-service-migration/lib/stack-composer.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/stack-composer.ts
@@ -354,6 +354,8 @@ export class StackComposer {
             servicesYaml.client_options = new ClientOptions()
             servicesYaml.client_options.user_agent_extra = props.migrationsUserAgent
         }
+        // Resolve source cluster version even for disabled source clusters
+        const resolvedSourceClusterVersion = servicesYaml.source_cluster?.version ?? sourceClusterField?.version
         const existingSnapshotDefinition = this.getContextForType('snapshot', 'object', defaultValues, contextJSON)
         let snapshotYaml
         if (existingSnapshotDefinition) {
@@ -467,7 +469,7 @@ export class StackComposer {
                 extraArgs: reindexFromSnapshotExtraArgs,
                 clusterAuthDetails: servicesYaml.target_cluster?.auth,
                 skipClusterCertCheck: servicesYaml.target_cluster?.allowInsecure,
-                sourceClusterVersion: servicesYaml.source_cluster?.version,
+                sourceClusterVersion: resolvedSourceClusterVersion,
                 stackName: `OSMigrations-${stage}-${region}-ReindexFromSnapshot`,
                 description: "This stack contains resources to assist migrating historical data, via Reindex from Snapshot, to a target cluster",
                 stage: stage,
@@ -585,7 +587,7 @@ export class StackComposer {
                 vpcDetails: networkStack.vpcDetails,
                 streamingSourceType: streamingSourceType,
                 servicesYaml: servicesYaml,
-                sourceClusterVersion: sourceClusterField?.version,
+                sourceClusterVersion: resolvedSourceClusterVersion,
                 stackName: `OSMigrations-${stage}-${region}-MigrationConsole`,
                 description: "This stack contains resources for the Migration Console ECS service",
                 stage: stage,

--- a/deployment/cdk/opensearch-service-migration/test/migration-services-yaml.test.ts
+++ b/deployment/cdk/opensearch-service-migration/test/migration-services-yaml.test.ts
@@ -357,7 +357,7 @@ describe('Migration Services YAML Tests', () => {
             migrationAssistanceEnabled: true,
             migrationConsoleServiceEnabled: true,
             sourceCluster: {
-                "version": "ES_7.10",
+                "version": "ES_7.9",
                 "disabled": true
             },
             targetCluster: {
@@ -391,7 +391,7 @@ describe('Migration Services YAML Tests', () => {
         const parsedFromYaml = yaml.parse(yamlFileContents);
 
         expect(parsedFromYaml.metadata_migration).toBeDefined();
-        expect(parsedFromYaml.metadata_migration.source_cluster_version).toBe("ES_7.10")
+        expect(parsedFromYaml.metadata_migration.source_cluster_version).toBe("ES_7.9")
 
         expect(parsedFromYaml.target_cluster).toBeDefined();
         expect(parsedFromYaml.target_cluster.basic_auth).toBeDefined();


### PR DESCRIPTION
### Description
Similar to https://github.com/opensearch-project/opensearch-migrations/pull/1826, we should enable proper source cluster version is used for RFS command args

### Issues Resolved
N/A

### Testing
Local CDK jest testing

### Check List
- [ ] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
