### PR TITLE
Update kubectl image due to deprication

### DIFF
--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/data/kubectl_describe_deployment_output.json
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/data/kubectl_describe_deployment_output.json
@@ -225,7 +225,7 @@
               "-c",
               "until kubectl wait --for=condition=Ready kafka/captured-traffic -n ma --timeout=10s; do echo waiting for kafka cluster is ready; sleep 1; done"
             ],
-            "image": "bitnami/kubectl:latest",
+            "image": "bitnamisecure/kubectl:latest",
             "imagePullPolicy": "Always",
             "name": "wait-for-kafka",
             "resources": {},

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/workflows/templates/fullMigrationWithClusters.yaml
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/workflows/templates/fullMigrationWithClusters.yaml
@@ -171,7 +171,7 @@ spec:
           - name: cluster-type
           - name: namespace
       container:
-        image: bitnami/kubectl:latest
+        image: bitnamisecure/kubectl:latest
         command: [sh, -c]
         args:
           - |

--- a/deployment/k8s/charts/components/captureProxy/templates/deployment.yaml
+++ b/deployment/k8s/charts/components/captureProxy/templates/deployment.yaml
@@ -19,7 +19,7 @@ spec:
            "MountName" $mountName
            "include" .Template.Include)) | nindent 8 }}
         - name: wait-for-kafka
-          image: bitnami/kubectl:latest  # or any image with curl/kubectl
+          image: bitnamisecure/kubectl:latest  # or any image with curl/kubectl
           command: [ 'sh', '-c',
                      'until kubectl wait --for=condition=Ready kafka/captured-traffic -n {{ .Release.Namespace }} --timeout=10s; do echo waiting for kafka cluster is ready; sleep 1; done' ]
       containers:

--- a/deployment/k8s/charts/components/replayer/templates/deployment.yaml
+++ b/deployment/k8s/charts/components/replayer/templates/deployment.yaml
@@ -21,7 +21,7 @@ spec:
            "PositionalArguments" (list "targetUri")
            "include" .Template.Include)) | nindent 8 }}
         - name: wait-for-kafka
-          image: bitnami/kubectl:latest  # or any image with curl/kubectl
+          image: bitnamisecure/kubectl:latest  # or any image with curl/kubectl
           command: [ 'sh', '-c',
                      'until kubectl wait --for=condition=Ready kafka/captured-traffic -n {{ .Release.Namespace }} --timeout=10s; do echo waiting for kafka cluster is ready; sleep 1; done' ]
       containers:


### PR DESCRIPTION
### Description
This PR replaces all usages of `bitnami/kubectl:latest` with `bitnamisecure/kubectl:latest`

The `bitnami/kubectl` image has been deprecated and is no longer available, which caused pods to fail with ImagePullBackOff errors. 

### Issues Resolved
No JIRA

### Testing
Validated by using the Argo based tests under `libraries/testAutomation`
- executed test using `pipenv run app`

### Check List
- [ ] New functionality includes testing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
