### PR TITLE
[Fix] ES8VectorFieldMappingsTransformationTest to have no replicas

### DIFF
--- a/MetadataMigration/src/test/java/org/opensearch/migrations/ES8VectorFieldMappingsTransformationTest.java
+++ b/MetadataMigration/src/test/java/org/opensearch/migrations/ES8VectorFieldMappingsTransformationTest.java
@@ -57,6 +57,9 @@ class ES8VectorFieldMappingsTransformationTest extends BaseMigrationTest {
         startClusters();
 
         String requestBody = "{\n" +
+                "  \"settings\": {\n" +
+                "    \"number_of_replicas\": 0\n" +
+                "  },\n" +
                 "  \"mappings\": \n" +
                 "    {\n" +
                 "        \"dynamic\": \"strict\",\n" +


### PR DESCRIPTION
### Description
This test was failing in CI due to unassigned primary shards preventing snapshot creation. The error occurred because the test created an index without specifying replica settings, causing Elasticsearch to default to 1 replica in a single-node cluster.

This PR explicitly adds 0 replicas to the index settings to ensure all shards can be assigned in the single-node test.environment.

### Issues Resolved
No Jira

### Testing
Local : ./gradlew :MetadataMigration:isolatedTest --tests "ES8VectorFieldMappingsTransformationTest"
Also validating with all GHA checks

### Check List
- [ ] New functionality includes testing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
