### PR TITLE
Enable ES 1x and 2x argo test on Jenkins

### DIFF
--- a/vars/k8sLocalDeployment.groovy
+++ b/vars/k8sLocalDeployment.groovy
@@ -12,7 +12,7 @@ def call(Map config = [:]) {
             string(name: 'GIT_BRANCH', defaultValue: 'main', description: 'Git branch to use for repository')
             choice(
                     name: 'SOURCE_VERSION',
-                    choices: ['ES_5.6', 'ES_7.10'],
+                    choices: ['ES_1.5', 'ES_2.4', 'ES_5.6', 'ES_7.10'],
                     description: 'Pick a specific source version'
             )
             choice(


### PR DESCRIPTION
### Description
A recent PR https://github.com/opensearch-project/opensearch-migrations/pull/1829
which got merged missed out on updating the Pipeline to accept these versions as available Source Cluster options. This PR fills that gap.

### Issues Resolved
N/A

### Testing
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
