### PR TITLE
Ensure OTEL service monitor is created after Prometheus CRDs

### DIFF
--- a/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/templates/resources/otel/simpleCollectorAsIndependentDaemonset.yaml
+++ b/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/templates/resources/otel/simpleCollectorAsIndependentDaemonset.yaml
@@ -94,6 +94,9 @@ kind: ServiceMonitor
 metadata:
   name: otel-collector-monitor
   namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "1"
   labels:
     app: otel-collector
     release: kube-prometheus-stack


### PR DESCRIPTION
### Description
Resolves this error:
```
2025-09-29 08:54:36,762 [ERROR] Error executing helm install ma ../../deployment/k8s/charts/aggregates/migrationAssistantWithArgo -n ma --create-namespace: Error: INSTALLATION FAILED: unable to build kubernetes objects from release manifest: resource mapping not found for name: "otel-collector-monitor" namespace: "ma" from "": no matches for kind "ServiceMonitor" in version "monitoring.coreos.com/v1"
ensure CRDs are installed first
```

### Issues Resolved
N/A

### Testing
Local testing

### Check List
- [ ] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
