### PR TITLE
Have sonarqube ignore the orchestrationSpecs directory

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -39,7 +39,8 @@ sonar.exclusions=\
     **/jest.config.js, \
     **/coverage/**/*, \
     **/frontend/out/**, \
-    **/frontend/src/generated/**
+    **/frontend/src/generated/**, \
+    **/orchestrationSpecs/**
 
 # Code coverage Specific Properties
 # sonar.coverage.exclusions=


### PR DESCRIPTION
### Description
Orchestration specs rely upon a custom DSL that has significant TypeScript constructs.  We don't rely upon that code itself to run our applications, but use it to generate other code that we test.

### Testing
CICD

### Check List
- [ ] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
