### PR TITLE
Increase default RFS memory to 8gb and cpu to 4vCPUs and initial-lease-duration to 60 minutes

### DIFF
--- a/deployment/cdk/opensearch-service-migration/lib/service-stacks/reindex-from-snapshot-stack.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/service-stacks/reindex-from-snapshot-stack.ts
@@ -90,7 +90,8 @@ export class ReindexFromSnapshotStack extends MigrationServiceCore {
         command = appendArgIfNotInExtraArgs(command, extraArgsDict, "--lucene-dir", `"${storagePath}/lucene"`)
         command = appendArgIfNotInExtraArgs(command, extraArgsDict, "--target-host", osClusterEndpoint)
         command = appendArgIfNotInExtraArgs(command, extraArgsDict, "--max-shard-size-bytes", `${Math.ceil(maxShardSizeBytes)}`)
-        command = appendArgIfNotInExtraArgs(command, extraArgsDict, "--max-connections", props.reindexFromSnapshotWorkerSize === "maximum" ? "100" : "10")
+        command = appendArgIfNotInExtraArgs(command, extraArgsDict, "--max-connections", props.reindexFromSnapshotWorkerSize === "maximum" ? "100" : "20")
+        command = appendArgIfNotInExtraArgs(command, extraArgsDict, "--initial-lease-duration", "PT60M")
         if (props.clusterAuthDetails.sigv4) {
             command = appendArgIfNotInExtraArgs(command, extraArgsDict, "--target-aws-service-signing-name", props.clusterAuthDetails.sigv4.serviceSigningName)
             command = appendArgIfNotInExtraArgs(command, extraArgsDict, "--target-aws-region", props.clusterAuthDetails.sigv4.region)
@@ -162,7 +163,7 @@ export class ReindexFromSnapshotStack extends MigrationServiceCore {
                     size: Size.gibibytes(shardVolumeSizeGiB),
                     volumeType: EbsDeviceVolumeType.GP3,
                     fileSystemType: FileSystemType.XFS,
-                    throughput: props.reindexFromSnapshotWorkerSize === "maximum" ? 450 : 125,
+                    throughput: props.reindexFromSnapshotWorkerSize === "maximum" ? 450 : 250,
                     tagSpecifications: [{
                         tags: {
                             Name: `rfs-snapshot-volume-${props.stage}`,
@@ -191,8 +192,8 @@ export class ReindexFromSnapshotStack extends MigrationServiceCore {
             mountPoints: mountPoints,
             taskRolePolicies: servicePolicies,
             cpuArchitecture: props.fargateCpuArch,
-            taskCpuUnits: props.reindexFromSnapshotWorkerSize === "maximum" ? 16 * 1024 : 2 * 1024,
-            taskMemoryLimitMiB: props.reindexFromSnapshotWorkerSize === "maximum" ? 32 * 1024 : 4 * 1024,
+            taskCpuUnits: props.reindexFromSnapshotWorkerSize === "maximum" ? 16 * 1024 : 4 * 1024,
+            taskMemoryLimitMiB: props.reindexFromSnapshotWorkerSize === "maximum" ? 32 * 1024 : 8 * 1024,
             ephemeralStorageGiB: ephemeralStorageGiB,
             environment: {
                 "RFS_COMMAND": command,

--- a/deployment/cdk/opensearch-service-migration/test/reindex-from-snapshot-stack.test.ts
+++ b/deployment/cdk/opensearch-service-migration/test/reindex-from-snapshot-stack.test.ts
@@ -74,8 +74,8 @@ describe('ReindexFromSnapshotStack Tests', () => {
     });
     // Assert CPU configuration
     template.hasResourceProperties('AWS::ECS::TaskDefinition', {
-      Cpu: "2048",
-      Memory: "4096",
+      Cpu: "4096",
+      Memory: "8192",
     });
   });
 
@@ -123,7 +123,7 @@ describe('ReindexFromSnapshotStack Tests', () => {
               {
                 "Ref": "SsmParameterValuemigrationunittestdefaultosClusterEndpointC96584B6F00A464EAD1953AFF4B05118Parameter",
               },
-              " --max-shard-size-bytes 94489280512 --max-connections 10 --source-version \"ES_7.10\""
+              " --max-shard-size-bytes 94489280512 --max-connections 20 --initial-lease-duration PT60M --source-version \"ES_7.10\""
             ],
           ],
         }
@@ -181,7 +181,7 @@ describe('ReindexFromSnapshotStack Tests', () => {
               {
                 "Ref": "SsmParameterValuemigrationunittestdefaultosClusterEndpointC96584B6F00A464EAD1953AFF4B05118Parameter",
               },
-              " --max-shard-size-bytes 94489280512 --max-connections 10 --target-aws-service-signing-name aoss --target-aws-region eu-west-1 --source-version \"ES_7.10\"",
+              " --max-shard-size-bytes 94489280512 --max-connections 20 --initial-lease-duration PT60M --target-aws-service-signing-name aoss --target-aws-region eu-west-1 --source-version \"ES_7.10\"",
             ],
           ],
         }
@@ -243,7 +243,7 @@ describe('ReindexFromSnapshotStack Tests', () => {
               {
                 "Ref": "SsmParameterValuemigrationunittestdefaultosClusterEndpointC96584B6F00A464EAD1953AFF4B05118Parameter",
               },
-              " --max-shard-size-bytes 94489280512 --max-connections 10 --source-version \"ES_7.10\""
+              " --max-shard-size-bytes 94489280512 --max-connections 20 --initial-lease-duration PT60M --source-version \"ES_7.10\""
             ],
           ],
         }
@@ -318,7 +318,7 @@ describe('ReindexFromSnapshotStack Tests', () => {
               {
                 "Ref": "SsmParameterValuemigrationunittestdefaultosClusterEndpointC96584B6F00A464EAD1953AFF4B05118Parameter",
               },
-              " --max-shard-size-bytes 94489280512 --max-connections 10 --source-version \"ES_7.10\" --custom-arg value --flag --snapshot-name \"custom-snapshot\""
+              " --max-shard-size-bytes 94489280512 --max-connections 20 --initial-lease-duration PT60M --source-version \"ES_7.10\" --custom-arg value --flag --snapshot-name \"custom-snapshot\""
             ]
           ]
         }
@@ -372,7 +372,7 @@ describe('ReindexFromSnapshotStack Tests', () => {
               {
                 "Ref": "SsmParameterValuemigrationunittestdefaultosClusterEndpointC96584B6F00A464EAD1953AFF4B05118Parameter",
               },
-              " --max-shard-size-bytes 94489280512 --max-connections 100 --source-version \"ES_7.10\"",
+              " --max-shard-size-bytes 94489280512 --max-connections 100 --initial-lease-duration PT60M --source-version \"ES_7.10\"",
             ],
           ],
         }
@@ -501,7 +501,7 @@ describe('ReindexFromSnapshotStack Tests', () => {
               {
                 "Ref": "SsmParameterValuemigrationunittestdefaultosClusterEndpointC96584B6F00A464EAD1953AFF4B05118Parameter",
               },
-              " --max-shard-size-bytes 1181117188 --max-connections 10 --target-aws-service-signing-name aoss --target-aws-region eu-west-1 --source-version \"ES_7.10\"",
+              " --max-shard-size-bytes 1181117188 --max-connections 20 --initial-lease-duration PT60M --target-aws-service-signing-name aoss --target-aws-region eu-west-1 --source-version \"ES_7.10\"",
             ],
           ],
         }
@@ -576,7 +576,7 @@ describe('ReindexFromSnapshotStack Tests', () => {
               {
                 "Ref": "SsmParameterValuemigrationunittestdefaultosClusterEndpointC96584B6F00A464EAD1953AFF4B05118Parameter",
               },
-              " --max-shard-size-bytes 94489280512 --max-connections 10 --source-version \"ES_7.9\""
+              " --max-shard-size-bytes 94489280512 --max-connections 20 --initial-lease-duration PT60M --source-version \"ES_7.9\""
             ],
           ],
         }


### PR DESCRIPTION
### Description

This PR updates the default configuration for the Reindex from Snapshot (RFS) worker to improve migration performance and reliability:

1. __Increased default worker resources__: Doubled the default CPU allocation from 2048 (2 vCPUs) to 4096 (4 vCPUs) and memory from 4096 MB to 8192 MB (8 GB) to better handle concurrent operations
2. __Increased max-connections__: Raised the default from 10 to 20 connections to improve throughput during document reindexing
3. __Added initial-lease-duration__: Introduced `--initial-lease-duration PT60M` parameter with a 60-minute default to provide more table lease management during migration operations
3. __Increased EBS Throughput__: Increased default RFS EBS throughput to 250MBps to support faster shard operations. 

These changes apply to the "default" worker size configuration. The "maximum" worker size remains unchanged (16 vCPUs, 32 GB RAM, 100 connections).

### Issues Resolved

Seeking to reduce OOM errors and improve performance in the majority of customers.

### Testing
<!-- Please provide details of testing done: unit testing, integration testing and manual testing -->

### Check List
- [ ] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
