### PR TITLE
Set minikube `kubectl` context in Jenkins pipeline

### DIFF
--- a/vars/k8sLocalDeployment.groovy
+++ b/vars/k8sLocalDeployment.groovy
@@ -112,6 +112,7 @@ def call(Map config = [:]) {
                                 }
                                 sh "pipenv install --deploy"
                                 sh "mkdir -p ./reports"
+                                sh "kubectl config use-context minikube"
                                 sh "pipenv run app --source-version=$sourceVer --target-version=$targetVer $testIdsArg --skip-delete --test-reports-dir='./reports'"
                             }
                         }
@@ -125,6 +126,7 @@ def call(Map config = [:]) {
                     dir('libraries/testAutomation') {
                         script {
                             sh "pipenv install --deploy"
+                            sh "kubectl config use-context minikube"
                             sh "pipenv run app --copy-logs-only"
                             archiveArtifacts artifacts: 'logs/**, reports/**', fingerprint: true, onlyIfSuccessful: false
                             sh "rm -rf ./reports"


### PR DESCRIPTION
### Description
Ensures minikube jenkins pipelines are using the proper `kubectl` context

### Issues Resolved
N/A

### Testing
N/A

### Check List
- [ ] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
