### PR TITLE
Disable log4j JMX in ES Testcontainer

### DIFF
--- a/RFS/src/testFixtures/java/org/opensearch/migrations/bulkload/framework/SearchClusterContainer.java
+++ b/RFS/src/testFixtures/java/org/opensearch/migrations/bulkload/framework/SearchClusterContainer.java
@@ -161,7 +161,8 @@ public class SearchClusterContainer extends GenericContainer<SearchClusterContai
             "ES_JAVA_OPTS", "-Xms2g -Xmx2g -Dlog4j2.disable.jmx=true -Dlog4j2.disableJmx=true",
             "cluster.routing.allocation.disk.watermark.low", "100%",
             "cluster.routing.allocation.disk.watermark.high", "100%",
-            "cluster.routing.allocation.disk.watermark.flood_stage", "100%"
+            "cluster.routing.allocation.disk.watermark.flood_stage", "100%",
+            "LOG4J_DISABLE_JMX", "true"
         )),
         ELASTICSEARCH(
             overrideAndRemoveEnv(


### PR DESCRIPTION
### Description
Recently getting exception which may be due to update in GHA docker or kernel. Attempt to fix by disabling JMX on GHA.

```
2025-10-17 20:28:28,996 main ERROR Could not reconfigure JMX java.lang.NullPointerException: Cannot invoke "jdk.internal.platform.CgroupInfo.getMountPoint()" because "anyController" is null |  
-- | --
at java.base/jdk.internal.platform.cgroupv2.CgroupV2Subsystem.getInstance(CgroupV2Subsystem.java:81) |  
at java.base/jdk.internal.platform.CgroupSubsystemFactory.create(CgroupSubsystemFactory.java:113) |  
at java.base/jdk.internal.platform.CgroupMetrics.getInstance(CgroupMetrics.java:167) |  
at java.base/jdk.internal.platform.SystemMetrics.instance(SystemMetrics.java:29) |  
at java.base/jdk.internal.platform.Metrics.systemMetrics(Metrics.java:58) |  
at java.base/jdk.internal.platform.Container.metrics(Container.java:43) |  
at jdk.management/com.sun.management.internal.OperatingSystemImpl.<init>(OperatingSystemImpl.java:182) |  
at jdk.management/com.sun.management.internal.PlatformMBeanProviderImpl.getOperatingSystemMXBean(PlatformMBeanProviderImpl.java:280) |  
at jdk.management/com.sun.management.internal.PlatformMBeanProviderImpl$3.nameToMBeanMap(PlatformMBeanProviderImpl.java:199) |  
at java.management/java.lang.management.ManagementFactory.lambda$getPlatformMBeanServer$0(ManagementFactory.java:488) |  
at java.base/java.util.stream.ReferencePipeline$7$1.accept(ReferencePipeline.java:273) |  
at java.base/java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:179) |  
at java.base/java.util.HashMap$ValueSpliterator.forEachRemaining(HashMap.java:1779) |  
at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509) |  
at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499) |  
at java.base/java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:150) |  
at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:173) |  
at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) |  
at java.base/java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:596) |  
at java.management/java.lang.management.ManagementFactory.getPlatformMBeanServer(ManagementFactory.java:489) |  
at org.apache.logging.log4j.core.jmx.Server.reregisterMBeansAfterReconfigure(Server.java:140) |  
at org.apache.logging.log4j.core.LoggerContext.setConfiguration(LoggerContext.java:637) |  
at org.apache.logging.log4j.core.LoggerContext.start(LoggerContext.java:302) |  
at org.apache.logging.log4j.core.impl.Log4jContextFactory.getContext(Log4jContextFactory.java:209) |  
at org.apache.logging.log4j.core.config.Configurator.initialize(Configurator.java:243) |  
at org.apache.logging.log4j.core.config.Configurator.initialize(Configurator.java:219) |  
at org.elasticsearch.common.logging.LogConfigurator.configureStatusLogger(LogConfigurator.java:248) |  
at org.elasticsearch.common.logging.LogConfigurator.configureWithoutConfig(LogConfigurator.java:95) |  
at org.elasticsearch.cli.CommandLoggingConfigurator.configureLoggingWithoutConfig(CommandLoggingConfigurator.java:29) |  
at org.elasticsearch.cli.Command.main(Command.java:74) |  
at org.elasticsearch.cli.keystore.KeyStoreCli.main(KeyStoreCli.java:33) |  
  |  
```
### Issues Resolved
<!-- List any GitHub or Jira issues this PR will resolve -->

### Testing
<!-- Please provide details of testing done: unit testing, integration testing and manual testing -->

### Check List
- [ ] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
