### PR TITLE
Increase document max name length from ~50kb -> 100mb

### DIFF
--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/common/ObjectMapperFactory.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/common/ObjectMapperFactory.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 
 public class ObjectMapperFactory {
     private static final int MAX_STRING_LENGTH = 100 * 1024 * 1024; // ~100 MB
+    private static final int MAX_NAME_LENGTH = 100 * 1024 * 1024; // ~100 MB
 
     /**
      * Returns a default ObjectMapper with fail-on-unknown-properties disabled.
@@ -16,7 +17,9 @@ public class ObjectMapperFactory {
         ObjectMapper mapper = JsonMapper.builder().build();
         mapper.getFactory()
             .setStreamReadConstraints(StreamReadConstraints.builder()
-                .maxStringLength(MAX_STRING_LENGTH).build());
+                .maxStringLength(MAX_STRING_LENGTH)
+                .maxNameLength(MAX_NAME_LENGTH)
+                .build());
         mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
         return mapper;
     }


### PR DESCRIPTION
### Description
Increase document max name length from ~50kb -> 100mb

### Issues Resolved
We had a report from a customer with larger document name length that was causing issues with document backfill.

### Check List
- [ ] ~New functionality includes testing~
- [ ] ~Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
