### PR TITLE
Enable compatibility with Java 11

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -43,6 +43,8 @@ updates:
       - dependency-name: "org.junit:junit-bom"
       - dependency-name: "org.junit.platform:*"
       - dependency-name: "org.junit.jupiter:*"
+      - dependency-name: "com.diffplug.spotless" # Spotless Plugin >= 8 requres java 17 which requires solutions release to update
+      - dependency-name: "io.freefair.lombok" # Lombok Plugin >= 9 requres java 17 which requires solutions release to update
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/build.gradle
+++ b/build.gradle
@@ -4,8 +4,8 @@ import groovy.json.JsonOutput
 plugins {
 //    Observing higher memory usage with task-tree plugin. Disabling except if needed
 //    id "com.dorongold.task-tree" version "4.0.1"
-    id "com.diffplug.spotless" version '8.0.0'
-    id 'io.freefair.lombok' version '9.0.0' apply false
+    id "com.diffplug.spotless" version '7.2.1'
+    id 'io.freefair.lombok' version '8.14.3' apply false
     id 'me.champeau.jmh' version '0.7.3' apply false
     id 'com.gradleup.shadow' version '8.3.8' apply false
     id 'com.avast.gradle.docker-compose' version "0.17.12" apply false


### PR DESCRIPTION
### Description
`com.diffplug.spotless` and `io.freefair.lombok` updates bumped the minimum gradle run jdk with java 17.
This breaks existing release processes that depend on build environments with java 11 home. Reverting this until they can be updated.

### Issues
Fixes failing jenkins test https://migrations.ci.opensearch.org/job/solutions-cfn-create-vpc-test/8449/

(Note, this uncovered a bug where this Jenkins test is running on the last release tag and not main and thus did not break until  after the release)

### Testing
Ran with jenkins: ~https://migrations.ci.opensearch.org/job/solutions-cfn-create-vpc-test/8450/~ https://migrations.ci.opensearch.org/job/solutions-cfn-create-vpc-test/8451/

### Check List
- [ ] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
