### PR TITLE
Update awsRunInitBootstrap.sh to init boostrap on main

### DIFF
--- a/test/awsRunInitBootstrap.sh
+++ b/test/awsRunInitBootstrap.sh
@@ -160,7 +160,7 @@ check_ssm_ready() {
 
 instance_id=$(get_instance_id)
 check_ssm_ready "$instance_id"
-init_command="cd /opensearch-migrations && ./initBootstrap.sh"
+init_command="cd /opensearch-migrations && ./initBootstrap.sh --branch main"
 verify_command="cdk --version && docker --version && java --version && python3 --version"
 init_command_timeout="4200" # 70 minutes
 verify_command_timeout="300" # 5 minutes


### PR DESCRIPTION
### Description
Update awsRunInitBootstrap.sh to init boostrap on main. Currently defaults to the same logic as customers which creates a cyclic loop where the jenkins test won't fail until AFTER the release which does not help to avoid breaking changes.

This test only changes the testing cycle, does not affect other ingresses

### Check List
- [ ] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
