### PR TITLE
Fix a regression in our kafka tools support that was caused by upgrading Kafka past 3.7

### DIFF
--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/kafkaExport.sh
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/kafkaExport.sh
@@ -84,7 +84,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 # Printing existing offsets in topic
-all_consumers_partition_offsets=$(./kafka/bin/kafka-run-class.sh kafka.tools.GetOffsetShell --broker-list "$broker_endpoints" --topic "$topic" --time -1 $(echo "$kafka_command_config"))
+all_consumers_partition_offsets=$(./kafka/bin/kafka-run-class.sh org.apache.kafka.tools.GetOffsetShell --broker-list "$broker_endpoints" --topic "$topic" --time -1 $(echo "$kafka_command_config"))
 comma_sep_all_consumers_partition_offsets="${all_consumers_partition_offsets// /,}"
 echo "Existing offsets from current Kafka topic across all consumer groups: "
 echo "$comma_sep_all_consumers_partition_offsets"

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/kafka.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/models/kafka.py
@@ -124,7 +124,8 @@ class MSK(Kafka):
         return get_result_for_command(command, "Describe Consumer Group")
 
     def describe_topic_records(self, topic_name='logging-traffic-topic') -> CommandResult:
-        command = ['/root/kafka-tools/kafka/bin/kafka-run-class.sh', 'kafka.tools.GetOffsetShell', '--broker-list',
+        command = ['/root/kafka-tools/kafka/bin/kafka-run-class.sh',
+                   'org.apache.kafka.tools.GetOffsetShell', '--broker-list',
                    f'{self.brokers}', '--topic', f'{topic_name}', '--time', '-1'] + MSK_AUTH_PARAMETERS
         logger.info(f"Executing command: {command}")
         result = get_result_for_command(command, "Describe Topic Records")
@@ -161,7 +162,8 @@ class StandardKafka(Kafka):
         return get_result_for_command(command, "Describe Consumer Group")
 
     def describe_topic_records(self, topic_name='logging-traffic-topic') -> CommandResult:
-        command = ['/root/kafka-tools/kafka/bin/kafka-run-class.sh', 'kafka.tools.GetOffsetShell', '--broker-list',
+        command = ['/root/kafka-tools/kafka/bin/kafka-run-class.sh',
+                   'org.apache.kafka.tools.GetOffsetShell', '--broker-list',
                    f'{self.brokers}', '--topic', f'{topic_name}', '--time', '-1']
         logger.info(f"Executing command: {command}")
         result = get_result_for_command(command, "Describe Topic Records")

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/test_kafka.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/test_kafka.py
@@ -133,7 +133,7 @@ def test_msk_kafka_describe_topic(mocker):
 
     assert result.success
     mock.assert_called_once_with(
-        ['/root/kafka-tools/kafka/bin/kafka-run-class.sh', 'kafka.tools.GetOffsetShell',
+        ['/root/kafka-tools/kafka/bin/kafka-run-class.sh', 'org.apache.kafka.tools.GetOffsetShell',
          '--broker-list', f"{config['broker_endpoints']}",
          '--topic', 'new_topic',
          '--time', '-1',
@@ -152,7 +152,7 @@ def test_standard_kafka_describe_topic(mocker):
 
     assert result.success
     mock.assert_called_once_with(
-        ['/root/kafka-tools/kafka/bin/kafka-run-class.sh', 'kafka.tools.GetOffsetShell',
+        ['/root/kafka-tools/kafka/bin/kafka-run-class.sh', 'org.apache.kafka.tools.GetOffsetShell',
          '--broker-list', f"{config['broker_endpoints']}",
          '--topic', 'new_topic',
          '--time', '-1'


### PR DESCRIPTION
### Description
This fixes a regression that was in our manual kafka tools that was caused by a class move that happened between Kafka 3.7 and 3.8.  This affected console kafka describe-topic-records and kafkaExport. 

See https://github.com/apache/kafka/pull/13562/files, which was released in Kafka 3.8.

### Issues Resolved
<!-- List any GitHub or Jira issues this PR will resolve -->

### Testing
manual testing of `console kafka describe-topic-records`

### Check List
- [ ] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
