### PR TITLE
Fix a regression that required all configurations to use basic auth for RFS tasks

### DIFF
--- a/orchestrationSpecs/packages/migration-workflow-templates/src/workflowTemplates/documentBulkLoad.ts
+++ b/orchestrationSpecs/packages/migration-workflow-templates/src/workflowTemplates/documentBulkLoad.ts
@@ -71,6 +71,11 @@ function getRfsReplicasetManifest
     rfsImageName: BaseExpression<string>,
     rfsImagePullPolicy: BaseExpression<IMAGE_PULL_POLICY>
 }): ReplicaSet {
+    const basicCredsSecretName = expr.ternary(
+        expr.isEmpty(args.basicCredsSecretNameOrEmpty),
+        expr.literal("empty"),
+        args.basicCredsSecretNameOrEmpty
+    );
     const useCustomLogging = expr.not(expr.isEmpty(args.loggingConfigMap));
     const baseContainerDefinition = {
         name: "bulk-loader",
@@ -95,7 +100,7 @@ function getRfsReplicasetManifest
                 name: "TARGET_USERNAME",
                 valueFrom: {
                     secretKeyRef: {
-                        name: makeStringTypeProxy(args.basicCredsSecretNameOrEmpty),
+                        name: makeStringTypeProxy(basicCredsSecretName),
                         key: "username",
                         optional: true
                     }
@@ -105,7 +110,7 @@ function getRfsReplicasetManifest
                 name: "TARGET_PASSWORD",
                 valueFrom: {
                     secretKeyRef: {
-                        name: makeStringTypeProxy(args.basicCredsSecretNameOrEmpty),
+                        name: makeStringTypeProxy(basicCredsSecretName),
                         key: "password",
                         optional: true
                     }


### PR DESCRIPTION
### Description
When the RFS replicaset's basicCredsSecretNameOrEmpty is actually empty, point the secret to "empty" so that k8s doesn't choke on an empty name.  Notice that I could set optional=false when it isn't empty, but it didn't seem worth it.

### Testing
Manually tested with a basic-auth secret setup and not.  RFS successfully comes up in both cases.

### Check List
- [ ] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
