### PR TITLE
Remove inactive maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # This should match the owning team set up in https://github.com/orgs/opensearch-project/teams
-*   @AndreKurait @chelma @gregschohn @lewijacn @mikaylathompson @peternied @sumobrian @jugal-chauhan
+*   @AndreKurait @gregschohn @sumobrian @jugal-chauhan

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -6,13 +6,9 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 
 | Maintainer         | GitHub ID                                             | Affiliation |
 | ------------------ |-------------------------------------------------------| ----------- |
-| Chris Helma        | [chelma](https://github.com/chelma)                   | Amazon      |
 | Greg Schohn        | [gregschohn](https://github.com/gregschohn)           | Amazon      |
-| Tanner Lewis       | [lewijacn](https://github.com/lewijacn)               | Amazon      |
-| Mikayla Thompson   | [mikaylathompson](https://github.com/mikaylathompson) | Amazon      |
 | Brian Presley      | [sumobrian](https://github.com/sumobrian)             | Amazon      |
 | Andre Kurait       | [andrekurait](https://github.com/AndreKurait)         | Amazon      |
-| Peter Nied         | [peternied](https://github.com/peternied)             | Amazon      |
 | Jugal Chauhan      | [jugal-chauhan](https://github.com/jugal-chauhan)     | Amazon      |
 
 
@@ -21,4 +17,7 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | ------------------ | ------------------------------------------------------- | ----------- |
 | Kartik Ganesh      | [kartg](https://github.com/kartg)                       | Amazon      |
 | Omar Khasawneh     | [okhasawn](https://github.com/okhasawn)                 | Amazon      |
-
+| Chris Helma        | [chelma](https://github.com/chelma)                     | Amazon      |
+| Tanner Lewis       | [lewijacn](https://github.com/lewijacn)                 | Amazon      |
+| Mikayla Thompson   | [mikaylathompson](https://github.com/mikaylathompson)   | Amazon      |
+| Peter Nied         | [peternied](https://github.com/peternied)               | Amazon      |


### PR DESCRIPTION
### Description
Update the full time maintainers to remove chelma, mikaylathompson, peternied and lewijacn to more accurately portray active resources to external viewers. 

After approval will reach out to project admins to adjust the github team.

### Issues Resolved
N/A

### Testing
N/A

### Check List
- [ ] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
