### PR TITLE
Minor bugs hit during workflow testing

### DIFF
--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/workflow/commands/submit.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/console_link/workflow/commands/submit.py
@@ -131,7 +131,7 @@ def submit_command(ctx, namespace, wait, timeout, wait_interval, session):
             # Construct arguments for the submission script
             args = [
                 f"--prefix {namespace}",
-                f"--etcd_endpoints {etcd_endpoints}"
+                f"--etcd-endpoints {etcd_endpoints}"
             ]
 
             submit_result = runner.submit_workflow(config_yaml, args)

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/workflow-tests/test_script_runner.py
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/lib/console_link/tests/workflow-tests/test_script_runner.py
@@ -45,7 +45,7 @@ class TestScriptRunner:
   requiresApproval: false
   approver: ""
 """
-        args = ["--prefix ma", "--etcd_endpoints http://etcd.ma.svc.cluster.local:2379"]
+        args = ["--prefix ma", "--etcd-endpoints http://etcd.ma.svc.cluster.local:2379"]
         result = runner.submit_workflow(test_config, args)
 
         # Real script returns workflow info dict
@@ -70,7 +70,7 @@ class TestScriptRunner:
   approver: ""
 """
         namespace = "custom-ns"
-        args = [f"--prefix {namespace}", f"--etcd_endpoints http://etcd.{namespace}.svc.cluster.local:2379"]
+        args = [f"--prefix {namespace}", f"--etcd-endpoints http://etcd.{namespace}.svc.cluster.local:2379"]
         result = runner.submit_workflow(test_config, args)
 
         assert result["namespace"] == namespace

--- a/deployment/k8s/charts/components/migrationConsole/templates/rbac.yaml
+++ b/deployment/k8s/charts/components/migrationConsole/templates/rbac.yaml
@@ -12,11 +12,11 @@ metadata:
 rules:
   - apiGroups: [ "" ]
     resources: ["secrets"]
-    verbs: ["list"]
+    verbs: ["list", "create", "update", "patch", "delete"]
   - apiGroups: [ "" ]
-    resources: ["configmaps", "persistentvolumeclaims", "pods", "pods/log"]
+    resources: ["configmaps", "persistentvolumeclaims", "pods", "pods/log", "events"]
     verbs: ["get", "watch", "list", "create", "update", "patch", "delete", "deletecollection"]
-  - apiGroups: [ "apps" ]
+  - apiGroups: ["apps"]
     resources: ["deployments", "deployments/scale"]
     verbs: ["get", "watch", "list", "create", "update", "patch", "delete", "deletecollection"]
 

--- a/orchestrationSpecs/packages/config-processor/scripts/createMigrationWorkflowFromUserConfiguration.sh
+++ b/orchestrationSpecs/packages/config-processor/scripts/createMigrationWorkflowFromUserConfiguration.sh
@@ -28,7 +28,7 @@ UUID=$(uuidgen | tr '[:upper:]' '[:lower:]')
 echo "Generated unique uniqueRunNonce: $UUID"
 
 echo "Running configuration conversion..."
-$INITIALIZE_CMD --user-config $CONFIG_FILENAME --unique-run-nonce $UUID "$@" > "$TEMPORARY_FILE"
+$INITIALIZE_CMD --user-config $CONFIG_FILENAME --unique-run-nonce $UUID $@ > "$TEMPORARY_FILE"
 
 # Set the name field based on environment variable
 if [ -n "$USE_GENERATE_NAME" ]; then


### PR DESCRIPTION
### Description
A few minor bugs hit during workflow testing:
1. `--etcd-endpoints` (with a hyphen instead of an underscore)
2. removing quoting from the etcd endpoint when passed to the initialization command
3. adding permissions to migration console role for adding/editing secrets and for whatever `events` are


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
