### PR TITLE
Add FAILED_REQUESTS_LOGGER_LEVEL env variable to control failed requests logging

### DIFF
--- a/DocumentsFromSnapshotMigration/src/test/resources/log4j2.properties
+++ b/DocumentsFromSnapshotMigration/src/test/resources/log4j2.properties
@@ -18,7 +18,7 @@ appender.FailedRequests.strategy.type = DefaultRolloverStrategy
 appender.FailedRequests.immediateFlush = false
 
 logger.FailedRequestsLogger.name = FailedRequestsLogger
-logger.FailedRequestsLogger.level = info
+logger.FailedRequestsLogger.level = ${env:FAILED_REQUESTS_LOGGER_LEVEL:-info}
 logger.FailedRequestsLogger.additivity = false
 logger.FailedRequestsLogger.appenderRef.FailedRequests.ref = FailedRequests
 

--- a/RFS/src/main/resources/log4j2.properties
+++ b/RFS/src/main/resources/log4j2.properties
@@ -17,7 +17,7 @@ appender.FailedRequests.strategy.type = DefaultRolloverStrategy
 appender.FailedRequests.immediateFlush = false
 
 logger.FailedRequestsLogger.name = FailedRequestsLogger
-logger.FailedRequestsLogger.level = info
+logger.FailedRequestsLogger.level = ${env:FAILED_REQUESTS_LOGGER_LEVEL:-info}
 logger.FailedRequestsLogger.additivity = false
 logger.FailedRequestsLogger.appenderRef.FailedRequests.ref = FailedRequests
 

--- a/orchestrationSpecs/packages/migration-workflow-templates/src/workflowTemplates/documentBulkLoad.ts
+++ b/orchestrationSpecs/packages/migration-workflow-templates/src/workflowTemplates/documentBulkLoad.ts
@@ -118,6 +118,11 @@ function getRfsReplicasetManifest
                         optional: true
                     }
                 }
+            },
+            // We don't have a mechanism to scrape these off disk so need to disable this to avoid filling up the disk
+            {
+                name: "FAILED_REQUESTS_LOGGER_LEVEL",
+                value: "OFF"
             }
         ],
         args: [

--- a/orchestrationSpecs/packages/migration-workflow-templates/tests/__snapshots__/outputMatch.test.ts.snap
+++ b/orchestrationSpecs/packages/migration-workflow-templates/tests/__snapshots__/outputMatch.test.ts.snap
@@ -1148,7 +1148,7 @@ spec:
           image: "{{inputs.parameters.imageReindexFromSnapshotLocation}}"
           imagePullPolicy: "{{inputs.parameters.imageReindexFromSnapshotPullPolicy}}"
           command:
-            - /rfs-app/runJavaWithClasspath.sh
+            - /rfs-app/runJavaWithClasspathWithRepeat.sh
           args:
             - org.opensearch.migrations.RfsMigrateDocuments
             - ---INLINE-JSON
@@ -1158,15 +1158,17 @@ spec:
             - name: TARGET_USERNAME
               valueFrom:
                 secretKeyRef:
-                  name: "{{inputs.parameters.basicCredsSecretNameOrEmpty}}"
+                  name: "{{=((0 == len(inputs.parameters.basicCredsSecretNameOrEmpty)) ? ('empty') : (inputs.parameters.basicCredsSecretNameOrEmpty))}}"
                   key: username
                   optional: true
             - name: TARGET_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: "{{inputs.parameters.basicCredsSecretNameOrEmpty}}"
+                  name: "{{=((0 == len(inputs.parameters.basicCredsSecretNameOrEmpty)) ? ('empty') : (inputs.parameters.basicCredsSecretNameOrEmpty))}}"
                   key: password
                   optional: true
+            - name: FAILED_REQUESTS_LOGGER_LEVEL
+              value: OFF
             - name: JAVA_OPTS
               value: "{{=' ' + ' ' + ((!(0 == len(inputs.parameters.loggingConfigurationOverrideConfigMap))) ? ('-Dlog4j2.configurationFile=/config/logConfiguration') : (''))}}"
             - name: AWS_SHARED_CREDENTIALS_FILE
@@ -1256,7 +1258,7 @@ spec:
                   },
                   {
                     "name": "rfsJsonConfig",
-                    "value": "{{=toJSON(sprig.merge(sprig.merge(sprig.merge((('authConfig' in fromJSON(inputs.parameters.targetConfig)) ? ((('sigv4' in fromJSON(inputs.parameters.targetConfig)['authConfig']) ? (sprig.dict("targetAwsServiceSigningName", fromJSON(inputs.parameters.targetConfig)['authConfig']['sigv4']['service'], "targetAwsRegion", fromJSON(inputs.parameters.targetConfig)['authConfig']['sigv4']['region'])) : ((('mtls' in fromJSON(inputs.parameters.targetConfig)['authConfig']) ? (sprig.dict("targetCaCert", fromJSON(inputs.parameters.targetConfig)['authConfig']['mtls']['caCert'])) : ({}))))) : ({})), sprig.dict("targetHost", jsonpath(inputs.parameters.targetConfig, '$.endpoint'), "targetInsecure", sprig.dig('allowInsecure', false, fromJSON(inputs.parameters.targetConfig)))), sprig.omit(fromJSON(inputs.parameters.documentBackfillConfig), 'loggingConfigurationOverrideConfigMap', 'podReplicas', 'resources')), sprig.merge(sprig.dict("snapshotName", fromJSON(inputs.parameters.snapshotConfig)['snapshotName'], "sourceVersion", inputs.parameters.sourceVersion, "sessionName", inputs.parameters.sessionName, "luceneDir", '/tmp'), sprig.dict("s3Endpoint", fromJSON(inputs.parameters.snapshotConfig)['repoConfig']['endpoint'], "s3RepoUri", fromJSON(inputs.parameters.snapshotConfig)['repoConfig']['s3RepoPathUri'], "s3Region", fromJSON(inputs.parameters.snapshotConfig)['repoConfig']['awsRegion'], "s3LocalDir", '/tmp'))))}}",
+                    "value": "{{=toJSON(sprig.merge(sprig.merge(sprig.merge((('authConfig' in fromJSON(inputs.parameters.targetConfig)) ? ((('sigv4' in fromJSON(inputs.parameters.targetConfig)['authConfig']) ? (sprig.dict("targetAwsServiceSigningName", fromJSON(inputs.parameters.targetConfig)['authConfig']['sigv4']['service'], "targetAwsRegion", fromJSON(inputs.parameters.targetConfig)['authConfig']['sigv4']['region'])) : ((('mtls' in fromJSON(inputs.parameters.targetConfig)['authConfig']) ? (sprig.dict("targetCaCert", fromJSON(inputs.parameters.targetConfig)['authConfig']['mtls']['caCert'])) : ({}))))) : ({})), sprig.dict("targetHost", jsonpath(inputs.parameters.targetConfig, '$.endpoint'), "targetInsecure", sprig.dig('allowInsecure', false, fromJSON(inputs.parameters.targetConfig)))), sprig.omit(fromJSON(inputs.parameters.documentBackfillConfig), 'loggingConfigurationOverrideConfigMap', 'podReplicas', 'resources')), sprig.merge(sprig.dict("snapshotName", fromJSON(inputs.parameters.snapshotConfig)['snapshotName'], "sourceVersion", inputs.parameters.sourceVersion, "sessionName", inputs.parameters.sessionName, "luceneDir", '/tmp', "cleanLocalDirs", true), sprig.dict("s3Endpoint", fromJSON(inputs.parameters.snapshotConfig)['repoConfig']['endpoint'], "s3RepoUri", fromJSON(inputs.parameters.snapshotConfig)['repoConfig']['s3RepoPathUri'], "s3Region", fromJSON(inputs.parameters.snapshotConfig)['repoConfig']['awsRegion'], "s3LocalDir", '/tmp'))))}}",
                   },
                   {
                     "name": "resources",
@@ -3148,7 +3150,7 @@ spec:
                   },
                   {
                     "name": "jsonConfig",
-                    "value": "{{=toJSON(sprig.merge(sprig.merge(sprig.merge((('authConfig' in fromJSON(inputs.parameters.targetConfig)) ? ((('sigv4' in fromJSON(inputs.parameters.targetConfig)['authConfig']) ? (sprig.dict("targettargetAwsServiceSigningName", fromJSON(inputs.parameters.targetConfig)['authConfig']['sigv4']['service'], "targetAwsRegion", fromJSON(inputs.parameters.targetConfig)['authConfig']['sigv4']['region'])) : ((('mtls' in fromJSON(inputs.parameters.targetConfig)['authConfig']) ? (sprig.dict("targetCaCert", fromJSON(inputs.parameters.targetConfig)['authConfig']['mtls']['caCert'])) : ({}))))) : ({})), sprig.dict("targetHost", jsonpath(inputs.parameters.targetConfig, '$.endpoint'), "targetInsecure", sprig.dig('allowInsecure', false, fromJSON(inputs.parameters.targetConfig)))), sprig.omit(fromJSON(inputs.parameters.replayerConfig), 'loggingConfigurationOverrideConfigMap', 'podReplicas', 'resources')), sprig.merge(sprig.dict(), sprig.dict())))}}",
+                    "value": "{{=toJSON(sprig.merge(sprig.merge(sprig.merge((('authConfig' in fromJSON(inputs.parameters.targetConfig)) ? ((('sigv4' in fromJSON(inputs.parameters.targetConfig)['authConfig']) ? (sprig.dict("targetAwsServiceSigningName", fromJSON(inputs.parameters.targetConfig)['authConfig']['sigv4']['service'], "targetAwsRegion", fromJSON(inputs.parameters.targetConfig)['authConfig']['sigv4']['region'])) : ((('mtls' in fromJSON(inputs.parameters.targetConfig)['authConfig']) ? (sprig.dict("targetCaCert", fromJSON(inputs.parameters.targetConfig)['authConfig']['mtls']['caCert'])) : ({}))))) : ({})), sprig.dict("targetHost", jsonpath(inputs.parameters.targetConfig, '$.endpoint'), "targetInsecure", sprig.dig('allowInsecure', false, fromJSON(inputs.parameters.targetConfig)))), sprig.omit(fromJSON(inputs.parameters.replayerConfig), 'loggingConfigurationOverrideConfigMap', 'podReplicas', 'resources')), sprig.merge(sprig.dict(), sprig.dict())))}}",
                   },
                 ],
               },


### PR DESCRIPTION
## Description
Add configurable environment variable to control failed requests logging in RFS and DocumentsFromSnapshotMigration.

## Changes
- Add `FAILED_REQUESTS_LOGGER_LEVEL` env variable to log4j2 configs (defaults to 'info')
- Set to 'OFF' in orchestrationSpecs reindex-from-snapshot container to avoid filling up disk
- Update Jest snapshots

## Rationale
We don't have a mechanism to scrape failed request logs off disk in the K8s environment, so we need to disable this to avoid filling up the disk.

https://opensearch.atlassian.net/browse/MIGRATIONS-2753