### PR TITLE
Upgrade nodejs to v22.

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -8,7 +8,7 @@ env:
   python-version: '3.11'
   java-version: '17'
   gradle-version: '8.12.1'
-  node-version: '18.x'
+  node-version: '22.x'
   gradle-test-parallelization: '30'
 
 # Prevent multiple simultaneous runs except on main repo

--- a/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/Dockerfile
+++ b/TrafficCapture/dockerSolution/src/main/docker/migrationConsole/Dockerfile
@@ -53,6 +53,7 @@ RUN dnf install -y  \
       --setopt=plugins=0 \
       --setopt=logfilelevel=0 \
         nodejs22 \
+        nodejs22-npm \
         && \
         dnf clean all && \
         rm -rf /var/cache/dnf

--- a/deployment/migration-assistant-solution/initBootstrap.sh
+++ b/deployment/migration-assistant-solution/initBootstrap.sh
@@ -35,7 +35,8 @@ while [[ "$#" -gt 0 ]]; do
   shift
 done
 
-yum update && yum install -y git java-11-amazon-corretto-devel docker nodejs https://s3.amazonaws.com/session-manager-downloads/plugin/latest/linux_64bit/session-manager-plugin.rpm
+# Check that these Node-22/NPM references are valid
+yum update && yum install -y git java-17-amazon-corretto-devel docker nodejs22 nodejs22-npm https://s3.amazonaws.com/session-manager-downloads/plugin/latest/linux_64bit/session-manager-plugin.rpm
 systemctl start docker
 git init
 git remote | grep "origin" || git remote add -f origin https://github.com/opensearch-project/opensearch-migrations.git


### PR DESCRIPTION
### Description
Upgrade nodejs to v22.  The orchestrationSpecs require that version.
Also bumped the java version to 17 for our build tools to take advantage of.

### Issues Resolved
Prereq for https://opensearch.atlassian.net/browse/MIGRATIONS-2747

### Testing
Ran the command on the bootstrap box & verified that node --version and a node script w/ Object.groupBy worked.

### Check List
- [ ] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
