### PR TITLE
Fix duplicate template entry in solution-manifest.yaml

### DIFF
--- a/deployment/migration-assistant-solution/solution-manifest.yaml
+++ b/deployment/migration-assistant-solution/solution-manifest.yaml
@@ -6,7 +6,7 @@ cloudformation_templates:
     main_template: true
   - template: migration-assistant-for-amazon-opensearch-service-import-vpc.template
     main_template: true
-  - template: migration-assistant-for-amazon-opensearch-service-import-vpc-v3.template
+  - template: migration-assistant-for-amazon-opensearch-service-create-vpc-v3.template
     main_template: true
   - template: migration-assistant-for-amazon-opensearch-service-import-vpc-v3.template
     main_template: true


### PR DESCRIPTION
### Description
Update template name from import-vpc-v3 to create-vpc-v3 to resolve duplicate entries in solution-manifest.yaml

This fixes the duplicate template entries introduced in https://github.com/opensearch-project/opensearch-migrations/pull/2013

### Issues Resolved
Fixes duplicate template entries that could cause deployment issues

### Testing
- Verified YAML syntax is valid
- Confirmed template name change is correct

### Check List
- [x] New functionality includes testing
- [ ] Public documentation issue/PR created, if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).