### PR TITLE
Allow set config when passed in to console

### DIFF
--- a/migrationConsole/lib/console_link/console_link/cli.py
+++ b/migrationConsole/lib/console_link/console_link/cli.py
@@ -25,6 +25,7 @@ from console_link.models.metrics_source import Component, MetricStatistic
 from console_link.workflow.models.store import WorkflowConfigStore
 from console_link.workflow.models.utils import KubernetesConfigNotFoundError
 from click.shell_completion import get_completion_class
+from click.core import ParameterSource
 
 import logging
 import os
@@ -100,8 +101,10 @@ def cli(ctx, config_file: str, force_use_config_file: bool, json: bool, verbose:
     logger.info(f"Logging set to {logging.getLevelName(logger.getEffectiveLevel())}")
 
     # Set the `force_use_config_file` based on the CLI flag OR the env var MIGRATION_USE_SERVICES_YAML_CONFIG
+    #  OR if --config-file was passed on the command line
     force_use_config_file = (force_use_config_file or
-                             (os.getenv("MIGRATION_USE_SERVICES_YAML_CONFIG", "false") not in ("false", 0)))
+                             (os.getenv("MIGRATION_USE_SERVICES_YAML_CONFIG", "false") not in ("false", 0)) or
+                             (ctx.get_parameter_source("config_file") == ParameterSource.COMMANDLINE))
     logger.info(f"force_use_config_file set to {force_use_config_file}")
     # Disabling all logging for gathering the context for shell completion (run automatically)
     # on container startup


### PR DESCRIPTION
### Description
Allow set config when passed in to console

Currently when `--config-file` is passed like in the workflows, it still defaults to the workflow config

### Issues Resolved

### Testing
Manual testing (until we have integ test)

### Check List
- [ ] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
