### PR TITLE
Don't throw/crash when a null secret value is encountered.

### DIFF
--- a/orchestrationSpecs/packages/config-processor/src/findSecrets.ts
+++ b/orchestrationSpecs/packages/config-processor/src/findSecrets.ts
@@ -41,7 +41,7 @@ export function getCategorizedCredentialsSecretsFromConfig(
     userConfig: Partial<z.infer<typeof OVERALL_MIGRATION_CONFIG>>
 ) {
     const rawSecrets = scrapeSecrets(userConfig);
-    return Object.groupBy(rawSecrets, s=> s.match(K8S_NAMING_PATTERN) ? "validSecrets" : "invalidSecrets");
+    return Object.groupBy(rawSecrets, s=> s && s.match(K8S_NAMING_PATTERN) ? "validSecrets" : "invalidSecrets");
 }
 
 export async function main() {


### PR DESCRIPTION
### Description
Don't throw/crash when a null secret value is encountered.

Now, this message is emitted "Error: Invalidly named secrets found: [None]"

### Issues Resolved
No jira

### Testing
manual testing

### Check List
- [ ] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
