### PR TITLE
fix: pin codecov-action to specific commit and use skip_validation input

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -107,12 +107,11 @@ jobs:
         run: echo "SANITIZED_PY_PROJECT=${PY_PROJECT//\//-}" >> $GITHUB_ENV
       - name: Upload coverage to Codecov
         if: always()
-        uses: codecov/codecov-action@v5
-        env:
-          CODECOV_SKIP_VALIDATION: true
+        uses: codecov/codecov-action@9b6d1f84bde660b0f784003009b1f0aa4663cdeb
         with:
           fail_ci_if_error: true
           flags: python
+          skip_validation: true
           token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true
 
@@ -185,12 +184,11 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: always()
-        uses: codecov/codecov-action@v5
-        env:
-          CODECOV_SKIP_VALIDATION: true
+        uses: codecov/codecov-action@9b6d1f84bde660b0f784003009b1f0aa4663cdeb
         with:
           fail_ci_if_error: true
           flags: gradle
+          skip_validation: true
           token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true
 
@@ -270,12 +268,11 @@ jobs:
         run: npm run test
       - name: Upload coverage to Codecov
         if: always()
-        uses: codecov/codecov-action@v5
-        env:
-          CODECOV_SKIP_VALIDATION: true
+        uses: codecov/codecov-action@9b6d1f84bde660b0f784003009b1f0aa4663cdeb
         with:
           fail_ci_if_error: true
           flags: node
+          skip_validation: true
           token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true
 


### PR DESCRIPTION
### Description
Pin codecov-action to a specific commit and update to use the new skip_validation input parameter instead of the deprecated environment variable. This change resolves intermittent CI failures caused by GPG key download issues in the codecov action.

### Issues Resolved
- Fixes GPG key download failures in codecov GitHub action
- Resolves intermittent CI failures during codecov uploads
- Updates to use the new codecov-action input parameters

### Testing
This change will be automatically tested with existing PRs as it affects the CI workflow:
- All three codecov upload steps (python, gradle, node) are updated consistently
- The pinned commit (9b6d1f84bde660b0f784003009b1f0aa4663cdeb) is a stable version from the main branch
- skip_validation input parameter replaces the deprecated CODECOV_SKIP_VALIDATION environment variable
- Existing test coverage and CI processes will validate the change

### Check List
- [x] New functionality includes testing (automatically tested via CI)
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
