### PR TITLE
Set up docker-registry to resolve to 127.0.0.1 on the GHA host

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -29,6 +29,11 @@ jobs:
     outputs:
       dockerhub-password: ${{ steps.retrieve-values.outputs.dockerhub-password }}
     steps:
+      - name: Alias docker-registry to 127.0.0.1
+        run: |
+          echo "127.0.0.1 docker-registry" | sudo tee -a /etc/hosts
+          getent hosts docker-registry
+          curl -sS http://docker-registry:5000/v2/ || true
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-env
       - id: get_data
@@ -56,11 +61,11 @@ jobs:
           # This has to match the -Pbuilder flag for buildImages/build.gradle
           name: local-remote-builder
           install: true
-          # ALLOW ACCESS TO HOST NETWORK (Required to see localhost:5000)
+          # ALLOW ACCESS TO HOST NETWORK (Required to see localhost:5000 for docker registry)
           driver-opts: network=host
-          # CONFIGURE INSECURE REGISTRY (Required for HTTP)
+          # CONFIGURE INSECURE REGISTRY (Required for HTTP for docker registry)
           config-inline: |
-            [registry."localhost:5000"]
+            [registry."docker-registry:5000"]
               http = true
               insecure = true
       - name: Create source archive


### PR DESCRIPTION
### Description
Set up docker-registry to resolve to 127.0.0.1 on the GHA host and fix the buildkit.toml config to refer to the registry it will use.

### Issues Resolved
https://opensearch.atlassian.net/browse/MIGRATIONS-2780

### Testing
Almost none - the fix concerns docker networking, so act wasn't of use.

### Check List
- [ ] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
