### PR TITLE
Fix Sync task deleting runtimeJars directory

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -75,6 +75,8 @@ jobs:
             HEAD
       - name: Build and Publish to Maven
         if: ${{ !github.event.act }}
+        env:
+          OS_MIGRATIONS_GRADLE_SCAN_TOS_AGREE_AND_ENABLED: ''
         run: |
           ./gradlew publishMavenJavaPublicationToMavenRepository -Dbuild.snapshot=false -Dbuild.version=0.${{ steps.get_data.outputs.version }} && tar -C build -cvf opensearch-migrations-artifacts.tar.gz repository
       - name: Configure AWS Credentials
@@ -97,6 +99,8 @@ jobs:
           username: ${{ secrets.MIGRATIONS_DOCKER_USERNAME }}
           password: ${{ steps.retrieve-values.outputs.dockerhub-password }}
       - name: Build and Push Docker Images
+        env:
+          OS_MIGRATIONS_GRADLE_SCAN_TOS_AGREE_AND_ENABLED: ''
         run: |
           # Preface Traffic Capture version with 0. to signal interface immaturity
           ./gradlew :buildImages:buildImagesToRegistry \

--- a/DocumentsFromSnapshotMigration/build.gradle
+++ b/DocumentsFromSnapshotMigration/build.gradle
@@ -64,7 +64,7 @@ application {
 }
 
 // Register copy version file task
-CommonUtils.copyVersionFileToDockerStaging(project, "reindexFromSnapshot", "docker/build")
+CommonUtils.syncVersionFileToDockerStaging(project, "reindexFromSnapshot", "docker/build/version")
 
 // Cleanup additional docker build directory
 def dockerBuildDir = file("./docker/build")
@@ -95,7 +95,7 @@ DockerServiceProps[] dockerServices = [
         new DockerServiceProps([projectName:"reindexFromSnapshot",
                                 dockerImageName:"reindex_from_snapshot",
                                 inputDir:"./docker",
-                                taskDependencies:["copyDockerRuntimeJars", "copyVersionFile_reindexFromSnapshot"]])
+                                taskDependencies:["copyDockerRuntimeJars", "syncVersionFile_reindexFromSnapshot"]])
 ] as DockerServiceProps[]
 
 for (dockerService in dockerServices) {

--- a/DocumentsFromSnapshotMigration/docker/Dockerfile
+++ b/DocumentsFromSnapshotMigration/docker/Dockerfile
@@ -8,7 +8,7 @@ RUN dnf install -y procps && \
 
 # Requires Gradle to genearte runtime jars initially
 COPY ./build/runtimeJars /rfs-app/jars
-COPY ./build/VERSION /rfs-app/VERSION
+COPY ./build/version/VERSION /rfs-app/VERSION
 WORKDIR /rfs-app
 
 # Copy the Java runner scripts into the container

--- a/build.gradle
+++ b/build.gradle
@@ -203,8 +203,8 @@ subprojects {
                 def index = System.getProperty("test.striping.index")
 
                 // Register striping params as inputs so tests rerun when striping changes
-                inputs.property("test.striping.total", total)
-                inputs.property("test.striping.index", index)
+                inputs.property("test.striping.total", total).optional(true)
+                inputs.property("test.striping.index", index).optional(true)
 
                 if (total != null) {
                     systemProperty "test.striping.total", total

--- a/buildImages/build.gradle
+++ b/buildImages/build.gradle
@@ -29,7 +29,7 @@ def jibProjects = [
                 imageName     : "traffic_replayer",
                 imageTag      : "latest",
                 requiredDependencies: [
-                    ":TrafficCapture:trafficReplayer": ["copyVersionFile_traffic_replayer"]
+                    ":TrafficCapture:trafficReplayer": ["syncVersionFile_traffic_replayer"]
                 ]
         ],
         "TrafficCapture:trafficCaptureProxyServer": [
@@ -41,7 +41,7 @@ def jibProjects = [
                 imageTag       : "latest",
                 requiredDependencies: [
                     "": ["buildKit_captureProxyBase"],
-                    ":TrafficCapture:trafficCaptureProxyServer": ["copyVersionFile_capture_proxy"]
+                    ":TrafficCapture:trafficCaptureProxyServer": ["syncVersionFile_capture_proxy"]
                 ]
         ]
 ]
@@ -69,7 +69,7 @@ def buildKitProjects = [
                 imageTag:   "latest",
                 requiredDependencies: [
                         ":DocumentsFromSnapshotMigration:copyDockerRuntimeJars",
-                        ":DocumentsFromSnapshotMigration:copyVersionFile_reindexFromSnapshot"
+                        ":DocumentsFromSnapshotMigration:syncVersionFile_reindexFromSnapshot"
                 ]
         ],
         [

--- a/buildSrc/src/main/groovy/org/opensearch/migrations/common/CommonUtils.groovy
+++ b/buildSrc/src/main/groovy/org/opensearch/migrations/common/CommonUtils.groovy
@@ -120,14 +120,10 @@ class CommonUtils {
         }
     }
 
-    static def copyVersionFileToDockerStaging(Project project, String destProjectName, String destDir) {
-        return project.tasks.register("copyVersionFile_${destProjectName}", Sync) {
+    static def syncVersionFileToDockerStaging(Project project, String destProjectName, String destDir) {
+        return project.tasks.register("syncVersionFile_${destProjectName}", Sync) {
             from(project.rootProject.layout.projectDirectory.file("VERSION"))
             into(project.layout.projectDirectory.dir(destDir))
-            
-            // Explicit inputs/outputs for incremental build support
-            inputs.file(project.rootProject.layout.projectDirectory.file("VERSION"))
-            outputs.dir(project.layout.projectDirectory.dir(destDir))
         }
     }
 

--- a/buildSrc/src/main/groovy/org/opensearch/migrations/image/RegistryImageBuildUtils.groovy
+++ b/buildSrc/src/main/groovy/org/opensearch/migrations/image/RegistryImageBuildUtils.groovy
@@ -58,8 +58,8 @@ class RegistryImageBuildUtils {
                 def imageName = config.imageName.toString()
 
                 // Create version file task ONCE per project, not per architecture
-                if (!project.tasks.findByName("copyVersionFile_${imageName}")) {
-                    CommonUtils.copyVersionFileToDockerStaging(project, imageName, "build/versionDir")
+                if (!project.tasks.findByName("syncVersionFile_${imageName}")) {
+                    CommonUtils.syncVersionFileToDockerStaging(project, imageName, "build/versionDir")
                 }
 
                 project.plugins.withId('com.google.cloud.tools.jib') {

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -6,7 +6,7 @@ COPY out /usr/share/nginx/html
 # overwrite default Nginx config
 COPY nginx.conf /etc/nginx/conf.d/default.conf
 
-COPY build/VERSION /VERSION
+COPY build/version/VERSION /VERSION
 
 EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/build.gradle
+++ b/frontend/build.gradle
@@ -34,7 +34,7 @@ def buildOutputs = [
 ]
 
 // Register copy version file task
-CommonUtils.copyVersionFileToDockerStaging(project, "frontend", "build/")
+CommonUtils.syncVersionFileToDockerStaging(project, "frontend", "build/version")
 
 def backendApiProject = project(':console_link')
 tasks.register('syncBackendClientDefinition', Sync) {
@@ -50,7 +50,7 @@ tasks.register('syncBackendClientDefinition', Sync) {
 tasks.register('generateBackendClient', NpmTask) {
     dependsOn 'npmInstall'
     dependsOn 'syncBackendClientDefinition'
-    dependsOn 'copyVersionFile_frontend'
+    dependsOn 'syncVersionFile_frontend'
     group = 'build'
     description = 'Generates the TypeScript API client from openapi.json'
 
@@ -105,7 +105,7 @@ tasks.register('cleanFrontend', Delete) {
 
 tasks.register('buildDockerImage', DockerBuildImage) {
     dependsOn 'buildFrontend'
-    dependsOn 'copyVersionFile_frontend'
+    dependsOn 'syncVersionFile_frontend'
     inputs.files fileTree(dir: '.', include: buildInputs, exclude: buildExclusions)
     outputs.file(imageIdFile)
 


### PR DESCRIPTION
## Description

This PR fixes the release build failure where the `reindex_from_snapshot` Docker image build was failing because `/build/runtimeJars` was not found.

**Root Cause:**
The `copyVersionFile_*` task used Gradle's `Sync` task which syncs to the same directory (`docker/build`) as `copyDockerRuntimeJars`. Since `Sync` deletes files in the destination that aren't in the source, it deleted the `runtimeJars` directory when it ran.

**Fix:**
Move the VERSION file to its own subdirectory so each Sync task has its own directory and won't conflict:
- `DocumentsFromSnapshotMigration`: `docker/build/version/VERSION`
- `frontend`: `build/version/VERSION`

**Changes:**
- Renamed task from `copyVersionFile_*` to `syncVersionFile_*` for clarity
- Updated destination paths to use `version/` subdirectory
- Updated Dockerfiles to COPY from the new `version/` subdirectory
- Disabled Gradle scan in release-drafter workflow

**Directory structure after fix:**
```
docker/build/
├── runtimeJars/  (from copyDockerRuntimeJars - preserved!)
└── version/
    └── VERSION   (from syncVersionFile - isolated!)
```

## Issues Resolved

Fixes release build failure for reindex-from-snapshot image (run 20281168457).

## Testing

- Verified locally that `runtimeJars` directory is preserved after both tasks run
- Verified Docker build proceeds past the COPY stage

## Check List

- [x] New functionality includes testing
- [ ] Public documentation issue/PR created, if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).