### PR TITLE
Rename RFS workflow tasks to historical backfill terminology and fix delete bug

### DIFF
--- a/orchestrationSpecs/packages/migration-workflow-templates/tests/__snapshots__/outputMatch.test.ts.snap
+++ b/orchestrationSpecs/packages/migration-workflow-templates/tests/__snapshots__/outputMatch.test.ts.snap
@@ -968,11 +968,11 @@ exports[`test workflow template renderings document-bulk-load 1`] = `
         "inputs": {
           "parameters": [
             {
-              "name": "name",
+              "name": "sessionName",
             },
           ],
         },
-        "name": "deletereplicaset",
+        "name": "stophistoricalbackfill",
         "outputs": {
           "parameters": [],
         },
@@ -984,7 +984,7 @@ exports[`test workflow template renderings document-bulk-load 1`] = `
           "manifest": "apiVersion: apps/v1
 kind: ReplicaSet
 metadata:
-  name: "{{='bulk-loader-'+inputs.parameters.name}}"
+  name: "{{=inputs.parameters.sessionName+'-reindex-from-snapshot'}}"
 ",
         },
       },
@@ -1055,7 +1055,7 @@ sys.exit(0 if all_finished else 1)'",
                   },
                 ],
               },
-              "name": "checkRfsCompletion",
+              "name": "checkHistoricalBackfillCompletion",
               "templateRef": {
                 "name": "migration-console",
                 "template": "runmigrationcommand",
@@ -1097,7 +1097,7 @@ sys.exit(0 if all_finished else 1)'",
             },
           ],
         },
-        "name": "createreplicaset",
+        "name": "starthistoricalbackfill",
         "outputs": {
           "parameters": [],
         },
@@ -1199,7 +1199,7 @@ spec:
             },
           ],
         },
-        "name": "createreplicasetfromconfig",
+        "name": "starthistoricalbackfillfromconfig",
         "outputs": {
           "parameters": [],
         },
@@ -1246,8 +1246,8 @@ spec:
                   },
                 ],
               },
-              "name": "createReplicaset",
-              "template": "createreplicaset",
+              "name": "startHistoricalBackfill",
+              "template": "starthistoricalbackfill",
             },
           ],
         ],
@@ -1327,8 +1327,8 @@ spec:
                   },
                 ],
               },
-              "name": "createReplicasetFromConfig",
-              "template": "createreplicasetfromconfig",
+              "name": "startHistoricalBackfillFromConfig",
+              "template": "starthistoricalbackfillfromconfig",
             },
           ],
           [
@@ -1383,13 +1383,13 @@ spec:
               "arguments": {
                 "parameters": [
                   {
-                    "name": "name",
+                    "name": "sessionName",
                     "value": "{{inputs.parameters.sessionName}}",
                   },
                 ],
               },
-              "name": "deleteReplicaSet",
-              "template": "deletereplicaset",
+              "name": "stopHistoricalBackfill",
+              "template": "stophistoricalbackfill",
             },
           ],
         ],


### PR DESCRIPTION
### Description
Rename workflow task names for clarity and consistency with the historical backfill terminology:
- `deleteReplicaSet` -> `stopHistoricalBackfill`
- `createReplicaset` -> `startHistoricalBackfill`
- `createReplicasetFromConfig` -> `startHistoricalBackfillFromConfig`
- `checkRfsCompletion` -> `checkHistoricalBackfillCompletion`

Also fixes a bug where `stopHistoricalBackfill` (formerly `deleteReplicaSet`) was using the wrong ReplicaSet name pattern (`bulk-loader-*` instead of `*-reindex-from-snapshot`). Added `getRfsReplicasetName` helper to share the name pattern between creation and deletion.

### Issues Resolved
N/A - Terminology improvement and bug fix

### Testing
- Snapshot tests updated and passing
- Implicitly validated that migrations still work with jenkins test

### Check List
- [x] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).