### PR TITLE
Reset default parameters for jenkins to use the migrations main repo instead of lewijacn's

### DIFF
--- a/jenkins/migrationIntegPipelines/eksIntegTestCover.groovy
+++ b/jenkins/migrationIntegPipelines/eksIntegTestCover.groovy
@@ -1,5 +1,5 @@
 def gitBranch = params.GIT_BRANCH ?: 'eks-pipeline'
-def gitUrl = params.GIT_REPO_URL ?: 'https://github.com/lewijacn/opensearch-migrations.git'
+def gitUrl = params.GIT_REPO_URL ?: 'https://github.com/opensearch-project/opensearch-migrations.git'
 
 library identifier: "migrations-lib@${gitBranch}", retriever: modernSCM(
         [$class: 'GitSCMSource',

--- a/vars/eksIntegPipeline.groovy
+++ b/vars/eksIntegPipeline.groovy
@@ -25,7 +25,7 @@ def call(Map config = [:]) {
         agent { label config.workerAgent ?: 'Jenkins-Default-Agent-X64-C5xlarge-Single-Host' }
 
         parameters {
-            string(name: 'GIT_REPO_URL', defaultValue: 'https://github.com/lewijacn/opensearch-migrations.git', description: 'Git repository url')
+            string(name: 'GIT_REPO_URL', defaultValue: 'https://github.com/opensearch-project/opensearch-migrations.git', description: 'Git repository url')
             string(name: 'GIT_BRANCH', defaultValue: 'eks-pipeline', description: 'Git branch to use for repository')
             string(name: 'STAGE', defaultValue: "${defaultStageId}", description: 'Stage name for deployment environment')
             choice(


### PR DESCRIPTION
### Description
Reset default parameters for jenkins to use the migrations main repo instead of lewijacn's

### Issues Resolved
I'm trying to resolve some broken jenkins builds.  It looks like about 2 days ago, we started to pull git repos from the lewijacn repo instead of main.  See these two build logs for examples
Broken: https://migrations.ci.opensearch.org/blue/organizations/jenkins/eks-integ-test/detail/eks-integ-test/1068/pipeline/11
Good: https://migrations.ci.opensearch.org/blue/organizations/jenkins/eks-integ-test/detail/eks-integ-test/1043/pipeline/11

### Testing
None

### Check List
- [ ] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
