### PR TITLE
[TEST] Verify CI trigger consolidation - label-based eks-integ-test

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -330,3 +330,4 @@ jobs:
           echo "One or more job cancelled, failed, or skipped" && exit 1
       - run: |
           echo '## :heavy_check_mark: All continuous integration checks pass' >> $GITHUB_STEP_SUMMARY
+# Test commit for CI trigger verification


### PR DESCRIPTION
## Test PR for CI trigger changes

This PR tests the label-based triggering for `eks-integ-test`.

**Expected behavior:**
- `eks-integ-test` should NOT run initially (no label)
- Adding `run-eks-tests` label should trigger `eks-integ-test`
- Subsequent commits should run `eks-integ-test` while label is present

**Do not merge** - this is just for testing the workflow changes.