### PR TITLE
Increase wait_for_service_status timeout to 3 minutes

### DIFF
--- a/migrationConsole/lib/integ_test/integ_test/common_utils.py
+++ b/migrationConsole/lib/integ_test/integ_test/common_utils.py
@@ -79,7 +79,7 @@ def execute_api_call(cluster: Cluster, path: str, method=HttpMethod.GET, data=No
     return last_response
 
 
-def wait_for_service_status(status_func, desired_status, max_attempts: int = 25, delay: float = 3.0):
+def wait_for_service_status(status_func, desired_status, max_attempts: int = 60, delay: float = 3.0):
     error_message = ""
     for attempt in range(1, max_attempts + 1):
         cmd_result = status_func()


### PR DESCRIPTION
Fargate ENI provisioning time can vary significantly (11s to 44s observed), causing replayer startup to occasionally exceed the previous 75s timeout.

Increase default max_attempts from 25 to 60 (180s total) to handle this variability.

**Root cause analysis:**
- Task 1: createdAt → pullStartedAt = 11 seconds
- Task 2: createdAt → pullStartedAt = 44 seconds (same test run)

The 33 second difference in ENI provisioning caused the test to timeout at 75s.