### PR TITLE
Fix missing syntax errors at the console for the migration initializer script

### DIFF
--- a/orchestrationSpecs/packages/config-processor/src/runMigrationInitializer.ts
+++ b/orchestrationSpecs/packages/config-processor/src/runMigrationInitializer.ts
@@ -3,6 +3,7 @@ import {MigrationInitializer} from "./migrationInitializer";
 import {MigrationConfigTransformer} from "./migrationConfigTransformer";
 import {parse} from "yaml";
 import {Console} from "console";
+import {formatInputValidationError, InputValidationError} from "./streamSchemaTransformer";
 
 global.console = new Console({
     stdout: process.stderr,
@@ -160,7 +161,11 @@ export async function main() {
             process.stdout.write(JSON.stringify(workflows, null, 2));
         }
     } catch (error) {
-        if (error instanceof SyntaxError) {
+        if (error instanceof InputValidationError) {
+            console.error('Validation error:');
+            console.error(formatInputValidationError(error));
+            process.exit(1);
+        } else if (error instanceof SyntaxError) {
             console.error('JSON parsing error:', error.message);
             process.exit(1);
         } else if (error instanceof Error) {

--- a/orchestrationSpecs/packages/config-processor/src/streamSchemaTransformer.ts
+++ b/orchestrationSpecs/packages/config-processor/src/streamSchemaTransformer.ts
@@ -13,16 +13,30 @@ export class InputValidationError extends Error {
     constructor(
         public readonly errors: InputValidationElememnt[]
     ) {
-        super(`Found ${errors.length} errors`);
+        super();
         this.name = 'InputValidationError';
         Error.captureStackTrace?.(this, this.constructor);
     }
+
+    get message(): string {
+        return `Found ${this.errors.length} errors: ${formatInputValidationError(this, {singleLine: true})}`;
+    }
 }
 
-export function formatInputValidationError(e: InputValidationError): string {
+export function formatInputValidationError(
+    e: InputValidationError,
+    options?: { singleLine?: boolean }
+): string {
+    const singleLine = options?.singleLine ?? false;
+
     return e.errors
-        .map(i=> [i.message, i.path.map(pk=> pk.toString()).join(".")])
-        .map(([k,v],idx) => `${k}... at:\n  ${v}`).join("\n");
+        .map(i => [i.message, i.path.map(pk => pk.toString()).join(".")])
+        .map(([k, v]) =>
+            singleLine
+                ? `${k} at: ${v}`
+                : `${k}... at:\n  ${v}`
+        )
+        .join(singleLine ? "; " : "\n");
 }
 
 export function deepStrict<T extends z.ZodTypeAny>(schema: T): T {


### PR DESCRIPTION
### Description
Now the message will always include all of the errors in it (in one line).  Furthermore, the top-level main program will format them a little bit prettier.

### Issues Resolved
No jira - but was really annoying and problematic for debugging/usablity

### Testing
manual testing

### Check List
- [ ] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
