### PR TITLE
Add Helm chart packaging to release workflow

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -163,8 +163,7 @@ jobs:
           output-file: opensearch-migrations-source-sbom.spdx.json
       - name: Install Helm
         uses: azure/setup-helm@v4
-        with:
-          version: v3.14.0
+        # Uses latest Helm version by default
       - name: Package Helm chart
         run: |
           helm package deployment/k8s/charts/aggregates/migrationAssistantWithArgo \


### PR DESCRIPTION
### Description
Packages the migrationAssistantWithArgo Helm chart and includes it in release assets as `migration-assistant-{version}.tgz`.

This enables users to download the Helm chart directly from GitHub releases for use with Terraform helm provider, `helm install`, or automated deployment pipelines.

### Changes
- Added `azure/setup-helm@v4` action (uses latest Helm version)
- Added helm package step to release-drafter.yml
- Included packaged chart in release artifacts

### Issues Resolved
N/A - New feature

### Testing
Will be tested on next release.

### Check List
- [x] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).