### PR TITLE
Fix etcd pod rescheduling and s3RoleArn placement

### DIFF
--- a/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/templates/resources/etcd-cluster.yaml
+++ b/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/templates/resources/etcd-cluster.yaml
@@ -1,0 +1,89 @@
+{{- if index .Values.conditionalPackageInstalls "etcd-druid" }}
+# Job to create Etcd cluster after etcd-druid operator is installed
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ .Release.Name }}-create-etcd-cluster
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "10"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 10
+  ttlSecondsAfterFinished: 300
+  template:
+    spec:
+      serviceAccountName: {{ .Values.installer.serviceAccount.name }}
+      restartPolicy: OnFailure
+      containers:
+      - name: create-etcd
+        image: {{ .Values.images.installer.repository }}:{{ .Values.images.installer.tag }}
+        command:
+        - /bin/sh
+        - -c
+        - |
+          set -e
+          echo "Waiting for etcd-druid CRD to be available..."
+          until kubectl get crd etcds.druid.gardener.cloud 2>/dev/null; do
+            echo "CRD not ready, waiting..."
+            sleep 5
+          done
+          echo "CRD is ready, waiting for etcd-druid operator..."
+          kubectl wait --for=condition=available deployment/etcd-druid -n etcd-druid --timeout=300s || true
+          sleep 10
+          
+          echo "Creating Etcd cluster..."
+          cat <<EOF | kubectl apply -f -
+          apiVersion: druid.gardener.cloud/v1alpha1
+          kind: Etcd
+          metadata:
+            name: {{ .Release.Name }}-etcd
+            namespace: {{ .Release.Namespace }}
+          spec:
+            replicas: {{ .Values.etcdCluster.replicas | default 3 }}
+            labels:
+              app.kubernetes.io/name: etcd
+              app.kubernetes.io/instance: {{ .Release.Name }}
+            etcd:
+              image: europe-docker.pkg.dev/gardener-project/releases/gardener/etcd-wrapper:v0.6.0
+              defragmentationSchedule: "0 */24 * * *"
+              resources:
+                requests:
+                  cpu: {{ .Values.etcdCluster.cpu }}
+                  memory: {{ .Values.etcdCluster.memory }}
+                limits:
+                  cpu: {{ .Values.etcdCluster.cpu }}
+                  memory: {{ .Values.etcdCluster.memory }}
+            storageCapacity: {{ .Values.etcdCluster.storageCapacity | default "10Gi" }}
+            backup:
+              image: europe-docker.pkg.dev/gardener-project/releases/gardener/etcdbrctl:v0.40.0
+              port: 8080
+              resources:
+                requests:
+                  cpu: 100m
+                  memory: 128Mi
+                limits:
+                  cpu: 100m
+                  memory: 128Mi
+          EOF
+          
+          echo "Creating etcd client service..."
+          cat <<EOF | kubectl apply -f -
+          apiVersion: v1
+          kind: Service
+          metadata:
+            name: etcd
+            namespace: {{ .Release.Namespace }}
+          spec:
+            type: ClusterIP
+            selector:
+              app.kubernetes.io/name: {{ .Release.Name }}-etcd
+            ports:
+            - name: client
+              port: 2379
+              targetPort: 2379
+          EOF
+          
+          echo "Etcd cluster created successfully"
+{{- end }}

--- a/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/values.yaml
+++ b/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/values.yaml
@@ -1,7 +1,7 @@
 conditionalPackageInstalls:
   kyverno: false
   # Migration infrastructure components
-  etcd: true                    # used by our Argo workflows for workflow coordination. May be used by strimzi clusters too
+  etcd-druid: true              # etcd operator for workflow coordination
   cert-manager: true            # needed by the otel operator
   kube-prometheus-stack: true   # will be needed for auto-scaling
   argo-workflows: true          # orchestrates the steps of a migration
@@ -25,6 +25,14 @@ conditionalPackageInstalls:
   gatekeeper: false
   grafana: false
   jaeger: true
+
+# etcd cluster configuration (managed by etcd-druid operator)
+etcdCluster:
+  replicas: 3
+  storageCapacity: 10Gi
+  storageClass: ""  # Use default storage class
+  cpu: 100m
+  memory: 256Mi
 
 # Kyverno policy toggles (requires conditionalPackageInstalls.kyverno: true)
 kyvernoPolicies:
@@ -184,64 +192,16 @@ otelConfiguration:
           exporters: [ debug ]
 
 charts:
-  # Coordinate workflows, maybe RFS, maybe more
-  etcd:
-    version: "1.1.2"
-    repository: "https://groundhog2k.github.io/helm-charts"
+  # etcd-druid operator - production-ready etcd management from Gardener project
+  # Handles node drain gracefully via member API, includes backup/restore, defrag
+  # See: https://gardener.github.io/etcd-druid/deployment/production-setup-recommendations.html
+  etcd-druid:
+    version: "v0.34.0"
+    repository: "oci://europe-docker.pkg.dev/gardener-project/releases/charts/gardener/etcd-druid"
+    namespace: etcd-druid
     values:
-      preUpgrade:
-        enabled: false
-      replicas: 3  # Changed from replicaCount: 1 to replicas: 3 for HA
-      auth:
-        rbac:
-          rootPassword: password
-      resources:
-        requests:
-          cpu: 1
-          memory: 2Gi
-        limits:
-          cpu: 2
-          memory: 4Gi
-      persistence:
-        enabled: true
-        storage:
-          requestedSize: 10Gi
-      service:
-        type: ClusterIP
-      metrics:
-        enabled: true
-        serviceMonitor:
-          enabled: true
-      # Pod Disruption Budget for resilience
-      podDisruptionBudget:
-        enabled: true
-        minAvailable: 2  # Ensure at least 2 of 3 replicas stay available
-      # Anti-affinity to spread pods across nodes
-      affinity:
-        podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 100
-            podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app.kubernetes.io/name: etcd
-              topologyKey: kubernetes.io/hostname
-      extraEnvVars:
-        - name: ETCD_AUTO_COMPACTION_RETENTION
-          value: "1"
-        - name: ETCD_QUOTA_BACKEND_BYTES
-          value: "8589934592" # 8GB
-        - name: ETCD_HEARTBEAT_INTERVAL
-          value: "100"
-        - name: ETCD_ELECTION_TIMEOUT
-          value: "1000"
-      startFromSnapshot:
-        enabled: false
-      serviceAccount:
-        create: true
-      podSecurityContext:
-        fsGroup: 1001
-        runAsUser: 1001
+      replicas: 1
+
 
   cert-manager:
     version: 1.17.2

--- a/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/valuesEks.yaml
+++ b/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/valuesEks.yaml
@@ -150,3 +150,9 @@ charts:
         - name: lua-scripts
           mountPath: /fluentbit/scripts
           readOnly: true
+
+
+# Higher resources for EKS production
+etcdCluster:
+  cpu: 500m
+  memory: 1Gi

--- a/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/valuesForLocalK8s.yaml
+++ b/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/valuesForLocalK8s.yaml
@@ -57,16 +57,14 @@ charts:
         replicas: 1
         pdb:
           enabled: false
-  # Lightweight etcd configuration for local development
-  etcd:
+
+
+  # Lightweight etcd-druid for local development
+  etcd-druid:
     values:
-      replicas: 1  # Single replica for dev
-      persistence:
-        enabled: false  # No persistence needed for dev
-      resources:
-        requests:
-          cpu: 100m  # Minimal resources for dev
-          memory: 256Mi
-        limits:
-          cpu: 500m
-          memory: 512Mi
+      replicas: 1
+
+# Lightweight etcd cluster for local development
+etcdCluster:
+  replicas: 1
+  storageCapacity: 1Gi

--- a/libraries/testAutomation/testAutomation/test_runner.py
+++ b/libraries/testAutomation/testAutomation/test_runner.py
@@ -193,6 +193,9 @@ class TestRunner:
 
     def cleanup_deployment(self) -> None:
         self.cleanup_clusters()
+        # Delete Etcd CRs before helm uninstall - operator must be running to remove finalizers
+        self.k8s_service.run_command(["kubectl", "delete", "etcds", "--all", "-n", self.k8s_service.namespace,
+                                      "--ignore-not-found", "--timeout=60s"], ignore_errors=True)
         self.k8s_service.helm_uninstall(release_name=MA_RELEASE_NAME)
         self.k8s_service.wait_for_all_healthy_pods()
         self.k8s_service.delete_all_pvcs()

--- a/migrationConsole/lib/integ_test/testWorkflows/fullMigrationImportedClusters.yaml
+++ b/migrationConsole/lib/integ_test/testWorkflows/fullMigrationImportedClusters.yaml
@@ -107,24 +107,18 @@ spec:
             
             SUFFIX=$(echo "{{workflow.uid}}" | cut -c1-8)
             
-            # Build snapshot repo config
+            # Build snapshot repo config (includes s3RoleArn if provided)
             SNAPSHOT_REPO=$(jq -n \
               --arg region "$S3_REGION" \
               --arg endpoint "$S3_ENDPOINT" \
               --arg bucket "$S3_BUCKET" \
               --arg suffix "$SUFFIX" \
+              --arg roleArn "$SNAPSHOT_ROLE_ARN" \
               '{
                 "awsRegion": $region,
                 "endpoint": $endpoint,
                 "s3RepoPathUri": ("s3://" + $bucket + "/" + $suffix)
-              }')
-            
-            # Build createSnapshotConfig with s3RoleArn if provided
-            if [ -n "$SNAPSHOT_ROLE_ARN" ]; then
-              CREATE_SNAPSHOT_CONFIG=$(jq -n --arg roleArn "$SNAPSHOT_ROLE_ARN" '{"s3RoleArn": $roleArn}')
-            else
-              CREATE_SNAPSHOT_CONFIG='{}'
-            fi
+              } + (if $roleArn != "" then {"s3RoleArn": $roleArn} else {} end)')
             
             # Function to transform cluster config to match workflow schema
             # - version: ES_7.10 -> ES 7.10 (replace underscore with space)
@@ -168,14 +162,14 @@ spec:
             ')
             
             # Build snapshotExtractAndLoadConfigs from snapshot-and-migration-configs
-            SNAPSHOT_CONFIGS=$(echo "$SOURCE_CONFIGS" | jq --argjson createConfig "$CREATE_SNAPSHOT_CONFIG" '[
+            SNAPSHOT_CONFIGS=$(echo "$SOURCE_CONFIGS" | jq '[
               .[0]["snapshot-and-migration-configs"][] | {
                 "snapshotConfig": {
                   "snapshotNameConfig": {
                     "snapshotNamePrefix": "testsnapshot"
                   }
                 },
-                "createSnapshotConfig": $createConfig,
+                "createSnapshotConfig": {},
                 "migrations": .migrations
               }
             ]')


### PR DESCRIPTION
### Description
Two fixes for EKS integration test failures:

1. **Replace groundhog2k etcd chart with etcd-druid operator** - Fixes etcd pods crashing with "member already bootstrapped" when rescheduled to different nodes. etcd-druid handles node drain gracefully via the etcd member API.

2. **Fix s3RoleArn placement in fullMigrationImportedClusters workflow** - Moves s3RoleArn from createSnapshotConfig to snapshotRepo where it belongs.

### Issues Resolved
- Fixes https://migrations.ci.opensearch.org/job/eks-integ-test/1141/ (etcd pod rescheduling crash)
- Fixes https://migrations.ci.opensearch.org/job/eks-integ-test/1133/ (s3RoleArn placement)

### Testing
- etcd-druid tested locally on minikube
- s3RoleArn fix verified against workflow schema

### Check List
- [x] New functionality includes testing
- [ ] Public documentation issue/PR created, if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.