### PR TITLE
Fix K8s local test reliability: Kyverno CRD race condition and cleanup improvements

### DIFF
--- a/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/templates/resources/kyvernoZeroResourceRequests.yaml
+++ b/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/templates/resources/kyvernoZeroResourceRequests.yaml
@@ -27,7 +27,7 @@ data:
                     - Pod
           preconditions:
             any:
-              - key: "{{`{{ request.object.spec.serviceAccountName }}`}}" # Backticks escape Helm, inner braces are Kyverno JMESPath
+              - key: "{{`{{ request.object.spec.serviceAccountName || '' }}`}}" # Backticks escape Helm, inner braces are Kyverno JMESPath
                 operator: In
                 value:
                   - migration-console-access-role
@@ -57,7 +57,7 @@ data:
                     - Pod
           preconditions:
             all:
-              - key: "{{`{{ request.object.spec.serviceAccountName }}`}}"
+              - key: "{{`{{ request.object.spec.serviceAccountName || '' }}`}}"
                 operator: In
                 value:
                   - migration-console-access-role
@@ -106,6 +106,9 @@ spec:
             - /bin/sh
             - -c
             - |
+              set -e
+              echo "Waiting for Kyverno CRD to be established..."
+              kubectl wait --for=condition=Established crd/clusterpolicies.kyverno.io --timeout=300s
               echo "Waiting for Kyverno admission controller to be ready..."
               kubectl wait --for=condition=ready pod -l app.kubernetes.io/component=admission-controller -n {{ .Release.Namespace }} --timeout=120s
               kubectl apply -f /policy/policy.yaml

--- a/libraries/testAutomation/testAutomation/k8s_service.py
+++ b/libraries/testAutomation/testAutomation/k8s_service.py
@@ -163,7 +163,7 @@ class K8sService:
             elapsed = time.time() - start_time
             if elapsed > timeout_seconds:
                 raise TimeoutError(f"Timeout reached: Not all PVCs were deleted within {timeout_seconds} seconds. "
-                                   f"Remaining PVCs: {', '.join(remaining_pvcs)}")
+                                   f"Remaining PVCs: {[pvc.metadata.name for pvc in remaining_pvcs]}")
 
             logger.info(f"Waiting for PVCs to be deleted. Remaining: {[pvc.metadata.name for pvc in remaining_pvcs]}")
             time.sleep(poll_interval)
@@ -181,6 +181,16 @@ class K8sService:
         else:
             logger.info(f"Namespace '{namespace}' already exists")
             return result
+
+    def delete_namespace(self) -> None:
+        logger.info(f"Deleting namespace '{self.namespace}'")
+        # Delete cluster-scoped kyverno webhooks that persist after namespace deletion
+        self.run_command(["kubectl", "delete", "mutatingwebhookconfigurations",
+                         "-l", "webhook.kyverno.io/managed-by=kyverno", "--ignore-not-found"], ignore_errors=True)
+        self.run_command(["kubectl", "delete", "validatingwebhookconfigurations",
+                         "-l", "webhook.kyverno.io/managed-by=kyverno", "--ignore-not-found"], ignore_errors=True)
+        self.run_command(["kubectl", "delete", "namespace", self.namespace,
+                         "--ignore-not-found", "--grace-period=0", "--force"])
 
     def check_helm_release_exists(self, release_name: str) -> bool:
         logger.info(f"Checking if {release_name} is already deployed in '{self.namespace}' namespace")

--- a/libraries/testAutomation/testAutomation/test_runner.py
+++ b/libraries/testAutomation/testAutomation/test_runner.py
@@ -193,15 +193,15 @@ class TestRunner:
 
     def cleanup_deployment(self) -> None:
         self.cleanup_clusters()
-        self.k8s_service.helm_uninstall(release_name=MA_RELEASE_NAME)
-        self.k8s_service.wait_for_all_healthy_pods()
-        self.k8s_service.delete_all_pvcs()
+        self.k8s_service.delete_namespace()
 
     def copy_logs(self, destination: str = "./logs") -> None:
         self.k8s_service.copy_log_files(destination=destination)
 
     def run(self, skip_delete: bool = False, keep_workflows: bool = False,
             reuse_clusters: bool = False, test_reports_dir: str = None, copy_logs: bool = False) -> None:
+        # Cleanup any stale resources from previous runs before starting
+        self.k8s_service.delete_namespace()
         self.k8s_service.create_namespace(self.k8s_service.namespace)
 
         combos_with_failures = []

--- a/migrationConsole/lib/console_link/console_link/models/argo_service.py
+++ b/migrationConsole/lib/console_link/console_link/models/argo_service.py
@@ -103,13 +103,15 @@ class ArgoService:
         # Print namespace resource summary
         try:
             logger.info(f"===== Namespace {self.namespace} resource summary =====")
-            get_args = {"get": "pods,services,deployments,statefulsets,workflows", "--namespace": self.namespace}
+            summary_resources = "pods,services,deployments,statefulsets,workflows"
+            get_args = {"get": summary_resources, "--namespace": self.namespace}
             self._run_kubectl_command(get_args)
         except Exception as e:
             logger.error(f"Failed to get namespace resources: {e}")
 
     def save_namespace_diagnostics(self, output_dir: str) -> Optional[str]:
         """Save detailed namespace diagnostics to a file for artifact collection."""
+        diagnostic_resources = "pods,services,deployments,statefulsets,workflows"
         try:
             os.makedirs(output_dir, exist_ok=True)
             output_file = os.path.join(output_dir, f"namespace-{self.namespace}-diagnostics.txt")
@@ -118,10 +120,10 @@ class ArgoService:
                 f.write(f"===== Namespace {self.namespace} Diagnostics =====\n\n")
 
                 # kubectl get resources
-                f.write("===== kubectl get pods,services,deployments,statefulsets,workflows =====\n")
+                f.write(f"===== kubectl get {diagnostic_resources} =====\n")
                 try:
                     result = CommandRunner("kubectl", {
-                        "get": "pods,services,deployments,statefulsets,workflows",
+                        "get": diagnostic_resources,
                         "--namespace": self.namespace,
                         "-o": "wide"
                     }).run()
@@ -130,10 +132,10 @@ class ArgoService:
                     f.write(f"Error: {e}\n\n")
 
                 # kubectl describe resources
-                f.write("===== kubectl describe pods,services,deployments,statefulsets,workflows =====\n")
+                f.write(f"===== kubectl describe {diagnostic_resources} =====\n")
                 try:
                     result = CommandRunner("kubectl", {
-                        "describe": "pods,services,deployments,statefulsets,workflows",
+                        "describe": diagnostic_resources,
                         "--namespace": self.namespace
                     }).run()
                     f.write(result + "\n\n")


### PR DESCRIPTION
### Description
This PR fixes several issues affecting K8s local test reliability:

1. **Kyverno CRD race condition**: The `ma-apply-kyverno-zero-resources` job was failing because it tried to apply a ClusterPolicy before the Kyverno CRDs were established. Added explicit wait for `crd/clusterpolicies.kyverno.io` before applying the policy.

2. **Stale webhook cleanup**: Kyverno registers cluster-scoped webhooks that persist after namespace deletion. When tests re-run, these stale webhooks cause failures like:
   ```
   failed calling webhook "mutate.kyverno.svc-fail": service "kyverno-svc" not found
   ```
   Added cleanup of Kyverno mutating/validating webhook configurations before namespace deletion.

3. **Pre-run cleanup**: Added namespace cleanup at the start of test runs to ensure a clean slate, removing any stale resources from previous interrupted runs.

4. **Simplified cleanup**: Replaced multi-step cleanup (helm uninstall → wait for pods → delete PVCs) with single namespace deletion, which is more reliable and faster.

5. **Bug fixes**:
   - Fixed PVC timeout error message that was trying to join PVC objects instead of their names
   - Fixed Kyverno policy preconditions to handle pods without serviceAccountName

### Issues Resolved
Fixes K8s local test failures caused by:
- Kyverno CRD not ready when policy job runs
- Stale Kyverno webhooks blocking pod creation after test reruns

### Testing
- Verified fix on Jenkins CI job elasticsearch-5x-k8s-local-test
- Kyverno installs correctly in release namespace (ma)
- ClusterPolicy `zero-resource-requests` applies successfully
- Workflow pods are mutated with zero resource requests
- Cleanup properly removes webhooks before namespace deletion

### Check List
- [x] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).