### PR TITLE
Rename Helm chart release artifact to migration-assistant-helm.tgz

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -169,6 +169,7 @@ jobs:
           helm package deployment/k8s/charts/aggregates/migrationAssistantWithArgo \
             --version ${{ steps.get_data.outputs.version }} \
             --app-version ${{ steps.get_data.outputs.version }}
+          mv migration-assistant-*.tgz migration-assistant-helm.tgz
       - name: Configure AWS Credentials for Solutions Credentials
         if: ${{ !github.event.act }}
         uses: aws-actions/configure-aws-credentials@v5
@@ -210,5 +211,7 @@ jobs:
             opensearch-migrations-source.tar.gz
             opensearch-migrations-build.tar.gz
             kiro-cli/build/kiro-assistant.tar.gz
-            migration-assistant-${{ steps.get_data.outputs.version }}.tgz
+            migration-assistant-helm.tgz
+            deployment/k8s/aws/aws-bootstrap.sh
+            deployment/k8s/dashboards/*.json
             **/*.spdx.json


### PR DESCRIPTION
## Description

Removes version from Helm chart filename since version is already in the release URL path. This simplifies downloading the chart programmatically (e.g., in bootstrap scripts).

**Before:** `migration-assistant-2.6.2.tgz`
**After:** `migration-assistant-helm.tgz`

The version information is still embedded in the chart itself and available via the release URL path.

## Testing

N/A - workflow change only

## Check List
- [x] New functionality includes testing
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff