### PR TITLE
[Update] index template exclusion list

### DIFF
--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/common/FilterScheme.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/common/FilterScheme.java
@@ -19,7 +19,7 @@ public class FilterScheme {
             "elastic-connectors-",
             "elastic_agent.",
             "ilm-history-",
-            "kibana_index_template:",
+            "kibana",
             "logs-elastic_agent",
             "logs-endpoint.",
             "logs-index_pattern",

--- a/RFS/src/test/java/org/opensearch/migrations/bulkload/common/FilterSchemeTest.java
+++ b/RFS/src/test/java/org/opensearch/migrations/bulkload/common/FilterSchemeTest.java
@@ -99,14 +99,16 @@ public class FilterSchemeTest {
     void testExcludedKibanaIndexTemplates() {
         var filter = FilterScheme.filterByAllowList(null);
 
-        // Should be excluded due to prefix
+        // Kibana index templates and indices should be excluded
         assertThat(filter.test("kibana_index_template:.kibana"), equalTo(false));
-        // This template has name containing '*' which is invalid in OpenSearch 2.x+
         assertThat(filter.test("kibana_index_template:.kibana_*"), equalTo(false));
+        assertThat(filter.test("kibana_logs"), equalTo(false));
+        assertThat(filter.test("kibana"), equalTo(false));
+        assertThat(filter.test(".kibana"), equalTo(false));
 
-        // User indices with kibana in the name should not be excluded
+        // User indices with kibana elsewhere in the name should not be excluded
         assertThat(filter.test("my_kibana_data"), equalTo(true));
-        assertThat(filter.test("kibana_index_logs"), equalTo(true));
+        assertThat(filter.test("my_kibana_logs"), equalTo(true));
     }
 
     @Test


### PR DESCRIPTION
### Description
A recent discovery revealed that AWS Managed Elasticsearch 6.8 domains create default index templates with names like:
- `kibana_index_template:.kibana`
- `kibana_index_template:.kibana_*`

These templates were not being filtered during migration because they don't start with `.` , rather they start with `kibana_index_template:.`. When Migration Assistant attempted to create these on an OpenSearch 2.x target, the metadata migration step failed as OpenSearch 2.x+ does not allow `*` in template names, and these Kibana system templates should not be migrated regardless.
```
invalid_index_template_exception: index_template [kibana_index_template:.kibana_*] invalid, 
cause [Validation Failed: 1: name must not contain a '*';]
```

WIth this PR, Migration Assistant will ignore anything starting with `kibana` , such as :
- `kibana_index_template:.kibana_*`
- `kibana_logs`
- `kibana`

Index and Template names containing `kibana` elsewhere is still allowed to migrate, such as :  
- `my_kibana_logs`
- `data_kibana`

### Issues Resolved
N/A

### Testing
- Added a unit test for this test case at `RFS/src/test/java/org/opensearch/migrations/bulkload/common/FilterSchemeTest.java`

### Check List
- [x] New functionality includes testing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
