### PR TITLE
Fix temp file cleanup in get_basic_creds_secrets_in_config

### DIFF
--- a/migrationConsole/lib/console_link/console_link/workflow/services/script_runner.py
+++ b/migrationConsole/lib/console_link/console_link/workflow/services/script_runner.py
@@ -275,8 +275,7 @@ class ScriptRunner:
         finally:
             # Clean up temporary file
             try:
-                # os.unlink(temp_file_path)
+                os.unlink(temp_file_path)
                 logger.debug(f"Cleaned up temporary file: {temp_file_path}")
             except OSError as e:
                 logger.warning(f"Failed to clean up temporary file {temp_file_path}: {e}")
-                raise e


### PR DESCRIPTION
## Summary

This PR fixes a bug in `ScriptRunner.get_basic_creds_secrets_in_config()` where temporary files were never being cleaned up.

## Problem

The `os.unlink(temp_file_path)` call was commented out, causing temporary YAML files to accumulate in the system's temp directory and never be deleted. This is a resource leak that could cause disk space issues over time.

## Changes

1. **Uncommented `os.unlink(temp_file_path)`** - Actually deletes the temporary file after use
2. **Removed `raise e`** - Makes cleanup failures non-fatal, consistent with the similar cleanup code in `submit_workflow()` method (lines 230-236)

## Testing

This is a minimal, low-risk change. The fix follows the same pattern used elsewhere in the same file (`submit_workflow` method).

## Related

File: `migrationConsole/lib/console_link/console_link/workflow/services/script_runner.py`