### PR TITLE
Fix typo: rename 'run_as_detatched' to 'run_as_detached'

### DIFF
--- a/migrationConsole/lib/console_link/console_link/models/command_runner.py
+++ b/migrationConsole/lib/console_link/console_link/models/command_runner.py
@@ -13,7 +13,7 @@ FlagOnlyArgument = None
 
 class CommandRunner:
     def __init__(self, command_root: str, command_args: Dict[str, Any], sensitive_fields: Optional[List[str]] = None,
-                 run_as_detatched: bool = False, log_file: Optional[str] = None):
+                 run_as_detached: bool = False, log_file: Optional[str] = None):
         self.command_args = command_args
         self.command = [command_root]
         for key, value in command_args.items():
@@ -24,7 +24,7 @@ class CommandRunner:
                 self.command.append(value)
 
         self.sensitive_fields = sensitive_fields
-        self.run_as_detached = run_as_detatched
+        self.run_as_detached = run_as_detached
         self.log_file = log_file
 
     def run(self, print_to_console=True, print_on_error=False, stream_output=False) -> CommandResult:


### PR DESCRIPTION
## Summary

This PR fixes a typo in the `CommandRunner` class where the parameter name `run_as_detatched` was misspelled.

## Changes

- Renamed parameter `run_as_detatched` to `run_as_detached` in `CommandRunner.__init__()`
- Updated the assignment to use the corrected parameter name

## File Changed

- `migrationConsole/lib/console_link/console_link/models/command_runner.py`

## Testing

- All existing tests in `tests/test_command_runner.py` pass (13/13)
- This is a safe change since no callers use this parameter by keyword argument

## Impact

This is a low-risk code quality improvement that corrects a spelling error for better code readability and maintainability.