### PR TITLE
Auto: Fix typos - successful, itself, superseded

### DIFF
--- a/migrationConsole/lib/console_link/console_link/models/backfill_base.py
+++ b/migrationConsole/lib/console_link/console_link/models/backfill_base.py
@@ -38,7 +38,7 @@ class Backfill(ABC):
 
     @abstractmethod
     def create(self, *args, **kwargs) -> CommandResult[str]:
-        """If necessary, create/deploy the backfill mechanism iteslf. After create succesfully completes,
+        """If necessary, create/deploy the backfill mechanism itself. After create successfully completes,
         the backfill should be ready to start."""
         pass
 

--- a/migrationConsole/lib/console_link/tests/middleware/test_clusters.py
+++ b/migrationConsole/lib/console_link/tests/middleware/test_clusters.py
@@ -16,7 +16,7 @@ def test_connection_check_with_exception(mocker):
     assert not result.connection_established
 
 
-def test_connection_check_succesful(requests_mock):
+def test_connection_check_successful(requests_mock):
     cluster = create_valid_cluster()
     requests_mock.get(f"{cluster.endpoint}/", json={'version': {'number': '2.15'}})
 

--- a/migrationConsole/lib/console_link/tests/test_ecs.py
+++ b/migrationConsole/lib/console_link/tests/test_ecs.py
@@ -36,7 +36,7 @@ def test_ecs_created_with_and_without_region():
     assert without_region.client is not None
 
 
-def test_ecs_update_service_succesful(ecs_stubber, ecs_service):
+def test_ecs_update_service_successful(ecs_stubber, ecs_service):
     with open(TEST_DATA_DIRECTORY / "ecs_update_service_response.json") as f:
         ecs_stubber.add_response("update_service", json.load(f))
     ecs_stubber.activate()

--- a/orchestrationSpecs/packages/migration-workflow-templates/src/workflowTemplates/captureReplay.ts
+++ b/orchestrationSpecs/packages/migration-workflow-templates/src/workflowTemplates/captureReplay.ts
@@ -157,7 +157,7 @@ export const CaptureReplay = WorkflowBuilder.create({
             /**
              * See the notes for deployConsole - it won't work as it is.
              * We might have some easy fixes in hand - but this part of the replayer workflow should
-             * be entirely superceded by the workflow focus command once that comes into being.
+             * be entirely superseded by the workflow focus command once that comes into being.
              */
             // .addTask("runMigrationConsole", MigrationConsole, "deployConsole", c =>
             //         c.register({


### PR DESCRIPTION
## Summary
This PR fixes several typos found in the codebase:

### Changes
- **test_ecs.py**: Fixed `succesful` → `successful` in test function name
- **test_clusters.py**: Fixed `succesful` → `successful` in test function name  
- **backfill_base.py**: Fixed `iteslf` → `itself` and `succesfully` → `successfully` in docstring
- **captureReplay.ts**: Fixed `superceded` → `superseded` in comment

### Testing
These are simple typo fixes in test function names, docstrings, and comments. No functional changes.

### Checklist
- [x] Changes are limited to typo corrections
- [x] No functional code changes
- [x] All changes are in non-critical paths (tests, comments, docstrings)