### PR TITLE
Auto: Fix typo in Cluster class docstring

### DIFF
--- a/migrationConsole/lib/console_link/console_link/models/cluster.py
+++ b/migrationConsole/lib/console_link/console_link/models/cluster.py
@@ -102,7 +102,7 @@ class AuthDetails(NamedTuple):
 
 class Cluster:
     """
-    An elasticcsearch or opensearch cluster.
+    An Elasticsearch or OpenSearch cluster.
     """
 
     config: Dict


### PR DESCRIPTION
## Summary
This PR fixes a typo in the `Cluster` class docstring in `cluster.py`.

### Changes
- Fixed `elasticcsearch` → `Elasticsearch` (corrected spelling and capitalization)
- Changed `opensearch` → `OpenSearch` (proper capitalization for consistency with official product name)

### File Changed
- `migrationConsole/lib/console_link/console_link/models/cluster.py`

### Testing
This is a simple documentation fix in a docstring. No functional changes.

### Checklist
- [x] Changes are limited to typo/documentation corrections
- [x] No functional code changes
- [x] Follows project naming conventions (Elasticsearch, OpenSearch)