### PR TITLE
Auto: Fix typo - rename 'dependantStacks' to 'dependentStacks'

### DIFF
--- a/deployment/cdk/opensearch-service-migration/lib/stack-composer.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/stack-composer.ts
@@ -95,8 +95,8 @@ export class StackComposer {
         return version
     }
 
-    private addDependentStacks(primaryStack: Stack, dependantStacks: (Stack|undefined)[]) {
-        for (const stack of dependantStacks) {
+    private addDependentStacks(primaryStack: Stack, dependentStacks: (Stack|undefined)[]) {
+        for (const stack of dependentStacks) {
             if (stack) {
                 primaryStack.addDependency(stack)
             }


### PR DESCRIPTION
## Summary

This PR fixes a typo in the CDK stack-composer.ts file where the parameter name `dependantStacks` used British spelling while the method name `addDependentStacks` used American spelling.

## Changes

- Renamed parameter `dependantStacks` to `dependentStacks` in the `addDependentStacks` method

## Why

Consistency in naming conventions improves code readability and maintainability. The American spelling 'dependent' is more commonly used in codebases.

## Testing

This is a minimal, low-risk change that only affects a local variable name. The functionality remains unchanged.