### PR TITLE
Auto: Fix typo 'aquired' -> 'acquired' in RFS DESIGN.md

### DIFF
--- a/RFS/docs/DESIGN.md
+++ b/RFS/docs/DESIGN.md
@@ -242,7 +242,7 @@ SHARD SETUP
 ID: shard_setup
 FIELDS:
     * creatorId (string): Unique id of the worker who created the task
-    * leaseHolderId (string): Unique id of the worker who has aquired the lease for the task
+    * leaseHolderId (string): Unique id of the worker who has acquired the lease for the task
     * expiration (timestamp): When the current lease expires
     * nextAcquisitionLeaseExponent (integer): Times the task has been attempted
     * completedAt (timestamp): If present, when the task was completed.


### PR DESCRIPTION
## Summary

This PR fixes a typo in the RFS DESIGN.md documentation file.

### Changes

- `RFS/docs/DESIGN.md`: Fixed `aquired` → `acquired` in the CMS Schema section

### Testing

This is a simple typo fix in documentation. No functional changes.

### Checklist

- [x] Changes are limited to typo corrections
- [x] No functional code changes
- [x] All changes are in documentation