### PR TITLE
Auto: Fix typo in Cluster class docstring

### DIFF
--- a/migrationConsole/lib/console_link/console_link/models/cluster.py
+++ b/migrationConsole/lib/console_link/console_link/models/cluster.py
@@ -102,7 +102,7 @@ class AuthDetails(NamedTuple):
 
 class Cluster:
     """
-    An elasticcsearch or opensearch cluster.
+    An Elasticsearch or OpenSearch cluster.
     """
 
     config: Dict


### PR DESCRIPTION
## Summary

This PR fixes a typo in the `Cluster` class docstring in `migrationConsole/lib/console_link/console_link/models/cluster.py`.

### Changes

- Fixed `elasticcsearch` → `Elasticsearch` (double 'c' typo)
- Fixed `opensearch` → `OpenSearch` (proper capitalization)

### Before
```python
class Cluster:
    """
    An elasticcsearch or opensearch cluster.
    """
```

### After
```python
class Cluster:
    """
    An Elasticsearch or OpenSearch cluster.
    """
```

### Testing

This is a simple documentation/docstring fix. No functional changes.

### Checklist

- [x] Changes are limited to typo/documentation corrections
- [x] No functional code changes
- [x] Follows project naming conventions (Elasticsearch, OpenSearch)