### PR TITLE
Auto: Fix typo - rename 'compute_dervived_values' to 'compute_derived_values'

### DIFF
--- a/migrationConsole/lib/console_link/console_link/models/backfill_rfs.py
+++ b/migrationConsole/lib/console_link/console_link/models/backfill_rfs.py
@@ -371,7 +371,7 @@ def get_detailed_status_obj(target_cluster,
     started_iso = datetime.fromtimestamp(started_epoch, tz=timezone.utc).isoformat() if started_epoch else None
 
     # finished: only if everything is done, take max completedAt
-    finished_iso, percentage_completed, eta_ms, status = compute_dervived_values(target_cluster,
+    finished_iso, percentage_completed, eta_ms, status = compute_derived_values(target_cluster,
                                                                                  index_to_check,
                                                                                  counts.total,
                                                                                  counts.completed,
@@ -391,7 +391,7 @@ def get_detailed_status_obj(target_cluster,
     )
 
 
-def compute_dervived_values(target_cluster, index_to_check, total, completed, started_epoch, active_workers: bool):
+def compute_derived_values(target_cluster, index_to_check, total, completed, started_epoch, active_workers: bool):
     # Consider it completed if there's nothing to do (total = 0) or we've completed all shards
     if total == 0 or (total > 0 and completed >= total):
         max_completed_epoch = _get_max_completed_epoch(target_cluster, index_to_check)

--- a/migrationConsole/lib/console_link/tests/test_backfill.py
+++ b/migrationConsole/lib/console_link/tests/test_backfill.py
@@ -11,7 +11,7 @@ from console_link.models.cluster import Cluster, HttpMethod
 from console_link.models.backfill_base import Backfill, BackfillStatus
 from console_link.models.step_state import StepStateWithPause
 from console_link.models.backfill_rfs import (DockerRFSBackfill, ECSRFSBackfill, RfsWorkersInProgress,
-                                              WorkingIndexDoesntExist, compute_dervived_values)
+                                              WorkingIndexDoesntExist, compute_derived_values)
 from console_link.models.ecs_service import ECSService
 from console_link.models.factories import UnsupportedBackfillTypeError, get_backfill
 from console_link.models.utils import DeploymentStatus
@@ -341,14 +341,14 @@ class TestComputeDerivedValues:
         self.test_index = ".migrations_working_state"
 
     def test_zero_indices(self):
-        """Test compute_dervived_values when there are 0 indices to migrate."""
+        """Test compute_derived_values when there are 0 indices to migrate."""
         # When total=0, it should report as COMPLETED
         total = 0
         completed = 0
         started_epoch = None
         active_workers = False
 
-        finished_iso, percentage_completed, eta_ms, status = compute_dervived_values(
+        finished_iso, percentage_completed, eta_ms, status = compute_derived_values(
             self.mock_cluster, self.test_index, total, completed, started_epoch, active_workers
         )
 
@@ -358,13 +358,13 @@ class TestComputeDerivedValues:
         assert finished_iso is not None  # Should have a timestamp for completion
 
     def test_all_completed(self):
-        """Test compute_dervived_values when all indices are completed."""
+        """Test compute_derived_values when all indices are completed."""
         total = 10
         completed = 10
         started_epoch = int(datetime.now(timezone.utc).timestamp()) - 3600  # Started 1 hour ago
         active_workers = False
 
-        finished_iso, percentage_completed, eta_ms, status = compute_dervived_values(
+        finished_iso, percentage_completed, eta_ms, status = compute_derived_values(
             self.mock_cluster, self.test_index, total, completed, started_epoch, active_workers
         )
 
@@ -374,13 +374,13 @@ class TestComputeDerivedValues:
         assert finished_iso is not None
 
     def test_partially_completed(self):
-        """Test compute_dervived_values when some indices are still in progress."""
+        """Test compute_derived_values when some indices are still in progress."""
         total = 10
         completed = 5
         started_epoch = int(datetime.now(timezone.utc).timestamp()) - 3600  # Started 1 hour ago
         active_workers = True
 
-        finished_iso, percentage_completed, eta_ms, status = compute_dervived_values(
+        finished_iso, percentage_completed, eta_ms, status = compute_derived_values(
             self.mock_cluster, self.test_index, total, completed, started_epoch, active_workers
         )
 
@@ -390,13 +390,13 @@ class TestComputeDerivedValues:
         assert finished_iso is None  # Not completed yet
 
     def test_partially_completed_paused(self):
-        """Test compute_dervived_values when some indices are completed but workers are paused."""
+        """Test compute_derived_values when some indices are completed but workers are paused."""
         total = 10
         completed = 5
         started_epoch = int(datetime.now(timezone.utc).timestamp()) - 3600  # Started 1 hour ago
         active_workers = False
 
-        finished_iso, percentage_completed, eta_ms, status = compute_dervived_values(
+        finished_iso, percentage_completed, eta_ms, status = compute_derived_values(
             self.mock_cluster, self.test_index, total, completed, started_epoch, active_workers
         )
 


### PR DESCRIPTION
## Summary

This PR fixes a typo in the function name `compute_dervived_values` which should be `compute_derived_values` (derived, not dervived).

## Changes

- Renamed function `compute_dervived_values` -> `compute_derived_values` in `backfill_rfs.py`
- Updated all references in `test_backfill.py`
- Updated docstrings in test methods

## Testing

All existing tests pass:
```
pytest tests/test_backfill.py::TestComputeDerivedValues -v
============================== 4 passed in 0.25s ===============================
```

## Files Changed

- `migrationConsole/lib/console_link/console_link/models/backfill_rfs.py`
- `migrationConsole/lib/console_link/tests/test_backfill.py`