### PR TITLE
Auto: Fix typo and use isinstance() for type checks

### DIFF
--- a/migrationConsole/lib/console_link/console_link/models/cluster.py
+++ b/migrationConsole/lib/console_link/console_link/models/cluster.py
@@ -102,7 +102,7 @@ class AuthDetails(NamedTuple):
 
 class Cluster:
     """
-    An elasticcsearch or opensearch cluster.
+    An Elasticsearch or OpenSearch cluster.
     """
 
     config: Dict
@@ -158,7 +158,7 @@ class Cluster:
             kubectl_runner = KubectlRunner("ma", "")
             secret_dict = kubectl_runner.read_secret(self.auth_details["k8s_secret_name"])
 
-        if not secret_dict or type(secret_dict) is not dict:
+        if not secret_dict or not isinstance(secret_dict, dict):
             raise ValueError("Secret is not a valid object containing a username and password.")
 
         missing_keys = [k for k in ("username", "password") if k not in secret_dict]

--- a/migrationConsole/lib/console_link/console_link/models/command_runner.py
+++ b/migrationConsole/lib/console_link/console_link/models/command_runner.py
@@ -19,7 +19,7 @@ class CommandRunner:
         for key, value in command_args.items():
             self.command.append(key)
             if value is not FlagOnlyArgument:
-                if type(value) is not str:
+                if not isinstance(value, str):
                     value = str(value)
                 self.command.append(value)
 

--- a/migrationConsole/lib/console_link/console_link/models/metrics_source.py
+++ b/migrationConsole/lib/console_link/console_link/models/metrics_source.py
@@ -120,9 +120,9 @@ class CloudwatchMetricsSource(MetricsSource):
         self.client_options = client_options
         logger.info(f"Initializing CloudwatchMetricsSource from config {config}")
         self.aws_region = None
-        if type(config["cloudwatch"]) is dict and "aws_region" in config["cloudwatch"]:
+        if isinstance(config["cloudwatch"], dict) and "aws_region" in config["cloudwatch"]:
             self.aws_region = config["cloudwatch"]["aws_region"]
-        if type(config["cloudwatch"]) is dict and "qualifier" in config["cloudwatch"]:
+        if isinstance(config["cloudwatch"], dict) and "qualifier" in config["cloudwatch"]:
             self.qualifier = config["cloudwatch"]["qualifier"]
 
         self.client = create_boto3_client(aws_service_name="cloudwatch", region=self.aws_region,


### PR DESCRIPTION
## Description

This PR makes minor code quality improvements:

### Changes

1. **Fix typo in docstring** (cluster.py)
   - Changed 'elasticcsearch' to 'Elasticsearch' in the Cluster class docstring

2. **Replace `type(x) is not dict` with `isinstance(x, dict)`** for better Python style
   - **cluster.py**: secret_dict type check
   - **command_runner.py**: value type check  
   - **metrics_source.py**: cloudwatch config type checks

### Why isinstance() is preferred

Using `isinstance()` is the recommended Python idiom for type checking because it:
- Properly handles subclasses
- Is more readable and Pythonic
- Is recommended by PEP 8

### Testing

These are minimal, safe changes that don't affect functionality:
- The typo fix is documentation only
- The `isinstance()` changes are semantically equivalent for the use cases in this codebase

### Check List

- [x] New functionality includes testing (N/A - no new functionality)
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.