### PR TITLE
Increase k8s integration test cluster resources and JVM heap settings

### DIFF
--- a/migrationConsole/lib/integ_test/integ_test/test_cases/multi_type_tests.py
+++ b/migrationConsole/lib/integ_test/integ_test/test_cases/multi_type_tests.py
@@ -1,6 +1,6 @@
 import logging
 from ..common_utils import convert_to_b64
-from ..cluster_version import ElasticsearchV5_X, OpensearchV1_X, OpensearchV2_X
+from ..cluster_version import ElasticsearchV5_X, OpensearchV1_X, OpensearchV2_X, OpensearchV3_X
 from .ma_argo_test_base import MATestBase, MATestUserArguments
 
 logger = logging.getLogger(__name__)
@@ -11,6 +11,7 @@ class Test0004MultiTypeUnionMigration(MATestBase):
         allow_combinations = [
             (ElasticsearchV5_X, OpensearchV1_X),
             (ElasticsearchV5_X, OpensearchV2_X),
+            (ElasticsearchV5_X, OpensearchV3_X),
         ]
         description = "Performs metadata and backfill migrations with a multi-type union transformation."
         super().__init__(user_args=user_args,
@@ -82,6 +83,7 @@ class Test0005MultiTypeSplitMigration(MATestBase):
         allow_combinations = [
             (ElasticsearchV5_X, OpensearchV1_X),
             (ElasticsearchV5_X, OpensearchV2_X),
+            (ElasticsearchV5_X, OpensearchV3_X),
         ]
         description = "Performs metadata and backfill migrations with a multi-type split transformation."
         super().__init__(user_args=user_args,

--- a/migrationConsole/lib/integ_test/testWorkflows/clusterWorkflows.yaml
+++ b/migrationConsole/lib/integ_test/testWorkflows/clusterWorkflows.yaml
@@ -448,7 +448,7 @@ spec:
             image: "docker.elastic.co/elasticsearch/elasticsearch"
             imageTag: "5.6.16"
             antiAffinity: "soft"
-            esJavaOpts: "-Xms1g -Xmx2g"
+            esJavaOpts: "-Xms2g -Xmx2g"
             protocol: "http"
             replicas: 1
             createCert: false
@@ -547,7 +547,7 @@ spec:
             image: "docker.elastic.co/elasticsearch/elasticsearch-oss"
             imageTag: "6.8.23"
             antiAffinity: "soft"
-            esJavaOpts: "-Xms1g -Xmx2g -XX:UseAVX=0 -Dcom.amazonaws.sdk.disableMBeans=true"
+            esJavaOpts: "-Xms2g -Xmx2g -XX:UseAVX=0 -Dcom.amazonaws.sdk.disableMBeans=true"
             protocol: "http"
             replicas: 1
             createCert: false
@@ -680,7 +680,7 @@ spec:
             image: "docker.elastic.co/elasticsearch/elasticsearch-oss"
             imageTag: "7.10.2"
             antiAffinity: "soft"
-            esJavaOpts: "-Xms1g -Xmx2g"
+            esJavaOpts: "-Xms2g -Xmx2g"
             protocol: "http"
             replicas: 1
             createCert: false
@@ -815,7 +815,7 @@ spec:
                 memory: "4Gi"
             persistence:
               enabled: false
-            opensearchJavaOpts: "-Xms1g -Xmx2g"
+            opensearchJavaOpts: "-Xms2g -Xmx2g"
             plugins:
               enabled: true
               installList:
@@ -907,7 +907,7 @@ spec:
                 memory: "4Gi"
             persistence:
               enabled: false
-            opensearchJavaOpts: "-Xms1g -Xmx2g"
+            opensearchJavaOpts: "-Xms2g -Xmx2g"
             plugins:
               enabled: true
               installList:
@@ -1128,7 +1128,7 @@ spec:
                             key: password
                             optional: false
                       - name: OPENSEARCH_JAVA_OPTS
-                        value: -Xms1g -Xmx2g
+                        value: -Xms2g -Xmx2g
                     resources:
                       requests:
                         cpu: "2"

--- a/vars/elasticsearch5xK8sLocalTest.groovy
+++ b/vars/elasticsearch5xK8sLocalTest.groovy
@@ -2,7 +2,7 @@ def call(Map config = [:]) {
     k8sLocalDeployment(
             jobName: 'elasticsearch-5x-k8s-local-test',
             sourceVersion: 'ES_5.6',
-            targetVersion: 'OS_2.19',
+            targetVersion: 'OS_3.1',
             testIds: '0001,0004,0005'
     )
 }


### PR DESCRIPTION
### Description

Increases resource sizing and JVM heap settings for k8s integration test clusters to improve stability.

### Changes
- Increase CPU requests/limits to 2 cores for all ES/OS test clusters
- Increase memory requests/limits to 4Gi for all ES/OS test clusters  
- Set JVM heap to 2g (Xms=Xmx) for all versions to satisfy ES bootstrap checks

### Testing
- Tested ES 5.6 locally on minikube to verify heap settings work

### Issues Resolved
N/A

### Check List
- [x] New functionality includes testing
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).