### PR TITLE
Update elasticsearch-5x-k8s-local-test target to OS_3.1

### DIFF
--- a/migrationConsole/lib/integ_test/integ_test/test_cases/multi_type_tests.py
+++ b/migrationConsole/lib/integ_test/integ_test/test_cases/multi_type_tests.py
@@ -1,6 +1,6 @@
 import logging
 from ..common_utils import convert_to_b64
-from ..cluster_version import ElasticsearchV5_X, OpensearchV1_X, OpensearchV2_X
+from ..cluster_version import ElasticsearchV5_X, OpensearchV1_X, OpensearchV2_X, OpensearchV3_X
 from .ma_argo_test_base import MATestBase, MATestUserArguments
 
 logger = logging.getLogger(__name__)
@@ -11,6 +11,7 @@ class Test0004MultiTypeUnionMigration(MATestBase):
         allow_combinations = [
             (ElasticsearchV5_X, OpensearchV1_X),
             (ElasticsearchV5_X, OpensearchV2_X),
+            (ElasticsearchV5_X, OpensearchV3_X),
         ]
         description = "Performs metadata and backfill migrations with a multi-type union transformation."
         super().__init__(user_args=user_args,
@@ -82,6 +83,7 @@ class Test0005MultiTypeSplitMigration(MATestBase):
         allow_combinations = [
             (ElasticsearchV5_X, OpensearchV1_X),
             (ElasticsearchV5_X, OpensearchV2_X),
+            (ElasticsearchV5_X, OpensearchV3_X),
         ]
         description = "Performs metadata and backfill migrations with a multi-type split transformation."
         super().__init__(user_args=user_args,

--- a/vars/elasticsearch5xK8sLocalTest.groovy
+++ b/vars/elasticsearch5xK8sLocalTest.groovy
@@ -2,7 +2,7 @@ def call(Map config = [:]) {
     k8sLocalDeployment(
             jobName: 'elasticsearch-5x-k8s-local-test',
             sourceVersion: 'ES_5.6',
-            targetVersion: 'OS_2.19',
+            targetVersion: 'OS_3.1',
             testIds: '0001,0004,0005'
     )
 }


### PR DESCRIPTION
### Description

Updates the `elasticsearch-5x-k8s-local-test` Jenkins job to target OpenSearch 3.1 instead of 2.19.

This ensures the GitHub Actions `k8s-local-integ-test` job uses the OpenSearch 3.1 manifest introduced in #2185.

**Changes:**
- `vars/elasticsearch5xK8sLocalTest.groovy`: Change `targetVersion` from `OS_2.19` to `OS_3.1`
- `migrationConsole/lib/integ_test/integ_test/test_cases/multi_type_tests.py`: Add `OpensearchV3_X` to allowed target combinations for Test0004 and Test0005

**Test IDs used:** `0001,0004,0005`
- `0001`: Single document backfill (already supported OS 3.x)
- `0004`: Multi-type union migration (now supports OS 3.x)
- `0005`: Multi-type split migration (now supports OS 3.x)

### Issues Resolved

Aligns ES 5.x integration test with the new OS 3.1 cluster template from #2185.

### Testing

- [ ] CI pipeline will validate ES 5.6 → OS 3.1 migration

### Check List
- [x] New functionality includes testing (N/A — config-only change)
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).