### PR TITLE
Update argo-workflows helm chart to 0.47.1 with v3.7.9 image

### DIFF
--- a/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/values.yaml
+++ b/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/values.yaml
@@ -281,11 +281,14 @@ charts:
           failureThreshold: 1
 
   argo-workflows:
-    version: "0.45.24"
+    version: "0.47.1"
     repository: "https://argoproj.github.io/argo-helm"
     values:
       fullnameOverride: "argo"
       images:
+        # Override appVersion v3.7.8 to v3.7.9 to incorporate retry delay overflow fix
+        # https://github.com/argoproj/argo-workflows/pull/15277
+        tag: v3.7.9
         pullPolicy: IfNotPresent
       controller:
         pdb:


### PR DESCRIPTION
### Description
Update argo-workflows chart version from 0.45.24 to 0.47.1 and override images.tag to v3.7.9 to incorporate the retry delay overflow fix.

### Issues Resolved
Fixes retry delay overflow issue: https://github.com/argoproj/argo-workflows/pull/15277

### Testing
- [x] Helm chart version and image tag verified in values.yaml

### Check List
- [ ] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).