### PR TITLE
Reduce monitor workflow backoff cap for faster test iteration

### DIFF
--- a/orchestrationSpecs/packages/migration-workflow-templates/src/workflowTemplates/testMigrationWithWorkflowCli.ts
+++ b/orchestrationSpecs/packages/migration-workflow-templates/src/workflowTemplates/testMigrationWithWorkflowCli.ts
@@ -56,12 +56,12 @@ export const TestMigrationWithWorkflowCli = WorkflowBuilder.create({
             )
         )
         .addRetryParameters({
-            limit: "33",          // ~30 minutes
+            limit: "100",
             retryPolicy: "Always",
             backoff: {
-                duration: "5",     // Start at 5 seconds
+                duration: "2",     // Start at 2 seconds
                 factor: "2",       // Exponential backoff  
-                cap: "60"         // Cap at 1 minute
+                cap: "15"          // Cap at 15 seconds
             }
         })
     )

--- a/orchestrationSpecs/packages/migration-workflow-templates/tests/__snapshots__/outputMatch.test.ts.snap
+++ b/orchestrationSpecs/packages/migration-workflow-templates/tests/__snapshots__/outputMatch.test.ts.snap
@@ -2359,11 +2359,11 @@ exit 0
         },
         "retryStrategy": {
           "backoff": {
-            "cap": "60",
-            "duration": "5",
+            "cap": "15",
+            "duration": "2",
             "factor": "2",
           },
-          "limit": "33",
+          "limit": "100",
           "retryPolicy": "Always",
         },
       },


### PR DESCRIPTION
### Description

Reduces the exponential backoff cap for the monitor workflow from 60s to 15s to speed up integration test feedback.

### Changes
- Backoff cap: 60s → 15s
- Initial duration: 5s → 2s
- Retry limit: 33 → 100 (maintains ~30 min total timeout)

### Testing
Tested locally - monitor now polls more frequently, reducing wait time between workflow completion and test verification.

### Issues Resolved
N/A

### Check List
- [x] New functionality includes testing
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).