### PR TITLE
[Add] dedicated coordinator cluster support for RFS work coordination

### DIFF
--- a/CreateSnapshot/src/main/java/org/opensearch/migrations/CreateSnapshot.java
+++ b/CreateSnapshot/src/main/java/org/opensearch/migrations/CreateSnapshot.java
@@ -128,7 +128,7 @@ public class CreateSnapshot {
     }
 
     public static void main(String[] args) throws Exception {
-        System.err.println("Starting program with: " + String.join(" ", ArgLogUtils.getRedactedArgs(args, ArgNameConstants.CENSORED_SOURCE_ARGS)));
+        System.err.println("Starting program with: " + String.join(" ", ArgLogUtils.getRedactedArgs(args, ArgNameConstants.CENSORED_ARGS)));
         Args arguments = EnvVarParameterPuller.injectFromEnv(new Args(), "CREATE_SNAPSHOT_");
         var argParser = JsonCommandLineParser.newBuilder().addObject(arguments).build();
         argParser.parse(args);

--- a/DocumentsFromSnapshotMigration/src/main/java/org/opensearch/migrations/RfsMigrateDocuments.java
+++ b/DocumentsFromSnapshotMigration/src/main/java/org/opensearch/migrations/RfsMigrateDocuments.java
@@ -388,7 +388,7 @@ public class RfsMigrateDocuments {
 
     public static void main(String[] args) throws Exception {
         var workerId = ProcessHelpers.getNodeInstanceName();
-        System.err.println("Starting program with: " + String.join(" ", ArgLogUtils.getRedactedArgs(args, ArgNameConstants.CENSORED_TARGET_ARGS)));
+        System.err.println("Starting program with: " + String.join(" ", ArgLogUtils.getRedactedArgs(args, ArgNameConstants.CENSORED_ARGS)));
         // Ensure that log4j2 doesn't execute shutdown hooks until ours have completed. This means that we need to take
         // responsibility for calling `LogManager.shutdown()` in our own shutdown hook..
         System.setProperty("log4j2.shutdownHookEnabled", "false");

--- a/MetadataMigration/src/main/java/org/opensearch/migrations/MetadataMigration.java
+++ b/MetadataMigration/src/main/java/org/opensearch/migrations/MetadataMigration.java
@@ -38,7 +38,7 @@ public class MetadataMigration {
     protected void run(String[] args) {
         System.err.println("Starting program with: " + String.join(" ", ArgLogUtils.getRedactedArgs(
                 args,
-                ArgNameConstants.joinLists(ArgNameConstants.CENSORED_SOURCE_ARGS, ArgNameConstants.CENSORED_TARGET_ARGS)
+                ArgNameConstants.CENSORED_ARGS
         )));
         var metadataArgs = EnvVarParameterPuller.injectFromEnv(new MetadataArgs(), ENV_PREFIX);
         var migrateArgs  = EnvVarParameterPuller.injectFromEnv(new MigrateArgs(),  ENV_PREFIX);

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/TrafficReplayer.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/TrafficReplayer.java
@@ -321,7 +321,7 @@ public class TrafficReplayer {
             jCommander.parse(args);
         } catch (ParameterException e) {
             System.err.println(e.getMessage());
-            System.err.println("Got args: " + String.join("; ", ArgLogUtils.getRedactedArgs(args, ArgNameConstants.CENSORED_TARGET_ARGS)));
+            System.err.println("Got args: " + String.join("; ", ArgLogUtils.getRedactedArgs(args, ArgNameConstants.CENSORED_ARGS)));
             jCommander.usage();
             System.exit(2);
             return null;
@@ -330,7 +330,7 @@ public class TrafficReplayer {
     }
 
     public static void main(String[] args) throws Exception {
-        System.err.println("Got args: " + String.join("; ", ArgLogUtils.getRedactedArgs(args, ArgNameConstants.CENSORED_TARGET_ARGS)));
+        System.err.println("Got args: " + String.join("; ", ArgLogUtils.getRedactedArgs(args, ArgNameConstants.CENSORED_ARGS)));
         final var workerId = ProcessHelpers.getNodeInstanceName();
         log.info("Starting Traffic Replayer with id=" + workerId);
 

--- a/coreUtilities/src/main/java/org/opensearch/migrations/arguments/ArgLogUtils.java
+++ b/coreUtilities/src/main/java/org/opensearch/migrations/arguments/ArgLogUtils.java
@@ -1,6 +1,7 @@
 package org.opensearch.migrations.arguments;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 public class ArgLogUtils {
@@ -11,7 +12,7 @@ public class ArgLogUtils {
 
     public static final String CENSORED_VALUE = "******";
 
-    public static List<String> getRedactedArgs(String[] args, List<String> censoredArgs) {
+    public static List<String> getRedactedArgs(String[] args, Collection<String> censoredArgs) {
         List<String> redactedArgs = new ArrayList<>();
         boolean shouldCensorNext = false;
 

--- a/coreUtilities/src/main/java/org/opensearch/migrations/arguments/ArgNameConstants.java
+++ b/coreUtilities/src/main/java/org/opensearch/migrations/arguments/ArgNameConstants.java
@@ -1,7 +1,6 @@
 package org.opensearch.migrations.arguments;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.Set;
 import java.util.regex.Pattern;
 
 public class ArgNameConstants {
@@ -21,15 +20,16 @@ public class ArgNameConstants {
     public static final String SOURCE_PASSWORD_ARG_CAMEL_CASE = "--sourcePassword";
     public static final String SOURCE_USERNAME_ARG_KEBAB_CASE = "--source-username";
     public static final String SOURCE_USERNAME_ARG_CAMEL_CASE = "--sourceUsername";
-    public static final List<String> CENSORED_TARGET_ARGS = List.of(TARGET_PASSWORD_ARG_KEBAB_CASE, TARGET_PASSWORD_ARG_CAMEL_CASE);
-    public static final List<String> CENSORED_SOURCE_ARGS = List.of(SOURCE_PASSWORD_ARG_KEBAB_CASE, SOURCE_PASSWORD_ARG_CAMEL_CASE);
-
-    @SafeVarargs
-    public static List<String> joinLists(List<String>... lists) {
-        List<String> result = new ArrayList<>();
-        for (List<String> list : lists) {
-            result.addAll(list);
-        }
-        return result;
-    }
+    public static final String COORDINATOR_PASSWORD_ARG_KEBAB_CASE = "--coordinator-password";
+    public static final String COORDINATOR_PASSWORD_ARG_CAMEL_CASE = "--coordinatorPassword";
+    public static final String COORDINATOR_USERNAME_ARG_KEBAB_CASE = "--coordinator-username";
+    public static final String COORDINATOR_USERNAME_ARG_CAMEL_CASE = "--coordinatorUsername";
+    public static final Set<String> CENSORED_ARGS = Set.of(
+        TARGET_PASSWORD_ARG_KEBAB_CASE,
+        TARGET_PASSWORD_ARG_CAMEL_CASE,
+        SOURCE_PASSWORD_ARG_KEBAB_CASE,
+        SOURCE_PASSWORD_ARG_CAMEL_CASE,
+        COORDINATOR_PASSWORD_ARG_KEBAB_CASE,
+        COORDINATOR_PASSWORD_ARG_CAMEL_CASE
+    );
 }

--- a/kiro-cli/kiro-cli-config/steering/workflow.md
+++ b/kiro-cli/kiro-cli-config/steering/workflow.md
@@ -312,7 +312,6 @@ kubectl create secret generic <secret-name> -n ma \
   "targetClusters": {
     "target": {
       "endpoint": "https://search-<domain>.<region>.es.amazonaws.com",
-      "version": "OS 3.3",
       "authConfig": {
         "sigv4": { "region": "us-east-2", "service": "es" }
       }
@@ -422,7 +421,6 @@ kubectl get configmap migrations-default-s3-config -n ma -o yaml
   "targetClusters": {
     "target": {
       "endpoint": "https://search-<domain>.<region>.es.amazonaws.com",
-      "version": "OS 3.3",
       "authConfig": {"sigv4": {"region": "us-east-2", "service": "es"}}
     }
   },
@@ -472,7 +470,6 @@ kubectl get configmap migrations-default-s3-config -n ma -o yaml
   "targetClusters": {
     "target": {
       "endpoint": "https://target:9200",
-      "version": "OS 2.11",
       "authConfig": {"basic": {"secretName": "target-creds"}}
     }
   },

--- a/migrationConsole/lib/integ_test/integ_test/test_cases/basic_tests.py
+++ b/migrationConsole/lib/integ_test/integ_test/test_cases/basic_tests.py
@@ -51,3 +51,58 @@ class Test0001SingleDocumentBackfill(MATestBase):
         # Validate single document exists on target
         self.target_operations.get_document(cluster=self.target_cluster, index_name=self.index_name,
                                             doc_id=self.doc_id, max_attempts=10, delay=3.0)
+
+
+class Test0002SingleDocumentBackfillWithRfsCoordinatorCluster(MATestBase):
+    def __init__(self, user_args: MATestUserArguments):
+        allow_combinations = [
+            (ElasticsearchV1_X, OpensearchV1_X),
+            (ElasticsearchV1_X, OpensearchV2_X),
+            (ElasticsearchV1_X, OpensearchV3_X),
+            (ElasticsearchV2_X, OpensearchV1_X),
+            (ElasticsearchV2_X, OpensearchV2_X),
+            (ElasticsearchV2_X, OpensearchV3_X),
+            (ElasticsearchV5_X, OpensearchV1_X),
+            (ElasticsearchV5_X, OpensearchV2_X),
+            (ElasticsearchV5_X, OpensearchV3_X),
+            (ElasticsearchV6_X, OpensearchV1_X),
+            (ElasticsearchV6_X, OpensearchV2_X),
+            (ElasticsearchV6_X, OpensearchV3_X),
+            (ElasticsearchV7_X, OpensearchV1_X),
+            (ElasticsearchV7_X, OpensearchV2_X),
+            (ElasticsearchV7_X, OpensearchV3_X),
+        ]
+        migrations_required = [MigrationType.BACKFILL]
+        description = "Performs backfill migration with dedicated coordinator cluster."
+        super().__init__(user_args=user_args,
+                         description=description,
+                         migrations_required=migrations_required,
+                         allow_source_target_combinations=allow_combinations)
+        self.index_name = f"test_0002_{self.unique_id}"
+        self.doc_id = "test_0002_doc"
+        self.doc_type = "sample_type"
+        self.source_cluster = None
+        self.target_cluster = None
+
+    def prepare_workflow_snapshot_and_migration_config(self):
+        snapshot_and_migration_configs = [{
+            "migrations": [{
+                "metadataMigrationConfig": {},
+                "documentBackfillConfig": {
+                    "useTargetClusterForWorkCoordination": False
+                }
+            }]
+        }]
+        self.workflow_snapshot_and_migration_config = snapshot_and_migration_configs
+
+    def prepare_clusters(self):
+        # Create single document
+        self.source_operations.create_document(cluster=self.source_cluster, index_name=self.index_name,
+                                               doc_id=self.doc_id, doc_type=self.doc_type)
+        self.source_operations.get_document(cluster=self.source_cluster, index_name=self.index_name, doc_id=self.doc_id,
+                                            doc_type=self.doc_type)
+
+    def verify_clusters(self):
+        # Validate single document exists on target
+        self.target_operations.get_document(cluster=self.target_cluster, index_name=self.index_name,
+                                            doc_id=self.doc_id, max_attempts=10, delay=3.0)

--- a/migrationConsole/lib/integ_test/testWorkflows/clusterWorkflows.yaml
+++ b/migrationConsole/lib/integ_test/testWorkflows/clusterWorkflows.yaml
@@ -842,7 +842,6 @@ spec:
             {
               "endpoint": "https://{{inputs.parameters.cluster-name}}:9200",
               "allowInsecure": true,
-              "version": "OS 1.3",
               "authConfig": {
                 "basic": {
                   "secretName": "{{inputs.parameters.cluster-name}}-creds"
@@ -934,7 +933,6 @@ spec:
             {
               "endpoint": "https://{{inputs.parameters.cluster-name}}:9200",
               "allowInsecure": true,
-              "version": "OS 2.19",
               "authConfig": {
                 "basic": {
                   "secretName": "{{inputs.parameters.cluster-name}}-creds"
@@ -1185,7 +1183,6 @@ spec:
               {
                 "endpoint": "https://{{inputs.parameters.cluster-name}}:9200",
                 "allowInsecure": true,
-                "version": "OS 3.1",
                 "authConfig": {
                   "basic": {
                     "secretName": "{{inputs.parameters.cluster-name}}-creds"

--- a/migrationConsole/lib/integ_test/testWorkflows/fullMigrationImportedClusters.yaml
+++ b/migrationConsole/lib/integ_test/testWorkflows/fullMigrationImportedClusters.yaml
@@ -153,8 +153,8 @@ spec:
             
             # Transform target config to match schema
             TARGET_TRANSFORMED=$(echo "$TARGET_CONFIG" | jq '
-              # Transform version format: OS_1.3 -> OS 1.3
-              .version = (.version | gsub("_"; " "))
+              # Target cluster schema does not accept a version field
+              del(.version)
               # Rename allow_insecure to allowInsecure
               | if has("allow_insecure") then .allowInsecure = .allow_insecure | del(.allow_insecure) else . end
               # Move sigv4 under authConfig

--- a/orchestrationSpecs/packages/argo-workflow-builders/src/models/k8sResourceBuilder.ts
+++ b/orchestrationSpecs/packages/argo-workflow-builders/src/models/k8sResourceBuilder.ts
@@ -102,8 +102,8 @@ export class K8sResourceBuilder<
         const newOutputs = {
             ...this.outputsScope,
             [name as string]: {
-                fromWhere: "path" as const,
-                path: pathValue,
+                fromWhere: "jsonPath" as const,
+                jsonPath: pathValue,
                 description: descriptionValue
             }
         } as ExtendScope<OutputParamsScope, { [K in Name]: OutputParamDef<T> }>;

--- a/orchestrationSpecs/packages/config-processor/scripts/sampleMigration.wf.yaml
+++ b/orchestrationSpecs/packages/config-processor/scripts/sampleMigration.wf.yaml
@@ -27,7 +27,6 @@
     "target": {
       "endpoint": "https://opensearch-cluster-master-headless:9200",
       "allowInsecure": true,
-      "version": "OS 2.11",
       "authConfig": {
         "basic": {
           "secretName": "target-creds"

--- a/orchestrationSpecs/packages/config-processor/tests/findSecrets.test.ts
+++ b/orchestrationSpecs/packages/config-processor/tests/findSecrets.test.ts
@@ -87,8 +87,7 @@ describe('scrapeSecrets', () => {
             },
             targetClusters: {
                 target1: {
-                    endpoint: 'https://target.example.com:9200',
-                    version: 'OS 2.5.0'
+                    endpoint: 'https://target.example.com:9200'
                 }
             },
             migrationConfigs: []
@@ -202,7 +201,7 @@ describe('scrapeAndCategorize', () => {
             },
             targetClusters: {
                 target1: {
-                    version: 'OS 2.5.0',
+                    endpoint: 'https://target.example.com:9200',
                     authConfig: {
                         basic: {
                             secretName: 'another-valid.secret'
@@ -210,6 +209,7 @@ describe('scrapeAndCategorize', () => {
                     }
                 },
                 target2: {
+                    endpoint: 'https://target2.example.com:9200',
                     authConfig: {
                         basic: {
                             secretName: '.bad.secret.name'

--- a/orchestrationSpecs/packages/config-processor/tests/migrationConfigTransformer.test.ts
+++ b/orchestrationSpecs/packages/config-processor/tests/migrationConfigTransformer.test.ts
@@ -30,10 +30,10 @@ describe('errorsArePrintedSuccinctly', () => {
             await processor.processFromObject(config);
         });
         expect(formatInputValidationError(error)).toBe(
-            `Invalid input: expected string, received undefined... at:\n` +
-            `  sourceClusters.source1.version\n` +
             `Invalid input... at:\n` +
             `  sourceClusters.source1.authConfig\n` +
+            `Invalid input: expected string, received undefined... at:\n` +
+            `  sourceClusters.source1.version\n` +
             `Invalid input: expected array, received undefined... at:\n` +
             `  migrationConfigs`);
     });

--- a/orchestrationSpecs/packages/config-processor/tests/migrationConfigTransformer.validation.test.ts
+++ b/orchestrationSpecs/packages/config-processor/tests/migrationConfigTransformer.validation.test.ts
@@ -33,7 +33,6 @@ describe('MigrationConfigTransformer validation', () => {
             "target1": {
                 "endpoint": "https://opensearch-cluster-master-headless:9200",
                 "allowInsecure": true,
-                "version": "OS 2.11",
                 "authConfig": {
                     "basic": {
                         "secretName": "target1-creds"

--- a/orchestrationSpecs/packages/config-processor/tests/semaphore.test.ts
+++ b/orchestrationSpecs/packages/config-processor/tests/semaphore.test.ts
@@ -29,7 +29,6 @@ describe('semaphore configuration', () => {
                 target: {
                     endpoint: "https://target.example.com",
                     allowInsecure: true,
-                    version: "OS 2.0.0",
                     authConfig: {
                         basic: {
                             secretName: "target-creds"
@@ -115,7 +114,6 @@ describe('semaphore configuration', () => {
                 target: {
                     endpoint: "https://target.example.com",
                     allowInsecure: true,
-                    version: "OS 2.0.0",
                     authConfig: {
                         basic: {
                             secretName: "target-creds"
@@ -218,7 +216,6 @@ describe('semaphore configuration', () => {
                 target: {
                     endpoint: "https://target.example.com",
                     allowInsecure: true,
-                    version: "OS 2.0.0",
                     authConfig: {
                         basic: {
                             secretName: "target-creds"

--- a/orchestrationSpecs/packages/migration-workflow-templates/src/workflowTemplates/allWorkflowTemplates.ts
+++ b/orchestrationSpecs/packages/migration-workflow-templates/src/workflowTemplates/allWorkflowTemplates.ts
@@ -8,6 +8,7 @@ import {TestMigrationWithWorkflowCli} from "./testMigrationWithWorkflowCli";
 import {MetadataMigration} from "./metadataMigration";
 import {MigrationConsole} from "./migrationConsole";
 import {Replayer} from "./replayer";
+import {RfsCoordinatorCluster} from "./rfsCoordinatorCluster";
 import {SetupKafka} from "./setupKafka";
 import {ConfigManagementHelpers} from "./configManagementHelpers";
 
@@ -21,6 +22,7 @@ export const AllWorkflowTemplates = [
     MetadataMigration,
     MigrationConsole,
     Replayer,
+    RfsCoordinatorCluster,
     SetupKafka,
     ConfigManagementHelpers,
     TestMigrationWithWorkflowCli,

--- a/orchestrationSpecs/packages/migration-workflow-templates/src/workflowTemplates/commonUtils/clusterSettingManipulators.ts
+++ b/orchestrationSpecs/packages/migration-workflow-templates/src/workflowTemplates/commonUtils/clusterSettingManipulators.ts
@@ -50,8 +50,8 @@ export function makeTargetParamDict(targetConfig: BaseExpression<Serialized<z.in
     return makeClusterParamDict("target", targetConfig);
 }
 
-export function makeCoordinatorParamDict(coordinatorConfig: BaseExpression<Serialized<z.infer<typeof TARGET_CLUSTER_CONFIG>>>) {
-    return makeClusterParamDict("coordinator", coordinatorConfig);
+export function makeRfsCoordinatorParamDict(rfsCoordinatorConfig: BaseExpression<Serialized<z.infer<typeof TARGET_CLUSTER_CONFIG>>>) {
+    return makeClusterParamDict("coordinator", rfsCoordinatorConfig);
 }
 
 // The functions below are still used by the replaer, but they should probably be replaced with the ones above

--- a/orchestrationSpecs/packages/migration-workflow-templates/src/workflowTemplates/rfsCoordinatorCluster.ts
+++ b/orchestrationSpecs/packages/migration-workflow-templates/src/workflowTemplates/rfsCoordinatorCluster.ts
@@ -1,0 +1,325 @@
+import {
+    BaseExpression,
+    expr,
+    INTERNAL,
+    makeStringTypeProxy,
+    typeToken,
+    WorkflowBuilder
+} from "@opensearch-migrations/argo-workflow-builders";
+import {CommonWorkflowParameters} from "./commonUtils/workflowParameters";
+
+export function getRfsCoordinatorClusterName(sessionName: BaseExpression<string>): BaseExpression<string> {
+    return expr.concat(sessionName, expr.literal("-rfs-coordinator"));
+}
+
+function createRfsCoordinatorSecretManifest(clusterName: BaseExpression<string>) {
+    return {
+        apiVersion: "v1",
+        kind: "Secret",
+        metadata: {
+            name: makeStringTypeProxy(expr.concat(clusterName, expr.literal("-creds"))),
+            labels: {
+                app: makeStringTypeProxy(clusterName)
+            }
+        },
+        type: "Opaque",
+        stringData: {
+            username: "admin",
+            password: "myStrongPassword123!"
+        }
+    };
+}
+
+function createRfsCoordinatorServiceManifest(clusterName: BaseExpression<string>) {
+    return {
+        apiVersion: "v1",
+        kind: "Service",
+        metadata: {
+            name: makeStringTypeProxy(clusterName),
+            labels: {
+                app: makeStringTypeProxy(clusterName)
+            }
+        },
+        spec: {
+            clusterIP: "None", // Headless service for direct pod communication in StatefulSet
+            selector: {
+                app: makeStringTypeProxy(clusterName)
+            },
+            ports: [
+                {
+                    name: "https",
+                    port: 9200,
+                    targetPort: "https"
+                }
+            ]
+        }
+    };
+}
+
+function createRfsCoordinatorStatefulSetManifest(clusterName: BaseExpression<string>) {
+    return {
+        apiVersion: "apps/v1",
+        kind: "StatefulSet",
+        metadata: {
+            name: makeStringTypeProxy(clusterName),
+            labels: {
+                app: makeStringTypeProxy(clusterName),
+                "app.kubernetes.io/instance": makeStringTypeProxy(clusterName)
+            }
+        },
+        spec: {
+            serviceName: makeStringTypeProxy(clusterName),
+            replicas: 1,
+            persistentVolumeClaimRetentionPolicy: {
+                whenDeleted: "Delete",
+                whenScaled: "Retain"
+            },
+            selector: {
+                matchLabels: {
+                    app: makeStringTypeProxy(clusterName)
+                }
+            },
+            template: {
+                metadata: {
+                    labels: {
+                        app: makeStringTypeProxy(clusterName),
+                        "app.kubernetes.io/instance": makeStringTypeProxy(clusterName)
+                    }
+                },
+                spec: {
+                    serviceAccountName: "argo-workflow-executor",
+                    securityContext: {
+                        fsGroup: 1000
+                    },
+                    containers: [
+                        {
+                            name: "opensearch",
+                            image: "opensearchproject/opensearch:3.1.0",
+                            ports: [
+                                {
+                                    name: "https",
+                                    containerPort: 9200
+                                }
+                            ],
+                            env: [
+                                {
+                                    name: "cluster.name",
+                                    value: makeStringTypeProxy(clusterName)
+                                },
+                                {
+                                    name: "discovery.type",
+                                    value: "single-node"
+                                },
+                                {
+                                    name: "OPENSEARCH_INITIAL_ADMIN_USERNAME",
+                                    valueFrom: {
+                                        secretKeyRef: {
+                                            name: makeStringTypeProxy(expr.concat(clusterName, expr.literal("-creds"))),
+                                            key: "username",
+                                            optional: false
+                                        }
+                                    }
+                                },
+                                {
+                                    name: "OPENSEARCH_INITIAL_ADMIN_PASSWORD",
+                                    valueFrom: {
+                                        secretKeyRef: {
+                                            name: makeStringTypeProxy(expr.concat(clusterName, expr.literal("-creds"))),
+                                            key: "password",
+                                            optional: false
+                                        }
+                                    }
+                                },
+                                {
+                                    name: "OPENSEARCH_JAVA_OPTS",
+                                    value: "-Xms1g -Xmx1g"
+                                }
+                            ],
+                            resources: {
+                                requests: {
+                                    cpu: "1",
+                                    memory: "2Gi"
+                                },
+                                limits: {
+                                    cpu: "1",
+                                    memory: "2Gi"
+                                }
+                            },
+                            readinessProbe: {
+                                exec: {
+                                    command: [
+                                        "sh",
+                                        "-c",
+                                        "curl -sk -u \"${OPENSEARCH_INITIAL_ADMIN_USERNAME}:${OPENSEARCH_INITIAL_ADMIN_PASSWORD}\" \"https://localhost:9200/_cluster/health?wait_for_status=yellow&timeout=10s\""
+                                    ]
+                                },
+                                // Waits and gives JVM time to start before probing
+                                initialDelaySeconds: 10,
+                                // Check every 15s; matched with timeoutSeconds to prevent overlapping probes
+                                periodSeconds: 15,
+                                // Must be >= the curl internal timeout (10s) to allow the API to respond
+                                timeoutSeconds: 15,
+                                // 20 failures * 15s = 300s (5m). Provides a 5min window for the
+                                // single-node cluster to reach 'yellow' status during bootstrap.
+                                failureThreshold: 20
+                            },
+                            volumeMounts: [
+                                {
+                                    name: "data",
+                                    mountPath: "/usr/share/opensearch/data"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            },
+            volumeClaimTemplates: [
+                {
+                    metadata: {
+                        name: "data"
+                    },
+                    spec: {
+                        accessModes: ["ReadWriteOnce"],
+                        resources: {
+                            requests: {
+                                storage: "1Gi"
+                            }
+                        }
+                    }
+                }
+            ]
+        }
+    };
+}
+
+export function makeRfsCoordinatorConfig(clusterName: BaseExpression<string>) {
+    return expr.makeDict({
+        endpoint: expr.concat(expr.literal("https://"), clusterName, expr.literal(":9200")),
+        label: clusterName,
+        allowInsecure: expr.literal(true),
+        authConfig: expr.makeDict({
+            basic: expr.makeDict({
+                secretName: expr.concat(clusterName, expr.literal("-creds"))
+            })
+        })
+    });
+}
+
+export const RfsCoordinatorCluster = WorkflowBuilder.create({
+    k8sResourceName: "rfs-coordinator-cluster",
+    serviceAccountName: "argo-workflow-executor"
+})
+    .addParams(CommonWorkflowParameters)
+
+    .addTemplate("createRfsCoordinatorSecret", t => t
+        .addRequiredInput("clusterName", typeToken<string>())
+        .addResourceTask(b => b
+            .setDefinition({
+                action: "apply",
+                setOwnerReference: true,
+                manifest: createRfsCoordinatorSecretManifest(b.inputs.clusterName)
+            }))
+    )
+
+    .addTemplate("createRfsCoordinatorService", t => t
+        .addRequiredInput("clusterName", typeToken<string>())
+        .addResourceTask(b => b
+            .setDefinition({
+                action: "apply",
+                setOwnerReference: true,
+                manifest: createRfsCoordinatorServiceManifest(b.inputs.clusterName)
+            }))
+    )
+
+    .addTemplate("createRfsCoordinatorStatefulSet", t => t
+        .addRequiredInput("clusterName", typeToken<string>())
+        .addResourceTask(b => b
+            .setDefinition({
+                action: "apply",
+                setOwnerReference: true,
+                successCondition: "status.readyReplicas > 0",
+                manifest: createRfsCoordinatorStatefulSetManifest(b.inputs.clusterName)
+            }))
+    )
+
+    .addTemplate("createRfsCoordinator", t => t
+        .addRequiredInput("clusterName", typeToken<string>())
+        .addOptionalInput("groupName", c => "Start RFS OpenSearch cluster for worker coordination")
+        .addSteps(b => b
+            .addStep("createSecret", INTERNAL, "createRfsCoordinatorSecret", c =>
+                c.register({ clusterName: b.inputs.clusterName }))
+            .addStepGroup(g => g
+                .addStep("createService", INTERNAL, "createRfsCoordinatorService", c =>
+                    c.register({ clusterName: b.inputs.clusterName }))
+                .addStep("createStatefulSet", INTERNAL, "createRfsCoordinatorStatefulSet", c =>
+                    c.register({ clusterName: b.inputs.clusterName }))
+            )
+        )
+    )
+
+    .addTemplate("deleteRfsCoordinatorStatefulSet", t => t
+        .addRequiredInput("clusterName", typeToken<string>())
+        .addResourceTask(b => b
+            .setDefinition({
+                action: "delete",
+                flags: ["--ignore-not-found"],
+                manifest: {
+                    apiVersion: "apps/v1",
+                    kind: "StatefulSet",
+                    metadata: {
+                        name: makeStringTypeProxy(b.inputs.clusterName)
+                    }
+                }
+            }))
+    )
+
+    .addTemplate("deleteRfsCoordinatorService", t => t
+        .addRequiredInput("clusterName", typeToken<string>())
+        .addResourceTask(b => b
+            .setDefinition({
+                action: "delete",
+                flags: ["--ignore-not-found"],
+                manifest: {
+                    apiVersion: "v1",
+                    kind: "Service",
+                    metadata: {
+                        name: makeStringTypeProxy(b.inputs.clusterName)
+                    }
+                }
+            }))
+    )
+
+    .addTemplate("deleteRfsCoordinatorSecret", t => t
+        .addRequiredInput("clusterName", typeToken<string>())
+        .addResourceTask(b => b
+            .setDefinition({
+                action: "delete",
+                flags: ["--ignore-not-found"],
+                manifest: {
+                    apiVersion: "v1",
+                    kind: "Secret",
+                    metadata: {
+                        name: makeStringTypeProxy(expr.concat(b.inputs.clusterName, expr.literal("-creds")))
+                    }
+                }
+            }))
+    )
+
+    .addTemplate("deleteRfsCoordinator", t => t
+        .addRequiredInput("clusterName", typeToken<string>())
+        .addOptionalInput("groupName", c => "Stop RFS OpenSearch cluster for worker coordination")
+        .addSteps(b => b
+            .addStepGroup(g => g
+                .addStep("deleteStatefulSet", INTERNAL, "deleteRfsCoordinatorStatefulSet", c =>
+                    c.register({ clusterName: b.inputs.clusterName }))
+                .addStep("deleteService", INTERNAL, "deleteRfsCoordinatorService", c =>
+                    c.register({ clusterName: b.inputs.clusterName }))
+            )
+            .addStepGroup(g => g
+                .addStep("deleteSecret", INTERNAL, "deleteRfsCoordinatorSecret", c =>
+                    c.register({ clusterName: b.inputs.clusterName }))
+            )
+        )
+    )
+
+    .getFullScope();

--- a/orchestrationSpecs/packages/migration-workflow-templates/tests/__snapshots__/outputMatch.test.ts.snap
+++ b/orchestrationSpecs/packages/migration-workflow-templates/tests/__snapshots__/outputMatch.test.ts.snap
@@ -1593,7 +1593,7 @@ spec:
               "name": "targetConfig",
             },
             {
-              "name": "coordinatorConfig",
+              "name": "rfsCoordinatorConfig",
             },
             {
               "name": "documentBackfillConfig",
@@ -1640,7 +1640,7 @@ spec:
                   },
                   {
                     "name": "coordinatorBasicCredsSecretNameOrEmpty",
-                    "value": "{{=sprig.dig('authConfig', 'basic', 'secretName', '', fromJSON(inputs.parameters.coordinatorConfig))}}",
+                    "value": "{{=sprig.dig('authConfig', 'basic', 'secretName', '', fromJSON(inputs.parameters.rfsCoordinatorConfig))}}",
                   },
                   {
                     "name": "loggingConfigurationOverrideConfigMap",
@@ -1652,7 +1652,7 @@ spec:
                   },
                   {
                     "name": "rfsJsonConfig",
-                    "value": "{{=toJSON(sprig.merge(sprig.merge(sprig.merge(sprig.merge(sprig.merge((('authConfig' in fromJSON(inputs.parameters.targetConfig)) ? ((('sigv4' in fromJSON(inputs.parameters.targetConfig)['authConfig']) ? (sprig.dict("targetAwsServiceSigningName", fromJSON(inputs.parameters.targetConfig)['authConfig']['sigv4']['service'], "targetAwsRegion", fromJSON(inputs.parameters.targetConfig)['authConfig']['sigv4']['region'])) : ((('mtls' in fromJSON(inputs.parameters.targetConfig)['authConfig']) ? (sprig.dict("targetCaCert", fromJSON(inputs.parameters.targetConfig)['authConfig']['mtls']['caCert'])) : ({}))))) : ({})), (('endpoint' in fromJSON(inputs.parameters.targetConfig)) ? (sprig.dict("targetHost", fromJSON(inputs.parameters.targetConfig)['endpoint'])) : ({}))), sprig.dict("targetInsecure", sprig.dig('allowInsecure', false, fromJSON(inputs.parameters.targetConfig)))), sprig.merge(sprig.merge((('authConfig' in fromJSON(inputs.parameters.coordinatorConfig)) ? ((('sigv4' in fromJSON(inputs.parameters.coordinatorConfig)['authConfig']) ? (sprig.dict("coordinatorAwsServiceSigningName", fromJSON(inputs.parameters.coordinatorConfig)['authConfig']['sigv4']['service'], "coordinatorAwsRegion", fromJSON(inputs.parameters.coordinatorConfig)['authConfig']['sigv4']['region'])) : ((('mtls' in fromJSON(inputs.parameters.coordinatorConfig)['authConfig']) ? (sprig.dict("coordinatorCaCert", fromJSON(inputs.parameters.coordinatorConfig)['authConfig']['mtls']['caCert'])) : ({}))))) : ({})), (('endpoint' in fromJSON(inputs.parameters.coordinatorConfig)) ? (sprig.dict("coordinatorHost", fromJSON(inputs.parameters.coordinatorConfig)['endpoint'])) : ({}))), sprig.dict("coordinatorInsecure", sprig.dig('allowInsecure', false, fromJSON(inputs.parameters.coordinatorConfig))))), sprig.omit(fromJSON(inputs.parameters.documentBackfillConfig), 'loggingConfigurationOverrideConfigMap', 'podReplicas', 'resources')), sprig.merge(sprig.dict("snapshotName", fromJSON(inputs.parameters.snapshotConfig)['snapshotName'], "sourceVersion", inputs.parameters.sourceVersion, "sessionName", inputs.parameters.sessionName, "luceneDir", '/tmp', "cleanLocalDirs", true), sprig.merge(sprig.merge(((0 == len(sprig.dig('endpoint', '', sprig.omit(fromJSON(inputs.parameters.snapshotConfig)['repoConfig'], 's3RoleArn')))) ? (sprig.dict()) : (sprig.dict("s3Endpoint", sprig.omit(fromJSON(inputs.parameters.snapshotConfig)['repoConfig'], 's3RoleArn')['endpoint']))), ((0 == len(sprig.dig('s3RoleArn', '', sprig.omit(fromJSON(inputs.parameters.snapshotConfig)['repoConfig'], 's3RoleArn')))) ? (sprig.dict()) : (sprig.dict("s3RoleArn", sprig.omit(fromJSON(inputs.parameters.snapshotConfig)['repoConfig'], 's3RoleArn')['s3RoleArn'])))), sprig.dict("s3RepoUri", sprig.omit(fromJSON(inputs.parameters.snapshotConfig)['repoConfig'], 's3RoleArn')['s3RepoPathUri'], "s3Region", sprig.omit(fromJSON(inputs.parameters.snapshotConfig)['repoConfig'], 's3RoleArn')['awsRegion'], "s3LocalDir", '/tmp')))))}}",
+                    "value": "{{=toJSON(sprig.merge(sprig.merge(sprig.merge(sprig.merge(sprig.merge((('authConfig' in fromJSON(inputs.parameters.targetConfig)) ? ((('sigv4' in fromJSON(inputs.parameters.targetConfig)['authConfig']) ? (sprig.dict("targetAwsServiceSigningName", fromJSON(inputs.parameters.targetConfig)['authConfig']['sigv4']['service'], "targetAwsRegion", fromJSON(inputs.parameters.targetConfig)['authConfig']['sigv4']['region'])) : ((('mtls' in fromJSON(inputs.parameters.targetConfig)['authConfig']) ? (sprig.dict("targetCaCert", fromJSON(inputs.parameters.targetConfig)['authConfig']['mtls']['caCert'])) : ({}))))) : ({})), (('endpoint' in fromJSON(inputs.parameters.targetConfig)) ? (sprig.dict("targetHost", fromJSON(inputs.parameters.targetConfig)['endpoint'])) : ({}))), sprig.dict("targetInsecure", sprig.dig('allowInsecure', false, fromJSON(inputs.parameters.targetConfig)))), sprig.merge(sprig.merge((('authConfig' in fromJSON(inputs.parameters.rfsCoordinatorConfig)) ? ((('sigv4' in fromJSON(inputs.parameters.rfsCoordinatorConfig)['authConfig']) ? (sprig.dict("coordinatorAwsServiceSigningName", fromJSON(inputs.parameters.rfsCoordinatorConfig)['authConfig']['sigv4']['service'], "coordinatorAwsRegion", fromJSON(inputs.parameters.rfsCoordinatorConfig)['authConfig']['sigv4']['region'])) : ((('mtls' in fromJSON(inputs.parameters.rfsCoordinatorConfig)['authConfig']) ? (sprig.dict("coordinatorCaCert", fromJSON(inputs.parameters.rfsCoordinatorConfig)['authConfig']['mtls']['caCert'])) : ({}))))) : ({})), (('endpoint' in fromJSON(inputs.parameters.rfsCoordinatorConfig)) ? (sprig.dict("coordinatorHost", fromJSON(inputs.parameters.rfsCoordinatorConfig)['endpoint'])) : ({}))), sprig.dict("coordinatorInsecure", sprig.dig('allowInsecure', false, fromJSON(inputs.parameters.rfsCoordinatorConfig))))), sprig.omit(fromJSON(inputs.parameters.documentBackfillConfig), 'loggingConfigurationOverrideConfigMap', 'podReplicas', 'resources', 'useTargetClusterForWorkCoordination')), sprig.merge(sprig.dict("snapshotName", fromJSON(inputs.parameters.snapshotConfig)['snapshotName'], "sourceVersion", inputs.parameters.sourceVersion, "sessionName", inputs.parameters.sessionName, "luceneDir", '/tmp', "cleanLocalDirs", true), sprig.merge(sprig.merge(((0 == len(sprig.dig('endpoint', '', sprig.omit(fromJSON(inputs.parameters.snapshotConfig)['repoConfig'], 's3RoleArn')))) ? (sprig.dict()) : (sprig.dict("s3Endpoint", sprig.omit(fromJSON(inputs.parameters.snapshotConfig)['repoConfig'], 's3RoleArn')['endpoint']))), ((0 == len(sprig.dig('s3RoleArn', '', sprig.omit(fromJSON(inputs.parameters.snapshotConfig)['repoConfig'], 's3RoleArn')))) ? (sprig.dict()) : (sprig.dict("s3RoleArn", sprig.omit(fromJSON(inputs.parameters.snapshotConfig)['repoConfig'], 's3RoleArn')['s3RoleArn'])))), sprig.dict("s3RepoUri", sprig.omit(fromJSON(inputs.parameters.snapshotConfig)['repoConfig'], 's3RoleArn')['s3RepoPathUri'], "s3Region", sprig.omit(fromJSON(inputs.parameters.snapshotConfig)['repoConfig'], 's3RoleArn')['awsRegion'], "s3LocalDir", '/tmp')))))}}",
                   },
                   {
                     "name": "resources",
@@ -1695,7 +1695,7 @@ spec:
               "name": "targetConfig",
             },
             {
-              "name": "coordinatorConfig",
+              "name": "rfsCoordinatorConfig",
             },
             {
               "name": "snapshotConfig",
@@ -1757,8 +1757,8 @@ spec:
                     "value": "{{inputs.parameters.targetConfig}}",
                   },
                   {
-                    "name": "coordinatorConfig",
-                    "value": "{{inputs.parameters.coordinatorConfig}}",
+                    "name": "rfsCoordinatorConfig",
+                    "value": "{{inputs.parameters.rfsCoordinatorConfig}}",
                   },
                   {
                     "name": "documentBackfillConfig",
@@ -1792,7 +1792,7 @@ spec:
                   },
                   {
                     "name": "targetConfig",
-                    "value": "{{inputs.parameters.coordinatorConfig}}",
+                    "value": "{{inputs.parameters.rfsCoordinatorConfig}}",
                   },
                   {
                     "name": "backfillSession",
@@ -1927,10 +1927,19 @@ spec:
           [
             {
               "arguments": {
-                "parameters": [],
+                "parameters": [
+                  {
+                    "name": "clusterName",
+                    "value": "{{=inputs.parameters.sessionName+'-rfs-coordinator'}}",
+                  },
+                ],
               },
-              "name": "configureCoordinator",
-              "template": "donothing",
+              "name": "createRfsCoordinator",
+              "templateRef": {
+                "name": "rfs-coordinator-cluster",
+                "template": "createrfscoordinator",
+              },
+              "when": "{{=!(fromJSON(inputs.parameters.documentBackfillConfig)['useTargetClusterForWorkCoordination'])}}",
             },
           ],
           [
@@ -1986,13 +1995,31 @@ spec:
                     "value": "{{inputs.parameters.imageMigrationConsolePullPolicy}}",
                   },
                   {
-                    "name": "coordinatorConfig",
-                    "value": "{{inputs.parameters.targetConfig}}",
+                    "name": "rfsCoordinatorConfig",
+                    "value": "{{=((!(fromJSON(inputs.parameters.documentBackfillConfig)['useTargetClusterForWorkCoordination'])) ? (toJSON(sprig.dict("endpoint", 'https://'+inputs.parameters.sessionName+'-rfs-coordinator'+':9200', "label", inputs.parameters.sessionName+'-rfs-coordinator', "allowInsecure", true, "authConfig", sprig.dict("basic", sprig.dict("secretName", inputs.parameters.sessionName+'-rfs-coordinator'+'-creds'))))) : (inputs.parameters.targetConfig))}}",
                   },
                 ],
               },
               "name": "runBulkLoad",
               "template": "runbulkload",
+            },
+          ],
+          [
+            {
+              "arguments": {
+                "parameters": [
+                  {
+                    "name": "clusterName",
+                    "value": "{{=inputs.parameters.sessionName+'-rfs-coordinator'}}",
+                  },
+                ],
+              },
+              "name": "cleanupRfsCoordinator",
+              "templateRef": {
+                "name": "rfs-coordinator-cluster",
+                "template": "deleterfscoordinator",
+              },
+              "when": "{{=!(fromJSON(inputs.parameters.documentBackfillConfig)['useTargetClusterForWorkCoordination'])}}",
             },
           ],
         ],
@@ -4126,6 +4153,399 @@ spec:
 }
 `;
 
+exports[`test workflow template renderings rfs-coordinator-cluster 1`] = `
+{
+  "apiVersion": "argoproj.io/v1alpha1",
+  "kind": "WorkflowTemplate",
+  "metadata": {
+    "name": "rfs-coordinator-cluster",
+  },
+  "spec": {
+    "arguments": {
+      "parameters": [
+        {
+          "name": "etcdEndpoints",
+          "value": "http://etcd.ma.svc.cluster.local:2379",
+        },
+        {
+          "name": "etcdUser",
+          "value": "root",
+        },
+        {
+          "name": "etcdPassword",
+          "value": "password",
+        },
+        {
+          "name": "s3SnapshotConfigMap",
+          "value": "s3-snapshot-config",
+        },
+        {
+          "name": "imageConfigMapName",
+          "value": "migration-image-config",
+        },
+        {
+          "name": "approvalConfigMapName",
+          "value": "approval-config",
+        },
+      ],
+    },
+    "entrypoint": undefined,
+    "parallelism": 100,
+    "serviceAccountName": "argo-workflow-executor",
+    "templates": [
+      {
+        "inputs": {
+          "parameters": [
+            {
+              "name": "clusterName",
+            },
+          ],
+        },
+        "name": "createrfscoordinatorsecret",
+        "outputs": {
+          "parameters": [],
+        },
+        "resource": {
+          "action": "apply",
+          "manifest": "apiVersion: v1
+kind: Secret
+metadata:
+  name: "{{=inputs.parameters.clusterName+'-creds'}}"
+  labels:
+    app: "{{inputs.parameters.clusterName}}"
+type: Opaque
+stringData:
+  username: admin
+  password: myStrongPassword123!
+",
+          "setOwnerReference": true,
+        },
+      },
+      {
+        "inputs": {
+          "parameters": [
+            {
+              "name": "clusterName",
+            },
+          ],
+        },
+        "name": "createrfscoordinatorservice",
+        "outputs": {
+          "parameters": [],
+        },
+        "resource": {
+          "action": "apply",
+          "manifest": "apiVersion: v1
+kind: Service
+metadata:
+  name: "{{inputs.parameters.clusterName}}"
+  labels:
+    app: "{{inputs.parameters.clusterName}}"
+spec:
+  clusterIP: None
+  selector:
+    app: "{{inputs.parameters.clusterName}}"
+  ports:
+    - name: https
+      port: 9200
+      targetPort: https
+",
+          "setOwnerReference": true,
+        },
+      },
+      {
+        "inputs": {
+          "parameters": [
+            {
+              "name": "clusterName",
+            },
+          ],
+        },
+        "name": "createrfscoordinatorstatefulset",
+        "outputs": {
+          "parameters": [],
+        },
+        "resource": {
+          "action": "apply",
+          "manifest": "apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: "{{inputs.parameters.clusterName}}"
+  labels:
+    app: "{{inputs.parameters.clusterName}}"
+    app.kubernetes.io/instance: "{{inputs.parameters.clusterName}}"
+spec:
+  serviceName: "{{inputs.parameters.clusterName}}"
+  replicas: 1
+  persistentVolumeClaimRetentionPolicy:
+    whenDeleted: Delete
+    whenScaled: Retain
+  selector:
+    matchLabels:
+      app: "{{inputs.parameters.clusterName}}"
+  template:
+    metadata:
+      labels:
+        app: "{{inputs.parameters.clusterName}}"
+        app.kubernetes.io/instance: "{{inputs.parameters.clusterName}}"
+    spec:
+      serviceAccountName: argo-workflow-executor
+      securityContext:
+        fsGroup: 1000
+      containers:
+        - name: opensearch
+          image: opensearchproject/opensearch:3.1.0
+          ports:
+            - name: https
+              containerPort: 9200
+          env:
+            - name: cluster.name
+              value: "{{inputs.parameters.clusterName}}"
+            - name: discovery.type
+              value: single-node
+            - name: OPENSEARCH_INITIAL_ADMIN_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: "{{=inputs.parameters.clusterName+'-creds'}}"
+                  key: username
+                  optional: false
+            - name: OPENSEARCH_INITIAL_ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: "{{=inputs.parameters.clusterName+'-creds'}}"
+                  key: password
+                  optional: false
+            - name: OPENSEARCH_JAVA_OPTS
+              value: -Xms1g -Xmx1g
+          resources:
+            requests:
+              cpu: "1"
+              memory: 2Gi
+            limits:
+              cpu: "1"
+              memory: 2Gi
+          readinessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - curl -sk -u "\${OPENSEARCH_INITIAL_ADMIN_USERNAME}:\${OPENSEARCH_INITIAL_ADMIN_PASSWORD}" "https://localhost:9200/_cluster/health?wait_for_status=yellow&timeout=10s"
+            initialDelaySeconds: 10
+            periodSeconds: 15
+            timeoutSeconds: 15
+            failureThreshold: 20
+          volumeMounts:
+            - name: data
+              mountPath: /usr/share/opensearch/data
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 1Gi
+",
+          "setOwnerReference": true,
+          "successCondition": "status.readyReplicas > 0",
+        },
+      },
+      {
+        "inputs": {
+          "parameters": [
+            {
+              "name": "clusterName",
+            },
+            {
+              "name": "groupName",
+              "value": "Start RFS OpenSearch cluster for worker coordination",
+            },
+          ],
+        },
+        "name": "createrfscoordinator",
+        "outputs": {
+          "parameters": [],
+        },
+        "steps": [
+          [
+            {
+              "arguments": {
+                "parameters": [
+                  {
+                    "name": "clusterName",
+                    "value": "{{inputs.parameters.clusterName}}",
+                  },
+                ],
+              },
+              "name": "createSecret",
+              "template": "createrfscoordinatorsecret",
+            },
+          ],
+          [
+            {
+              "arguments": {
+                "parameters": [
+                  {
+                    "name": "clusterName",
+                    "value": "{{inputs.parameters.clusterName}}",
+                  },
+                ],
+              },
+              "name": "createService",
+              "template": "createrfscoordinatorservice",
+            },
+            {
+              "arguments": {
+                "parameters": [
+                  {
+                    "name": "clusterName",
+                    "value": "{{inputs.parameters.clusterName}}",
+                  },
+                ],
+              },
+              "name": "createStatefulSet",
+              "template": "createrfscoordinatorstatefulset",
+            },
+          ],
+        ],
+      },
+      {
+        "inputs": {
+          "parameters": [
+            {
+              "name": "clusterName",
+            },
+          ],
+        },
+        "name": "deleterfscoordinatorstatefulset",
+        "outputs": {
+          "parameters": [],
+        },
+        "resource": {
+          "action": "delete",
+          "flags": [
+            "--ignore-not-found",
+          ],
+          "manifest": "apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: "{{inputs.parameters.clusterName}}"
+",
+        },
+      },
+      {
+        "inputs": {
+          "parameters": [
+            {
+              "name": "clusterName",
+            },
+          ],
+        },
+        "name": "deleterfscoordinatorservice",
+        "outputs": {
+          "parameters": [],
+        },
+        "resource": {
+          "action": "delete",
+          "flags": [
+            "--ignore-not-found",
+          ],
+          "manifest": "apiVersion: v1
+kind: Service
+metadata:
+  name: "{{inputs.parameters.clusterName}}"
+",
+        },
+      },
+      {
+        "inputs": {
+          "parameters": [
+            {
+              "name": "clusterName",
+            },
+          ],
+        },
+        "name": "deleterfscoordinatorsecret",
+        "outputs": {
+          "parameters": [],
+        },
+        "resource": {
+          "action": "delete",
+          "flags": [
+            "--ignore-not-found",
+          ],
+          "manifest": "apiVersion: v1
+kind: Secret
+metadata:
+  name: "{{=inputs.parameters.clusterName+'-creds'}}"
+",
+        },
+      },
+      {
+        "inputs": {
+          "parameters": [
+            {
+              "name": "clusterName",
+            },
+            {
+              "name": "groupName",
+              "value": "Stop RFS OpenSearch cluster for worker coordination",
+            },
+          ],
+        },
+        "name": "deleterfscoordinator",
+        "outputs": {
+          "parameters": [],
+        },
+        "steps": [
+          [
+            {
+              "arguments": {
+                "parameters": [
+                  {
+                    "name": "clusterName",
+                    "value": "{{inputs.parameters.clusterName}}",
+                  },
+                ],
+              },
+              "name": "deleteStatefulSet",
+              "template": "deleterfscoordinatorstatefulset",
+            },
+            {
+              "arguments": {
+                "parameters": [
+                  {
+                    "name": "clusterName",
+                    "value": "{{inputs.parameters.clusterName}}",
+                  },
+                ],
+              },
+              "name": "deleteService",
+              "template": "deleterfscoordinatorservice",
+            },
+          ],
+          [
+            {
+              "arguments": {
+                "parameters": [
+                  {
+                    "name": "clusterName",
+                    "value": "{{inputs.parameters.clusterName}}",
+                  },
+                ],
+              },
+              "name": "deleteSecret",
+              "template": "deleterfscoordinatorsecret",
+            },
+          ],
+        ],
+      },
+    ],
+  },
+}
+`;
+
 exports[`test workflow template renderings setup-kafka 1`] = `
 {
   "apiVersion": "argoproj.io/v1alpha1",
@@ -4180,7 +4600,7 @@ exports[`test workflow template renderings setup-kafka 1`] = `
             {
               "name": "brokers",
               "valueFrom": {
-                "path": "{.status.listeners[?(@.name=='plain')].bootstrapServers}",
+                "jsonPath": "{.status.listeners[?(@.name=='plain')].bootstrapServers}",
               },
             },
           ],
@@ -4272,7 +4692,7 @@ spec:
             {
               "name": "brokers",
               "valueFrom": {
-                "path": "{.status.listeners[?(@.name=='plain')].bootstrapServers}",
+                "jsonPath": "{.status.listeners[?(@.name=='plain')].bootstrapServers}",
               },
             },
           ],
@@ -4420,7 +4840,7 @@ spec:
             {
               "name": "topicName",
               "valueFrom": {
-                "path": "{.status.topicName}",
+                "jsonPath": "{.status.topicName}",
               },
             },
           ],

--- a/orchestrationSpecs/packages/schemas/src/userSchemas.ts
+++ b/orchestrationSpecs/packages/schemas/src/userSchemas.ts
@@ -196,6 +196,7 @@ export const USER_RFS_OPTIONS = z.object({
     otelCollectorEndpoint: z.string().default("http://otel-collector:4317").optional(),
 
     skipApproval: z.boolean().default(false).optional(),  // TODO - fullmigration
+    useTargetClusterForWorkCoordination: z.boolean().default(true),
     resources: z.preprocess((v) =>
             deepmerge(DEFAULT_RESOURCES.RFS, (v ?? {})),
         RESOURCE_REQUIREMENTS
@@ -276,7 +277,6 @@ export const CLUSTER_VERSION_STRING = z.string().regex(/^(?:ES [125678]|OS [123]
 export const CLUSTER_CONFIG = z.object({
     endpoint:  z.string().regex(/^(?:https?:\/\/[^:\/\s]+(:\d+)?(\/)?)?$/).default("").optional(),
     allowInsecure: z.boolean().default(false).optional(),
-    version: CLUSTER_VERSION_STRING,
     authConfig: z.union([HTTP_AUTH_BASIC, HTTP_AUTH_SIGV4, HTTP_AUTH_MTLS]).optional(),
 });
 
@@ -288,6 +288,7 @@ export const SOURCE_CLUSTER_REPOS_RECORD = z.record(z.string(), S3_REPO_CONFIG)
     .describe("Keys are the repository names that are managed by the source cluster");
 
 export const SOURCE_CLUSTER_CONFIG = CLUSTER_CONFIG.extend({
+    version: CLUSTER_VERSION_STRING,
     snapshotRepos: SOURCE_CLUSTER_REPOS_RECORD.optional(),
     proxy: PROXY_OPTIONS.optional()
 });

--- a/orchestrationSpecs/packages/schemas/tests/__snapshots__/argoSchemaSnapshot.test.ts.snap
+++ b/orchestrationSpecs/packages/schemas/tests/__snapshots__/argoSchemaSnapshot.test.ts.snap
@@ -21,10 +21,6 @@ exports[`test schemas matches expected argo schema matches expected 1`] = `
                 "type": "boolean",
                 "default": false
               },
-              "version": {
-                "type": "string",
-                "pattern": "^(?:ES [125678]|OS [123])(?:\\\\.[0-9]+)+$"
-              },
               "authConfig": {
                 "anyOf": [
                   {
@@ -94,6 +90,10 @@ exports[`test schemas matches expected argo schema matches expected 1`] = `
                     ]
                   }
                 ]
+              },
+              "version": {
+                "type": "string",
+                "pattern": "^(?:ES [125678]|OS [123])(?:\\\\.[0-9]+)+$"
               },
               "snapshotRepos": {
                 "type": "object",
@@ -167,10 +167,6 @@ exports[`test schemas matches expected argo schema matches expected 1`] = `
               "allowInsecure": {
                 "type": "boolean",
                 "default": false
-              },
-              "version": {
-                "type": "string",
-                "pattern": "^(?:ES [125678]|OS [123])(?:\\\\.[0-9]+)+$"
               },
               "authConfig": {
                 "anyOf": [
@@ -249,7 +245,6 @@ exports[`test schemas matches expected argo schema matches expected 1`] = `
             },
             "required": [
               "endpoint",
-              "version",
               "label"
             ]
           },
@@ -428,6 +423,10 @@ exports[`test schemas matches expected argo schema matches expected 1`] = `
                           "otelCollectorEndpoint": {
                             "type": "string",
                             "default": "http://otel-collector:4317"
+                          },
+                          "useTargetClusterForWorkCoordination": {
+                            "type": "boolean",
+                            "default": true
                           },
                           "resources": {
                             "type": "object",
@@ -712,10 +711,6 @@ exports[`test schemas matches expected argo user matches expected 1`] = `
             "type": "boolean",
             "default": false
           },
-          "version": {
-            "type": "string",
-            "pattern": "^(?:ES [125678]|OS [123])(?:\\\\.[0-9]+)+$"
-          },
           "authConfig": {
             "anyOf": [
               {
@@ -785,6 +780,10 @@ exports[`test schemas matches expected argo user matches expected 1`] = `
                 ]
               }
             ]
+          },
+          "version": {
+            "type": "string",
+            "pattern": "^(?:ES [125678]|OS [123])(?:\\\\.[0-9]+)+$"
           },
           "snapshotRepos": {
             "type": "object",
@@ -858,10 +857,6 @@ exports[`test schemas matches expected argo user matches expected 1`] = `
             "type": "boolean",
             "default": false
           },
-          "version": {
-            "type": "string",
-            "pattern": "^(?:ES [125678]|OS [123])(?:\\\\.[0-9]+)+$"
-          },
           "authConfig": {
             "anyOf": [
               {
@@ -934,8 +929,7 @@ exports[`test schemas matches expected argo user matches expected 1`] = `
           }
         },
         "required": [
-          "endpoint",
-          "version"
+          "endpoint"
         ]
       }
     },
@@ -1176,6 +1170,10 @@ exports[`test schemas matches expected argo user matches expected 1`] = `
                           "skipApproval": {
                             "type": "boolean",
                             "default": false
+                          },
+                          "useTargetClusterForWorkCoordination": {
+                            "type": "boolean",
+                            "default": true
                           },
                           "resources": {
                             "type": "object",

--- a/vars/eksIntegPipeline.groovy
+++ b/vars/eksIntegPipeline.groovy
@@ -19,7 +19,7 @@ def call(Map config = [:]) {
     def targetVersion = config.targetVersion ?: ""
     def sourceClusterType = config.sourceClusterType ?: ""
     def targetClusterType = config.targetClusterType ?: ""
-    def testIds = config.testIds ?: "0001"
+    def testIds = config.testIds ?: "0001,0002"
     def clusterContextFilePath = "tmp/cluster-context-integ-${currentBuild.number}.json"
     pipeline {
         agent { label config.workerAgent ?: 'Jenkins-Default-Agent-X64-C5xlarge-Single-Host' }

--- a/vars/elasticsearch5xK8sLocalTest.groovy
+++ b/vars/elasticsearch5xK8sLocalTest.groovy
@@ -3,6 +3,6 @@ def call(Map config = [:]) {
             jobName: 'elasticsearch-5x-k8s-local-test',
             sourceVersion: 'ES_5.6',
             targetVersion: 'OS_3.1',
-            testIds: '0001,0004,0005'
+            testIds: '0001,0002,0004,0005'
     )
 }


### PR DESCRIPTION
### Description
This PR introduces support for deploying a dedicated OpenSearch 3.1 coordinator cluster for RFS work coordination, providing an alternative to using the target cluster. It also removes the version field from TARGET_CLUSTER_CONFIG (keeping it required only on SOURCE_CLUSTER_CONFIG) and consolidates censored argument handling across Java services.

### Issues Resolved
[MIGRATIONS-2875](https://opensearch.atlassian.net/browse/MIGRATIONS-2857)
[MIGRATIONS-2859](https://opensearch.atlassian.net/browse/MIGRATIONS-2859)

### Testing
- Success on Jenkins (with new test 0002)
- Success on GHA
- Jenkins ['elasticsearch-5x-k8s-local-test'](https://migrations.ci.opensearch.org/blue/organizations/jenkins/elasticsearch-5x-k8s-local-test/detail/elasticsearch-5x-k8s-local-test/12117/pipeline/) job passes
- Jenkins ['eks-integ-test'](https://migrations.ci.opensearch.org/blue/organizations/jenkins/eks-integ-test/detail/eks-integ-test/1767/pipeline) job passes even though GHA shows cancelled

#### Changes:

New `useTargetClusterForWorkCoordination` flag
- Added to `USER_RFS_OPTIONS` schema (defaults to true, preserving existing behavior).
- When false, the workflow deploys a single-node OpenSearch 3.1 StatefulSet for work coordination, then cleans it up after backfill completes.
- The flag is omitted from the RFS args dict passed to containers.

New `rfsCoordinatorCluster.ts` workflow template
- Defines K8s manifests for a coordinator cluster: StatefulSet (single-node OS 3.1, 1 vCPU / 2Gi memory, 1Gi heap), headless Service, Secret (basic auth credentials), and a PVC for data.
- Provides `createAllRfsCoordinator` and `deleteAllRfsCoordinator` orchestration templates with parallelized create/delete of service and statefulset resources.
- Exports `makeRfsCoordinatorConfig()` to dynamically construct the coordinator connection config (endpoint, auth secret reference, allowInsecure: true)

`documentBulkLoad.ts` conditional coordinator integration
- `setupAndRunBulkLoad` conditionally deploys/deletes the coordinator cluster when the flag is false, using `expr.ternary()` to pass either the deployed coordinator config or the target config as `rfsCoordinatorConfig`

`TARGET_CLUSTER_CONFIG` schema change
- Removed version from `CLUSTER_CONFIG` base schema
- version remains required on `SOURCE_CLUSTER_CONFIG` only
- Removed version from target cluster entries in sampleMigration.wf.yaml

Consolidated censored args (Java)
- Replaced `CENSORED_TARGET_ARGS`, `CENSORED_SOURCE_ARGS`, and `joinLists()` in `ArgNameConstants` with a single `CENSORED_ARGS Set<String>` containing all sensitive argument names (target, source, and new coordinator password args)

Workflow builder improvements (argo-workflow-builders)
- K8sResourceBuilder output params now use jsonPath instead of path for correct Argo resource output references
- `StepsBuilder.addStepGroup` simplified to require the callback to return a `StepGroupBuilder` directly, removing the runtime BuilderLike duck-typing check
- Added typed `StepGroupBuilder.addStep` method for type-safe step additions within parallel groups

clusterSettingManipulators.ts
- Renamed `makeCoordinatorParamDict` to `makeRfsCoordinatorParamDict`

#### Workflow Status on the terminal
```
[+] Workflow: migration-workflow
  Phase: Succeeded
  Started: 2026-02-11T21:38:01Z
  Finished: 2026-02-11T21:41:46Z

Workflow Steps
├── ✓  2026-02-11 21:41:36: Migration (source1 to target1) (Succeeded)
│   └── ✓  2026-02-11 21:41:36: Get Snapshot Then Migrate Snapshot (snapshot-0) (Succeeded)
│       ├── ✓  2026-02-11 21:38:11: createSnapshot (Succeeded)
│       ├── ✓  2026-02-11 21:38:32: Wait For Completion (checks) (Succeeded): Snapshot completed successfully
│        │   └── ✓  2026-02-11 21:38:27: checkSnapshotCompletion (Succeeded): Snapshot completed successfully
│       └── ✓  2026-02-11 21:41:36: Migrate From Snapshot (snapshot-migration-0) (Succeeded)
│           ├── ✓  2026-02-11 21:38:49: evaluateMetadata (Succeeded)
│           ├── ~  2026-02-11 21:38:59: approveEvaluate (Skipped)
│           ├── ✓  2026-02-11 21:39:15: migrateMetadata (Succeeded)
│           ├── ✓  2026-02-11 21:40:30: Create Rfs Coordinator (Start RFS OpenSearch cluster for worker coordination  (Succeeded)
│           │   ├── ✓  2026-02-11 21:39:28: createSecret (Succeeded)
│           │   ├── ✓  2026-02-11 21:39:39: createService (Succeeded)
│           │   └── ✓  2026-02-11 21:40:21: createStatefulset (Succeeded)
│           ├── ~  2026-02-11 21:39:25: approveMigrate (Skipped)
│           ├── ✓  2026-02-11 21:40:33: startHistoricalBackfill (Succeeded)
│           ├── ✓  2026-02-11 21:41:05: Wait For Completion (checks)
│           │   (Succeeded): complete: 40.00%, ETA: 12s; shards in-progress: 0;
│           │   remaining: 3; shards complete/total: 2/5
│           │   ├── ▶  2026-02-11 21:40:47: checkBackfillStatus (Checked):
│           │   │   complete: 40.00%, ETA: 12s; shards in-progress: 0;
│           │   │   remaining: 3; shards complete/total: 2/5
│           │   └── ✓  2026-02-11 21:41:01: checkBackfillStatus (Succeeded):
│           │       complete: 100.00%, ETA: unknown; shards in-progress: 0;
│           │       remaining: 0; shards complete/total: 5/5
│           ├── ✓  2026-02-11 21:41:09: stopHistoricalBackfill (Succeeded)
│           └── ✓  2026-02-11 21:41:36: Cleanup Rfs Coordinator (Stop RFS OpenSearch cluster for worker coordination) (Succeeded)
│               ├── ✓  2026-02-11 21:41:19: deleteService (Succeeded)
│               ├── ✓  2026-02-11 21:41:19: deleteStatefulset (Succeeded)
│               └── ✓  2026-02-11 21:41:29: deleteSecret (Succeeded)
└── ✓  2026-02-11 21:41:40: cleanup (Succeeded)

Migration workflow completed successfully
```

### Check List
- [x] New functionality includes testing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
