### PR TITLE
Fix Docker API version mismatch with minikube in buildOpenApiDockerImage

### DIFF
--- a/deployment/k8s/buildDockerImagesMini.sh
+++ b/deployment/k8s/buildDockerImagesMini.sh
@@ -131,7 +131,7 @@ fi
 eval $(minikube docker-env)
 
 if [ "$SKIP_BUILD" = "false" ]; then
-  ./gradlew :buildDockerImages -x test
+  ./gradlew :buildDockerImages -x test --info --stacktrace
 fi
 
 # Push images to minikube registry addon

--- a/migrationConsole/lib/console_link/build.gradle
+++ b/migrationConsole/lib/console_link/build.gradle
@@ -51,8 +51,21 @@ tasks.register('buildOpenApiDockerImage') {
             '-t', dockerImageName,
             '.'
         ]
-        def proc = buildCommand.execute(null, projectDirRef)
+        def env = System.getenv().collect { k, v -> "$k=$v" }
+        env.removeAll { it.startsWith('DOCKER_API_VERSION=') }
+        env.add('DOCKER_API_VERSION=1.44')
+        def proc = buildCommand.execute(env, projectDirRef)
+        def stdout = new StringBuilder()
+        def stderr = new StringBuilder()
+        proc.consumeProcessOutput(stdout, stderr)
         def exitCode = proc.waitFor()
+
+        if (stdout) {
+            logger.lifecycle("Docker build stdout:\n${stdout}")
+        }
+        if (stderr) {
+            logger.lifecycle("Docker build stderr:\n${stderr}")
+        }
 
         if (exitCode != 0) {
             throw new GradleException("Docker image build failed with exit code $exitCode")


### PR DESCRIPTION
### Description
Fix Docker API version mismatch that causes `buildOpenApiDockerImage` to fail when building against minikube's Docker daemon.

**Root cause:** Minikube 1.38.0 bundles Docker 28.5.2 internally, which requires API version 1.44+. When `eval $(minikube docker-env)` redirects the host Docker CLI to minikube's daemon, the host CLI defaults to API 1.43, causing the error:
```
client version 1.43 is too old. Minimum supported API version is 1.44
```

**Fix:** 
- Set `DOCKER_API_VERSION=1.44` environment variable in the Gradle task
- Add stdout/stderr capture to surface Docker build errors in logs
- Add `--info --stacktrace` flags to Gradle for better CI debugging

### Issues Resolved
Fixes CI failures like: https://migrations.ci.opensearch.org/job/k8s-local-integ-test/1280/console

### Testing
- Verified locally that the Docker build succeeds with the API version fix

### Check List
- [x] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).