### PR TITLE
[Update] removed the version field from TARGET_CLUSTER_CONFIG

### DIFF
--- a/orchestrationSpecs/packages/config-processor/tests/findSecrets.test.ts
+++ b/orchestrationSpecs/packages/config-processor/tests/findSecrets.test.ts
@@ -87,8 +87,7 @@ describe('scrapeSecrets', () => {
             },
             targetClusters: {
                 target1: {
-                    endpoint: 'https://target.example.com:9200',
-                    version: 'OS 2.5.0'
+                    endpoint: 'https://target.example.com:9200'
                 }
             },
             migrationConfigs: []
@@ -202,7 +201,7 @@ describe('scrapeAndCategorize', () => {
             },
             targetClusters: {
                 target1: {
-                    version: 'OS 2.5.0',
+                    endpoint: 'https://target.example.com:9200',
                     authConfig: {
                         basic: {
                             secretName: 'another-valid.secret'
@@ -210,6 +209,7 @@ describe('scrapeAndCategorize', () => {
                     }
                 },
                 target2: {
+                    endpoint: 'https://target2.example.com:9200',
                     authConfig: {
                         basic: {
                             secretName: '.bad.secret.name'

--- a/orchestrationSpecs/packages/migration-workflow-templates/src/workflowTemplates/commonUtils/clusterSettingManipulators.ts
+++ b/orchestrationSpecs/packages/migration-workflow-templates/src/workflowTemplates/commonUtils/clusterSettingManipulators.ts
@@ -23,8 +23,8 @@ function makeAuthDict(clusterType: string, targetConfig: BaseExpression<Serializ
         expr.literal({}));
 }
 
-export function getHttpAuthSecretName(clusterConfig: BaseExpression<Serialized<z.infer<typeof CLUSTER_CONFIG>>>) {
-    return expr.dig(expr.deserializeRecord(clusterConfig), ["authConfig", "basic", "secretName"], "");
+export function getHttpAuthSecretName(clusterConfig: BaseExpression<Serialized<z.infer<typeof CLUSTER_CONFIG>>> | BaseExpression<Serialized<z.infer<typeof TARGET_CLUSTER_CONFIG>>>) {
+    return expr.dig(expr.deserializeRecord(clusterConfig as BaseExpression<Serialized<z.infer<typeof CLUSTER_CONFIG>>>), ["authConfig", "basic", "secretName"], "");
 }
 
 export function makeClusterParamDict(clusterType: string, clusterConfig: BaseExpression<Serialized<z.infer<typeof CLUSTER_CONFIG>>>) {
@@ -47,11 +47,11 @@ export function makeClusterParamDict(clusterType: string, clusterConfig: BaseExp
 }
 
 export function makeTargetParamDict(targetConfig: BaseExpression<Serialized<z.infer<typeof TARGET_CLUSTER_CONFIG>>>) {
-    return makeClusterParamDict("target", targetConfig);
+    return makeClusterParamDict("target", targetConfig as BaseExpression<Serialized<z.infer<typeof CLUSTER_CONFIG>>>);
 }
 
 export function makeCoordinatorParamDict(coordinatorConfig: BaseExpression<Serialized<z.infer<typeof TARGET_CLUSTER_CONFIG>>>) {
-    return makeClusterParamDict("coordinator", coordinatorConfig);
+    return makeClusterParamDict("coordinator", coordinatorConfig as BaseExpression<Serialized<z.infer<typeof CLUSTER_CONFIG>>>);
 }
 
 // The functions below are still used by the replaer, but they should probably be replaced with the ones above
@@ -79,5 +79,5 @@ export function extractSourceKeysToExpressionMap(sourceConfig: BaseExpression<Se
 }
 
 export function extractTargetKeysToExpressionMap(targetConfig: BaseExpression<Serialized<z.infer<typeof TARGET_CLUSTER_CONFIG>>>) {
-    return extractConnectionKeysToExpressionMap("target", targetConfig);
+    return extractConnectionKeysToExpressionMap("target", targetConfig as BaseExpression<Serialized<z.infer<typeof CLUSTER_CONFIG>>>);
 }

--- a/orchestrationSpecs/packages/schemas/src/userSchemas.ts
+++ b/orchestrationSpecs/packages/schemas/src/userSchemas.ts
@@ -281,7 +281,7 @@ export const CLUSTER_CONFIG = z.object({
     authConfig: z.union([HTTP_AUTH_BASIC, HTTP_AUTH_SIGV4, HTTP_AUTH_MTLS]).optional(),
 });
 
-export const TARGET_CLUSTER_CONFIG = CLUSTER_CONFIG.extend({
+export const TARGET_CLUSTER_CONFIG = CLUSTER_CONFIG.omit({ version: true }).extend({
     endpoint:  z.string().regex(/^https?:\/\/[^:\/\s]+(:\d+)?(\/)?$/), // override to required
 });
 

--- a/orchestrationSpecs/packages/schemas/tests/__snapshots__/argoSchemaSnapshot.test.ts.snap
+++ b/orchestrationSpecs/packages/schemas/tests/__snapshots__/argoSchemaSnapshot.test.ts.snap
@@ -168,10 +168,6 @@ exports[`test schemas matches expected argo schema matches expected 1`] = `
                 "type": "boolean",
                 "default": false
               },
-              "version": {
-                "type": "string",
-                "pattern": "^(?:ES [125678]|OS [123])(?:\\\\.[0-9]+)+$"
-              },
               "authConfig": {
                 "anyOf": [
                   {
@@ -249,7 +245,6 @@ exports[`test schemas matches expected argo schema matches expected 1`] = `
             },
             "required": [
               "endpoint",
-              "version",
               "name"
             ]
           },
@@ -843,10 +838,6 @@ exports[`test schemas matches expected argo user matches expected 1`] = `
             "type": "boolean",
             "default": false
           },
-          "version": {
-            "type": "string",
-            "pattern": "^(?:ES [125678]|OS [123])(?:\\\\.[0-9]+)+$"
-          },
           "authConfig": {
             "anyOf": [
               {
@@ -919,8 +910,7 @@ exports[`test schemas matches expected argo user matches expected 1`] = `
           }
         },
         "required": [
-          "endpoint",
-          "version"
+          "endpoint"
         ]
       }
     },


### PR DESCRIPTION
### Description
This change removes the version field from target cluster configuration while keeping it required for source clusters. The motivation behind this change is supporting OpenSearch Serverless (AOSS) as a target variant and AOSS do not have a version field.

### Issues Resolved
[MIGRATIONS-2857](https://opensearch.atlassian.net/browse/MIGRATIONS-2857)

### Testing
<!-- Please provide details of testing done: unit testing, integration testing and manual testing -->

### Check List
- [x] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
