### PR TITLE
Helm: fail fast by pre-installing migration console NodePool

### DIFF
--- a/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/templates/resources/migrationConsole.yaml
+++ b/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/templates/resources/migrationConsole.yaml
@@ -41,6 +41,10 @@ apiVersion: karpenter.sh/v1
 kind: NodePool
 metadata:
   name: dedicated-small-instance-migration-console-pool
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-10"
+    "helm.sh/hook-delete-policy": before-hook-creation
 spec:
   limits:
     cpu: 4000m


### PR DESCRIPTION
### Description
Adds Helm pre-install/pre-upgrade hook annotations to the dedicated migration console Karpenter NodePool so chart failures happen before the rest of the release resources are applied on EKS.

### Issues Resolved
N/A

### Testing
- Rendered the chart with `helm template` and verified the NodePool includes the hook annotations.

This **correctly** alongside helm 4.1.0 fails with
```
+ ./aws-bootstrap.sh --skip-git-pull --base-dir /home/ec2-user/workspace/eks-integ-test --use-public-images false --skip-console-exec --stage eks-integ-2
Updated context arn:aws:eks:us-east-1:****:cluster/migration-eks-cluster-eks-integ-2-us-east-1 in /home/ec2-user/.kube/config
Installing Migration Assistant chart now, this can take a couple minutes...
Error: INSTALLATION FAILED: failed pre-install: warning: Hook pre-install migration-assistant/templates/resources/migrationConsole.yaml failed: failed to create typed patch object (/dedicated-small-instance-migration-console-pool; karpenter.sh/v1, Kind=NodePool): .spec.template.disruption: field not declared in schema
Installing Migration Assistant chart failed...
```

### Check List
- [ ] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).