### PR TITLE
Fix Karpenter NodePool disruption field nesting

### DIFF
--- a/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/templates/resources/migrationConsole.yaml
+++ b/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/templates/resources/migrationConsole.yaml
@@ -45,6 +45,9 @@ spec:
   limits:
     cpu: 4000m
     memory: 4Gi
+  disruption:
+    consolidationPolicy: WhenEmpty
+    consolidateAfter: 5m  # No reason to wait long if the console exits
   template:
     spec:
       nodeClassRef:
@@ -70,9 +73,6 @@ spec:
         - key: "migration-console" # Taint to ensure only migration console pods land here
           value: "dedicated"
           effect: NoSchedule
-    disruption:
-      consolidationPolicy: WhenEmpty
-      consolidateAfter: 5m  # No reason to wait long if the console exits
 ---
 {{- end }}
 {{ $sharedLogsVolumeEnabled := .Values.logs.sharedLogsVolume.enabled }}


### PR DESCRIPTION
### Description
Fixes the migration console dedicated Karpenter NodePool manifest to place `disruption` under `spec.disruption` (instead of `spec.template.disruption`), matching the Karpenter v1 schema on EKS.

### Issues Resolved
N/A

### Testing
- Rendered the chart with `helm template` and verified the NodePool includes `spec.disruption`.

### Check List
- [ ] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).