### PR TITLE
Remove --build-images and related flags from aws-bootstrap.sh

### DIFF
--- a/deployment/k8s/aws/README.md
+++ b/deployment/k8s/aws/README.md
@@ -83,7 +83,7 @@ To update images see [buildImages](../../../buildImages/README.md).
 To update the K8s deployment (other than images, configmaps, workflow templates,
 resource settings, etc.) see the [k8s README](../README.md).
 
-When building images (`--build-images` or `--build-images-locally`), the script,
+When building images (`--build-images-locally`), the script,
 by default, automatically configures cross-platform builds for amd64 and arm64.
 
 1. A `general-work-pool` NodePool is pre-created from the Migration Assistant  

--- a/deployment/k8s/aws/aws-bootstrap.sh
+++ b/deployment/k8s/aws/aws-bootstrap.sh
@@ -3,10 +3,8 @@
 # Bootstrap EKS Environment for OpenSearch Migration Assistant
 #
 # This script prepares an existing EKS cluster to use the Migration Assistant tooling.
-# As a default public images will be used from https://gallery.ecr.aws/opensearchproject.
-# However, images can also be built from source with the --build-images=true flag
-# which kicks-off a buildImages chart which will build required images for the
-# Migration Assistant inside of an EKS pod and push these images to a private ECR for use.
+# By default, public images will be used from https://gallery.ecr.aws/opensearchproject.
+# Images can also be built from source locally with the --build-images-locally flag.
 #
 # Usage:
 #   Run directly: curl -s https://raw.githubusercontent.com/opensearch-project/opensearch-migrations/main/deployment/k8s/aws/aws-bootstrap.sh | bash
@@ -24,10 +22,7 @@ skip_git_pull=false
 
 base_dir="./opensearch-migrations"
 namespace="ma"
-build_images=false
 build_images_locally=false
-keep_build_images_job_alive=false
-use_existing_built_images=false
 use_public_images=true
 skip_console_exec=false
 stage_filter=""
@@ -44,14 +39,9 @@ while [[ $# -gt 0 ]]; do
     --tag) tag="$2"; shift 2 ;;
     --skip-git-pull) skip_git_pull=true; shift 1 ;;
     --base-dir) base_dir="$2"; shift 2 ;;
-    --build-images-chart-dir) build_images_chart_dir="$2"; shift 2 ;;
     --ma-chart-dir) ma_chart_dir="$2"; shift 2 ;;
     --namespace) namespace="$2"; shift 2 ;;
-    --build-images) build_images="$2"; shift 2 ;;
     --build-images-locally) build_images_locally=true; shift 1 ;;
-    --use-existing-built-images) use_existing_built_images=true; shift ;;
-    --use-public-images) use_public_images="$2"; shift 2 ;;
-    --keep-build-images-job-alive) keep_build_images_job_alive=true; shift 1 ;;
     --skip-console-exec) skip_console_exec=true; shift 1 ;;
     --stage) stage_filter="$2"; shift 2 ;;
     --helm-values) extra_helm_values="$2"; shift 2 ;;
@@ -66,14 +56,9 @@ while [[ $# -gt 0 ]]; do
       echo "  --tag <val>                               (default: $tag)"
       echo "  --skip-git-pull                           (default: $skip_git_pull)"
       echo "  --base-dir <path>                         (default: $base_dir)"
-      echo "  --build-images-chart-dir <path>           (default: $build_images_chart_dir)"
       echo "  --ma-chart-dir <path>                     (default: $ma_chart_dir)"
       echo "  --namespace <val>                         (default: $namespace)"
-      echo "  --build-images <true|false>               (default: $build_images)"
-      echo "  --build-images-locally                    (default: $build_images_locally)"
-      echo "  --use-existing-built-images               (default: $use_existing_built_images)"
-      echo "  --use-public-images <true|false>          (default: $use_public_images)"
-      echo "  --keep-build-images-job-alive             (default: $keep_build_images_job_alive)"
+      echo "  --build-images-locally                    Build images from source locally (default: $build_images_locally)"
       echo "  --skip-console-exec                       (default: $skip_console_exec)"
       echo "  --stage <val>                             Filter CFN exports by stage name"
       echo "  --helm-values <path>                      Extra values file for helm install"
@@ -89,17 +74,6 @@ while [[ $# -gt 0 ]]; do
 done
 
 if [[ "$build_images_locally" == "true" ]]; then
-  build_images="true"
-fi
-
-if [[ "$use_existing_built_images" == "true" && "$build_images" == "true" ]]; then
-  echo "Error: --use-existing-built-images and --build-images/--build-images-locally are mutually exclusive."
-  exit 1
-fi
-
-# --- validation ---
-if [[ "$build_images" == "true" && "$use_public_images" == "true" ]]; then
-  echo "Note: --build-images is enabled, so public images will NOT be used."
   use_public_images=false
 fi
 
@@ -112,7 +86,6 @@ esac
 OS=$(uname -s | tr '[:upper:]' '[:lower:]')
 HELM_VERSION="3.14.0"
 
-build_images_chart_dir="${base_dir}/deployment/k8s/charts/components/buildImages"
 ma_chart_dir="${base_dir}/deployment/k8s/charts/aggregates/migrationAssistantWithArgo"
 
 install_helm() {
@@ -346,72 +319,27 @@ if [[ "$skip_git_pull" == "false" ]]; then
 fi
 
 
-if [[ "$build_images" == "true" ]]; then
-  # Always build for both architectures on EKS - buildImages chart creates its own nodepool
+if [[ "$build_images_locally" == "true" ]]; then
+  # Always build for both architectures on EKS
   MULTI_ARCH_NATIVE=true
   BUILD_TARGET="buildImagesToRegistry"
   export MULTI_ARCH_NATIVE
 
-  if [[ "$build_images_locally" == "true" ]]; then
-    if docker buildx inspect local-remote-builder --bootstrap &>/dev/null; then
-      echo "Buildkit already configured and healthy, skipping setup"
-    else
-      echo "Setting up buildkit for local builds..."
-      "${base_dir}/buildImages/setUpK8sImageBuildServices.sh"
-    fi
-
-    echo "Building images to MIGRATIONS_ECR_REGISTRY=$MIGRATIONS_ECR_REGISTRY"
-    pushd "$base_dir" || exit
-    ./gradlew :buildImages:${BUILD_TARGET} -PregistryEndpoint="$MIGRATIONS_ECR_REGISTRY" -x test || exit
-    popd > /dev/null || exit
-
-    echo "Cleaning up docker buildx builder to free buildkit pods..."
-    docker buildx rm local-remote-builder 2>/dev/null || true
-    echo "Builder removed. Buildkit pods will be terminated by kubernetes driver."
+  if docker buildx inspect local-remote-builder --bootstrap &>/dev/null; then
+    echo "Buildkit already configured and healthy, skipping setup"
   else
-    if helm status build-images -n "$namespace" >/dev/null 2>&1; then
-      echo "Helm release 'build-images' already exists in namespace '$namespace'."
-      echo "The 'build-images' release must be uninstalled before proceeding."
-      echo
-      echo "To uninstall, run:"
-      echo "  helm uninstall build-images -n $namespace"
-      echo
-      echo "Then re-run this bootstrap script."
-      exit 1
-    fi
-    helm install build-images "${build_images_chart_dir}" \
-      --namespace "$namespace" \
-      --set registryEndpoint="${MIGRATIONS_ECR_REGISTRY}" \
-      --set awsEKSEnabled=true \
-      --set multiArchNative="${MULTI_ARCH_NATIVE}" \
-      --set keepJobAlive="${keep_build_images_job_alive}" \
-      --set repositoryUrl="https://github.com/${org_name}/${repo_name}.git" \
-      --set repositoryBranch="${branch}" \
-      || { echo "Installing buildImages chart failed..."; exit 1; }
-
-    if [[ "$keep_build_images_job_alive" == "true" ]]; then
-      echo "The keep_build_images_job_alive setting was enabled, will not proceed with installing the Migration Assistant chart"
-      exit 0
-    fi
-    pod_name=$(kubectl get pod -n "$namespace" -o name | grep '^pod/build-images' | cut -d/ -f2)
-    echo "Waiting for pod ${pod_name} to be ready..."
-    kubectl -n "$namespace" wait --for=condition=ready pod/"$pod_name" --timeout=300s
-    sleep 5
-    echo "Tailing logs for ${pod_name}..."
-    echo "-------------------------------"
-    kubectl -n "$namespace" logs -f "$pod_name"
-    echo "-------------------------------"
-    sleep 5
-    final_status=$(kubectl get pod "$pod_name" -n "$namespace" -o jsonpath='{.status.phase}')
-    echo "Pod ${pod_name} ended with status: ${final_status}"
-    if [[ "$final_status" != "Succeeded" ]]; then
-      echo "The $pod_name pod did not end with 'Succeeded'. Exiting..."
-      exit 1
-    else
-      echo "Uninstalling buildImages chart after successful setup"
-      helm uninstall build-images -n "$namespace"
-    fi
+    echo "Setting up buildkit for local builds..."
+    "${base_dir}/buildImages/setUpK8sImageBuildServices.sh"
   fi
+
+  echo "Building images to MIGRATIONS_ECR_REGISTRY=$MIGRATIONS_ECR_REGISTRY"
+  pushd "$base_dir" || exit
+  ./gradlew :buildImages:${BUILD_TARGET} -PregistryEndpoint="$MIGRATIONS_ECR_REGISTRY" -x test || exit
+  popd > /dev/null || exit
+
+  echo "Cleaning up docker buildx builder to free buildkit pods..."
+  docker buildx rm local-remote-builder 2>/dev/null || true
+  echo "Builder removed. Buildkit pods will be terminated by kubernetes driver."
 fi
 
 if [[ "$use_public_images" == "false" ]]; then


### PR DESCRIPTION
### Description

Remove the EKS pod-based image building path from `aws-bootstrap.sh` (the `buildImages` Helm chart approach). Keep `--build-images-locally` which builds via local docker buildx.

**Flags removed (5):**
- `--build-images <true|false>` — EKS pod-based build via Helm chart
- `--build-images-chart-dir <path>`
- `--use-existing-built-images`
- `--use-public-images <true|false>`
- `--keep-build-images-job-alive`

**Flag kept:**
- `--build-images-locally` — builds images via local docker buildx, pushes to private ECR. When used, public images are automatically skipped.

**Code removed (~70 lines):**
- Entire EKS pod build `else` branch (Helm install build-images chart, pod log tailing, status checking, cleanup)
- `--build-images-chart-dir` variable and arg
- `--use-existing-built-images` / `--build-images` mutual exclusivity validation
- `--keep-build-images-job-alive` early exit logic

**Wiki updated:** The [Deploying to EKS](https://github.com/opensearch-project/opensearch-migrations/wiki/Deploying-to-EKS) wiki page "Build images from source" example now uses `--build-images-locally` instead of `--build-images true`.

### Issues Resolved

N/A — simplification to remove unused EKS pod-based build path.

### Testing

- Verified no remaining references to removed flags (`build_images`, `keep_build_images_job_alive`, `use_existing_built_images`, `build_images_chart_dir`) in the script.
- `--build-images-locally` code path preserved unchanged.
- `use_public_images` toggle preserved (automatically set to `false` when `--build-images-locally` is used).

### Check List
- [x] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).