### PR TITLE
Update dependabot config: fix eslint failures and add pip ecosystem entries

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,10 @@ updates:
       migration-assistant-npm:
         patterns:
           - "*"
+    ignore:
+      - dependency-name: "eslint"
+        update-types:
+          - "version-update:semver-major"
 
   - package-ecosystem: "npm"
     directory: "/deployment/cdk/opensearch-service-migration"
@@ -17,6 +21,10 @@ updates:
       opensearch-cdk-npm:
         patterns:
           - "*"
+    ignore:
+      - dependency-name: "eslint"
+        update-types:
+          - "version-update:semver-major"
 
   - package-ecosystem: "gradle"
     directory: "/"
@@ -55,5 +63,77 @@ updates:
       interval: "weekly"
     groups:
       github-actions-all:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "pip"
+    directory: "/migrationConsole/lib/console_link"
+    schedule:
+      interval: "weekly"
+    groups:
+      pip-console-link:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "pip"
+    directory: "/migrationConsole/cluster_tools"
+    schedule:
+      interval: "weekly"
+    groups:
+      pip-cluster-tools:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "pip"
+    directory: "/migrationConsole/lib/integ_test"
+    schedule:
+      interval: "weekly"
+    groups:
+      pip-integ-test:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "pip"
+    directory: "/libraries/testAutomation"
+    schedule:
+      interval: "weekly"
+    groups:
+      pip-test-automation:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "pip"
+    directory: "/test/cleanupDeployment"
+    schedule:
+      interval: "weekly"
+    groups:
+      pip-cleanup-deployment:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "pip"
+    directory: "/TrafficCapture/dockerSolution/src/main/docker/elasticsearchTestConsole"
+    schedule:
+      interval: "weekly"
+    groups:
+      pip-es-test-console:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "pip"
+    directory: "/TrafficCapture/dockerSolution/src/main/docker/k8sConfigMapUtilScripts"
+    schedule:
+      interval: "weekly"
+    groups:
+      pip-k8s-configmap-utils:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "pip"
+    directory: "/TrafficCapture/dockerSolution/otelConfigs"
+    schedule:
+      interval: "weekly"
+    groups:
+      pip-otel-configs:
         patterns:
           - "*"


### PR DESCRIPTION
## Summary

Update `.github/dependabot.yml` to fix failing npm PRs and add Python dependency management.

## Changes

### 1. Ignore eslint major version bumps (fixes PRs #2237 & #2238)

Added `ignore` rules to both npm ecosystem entries to skip `eslint` semver-major updates. `typescript-eslint@8.x` only supports eslint `^8.57.0 || ^9.0.0` — the eslint 10.0.0 bump causes `ERESOLVE` failures during `npm ci`. Minor/patch updates still come through.

### 2. Add pip ecosystem entries with grouping (8 directories)

Added weekly pip entries for all Python directories with Pipfile/setup.py:
- `/migrationConsole/lib/console_link`
- `/migrationConsole/cluster_tools`
- `/migrationConsole/lib/integ_test`
- `/libraries/testAutomation`
- `/test/cleanupDeployment`
- `/TrafficCapture/dockerSolution/src/main/docker/elasticsearchTestConsole`
- `/TrafficCapture/dockerSolution/src/main/docker/k8sConfigMapUtilScripts`
- `/TrafficCapture/dockerSolution/otelConfigs`

Each uses `patterns: ["*"]` grouping so all deps in a directory get batched into one PR. This ensures security updates (like pillow, cryptography) come through as grouped PRs managed by dependabot version updates rather than individual security-only PRs.

## Config change

4 ecosystem entries → 12 (2 npm + 1 gradle + 1 github-actions + 8 pip)