### PR TITLE
Disable incremental compilation in typecheck tsconfigs to fix tsgo stack overflow

### DIFF
--- a/orchestrationSpecs/tsconfig.typecheck.processor.json
+++ b/orchestrationSpecs/tsconfig.typecheck.processor.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.base.json",
   "compilerOptions": {
     "noEmit": true,
+    "incremental": false,
     "moduleResolution": "bundler",
     "paths": {
       "@opensearch-migrations/schemas": ["./packages/schemas/src/index.ts"]

--- a/orchestrationSpecs/tsconfig.typecheck.templates.json
+++ b/orchestrationSpecs/tsconfig.typecheck.templates.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.base.json",
   "compilerOptions": {
     "noEmit": true,
+    "incremental": false,
     "moduleResolution": "bundler",
     "paths": {
       "@opensearch-migrations/argo-workflow-builders": ["./packages/argo-workflow-builders/src/index.ts"],


### PR DESCRIPTION
## Description

The `tsgo` type-checker (v7.0.0-dev) crashes with a stack overflow during CI builds due to infinite recursion in its incremental compilation handler.

### Root Cause

`tsconfig.base.json` sets `"incremental": true`, which is inherited by the typecheck configs (`tsconfig.typecheck.processor.json` and `tsconfig.typecheck.templates.json`). When `tsgo` runs with `--noEmit` and incremental mode enabled, it enters infinite mutual recursion between `handleDtsMayChangeOfFileAndExportsOfFile` and `getReferencedBy` in `affectedfileshandler.go`.

### Fix

Add `"incremental": false` to both typecheck tsconfigs. This is safe because:

- These configs run with `--noEmit`, so incremental compilation provides **zero benefit** (no `.tsbuildinfo` is cached)
- The override prevents `tsgo` from entering the buggy incremental code path
- `tsgo` speed advantage over `tsc` is preserved for type-checking

### Changes

- `orchestrationSpecs/tsconfig.typecheck.processor.json` — added `"incremental": false`
- `orchestrationSpecs/tsconfig.typecheck.templates.json` — added `"incremental": false`

### Testing

This fix addresses the stack overflow seen in [full-es68source-e2e-test #17292](https://migrations.ci.opensearch.org/job/full-es68source-e2e-test/17292/console). The change is minimal and only affects the type-checking step — no runtime behavior is modified.