### PR TITLE
Fix Kyverno reliability: safe uninstall and webhook cleanup (same namespace)

### DIFF
--- a/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/templates/childrenChartInstaller/uninstallJob.yaml
+++ b/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/templates/childrenChartInstaller/uninstallJob.yaml
@@ -34,10 +34,14 @@ spec:
               set -e
 
               {{ include "migration.helmUninstallFunctions" . | nindent 14 }}
-              # Skip fluent-bit (logging); kyverno handled at end of uninstall_charts
+              # Phase 1: Uninstall all charts except fluent-bit (kept for logging) and kyverno (uninstalled last).
+              # See _uninstallHelper.tpl for the full uninstall strategy documentation.
               uninstall_charts fluent-bit
 
 ---
+# Phase 2: Post-delete job to clean up charts that were intentionally kept alive during Phase 1.
+# Runs after Helm deletes the umbrella chart's own resources. The service account and RBAC
+# survive because they are hook resources (delete-policy: before-hook-creation), not chart resources.
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -74,4 +78,6 @@ spec:
               set -e
 
               {{ include "migration.helmUninstallFunctions" . | nindent 14 }}
+              # Phase 2: Uninstall remaining charts (fluent-bit etc.) that were kept active during Phase 1.
+              # Charts already removed in Phase 1 are safely skipped (discovery-based, ownership-checked).
               uninstall_charts

--- a/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/templates/helpers/_uninstallHelper.tpl
+++ b/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/templates/helpers/_uninstallHelper.tpl
@@ -1,36 +1,78 @@
+{{/*
+  Uninstall Helper — Helm Release Cleanup Functions
+  ==================================================
+
+  This template defines `uninstall_charts`, the core function used by both the
+  pre-delete and post-delete uninstall jobs.
+
+  ## Uninstall Strategy (Two-Phase)
+
+  Phase 1 — Pre-delete hook (uninstallJob.yaml, hook-weight: -10):
+    Runs BEFORE Helm deletes the umbrella chart's own resources.
+    Calls: uninstall_charts fluent-bit
+    Effect: Uninstalls all managed child charts IN PARALLEL, except:
+      - fluent-bit: kept alive so logs are captured during teardown
+      - kyverno: always uninstalled LAST and SYNCHRONOUSLY (see below)
+
+  Phase 2 — Post-delete hook (uninstallJob.yaml, hook-weight: 10):
+    Runs AFTER Helm deletes the umbrella chart's own resources.
+    Calls: uninstall_charts
+    Effect: Uninstalls any remaining charts (primarily fluent-bit).
+    The function re-discovers releases dynamically, so charts already removed
+    in Phase 1 are simply not found — no double-uninstall occurs.
+
+  ## Why Kyverno Is Uninstalled Last
+
+  Kyverno installs admission webhooks that intercept API requests cluster-wide.
+  If kyverno is removed while other charts are still being uninstalled, the
+  webhook endpoints disappear but the webhook configurations remain, causing
+  API calls from other helm uninstalls to hang or fail. By uninstalling kyverno
+  synchronously after all other charts are gone, we avoid this.
+
+  The kyverno cleanup sequence is:
+    1. Delete webhook configurations (prevents API blocking)
+    2. helm uninstall with timeout (clean removal)
+    3. Force-delete remaining resources if timeout exceeded
+    4. Delete CRDs (final cleanup)
+
+  ## Ownership Model
+
+  Each child chart is tagged with `global.managedBy=<release-name>` during
+  install. The uninstall function only removes charts whose managedBy value
+  matches the current umbrella release, preventing accidental deletion of
+  charts managed by other releases.
+*/}}
 {{- define "migration.helmUninstallFunctions" -}}
+{{- $kyvernoChart := index .Values.charts "kyverno" -}}
 uninstall_charts() {
-  # Accepts space-separated list of releases to skip
+  # Args: space-separated release names to skip in the parallel uninstall phase
   local RELEASES_TO_SKIP=("$@")
-  # Always skip kyverno in parallel uninstall - handled synchronously at end
+  # Kyverno is always handled separately at the end (see header comment)
   RELEASES_TO_SKIP+=("kyverno")
 
   echo "Starting Helm uninstallation sequence..."
   UMBRELLA_CHART_ID="{{ .Release.Name }}"
 
-  # Find all helm releases in the cluster across all namespaces
+  # Discover all helm releases across all namespaces by inspecting helm secrets.
+  # This is dynamic — we don't rely on values.yaml to know what's installed.
   echo "Discovering all Helm releases in the cluster..."
-
-  # Get list of all namespaces
   NAMESPACES=$(kubectl get namespaces -o jsonpath='{.items[*].metadata.name}')
 
   for NAMESPACE in $NAMESPACES; do
     echo "Checking for Helm releases in namespace: $NAMESPACE"
 
-    # Get all Secret resources of type helm.sh/release.v1
     HELM_SECRETS=$(kubectl get secrets -n $NAMESPACE -l "owner=helm" -o jsonpath='{.items[*].metadata.name}' 2>/dev/null || echo "")
 
     if [ -n "$HELM_SECRETS" ]; then
       for SECRET in $HELM_SECRETS; do
-        # Extract the release name from the secret
         RELEASE_NAME=$(echo $SECRET | sed -E 's/sh\.helm\.release\.v1\.([^\.]+).*$/\1/')
 
-        # Skip if in skip list
+        # Skip releases in the exclusion list
         if [ "${#RELEASES_TO_SKIP[@]}" -gt 0 ]; then
           for CANDIDATE in "${RELEASES_TO_SKIP[@]}"; do
             if [ "$RELEASE_NAME" = "$CANDIDATE" ]; then
               echo "Skipping release $RELEASE_NAME (explicitly excluded)"
-              continue 2  # skip outer loop (not just inner)
+              continue 2  # skip outer for-loop iteration
             fi
           done
         fi
@@ -38,16 +80,12 @@ uninstall_charts() {
         if [ -n "$RELEASE_NAME" ]; then
           echo "Found Helm release: $RELEASE_NAME in namespace: $NAMESPACE"
 
-          # Get the chart values and check for our ownership label
+          # Only uninstall charts owned by this umbrella release
           OWNERSHIP=$(helm get values $RELEASE_NAME -n $NAMESPACE -o json 2>/dev/null | jq -r '.global.managedBy // empty')
 
           if [ "$OWNERSHIP" = "$UMBRELLA_CHART_ID" ]; then
             echo "Chart $RELEASE_NAME is managed by this umbrella chart. Uninstalling..."
-
-            # Uninstall chart
-            helm uninstall $RELEASE_NAME -n $NAMESPACE --debug &
-
-            echo "Successfully uninstalled chart: $RELEASE_NAME"
+            (helm uninstall $RELEASE_NAME -n $NAMESPACE --debug && echo "Successfully uninstalled chart: $RELEASE_NAME" || echo "Failed to uninstall chart: $RELEASE_NAME") &
           else
             echo "Chart $RELEASE_NAME exists but is not managed by this umbrella chart ($UMBRELLA_CHART_ID). Skipping."
           fi
@@ -58,15 +96,33 @@ uninstall_charts() {
     fi
   done
 
+  # Wait for all parallel uninstalls to complete before handling kyverno
   wait
-  echo "Uninstallation sequence completed!"
+  echo "Parallel uninstallation sequence completed."
 
-  # Uninstall kyverno last (synchronously) to avoid webhook issues
+  # Kyverno cleanup: always attempted, discovery-based (safe no-op if not installed)
   for NAMESPACE in $NAMESPACES; do
     OWNERSHIP=$(helm get values kyverno -n $NAMESPACE -o json 2>/dev/null | jq -r '.global.managedBy // empty')
     if [ "$OWNERSHIP" = "$UMBRELLA_CHART_ID" ]; then
+{{- if and $kyvernoChart $kyvernoChart.preUninstallCleanup $kyvernoChart.preUninstallCleanup.webhooks }}
+      # Step 1: Remove webhook configs first so they don't block API calls during uninstall
+      echo "Deleting kyverno webhook configurations..."
+      kubectl delete mutatingwebhookconfigurations -l app.kubernetes.io/instance=kyverno --ignore-not-found
+      kubectl delete validatingwebhookconfigurations -l app.kubernetes.io/instance=kyverno --ignore-not-found
+{{- end }}
+
+      # Step 2: Uninstall with timeout; force-clean if it hangs
       echo "Uninstalling kyverno last..."
-      helm uninstall kyverno -n $NAMESPACE --debug
+      timeout {{ if and $kyvernoChart $kyvernoChart.uninstallTimeout }}{{ $kyvernoChart.uninstallTimeout }}{{ else }}120{{ end }} helm uninstall kyverno -n $NAMESPACE --debug || {
+        echo "kyverno uninstall timed out, force-cleaning remaining resources..."
+        kubectl delete all -l app.kubernetes.io/instance=kyverno -n $NAMESPACE --force --grace-period=0 || true
+      }
+
+{{- if and $kyvernoChart $kyvernoChart.postUninstallCleanup $kyvernoChart.postUninstallCleanup.crds }}
+      # Step 3: CRDs aren't removed by helm uninstall — clean them up explicitly
+      echo "Cleaning up kyverno CRDs..."
+      kubectl delete crd -l app.kubernetes.io/instance=kyverno --ignore-not-found
+{{- end }}
       break
     fi
   done

--- a/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/templates/resources/kyvernoMountLocalAwsCreds.yaml
+++ b/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/templates/resources/kyvernoMountLocalAwsCreds.yaml
@@ -76,7 +76,7 @@ metadata:
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
   ttlSecondsAfterFinished: 300
-  backoffLimit: 5
+  backoffLimit: 10
   template:
     spec:
       serviceAccountName: {{ .Values.installer.serviceAccount.name }}
@@ -89,6 +89,11 @@ spec:
             - /bin/sh
             - -c
             - |
+              set -e
+              echo "Waiting for Kyverno CRD to be established..."
+              kubectl wait --for=condition=Established crd/clusterpolicies.kyverno.io --timeout=300s
+              echo "Waiting for Kyverno admission controller to be ready..."
+              kubectl wait --for=condition=ready pod -l app.kubernetes.io/component=admission-controller -n {{ .Release.Namespace }} --timeout=120s
               kubectl apply -f /policy/policy.yaml
           volumeMounts:
             - name: policy

--- a/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/values.yaml
+++ b/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/values.yaml
@@ -621,6 +621,11 @@ charts:
         enabled: false
 
   kyverno:
+    uninstallTimeout: 120         # Timeout for helm uninstall (seconds), with force-cleanup fallback
+    preUninstallCleanup:
+      webhooks: true             # Delete mutating/validating webhook configs before uninstall
+    postUninstallCleanup:
+      crds: true                 # Delete CRDs after uninstall
     version: "3.5.2"
     repository: "https://kyverno.github.io/kyverno/"
     namespace: ma
@@ -651,4 +656,4 @@ charts:
           requests: null
           limits: null
       config:
-        excludeKyvernoNamespace: false
+        excludeKyvernoNamespace: true

--- a/libraries/testAutomation/testAutomation/test_runner.py
+++ b/libraries/testAutomation/testAutomation/test_runner.py
@@ -193,8 +193,31 @@ class TestRunner:
             logger.warning(f"Failed to cleanup labeled Kubernetes resources: {e}")
 
     def cleanup_deployment(self) -> None:
+        helm_uninstall_error = None
+        try:
+            self.k8s_service.helm_uninstall(release_name=MA_RELEASE_NAME)
+        except Exception as e:
+            logger.error(f"Helm uninstall of '{MA_RELEASE_NAME}' release failed: {e}")
+            helm_uninstall_error = e
+
+        # Verify helm uninstall cleanly removed kyverno webhooks
+        remaining_webhooks = self.k8s_service.get_kyverno_webhooks()
+        if remaining_webhooks:
+            logger.error(f"Kyverno webhooks still present after helm uninstall: {remaining_webhooks}")
+
         self.cleanup_clusters()
         self.k8s_service.delete_namespace()
+
+        if helm_uninstall_error:
+            raise HelmCommandFailed(
+                f"Helm uninstall of '{MA_RELEASE_NAME}' release failed cleanly. "
+                f"This may indicate webhook or finalizer issues (e.g. Kyverno)."
+            ) from helm_uninstall_error
+        if remaining_webhooks:
+            raise HelmCommandFailed(
+                f"Helm uninstall did not cleanly remove kyverno webhooks: {remaining_webhooks}. "
+                f"The helm uninstall hooks should handle webhook cleanup."
+            )
 
     def copy_logs(self, destination: str = "./logs") -> None:
         self.k8s_service.copy_log_files(destination=destination)


### PR DESCRIPTION
## Motivation

Kyverno uses [admission webhooks](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/) with `failurePolicy=Fail` to enforce policies. This creates two reliability risks:

1. **Self-deadlock on uninstall**: `helm uninstall kyverno` triggers pre-delete hooks that need to create pods, but those pod creations are intercepted by Kyverno's own webhooks — which are being torn down. The uninstall hangs indefinitely. See [Kyverno webhook troubleshooting](https://kyverno.io/docs/troubleshooting/webhook/).

2. **Self-deadlock on crash recovery**: If Kyverno's admission controller crashes, Kubernetes tries to restart it, but the pod creation is blocked by the still-registered webhook (`failurePolicy=Fail`). The fix is [`excludeKyvernoNamespace`](https://kyverno.io/docs/installation/customization/#resource-filters) — Kyverno skips its own namespace so it can always restart.

## Approach

**Kyverno stays in the `ma` namespace** — no separate namespace. Reliability is achieved through ordering and cleanup rules:

1. **Uninstall ordering**: Kyverno is always uninstalled last, after all other charts are done. This prevents its webhooks from blocking other helm operations.
2. **Webhook cleanup**: Webhook configurations are deleted before `helm uninstall kyverno`, breaking the chicken-and-egg deadlock.
3. **Timeout + force-cleanup**: 120s timeout on kyverno uninstall with force-delete fallback.
4. **CRD cleanup**: Kyverno CRDs are deleted after uninstall (helm doesn't remove CRDs by default).
5. **`excludeKyvernoNamespace: true`**: Prevents kyverno from enforcing policies on its own namespace, avoiding circular dependency on crash recovery.

This is a simpler alternative to [PR #2234](https://github.com/opensearch-project/opensearch-migrations/pull/2234) which uses a separate `kyverno-ma` namespace with ownerReference cascade deletion.

## Changes

### Uninstall reliability (`_uninstallHelper.tpl`, `uninstallJob.yaml`)
- **Two-phase uninstall strategy**: Pre-delete hook uninstalls all charts except fluent-bit (kept for logging) and kyverno (uninstalled last). Post-delete hook cleans up remaining charts (fluent-bit).
- **Hardcoded kyverno/fluent-bit ordering** — no user-configurable flags.
- Delete webhook configurations *before* `helm uninstall kyverno`
- 120s timeout + force-cleanup fallback
- CRD cleanup after uninstall
- Discovery-based cleanup — safe no-op when kyverno isn't installed
- Comprehensive documentation in `_uninstallHelper.tpl`

### Setup reliability (`values.yaml`, `kyvernoMountLocalAwsCreds.yaml`)
- Set `excludeKyvernoNamespace: true`
- Add uninstall config: timeout, webhook cleanup, CRD cleanup
- Wait for CRD establishment + admission controller readiness before applying policies
- Increase `backoffLimit` 5→10, add `set -e` for fail-fast

### CI / test cleanup (`k8s_service.py`, `test_runner.py`, `k8sLocalDeployment.groovy`)
- `cleanup_deployment()` runs `helm uninstall` before namespace deletion
- Delete kyverno webhooks before namespace deletion
- Jenkins cleanup stage deletes kyverno webhooks before `ma` namespace

## Coverage

| Issue | Severity | Status |
|-------|----------|--------|
| Kyverno self-deadlock on crash recovery | 🔴 Critical | ✅ Fixed (`excludeKyvernoNamespace`) |
| Webhook deadlock on uninstall | 🔴 Critical | ✅ Fixed (pre-delete webhook cleanup) |
| No timeout on `helm uninstall kyverno` | 🟡 Medium | ✅ Fixed (120s timeout + force-cleanup) |
| Policy apply race condition | 🟡 Medium | ✅ Fixed (CRD + admission controller wait) |
| CRD/ClusterPolicy cleanup | 🟢 Low | ✅ Fixed (CRD deletion cascades to policies) |
