### PR TITLE
Change EKS initialLeaseDuration default from PT10M to PT1H

### DIFF
--- a/orchestrationSpecs/packages/schemas/src/userSchemas.ts
+++ b/orchestrationSpecs/packages/schemas/src/userSchemas.ts
@@ -194,7 +194,7 @@ export const USER_RFS_OPTIONS = z.object({
     allowLooseVersionMatching: z.boolean().default(true).describe("").optional(),
     docTransformerConfigBase64: z.string().default("").optional(),
     documentsPerBulkRequest: z.number().default(0x7fffffff).optional(),
-    initialLeaseDuration: z.string().default("PT10M").optional(),
+    initialLeaseDuration: z.string().default("PT1H").optional(),
     maxConnections: z.number().default(10).optional(),
     maxShardSizeBytes: z.number().default(80*1024*1024*1024).optional(),
     otelCollectorEndpoint: z.string().default("http://otel-collector:4317").optional(),

--- a/orchestrationSpecs/packages/schemas/tests/__snapshots__/argoSchemaSnapshot.test.ts.snap
+++ b/orchestrationSpecs/packages/schemas/tests/__snapshots__/argoSchemaSnapshot.test.ts.snap
@@ -422,7 +422,7 @@ exports[`test schemas matches expected argo schema matches expected 1`] = `
                           },
                           "initialLeaseDuration": {
                             "type": "string",
-                            "default": "PT10M"
+                            "default": "PT1H"
                           },
                           "maxConnections": {
                             "type": "number",
@@ -1181,7 +1181,7 @@ exports[`test schemas matches expected argo user matches expected 1`] = `
                           },
                           "initialLeaseDuration": {
                             "type": "string",
-                            "default": "PT10M"
+                            "default": "PT1H"
                           },
                           "maxConnections": {
                             "type": "number",


### PR DESCRIPTION
## Description
Change the EKS `initialLeaseDuration` default from `PT10M` (10 minutes) to `PT1H` (1 hour) to sync with ECS behavior and speed up starting document migration for larger shard sizes.

### Changes
- `orchestrationSpecs/packages/schemas/src/userSchemas.ts`: Updated default from `PT10M` to `PT1H`
- Updated corresponding snapshot file

### Context
The ECS deployment already uses `PT60M` for the initial lease duration (set in `reindex-from-snapshot-stack.ts`). This change aligns the EKS default to match, which helps avoid unnecessary lease renewals during document migration of larger shards.

### Testing
Snapshot updated to reflect the new default value.