### PR TITLE
[Fix] recurring IMDSv1 regression in `full-es68source-e2e-test` pipeline

### DIFF
--- a/vars/fullES68SourceE2ETest.groovy
+++ b/vars/fullES68SourceE2ETest.groovy
@@ -100,6 +100,39 @@ def call(Map config = [:]) {
             skipCaptureProxyOnNodeSetup: true,
             jobName: 'full-es68source-e2e-test',
             testUniqueId: testUniqueId,
-            integTestCommand: '/root/lib/integ_test/integ_test/full_tests.py --source_proxy_alb_endpoint https://alb.migration.<STAGE>.local:9201 --target_proxy_alb_endpoint https://alb.migration.<STAGE>.local:9202'
+            integTestCommand: '/root/lib/integ_test/integ_test/full_tests.py --source_proxy_alb_endpoint https://alb.migration.<STAGE>.local:9201 --target_proxy_alb_endpoint https://alb.migration.<STAGE>.local:9202',
+            deployStep: {
+                echo "Acquired deployment stage: ${stage}"
+                def baseCommand = "./awsE2ESolutionSetup.sh --source-context-file './sourceJenkinsContext.json' " +
+                        "--migration-context-file './migrationJenkinsContext.json' " +
+                        "--source-context-id ${sourceContextId} " +
+                        "--migration-context-id ${migrationContextId} " +
+                        "--stage ${stage} " +
+                        "--migrations-git-url ${params.GIT_REPO_URL} " +
+                        "--migrations-git-branch ${params.GIT_BRANCH} " +
+                        "--skip-capture-proxy"
+                withCredentials([string(credentialsId: 'migrations-test-account-id', variable: 'MIGRATIONS_TEST_ACCOUNT_ID')]) {
+                    withAWS(role: 'JenkinsDeploymentRole', roleAccount: "${MIGRATIONS_TEST_ACCOUNT_ID}", duration: 5400, roleSessionName: 'jenkins-session') {
+                        sh baseCommand
+                        // Workaround: CDK does not set HttpTokens=optional despite requireImdsv2=false in context.
+                        // Source EC2 instances need IMDSv1 for the ES repository-s3 plugin to obtain credentials.
+                        // Without this, S3 snapshot operations fail with ExpiredToken errors.
+                        sh '''
+                            for id in $(aws ec2 describe-instances \
+                              --region us-east-1 \
+                              --filters "Name=tag:Name,Values=*ec2-source-'"${stage}"'*" "Name=instance-state-name,Values=running" \
+                              --query "Reservations[].Instances[].InstanceId" \
+                              --output text); do
+                                echo "Setting IMDSv1 (HttpTokens=optional) on instance $id"
+                                aws ec2 modify-instance-metadata-options \
+                                  --region us-east-1 \
+                                  --instance-id "$id" \
+                                  --http-tokens optional \
+                                  --http-endpoint enabled
+                            done
+                        '''
+                    }
+                }
+            }
     )
 }


### PR DESCRIPTION
### Description
The es68 E2E pipeline has been failing repeatedly with ExpiredToken errors when the migration console tries to access S3 snapshots:
```
repository_exception: [migration_assistant_repo] could not read repository data from index blob
caused_by: AmazonS3Exception: The provided token has expired. (Status Code: 400; Error Code: ExpiredToken)
```

The root cause is that the ES 6.8 repository-s3 plugin relies on IMDSv1 to obtain instance credentials, but the source EC2 instances are launched with HttpTokens=required (IMDSv2-only), causing credential retrieval to
fail.

We've been manually applying an SOP to set HttpTokens=optional on the instances, but the fix keeps getting undone. This happens because each pipeline run executes cdk deploy, and the source EC2 stack uses a dynamic
SSM parameter for the AMI (/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2). Whenever AWS publishes a new Amazon Linux 2 AMI, CloudFormation replaces the EC2 instance entirely — and the new instance
comes up with the account default of IMDSv2 enforced, wiping out the manual fix.

The CDK context already has "requireImdsv2": false, but the external opensearch-cluster-cdk repo (branch migration-es) does not translate this into MetadataOptions on the CloudFormation AWS::EC2::Instance resource.

### Fix

This PR overrides the `deployStep` in the es68 pipeline to automatically set `HttpTokens=optional` on all source EC2 instances immediately after the CDK deploy completes. This ensures the fix is re-applied every run, regardless of whether the instance was replaced.

### Why this approach

- The proper fix would be in the upstream `opensearch-cluster-cdk` repo to honor `requireImdsv2: false`, but we don't own that repo and we may not want to maintain this pipeline in the future.
- The override uses the existing `deployStep` hook in `defaultIntegPipeline`, so no changes to shared pipeline infrastructure are needed.
- The tradeoff is duplicating the default deploy logic, which is acceptable given the short maintenance window.


### Issues Resolved
N/A

### Testing
<!-- Please provide details of testing done: unit testing, integration testing and manual testing -->

### Check List
- [ ] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
