### PR TITLE
Fix Dockerfile lint warnings and Gradle configuration cache failures

### DIFF
--- a/TrafficCapture/dockerSolution/src/main/docker/elasticsearchTestConsole/Dockerfile
+++ b/TrafficCapture/dockerSolution/src/main/docker/elasticsearchTestConsole/Dockerfile
@@ -19,8 +19,8 @@ RUN dnf install -y \
       python3.11-wheel \
   && dnf clean all
 
-ENV PIP_ROOT_USER_ACTION ignore
-ENV LANG C.UTF-8
+ENV PIP_ROOT_USER_ACTION=ignore
+ENV LANG=C.UTF-8
 
 # Define the virtual environment path to use for all pipenv runs
 ENV WORKON_HOME=/
@@ -38,8 +38,8 @@ RUN pipenv install --deploy
 # ---------- 2) Runtime ----------
 FROM amazonlinux:2023
 
-ENV PIP_ROOT_USER_ACTION ignore
-ENV LANG C.UTF-8
+ENV PIP_ROOT_USER_ACTION=ignore
+ENV LANG=C.UTF-8
 
 # Minimal runtime deps (no compilers, no *-devel)
 RUN dnf install -y \
@@ -94,4 +94,4 @@ RUN chmod ug+x /root/*.sh
 RUN chmod ug+x /root/*.py
 RUN ln -s $(command -v vim) /usr/local/bin/vi
 
-CMD tail -f /dev/null
+CMD ["tail", "-f", "/dev/null"]

--- a/TrafficCapture/dockerSolution/src/main/docker/k8sConfigMapUtilScripts/Dockerfile
+++ b/TrafficCapture/dockerSolution/src/main/docker/k8sConfigMapUtilScripts/Dockerfile
@@ -1,7 +1,7 @@
 FROM amazonlinux:2023
 
-ENV PIP_ROOT_USER_ACTION ignore
-ENV LANG C.UTF-8
+ENV PIP_ROOT_USER_ACTION=ignore
+ENV LANG=C.UTF-8
 
 RUN dnf install -y \
         jq \

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,6 @@
 org.gradle.caching=true
 org.gradle.configuration-cache=true
+org.gradle.configuration-cache.problems=warn
 # Set Gradle Daemon's idle timeout to 30 minutes
 org.gradle.daemon.idletimeout=1800000
 org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8


### PR DESCRIPTION
## Description

Fixes two CI build failures:

### 1. Dockerfile lint warnings (LegacyKeyValueFormat, JSONArgsRecommended)

`elasticsearchTestConsole/Dockerfile` and `k8sConfigMapUtilScripts/Dockerfile` used the legacy `ENV key value` syntax. Updated to the modern `ENV key=value` format. Also converted `CMD tail -f /dev/null` to exec/JSON form `CMD ["tail", "-f", "/dev/null"]` to ensure proper OS signal handling.

### 2. Gradle configuration cache failure with Jib plugin

The Jib Gradle plugin (3.5.2) is not compatible with Gradle's configuration cache ([jib#3132](https://github.com/GoogleContainerTools/jib/issues/3132)). The build already declares `notCompatibleWithConfigurationCache()` on JibTask, but since Gradle 8.4 this no longer suppresses problem reporting — the build fails with `problems=fail` (default) even though the cache entry is correctly discarded.

Setting `org.gradle.configuration-cache.problems=warn` allows the build to proceed while still reporting problems as warnings. The existing `notCompatibleWithConfigurationCache()` declaration ensures the configuration cache entry is discarded when Jib tasks are present.

## Changes

- `elasticsearchTestConsole/Dockerfile`: `ENV key value` → `ENV key=value` (4 lines), `CMD` → exec form
- `k8sConfigMapUtilScripts/Dockerfile`: `ENV key value` → `ENV key=value` (2 lines)
- `gradle.properties`: Add `org.gradle.configuration-cache.problems=warn`

## Testing

- Verified no remaining legacy `ENV` format across all Dockerfiles
- The Gradle change is a well-documented property that changes problem reporting from fail to warn