### PR TITLE
Disable configuration cache globally via gradle.properties

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -113,7 +113,6 @@ jobs:
             -Dbuild.snapshot=false \
             -Dbuild.version=0.${{ steps.get_data.outputs.version }} \
             --no-build-cache \
-            --no-configuration-cache \
             --no-daemon \
             --no-continue \
             --info

--- a/deployment/k8s/aws/aws-bootstrap.sh
+++ b/deployment/k8s/aws/aws-bootstrap.sh
@@ -937,7 +937,7 @@ if [[ "$build_images" == "true" ]]; then
     | docker login --username AWS --password-stdin "$ecr_domain" \
     || { echo "ECR login failed"; exit 1; }
 
-  "$base_dir/gradlew" -p "$base_dir" :buildImages:${BUILD_TARGET} -PregistryEndpoint="$MIGRATIONS_ECR_REGISTRY" -x test --no-configuration-cache || exit
+  "$base_dir/gradlew" -p "$base_dir" :buildImages:${BUILD_TARGET} -PregistryEndpoint="$MIGRATIONS_ECR_REGISTRY" -x test || exit
 
   echo "Cleaning up docker buildx builder to free buildkit pods..."
   docker buildx rm local-remote-builder 2>/dev/null || true

--- a/deployment/k8s/charts/components/buildImages/templates/build-images-job.yaml
+++ b/deployment/k8s/charts/components/buildImages/templates/build-images-job.yaml
@@ -76,8 +76,8 @@ spec:
               export BUILDKIT_NAMESPACE={{ .Values.namespace }}
               ./buildImages/setupK8sBuilders.sh
 
-              # Build without configuration cache since this will be run once on a new container
-              GRADLE_CMD="./gradlew buildImagesToRegistry -PregistryEndpoint='{{ .Values.registryEndpoint }}' -x test --no-configuration-cache --no-build-cache --no-daemon"
+              # Build without build cache since this will be run once on a new container
+              GRADLE_CMD="./gradlew buildImagesToRegistry -PregistryEndpoint='{{ .Values.registryEndpoint }}' -x test --no-build-cache --no-daemon"
               echo "Running Gradle build with:"
               echo "$GRADLE_CMD"
               eval "$GRADLE_CMD"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 org.gradle.caching=true
-org.gradle.configuration-cache=true
+org.gradle.configuration-cache=false
 org.gradle.configuration-cache.problems=warn
 # Set Gradle Daemon's idle timeout to 30 minutes
 org.gradle.daemon.idletimeout=1800000

--- a/vars/eksBYOSIntegPipeline.groovy
+++ b/vars/eksBYOSIntegPipeline.groovy
@@ -345,7 +345,7 @@ def call(Map config = [:]) {
                                     echo "Creating buildx builder ecr-builder"
                                     sh "docker buildx create --name ecr-builder --driver docker-container --bootstrap"
                                     sh "docker buildx use ecr-builder"
-                                    sh "./gradlew buildImagesToRegistry -PregistryEndpoint=${env.registryEndpoint} -Pbuilder=ecr-builder --no-configuration-cache"
+                                    sh "./gradlew buildImagesToRegistry -PregistryEndpoint=${env.registryEndpoint} -Pbuilder=ecr-builder"
                                 }
                             }
                         }

--- a/vars/k8sLocalDeployment.groovy
+++ b/vars/k8sLocalDeployment.groovy
@@ -95,7 +95,7 @@ def call(Map config = [:]) {
                             sh "kubectl config use-context minikube"
                             sh "helm uninstall buildkit -n buildkit 2>/dev/null || true"
                             sh "USE_LOCAL_REGISTRY=true BUILDKIT_HELM_ARGS='--set buildkitd.maxParallelism=16 --set buildkitd.resources.requests.cpu=0 --set buildkitd.resources.requests.memory=0 --set buildkitd.resources.limits.cpu=0 --set buildkitd.resources.limits.memory=0' ./buildImages/setUpK8sImageBuildServices.sh"
-                            sh "./gradlew :buildImages:buildImagesToRegistry_amd64 -x test --no-configuration-cache --info --stacktrace --profile --scan"
+                            sh "./gradlew :buildImages:buildImagesToRegistry_amd64 -x test --info --stacktrace --profile --scan"
                             sh "docker buildx rm local-remote-builder 2>/dev/null || true"
                             sh "helm uninstall buildkit -n buildkit 2>/dev/null || true"
                         }


### PR DESCRIPTION
Sets `org.gradle.configuration-cache=false` in `gradle.properties` to disable configuration cache globally, and removes all `--no-configuration-cache` flags that were previously needed as workarounds.

### Changes
- `gradle.properties`: `org.gradle.configuration-cache=true` → `false`
- Removed `--no-configuration-cache` from:
  - `vars/k8sLocalDeployment.groovy`
  - `vars/eksBYOSIntegPipeline.groovy`
  - `.github/workflows/release-drafter.yml`
  - `deployment/k8s/charts/components/buildImages/templates/build-images-job.yaml`
  - `deployment/k8s/aws/aws-bootstrap.sh`

Signed-off-by: Andre Kurait <andrekurait@gmail.com>