### PR TITLE
Use mirror.gcr.io for all DockerHub image references

### DIFF
--- a/DocumentsFromSnapshotMigration/docker/Dockerfile
+++ b/DocumentsFromSnapshotMigration/docker/Dockerfile
@@ -1,5 +1,5 @@
 # Using same base image as other Java containers in this repo
-FROM amazoncorretto:17-al2023-headless
+FROM mirror.gcr.io/library/amazoncorretto:17-al2023-headless
 
 # Install procps to use pgrep in entrypoint.sh
 RUN dnf install -y procps && \

--- a/TrafficCapture/dockerSolution/src/main/docker/captureProxyBase/Dockerfile
+++ b/TrafficCapture/dockerSolution/src/main/docker/captureProxyBase/Dockerfile
@@ -1,7 +1,7 @@
 # =======================
 # Stage 1: Certificate Generation
 # =======================
-FROM amazonlinux:2023 AS cert-builder
+FROM mirror.gcr.io/library/amazonlinux:2023 AS cert-builder
 
 # Install OpenSSL
 RUN yum update -y && \
@@ -21,7 +21,7 @@ RUN mkdir -p /certs && \
 # =======================
 # Stage 2: Final Image
 # =======================
-FROM amazoncorretto:11-al2023-headless
+FROM mirror.gcr.io/library/amazoncorretto:11-al2023-headless
 
 # Set environment variables
 ENV CONFIG_HOME=/usr/share/captureProxy/config

--- a/TrafficCapture/dockerSolution/src/main/docker/docker-compose.yml
+++ b/TrafficCapture/dockerSolution/src/main/docker/docker-compose.yml
@@ -4,7 +4,7 @@ services:
 
   prometheus:
     container_name: prometheus
-    image: prom/prometheus:v2.53.0
+    image: mirror.gcr.io/prom/prometheus:v2.53.0
     networks:
       - migrations
     volumes:
@@ -19,7 +19,7 @@ services:
   # Found regression with latest tag not being able to connect to port 4317 on docker startup, reverted to '1' tag
   # until resolved
   jaeger:
-    image: jaegertracing/all-in-one:1.58.1
+    image: mirror.gcr.io/jaegertracing/all-in-one:1.58.1
     networks:
       - migrations
     ports:
@@ -43,7 +43,7 @@ services:
       - prometheus
 
   kafka:
-    image: apache/kafka:3.9.1
+    image: mirror.gcr.io/apache/kafka:3.9.1
     networks:
       - migrations
     ports:
@@ -81,7 +81,7 @@ services:
 #   command: /bin/sh -c "/runJavaWithClasspath.sh org.opensearch.migrations.replay.TrafficReplayer --speedup-factor 2 https://opensearchtarget:9200 --auth-header-value Basic\\ YWRtaW46bXlTdHJvbmdQYXNzd29yZDEyMyE= --insecure --kafka-traffic-brokers kafka:9092 --kafka-traffic-topic logging-traffic-topic --kafka-traffic-group-id logging-group-default --otelCollectorEndpoint http://otel-collector:4317  "
     command: /bin/sh -c "/runJavaWithClasspath.sh org.opensearch.migrations.replay.TrafficReplayer --speedup-factor 2 https://opensearchtarget:9200 --auth-header-value Basic\\ YWRtaW46bXlTdHJvbmdQYXNzd29yZDEyMyE= --insecure --kafka-traffic-brokers kafka:9092 --kafka-traffic-topic logging-traffic-topic --kafka-traffic-group-id logging-group-default --otelCollectorEndpoint http://otel-collector:4317 --transformer-config '[{\"TypeMappingSanitizationTransformerProvider\":{\"sourceProperties\":{\"version\":{\"major\":7,\"minor\":10}}}}]'"
   opensearchtarget:
-    image: 'opensearchproject/opensearch:2.15.0'
+    image: 'mirror.gcr.io/opensearchproject/opensearch:2.15.0'
     environment:
       - discovery.type=single-node
       - OPENSEARCH_INITIAL_ADMIN_PASSWORD=myStrongPassword123!

--- a/TrafficCapture/dockerSolution/src/main/docker/elasticsearchTestConsole/Dockerfile
+++ b/TrafficCapture/dockerSolution/src/main/docker/elasticsearchTestConsole/Dockerfile
@@ -1,5 +1,5 @@
 # ---------- 1) Builder ----------
-FROM amazonlinux:2023 AS builder
+FROM mirror.gcr.io/library/amazonlinux:2023 AS builder
 
 # Build deps (toolchain + headers)
 RUN dnf install -y \
@@ -36,7 +36,7 @@ COPY Pipfile Pipfile.lock ./
 RUN pipenv install --deploy
 
 # ---------- 2) Runtime ----------
-FROM amazonlinux:2023
+FROM mirror.gcr.io/library/amazonlinux:2023
 
 ENV PIP_ROOT_USER_ACTION=ignore
 ENV LANG=C.UTF-8

--- a/TrafficCapture/dockerSolution/src/main/docker/grafana/Dockerfile
+++ b/TrafficCapture/dockerSolution/src/main/docker/grafana/Dockerfile
@@ -1,3 +1,3 @@
-FROM grafana/grafana:11.6.1
+FROM mirror.gcr.io/grafana/grafana:11.6.1
 
 COPY datasources.yaml /usr/share/grafana/conf/provisioning/datasources/

--- a/TrafficCapture/dockerSolution/src/main/docker/k8sConfigMapUtilScripts/Dockerfile
+++ b/TrafficCapture/dockerSolution/src/main/docker/k8sConfigMapUtilScripts/Dockerfile
@@ -1,4 +1,4 @@
-FROM amazonlinux:2023
+FROM mirror.gcr.io/library/amazonlinux:2023
 
 ENV PIP_ROOT_USER_ACTION=ignore
 ENV LANG=C.UTF-8

--- a/buildImages/build.gradle
+++ b/buildImages/build.gradle
@@ -24,6 +24,8 @@ def getRepoNameIfPublishing = { Map cfg ->
 
 def jibProjects = [
         "TrafficCapture:trafficReplayer": [
+                baseImageRegistryEndpoint: "mirror.gcr.io",
+                baseImageGroup : "library",
                 baseImageName : "amazoncorretto",
                 baseImageTag  : "17-al2023-headless",
                 imageName     : "traffic_replayer",

--- a/buildImages/docker-registry.yaml
+++ b/buildImages/docker-registry.yaml
@@ -46,7 +46,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: registry
-          image: registry:2
+          image: mirror.gcr.io/library/registry:2
           ports:
             - containerPort: 5000
               name: registry

--- a/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/scripts/privateEcrManifest.sh
+++ b/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/scripts/privateEcrManifest.sh
@@ -48,7 +48,7 @@ quay.io/argoproj/argoexec:v3.7.9
 
 # --- fluent-bit ---
 cr.fluentbit.io/fluent/fluent-bit:4.0.1
-docker.io/library/busybox:latest
+mirror.gcr.io/library/busybox:latest
 
 # --- kube-prometheus-stack ---
 quay.io/prometheus/prometheus:v3.3.1
@@ -59,7 +59,7 @@ quay.io/prometheus/alertmanager:v0.28.1
 quay.io/kiwigrid/k8s-sidecar:1.30.0
 registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.15.0
 registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.5.3
-docker.io/bats/bats:v1.4.1
+mirror.gcr.io/bats/bats:v1.4.1
 quay.io/thanos/thanos:v0.38.0
 
 # --- etcd-operator ---
@@ -75,14 +75,14 @@ ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator:0.122.0
 quay.io/brancz/kube-rbac-proxy:v0.18.1
 
 # --- grafana ---
-docker.io/grafana/grafana:11.6.1
+mirror.gcr.io/grafana/grafana:11.6.1
 
 # --- jaeger ---
-docker.io/jaegertracing/jaeger-agent:1.53.0
-docker.io/jaegertracing/jaeger-collector:1.53.0
-docker.io/jaegertracing/jaeger-query:1.53.0
-docker.io/jaegertracing/jaeger-cassandra-schema:1.53.0
-docker.io/library/cassandra:3.11.6
+mirror.gcr.io/jaegertracing/jaeger-agent:1.53.0
+mirror.gcr.io/jaegertracing/jaeger-collector:1.53.0
+mirror.gcr.io/jaegertracing/jaeger-query:1.53.0
+mirror.gcr.io/jaegertracing/jaeger-cassandra-schema:1.53.0
+mirror.gcr.io/library/cassandra:3.11.6
 
 # --- kyverno ---
 reg.kyverno.io/kyverno/kyverno:v1.15.2
@@ -92,15 +92,15 @@ reg.kyverno.io/kyverno/cleanup-controller:v1.15.2
 reg.kyverno.io/kyverno/reports-controller:v1.15.2
 reg.kyverno.io/kyverno/kyverno-cli:v1.15.2
 registry.k8s.io/kubectl:v1.32.7
-docker.io/library/busybox:1.35
+mirror.gcr.io/library/busybox:1.35
 
 # --- localstack ---
-docker.io/localstack/localstack:4.3.0
-docker.io/amazon/aws-cli:latest
+mirror.gcr.io/localstack/localstack:4.3.0
+mirror.gcr.io/amazon/aws-cli:latest
 
 # --- direct template references ---
-docker.io/amazon/aws-cli:2.25.11
+mirror.gcr.io/amazon/aws-cli:2.25.11
 
 # --- coordinator cluster (used by RFS workflow) ---
-docker.io/opensearchproject/opensearch:3.1.0
+mirror.gcr.io/opensearchproject/opensearch:3.1.0
 "

--- a/deployment/k8s/charts/components/buildImages/templates/buildkitd-pod.yaml
+++ b/deployment/k8s/charts/components/buildImages/templates/buildkitd-pod.yaml
@@ -46,7 +46,7 @@ spec:
       effect: "NoSchedule"
   containers:
     - name: buildkitd
-      image: {{ .Values.buildkitImage | default "moby/buildkit:v0.22.0" }}
+      image: {{ .Values.buildkitImage | default "mirror.gcr.io/moby/buildkit:v0.22.0" }}
       args: [
         "--addr", "tcp://0.0.0.0:1234",
         "--config", "/etc/buildkit/buildkitd.toml"
@@ -114,7 +114,7 @@ spec:
   serviceAccountName: {{ .Values.serviceAccountName }}
   containers:
     - name: buildkitd
-      image: {{ .Values.buildkitImage | default "moby/buildkit:v0.22.0" }}
+      image: {{ .Values.buildkitImage | default "mirror.gcr.io/moby/buildkit:v0.22.0" }}
       args: [
         "--addr", "tcp://0.0.0.0:1234",
         "--config", "/etc/buildkit/buildkitd.toml"

--- a/deployment/k8s/charts/imageMirroringHelpers/AGENT_UPDATE_MANIFESTS.md
+++ b/deployment/k8s/charts/imageMirroringHelpers/AGENT_UPDATE_MANIFESTS.md
@@ -128,3 +128,29 @@ Add it, re-mirror, and retry until all pods are Running.
 3. Not updating the OCI chart version override for cert-manager (`v` prefix)
 4. Missing the `docker.io/` prefix — images like `busybox:latest` are actually `docker.io/library/busybox:latest`
 5. Not checking the `testClusters` and `buildImages` manifests separately
+
+---
+
+# Agent Prompt: Convert Helm Chart DockerHub Images to mirror.gcr.io
+
+When pulling images referenced by helm charts, convert DockerHub images to use
+Google's `mirror.gcr.io` to avoid Docker Hub rate limits.
+
+## How to convert
+
+Replace the `docker.io` registry with `mirror.gcr.io`:
+- `docker.io/library/<image>:<tag>` → `mirror.gcr.io/library/<image>:<tag>`
+- `docker.io/<namespace>/<image>:<tag>` → `mirror.gcr.io/<namespace>/<image>:<tag>`
+- Bare names like `busybox:latest` → `mirror.gcr.io/library/busybox:latest`
+
+## Verify locally
+
+Before committing, confirm the image exists on the mirror:
+
+```bash
+docker pull mirror.gcr.io/library/<image>:<tag>
+# or for namespaced images:
+docker pull mirror.gcr.io/<namespace>/<image>:<tag>
+```
+
+If the pull fails, the image is not mirrored — leave it as-is.

--- a/dev-tools/jenkinsdocker/Dockerfile
+++ b/dev-tools/jenkinsdocker/Dockerfile
@@ -1,4 +1,4 @@
-FROM jenkins/jenkins:lts
+FROM mirror.gcr.io/jenkins/jenkins:lts
 
 USER root
 RUN apt -y update

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:stable-alpine3.21-slim
+FROM mirror.gcr.io/library/nginx:stable-alpine3.21-slim
 
 # copy exported static site
 COPY out /usr/share/nginx/html

--- a/migrationConsole/lib/console_link/Dockerfile.openapi
+++ b/migrationConsole/lib/console_link/Dockerfile.openapi
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM mirror.gcr.io/library/python:3.11-slim
 
 # Set working directory
 WORKDIR /app

--- a/migrationConsole/lib/integ_test/testWorkflows/clusterWorkflows.yaml
+++ b/migrationConsole/lib/integ_test/testWorkflows/clusterWorkflows.yaml
@@ -12,7 +12,7 @@ spec:
           - name: cluster-name
           - name: namespace
       container:
-        image: dtzar/helm-kubectl:3.18.6
+        image: mirror.gcr.io/dtzar/helm-kubectl:3.18.6
         command: [ sh, -c ]
         args:
           - |
@@ -82,7 +82,7 @@ spec:
                     fsGroup: 1000
                   initContainers:
                     - name: install-s3-plugin
-                      image: elasticsearch:1.5.2
+                      image: mirror.gcr.io/library/elasticsearch:1.5.2
                       command: ["sh","-c"]
                       args:
                         - |
@@ -113,7 +113,7 @@ spec:
                         runAsNonRoot: true
                   containers:
                     - name: elasticsearch
-                      image: elasticsearch:1.5.2
+                      image: mirror.gcr.io/library/elasticsearch:1.5.2
                       imagePullPolicy: IfNotPresent
                       env:
                         - name: ES_HEAP_SIZE
@@ -229,7 +229,7 @@ spec:
           - name: cluster-name
           - name: namespace
       container:
-        image: dtzar/helm-kubectl:3.18.6
+        image: mirror.gcr.io/dtzar/helm-kubectl:3.18.6
         command: [sh, -c]
         args:
           - |
@@ -298,7 +298,7 @@ spec:
                     fsGroup: 1000
                   initContainers:
                     - name: install-s3-plugin
-                      image: elasticsearch:2.4.6
+                      image: mirror.gcr.io/library/elasticsearch:2.4.6
                       command: ["sh","-c"]
                       args:
                         - /usr/share/elasticsearch/bin/plugin install cloud-aws
@@ -311,7 +311,7 @@ spec:
                         runAsNonRoot: true
                   containers:
                     - name: elasticsearch
-                      image: elasticsearch:2.4.6
+                      image: mirror.gcr.io/library/elasticsearch:2.4.6
                       imagePullPolicy: IfNotPresent
                       env:
                         - name: ES_HEAP_SIZE
@@ -424,7 +424,7 @@ spec:
           - name: cluster-name
           - name: namespace
       container:
-        image: dtzar/helm-kubectl:3.18.6
+        image: mirror.gcr.io/dtzar/helm-kubectl:3.18.6
         command: [sh, -c]
         args:
           - |
@@ -524,7 +524,7 @@ spec:
           - name: cluster-name
           - name: namespace
       container:
-        image: dtzar/helm-kubectl:3.18.6
+        image: mirror.gcr.io/dtzar/helm-kubectl:3.18.6
         command: [sh, -c]
         args:
           - |
@@ -662,7 +662,7 @@ spec:
           - name: cluster-name
           - name: namespace
       container:
-        image: dtzar/helm-kubectl:3.18.6
+        image: mirror.gcr.io/dtzar/helm-kubectl:3.18.6
         command: [sh, -c]
         args:
           - |
@@ -782,7 +782,7 @@ spec:
           - name: cluster-name
           - name: namespace
       container:
-        image: dtzar/helm-kubectl:3.18.6
+        image: mirror.gcr.io/dtzar/helm-kubectl:3.18.6
         command: [sh, -c]
         args:
           - |
@@ -870,7 +870,7 @@ spec:
           - name: cluster-name
           - name: namespace
       container:
-        image: dtzar/helm-kubectl:3.18.6
+        image: mirror.gcr.io/dtzar/helm-kubectl:3.18.6
         command: [sh, -c]
         args:
           - |
@@ -1089,7 +1089,7 @@ spec:
                 serviceAccountName: migration-console-access-role
                 initContainers:
                   - name: install-plugins
-                    image: opensearchproject/opensearch:3.1.0
+                    image: mirror.gcr.io/opensearchproject/opensearch:3.1.0
                     command:
                       - sh
                       - -c
@@ -1104,7 +1104,7 @@ spec:
                         mountPath: /plugins
                 containers:
                   - name: opensearch
-                    image: opensearchproject/opensearch:3.1.0
+                    image: mirror.gcr.io/opensearchproject/opensearch:3.1.0
                     ports:
                       - name: https
                         containerPort: 9200

--- a/migrationConsole/lib/integ_test/testWorkflows/fullMigrationWithClusters.yaml
+++ b/migrationConsole/lib/integ_test/testWorkflows/fullMigrationWithClusters.yaml
@@ -211,7 +211,7 @@ spec:
           - name: cluster-type
           - name: namespace
       container:
-        image: bitnamisecure/kubectl:latest
+        image: mirror.gcr.io/bitnamisecure/kubectl:latest
         command: [sh, -c]
         args:
           - |
@@ -378,7 +378,7 @@ spec:
 
     - name: cleanup-all-clusters
       container:
-        image: dtzar/helm-kubectl:3.18.6
+        image: mirror.gcr.io/dtzar/helm-kubectl:3.18.6
         command: [sh, -c]
         args:
           - |

--- a/orchestrationSpecs/argoSamples/configMap.yaml
+++ b/orchestrationSpecs/argoSamples/configMap.yaml
@@ -9,7 +9,7 @@ spec:
   templates:
     - name: configmap-demo
       container:
-        image: busybox:1.35
+        image: mirror.gcr.io/library/busybox:1.35
         command: [sh, -c]
         args:
           - |

--- a/orchestrationSpecs/argoSamples/dig.yaml
+++ b/orchestrationSpecs/argoSamples/dig.yaml
@@ -18,7 +18,7 @@ spec:
           - name: dr
             value: "{{=sprig.dig('documentBackfillConfigs', 'indices2', \"zoo\", fromJSON(inputs.parameters.migrationConfig)) }}"
       container:
-        image: alpine:latest
+        image: mirror.gcr.io/library/alpine:latest
         command: [sh, -c]
         args:
           - |

--- a/orchestrationSpecs/argoSamples/inputParameterSerialization.yaml
+++ b/orchestrationSpecs/argoSamples/inputParameterSerialization.yaml
@@ -19,7 +19,7 @@ spec:
           - name: drBase64
             value: "{{=toBase64(sprig.dig('documentBackfillConfigs', 'options', toJSON({'a':9}), fromJSON(inputs.parameters.migrationConfig)))}}"
       container:
-        image: alpine:latest
+        image: mirror.gcr.io/library/alpine:latest
         command: [sh, -c]
         args:
           - |

--- a/orchestrationSpecs/argoSamples/mergeJson.yaml
+++ b/orchestrationSpecs/argoSamples/mergeJson.yaml
@@ -22,7 +22,7 @@ spec:
           - name: merged
             value: "{{= toJSON(sprig.merge(sprig.dict(\"inner\", fromJSON('{\"a\":\"b\"}')), fromJSON(inputs.parameters.ib))) }}"
       container:
-        image: alpine
+        image: mirror.gcr.io/library/alpine
         command: [echo]
         args:
           - |

--- a/orchestrationSpecs/argoSamples/numberTypes.yaml
+++ b/orchestrationSpecs/argoSamples/numberTypes.yaml
@@ -24,7 +24,7 @@ spec:
             value: "{{inputs.parameters.num}}-{{inputs.parameters.obj}}"
       container:
         name: main
-        image: argoproj/argosay:v2
+        image: mirror.gcr.io/argoproj/argosay:v2
         command:
           - /argosay
         args:

--- a/orchestrationSpecs/argoSamples/when.yaml
+++ b/orchestrationSpecs/argoSamples/when.yaml
@@ -36,6 +36,6 @@ spec:
         parameters:
           - name: message
       container:
-        image: alpine:latest
+        image: mirror.gcr.io/library/alpine:latest
         command: [echo]
         args: ["{{inputs.parameters.message}}"]


### PR DESCRIPTION
## Description

Replace all direct DockerHub image references with mirror.gcr.io equivalents to avoid Docker Hub rate limits.

### Changes

**Library images** (official Docker images) use `mirror.gcr.io/library/<image>`:
- amazonlinux:2023 (4 Dockerfiles)
- amazoncorretto:11-al2023-headless, amazoncorretto:17-al2023-headless
- nginx:stable-alpine3.21-slim, python:3.11-slim
- registry:2, elasticsearch:1.5.2, elasticsearch:2.4.6
- busybox:1.35, alpine:latest, alpine

**Namespaced images** use `mirror.gcr.io/<namespace>/<image>`:
- jenkins/jenkins:lts, grafana/grafana:11.6.1
- moby/buildkit:v0.22.0, opensearchproject/opensearch:3.1.0, opensearchproject/opensearch:2.15.0
- dtzar/helm-kubectl:3.18.6, bitnamisecure/kubectl:latest
- argoproj/argosay:v2, jaegertracing/all-in-one:1.58.1
- apache/kafka:3.9.1, prom/prometheus:v2.53.0

**Not changed** (not DockerHub):
- docker.elastic.co/* images
- public.ecr.aws/* images
- ghcr.io/* images
- migrations/* (locally built images)
- Helm template variable references

All updated images were verified with `docker pull` against mirror.gcr.io.

### Testing

Every image was tested with `docker pull mirror.gcr.io/...` to confirm availability.

19 files changed, 38 insertions(+), 38 deletions(-)