### PR TITLE
Fix eksSolutionsCFNTest CFN template-body size limit

### DIFF
--- a/vars/eksSolutionsCFNTest.groovy
+++ b/vars/eksSolutionsCFNTest.groovy
@@ -97,7 +97,7 @@ def call(Map config = [:]) {
                             def buildImagesArg = params.BUILD_IMAGES ? "--build-images" : ""
 
                             withCredentials([string(credentialsId: 'migrations-test-account-id', variable: 'MIGRATIONS_TEST_ACCOUNT_ID')]) {
-                                withAWS(role: 'JenkinsDeploymentRole', roleAccount: "${MIGRATIONS_TEST_ACCOUNT_ID}", region: "${params.REGION}", duration: 3600, roleSessionName: 'jenkins-session') {
+                                withAWS(role: 'JenkinsDeploymentRole', roleAccount: "${MIGRATIONS_TEST_ACCOUNT_ID}", region: "${params.REGION}", duration: 7200, roleSessionName: 'jenkins-session') {
                                     sh """
                                         set -euo pipefail
                                         ./deployment/k8s/aws/aws-bootstrap.sh \
@@ -119,7 +119,7 @@ def call(Map config = [:]) {
 
             stage('Validate EKS Deployment') {
                 steps {
-                    timeout(time: 10, unit: 'MINUTES') {
+                    timeout(time: 15, unit: 'MINUTES') {
                         script {
                             withCredentials([string(credentialsId: 'migrations-test-account-id', variable: 'MIGRATIONS_TEST_ACCOUNT_ID')]) {
                                 withAWS(role: 'JenkinsDeploymentRole', roleAccount: "${MIGRATIONS_TEST_ACCOUNT_ID}", region: "${params.REGION}", duration: 3600, roleSessionName: 'jenkins-session') {


### PR DESCRIPTION
## Description

The `deploy-eks-cfn-create-vpc` Jenkins job was failing because the CloudFormation template exceeded the 51,200 byte `--template-body` inline limit. The job was manually running `npx cdk synth '*'` which produces non-minified templates, then passing them via `--template-body file://cdk.out/...`.

## Changes

Replaced the manual CDK synth + CloudFormation deploy stages in `vars/eksSolutionsCFNTest.groovy` with `aws-bootstrap.sh`:

- **Removed** `Synth EKS CFN Template` stage (manual `npx cdk synth '*'` producing non-minified templates)
- **Removed** `Deploy EKS CFN Stack` stage (manual `aws cloudformation create-stack --template-body` which hit the 51,200 byte limit)
- **Added** `Deploy & Install` stage using `aws-bootstrap.sh --deploy-create-vpc-cfn --build-cfn --version latest --skip-console-exec`
  - `--build-cfn` runs `cdkSynthMinified` which produces minified JSON templates in `cdk.out-minified/` and validates they're under 51,200 bytes
  - Handles both create-vpc and import-vpc modes
  - Handles BUILD_IMAGES parameter
- **Simplified** `Install & Validate` to just `Validate EKS Deployment` since aws-bootstrap.sh already handles kubectl config, helm install, and dashboards

**37 insertions, 99 deletions** — net reduction in code while gaining the minification safety check.