### PR TITLE
[Fix] replayer warning firing when no replayer is configured

### DIFF
--- a/orchestrationSpecs/packages/config-processor/src/migrationConfigTransformer.ts
+++ b/orchestrationSpecs/packages/config-processor/src/migrationConfigTransformer.ts
@@ -219,7 +219,7 @@ export class MigrationConfigTransformer extends StreamSchemaTransformer<
             seen.add(keyPair);
 
             const sourceCluster = userConfig.sourceClusters[fromSource];
-            if (sourceCluster.proxy === undefined) {
+            if (sourceCluster.proxy === undefined && replayerConfig !== undefined) {
                 console.warn(`Replayer is configured for ${fromSource} but a proxy is not. ` +
                     `A replayer won't be configured for the target (${toTarget})`);
                 replayerConfig = undefined;


### PR DESCRIPTION
### Description
The config processor's `transformSync` warned about a missing proxy and cleared `replayerConfig` whenever `sourceCluster.proxy` was undefined, even when no replayer was configured. This caused `workflow submit` to fail with a misleading Argo schema validation error for any migration that didn't use capture/replay.

The fix adds a check for `replayerConfig !== undefined` so the warning only fires when a replayer is actually configured but the source proxy is missing.

### Issues Resolved
N/A

### Testing
- manually testing this change on EKS

### Check List
- [x] New functionality includes testing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
