### PR TITLE
docs: Add team members to CODEOWNERS and MAINTAINERS.md

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # This should match the owning team set up in https://github.com/orgs/opensearch-project/teams
-*   @AndreKurait @gregschohn @sumobrian @jugal-chauhan @prenake @akshay2000 @k-rooot @nagarajg17 @niravpi @pgtgrly @krishna-ggk
+*   @AndreKurait @gregschohn @sumobrian @jugal-chauhan @prenake @akshay2000 @k-rooot @nagarajg17 @niravpi @pgtgrly @krishna-ggk @shuklas

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -17,6 +17,7 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Nirav Pithadiya    | [niravpi](https://github.com/niravpi)                 | Amazon      |
 | Pranav Garg        | [pgtgrly](https://github.com/pgtgrly)                 | Amazon      |
 | Gopala Krishna A   | [krishna-ggk](https://github.com/krishna-ggk)         | Amazon      |
+| Sachin Shukla      | [shuklas](https://github.com/shuklas)                  | Amazon      |
 
 
 ## Emeritus


### PR DESCRIPTION
## Summary

Add 7 new team members with GitHub aliases to CODEOWNERS and MAINTAINERS.md.

### New Maintainers Added

| Name | GitHub ID |
|------|-----------|
| Prasad Renake | @prenake |
| Akshay Zade | @akshay2000 |
| Karthic Kannan | @k-rooot |
| Nagaraj G | @nagarajg17 |
| Nirav Pithadiya | @niravpi |
| Pranav Garg | @pgtgrly |
| Gopala Krishna Ambareesh | @krishna-ggk |
|Sachin Shukla|@shuklas|

### Files Changed
- `.github/CODEOWNERS` — added 7 GitHub handles to the wildcard rule
- `MAINTAINERS.md` — added 7 entries to the Current Maintainers table

Signed-off-by: Brian Presley <bjpres@amazon.com>