### PR TITLE
Fix NPE in NettyJsonBodyAccumulateHandler.hasRequestContentTypeMatching

### DIFF
--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/http/NettyJsonBodyAccumulateHandler.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/http/NettyJsonBodyAccumulateHandler.java
@@ -167,6 +167,9 @@ public class NettyJsonBodyAccumulateHandler extends ChannelInboundHandlerAdapter
 
     private boolean hasRequestContentTypeMatching(HttpJsonMessageWithFaultingPayload message,
                                                   Predicate<String> contentTypeFilter) {
+        if (message == null) {
+            return false;
+        }
         // ContentType not text if specified and has a value with / and that value does not start with text/
         return Optional.ofNullable(message.headers().insensitiveGet(HttpHeaderNames.CONTENT_TYPE.toString()))
             .map(s -> s.stream()


### PR DESCRIPTION
## Description

Adds a null guard for the `message` parameter in `NettyJsonBodyAccumulateHandler.hasRequestContentTypeMatching()`.

## Problem

When a `ReadTimeoutException` occurs on the target connection, Netty's HTTP decoder may emit `HttpContent` chunks without first emitting an `HttpResponse` header. In this case, `capturedHttpJsonMessage` is never set (remains null), and calling `message.headers()` in `hasRequestContentTypeMatching()` throws an NPE:

```
java.lang.NullPointerException: Cannot invoke "...HttpJsonMessageWithFaultingPayload.headers()" because "message" is null
    at ...NettyJsonBodyAccumulateHandler.hasRequestContentTypeMatching(NettyJsonBodyAccumulateHandler.java:171)
    at ...NettyJsonBodyAccumulateHandler.channelRead(NettyJsonBodyAccumulateHandler.java:133)
```

## Fix

Return `false` from `hasRequestContentTypeMatching()` when `message` is null, which causes the handler to treat the content as non-JSON and pass it through without attempting JSON parsing.

## Testing

Minimal change — null guard only. The existing behavior is preserved for all non-null cases.