### PR TITLE
Add Argo Workflows CI/CD framework to replace Jenkins pipelines

### DIFF
--- a/argo/Makefile
+++ b/argo/Makefile
@@ -1,0 +1,84 @@
+# Argo CI/CD — Build and Deploy Targets
+
+REGISTRY ?= $(shell aws sts get-caller-identity --query Account --output text).dkr.ecr.$(AWS_REGION).amazonaws.com
+AWS_REGION ?= us-east-1
+TAG ?= latest
+
+.PHONY: help build-ci-runner build-release-runner build-all push-all deploy-minikube deploy-prod lint validate
+
+help: ## Show this help
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-25s\033[0m %s\n", $$1, $$2}'
+
+# === Docker Images ===
+
+build-ci-runner: ## Build ci-runner Docker image
+	docker build -t ci-runner:$(TAG) images/ci-runner/
+
+build-release-runner: ## Build release-runner Docker image
+	docker build -t release-runner:$(TAG) images/release-runner/
+
+build-all: build-ci-runner build-release-runner ## Build all Docker images
+
+push-ci-runner: build-ci-runner ## Push ci-runner to ECR
+	docker tag ci-runner:$(TAG) $(REGISTRY)/ci-runner:$(TAG)
+	docker push $(REGISTRY)/ci-runner:$(TAG)
+
+push-release-runner: build-release-runner ## Push release-runner to ECR
+	docker tag release-runner:$(TAG) $(REGISTRY)/release-runner:$(TAG)
+	docker push $(REGISTRY)/release-runner:$(TAG)
+
+push-all: push-ci-runner push-release-runner ## Push all images to ECR
+
+# === Deployment ===
+
+deploy-minikube: ## Deploy all components on minikube
+	./deploy.sh --all
+
+deploy-prod: ## Deploy workflow templates on production EKS
+	kubectl apply -n ma -f workflows/common-ci-steps.yaml
+	kubectl apply -n ma -f workflows/build-images.yaml
+	kubectl apply -n ma -f workflows/argo-ci-pipeline.yaml
+	kubectl apply -n ma -f workflows/k8s-local-test.yaml
+	kubectl apply -n ma -f workflows/k8s-matrix-test.yaml
+	kubectl apply -n ma -f workflows/upload-results.yaml
+	kubectl apply -n ma -f workflows/aws-integ/
+	kubectl apply -n ma -f ci-stage-locks-configmap.yaml
+	kubectl apply -n ma -f cron/nightly-matrix.yaml
+	kubectl apply -f events/
+
+# === Validation ===
+
+lint: ## Lint all YAML files
+	@echo "Checking YAML syntax..."
+	@ERRORS=0; \
+	for f in $$(find . -name '*.yaml' -o -name '*.yml' | grep -v node_modules); do \
+		python3 -c "import yaml; yaml.safe_load(open('$$f'))" 2>/dev/null || \
+		{ echo "  FAIL: $$f"; ERRORS=$$((ERRORS+1)); }; \
+	done; \
+	echo "$$ERRORS errors found"; \
+	[ $$ERRORS -eq 0 ]
+
+validate: lint ## Validate all files (lint + shell syntax)
+	@echo "Checking shell scripts..."
+	@bash -n setup-minikube-ci.sh && echo "  OK: setup-minikube-ci.sh"
+	@bash -n deploy.sh && echo "  OK: deploy.sh"
+	@bash -n reportportal/install.sh && echo "  OK: reportportal/install.sh"
+	@echo "Checking Dockerfiles..."
+	@docker build --check images/ci-runner/ 2>/dev/null && echo "  OK: ci-runner/Dockerfile" || echo "  SKIP: ci-runner (docker not available)"
+	@docker build --check images/release-runner/ 2>/dev/null && echo "  OK: release-runner/Dockerfile" || echo "  SKIP: release-runner (docker not available)"
+	@echo "Validation complete"
+
+# === Quick Test ===
+
+test-checkout: ## Quick test: run git-checkout template
+	argo submit -n ma --from workflowtemplate/common-ci-steps \
+		--entrypoint git-checkout -p branch=main --watch
+
+test-single: ## Quick test: run single k8s-local-test
+	argo submit -n ma examples/run-single-test.yaml --watch
+
+test-matrix: ## Quick test: run matrix test
+	argo submit -n ma examples/run-matrix.yaml --watch
+
+test-ci: ## Quick test: run CI pipeline (4 stripes for local)
+	argo submit -n ma examples/run-ci-pipeline.yaml --watch

--- a/argo/README.md
+++ b/argo/README.md
@@ -1,0 +1,275 @@
+# Argo CI/CD — Jenkins & GHA Replacement
+
+Replaces Jenkins CI/CD pipelines and GitHub Actions CI.yml fan-out with Argo Workflows + Argo Events + ReportPortal.
+
+## Architecture
+
+```
+GitHub Events (push/PR/release/label)
+    │
+    ▼
+┌─────────────────────────────────────────────────────────┐
+│  Argo Events (argo-events namespace)                     │
+│  EventBus (NATS) ← EventSource (GitHub webhook)         │
+│  Sensors: ci-pipeline, integ-tests, release              │
+└──────────────────────┬──────────────────────────────────┘
+                       ▼
+┌─────────────────────────────────────────────────────────┐
+│  Argo Workflows (ma namespace)                           │
+│                                                          │
+│  CI Pipeline (replaces CI.yml):                          │
+│    30x gradle stripes, 3x python, 3x node, lint, e2e    │
+│                                                          │
+│  Integration Tests (replaces Jenkins):                   │
+│    k8s-local, k8s-matrix, full-es68, rfs, traffic-replay │
+│    eks-integ, cleanup-deployment, release-pipeline        │
+│                                                          │
+│  Shared Templates: common-ci-steps, build-images         │
+│  CronWorkflows: nightly-k8s-matrix                       │
+│  Synchronization: semaphores via ConfigMap               │
+└──────────────────────┬──────────────────────────────────┘
+                       ▼
+┌─────────────────────────────────────────────────────────┐
+│  ReportPortal (reportportal namespace)                   │
+│  JUnit XML import, JSON report upload, dashboards        │
+└─────────────────────────────────────────────────────────┘
+```
+
+## Directory Structure
+
+```
+argo/
+├── setup-minikube-ci.sh              # P0: One-command minikube CI setup
+├── deploy.sh                         # Unified deploy: --all, --p0..--p5, --test
+├── Makefile                          # Build images, deploy, validate, test
+├── ci-stage-locks-configmap.yaml     # Semaphore concurrency limits
+│
+├── workflows/                         # WorkflowTemplates
+│   ├── common-ci-steps.yaml          # git-checkout, gradle-build, build-docker-images,
+│   │                                 # cleanup-ma, get-registry-ip, notify-github-status
+│   ├── build-images.yaml             # Standalone image build workflow
+│   ├── argo-ci-pipeline.yaml         # Replaces CI.yml (30x gradle, python, node fan-out)
+│   ├── k8s-local-test.yaml           # Replaces k8sLocalDeployment.groovy
+│   ├── k8s-matrix-test.yaml          # Replaces k8sMatrixTest.groovy
+│   ├── upload-results.yaml           # ReportPortal upload (JUnit XML, JSON, streaming)
+│   └── aws-integ/                    # AWS integration test pipelines
+│       ├── default-integ-pipeline.yaml   # Base: checkout → build → CDK deploy → pytest → cleanup
+│       ├── full-es68-e2e.yaml            # ES 6.8 → OS 2.19 full migration
+│       ├── rfs-and-traffic-replay.yaml   # RFS-only + traffic replay (thin wrappers)
+│       ├── eks-integ-pipeline.yaml       # EKS-based with ordered CFN cleanup
+│       ├── eks-byos-integ-pipeline.yaml  # Bring-Your-Own-Snapshot via EKS
+│       ├── eks-solutions-cfn-test.yaml   # EKS CFN Create-VPC/Import-VPC validation
+│       ├── eks-isolated-deploy.yaml      # Isolated network EKS deployment
+│       ├── solutions-cfn-test.yaml       # EC2-based Solutions CFN validation
+│       ├── cleanup-deployment.yaml       # Teardown a deployment stage
+│       └── release-pipeline.yaml         # S3 publish, Maven, Docker image copy
+│
+├── events/                            # Argo Events config
+│   ├── eventbus.yaml                 # NATS Jetstream backbone
+│   ├── eventsource-github.yaml       # GitHub webhook receiver (PR + release)
+│   ├── sensor-ci-pipeline.yaml       # CI pipeline trigger (replaces CI.yml)
+│   ├── sensor-integ-tests.yaml       # Integration test triggers (replaces jenkins_tests.yml)
+│   └── sensor-release.yaml           # Release trigger (draft release → workflow)
+│
+├── cron/
+│   └── nightly-matrix.yaml           # CronWorkflow (0 22 * * * UTC)
+│
+├── config/                            # Production EKS configs
+│   ├── production-eks.yaml           # IRSA SAs, secrets, Karpenter NodePool
+│   └── s3-artifact-repo.yaml         # S3 artifact repo (replaces MinIO)
+│
+├── images/                            # Container images
+│   ├── ci-runner/Dockerfile          # Python, AWS CLI, kubectl, helm, CDK, Java 17
+│   └── release-runner/Dockerfile     # skopeo, AWS CLI, Maven, Java 17
+│
+├── reportportal/
+│   ├── install.sh                    # Helm install with minikube values
+│   └── values-minikube.yaml          # Lightweight resource requests
+│
+└── examples/
+    ├── run-single-test.yaml          # Quick: ES_7.10 → OS_2.19
+    ├── run-matrix.yaml               # Quick: matrix across OS_2.19, OS_3.1
+    ├── run-ci-pipeline.yaml          # Quick: full CI pipeline (4 stripes for local)
+    └── run-es-version-tests.yaml     # Quick: ES 5.6 and ES 8.x tests
+```
+
+## Quick Start
+
+```bash
+# Full setup from scratch
+./argo/deploy.sh --all
+
+# Or iteratively by priority
+./argo/deploy.sh --p0                     # Infrastructure
+./argo/deploy.sh --skip-infra --p1 --p2   # CI templates + integration test
+./argo/deploy.sh --skip-infra --p3        # Matrix + cron
+./argo/deploy.sh --skip-infra --p4        # Argo Events
+./argo/deploy.sh --skip-infra --p5        # ReportPortal
+
+# Run tests
+argo submit -n ma argo/examples/run-single-test.yaml --watch
+argo submit -n ma argo/examples/run-matrix.yaml --watch
+```
+
+## Jenkins → Argo Feature Mapping
+
+| Jenkins Pipeline | Argo Replacement | File |
+|---|---|---|
+| `k8sLocalDeployment.groovy` | `k8s-local-test.yaml` | WorkflowTemplate + DAG + onExit |
+| `k8sMatrixTest.groovy` | `k8s-matrix-test.yaml` | Workflow-of-Workflows + withParam |
+| `defaultIntegPipeline.groovy` | `aws-integ/default-integ-pipeline.yaml` | WorkflowTemplate + IRSA |
+| `eksIntegPipeline.groovy` | `aws-integ/eks-integ-pipeline.yaml` | Ordered CFN cleanup DAG |
+| `eksBYOSIntegPipeline.groovy` | `aws-integ/eks-byos-integ-pipeline.yaml` | BYOS via EKS |
+| `eksSolutionsCFNTest.groovy` | `aws-integ/eks-solutions-cfn-test.yaml` | Create-VPC + Import-VPC modes |
+| `solutionsCFNTest.groovy` | `aws-integ/solutions-cfn-test.yaml` | CDK deploy + validate |
+| `eksIsolatedDeploy.groovy` | `aws-integ/eks-isolated-deploy.yaml` | Build EKS + isolated EKS |
+| `fullES68SourceE2ETest.groovy` | `aws-integ/full-es68-e2e.yaml` | WorkflowTemplate |
+| `rfsDefaultE2ETest.groovy` | `aws-integ/rfs-and-traffic-replay.yaml` | Thin wrapper Workflow |
+| `trafficReplayDefaultE2ETest.groovy` | `aws-integ/rfs-and-traffic-replay.yaml` | Thin wrapper Workflow |
+| `cleanupDeployment.groovy` | `aws-integ/cleanup-deployment.yaml` | WorkflowTemplate + mutex |
+| `release.jenkinsFile` | `aws-integ/release-pipeline.yaml` | DAG: S3+Maven+Docker+GitHub |
+| `CI.yml` (GHA) | `argo-ci-pipeline.yaml` | 30x gradle, 3x python, 3x node |
+| `jenkins_tests.yml` (GHA) | `events/sensor-integ-tests.yaml` | Argo Events Sensor |
+| `cron('H 22 * * *')` | `cron/nightly-matrix.yaml` | CronWorkflow |
+| `lock(label: STAGE)` | `ci-stage-locks-configmap.yaml` | synchronization.semaphores |
+| `withAWS(role: ...)` | IRSA + STS AssumeRole | ServiceAccount annotations |
+| `post { always }` | `onExit` handler | Exit handler DAG |
+| `archiveArtifacts` | S3 artifact outputs | MinIO (local) / S3 (prod) |
+| Console logs + Blue Ocean | Argo UI + ReportPortal | `upload-results.yaml` |
+
+## GHA Workflows — What Stays vs Moves
+
+| Workflow | Decision | Rationale |
+|---|---|---|
+| `CI.yml` | → Argo (`argo-ci-pipeline`) | 30x fan-out, cheaper on EKS |
+| `jenkins_tests.yml` | → Eliminated | Argo Events receives GitHub events directly |
+| `codeql.yml` | Stays in GHA | GitHub-native security scanning |
+| `sonar-qube.yml` | Stays in GHA | Self-contained, no infra needed |
+| `release-drafter.yml` | Stays in GHA | GitHub-native |
+| `backport.yml` | Stays in GHA | Branch management |
+
+## Production vs Minikube
+
+| Component | Minikube | Production EKS |
+|---|---|---|
+| EventBus replicas | 1 | 3 |
+| Artifact storage | MinIO | S3 (`config/s3-artifact-repo.yaml`) |
+| Image registry | minikube local | ECR |
+| Node scheduling | Single node | Karpenter (`config/production-eks.yaml`) |
+| AWS auth | N/A | IRSA service accounts |
+| Secrets | K8s secrets | External Secrets Operator |
+
+## Production Setup
+
+Before deploying to production EKS, update these placeholder values in `config/production-eks.yaml`:
+
+| Placeholder | Description | Example |
+|---|---|---|
+| `ACCOUNT_ID` | AWS account ID for CI/CD | `123456789012` |
+| `CLUSTER_NAME` | EKS cluster name | `migrations-ci-prod` |
+| `REPLACE_WITH_TEST_ACCOUNT_ID` | AWS account ID for test deployments | `987654321098` |
+| `REPLACE_WITH_GITHUB_TOKEN` | GitHub personal access token or app token | `ghp_...` |
+
+```bash
+# Replace placeholders
+sed -i 's/ACCOUNT_ID/123456789012/g' config/production-eks.yaml
+sed -i 's/CLUSTER_NAME/migrations-ci-prod/g' config/production-eks.yaml
+
+# Apply production config
+kubectl apply -f config/production-eks.yaml
+kubectl apply -f config/s3-artifact-repo.yaml
+
+# Build and push CI images
+make push-all REGISTRY=123456789012.dkr.ecr.us-east-1.amazonaws.com
+
+# Deploy all templates
+make deploy-prod
+```
+
+## Troubleshooting
+
+### Workflow stuck in Pending
+```bash
+# Check if semaphore is blocking
+argo get -n ma @latest -o yaml | grep -A5 synchronization
+
+# Check stage locks
+kubectl get configmap ci-stage-locks -n ma -o yaml
+
+# List all running workflows (may be holding locks)
+argo list -n ma --running
+```
+
+### Artifact upload/download failures
+```bash
+# Verify MinIO is running (minikube)
+kubectl get pods -n minio
+kubectl -n minio port-forward svc/minio-console 9001:9001
+# Browse http://localhost:9001 — check argo-artifacts bucket exists
+
+# Verify artifact repo config
+kubectl -n ma get configmap workflow-controller-configmap -o yaml | grep -A10 artifactRepository
+
+# Check workflow controller logs
+kubectl logs -n ma -l app.kubernetes.io/name=argo-workflows --tail=50
+```
+
+### Argo Events sensor not triggering
+```bash
+# Check EventSource pod
+kubectl get pods -n argo-events
+kubectl logs -n argo-events -l eventsource-name=github-migrations --tail=30
+
+# Check Sensor pod
+kubectl logs -n argo-events -l sensor-name=ci-pipeline-sensor --tail=30
+
+# Verify EventBus is healthy
+kubectl get eventbus -n argo-events
+kubectl get pods -n argo-events -l eventbus-name=default
+
+# Test webhook manually
+kubectl port-forward -n argo-events svc/github-migrations-eventsrc-svc 12000:12000 &
+curl -X POST http://localhost:12000/github/pr \
+  -H "Content-Type: application/json" \
+  -H "X-GitHub-Event: pull_request" \
+  -d '{"action":"opened","pull_request":{"number":1,"head":{"ref":"test","sha":"abc","repo":{"clone_url":"https://github.com/test/test.git"}}}}'
+```
+
+### ReportPortal not receiving results
+```bash
+# Check ReportPortal pods
+kubectl get pods -n reportportal
+
+# Verify API is accessible
+kubectl -n reportportal port-forward svc/reportportal-serviceapi 8585:8585 &
+curl -s http://localhost:8585/health | jq .
+
+# Check token secret exists
+kubectl get secret reportportal-token -n ma
+
+# Test upload manually
+curl -X POST http://localhost:8585/api/v1/opensearch_migrations/launch/import \
+  -H "Authorization: Bearer superadmin_personal" \
+  -F "file=@test-results.xml"
+```
+
+### Cleanup handler not running
+```bash
+# Exit handlers run even on failure, but check:
+argo get -n ma <workflow-name> -o yaml | grep -A5 onExit
+
+# If cleanup is stuck, force-delete
+argo terminate -n ma <workflow-name>
+helm uninstall ma -n ma || true
+kubectl delete namespace kyverno-ma --ignore-not-found
+```
+
+### Docker build failures (DinD sidecar)
+```bash
+# Check if DinD sidecar started
+argo logs -n ma <workflow-name> --container dind
+
+# Common issue: privileged containers not allowed
+# Fix: ensure PodSecurityPolicy/PodSecurityStandard allows privileged
+kubectl get psp  # or check namespace labels for PSS
+```

--- a/argo/ci-stage-locks-configmap.yaml
+++ b/argo/ci-stage-locks-configmap.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ci-stage-locks
+  namespace: ma
+data:
+  # Minikube limits — increase for production EKS
+  k8s-matrix: "1"      # only 1 matrix at a time on minikube
+  k8s-local: "2"       # allow 2 concurrent local tests
+  integ-test: "1"      # 1 AWS integ test at a time
+  eks-integ: "1"       # 1 EKS integ test at a time
+  full-es68: "1"       # 1 full ES 6.8 test at a time
+  rfs-integ: "1"       # 1 RFS test at a time
+  gradle-ci: "3"       # 3 concurrent CI pipelines (production)

--- a/argo/config/production-eks.yaml
+++ b/argo/config/production-eks.yaml
@@ -1,0 +1,103 @@
+# Production EKS Configuration
+# IRSA service accounts, Karpenter node pool, S3 artifact repository
+
+---
+# CI deployment service account with cross-account access
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ci-deployment-sa
+  namespace: ma
+  annotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::ACCOUNT_ID:role/ArgoDeploymentRole
+  labels:
+    app: ci-pipeline
+
+---
+# Release pipeline service account with prod S3 + ECR access
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ci-release-sa
+  namespace: ma
+  annotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::ACCOUNT_ID:role/ArgoReleaseRole
+  labels:
+    app: ci-pipeline
+
+---
+# Test account ID secret (populated by External Secrets Operator or manually)
+apiVersion: v1
+kind: Secret
+metadata:
+  name: migrations-test-account-id
+  namespace: ma
+type: Opaque
+stringData:
+  account-id: "REPLACE_WITH_TEST_ACCOUNT_ID"
+
+---
+# GitHub token secret (populated by External Secrets Operator or manually)
+apiVersion: v1
+kind: Secret
+metadata:
+  name: github-token
+  namespace: ma
+type: Opaque
+stringData:
+  token: "REPLACE_WITH_GITHUB_TOKEN"
+
+---
+# Karpenter NodePool for CI workloads
+apiVersion: karpenter.sh/v1
+kind: NodePool
+metadata:
+  name: ci-workloads
+spec:
+  template:
+    metadata:
+      labels:
+        node-type: ci
+    spec:
+      requirements:
+        - key: node.kubernetes.io/instance-type
+          operator: In
+          values: [c5.xlarge, c5.2xlarge, c5.4xlarge]
+        - key: karpenter.sh/capacity-type
+          operator: In
+          values: [on-demand, spot]
+        - key: kubernetes.io/arch
+          operator: In
+          values: [amd64]
+      taints:
+        - key: ci-workload
+          value: "true"
+          effect: NoSchedule
+  limits:
+    cpu: 256
+  disruption:
+    consolidationPolicy: WhenEmpty
+    consolidateAfter: 30s
+
+---
+# Karpenter EC2NodeClass for CI nodes
+apiVersion: karpenter.k8s.aws/v1
+kind: EC2NodeClass
+metadata:
+  name: ci-workloads
+spec:
+  amiSelectorTerms:
+    - alias: al2023@latest
+  subnetSelectorTerms:
+    - tags:
+        karpenter.sh/discovery: "CLUSTER_NAME"
+  securityGroupSelectorTerms:
+    - tags:
+        karpenter.sh/discovery: "CLUSTER_NAME"
+  role: "KarpenterNodeRole-CLUSTER_NAME"
+  blockDeviceMappings:
+    - deviceName: /dev/xvda
+      ebs:
+        volumeSize: 100Gi
+        volumeType: gp3
+        deleteOnTermination: true

--- a/argo/config/s3-artifact-repo.yaml
+++ b/argo/config/s3-artifact-repo.yaml
@@ -1,0 +1,33 @@
+# Production S3 artifact repository configuration
+# Patch this into workflow-controller-configmap on production EKS
+# Replaces MinIO used in minikube setup
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: workflow-controller-configmap-prod-patch
+  namespace: ma
+  labels:
+    app: ci-pipeline
+data:
+  artifactRepository: |
+    archiveLogs: true
+    s3:
+      bucket: opensearch-migrations-ci-artifacts
+      region: us-east-1
+      endpoint: s3.amazonaws.com
+      keyFormat: "{{workflow.name}}/{{pod.name}}"
+      useSDKCreds: true
+  persistence: |
+    archive: true
+    archiveTTL: 30d
+    postgresql:
+      host: argo-postgres.ma.svc.cluster.local
+      port: 5432
+      database: argo
+      tableName: argo_workflows
+      userNameSecret:
+        name: argo-postgres-config
+        key: username
+      passwordSecret:
+        name: argo-postgres-config
+        key: password

--- a/argo/cron/nightly-matrix.yaml
+++ b/argo/cron/nightly-matrix.yaml
@@ -1,0 +1,31 @@
+apiVersion: argoproj.io/v1alpha1
+kind: CronWorkflow
+metadata:
+  name: nightly-k8s-matrix
+  namespace: ma
+  labels:
+    app: ci-pipeline
+    schedule: nightly
+spec:
+  schedule: "0 22 * * *"
+  timezone: "UTC"
+  concurrencyPolicy: Replace  # cancel previous if still running
+  startingDeadlineSeconds: 300  # skip if >5min late
+  successfulJobsHistoryLimit: 7
+  failedJobsHistoryLimit: 14
+  workflowSpec:
+    workflowTemplateRef:
+      name: k8s-matrix-test
+    arguments:
+      parameters:
+        - name: source-version
+          value: "all"
+        - name: target-versions
+          value: '["OS_1.3","OS_2.19","OS_3.1"]'
+    # Nightly runs get longer TTL for debugging
+    ttlStrategy:
+      secondsAfterCompletion: 86400  # 24 hours
+      secondsAfterSuccess: 43200     # 12 hours
+      secondsAfterFailure: 172800    # 48 hours
+    podGC:
+      strategy: OnPodCompletion

--- a/argo/deploy.sh
+++ b/argo/deploy.sh
@@ -1,0 +1,224 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+usage() {
+  cat <<EOF
+Usage: $0 [OPTIONS]
+
+Deploy Argo CI/CD components on minikube, iteratively or all together.
+
+Options:
+  --all           Run all priorities P0-P5 (default if no options given)
+  --p0            P0: Infrastructure (minikube, Argo Workflows, Events, MinIO)
+  --p1            P1: Apply CI WorkflowTemplates
+  --p2            P2: Apply integration test workflow
+  --p3            P3: Apply matrix test + cron + stage locks
+  --p4            P4: Apply Argo Events (EventSource + Sensors)
+  --p5            P5: Install ReportPortal + upload templates
+  --skip-infra    Skip P0 infrastructure (assume already running)
+  --test          Run a quick smoke test after deployment
+  -h, --help      Show this help
+
+Examples:
+  $0 --all                    # Full setup from scratch
+  $0 --p0                     # Just infrastructure
+  $0 --skip-infra --p1 --p2   # Apply P1+P2 templates (infra already up)
+  $0 --all --test             # Full setup + smoke test
+EOF
+  exit 0
+}
+
+# Parse args
+RUN_P0=false RUN_P1=false RUN_P2=false RUN_P3=false RUN_P4=false RUN_P5=false
+RUN_ALL=false SKIP_INFRA=false RUN_TEST=false
+
+if [ $# -eq 0 ]; then
+  RUN_ALL=true
+fi
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --all)        RUN_ALL=true ;;
+    --p0)         RUN_P0=true ;;
+    --p1)         RUN_P1=true ;;
+    --p2)         RUN_P2=true ;;
+    --p3)         RUN_P3=true ;;
+    --p4)         RUN_P4=true ;;
+    --p5)         RUN_P5=true ;;
+    --skip-infra) SKIP_INFRA=true ;;
+    --test)       RUN_TEST=true ;;
+    -h|--help)    usage ;;
+    *)            echo "Unknown option: $1"; usage ;;
+  esac
+  shift
+done
+
+if $RUN_ALL; then
+  RUN_P0=true RUN_P1=true RUN_P2=true RUN_P3=true RUN_P4=true RUN_P5=true
+fi
+
+echo "=========================================="
+echo "  Argo CI/CD Deployment"
+echo "=========================================="
+
+# --- P0: Infrastructure ---
+if $RUN_P0 && ! $SKIP_INFRA; then
+  echo ""
+  echo ">>> P0: Infrastructure Setup"
+  "${SCRIPT_DIR}/setup-minikube-ci.sh"
+
+  # Validate P0
+  echo "  Validating P0..."
+  kubectl get pods -n ma -l app.kubernetes.io/name=argo-workflows --no-headers | head -1 || \
+    { echo "ERROR: Argo Workflows not running"; exit 1; }
+  kubectl get pods -n argo-events --no-headers | head -1 || \
+    { echo "ERROR: Argo Events not running"; exit 1; }
+  kubectl get pods -n minio --no-headers | head -1 || \
+    { echo "ERROR: MinIO not running"; exit 1; }
+  echo ">>> P0: Complete (validated)"
+fi
+
+# --- P1: CI Templates ---
+if $RUN_P1; then
+  echo ""
+  echo ">>> P1: Applying CI WorkflowTemplates"
+  kubectl apply -n ma -f "${SCRIPT_DIR}/workflows/common-ci-steps.yaml"
+  kubectl apply -n ma -f "${SCRIPT_DIR}/workflows/build-images.yaml"
+  kubectl apply -n ma -f "${SCRIPT_DIR}/workflows/argo-ci-pipeline.yaml"
+
+  # Validate P1
+  echo "  Validating P1..."
+  for tmpl in common-ci-steps build-images argo-ci-pipeline; do
+    kubectl get workflowtemplate -n ma "${tmpl}" --no-headers || \
+      { echo "ERROR: WorkflowTemplate ${tmpl} not found"; exit 1; }
+  done
+  echo ">>> P1: Complete"
+  echo "  Templates: common-ci-steps, build-images, argo-ci-pipeline"
+fi
+
+# --- P2: Integration Test ---
+if $RUN_P2; then
+  echo ""
+  echo ">>> P2: Applying Integration Test Workflow"
+  kubectl apply -n ma -f "${SCRIPT_DIR}/workflows/k8s-local-test.yaml"
+  echo ">>> P2: Complete"
+  echo "  Template: k8s-local-test"
+  echo "  Test: argo submit -n ma ${SCRIPT_DIR}/examples/run-single-test.yaml --watch"
+fi
+
+# --- P3: Matrix + Cron + Stage Locks ---
+if $RUN_P3; then
+  echo ""
+  echo ">>> P3: Applying Matrix Test + Cron + Stage Locks + AWS Integ Templates"
+  kubectl apply -n ma -f "${SCRIPT_DIR}/ci-stage-locks-configmap.yaml"
+  kubectl apply -n ma -f "${SCRIPT_DIR}/workflows/k8s-matrix-test.yaml"
+  kubectl apply -n ma -f "${SCRIPT_DIR}/cron/nightly-matrix.yaml"
+  # AWS integration test templates (for production use)
+  kubectl apply -n ma -f "${SCRIPT_DIR}/workflows/aws-integ/" 2>/dev/null || \
+    echo "  (some aws-integ templates skipped — may reference missing CRDs on minikube)"
+
+  # Validate P3
+  echo "  Validating P3..."
+  kubectl get workflowtemplate -n ma k8s-matrix-test --no-headers || true
+  kubectl get cronworkflow -n ma nightly-k8s-matrix --no-headers || true
+  kubectl get configmap -n ma ci-stage-locks --no-headers || true
+  echo ">>> P3: Complete"
+  echo "  Templates: k8s-matrix-test + AWS integ pipelines"
+  echo "  CronWorkflow: nightly-k8s-matrix (0 22 * * * UTC)"
+  echo "  Test: argo submit -n ma ${SCRIPT_DIR}/examples/run-matrix.yaml --watch"
+fi
+
+# --- P4: Argo Events ---
+if $RUN_P4; then
+  echo ""
+  echo ">>> P4: Applying Argo Events"
+
+  # Create secrets for local testing
+  kubectl create secret generic github-webhook-secret \
+    -n argo-events --from-literal=secret=my-test-secret \
+    --dry-run=client -o yaml | kubectl apply -f -
+  kubectl create secret generic github-token \
+    -n argo-events --from-literal=token=ghp_placeholder \
+    --dry-run=client -o yaml | kubectl apply -f -
+
+  kubectl apply -f "${SCRIPT_DIR}/events/eventsource-github.yaml"
+  kubectl apply -f "${SCRIPT_DIR}/events/sensor-ci-pipeline.yaml"
+  kubectl apply -f "${SCRIPT_DIR}/events/sensor-integ-tests.yaml"
+  kubectl apply -f "${SCRIPT_DIR}/events/sensor-release.yaml"
+  echo ">>> P4: Complete"
+  echo "  EventSource: github-migrations"
+  echo "  Sensors: ci-pipeline-sensor, integ-test-sensor, release-sensor"
+  echo "  Test webhook:"
+  echo "    kubectl port-forward -n argo-events svc/github-migrations-eventsrc-svc 12000:12000 &"
+  echo '    PAYLOAD='"'"'{"action":"opened","pull_request":{"number":123,"head":{"ref":"test","sha":"abc123","repo":{"clone_url":"https://github.com/opensearch-project/opensearch-migrations.git"}}}}'"'"''
+  echo '    SIGNATURE=$(echo -n "$PAYLOAD" | openssl dgst -sha256 -hmac "my-test-secret" | awk '"'"'{print $2}'"'"')'
+  echo '    curl -X POST http://localhost:12000/github/pr -H "Content-Type: application/json" -H "X-GitHub-Event: pull_request" -H "X-Hub-Signature-256: sha256=${SIGNATURE}" -d "$PAYLOAD"'
+fi
+
+# --- P5: ReportPortal ---
+if $RUN_P5; then
+  echo ""
+  echo ">>> P5: Installing ReportPortal"
+  "${SCRIPT_DIR}/reportportal/install.sh"
+  kubectl apply -n ma -f "${SCRIPT_DIR}/workflows/upload-results.yaml"
+  echo ">>> P5: Complete"
+  echo "  Template: reportportal-upload"
+  echo "  UI: kubectl -n reportportal port-forward svc/reportportal-ui 8080:8080"
+fi
+
+# --- Smoke Test ---
+if $RUN_TEST; then
+  echo ""
+  echo ">>> Running Smoke Test"
+  echo "Verifying all components..."
+
+  echo "  Checking Argo Workflows..."
+  kubectl get pods -n ma -l app.kubernetes.io/name=argo-workflows --no-headers | head -3
+
+  echo "  Checking WorkflowTemplates..."
+  kubectl get workflowtemplates -n ma --no-headers
+
+  echo "  Checking CronWorkflows..."
+  kubectl get cronworkflows -n ma --no-headers 2>/dev/null || echo "  (none)"
+
+  echo "  Checking Argo Events..."
+  kubectl get eventsources -n argo-events --no-headers 2>/dev/null || echo "  (none)"
+  kubectl get sensors -n argo-events --no-headers 2>/dev/null || echo "  (none)"
+
+  echo "  Checking MinIO..."
+  kubectl get pods -n minio --no-headers | head -3
+
+  echo "  Checking ReportPortal..."
+  kubectl get pods -n reportportal --no-headers 2>/dev/null | head -3 || echo "  (not installed)"
+
+  echo ""
+  echo "  Submitting test git-checkout workflow..."
+  argo submit -n ma --from workflowtemplate/common-ci-steps \
+    --entrypoint git-checkout \
+    -p repo-url=https://github.com/opensearch-project/opensearch-migrations.git \
+    -p branch=main \
+    --wait --log 2>&1 | tail -20 || echo "  (checkout test completed or failed)"
+
+  echo ""
+  echo ">>> Smoke Test Complete"
+fi
+
+echo ""
+echo "=========================================="
+echo "  Deployment Summary"
+echo "=========================================="
+echo ""
+echo "Directory structure:"
+find "${SCRIPT_DIR}" -type f | sort | sed "s|${SCRIPT_DIR}/|  argo/|"
+echo ""
+echo "Quick commands:"
+echo "  Argo UI:        kubectl -n ma port-forward svc/argo-workflows-server 2746:2746"
+echo "  MinIO UI:       kubectl -n minio port-forward svc/minio-console 9001:9001"
+echo "  ReportPortal:   kubectl -n reportportal port-forward svc/reportportal-ui 8080:8080"
+echo "  Run single:     argo submit -n ma argo/examples/run-single-test.yaml --watch"
+echo "  Run matrix:     argo submit -n ma argo/examples/run-matrix.yaml --watch"
+echo "  List workflows: argo list -n ma"
+echo "  Trigger cron:   argo cron trigger -n ma nightly-k8s-matrix"
+echo ""

--- a/argo/events/eventbus.yaml
+++ b/argo/events/eventbus.yaml
@@ -1,0 +1,10 @@
+apiVersion: argoproj.io/v1alpha1
+kind: EventBus
+metadata:
+  name: default
+  namespace: argo-events
+spec:
+  nats:
+    native:
+      replicas: 1  # single replica for minikube (use 3 in production)
+      auth: none

--- a/argo/events/eventsource-github.yaml
+++ b/argo/events/eventsource-github.yaml
@@ -1,0 +1,45 @@
+apiVersion: argoproj.io/v1alpha1
+kind: EventSource
+metadata:
+  name: github-migrations
+  namespace: argo-events
+spec:
+  service:
+    ports:
+      - port: 12000
+        targetPort: 12000
+  github:
+    pr-events:
+      repositories:
+        - owner: opensearch-project
+          names: [opensearch-migrations]
+      webhook:
+        endpoint: /github/pr
+        port: "12000"
+      events:
+        - pull_request
+        - push
+      apiToken:
+        name: github-token
+        key: token
+      webhookSecret:
+        name: github-webhook-secret
+        key: secret
+      insecure: true  # HTTP for minikube; set false + TLS in production
+
+    release-events:
+      repositories:
+        - owner: opensearch-project
+          names: [opensearch-migrations]
+      webhook:
+        endpoint: /github/release
+        port: "12000"
+      events:
+        - release
+      apiToken:
+        name: github-token
+        key: token
+      webhookSecret:
+        name: github-webhook-secret
+        key: secret
+      insecure: true

--- a/argo/events/sensor-ci-pipeline.yaml
+++ b/argo/events/sensor-ci-pipeline.yaml
@@ -1,0 +1,70 @@
+# Triggers CI pipeline on PR and push events (replaces CI.yml GHA workflow trigger)
+apiVersion: argoproj.io/v1alpha1
+kind: Sensor
+metadata:
+  name: ci-pipeline-sensor
+  namespace: argo-events
+spec:
+  dependencies:
+    - name: pr-push
+      eventSourceName: github-migrations
+      eventName: pr-events
+      filters:
+        data:
+          - path: body.action
+            type: string
+            value:
+              - opened
+              - synchronize
+              - reopened
+              - ""  # push events have no action field
+  triggers:
+    - template:
+        name: ci-pipeline
+        conditions: pr-push
+        argoWorkflow:
+          operation: submit
+          source:
+            resource:
+              apiVersion: argoproj.io/v1alpha1
+              kind: Workflow
+              metadata:
+                generateName: ci-
+                namespace: ma
+                labels:
+                  trigger: github-event
+                  test-type: ci-pipeline
+              spec:
+                workflowTemplateRef:
+                  name: argo-ci-pipeline
+                arguments:
+                  parameters:
+                    - name: repo-url
+                      value: ""
+                    - name: branch
+                      value: ""
+                    - name: sha
+                      value: ""
+                    - name: pr-number
+                      value: ""
+          parameters:
+            - src:
+                dependencyName: pr-push
+                dataKey: body.pull_request.head.repo.clone_url
+                useRawData: true
+              dest: spec.arguments.parameters.0.value
+            - src:
+                dependencyName: pr-push
+                dataKey: body.pull_request.head.ref
+                useRawData: true
+              dest: spec.arguments.parameters.1.value
+            - src:
+                dependencyName: pr-push
+                dataKey: body.pull_request.head.sha
+                useRawData: true
+              dest: spec.arguments.parameters.2.value
+            - src:
+                dependencyName: pr-push
+                dataKey: body.pull_request.number
+                useRawData: true
+              dest: spec.arguments.parameters.3.value

--- a/argo/events/sensor-integ-tests.yaml
+++ b/argo/events/sensor-integ-tests.yaml
@@ -1,0 +1,145 @@
+# Triggers integration tests on PR/push (replaces jenkins_tests.yml GHA→Jenkins bridge)
+apiVersion: argoproj.io/v1alpha1
+kind: Sensor
+metadata:
+  name: integ-test-sensor
+  namespace: argo-events
+spec:
+  dependencies:
+    - name: pr-push
+      eventSourceName: github-migrations
+      eventName: pr-events
+      filters:
+        data:
+          - path: body.action
+            type: string
+            value: [opened, synchronize, reopened, ""]
+
+    - name: labeled
+      eventSourceName: github-migrations
+      eventName: pr-events
+      filters:
+        data:
+          - path: body.action
+            type: string
+            value: [labeled]
+          - path: body.label.name
+            type: string
+            value: ["run-eks-tests"]
+
+  triggers:
+    # --- full-es68-e2e (always on PR/push to main) ---
+    - template:
+        name: full-es68-e2e
+        conditions: pr-push
+        argoWorkflow:
+          operation: submit
+          source:
+            resource:
+              apiVersion: argoproj.io/v1alpha1
+              kind: Workflow
+              metadata:
+                generateName: full-es68-
+                namespace: ma
+                labels:
+                  trigger: github-event
+                  test-type: full-es68-e2e
+              spec:
+                workflowTemplateRef:
+                  name: full-es68-e2e
+                arguments:
+                  parameters:
+                    - name: repo-url
+                      value: ""
+                    - name: branch
+                      value: ""
+          parameters:
+            - src:
+                dependencyName: pr-push
+                dataKey: body.pull_request.head.repo.clone_url
+                useRawData: true
+              dest: spec.arguments.parameters.0.value
+            - src:
+                dependencyName: pr-push
+                dataKey: body.pull_request.head.ref
+                useRawData: true
+              dest: spec.arguments.parameters.1.value
+
+    # --- es5x-k8s-local (always on PR/push) ---
+    - template:
+        name: es5x-k8s-local
+        conditions: pr-push
+        argoWorkflow:
+          operation: submit
+          source:
+            resource:
+              apiVersion: argoproj.io/v1alpha1
+              kind: Workflow
+              metadata:
+                generateName: es5x-k8s-
+                namespace: ma
+                labels:
+                  trigger: github-event
+                  test-type: k8s-local
+                  source-version: ES_5.6
+              spec:
+                workflowTemplateRef:
+                  name: k8s-local-test
+                arguments:
+                  parameters:
+                    - name: repo-url
+                      value: ""
+                    - name: branch
+                      value: ""
+                    - name: source-version
+                      value: "ES_5.6"
+                    - name: target-version
+                      value: "OS_3.1"
+          parameters:
+            - src:
+                dependencyName: pr-push
+                dataKey: body.pull_request.head.repo.clone_url
+                useRawData: true
+              dest: spec.arguments.parameters.0.value
+            - src:
+                dependencyName: pr-push
+                dataKey: body.pull_request.head.ref
+                useRawData: true
+              dest: spec.arguments.parameters.1.value
+
+    # --- eks-integ (label-gated: only when 'run-eks-tests' label is added) ---
+    - template:
+        name: eks-integ
+        conditions: labeled
+        argoWorkflow:
+          operation: submit
+          source:
+            resource:
+              apiVersion: argoproj.io/v1alpha1
+              kind: Workflow
+              metadata:
+                generateName: eks-integ-
+                namespace: ma
+                labels:
+                  trigger: github-label
+                  test-type: eks-integ
+              spec:
+                workflowTemplateRef:
+                  name: eks-integ-pipeline
+                arguments:
+                  parameters:
+                    - name: repo-url
+                      value: ""
+                    - name: branch
+                      value: ""
+          parameters:
+            - src:
+                dependencyName: labeled
+                dataKey: body.pull_request.head.repo.clone_url
+                useRawData: true
+              dest: spec.arguments.parameters.0.value
+            - src:
+                dependencyName: labeled
+                dataKey: body.pull_request.head.ref
+                useRawData: true
+              dest: spec.arguments.parameters.1.value

--- a/argo/events/sensor-release.yaml
+++ b/argo/events/sensor-release.yaml
@@ -1,0 +1,55 @@
+# Triggers release pipeline when a draft GitHub release is created
+apiVersion: argoproj.io/v1alpha1
+kind: Sensor
+metadata:
+  name: release-sensor
+  namespace: argo-events
+spec:
+  dependencies:
+    - name: release-created
+      eventSourceName: github-migrations
+      eventName: release-events
+      filters:
+        data:
+          - path: body.action
+            type: string
+            value: [created]
+          - path: body.release.draft
+            type: bool
+            value: ["true"]
+  triggers:
+    - template:
+        name: release
+        conditions: release-created
+        argoWorkflow:
+          operation: submit
+          source:
+            resource:
+              apiVersion: argoproj.io/v1alpha1
+              kind: Workflow
+              metadata:
+                generateName: release-
+                namespace: ma
+                labels:
+                  trigger: github-release
+                  test-type: release
+              spec:
+                workflowTemplateRef:
+                  name: release-pipeline
+                arguments:
+                  parameters:
+                    - name: release-tag
+                      value: ""
+                    - name: release-id
+                      value: ""
+          parameters:
+            - src:
+                dependencyName: release-created
+                dataKey: body.release.tag_name
+                useRawData: true
+              dest: spec.arguments.parameters.0.value
+            - src:
+                dependencyName: release-created
+                dataKey: body.release.id
+                useRawData: true
+              dest: spec.arguments.parameters.1.value

--- a/argo/examples/run-ci-pipeline.yaml
+++ b/argo/examples/run-ci-pipeline.yaml
@@ -1,0 +1,25 @@
+# Submit with: argo submit -n ma argo/examples/run-ci-pipeline.yaml --watch
+# Runs the full CI pipeline (replaces CI.yml) with configurable parallelization
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: ci-pipeline-
+  namespace: ma
+  labels:
+    test-type: ci-pipeline
+spec:
+  workflowTemplateRef:
+    name: argo-ci-pipeline
+  arguments:
+    parameters:
+      - name: repo-url
+        value: "https://github.com/opensearch-project/opensearch-migrations.git"
+      - name: branch
+        value: "main"
+      - name: sha
+        value: ""
+      - name: pr-number
+        value: ""
+      # Reduce parallelization for local testing (30 is for production)
+      - name: gradle-parallelization
+        value: "4"

--- a/argo/examples/run-es-version-tests.yaml
+++ b/argo/examples/run-es-version-tests.yaml
@@ -1,0 +1,39 @@
+# Replaces: jenkins/migrationIntegPipelines/elasticsearch5xK8sLocalTest.groovy
+# Submit with: argo submit -n ma argo/examples/run-es5x-test.yaml --watch
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: es5x-k8s-local-
+  namespace: ma
+  labels:
+    test-type: k8s-local
+    source-version: ES_5.6
+spec:
+  workflowTemplateRef:
+    name: k8s-local-test
+  arguments:
+    parameters:
+      - name: source-version
+        value: "ES_5.6"
+      - name: target-version
+        value: "OS_3.1"
+---
+# Replaces: jenkins/migrationIntegPipelines/elasticsearch8xK8sLocalTest.groovy
+# Submit with: argo submit -n ma argo/examples/run-es8x-test.yaml --watch
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: es8x-k8s-local-
+  namespace: ma
+  labels:
+    test-type: k8s-local
+    source-version: ES_8.x
+spec:
+  workflowTemplateRef:
+    name: k8s-local-test
+  arguments:
+    parameters:
+      - name: source-version
+        value: "ES_7.10"  # closest available
+      - name: target-version
+        value: "OS_2.19"

--- a/argo/examples/run-matrix.yaml
+++ b/argo/examples/run-matrix.yaml
@@ -1,0 +1,17 @@
+# Submit with: argo submit -n ma argo/examples/run-matrix.yaml --watch
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: k8s-matrix-
+  namespace: ma
+  labels:
+    test-type: k8s-matrix
+spec:
+  workflowTemplateRef:
+    name: k8s-matrix-test
+  arguments:
+    parameters:
+      - name: source-version
+        value: "all"
+      - name: target-versions
+        value: '["OS_2.19","OS_3.1"]'

--- a/argo/examples/run-single-test.yaml
+++ b/argo/examples/run-single-test.yaml
@@ -1,0 +1,19 @@
+# Submit with: argo submit -n ma argo/examples/run-single-test.yaml --watch
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: k8s-local-test-
+  namespace: ma
+  labels:
+    test-type: k8s-local
+spec:
+  workflowTemplateRef:
+    name: k8s-local-test
+  arguments:
+    parameters:
+      - name: source-version
+        value: "ES_7.10"
+      - name: target-version
+        value: "OS_2.19"
+      - name: test-ids
+        value: "all"

--- a/argo/images/ci-runner/Dockerfile
+++ b/argo/images/ci-runner/Dockerfile
@@ -1,0 +1,40 @@
+# CI Runner image for AWS integration tests
+# Contains: Python, pipenv, pytest, aws-cli, kubectl, helm, jq, CDK, Gradle
+FROM python:3.11-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl \
+    unzip \
+    git \
+    jq \
+    openssh-client \
+    && rm -rf /var/lib/apt/lists/*
+
+# AWS CLI v2
+RUN curl -sf "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m).zip" -o /tmp/awscliv2.zip \
+    && unzip -q /tmp/awscliv2.zip -d /tmp \
+    && /tmp/aws/install \
+    && rm -rf /tmp/aws /tmp/awscliv2.zip
+
+# kubectl
+RUN curl -sfL "https://dl.k8s.io/release/$(curl -sL https://dl.k8s.io/release/stable.txt)/bin/linux/$(dpkg --print-architecture)/kubectl" \
+    -o /usr/local/bin/kubectl \
+    && chmod +x /usr/local/bin/kubectl
+
+# Helm
+RUN curl -sf https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+
+# Node.js + CDK (for CDK deploy/destroy)
+RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+    && apt-get install -y nodejs \
+    && npm install -g aws-cdk \
+    && rm -rf /var/lib/apt/lists/*
+
+# Java 17 (for Gradle builds)
+RUN apt-get update && apt-get install -y --no-install-recommends openjdk-17-jdk-headless \
+    && rm -rf /var/lib/apt/lists/*
+
+# Python tools
+RUN pip install --no-cache-dir pipenv pytest
+
+WORKDIR /workspace

--- a/argo/images/release-runner/Dockerfile
+++ b/argo/images/release-runner/Dockerfile
@@ -1,0 +1,23 @@
+# Release Runner image for release pipeline
+# Contains: skopeo, aws-cli, Maven, curl, jq
+FROM python:3.11-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl \
+    unzip \
+    jq \
+    skopeo \
+    maven \
+    && rm -rf /var/lib/apt/lists/*
+
+# AWS CLI v2
+RUN curl -sf "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m).zip" -o /tmp/awscliv2.zip \
+    && unzip -q /tmp/awscliv2.zip -d /tmp \
+    && /tmp/aws/install \
+    && rm -rf /tmp/aws /tmp/awscliv2.zip
+
+# Java 11 (for Maven — matches Jenkins release agent)
+RUN apt-get update && apt-get install -y --no-install-recommends openjdk-17-jdk-headless \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /release

--- a/argo/reportportal/install.sh
+++ b/argo/reportportal/install.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "Installing ReportPortal on minikube..."
+
+helm repo add reportportal https://reportportal.io/kubernetes 2>/dev/null || true
+helm repo update reportportal
+
+kubectl create namespace reportportal 2>/dev/null || true
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+helm upgrade --install reportportal reportportal/reportportal \
+  -n reportportal \
+  --wait --timeout 10m \
+  -f "${SCRIPT_DIR}/values-minikube.yaml"
+
+# Create API token secret in ma namespace for workflow access
+RP_TOKEN="superadmin_personal"  # default token for local dev
+kubectl -n ma create secret generic reportportal-token \
+  --from-literal=token="${RP_TOKEN}" \
+  --dry-run=client -o yaml | kubectl apply -f -
+
+echo ""
+echo "ReportPortal installed!"
+echo "UI: kubectl -n reportportal port-forward svc/reportportal-ui 8080:8080"
+echo "Then open: http://localhost:8080"
+echo "Login: superadmin / erebus"
+echo ""
+echo "Create project 'opensearch_migrations' in the UI before running tests."

--- a/argo/reportportal/values-minikube.yaml
+++ b/argo/reportportal/values-minikube.yaml
@@ -1,0 +1,52 @@
+# Lightweight config for minikube — minimal resource requests
+postgresql:
+  enabled: true
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+  persistence:
+    size: 2Gi
+
+opensearch:
+  enabled: true
+  replicas: 1
+  resources:
+    requests:
+      cpu: 100m
+      memory: 512Mi
+  persistence:
+    size: 2Gi
+
+minio:
+  enabled: true
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+  persistence:
+    size: 1Gi
+
+serviceapi:
+  resources:
+    requests:
+      cpu: 100m
+      memory: 512Mi
+
+uat:
+  resources:
+    requests:
+      cpu: 50m
+      memory: 256Mi
+
+serviceui:
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+
+serviceanalyzer:
+  resources:
+    requests:
+      cpu: 50m
+      memory: 256Mi

--- a/argo/setup-minikube-ci.sh
+++ b/argo/setup-minikube-ci.sh
@@ -1,0 +1,216 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+echo "=== P0: Setting up Argo CI/CD on Minikube ==="
+
+# --- Step 1: Ensure minikube is running with adequate resources ---
+MINIKUBE_CPU_COUNT="${MINIKUBE_CPU_COUNT:-8}"
+MINIKUBE_MEMORY_SIZE="${MINIKUBE_MEMORY_SIZE:-18000}"
+
+if ! minikube status --format='{{.Host}}' 2>/dev/null | grep -q Running; then
+  echo "Starting minikube (${MINIKUBE_CPU_COUNT} CPUs, ${MINIKUBE_MEMORY_SIZE}MB RAM)..."
+  minikube config set cpus "$MINIKUBE_CPU_COUNT"
+  minikube config set memory "$MINIKUBE_MEMORY_SIZE"
+  INSECURE_REGISTRY_CIDR="${INSECURE_REGISTRY_CIDR:-0.0.0.0/0}"
+  minikube start \
+    --extra-config=kubelet.authentication-token-webhook=true \
+    --extra-config=kubelet.authorization-mode=Webhook \
+    --extra-config=scheduler.bind-address=0.0.0.0 \
+    --extra-config=controller-manager.bind-address=0.0.0.0 \
+    --insecure-registry="${INSECURE_REGISTRY_CIDR}"
+else
+  echo "Minikube already running"
+fi
+kubectl config use-context minikube
+
+# --- Step 2: Build images via existing BuildKit infrastructure ---
+echo "Setting up BuildKit and building images..."
+export USE_LOCAL_REGISTRY="${USE_LOCAL_REGISTRY:-true}"
+"${REPO_ROOT}/buildImages/setUpK8sImageBuildServices.sh"
+
+LOCAL_REGISTRY_PORT="${LOCAL_REGISTRY_PORT:-30500}"
+MINIKUBE_IP="$(minikube ip)"
+LOCAL_REGISTRY="${MINIKUBE_IP}:${LOCAL_REGISTRY_PORT}"
+export LOCAL_REGISTRY
+
+ARCH=$(uname -m)
+case "$ARCH" in
+  x86_64)  PLATFORM="amd64" ;;
+  arm64|aarch64) PLATFORM="arm64" ;;
+  *) echo "Unsupported architecture: $ARCH"; exit 1 ;;
+esac
+"${REPO_ROOT}/gradlew" :buildImages:buildImagesToRegistry_${PLATFORM} -x test --info
+
+# --- Step 3: Install test clusters + MA with Argo Workflows ---
+echo "Installing test clusters + migration assistant with Argo..."
+cd "${REPO_ROOT}/deployment/k8s/"
+helm dependency update charts/aggregates/testClusters
+helm dependency update charts/aggregates/migrationAssistantWithArgo
+
+kubectl config set-context --current --namespace=ma
+
+helm upgrade --install --create-namespace -n ma tc charts/aggregates/testClusters \
+  --wait --timeout 10m \
+  --set "source.image=${LOCAL_REGISTRY}/migrations/elasticsearch_searchguard"
+
+helm upgrade --install --create-namespace -n ma ma charts/aggregates/migrationAssistantWithArgo \
+  --wait --timeout 10m \
+  -f charts/aggregates/migrationAssistantWithArgo/valuesForLocalK8s.yaml \
+  --set "images.captureProxy.repository=${LOCAL_REGISTRY}/migrations/capture_proxy" \
+  --set "images.captureProxy.tag=latest" \
+  --set "images.captureProxy.pullPolicy=Always" \
+  --set "images.installer.repository=${LOCAL_REGISTRY}/migrations/migration_console" \
+  --set "images.installer.tag=latest" \
+  --set "images.installer.pullPolicy=Always" \
+  --set "images.migrationConsole.repository=${LOCAL_REGISTRY}/migrations/migration_console" \
+  --set "images.migrationConsole.tag=latest" \
+  --set "images.migrationConsole.pullPolicy=Always" \
+  --set "images.trafficReplayer.repository=${LOCAL_REGISTRY}/migrations/traffic_replayer" \
+  --set "images.trafficReplayer.tag=latest" \
+  --set "images.trafficReplayer.pullPolicy=Always" \
+  --set "images.reindexFromSnapshot.repository=${LOCAL_REGISTRY}/migrations/reindex_from_snapshot" \
+  --set "images.reindexFromSnapshot.tag=latest" \
+  --set "images.reindexFromSnapshot.pullPolicy=Always"
+
+cd "${REPO_ROOT}"
+
+# --- Step 4: Install Argo Events ---
+echo "Installing Argo Events..."
+kubectl create namespace argo-events 2>/dev/null || true
+helm repo add argo https://argoproj.github.io/argo-helm 2>/dev/null || true
+helm repo update argo
+
+helm upgrade --install argo-events argo/argo-events \
+  -n argo-events \
+  --wait --timeout 5m \
+  --set crds.install=true
+
+# EventBus (NATS message backbone)
+kubectl apply -n argo-events -f "${SCRIPT_DIR}/events/eventbus.yaml"
+
+# --- Step 5: Install MinIO for artifact storage (minikube only) ---
+echo "Installing MinIO for Argo artifact storage..."
+kubectl create namespace minio 2>/dev/null || true
+helm repo add minio https://charts.min.io/ 2>/dev/null || true
+helm repo update minio
+
+helm upgrade --install minio minio/minio \
+  -n minio \
+  --wait --timeout 5m \
+  --set rootUser=minioadmin \
+  --set rootPassword=minioadmin \
+  --set mode=standalone \
+  --set replicas=1 \
+  --set persistence.size=5Gi \
+  --set resources.requests.cpu=100m \
+  --set resources.requests.memory=256Mi \
+  --set buckets[0].name=argo-artifacts \
+  --set buckets[0].policy=none
+
+# Create artifact repository secret for Argo
+kubectl -n ma create secret generic argo-artifact-repo-creds \
+  --from-literal=accesskey=minioadmin \
+  --from-literal=secretkey=minioadmin \
+  --dry-run=client -o yaml | kubectl apply -f -
+
+# Patch workflow-controller-configmap to use MinIO artifact repo
+MINIO_SVC="minio.minio.svc.cluster.local:9000"
+kubectl -n ma get configmap workflow-controller-configmap -o yaml 2>/dev/null || \
+  kubectl -n ma create configmap workflow-controller-configmap
+kubectl -n ma patch configmap workflow-controller-configmap --type merge -p "
+data:
+  artifactRepository: |
+    archiveLogs: true
+    s3:
+      bucket: argo-artifacts
+      endpoint: ${MINIO_SVC}
+      insecure: true
+      accessKeySecret:
+        name: argo-artifact-repo-creds
+        key: accesskey
+      secretKeySecret:
+        name: argo-artifact-repo-creds
+        key: secretkey
+      keyFormat: \"{{workflow.name}}/{{pod.name}}\"
+"
+
+# --- Step 6: CI-specific RBAC ---
+echo "Applying CI RBAC..."
+kubectl apply -n ma -f - <<'EOF'
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: ci-workflow-role
+  namespace: ma
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "pods/log", "pods/exec", "services", "configmaps", "secrets", "persistentvolumeclaims"]
+    verbs: ["*"]
+  - apiGroups: ["apps"]
+    resources: ["deployments", "statefulsets"]
+    verbs: ["*"]
+  - apiGroups: ["argoproj.io"]
+    resources: ["workflows", "workflowtemplates", "workflowtaskresults"]
+    verbs: ["*"]
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["*"]
+  - apiGroups: ["helm.toolkit.fluxcd.io"]
+    resources: ["helmreleases"]
+    verbs: ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: ci-workflow-rolebinding
+  namespace: ma
+subjects:
+  - kind: ServiceAccount
+    name: argo-workflow-executor
+    namespace: ma
+roleRef:
+  kind: Role
+  name: ci-workflow-role
+  apiGroup: rbac.authorization.k8s.io
+---
+# Cross-namespace role for argo-events to submit workflows in ma namespace
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: argo-events-submit-workflows
+  namespace: ma
+subjects:
+  - kind: ServiceAccount
+    name: argo-events-sa
+    namespace: argo-events
+roleRef:
+  kind: Role
+  name: ci-workflow-role
+  apiGroup: rbac.authorization.k8s.io
+EOF
+
+# --- Step 7: Apply CI workflow templates ---
+echo "Applying CI workflow templates..."
+# Only apply minikube-compatible templates (skip aws-integ/ which needs ci-runner image)
+for f in "${SCRIPT_DIR}/workflows/"*.yaml; do
+  echo "  Applying $(basename "$f")..."
+  kubectl apply -n ma -f "$f"
+done
+echo "  (Skipping aws-integ/ templates — they require ci-runner image built for production EKS)"
+
+# --- Step 8: Apply stage locks ConfigMap ---
+echo "Applying stage locks..."
+kubectl apply -n ma -f "${SCRIPT_DIR}/ci-stage-locks-configmap.yaml"
+
+echo ""
+echo "=== P0 Complete ==="
+echo "Argo Workflows UI: kubectl -n ma port-forward svc/argo-workflows-server 2746:2746"
+echo "Then open: https://localhost:2746"
+echo ""
+echo "MinIO Console: kubectl -n minio port-forward svc/minio-console 9001:9001"
+echo "Then open: http://localhost:9001 (minioadmin/minioadmin)"
+echo ""
+echo "Registry IP: ${LOCAL_REGISTRY}"

--- a/argo/workflows/argo-ci-pipeline.yaml
+++ b/argo/workflows/argo-ci-pipeline.yaml
@@ -1,0 +1,431 @@
+# Replaces: .github/workflows/CI.yml
+# Full CI pipeline with 30x gradle stripe fan-out, python tests, node tests, lint, link-checker
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: argo-ci-pipeline
+  namespace: ma
+  labels:
+    app: ci-pipeline
+    replaces: CI.yml
+spec:
+  entrypoint: ci
+  onExit: report-and-notify
+  serviceAccountName: argo-workflow-executor
+  arguments:
+    parameters:
+      - name: repo-url
+        value: "https://github.com/opensearch-project/opensearch-migrations.git"
+      - name: branch
+        value: "main"
+      - name: sha
+        value: ""
+      - name: pr-number
+        value: ""
+      - name: gradle-parallelization
+        value: "30"
+  activeDeadlineSeconds: 14400  # 4 hours
+
+  templates:
+    # ================================================================
+    # ROOT DAG — mirrors CI.yml job dependency graph
+    # All jobs run in parallel after checkout, gated by all-ci-checks-pass
+    # ================================================================
+    - name: ci
+      dag:
+        tasks:
+          - name: checkout
+            templateRef:
+              name: common-ci-steps
+              template: git-checkout
+            arguments:
+              parameters:
+                - name: repo-url
+                  value: "{{workflow.parameters.repo-url}}"
+                - name: branch
+                  value: "{{workflow.parameters.branch}}"
+
+          - name: generate-stripe-indices
+            template: generate-indices
+            arguments:
+              parameters:
+                - name: count
+                  value: "{{workflow.parameters.gradle-parallelization}}"
+
+          # --- gradle-extended-check (2x: spotlessCheck, publishToMavenLocal) ---
+          - name: gradle-extended-check
+            depends: checkout
+            template: gradle-task
+            arguments:
+              parameters:
+                - name: task
+                  value: "{{item}}"
+              artifacts:
+                - name: source
+                  from: "{{tasks.checkout.outputs.artifacts.source}}"
+            withItems:
+              - spotlessCheck
+              - publishToMavenLocal
+
+          # --- python-lint ---
+          - name: python-lint
+            depends: checkout
+            template: python-lint
+            arguments:
+              artifacts:
+                - name: source
+                  from: "{{tasks.checkout.outputs.artifacts.source}}"
+
+          # --- python-tests (3x matrix) ---
+          - name: python-tests
+            depends: checkout
+            template: python-test
+            arguments:
+              parameters:
+                - name: py-project
+                  value: "{{item}}"
+              artifacts:
+                - name: source
+                  from: "{{tasks.checkout.outputs.artifacts.source}}"
+            withItems:
+              - migrationConsole/lib/console_link
+              - migrationConsole/cluster_tools
+              - k8sConfigMapUtilScripts
+
+          # --- gradle-tests (30x striped fan-out) ---
+          - name: gradle-tests
+            depends: "checkout && generate-stripe-indices"
+            template: gradle-test-stripe
+            arguments:
+              parameters:
+                - name: stripe-index
+                  value: "{{item}}"
+                - name: total-stripes
+                  value: "{{workflow.parameters.gradle-parallelization}}"
+              artifacts:
+                - name: source
+                  from: "{{tasks.checkout.outputs.artifacts.source}}"
+            withParam: "{{tasks.generate-stripe-indices.outputs.result}}"
+
+          # --- python-e2e-tests (Docker Compose) ---
+          - name: python-e2e-tests
+            depends: checkout
+            template: python-e2e
+            arguments:
+              artifacts:
+                - name: source
+                  from: "{{tasks.checkout.outputs.artifacts.source}}"
+
+          # --- node-tests (3x matrix) ---
+          - name: node-tests
+            depends: checkout
+            template: node-test
+            arguments:
+              parameters:
+                - name: npm-project
+                  value: "{{item}}"
+              artifacts:
+                - name: source
+                  from: "{{tasks.checkout.outputs.artifacts.source}}"
+            withItems:
+              - ./deployment/cdk/opensearch-service-migration
+              - ./deployment/migration-assistant-solution
+              - ./frontend
+
+          # --- link-checker ---
+          - name: link-checker
+            depends: checkout
+            template: link-checker
+            arguments:
+              artifacts:
+                - name: source
+                  from: "{{tasks.checkout.outputs.artifacts.source}}"
+
+    # ================================================================
+    # GENERATE STRIPE INDICES [0..N-1] as JSON array
+    # ================================================================
+    - name: generate-indices
+      inputs:
+        parameters:
+          - name: count
+      script:
+        image: python:3.11-alpine
+        command: [python]
+        source: |
+          import json
+          print(json.dumps(list(range(int("{{inputs.parameters.count}}")))))
+
+    # ================================================================
+    # GRADLE TEST STRIPE — each of the 30 GHA matrix jobs
+    # ================================================================
+    - name: gradle-test-stripe
+      retryStrategy:
+        limit: 1
+        retryPolicy: OnFailure
+      inputs:
+        parameters:
+          - name: stripe-index
+          - name: total-stripes
+        artifacts:
+          - name: source
+            path: /workspace
+      outputs:
+        artifacts:
+          - name: test-reports
+            path: /workspace/build/reports/
+            optional: true
+            archive:
+              none: {}
+          - name: junit-xml
+            path: /workspace/build/test-results/
+            optional: true
+            archive:
+              none: {}
+      container:
+        image: gradle:8-jdk17
+        workingDir: /workspace
+        command: [bash, -c]
+        args:
+          - |
+            MAX_WORKERS=$(( $(nproc) - 1 ))
+            [ "$MAX_WORKERS" -lt 1 ] && MAX_WORKERS=1
+            ./gradlew allTests mergeJacocoReports \
+              --max-workers $MAX_WORKERS \
+              -Dtest.striping.total={{inputs.parameters.total-stripes}} \
+              -Dtest.striping.index={{inputs.parameters.stripe-index}} \
+              -x spotlessCheck --stacktrace --continue || true
+            echo "Stripe {{inputs.parameters.stripe-index}} complete"
+        resources:
+          requests:
+            cpu: "2"
+            memory: "4Gi"
+          limits:
+            memory: "8Gi"
+        activeDeadlineSeconds: 3600  # 1 hour per stripe
+
+    # ================================================================
+    # GRADLE TASK (spotlessCheck, publishToMavenLocal)
+    # ================================================================
+    - name: gradle-task
+      inputs:
+        parameters:
+          - name: task
+        artifacts:
+          - name: source
+            path: /workspace
+      container:
+        image: gradle:8-jdk17
+        workingDir: /workspace
+        command: [bash, -c]
+        args:
+          - ./gradlew {{inputs.parameters.task}} --no-daemon
+        resources:
+          requests:
+            cpu: "2"
+            memory: "4Gi"
+          limits:
+            memory: "8Gi"
+        activeDeadlineSeconds: 1800  # 30 min
+
+    # ================================================================
+    # PYTHON TEST (per project)
+    # ================================================================
+    - name: python-test
+      inputs:
+        parameters:
+          - name: py-project
+        artifacts:
+          - name: source
+            path: /workspace
+      outputs:
+        artifacts:
+          - name: coverage-xml
+            path: /workspace/coverage.xml
+            optional: true
+      script:
+        image: python:3.11-slim
+        resources:
+          requests:
+            cpu: "1"
+            memory: "2Gi"
+          limits:
+            memory: "4Gi"
+        command: [bash]
+        source: |
+          set -euo pipefail
+          apt-get update -qq && apt-get install -y -qq pipenv > /dev/null 2>&1
+
+          PROJECT="{{inputs.parameters.py-project}}"
+          if [[ "$PROJECT" == migrationConsole/* ]]; then
+            WORKDIR="/workspace/${PROJECT}"
+          else
+            WORKDIR="/workspace/TrafficCapture/dockerSolution/src/main/docker/${PROJECT}"
+          fi
+
+          cd "$WORKDIR"
+          pipenv install --deploy --dev
+          pipenv run test
+          pipenv run coverage xml -o /workspace/coverage.xml || true
+
+    # ================================================================
+    # PYTHON LINT
+    # ================================================================
+    - name: python-lint
+      inputs:
+        artifacts:
+          - name: source
+            path: /workspace
+      container:
+        image: python:3.11-slim
+        workingDir: /workspace
+        command: [bash, -c]
+        args:
+          - |
+            pip install flake8 -q
+            flake8 $(find . -name '*.py' \
+              -not -path '*/node_modules/*' \
+              -not -path '*/.git/*' \
+              -not -path '*/build/*' \
+              -not -path '*/.gradle/*')
+        resources:
+          requests:
+            cpu: "500m"
+            memory: "1Gi"
+        activeDeadlineSeconds: 600  # 10 min
+
+    # ================================================================
+    # PYTHON E2E (Docker Compose — needs DinD sidecar)
+    # ================================================================
+    - name: python-e2e
+      inputs:
+        artifacts:
+          - name: source
+            path: /workspace
+      outputs:
+        artifacts:
+          - name: e2e-logs
+            path: /workspace/logs/
+            optional: true
+      sidecars:
+        - name: dind
+          image: docker:27-dind
+          securityContext:
+            privileged: true
+          env:
+            - name: DOCKER_TLS_CERTDIR
+              value: ""
+          mirrorVolumeMounts: true
+      container:
+        image: gradle:8-jdk17
+        workingDir: /workspace
+        env:
+          - name: DOCKER_HOST
+            value: tcp://localhost:2375
+        command: [bash, -c]
+        args:
+          - |
+            # Wait for Docker
+            for i in $(seq 1 30); do docker info >/dev/null 2>&1 && break; sleep 2; done
+
+            # Start Docker Solution
+            ./gradlew -p TrafficCapture dockerSolution:ComposeUp \
+              -x test -x spotlessCheck --info --stacktrace
+
+            # Run E2E tests
+            docker exec $(docker ps --filter "name=migration-console" -q) \
+              pipenv run pytest /root/lib/integ_test/integ_test/replayer_tests.py \
+              --unique_id="testindex" -s --junitxml=/tmp/e2e-results.xml
+
+            # Collect logs
+            mkdir -p logs/docker
+            for container in $(docker ps -aq); do
+              name=$(docker inspect --format '{{.Name}}' $container | sed 's/\///')
+              docker logs $container > logs/docker/${name}.txt 2>&1
+            done
+        resources:
+          requests:
+            cpu: "4"
+            memory: "8Gi"
+        activeDeadlineSeconds: 3600
+
+    # ================================================================
+    # NODE TEST (per npm project)
+    # ================================================================
+    - name: node-test
+      inputs:
+        parameters:
+          - name: npm-project
+        artifacts:
+          - name: source
+            path: /workspace
+      container:
+        image: node:22-slim
+        workingDir: /workspace/{{inputs.parameters.npm-project}}
+        command: [bash, -c]
+        args:
+          - |
+            npm ci
+            npm run test
+        resources:
+          requests:
+            cpu: "1"
+            memory: "2Gi"
+          limits:
+            memory: "4Gi"
+        activeDeadlineSeconds: 1800  # 30 min
+
+    # ================================================================
+    # LINK CHECKER
+    # ================================================================
+    - name: link-checker
+      inputs:
+        artifacts:
+          - name: source
+            path: /workspace
+      container:
+        image: lycheeverse/lychee:latest
+        workingDir: /workspace
+        command: [lychee]
+        args:
+          - "--verbose"
+          - "--accept=200,403,429"
+          - "--offline"
+          - "--exclude=file:///github/workspace/*"
+          - "--exclude=http://localhost*"
+          - "--exclude=https://localhost*"
+          - "--exclude=http://capture-proxy*"
+          - "--exclude-path=TrafficCapture/dockerSolution/src/main/docker/k8sConfigMapUtilScripts/tests/data"
+          - "**/*.html"
+          - "**/*.md"
+          - "**/*.txt"
+          - "**/*.json"
+        resources:
+          requests:
+            cpu: "500m"
+            memory: "1Gi"
+        activeDeadlineSeconds: 600  # 10 min
+
+    # ================================================================
+    # EXIT HANDLER: Report + Notify
+    # ================================================================
+    - name: report-and-notify
+      dag:
+        tasks:
+          - name: upload-results
+            templateRef:
+              name: reportportal-upload
+              template: upload-junit
+            arguments:
+              parameters:
+                - name: launch-name
+                  value: "ci-{{workflow.parameters.branch}}"
+          - name: notify-github
+            templateRef:
+              name: common-ci-steps
+              template: notify-github-status
+            arguments:
+              parameters:
+                - name: sha
+                  value: "{{workflow.parameters.sha}}"
+                - name: context
+                  value: "argo/ci-pipeline"

--- a/argo/workflows/aws-integ/cleanup-deployment.yaml
+++ b/argo/workflows/aws-integ/cleanup-deployment.yaml
@@ -1,0 +1,81 @@
+# Replaces: vars/cleanupDeployment.groovy
+# Simple pipeline that runs cleanup_deployment.py for a given stage
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: cleanup-deployment
+  namespace: ma
+  labels:
+    app: ci-pipeline
+    replaces: cleanupDeployment.groovy
+spec:
+  entrypoint: cleanup
+  serviceAccountName: ci-deployment-sa
+  arguments:
+    parameters:
+      - name: repo-url
+        value: "https://github.com/opensearch-project/opensearch-migrations.git"
+      - name: branch
+        value: "main"
+      - name: stage
+        value: ""  # required
+      - name: region
+        value: "us-east-1"
+  activeDeadlineSeconds: 3600  # 1 hour
+
+  synchronization:
+    mutexes:
+      - name: "cleanup-{{workflow.parameters.stage}}"
+
+  templates:
+    - name: cleanup
+      dag:
+        tasks:
+          - name: checkout
+            templateRef:
+              name: common-ci-steps
+              template: git-checkout
+            arguments:
+              parameters:
+                - name: repo-url
+                  value: "{{workflow.parameters.repo-url}}"
+                - name: branch
+                  value: "{{workflow.parameters.branch}}"
+
+          - name: run-cleanup
+            depends: checkout
+            template: run-cleanup
+            arguments:
+              artifacts:
+                - name: source
+                  from: "{{tasks.checkout.outputs.artifacts.source}}"
+
+    - name: run-cleanup
+      inputs:
+        artifacts:
+          - name: source
+            path: /workspace
+      container:
+        image: ci-runner:latest
+        workingDir: /workspace/test/cleanupDeployment
+        command: [bash, -c]
+        args:
+          - |
+            set -euo pipefail
+            CREDS=$(aws sts assume-role \
+              --role-arn "arn:aws:iam::${TEST_ACCOUNT_ID}:role/ArgoTestDeploymentRole" \
+              --role-session-name "argo-cleanup" --duration-seconds 3600)
+            export AWS_ACCESS_KEY_ID=$(echo $CREDS | jq -r .Credentials.AccessKeyId)
+            export AWS_SECRET_ACCESS_KEY=$(echo $CREDS | jq -r .Credentials.SecretAccessKey)
+            export AWS_SESSION_TOKEN=$(echo $CREDS | jq -r .Credentials.SessionToken)
+
+            pipenv install --deploy --ignore-pipfile
+            pipenv run python3 cleanup_deployment.py \
+              --stage "{{workflow.parameters.stage}}"
+        env:
+          - name: TEST_ACCOUNT_ID
+            valueFrom:
+              secretKeyRef:
+                name: migrations-test-account-id
+                key: account-id
+        activeDeadlineSeconds: 3600

--- a/argo/workflows/aws-integ/default-integ-pipeline.yaml
+++ b/argo/workflows/aws-integ/default-integ-pipeline.yaml
@@ -1,0 +1,398 @@
+# Replaces: vars/defaultIntegPipeline.groovy
+# Base AWS integration test pipeline: checkout → build → deploy CDK → run pytest → cleanup
+# Used directly or as a base for full-es68, rfs-default, traffic-replay tests
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: default-integ-pipeline
+  namespace: ma
+  labels:
+    app: ci-pipeline
+    replaces: defaultIntegPipeline.groovy
+spec:
+  entrypoint: main
+  onExit: cleanup-handler
+  serviceAccountName: ci-deployment-sa  # IRSA with cross-account access
+  arguments:
+    parameters:
+      - name: repo-url
+        value: "https://github.com/opensearch-project/opensearch-migrations.git"
+      - name: branch
+        value: "main"
+      - name: stage
+        value: "aws-integ"
+      - name: source-context-id
+        value: "source-single-node-ec2"
+      - name: migration-context-id
+        value: "migration-default"
+      - name: source-context
+        value: "{}"  # JSON CDK context for source cluster
+      - name: migration-context
+        value: "{}"  # JSON CDK context for migration stack
+      - name: skip-capture-proxy
+        value: "false"
+      - name: integ-test-command
+        value: "/root/lib/integ_test/integ_test/replayer_tests.py"
+      - name: test-unique-id
+        value: ""  # auto-generated if empty
+  activeDeadlineSeconds: 10800  # 3 hours (matches Jenkins)
+
+  synchronization:
+    semaphores:
+      - configMapKeyRef:
+          name: ci-stage-locks
+          key: integ-test
+
+  templates:
+    - name: main
+      dag:
+        tasks:
+          - name: checkout
+            templateRef:
+              name: common-ci-steps
+              template: git-checkout
+            arguments:
+              parameters:
+                - name: repo-url
+                  value: "{{workflow.parameters.repo-url}}"
+                - name: branch
+                  value: "{{workflow.parameters.branch}}"
+
+          - name: verify-aws-identity
+            template: verify-aws-identity
+
+          - name: setup-cdk-context
+            depends: checkout
+            template: setup-cdk-context
+            arguments:
+              artifacts:
+                - name: source
+                  from: "{{tasks.checkout.outputs.artifacts.source}}"
+
+          - name: build
+            depends: checkout
+            template: gradle-build
+            arguments:
+              artifacts:
+                - name: source
+                  from: "{{tasks.checkout.outputs.artifacts.source}}"
+
+          - name: deploy
+            depends: "build && setup-cdk-context && verify-aws-identity"
+            template: deploy-cdk-stack
+            arguments:
+              artifacts:
+                - name: source
+                  from: "{{tasks.build.outputs.artifacts.source}}"
+
+          - name: run-tests
+            depends: deploy
+            template: run-integ-tests
+            arguments:
+              artifacts:
+                - name: source
+                  from: "{{tasks.deploy.outputs.artifacts.source}}"
+
+    # ================================================================
+    # VERIFY AWS IDENTITY — replaces Jenkins 'Test Caller Identity' stage
+    # ================================================================
+    - name: verify-aws-identity
+      container:
+        image: amazon/aws-cli:2.15.0
+        command: [bash, -c]
+        args:
+          - |
+            echo "Verifying AWS identity..."
+            aws sts get-caller-identity
+            echo "Assuming cross-account role for test account..."
+            CREDS=$(aws sts assume-role \
+              --role-arn "arn:aws:iam::${TEST_ACCOUNT_ID}:role/ArgoTestDeploymentRole" \
+              --role-session-name "argo-ci" \
+              --duration-seconds 5400 \
+              --output json)
+            echo "Successfully assumed role in test account"
+        env:
+          - name: TEST_ACCOUNT_ID
+            valueFrom:
+              secretKeyRef:
+                name: migrations-test-account-id
+                key: account-id
+
+    # ================================================================
+    # SETUP CDK CONTEXT — replaces Jenkins 'Setup E2E CDK Context' stage
+    # Writes source and migration context JSON files
+    # ================================================================
+    - name: setup-cdk-context
+      inputs:
+        artifacts:
+          - name: source
+            path: /workspace
+      outputs:
+        artifacts:
+          - name: source
+            path: /workspace
+      script:
+        image: python:3.11-alpine
+        command: [sh]
+        source: |
+          set -euo pipefail
+          cd /workspace/test
+
+          # Write source context (with stage substitution)
+          STAGE="{{workflow.parameters.stage}}"
+          echo '{{workflow.parameters.source-context}}' | \
+            sed "s/<STAGE>/${STAGE}/g" > sourceJenkinsContext.json
+          echo "Source context:" && cat sourceJenkinsContext.json
+
+          # Write migration context (with stage and VPC substitution)
+          echo '{{workflow.parameters.migration-context}}' | \
+            sed "s/<STAGE>/${STAGE}/g" > migrationJenkinsContext.json
+          echo "Migration context:" && cat migrationJenkinsContext.json
+
+    # ================================================================
+    # GRADLE BUILD — replaces Jenkins 'Build' stage
+    # ================================================================
+    - name: gradle-build
+      inputs:
+        artifacts:
+          - name: source
+            path: /workspace
+      outputs:
+        artifacts:
+          - name: source
+            path: /workspace
+      container:
+        image: gradle:8-jdk17
+        workingDir: /workspace
+        command: [bash, -c]
+        args:
+          - |
+            ./gradlew clean build --no-daemon --stacktrace 2>&1 | tail -100
+        resources:
+          requests:
+            cpu: "2"
+            memory: "4Gi"
+        activeDeadlineSeconds: 3600  # 1 hour
+
+    # ================================================================
+    # DEPLOY CDK STACK — replaces Jenkins 'Deploy' stage
+    # Runs awsE2ESolutionSetup.sh with cross-account role assumption
+    # ================================================================
+    - name: deploy-cdk-stack
+      inputs:
+        artifacts:
+          - name: source
+            path: /workspace
+      outputs:
+        artifacts:
+          - name: source
+            path: /workspace
+      container:
+        image: ci-runner:latest
+        workingDir: /workspace/test
+        command: [bash, -c]
+        args:
+          - |
+            set -euo pipefail
+
+            # Assume cross-account role
+            CREDS=$(aws sts assume-role \
+              --role-arn "arn:aws:iam::${TEST_ACCOUNT_ID}:role/ArgoTestDeploymentRole" \
+              --role-session-name "argo-deploy" \
+              --duration-seconds 5400)
+            export AWS_ACCESS_KEY_ID=$(echo $CREDS | jq -r .Credentials.AccessKeyId)
+            export AWS_SECRET_ACCESS_KEY=$(echo $CREDS | jq -r .Credentials.SecretAccessKey)
+            export AWS_SESSION_TOKEN=$(echo $CREDS | jq -r .Credentials.SessionToken)
+
+            SKIP_PROXY_ARG=""
+            if [ "{{workflow.parameters.skip-capture-proxy}}" = "true" ]; then
+              SKIP_PROXY_ARG="--skip-capture-proxy"
+            fi
+
+            ./awsE2ESolutionSetup.sh \
+              --source-context-file './sourceJenkinsContext.json' \
+              --migration-context-file './migrationJenkinsContext.json' \
+              --source-context-id '{{workflow.parameters.source-context-id}}' \
+              --migration-context-id '{{workflow.parameters.migration-context-id}}' \
+              --stage '{{workflow.parameters.stage}}' \
+              --migrations-git-url '{{workflow.parameters.repo-url}}' \
+              --migrations-git-branch '{{workflow.parameters.branch}}' \
+              $SKIP_PROXY_ARG
+        env:
+          - name: TEST_ACCOUNT_ID
+            valueFrom:
+              secretKeyRef:
+                name: migrations-test-account-id
+                key: account-id
+        resources:
+          requests:
+            cpu: "1"
+            memory: "2Gi"
+        activeDeadlineSeconds: 5400  # 90 min (matches Jenkins)
+
+    # ================================================================
+    # RUN INTEG TESTS — replaces Jenkins 'Integ Tests' stage
+    # Runs pytest via awsRunIntegTests.sh with cross-account role
+    # ================================================================
+    - name: run-integ-tests
+      inputs:
+        artifacts:
+          - name: source
+            path: /workspace
+      outputs:
+        artifacts:
+          - name: test-results
+            path: /workspace/test/reports/
+            optional: true
+            archive:
+              none: {}
+            s3:
+              key: "{{workflow.name}}/test-results/"
+      container:
+        image: ci-runner:latest
+        workingDir: /workspace/test
+        command: [bash, -c]
+        args:
+          - |
+            set -euo pipefail
+
+            # Assume cross-account role
+            CREDS=$(aws sts assume-role \
+              --role-arn "arn:aws:iam::${TEST_ACCOUNT_ID}:role/ArgoTestDeploymentRole" \
+              --role-session-name "argo-test" \
+              --duration-seconds 3600)
+            export AWS_ACCESS_KEY_ID=$(echo $CREDS | jq -r .Credentials.AccessKeyId)
+            export AWS_SECRET_ACCESS_KEY=$(echo $CREDS | jq -r .Credentials.SecretAccessKey)
+            export AWS_SESSION_TOKEN=$(echo $CREDS | jq -r .Credentials.SessionToken)
+
+            # Generate unique ID
+            UNIQUE_ID="{{workflow.parameters.test-unique-id}}"
+            if [ -z "$UNIQUE_ID" ]; then
+              UNIQUE_ID="integ_full_$(date +%s)_argo"
+            fi
+
+            TEST_DIR="/root/lib/integ_test/integ_test"
+            RESULT_FILE="${TEST_DIR}/reports/${UNIQUE_ID}/report.xml"
+            INTEG_CMD=$(echo '{{workflow.parameters.integ-test-command}}' | \
+              sed "s/<STAGE>/{{workflow.parameters.stage}}/g")
+
+            COMMAND="pipenv run pytest --log-file=${TEST_DIR}/reports/${UNIQUE_ID}/pytest.log \
+              --junitxml=${RESULT_FILE} ${INTEG_CMD} \
+              --unique_id ${UNIQUE_ID} \
+              --stage {{workflow.parameters.stage}} -s"
+
+            ./awsRunIntegTests.sh \
+              --command "${COMMAND}" \
+              --test-result-file "${RESULT_FILE}" \
+              --stage "{{workflow.parameters.stage}}"
+
+            # Copy results to output path
+            mkdir -p /workspace/test/reports/
+            cp -r ${TEST_DIR}/reports/ /workspace/test/reports/ 2>/dev/null || true
+        env:
+          - name: TEST_ACCOUNT_ID
+            valueFrom:
+              secretKeyRef:
+                name: migrations-test-account-id
+                key: account-id
+        resources:
+          requests:
+            cpu: "1"
+            memory: "2Gi"
+        activeDeadlineSeconds: 3600  # 1 hour
+
+    # ================================================================
+    # CLEANUP HANDLER — replaces Jenkins post { always } block
+    # Destroys CDK stacks in correct order, uploads results, notifies
+    # ================================================================
+    - name: cleanup-handler
+      dag:
+        tasks:
+          - name: destroy-migration-stack
+            template: destroy-cdk-stacks
+          - name: upload-results
+            templateRef:
+              name: reportportal-upload
+              template: upload-junit
+            arguments:
+              parameters:
+                - name: launch-name
+                  value: "integ-{{workflow.parameters.stage}}"
+          - name: notify-github
+            depends: destroy-migration-stack
+            templateRef:
+              name: common-ci-steps
+              template: notify-github-status
+            arguments:
+              parameters:
+                - name: sha
+                  value: ""
+                - name: context
+                  value: "argo/{{workflow.parameters.stage}}"
+
+    - name: destroy-cdk-stacks
+      retryStrategy:
+        limit: 2
+        retryPolicy: Always
+        backoff:
+          duration: "30s"
+          factor: 2
+      container:
+        image: ci-runner:latest
+        workingDir: /workspace/test
+        command: [bash, -c]
+        args:
+          - |
+            set +e
+            STAGE="{{workflow.parameters.stage}}"
+
+            CREDS=$(aws sts assume-role \
+              --role-arn "arn:aws:iam::${TEST_ACCOUNT_ID}:role/ArgoTestDeploymentRole" \
+              --role-session-name "argo-cleanup" --duration-seconds 5400)
+            export AWS_ACCESS_KEY_ID=$(echo $CREDS | jq -r .Credentials.AccessKeyId)
+            export AWS_SECRET_ACCESS_KEY=$(echo $CREDS | jq -r .Credentials.SecretAccessKey)
+            export AWS_SESSION_TOKEN=$(echo $CREDS | jq -r .Credentials.SessionToken)
+
+            echo "=== Destroying CDK stacks for stage: ${STAGE} ==="
+
+            # 1. Destroy migration stack first (depends on domain stacks)
+            echo "Destroying migration stack..."
+            cd /workspace/test 2>/dev/null && \
+              npx cdk destroy --force \
+                --context stage="${STAGE}" \
+                --context contextId="{{workflow.parameters.migration-context-id}}" \
+                2>&1 | tail -20 || true
+
+            # 2. Destroy source cluster stack
+            echo "Destroying source cluster stack..."
+            npx cdk destroy --force \
+              --context stage="${STAGE}" \
+              --context contextId="{{workflow.parameters.source-context-id}}" \
+              2>&1 | tail -20 || true
+
+            # 3. Fallback: delete stacks by name pattern if CDK destroy fails
+            for STACK in $(aws cloudformation list-stacks \
+              --stack-status-filter CREATE_COMPLETE UPDATE_COMPLETE \
+              --query "StackSummaries[?contains(StackName,'${STAGE}')].StackName" \
+              --output text 2>/dev/null); do
+              echo "Deleting remaining stack: ${STACK}"
+              aws cloudformation delete-stack --stack-name "${STACK}" || true
+            done
+
+            # 4. Wait for all stacks to be deleted
+            for STACK in $(aws cloudformation list-stacks \
+              --stack-status-filter DELETE_IN_PROGRESS \
+              --query "StackSummaries[?contains(StackName,'${STAGE}')].StackName" \
+              --output text 2>/dev/null); do
+              echo "Waiting for ${STACK} deletion..."
+              aws cloudformation wait stack-delete-complete --stack-name "${STACK}" || true
+            done
+
+            echo "=== CDK cleanup complete ==="
+        env:
+          - name: TEST_ACCOUNT_ID
+            valueFrom:
+              secretKeyRef:
+                name: migrations-test-account-id
+                key: account-id
+        activeDeadlineSeconds: 3600  # 1 hour for cleanup

--- a/argo/workflows/aws-integ/eks-byos-integ-pipeline.yaml
+++ b/argo/workflows/aws-integ/eks-byos-integ-pipeline.yaml
@@ -1,0 +1,278 @@
+# Replaces: vars/eksBYOSIntegPipeline.groovy
+# Bring-Your-Own-Snapshot migration test (S3 snapshot → AOS target via EKS)
+# Similar to eks-integ but source is an S3 snapshot, not a live cluster
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: eks-byos-integ-pipeline
+  namespace: ma
+  labels:
+    app: ci-pipeline
+    replaces: eksBYOSIntegPipeline.groovy
+spec:
+  entrypoint: main
+  onExit: cleanup-handler
+  serviceAccountName: ci-deployment-sa
+  arguments:
+    parameters:
+      - name: repo-url
+        value: "https://github.com/opensearch-project/opensearch-migrations.git"
+      - name: branch
+        value: "main"
+      - name: stage
+        value: "eks-byos"
+      - name: source-version
+        value: "ES_7.10"
+      - name: target-version
+        value: "OS_2.19"
+      - name: region
+        value: "us-east-1"
+      - name: snapshot-s3-uri
+        value: ""  # S3 URI of the snapshot to restore from
+  activeDeadlineSeconds: 10800  # 3 hours
+
+  synchronization:
+    semaphores:
+      - configMapKeyRef:
+          name: ci-stage-locks
+          key: eks-integ
+
+  templates:
+    - name: main
+      dag:
+        tasks:
+          - name: checkout
+            templateRef:
+              name: common-ci-steps
+              template: git-checkout
+            arguments:
+              parameters:
+                - name: repo-url
+                  value: "{{workflow.parameters.repo-url}}"
+                - name: branch
+                  value: "{{workflow.parameters.branch}}"
+
+          - name: build
+            depends: checkout
+            templateRef:
+              name: default-integ-pipeline
+              template: gradle-build
+            arguments:
+              artifacts:
+                - name: source
+                  from: "{{tasks.checkout.outputs.artifacts.source}}"
+
+          - name: deploy-target-cluster
+            depends: build
+            template: deploy-target-cluster
+            arguments:
+              artifacts:
+                - name: source
+                  from: "{{tasks.build.outputs.artifacts.source}}"
+
+          - name: deploy-ma-on-eks
+            depends: deploy-target-cluster
+            template: deploy-ma-on-eks
+            arguments:
+              artifacts:
+                - name: source
+                  from: "{{tasks.deploy-target-cluster.outputs.artifacts.source}}"
+
+          - name: run-tests
+            depends: deploy-ma-on-eks
+            template: run-byos-tests
+            arguments:
+              artifacts:
+                - name: source
+                  from: "{{tasks.deploy-ma-on-eks.outputs.artifacts.source}}"
+
+    # ================================================================
+    # DEPLOY TARGET CLUSTER — only target AOS domain (no source, using snapshot)
+    # ================================================================
+    - name: deploy-target-cluster
+      inputs:
+        artifacts:
+          - name: source
+            path: /workspace
+      outputs:
+        artifacts:
+          - name: source
+            path: /workspace
+      container:
+        image: ci-runner:latest
+        workingDir: /workspace/test
+        command: [bash, -c]
+        args:
+          - |
+            set -euo pipefail
+            CREDS=$(aws sts assume-role \
+              --role-arn "arn:aws:iam::${TEST_ACCOUNT_ID}:role/ArgoTestDeploymentRole" \
+              --role-session-name "argo-deploy-target" --duration-seconds 3600)
+            export AWS_ACCESS_KEY_ID=$(echo $CREDS | jq -r .Credentials.AccessKeyId)
+            export AWS_SECRET_ACCESS_KEY=$(echo $CREDS | jq -r .Credentials.SecretAccessKey)
+            export AWS_SESSION_TOKEN=$(echo $CREDS | jq -r .Credentials.SessionToken)
+
+            # Deploy only target cluster (BYOS = no source cluster needed)
+            python3 deployClusters.py \
+              --stage "{{workflow.parameters.stage}}" \
+              --target-version "{{workflow.parameters.target-version}}" \
+              --target-cluster-type "OPENSEARCH_MANAGED_SERVICE" \
+              --skip-source \
+              --output-file /workspace/test/cluster-context.json
+        env:
+          - name: TEST_ACCOUNT_ID
+            valueFrom:
+              secretKeyRef:
+                name: migrations-test-account-id
+                key: account-id
+        activeDeadlineSeconds: 3600
+
+    # ================================================================
+    # DEPLOY MA ON EKS — aws-bootstrap.sh with BYOS configuration
+    # ================================================================
+    - name: deploy-ma-on-eks
+      inputs:
+        artifacts:
+          - name: source
+            path: /workspace
+      outputs:
+        artifacts:
+          - name: source
+            path: /workspace
+      container:
+        image: ci-runner:latest
+        workingDir: /workspace
+        command: [bash, -c]
+        args:
+          - |
+            set -euo pipefail
+            STAGE="{{workflow.parameters.stage}}"
+            REGION="{{workflow.parameters.region}}"
+            STACK_NAME="Migration-Assistant-Infra-Import-VPC-eks-${STAGE}-${REGION}"
+
+            CREDS=$(aws sts assume-role \
+              --role-arn "arn:aws:iam::${TEST_ACCOUNT_ID}:role/ArgoTestDeploymentRole" \
+              --role-session-name "argo-deploy-eks-byos" --duration-seconds 5400)
+            export AWS_ACCESS_KEY_ID=$(echo $CREDS | jq -r .Credentials.AccessKeyId)
+            export AWS_SECRET_ACCESS_KEY=$(echo $CREDS | jq -r .Credentials.SecretAccessKey)
+            export AWS_SESSION_TOKEN=$(echo $CREDS | jq -r .Credentials.SessionToken)
+
+            CLUSTER_DETAILS=$(cat /workspace/test/cluster-context.json)
+            VPC_ID=$(echo "$CLUSTER_DETAILS" | jq -r '.target.vpcId')
+            SUBNET_IDS=$(echo "$CLUSTER_DETAILS" | jq -r '.target.subnetIds')
+
+            ./deployment/k8s/aws/aws-bootstrap.sh \
+              --deploy-import-vpc-cfn \
+              --build-cfn \
+              --stack-name "${STACK_NAME}" \
+              --vpc-id "${VPC_ID}" \
+              --subnet-ids "${SUBNET_IDS}" \
+              --stage "${STAGE}" \
+              --eks-access-principal-arn "arn:aws:iam::${TEST_ACCOUNT_ID}:role/ArgoTestDeploymentRole" \
+              --build-images \
+              --build-chart-and-dashboards \
+              --base-dir "$(pwd)" \
+              --skip-console-exec \
+              --region "${REGION}" \
+              2>&1 | while IFS= read -r line; do printf '%s | %s\n' "$(date '+%H:%M:%S')" "$line"; done
+        env:
+          - name: TEST_ACCOUNT_ID
+            valueFrom:
+              secretKeyRef:
+                name: migrations-test-account-id
+                key: account-id
+        resources:
+          requests:
+            cpu: "2"
+            memory: "4Gi"
+        activeDeadlineSeconds: 9000
+
+    # ================================================================
+    # RUN BYOS TESTS — RFS backfill from S3 snapshot
+    # ================================================================
+    - name: run-byos-tests
+      inputs:
+        artifacts:
+          - name: source
+            path: /workspace
+      outputs:
+        artifacts:
+          - name: test-results
+            path: /workspace/libraries/testAutomation/reports/
+            optional: true
+            archive:
+              none: {}
+            s3:
+              key: "{{workflow.name}}/test-results/"
+      container:
+        image: ci-runner:latest
+        workingDir: /workspace/libraries/testAutomation
+        command: [bash, -c]
+        args:
+          - |
+            set -euo pipefail
+            CREDS=$(aws sts assume-role \
+              --role-arn "arn:aws:iam::${TEST_ACCOUNT_ID}:role/ArgoTestDeploymentRole" \
+              --role-session-name "argo-byos-test" --duration-seconds 3600)
+            export AWS_ACCESS_KEY_ID=$(echo $CREDS | jq -r .Credentials.AccessKeyId)
+            export AWS_SECRET_ACCESS_KEY=$(echo $CREDS | jq -r .Credentials.SecretAccessKey)
+            export AWS_SESSION_TOKEN=$(echo $CREDS | jq -r .Credentials.SessionToken)
+
+            pipenv install --deploy
+            pipenv run app \
+              --source-version={{workflow.parameters.source-version}} \
+              --target-version={{workflow.parameters.target-version}} \
+              --reuse-clusters --skip-delete --skip-install \
+              --test-ids="backfill"
+        env:
+          - name: TEST_ACCOUNT_ID
+            valueFrom:
+              secretKeyRef:
+                name: migrations-test-account-id
+                key: account-id
+        activeDeadlineSeconds: 7200
+
+    # ================================================================
+    # CLEANUP HANDLER — ordered CFN stack deletion (same as eks-integ)
+    # ================================================================
+    - name: cleanup-handler
+      dag:
+        tasks:
+          - name: delete-ma-stack
+            templateRef:
+              name: eks-integ-pipeline
+              template: delete-cfn-stack
+            arguments:
+              parameters:
+                - name: stack-name
+                  value: "Migration-Assistant-Infra-Import-VPC-eks-{{workflow.parameters.stage}}-{{workflow.parameters.region}}"
+          - name: delete-target-domain
+            depends: delete-ma-stack
+            templateRef:
+              name: eks-integ-pipeline
+              template: delete-cfn-stack
+            arguments:
+              parameters:
+                - name: stack-name
+                  value: "OpenSearchDomain-target-{{workflow.parameters.stage}}-{{workflow.parameters.region}}"
+          - name: delete-network-stack
+            depends: delete-target-domain
+            templateRef:
+              name: eks-integ-pipeline
+              template: delete-cfn-stack
+            arguments:
+              parameters:
+                - name: stack-name
+                  value: "NetworkInfra-{{workflow.parameters.stage}}-{{workflow.parameters.region}}"
+          - name: upload-results
+            templateRef:
+              name: reportportal-upload
+              template: upload-junit
+            arguments:
+              parameters:
+                - name: launch-name
+                  value: "eks-byos-integ"
+                - name: source-version
+                  value: "{{workflow.parameters.source-version}}"
+                - name: target-version
+                  value: "{{workflow.parameters.target-version}}"

--- a/argo/workflows/aws-integ/eks-integ-pipeline.yaml
+++ b/argo/workflows/aws-integ/eks-integ-pipeline.yaml
@@ -1,0 +1,457 @@
+# Replaces: vars/eksIntegPipeline.groovy
+# EKS-based integration test: AOS source → AOS target via EKS/k8s
+# Deploys clusters, EKS infra via aws-bootstrap.sh, runs tests, ordered cleanup
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: eks-integ-pipeline
+  namespace: ma
+  labels:
+    app: ci-pipeline
+    replaces: eksIntegPipeline.groovy
+spec:
+  entrypoint: main
+  onExit: cleanup-handler
+  serviceAccountName: ci-deployment-sa
+  arguments:
+    parameters:
+      - name: repo-url
+        value: "https://github.com/opensearch-project/opensearch-migrations.git"
+      - name: branch
+        value: "main"
+      - name: stage
+        value: "eks-integ"
+      - name: source-version
+        value: "ES_7.10"
+      - name: target-version
+        value: "OS_2.19"
+      - name: source-cluster-type
+        value: "OPENSEARCH_MANAGED_SERVICE"
+      - name: target-cluster-type
+        value: "OPENSEARCH_MANAGED_SERVICE"
+      - name: test-ids
+        value: "all"
+      - name: region
+        value: "us-east-1"
+  activeDeadlineSeconds: 10800  # 3 hours
+
+  synchronization:
+    semaphores:
+      - configMapKeyRef:
+          name: ci-stage-locks
+          key: eks-integ
+
+  templates:
+    - name: main
+      dag:
+        tasks:
+          - name: checkout
+            templateRef:
+              name: common-ci-steps
+              template: git-checkout
+            arguments:
+              parameters:
+                - name: repo-url
+                  value: "{{workflow.parameters.repo-url}}"
+                - name: branch
+                  value: "{{workflow.parameters.branch}}"
+
+          - name: build
+            depends: checkout
+            templateRef:
+              name: default-integ-pipeline
+              template: gradle-build
+            arguments:
+              artifacts:
+                - name: source
+                  from: "{{tasks.checkout.outputs.artifacts.source}}"
+
+          - name: deploy-clusters
+            depends: build
+            template: deploy-clusters
+            arguments:
+              artifacts:
+                - name: source
+                  from: "{{tasks.build.outputs.artifacts.source}}"
+
+          - name: deploy-ma-on-eks
+            depends: deploy-clusters
+            template: deploy-ma-on-eks
+            arguments:
+              artifacts:
+                - name: source
+                  from: "{{tasks.deploy-clusters.outputs.artifacts.source}}"
+
+          - name: post-cluster-setup
+            depends: deploy-ma-on-eks
+            template: post-cluster-setup
+
+          - name: run-tests
+            depends: post-cluster-setup
+            template: run-eks-tests
+            arguments:
+              artifacts:
+                - name: source
+                  from: "{{tasks.deploy-ma-on-eks.outputs.artifacts.source}}"
+
+    # ================================================================
+    # DEPLOY CLUSTERS — creates AOS source + target domains via deployClustersStep
+    # ================================================================
+    - name: deploy-clusters
+      inputs:
+        artifacts:
+          - name: source
+            path: /workspace
+      outputs:
+        artifacts:
+          - name: source
+            path: /workspace
+      container:
+        image: ci-runner:latest
+        workingDir: /workspace/test
+        command: [bash, -c]
+        args:
+          - |
+            set -euo pipefail
+            CREDS=$(aws sts assume-role \
+              --role-arn "arn:aws:iam::${TEST_ACCOUNT_ID}:role/ArgoTestDeploymentRole" \
+              --role-session-name "argo-deploy-clusters" --duration-seconds 3600)
+            export AWS_ACCESS_KEY_ID=$(echo $CREDS | jq -r .Credentials.AccessKeyId)
+            export AWS_SECRET_ACCESS_KEY=$(echo $CREDS | jq -r .Credentials.SecretAccessKey)
+            export AWS_SESSION_TOKEN=$(echo $CREDS | jq -r .Credentials.SessionToken)
+
+            # Deploy source and target AOS domains
+            python3 deployClusters.py \
+              --stage "{{workflow.parameters.stage}}" \
+              --source-version "{{workflow.parameters.source-version}}" \
+              --source-cluster-type "{{workflow.parameters.source-cluster-type}}" \
+              --target-version "{{workflow.parameters.target-version}}" \
+              --target-cluster-type "{{workflow.parameters.target-cluster-type}}" \
+              --output-file /tmp/cluster-context.json
+
+            # Save cluster context for later stages
+            cp /tmp/cluster-context.json /workspace/test/cluster-context.json
+        env:
+          - name: TEST_ACCOUNT_ID
+            valueFrom:
+              secretKeyRef:
+                name: migrations-test-account-id
+                key: account-id
+        activeDeadlineSeconds: 3600  # 60 min
+
+    # ================================================================
+    # DEPLOY MA ON EKS — runs aws-bootstrap.sh to create EKS infra + helm install
+    # ================================================================
+    - name: deploy-ma-on-eks
+      inputs:
+        artifacts:
+          - name: source
+            path: /workspace
+      outputs:
+        artifacts:
+          - name: source
+            path: /workspace
+      container:
+        image: ci-runner:latest
+        workingDir: /workspace
+        command: [bash, -c]
+        args:
+          - |
+            set -euo pipefail
+            STAGE="{{workflow.parameters.stage}}"
+            REGION="{{workflow.parameters.region}}"
+            STACK_NAME="Migration-Assistant-Infra-Import-VPC-eks-${STAGE}-${REGION}"
+
+            CREDS=$(aws sts assume-role \
+              --role-arn "arn:aws:iam::${TEST_ACCOUNT_ID}:role/ArgoTestDeploymentRole" \
+              --role-session-name "argo-deploy-eks" --duration-seconds 3600)
+            export AWS_ACCESS_KEY_ID=$(echo $CREDS | jq -r .Credentials.AccessKeyId)
+            export AWS_SECRET_ACCESS_KEY=$(echo $CREDS | jq -r .Credentials.SecretAccessKey)
+            export AWS_SESSION_TOKEN=$(echo $CREDS | jq -r .Credentials.SessionToken)
+
+            # Read cluster context
+            CLUSTER_DETAILS=$(cat /workspace/test/cluster-context.json)
+            VPC_ID=$(echo "$CLUSTER_DETAILS" | jq -r '.target.vpcId')
+            SUBNET_IDS=$(echo "$CLUSTER_DETAILS" | jq -r '.target.subnetIds')
+
+            # Deploy EKS + MA via aws-bootstrap.sh
+            ./deployment/k8s/aws/aws-bootstrap.sh \
+              --deploy-import-vpc-cfn \
+              --build-cfn \
+              --stack-name "${STACK_NAME}" \
+              --vpc-id "${VPC_ID}" \
+              --subnet-ids "${SUBNET_IDS}" \
+              --stage "${STAGE}" \
+              --eks-access-principal-arn "arn:aws:iam::${TEST_ACCOUNT_ID}:role/ArgoTestDeploymentRole" \
+              --build-images \
+              --build-chart-and-dashboards \
+              --base-dir "$(pwd)" \
+              --skip-console-exec \
+              --region "${REGION}" \
+              2>&1 | while IFS= read -r line; do printf '%s | %s\n' "$(date '+%H:%M:%S')" "$line"; done
+
+            # Capture exports for cleanup
+            RAW_OUTPUT=$(aws cloudformation describe-stacks \
+              --stack-name "${STACK_NAME}" \
+              --query "Stacks[0].Outputs[?OutputKey=='MigrationsExportString'].OutputValue" \
+              --output text)
+            echo "${RAW_OUTPUT}" > /workspace/test/cfn-exports.txt
+        env:
+          - name: TEST_ACCOUNT_ID
+            valueFrom:
+              secretKeyRef:
+                name: migrations-test-account-id
+                key: account-id
+        resources:
+          requests:
+            cpu: "2"
+            memory: "4Gi"
+        activeDeadlineSeconds: 9000  # 150 min
+
+    # ================================================================
+    # POST-CLUSTER SETUP — create configmaps, modify security groups
+    # Reads cluster-context.json from deploy-clusters and:
+    #   1. Creates source/target cluster configmaps for testAutomation
+    #   2. Adds SG ingress rules so EKS pods can reach AOS domains
+    #   3. Updates kubeconfig for the EKS cluster
+    # ================================================================
+    - name: post-cluster-setup
+      container:
+        image: ci-runner:latest
+        command: [bash, -c]
+        args:
+          - |
+            set -euo pipefail
+            STAGE="{{workflow.parameters.stage}}"
+            REGION="{{workflow.parameters.region}}"
+
+            CREDS=$(aws sts assume-role \
+              --role-arn "arn:aws:iam::${TEST_ACCOUNT_ID}:role/ArgoTestDeploymentRole" \
+              --role-session-name "argo-post-setup" --duration-seconds 3600)
+            export AWS_ACCESS_KEY_ID=$(echo $CREDS | jq -r .Credentials.AccessKeyId)
+            export AWS_SECRET_ACCESS_KEY=$(echo $CREDS | jq -r .Credentials.SecretAccessKey)
+            export AWS_SESSION_TOKEN=$(echo $CREDS | jq -r .Credentials.SessionToken)
+
+            CLUSTER_DETAILS=$(cat /workspace/test/cluster-context.json)
+
+            # 1. Update kubeconfig for the EKS cluster
+            EKS_CLUSTER_NAME="migration-${STAGE}"
+            echo "Updating kubeconfig for ${EKS_CLUSTER_NAME}..."
+            aws eks update-kubeconfig --name "${EKS_CLUSTER_NAME}" --region "${REGION}"
+
+            # 2. Get security group IDs for EKS node group and AOS domains
+            EKS_SG=$(aws eks describe-cluster --name "${EKS_CLUSTER_NAME}" \
+              --query "cluster.resourcesVpcConfig.clusterSecurityGroupId" --output text)
+            SOURCE_SG=$(echo "$CLUSTER_DETAILS" | jq -r '.source.securityGroupId // empty')
+            TARGET_SG=$(echo "$CLUSTER_DETAILS" | jq -r '.target.securityGroupId // empty')
+
+            # 3. Add SG ingress rules: allow EKS → AOS on port 443
+            for SG in ${SOURCE_SG} ${TARGET_SG}; do
+              if [ -n "${SG}" ]; then
+                echo "Adding ingress rule: ${SG} ← ${EKS_SG} (port 443)"
+                aws ec2 authorize-security-group-ingress \
+                  --group-id "${SG}" \
+                  --protocol tcp --port 443 \
+                  --source-group "${EKS_SG}" \
+                  --region "${REGION}" 2>/dev/null || echo "  (rule may already exist)"
+              fi
+            done
+
+            # 4. Create source/target configmaps for testAutomation
+            SOURCE_ENDPOINT=$(echo "$CLUSTER_DETAILS" | jq -r '.source.endpoint // empty')
+            TARGET_ENDPOINT=$(echo "$CLUSTER_DETAILS" | jq -r '.target.endpoint // empty')
+
+            if [ -n "${SOURCE_ENDPOINT}" ]; then
+              kubectl create configmap source-cluster-config -n ma \
+                --from-literal=endpoint="${SOURCE_ENDPOINT}" \
+                --from-literal=version="{{workflow.parameters.source-version}}" \
+                --from-literal=auth-type="none" \
+                --dry-run=client -o yaml | kubectl apply -f -
+            fi
+
+            if [ -n "${TARGET_ENDPOINT}" ]; then
+              kubectl create configmap target-cluster-config -n ma \
+                --from-literal=endpoint="${TARGET_ENDPOINT}" \
+                --from-literal=version="{{workflow.parameters.target-version}}" \
+                --from-literal=auth-type="none" \
+                --dry-run=client -o yaml | kubectl apply -f -
+            fi
+
+            # 5. Wait for MA pods to be ready
+            echo "Waiting for MA pods to be ready..."
+            kubectl wait --for=condition=ready pod -l app=migration-console -n ma --timeout=300s || true
+
+            echo "Post-cluster setup complete"
+        env:
+          - name: TEST_ACCOUNT_ID
+            valueFrom:
+              secretKeyRef:
+                name: migrations-test-account-id
+                key: account-id
+        activeDeadlineSeconds: 900  # 15 min
+
+    # ================================================================
+    # RUN EKS TESTS — runs pytest via testAutomation framework
+    # ================================================================
+    - name: run-eks-tests
+      inputs:
+        artifacts:
+          - name: source
+            path: /workspace
+      outputs:
+        artifacts:
+          - name: test-results
+            path: /workspace/libraries/testAutomation/reports/
+            optional: true
+            archive:
+              none: {}
+            s3:
+              key: "{{workflow.name}}/test-results/"
+      container:
+        image: ci-runner:latest
+        workingDir: /workspace/libraries/testAutomation
+        command: [bash, -c]
+        args:
+          - |
+            set -euo pipefail
+            CREDS=$(aws sts assume-role \
+              --role-arn "arn:aws:iam::${TEST_ACCOUNT_ID}:role/ArgoTestDeploymentRole" \
+              --role-session-name "argo-eks-test" --duration-seconds 3600)
+            export AWS_ACCESS_KEY_ID=$(echo $CREDS | jq -r .Credentials.AccessKeyId)
+            export AWS_SECRET_ACCESS_KEY=$(echo $CREDS | jq -r .Credentials.SecretAccessKey)
+            export AWS_SESSION_TOKEN=$(echo $CREDS | jq -r .Credentials.SessionToken)
+
+            TEST_IDS_ARG=""
+            if [ "{{workflow.parameters.test-ids}}" != "all" ]; then
+              TEST_IDS_ARG="--test-ids='{{workflow.parameters.test-ids}}'"
+            fi
+
+            pipenv install --deploy
+            pipenv run app \
+              --source-version={{workflow.parameters.source-version}} \
+              --target-version={{workflow.parameters.target-version}} \
+              ${TEST_IDS_ARG} \
+              --reuse-clusters --skip-delete --skip-install
+        env:
+          - name: TEST_ACCOUNT_ID
+            valueFrom:
+              secretKeyRef:
+                name: migrations-test-account-id
+                key: account-id
+        activeDeadlineSeconds: 7200  # 2 hours
+
+    # ================================================================
+    # CLEANUP HANDLER — ordered CFN stack deletion
+    # Order: MA stack → domain stacks → network stack (VPC dependencies)
+    # ================================================================
+    - name: cleanup-handler
+      dag:
+        tasks:
+          - name: eks-cleanup
+            template: eks-cleanup
+          - name: delete-ma-stack
+            depends: eks-cleanup
+            template: delete-cfn-stack
+            arguments:
+              parameters:
+                - name: stack-name
+                  value: "Migration-Assistant-Infra-Import-VPC-eks-{{workflow.parameters.stage}}-{{workflow.parameters.region}}"
+          - name: delete-source-domain
+            depends: delete-ma-stack
+            template: delete-cfn-stack
+            arguments:
+              parameters:
+                - name: stack-name
+                  value: "OpenSearchDomain-source-{{workflow.parameters.stage}}-{{workflow.parameters.region}}"
+          - name: delete-target-domain
+            depends: delete-ma-stack
+            template: delete-cfn-stack
+            arguments:
+              parameters:
+                - name: stack-name
+                  value: "OpenSearchDomain-target-{{workflow.parameters.stage}}-{{workflow.parameters.region}}"
+          - name: delete-network-stack
+            depends: "delete-source-domain && delete-target-domain"
+            template: delete-cfn-stack
+            arguments:
+              parameters:
+                - name: stack-name
+                  value: "NetworkInfra-{{workflow.parameters.stage}}-{{workflow.parameters.region}}"
+          - name: upload-results
+            templateRef:
+              name: reportportal-upload
+              template: upload-junit
+            arguments:
+              parameters:
+                - name: launch-name
+                  value: "eks-integ"
+                - name: source-version
+                  value: "{{workflow.parameters.source-version}}"
+                - name: target-version
+                  value: "{{workflow.parameters.target-version}}"
+
+    # EKS-specific cleanup: helm uninstall, revoke SG rules
+    - name: eks-cleanup
+      container:
+        image: ci-runner:latest
+        command: [bash, -c]
+        args:
+          - |
+            set +e
+            CREDS=$(aws sts assume-role \
+              --role-arn "arn:aws:iam::${TEST_ACCOUNT_ID}:role/ArgoTestDeploymentRole" \
+              --role-session-name "argo-cleanup" --duration-seconds 4500)
+            export AWS_ACCESS_KEY_ID=$(echo $CREDS | jq -r .Credentials.AccessKeyId)
+            export AWS_SECRET_ACCESS_KEY=$(echo $CREDS | jq -r .Credentials.SecretAccessKey)
+            export AWS_SESSION_TOKEN=$(echo $CREDS | jq -r .Credentials.SessionToken)
+
+            # Helm uninstall + namespace cleanup
+            kubectl -n ma get pods || true
+            cd /workspace/libraries/testAutomation 2>/dev/null && pipenv install --deploy && pipenv run app --delete-only || true
+            kubectl delete namespace ma --ignore-not-found --timeout=60s || true
+            echo "EKS cleanup complete"
+        env:
+          - name: TEST_ACCOUNT_ID
+            valueFrom:
+              secretKeyRef:
+                name: migrations-test-account-id
+                key: account-id
+        activeDeadlineSeconds: 1800  # 30 min
+
+    # Generic CFN stack deletion with retry
+    - name: delete-cfn-stack
+      inputs:
+        parameters:
+          - name: stack-name
+      retryStrategy:
+        limit: 3
+        retryPolicy: Always
+        backoff:
+          duration: "30s"
+          factor: 2
+          maxDuration: "5m"
+      container:
+        image: amazon/aws-cli:2.15.0
+        command: [bash, -c]
+        args:
+          - |
+            set +e
+            CREDS=$(aws sts assume-role \
+              --role-arn "arn:aws:iam::${TEST_ACCOUNT_ID}:role/ArgoTestDeploymentRole" \
+              --role-session-name "argo-cfn-delete" --duration-seconds 3600)
+            export AWS_ACCESS_KEY_ID=$(echo $CREDS | jq -r .Credentials.AccessKeyId)
+            export AWS_SECRET_ACCESS_KEY=$(echo $CREDS | jq -r .Credentials.SecretAccessKey)
+            export AWS_SESSION_TOKEN=$(echo $CREDS | jq -r .Credentials.SessionToken)
+
+            STACK="{{inputs.parameters.stack-name}}"
+            echo "Deleting CFN stack: ${STACK}"
+            aws cloudformation delete-stack --stack-name "${STACK}" --region "{{workflow.parameters.region}}" || true
+            aws cloudformation wait stack-delete-complete --stack-name "${STACK}" --region "{{workflow.parameters.region}}" || true
+            echo "Stack ${STACK} deleted"
+        env:
+          - name: TEST_ACCOUNT_ID
+            valueFrom:
+              secretKeyRef:
+                name: migrations-test-account-id
+                key: account-id
+        activeDeadlineSeconds: 1800  # 30 min per stack

--- a/argo/workflows/aws-integ/eks-isolated-deploy.yaml
+++ b/argo/workflows/aws-integ/eks-isolated-deploy.yaml
@@ -1,0 +1,275 @@
+# Replaces: vars/eksIsolatedDeploy.groovy
+# Isolated network (no internet) EKS deployment test
+# Builds EKS cluster + isolated EKS with VPC endpoints, validates connectivity
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: eks-isolated-deploy
+  namespace: ma
+  labels:
+    app: ci-pipeline
+    replaces: eksIsolatedDeploy.groovy
+spec:
+  entrypoint: main
+  onExit: cleanup-handler
+  serviceAccountName: ci-deployment-sa
+  arguments:
+    parameters:
+      - name: repo-url
+        value: "https://github.com/opensearch-project/opensearch-migrations.git"
+      - name: branch
+        value: "main"
+      - name: stage
+        value: "eks-isolated"
+      - name: region
+        value: "us-east-1"
+  activeDeadlineSeconds: 14400  # 4 hours (isolated deploy is slow)
+
+  synchronization:
+    semaphores:
+      - configMapKeyRef:
+          name: ci-stage-locks
+          key: eks-integ
+
+  templates:
+    - name: main
+      dag:
+        tasks:
+          - name: checkout
+            templateRef:
+              name: common-ci-steps
+              template: git-checkout
+            arguments:
+              parameters:
+                - name: repo-url
+                  value: "{{workflow.parameters.repo-url}}"
+                - name: branch
+                  value: "{{workflow.parameters.branch}}"
+
+          - name: build
+            depends: checkout
+            templateRef:
+              name: default-integ-pipeline
+              template: gradle-build
+            arguments:
+              artifacts:
+                - name: source
+                  from: "{{tasks.checkout.outputs.artifacts.source}}"
+
+          - name: deploy-build-eks
+            depends: build
+            template: deploy-build-eks
+            arguments:
+              artifacts:
+                - name: source
+                  from: "{{tasks.build.outputs.artifacts.source}}"
+
+          - name: deploy-isolated-eks
+            depends: deploy-build-eks
+            template: deploy-isolated-eks
+            arguments:
+              artifacts:
+                - name: source
+                  from: "{{tasks.deploy-build-eks.outputs.artifacts.source}}"
+
+          - name: validate-isolated
+            depends: deploy-isolated-eks
+            template: validate-isolated-deployment
+
+    # ================================================================
+    # DEPLOY BUILD EKS — standard EKS cluster for building images
+    # ================================================================
+    - name: deploy-build-eks
+      inputs:
+        artifacts:
+          - name: source
+            path: /workspace
+      outputs:
+        artifacts:
+          - name: source
+            path: /workspace
+      container:
+        image: ci-runner:latest
+        workingDir: /workspace
+        command: [bash, -c]
+        args:
+          - |
+            set -euo pipefail
+            STAGE="{{workflow.parameters.stage}}"
+            REGION="{{workflow.parameters.region}}"
+            BUILD_STACK="Migration-Assistant-Build-EKS-${STAGE}-${REGION}"
+
+            CREDS=$(aws sts assume-role \
+              --role-arn "arn:aws:iam::${TEST_ACCOUNT_ID}:role/ArgoTestDeploymentRole" \
+              --role-session-name "argo-build-eks" --duration-seconds 5400)
+            export AWS_ACCESS_KEY_ID=$(echo $CREDS | jq -r .Credentials.AccessKeyId)
+            export AWS_SECRET_ACCESS_KEY=$(echo $CREDS | jq -r .Credentials.SecretAccessKey)
+            export AWS_SESSION_TOKEN=$(echo $CREDS | jq -r .Credentials.SessionToken)
+
+            echo "Deploying build EKS cluster..."
+            ./deployment/k8s/aws/aws-bootstrap.sh \
+              --deploy-create-vpc-cfn \
+              --build-cfn \
+              --stack-name "${BUILD_STACK}" \
+              --stage "${STAGE}-build" \
+              --eks-access-principal-arn "arn:aws:iam::${TEST_ACCOUNT_ID}:role/ArgoTestDeploymentRole" \
+              --build-images \
+              --build-chart-and-dashboards \
+              --base-dir "$(pwd)" \
+              --skip-console-exec \
+              --region "${REGION}" \
+              2>&1 | while IFS= read -r line; do printf '%s | %s\n' "$(date '+%H:%M:%S')" "$line"; done
+
+            # Save build cluster info
+            aws cloudformation describe-stacks --stack-name "${BUILD_STACK}" \
+              --query "Stacks[0].Outputs" --output json > /workspace/test/build-cluster-outputs.json
+        env:
+          - name: TEST_ACCOUNT_ID
+            valueFrom:
+              secretKeyRef:
+                name: migrations-test-account-id
+                key: account-id
+        resources:
+          requests:
+            cpu: "2"
+            memory: "4Gi"
+        activeDeadlineSeconds: 5400
+
+    # ================================================================
+    # DEPLOY ISOLATED EKS — EKS with no internet, VPC endpoints only
+    # ================================================================
+    - name: deploy-isolated-eks
+      inputs:
+        artifacts:
+          - name: source
+            path: /workspace
+      outputs:
+        artifacts:
+          - name: source
+            path: /workspace
+      container:
+        image: ci-runner:latest
+        workingDir: /workspace
+        command: [bash, -c]
+        args:
+          - |
+            set -euo pipefail
+            STAGE="{{workflow.parameters.stage}}"
+            REGION="{{workflow.parameters.region}}"
+            ISOLATED_STACK="Migration-Assistant-Isolated-EKS-${STAGE}-${REGION}"
+
+            CREDS=$(aws sts assume-role \
+              --role-arn "arn:aws:iam::${TEST_ACCOUNT_ID}:role/ArgoTestDeploymentRole" \
+              --role-session-name "argo-isolated-eks" --duration-seconds 5400)
+            export AWS_ACCESS_KEY_ID=$(echo $CREDS | jq -r .Credentials.AccessKeyId)
+            export AWS_SECRET_ACCESS_KEY=$(echo $CREDS | jq -r .Credentials.SecretAccessKey)
+            export AWS_SESSION_TOKEN=$(echo $CREDS | jq -r .Credentials.SessionToken)
+
+            echo "Deploying isolated EKS cluster (no internet)..."
+            ./deployment/k8s/aws/aws-bootstrap.sh \
+              --deploy-create-vpc-cfn \
+              --build-cfn \
+              --stack-name "${ISOLATED_STACK}" \
+              --stage "${STAGE}-isolated" \
+              --eks-access-principal-arn "arn:aws:iam::${TEST_ACCOUNT_ID}:role/ArgoTestDeploymentRole" \
+              --use-public-images false \
+              --isolated-deployment \
+              --base-dir "$(pwd)" \
+              --skip-console-exec \
+              --region "${REGION}" \
+              2>&1 | while IFS= read -r line; do printf '%s | %s\n' "$(date '+%H:%M:%S')" "$line"; done
+        env:
+          - name: TEST_ACCOUNT_ID
+            valueFrom:
+              secretKeyRef:
+                name: migrations-test-account-id
+                key: account-id
+        resources:
+          requests:
+            cpu: "2"
+            memory: "4Gi"
+        activeDeadlineSeconds: 5400
+
+    # ================================================================
+    # VALIDATE ISOLATED DEPLOYMENT — verify pods are running without internet
+    # ================================================================
+    - name: validate-isolated-deployment
+      container:
+        image: ci-runner:latest
+        command: [bash, -c]
+        args:
+          - |
+            set -euo pipefail
+            STAGE="{{workflow.parameters.stage}}"
+            REGION="{{workflow.parameters.region}}"
+
+            CREDS=$(aws sts assume-role \
+              --role-arn "arn:aws:iam::${TEST_ACCOUNT_ID}:role/ArgoTestDeploymentRole" \
+              --role-session-name "argo-validate" --duration-seconds 3600)
+            export AWS_ACCESS_KEY_ID=$(echo $CREDS | jq -r .Credentials.AccessKeyId)
+            export AWS_SECRET_ACCESS_KEY=$(echo $CREDS | jq -r .Credentials.SecretAccessKey)
+            export AWS_SESSION_TOKEN=$(echo $CREDS | jq -r .Credentials.SessionToken)
+
+            # Update kubeconfig for isolated cluster
+            CLUSTER_NAME="migration-${STAGE}-isolated"
+            aws eks update-kubeconfig --name "${CLUSTER_NAME}" --region "${REGION}"
+
+            echo "Validating isolated deployment..."
+
+            # Check all pods are running
+            kubectl get pods -n ma --no-headers | while read -r line; do
+              POD=$(echo "$line" | awk '{print $1}')
+              STATUS=$(echo "$line" | awk '{print $3}')
+              if [ "${STATUS}" != "Running" ] && [ "${STATUS}" != "Completed" ]; then
+                echo "ERROR: Pod ${POD} is in state ${STATUS}"
+                kubectl describe pod -n ma "${POD}" | tail -20
+                exit 1
+              fi
+              echo "  OK: ${POD} (${STATUS})"
+            done
+
+            # Verify no internet access from pods
+            kubectl run --rm -i --tty --restart=Never net-test \
+              --image=busybox -n ma -- sh -c \
+              "wget -q -O /dev/null --timeout=5 https://google.com 2>&1 && echo 'ERROR: Internet accessible' && exit 1 || echo 'OK: No internet access (expected)'" || true
+
+            echo "Isolated deployment validation PASSED"
+        env:
+          - name: TEST_ACCOUNT_ID
+            valueFrom:
+              secretKeyRef:
+                name: migrations-test-account-id
+                key: account-id
+        activeDeadlineSeconds: 900
+
+    # ================================================================
+    # CLEANUP HANDLER — delete both EKS clusters
+    # ================================================================
+    - name: cleanup-handler
+      dag:
+        tasks:
+          - name: delete-isolated-stack
+            templateRef:
+              name: eks-integ-pipeline
+              template: delete-cfn-stack
+            arguments:
+              parameters:
+                - name: stack-name
+                  value: "Migration-Assistant-Isolated-EKS-{{workflow.parameters.stage}}-{{workflow.parameters.region}}"
+          - name: delete-build-stack
+            depends: delete-isolated-stack
+            templateRef:
+              name: eks-integ-pipeline
+              template: delete-cfn-stack
+            arguments:
+              parameters:
+                - name: stack-name
+                  value: "Migration-Assistant-Build-EKS-{{workflow.parameters.stage}}-{{workflow.parameters.region}}"
+          - name: upload-results
+            templateRef:
+              name: reportportal-upload
+              template: upload-junit
+            arguments:
+              parameters:
+                - name: launch-name
+                  value: "eks-isolated-deploy"

--- a/argo/workflows/aws-integ/eks-solutions-cfn-test.yaml
+++ b/argo/workflows/aws-integ/eks-solutions-cfn-test.yaml
@@ -1,0 +1,239 @@
+# Replaces: vars/eksSolutionsCFNTest.groovy
+# EKS CFN deployment validation — tests Create-VPC and Import-VPC modes
+# Deploys EKS cluster via aws-bootstrap.sh, validates stack outputs, tears down
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: eks-solutions-cfn-test
+  namespace: ma
+  labels:
+    app: ci-pipeline
+    replaces: eksSolutionsCFNTest.groovy
+spec:
+  entrypoint: main
+  onExit: cleanup-handler
+  serviceAccountName: ci-deployment-sa
+  arguments:
+    parameters:
+      - name: repo-url
+        value: "https://github.com/opensearch-project/opensearch-migrations.git"
+      - name: branch
+        value: "main"
+      - name: stage
+        value: "eks-cfn-test"
+      - name: region
+        value: "us-east-1"
+  activeDeadlineSeconds: 10800  # 3 hours
+
+  synchronization:
+    semaphores:
+      - configMapKeyRef:
+          name: ci-stage-locks
+          key: eks-integ
+
+  templates:
+    - name: main
+      dag:
+        tasks:
+          - name: checkout
+            templateRef:
+              name: common-ci-steps
+              template: git-checkout
+            arguments:
+              parameters:
+                - name: repo-url
+                  value: "{{workflow.parameters.repo-url}}"
+                - name: branch
+                  value: "{{workflow.parameters.branch}}"
+
+          - name: build
+            depends: checkout
+            templateRef:
+              name: default-integ-pipeline
+              template: gradle-build
+            arguments:
+              artifacts:
+                - name: source
+                  from: "{{tasks.checkout.outputs.artifacts.source}}"
+
+          - name: test-create-vpc
+            depends: build
+            template: test-cfn-mode
+            arguments:
+              parameters:
+                - name: mode
+                  value: "create-vpc"
+              artifacts:
+                - name: source
+                  from: "{{tasks.build.outputs.artifacts.source}}"
+
+          - name: test-import-vpc
+            depends: test-create-vpc
+            template: test-cfn-mode
+            arguments:
+              parameters:
+                - name: mode
+                  value: "import-vpc"
+              artifacts:
+                - name: source
+                  from: "{{tasks.build.outputs.artifacts.source}}"
+
+    # ================================================================
+    # TEST CFN MODE — deploy EKS via aws-bootstrap.sh, validate, destroy
+    # ================================================================
+    - name: test-cfn-mode
+      inputs:
+        parameters:
+          - name: mode
+        artifacts:
+          - name: source
+            path: /workspace
+      retryStrategy:
+        limit: 1
+        retryPolicy: OnFailure
+      container:
+        image: ci-runner:latest
+        workingDir: /workspace
+        command: [bash, -c]
+        args:
+          - |
+            set -euo pipefail
+            STAGE="{{workflow.parameters.stage}}"
+            REGION="{{workflow.parameters.region}}"
+            MODE="{{inputs.parameters.mode}}"
+            STACK_NAME="Migration-Assistant-Infra-${MODE}-eks-${STAGE}-${REGION}"
+
+            CREDS=$(aws sts assume-role \
+              --role-arn "arn:aws:iam::${TEST_ACCOUNT_ID}:role/ArgoTestDeploymentRole" \
+              --role-session-name "argo-eks-cfn-${MODE}" --duration-seconds 5400)
+            export AWS_ACCESS_KEY_ID=$(echo $CREDS | jq -r .Credentials.AccessKeyId)
+            export AWS_SECRET_ACCESS_KEY=$(echo $CREDS | jq -r .Credentials.SecretAccessKey)
+            export AWS_SESSION_TOKEN=$(echo $CREDS | jq -r .Credentials.SessionToken)
+
+            echo "=== Testing ${MODE} mode ==="
+
+            BOOTSTRAP_ARGS="--stack-name ${STACK_NAME} --stage ${STAGE} --region ${REGION}"
+            BOOTSTRAP_ARGS="${BOOTSTRAP_ARGS} --build-cfn --build-images --build-chart-and-dashboards"
+            BOOTSTRAP_ARGS="${BOOTSTRAP_ARGS} --base-dir $(pwd) --skip-console-exec"
+
+            if [ "${MODE}" = "create-vpc" ]; then
+              BOOTSTRAP_ARGS="${BOOTSTRAP_ARGS} --deploy-create-vpc-cfn"
+            else
+              # Import-VPC: create a test VPC first, then import it
+              echo "Creating test VPC for import..."
+              VPC_ID=$(aws ec2 create-vpc --cidr-block 10.0.0.0/16 \
+                --tag-specifications "ResourceType=vpc,Tags=[{Key=Name,Value=test-import-${STAGE}}]" \
+                --query 'Vpc.VpcId' --output text)
+              SUBNET_ID=$(aws ec2 create-subnet --vpc-id "${VPC_ID}" \
+                --cidr-block 10.0.1.0/24 --query 'Subnet.SubnetId' --output text)
+              BOOTSTRAP_ARGS="${BOOTSTRAP_ARGS} --deploy-import-vpc-cfn --vpc-id ${VPC_ID} --subnet-ids ${SUBNET_ID}"
+            fi
+
+            # Deploy
+            ./deployment/k8s/aws/aws-bootstrap.sh ${BOOTSTRAP_ARGS} 2>&1 | \
+              while IFS= read -r line; do printf '%s | %s\n' "$(date '+%H:%M:%S')" "$line"; done
+
+            # Validate stack outputs
+            echo "Validating stack outputs..."
+            OUTPUTS=$(aws cloudformation describe-stacks --stack-name "${STACK_NAME}" \
+              --query "Stacks[0].Outputs" --output json --region "${REGION}")
+            echo "${OUTPUTS}" | jq .
+
+            EXPORT_STRING=$(echo "${OUTPUTS}" | jq -r '.[] | select(.OutputKey=="MigrationsExportString") | .OutputValue')
+            if [ -z "${EXPORT_STRING}" ]; then
+              echo "ERROR: MigrationsExportString not found in stack outputs"
+              exit 1
+            fi
+            echo "Stack validated: MigrationsExportString present"
+
+            # Cleanup
+            echo "Deleting stack ${STACK_NAME}..."
+            aws cloudformation delete-stack --stack-name "${STACK_NAME}" --region "${REGION}"
+            aws cloudformation wait stack-delete-complete --stack-name "${STACK_NAME}" --region "${REGION}" || true
+
+            if [ "${MODE}" = "import-vpc" ]; then
+              echo "Cleaning up test VPC..."
+              aws ec2 delete-subnet --subnet-id "${SUBNET_ID}" || true
+              aws ec2 delete-vpc --vpc-id "${VPC_ID}" || true
+            fi
+
+            echo "=== ${MODE} mode test PASSED ==="
+        env:
+          - name: TEST_ACCOUNT_ID
+            valueFrom:
+              secretKeyRef:
+                name: migrations-test-account-id
+                key: account-id
+        resources:
+          requests:
+            cpu: "2"
+            memory: "4Gi"
+        activeDeadlineSeconds: 5400  # 90 min per mode
+
+    # ================================================================
+    # CLEANUP HANDLER
+    # ================================================================
+    - name: cleanup-handler
+      dag:
+        tasks:
+          - name: delete-create-vpc-stack
+            template: delete-cfn-stack-safe
+            arguments:
+              parameters:
+                - name: stack-name
+                  value: "Migration-Assistant-Infra-create-vpc-eks-{{workflow.parameters.stage}}-{{workflow.parameters.region}}"
+          - name: delete-import-vpc-stack
+            template: delete-cfn-stack-safe
+            arguments:
+              parameters:
+                - name: stack-name
+                  value: "Migration-Assistant-Infra-import-vpc-eks-{{workflow.parameters.stage}}-{{workflow.parameters.region}}"
+          - name: upload-results
+            templateRef:
+              name: reportportal-upload
+              template: upload-junit
+            arguments:
+              parameters:
+                - name: launch-name
+                  value: "eks-solutions-cfn-test"
+
+    - name: delete-cfn-stack-safe
+      inputs:
+        parameters:
+          - name: stack-name
+      retryStrategy:
+        limit: 2
+        retryPolicy: Always
+        backoff:
+          duration: "30s"
+          factor: 2
+      container:
+        image: amazon/aws-cli:2.15.0
+        command: [bash, -c]
+        args:
+          - |
+            set +e
+            CREDS=$(aws sts assume-role \
+              --role-arn "arn:aws:iam::${TEST_ACCOUNT_ID}:role/ArgoTestDeploymentRole" \
+              --role-session-name "argo-cleanup" --duration-seconds 3600)
+            export AWS_ACCESS_KEY_ID=$(echo $CREDS | jq -r .Credentials.AccessKeyId)
+            export AWS_SECRET_ACCESS_KEY=$(echo $CREDS | jq -r .Credentials.SecretAccessKey)
+            export AWS_SESSION_TOKEN=$(echo $CREDS | jq -r .Credentials.SessionToken)
+
+            STACK="{{inputs.parameters.stack-name}}"
+            STATUS=$(aws cloudformation describe-stacks --stack-name "${STACK}" \
+              --query "Stacks[0].StackStatus" --output text 2>/dev/null || echo "DOES_NOT_EXIST")
+            if [ "${STATUS}" = "DOES_NOT_EXIST" ]; then
+              echo "Stack ${STACK} does not exist, skipping"
+              exit 0
+            fi
+            echo "Deleting stack ${STACK} (status: ${STATUS})..."
+            aws cloudformation delete-stack --stack-name "${STACK}" --region "{{workflow.parameters.region}}"
+            aws cloudformation wait stack-delete-complete --stack-name "${STACK}" --region "{{workflow.parameters.region}}" || true
+        env:
+          - name: TEST_ACCOUNT_ID
+            valueFrom:
+              secretKeyRef:
+                name: migrations-test-account-id
+                key: account-id
+        activeDeadlineSeconds: 1800

--- a/argo/workflows/aws-integ/full-es68-e2e.yaml
+++ b/argo/workflows/aws-integ/full-es68-e2e.yaml
@@ -1,0 +1,349 @@
+# Replaces: vars/fullES68SourceE2ETest.groovy
+# Full ES 6.8 → OS 2.19 migration test (capture+replay+RFS+transformations)
+# Thin wrapper around default-integ-pipeline with ES 6.8 CDK context
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: full-es68-e2e
+  namespace: ma
+  labels:
+    app: ci-pipeline
+    replaces: fullES68SourceE2ETest.groovy
+spec:
+  entrypoint: main
+  onExit: cleanup-handler
+  serviceAccountName: ci-deployment-sa
+  arguments:
+    parameters:
+      - name: repo-url
+        value: "https://github.com/opensearch-project/opensearch-migrations.git"
+      - name: branch
+        value: "main"
+      - name: stage
+        value: "full-es68"
+  activeDeadlineSeconds: 10800  # 3 hours
+
+  synchronization:
+    semaphores:
+      - configMapKeyRef:
+          name: ci-stage-locks
+          key: full-es68
+
+  templates:
+    - name: main
+      dag:
+        tasks:
+          - name: checkout
+            templateRef:
+              name: common-ci-steps
+              template: git-checkout
+            arguments:
+              parameters:
+                - name: repo-url
+                  value: "{{workflow.parameters.repo-url}}"
+                - name: branch
+                  value: "{{workflow.parameters.branch}}"
+
+          - name: build
+            depends: checkout
+            templateRef:
+              name: default-integ-pipeline
+              template: gradle-build
+            arguments:
+              artifacts:
+                - name: source
+                  from: "{{tasks.checkout.outputs.artifacts.source}}"
+
+          - name: setup-context
+            depends: checkout
+            template: setup-es68-context
+            arguments:
+              artifacts:
+                - name: source
+                  from: "{{tasks.checkout.outputs.artifacts.source}}"
+
+          - name: deploy
+            depends: "build && setup-context"
+            templateRef:
+              name: default-integ-pipeline
+              template: deploy-cdk-stack
+            arguments:
+              artifacts:
+                - name: source
+                  from: "{{tasks.build.outputs.artifacts.source}}"
+
+          - name: pre-integ-cleanup
+            depends: deploy
+            template: pre-integ-cleanup
+
+          - name: run-tests
+            depends: pre-integ-cleanup
+            template: run-full-es68-tests
+            arguments:
+              artifacts:
+                - name: source
+                  from: "{{tasks.deploy.outputs.artifacts.source}}"
+
+    # ES 6.8 specific CDK context setup
+    - name: setup-es68-context
+      inputs:
+        artifacts:
+          - name: source
+            path: /workspace
+      outputs:
+        artifacts:
+          - name: source
+            path: /workspace
+      script:
+        image: python:3.11-alpine
+        command: [sh]
+        source: |
+          set -euo pipefail
+          STAGE="{{workflow.parameters.stage}}"
+          cd /workspace/test
+
+          cat > sourceJenkinsContext.json << 'SRCEOF'
+          {
+            "source-single-node-ec2": {
+              "suffix": "ec2-source-STAGE_PLACEHOLDER",
+              "networkStackSuffix": "ec2-source-STAGE_PLACEHOLDER",
+              "distVersion": "6.8.23",
+              "distributionUrl": "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-oss-6.8.23.tar.gz",
+              "captureProxyEnabled": false,
+              "securityDisabled": true,
+              "minDistribution": false,
+              "cpuArch": "x64",
+              "isInternal": true,
+              "singleNodeCluster": true,
+              "networkAvailabilityZones": 2,
+              "dataNodeCount": 1,
+              "managerNodeCount": 0,
+              "serverAccessType": "ipv4",
+              "restrictServerAccessTo": "0.0.0.0/0",
+              "enableImdsCredentialRefresh": true,
+              "requireImdsv2": true
+            }
+          }
+          SRCEOF
+          sed -i "s/STAGE_PLACEHOLDER/${STAGE}/g" sourceJenkinsContext.json
+
+          cat > migrationJenkinsContext.json << 'MIGEOF'
+          {
+            "full-migration": {
+              "stage": "STAGE_PLACEHOLDER",
+              "engineVersion": "OS_2.19",
+              "domainName": "os-cluster-STAGE_PLACEHOLDER",
+              "dataNodeCount": 2,
+              "openAccessPolicyEnabled": true,
+              "domainRemovalPolicy": "DESTROY",
+              "artifactBucketRemovalPolicy": "DESTROY",
+              "captureProxyServiceEnabled": true,
+              "targetClusterProxyServiceEnabled": true,
+              "trafficReplayerServiceEnabled": true,
+              "trafficReplayerExtraArgs": "--speedup-factor 10.0",
+              "reindexFromSnapshotServiceEnabled": true,
+              "sourceCluster": {
+                "auth": {"type": "none"},
+                "version": "ES_6.8.23"
+              },
+              "tlsSecurityPolicy": "TLS_1_2",
+              "enforceHTTPS": true,
+              "nodeToNodeEncryptionEnabled": true,
+              "encryptionAtRestEnabled": true,
+              "vpcEnabled": true,
+              "vpcAZCount": 2,
+              "mskAZCount": 2,
+              "migrationAssistanceEnabled": true,
+              "replayerOutputEFSRemovalPolicy": "DESTROY",
+              "migrationConsoleServiceEnabled": true,
+              "otelCollectorEnabled": true
+            }
+          }
+          MIGEOF
+          sed -i "s/STAGE_PLACEHOLDER/${STAGE}/g" migrationJenkinsContext.json
+
+    # Pre-integ cleanup: delete snapshot, snapshot repo, S3 snapshot files
+    - name: pre-integ-cleanup
+      container:
+        image: ci-runner:latest
+        command: [bash, -c]
+        args:
+          - |
+            set +e
+            STAGE="{{workflow.parameters.stage}}"
+            SOURCE_ENDPOINT="https://alb.migration.${STAGE}.local:9201"
+            CLUSTER_NAME="migration-${STAGE}-ecs-cluster"
+
+            # Assume role
+            CREDS=$(aws sts assume-role \
+              --role-arn "arn:aws:iam::${TEST_ACCOUNT_ID}:role/ArgoTestDeploymentRole" \
+              --role-session-name "argo-pre-cleanup" --duration-seconds 3600)
+            export AWS_ACCESS_KEY_ID=$(echo $CREDS | jq -r .Credentials.AccessKeyId)
+            export AWS_SECRET_ACCESS_KEY=$(echo $CREDS | jq -r .Credentials.SecretAccessKey)
+            export AWS_SESSION_TOKEN=$(echo $CREDS | jq -r .Credentials.SessionToken)
+
+            TASK_ARN=$(aws ecs list-tasks --cluster "${CLUSTER_NAME}" \
+              --family "migration-${STAGE}-migration-console" | jq -r '.taskArns[0]')
+
+            # Delete snapshot
+            aws ecs execute-command --cluster "${CLUSTER_NAME}" --task "${TASK_ARN}" \
+              --container 'migration-console' --interactive \
+              --command "curl -k -X DELETE ${SOURCE_ENDPOINT}/_snapshot/migration_assistant_repo/rfs-snapshot" || true
+
+            # Delete snapshot repo
+            aws ecs execute-command --cluster "${CLUSTER_NAME}" --task "${TASK_ARN}" \
+              --container 'migration-console' --interactive \
+              --command "curl -k -X DELETE ${SOURCE_ENDPOINT}/_snapshot/migration_assistant_repo" || true
+
+            # Delete S3 snapshot files
+            ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+            REGION=$(aws configure get region || echo us-east-1)
+            aws s3 rm "s3://migration-artifacts-${ACCOUNT_ID}-${STAGE}-${REGION}/rfs-snapshot-repo" --recursive || true
+        env:
+          - name: TEST_ACCOUNT_ID
+            valueFrom:
+              secretKeyRef:
+                name: migrations-test-account-id
+                key: account-id
+        activeDeadlineSeconds: 600  # 10 min
+
+    # Run full ES 6.8 tests with custom test command
+    - name: run-full-es68-tests
+      inputs:
+        artifacts:
+          - name: source
+            path: /workspace
+      outputs:
+        artifacts:
+          - name: test-results
+            path: /workspace/test/reports/
+            optional: true
+            archive:
+              none: {}
+            s3:
+              key: "{{workflow.name}}/test-results/"
+      container:
+        image: ci-runner:latest
+        workingDir: /workspace/test
+        command: [bash, -c]
+        args:
+          - |
+            set -euo pipefail
+            STAGE="{{workflow.parameters.stage}}"
+
+            CREDS=$(aws sts assume-role \
+              --role-arn "arn:aws:iam::${TEST_ACCOUNT_ID}:role/ArgoTestDeploymentRole" \
+              --role-session-name "argo-test" --duration-seconds 3600)
+            export AWS_ACCESS_KEY_ID=$(echo $CREDS | jq -r .Credentials.AccessKeyId)
+            export AWS_SECRET_ACCESS_KEY=$(echo $CREDS | jq -r .Credentials.SecretAccessKey)
+            export AWS_SESSION_TOKEN=$(echo $CREDS | jq -r .Credentials.SessionToken)
+
+            UNIQUE_ID="integ_full_$(date +%s)_argo"
+            TEST_DIR="/root/lib/integ_test/integ_test"
+            RESULT_FILE="${TEST_DIR}/reports/${UNIQUE_ID}/report.xml"
+
+            COMMAND="pipenv run pytest --log-file=${TEST_DIR}/reports/${UNIQUE_ID}/pytest.log \
+              --junitxml=${RESULT_FILE} \
+              ${TEST_DIR}/full_tests.py \
+              --source_proxy_alb_endpoint https://alb.migration.${STAGE}.local:9201 \
+              --target_proxy_alb_endpoint https://alb.migration.${STAGE}.local:9202 \
+              --unique_id ${UNIQUE_ID} --stage ${STAGE} -s"
+
+            ./awsRunIntegTests.sh --command "${COMMAND}" \
+              --test-result-file "${RESULT_FILE}" --stage "${STAGE}"
+
+            mkdir -p /workspace/test/reports/
+            cp -r ${TEST_DIR}/reports/ /workspace/test/reports/ 2>/dev/null || true
+        env:
+          - name: TEST_ACCOUNT_ID
+            valueFrom:
+              secretKeyRef:
+                name: migrations-test-account-id
+                key: account-id
+        activeDeadlineSeconds: 3600
+
+    # Cleanup handler — destroy CDK stacks + upload results
+    - name: cleanup-handler
+      dag:
+        tasks:
+          - name: destroy-stacks
+            template: destroy-es68-stacks
+          - name: upload-results
+            templateRef:
+              name: reportportal-upload
+              template: upload-junit
+            arguments:
+              parameters:
+                - name: launch-name
+                  value: "full-es68-e2e"
+                - name: source-version
+                  value: "ES_6.8"
+                - name: target-version
+                  value: "OS_2.19"
+          - name: notify
+            depends: destroy-stacks
+            templateRef:
+              name: common-ci-steps
+              template: notify-github-status
+            arguments:
+              parameters:
+                - name: sha
+                  value: ""
+                - name: context
+                  value: "argo/full-es68-e2e"
+
+    - name: destroy-es68-stacks
+      retryStrategy:
+        limit: 2
+        retryPolicy: Always
+        backoff:
+          duration: "30s"
+          factor: 2
+      container:
+        image: ci-runner:latest
+        workingDir: /workspace/test
+        command: [bash, -c]
+        args:
+          - |
+            set +e
+            STAGE="{{workflow.parameters.stage}}"
+
+            CREDS=$(aws sts assume-role \
+              --role-arn "arn:aws:iam::${TEST_ACCOUNT_ID}:role/ArgoTestDeploymentRole" \
+              --role-session-name "argo-cleanup" --duration-seconds 5400)
+            export AWS_ACCESS_KEY_ID=$(echo $CREDS | jq -r .Credentials.AccessKeyId)
+            export AWS_SECRET_ACCESS_KEY=$(echo $CREDS | jq -r .Credentials.SecretAccessKey)
+            export AWS_SESSION_TOKEN=$(echo $CREDS | jq -r .Credentials.SessionToken)
+
+            echo "=== Destroying ES 6.8 E2E stacks for stage: ${STAGE} ==="
+
+            # Destroy migration stack (full-migration context)
+            cd /workspace/test 2>/dev/null && \
+              npx cdk destroy --force \
+                --context stage="${STAGE}" \
+                --context contextId="full-migration" \
+                2>&1 | tail -20 || true
+
+            # Destroy source cluster stack
+            npx cdk destroy --force \
+              --context stage="${STAGE}" \
+              --context contextId="source-single-node-ec2" \
+              2>&1 | tail -20 || true
+
+            # Fallback: delete by name pattern
+            for STACK in $(aws cloudformation list-stacks \
+              --stack-status-filter CREATE_COMPLETE UPDATE_COMPLETE \
+              --query "StackSummaries[?contains(StackName,'${STAGE}')].StackName" \
+              --output text 2>/dev/null); do
+              echo "Deleting remaining stack: ${STACK}"
+              aws cloudformation delete-stack --stack-name "${STACK}" || true
+            done
+
+            echo "=== ES 6.8 cleanup complete ==="
+        env:
+          - name: TEST_ACCOUNT_ID
+            valueFrom:
+              secretKeyRef:
+                name: migrations-test-account-id
+                key: account-id
+        activeDeadlineSeconds: 3600

--- a/argo/workflows/aws-integ/release-pipeline.yaml
+++ b/argo/workflows/aws-integ/release-pipeline.yaml
@@ -1,0 +1,280 @@
+# Replaces: jenkins/release.jenkinsFile
+# Release pipeline: download artifacts → publish to S3/Maven → copy Docker images → mark non-draft
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: release-pipeline
+  namespace: ma
+  labels:
+    app: ci-pipeline
+    replaces: release.jenkinsFile
+spec:
+  entrypoint: release
+  serviceAccountName: ci-release-sa  # IRSA with prod S3 + ECR access
+  arguments:
+    parameters:
+      - name: release-tag
+        value: ""
+      - name: release-id
+        value: ""
+  activeDeadlineSeconds: 3600  # 1 hour
+
+  templates:
+    - name: release
+      dag:
+        tasks:
+          - name: download-artifacts
+            template: download-release-assets
+
+          - name: publish-s3
+            depends: download-artifacts
+            template: publish-to-s3
+            arguments:
+              artifacts:
+                - name: release-assets
+                  from: "{{tasks.download-artifacts.outputs.artifacts.release-assets}}"
+
+          - name: publish-maven
+            depends: download-artifacts
+            template: publish-to-maven
+            arguments:
+              artifacts:
+                - name: release-assets
+                  from: "{{tasks.download-artifacts.outputs.artifacts.release-assets}}"
+
+          - name: copy-images
+            depends: download-artifacts
+            template: copy-docker-images
+
+          - name: mark-released
+            depends: "publish-s3 && publish-maven && copy-images"
+            template: mark-release-non-draft
+
+    # ================================================================
+    # DOWNLOAD RELEASE ASSETS from GitHub
+    # ================================================================
+    - name: download-release-assets
+      outputs:
+        artifacts:
+          - name: release-assets
+            path: /release
+      script:
+        image: curlimages/curl:latest
+        command: [sh]
+        source: |
+          set -euo pipefail
+          mkdir -p /release
+          cd /release
+
+          TAG="{{workflow.parameters.release-tag}}"
+          REPO="opensearch-project/opensearch-migrations"
+          API="https://api.github.com/repos/${REPO}/releases/tags/${TAG}"
+
+          echo "Fetching release assets for ${TAG}..."
+          ASSETS=$(curl -sf -H "Authorization: token ${GITHUB_TOKEN}" \
+            -H "Accept: application/vnd.github+json" "${API}" | \
+            python3 -c "import sys,json; [print(a['url'],a['name']) for a in json.load(sys.stdin).get('assets',[])]")
+
+          echo "$ASSETS" | while read -r url name; do
+            echo "Downloading ${name}..."
+            curl -sfL -H "Accept: application/octet-stream" \
+              -H "Authorization: token ${GITHUB_TOKEN}" \
+              "${url}" -o "${name}"
+          done
+
+          # Extract tarballs
+          [ -f opensearch-migrations-source.tar.gz ] && tar -xf opensearch-migrations-source.tar.gz
+          [ -f opensearch-migrations-build.tar.gz ] && tar -xf opensearch-migrations-build.tar.gz
+
+          echo "Downloaded assets:"
+          ls -la
+        env:
+          - name: GITHUB_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: github-token
+                key: token
+
+    # ================================================================
+    # PUBLISH TO S3 — replaces publishToArtifactsProdBucket
+    # ================================================================
+    - name: publish-to-s3
+      inputs:
+        artifacts:
+          - name: release-assets
+            path: /release
+      container:
+        image: amazon/aws-cli:2.15.0
+        command: [bash, -c]
+        args:
+          - |
+            set -euo pipefail
+            TAG="{{workflow.parameters.release-tag}}"
+
+            echo "Publishing to S3 artifacts bucket..."
+            aws s3 cp /release/opensearch-migrations-source.tar.gz \
+              "s3://artifacts.opensearch.org/migrations/${TAG}/opensearch-migrations-${TAG}.tar.gz"
+
+            echo "Published to S3 successfully"
+
+    # ================================================================
+    # PUBLISH TO MAVEN — replaces publishToMaven
+    # Uses Gradle publishToMaven task from opensearch-build-libraries
+    # ================================================================
+    - name: publish-to-maven
+      inputs:
+        artifacts:
+          - name: release-assets
+            path: /release
+      container:
+        image: release-runner:latest
+        workingDir: /release
+        command: [bash, -c]
+        args:
+          - |
+            set -euo pipefail
+            echo "Publishing to Maven..."
+
+            if [ -d repository ]; then
+              cd repository
+
+              # Configure Maven settings with signing credentials
+              mkdir -p ~/.m2
+              cat > ~/.m2/settings.xml << 'SETTINGS'
+            <settings>
+              <servers>
+                <server>
+                  <id>sonatype-nexus-staging</id>
+                  <username>${env.SONATYPE_USERNAME}</username>
+                  <password>${env.SONATYPE_PASSWORD}</password>
+                </server>
+              </servers>
+              <profiles>
+                <profile>
+                  <id>sign</id>
+                  <activation><activeByDefault>true</activeByDefault></activation>
+                  <properties>
+                    <gpg.executable>gpg</gpg.executable>
+                    <gpg.passphrase>${env.GPG_PASSPHRASE}</gpg.passphrase>
+                  </properties>
+                </profile>
+              </profiles>
+            </settings>
+            SETTINGS
+
+              # Deploy all artifacts in the local repository
+              for POM in $(find . -name "*.pom" -type f); do
+                DIR=$(dirname "${POM}")
+                ARTIFACT=$(basename "${POM}" .pom)
+                JAR="${DIR}/${ARTIFACT}.jar"
+                SOURCES="${DIR}/${ARTIFACT}-sources.jar"
+                JAVADOC="${DIR}/${ARTIFACT}-javadoc.jar"
+
+                DEPLOY_ARGS="-DpomFile=${POM}"
+                [ -f "${JAR}" ] && DEPLOY_ARGS="${DEPLOY_ARGS} -Dfile=${JAR}" || DEPLOY_ARGS="${DEPLOY_ARGS} -Dfile=${POM} -Dpackaging=pom"
+                [ -f "${SOURCES}" ] && DEPLOY_ARGS="${DEPLOY_ARGS} -Dsources=${SOURCES}"
+                [ -f "${JAVADOC}" ] && DEPLOY_ARGS="${DEPLOY_ARGS} -Djavadoc=${JAVADOC}"
+
+                echo "Deploying ${ARTIFACT}..."
+                mvn gpg:sign-and-deploy-file \
+                  -DrepositoryId=sonatype-nexus-staging \
+                  -Durl=https://aws.oss.sonatype.org/service/local/staging/deploy/maven2/ \
+                  ${DEPLOY_ARGS} || echo "Warning: Failed to deploy ${ARTIFACT}"
+              done
+
+              echo "Maven publish complete"
+            else
+              echo "No Maven repository directory found in release assets, skipping"
+            fi
+        env:
+          - name: SONATYPE_USERNAME
+            valueFrom:
+              secretKeyRef:
+                name: maven-credentials
+                key: username
+                optional: true
+          - name: SONATYPE_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: maven-credentials
+                key: password
+                optional: true
+          - name: GPG_PASSPHRASE
+            valueFrom:
+              secretKeyRef:
+                name: gpg-credentials
+                key: passphrase
+                optional: true
+
+    # ================================================================
+    # COPY DOCKER IMAGES — replaces docker-copy Jenkins jobs
+    # Uses skopeo to copy from opensearchstaging → public.ecr.aws
+    # ================================================================
+    - name: copy-docker-images
+      steps:
+        - - name: copy-image
+            template: copy-single-image
+            arguments:
+              parameters:
+                - name: image-name
+                  value: "{{item}}"
+            withItems:
+              - opensearch-migrations-console
+              - opensearch-migrations-traffic-replayer
+              - opensearch-migrations-traffic-capture-proxy
+              - opensearch-migrations-reindex-from-snapshot
+
+    - name: copy-single-image
+      inputs:
+        parameters:
+          - name: image-name
+      container:
+        image: release-runner:latest
+        command: [bash, -c]
+        args:
+          - |
+            set -euo pipefail
+            TAG="{{workflow.parameters.release-tag}}"
+            IMAGE="{{inputs.parameters.image-name}}"
+            SRC="docker://opensearchstaging/${IMAGE}"
+            DST="docker://public.ecr.aws/opensearchproject/${IMAGE}"
+
+            echo "Copying ${IMAGE}:${TAG}..."
+            skopeo copy "${SRC}:${TAG}" "${DST}:${TAG}"
+
+            echo "Copying ${IMAGE}:latest..."
+            skopeo copy "${SRC}:${TAG}" "${DST}:latest"
+
+            echo "Image ${IMAGE} copied successfully"
+
+    # ================================================================
+    # MARK RELEASE NON-DRAFT — replaces Jenkins post.success block
+    # ================================================================
+    - name: mark-release-non-draft
+      script:
+        image: curlimages/curl:latest
+        command: [sh]
+        source: |
+          TAG="{{workflow.parameters.release-tag}}"
+          REPO="opensearch-project/opensearch-migrations"
+          RELEASE_URL="https://api.github.com/repos/${REPO}/releases/tags/${TAG}"
+
+          # Get release ID
+          RELEASE_ID=$(curl -sf -H "Authorization: token ${GITHUB_TOKEN}" \
+            -H "Accept: application/vnd.github+json" "${RELEASE_URL}" | \
+            python3 -c "import sys,json; print(json.load(sys.stdin)['id'])")
+
+          echo "Marking release ${TAG} (ID: ${RELEASE_ID}) as non-draft..."
+          curl -sf -X PATCH \
+            "https://api.github.com/repos/${REPO}/releases/${RELEASE_ID}" \
+            -H "Authorization: token ${GITHUB_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            -d '{"tag_name":"'"${TAG}"'","draft":false,"prerelease":false}'
+
+          echo "Release ${TAG} marked as non-draft"
+        env:
+          - name: GITHUB_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: github-token
+                key: token

--- a/argo/workflows/aws-integ/rfs-and-traffic-replay.yaml
+++ b/argo/workflows/aws-integ/rfs-and-traffic-replay.yaml
@@ -1,0 +1,147 @@
+# Replaces: vars/rfsDefaultE2ETest.groovy
+# RFS-only backfill test (ES 7.10 → OS 2.19)
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: rfs-default-e2e-
+  namespace: ma
+  labels:
+    test-type: aws-integ
+    replaces: rfsDefaultE2ETest.groovy
+spec:
+  workflowTemplateRef:
+    name: default-integ-pipeline
+  arguments:
+    parameters:
+      - name: stage
+        value: "rfs-integ"
+      - name: source-context-id
+        value: "source-single-node-ec2"
+      - name: migration-context-id
+        value: "migration-rfs"
+      - name: skip-capture-proxy
+        value: "true"
+      - name: integ-test-command
+        value: "/root/lib/integ_test/integ_test/backfill_tests.py"
+      - name: source-context
+        value: |
+          {
+            "source-single-node-ec2": {
+              "suffix": "ec2-source-<STAGE>",
+              "networkStackSuffix": "ec2-source-<STAGE>",
+              "distVersion": "7.10.2",
+              "distributionUrl": "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-oss-7.10.2-linux-x86_64.tar.gz",
+              "captureProxyEnabled": false,
+              "securityDisabled": true,
+              "minDistribution": false,
+              "cpuArch": "x64",
+              "isInternal": true,
+              "singleNodeCluster": true,
+              "networkAvailabilityZones": 2,
+              "dataNodeCount": 1,
+              "managerNodeCount": 0,
+              "serverAccessType": "ipv4",
+              "restrictServerAccessTo": "0.0.0.0/0",
+              "enableImdsCredentialRefresh": true
+            }
+          }
+      - name: migration-context
+        value: |
+          {
+            "migration-rfs": {
+              "stage": "<STAGE>",
+              "engineVersion": "OS_2.19",
+              "domainName": "os-cluster-<STAGE>",
+              "dataNodeCount": 2,
+              "openAccessPolicyEnabled": true,
+              "domainRemovalPolicy": "DESTROY",
+              "artifactBucketRemovalPolicy": "DESTROY",
+              "trafficReplayerServiceEnabled": false,
+              "reindexFromSnapshotServiceEnabled": true,
+              "tlsSecurityPolicy": "TLS_1_2",
+              "enforceHTTPS": true,
+              "nodeToNodeEncryptionEnabled": true,
+              "encryptionAtRestEnabled": true,
+              "vpcEnabled": true,
+              "vpcAZCount": 2,
+              "mskAZCount": 2,
+              "migrationAssistanceEnabled": true,
+              "replayerOutputEFSRemovalPolicy": "DESTROY",
+              "migrationConsoleServiceEnabled": true,
+              "otelCollectorEnabled": true
+            }
+          }
+---
+# Replaces: vars/trafficReplayDefaultE2ETest.groovy
+# Traffic capture & replay test (ES 7.10 → OS 2.19 with transformations)
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: traffic-replay-e2e-
+  namespace: ma
+  labels:
+    test-type: aws-integ
+    replaces: trafficReplayDefaultE2ETest.groovy
+spec:
+  workflowTemplateRef:
+    name: default-integ-pipeline
+  arguments:
+    parameters:
+      - name: stage
+        value: "aws-integ"
+      - name: source-context-id
+        value: "source-single-node-ec2"
+      - name: migration-context-id
+        value: "migration-default"
+      - name: integ-test-command
+        value: "/root/lib/integ_test/integ_test/replayer_tests.py"
+      - name: source-context
+        value: |
+          {
+            "source-single-node-ec2": {
+              "suffix": "ec2-source-<STAGE>",
+              "networkStackSuffix": "ec2-source-<STAGE>",
+              "distVersion": "7.10.2",
+              "cidr": "12.0.0.0/16",
+              "distributionUrl": "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-oss-7.10.2-linux-x86_64.tar.gz",
+              "captureProxyEnabled": true,
+              "securityDisabled": true,
+              "minDistribution": false,
+              "cpuArch": "x64",
+              "isInternal": true,
+              "singleNodeCluster": true,
+              "networkAvailabilityZones": 2,
+              "dataNodeCount": 1,
+              "managerNodeCount": 0,
+              "serverAccessType": "ipv4",
+              "restrictServerAccessTo": "0.0.0.0/0",
+              "enableImdsCredentialRefresh": true
+            }
+          }
+      - name: migration-context
+        value: |
+          {
+            "migration-default": {
+              "stage": "<STAGE>",
+              "engineVersion": "OS_2.19",
+              "domainName": "os-cluster-<STAGE>",
+              "dataNodeCount": 2,
+              "openAccessPolicyEnabled": true,
+              "domainRemovalPolicy": "DESTROY",
+              "artifactBucketRemovalPolicy": "DESTROY",
+              "trafficReplayerServiceEnabled": true,
+              "trafficReplayerExtraArgs": "--speedup-factor 10.0",
+              "reindexFromSnapshotServiceEnabled": true,
+              "tlsSecurityPolicy": "TLS_1_2",
+              "enforceHTTPS": true,
+              "nodeToNodeEncryptionEnabled": true,
+              "encryptionAtRestEnabled": true,
+              "vpcEnabled": true,
+              "vpcAZCount": 2,
+              "mskAZCount": 2,
+              "migrationAssistanceEnabled": true,
+              "replayerOutputEFSRemovalPolicy": "DESTROY",
+              "migrationConsoleServiceEnabled": true,
+              "otelCollectorEnabled": true
+            }
+          }

--- a/argo/workflows/aws-integ/solutions-cfn-test.yaml
+++ b/argo/workflows/aws-integ/solutions-cfn-test.yaml
@@ -1,0 +1,202 @@
+# Replaces: vars/solutionsCFNTest.groovy
+# EC2-based Solutions CFN deployment validation
+# Deploys migration console EC2 via CDK, validates, tears down
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: solutions-cfn-test
+  namespace: ma
+  labels:
+    app: ci-pipeline
+    replaces: solutionsCFNTest.groovy
+spec:
+  entrypoint: main
+  onExit: cleanup-handler
+  serviceAccountName: ci-deployment-sa
+  arguments:
+    parameters:
+      - name: repo-url
+        value: "https://github.com/opensearch-project/opensearch-migrations.git"
+      - name: branch
+        value: "main"
+      - name: stage
+        value: "solutions-cfn"
+      - name: region
+        value: "us-east-1"
+  activeDeadlineSeconds: 7200  # 2 hours
+
+  synchronization:
+    semaphores:
+      - configMapKeyRef:
+          name: ci-stage-locks
+          key: integ-test
+
+  templates:
+    - name: main
+      dag:
+        tasks:
+          - name: checkout
+            templateRef:
+              name: common-ci-steps
+              template: git-checkout
+            arguments:
+              parameters:
+                - name: repo-url
+                  value: "{{workflow.parameters.repo-url}}"
+                - name: branch
+                  value: "{{workflow.parameters.branch}}"
+
+          - name: build
+            depends: checkout
+            templateRef:
+              name: default-integ-pipeline
+              template: gradle-build
+            arguments:
+              artifacts:
+                - name: source
+                  from: "{{tasks.checkout.outputs.artifacts.source}}"
+
+          - name: deploy-and-validate
+            depends: build
+            template: deploy-and-validate
+            arguments:
+              artifacts:
+                - name: source
+                  from: "{{tasks.build.outputs.artifacts.source}}"
+
+    # ================================================================
+    # DEPLOY AND VALIDATE — CDK deploy migration console EC2, validate it starts
+    # ================================================================
+    - name: deploy-and-validate
+      inputs:
+        artifacts:
+          - name: source
+            path: /workspace
+      container:
+        image: ci-runner:latest
+        workingDir: /workspace
+        command: [bash, -c]
+        args:
+          - |
+            set -euo pipefail
+            STAGE="{{workflow.parameters.stage}}"
+            REGION="{{workflow.parameters.region}}"
+
+            CREDS=$(aws sts assume-role \
+              --role-arn "arn:aws:iam::${TEST_ACCOUNT_ID}:role/ArgoTestDeploymentRole" \
+              --role-session-name "argo-solutions-cfn" --duration-seconds 5400)
+            export AWS_ACCESS_KEY_ID=$(echo $CREDS | jq -r .Credentials.AccessKeyId)
+            export AWS_SECRET_ACCESS_KEY=$(echo $CREDS | jq -r .Credentials.SecretAccessKey)
+            export AWS_SESSION_TOKEN=$(echo $CREDS | jq -r .Credentials.SessionToken)
+
+            # Write CDK context for solutions deployment
+            cd deployment/migration-assistant-solution
+            cat > cdk.context.json << EOF
+            {
+              "stage": "${STAGE}",
+              "vpcEnabled": true,
+              "migrationConsoleServiceEnabled": true,
+              "sourceCluster": {
+                "endpoint": "https://vpc-source-${STAGE}.${REGION}.es.amazonaws.com:443",
+                "auth": {"type": "none"},
+                "version": "ES_7.10"
+              },
+              "targetCluster": {
+                "endpoint": "https://vpc-target-${STAGE}.${REGION}.es.amazonaws.com:443",
+                "auth": {"type": "none"},
+                "version": "OS_2.19"
+              }
+            }
+            EOF
+
+            echo "Deploying Solutions CFN stack..."
+            npm ci
+            npx cdk synth --context stage="${STAGE}"
+            npx cdk deploy --require-approval never --context stage="${STAGE}" \
+              --outputs-file /tmp/cdk-outputs.json 2>&1 | tail -50
+
+            echo "Validating deployment..."
+            cat /tmp/cdk-outputs.json | jq .
+
+            # Validate migration console EC2 instance is running
+            INSTANCE_ID=$(aws ec2 describe-instances \
+              --filters "Name=tag:Name,Values=*${STAGE}*migration-console*" \
+                        "Name=instance-state-name,Values=running" \
+              --query "Reservations[0].Instances[0].InstanceId" --output text)
+
+            if [ "${INSTANCE_ID}" = "None" ] || [ -z "${INSTANCE_ID}" ]; then
+              echo "ERROR: Migration console EC2 instance not found or not running"
+              exit 1
+            fi
+            echo "Migration console EC2 instance running: ${INSTANCE_ID}"
+
+            # Validate SSM connectivity
+            aws ssm start-session --target "${INSTANCE_ID}" \
+              --document-name AWS-StartNonInteractiveCommand \
+              --parameters '{"command":["echo SSM connectivity validated"]}' || \
+              echo "Warning: SSM session failed (may need VPC endpoint)"
+
+            echo "Solutions CFN test PASSED"
+        env:
+          - name: TEST_ACCOUNT_ID
+            valueFrom:
+              secretKeyRef:
+                name: migrations-test-account-id
+                key: account-id
+        resources:
+          requests:
+            cpu: "1"
+            memory: "2Gi"
+        activeDeadlineSeconds: 5400  # 90 min
+
+    # ================================================================
+    # CLEANUP HANDLER — destroy CDK stack
+    # ================================================================
+    - name: cleanup-handler
+      dag:
+        tasks:
+          - name: destroy-stack
+            template: destroy-cdk-stack
+          - name: upload-results
+            templateRef:
+              name: reportportal-upload
+              template: upload-junit
+            arguments:
+              parameters:
+                - name: launch-name
+                  value: "solutions-cfn-test"
+
+    - name: destroy-cdk-stack
+      retryStrategy:
+        limit: 2
+        retryPolicy: Always
+        backoff:
+          duration: "30s"
+          factor: 2
+      container:
+        image: ci-runner:latest
+        workingDir: /workspace/deployment/migration-assistant-solution
+        command: [bash, -c]
+        args:
+          - |
+            set +e
+            STAGE="{{workflow.parameters.stage}}"
+
+            CREDS=$(aws sts assume-role \
+              --role-arn "arn:aws:iam::${TEST_ACCOUNT_ID}:role/ArgoTestDeploymentRole" \
+              --role-session-name "argo-cleanup" --duration-seconds 3600)
+            export AWS_ACCESS_KEY_ID=$(echo $CREDS | jq -r .Credentials.AccessKeyId)
+            export AWS_SECRET_ACCESS_KEY=$(echo $CREDS | jq -r .Credentials.SecretAccessKey)
+            export AWS_SESSION_TOKEN=$(echo $CREDS | jq -r .Credentials.SessionToken)
+
+            echo "Destroying Solutions CFN stack for stage ${STAGE}..."
+            npm ci 2>/dev/null
+            npx cdk destroy --force --context stage="${STAGE}" 2>&1 | tail -30 || true
+            echo "CDK destroy complete"
+        env:
+          - name: TEST_ACCOUNT_ID
+            valueFrom:
+              secretKeyRef:
+                name: migrations-test-account-id
+                key: account-id
+        activeDeadlineSeconds: 1800

--- a/argo/workflows/build-images.yaml
+++ b/argo/workflows/build-images.yaml
@@ -1,0 +1,47 @@
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: build-images
+  namespace: ma
+  labels:
+    app: ci-pipeline
+spec:
+  entrypoint: build
+  serviceAccountName: argo-workflow-executor
+  arguments:
+    parameters:
+      - name: repo-url
+        value: "https://github.com/opensearch-project/opensearch-migrations.git"
+      - name: branch
+        value: "main"
+      - name: platform
+        value: "amd64"
+  activeDeadlineSeconds: 3600  # 1 hour
+
+  templates:
+    - name: build
+      dag:
+        tasks:
+          - name: checkout
+            templateRef:
+              name: common-ci-steps
+              template: git-checkout
+            arguments:
+              parameters:
+                - name: repo-url
+                  value: "{{workflow.parameters.repo-url}}"
+                - name: branch
+                  value: "{{workflow.parameters.branch}}"
+
+          - name: build-images
+            depends: checkout
+            templateRef:
+              name: common-ci-steps
+              template: build-docker-images
+            arguments:
+              parameters:
+                - name: platform
+                  value: "{{workflow.parameters.platform}}"
+              artifacts:
+                - name: source
+                  from: "{{tasks.checkout.outputs.artifacts.source}}"

--- a/argo/workflows/common-ci-steps.yaml
+++ b/argo/workflows/common-ci-steps.yaml
@@ -1,0 +1,275 @@
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: common-ci-steps
+  namespace: ma
+  labels:
+    app: ci-pipeline
+spec:
+  templates:
+    # ================================================================
+    # GIT CHECKOUT — replaces Jenkins 'Checkout' stage
+    # Uses shallow clone for speed
+    # ================================================================
+    - name: git-checkout
+      inputs:
+        parameters:
+          - name: repo-url
+            default: "https://github.com/opensearch-project/opensearch-migrations.git"
+          - name: branch
+            default: "main"
+      outputs:
+        artifacts:
+          - name: source
+            path: /workspace
+      script:
+        image: alpine/git:2.43.0
+        command: [sh]
+        source: |
+          set -euo pipefail
+          cd /workspace
+
+          echo "Cloning {{inputs.parameters.repo-url}} @ {{inputs.parameters.branch}}..."
+          git clone --depth 1 --branch "{{inputs.parameters.branch}}" \
+            "{{inputs.parameters.repo-url}}" .
+
+          COMMIT=$(git rev-parse --short HEAD)
+          echo "Checked out commit: ${COMMIT}"
+          echo "${COMMIT}" > /tmp/commit-sha
+          ls -la
+        volumeMounts:
+          - name: workspace
+            mountPath: /workspace
+      volumes:
+        - name: workspace
+          emptyDir: {}
+
+    # ================================================================
+    # GRADLE BUILD — compiles without running tests
+    # ================================================================
+    - name: gradle-build
+      inputs:
+        artifacts:
+          - name: source
+            path: /workspace
+      outputs:
+        artifacts:
+          - name: source
+            path: /workspace
+      container:
+        image: gradle:8-jdk17
+        workingDir: /workspace
+        command: [bash, -c]
+        args:
+          - |
+            set -euo pipefail
+            echo "Running Gradle build..."
+            ./gradlew clean build -x test --no-daemon --stacktrace 2>&1 | tail -100
+            echo "Gradle build complete"
+        resources:
+          requests:
+            cpu: "2"
+            memory: "4Gi"
+          limits:
+            memory: "8Gi"
+
+    # ================================================================
+    # BUILD DOCKER IMAGES — replaces Jenkins 'Build Docker Images (BuildKit)' stage
+    # ================================================================
+    - name: build-docker-images
+      inputs:
+        parameters:
+          - name: platform
+            default: "amd64"
+        artifacts:
+          - name: source
+            path: /workspace
+      outputs:
+        parameters:
+          - name: registry-prefix
+            valueFrom:
+              path: /tmp/registry-prefix
+      sidecars:
+        - name: dind
+          image: docker:27-dind
+          securityContext:
+            privileged: true
+          env:
+            - name: DOCKER_TLS_CERTDIR
+              value: ""
+          mirrorVolumeMounts: true
+      container:
+        image: docker:27-cli
+        workingDir: /workspace
+        env:
+          - name: DOCKER_HOST
+            value: tcp://localhost:2375
+          - name: USE_LOCAL_REGISTRY
+            value: "true"
+        command: [sh, -c]
+        args:
+          - |
+            set -euo pipefail
+
+            # Wait for Docker daemon
+            echo "Waiting for Docker daemon..."
+            for i in $(seq 1 30); do
+              docker info >/dev/null 2>&1 && break
+              sleep 2
+            done
+            docker info >/dev/null 2>&1 || { echo "Docker daemon failed to start"; exit 1; }
+
+            # Install required tools
+            apk add --no-cache bash helm kubectl gradle openjdk17 curl
+
+            # Setup BuildKit
+            helm uninstall buildkit -n buildkit 2>/dev/null || true
+            BUILDKIT_HELM_ARGS='--set buildkitd.maxParallelism=16 --set buildkitd.resources.requests.cpu=0 --set buildkitd.resources.requests.memory=0 --set buildkitd.resources.limits.cpu=0 --set buildkitd.resources.limits.memory=0' \
+              ./buildImages/setUpK8sImageBuildServices.sh
+
+            # Get registry IP
+            REGISTRY_IP=$(kubectl get svc -n buildkit docker-registry -o jsonpath='{.spec.clusterIP}' 2>/dev/null || echo "localhost")
+            echo "${REGISTRY_IP}:5000/" > /tmp/registry-prefix
+            echo "Registry prefix: ${REGISTRY_IP}:5000/"
+
+            # Build images
+            ./gradlew :buildImages:buildImagesToRegistry_{{inputs.parameters.platform}} \
+              -x test --info --stacktrace 2>&1 | tail -50
+
+            # Cleanup BuildKit
+            docker buildx rm local-remote-builder 2>/dev/null || true
+            helm uninstall buildkit -n buildkit 2>/dev/null || true
+
+            echo "Image build complete"
+        resources:
+          requests:
+            cpu: "4"
+            memory: "8Gi"
+        activeDeadlineSeconds: 1800  # 30 min timeout
+
+    # ================================================================
+    # CLEANUP PREVIOUS MA — replaces Jenkins 'Cleanup Previous MA Deployment' stage
+    # ================================================================
+    - name: cleanup-ma
+      container:
+        image: bitnami/kubectl:latest
+        command: [bash, -c]
+        args:
+          - |
+            set +e
+            echo "Cleaning up previous MA deployment..."
+
+            helm uninstall ma -n ma || true
+
+            kubectl delete mutatingwebhookconfigurations \
+              -l app.kubernetes.io/instance=kyverno --ignore-not-found || true
+            kubectl delete validatingwebhookconfigurations \
+              -l app.kubernetes.io/instance=kyverno --ignore-not-found || true
+
+            kubectl delete namespace kyverno-ma --ignore-not-found --grace-period=0 || true
+            kubectl delete namespace ma --ignore-not-found --grace-period=0 --force || true
+
+            for i in $(seq 1 30); do
+              kubectl get namespace ma >/dev/null 2>&1 || break
+              echo "Waiting for ma namespace to terminate... ($i/30)"
+              sleep 2
+            done
+
+            kubectl create namespace ma 2>/dev/null || true
+            echo "Cleanup complete"
+        activeDeadlineSeconds: 180  # 3 min timeout
+
+    # ================================================================
+    # GET REGISTRY IP — utility to discover BuildKit registry ClusterIP
+    # ================================================================
+    - name: get-registry-ip
+      script:
+        image: bitnami/kubectl:latest
+        command: [bash]
+        source: |
+          REGISTRY_IP=$(kubectl get svc -n buildkit docker-registry \
+            -o jsonpath='{.spec.clusterIP}' 2>/dev/null || echo "localhost")
+          echo "${REGISTRY_IP}"
+
+    # ================================================================
+    # NOTIFY GITHUB — post commit status to GitHub
+    # ================================================================
+    - name: notify-github-status
+      inputs:
+        parameters:
+          - name: sha
+          - name: state
+            default: ""  # auto-detect from workflow.status if empty
+          - name: context
+            default: "argo/integration-test"
+          - name: description
+            default: ""
+          - name: target-url
+            default: ""
+          - name: repo
+            default: "opensearch-project/opensearch-migrations"
+      script:
+        image: curlimages/curl:latest
+        command: [sh]
+        source: |
+          STATE="{{inputs.parameters.state}}"
+          if [ -z "$STATE" ]; then
+            case "{{workflow.status}}" in
+              Succeeded) STATE="success" ;;
+              Failed|Error) STATE="failure" ;;
+              *) STATE="error" ;;
+            esac
+          fi
+
+          DESC="{{inputs.parameters.description}}"
+          if [ -z "$DESC" ]; then
+            DESC="{{workflow.status}} ({{workflow.duration}}s)"
+          fi
+
+          TARGET_URL="{{inputs.parameters.target-url}}"
+          if [ -z "$TARGET_URL" ]; then
+            TARGET_URL="https://argo.internal/workflows/ma/{{workflow.name}}"
+          fi
+
+          echo "Posting status: ${STATE} for {{inputs.parameters.sha}}"
+
+          curl -sf -X POST \
+            "https://api.github.com/repos/{{inputs.parameters.repo}}/statuses/{{inputs.parameters.sha}}" \
+            -H "Authorization: token ${GITHUB_TOKEN}" \
+            -H "Content-Type: application/json" \
+            -d "{
+              \"state\": \"${STATE}\",
+              \"target_url\": \"${TARGET_URL}\",
+              \"description\": \"${DESC}\",
+              \"context\": \"{{inputs.parameters.context}}\"
+            }" && echo "Status posted successfully" || echo "Warning: Failed to post status (token may not be configured)"
+        env:
+          - name: GITHUB_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: github-token
+                key: token
+                optional: true  # don't fail if secret doesn't exist (local testing)
+
+    # ================================================================
+    # HELM DEPENDENCY UPDATE — ensure chart deps are current
+    # ================================================================
+    - name: helm-dep-update
+      inputs:
+        artifacts:
+          - name: source
+            path: /workspace
+      outputs:
+        artifacts:
+          - name: source
+            path: /workspace
+      container:
+        image: alpine/helm:3.14
+        workingDir: /workspace/deployment/k8s
+        command: [sh, -c]
+        args:
+          - |
+            set -euo pipefail
+            helm dependency update charts/aggregates/testClusters
+            helm dependency update charts/aggregates/migrationAssistantWithArgo
+            echo "Helm dependencies updated"

--- a/argo/workflows/k8s-local-test.yaml
+++ b/argo/workflows/k8s-local-test.yaml
@@ -1,0 +1,255 @@
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: k8s-local-test
+  namespace: ma
+  labels:
+    app: ci-pipeline
+    replaces: k8sLocalDeployment.groovy
+spec:
+  entrypoint: main
+  onExit: cleanup-handler
+  serviceAccountName: argo-workflow-executor
+  arguments:
+    parameters:
+      - name: repo-url
+        value: "https://github.com/opensearch-project/opensearch-migrations.git"
+      - name: branch
+        value: "main"
+      - name: source-version
+        value: "ES_7.10"
+      - name: target-version
+        value: "OS_2.19"
+      - name: test-ids
+        value: "all"
+      - name: unique-id
+        value: ""  # auto-generated if empty
+  activeDeadlineSeconds: 10800  # 3 hours (matches Jenkins timeout)
+
+  artifactGC:
+    strategy: OnWorkflowDeletion
+
+  templates:
+    # ================================================================
+    # MAIN DAG — orchestrates the full pipeline
+    # Mirrors Jenkins stages: Checkout → Build Images → Cleanup Previous → Deploy+Test
+    # ================================================================
+    - name: main
+      dag:
+        tasks:
+          - name: checkout
+            templateRef:
+              name: common-ci-steps
+              template: git-checkout
+            arguments:
+              parameters:
+                - name: repo-url
+                  value: "{{workflow.parameters.repo-url}}"
+                - name: branch
+                  value: "{{workflow.parameters.branch}}"
+
+          - name: get-registry-ip
+            templateRef:
+              name: common-ci-steps
+              template: get-registry-ip
+
+          - name: build-images
+            depends: checkout
+            templateRef:
+              name: common-ci-steps
+              template: build-docker-images
+            arguments:
+              artifacts:
+                - name: source
+                  from: "{{tasks.checkout.outputs.artifacts.source}}"
+
+          - name: cleanup-previous
+            templateRef:
+              name: common-ci-steps
+              template: cleanup-ma
+
+          - name: deploy-and-test
+            depends: "checkout && build-images && cleanup-previous && get-registry-ip"
+            template: deploy-and-test
+            arguments:
+              parameters:
+                - name: registry-ip
+                  value: "{{tasks.get-registry-ip.outputs.result}}"
+              artifacts:
+                - name: source
+                  from: "{{tasks.checkout.outputs.artifacts.source}}"
+
+    # ================================================================
+    # DEPLOY AND TEST — the core step
+    # Runs the Python testAutomation framework which:
+    #   1. helm install MA chart with registry prefix
+    #   2. Wait for all pods healthy
+    #   3. kubectl exec into migration-console to run pytest
+    #   4. Collect test reports (JSON) and logs
+    # ================================================================
+    - name: deploy-and-test
+      inputs:
+        parameters:
+          - name: registry-ip
+        artifacts:
+          - name: source
+            path: /workspace
+      outputs:
+        artifacts:
+          - name: test-reports
+            path: /workspace/libraries/testAutomation/reports
+            optional: true
+            archive:
+              none: {}
+            s3:
+              key: "{{workflow.name}}/test-reports/"
+          - name: test-logs
+            path: /workspace/libraries/testAutomation/logs
+            optional: true
+            archive:
+              tar:
+                compressionLevel: 6
+            s3:
+              key: "{{workflow.name}}/logs/"
+      container:
+        image: python:3.11-slim
+        workingDir: /workspace/libraries/testAutomation
+        command: [bash, -c]
+        args:
+          - |
+            set -euo pipefail
+
+            # Install system dependencies
+            apt-get update -qq && apt-get install -y -qq \
+              curl pipenv kubectl helm > /dev/null 2>&1
+
+            # Install Python dependencies
+            pipenv install --deploy
+
+            # Create output directories
+            mkdir -p ./reports ./logs
+
+            # Configure kubectl
+            kubectl config set-context --current --namespace=ma 2>/dev/null || true
+
+            # Resolve test-ids argument
+            TEST_IDS_ARG=""
+            if [ "{{workflow.parameters.test-ids}}" != "all" ] && [ -n "{{workflow.parameters.test-ids}}" ]; then
+              TEST_IDS_ARG="--test-ids='{{workflow.parameters.test-ids}}'"
+            fi
+
+            # Generate unique ID if not provided
+            UNIQUE_ID="{{workflow.parameters.unique-id}}"
+            if [ -z "$UNIQUE_ID" ]; then
+              UNIQUE_ID="argo-$(date +%Y%m%d%H%M%S)-$(head -c 4 /dev/urandom | xxd -p)"
+            fi
+
+            # Run the test automation framework
+            echo "============================================"
+            echo "Running: {{workflow.parameters.source-version}} → {{workflow.parameters.target-version}}"
+            echo "Registry: {{inputs.parameters.registry-ip}}:5000/"
+            echo "Unique ID: ${UNIQUE_ID}"
+            echo "============================================"
+
+            pipenv run app \
+              --source-version={{workflow.parameters.source-version}} \
+              --target-version={{workflow.parameters.target-version}} \
+              ${TEST_IDS_ARG} \
+              --unique-id="${UNIQUE_ID}" \
+              --test-reports-dir='./reports' \
+              --copy-logs \
+              --registry-prefix='{{inputs.parameters.registry-ip}}:5000/'
+
+            echo "Tests complete. Reports:"
+            ls -la ./reports/ || true
+        resources:
+          requests:
+            cpu: "1"
+            memory: "2Gi"
+        activeDeadlineSeconds: 7200  # 2 hours for tests
+
+    # ================================================================
+    # CLEANUP HANDLER — exit handler, always runs
+    # Replaces Jenkins post { always { ... } } block
+    # ================================================================
+    - name: cleanup-handler
+      dag:
+        tasks:
+          - name: archive-logs
+            template: archive-remaining-logs
+
+          - name: cleanup-deployment
+            depends: archive-logs
+            template: cleanup-deployment
+
+          - name: upload-results
+            templateRef:
+              name: reportportal-upload
+              template: upload-json-reports
+            arguments:
+              parameters:
+                - name: launch-name
+                  value: "k8s-local-{{workflow.parameters.source-version}}-{{workflow.parameters.target-version}}"
+
+    - name: cleanup-deployment
+      retryStrategy:
+        limit: 2
+        retryPolicy: Always
+        backoff:
+          duration: "10s"
+          factor: 2
+      container:
+        image: bitnami/kubectl:latest
+        command: [bash, -c]
+        args:
+          - |
+            set +e  # don't fail on cleanup errors
+
+            echo "Running cleanup..."
+
+            # Always do basic cleanup — works even if workspace/pipenv isn't available
+            helm uninstall ma -n ma 2>/dev/null || true
+
+            # Delete kyverno webhooks
+            kubectl delete mutatingwebhookconfigurations \
+              -l app.kubernetes.io/instance=kyverno --ignore-not-found || true
+            kubectl delete validatingwebhookconfigurations \
+              -l app.kubernetes.io/instance=kyverno --ignore-not-found || true
+
+            # Delete kyverno namespace
+            kubectl delete namespace kyverno-ma --ignore-not-found --grace-period=0 || true
+
+            # Wait for resources to terminate
+            for i in $(seq 1 30); do
+              REMAINING=$(kubectl get pods -n ma --no-headers 2>/dev/null | wc -l)
+              [ "$REMAINING" -eq 0 ] && break
+              echo "Waiting for $REMAINING pods to terminate... ($i/30)"
+              sleep 5
+            done
+
+            echo "Cleanup complete"
+        activeDeadlineSeconds: 900  # 15 min
+
+    - name: archive-remaining-logs
+      outputs:
+        artifacts:
+          - name: pod-logs
+            path: /tmp/pod-logs
+            optional: true
+            archive:
+              tar:
+                compressionLevel: 6
+            s3:
+              key: "{{workflow.name}}/pod-logs/"
+      container:
+        image: bitnami/kubectl:latest
+        command: [bash, -c]
+        args:
+          - |
+            set +e
+            echo "Archiving any remaining pod logs..."
+            mkdir -p /tmp/pod-logs
+            for pod in $(kubectl get pods -n ma -o jsonpath='{.items[*].metadata.name}' 2>/dev/null); do
+              kubectl logs -n ma "$pod" --all-containers > "/tmp/pod-logs/${pod}.log" 2>&1 || true
+            done
+            echo "Archived $(ls /tmp/pod-logs/ 2>/dev/null | wc -l) pod logs"

--- a/argo/workflows/k8s-matrix-test.yaml
+++ b/argo/workflows/k8s-matrix-test.yaml
@@ -1,0 +1,206 @@
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: k8s-matrix-test
+  namespace: ma
+  labels:
+    app: ci-pipeline
+    replaces: k8sMatrixTest.groovy
+spec:
+  entrypoint: matrix
+  onExit: aggregate-and-report
+  serviceAccountName: argo-workflow-executor
+  arguments:
+    parameters:
+      - name: repo-url
+        value: "https://github.com/opensearch-project/opensearch-migrations.git"
+      - name: branch
+        value: "main"
+      - name: source-version
+        value: "all"
+      - name: target-versions
+        value: '["OS_1.3","OS_2.19","OS_3.1"]'
+  activeDeadlineSeconds: 10800  # 3 hours
+
+  # Workflow-level semaphore: only 1 matrix at a time on minikube
+  synchronization:
+    semaphores:
+      - configMapKeyRef:
+          name: ci-stage-locks
+          key: k8s-matrix
+
+  templates:
+    # ================================================================
+    # MATRIX DAG — fans out to child workflows per target version
+    # ================================================================
+    - name: matrix
+      dag:
+        tasks:
+          - name: run-target
+            template: spawn-child
+            arguments:
+              parameters:
+                - name: target-version
+                  value: "{{item}}"
+            withParam: "{{workflow.parameters.target-versions}}"
+
+    # ================================================================
+    # SPAWN CHILD — creates a k8s-local-test Workflow per target version
+    # Replaces Jenkins build(job: childJobName, parameters: [...])
+    # ================================================================
+    - name: spawn-child
+      inputs:
+        parameters:
+          - name: target-version
+      # Per-child semaphore: limit concurrent k8s-local tests
+      synchronization:
+        semaphores:
+          - configMapKeyRef:
+              name: ci-stage-locks
+              key: k8s-local
+      resource:
+        action: create
+        successCondition: status.phase == Succeeded
+        failureCondition: status.phase in (Failed, Error)
+        manifest: |
+          apiVersion: argoproj.io/v1alpha1
+          kind: Workflow
+          metadata:
+            generateName: k8s-local-{{inputs.parameters.target-version}}-
+            namespace: ma
+            labels:
+              parent-workflow: "{{workflow.name}}"
+              test-type: k8s-local-matrix-child
+              target-version: "{{inputs.parameters.target-version}}"
+          spec:
+            workflowTemplateRef:
+              name: k8s-local-test
+            arguments:
+              parameters:
+                - name: repo-url
+                  value: "{{workflow.parameters.repo-url}}"
+                - name: branch
+                  value: "{{workflow.parameters.branch}}"
+                - name: source-version
+                  value: "{{workflow.parameters.source-version}}"
+                - name: target-version
+                  value: "{{inputs.parameters.target-version}}"
+            # Child workflow TTL — auto-cleanup after completion
+            ttlStrategy:
+              secondsAfterCompletion: 3600
+              secondsAfterSuccess: 1800
+              secondsAfterFailure: 7200
+
+    # ================================================================
+    # AGGREGATE AND REPORT — exit handler
+    # Collects child workflow statuses and prints summary table
+    # ================================================================
+    - name: aggregate-and-report
+      dag:
+        tasks:
+          - name: collect-results
+            template: collect-child-results
+          - name: print-summary
+            depends: collect-results
+            template: print-summary
+            arguments:
+              artifacts:
+                - name: aggregated-reports
+                  from: "{{tasks.collect-results.outputs.artifacts.aggregated-reports}}"
+          - name: upload-results
+            depends: collect-results
+            templateRef:
+              name: reportportal-upload
+              template: upload-json-reports
+            arguments:
+              parameters:
+                - name: launch-name
+                  value: "k8s-matrix-nightly"
+
+    - name: collect-child-results
+      outputs:
+        artifacts:
+          - name: aggregated-reports
+            path: /tmp/reports
+            optional: true
+            archive:
+              none: {}
+            s3:
+              key: "{{workflow.name}}/aggregated-reports/"
+      script:
+        image: bitnami/kubectl:latest
+        command: [bash]
+        source: |
+          set -euo pipefail
+          mkdir -p /tmp/reports
+
+          echo "Collecting child workflow results..."
+
+          # Find all child workflows by parent label
+          CHILDREN=$(kubectl get workflows -n ma \
+            -l "parent-workflow={{workflow.name}}" \
+            -o json 2>/dev/null || echo '{"items":[]}')
+
+          echo "$CHILDREN" | python3 -c "
+          import json, sys
+          data = json.load(sys.stdin)
+          items = data.get('items', [])
+          results = []
+          for w in items:
+              name = w['metadata']['name']
+              phase = w.get('status', {}).get('phase', 'Unknown')
+              target = w['metadata'].get('labels', {}).get('target-version', 'unknown')
+              duration = w.get('status', {}).get('estimatedDuration', 0)
+              results.append({'name': name, 'phase': phase, 'target': target, 'duration': duration})
+          with open('/tmp/reports/matrix-results.json', 'w') as f:
+              json.dump(results, f, indent=2)
+          print(f'Collected results from {len(results)} child workflows')
+          " 2>/dev/null || echo "No child results found"
+
+    - name: print-summary
+      inputs:
+        artifacts:
+          - name: aggregated-reports
+            path: /tmp/reports
+            optional: true
+      script:
+        image: python:3.11-alpine
+        command: [python]
+        source: |
+          import json, sys, os
+
+          results_file = "/tmp/reports/matrix-results.json"
+          if not os.path.exists(results_file):
+              print("No results file found — children may not have completed")
+              sys.exit(0)
+
+          with open(results_file) as f:
+              results = json.load(f)
+
+          passed = sum(1 for r in results if r["phase"] == "Succeeded")
+          failed = sum(1 for r in results if r["phase"] in ("Failed", "Error"))
+          total = len(results)
+
+          print("=" * 60)
+          print(f"MIGRATION TEST RESULTS SUMMARY")
+          print("=" * 60)
+
+          for r in results:
+              icon = "PASS" if r["phase"] == "Succeeded" else "FAIL"
+              target = r["target"]
+              name = r["name"]
+              phase = r["phase"]
+              print(f"  [{icon}] {target:20s} | {name} | {phase}")
+
+          print("=" * 60)
+          print(f"SUMMARY: {passed}/{total} tests passed, {failed} failed")
+          print("=" * 60)
+
+          if failed > 0:
+              if passed == 0:
+                  print("All tests failed!")
+              else:
+                  print("Some tests failed")
+              sys.exit(1)
+          else:
+              print("All tests passed successfully!")

--- a/argo/workflows/upload-results.yaml
+++ b/argo/workflows/upload-results.yaml
@@ -1,0 +1,253 @@
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: reportportal-upload
+  namespace: ma
+  labels:
+    app: ci-pipeline
+spec:
+  templates:
+    # ================================================================
+    # UPLOAD JUNIT XML — post-hoc import of test results
+    # ================================================================
+    - name: upload-junit
+      inputs:
+        parameters:
+          - name: launch-name
+          - name: source-version
+            default: ""
+          - name: target-version
+            default: ""
+          - name: rp-endpoint
+            default: "http://reportportal-serviceapi.reportportal:8585"
+          - name: rp-project
+            default: "opensearch_migrations"
+        artifacts:
+          - name: junit-xml
+            path: /results/
+            optional: true
+      script:
+        image: python:3.11-alpine
+        command: [python]
+        source: |
+          import os, glob, json
+          try:
+              import requests
+          except ImportError:
+              os.system("pip install requests -q")
+              import requests
+
+          rp_endpoint = "{{inputs.parameters.rp-endpoint}}"
+          rp_project = "{{inputs.parameters.rp-project}}"
+          rp_token = os.environ.get("RP_TOKEN", "superadmin_personal")
+
+          xml_files = glob.glob("/results/**/*.xml", recursive=True)
+          if not xml_files:
+              print("No JUnit XML files found in /results/")
+              exit(0)
+
+          print(f"Found {len(xml_files)} XML files to upload")
+
+          attrs = [{"key": "workflow", "value": "{{workflow.name}}"}]
+          source = "{{inputs.parameters.source-version}}"
+          target = "{{inputs.parameters.target-version}}"
+          if source:
+              attrs.append({"key": "source", "value": source})
+          if target:
+              attrs.append({"key": "target", "value": target})
+
+          launch_import = {
+              "name": "{{inputs.parameters.launch-name}}",
+              "attributes": attrs
+          }
+
+          headers = {"Authorization": f"Bearer {rp_token}"}
+          url = f"{rp_endpoint}/api/v1/{rp_project}/launch/import"
+
+          success = 0
+          for xml_file in xml_files:
+              try:
+                  with open(xml_file, "rb") as f:
+                      resp = requests.post(
+                          url,
+                          headers=headers,
+                          files={"file": (os.path.basename(xml_file), f, "application/xml")},
+                          data={"launchImportRq": json.dumps(launch_import)}
+                      )
+                  if resp.ok:
+                      success += 1
+                      print(f"  Uploaded {xml_file}")
+                  else:
+                      print(f"  Failed {xml_file}: {resp.status_code} {resp.text[:200]}")
+              except Exception as e:
+                  print(f"  Error uploading {xml_file}: {e}")
+
+          print(f"\nUploaded {success}/{len(xml_files)} files to ReportPortal")
+          if success == 0 and xml_files:
+              print("Warning: No files uploaded successfully. Check ReportPortal connectivity.")
+        env:
+          - name: RP_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: reportportal-token
+                key: token
+                optional: true
+
+    # ================================================================
+    # UPLOAD JSON REPORTS — for testAutomation JSON format
+    # ================================================================
+    - name: upload-json-reports
+      inputs:
+        parameters:
+          - name: launch-name
+          - name: rp-endpoint
+            default: "http://reportportal-serviceapi.reportportal:8585"
+          - name: rp-project
+            default: "opensearch_migrations"
+        artifacts:
+          - name: test-reports
+            path: /reports/
+            optional: true
+      script:
+        image: python:3.11-alpine
+        command: [python]
+        source: |
+          import os, glob, json
+          try:
+              import requests
+          except ImportError:
+              os.system("pip install requests -q")
+              import requests
+
+          rp_endpoint = "{{inputs.parameters.rp-endpoint}}"
+          rp_project = "{{inputs.parameters.rp-project}}"
+          rp_token = os.environ.get("RP_TOKEN", "superadmin_personal")
+          headers = {
+              "Authorization": f"Bearer {rp_token}",
+              "Content-Type": "application/json"
+          }
+
+          json_files = glob.glob("/reports/**/*.json", recursive=True)
+          if not json_files:
+              print("No JSON report files found")
+              exit(0)
+
+          for json_file in json_files:
+              with open(json_file) as f:
+                  data = json.load(f)
+
+              summary = data.get("summary", {})
+              tests = data.get("tests", [])
+              source = summary.get("source_version", "unknown")
+              target = summary.get("target_version", "unknown")
+
+              # Start launch
+              launch_resp = requests.post(
+                  f"{rp_endpoint}/api/v2/{rp_project}/launch",
+                  headers=headers,
+                  json={
+                      "name": "{{inputs.parameters.launch-name}}",
+                      "startTime": "{{workflow.creationTimestamp}}",
+                      "attributes": [
+                          {"key": "source", "value": source},
+                          {"key": "target", "value": target},
+                          {"key": "workflow", "value": "{{workflow.name}}"}
+                      ]
+                  }
+              )
+              if not launch_resp.ok:
+                  print(f"Failed to create launch: {launch_resp.text[:200]}")
+                  continue
+
+              launch_id = launch_resp.json().get("id")
+
+              # Report each test
+              for test in tests:
+                  status = "PASSED" if test["result"] == "passed" else "FAILED"
+                  # Start test item
+                  item_resp = requests.post(
+                      f"{rp_endpoint}/api/v2/{rp_project}/item",
+                      headers=headers,
+                      json={
+                          "launchUuid": launch_id,
+                          "name": test["name"],
+                          "type": "TEST",
+                          "description": test.get("description", ""),
+                          "startTime": "{{workflow.creationTimestamp}}",
+                      }
+                  )
+                  if item_resp.ok:
+                      item_id = item_resp.json().get("id")
+                      # Finish test item with status
+                      requests.put(
+                          f"{rp_endpoint}/api/v2/{rp_project}/item/{item_id}",
+                          headers=headers,
+                          json={
+                              "launchUuid": launch_id,
+                              "endTime": "now",
+                              "status": status,
+                          }
+                      )
+
+              # Finish launch
+              requests.put(
+                  f"{rp_endpoint}/api/v2/{rp_project}/launch/{launch_id}/finish",
+                  headers=headers,
+                  json={"endTime": "now"}
+              )
+              print(f"Uploaded {len(tests)} tests from {json_file} ({source} -> {target})")
+        env:
+          - name: RP_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: reportportal-token
+                key: token
+                optional: true
+
+    # ================================================================
+    # PYTEST WITH REPORTPORTAL — live streaming via pytest-reportportal
+    # ================================================================
+    - name: run-tests-with-rp-streaming
+      inputs:
+        parameters:
+          - name: source-version
+          - name: target-version
+          - name: registry-prefix
+          - name: rp-endpoint
+            default: "http://reportportal-serviceapi.reportportal:8585"
+          - name: rp-project
+            default: "opensearch_migrations"
+        artifacts:
+          - name: source
+            path: /workspace
+      outputs:
+        artifacts:
+          - name: test-reports
+            path: /workspace/libraries/testAutomation/reports
+            optional: true
+      container:
+        image: python:3.11-slim
+        workingDir: /workspace/libraries/testAutomation
+        command: [bash, -c]
+        args:
+          - |
+            set -euo pipefail
+            apt-get update -qq && apt-get install -y -qq pipenv kubectl helm > /dev/null 2>&1
+            pipenv install --deploy
+            pip install pytest-reportportal
+
+            mkdir -p ./reports
+
+            pipenv run app \
+              --source-version={{inputs.parameters.source-version}} \
+              --target-version={{inputs.parameters.target-version}} \
+              --test-reports-dir='./reports' \
+              --copy-logs \
+              --registry-prefix='{{inputs.parameters.registry-prefix}}'
+        env:
+          - name: RP_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: reportportal-token
+                key: token
+                optional: true


### PR DESCRIPTION
## Description

Introduces `argo/` directory with Argo Workflows + Argo Events + ReportPortal configuration as an OSS framework to replace Jenkins CI/CD pipelines and GitHub Actions fan-out jobs.

### What this replaces

| Current System | Argo Replacement |
|---|---|
| 16 Jenkins `vars/*.groovy` pipelines | WorkflowTemplates in `argo/workflows/` |
| `jenkins_tests.yml` GHA→Jenkins bridge | Argo Events sensors in `argo/events/` |
| `CI.yml` 30x gradle stripe fan-out | `argo-ci-pipeline.yaml` |
| Jenkins `cron('H 22 * * *')` | CronWorkflow in `argo/cron/` |
| Jenkins `lock(label: STAGE)` | Synchronization semaphores via ConfigMap |
| Jenkins `post { always }` cleanup | `onExit` exit handlers |
| `archiveArtifacts` / `copyArtifacts` | S3 artifact repository |

### Directory structure

```
argo/
├── README.md                          # Architecture, quick start, feature mapping
├── setup-minikube-ci.sh               # One-command minikube CI setup
├── deploy.sh                          # Unified deploy: --all, --p0..--p5, --test
├── ci-stage-locks-configmap.yaml      # Semaphore concurrency limits
├── workflows/
│   ├── common-ci-steps.yaml           # Shared: git-checkout, cleanup, notify-github
│   ├── build-images.yaml              # BuildKit image build
│   ├── argo-ci-pipeline.yaml          # Replaces CI.yml (30x gradle, python, node)
│   ├── k8s-local-test.yaml            # Replaces k8sLocalDeployment.groovy
│   ├── k8s-matrix-test.yaml           # Replaces k8sMatrixTest.groovy
│   ├── upload-results.yaml            # ReportPortal JUnit/JSON upload
│   └── aws-integ/                     # AWS integration test pipelines
│       ├── default-integ-pipeline.yaml
│       ├── full-es68-e2e.yaml
│       ├── rfs-and-traffic-replay.yaml
│       ├── eks-integ-pipeline.yaml
│       ├── eks-byos-integ-pipeline.yaml
│       ├── eks-solutions-cfn-test.yaml
│       ├── solutions-cfn-test.yaml
│       ├── eks-isolated-deploy.yaml
│       ├── cleanup-deployment.yaml
│       └── release-pipeline.yaml
├── events/                            # Argo Events (GitHub webhook → workflow)
├── cron/                              # Nightly matrix CronWorkflow
├── config/                            # Production EKS config (IRSA, Karpenter)
├── images/                            # CI runner Dockerfiles
├── reportportal/                      # ReportPortal Helm values
└── examples/                          # Quick-test workflow submissions
```

### Jenkins pipeline coverage

All 16 Jenkins pipelines have Argo equivalents:
- `k8sLocalDeployment` → `k8s-local-test.yaml`
- `k8sMatrixTest` → `k8s-matrix-test.yaml`
- `elasticsearch5x/8xK8sLocalTest` → `examples/run-es-version-tests.yaml`
- `defaultIntegPipeline` → `aws-integ/default-integ-pipeline.yaml`
- `fullES68SourceE2ETest` → `aws-integ/full-es68-e2e.yaml`
- `rfsDefaultE2ETest` / `trafficReplayDefaultE2ETest` → `aws-integ/rfs-and-traffic-replay.yaml`
- `eksIntegPipeline` → `aws-integ/eks-integ-pipeline.yaml`
- `eksBYOSIntegPipeline` → `aws-integ/eks-byos-integ-pipeline.yaml`
- `eksSolutionsCFNTest` → `aws-integ/eks-solutions-cfn-test.yaml`
- `solutionsCFNTest` → `aws-integ/solutions-cfn-test.yaml`
- `eksIsolatedDeploy` → `aws-integ/eks-isolated-deploy.yaml`
- `cleanupDeployment` → `aws-integ/cleanup-deployment.yaml`
- `release.jenkinsFile` → `aws-integ/release-pipeline.yaml`

### How to test locally

```bash
# Full setup
./argo/deploy.sh --all

# Or iteratively by priority
./argo/deploy.sh --p0          # Infrastructure
./argo/deploy.sh --skip-infra --p1  # CI templates
./argo/deploy.sh --skip-infra --p2  # Integration test
argo submit -n ma argo/examples/run-single-test.yaml --watch
```

### Migration phases

- **P0-P1**: Infrastructure + CI templates (minikube)
- **P2-P3**: Integration tests + matrix fan-out (minikube)
- **P4**: Argo Events triggering (minikube with webhook simulation)
- **P5**: ReportPortal integration
- **P6+**: Production EKS with IRSA, Karpenter, real AWS integration tests

### What stays in GHA

- `codeql.yml` — GitHub-native security scanning
- `sonar-qube.yml` — self-contained analysis
- `release-drafter.yml` — GitHub-native release notes
- `backport.yml` / `delete_backport_branch.yml` — branch management
- `add-untriaged.yml` — issue triage

### Check List
- [x] New functionality includes testing
- [x] New functionality has been documented
- [ ] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
