### PR TITLE
Make buildx builder name context-aware for multi-cluster dev support

### DIFF
--- a/buildImages/build.gradle
+++ b/buildImages/build.gradle
@@ -1,7 +1,7 @@
 import org.opensearch.migrations.image.RegistryImageBuildUtils
 import org.opensearch.migrations.image.RegistryImageBuildUtils.Registry
 
-def publishedUrl = rootProject.findProperty('registryEndpoint') ?: 'localhost:5001'
+def publishedUrl = rootProject.findProperty('registryEndpoint') ?: 'localhost:5002'
 def intermediateUrl = rootProject.findProperty('intermediateRegistry') ?: publishedUrl
 
 def publishedRegistry = new Registry(publishedUrl.toString())

--- a/buildImages/setUpK8sImageBuildServices.sh
+++ b/buildImages/setUpK8sImageBuildServices.sh
@@ -55,8 +55,8 @@ if [ "${USE_LOCAL_REGISTRY:-false}" = "true" ]; then
   echo "Waiting for docker-registry deployment to be available..."
   kubectl "${CONTEXT_ARGS[@]}" rollout status deployment/docker-registry -n buildkit --timeout=120s
 
-  if ! pgrep -f "kubectl port-forward.*docker-registry.*5001:5000" >/dev/null; then
-    nohup kubectl "${CONTEXT_ARGS[@]}" port-forward -n buildkit svc/docker-registry 5001:5000 --address 0.0.0.0 > /tmp/registry-forward.log 2>&1 &
+  if ! pgrep -f "kubectl port-forward.*docker-registry.*5002:5000" >/dev/null; then
+    nohup kubectl "${CONTEXT_ARGS[@]}" port-forward -n buildkit svc/docker-registry 5002:5000 --address 0.0.0.0 > /tmp/registry-forward.log 2>&1 &
   else
     echo "registry port-forward already running"
   fi

--- a/buildImages/setupK8sBuilders.sh
+++ b/buildImages/setupK8sBuilders.sh
@@ -1,13 +1,18 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-BUILDER_NAME="local-remote-builder"
-
 # Use KUBE_CONTEXT env var if set, for explicit context targeting
 CONTEXT_ARGS=()
 if [[ -n "${KUBE_CONTEXT:-}" ]]; then
+  CONTEXT="${KUBE_CONTEXT}"
   CONTEXT_ARGS=("--context=${KUBE_CONTEXT}")
+else
+  CONTEXT=$(kubectl config current-context 2>/dev/null)
 fi
+
+# Derive builder name from context so each cluster gets its own builder
+# NOTE: This naming convention must match RegistryImageBuildUtils.groovy's builder name derivation
+BUILDER_NAME="builder-${CONTEXT//[^a-zA-Z0-9_-]/-}"
 
 # Check if builder already exists and is healthy
 if docker buildx inspect "$BUILDER_NAME" --bootstrap &>/dev/null; then
@@ -22,11 +27,6 @@ docker buildx rm "$BUILDER_NAME" 2>/dev/null || true
 NAMESPACE="${BUILDKIT_NAMESPACE:-buildkit}"
 
 # Detect cloud vs local K8s
-if [[ -n "${KUBE_CONTEXT:-}" ]]; then
-  CONTEXT="${KUBE_CONTEXT}"
-else
-  CONTEXT=$(kubectl config current-context 2>/dev/null)
-fi
 if [[ "$CONTEXT" =~ (eks:|gke_|aks-|migration-eks-) ]]; then
   echo "Detected cloud K8s, using kubernetes driver with native multi-arch builds"
   
@@ -73,5 +73,6 @@ else
 fi
 
 docker buildx use "$BUILDER_NAME"
+echo "BUILDX_BUILDER=${BUILDER_NAME}"
 echo "Bootstrapping builder..."
 docker buildx inspect --bootstrap

--- a/buildSrc/src/main/groovy/org/opensearch/migrations/image/RegistryImageBuildUtils.groovy
+++ b/buildSrc/src/main/groovy/org/opensearch/migrations/image/RegistryImageBuildUtils.groovy
@@ -194,7 +194,20 @@ class RegistryImageBuildUtils {
         Registry targetReg = repoName ? finalRegistry : intermediateRegistry
         def registryEndpoint = targetReg.containerUrl
 
-        def builder = project.findProperty("builder") ?: "local-remote-builder"
+        def builder = project.findProperty("builder") ?: ""
+        if (!builder) {
+            try {
+                def context = "kubectl config current-context".execute().text.trim()
+                if (context) {
+                    // NOTE: This naming convention must match setupK8sBuilders.sh's BUILDER_NAME derivation
+                    builder = "builder-" + context.replaceAll("[^a-zA-Z0-9_-]", "-")
+                    project.logger.lifecycle("No -Pbuilder specified, derived '${builder}' from kube context '${context}'")
+                }
+            } catch (Exception ignored) {}
+            if (!builder) {
+                throw new GradleException("No -Pbuilder specified and no kube context set. Use -Pbuilder=<name> or set a kube context.")
+            }
+        }
         def imageName = cfg.get("imageName").toString()
         def imageTag = cfg.get("imageTag", "latest").toString()
         def contextPath = project.file(cfg.get("contextDir", ".")).path
@@ -249,7 +262,7 @@ class RegistryImageBuildUtils {
                             "docker buildx build",
                             "--progress=plain",
                             "--platform ${platform}",
-                            "--builder ${builder}",
+                            *(builder ? ["--builder ${builder}"] : []),
                             // don't include the suffix - this is dangerous, but single-platform builds are supported
                             // as a convenience to developers that are purposefully ONLY supporting PART of the
                             // potential architectures
@@ -277,7 +290,7 @@ class RegistryImageBuildUtils {
                         "docker buildx build",
                         "--progress=plain",
                         "--platform linux/amd64,linux/arm64",
-                        "--builder ${builder}",
+                        *(builder ? ["--builder ${builder}"] : []),
                         "-t ${primaryDest}",
                         *(versionTaggedDest ? ["-t", "${versionTaggedDest}"] : []),
                         "--push",

--- a/deployment/k8s/aws/aws-bootstrap.sh
+++ b/deployment/k8s/aws/aws-bootstrap.sh
@@ -955,7 +955,8 @@ if [[ "$build_images" == "true" ]]; then
   # When mirroring, buildkit still pulls from public registries — building on
   # isolated clusters is not supported. Use --ma-images-source instead.
 
-  if docker buildx inspect local-remote-builder --bootstrap &>/dev/null; then
+  BUILDER_NAME="builder-${KUBE_CONTEXT//[^a-zA-Z0-9_-]/-}"
+  if docker buildx inspect "$BUILDER_NAME" --bootstrap &>/dev/null; then
     echo "Buildkit already configured and healthy, skipping setup"
   else
     echo "Setting up buildkit for local builds..."
@@ -969,10 +970,10 @@ if [[ "$build_images" == "true" ]]; then
     | docker login --username AWS --password-stdin "$ecr_domain" \
     || { echo "ECR login failed"; exit 1; }
 
-  "$base_dir/gradlew" -p "$base_dir" :buildImages:${BUILD_TARGET} -PregistryEndpoint="$MIGRATIONS_ECR_REGISTRY" -x test || exit
+  "$base_dir/gradlew" -p "$base_dir" :buildImages:${BUILD_TARGET} -PregistryEndpoint="$MIGRATIONS_ECR_REGISTRY" -Pbuilder="$BUILDER_NAME" -x test || exit
 
   echo "Cleaning up docker buildx builder to free buildkit pods..."
-  docker buildx rm local-remote-builder 2>/dev/null || true
+  docker buildx rm "$BUILDER_NAME" 2>/dev/null || true
   echo "Builder removed. Buildkit pods will be terminated by kubernetes driver."
 fi
 

--- a/deployment/k8s/localTesting.sh
+++ b/deployment/k8s/localTesting.sh
@@ -24,8 +24,12 @@ gradlew() {
     "${MIGRATIONS_REPO_ROOT_DIR}/gradlew" "$@"
 }
 
+export KUBE_CONTEXT="${KUBE_CONTEXT:-minikube}"
+
 export USE_LOCAL_REGISTRY="${USE_LOCAL_REGISTRY:-true}"
 "${MIGRATIONS_REPO_ROOT_DIR}"/buildImages/setUpK8sImageBuildServices.sh
+
+BUILDER_NAME="builder-${KUBE_CONTEXT//[^a-zA-Z0-9_-]/-}"
 
 LOCAL_REGISTRY_PORT="${LOCAL_REGISTRY_PORT:-30500}"
 MINIKUBE_IP="$(minikube ip)"
@@ -47,7 +51,7 @@ case "$ARCH" in
     ;;
 esac
 
-gradlew :buildImages:buildImagesToRegistry_$PLATFORM
+gradlew :buildImages:buildImagesToRegistry_$PLATFORM -Pbuilder="$BUILDER_NAME"
 
 kubectl config set-context --current --namespace=ma
 

--- a/vars/k8sLocalDeployment.groovy
+++ b/vars/k8sLocalDeployment.groovy
@@ -95,8 +95,8 @@ def call(Map config = [:]) {
                             sh "kubectl config unset current-context || true"
                             sh "helm --kube-context=minikube uninstall buildkit -n buildkit 2>/dev/null || true"
                             sh "USE_LOCAL_REGISTRY=true KUBE_CONTEXT=minikube BUILDKIT_HELM_ARGS='--set buildkitd.maxParallelism=16 --set buildkitd.resources.requests.cpu=0 --set buildkitd.resources.requests.memory=0 --set buildkitd.resources.limits.cpu=0 --set buildkitd.resources.limits.memory=0' ./buildImages/setUpK8sImageBuildServices.sh"
-                            sh "./gradlew :buildImages:buildImagesToRegistry_amd64 -x test --info --stacktrace --profile --scan"
-                            sh "docker buildx rm local-remote-builder 2>/dev/null || true"
+                            sh "./gradlew :buildImages:buildImagesToRegistry_amd64 -Pbuilder=builder-minikube -x test --info --stacktrace --profile --scan"
+                            sh "docker buildx rm builder-minikube 2>/dev/null || true"
                             sh "helm --kube-context=minikube uninstall buildkit -n buildkit 2>/dev/null || true"
                         }
                     }


### PR DESCRIPTION
### Description

Derive builder name from kube context (builder-<context>) instead of hardcoding 'local-remote-builder'. This allows minikube and EKS builders to coexist, so switching clusters doesn't require tearing down the existing builder.

- setupK8sBuilders.sh: builder name derived from KUBE_CONTEXT
- RegistryImageBuildUtils.groovy: default to active builder (no --builder flag) instead of hardcoding name; still overridable via -Pbuilder
- aws-bootstrap.sh: use context-aware name for builder check/cleanup
- k8sLocalDeployment.groovy: use builder-minikube for Jenkins cleanup
- release-drafter.yml: update stale comment

### Testing
Ran aws-bootstrap.sh and localTesting.sh simultaneously to deploy to EKS and minikube.  Ran `gradle buildimagesToRegistry` w/ and w/out -Pbuilder=builder-minikube.  When it was missing, if the kubecontext was set, it applied the right one. If there was no context, the user gets an error: 

`% agradle buildImagesToRegistry `:

```  
FAILURE: Build failed with an exception.

* Where:
Build file '/Users/schohn/dev/m2/buildImages/build.gradle' line: 133

* What went wrong:
No -Pbuilder specified and no kube context set. Use -Pbuilder=<name> or set a kube context.

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Get more help at https://help.gradle.org.

BUILD FAILED in 1s
```

### Check List
- [ ] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
