### PR TITLE
Fix cleanDockerImage task failing when Docker image doesn't exist

### DIFF
--- a/migrationConsole/lib/console_link/build.gradle
+++ b/migrationConsole/lib/console_link/build.gradle
@@ -110,7 +110,6 @@ tasks.register('cleanDockerImage') {
         // Remove the Docker image
         def removeCommand = ['docker', 'rmi', dockerImageName]
         def proc = removeCommand.execute(null, projectDirRef)
-        proc.waitFor()
         def stdout = new ByteArrayOutputStream()
         def stderr = new ByteArrayOutputStream()
         proc.consumeProcessOutput(stdout, stderr)
@@ -123,7 +122,7 @@ tasks.register('cleanDockerImage') {
                 logger.info("Docker image not found (already removed): ${dockerImageName}")
             } else {
                 logger.error("Failed to remove Docker image: ${dockerImageName}\n${errMsg}")
-                throw new GradleException("Failed to remove Docker image: ${dockerImageName}")
+                throw new GradleException("Failed to remove Docker image: ${dockerImageName}\n${errMsg}")
             }
         }
     }


### PR DESCRIPTION
## Description

`./gradlew clean` fails when the `console-link-openapi-generator:latest` Docker image does not exist, because the `cleanDockerImage` task throws an exception instead of gracefully handling the missing image.

## Root Cause

`proc.waitFor()` was called **before** `proc.consumeProcessOutput(stdout, stderr)`. By the time stderr was read, the process had already completed and the output streams were empty. This meant the `"No such image"` check in stderr never matched, so the task always threw an exception when the image was absent.

## Fix

Removed the premature `proc.waitFor()` call. The existing second `proc.waitFor()` (after `consumeProcessOutput`) correctly waits for the process to complete with captured output, allowing the `"No such image"` check to work as intended.

## Testing

Verified on a host without the Docker image present:
- `./gradlew :console_link:cleanDockerImage` → `BUILD SUCCESSFUL` ✅
- `./gradlew clean` → `BUILD SUCCESSFUL` ✅

Also verified it still successfully removes the image when it does exist.