### PR TITLE
Remove unassignable users from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # This should match the owning team set up in https://github.com/orgs/opensearch-project/teams
-*   @AndreKurait @gregschohn @sumobrian @jugal-chauhan @prenake @akshay2000 @k-rooot @nagarajg17 @niravpi @pgtgrly @krishna-ggk @shuklas
+*   @AndreKurait @gregschohn @sumobrian @jugal-chauhan


### PR DESCRIPTION
## Problem
The release process fails with a GitHub API 422 error when trying to create issues:

```
error creating issue: POST https://api.github.com/repos/opensearch-project/opensearch-migrations/issues: 422 Validation Failed
[{Resource:Issue Field:assignees Code:invalid Message:assignees akshay2000, k-rooot, krishna-ggk, nagarajg17, niravpi, pgtgrly, prenake, shuklas cannot be assigned to this issue}]
```

These users are listed in CODEOWNERS but don't have the required repository permissions in the opensearch-project GitHub org to be assigned to issues.

## Fix
Remove the unassignable users from CODEOWNERS. They remain in MAINTAINERS.md and can be re-added to CODEOWNERS once their org permissions are resolved.

## Impact
This unblocks the release process. PR reviews will only auto-request from: @AndreKurait @gregschohn @sumobrian @jugal-chauhan