### PR TITLE
Skip kube-config loading for report-summary-only mode

### DIFF
--- a/libraries/testAutomation/testAutomation/test_runner.py
+++ b/libraries/testAutomation/testAutomation/test_runner.py
@@ -446,6 +446,19 @@ def parse_args() -> argparse.Namespace:
 
 def main() -> None:
     args = parse_args()
+
+    # Handle report summary early — no K8s access needed
+    if args.output_reports_summary_only:
+        if not args.test_reports_dir:
+            raise ValueError("The '--test-reports-dir' arg must be provided when using '--output-reports-summary-only")
+        # Create a minimal TestRunner without K8sService for summary-only mode
+        test_runner = TestRunner(k8s_service=None,
+                                 unique_id=args.unique_id,
+                                 test_ids=[],
+                                 ma_chart_path="",
+                                 combinations=[])
+        return test_runner.collect_reports_and_print_summary(reports_dir=args.test_reports_dir)
+
     k8s_service = K8sService(kube_context=args.kube_context)
     helm_k8s_base_path = "../../deployment/k8s"
     helm_charts_base_path = f"{helm_k8s_base_path}/charts"
@@ -469,10 +482,6 @@ def main() -> None:
         return test_runner.cleanup_deployment()
     if args.delete_clusters_only:
         return test_runner.cleanup_clusters()
-    if args.output_reports_summary_only:
-        if not args.test_reports_dir:
-            raise ValueError("The '--test-reports-dir' arg must be provided when using '--output-reports-summary-only")
-        return test_runner.collect_reports_and_print_summary(reports_dir=args.test_reports_dir)
     skip_delete = args.skip_delete
     keep_workflows = args.keep_workflows
     reuse_clusters = args.reuse_clusters


### PR DESCRIPTION
## Description

The `k8sMatrixTest` Jenkins pipeline's **Print Complete Results** stage runs:
```
pipenv run app --test-reports-dir='./reports' --output-reports-summary-only
```

This only reads JSON report files and prints a summary table — no Kubernetes access needed.

However, `main()` in `test_runner.py` always creates `K8sService` (which calls `config.load_kube_config()`) **before** checking the `--output-reports-summary-only` flag. On the Jenkins matrix test agent, the kube-config file has invalid entries (missing `name` in contexts), causing:

```
Fatal error: Invalid kube-config file. Expected object with name in /home/ec2-user/.kube/config/contexts list
```

### Fix

Move the `output_reports_summary_only` check to **before** `K8sService` creation. When this flag is set, create a minimal `TestRunner` with `k8s_service=None` and return early after printing the summary.

### Testing

- Verified `collect_reports_and_print_summary` does not use `self.k8s_service` — it only reads JSON files from disk and calls `_print_summary_table`
- AST validation confirms the check now precedes `K8sService` creation