### PR TITLE
Add build number to CFN stack names in eksSolutionsCFNTest

### DIFF
--- a/vars/eksSolutionsCFNTest.groovy
+++ b/vars/eksSolutionsCFNTest.groovy
@@ -42,7 +42,7 @@ def call(Map config = [:]) {
         }
 
         environment {
-            TEST_VPC_STACK_NAME = "test-vpc-${stage}-${params.REGION}"
+            TEST_VPC_STACK_NAME = "test-vpc-${stage}-${currentBuild.number}-${params.REGION}"
         }
 
         stages {
@@ -104,7 +104,7 @@ def call(Map config = [:]) {
                     timeout(time: 90, unit: 'MINUTES') {
                         script {
                             def templateName = isImportVpc ? "Migration-Assistant-Infra-Import-VPC-eks" : "Migration-Assistant-Infra-Create-VPC-eks"
-                            env.STACK_NAME = "${templateName}-${stage}-${params.REGION}"
+                            env.STACK_NAME = "${templateName}-${stage}-${currentBuild.number}-${params.REGION}"
 
                             def bootstrapArgs = isImportVpc ?
                                 "--deploy-import-vpc-cfn --vpc-id ${env.TEST_VPC_ID} --subnet-ids ${env.TEST_SUBNET_IDS}" :


### PR DESCRIPTION
## Problem

The `eksSolutionsCFNTest` pipeline uses deterministic stack names like `Migration-Assistant-Infra-Create-VPC-eks-ekscreatevpc-us-east-1`. When a stack gets stuck in `DELETE_FAILED`, the next run tries to delete it, fails again, and aborts — blocking all subsequent runs.

Additionally, EKS stack deletes are currently hitting an internal IAM error:

```
Resource handler returned message: "Cannot delete entity, must remove roles from instance profile first.
(Service: Iam, Status Code: 409, Request ID: <REDACTED>)"
(RequestToken: <REDACTED>, HandlerErrorCode: GeneralServiceException)
```

This causes stacks to land in `DELETE_FAILED`, which then blocks subsequent runs that try to reuse the same deterministic stack name.

## Fix

Include `currentBuild.number` in both stack names in `vars/eksSolutionsCFNTest.groovy`:

- `env.STACK_NAME`: `${templateName}-${stage}-${currentBuild.number}-${params.REGION}`
- `TEST_VPC_STACK_NAME`: `test-vpc-${stage}-${currentBuild.number}-${params.REGION}`

Now each build gets a unique stack name (e.g. `...-ekscreatevpc-42-us-east-1`), so a stuck `DELETE_FAILED` stack from a previous run won't block new runs.

This applies to both create-vpc and import-vpc paths since `env.STACK_NAME` is set in the shared `Deploy & Install` stage. The cleanup `post` block already references `env.STACK_NAME` and `env.TEST_VPC_STACK_NAME`, so it correctly cleans up the uniquely-named stacks.

Follows the same pattern already used by `eksIsolatedDeploy.groovy`.
