### PR TITLE
Update Jenkins workflow concurrency to per-job per-PR

### DIFF
--- a/.github/workflows/jenkins_tests.yml
+++ b/.github/workflows/jenkins_tests.yml
@@ -7,10 +7,6 @@ on:
   pull_request_target:
     types: [opened, synchronize, reopened, labeled]
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}
-  cancel-in-progress: ${{ !(github.event_name == 'push' && github.repository == 'opensearch-project/opensearch-migrations' && github.ref == 'refs/heads/main') }}
-
 env:
   python-version: '3.11'
 
@@ -30,6 +26,9 @@ jobs:
     needs: [get-require-approval, sanitize-input]
     environment: ${{ needs.get-require-approval.outputs.is-require-approval }}
     runs-on: ubuntu-22.04
+    concurrency:
+      group: ${{ github.workflow }}-full-es68-e2e-aws-test-${{ github.event.pull_request.number || github.run_id }}
+      cancel-in-progress: ${{ github.event_name != 'push' }}
     steps:
       - name: Jenkins Job Trigger and Monitor
         uses: jugal-chauhan/jenkins-trigger@1.0.6
@@ -43,6 +42,9 @@ jobs:
     needs: [get-require-approval, sanitize-input]
     environment: ${{ needs.get-require-approval.outputs.is-require-approval }}
     runs-on: ubuntu-22.04
+    concurrency:
+      group: ${{ github.workflow }}-elasticsearch-5x-k8s-local-test-${{ github.event.pull_request.number || github.run_id }}
+      cancel-in-progress: ${{ github.event_name != 'push' }}
     steps:
       - name: Jenkins Job Trigger and Monitor
         uses: jugal-chauhan/jenkins-trigger@1.0.6
@@ -61,6 +63,9 @@ jobs:
     environment: ${{ needs.get-require-approval.outputs.is-require-approval }}
     runs-on: ubuntu-22.04
     timeout-minutes: 120
+    concurrency:
+      group: ${{ github.workflow }}-eks-integ-test-${{ github.event.pull_request.number || github.run_id }}
+      cancel-in-progress: ${{ github.event_name != 'push' }}
     steps:
       - name: Jenkins Job Trigger and Monitor
         uses: jugal-chauhan/jenkins-trigger@1.0.6


### PR DESCRIPTION
## Description

The current top-level concurrency group limits the entire Jenkins workflow to one run per branch, which means:
- On main: pushes don't cancel each other (good), but they're serialized into one concurrent run
- On PRs: a new push cancels **all** running Jenkins tests, not just the same test

### Changes

Removed the top-level concurrency group and added per-job concurrency:

| Scenario | Behavior |
|----------|----------|
| **Main pushes** | Unlimited concurrency — each run gets a unique group via `github.run_id`, so runs never block or cancel each other |
| **PR pushes** | 1 concurrent run per test per PR — grouped by `PR number + job name`, with `cancel-in-progress: true` so a new push to the same PR cancels only the same test's previous run |

This means on a PR, pushing a new commit will cancel the old `full-es68-e2e-aws-test` run for that PR but won't affect the `elasticsearch-5x-k8s-local-test` or `eks-integ-test` runs.