### PR TITLE
fix: Route legacy DockerBuildImage tasks through ECR pull-through cache

### DIFF
--- a/DocumentsFromSnapshotMigration/build.gradle
+++ b/DocumentsFromSnapshotMigration/build.gradle
@@ -8,6 +8,10 @@ plugins {
 import com.bmuschko.gradle.docker.tasks.image.DockerBuildImage
 import groovy.transform.Canonical
 import org.opensearch.migrations.common.CommonUtils
+import org.opensearch.migrations.image.PullThroughCacheHelper
+
+def ptcEndpoint = rootProject.findProperty('pullThroughCacheEndpoint')?.toString() ?: ''
+def ptc = new PullThroughCacheHelper(ptcEndpoint)
 
 @Canonical
 class DockerServiceProps {
@@ -95,6 +99,7 @@ DockerServiceProps[] dockerServices = [
         new DockerServiceProps([projectName:"reindexFromSnapshot",
                                 dockerImageName:"reindex_from_snapshot",
                                 inputDir:"./docker",
+                                buildArgs:[BASE_IMAGE: ptc.rewrite("docker.io/library/amazoncorretto:17-al2023-headless")],
                                 taskDependencies:["copyDockerRuntimeJars", "syncVersionFile_reindexFromSnapshot"]])
 ] as DockerServiceProps[]
 

--- a/TrafficCapture/dockerSolution/build.gradle
+++ b/TrafficCapture/dockerSolution/build.gradle
@@ -1,5 +1,6 @@
 import org.opensearch.migrations.common.CommonUtils
 import com.bmuschko.gradle.docker.tasks.image.DockerBuildImage
+import org.opensearch.migrations.image.PullThroughCacheHelper
 
 plugins {
     id 'org.opensearch.migrations.java-library-conventions'
@@ -12,6 +13,27 @@ plugins {
 def migrationConsoleStagingDirName = "staging"
 def sourceDirectoryOverrides = [
         "staging": "migrationConsoleStaging"
+]
+
+def ptcEndpoint = rootProject.findProperty('pullThroughCacheEndpoint')?.toString() ?: ''
+def ptc = new PullThroughCacheHelper(ptcEndpoint)
+
+// Build args for Dockerfiles that pull external base images
+def dockerBuildArgsMap = [
+        "capture_proxy_base": [
+                CERT_BUILDER_IMAGE: ptc.rewrite("docker.io/library/amazonlinux:2023"),
+                RUNTIME_IMAGE: ptc.rewrite("docker.io/library/amazoncorretto:11-al2023-headless"),
+        ],
+        "elasticsearch_client_test_console": [
+                BUILDER_IMAGE: ptc.rewrite("docker.io/library/amazonlinux:2023"),
+                RUNTIME_IMAGE: ptc.rewrite("docker.io/library/amazonlinux:2023"),
+        ],
+        "otel_collector": [
+                BASE_IMAGE: ptc.rewrite("public.ecr.aws/aws-observability/aws-otel-collector:v0.43.3"),
+        ],
+        "grafana": [
+                BASE_IMAGE: ptc.rewrite("docker.io/grafana/grafana:11.6.1"),
+        ],
 ]
 
 def dockerFilesForExternalServices = [
@@ -65,6 +87,11 @@ dockerFilesForExternalServices.each { dockerImageName, projectName ->
             def hashNonce = CommonUtils.calculateDockerHash(project.fileTree(inputDir))
             images.add("migrations/${dockerImageName}:${hashNonce}".toString())
             images.add("migrations/${dockerImageName}:latest".toString())
+        }
+        // Pass pull-through cache build args if configured for this image
+        def extraArgs = dockerBuildArgsMap.get(dockerImageName, [:])
+        if (extraArgs) {
+            buildArgs = extraArgs
         }
     }
 }

--- a/deployment/cdk/opensearch-service-migration/buildDockerImages.sh
+++ b/deployment/cdk/opensearch-service-migration/buildDockerImages.sh
@@ -6,4 +6,11 @@ script_dir_abs_path=$(dirname "$script_abs_path")
 cd "$script_dir_abs_path" || exit
 
 cd ../../.. || exit
-./gradlew :buildDockerImages -x test "$@"
+
+# Pass ECR pull-through cache endpoint to Gradle if available
+PTC_ARG=""
+if [ -n "$ECR_PULL_THROUGH_ENDPOINT" ]; then
+  PTC_ARG="-PpullThroughCacheEndpoint=$ECR_PULL_THROUGH_ENDPOINT"
+fi
+
+./gradlew :buildDockerImages -x test $PTC_ARG "$@"


### PR DESCRIPTION
## Description

The Deploy stage in Jenkins CI uses `DockerBuildImage` tasks (com.bmuschko.gradle.docker) which invoke the **legacy Docker builder** (not BuildKit). The legacy builder doesn't use containerd's `hosts.toml` registry mirrors — it uses the Docker daemon's own registry resolution via `daemon.json`.

After removing `daemon.json` `registry-mirrors` in PR #2351 (because it's incompatible with ECR pull-through cache path prefixes), these legacy `docker build` tasks pull base images directly from Docker Hub, hitting rate limits.

### Root Cause

| Pull Method | Uses containerd mirror? | Uses pull-through cache? |
|---|---|---|
| **Jib** (`-PpullThroughCacheEndpoint`) | ❌ Own client | ✅ Yes |
| **BuildKit** (`buildImages/build.gradle`) | ❌ Own resolver | ✅ Yes (via `ptc.rewrite()`) |
| **Legacy `docker build`** (`DockerBuildImage`) | ❌ daemon.json | ❌ **No** — goes to Docker Hub |

### Fix

1. Wire `PullThroughCacheHelper` into `DockerBuildImage` tasks in `DocumentsFromSnapshotMigration/build.gradle` and `TrafficCapture/dockerSolution/build.gradle` to rewrite base image ARGs through ECR pull-through cache
2. Update `buildDockerImages.sh` to pass `ECR_PULL_THROUGH_ENDPOINT` env var to Gradle as `-PpullThroughCacheEndpoint`

### Files Changed

| File | Change |
|---|---|
| `DocumentsFromSnapshotMigration/build.gradle` | Add `PullThroughCacheHelper` to rewrite `BASE_IMAGE` ARG |
| `TrafficCapture/dockerSolution/build.gradle` | Add `PullThroughCacheHelper` to rewrite base image ARGs for all external Dockerfiles |
| `deployment/cdk/opensearch-service-migration/buildDockerImages.sh` | Pass `ECR_PULL_THROUGH_ENDPOINT` to Gradle |

### Testing

- `./gradlew :buildDockerImages --dry-run` passes
- Without `-PpullThroughCacheEndpoint`: behavior unchanged (no-op rewrite)
- With `-PpullThroughCacheEndpoint=<ecr>`: base image ARGs rewritten to ECR pull-through cache URIs

Signed-off-by: Andre Kurait <andrekurait@gmail.com>