### PR TITLE
[Fix] retryStrategy limit type in argo-workflow-builders tests

### DIFF
--- a/orchestrationSpecs/packages/argo-workflow-builders/tests/podConfig.test.ts
+++ b/orchestrationSpecs/packages/argo-workflow-builders/tests/podConfig.test.ts
@@ -733,7 +733,7 @@ describe('Pod Config - RetryStrategy', () => {
                 .addImageInfo('nginx:latest', 'IfNotPresent')
                 .addCommand(['echo'])
                 .addResources(EXAMPLE_RESOURCES)
-                .addRetryParameters({ limit: 3, retryPolicy: 'OnFailure' })
+                .addRetryParameters({ limit: "3", retryPolicy: 'OnFailure' })
             )
         )
         .getFullScope();
@@ -741,7 +741,7 @@ describe('Pod Config - RetryStrategy', () => {
         const rendered = renderWorkflowTemplate(wf);
         const template = rendered.spec.templates.find((t: any) => t.name === 'test');
 
-        expect(template.retryStrategy).toEqual({ limit: 3, retryPolicy: 'OnFailure' });
+        expect(template.retryStrategy).toEqual({ limit: "3", retryPolicy: 'OnFailure' });
     });
 
     it('should reject duplicate addRetryParameters calls at compile time', () => {
@@ -755,8 +755,8 @@ describe('Pod Config - RetryStrategy', () => {
                 .addImageInfo('nginx:latest', 'IfNotPresent')
                 .addCommand(['echo'])
                 .addResources(EXAMPLE_RESOURCES)
-                .addRetryParameters({ limit: 3 })
-                .addRetryParameters({ limit: 5 })
+                .addRetryParameters({ limit: "3" })
+                .addRetryParameters({ limit: "5" })
             )
         );
         expect(true).toBe(true);


### PR DESCRIPTION
### Description
Argo CRD defines `retryStrategy.limit` as `IntOrString`. All workflow templates already use `string` values, but the tests in podConfig.test.ts were passing numeric literals. This aligns the test values with the rest of the codebase.

### Issues Resolved
N/A

### Testing
- All argo-workflow-builders and migration-workflow-templates tests pass. No snapshot updates needed.
- Existing GHA

### Check List
- [x] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
