### PR TITLE
Added Translation for Range Facets

### DIFF
--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/cases.testcase.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/cases.testcase.ts
@@ -113,7 +113,7 @@ export const testCases: TestCase[] = [
     requestPath:
       '/solr/testcollection/select?q=*:*&wt=json&json.facet=' +
       encodeURIComponent(JSON.stringify({
-        categories: { type: 'terms', field: 'category', sort: 'count desc' },
+          categories: { type: 'terms', field: 'category', sort: 'count desc' },
       })),
     solrSchema: {
       fields: {
@@ -172,6 +172,91 @@ export const testCases: TestCase[] = [
         reason:
           'OpenSearch has no native offset for terms aggs — proxy returns size=offset+limit buckets. ' +
           'The last `limit` buckets (after skipping the first 1) must match Solr exactly.',
+      },
+    ],
+  }),
+
+  solrTest('facet-basic-range', {
+    description: 'Basic range facet on a numeric field using start/end/gap',
+    documents: [
+      { id: '1', title: 'cheap item', price: 10 },
+      { id: '2', title: 'mid item', price: 35 },
+      { id: '3', title: 'pricey item', price: 55 },
+      { id: '4', title: 'expensive item', price: 80 },
+      { id: '5', title: 'luxury item', price: 95 },
+    ],
+    requestPath:
+      '/solr/testcollection/select?q=*:*&wt=json&json.facet=' +
+      encodeURIComponent(
+        JSON.stringify({
+          prices: { type: 'range', field: 'price', start: 0, end: 100, gap: 20 },
+        }),
+      ),
+    solrSchema: {
+      fields: {
+        title: { type: 'text_general' },
+        price: { type: 'pfloat' },
+      },
+    },
+    opensearchMapping: {
+      properties: {
+        title: { type: 'text' },
+        price: { type: 'float' },
+      },
+    },
+    assertionRules: [
+      ...SOLR_INTERNAL_RULES,
+      {
+        path: '$.response',
+        rule: 'ignore',
+        reason: 'Facet test — only validating $.facets, not hits',
+      },
+    ],
+  }),
+
+  solrTest('facet-arbitrary-range', {
+    description: 'Arbitrary range facet with custom bucket boundaries',
+    documents: [
+      { id: '1', title: 'cheap item', price: 10 },
+      { id: '2', title: 'mid item', price: 35 },
+      { id: '3', title: 'pricey item', price: 55 },
+      { id: '4', title: 'expensive item', price: 80 },
+      { id: '5', title: 'luxury item', price: 95 },
+    ],
+    requestPath:
+      '/solr/testcollection/select?q=*:*&wt=json&json.facet=' +
+      encodeURIComponent(
+        JSON.stringify({
+          price_ranges: {
+            type: 'range',
+            field: 'price',
+            ranges: [
+              { range: '[0,25)' },
+              { range: '[25,50)' },
+              { range: '[50,75)' },
+              { range: '[75,*)' },
+            ],
+          },
+        }),
+      ),
+    solrSchema: {
+      fields: {
+        title: { type: 'text_general' },
+        price: { type: 'pfloat' },
+      },
+    },
+    opensearchMapping: {
+      properties: {
+        title: { type: 'text' },
+        price: { type: 'float' },
+      },
+    },
+    assertionRules: [
+      ...SOLR_INTERNAL_RULES,
+      {
+        path: '$.response',
+        rule: 'ignore',
+        reason: 'Facet test — only validating $.facets, not hits',
       },
     ],
   }),

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/json-facets.test.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/json-facets.test.ts
@@ -1,8 +1,11 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { request } from './json-facets';
 import type { RequestContext, JavaMap } from '../context';
+import { convertSort } from './utils';
 
 const FACET_NAME = 'myFacet';
+
+// region Test helpers
 
 /**
  * Helper: build a RequestContext whose body contains a json.facet Map
@@ -47,10 +50,34 @@ function termsInner(aggs: JavaMap): JavaMap {
   return aggs.get(FACET_NAME).get('terms');
 }
 
-/** Shortcut: apply the transform to a body-based context and return the inner terms map. */
-function applyBodyFacet(obj: Record<string, any>): JavaMap {
-  return termsInner(applyAndGetAggs(ctxWithBodyFacet(obj)));
+/** Extract the inner "histogram" map from the aggs result for the default facet name. */
+function histogramInner(aggs: JavaMap): JavaMap {
+  return aggs.get(FACET_NAME).get('histogram');
 }
+
+/** Extract the inner "range" map from the aggs result for the default facet name. */
+function rangeInner(aggs: JavaMap): JavaMap {
+  return aggs.get(FACET_NAME).get('range');
+}
+
+/** Build a terms facet context, apply the transform, and return the inner terms map. */
+function applyBodyTerms(obj: Record<string, any>): JavaMap {
+  return termsInner(applyAndGetAggs(ctxWithBodyFacet({ type: 'terms', ...obj })));
+}
+
+/** Build a range facet context, apply the transform, and return the inner histogram map. */
+function applyBodyHistogram(obj: Record<string, any>): JavaMap {
+  return histogramInner(applyAndGetAggs(ctxWithBodyFacet({ type: 'range', ...obj })));
+}
+
+/** Build a range facet context (with ranges), apply the transform, and return the inner range map. */
+function applyBodyRange(obj: Record<string, any>): JavaMap {
+  return rangeInner(applyAndGetAggs(ctxWithBodyFacet({ type: 'range', ...obj })));
+}
+
+// endregion
+
+// General transform behaviour (match / apply / source selection)
 
 describe('json-facets MicroTransform', () => {
   describe('match', () => {
@@ -99,143 +126,547 @@ describe('json-facets MicroTransform', () => {
       expect(inner.get('field')).toBe('category');
     });
   });
+});
 
-  describe('terms facet conversion', () => {
-    it('should set the field on the terms aggregation', () => {
-      const inner = applyBodyFacet({ type: 'terms', field: 'category' });
-      expect(inner.get('field')).toBe('category');
+// Terms facet → OpenSearch terms aggregation
+
+describe('terms facet conversion', () => {
+  it('should set the field on the terms aggregation', () => {
+    const inner = applyBodyTerms({ field: 'category' });
+    expect(inner.get('field')).toBe('category');
+  });
+
+  it('should map limit to size', () => {
+    const inner = applyBodyTerms({ field: 'category', limit: 5 });
+    expect(inner.get('size')).toBe(5);
+  });
+
+  it('should not set size when limit is absent', () => {
+    const inner = applyBodyTerms({ field: 'category' });
+    expect(inner.has('size')).toBe(false);
+  });
+
+  it('should combine offset with default limit into size', () => {
+    const inner = applyBodyTerms({ field: 'category', offset: 10 });
+    // offset=10 + default limit=10 → size=20
+    expect(inner.get('size')).toBe(20);
+  });
+
+  it('should map mincount to min_doc_count', () => {
+    const inner = applyBodyTerms({ field: 'category', mincount: 2 });
+    expect(inner.get('min_doc_count')).toBe(2);
+  });
+
+  it('should not set min_doc_count when mincount is absent', () => {
+    const inner = applyBodyTerms({ field: 'category' });
+    expect(inner.has('min_doc_count')).toBe(false);
+  });
+
+  it('should map prefix to an include regex pattern', () => {
+    const inner = applyBodyTerms({ field: 'category', prefix: 'foo' });
+    expect(inner.get('include')).toBe('foo.*');
+  });
+
+  it('should not set include when prefix is absent', () => {
+    const inner = applyBodyTerms({ field: 'category' });
+    expect(inner.has('include')).toBe(false);
+  });
+
+  it('should set missing to empty string when missing is true', () => {
+    const inner = applyBodyTerms({ field: 'category', missing: true });
+    expect(inner.get('missing')).toBe('');
+  });
+
+  it('should not set missing when missing is false', () => {
+    const inner = applyBodyTerms({ field: 'category', missing: false });
+    expect(inner.has('missing')).toBe(false);
+  });
+
+  it('should not set missing when missing is absent', () => {
+    const inner = applyBodyTerms({ field: 'category' });
+    expect(inner.has('missing')).toBe(false);
+  });
+
+  describe('sort conversion', () => {
+    it('should map "count desc" to order {_count: "desc"}', () => {
+      const inner = applyBodyTerms({ field: 'category', sort: 'count desc' });
+      expect(inner.get('order').get('_count')).toBe('desc');
     });
 
-    it('should map limit to size', () => {
-      const inner = applyBodyFacet({ type: 'terms', field: 'category', limit: 5 });
-      expect(inner.get('size')).toBe(5);
+    it('should map "count asc" to order {_count: "asc"}', () => {
+      const inner = applyBodyTerms({ field: 'category', sort: 'count asc' });
+      expect(inner.get('order').get('_count')).toBe('asc');
     });
 
-    it('should not set size when limit is absent', () => {
-      const inner = applyBodyFacet({ type: 'terms', field: 'category' });
-      expect(inner.has('size')).toBe(false);
-    });
-
-    it('should map offset to size without limit', () => {
-      const inner = applyBodyFacet({ type: 'terms', field: 'category', offset: 10 });
-      expect(inner.get('size')).toBe(20);
-    });
-
-    it('should map mincount to min_doc_count', () => {
-      const inner = applyBodyFacet({ type: 'terms', field: 'category', mincount: 2 });
-      expect(inner.get('min_doc_count')).toBe(2);
-    });
-
-    it('should not set min_doc_count when mincount is absent', () => {
-      const inner = applyBodyFacet({ type: 'terms', field: 'category' });
-      expect(inner.has('min_doc_count')).toBe(false);
-    });
-
-    it('should map prefix to an include regex pattern', () => {
-      const inner = applyBodyFacet({ type: 'terms', field: 'category', prefix: 'foo' });
-      expect(inner.get('include')).toBe('foo.*');
-    });
-
-    it('should not set include when prefix is absent', () => {
-      const inner = applyBodyFacet({ type: 'terms', field: 'category' });
-      expect(inner.has('include')).toBe(false);
-    });
-
-    it('should set missing to empty string when missing is true', () => {
-      const inner = applyBodyFacet({ type: 'terms', field: 'category', missing: true });
-      expect(inner.get('missing')).toBe('');
-    });
-
-    it('should not set missing when missing is false', () => {
-      const inner = applyBodyFacet({ type: 'terms', field: 'category', missing: false });
-      expect(inner.has('missing')).toBe(false);
-    });
-
-    it('should not set missing when missing is absent', () => {
-      const inner = applyBodyFacet({ type: 'terms', field: 'category' });
-      expect(inner.has('missing')).toBe(false);
-    });
-
-    describe('sort conversion', () => {
-      it('should map "count desc" to order {_count: "desc"}', () => {
-        const inner = applyBodyFacet({ type: 'terms', field: 'category', sort: 'count desc' });
-        expect(inner.get('order').get('_count')).toBe('desc');
-      });
-
-      it('should map "count asc" to order {_count: "asc"}', () => {
-        const inner = applyBodyFacet({ type: 'terms', field: 'category', sort: 'count asc' });
-        expect(inner.get('order').get('_count')).toBe('asc');
-      });
-
-      it('should map "index asc" to order {_key: "asc"}', () => {
-        const inner = applyBodyFacet({ type: 'terms', field: 'category', sort: 'index asc' });
-        expect(inner.get('order').get('_key')).toBe('asc');
-      });
-
-      it('should map "index desc" to order {_key: "desc"}', () => {
-        const inner = applyBodyFacet({ type: 'terms', field: 'category', sort: 'index desc' });
-        expect(inner.get('order').get('_key')).toBe('desc');
-      });
-
-      it('should default sort direction to desc when direction is omitted', () => {
-        const inner = applyBodyFacet({ type: 'terms', field: 'category', sort: 'count' });
-        expect(inner.get('order').get('_count')).toBe('desc');
-      });
-
-      it('should pass through unknown sort keys as-is', () => {
-        const inner = applyBodyFacet({ type: 'terms', field: 'category', sort: 'my_metric asc' });
-        expect(inner.get('order').get('my_metric')).toBe('asc');
-      });
-
-      it('should not set order when sort is absent', () => {
-        const inner = applyBodyFacet({ type: 'terms', field: 'category' });
-        expect(inner.has('order')).toBe(false);
-      });
-    });
-
-    it('should handle limit of 0', () => {
-      const inner = applyBodyFacet({ type: 'terms', field: 'category', limit: 0 });
-      expect(inner.get('size')).toBe(0);
-    });
-
-    it('should handle mincount of 0', () => {
-      const inner = applyBodyFacet({ type: 'terms', field: 'category', mincount: 0 });
-      expect(inner.get('min_doc_count')).toBe(0);
-    });
-
-    it('should handle all options combined', () => {
-      const inner = applyBodyFacet({
-        type: 'terms',
-        field: 'status',
-        limit: 20,
-        offset: 5,
-        mincount: 1,
-        prefix: 'active',
-        missing: true,
-        sort: 'index asc',
-      });
-
-      expect(inner.get('field')).toBe('status');
-      expect(inner.get('size')).toBe(25);
-      expect(inner.get('min_doc_count')).toBe(1);
-      expect(inner.get('include')).toBe('active.*');
-      expect(inner.get('missing')).toBe('');
+    it('should map "index asc" to order {_key: "asc"}', () => {
+      const inner = applyBodyTerms({ field: 'category', sort: 'index asc' });
       expect(inner.get('order').get('_key')).toBe('asc');
     });
 
-    it('should only have field when no optional properties are provided', () => {
-      const inner = applyBodyFacet({ type: 'terms', field: 'category' });
-      expect(inner.size).toBe(1);
-      expect(inner.get('field')).toBe('category');
+    it('should map "index desc" to order {_key: "desc"}', () => {
+      const inner = applyBodyTerms({ field: 'category', sort: 'index desc' });
+      expect(inner.get('order').get('_key')).toBe('desc');
     });
 
-    it('should return a Map with exactly one top-level "terms" key', () => {
-      const aggs = applyAndGetAggs(
-        ctxWithBodyFacet({ type: 'terms', field: 'category', limit: 10 }),
-      );
-      const agg = aggs.get(FACET_NAME);
-      expect(agg.size).toBe(1);
-      expect(agg.has('terms')).toBe(true);
+    it('should default sort direction to desc when direction is omitted', () => {
+      const inner = applyBodyTerms({ field: 'category', sort: 'count' });
+      expect(inner.get('order').get('_count')).toBe('desc');
     });
+
+    it('should pass through unknown sort keys as-is', () => {
+      const inner = applyBodyTerms({ field: 'category', sort: 'my_metric asc' });
+      expect(inner.get('order').get('my_metric')).toBe('asc');
+    });
+
+    it('should not set order when sort is absent', () => {
+      const inner = applyBodyTerms({ field: 'category' });
+      expect(inner.has('order')).toBe(false);
+    });
+  });
+
+  it('should handle limit of 0', () => {
+    const inner = applyBodyTerms({ field: 'category', limit: 0 });
+    expect(inner.get('size')).toBe(0);
+  });
+
+  it('should handle mincount of 0', () => {
+    const inner = applyBodyTerms({ field: 'category', mincount: 0 });
+    expect(inner.get('min_doc_count')).toBe(0);
+  });
+
+  it('should handle all options combined', () => {
+    const inner = applyBodyTerms({
+      field: 'status',
+      limit: 20,
+      offset: 5,
+      mincount: 1,
+      prefix: 'active',
+      missing: true,
+      sort: 'index asc',
+    });
+
+    expect(inner.get('field')).toBe('status');
+    // offset=5 + limit=20 → size=25
+    expect(inner.get('size')).toBe(25);
+    expect(inner.get('min_doc_count')).toBe(1);
+    expect(inner.get('include')).toBe('active.*');
+    expect(inner.get('missing')).toBe('');
+    expect(inner.get('order').get('_key')).toBe('asc');
+  });
+
+  it('should only have field when no optional properties are provided', () => {
+    const inner = applyBodyTerms({ field: 'category' });
+    expect(inner.size).toBe(1);
+    expect(inner.get('field')).toBe('category');
+  });
+
+  it('should return a Map with exactly one top-level "terms" key', () => {
+    const aggs = applyAndGetAggs(
+      ctxWithBodyFacet({ type: 'terms', field: 'category', limit: 10 }),
+    );
+    const agg = aggs.get(FACET_NAME);
+    expect(agg.size).toBe(1);
+    expect(agg.has('terms')).toBe(true);
+  });
+});
+
+// Uniform range facet (start/end/gap) → OpenSearch histogram aggregation
+
+describe('uniform range facet conversion (histogram)', () => {
+  it('should produce a histogram aggregation with field and interval', () => {
+    const inner = applyBodyHistogram({ field: 'price', start: 0, end: 100, gap: 10 });
+    expect(inner.get('field')).toBe('price');
+    expect(inner.get('interval')).toBe(10);
+  });
+
+  it('should return a Map with exactly one top-level "histogram" key', () => {
+    const aggs = applyAndGetAggs(
+      ctxWithBodyFacet({ type: 'range', field: 'price', start: 0, end: 100, gap: 10 }),
+    );
+    const agg = aggs.get(FACET_NAME);
+    expect(agg.size).toBe(1);
+    expect(agg.has('histogram')).toBe(true);
+  });
+
+  it('should set extended_bounds from start and end', () => {
+    const inner = applyBodyHistogram({ field: 'price', start: 0, end: 100, gap: 10 });
+    const bounds = inner.get('extended_bounds');
+    expect(bounds).toBeDefined();
+    expect(bounds.get('min')).toBe(0);
+    // max = end - gap = 100 - 10 = 90
+    expect(bounds.get('max')).toBe(90);
+  });
+
+  it('should set extended_bounds.max to end when gap is absent', () => {
+    const inner = applyBodyHistogram({ field: 'price', start: 0, end: 100 });
+    const bounds = inner.get('extended_bounds');
+    expect(bounds.get('max')).toBe(100);
+  });
+
+  it('should set only extended_bounds.min when end is absent', () => {
+    const inner = applyBodyHistogram({ field: 'price', start: 0, gap: 10 });
+    const bounds = inner.get('extended_bounds');
+    expect(bounds.get('min')).toBe(0);
+    expect(bounds.has('max')).toBe(false);
+  });
+
+  it('should not set extended_bounds when start and end are both absent', () => {
+    const inner = applyBodyHistogram({ field: 'price', gap: 10 });
+    expect(inner.has('extended_bounds')).toBe(false);
+  });
+
+  it('should map mincount to min_doc_count', () => {
+    const inner = applyBodyHistogram({
+      field: 'price',
+      start: 0,
+      end: 100,
+      gap: 10,
+      mincount: 1,
+    });
+    expect(inner.get('min_doc_count')).toBe(1);
+  });
+
+  it('should not set min_doc_count when mincount is absent', () => {
+    const inner = applyBodyHistogram({ field: 'price', start: 0, end: 100, gap: 10 });
+    expect(inner.has('min_doc_count')).toBe(false);
+  });
+
+  it('should handle mincount of 0', () => {
+    const inner = applyBodyHistogram({
+      field: 'price',
+      start: 0,
+      end: 100,
+      gap: 10,
+      mincount: 0,
+    });
+    expect(inner.get('min_doc_count')).toBe(0);
+  });
+
+  it('should only have field when no optional parameters are provided', () => {
+    const inner = applyBodyHistogram({ field: 'price' });
+    expect(inner.size).toBe(1);
+    expect(inner.get('field')).toBe('price');
+  });
+
+  it('should work from a query-string param', () => {
+    const ctx = ctxWithParamFacet({ type: 'range', field: 'price', start: 0, end: 50, gap: 5 });
+    request.apply(ctx);
+    const inner = histogramInner(ctx.body.get('aggs'));
+    expect(inner.get('field')).toBe('price');
+    expect(inner.get('interval')).toBe(5);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Arbitrary range facet (ranges array) → OpenSearch range aggregation
+// ---------------------------------------------------------------------------
+
+describe('arbitrary range facet conversion (range)', () => {
+  it('should produce a range aggregation with field', () => {
+    const inner = applyBodyRange({
+      field: 'price',
+      ranges: ['[0,25)', '[25,50)', '[50,*)'],
+    });
+    expect(inner.get('field')).toBe('price');
+  });
+
+  it('should return a Map with exactly one top-level "range" key', () => {
+    const aggs = applyAndGetAggs(
+      ctxWithBodyFacet({ type: 'range', field: 'price', ranges: ['[0,25)'] }),
+    );
+    const agg = aggs.get(FACET_NAME);
+    expect(agg.size).toBe(1);
+    expect(agg.has('range')).toBe(true);
+  });
+
+  describe('string range parsing', () => {
+    it('should parse "[0,25)" into from=0, to=25 with key preserved', () => {
+      const inner = applyBodyRange({ field: 'price', ranges: ['[0,25)'] });
+      const ranges = inner.get('ranges') as JavaMap[];
+      expect(ranges).toHaveLength(1);
+      expect(ranges[0].get('key')).toBe('[0,25)');
+      expect(ranges[0].get('from')).toBe(0);
+      expect(ranges[0].get('to')).toBe(25);
+    });
+
+    it('should parse "[50,*)" as from=50, no to (unbounded upper)', () => {
+      const inner = applyBodyRange({ field: 'price', ranges: ['[50,*)'] });
+      const ranges = inner.get('ranges') as JavaMap[];
+      expect(ranges[0].get('from')).toBe(50);
+      expect(ranges[0].has('to')).toBe(false);
+    });
+
+    it('should parse "[*,25)" as to=25, no from (unbounded lower)', () => {
+      const inner = applyBodyRange({ field: 'price', ranges: ['[*,25)'] });
+      const ranges = inner.get('ranges') as JavaMap[];
+      expect(ranges[0].has('from')).toBe(false);
+      expect(ranges[0].get('to')).toBe(25);
+    });
+
+    it('should handle multiple string ranges', () => {
+      const inner = applyBodyRange({
+        field: 'price',
+        ranges: ['[0,25)', '[25,50)', '[50,100)'],
+      });
+      const ranges = inner.get('ranges') as JavaMap[];
+      expect(ranges).toHaveLength(3);
+      expect(ranges[0].get('from')).toBe(0);
+      expect(ranges[0].get('to')).toBe(25);
+      expect(ranges[1].get('from')).toBe(25);
+      expect(ranges[1].get('to')).toBe(50);
+      expect(ranges[2].get('from')).toBe(50);
+      expect(ranges[2].get('to')).toBe(100);
+    });
+
+    it('should handle decimal values in ranges', () => {
+      const inner = applyBodyRange({
+        field: 'score',
+        ranges: ['[0.0,0.5)', '[0.5,1.0)'],
+      });
+      const ranges = inner.get('ranges') as JavaMap[];
+      expect(ranges[0].get('from')).toBe(0);
+      expect(ranges[0].get('to')).toBe(0.5);
+      expect(ranges[1].get('from')).toBe(0.5);
+      expect(ranges[1].get('to')).toBe(1);
+    });
+  });
+
+  describe('object range items (plain JS objects from query-string)', () => {
+    it('should handle objects with range string property', () => {
+      const inner = applyBodyRange({
+        field: 'price',
+        ranges: [{ range: '[0,50)' }, { range: '[50,100)' }],
+      });
+      const ranges = inner.get('ranges') as JavaMap[];
+      expect(ranges).toHaveLength(2);
+      expect(ranges[0].get('key')).toBe('[0,50)');
+      expect(ranges[0].get('from')).toBe(0);
+      expect(ranges[0].get('to')).toBe(50);
+    });
+
+    it('should handle objects with from/to/key properties', () => {
+      const inner = applyBodyRange({
+        field: 'price',
+        ranges: [
+          { from: 0, to: 50, key: 'cheap' },
+          { from: 50, to: 100, key: 'expensive' },
+        ],
+      });
+      const ranges = inner.get('ranges') as JavaMap[];
+      expect(ranges).toHaveLength(2);
+      expect(ranges[0].get('from')).toBe(0);
+      expect(ranges[0].get('to')).toBe(50);
+      expect(ranges[0].get('key')).toBe('cheap');
+      expect(ranges[1].get('from')).toBe(50);
+      expect(ranges[1].get('to')).toBe(100);
+      expect(ranges[1].get('key')).toBe('expensive');
+    });
+
+    it('should handle objects with only from (unbounded upper)', () => {
+      const inner = applyBodyRange({ field: 'price', ranges: [{ from: 100 }] });
+      const ranges = inner.get('ranges') as JavaMap[];
+      expect(ranges[0].get('from')).toBe(100);
+      expect(ranges[0].has('to')).toBe(false);
+    });
+
+    it('should handle objects with only to (unbounded lower)', () => {
+      const inner = applyBodyRange({ field: 'price', ranges: [{ to: 50 }] });
+      const ranges = inner.get('ranges') as JavaMap[];
+      expect(ranges[0].has('from')).toBe(false);
+      expect(ranges[0].get('to')).toBe(50);
+    });
+  });
+
+  describe('Map-like range items (from Jackson / GraalVM interop)', () => {
+    it('should handle Map-like items with range string', () => {
+      const rangeItem = new Map([['range', '[10,20)']]) as unknown as JavaMap;
+      const inner = applyBodyRange({ field: 'price', ranges: [rangeItem] });
+      const ranges = inner.get('ranges') as JavaMap[];
+      expect(ranges).toHaveLength(1);
+      expect(ranges[0].get('key')).toBe('[10,20)');
+      expect(ranges[0].get('from')).toBe(10);
+      expect(ranges[0].get('to')).toBe(20);
+    });
+
+    it('should handle Map-like items with from/to/key', () => {
+      const rangeItem = new Map<string, any>([
+        ['from', 0],
+        ['to', 50],
+        ['key', 'low'],
+      ]) as unknown as JavaMap;
+      const inner = applyBodyRange({ field: 'price', ranges: [rangeItem] });
+      const ranges = inner.get('ranges') as JavaMap[];
+      expect(ranges[0].get('from')).toBe(0);
+      expect(ranges[0].get('to')).toBe(50);
+      expect(ranges[0].get('key')).toBe('low');
+    });
+  });
+
+  it('should handle an empty ranges array', () => {
+    const inner = applyBodyRange({ field: 'price', ranges: [] });
+    const ranges = inner.get('ranges') as JavaMap[];
+    expect(ranges).toHaveLength(0);
+  });
+
+  it('should work from a query-string param with arbitrary ranges', () => {
+    const ctx = ctxWithParamFacet({
+      type: 'range',
+      field: 'price',
+      ranges: [{ range: '[0,50)' }, { range: '[50,*)' }],
+    });
+    request.apply(ctx);
+    const inner = rangeInner(ctx.body.get('aggs'));
+    expect(inner.get('field')).toBe('price');
+    const ranges = inner.get('ranges') as JavaMap[];
+    expect(ranges).toHaveLength(2);
+    expect(ranges[0].get('from')).toBe(0);
+    expect(ranges[0].get('to')).toBe(50);
+    expect(ranges[1].get('from')).toBe(50);
+    expect(ranges[1].has('to')).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// convertSort — Map input coverage (utils.ts lines 26-30)
+// ---------------------------------------------------------------------------
+
+describe('convertSort with Map input', () => {
+  it('should convert a Map with count key to _count', () => {
+    const sortMap = new Map([['count', 'desc']]) as unknown as JavaMap;
+    const order = convertSort(sortMap);
+    expect(order.get('_count')).toBe('desc');
+  });
+
+  it('should convert a Map with index key to _key', () => {
+    const sortMap = new Map([['index', 'asc']]) as unknown as JavaMap;
+    const order = convertSort(sortMap);
+    expect(order.get('_key')).toBe('asc');
+  });
+
+  it('should default to desc when Map value is falsy', () => {
+    const sortMap = new Map([['count', '']]) as unknown as JavaMap;
+    const order = convertSort(sortMap);
+    expect(order.get('_count')).toBe('desc');
+  });
+
+  it('should pass through unknown sort keys from a Map', () => {
+    const sortMap = new Map([['my_stat', 'ASC']]) as unknown as JavaMap;
+    const order = convertSort(sortMap);
+    expect(order.get('my_stat')).toBe('asc');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Edge cases and warning paths (json-facets.ts coverage gaps)
+// ---------------------------------------------------------------------------
+
+describe('edge cases and warning paths', () => {
+  it('should return key-only map for an invalid range string that does not match regex', () => {
+    const inner = applyBodyRange({ field: 'price', ranges: ['not-a-range'] });
+    const ranges = inner.get('ranges') as JavaMap[];
+    expect(ranges).toHaveLength(1);
+    expect(ranges[0].get('key')).toBe('not-a-range');
+    expect(ranges[0].has('from')).toBe(false);
+    expect(ranges[0].has('to')).toBe(false);
+  });
+
+  it('should warn for non-standard boundary semantics like (10,20]', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const inner = applyBodyRange({ field: 'price', ranges: ['(10,20]'] });
+    const ranges = inner.get('ranges') as JavaMap[];
+    expect(ranges[0].get('from')).toBe(10);
+    expect(ranges[0].get('to')).toBe(20);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('may not map exactly'),
+    );
+    warnSpy.mockRestore();
+  });
+
+  it('should skip unrecognised range item types (e.g. number) and warn', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const inner = applyBodyRange({ field: 'price', ranges: [42] });
+    const ranges = inner.get('ranges') as JavaMap[];
+    expect(ranges).toHaveLength(0);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Skipping unrecognised range item'),
+    );
+    warnSpy.mockRestore();
+  });
+
+  it('should warn about unknown keys in a terms facet definition', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    applyBodyTerms({ field: 'category', unknownParam: 'foo' });
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Unprocessed keys in terms facet'),
+    );
+    warnSpy.mockRestore();
+  });
+
+  it('should warn about unsupported range params (hardend, include, other)', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    applyBodyHistogram({
+      field: 'price',
+      start: 0,
+      end: 100,
+      gap: 10,
+      hardend: true,
+      include: 'lower',
+      other: 'before',
+    });
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('no direct OpenSearch histogram equivalent'),
+    );
+    warnSpy.mockRestore();
+  });
+
+  it('should warn about unknown keys in a range facet definition', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    applyBodyHistogram({
+      field: 'price',
+      start: 0,
+      end: 100,
+      gap: 10,
+      customUnknown: true,
+    });
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Unprocessed keys in range facet'),
+    );
+    warnSpy.mockRestore();
+  });
+
+  it('should throw for an unimplemented facet type', () => {
+    expect(() => {
+      applyAndGetAggs(ctxWithBodyFacet({ type: 'query', field: 'x' }));
+    }).toThrow("Facet type 'query' is not implemented");
+  });
+
+  it('should return empty map for non-map facet definition', () => {
+    // Build a context where the facet value is a string instead of a Map
+    const jsonFacet = new Map([[FACET_NAME, 'not-a-map']]) as unknown as JavaMap;
+    const body = new Map([['json.facet', jsonFacet]]) as unknown as JavaMap;
+    const ctx: RequestContext = {
+      msg: new Map() as unknown as JavaMap,
+      endpoint: 'select',
+      collection: 'testcollection',
+      params: new URLSearchParams(),
+      body,
+    };
+    request.apply(ctx);
+    const agg = ctx.body.get('aggs').get(FACET_NAME);
+    expect(agg.size).toBe(0);
+  });
+
+  it('should not set aggs when json.facet body map is empty', () => {
+    const jsonFacet = new Map() as unknown as JavaMap;
+    const body = new Map([['json.facet', jsonFacet]]) as unknown as JavaMap;
+    const ctx: RequestContext = {
+      msg: new Map() as unknown as JavaMap,
+      endpoint: 'select',
+      collection: 'testcollection',
+      params: new URLSearchParams(),
+      body,
+    };
+    request.apply(ctx);
+    expect(ctx.body.has('aggs')).toBe(false);
   });
 });

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/json-facets.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/json-facets.ts
@@ -11,6 +11,10 @@ import type { MicroTransform } from '../pipeline';
 import type { RequestContext, JavaMap } from '../context';
 import { convertSort, isMapLike } from './utils';
 
+const FEATURE_NAME = 'json-facets';
+
+// region Terms facet
+
 function convertTermsFacet(def: JavaMap): JavaMap {
   const termsInner = new Map<string, any>();
   termsInner.set('field', def.get('field'));
@@ -37,13 +41,252 @@ function convertTermsFacet(def: JavaMap): JavaMap {
   if (missing === true) termsInner.set('missing', '');
 
   const sort = def.get('sort');
-  if (sort && typeof sort === 'string') {
+  if (sort) {
     termsInner.set('order', convertSort(sort));
   }
+
+  const knownKeys = new Set([
+    'type',
+    'field',
+    'limit',
+    'offset',
+    'mincount',
+    'prefix',
+    'missing',
+    'sort',
+  ]);
+  warnUnknownKeys(def, knownKeys, 'terms');
 
   const result = new Map<string, any>([['terms', termsInner]]);
 
   return result;
+}
+
+// endregion
+
+// region Range facet
+
+/**
+ * Parse a Solr range string like "[0,20)" or "[50,*]" into an OpenSearch range object.
+ *
+ * Solr range syntax: [inclusive or (exclusive for boundaries, * for unbounded.
+ * OpenSearch range agg: `from` is inclusive, `to` is exclusive by default.
+ */
+function parseSolrRange(rangeStr: string): JavaMap {
+  const range = new Map<string, any>();
+
+  // Always preserve the original Solr range string as the bucket key
+  // so OpenSearch bucket labels match Solr's (e.g., "[0,25)" instead of "0.0-25.0")
+  range.set('key', rangeStr);
+
+  // Match patterns like [0,20) or (10,*] or [50,*]
+  const match = new RegExp(/^([[(])\s*([^,]*?)\s*,\s*([^)\]]*?)\s*([\])])$/).exec(rangeStr);
+  if (!match) {
+    return range;
+  }
+
+  const [, openBracket, lower, upper, closeBracket] = match;
+
+  if (lower !== '*') {
+    const lowerVal = Number(lower);
+    range.set('from', Number.isNaN(lowerVal) ? lower : lowerVal);
+  }
+
+  if (upper !== '*') {
+    const upperVal = Number(upper);
+    range.set('to', Number.isNaN(upperVal) ? upper : upperVal);
+  }
+
+  // Warn if boundary semantics don't match OpenSearch defaults
+  // OpenSearch default: from=inclusive, to=exclusive (equivalent to Solr's "[x,y)")
+  if (openBracket === '(' || closeBracket === ']') {
+    console.warn(
+      `[${FEATURE_NAME}] Range boundary "${rangeStr}" may not map exactly to OpenSearch (default: from=inclusive, to=exclusive)`,
+    );
+  }
+
+  return range;
+}
+
+/**
+ * Convert a Solr range facet to an OpenSearch aggregation.
+ *
+ * Two modes:
+ *   1. Uniform ranges (start/end/gap) → OpenSearch `histogram` aggregation
+ *   2. Arbitrary ranges (ranges param) → OpenSearch `range` aggregation
+ *
+ * Solr range facet parameters:
+ *   - field, start, end, gap  → histogram field, extended_bounds, interval
+ *   - ranges                  → range aggregation with custom buckets
+ *   - mincount                → min_doc_count
+ *   - hardend                 → No direct OpenSearch equivalent (histogram always snaps to interval)
+ *   - include (lower/upper/edge/outer/all) → No direct OpenSearch equivalent
+ *   - other (before/after/between/none/all) → No direct OpenSearch equivalent
+ */
+function convertRangeFacet(def: JavaMap): JavaMap {
+  const ranges = def.get('ranges');
+
+  // Arbitrary ranges → OpenSearch `range` aggregation
+  if (ranges != null) {
+    return convertArbitraryRangeFacet(def, ranges);
+  }
+
+  // Uniform ranges → OpenSearch `histogram` aggregation
+  return convertUniformRangeFacet(def);
+}
+
+/**
+ * Convert a single range item (string, Map-like, or plain object) to an OpenSearch range entry.
+ * Returns null if the item type is unrecognised.
+ */
+function convertRangeItem(item: any): JavaMap | null {
+  if (typeof item === 'string') {
+    return parseSolrRange(item);
+  }
+  if (isMapLike(item)) {
+    return convertMapLikeRangeItem(item);
+  }
+  if (item && typeof item === 'object') {
+    return convertPlainObjectRangeItem(item);
+  }
+  console.warn(
+    `[${FEATURE_NAME}] Skipping unrecognised range item of type "${typeof item}": ${JSON.stringify(item)}`,
+  );
+  return null;
+}
+
+/** Convert a Map-like range item (from Jackson / GraalVM interop) to an OpenSearch range entry. */
+function convertMapLikeRangeItem(item: JavaMap): JavaMap {
+  const rangeStr = item.get('range');
+  if (rangeStr && typeof rangeStr === 'string') {
+    return parseSolrRange(rangeStr);
+  }
+  const osRange = new Map<string, any>();
+  const from = item.get('from');
+  const to = item.get('to');
+  const key = item.get('key');
+  if (from != null) osRange.set('from', from);
+  if (to != null) osRange.set('to', to);
+  if (key != null) osRange.set('key', key);
+  return osRange;
+}
+
+/** Convert a plain JS object range item (from query-string JSON parse) to an OpenSearch range entry. */
+function convertPlainObjectRangeItem(item: Record<string, any>): JavaMap {
+  const rangeStr = item.range;
+  if (rangeStr && typeof rangeStr === 'string') {
+    return parseSolrRange(rangeStr);
+  }
+  const osRange = new Map<string, any>();
+  if (item.from != null) osRange.set('from', item.from);
+  if (item.to != null) osRange.set('to', item.to);
+  if (item.key != null) osRange.set('key', item.key);
+  return osRange;
+}
+
+/**
+ * Convert Solr arbitrary ranges to an OpenSearch `range` aggregation.
+ */
+function convertArbitraryRangeFacet(def: JavaMap, ranges: any): JavaMap {
+  const rangeInner = new Map<string, any>();
+  rangeInner.set('field', def.get('field'));
+
+  // ranges can be an array of objects with {range: "[0,20)"} or {from: 0, to: 20}
+  const rangeItems = Array.isArray(ranges) ? ranges : Array.from(ranges as Iterable<any>);
+  const osRanges: JavaMap[] = [];
+
+  for (const item of rangeItems) {
+    const converted = convertRangeItem(item);
+    if (converted) {
+      osRanges.push(converted);
+    }
+  }
+
+  rangeInner.set('ranges', osRanges);
+
+  const knownKeys = new Set(['type', 'field', 'ranges', 'mincount', 'hardend', 'include', 'other']);
+  warnUnknownKeys(def, knownKeys, 'arbitrary range');
+
+  return new Map<string, any>([['range', rangeInner]]);
+}
+
+/**
+ * Convert Solr uniform range (start/end/gap) to an OpenSearch `histogram` aggregation.
+ */
+function convertUniformRangeFacet(def: JavaMap): JavaMap {
+  const histogramInner = new Map<string, any>();
+  histogramInner.set('field', def.get('field'));
+
+  const gap = def.get('gap');
+  if (gap != null) histogramInner.set('interval', gap);
+
+  const start = def.get('start');
+  const end = def.get('end');
+  if (start != null || end != null) {
+    const bounds = new Map<string, any>();
+    if (start != null) bounds.set('min', start);
+    // Solr's end is exclusive — the last bucket starts at (end - gap).
+    // extended_bounds.max means "ensure a bucket containing this value exists",
+    // so we use (end - gap) to avoid creating an extra bucket at `end`.
+    if (end != null && gap != null) {
+      bounds.set('max', end - gap);
+    } else if (end != null) {
+      bounds.set('max', end);
+    }
+    histogramInner.set('extended_bounds', bounds);
+  }
+
+  const mincount = def.get('mincount');
+  if (mincount != null) histogramInner.set('min_doc_count', mincount);
+
+  // These Solr parameters have no direct OpenSearch histogram equivalent — warn if present.
+  const unsupportedParams: string[] = [];
+  const hardend = def.get('hardend');
+  if (hardend != null) unsupportedParams.push(`hardend=${hardend}`);
+
+  const include = def.get('include');
+  if (include != null) unsupportedParams.push(`include=${include}`);
+
+  const other = def.get('other');
+  if (other != null) unsupportedParams.push(`other=${other}`);
+
+  if (unsupportedParams.length > 0) {
+    console.warn(
+      `[${FEATURE_NAME}] Range facet parameters with no direct OpenSearch histogram equivalent: ${unsupportedParams.join(', ')}`,
+    );
+  }
+
+  const knownKeys = new Set([
+    'type',
+    'field',
+    'start',
+    'end',
+    'gap',
+    'mincount',
+    'hardend',
+    'include',
+    'other',
+  ]);
+  warnUnknownKeys(def, knownKeys, 'range');
+
+  return new Map<string, any>([['histogram', histogramInner]]);
+}
+
+// endregion
+
+/** Log a warning for any keys in a facet definition that are not in the known set. */
+function warnUnknownKeys(def: JavaMap, knownKeys: Set<string>, facetType: string): void {
+  const unknownKeys: string[] = [];
+  for (const key of def.keys()) {
+    if (!knownKeys.has(key)) {
+      unknownKeys.push(key);
+    }
+  }
+  if (unknownKeys.length > 0) {
+    console.warn(
+      `[${FEATURE_NAME}] Unprocessed keys in ${facetType} facet definition: ${unknownKeys.join(', ')}`,
+    );
+  }
 }
 
 /**
@@ -56,9 +299,11 @@ function convertSingleFacet(facetDef: any): JavaMap {
 
   const type = (facetDef.get('type') || '').toString().toLowerCase();
 
-  switch (type) {  // NOSONAR
+  switch (type) {
     case 'terms':
       return convertTermsFacet(facetDef);
+    case 'range':
+      return convertRangeFacet(facetDef);
     default:
       throw new Error(`Facet type '${type}' is not implemented`);
   }
@@ -80,7 +325,7 @@ export function convertJsonFacets(solrJsonFacet: JavaMap): JavaMap {
 }
 
 export const request: MicroTransform<RequestContext> = {
-  name: 'json-facets',
+  name: FEATURE_NAME,
   match: (ctx) => ctx.body.has('json.facet') || ctx.params.has('json.facet'),
   apply: (ctx) => {
     let facetMap: JavaMap | undefined;

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/utils.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/utils.ts
@@ -6,15 +6,31 @@ const SORT_KEY_MAP: Record<string, string> = {
 };
 
 /**
- * Parse a Solr sort spec like "count desc" or "index asc" into an OpenSearch order map.
+ * Convert a Solr sort specification to an OpenSearch order map.
+ *
+ * Accepts either:
+ *   - A string like "count desc" or "index asc"
+ *   - A Map like {count: "desc"}
+ *
+ * Translates Solr sort keys (count, index) to their OpenSearch equivalents (_count, _key).
  */
-export function convertSort(sortSpec: string): JavaMap {
-  const order = new Map();
-  const parts = sortSpec.trim().split(/\s+/);
-  const key = parts[0];
-  const direction = parts[1] || 'desc';
-  const osKey = SORT_KEY_MAP[key] || key;
-  order.set(osKey, direction.toLowerCase());
+export function convertSort(sortSpec: string | JavaMap): JavaMap {
+  const order = new Map<string, any>();
+
+  if (typeof sortSpec === 'string') {
+    const parts = sortSpec.trim().split(/\s+/);
+    const key = parts[0];
+    const direction = parts[1] || 'desc';
+    const osKey = SORT_KEY_MAP[key] || key;
+    order.set(osKey, direction.toLowerCase());
+  } else if (isMapLike(sortSpec)) {
+    for (const key of sortSpec.keys()) {
+      const direction = (sortSpec.get(key) || 'desc').toString().toLowerCase();
+      const osKey = SORT_KEY_MAP[key] || key;
+      order.set(osKey, direction);
+    }
+  }
+
   return order;
 }
 


### PR DESCRIPTION
### Description
This is continuation of #2379. This PR adds the support for translating Solr [range facets](https://solr.apache.org/guide/solr/latest/query-guide/json-facet-api.html#range-facet) to OpenSearch aggregations.

Supported scenarios:
- Aggregating over regular numeric ranges.
- Aggregating over custom (arbitrary) ranges.

Scenarios not yet supported:
- Aggregating over date/time ranges.

### Testing
1. Unit tests
2. End to end integration tests.

### Check List
- [x] New functionality includes testing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
