### PR TITLE
feat(solr-transforms): Add query engine skeleton with interfaces

### DIFF
--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/README.md
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/README.md
@@ -1,0 +1,271 @@
+# Query Engine — Architecture
+
+Translates Solr query strings into OpenSearch Query DSL. This is a self-contained module used by the micro-transform layer — it has no knowledge of HTTP, GraalVM, or the shim proxy.
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Pipeline Flow](#pipeline-flow)
+- [Component Architecture](#component-architecture)
+- [Data Flow Example](#data-flow-example)
+- [AST Node Types](#ast-node-types)
+- [Transformer Rules](#transformer-rules)
+- [Error Handling](#error-handling)
+- [Extending the Engine](#extending-the-engine)
+
+
+## Overview
+
+The query engine converts Solr query syntax into OpenSearch Query DSL through a two-stage pipeline:
+
+```mermaid
+graph LR
+    A["Solr query string"] --> B[Parser]
+    B -->|"AST"| C[Transformer]
+    C -->|"Map&lt;string,any&gt;"| D["OpenSearch DSL"]
+
+    subgraph "Orchestrator (translateQ)"
+        B
+        C
+    end
+```
+
+The **Parser** (`parser/parser.ts`) parses a Solr query string into an AST. It also applies the default field (`df`) from the params map to bare values and unfielded phrases — the caller is responsible for providing `df` in the params map (e.g., from `solrconfig.xml` defaults), and the parser applies it where needed so every AST node has a resolved field.
+
+The **Transformer** converts AST nodes into OpenSearch DSL Maps using a registry of `TransformRuleFn` functions — one per AST node type.
+
+The **Orchestrator** (`orchestrator/translateQ.ts`) wires these stages together and handles errors.
+
+
+## Pipeline Flow
+
+```mermaid
+sequenceDiagram
+    participant Caller as Micro-Transform
+    participant Orch as Orchestrator
+    participant Parser as Parser
+    participant Xform as Transformer
+    participant Rules as TransformRuleFn
+
+    Caller->>Orch: translateQ(params, mode?)
+    Orch->>Orch: Read q from params
+    Orch->>Parser: parseSolrQuery(q, params)
+    Parser->>Parser: Parse query string into AST
+    Parser->>Parser: Apply df to bare values/phrases
+    Parser-->>Orch: ParseResult { ast, errors }
+
+    alt ast is null (parse failure)
+        Orch-->>Caller: query_string passthrough + warnings
+    end
+
+    Orch->>Xform: transformNode(ast)
+    Xform->>Xform: Look up TransformRuleFn by node.type
+    Xform->>Rules: rule(node, transformNode)
+
+    alt passthrough-on-error mode + unsupported construct
+        Xform-->>Orch: abort
+        Orch-->>Caller: query_string passthrough + warnings
+    end
+
+    Rules-->>Xform: Map<string, any>
+    Xform-->>Orch: OpenSearch DSL Map
+    Orch-->>Caller: TranslateResult { dsl, warnings }
+```
+
+
+## Component Architecture
+
+```mermaid
+graph TB
+    subgraph "query-engine/"
+        subgraph Orchestrator["orchestrator/"]
+            TQ["translateQ.ts<br/><i>Entry point — wires the pipeline</i>"]
+        end
+
+        subgraph Parser["parser/"]
+            PP["parser.ts<br/><i>Parses query, applies df</i>"]
+            PT["types.ts<br/><i>ParseResult, ParseError</i>"]
+        end
+
+        subgraph AST["ast/"]
+            NODES["nodes.ts<br/><i>AST node types</i>"]
+        end
+
+        subgraph Transformer["transformer/"]
+            XFORM["astToOpenSearch.ts<br/><i>Dispatcher — registry lookup</i>"]
+            TT["types.ts<br/><i>TransformRuleFn, TransformChild</i>"]
+            subgraph Rules["rules/"]
+                BR["boolRule.ts"]
+                MORE["...more rules"]
+            end
+        end
+    end
+
+    TQ --> PP
+    PP --> NODES
+    PP --> PT
+    TQ --> XFORM
+    XFORM --> TT
+    XFORM --> Rules
+    Rules --> TT
+    XFORM --> NODES
+```
+
+### Directory Structure
+
+```
+query-engine/
+  README.md                  ← This file
+  orchestrator/
+    translateQ.ts             ← Entry point. Wires parser → transformer.
+  parser/
+    parser.ts                 ← Parses query string, applies df to bare values.
+    types.ts                  ← Shared types: ParseResult, ParseError.
+  ast/
+    nodes.ts                  ← AST node type definitions.
+  transformer/
+    astToOpenSearch.ts        ← Dispatcher: looks up TransformRuleFn by node.type.
+    types.ts                  ← Shared types: TransformRuleFn, TransformChild.
+    rules/
+      boolRule.ts             ← BoolNode → OpenSearch bool query.
+      (more rules added per node type)
+```
+
+
+## Data Flow Example
+
+Tracing `title:java AND price:[10 TO 100]` through each stage:
+
+### Stage 1: Parser
+
+Input: `"title:java AND price:[10 TO 100]"`
+
+Output:
+```
+BoolNode {
+  and: [
+    FieldNode { field: "title", value: "java" },
+    RangeNode { field: "price", lower: "10", upper: "100",
+                lowerInclusive: true, upperInclusive: true }
+  ],
+  or: [],
+  not: []
+}
+```
+
+### Default field resolution
+
+When the query contains bare values (no `field:` prefix), the parser applies `df` from the params map:
+
+Input: `"java"` with params `df=title`
+
+Output:
+```
+FieldNode { field: "title", value: "java" }
+```
+
+The caller provides `df` in the params map. The parser applies it to produce a complete AST where every node has a resolved field.
+
+### Stage 2: Transformer
+
+Input: AST root node (BoolNode in this example)
+
+The dispatcher looks up the `TransformRuleFn` for each node type and calls it:
+```
+transformNode(BoolNode)
+  → rules["bool"](BoolNode, transformNode)
+    → transformNode(FieldNode) → rules["field"](...) → Map{"term" → ...}
+    → transformNode(RangeNode) → rules["range"](...) → Map{"range" → ...}
+    → assemble bool wrapper
+```
+
+Output:
+```
+Map { "bool" → Map {
+  "must" → [
+    Map { "term" → Map { "title" → "java" } },
+    Map { "range" → Map { "price" → Map { "gte" → "10", "lte" → "100" } } }
+  ]
+}}
+```
+
+
+## AST Node Types
+
+Each node represents a Solr query construct. See `ast/nodes.ts` for full definitions.
+
+| Node | Solr Syntax | Example |
+|------|-------------|---------|
+| `FieldNode` | `field:value` | `title:java` |
+| `PhraseNode` | `"text"` or `field:"text"` | `title:"hello world"` |
+| `BoolNode` | `AND`, `OR`, `NOT` | `a AND b OR c NOT d` |
+| `RangeNode` | `[low TO high]`, `{low TO high}` | `price:[10 TO 100]` |
+| `MatchAllNode` | `*:*` | `*:*` |
+| `GroupNode` | `(expr)` | `(a OR b)` |
+| `BoostNode` | `expr^N` | `title:java^2` |
+
+
+## Transformer Rules
+
+Each AST node type has a corresponding `TransformRuleFn` registered in the dispatcher. The dispatcher looks up the function by `node.type` and calls it with the node and a `transformChild` callback for recursion.
+
+```mermaid
+graph LR
+    AST["ASTNode"] --> D["astToOpenSearch.ts<br/>(dispatcher)"]
+    D -->|"rules[node.type]"| FN["TransformRuleFn"]
+    FN --> OUT["Map&lt;string,any&gt;"]
+```
+
+Leaf rules (FieldNode, PhraseNode, RangeNode, MatchAllNode) ignore the `transformChild` callback. Composite rules (BoolNode, GroupNode, BoostNode) use it to recurse into children.
+
+
+## Error Handling
+
+```mermaid
+flowchart TD
+    A["Parse result: ast is null?"] -->|Yes| B["Return query_string passthrough + warnings<br/>(same for both modes)"]
+    A -->|No| C[Transform AST → DSL]
+    C -->|"Unsupported construct<br/>(passthrough-on-error mode)"| B
+    C -->|"Unsupported construct<br/>(partial mode)"| D["Skip unsupported, collect warnings,<br/>continue translating"]
+    C -->|"Fully supported"| E["Return TranslateResult { dsl, warnings: [] }"]
+    D --> F["Return TranslateResult { dsl, warnings }"]
+```
+
+### Passthrough Fallback
+
+When parsing fails or passthrough-on-error mode encounters an unsupported construct, the orchestrator wraps the raw query in a `query_string` passthrough:
+```
+Map { "query_string" → Map { "query" → "the original solr query" } }
+```
+
+### Translation Modes
+
+| Mode | Parse failure | Unsupported construct during transform |
+|------|--------------|---------------------------------------|
+| `passthrough-on-error` (default) | Passthrough + warnings | Abort immediately, passthrough + warnings |
+| `partial` | Passthrough + warnings | Translate supported parts, skip unsupported, collect warnings |
+
+
+## Extending the Engine
+
+### Adding a New AST Node Type
+
+1. Add the interface to `ast/nodes.ts` and include it in the `ASTNode` union
+2. Add parsing support in `parser/parser.ts`
+3. Create a `TransformRuleFn` in `transformer/rules/`
+4. Register the function in the dispatcher's rules registry in `transformer/astToOpenSearch.ts`
+
+### Adding Support for a New Solr Feature
+
+1. Extend the parser to handle the new syntax
+2. Add corresponding AST node types if needed
+3. Add `TransformRuleFn` implementations for the new nodes
+
+
+## Constraints
+
+- **All transformer output must use `new Map()`** — never plain JS objects. GraalVM runtime requirement.
+- **The query engine has no side effects** — no I/O, no logging, no config file access. Pure function: params in, DSL out.
+- **The AST is Solr-specific** — represents what the user wrote, not how it maps to any target system.
+- **The parser handles all Solr parser types** — Lucene, eDisMax, DisMax share the same core syntax. Parser-specific behavior (e.g., eDisMax qf distribution) is a post-parse AST transformation.
+- **The caller provides configuration** — `df`, `qf`, `pf` etc. come from the params map. The query engine does not read config files.

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/ast/nodes.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/ast/nodes.ts
@@ -1,0 +1,116 @@
+/**
+ * AST node types for the Solr query parser.
+ *
+ * Represents the parsed structure of a Solr query as a tree of typed nodes.
+ * Each node carries a `type` string literal discriminant that identifies
+ * its variant (TypeScript discriminated union pattern).
+ *
+ * The AST is purely a Solr query representation — it describes what the
+ * user wrote, not how it will be executed by any search engine.
+ */
+
+/**
+ * Boolean query node — represents Solr's AND/OR/NOT boolean operators.
+ *
+ * Example: `title:java AND author:smith OR year:2024 NOT status:draft`
+ *   → and: [FieldNode(title,java), FieldNode(author,smith)]
+ *   → or: [FieldNode(year,2024)]
+ *   → not: [FieldNode(status,draft)]
+ */
+export interface BoolNode {
+  type: 'bool';
+  /** AND clauses. `a AND b AND c` → and: [a, b, c] */
+  and: ASTNode[];
+  /** OR clauses. `a OR b` → or: [a, b]. Also used for implicit OR: `a b` → or: [a, b] */
+  or: ASTNode[];
+  /** NOT clauses. `NOT a` → not: [a] */
+  not: ASTNode[];
+}
+
+/**
+ * Field-value query node — a `field:value` expression in Solr syntax.
+ *
+ * Example: `title:java` → field="title", value="java"
+ */
+export interface FieldNode {
+  type: 'field';
+  field: string;
+  value: string;
+}
+
+/**
+ * Phrase query node — a quoted phrase search.
+ *
+ * Examples:
+ *   `title:"hello world"` → text="hello world", field="title"
+ *   `"hello world"` with df="content" → text="hello world", field="content"
+ */
+export interface PhraseNode {
+  type: 'phrase';
+  /** The phrase text without quotes. */
+  text: string;
+  /**
+   * The target field. The parser sets this to the explicit field (e.g., `title:"..."`)
+   * or the default field (df) for bare phrases like `"hello world"`.
+   */
+  field: string;
+}
+
+/**
+ * Range query node — a bounded range search.
+ *
+ * Examples:
+ *   `price:[10 TO 100]` → field="price", lower="10", upper="100", lowerInclusive=true, upperInclusive=true
+ *   `price:{10 TO 100}` → field="price", lower="10", upper="100", lowerInclusive=false, upperInclusive=false
+ *   `price:[10 TO 100}` → field="price", lower="10", upper="100", lowerInclusive=true, upperInclusive=false
+ */
+export interface RangeNode {
+  type: 'range';
+  field: string;
+  lower: string;
+  upper: string;
+  /** true when lower bound uses `[` (value included), false when `{` (value excluded). */
+  lowerInclusive: boolean;
+  /** true when upper bound uses `]` (value included), false when `}` (value excluded). */
+  upperInclusive: boolean;
+}
+
+/**
+ * Match-all node — matches every document.
+ *
+ * Example: `*:*` → MatchAllNode (no properties)
+ */
+export interface MatchAllNode {
+  type: 'matchAll';
+}
+
+/**
+ * Grouping node — preserves operator precedence from parentheses.
+ *
+ * Example: `(title:java OR title:python)` → child=BoolNode(or: [FieldNode, FieldNode])
+ */
+export interface GroupNode {
+  type: 'group';
+  child: ASTNode;
+}
+
+/**
+ * Boost node — applies a relevance boost to a sub-expression.
+ *
+ * Example: `title:java^2` → child=FieldNode(title,java), value=2
+ */
+export interface BoostNode {
+  type: 'boost';
+  child: ASTNode;
+  value: number;
+}
+
+/** Union of all AST node types. Every node in the parsed Solr query tree is one of these variants. */
+export type ASTNode =
+  | BoolNode
+  | FieldNode
+  | PhraseNode
+  | RangeNode
+  | MatchAllNode
+  | GroupNode
+  | BoostNode;

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/orchestrator/translateQ.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/orchestrator/translateQ.ts
@@ -1,0 +1,87 @@
+/**
+ * Orchestrator — wires the Parser → Transformer pipeline.
+ *
+ * This is the single entry point for translating a Solr query string into
+ * OpenSearch Query DSL. It coordinates the pipeline stages:
+ *   1. Read `q` from the params map
+ *   2. Parse the query string into an AST
+ *   3. Transform the AST into OpenSearch DSL Maps
+ *
+ * Error handling: fail-safe with passthrough.
+ * In both modes, the result always contains a `dsl` value and never throws.
+ * Issues are reported via the `warnings` array, where each warning includes
+ * a machine-readable construct name (e.g., "parse_error", "function_query"),
+ * the position in the original query, and a human-readable message. On parse
+ * failure or when passthrough-on-error mode encounters an unsupported
+ * construct, `dsl` is a query_string passthrough. In partial mode, `dsl`
+ * is the partially translated query with unsupported parts skipped.
+ *
+ * Two modes:
+ *   - passthrough-on-error (default): the first unsupported construct stops the
+ *     pipeline and falls back to query_string passthrough immediately.
+ *   - partial: translates all supported parts of the query
+ *     and attaches warnings for unsupported parts.
+ */
+
+export interface TranslateResult {
+  /**
+   * The OpenSearch Query DSL as a nested Map structure.
+   * Always present — on error, this is a query_string passthrough.
+   */
+  dsl: Map<string, any>;
+  /**
+   * Warnings about unsupported constructs or translation issues.
+   * Empty when the translation is fully successful.
+   */
+  warnings: TranslationWarning[];
+}
+
+/**
+ * A warning about an unsupported or partially translated construct.
+ *
+ * Examples:
+ *   Parse error:
+ *     { construct: "parse_error", position: 5, message: "Unexpected ')' at position 5" }
+ *
+ *   Unsupported function query:
+ *     { construct: "function_query", position: 12, message: "Function queries not yet supported" }
+ */
+export interface TranslationWarning {
+  /** Machine-readable identifier for the issue. */
+  construct: string;
+  /** 0-based index in the original query where the issue was detected. */
+  position?: number;
+  /** Human-readable description of the issue and its impact. */
+  message: string;
+}
+
+/** Controls how the orchestrator handles unsupported constructs. */
+export type TranslationMode = 'partial' | 'passthrough-on-error';
+
+/**
+ * Translate a Solr query into OpenSearch Query DSL.
+ *
+ * @param params - All Solr request parameters. The orchestrator reads `q`
+ *                 from this map and passes the full map to the parser
+ *                 for configuration (e.g., `df`, `qf`, `pf`).
+ * @param mode - 'passthrough-on-error' (default) or 'partial'.
+ *
+ * Example:
+ *   translateQ(new Map([['q', 'title:java'], ['df', 'content']]))
+ *   → { dsl: Map{"term" → Map{"title" → "java"}}, warnings: [] }
+ */
+export function translateQ(
+  params: ReadonlyMap<string, string>,
+  mode?: TranslationMode,
+): TranslateResult {
+  // TODO: implement
+  // 1. Read q from params (default to '*:*')
+  // 2. Call parseSolrQuery(q, params) from ../parser/parser
+  // 3. If ast is null (parse failure): return query_string passthrough
+  //    + warnings (same behavior for both modes — no AST to work with)
+  // 4. Call transformNode(ast) from ../transformer/astToOpenSearch
+  //    - In passthrough-on-error mode: abort on first unsupported construct, return passthrough
+  //    - In partial mode: translate supported parts, collect warnings
+  // 5. Return { dsl, warnings }
+  throw new Error('Not implemented');
+}

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/parser/parser.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/parser/parser.ts
@@ -1,0 +1,39 @@
+/**
+ * Solr query parser.
+ *
+ * Parses a Solr query string into an AST matching the types in
+ * ../ast/nodes.ts.
+ *
+ * Responsibilities:
+ *   - Parse the query string into an AST
+ *   - Resolve default fields (df) on bare values and phrases
+ *   - Return parse errors as ParseError (never throws)
+ */
+
+import type { ParseResult } from './types';
+
+/**
+ * Parse a Solr query string into an AST.
+ *
+ * @param query - The raw Solr query string (the `q` parameter value)
+ * @param params - Request parameters. Reads `df` to resolve bare
+ *                 values and unfielded phrases to a default field.
+ * @returns ParseResult with the AST and any errors
+ *
+ * Example:
+ *   parseSolrQuery("title:java AND price:[10 TO 100]", new Map([["df", "content"]]))
+ *   → { ast: BoolNode { and: [FieldNode, RangeNode] }, errors: [] }
+ *
+ *   parseSolrQuery("java", new Map([["df", "title"]]))
+ *   → { ast: FieldNode { field: "title", value: "java" }, errors: [] }
+ */
+export function parseSolrQuery(
+  query: string,
+  params: ReadonlyMap<string, string>,
+): ParseResult {
+  // TODO: implement
+  // 1. Parse query string into AST
+  // 2. Resolve default fields (df) on bare values and phrases
+  // 3. On parse failure: return { ast: null, errors: [...] }
+  throw new Error('Not implemented');
+}

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/parser/types.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/parser/types.ts
@@ -1,0 +1,28 @@
+/**
+ * Shared types for the parser layer.
+ */
+
+import type { ASTNode } from '../ast/nodes';
+
+/**
+ * The result of parsing a Solr query string.
+ */
+export interface ParseResult {
+  /** The parsed AST, or null when parsing fails. */
+  ast: ASTNode | null;
+  /** Errors encountered during parsing. Empty when parsing succeeds. */
+  errors: ParseError[];
+}
+
+/**
+ * An error encountered during parsing.
+ *
+ * Example: parsing `title:java AND )` fails because `)` appears
+ * where an expression is expected (position 16 is the `)` character).
+ *   → { message: "Expected field, phrase, or value after 'AND'", position: 16 }
+ */
+export interface ParseError {
+  message: string;
+  /** 0-based index in the query string where the error occurred. */
+  position: number;
+}

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/transformer/astToOpenSearch.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/transformer/astToOpenSearch.ts
@@ -1,0 +1,60 @@
+/**
+ * AST-to-OpenSearch transformer.
+ *
+ * Converts Solr AST nodes into OpenSearch Query DSL as nested Maps.
+ * Uses a registry of transform functions — one per AST node type.
+ * The dispatcher looks up the function by `node.type` and calls it.
+ *
+ * IMPORTANT: All output must use `new Map()` — never plain JS objects (`{}`).
+ * This is a GraalVM runtime requirement, not a style choice. The Java-side
+ * Jackson serializer accesses JS Maps directly as Java LinkedHashMaps via
+ * GraalVM's `allowMapAccess(true)`. Plain objects don't get this bridge and
+ * will cause serialization failures at runtime.
+ *
+ * Transformation rules (Solr syntax → AST node → OpenSearch DSL):
+ *
+ *   `*:*`
+ *     MatchAllNode → Map{"match_all" → Map{}}
+ *
+ *   `title:java`
+ *     FieldNode(title, java) → Map{"term" → Map{"title" → "java"}}
+ *
+ *   `"hello world"` (with df="content")
+ *     PhraseNode(hello world) → Map{"match_phrase" → Map{"content" → "hello world"}}
+ *
+ *   `title:java AND author:smith`
+ *     BoolNode(and: [...]) → Map{"bool" → Map{"must" → [...]}}
+ *
+ *   `price:[10 TO 100]`
+ *     RangeNode(price, 10, 100) → Map{"range" → Map{"price" → Map{"gte" → "10", "lte" → "100"}}}
+ *
+ *   `title:java^2`
+ *     BoostNode(FieldNode, 2) → Map{"term" → Map{"title" → "java", "boost" → 2}}
+ *
+ *   `(a OR b)`
+ *     GroupNode → transparent, recurses into child
+ */
+
+import type { ASTNode } from '../ast/nodes';
+
+/**
+ * Transform an AST node into an OpenSearch DSL Map.
+ *
+ * Looks up the TransformRuleFn for the node's type from the registry
+ * and calls it. The parser is expected to have resolved all field
+ * names — including applying the default field (df) to bare phrases
+ * and values.
+ *
+ * @param node - The AST node to transform
+ * @returns A nested Map structure representing OpenSearch Query DSL
+ */
+export function transformNode(node: ASTNode): Map<string, any> {
+  // TODO: implement
+  // 1. Look up TransformRuleFn by node.type from the rules registry
+  // 2. Call rule(node, transformNode) for recursive dispatch
+  // 3. Throw if no rule registered for the node type — the orchestrator
+  //    catches this and handles it based on the translation mode:
+  //    - passthrough-on-error: returns query_string passthrough + warning
+  //    - partial: skips the node, adds a warning, continues translating
+  throw new Error('Not implemented');
+}

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/transformer/rules/boolRule.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/transformer/rules/boolRule.ts
@@ -1,0 +1,34 @@
+/**
+ * Transformation rule for BoolNode → OpenSearch `bool` query.
+ *
+ * Maps Solr's AND/OR/NOT boolean operators to OpenSearch's bool query clauses:
+ *   BoolNode.and → bool.must    (all clauses required)
+ *   BoolNode.or  → bool.should  (at least one clause matches)
+ *   BoolNode.not → bool.must_not (clauses excluded)
+ *
+ * Example:
+ *   Input: BoolNode { and: [FieldNode(title,java), RangeNode(price,10,100)], or: [], not: [] }
+ *   Output: Map{"bool" → Map{"must" → [Map{"term"→...}, Map{"range"→...}]}}
+ *
+ * Empty clause arrays are omitted from the output Map — only clauses with
+ * children are included. For example, `title:java AND author:smith` has
+ * and=[...] but or=[] and not=[], so the output is:
+ *   Map{"bool" → Map{"must" → [...]}}
+ * not:
+ *   Map{"bool" → Map{"must" → [...], "should" → [], "must_not" → []}}
+ * This produces cleaner DSL matching what OpenSearch clients typically generate.
+ */
+
+import type { ASTNode } from '../../ast/nodes';
+import type { TransformRuleFn, TransformChild } from '../types';
+
+export const boolRule: TransformRuleFn = (
+  node: ASTNode,
+  transformChild: TransformChild,
+): Map<string, any> => {
+  // TODO: implement
+  // 1. Transform each child in and/or/not via transformChild
+  // 2. Build Map{"bool" → Map{"must" → [...], "should" → [...], "must_not" → [...]}}
+  // 3. Omit empty clause arrays from the output
+  throw new Error('Not implemented');
+};

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/transformer/types.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/transformer/types.ts
@@ -1,0 +1,35 @@
+/**
+ * Shared types for the transformer layer.
+ */
+
+import type { ASTNode } from '../ast/nodes';
+
+/**
+ * A callback that recursively transforms a child AST node into
+ * OpenSearch DSL. Provided by the dispatcher to rules that have
+ * children (BoolNode, GroupNode, BoostNode).
+ */
+export type TransformChild = (child: ASTNode) => Map<string, any>;
+
+/**
+ * A function that transforms an AST node into an OpenSearch DSL Map.
+ *
+ * Each AST node type has a corresponding TransformRuleFn. The dispatcher
+ * looks up the function by `node.type` and calls it.
+ *
+ * Rules for leaf nodes (FieldNode, PhraseNode, RangeNode, MatchAllNode)
+ * can ignore the `transformChild` parameter. Rules for composite nodes
+ * (BoolNode, GroupNode, BoostNode) use it to recurse into children.
+ *
+ * Example (leaf rule):
+ *   (FieldNode { field: "title", value: "java" }, _)
+ *   → Map{"term" → Map{"title" → "java"}}
+ *
+ * Example (composite rule):
+ *   (BoolNode { and: [FieldNode, RangeNode], ... }, transformChild)
+ *   → Map{"bool" → Map{"must" → [transformChild(FieldNode), transformChild(RangeNode)]}}
+ */
+export type TransformRuleFn = (
+  node: ASTNode,
+  transformChild: TransformChild,
+) => Map<string, any>;


### PR DESCRIPTION
Introduce the foundational query-engine module under solr-to-opensearch/ with interfaces and type definitions for the Solr query translation pipeline.

Modules:
- ast/nodes.ts: Discriminated union AST types (BoolNode, FieldNode, PhraseNode, RangeNode, MatchAllNode, GroupNode, BoostNode)
- parser/: ParseResult, ParserFn  interfaces
- transformer/: AST-to-OpenSearch dispatcher and rules/ pattern
- orchestrator/translateQ.ts: Pipeline entry point with TranslateResult

Includes README.md with mermaid diagrams documenting the architecture, pipeline flow, data flow examples, and extension guides.

### Description
<!-- Describe what this change achieves -->

### Issues Resolved
<!-- List any GitHub or Jira issues this PR will resolve -->

### Testing
<!-- Please provide details of testing done: unit testing, integration testing and manual testing -->

### Check List
- [ ] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
