### PR TITLE
Add repository-s3 plugin to target OpenSearch test cluster

### DIFF
--- a/deployment/k8s/charts/aggregates/testClusters/values.yaml
+++ b/deployment/k8s/charts/aggregates/testClusters/values.yaml
@@ -115,3 +115,7 @@ target:
   singleNode: true
   persistence:
     enabled: false
+  plugins:
+    enabled: true
+    installList:
+      - repository-s3


### PR DESCRIPTION
## Description

Adds repository-s3 plugin installation to the target OpenSearch test cluster configuration.

## Problem
Target OpenSearch cluster was deployed without the repository-s3 plugin, preventing:
- S3 snapshot repository registration
- Snapshot restore operations
- Backfill migrations using snapshot-based approach

The source Elasticsearch cluster already has the S3 plugin installed, creating an asymmetry.

## Solution
Added `plugins` configuration to `testClusters/values.yaml`:
```yaml
plugins:
  enabled: true
  installList:
    - repository-s3
```

## Impact
✅ Enables S3 snapshot repository on target cluster
✅ Allows snapshot-based backfill migrations
✅ Matches source cluster capabilities
✅ Required for reindex-from-snapshot workflow

## Testing
- Plugin will be installed automatically via OpenSearch helm chart
- Installation happens during cluster initialization
- No manual intervention required

## Related Issues
Discovered during migration testing - Bug #2 from comprehensive testing session.
