### PR TITLE
Fix StopIteration on empty config in get_snapshot and get_replayer

### DIFF
--- a/migrationConsole/lib/console_link/console_link/models/factories.py
+++ b/migrationConsole/lib/console_link/console_link/models/factories.py
@@ -51,9 +51,7 @@ def get_snapshot(config: Dict, source_cluster: Optional[Cluster]):
     elif 's3' in config:
         return S3Snapshot(config, source_cluster)
     logger.error(f"An unsupported snapshot type was provided: {config.keys()}")
-    if len(config.keys()) > 1:
-        raise UnsupportedSnapshotError(', '.join(config.keys()))
-    raise UnsupportedSnapshotError(next(iter(config.keys())))
+    raise UnsupportedSnapshotError(', '.join(config.keys()) if config else '<empty>')
 
 
 def get_replayer(config: Dict, client_options: Optional[ClientOptions] = None):
@@ -64,7 +62,7 @@ def get_replayer(config: Dict, client_options: Optional[ClientOptions] = None):
     if 'k8s' in config:
         return K8sReplayer(config=config, client_options=client_options)
     logger.error(f"An unsupported replayer type was provided: {config.keys()}")
-    raise UnsupportedReplayerError(next(iter(config.keys())))
+    raise UnsupportedReplayerError(', '.join(config.keys()) if config else '<empty>')
 
 
 def get_kafka(config: Dict):

--- a/migrationConsole/lib/console_link/tests/test_factories.py
+++ b/migrationConsole/lib/console_link/tests/test_factories.py
@@ -1,0 +1,78 @@
+"""
+Tests for factory functions in console_link.models.factories.
+
+These tests target edge cases in the factory dispatch functions,
+specifically empty config handling that previously raised StopIteration
+instead of the expected UnsupportedXxxError.
+"""
+import pytest
+
+from console_link.models.factories import (
+    get_snapshot,
+    get_replayer,
+    get_kafka,
+    get_backfill,
+    get_metrics_source,
+    UnsupportedSnapshotError,
+    UnsupportedReplayerError,
+    UnsupportedKafkaError,
+    UnsupportedBackfillTypeError,
+    UnsupportedMetricsSourceError,
+)
+from tests.utils import create_valid_cluster
+
+
+class TestGetSnapshotFactory:
+    def test_empty_config_raises_unsupported_error(self):
+        """Empty config must raise UnsupportedSnapshotError, not StopIteration."""
+        with pytest.raises(UnsupportedSnapshotError):
+            get_snapshot({}, None)
+
+    def test_single_unknown_key_raises_unsupported_error(self):
+        with pytest.raises(UnsupportedSnapshotError):
+            get_snapshot({"unknown": {}}, None)
+
+    def test_multiple_unknown_keys_raises_unsupported_error(self):
+        with pytest.raises(UnsupportedSnapshotError):
+            get_snapshot({"a": {}, "b": {}}, None)
+
+
+class TestGetReplayerFactory:
+    def test_empty_config_raises_unsupported_error(self):
+        """Empty config must raise UnsupportedReplayerError, not StopIteration."""
+        with pytest.raises(UnsupportedReplayerError):
+            get_replayer({})
+
+    def test_unknown_key_raises_unsupported_error(self):
+        with pytest.raises(UnsupportedReplayerError):
+            get_replayer({"unknown": {}})
+
+
+class TestGetKafkaFactory:
+    def test_empty_config_raises_unsupported_error(self):
+        with pytest.raises(UnsupportedKafkaError):
+            get_kafka({})
+
+    def test_unknown_key_raises_unsupported_error(self):
+        with pytest.raises(UnsupportedKafkaError):
+            get_kafka({"unknown": {}})
+
+
+class TestGetBackfillFactory:
+    def test_empty_config_raises_unsupported_error(self):
+        with pytest.raises(UnsupportedBackfillTypeError):
+            get_backfill({}, create_valid_cluster())
+
+    def test_unknown_key_raises_unsupported_error(self):
+        with pytest.raises(UnsupportedBackfillTypeError):
+            get_backfill({"unknown": {}}, create_valid_cluster())
+
+
+class TestGetMetricsSourceFactory:
+    def test_empty_config_raises_unsupported_error(self):
+        with pytest.raises(UnsupportedMetricsSourceError):
+            get_metrics_source({})
+
+    def test_unknown_key_raises_unsupported_error(self):
+        with pytest.raises(UnsupportedMetricsSourceError):
+            get_metrics_source({"unknown": {}})


### PR DESCRIPTION
## Description

Fixes `get_snapshot({})` and `get_replayer({})` raising `StopIteration` instead of the expected `UnsupportedSnapshotError`/`UnsupportedReplayerError`.

## Bug

```python
>>> get_snapshot({}, None)
StopIteration  # Should be UnsupportedSnapshotError

>>> get_replayer({})
StopIteration  # Should be UnsupportedReplayerError
```

Root cause: `next(iter(config.keys()))` raises `StopIteration` when `config` is an empty dict. `StopIteration` is not caught by typical error handling and can silently break generator-based code.

## Fix

Replace `next(iter(config.keys()))` with `', '.join(config.keys()) if config else '<empty>'`, consistent with how multi-key configs are already handled.

## Tests

Added `test_factories.py` with tests for all 5 factory functions:
- `get_snapshot` - empty config, unknown key, multiple unknown keys
- `get_replayer` - empty config, unknown key
- `get_kafka` - empty config, unknown key
- `get_backfill` - empty config, unknown key
- `get_metrics_source` - empty config, unknown key

Verified: tests fail without fix, pass with fix.
