### PR TITLE
Fix CommandResult.display() swallowing falsy values like 0 and False

### DIFF
--- a/migrationConsole/lib/console_link/console_link/models/command_result.py
+++ b/migrationConsole/lib/console_link/console_link/models/command_result.py
@@ -12,6 +12,6 @@ class CommandResult(Generic[T]):
     output: CompletedProcess | None = None
 
     def display(self) -> str:
-        if self.value:
+        if self.value is not None:
             return str(self.value)
         return ""

--- a/migrationConsole/lib/console_link/tests/test_command_result.py
+++ b/migrationConsole/lib/console_link/tests/test_command_result.py
@@ -1,0 +1,33 @@
+"""
+Tests for CommandResult.display() handling of falsy values.
+
+CommandResult.display() previously used `if self.value:` which returns ""
+for falsy values like 0, False, and "". The fix uses `is not None` instead.
+"""
+from console_link.models.command_result import CommandResult
+
+
+class TestCommandResultDisplay:
+    def test_display_string_value(self):
+        assert CommandResult(success=True, value="hello").display() == "hello"
+
+    def test_display_none_value(self):
+        assert CommandResult(success=True, value=None).display() == ""
+
+    def test_display_zero_value(self):
+        """Zero is a valid value and should display as '0', not ''."""
+        assert CommandResult(success=True, value=0).display() == "0"
+
+    def test_display_false_value(self):
+        """False is a valid value and should display as 'False', not ''."""
+        assert CommandResult(success=True, value=False).display() == "False"
+
+    def test_display_empty_string_value(self):
+        """Empty string is a valid value and should display as '', not ''."""
+        assert CommandResult(success=True, value="").display() == ""
+
+    def test_display_exception_value(self):
+        assert CommandResult(success=False, value=ValueError("err")).display() == "err"
+
+    def test_display_integer_value(self):
+        assert CommandResult(success=True, value=42).display() == "42"


### PR DESCRIPTION
## Description

`CommandResult.display()` returns empty string for falsy values like `0` and `False`.

## Bug

```python
>>> CommandResult(success=True, value=0).display()
''  # Should be '0'

>>> CommandResult(success=True, value=False).display()
''  # Should be 'False'
```

Root cause: `if self.value:` is falsy for `0`, `False`, and `''`.

## Fix

Changed `if self.value:` to `if self.value is not None:`.

## Tests

Added `test_command_result.py` with 7 tests covering all value types.
