### PR TITLE
Fix test_replay.py ecs_replayer fixture to mock boto3 client

### DIFF
--- a/migrationConsole/lib/console_link/tests/test_replay.py
+++ b/migrationConsole/lib/console_link/tests/test_replay.py
@@ -34,7 +34,8 @@ def docker_replayer():
 
 
 @pytest.fixture
-def ecs_replayer():
+def ecs_replayer(monkeypatch):
+    monkeypatch.setattr("console_link.models.ecs_service.create_boto3_client", lambda *a, **kw: None)
     config = {
         "ecs": {
             "cluster_name": "migration-aws-integ-ecs-cluster",


### PR DESCRIPTION
## Description

The `ecs_replayer` fixture in `test_replay.py` creates a real boto3 ECS client during test setup, which fails with `NoRegionError` in environments without `AWS_DEFAULT_REGION` configured.

## Problem

```
botocore.exceptions.NoRegionError: You must specify a region.
```

6 of 15 replay tests fail/error when no AWS region is configured. The fixture calls `get_replayer(config)` which instantiates `ECSReplayer` → `ECSService` → `create_boto3_client()` without a region.

## Fix

Mock `create_boto3_client` in the `ecs_replayer` fixture using `monkeypatch`:

```python
@pytest.fixture
def ecs_replayer(monkeypatch):
    monkeypatch.setattr("console_link.models.ecs_service.create_boto3_client", lambda *a, **kw: None)
    ...
```

Before: 6 passed, 5 failed, 1 error
After: 15 passed
