### PR TITLE
Adding request translator for field list parameter

### DIFF
--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/cases.testcase.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/cases.testcase.ts
@@ -132,4 +132,31 @@ export const testCases: TestCase[] = [
       { path: '$.response', rule: 'ignore', reason: 'Facet test — only validating $.facets, not hits' },
     ],
   }),
+
+  // ───────────────────────────────────────────────────────────
+  // Field list (fl) tests — _source filtering
+  // ───────────────────────────────────────────────────────────
+
+  solrTest('field-list-param', {
+    description: 'fl parameter with mixed comma/space separators and glob pattern (na*)',
+    documents: [
+      { id: '1', name: 'Alice', name_full: 'Alice Smith', price: 100 },
+      { id: '2', name: 'Bob', name_full: 'Bob Jones', price: 200 },
+    ],
+    requestPath: '/solr/testcollection/select?q=*:*&fl=id,na*%20price&wt=json',
+    solrSchema: {
+      fields: {
+        name: { type: 'text_general' },
+        name_full: { type: 'text_general' },
+        price: { type: 'pint' },
+      },
+    },
+    opensearchMapping: {
+      properties: {
+        name: { type: 'text' },
+        name_full: { type: 'text' },
+        price: { type: 'integer' },
+      },
+    },
+  }),
 ];

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/field-list.test.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/field-list.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest';
+import { request } from './field-list';
+import type { RequestContext, JavaMap } from '../context';
+
+/**
+ * Helper: build a RequestContext with the given params and an empty body.
+ */
+function buildCtx(params: string): RequestContext {
+  return {
+    msg: new Map() as unknown as JavaMap,
+    endpoint: 'select',
+    collection: 'testcollection',
+    params: new URLSearchParams(params),
+    body: new Map() as unknown as JavaMap,
+  };
+}
+
+describe('field-list MicroTransform', () => {
+  describe('apply', () => {
+    it('should not set _source when fl is absent', () => {
+      const ctx = buildCtx('');
+      request.apply(ctx);
+      expect(ctx.body.has('_source')).toBe(false);
+    });
+
+    it('should not set _source when fl=*', () => {
+      const ctx = buildCtx('fl=*');
+      request.apply(ctx);
+      expect(ctx.body.has('_source')).toBe(false);
+    });
+
+    it('should not set _source when fl is only whitespace', () => {
+      const ctx = buildCtx('fl=  ');
+      request.apply(ctx);
+      expect(ctx.body.has('_source')).toBe(false);
+    });
+
+    it('should set _source for comma-separated fields', () => {
+      const ctx = buildCtx('fl=id,name,price');
+      request.apply(ctx);
+      expect(ctx.body.get('_source')).toEqual(['id', 'name', 'price']);
+    });
+
+    it('should set _source for space-separated fields', () => {
+      const ctx = buildCtx('fl=id name price');
+      request.apply(ctx);
+      expect(ctx.body.get('_source')).toEqual(['id', 'name', 'price']);
+    });
+
+    it('should set _source for mixed comma and space separated fields', () => {
+      const ctx = buildCtx('fl=id,name price');
+      request.apply(ctx);
+      expect(ctx.body.get('_source')).toEqual(['id', 'name', 'price']);
+    });
+
+    it('should filter out score pseudo-field', () => {
+      const ctx = buildCtx('fl=id,score,name');
+      request.apply(ctx);
+      expect(ctx.body.get('_source')).toEqual(['id', 'name']);
+    });
+
+    it('should filter out * wildcard when mixed with other fields', () => {
+      const ctx = buildCtx('fl=*,score');
+      request.apply(ctx);
+      expect(ctx.body.has('_source')).toBe(false);
+    });
+
+    it('should pass through glob patterns like na*', () => {
+      const ctx = buildCtx('fl=id,na*,price');
+      request.apply(ctx);
+      expect(ctx.body.get('_source')).toEqual(['id', 'na*', 'price']);
+    });
+
+    it('should handle glob pattern na*e', () => {
+      const ctx = buildCtx('fl=id na*e price');
+      request.apply(ctx);
+      expect(ctx.body.get('_source')).toEqual(['id', 'na*e', 'price']);
+    });
+
+    it('should filter out document transformers like [explain]', () => {
+      const ctx = buildCtx('fl=id,[explain],name');
+      request.apply(ctx);
+      expect(ctx.body.get('_source')).toEqual(['id', 'name']);
+    });
+
+    it('should handle single field', () => {
+      const ctx = buildCtx('fl=id');
+      request.apply(ctx);
+      expect(ctx.body.get('_source')).toEqual(['id']);
+    });
+
+    it('should handle fields with extra whitespace', () => {
+      const ctx = buildCtx('fl=  id  ,  name  ');
+      request.apply(ctx);
+      expect(ctx.body.get('_source')).toEqual(['id', 'name']);
+    });
+
+    it('should return null when all fields are pseudo-fields', () => {
+      const ctx = buildCtx('fl=score');
+      request.apply(ctx);
+      expect(ctx.body.has('_source')).toBe(false);
+    });
+  });
+});

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/field-list.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/field-list.ts
@@ -1,0 +1,46 @@
+/**
+ * Field list (fl) parameter — convert Solr fl param to OpenSearch _source.
+ *
+ * Handles:
+ *   - fl=* or absent → no _source filter (return all fields)
+ *   - fl=field1,field2 → _source: ["field1", "field2"]
+ *   - fl=field1 field2 → _source: ["field1", "field2"]
+ *   - fl=id na* price → _source: ["id", "na*", "price"] (glob patterns passed through)
+ *   - Filters out pseudo-fields like "score" (not stored in _source)
+ *
+ * Request-only. All output is Maps/arrays for zero-serialization GraalVM interop.
+ */
+import type { MicroTransform } from '../pipeline';
+import type { RequestContext } from '../context';
+
+// Pseudo-fields that don't exist in _source (standalone * means all fields)
+const PSEUDO_FIELDS = new Set(['score', '*']);
+
+function parseFieldList(fl: string | null): string[] | null {
+  if (!fl || fl.trim() === '*') return null; // all fields
+
+  // Solr accepts comma or space separated
+  const fields = fl
+    .split(/[,\s]+/)
+    .map((f) => f.trim())
+    .filter((f) => {
+      if (f?.startsWith('[')) {
+        console.warn(`[field-list] Unsupported Solr document transformer ignored: ${f}`);
+        return false;
+      }
+      return f && !PSEUDO_FIELDS.has(f);
+    });
+
+  return fields.length > 0 ? fields : null;
+}
+
+export const request: MicroTransform<RequestContext> = {
+  name: 'field-list',
+  apply: (ctx) => {
+    const fl = ctx.params.get('fl');
+    const fields = parseFieldList(fl);
+    if (fields) {
+      ctx.body.set('_source', fields);
+    }
+  },
+};

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/hits-to-docs.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/hits-to-docs.ts
@@ -20,8 +20,18 @@ export const response: MicroTransform<ResponseContext> = {
       const doc = new Map();
       for (const key of source.keys()) {
         const value = source.get(key);
-        // Solr wraps multi-valued field values in arrays; id is single-valued
-        doc.set(key, key === 'id' || Array.isArray(value) ? value : [value]);
+        // Solr field type behavior:
+        // - text_general: by default returns arrays, even for single values
+        // - pint, pfloat, plong, pdouble (numeric): returns scalar values
+        // - string (keyword): returns scalar values
+        // - boolean: returns scalar values
+        if (key === 'id' || typeof value === 'number' || typeof value === 'boolean') {
+          doc.set(key, value);
+        } else if (Array.isArray(value)) {
+          doc.set(key, value);
+        } else {
+          doc.set(key, [value]);
+        }
       }
       // Solr adds _version_ (optimistic concurrency) to every doc
       doc.set('_version_', hit.has('_version') ? hit.get('_version') : 0);

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/registry.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/registry.ts
@@ -11,6 +11,7 @@ import type { RequestContext, ResponseContext } from './context';
 
 import * as selectUri from './features/select-uri';
 import * as queryQ from './features/query-q';
+import * as fieldList from './features/field-list';
 import * as jsonFacets from './features/json-facets';
 import * as hitsToDocs from './features/hits-to-docs';
 import * as aggsToFacets from './features/aggs-to-facets';
@@ -22,7 +23,8 @@ export const requestRegistry: TransformRegistry<RequestContext> = {
     select: [
       selectUri.request, // URI rewrite — must be first
       queryQ.request, // q=... → query DSL
-      jsonFacets.request, // json.facet → aggs
+      jsonFacets.request, // json.facet → aggs,
+      fieldList.request, // fl=... → _source
     ],
   },
 };


### PR DESCRIPTION
### Description
This translates [Solr field list](https://solr.apache.org/guide/solr/latest/query-guide/common-query-parameters.html#fl-field-list-parameter) (`fl`) param to OpenSearch equivalent

### Testing
UTs and integ test

### Check List
- [x] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
