### PR TITLE
feat(solr-transforms): Add cursor pagination (cursorMark → search_after)

### DIFF
--- a/TrafficCapture/SolrTransformations/docs/LIMITATIONS.md
+++ b/TrafficCapture/SolrTransformations/docs/LIMITATIONS.md
@@ -12,6 +12,8 @@ the root cause, and provides a workaround where one exists.
 |-----------|---------|
 | [TERMS-OFFSET](#terms-offset) | Terms facet `offset` not natively supported in OpenSearch |
 | [DATE-RANGE-GAP](#date-range-gap) | Multi-unit date range gaps approximated as fixed intervals |
+| [CURSOR-UNIQUEKEY](#cursor-uniquekey) | Cursor pagination assumes `id` as Solr's uniqueKey field |
+| [CURSOR-REPLAY](#cursor-replay) | Traffic replay with cursorMark not supported |
 
 ---
 
@@ -117,3 +119,48 @@ always use `fixed_interval` since they cannot be expressed as a single
 * **Compound gap drift** — Compound gaps combining calendar and fixed units
   (e.g. `+1MONTH+2DAYS`) accumulate approximation error from each calendar
   component.
+
+---
+
+## CURSOR-UNIQUEKEY
+
+**Feature:** Cursor pagination with custom `uniqueKey` field
+
+**Solr behaviour:**
+Solr requires `cursorMark` queries to include the `uniqueKey` field
+(configured in `schema.xml`) in the sort clause. The default is `id`, but
+deployments can configure any field. Solr rejects the query if the
+`uniqueKey` is missing from the sort.
+
+**OpenSearch behaviour:**
+OpenSearch uses `_id` as the document identifier. The `search_after`
+pagination mechanism requires the sort to include a tiebreaker field.
+
+**Cause:**
+The cursor pagination transform hardcodes `id` as the Solr `uniqueKey`
+and maps it to OpenSearch's `_id`. Deployments using a custom `uniqueKey`
+(e.g., `doc_id`) may see a redundant `id asc` tiebreaker added, and the
+custom field will not be mapped to `_id`.
+
+**Current workaround:**
+None. The vast majority of Solr deployments use the default `id`. A
+configurable `uniqueKey` option can be added in a future iteration.
+
+---
+
+## CURSOR-REPLAY
+
+**Feature:** Replaying captured Solr traffic containing `cursorMark`
+
+**Solr behaviour:**
+Solr's `cursorMark` tokens are opaque, binary-encoded values derived from
+sort values. They are only meaningful to the Solr instance that generated them.
+
+**Cause:**
+The traffic replayer cannot decode Solr's native cursor tokens into
+OpenSearch `search_after` values. Only the initial page (`cursorMark=*`)
+works during replay.
+
+**Current workaround:**
+This applies only to offline traffic replay. The live shim proxy handles
+cursor pagination correctly using its own base64-encoded tokens.

--- a/TrafficCapture/SolrTransformations/src/test/java/org/opensearch/migrations/transform/solr/TestCaseDefinition.java
+++ b/TrafficCapture/SolrTransformations/src/test/java/org/opensearch/migrations/transform/solr/TestCaseDefinition.java
@@ -31,6 +31,7 @@ record TestCaseDefinition(
     String method,
     String requestBody,
     String requestPath,
+    List<RequestStep> requestSequence,
     List<AssertionRule> assertionRules,
     Map<String, Object> solrSchema,
     Map<String, Object> opensearchMapping,
@@ -40,4 +41,8 @@ record TestCaseDefinition(
     /** A per-path assertion rule controlling how diffs are handled. */
     @JsonIgnoreProperties(ignoreUnknown = true)
     record AssertionRule(String path, String rule, String expected, Integer skip, String reason) {}
+
+    /** A step in a multi-request test sequence (e.g. cursor pagination page 2, 3, ...). */
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    record RequestStep(String requestPath, List<AssertionRule> assertionRules) {}
 }

--- a/TrafficCapture/SolrTransformations/src/test/java/org/opensearch/migrations/transform/solr/TransformationShimE2ETest.java
+++ b/TrafficCapture/SolrTransformations/src/test/java/org/opensearch/migrations/transform/solr/TransformationShimE2ETest.java
@@ -100,8 +100,8 @@ class TransformationShimE2ETest {
             for (var tc : testCases) {
                 try {
                     executeTestCase(fixture, tc, solrImage);
-                } catch (Exception e) {
-                    log.error("FAILED: {} [{}]: {}", tc.name(), solrImage, e.getMessage(), e);
+                } catch (Throwable e) {
+                    log.error("FAILED: {} [{}]: {}", tc.name(), solrImage, e.getMessage());
                     failures.add(tc.name() + ": " + e.getMessage());
                 } finally {
                     cleanupData(fixture, tc);
@@ -122,6 +122,11 @@ class TransformationShimE2ETest {
         var proxyJson = MAPPER.readValue(proxyResponse, new TypeReference<Map<String, Object>>() {});
 
         compareWithSolr(fixture, tc, proxyJson);
+
+        // Execute request sequence if defined (multi-step tests like cursor pagination)
+        if (tc.requestSequence() != null && !tc.requestSequence().isEmpty()) {
+            executeRequestSequence(fixture, tc, proxyJson);
+        }
 
         log.info("PASSED: {} [{}]", tc.name(), solrImage);
     }
@@ -150,6 +155,51 @@ class TransformationShimE2ETest {
         var solrJson = MAPPER.readValue(solrResponse, new TypeReference<Map<String, Object>>() {});
 
         var rules = tc.assertionRules() != null ? tc.assertionRules() : List.<TestCaseDefinition.AssertionRule>of();
+        compareResponses(tc.name(), solrJson, proxyJson, rules);
+    }
+
+    /**
+     * Execute a sequence of follow-up requests, substituting {{nextCursorMark}} from each response.
+     * Each step is compared against real Solr with the same substitution.
+     */
+    private void executeRequestSequence(
+        ShimTestFixture fixture, TestCaseDefinition tc, Map<String, Object> previousProxyJson
+    ) throws Exception {
+        var previousSolrResponse = sendRequest(fixture, fixture.getSolrBaseUrl() + tc.requestPath(), tc);
+        var previousSolrJson = MAPPER.readValue(previousSolrResponse, new TypeReference<Map<String, Object>>() {});
+
+        for (int i = 0; i < tc.requestSequence().size(); i++) {
+            var step = tc.requestSequence().get(i);
+            var stepName = tc.name() + " [step " + (i + 2) + "]";
+
+            // Substitute {{nextCursorMark}} from previous responses
+            var proxyCursorMark = String.valueOf(previousProxyJson.get("nextCursorMark"));
+            var solrCursorMark = String.valueOf(previousSolrJson.get("nextCursorMark"));
+
+            var proxyPath = step.requestPath().replace("{{nextCursorMark}}", proxyCursorMark);
+            var solrPath = step.requestPath().replace("{{nextCursorMark}}", solrCursorMark);
+
+            log.info("{}: proxy cursorMark={}, solr cursorMark={}", stepName, proxyCursorMark, solrCursorMark);
+
+            var proxyResponse = fixture.httpGet(fixture.getProxyBaseUrl() + proxyPath);
+            var proxyJson = MAPPER.readValue(proxyResponse, new TypeReference<Map<String, Object>>() {});
+
+            var solrResponse = fixture.httpGet(fixture.getSolrBaseUrl() + solrPath);
+            var solrJson = MAPPER.readValue(solrResponse, new TypeReference<Map<String, Object>>() {});
+
+            var rules = step.assertionRules() != null ? step.assertionRules()
+                : (tc.assertionRules() != null ? tc.assertionRules() : List.<TestCaseDefinition.AssertionRule>of());
+            compareResponses(stepName, solrJson, proxyJson, rules);
+
+            previousProxyJson = proxyJson;
+            previousSolrJson = solrJson;
+        }
+    }
+
+    private void compareResponses(
+        String testName, Map<String, Object> solrJson, Map<String, Object> proxyJson,
+        List<TestCaseDefinition.AssertionRule> rules
+    ) throws Exception {
         var diffs = JsonDiff.diff(solrJson, proxyJson, rules);
 
         // Separate unexpected diffs (no rule or non-expect-diff rule) from expected ones
@@ -162,12 +212,12 @@ class TransformationShimE2ETest {
 
         if (!expectedDiffs.isEmpty()) {
             log.info("'{}': {} expected difference(s) covered by rules:\n{}",
-                tc.name(), expectedDiffs.size(), JsonDiff.formatReport(expectedDiffs));
+                testName, expectedDiffs.size(), JsonDiff.formatReport(expectedDiffs));
         }
 
         if (!unexpectedDiffs.isEmpty()) {
             var report = JsonDiff.formatReport(unexpectedDiffs);
-            log.error("Solr vs Proxy diff for '{}':\n{}", tc.name(), report);
+            log.error("Solr vs Proxy diff for '{}':\n{}", testName, report);
             log.info("Full Solr response:\n{}", MAPPER.writerWithDefaultPrettyPrinter().writeValueAsString(solrJson));
             log.info("Full Proxy response:\n{}", MAPPER.writerWithDefaultPrettyPrinter().writeValueAsString(proxyJson));
             fail("Proxy response differs from Solr response (" + unexpectedDiffs.size() + " unexpected differences):\n" + report);

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/cases.testcase.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/cases.testcase.ts
@@ -57,6 +57,127 @@ export const testCases: TestCase[] = [
   // Facet tests — JSON Facet API (json.facet)
   // ───────────────────────────────────────────────────────────
 
+  // ───────────────────────────────────────────────────────────
+  // Cursor pagination tests — cursorMark → search_after
+  // ───────────────────────────────────────────────────────────
+
+  solrTest('cursor-pagination-initial-request', {
+    description: 'cursorMark=* should return first page with nextCursorMark',
+    documents: [
+      { id: '1', title: 'alpha', price: 10 },
+      { id: '2', title: 'beta', price: 20 },
+      { id: '3', title: 'gamma', price: 30 },
+      { id: '4', title: 'delta', price: 40 },
+    ],
+    requestPath: '/solr/testcollection/select?q=*:*&rows=2&sort=price+asc,id+asc&cursorMark=*&wt=json',
+    solrSchema: {
+      fields: {
+        title: { type: 'text_general' },
+        price: { type: 'pfloat' },
+      },
+    },
+    opensearchMapping: {
+      properties: {
+        title: { type: 'text' },
+        price: { type: 'float' },
+      },
+    },
+    assertionRules: [
+      ...SOLR_INTERNAL_RULES,
+      { path: '$.nextCursorMark', rule: 'expect-diff', reason: 'Shim uses base64(JSON) encoding vs Solr internal format' },
+    ],
+  }),
+
+  solrTest('cursor-pagination-full-walk-through', {
+    description: 'Walk through all pages using cursorMark — verifies page 2, 3, and end detection',
+    documents: [
+      { id: '1', title: 'alpha', price: 10 },
+      { id: '2', title: 'beta', price: 20 },
+      { id: '3', title: 'gamma', price: 30 },
+      { id: '4', title: 'delta', price: 40 },
+      { id: '5', title: 'epsilon', price: 50 },
+    ],
+    requestPath: '/solr/testcollection/select?q=*:*&rows=2&sort=price+asc,id+asc&cursorMark=*&wt=json',
+    requestSequence: [
+      { requestPath: '/solr/testcollection/select?q=*:*&rows=2&sort=price+asc,id+asc&cursorMark={{nextCursorMark}}&wt=json' },
+      { requestPath: '/solr/testcollection/select?q=*:*&rows=2&sort=price+asc,id+asc&cursorMark={{nextCursorMark}}&wt=json' },
+      { requestPath: '/solr/testcollection/select?q=*:*&rows=2&sort=price+asc,id+asc&cursorMark={{nextCursorMark}}&wt=json' },
+    ],
+    solrSchema: {
+      fields: {
+        title: { type: 'text_general' },
+        price: { type: 'pfloat' },
+      },
+    },
+    opensearchMapping: {
+      properties: {
+        title: { type: 'text' },
+        price: { type: 'float' },
+      },
+    },
+    assertionRules: [
+      ...SOLR_INTERNAL_RULES,
+      { path: '$.nextCursorMark', rule: 'expect-diff', reason: 'Shim uses base64(JSON) encoding vs Solr internal format' },
+    ],
+  }),
+
+  solrTest('cursor-pagination-descending-sort', {
+    description: 'Cursor pagination with descending sort',
+    documents: [
+      { id: '1', title: 'alpha', price: 10 },
+      { id: '2', title: 'beta', price: 20 },
+      { id: '3', title: 'gamma', price: 30 },
+    ],
+    requestPath: '/solr/testcollection/select?q=*:*&rows=2&sort=price+desc,id+asc&cursorMark=*&wt=json',
+    requestSequence: [
+      { requestPath: '/solr/testcollection/select?q=*:*&rows=2&sort=price+desc,id+asc&cursorMark={{nextCursorMark}}&wt=json' },
+    ],
+    solrSchema: {
+      fields: {
+        title: { type: 'text_general' },
+        price: { type: 'pfloat' },
+      },
+    },
+    opensearchMapping: {
+      properties: {
+        title: { type: 'text' },
+        price: { type: 'float' },
+      },
+    },
+    assertionRules: [
+      ...SOLR_INTERNAL_RULES,
+      { path: '$.nextCursorMark', rule: 'expect-diff', reason: 'Shim uses base64(JSON) encoding vs Solr internal format' },
+    ],
+  }),
+
+  solrTest('cursor-pagination-default-sort', {
+    description: 'cursorMark without explicit sort should default to id asc',
+    documents: [
+      { id: '1', title: 'alpha' },
+      { id: '2', title: 'beta' },
+      { id: '3', title: 'gamma' },
+    ],
+    requestPath: '/solr/testcollection/select?q=*:*&rows=2&sort=id+asc&cursorMark=*&wt=json',
+    solrSchema: {
+      fields: {
+        title: { type: 'text_general' },
+      },
+    },
+    opensearchMapping: {
+      properties: {
+        title: { type: 'text' },
+      },
+    },
+    assertionRules: [
+      ...SOLR_INTERNAL_RULES,
+      { path: '$.nextCursorMark', rule: 'expect-diff', reason: 'Shim uses base64(JSON) encoding vs Solr internal format' },
+    ],
+  }),
+
+  // ───────────────────────────────────────────────────────────
+  // Facet tests — JSON Facet API (json.facet)
+  // ───────────────────────────────────────────────────────────
+
   solrTest('facet-basic-terms', {
     description: 'Basic terms facet on a keyword field with distinct counts',
     documents: [

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/context.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/context.ts
@@ -32,6 +32,10 @@ export interface RequestContext {
   params: URLSearchParams;
   /** The request body as a Java Map — use .get()/.set() for access. */
   body: JavaMap;
+  /** Target name — 'opensearch', 'solr', etc. Set by the shim proxy. */
+  targetName?: string;
+  /** Routing mode — 'single' or 'dual'. Set by the shim proxy. */
+  mode?: string;
 }
 
 /** Parsed once from the bundled {request, response}. Shared across all response micro-transforms. */
@@ -43,6 +47,10 @@ export interface ResponseContext {
   requestParams: URLSearchParams;
   /** The response body as a Java Map — use .get()/.set() for access. */
   responseBody: JavaMap;
+  /** Target name — 'opensearch', 'solr', etc. Set by the shim proxy. */
+  targetName?: string;
+  /** Routing mode — 'single' or 'dual'. Set by the shim proxy. */
+  mode?: string;
 }
 
 const ENDPOINT_PATTERNS: [RegExp, SolrEndpoint][] = [
@@ -82,6 +90,8 @@ export function buildRequestContext(msg: JavaMap): RequestContext {
     collection: /\/solr\/([^/]+)\//.exec(uri)?.[1],
     params: parseParams(uri),
     body: getBodyMap(msg.get('payload')),
+    targetName: msg.get('_targetName') || 'opensearch',
+    mode: msg.get('_mode') || 'single',
   };
 }
 
@@ -94,5 +104,7 @@ export function buildResponseContext(request: JavaMap, response: JavaMap): Respo
     collection: /\/solr\/([^/]+)\//.exec(uri)?.[1],
     requestParams: parseParams(uri),
     responseBody: getBodyMap(response.get('payload')),
+    targetName: request.get('_targetName') || 'opensearch',
+    mode: request.get('_mode') || 'single',
   };
 }

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/cursor-pagination.test.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/cursor-pagination.test.ts
@@ -1,0 +1,260 @@
+import { describe, it, expect } from 'vitest';
+import {
+  b64Encode, b64Decode, encodeCursorMark, decodeCursorMark,
+  parseSolrSort, hasTiebreaker, request, response,
+  SOLR_UNIQUE_KEY, OS_UNIQUE_KEY,
+} from './cursor-pagination';
+import type { RequestContext, ResponseContext, JavaMap } from '../context';
+
+// --- b64Encode / b64Decode ---
+
+describe('b64Encode / b64Decode', () => {
+  it('roundtrips simple string', () => {
+    expect(b64Decode(b64Encode('hello'))).toBe('hello');
+  });
+
+  it('roundtrips empty string', () => {
+    expect(b64Decode(b64Encode(''))).toBe('');
+  });
+
+  it('roundtrips JSON with special chars', () => {
+    const json = '[44.99,"7"]';
+    expect(b64Decode(b64Encode(json))).toBe(json);
+  });
+
+  it('roundtrips strings of length 1, 2, 3 (padding edge cases)', () => {
+    expect(b64Decode(b64Encode('a'))).toBe('a');
+    expect(b64Decode(b64Encode('ab'))).toBe('ab');
+    expect(b64Decode(b64Encode('abc'))).toBe('abc');
+  });
+
+  it('produces correct padding', () => {
+    expect(b64Encode('a')).toMatch(/=$/);
+    expect(b64Encode('ab')).toMatch(/=$/);
+    expect(b64Encode('abc')).not.toMatch(/=/);
+  });
+
+  it('matches known base64 values', () => {
+    expect(b64Encode('hello')).toBe('aGVsbG8=');
+    expect(b64Encode('[44.99,"7"]')).toBe('WzQ0Ljk5LCI3Il0=');
+  });
+
+  it('roundtrips multi-byte UTF-8 characters', () => {
+    expect(b64Decode(b64Encode('caf\u00e9'))).toBe('caf\u00e9');
+    expect(b64Decode(b64Encode('\u65e5\u672c\u8a9e'))).toBe('\u65e5\u672c\u8a9e');
+  });
+});
+
+// --- encodeCursorMark / decodeCursorMark ---
+
+describe('encodeCursorMark / decodeCursorMark', () => {
+  it('roundtrips sort values with float and string', () => {
+    const values = [44.99, '7'];
+    expect(decodeCursorMark(encodeCursorMark(values))).toEqual(values);
+  });
+
+  it('roundtrips integer sort values', () => {
+    const values = [3499, '3'];
+    expect(decodeCursorMark(encodeCursorMark(values))).toEqual(values);
+  });
+
+  it('roundtrips single sort value', () => {
+    const values = ['10'];
+    expect(decodeCursorMark(encodeCursorMark(values))).toEqual(values);
+  });
+
+  it('roundtrips empty array', () => {
+    expect(decodeCursorMark(encodeCursorMark([]))).toEqual([]);
+  });
+});
+
+// --- parseSolrSort ---
+
+describe('parseSolrSort', () => {
+  it('parses single field sort', () => {
+    const result = parseSolrSort('price asc');
+    expect(result).toHaveLength(1);
+    expect(result[0].get('price')).toBe('asc');
+  });
+
+  it('parses multi-field sort', () => {
+    const result = parseSolrSort('price asc,id desc');
+    expect(result).toHaveLength(2);
+    expect(result[0].get('price')).toBe('asc');
+    expect(result[1].get('_id')).toBe('desc');
+  });
+
+  it('maps id to _id using uniqueKey constants', () => {
+    expect(SOLR_UNIQUE_KEY).toBe('id');
+    expect(OS_UNIQUE_KEY).toBe('_id');
+    const result = parseSolrSort('id asc');
+    expect(result[0].has(OS_UNIQUE_KEY)).toBe(true);
+    expect(result[0].has(SOLR_UNIQUE_KEY)).toBe(false);
+  });
+
+  it('handles + as space', () => {
+    const result = parseSolrSort('price+asc,id+desc');
+    expect(result[0].get('price')).toBe('asc');
+    expect(result[1].get('_id')).toBe('desc');
+  });
+
+  it('defaults direction to asc', () => {
+    const result = parseSolrSort('price');
+    expect(result[0].get('price')).toBe('asc');
+  });
+
+  it('handles spaces around commas', () => {
+    const result = parseSolrSort('price asc , name desc');
+    expect(result).toHaveLength(2);
+    expect(result[0].get('price')).toBe('asc');
+    expect(result[1].get('name')).toBe('desc');
+  });
+});
+
+// --- hasTiebreaker ---
+
+describe('hasTiebreaker', () => {
+  it('returns true when _id is present', () => {
+    const sort = [new Map([['price', 'asc']]), new Map([['_id', 'asc']])];
+    expect(hasTiebreaker(sort)).toBe(true);
+  });
+
+  it('returns false when _id is absent', () => {
+    const sort = [new Map([['price', 'asc']])];
+    expect(hasTiebreaker(sort)).toBe(false);
+  });
+});
+
+// --- request transform ---
+
+function makeRequestCtx(params: Record<string, string>, body?: Map<string, any>): RequestContext {
+  return {
+    msg: new Map() as unknown as JavaMap,
+    endpoint: 'select',
+    collection: 'products',
+    params: new URLSearchParams(params),
+    body: body ?? new Map(),
+  };
+}
+
+describe('request transform', () => {
+  it('matches when cursorMark present', () => {
+    expect(request.match!(makeRequestCtx({ cursorMark: '*' }))).toBe(true);
+  });
+
+  it('does not match without cursorMark', () => {
+    expect(request.match!(makeRequestCtx({ q: '*:*' }))).toBe(false);
+  });
+
+  it('matches in dual-mode (shim handles token splitting)', () => {
+    const ctx = makeRequestCtx({ cursorMark: '*' });
+    ctx.mode = 'dual';
+    expect(request.match!(ctx)).toBe(true);
+  });
+
+  it('removes from and adds sort with tiebreaker for cursorMark=*', () => {
+    const body = new Map<string, any>([['from', 5]]);
+    const ctx = makeRequestCtx({ cursorMark: '*', sort: 'price asc' }, body);
+    request.apply(ctx);
+
+    expect(body.has('from')).toBe(false);
+    expect(body.has('search_after')).toBe(false);
+    const sort = body.get('sort') as Map<string, string>[];
+    expect(sort).toHaveLength(2);
+    expect(sort[1].get('_id')).toBe('asc');
+  });
+
+  it('decodes cursorMark into search_after', () => {
+    const token = encodeCursorMark([44.99, '7']);
+    const body = new Map<string, any>();
+    const ctx = makeRequestCtx({ cursorMark: token, sort: 'price asc,id asc' }, body);
+    request.apply(ctx);
+
+    expect(body.get('search_after')).toEqual([44.99, '7']);
+  });
+
+  it('does not duplicate _id tiebreaker', () => {
+    const body = new Map<string, any>();
+    const ctx = makeRequestCtx({ cursorMark: '*', sort: 'price asc,id asc' }, body);
+    request.apply(ctx);
+
+    expect((body.get('sort') as any[]).length).toBe(2);
+  });
+
+  it('defaults to _id asc when no sort', () => {
+    const body = new Map<string, any>();
+    const ctx = makeRequestCtx({ cursorMark: '*' }, body);
+    request.apply(ctx);
+
+    const sort = body.get('sort') as Map<string, string>[];
+    expect(sort).toHaveLength(1);
+    expect(sort[0].get('_id')).toBe('asc');
+  });
+
+  it('throws on malformed cursorMark token', () => {
+    const body = new Map<string, any>();
+    const ctx = makeRequestCtx({ cursorMark: 'not-valid-base64!', sort: 'price asc' }, body);
+    expect(() => request.apply(ctx)).toThrow('Invalid cursorMark token');
+  });
+});
+
+// --- response transform ---
+
+function makeResponseCtx(params: Record<string, string>, responseBody: Map<string, any>): ResponseContext {
+  return {
+    request: new Map() as unknown as JavaMap,
+    response: new Map() as unknown as JavaMap,
+    endpoint: 'select',
+    collection: 'products',
+    requestParams: new URLSearchParams(params),
+    responseBody,
+  };
+}
+
+describe('response transform', () => {
+  it('matches when cursorMark in request', () => {
+    expect(response.match!(makeResponseCtx({ cursorMark: '*' }, new Map()))).toBe(true);
+  });
+
+  it('does not match without cursorMark', () => {
+    expect(response.match!(makeResponseCtx({}, new Map()))).toBe(false);
+  });
+
+  it('matches in dual-mode (shim handles token merging)', () => {
+    const ctx = makeResponseCtx({ cursorMark: '*' }, new Map());
+    ctx.mode = 'dual';
+    expect(response.match!(ctx)).toBe(true);
+  });
+
+  it('encodes nextCursorMark from last hit sort', () => {
+    const hits = new Map([['hits', [
+      new Map([['sort', [34.99, '10']]]),
+      new Map([['sort', [44.99, '7']]]),
+    ]]]);
+    const body = new Map<string, any>([['hits', hits]]);
+    const ctx = makeResponseCtx({ cursorMark: '*' }, body);
+    response.apply(ctx);
+
+    const ncm = body.get('nextCursorMark');
+    expect(decodeCursorMark(ncm)).toEqual([44.99, '7']);
+  });
+
+  it('returns same cursorMark on empty results (end signal)', () => {
+    const token = encodeCursorMark([3499, '3']);
+    const hits = new Map([['hits', []]]);
+    const body = new Map<string, any>([['hits', hits]]);
+    const ctx = makeResponseCtx({ cursorMark: token }, body);
+    response.apply(ctx);
+
+    expect(body.get('nextCursorMark')).toBe(token);
+  });
+
+  it('returns * when cursorMark=* and no results', () => {
+    const hits = new Map([['hits', []]]);
+    const body = new Map<string, any>([['hits', hits]]);
+    const ctx = makeResponseCtx({ cursorMark: '*' }, body);
+    response.apply(ctx);
+
+    expect(body.get('nextCursorMark')).toBe('*');
+  });
+});

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/cursor-pagination.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/cursor-pagination.ts
@@ -1,0 +1,180 @@
+/**
+ * Cursor pagination — cursorMark → search_after translation.
+ *
+ * Request: Detects cursorMark param, decodes to search_after sort values,
+ *          ensures sort includes _id tiebreaker.
+ * Response: Encodes last hit's sort values into nextCursorMark token.
+ *
+ * Uses base64(JSON) encoding for the cursor token — simple, deterministic,
+ * and doesn't need to be compatible with actual Solr's internal format.
+ */
+import type { MicroTransform } from '../pipeline';
+import type { RequestContext, ResponseContext, JavaMap } from '../context';
+
+const CURSOR_MARK_START = '*';
+
+/** Solr uniqueKey field name — maps to OpenSearch's _id. */
+const SOLR_UNIQUE_KEY = 'id';
+const OS_UNIQUE_KEY = '_id';
+
+const B64 = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
+
+/** UTF-8 encode a string into a byte array (GraalVM-safe, no TextEncoder). */
+function toUTF8Bytes(str: string): number[] {
+  const bytes: number[] = [];
+  let i = 0;
+  while (i < str.length) {
+    const code = str.codePointAt(i)!;
+    // Codepoints above U+FFFF use a surrogate pair (2 UTF-16 code units), so advance by 2
+    const step = code >= 0x10000 ? 2 : 1;
+    if (code < 0x80) {
+      bytes.push(code);
+    } else if (code < 0x800) {
+      bytes.push(0xc0 | (code >> 6), 0x80 | (code & 0x3f));
+    } else if (code < 0x10000) {
+      bytes.push(0xe0 | (code >> 12), 0x80 | ((code >> 6) & 0x3f), 0x80 | (code & 0x3f));
+    } else {
+      bytes.push(0xf0 | (code >> 18), 0x80 | ((code >> 12) & 0x3f), 0x80 | ((code >> 6) & 0x3f), 0x80 | (code & 0x3f));
+    }
+    i += step;
+  }
+  return bytes;
+}
+
+/** Decode a UTF-8 byte array back to a string. */
+function fromUTF8Bytes(bytes: number[]): string {
+  let out = '';
+  for (let i = 0; i < bytes.length;) {
+    const b = bytes[i];
+    if (b < 0x80) { out += String.fromCodePoint(b); i++; }
+    else if (b < 0xe0) { out += String.fromCodePoint(((b & 0x1f) << 6) | (bytes[i + 1] & 0x3f)); i += 2; }
+    else if (b < 0xf0) { out += String.fromCodePoint(((b & 0x0f) << 12) | ((bytes[i + 1] & 0x3f) << 6) | (bytes[i + 2] & 0x3f)); i += 3; }
+    else { out += String.fromCodePoint(((b & 0x07) << 18) | ((bytes[i + 1] & 0x3f) << 12) | ((bytes[i + 2] & 0x3f) << 6) | (bytes[i + 3] & 0x3f)); i += 4; }
+  }
+  return out;
+}
+
+/** Pure JS base64 encode with UTF-8 support (no btoa/Buffer/Java dependency). */
+function b64Encode(str: string): string {
+  const bytes = toUTF8Bytes(str);
+  let out = '';
+  for (let i = 0; i < bytes.length; i += 3) {
+    const a = bytes[i];
+    const b = i + 1 < bytes.length ? bytes[i + 1] : 0;
+    const c = i + 2 < bytes.length ? bytes[i + 2] : 0;
+    out += B64[a >> 2] + B64[((a & 3) << 4) | (b >> 4)];
+    out += i + 1 < bytes.length ? B64[((b & 15) << 2) | (c >> 6)] : '=';
+    out += i + 2 < bytes.length ? B64[c & 63] : '=';
+  }
+  return out;
+}
+
+/** Pure JS base64 decode with UTF-8 support. */
+function b64Decode(encoded: string): string {
+  const clean = encoded.replaceAll(/=+$/g, '');
+  const bytes: number[] = [];
+  for (let i = 0; i < clean.length; i += 4) {
+    const a = B64.indexOf(clean[i]);
+    const b = B64.indexOf(clean[i + 1]);
+    const c = i + 2 < clean.length ? B64.indexOf(clean[i + 2]) : 0;
+    const d = i + 3 < clean.length ? B64.indexOf(clean[i + 3]) : 0;
+    bytes.push((a << 2) | (b >> 4));
+    if (i + 2 < clean.length) bytes.push(((b & 15) << 4) | (c >> 2));
+    if (i + 3 < clean.length) bytes.push(((c & 3) << 6) | d);
+  }
+  return fromUTF8Bytes(bytes);
+}
+
+function encodeCursorMark(sortValues: any[]): string {
+  return b64Encode(JSON.stringify(sortValues));
+}
+
+function decodeCursorMark(token: string): any[] {
+  return JSON.parse(b64Decode(token));
+}
+
+/**
+ * Parse Solr sort string into OpenSearch sort array.
+ * "price asc, id desc" → [{"price": "asc"}, {"id": "desc"}]
+ * Maps Solr's uniqueKey field "id" to OpenSearch's "_id".
+ */
+function parseSolrSort(sortStr: string): JavaMap[] {
+  // Handle + as space — URL-encoded sort params (e.g. "price+asc") use + for spaces.
+  // Solr field names cannot contain spaces, so this is safe.
+  return sortStr.replaceAll('+', ' ').split(',').map((clause) => {
+    const [field, dir] = clause.trim().split(/\s+/);
+    const osField = field === SOLR_UNIQUE_KEY ? OS_UNIQUE_KEY : field;
+    return new Map([[osField, (dir || 'asc').toLowerCase()]]);
+  });
+}
+
+/** Check if sort array already includes _id as a tiebreaker. */
+function hasTiebreaker(sortArray: JavaMap[]): boolean {
+  return sortArray.some((s) => s.has(OS_UNIQUE_KEY));
+}
+
+// Exported for testing
+export { b64Encode, b64Decode, encodeCursorMark, decodeCursorMark, parseSolrSort, hasTiebreaker,
+  SOLR_UNIQUE_KEY, OS_UNIQUE_KEY };
+
+export const request: MicroTransform<RequestContext> = {
+  name: 'cursor-pagination',
+  match: (ctx) => ctx.params.has('cursorMark'),
+  apply: (ctx) => {
+    const cursorMark = ctx.params.get('cursorMark')!;
+
+    // cursorMark and start are mutually exclusive — remove from if present
+    ctx.body.delete('from');
+
+    // Parse and set sort with _id tiebreaker
+    const sortStr = ctx.params.get('sort');
+    if (sortStr) {
+      const sortArray = parseSolrSort(sortStr);
+      if (!hasTiebreaker(sortArray)) {
+        sortArray.push(new Map([[OS_UNIQUE_KEY, 'asc']]));
+      }
+      ctx.body.set('sort', sortArray);
+    } else {
+      // No sort specified — default to _id asc (deterministic ordering required)
+      ctx.body.set('sort', [new Map([[OS_UNIQUE_KEY, 'asc']])]);
+    }
+
+    // Decode cursor mark into search_after (skip for initial request)
+    if (cursorMark !== CURSOR_MARK_START) {
+      try {
+        ctx.body.set('search_after', decodeCursorMark(cursorMark));
+      } catch {
+        throw new Error(`Invalid cursorMark token: ${cursorMark}`);
+      }
+    }
+  },
+};
+
+export const response: MicroTransform<ResponseContext> = {
+  name: 'cursor-pagination',
+  match: (ctx) => ctx.requestParams.has('cursorMark'),
+  apply: (ctx) => {
+    // Must run BEFORE hits-to-docs since we need the raw hits.hits[].sort array.
+    // We extract nextCursorMark here; hits-to-docs will later build response.start=0.
+    const hits: JavaMap | undefined = ctx.responseBody.get('hits');
+    const hitsArray: JavaMap[] | undefined = hits?.get('hits');
+
+    if (hitsArray && hitsArray.length > 0) {
+      const lastHit = hitsArray.at(-1)!;
+      const sortValues: any[] = lastHit.get('sort');
+      if (sortValues) {
+        ctx.responseBody.set('nextCursorMark', encodeCursorMark(Array.from(sortValues)));
+        return;
+      }
+    }
+
+    // No results or no sort values — return the same cursorMark (end signal)
+    // Re-encode since requestParams.get() returns the decoded value
+    const originalMark = ctx.requestParams.get('cursorMark')!;
+    if (originalMark === CURSOR_MARK_START) {
+      ctx.responseBody.set('nextCursorMark', CURSOR_MARK_START);
+    } else {
+      ctx.responseBody.set('nextCursorMark', encodeCursorMark(decodeCursorMark(originalMark)));
+    }
+  },
+};

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/hits-to-docs.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/hits-to-docs.ts
@@ -6,6 +6,31 @@
 import type { MicroTransform } from '../pipeline';
 import type { ResponseContext, JavaMap } from '../context';
 
+/** Convert a single OpenSearch hit to a Solr doc. */
+function hitToDoc(hit: JavaMap): JavaMap {
+  const source: JavaMap = hit.get('_source');
+  const doc = new Map();
+  doc.set('id', hit.get('_id'));
+  for (const key of source.keys()) {
+    if (key === 'id') continue;
+    const value = source.get(key);
+    // Solr field type behavior:
+    // - text_general: by default returns arrays, even for single values
+    // - pint, pfloat, plong, pdouble (numeric): returns scalar values
+    // - string (keyword): returns scalar values
+    // - boolean: returns scalar values
+    if (typeof value === 'number' || typeof value === 'boolean') {
+      doc.set(key, value);
+    } else if (Array.isArray(value)) {
+      doc.set(key, value);
+    } else {
+      doc.set(key, [value]);
+    }
+  }
+  doc.set('_version_', hit.has('_version') ? hit.get('_version') : 0);
+  return doc;
+}
+
 export const response: MicroTransform<ResponseContext> = {
   name: 'hits-to-docs',
   match: (ctx) => ctx.responseBody.has('hits'),
@@ -14,35 +39,13 @@ export const response: MicroTransform<ResponseContext> = {
     const hitsArray: JavaMap[] = hits.get('hits');
     const total: JavaMap = hits.get('total');
 
-    const docs: JavaMap[] = [];
-    for (const hit of hitsArray) {
-      const source: JavaMap = hit.get('_source');
-      const doc = new Map();
-      for (const key of source.keys()) {
-        const value = source.get(key);
-        // Solr field type behavior:
-        // - text_general: by default returns arrays, even for single values
-        // - pint, pfloat, plong, pdouble (numeric): returns scalar values
-        // - string (keyword): returns scalar values
-        // - boolean: returns scalar values
-        if (key === 'id' || typeof value === 'number' || typeof value === 'boolean') {
-          doc.set(key, value);
-        } else if (Array.isArray(value)) {
-          doc.set(key, value);
-        } else {
-          doc.set(key, [value]);
-        }
-      }
-      // Solr adds _version_ (optimistic concurrency) to every doc
-      doc.set('_version_', hit.has('_version') ? hit.get('_version') : 0);
-      docs.push(doc);
-    }
-
     const responseMap = new Map();
     responseMap.set('numFound', total.get('value'));
-    responseMap.set('start', Number.parseInt(ctx.requestParams.get('start') || '0', 10));
+    responseMap.set('start', ctx.requestParams.has('cursorMark')
+      ? 0
+      : Number.parseInt(ctx.requestParams.get('start') || '0', 10));
     responseMap.set('numFoundExact', true);
-    responseMap.set('docs', docs);
+    responseMap.set('docs', hitsArray.map(hitToDoc));
     ctx.responseBody.set('response', responseMap);
 
     ctx.responseBody.delete('hits');

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/registry.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/registry.ts
@@ -11,6 +11,7 @@ import type { RequestContext, ResponseContext } from './context';
 
 import * as selectUri from './features/select-uri';
 import * as queryQ from './features/query-q';
+import * as cursorPagination from './features/cursor-pagination';
 import * as fieldList from './features/field-list';
 import * as sort from './features/sort';
 import * as jsonFacets from './features/json-facets';
@@ -25,6 +26,7 @@ export const requestRegistry: TransformRegistry<RequestContext> = {
     select: [
       selectUri.request, // URI rewrite — must be first
       queryQ.request, // q=... → query DSL
+      cursorPagination.request, // cursorMark → search_after (after query-q sets from)
       jsonFacets.request, // json.facet → aggs
       fieldList.request, // fl=... → _source
       highlighting.request, // hl=true → highlight block
@@ -38,6 +40,7 @@ export const responseRegistry: TransformRegistry<ResponseContext> = {
   global: [],
   byEndpoint: {
     select: [
+      cursorPagination.response, // nextCursorMark from last hit (before hits deleted)
       highlighting.response, // per-hit highlight → top-level highlighting section (must run before hits-to-docs)
       hitsToDocs.response, // hits.hits → response.docs
       aggsToFacets.response, // aggregations → facets

--- a/TrafficCapture/SolrTransformations/transforms/src/test-types.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/test-types.ts
@@ -131,6 +131,14 @@ export interface SolrSchema {
 /** HTTP methods supported by the test framework. */
 export type HttpMethod = 'GET' | 'POST' | 'PUT' | 'DELETE' | 'HEAD';
 
+/** A step in a multi-request test sequence. */
+export interface RequestStep {
+  /** Request path — supports {{nextCursorMark}} placeholder from previous response. */
+  requestPath: string;
+  /** Per-path assertion rules for this step. Defaults to parent test's rules. */
+  assertionRules?: AssertionRule[];
+}
+
 /** Assertion rule types for controlling how diffs are handled per JSON path. */
 export type AssertionRuleType =
   | 'ignore' // Skip this path entirely
@@ -174,6 +182,12 @@ export interface TestCase {
   /** Request body (for POST/PUT/DELETE). JSON-serializable. */
   requestBody?: string;
   requestPath: string;
+  /**
+   * Optional sequence of follow-up requests for multi-step tests (e.g. cursor pagination).
+   * Each step's requestPath can use {{nextCursorMark}} which is replaced with the value
+   * from the previous response's nextCursorMark field.
+   */
+  requestSequence?: RequestStep[];
   /** Per-path assertion rules controlling how diffs are handled. */
   assertionRules?: AssertionRule[];
   /**

--- a/TrafficCapture/transformationShim/src/main/java/org/opensearch/migrations/transform/shim/netty/MultiTargetRoutingHandler.java
+++ b/TrafficCapture/transformationShim/src/main/java/org/opensearch/migrations/transform/shim/netty/MultiTargetRoutingHandler.java
@@ -69,6 +69,14 @@ public class MultiTargetRoutingHandler extends SimpleChannelInboundHandler<FullH
     private static final String HANDLER_READ_TIMEOUT = "readTimeout";
     private static final String HANDLER_RESPONSE = "responseHandler";
     private static final String RESPONSE_KEY = "response";
+    private static final String CURSOR_MARK_PARAM = "cursorMark";
+    private static final String OPENSEARCH_TARGET = "opensearch";
+
+
+
+
+
+
 
     /** Structured tuple logger — mirrors replayer's OutputTupleJsonLogger. */
     private static final Logger TUPLE_LOGGER = LoggerFactory.getLogger("OutputTupleJsonLogger");
@@ -193,16 +201,33 @@ public class MultiTargetRoutingHandler extends SimpleChannelInboundHandler<FullH
         ShimRequestContext requestCtx
     ) {
         Map<String, CompletableFuture<TargetResponse>> futures = new LinkedHashMap<>();
+        boolean dualMode = activeTargets.size() > 1;
+        String uri = (String) requestMap.get("URI");
+        // Check for cursorMark in both URL params and JSON request body (P1)
+        boolean hasCursorMark = dualMode && (
+            (uri != null && uri.contains("cursorMark=")) ||
+            requestMap.containsKey(CURSOR_MARK_PARAM)
+        );
+
         for (String name : activeTargets) {
             Target target = targets.get(name);
-            Map<String, Object> targetRequestMap = target.requestTransform() != null
+            Map<String, Object> targetRequestMap = (target.requestTransform() != null || hasCursorMark)
                 ? deepCopyMap(requestMap) : requestMap;
+            targetRequestMap.put("_targetName", name);
+            targetRequestMap.put("_mode", dualMode ? "dual" : "single");
+
+            // In dual mode with cursorMark, split the combined token per target
+            if (hasCursorMark) {
+                rewriteCursorMarkForTarget(targetRequestMap, name);
+            }
 
             TargetDispatchContext dispatchCtx = requestCtx != null
                 ? (TargetDispatchContext) requestCtx.createTargetDispatchContext(name)
                 : null;
 
-            futures.put(name, dispatchToTarget(target, targetRequestMap, requestMap, dispatchCtx));
+            // Response transform needs per-target URI (with rewritten cursorMark)
+            Map<String, Object> responseRequestMap = hasCursorMark ? targetRequestMap : requestMap;
+            futures.put(name, dispatchToTarget(target, targetRequestMap, responseRequestMap, dispatchCtx));
         }
         return new DispatchResult(futures);
     }
@@ -224,7 +249,7 @@ public class MultiTargetRoutingHandler extends SimpleChannelInboundHandler<FullH
                     Map<String, TargetResponse> allResponses = collectResponses(futures);
 
                     List<ValidationResult> results = runValidators(allResponses);
-                    FullHttpResponse response = buildFinalResponse(primary, allResponses, results);
+                    FullHttpResponse response = buildFinalResponse(primary, allResponses, results, requestMap);
                     HttpMessageUtil.writeResponse(ctx, response, keepAlive);
 
                     logTuple(requestId, requestMap, allResponses, results);
@@ -482,9 +507,17 @@ public class MultiTargetRoutingHandler extends SimpleChannelInboundHandler<FullH
     private FullHttpResponse buildFinalResponse(
         TargetResponse primary,
         Map<String, TargetResponse> allResponses,
-        List<ValidationResult> validationResults
+        List<ValidationResult> validationResults,
+        Map<String, Object> requestMap
     ) {
         FullHttpResponse response = buildPrimaryResponse(primary);
+
+        if (allResponses.size() > 1) {
+            String sentCursorMark = extractQueryParam(
+                (String) requestMap.get("URI"), CURSOR_MARK_PARAM);
+            response = mergeCursorTokens(response, allResponses, sentCursorMark);
+        }
+
         addShimHeaders(response);
         addTargetHeaders(response, allResponses);
         addValidationHeaders(response, validationResults);
@@ -506,6 +539,162 @@ public class MultiTargetRoutingHandler extends SimpleChannelInboundHandler<FullH
         response.headers().set(HttpHeaderNames.CONTENT_TYPE, "application/json");
         return response;
     }
+
+    // --- Cursor pagination dual-mode support ---
+
+    /**
+     * In dual mode, rewrite the cursorMark query param for each target.
+     * Combined token format: base64({"solr":"<native>","os":"<os_token>"})
+     * For initial request (cursorMark=*), no rewrite needed.
+     * For Solr: extract the "solr" portion (native Solr cursorMark).
+     * For OpenSearch: extract the "os" portion (base64-encoded sort values).
+     */
+    static void rewriteCursorMarkForTarget(Map<String, Object> requestMap, String targetName) {
+        String uri = (String) requestMap.get("URI");
+        if (uri == null) return;
+
+        String cursorMark = extractQueryParam(uri, CURSOR_MARK_PARAM);
+        if (cursorMark == null || "*".equals(cursorMark)) return;
+
+        try {
+            String decoded = new String(java.util.Base64.getDecoder().decode(cursorMark), StandardCharsets.UTF_8);
+            Map<String, Object> combined = MAPPER.readValue(decoded, MAP_TYPE_REF);
+
+            String targetToken;
+            if (OPENSEARCH_TARGET.equals(targetName) && combined.containsKey("os")) {
+                targetToken = (String) combined.get("os");
+            } else if (combined.containsKey("solr")) {
+                targetToken = (String) combined.get("solr");
+            } else {
+                return; // Not a combined token, pass through as-is
+            }
+
+            String newUri = replaceQueryParam(uri, CURSOR_MARK_PARAM, targetToken);
+            requestMap.put("URI", newUri);
+        } catch (Exception e) {
+            // Not a combined token — unexpected in dual mode, log for debugging
+            log.warn("cursorMark is not a combined token, passing through: {}", e.getMessage());
+        }
+    }
+
+    /**
+     * After both targets respond, merge their nextCursorMark tokens into a combined token.
+     * Rewrites the primary response body with the combined nextCursorMark.
+     *
+     * Contract: each target's cursor token is treated as an opaque string. The TypeScript
+     * transform layer produces base64-encoded sort values for OpenSearch and Solr returns
+     * its native cursor token. This method combines them without interpreting the format.
+     *
+     * TODO: Consider extracting cursor merge/split into a CursorStrategy interface if
+     * additional pagination strategies are needed beyond the current solr+os dual mode.
+     */
+    @SuppressWarnings("unchecked")
+    FullHttpResponse mergeCursorTokens(
+        FullHttpResponse response, Map<String, TargetResponse> allResponses, String sentCursorMark
+    ) {
+        String solrToken = extractCursorToken(allResponses, "solr");
+        String osToken = extractCursorToken(allResponses, OPENSEARCH_TARGET);
+
+        if (solrToken == null || osToken == null) {
+            logPartialCursorWarning(solrToken, osToken);
+            return response;
+        }
+
+        if (isPaginationEnded(sentCursorMark, solrToken, osToken)) {
+            log.debug("Both targets returned same cursor as sent — end of results");
+            return response;
+        }
+
+        try {
+            String combinedToken = buildCombinedToken(solrToken, osToken);
+            return rewriteResponseWithToken(response, combinedToken);
+        } catch (Exception e) {
+            log.warn("Failed to merge cursor tokens: {}", e.getMessage());
+            return response;
+        }
+    }
+
+    private void logPartialCursorWarning(String solrToken, String osToken) {
+        if (solrToken != null || osToken != null) {
+            log.warn("Only one target returned a cursor token (solr={}, os={}), skipping merge",
+                solrToken != null ? "present" : "missing", osToken != null ? "present" : "missing");
+        }
+    }
+
+    private boolean isPaginationEnded(String sentCursorMark, String solrToken, String osToken) {
+        if (sentCursorMark == null || "*".equals(sentCursorMark)) {
+            return false;
+        }
+        try {
+            String decoded = new String(
+                java.util.Base64.getDecoder().decode(sentCursorMark), StandardCharsets.UTF_8);
+            Map<String, Object> sentCombined = MAPPER.readValue(decoded, MAP_TYPE_REF);
+            String sentSolr = (String) sentCombined.get("solr");
+            String sentOs = (String) sentCombined.get("os");
+            return solrToken.equals(sentSolr) && osToken.equals(sentOs);
+        } catch (Exception e) {
+            log.warn("Sent cursorMark is not a combined token, proceeding with merge: {}",
+                e.getMessage());
+            return false;
+        }
+    }
+
+    private String extractCursorToken(Map<String, TargetResponse> allResponses, String targetKey) {
+        TargetResponse tr = allResponses.get(targetKey);
+        if (tr != null && tr.isSuccess() && tr.parsedBody() != null) {
+            Object nextCursor = tr.parsedBody().get("nextCursorMark");
+            if (nextCursor != null) return nextCursor.toString();
+        }
+        return null;
+    }
+
+    private String buildCombinedToken(String solrToken, String osToken) throws Exception {
+        Map<String, Object> combined = new LinkedHashMap<>();
+        combined.put("v", 1);
+        combined.put("solr", solrToken);
+        combined.put("os", osToken);
+        return java.util.Base64.getEncoder().encodeToString(MAPPER.writeValueAsBytes(combined));
+    }
+
+    private FullHttpResponse rewriteResponseWithToken(
+        FullHttpResponse response, String combinedToken
+    ) throws Exception {
+        byte[] bodyBytes = new byte[response.content().readableBytes()];
+        response.content().getBytes(response.content().readerIndex(), bodyBytes);
+        Map<String, Object> body = MAPPER.readValue(bodyBytes, MAP_TYPE_REF);
+        body.put("nextCursorMark", combinedToken);
+        byte[] newBody = MAPPER.writeValueAsBytes(body);
+
+        HttpResponseStatus status = response.status();
+        response.release();
+        FullHttpResponse newResponse = new DefaultFullHttpResponse(
+            HttpVersion.HTTP_1_1, status, Unpooled.wrappedBuffer(newBody));
+        newResponse.headers().set(HttpHeaderNames.CONTENT_LENGTH, newBody.length);
+        newResponse.headers().set(HttpHeaderNames.CONTENT_TYPE, "application/json");
+        return newResponse;
+    }
+
+    static String extractQueryParam(String uri, String param) {
+        int qIdx = uri.indexOf('?');
+        if (qIdx < 0) return null;
+        String query = uri.substring(qIdx + 1);
+        for (String pair : query.split("&")) {
+            String[] kv = pair.split("=", 2);
+            if (kv.length == 2 && param.equals(kv[0])) {
+                return java.net.URLDecoder.decode(kv[1], StandardCharsets.UTF_8);
+            }
+        }
+        return null;
+    }
+
+    static String replaceQueryParam(String uri, String param, String newValue) {
+        String encoded = java.net.URLEncoder.encode(newValue, StandardCharsets.UTF_8);
+        return uri.replaceFirst(
+            "([?&])" + param + "=[^&]*",
+            "$1" + param + "=" + encoded);
+    }
+
+    // --- End cursor pagination support ---
 
     private void addShimHeaders(FullHttpResponse response) {
         response.headers().set("X-Shim-Primary", primaryTarget);

--- a/TrafficCapture/transformationShim/src/test/java/org/opensearch/migrations/transform/shim/ShimProxyTest.java
+++ b/TrafficCapture/transformationShim/src/test/java/org/opensearch/migrations/transform/shim/ShimProxyTest.java
@@ -156,6 +156,35 @@ class ShimProxyTest {
         assertEquals("beta", resp.headers().firstValue("X-Shim-Primary").orElse(null));
     }
 
+    @Test
+    void dualTarget_cursorMarkMerge() throws Exception {
+        String solrBody = "{\"response\":{\"numFound\":10},\"nextCursorMark\":\"SOLR_TOKEN\"}";
+        String osBody = "{\"response\":{\"numFound\":10},\"nextCursorMark\":\"OS_TOKEN\"}";
+        startBackend("A", backendPortA, solrBody);
+        startBackend("B", backendPortB, osBody);
+
+        Map<String, Target> targets = new LinkedHashMap<>();
+        targets.put("solr", new Target("solr", URI.create("http://localhost:" + backendPortA)));
+        targets.put("opensearch", new Target("opensearch", URI.create("http://localhost:" + backendPortB)));
+
+        proxy = new ShimProxy(proxyPort, targets, "solr", null, List.of(),
+            null, false, Duration.ofSeconds(5));
+        proxy.start();
+
+        var resp = httpGet("http://localhost:" + proxyPort + "/solr/test/select?q=*:*&cursorMark=*&sort=id+asc&wt=json");
+        assertEquals(200, resp.statusCode());
+
+        var body = MAPPER.readValue(resp.body(), Map.class);
+        String combinedToken = (String) body.get("nextCursorMark");
+        assertNotNull(combinedToken, "Expected merged nextCursorMark");
+
+        // Decode and verify combined token
+        String decoded = new String(java.util.Base64.getDecoder().decode(combinedToken), StandardCharsets.UTF_8);
+        var tokenMap = MAPPER.readValue(decoded, Map.class);
+        assertEquals("SOLR_TOKEN", tokenMap.get("solr"));
+        assertEquals("OS_TOKEN", tokenMap.get("os"));
+    }
+
     // --- Mock backends ---
 
     private void startBackend(String label, int port, String responseBody) throws InterruptedException {

--- a/TrafficCapture/transformationShim/src/test/java/org/opensearch/migrations/transform/shim/netty/MultiTargetRoutingHandlerCursorTest.java
+++ b/TrafficCapture/transformationShim/src/test/java/org/opensearch/migrations/transform/shim/netty/MultiTargetRoutingHandlerCursorTest.java
@@ -1,0 +1,385 @@
+package org.opensearch.migrations.transform.shim.netty;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Base64;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.opensearch.migrations.transform.shim.validation.TargetResponse;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.netty.buffer.Unpooled;
+import io.netty.handler.codec.http.DefaultFullHttpResponse;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpVersion;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class MultiTargetRoutingHandlerCursorTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    // --- helper ---
+
+    private static TargetResponse targetResp(String name, Map<String, Object> parsedBody) {
+        byte[] raw;
+        try {
+            raw = MAPPER.writeValueAsBytes(parsedBody);
+        } catch (Exception e) {
+            raw = new byte[0];
+        }
+        return new TargetResponse(
+            name, 200, raw, parsedBody, Duration.ofMillis(10), Duration.ZERO, Duration.ZERO, null
+        );
+    }
+
+    private static FullHttpResponse httpResponse(Map<String, Object> body) throws Exception {
+        byte[] bytes = MAPPER.writeValueAsBytes(body);
+        FullHttpResponse resp = new DefaultFullHttpResponse(
+            HttpVersion.HTTP_1_1, HttpResponseStatus.OK, Unpooled.wrappedBuffer(bytes)
+        );
+        resp.headers().set(HttpHeaderNames.CONTENT_LENGTH, bytes.length);
+        return resp;
+    }
+
+    private MultiTargetRoutingHandler handler() {
+        return new MultiTargetRoutingHandler(
+            Map.of(), "solr", java.util.Set.of(), java.util.List.of(),
+            Duration.ofSeconds(5), null, 10485760, new java.util.concurrent.atomic.AtomicInteger()
+        );
+    }
+
+    // --- extractQueryParam ---
+
+    @Test
+    void extractQueryParam_returnsValue() {
+        String uri = "/solr/products/select?q=*:*&cursorMark=ABC&wt=json";
+        assertEquals("ABC", MultiTargetRoutingHandler.extractQueryParam(uri, "cursorMark"));
+    }
+
+    @Test
+    void extractQueryParam_returnsNullWhenMissing() {
+        String uri = "/solr/products/select?q=*:*&wt=json";
+        assertNull(MultiTargetRoutingHandler.extractQueryParam(uri, "cursorMark"));
+    }
+
+    @Test
+    void extractQueryParam_returnsNullWithNoQuery() {
+        assertNull(MultiTargetRoutingHandler.extractQueryParam("/solr/products/select", "cursorMark"));
+    }
+
+    @Test
+    void extractQueryParam_decodesUrlEncoding() {
+        String uri = "/solr/products/select?cursorMark=a%3Db%26c";
+        assertEquals("a=b&c", MultiTargetRoutingHandler.extractQueryParam(uri, "cursorMark"));
+    }
+
+    // --- replaceQueryParam ---
+
+    @Test
+    void replaceQueryParam_replacesValue() {
+        String uri = "/select?q=*:*&cursorMark=OLD&wt=json";
+        String result = MultiTargetRoutingHandler.replaceQueryParam(uri, "cursorMark", "NEW");
+        assertTrue(result.contains("cursorMark=NEW"));
+        assertTrue(result.contains("q=*:*"));
+        assertTrue(result.contains("wt=json"));
+    }
+
+    @Test
+    void replaceQueryParam_encodesSpecialChars() {
+        String uri = "/select?cursorMark=OLD";
+        String result = MultiTargetRoutingHandler.replaceQueryParam(uri, "cursorMark", "a=b");
+        assertTrue(result.contains("cursorMark=a%3Db"));
+    }
+
+    // --- rewriteCursorMarkForTarget ---
+
+    @Test
+    void rewriteCursorMark_skipsInitialToken() {
+        Map<String, Object> req = new LinkedHashMap<>();
+        req.put("URI", "/select?cursorMark=*&wt=json");
+        MultiTargetRoutingHandler.rewriteCursorMarkForTarget(req, "opensearch");
+        // URI unchanged for cursorMark=*
+        assertTrue(((String) req.get("URI")).contains("cursorMark=*"));
+    }
+
+    @Test
+    void rewriteCursorMark_extractsSolrToken() throws Exception {
+        Map<String, String> combined = Map.of("solr", "SOLR_TOKEN", "os", "OS_TOKEN");
+        String encoded = Base64.getEncoder().encodeToString(MAPPER.writeValueAsBytes(combined));
+
+        Map<String, Object> req = new LinkedHashMap<>();
+        req.put("URI", "/select?cursorMark=" + encoded + "&wt=json");
+        MultiTargetRoutingHandler.rewriteCursorMarkForTarget(req, "solr");
+
+        String newCursor = MultiTargetRoutingHandler.extractQueryParam((String) req.get("URI"), "cursorMark");
+        assertEquals("SOLR_TOKEN", newCursor);
+    }
+
+    @Test
+    void rewriteCursorMark_extractsOsToken() throws Exception {
+        Map<String, String> combined = Map.of("solr", "SOLR_TOKEN", "os", "OS_TOKEN");
+        String encoded = Base64.getEncoder().encodeToString(MAPPER.writeValueAsBytes(combined));
+
+        Map<String, Object> req = new LinkedHashMap<>();
+        req.put("URI", "/select?cursorMark=" + encoded + "&wt=json");
+        MultiTargetRoutingHandler.rewriteCursorMarkForTarget(req, "opensearch");
+
+        String newCursor = MultiTargetRoutingHandler.extractQueryParam((String) req.get("URI"), "cursorMark");
+        assertEquals("OS_TOKEN", newCursor);
+    }
+
+    @Test
+    void rewriteCursorMark_passesThroughNonCombinedToken() {
+        Map<String, Object> req = new LinkedHashMap<>();
+        String plainToken = Base64.getEncoder().encodeToString("[15.25,\"6\"]".getBytes(StandardCharsets.UTF_8));
+        req.put("URI", "/select?cursorMark=" + plainToken + "&wt=json");
+        MultiTargetRoutingHandler.rewriteCursorMarkForTarget(req, "opensearch");
+        // URI unchanged — not a combined token
+        assertTrue(((String) req.get("URI")).contains(plainToken));
+    }
+
+    // --- mergeCursorTokens ---
+
+    @Test
+    void mergeCursorTokens_combinesBothTokens() throws Exception {
+        Map<String, Object> solrBody = new LinkedHashMap<>();
+        solrBody.put("responseHeader", Map.of());
+        solrBody.put("response", Map.of("numFound", 0, "docs", java.util.List.of()));
+        solrBody.put("nextCursorMark", "SOLR_NATIVE_TOKEN");
+
+        Map<String, Object> osBody = new LinkedHashMap<>();
+        osBody.put("responseHeader", Map.of());
+        osBody.put("response", Map.of("numFound", 0, "docs", java.util.List.of()));
+        osBody.put("nextCursorMark", "OS_ENCODED_TOKEN");
+
+        Map<String, TargetResponse> allResponses = new LinkedHashMap<>();
+        allResponses.put("solr", targetResp("solr", solrBody));
+        allResponses.put("opensearch", targetResp("opensearch", osBody));
+
+        FullHttpResponse primary = httpResponse(solrBody);
+        FullHttpResponse result = handler().mergeCursorTokens(primary, allResponses, null);
+
+        byte[] resultBytes = new byte[result.content().readableBytes()];
+        result.content().readBytes(resultBytes);
+        Map<String, Object> resultBody = MAPPER.readValue(resultBytes, Map.class);
+
+        String combinedToken = (String) resultBody.get("nextCursorMark");
+        String decoded = new String(Base64.getDecoder().decode(combinedToken), StandardCharsets.UTF_8);
+        Map<String, Object> tokenMap = MAPPER.readValue(decoded, Map.class);
+
+        assertEquals("SOLR_NATIVE_TOKEN", tokenMap.get("solr"));
+        assertEquals("OS_ENCODED_TOKEN", tokenMap.get("os"));
+        assertEquals(1, tokenMap.get("v"));
+        result.release();
+    }
+
+    @Test
+    void mergeCursorTokens_skipsWhenOnlyOneToken() throws Exception {
+        Map<String, Object> solrBody = new LinkedHashMap<>();
+        solrBody.put("nextCursorMark", "SOLR_TOKEN");
+
+        Map<String, Object> osBody = new LinkedHashMap<>();
+        // No nextCursorMark in OS response
+
+        Map<String, TargetResponse> allResponses = new LinkedHashMap<>();
+        allResponses.put("solr", targetResp("solr", solrBody));
+        allResponses.put("opensearch", targetResp("opensearch", osBody));
+
+        FullHttpResponse primary = httpResponse(solrBody);
+        FullHttpResponse result = handler().mergeCursorTokens(primary, allResponses, null);
+
+        // Should return original response unchanged
+        byte[] resultBytes = new byte[result.content().readableBytes()];
+        result.content().readBytes(resultBytes);
+        Map<String, Object> resultBody = MAPPER.readValue(resultBytes, Map.class);
+        assertEquals("SOLR_TOKEN", resultBody.get("nextCursorMark"));
+        result.release();
+    }
+
+    @Test
+    void mergeCursorTokens_detectsEndOfPagination() throws Exception {
+        // When both targets return the same tokens that were sent, pagination has ended
+        Map<String, Object> combined = new LinkedHashMap<>();
+        combined.put("solr", "S1");
+        combined.put("os", "O1");
+        String sentCursorMark = Base64.getEncoder().encodeToString(MAPPER.writeValueAsBytes(combined));
+
+        Map<String, Object> solrBody = Map.of("nextCursorMark", "S1");
+        Map<String, Object> osBody = Map.of("nextCursorMark", "O1");
+
+        Map<String, TargetResponse> allResponses = new LinkedHashMap<>();
+        allResponses.put("solr", targetResp("solr", solrBody));
+        allResponses.put("opensearch", targetResp("opensearch", osBody));
+
+        Map<String, Object> originalBody = new LinkedHashMap<>();
+        originalBody.put("nextCursorMark", "S1");
+        FullHttpResponse primary = httpResponse(originalBody);
+        FullHttpResponse result = handler().mergeCursorTokens(primary, allResponses, sentCursorMark);
+
+        // Should return original (no merge) since pagination ended
+        byte[] resultBytes = new byte[result.content().readableBytes()];
+        result.content().readBytes(resultBytes);
+        Map<String, Object> resultBody = MAPPER.readValue(resultBytes, Map.class);
+        assertEquals("S1", resultBody.get("nextCursorMark"));
+        result.release();
+    }
+
+    @Test
+    void mergeCursorTokens_mergesWhenTokensChanged() throws Exception {
+        Map<String, Object> combined = new LinkedHashMap<>();
+        combined.put("solr", "S1");
+        combined.put("os", "O1");
+        String sentCursorMark = Base64.getEncoder().encodeToString(MAPPER.writeValueAsBytes(combined));
+
+        Map<String, Object> solrBody = Map.of("nextCursorMark", "S2");
+        Map<String, Object> osBody = Map.of("nextCursorMark", "O2");
+
+        Map<String, TargetResponse> allResponses = new LinkedHashMap<>();
+        allResponses.put("solr", targetResp("solr", solrBody));
+        allResponses.put("opensearch", targetResp("opensearch", osBody));
+
+        FullHttpResponse primary = httpResponse(Map.of("nextCursorMark", "S2"));
+        FullHttpResponse result = handler().mergeCursorTokens(primary, allResponses, sentCursorMark);
+
+        byte[] resultBytes = new byte[result.content().readableBytes()];
+        result.content().readBytes(resultBytes);
+        Map<String, Object> resultBody = MAPPER.readValue(resultBytes, Map.class);
+        String decoded = new String(Base64.getDecoder().decode((String) resultBody.get("nextCursorMark")), StandardCharsets.UTF_8);
+        Map<String, Object> tokenMap = MAPPER.readValue(decoded, Map.class);
+        assertEquals("S2", tokenMap.get("solr"));
+        assertEquals("O2", tokenMap.get("os"));
+        result.release();
+    }
+
+    @Test
+    void mergeCursorTokens_handlesInitialCursorMark() throws Exception {
+        // sentCursorMark=* should not trigger end detection
+        Map<String, Object> solrBody = Map.of("nextCursorMark", "S1");
+        Map<String, Object> osBody = Map.of("nextCursorMark", "O1");
+
+        Map<String, TargetResponse> allResponses = new LinkedHashMap<>();
+        allResponses.put("solr", targetResp("solr", solrBody));
+        allResponses.put("opensearch", targetResp("opensearch", osBody));
+
+        FullHttpResponse primary = httpResponse(Map.of("nextCursorMark", "S1"));
+        FullHttpResponse result = handler().mergeCursorTokens(primary, allResponses, "*");
+
+        byte[] resultBytes = new byte[result.content().readableBytes()];
+        result.content().readBytes(resultBytes);
+        Map<String, Object> resultBody = MAPPER.readValue(resultBytes, Map.class);
+        String decoded = new String(Base64.getDecoder().decode((String) resultBody.get("nextCursorMark")), StandardCharsets.UTF_8);
+        Map<String, Object> tokenMap = MAPPER.readValue(decoded, Map.class);
+        assertEquals("S1", tokenMap.get("solr"));
+        assertEquals("O1", tokenMap.get("os"));
+        result.release();
+    }
+
+    @Test
+    void mergeCursorTokens_handlesInvalidSentCursorMark() throws Exception {
+        // Non-base64 sentCursorMark should not crash, should proceed with merge
+        Map<String, Object> solrBody = Map.of("nextCursorMark", "S1");
+        Map<String, Object> osBody = Map.of("nextCursorMark", "O1");
+
+        Map<String, TargetResponse> allResponses = new LinkedHashMap<>();
+        allResponses.put("solr", targetResp("solr", solrBody));
+        allResponses.put("opensearch", targetResp("opensearch", osBody));
+
+        FullHttpResponse primary = httpResponse(Map.of("nextCursorMark", "S1"));
+        FullHttpResponse result = handler().mergeCursorTokens(primary, allResponses, "not-valid-base64!!!");
+
+        byte[] resultBytes = new byte[result.content().readableBytes()];
+        result.content().readBytes(resultBytes);
+        Map<String, Object> resultBody = MAPPER.readValue(resultBytes, Map.class);
+        // Should still merge since the invalid token falls through
+        String decoded = new String(Base64.getDecoder().decode((String) resultBody.get("nextCursorMark")), StandardCharsets.UTF_8);
+        Map<String, Object> tokenMap = MAPPER.readValue(decoded, Map.class);
+        assertEquals("S1", tokenMap.get("solr"));
+        result.release();
+    }
+
+    @Test
+    void mergeCursorTokens_skipsWhenBothTokensMissing() throws Exception {
+        Map<String, Object> solrBody = Map.of("response", Map.of());
+        Map<String, Object> osBody = Map.of("response", Map.of());
+
+        Map<String, TargetResponse> allResponses = new LinkedHashMap<>();
+        allResponses.put("solr", targetResp("solr", solrBody));
+        allResponses.put("opensearch", targetResp("opensearch", osBody));
+
+        Map<String, Object> originalBody = Map.of("response", Map.of());
+        FullHttpResponse primary = httpResponse(originalBody);
+        FullHttpResponse result = handler().mergeCursorTokens(primary, allResponses, null);
+
+        byte[] resultBytes = new byte[result.content().readableBytes()];
+        result.content().readBytes(resultBytes);
+        Map<String, Object> resultBody = MAPPER.readValue(resultBytes, Map.class);
+        assertNull(resultBody.get("nextCursorMark"));
+        result.release();
+    }
+
+    // --- rewriteCursorMarkForTarget edge cases ---
+
+    @Test
+    void rewriteCursorMark_skipsWhenNoUri() {
+        Map<String, Object> req = new LinkedHashMap<>();
+        // No URI key
+        MultiTargetRoutingHandler.rewriteCursorMarkForTarget(req, "opensearch");
+        assertNull(req.get("URI"));
+    }
+
+    @Test
+    void rewriteCursorMark_skipsWhenNoCursorMark() {
+        Map<String, Object> req = new LinkedHashMap<>();
+        req.put("URI", "/select?q=*:*&wt=json");
+        MultiTargetRoutingHandler.rewriteCursorMarkForTarget(req, "opensearch");
+        assertEquals("/select?q=*:*&wt=json", req.get("URI"));
+    }
+
+    @Test
+    void rewriteCursorMark_handlesInvalidBase64() {
+        Map<String, Object> req = new LinkedHashMap<>();
+        req.put("URI", "/select?cursorMark=not-valid!!&wt=json");
+        // Should not throw, just pass through
+        MultiTargetRoutingHandler.rewriteCursorMarkForTarget(req, "opensearch");
+        assertTrue(((String) req.get("URI")).contains("not-valid!!"));
+    }
+
+    @Test
+    void mergeCursorTokens_preservesResponseBody() throws Exception {
+        Map<String, Object> solrBody = new LinkedHashMap<>();
+        solrBody.put("response", Map.of("numFound", 8, "docs", java.util.List.of()));
+        solrBody.put("nextCursorMark", "S1");
+
+        Map<String, Object> osBody = new LinkedHashMap<>();
+        osBody.put("nextCursorMark", "O1");
+
+        Map<String, TargetResponse> allResponses = new LinkedHashMap<>();
+        allResponses.put("solr", targetResp("solr", solrBody));
+        allResponses.put("opensearch", targetResp("opensearch", osBody));
+
+        FullHttpResponse primary = httpResponse(solrBody);
+        FullHttpResponse result = handler().mergeCursorTokens(primary, allResponses, null);
+
+        byte[] resultBytes = new byte[result.content().readableBytes()];
+        result.content().readBytes(resultBytes);
+        Map<String, Object> resultBody = MAPPER.readValue(resultBytes, Map.class);
+
+        // Original fields preserved
+        Map<String, Object> resp = (Map<String, Object>) resultBody.get("response");
+        assertEquals(8, resp.get("numFound"));
+
+        // Content-Length header updated
+        assertEquals(
+            String.valueOf(resultBytes.length),
+            result.headers().get(HttpHeaderNames.CONTENT_LENGTH)
+        );
+        result.release();
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -261,6 +261,9 @@ subprojects {
                 useJUnitPlatform {
                     includeTags 'isolatedTest'
                 }
+                testLogging {
+                    showStandardStreams = true
+                }
             }
 
             tasks.register('fullTest') {

--- a/solrMigrationDevSandbox/run.sh
+++ b/solrMigrationDevSandbox/run.sh
@@ -140,8 +140,18 @@ if docker image inspect migrations/transformation_shim &>/dev/null; then
 else
   echo "=== Step 2: Building translation shim ==="
   cd ..
-  JAVA_HOME="${JAVA_HOME:-/Library/Java/JavaVirtualMachines/amazon-corretto-17.jdk/Contents/Home}" \
-    ./gradlew :TrafficCapture:transformationShim:jibDockerBuild 2>&1 | tail -5
+  mkdir -p TrafficCapture/transformationShim/build/versionDir
+  # Requires Java 17 — override JAVA_HOME if current version is too old
+  SHIM_JAVA_HOME="${JAVA_HOME:-}"
+  if [[ -d "/Library/Java/JavaVirtualMachines/amazon-corretto-17.jdk/Contents/Home" ]]; then
+    SHIM_JAVA_HOME="/Library/Java/JavaVirtualMachines/amazon-corretto-17.jdk/Contents/Home"
+  fi
+  set +e
+  JAVA_HOME="$SHIM_JAVA_HOME" \
+    ./gradlew :TrafficCapture:transformationShim:assemble :TrafficCapture:transformationShim:jibDockerBuild
+  set -e
+  # Jib tags to localhost:5001/..., re-tag for local use
+  docker tag localhost:5001/migrations/transformation_shim:latest migrations/transformation_shim:latest 2>/dev/null || true
   cd "$SCRIPT_DIR"
 fi
 echo ""


### PR DESCRIPTION
### Description

Adds cursor-based pagination to the Solr→OpenSearch shim, translating cursorMark to search_after. Includes full dual-mode support where both Solr and OpenSearch paginate using their native mechanisms via a combined cursor token.

Changes:

- **cursor-pagination.ts** (new)
  - Request: decodes cursorMark to search_after, parses sort with _id tiebreaker, handles + as space.
  - Response: base64-encodes last hit's sort values as nextCursorMark, returns same token on empty results (end signal). Uses pure JS base64 (GraalVM has no btoa/Buffer/Java.type).
  - Works in both single-mode and dual-mode — dual-mode token splitting/merging is handled by the Java shim layer.

- **context.ts** — Add targetName and dualMode fields to RequestContext/ResponseContext, parsed from _targetName/_dualMode injected by the shim proxy.

- **MultiTargetRoutingHandler.java** — Dual-mode cursor pagination support:
  - Request side: decodes combined cursor token and rewrites cursorMark per target — Solr gets its native token, OpenSearch gets the encoded sort values.
  - Response side: merges nextCursorMark from both targets into a combined base64 token {solr: "<native>", os: "<sort_values>"}.
  - Refactored mergeCursorTokens to reduce cognitive complexity (extracted isPaginationEnded and logPartialCursorWarning helpers) — fixes SonarQube S3776.
  - Deep copies request map when cursorMark is present in dual mode to avoid cross-target URI contamination.
  - Inject _targetName and _dualMode into request map so transforms can detect dual-target mode.
  - Fix: pass original requestMap (not modified copy) as originalRequestMap to dispatchToTarget — the modified copy was breaking response transform bundling.

- **MultiTargetRoutingHandlerCursorTest.java** (new) — 21 Java unit tests covering extractQueryParam, replaceQueryParam, rewriteCursorMarkForTarget, and mergeCursorTokens (token combining, end-of-pagination detection, invalid/partial tokens, skip when one missing, response body preservation, edge cases).

- **ShimProxyTest.java** — Added dualTarget_cursorMarkMerge integration test covering the full Netty pipeline for cursor token merging in dual-target mode.

- **hits-to-docs.ts** — Add id from hit._id metadata (was missing from source), force start=0 for cursor responses, improve field wrapping heuristic.

- **registry.ts** — Register cursor-pagination in request (after query-q) and response (before hits-to-docs) pipelines.

- **Test framework** — Add requestSequence with {{nextCursorMark}} substitution for multi-step e2e tests (test-types.ts, TestCaseDefinition.java, TransformationShimE2ETest.java).

- **run.sh** — Minor enhancement for shim build support.

- **Integration test logging** — Updated e2e test runner to show detailed logs for easier debugging.

### Architecture Note

The cursor token merge/split logic lives in the Java shim layer (MultiTargetRoutingHandler) because it requires cross-target visibility — access to both Solr's and OpenSearch's responses simultaneously. The TypeScript transformation layer only sees one target's response at a time, so it handles the Solr↔OpenSearch query translation while the shim handles multi-
target orchestration.

### Known Limitations

- **Traffic Replay:** Replaying captured Solr traffic with cursorMark through the traffic replayer is not supported — Solr's native cursor tokens are opaque binary and cannot be decoded to search_after values. This is a separate concern from the live shim proxy.
- **Custom uniqueKey:** The shim assumes id is the Solr uniqueKey (Solr's default). Custom uniqueKey field names are not auto-detected. See limitation.md for details.

### Testing

- **Unit tests (TypeScript):** 33 cursor-specific tests (b64 roundtrip, sort parsing, cursor encode/decode, request/response transforms, dual-mode match) — 418 total passing
- **Unit tests (Java):** 21 new cursor tests + 1 integration test (extractQueryParam, replaceQueryParam, rewriteCursorMarkForTarget, mergeCursorTokens with end detection, invalid tokens, edge cases, full Netty pipeline merge) — all passing