### PR TITLE
Ignore opensearch-security in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -60,6 +60,7 @@ updates:
       - dependency-name: "org.gradle.toolchains.foojay-resolver-convention"
       - dependency-name: "org.jcommander:jcommander"
       - dependency-name: "org.opensearch:*"
+      - dependency-name: "org.opensearch.plugin:opensearch-security" # Version is derived from openSearch base version in build.gradle
       - dependency-name: "org.opensearch.plugin:*"
         update-types:
           - "version-update:semver-major"


### PR DESCRIPTION
## Problem
All CI checks on dependabot PR #2421 fail with:
```
Could not find org.opensearch.plugin:opensearch-security:2.19.5.0.0
```

## Root Cause
In `TrafficCapture/trafficCaptureProxyServer/build.gradle`, the `openSearch` variable holds the base OpenSearch version (e.g. `2.19.4`), and the security plugin dependency appends `.0`:
```groovy
def openSearch = '2.19.4'
opensearchSecurityPlugin "org.opensearch.plugin:opensearch-security:${openSearch}.0"
```

Dependabot sees `opensearch-security:2.19.4.0` and tries to bump it to `2.19.5.0`, changing `openSearch` to `2.19.5.0`. This causes the resolved version to become `2.19.5.0.0` (non-existent), and also breaks the other `opensearch`, `opensearch-core`, and `opensearch-common` dependencies that use the same variable.

## Fix
Fully ignore `org.opensearch.plugin:opensearch-security` in dependabot since its version is derived from the base OpenSearch version and cannot be independently bumped.

Closes #2421