### PR TITLE
Remove service account precondition from Kyverno zero-resources policy

### DIFF
--- a/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/templates/resources/kyvernoZeroResourceRequests.yaml
+++ b/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/templates/resources/kyvernoZeroResourceRequests.yaml
@@ -24,14 +24,6 @@ data:
               - resources:
                   kinds:
                     - Pod
-          preconditions:
-            any:
-              - key: "{{`{{ request.object.spec.serviceAccountName || '' }}`}}"
-                operator: In
-                value:
-                  - migration-console-access-role
-                  - argo-workflow-executor
-                  - build-images-service-account
           mutate:
             patchStrategicMerge:
               metadata:


### PR DESCRIPTION
## Summary

Removes the service account precondition from the Kyverno zero-resource-requests policy so it applies to **all** pods, not just those with specific service accounts.

## Problem

The policy previously only zeroed resources for pods with service accounts: `migration-console-access-role`, `argo-workflow-executor`, `build-images-service-account`. Other pods (Kafka brokers, OTEL collectors, test clusters, cert-manager, etc.) kept their original resource requests, causing scheduling failures on resource-constrained local dev clusters (kind/minikube/Colima).

## Change

Removed the `preconditions` block from the ClusterPolicy. The policy now matches all pods and zeros out CPU/memory requests and limits for all containers and init containers.

## Safety

- The policy is gated by `kyvernoPolicies.zeroResourceRequests` in Helm values
- Only enabled in `valuesForLocalK8s.yaml` (set to `true`)
- Disabled by default in `values.yaml` (set to `false`)
- Not set in `valuesEks.yaml` — production deployments are unaffected

## Testing

- `helm template` renders cleanly with `valuesForLocalK8s.yaml`
- Verified the policy is not enabled in default or EKS values
