### PR TITLE
Pass --region to CloudWatch dashboard deploy/validate calls

### DIFF
--- a/deployment/k8s/aws/aws-bootstrap.sh
+++ b/deployment/k8s/aws/aws-bootstrap.sh
@@ -536,10 +536,11 @@ deploy_dashboard() {
   local full_name="MA-${STAGE}-${AWS_CFN_REGION}-${dashboard_name}"
   aws cloudwatch put-dashboard \
     --dashboard-name "$full_name" \
-    --dashboard-body "file://${tmp_json}" >/dev/null
+    --dashboard-body "file://${tmp_json}" \
+    --region "${AWS_CFN_REGION}" >/dev/null
 
   # Validate dashboards on CloudWatch
-  if aws cloudwatch get-dashboard --dashboard-name "$full_name" >/dev/null 2>&1; then
+  if aws cloudwatch get-dashboard --dashboard-name "$full_name" --region "${AWS_CFN_REGION}" >/dev/null 2>&1; then
     echo "OK: Dashboard available: ${full_name}"
   else
     echo "WARN: Could not read back dashboard: ${full_name}"


### PR DESCRIPTION
The put-dashboard and get-dashboard calls were missing --region, causing failures when AWS_DEFAULT_REGION is not set in the environment.

### Check List
- [ ] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
