### PR TITLE
feat(solr-transforms): Add PEG-based Solr query parser

### DIFF
--- a/TrafficCapture/SolrTransformations/transforms/package-lock.json
+++ b/TrafficCapture/SolrTransformations/transforms/package-lock.json
@@ -15,6 +15,7 @@
         "esbuild": "^0.25.0",
         "eslint": "^10.0.2",
         "eslint-config-prettier": "^10.1.8",
+        "peggy": "^5.1.0",
         "prettier": "^3.8.1",
         "vitest": "^4.0.18"
       },
@@ -673,6 +674,19 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@peggyjs/from-mem": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@peggyjs/from-mem/-/from-mem-3.1.3.tgz",
+      "integrity": "sha512-LLlgtfXIaeYXoOYovOI0spLM8ZXaqkAlmcRRrLzHJzLMqkU6Sw0R4KMoCoHx1PjaP815pSCBlS+BN6aD8t1Jgg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "7.7.4"
+      },
+      "engines": {
+        "node": ">=20.8"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -1647,6 +1661,16 @@
         "node": ">=18"
       }
     },
+    "node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -2438,6 +2462,24 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/peggy": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/peggy/-/peggy-5.1.0.tgz",
+      "integrity": "sha512-IEo5aYRZ2kXH4Qby06cjtL114PZnwLoTiA41vUmg2vPZgANn+c87m5BUurhuDr5/cu758ZlpgsAfBVx+hhO5+w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@peggyjs/from-mem": "3.1.3",
+        "commander": "^14.0.3",
+        "source-map-generator": "2.0.6"
+      },
+      "bin": {
+        "peggy": "bin/peggy.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -2610,6 +2652,16 @@
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/source-map-generator": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/source-map-generator/-/source-map-generator-2.0.6.tgz",
+      "integrity": "sha512-IlassDs1Ve8nV6uyQZXF9kdkJpVKnMte2JZQXu13M0A5zwc+vu6+LNHfmxsHBMDtoZE21RHiKI0/xvpecZRCNg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
@@ -3750,6 +3802,15 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "@peggyjs/from-mem": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@peggyjs/from-mem/-/from-mem-3.1.3.tgz",
+      "integrity": "sha512-LLlgtfXIaeYXoOYovOI0spLM8ZXaqkAlmcRRrLzHJzLMqkU6Sw0R4KMoCoHx1PjaP815pSCBlS+BN6aD8t1Jgg==",
+      "dev": true,
+      "requires": {
+        "semver": "7.7.4"
+      }
+    },
     "@rollup/rollup-android-arm-eabi": {
       "version": "4.59.0",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.59.0.tgz",
@@ -4301,6 +4362,12 @@
       "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
       "dev": true
     },
+    "commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "dev": true
+    },
     "cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -4825,6 +4892,17 @@
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true
     },
+    "peggy": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/peggy/-/peggy-5.1.0.tgz",
+      "integrity": "sha512-IEo5aYRZ2kXH4Qby06cjtL114PZnwLoTiA41vUmg2vPZgANn+c87m5BUurhuDr5/cu758ZlpgsAfBVx+hhO5+w==",
+      "dev": true,
+      "requires": {
+        "@peggyjs/from-mem": "3.1.3",
+        "commander": "^14.0.3",
+        "source-map-generator": "2.0.6"
+      }
+    },
     "picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -4926,6 +5004,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true
+    },
+    "source-map-generator": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/source-map-generator/-/source-map-generator-2.0.6.tgz",
+      "integrity": "sha512-IlassDs1Ve8nV6uyQZXF9kdkJpVKnMte2JZQXu13M0A5zwc+vu6+LNHfmxsHBMDtoZE21RHiKI0/xvpecZRCNg==",
       "dev": true
     },
     "source-map-js": {

--- a/TrafficCapture/SolrTransformations/transforms/package.json
+++ b/TrafficCapture/SolrTransformations/transforms/package.json
@@ -22,6 +22,7 @@
     "esbuild": "^0.25.0",
     "eslint": "^10.0.2",
     "eslint-config-prettier": "^10.1.8",
+    "peggy": "^5.1.0",
     "prettier": "^3.8.1",
     "vitest": "^4.0.18"
   },

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/parser/README.md
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/parser/README.md
@@ -1,0 +1,11 @@
+# Parser — Design Decisions
+
+## Why a Custom PEG Grammar
+
+We evaluated existing libraries ([liqe](https://github.com/gajus/liqe), [lucene-kit](https://github.com/oxdev03/lucene-kit)) as alternatives to a custom grammar and chose to implement a custom PEG-based grammar using [Peggy](https://github.com/peggyjs/peggy).
+
+The migration use case requires support for Solr-specific query syntax — implicit boolean operators, field boosts, all four range bracket combinations (`[]`, `{}`, `[}`, `{]`), `*:*` match-all, and parser-specific behaviors introduced by eDisMax and DisMax. While liqe and lucene-kit provide general-purpose query parsing, neither is designed to fully support Solr's query language. liqe targets in-memory object filtering with its own dialect. lucene-kit extends Lucene syntax with features like regex, variables, and functions, but its coverage of Solr-specific constructs is incomplete. Both would require significant AST reshaping or post-processing to bridge the gap between their output and the structure needed for OpenSearch DSL generation.
+
+Both libraries also impose constraints on grammar coverage and AST structure that make them difficult to extend for Solr-specific features such as local parameters, spatial queries, function queries, and streaming expressions. Adapting them would likely require maintaining custom forks or complex adapter layers, reducing the practical benefit of reuse.
+
+By defining a custom PEG grammar, we retain full control over syntax coverage, AST design, and extensibility. The grammar produces AST nodes directly — no adapter layer needed. Parser-specific semantics (such as eDisMax field expansion via `qf` and `pf`) are handled as clean post-parse AST transformations rather than being embedded in the grammar. This provides a more maintainable and predictable foundation for the Solr-to-OpenSearch query translation pipeline, with a grammar that is ~120 lines and has no dependencies beyond Peggy.

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/parser/parser.test.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/parser/parser.test.ts
@@ -1,0 +1,602 @@
+import { describe, it, expect } from 'vitest';
+import { parseSolrQuery, toParseError } from './parser';
+
+const emptyParams = new Map<string, string>();
+const paramsWithDf = (df: string) => new Map([['df', df]]);
+
+describe('parseSolrQuery', () => {
+  // ─── MatchAllNode ────────────────────────────────────────────────────────
+
+  describe('MatchAllNode', () => {
+    it('parses *:*', () => {
+      const { ast, errors } = parseSolrQuery('*:*', emptyParams);
+      expect(errors).toEqual([]);
+      expect(ast).toEqual({ type: 'matchAll' });
+    });
+
+    it('returns matchAll for empty query', () => {
+      const { ast, errors } = parseSolrQuery('', emptyParams);
+      expect(errors).toEqual([]);
+      expect(ast).toEqual({ type: 'matchAll' });
+    });
+
+    it('returns matchAll for whitespace-only query', () => {
+      const { ast, errors } = parseSolrQuery('   ', emptyParams);
+      expect(errors).toEqual([]);
+      expect(ast).toEqual({ type: 'matchAll' });
+    });
+  });
+
+  // ─── FieldNode ───────────────────────────────────────────────────────────
+
+  describe('FieldNode', () => {
+    it('parses field:value', () => {
+      const { ast, errors } = parseSolrQuery('title:java', emptyParams);
+      expect(errors).toEqual([]);
+      expect(ast).toEqual({ type: 'field', field: 'title', value: 'java' });
+    });
+
+    it('resolves bare value to df', () => {
+      const { ast, errors } = parseSolrQuery('java', paramsWithDf('title'));
+      expect(errors).toEqual([]);
+      expect(ast).toEqual({ type: 'field', field: 'title', value: 'java' });
+    });
+
+    it('defaults df to _text_ when not provided', () => {
+      const { ast, errors } = parseSolrQuery('java', emptyParams);
+      expect(errors).toEqual([]);
+      expect(ast).toEqual({ type: 'field', field: '_text_', value: 'java' });
+    });
+  });
+
+  // ─── PhraseNode ──────────────────────────────────────────────────────────
+
+  describe('PhraseNode', () => {
+    it('parses field:"phrase"', () => {
+      const { ast, errors } = parseSolrQuery('title:"hello world"', emptyParams);
+      expect(errors).toEqual([]);
+      expect(ast).toEqual({ type: 'phrase', text: 'hello world', field: 'title' });
+    });
+
+    it('resolves bare phrase to df', () => {
+      const { ast, errors } = parseSolrQuery('"hello world"', paramsWithDf('content'));
+      expect(errors).toEqual([]);
+      expect(ast).toEqual({ type: 'phrase', text: 'hello world', field: 'content' });
+    });
+  });
+
+  // ─── RangeNode ───────────────────────────────────────────────────────────
+
+  describe('RangeNode', () => {
+    it('parses inclusive range [low TO high]', () => {
+      const { ast, errors } = parseSolrQuery('price:[10 TO 100]', emptyParams);
+      expect(errors).toEqual([]);
+      expect(ast).toEqual({
+        type: 'range', field: 'price',
+        lower: '10', upper: '100',
+        lowerInclusive: true, upperInclusive: true,
+      });
+    });
+
+    it('parses exclusive range {low TO high}', () => {
+      const { ast, errors } = parseSolrQuery('price:{10 TO 100}', emptyParams);
+      expect(errors).toEqual([]);
+      expect(ast).toEqual({
+        type: 'range', field: 'price',
+        lower: '10', upper: '100',
+        lowerInclusive: false, upperInclusive: false,
+      });
+    });
+
+    it('parses mixed range [low TO high}', () => {
+      const { ast, errors } = parseSolrQuery('price:[10 TO 100}', emptyParams);
+      expect(errors).toEqual([]);
+      expect(ast).toEqual({
+        type: 'range', field: 'price',
+        lower: '10', upper: '100',
+        lowerInclusive: true, upperInclusive: false,
+      });
+    });
+
+    it('parses mixed range {low TO high]', () => {
+      const { ast, errors } = parseSolrQuery('price:{10 TO 100]', emptyParams);
+      expect(errors).toEqual([]);
+      expect(ast).toEqual({
+        type: 'range', field: 'price',
+        lower: '10', upper: '100',
+        lowerInclusive: false, upperInclusive: true,
+      });
+    });
+
+    it('parses unbounded range [* TO 100]', () => {
+      const { ast, errors } = parseSolrQuery('price:[* TO 100]', emptyParams);
+      expect(errors).toEqual([]);
+      expect(ast).toEqual({
+        type: 'range', field: 'price',
+        lower: '*', upper: '100',
+        lowerInclusive: true, upperInclusive: true,
+      });
+    });
+  });
+
+  // ─── BoolNode ────────────────────────────────────────────────────────────
+
+  describe('BoolNode', () => {
+    it('parses AND', () => {
+      const { ast, errors } = parseSolrQuery('title:java AND author:smith', emptyParams);
+      expect(errors).toEqual([]);
+      expect(ast).toEqual({
+        type: 'bool',
+        and: [
+          { type: 'field', field: 'title', value: 'java' },
+          { type: 'field', field: 'author', value: 'smith' },
+        ],
+        or: [],
+        not: [],
+      });
+    });
+
+    it('parses OR', () => {
+      const { ast, errors } = parseSolrQuery('title:java OR title:python', emptyParams);
+      expect(errors).toEqual([]);
+      expect(ast).toEqual({
+        type: 'bool',
+        and: [],
+        or: [
+          { type: 'field', field: 'title', value: 'java' },
+          { type: 'field', field: 'title', value: 'python' },
+        ],
+        not: [],
+      });
+    });
+
+    it('parses implicit OR (adjacency)', () => {
+      const { ast, errors } = parseSolrQuery('title:java title:python', emptyParams);
+      expect(errors).toEqual([]);
+      expect(ast).toEqual({
+        type: 'bool',
+        and: [],
+        or: [
+          { type: 'field', field: 'title', value: 'java' },
+          { type: 'field', field: 'title', value: 'python' },
+        ],
+        not: [],
+      });
+    });
+
+    it('parses NOT', () => {
+      const { ast, errors } = parseSolrQuery('NOT status:draft', emptyParams);
+      expect(errors).toEqual([]);
+      expect(ast).toEqual({
+        type: 'bool',
+        and: [],
+        or: [],
+        not: [{ type: 'field', field: 'status', value: 'draft' }],
+      });
+    });
+
+    it('respects precedence: AND binds tighter than OR', () => {
+      const { ast, errors } = parseSolrQuery('title:java OR author:smith AND year:2024', emptyParams);
+      expect(errors).toEqual([]);
+      // title:java OR (author:smith AND year:2024)
+      expect(ast).toEqual({
+        type: 'bool',
+        and: [],
+        or: [
+          { type: 'field', field: 'title', value: 'java' },
+          {
+            type: 'bool',
+            and: [
+              { type: 'field', field: 'author', value: 'smith' },
+              { type: 'field', field: 'year', value: '2024' },
+            ],
+            or: [],
+            not: [],
+          },
+        ],
+        not: [],
+      });
+    });
+
+    it('respects precedence: NOT binds tighter than AND', () => {
+      const { ast, errors } = parseSolrQuery('title:java AND NOT status:draft', emptyParams);
+      expect(errors).toEqual([]);
+      // title:java AND (NOT status:draft)
+      expect(ast).toEqual({
+        type: 'bool',
+        and: [
+          { type: 'field', field: 'title', value: 'java' },
+          { type: 'bool', and: [], or: [], not: [{ type: 'field', field: 'status', value: 'draft' }] },
+        ],
+        or: [],
+        not: [],
+      });
+    });
+
+    it('respects full precedence chain: OR < AND < NOT', () => {
+      const { ast, errors } = parseSolrQuery('title:java OR author:smith AND NOT status:draft', emptyParams);
+      expect(errors).toEqual([]);
+      // title:java OR (author:smith AND (NOT status:draft))
+      expect(ast).toEqual({
+        type: 'bool',
+        and: [],
+        or: [
+          { type: 'field', field: 'title', value: 'java' },
+          {
+            type: 'bool',
+            and: [
+              { type: 'field', field: 'author', value: 'smith' },
+              { type: 'bool', and: [], or: [], not: [{ type: 'field', field: 'status', value: 'draft' }] },
+            ],
+            or: [],
+            not: [],
+          },
+        ],
+        not: [],
+      });
+    });
+
+    it('respects precedence: NOT binds tighter than OR', () => {
+      const { ast, errors } = parseSolrQuery('title:java OR NOT status:draft', emptyParams);
+      expect(errors).toEqual([]);
+      // title:java OR (NOT status:draft)
+      expect(ast).toEqual({
+        type: 'bool',
+        and: [],
+        or: [
+          { type: 'field', field: 'title', value: 'java' },
+          { type: 'bool', and: [], or: [], not: [{ type: 'field', field: 'status', value: 'draft' }] },
+        ],
+        not: [],
+      });
+    });
+
+    it('parentheses override natural precedence', () => {
+      const { ast, errors } = parseSolrQuery('(title:java OR author:smith) AND NOT status:draft', emptyParams);
+      expect(errors).toEqual([]);
+      // (title:java OR author:smith) AND (NOT status:draft)
+      expect(ast).toEqual({
+        type: 'bool',
+        and: [
+          {
+            type: 'group',
+            child: {
+              type: 'bool', and: [], not: [],
+              or: [
+                { type: 'field', field: 'title', value: 'java' },
+                { type: 'field', field: 'author', value: 'smith' },
+              ],
+            },
+          },
+          { type: 'bool', and: [], or: [], not: [{ type: 'field', field: 'status', value: 'draft' }] },
+        ],
+        or: [],
+        not: [],
+      });
+    });
+  });
+
+  // ─── GroupNode ───────────────────────────────────────────────────────────
+
+  describe('GroupNode', () => {
+    it('parses parenthesized group', () => {
+      const { ast, errors } = parseSolrQuery('(title:java OR title:python)', emptyParams);
+      expect(errors).toEqual([]);
+      expect(ast).toEqual({
+        type: 'group',
+        child: {
+          type: 'bool',
+          and: [],
+          or: [
+            { type: 'field', field: 'title', value: 'java' },
+            { type: 'field', field: 'title', value: 'python' },
+          ],
+          not: [],
+        },
+      });
+    });
+
+    it('parses adjacent groups with AND', () => {
+      const { ast, errors } = parseSolrQuery('(title:java OR title:python) AND (status:active OR status:pending)', emptyParams);
+      expect(errors).toEqual([]);
+      expect(ast).toEqual({
+        type: 'bool',
+        and: [
+          {
+            type: 'group',
+            child: {
+              type: 'bool', and: [], not: [],
+              or: [
+                { type: 'field', field: 'title', value: 'java' },
+                { type: 'field', field: 'title', value: 'python' },
+              ],
+            },
+          },
+          {
+            type: 'group',
+            child: {
+              type: 'bool', and: [], not: [],
+              or: [
+                { type: 'field', field: 'status', value: 'active' },
+                { type: 'field', field: 'status', value: 'pending' },
+              ],
+            },
+          },
+        ],
+        or: [],
+        not: [],
+      });
+    });
+
+    it('parses nested groups', () => {
+      // (title:java AND (author:smith OR author:doe))
+      const { ast, errors } = parseSolrQuery('(title:java AND (author:smith OR author:doe))', emptyParams);
+      expect(errors).toEqual([]);
+      expect(ast).toEqual({
+        type: 'group',
+        child: {
+          type: 'bool',
+          and: [
+            { type: 'field', field: 'title', value: 'java' },
+            {
+              type: 'group',
+              child: {
+                type: 'bool', and: [], not: [],
+                or: [
+                  { type: 'field', field: 'author', value: 'smith' },
+                  { type: 'field', field: 'author', value: 'doe' },
+                ],
+              },
+            },
+          ],
+          or: [],
+          not: [],
+        },
+      });
+    });
+  });
+
+  // ─── BoostNode ───────────────────────────────────────────────────────────
+
+  describe('BoostNode', () => {
+    it('parses field:value^N', () => {
+      const { ast, errors } = parseSolrQuery('title:java^2', emptyParams);
+      expect(errors).toEqual([]);
+      expect(ast).toEqual({
+        type: 'boost',
+        child: { type: 'field', field: 'title', value: 'java' },
+        value: 2,
+      });
+    });
+
+    it('parses decimal boost', () => {
+      const { ast, errors } = parseSolrQuery('title:java^0.5', emptyParams);
+      expect(errors).toEqual([]);
+      expect(ast).toEqual({
+        type: 'boost',
+        child: { type: 'field', field: 'title', value: 'java' },
+        value: 0.5,
+      });
+    });
+
+    it('parses boost on group', () => {
+      const { ast, errors } = parseSolrQuery('(title:java OR author:smith)^3', emptyParams);
+      expect(errors).toEqual([]);
+      expect(ast).toEqual({
+        type: 'boost',
+        child: {
+          type: 'group',
+          child: {
+            type: 'bool', and: [], not: [],
+            or: [
+              { type: 'field', field: 'title', value: 'java' },
+              { type: 'field', field: 'author', value: 'smith' },
+            ],
+          },
+        },
+        value: 3,
+      });
+    });
+
+    it('resolves df through boost on bare value', () => {
+      const { ast, errors } = parseSolrQuery('java^2', paramsWithDf('title'));
+      expect(errors).toEqual([]);
+      expect(ast).toEqual({
+        type: 'boost',
+        child: { type: 'field', field: 'title', value: 'java' },
+        value: 2,
+      });
+    });
+  });
+
+  // ─── Combined query ──────────────────────────────────────────────────────
+
+  describe('combined query', () => {
+    it('parses a realistic query with multiple node types', () => {
+      const { ast, errors } = parseSolrQuery(
+        'title:java^2 AND price:[10 TO 100] AND NOT "hello world"',
+        paramsWithDf('content'),
+      );
+      expect(errors).toEqual([]);
+      // title:java^2 AND price:[10 TO 100] AND (NOT "hello world")
+      expect(ast).toEqual({
+        type: 'bool',
+        and: [
+          {
+            type: 'boost',
+            child: { type: 'field', field: 'title', value: 'java' },
+            value: 2,
+          },
+          {
+            type: 'range', field: 'price',
+            lower: '10', upper: '100',
+            lowerInclusive: true, upperInclusive: true,
+          },
+          {
+            type: 'bool', and: [], or: [], not: [
+              { type: 'phrase', text: 'hello world', field: 'content' },
+            ],
+          },
+        ],
+        or: [],
+        not: [],
+      });
+    });
+  });
+
+  // ─── Error handling ──────────────────────────────────────────────────────
+
+  describe('error handling', () => {
+    it.each([
+      ['invalid query (unexpected closing paren)', 'title:java AND )'],
+      ['unmatched opening parenthesis', '(title:java'],
+      ['unclosed phrase', 'title:"hello world'],
+    ])('returns null ast and error for %s', (_label, query) => {
+      const { ast, errors } = parseSolrQuery(query, emptyParams);
+      expect(ast).toBeNull();
+      expect(errors).toHaveLength(1);
+      expect(errors[0]).toEqual(
+        expect.objectContaining({
+          message: expect.any(String),
+          position: expect.any(Number),
+        }),
+      );
+    });
+  });
+
+  // ─── q.op parameter ──────────────────────────────────────────────────────
+
+  describe('q.op=AND', () => {
+    const paramsWithQopAnd = new Map([['q.op', 'AND']]);
+
+    it('converts implicit OR to AND when q.op=AND', () => {
+      const { ast, errors } = parseSolrQuery('title:java title:python', paramsWithQopAnd);
+      expect(errors).toEqual([]);
+      expect(ast).toEqual({
+        type: 'bool',
+        and: [
+          { type: 'field', field: 'title', value: 'java' },
+          { type: 'field', field: 'title', value: 'python' },
+        ],
+        or: [],
+        not: [],
+      });
+    });
+
+    it('leaves explicit OR unchanged when q.op=AND', () => {
+      const { ast, errors } = parseSolrQuery('title:java OR title:python', paramsWithQopAnd);
+      expect(errors).toEqual([]);
+      expect(ast).toEqual({
+        type: 'bool',
+        and: [],
+        or: [
+          { type: 'field', field: 'title', value: 'java' },
+          { type: 'field', field: 'title', value: 'python' },
+        ],
+        not: [],
+      });
+    });
+
+    it('leaves explicit AND unchanged when q.op=AND', () => {
+      const { ast, errors } = parseSolrQuery('title:java AND author:smith', paramsWithQopAnd);
+      expect(errors).toEqual([]);
+      expect(ast).toEqual({
+        type: 'bool',
+        and: [
+          { type: 'field', field: 'title', value: 'java' },
+          { type: 'field', field: 'author', value: 'smith' },
+        ],
+        or: [],
+        not: [],
+      });
+    });
+
+    it('does not convert when q.op is not set', () => {
+      const { ast, errors } = parseSolrQuery('title:java title:python', emptyParams);
+      expect(errors).toEqual([]);
+      expect(ast).toEqual({
+        type: 'bool',
+        and: [],
+        or: [
+          { type: 'field', field: 'title', value: 'java' },
+          { type: 'field', field: 'title', value: 'python' },
+        ],
+        not: [],
+      });
+    });
+
+    it('does not leak implicit flag into the returned AST', () => {
+      const { ast } = parseSolrQuery('title:java title:python', emptyParams);
+      expect(ast).not.toBeNull();
+      expect(ast).not.toHaveProperty('implicit');
+    });
+
+    it('converts nested implicit OR inside groups when q.op=AND', () => {
+      const { ast, errors } = parseSolrQuery('(title:java title:python) AND author:smith', paramsWithQopAnd);
+      expect(errors).toEqual([]);
+      expect(ast).toEqual({
+        type: 'bool',
+        and: [
+          {
+            type: 'group',
+            child: {
+              type: 'bool',
+              and: [
+                { type: 'field', field: 'title', value: 'java' },
+                { type: 'field', field: 'title', value: 'python' },
+              ],
+              or: [],
+              not: [],
+            },
+          },
+          { type: 'field', field: 'author', value: 'smith' },
+        ],
+        or: [],
+        not: [],
+      });
+    });
+
+    it('handles q.op=AND with mixed node types', () => {
+      const { ast, errors } = parseSolrQuery(
+        'title:java^2 "hello world" price:[10 TO 100]',
+        new Map([['q.op', 'AND'], ['df', 'content']]),
+      );
+      expect(errors).toEqual([]);
+      // All three terms joined by implicit adjacency → converted to AND
+      expect(ast).not.toBeNull();
+      expect(ast!.type).toBe('bool');
+      if (ast!.type === 'bool') {
+        expect(ast!.and).toHaveLength(3);
+        expect(ast!.or).toHaveLength(0);
+      }
+    });
+  });
+
+  // ─── toParseError ────────────────────────────────────────────────────────
+
+  describe('toParseError', () => {
+    it('extracts message and position from peggy SyntaxError', () => {
+      const err = { message: 'Expected ")"', location: { start: { offset: 5 } } };
+      expect(toParseError(err)).toEqual({ message: 'Expected ")"', position: 5 });
+    });
+
+    it('falls back to default message when error has no message', () => {
+      const err = { location: { start: { offset: 3 } } };
+      expect(toParseError(err)).toEqual({ message: 'Parse error', position: 3 });
+    });
+
+    it('falls back to position 0 when error has no location', () => {
+      const err = { message: 'Something broke' };
+      expect(toParseError(err)).toEqual({ message: 'Something broke', position: 0 });
+    });
+
+    it('falls back to both defaults for a bare object', () => {
+      expect(toParseError({})).toEqual({ message: 'Parse error', position: 0 });
+    });
+
+    it('handles null/undefined error', () => {
+      expect(toParseError(null)).toEqual({ message: 'Parse error', position: 0 });
+      expect(toParseError(undefined)).toEqual({ message: 'Parse error', position: 0 });
+    });
+  });
+});

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/parser/parser.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/parser/parser.ts
@@ -2,15 +2,61 @@
  * Solr query parser.
  *
  * Parses a Solr query string into an AST matching the types in
- * ../ast/nodes.ts.
+ * ../ast/nodes.ts. Uses a PEG grammar (solr.pegjs) internally.
+ *
+ * The grammar's action blocks return plain JS objects whose shape matches
+ * the TypeScript interfaces in nodes.ts. The `type` field is the
+ * discriminant for the ASTNode union. Peggy doesn't know about TypeScript
+ * — this module casts the result via `as ASTNode`.
+ *
+ * Grammar rule → AST node mapping:
+ *   orExpr / andExpr / unaryExpr → BoolNode
+ *   fieldExpr (field:value)      → FieldNode
+ *   fieldExpr (field:"text")     → PhraseNode
+ *   barePhrase ("text")          → PhraseNode (field="" → resolved to df)
+ *   bareValue (text)             → FieldNode  (field="" → resolved to df)
+ *   fieldExpr (field:[range])    → RangeNode
+ *   matchAll / empty query       → MatchAllNode
+ *   group                        → GroupNode
+ *   boost suffix (^N)            → BoostNode wrapping the boosted node
+ *
+ * Trace example for `title:java AND price:[10 TO 100]`:
+ *   1. query → orExpr → andExpr
+ *   2. andExpr matches: head "AND" tail
+ *      - head → fieldExpr matches `title:java`
+ *        → { type:'field', field:'title', value:'java' }                 (FieldNode)
+ *      - tail → fieldExpr matches `price:[10 TO 100]`
+ *        → { type:'range', field:'price', lower:'10', upper:'100',
+ *            lowerInclusive:true, upperInclusive:true }                  (RangeNode)
+ *   3. andExpr action returns
+ *        → { type:'bool', and:[FieldNode, RangeNode], or:[], not:[] }   (BoolNode)
  *
  * Responsibilities:
  *   - Parse the query string into an AST
- *   - Resolve default fields (df) on bare values and phrases
+ *   - Apply the default field (df) from params to bare values and phrases
  *   - Return parse errors as ParseError (never throws)
  */
 
-import type { ParseResult } from './types';
+import * as peggy from 'peggy';
+import { readFileSync } from 'node:fs';
+import type { ASTNode } from '../ast/nodes';
+import type { ParseResult, ParseError } from './types';
+
+// Lazily compiled parser — the grammar is read from disk and compiled
+// on the first call to parseSolrQuery, then cached for all subsequent calls.
+// This avoids paying the compile cost at module import time.
+let parserInstance: peggy.Parser | null = null;
+
+// Path to the grammar file, co-located with this module.
+const GRAMMAR_PATH = new URL('solr.pegjs', import.meta.url);
+
+/** Return the cached parser, compiling the grammar on first call. */
+function getParser(): peggy.Parser {
+  if (parserInstance) return parserInstance;
+  const grammar = readFileSync(GRAMMAR_PATH, 'utf-8');
+  parserInstance = peggy.generate(grammar);
+  return parserInstance;
+}
 
 /**
  * Parse a Solr query string into an AST.
@@ -20,20 +66,141 @@ import type { ParseResult } from './types';
  *                 values and unfielded phrases to a default field.
  * @returns ParseResult with the AST and any errors
  *
- * Example:
+ * Examples:
  *   parseSolrQuery("title:java AND price:[10 TO 100]", new Map([["df", "content"]]))
  *   → { ast: BoolNode { and: [FieldNode, RangeNode] }, errors: [] }
  *
  *   parseSolrQuery("java", new Map([["df", "title"]]))
  *   → { ast: FieldNode { field: "title", value: "java" }, errors: [] }
+ *
+ *   parseSolrQuery("title:java AND )", new Map())
+ *   → { ast: null, errors: [{ message: "...", position: 16 }] }
  */
 export function parseSolrQuery(
   query: string,
   params: ReadonlyMap<string, string>,
 ): ParseResult {
-  // TODO: implement
-  // 1. Parse query string into AST
-  // 2. Resolve default fields (df) on bare values and phrases
-  // 3. On parse failure: return { ast: null, errors: [...] }
-  throw new Error('Not implemented');
+  // _text_ is Solr's default catch-all field in the _default_ configset.
+  // Callers should provide df explicitly when they know the schema's default;
+  // _text_ is a safety net for when df is not in the params map.
+  const df = params.get('df') || '_text_';
+
+  // q.op controls the default boolean operator for implicit adjacency.
+  // When q.op=AND, `title:java title:python` is treated as AND instead of OR.
+  // Solr accepts both "AND" and "and", so we normalize to uppercase.
+  const qOp = params.get('q.op')?.toUpperCase();
+
+  try {
+    const ast = getParser().parse(query) as ASTNode;
+    // Apply q.op before resolveDefaultFields — applyDefaultOperator reads
+    // the `implicit` flag which resolveDefaultFields cleans up.
+    if (qOp === 'AND') {
+      applyDefaultOperator(ast);
+    }
+    resolveDefaultFields(ast, df);
+    return { ast, errors: [] };
+  } catch (err: unknown) {
+    return { ast: null, errors: [toParseError(err)] };
+  }
 }
+
+/**
+ * Convert an unknown caught error into a ParseError.
+ * Peggy throws SyntaxError with message and location.start.offset.
+ * The fallbacks handle non-peggy errors (e.g., grammar compilation failures).
+ */
+export function toParseError(err: unknown): ParseError {
+  const e = err as Record<string, any>;
+  return {
+    message: e?.message || 'Parse error',
+    position: e?.location?.start?.offset ?? 0,
+  };
+}
+
+/** Walk the AST and replace empty field strings with the default field.
+ *
+ * This handles the Lucene parser's single `df` parameter. For eDisMax's
+ * multi-field `qf` (e.g., `qf=title^2 content^1`), bare terms need to be
+ * expanded into a BoolNode with one clause per qf field — that's a separate
+ * post-parse AST transformation, not handled here.
+ *
+ * Uses an explicit switch over node types instead of duck-typing ('field' in node)
+ * to keep full type safety — the compiler catches missing cases when new node
+ * types are added to the ASTNode union.
+ */
+function resolveDefaultFields(node: ASTNode, df: string): void {
+  switch (node.type) {
+    case 'field':
+    case 'phrase':
+    case 'range':
+      if (node.field === '') node.field = df;
+      break;
+    case 'bool':
+      // Clean up grammar artifact — implicit flag shouldn't leak into AST
+      delete (node as any).implicit;
+      node.and.forEach((child) => resolveDefaultFields(child, df));
+      node.or.forEach((child) => resolveDefaultFields(child, df));
+      node.not.forEach((child) => resolveDefaultFields(child, df));
+      break;
+    case 'boost':
+    case 'group':
+      resolveDefaultFields(node.child, df);
+      break;
+    case 'matchAll':
+      break;
+    // Compile-time exhaustive check, unreachable at runtime.
+    // Assigning `node` to `never` causes a compile error if a new type is added
+    // to the ASTNode union without adding a corresponding case here. The runtime
+    // throw is a safety net in case the compile check is bypassed (e.g., via
+    // `as any` casts or untyped data from the peggy grammar).
+    /* v8 ignore next 3 */
+    default: {
+      const _exhaustive: never = node;
+      throw new Error(`Unhandled node type: ${(_exhaustive as ASTNode).type}`);
+    }
+  }
+}
+
+/**
+ * When q.op=AND, convert implicit-OR BoolNodes to AND.
+ *
+ * The grammar always treats implicit adjacency (e.g., `title:java title:python`)
+ * as OR — Solr's default. When q.op=AND, these implicit-OR nodes should be AND
+ * instead. The grammar tags implicit adjacency BoolNodes with `implicit: true`
+ * to distinguish them from explicit `OR` operators.
+ *
+ * BoolNodes with explicit OR (`implicit: false`) are left unchanged.
+ */
+function applyDefaultOperator(node: ASTNode): void {
+  switch (node.type) {
+    case 'bool': {
+      // Only convert if this BoolNode was produced by implicit adjacency,
+      // not by an explicit OR keyword.
+      const boolNode = node as ASTNode & { implicit?: boolean };
+      if (boolNode.implicit && node.or.length > 0) {
+        node.and = node.or;
+        node.or = [];
+      }
+      // Recurse into all children
+      node.and.forEach((child) => applyDefaultOperator(child));
+      node.or.forEach((child) => applyDefaultOperator(child));
+      node.not.forEach((child) => applyDefaultOperator(child));
+      break;
+    }
+    case 'boost':
+    case 'group':
+      applyDefaultOperator(node.child);
+      break;
+    case 'field':
+    case 'phrase':
+    case 'range':
+    case 'matchAll':
+      break;
+    /* v8 ignore next 3 */
+    default: {
+      const _exhaustive: never = node;
+      throw new Error(`Unhandled node type: ${(_exhaustive as ASTNode).type}`);
+    }
+  }
+}
+

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/parser/solr.pegjs
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/parser/solr.pegjs
@@ -1,0 +1,205 @@
+/**
+ * Peggy grammar for Solr query syntax.
+ *
+ * Handles the core query syntax shared by all Solr query parser types
+ * (Lucene, eDisMax, DisMax). Parser-specific behavior (e.g., eDisMax's
+ * multi-field distribution via qf/pf) is handled as a post-parse AST
+ * transformation, not in this grammar — the query syntax is the same
+ * across parser types; what differs is the semantics applied after
+ * parsing (e.g., how bare terms are expanded using runtime parameters
+ * like qf, pf, mm). A PEG grammar is purely syntactic and has no
+ * access to the request params map, so keeping this separation means
+ * one grammar for all parser types with no duplication.
+ *
+ * Operator precedence (lowest → highest):
+ *   1. OR  — `a OR b` or implicit adjacency `a b`
+ *   2. AND — `a AND b`
+ *   3. NOT — `NOT a`
+ *   4. ()  — grouping overrides precedence
+ *
+ * Example: `a OR b AND NOT c` parses as `a OR (b AND (NOT c))`
+ */
+
+// ─── Entry point ──────────────────────────────────────────────────────────────
+
+// A query is an OR expression surrounded by optional whitespace.
+// An empty query (e.g., "") produces a MatchAllNode.
+query
+  = _ expr:orExpr _ { return expr; }
+  / _ { return { type: 'matchAll' }; }
+
+// ─── Boolean operators ────────────────────────────────────────────────────────
+// Precedence is encoded by nesting: orExpr → andExpr → unaryExpr → primary.
+// Deeper rules bind tighter.
+
+// OR expression: one or more AND expressions separated by "OR" or by
+// implicit adjacency (two terms next to each other without an operator).
+// `a OR b` produces BoolNode { or: [a, b], implicit: false }.
+// `a b` produces BoolNode { or: [a, b], implicit: true }.
+// The `implicit` flag lets parser.ts distinguish between explicit OR and
+// implicit adjacency when applying q.op=AND.
+orExpr
+  = head:andExpr tail:(_ ("OR" __)? andExpr)+ {
+      const hasExplicitOr = tail.some(t => t[1] !== null);
+      const children = [head, ...tail.map(t => t[2])];
+      if (children.length === 1) return children[0];
+      return { type: 'bool', and: [], or: children, not: [], implicit: !hasExplicitOr };
+    }
+  / andExpr
+
+// AND expression: one or more unary expressions separated by "AND".
+// AND binds tighter than OR: `a OR b AND c` → `a OR (b AND c)`.
+andExpr
+  = head:unaryExpr tail:(__ "AND" __ unaryExpr)+ {
+      const children = [head, ...tail.map(t => t[3])];
+      if (children.length === 1) return children[0];
+      return { type: 'bool', and: children, or: [], not: [] };
+    }
+  / unaryExpr
+
+// NOT expression: unary prefix operator. Binds tightest of the boolean ops.
+// `NOT title:java` → BoolNode { not: [FieldNode] }
+// Recursive: `NOT NOT a` is valid (double negation).
+unaryExpr
+  = "NOT" __ expr:unaryExpr {
+      return { type: 'bool', and: [], or: [], not: [expr] };
+    }
+  / primary
+
+// ─── Primary expressions ─────────────────────────────────────────────────────
+// The smallest building blocks. Order matters in PEG — first match wins.
+// matchAll (*:*) must come before fieldExpr to prevent `*` being consumed
+// as a field name.
+
+primary
+  = group
+  / matchAll
+  / fieldExpr
+  / barePhrase
+  / bareValue
+
+// GroupNode: parenthesized sub-expression that overrides operator precedence.
+// `(a OR b) AND c` → GroupNode wrapping BoolNode.
+// Optional boost: `(a OR b)^2` → BoostNode wrapping GroupNode.
+group
+  = "(" _ expr:query _ ")" boost:boost? {
+      const node = { type: 'group', child: expr };
+      if (boost !== null) return { type: 'boost', child: node, value: boost };
+      return node;
+    }
+
+// MatchAllNode: `*:*` matches every document.
+// Must be checked before fieldExpr to prevent `*` being parsed as a field name.
+matchAll
+  = "*:*" { return { type: 'matchAll' }; }
+
+// ─── Field expressions ───────────────────────────────────────────────────────
+// Matches field:value, field:"phrase", and field:[range] / field:{range}.
+// Each variant is a separate PEG alternative (first match wins).
+// All field expressions support an optional boost suffix: field:value^2.
+
+fieldExpr
+  // PhraseNode: field:"quoted text"
+  // `title:"hello world"` → PhraseNode { text: "hello world", field: "title" }
+  = field:identifier ":" "\"" text:$[^"]* "\"" boost:boost? {
+      const node = { type: 'phrase', text: text, field: field };
+      if (boost !== null) return { type: 'boost', child: node, value: boost };
+      return node;
+    }
+  // RangeNode (inclusive both): field:[low TO high]
+  // `price:[10 TO 100]` → RangeNode { lowerInclusive: true, upperInclusive: true }
+  / field:identifier ":" "[" _ lo:rangeVal _ "TO" _ hi:rangeVal _ "]" boost:boost? {
+      const node = { type: 'range', field, lower: lo, upper: hi, lowerInclusive: true, upperInclusive: true };
+      if (boost !== null) return { type: 'boost', child: node, value: boost };
+      return node;
+    }
+  // RangeNode (exclusive both): field:{low TO high}
+  // `price:{10 TO 100}` → RangeNode { lowerInclusive: false, upperInclusive: false }
+  / field:identifier ":" "{" _ lo:rangeVal _ "TO" _ hi:rangeVal _ "}" boost:boost? {
+      const node = { type: 'range', field, lower: lo, upper: hi, lowerInclusive: false, upperInclusive: false };
+      if (boost !== null) return { type: 'boost', child: node, value: boost };
+      return node;
+    }
+  // RangeNode (mixed: inclusive lower, exclusive upper): field:[low TO high}
+  / field:identifier ":" "[" _ lo:rangeVal _ "TO" _ hi:rangeVal _ "}" boost:boost? {
+      const node = { type: 'range', field, lower: lo, upper: hi, lowerInclusive: true, upperInclusive: false };
+      if (boost !== null) return { type: 'boost', child: node, value: boost };
+      return node;
+    }
+  // RangeNode (mixed: exclusive lower, inclusive upper): field:{low TO high]
+  / field:identifier ":" "{" _ lo:rangeVal _ "TO" _ hi:rangeVal _ "]" boost:boost? {
+      const node = { type: 'range', field, lower: lo, upper: hi, lowerInclusive: false, upperInclusive: true };
+      if (boost !== null) return { type: 'boost', child: node, value: boost };
+      return node;
+    }
+  // FieldNode: field:value (unquoted)
+  // `title:java` → FieldNode { field: "title", value: "java" }
+  / field:identifier ":" val:valueChars boost:boost? {
+      const node = { type: 'field', field: field, value: val };
+      if (boost !== null) return { type: 'boost', child: node, value: boost };
+      return node;
+    }
+
+// ─── Bare expressions (no field prefix) ──────────────────────────────────────
+// These produce nodes with field=''. The parser.ts wrapper resolves the
+// empty field to the default field (df) from the params map after parsing.
+
+// PhraseNode (bare): "hello world" without a field prefix.
+// `"hello world"` → PhraseNode { text: "hello world", field: "" }
+// field is resolved to df by parser.ts after parsing.
+barePhrase
+  = "\"" text:$[^"]* "\"" boost:boost? {
+      const node = { type: 'phrase', text: text, field: '' };
+      if (boost !== null) return { type: 'boost', child: node, value: boost };
+      return node;
+    }
+
+// FieldNode (bare): a search term without a field prefix.
+// `java` → FieldNode { field: "", value: "java" }
+// field is resolved to df by parser.ts after parsing.
+// Keywords (AND, OR, NOT, TO) are excluded to prevent them from being
+// consumed as values — they return undefined so peggy backtracks.
+bareValue
+  = val:valueChars boost:boost? {
+      if (['AND','OR','NOT','TO'].includes(val)) return undefined;
+      const node = { type: 'field', field: '', value: val };
+      if (boost !== null) return { type: 'boost', child: node, value: boost };
+      return node;
+    }
+
+// ─── Terminals ───────────────────────────────────────────────────────────────
+
+// Range bound value: alphanumeric string or * (for unbounded ranges like [* TO 100]).
+rangeVal
+  = "*" { return '*'; }
+  / $[a-zA-Z0-9._\-]+
+
+// Unquoted value characters: letters, digits, and common special chars.
+// Determines what can appear in unquoted field values.
+valueChars
+  = $[a-zA-Z0-9._\-*#$@?+/]+
+
+// Field name identifier: starts with a letter or underscore, followed by
+// value characters. More restrictive first character prevents numbers from
+// being parsed as field names (e.g., `123` is a value, not a field).
+identifier
+  = $([a-zA-Z_][a-zA-Z0-9._\-*#$@?+/]*)
+
+// BoostNode modifier: ^N where N is a number (integer or decimal).
+// `title:java^2` → BoostNode { child: FieldNode, value: 2 }
+// `title:java^0.5` → BoostNode { child: FieldNode, value: 0.5 }
+// Returns the numeric value, not a string.
+// Note: Solr also accepts NaN and Infinity via Java's Float.parseFloat().
+// These are not currently supported as they produce undefined scoring behavior.
+boost
+  = "^" val:$[0-9.]+ { return parseFloat(val); }
+
+// Required whitespace — at least one space, tab, or newline.
+// Used between keywords: `a AND b` requires spaces around AND.
+__ "required whitespace"
+  = [ \t\n\r]+
+
+// Optional whitespace — zero or more spaces, tabs, or newlines.
+// Used inside ranges, groups, and at query boundaries.
+_ "whitespace"
+  = [ \t\n\r]*


### PR DESCRIPTION
Implements the parser component of the Solr-to-OpenSearch query translation pipeline using a PEG grammar (Peggy). This PR lays the foundation for the parsing framework; comprehensive support for all Solr query types and edge cases will be incrementally added in subsequent PRs.
    
The parser handles:
      - Core Solr query syntax - field queries, phrases, ranges, boolean operators,
        grouping, boosting, and match-all using a PEG grammar (solr.pegjs)
      - Default field resolution (df) for bare values and phrases
      - Default operator (q.op=AND) for implicit adjacency
      - Parse error handling (returns null AST with errors, never throws)
    
Also adds a design decision README explaining why a custom grammar was chosen over existing libraries (liqe, lucene-kit).


### Description
<!-- Describe what this change achieves -->

### Issues Resolved
<!-- List any GitHub or Jira issues this PR will resolve -->

### Testing
<!-- Please provide details of testing done: unit testing, integration testing and manual testing -->

### Check List
- [ ] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
