### PR TITLE
Adding request translator for sort parameter

### DIFF
--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/cases.testcase.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/cases.testcase.ts
@@ -53,49 +53,6 @@ export const testCases: TestCase[] = [
     },
   }),
 
-  solrTest('rows-limits-returned-documents', {
-    documents: [
-      { id: '1', title: 'first doc', content: 'alpha' },
-      { id: '2', title: 'second doc', content: 'beta' },
-      { id: '3', title: 'third doc', content: 'gamma' },
-    ],
-    requestPath: '/solr/testcollection/select?q=*:*&rows=2&wt=json',
-    solrSchema: {
-      fields: {
-        title: { type: 'text_general' },
-        content: { type: 'text_general' },
-      },
-    },
-    opensearchMapping: {
-      properties: {
-        title: { type: 'text' },
-        content: { type: 'text' },
-      },
-    },
-  }),
-
-  solrTest('rows-with-start-pagination', {
-    documents: [
-      { id: '1', title: 'first doc', content: 'alpha' },
-      { id: '2', title: 'second doc', content: 'beta' },
-      { id: '3', title: 'third doc', content: 'gamma' },
-      { id: '4', title: 'fourth doc', content: 'delta' },
-    ],
-    requestPath: '/solr/testcollection/select?q=*:*&rows=2&start=2&wt=json',
-    solrSchema: {
-      fields: {
-        title: { type: 'text_general' },
-        content: { type: 'text_general' },
-      },
-    },
-    opensearchMapping: {
-      properties: {
-        title: { type: 'text' },
-        content: { type: 'text' },
-      },
-    },
-  }),
-
   // ───────────────────────────────────────────────────────────
   // Facet tests — JSON Facet API (json.facet)
   // ───────────────────────────────────────────────────────────
@@ -259,33 +216,6 @@ export const testCases: TestCase[] = [
         reason: 'Facet test — only validating $.facets, not hits',
       },
     ],
-  }),
-
-  // ───────────────────────────────────────────────────────────
-  // Field list (fl) tests — _source filtering
-  // ───────────────────────────────────────────────────────────
-
-  solrTest('field-list-param', {
-    description: 'fl parameter with mixed comma/space separators and glob pattern (na*)',
-    documents: [
-      { id: '1', name: 'Alice', name_full: 'Alice Smith', price: 100 },
-      { id: '2', name: 'Bob', name_full: 'Bob Jones', price: 200 },
-    ],
-    requestPath: '/solr/testcollection/select?q=*:*&fl=id,na*%20price&wt=json',
-    solrSchema: {
-      fields: {
-        name: { type: 'text_general' },
-        name_full: { type: 'text_general' },
-        price: { type: 'pint' },
-      },
-    },
-    opensearchMapping: {
-      properties: {
-        name: { type: 'text' },
-        name_full: { type: 'text' },
-        price: { type: 'integer' },
-      },
-    },
   }),
 
   // ───────────────────────────────────────────────────────────

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/common-query-params.testcase.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/common-query-params.testcase.ts
@@ -1,0 +1,123 @@
+/**
+ * Test cases for the Solr → OpenSearch transformation for common Solr query parameters.
+ * Reference: https://solr.apache.org/guide/solr/latest/query-guide/common-query-parameters.html
+ *
+ * Adding a new test: just add a solrTest() entry below.
+ * It automatically runs against every Solr version in matrix.config.ts.
+ *
+ * Each test case defines:
+ * - solrSchema: the Solr collection's field types (applied via Schema API)
+ * - opensearchMapping: the corresponding OpenSearch index mapping
+ * - documents: data seeded into both backends
+ * - requestPath: the Solr query to test
+ * - assertionRules: expected differences from Solr (everything else must match exactly)
+ */
+import { solrTest } from '../test-types';
+import type { TestCase } from '../test-types';
+
+export const testCases: TestCase[] = [
+  // ───────────────────────────────────────────────────────────
+  // Pagination tests — rows and start parameters
+  // ───────────────────────────────────────────────────────────
+
+  solrTest('rows-limits-returned-documents', {
+    documents: [
+      { id: '1', title: 'first doc', content: 'alpha' },
+      { id: '2', title: 'second doc', content: 'beta' },
+      { id: '3', title: 'third doc', content: 'gamma' },
+    ],
+    requestPath: '/solr/testcollection/select?q=*:*&rows=2&wt=json',
+    solrSchema: {
+      fields: {
+        title: { type: 'text_general' },
+        content: { type: 'text_general' },
+      },
+    },
+    opensearchMapping: {
+      properties: {
+        title: { type: 'text' },
+        content: { type: 'text' },
+      },
+    },
+  }),
+
+  solrTest('rows-with-start-pagination', {
+    documents: [
+      { id: '1', title: 'first doc', content: 'alpha' },
+      { id: '2', title: 'second doc', content: 'beta' },
+      { id: '3', title: 'third doc', content: 'gamma' },
+      { id: '4', title: 'fourth doc', content: 'delta' },
+    ],
+    requestPath: '/solr/testcollection/select?q=*:*&rows=2&start=2&wt=json',
+    solrSchema: {
+      fields: {
+        title: { type: 'text_general' },
+        content: { type: 'text_general' },
+      },
+    },
+    opensearchMapping: {
+      properties: {
+        title: { type: 'text' },
+        content: { type: 'text' },
+      },
+    },
+  }),
+
+  // ───────────────────────────────────────────────────────────
+  // Field list (fl) tests — _source filtering
+  // ───────────────────────────────────────────────────────────
+
+  solrTest('field-list-param', {
+    description: 'fl parameter with mixed comma/space separators and glob pattern (na*)',
+    documents: [
+      { id: '1', name: 'Alice', name_full: 'Alice Smith', price: 100, category: 'user' },
+      { id: '2', name: 'Bob', name_full: 'Bob Jones', price: 200, category: 'admin' },
+    ],
+    requestPath: '/solr/testcollection/select?q=*:*&wt=json&fl=' + encodeURIComponent('id,na* price'),
+    solrSchema: {
+      fields: {
+        name: { type: 'text_general' },
+        name_full: { type: 'text_general' },
+        price: { type: 'pint' },
+        category: { type: 'text_general' },
+      },
+    },
+    opensearchMapping: {
+      properties: {
+        name: { type: 'text' },
+        name_full: { type: 'text' },
+        price: { type: 'integer' },
+        category: { type: 'text' },
+      },
+    },
+  }),
+
+  // ───────────────────────────────────────────────────────────
+  // Sort tests — sort parameter
+  // ───────────────────────────────────────────────────────────
+
+  solrTest('sort-multiple-fields', {
+    description: 'sort parameter with multiple fields',
+    documents: [
+      { id: '1', title: 'a', quantity: 10, price: 200 },
+      { id: '2', title: 'b', quantity: 10, price: 100 },
+      { id: '3', title: 'c', quantity: 5, price: 150 },
+      { id: '4', title: 'd', quantity: 5, price: 50 },
+    ],
+    requestPath: '/solr/testcollection/select?q=*:*&wt=json&sort=' + encodeURIComponent('quantity asc, price desc'),
+    solrSchema: {
+      fields: {
+        title: { type: 'text_general' },
+        quantity: { type: 'pint' },
+        price: { type: 'pint' },
+      },
+    },
+    opensearchMapping: {
+      properties: {
+        title: { type: 'text' },
+        quantity: { type: 'integer' },
+        price: { type: 'integer' },
+      },
+    },
+  }),
+];

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/sort.test.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/sort.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from 'vitest';
+import { request } from './sort';
+import type { RequestContext, JavaMap } from '../context';
+
+/**
+ * Helper: build a RequestContext with the given params and an empty body.
+ */
+function buildCtx(params: string): RequestContext {
+  return {
+    msg: new Map() as unknown as JavaMap,
+    endpoint: 'select',
+    collection: 'testcollection',
+    params: new URLSearchParams(params),
+    body: new Map() as unknown as JavaMap,
+  };
+}
+
+describe('sort MicroTransform', () => {
+  describe('apply', () => {
+    it('should not set sort when sort param is absent', () => {
+      const ctx = buildCtx('');
+      request.apply(ctx);
+      expect(ctx.body.has('sort')).toBe(false);
+    });
+
+    it('should handle single field ascending', () => {
+      const ctx = buildCtx('sort=price asc');
+      request.apply(ctx);
+      const sort = ctx.body.get('sort');
+      expect(sort).toHaveLength(1);
+      expect(sort[0].get('price').get('order')).toBe('asc');
+    });
+
+    it('should handle single field descending', () => {
+      const ctx = buildCtx('sort=price desc');
+      request.apply(ctx);
+      const sort = ctx.body.get('sort');
+      expect(sort).toHaveLength(1);
+      expect(sort[0].get('price').get('order')).toBe('desc');
+    });
+
+    it('should throw error when order is not specified', () => {
+      const ctx = buildCtx('sort=price');
+      expect(() => request.apply(ctx)).toThrow("Invalid sort clause 'price': must specify 'asc' or 'desc' direction");
+    });
+
+    it('should throw error for invalid sort direction', () => {
+      const ctx = buildCtx('sort=price up');
+      expect(() => request.apply(ctx)).toThrow("Invalid sort direction 'up' in 'price up': must be 'asc' or 'desc'");
+    });
+
+    it('should handle multiple sort fields', () => {
+      const ctx = buildCtx('sort=inStock desc, price asc');
+      request.apply(ctx);
+      const sort = ctx.body.get('sort');
+      expect(sort).toHaveLength(2);
+      expect(sort[0].get('inStock').get('order')).toBe('desc');
+      expect(sort[1].get('price').get('order')).toBe('asc');
+    });
+
+    it('should map score desc to _score', () => {
+      const ctx = buildCtx('sort=score desc');
+      request.apply(ctx);
+      const sort = ctx.body.get('sort');
+      expect(sort).toHaveLength(1);
+      expect(sort[0].get('_score').get('order')).toBe('desc');
+    });
+
+    it('should handle score asc with explicit order', () => {
+      const ctx = buildCtx('sort=score asc');
+      request.apply(ctx);
+      const sort = ctx.body.get('sort');
+      expect(sort).toHaveLength(1);
+      expect(sort[0].get('_score').get('order')).toBe('asc');
+    });
+
+    it('should handle mixed score and field sort', () => {
+      const ctx = buildCtx('sort=score desc, price asc');
+      request.apply(ctx);
+      const sort = ctx.body.get('sort');
+      expect(sort).toHaveLength(2);
+      expect(sort[0].get('_score').get('order')).toBe('desc');
+      expect(sort[1].get('price').get('order')).toBe('asc');
+    });
+
+    it('should throw error for function-based sorting', () => {
+      const ctx = buildCtx('sort=div(popularity,price) desc');
+      expect(() => request.apply(ctx)).toThrow("Unsupported sort 'div(popularity,price) desc': function-based sorting is not supported");
+    });
+
+    it('should throw error for field() function sorting', () => {
+      const ctx = buildCtx('sort=field(categories,min) asc');
+      expect(() => request.apply(ctx)).toThrow("Unsupported sort 'field(categories,min) asc': function-based sorting is not supported");
+    });
+
+    it('should handle empty sort param', () => {
+      const ctx = buildCtx('sort=');
+      request.apply(ctx);
+      expect(ctx.body.has('sort')).toBe(false);
+    });
+
+    it('should handle whitespace-only sort param', () => {
+      const ctx = buildCtx('sort=   ');
+      request.apply(ctx);
+      expect(ctx.body.has('sort')).toBe(false);
+    });
+  });
+});

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/sort.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/sort.ts
@@ -1,0 +1,68 @@
+/**
+ * Sort parameter — convert Solr sort param to OpenSearch sort DSL.
+ *
+ * Handles:
+ *   - sort=field asc/desc → sort: [{ field: "asc" }]
+ *   - sort=field1 desc, field2 asc → sort: [{ field1: "desc" }, { field2: "asc" }]
+ *   - sort=score desc → sort: ["_score"]
+ *   - Absent sort → no sort clause (OpenSearch defaults to _score desc)
+ *
+ * Request-only. All output is Maps/arrays for zero-serialization GraalVM interop.
+ */
+import type { MicroTransform } from '../pipeline';
+import type { RequestContext } from '../context';
+
+function parseSortClause(clause: string): Map<string, any> {
+  const parts = clause.trim().split(/\s+/);
+  if (parts.length < 2 || !parts[0]) {
+    const msg = `Invalid sort clause '${clause}': must specify 'asc' or 'desc' direction`;
+    console.error(`[sort] ${msg}`);
+    throw new Error(msg);
+  }
+
+  const field = parts[0];
+  const order = parts[1].toLowerCase();
+
+  if (order !== 'asc' && order !== 'desc') {
+    const msg = `Invalid sort direction '${parts[1]}' in '${clause}': must be 'asc' or 'desc'`;
+    console.error(`[sort] ${msg}`);
+    throw new Error(msg);
+  }
+
+  // score maps to _score in OpenSearch
+  if (field === 'score') {
+    return new Map([['_score', new Map([['order', order]])]]);
+  }
+
+  return new Map([[field, new Map([['order', order]])]]);
+}
+
+function parseSort(sort: string | null): Array<Map<string, any>> | null {
+  if (!sort?.trim()) return null;
+
+  // Detect function-based sorting before splitting (e.g., div(popularity,price), field(name,min))
+  if (sort.includes('(')) {
+    const msg = `Unsupported sort '${sort}': function-based sorting is not supported`;
+    console.error(`[sort] ${msg}`);
+    throw new Error(msg);
+  }
+
+  const clauses = sort.split(',').map((c) => c.trim()).filter(Boolean);
+  if (clauses.length === 0) {
+    console.warn(`[sort] Empty sort clauses after parsing: '${sort}'`);
+    return null;
+  }
+
+  return clauses.map(parseSortClause);
+}
+
+export const request: MicroTransform<RequestContext> = {
+  name: 'sort',
+  apply: (ctx) => {
+    const sort = ctx.params.get('sort');
+    const sortClauses = parseSort(sort);
+    if (sortClauses) {
+      ctx.body.set('sort', sortClauses);
+    }
+  },
+};

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/registry.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/registry.ts
@@ -12,6 +12,7 @@ import type { RequestContext, ResponseContext } from './context';
 import * as selectUri from './features/select-uri';
 import * as queryQ from './features/query-q';
 import * as fieldList from './features/field-list';
+import * as sort from './features/sort';
 import * as jsonFacets from './features/json-facets';
 import * as highlighting from './features/highlighting';
 import * as hitsToDocs from './features/hits-to-docs';
@@ -27,6 +28,8 @@ export const requestRegistry: TransformRegistry<RequestContext> = {
       jsonFacets.request, // json.facet → aggs
       fieldList.request, // fl=... → _source
       highlighting.request, // hl=true → highlight block
+      sort.request, // sort=... → sort DSL
+      jsonFacets.request, // json.facet → aggs
     ],
   },
 };


### PR DESCRIPTION
### Description
This translates [Solr sort param](https://solr.apache.org/guide/solr/latest/query-guide/common-query-parameters.html#sort-parameter) param to OpenSearch equivalent

### Testing
UTs and integ test

### Check List
- [x] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
