### PR TITLE
Fix k8s local test: move cleanup before BuildKit, delete all webhooks

### DIFF
--- a/vars/k8sLocalDeployment.groovy
+++ b/vars/k8sLocalDeployment.groovy
@@ -78,6 +78,28 @@ def call(Map config = [:]) {
                 }
             }
 
+            stage('Cleanup Previous MA Deployment') {
+                steps {
+                    timeout(time: 3, unit: 'MINUTES') {
+                        script {
+                            sh "kubectl config unset current-context || true"
+                            sh """
+                                # Delete all webhook configurations first — stale webhooks can block all API calls
+                                kubectl --context=minikube delete mutatingwebhookconfigurations --all --ignore-not-found || true
+                                kubectl --context=minikube delete validatingwebhookconfigurations --all --ignore-not-found || true
+
+                                # Helm uninstall with --no-hooks to avoid failing pre-delete hooks on terminating namespaces
+                                helm --kube-context=minikube uninstall ma -n ma --no-hooks || true
+
+                                # Force-delete namespaces if they still exist
+                                kubectl --context=minikube delete namespace kyverno-ma --ignore-not-found --grace-period=0 || true
+                                kubectl --context=minikube delete namespace ma --ignore-not-found --grace-period=0 --force || true
+                            """
+                        }
+                    }
+                }
+            }
+
             stage('Build Docker Images (BuildKit)') {
                 steps {
                     timeout(time: 30, unit: 'MINUTES') {
@@ -89,28 +111,6 @@ def call(Map config = [:]) {
                             sh "./gradlew :buildImages:buildImagesToRegistry_amd64 -Pbuilder=builder-minikube -x test --info --stacktrace --profile --scan${pullThroughCacheEndpoint ? " -PpullThroughCacheEndpoint=${pullThroughCacheEndpoint}" : ""}"
                             sh "docker buildx rm builder-minikube 2>/dev/null || true"
                             sh "helm --kube-context=minikube uninstall buildkit -n buildkit 2>/dev/null || true"
-                        }
-                    }
-                }
-            }
-
-            stage('Cleanup Previous MA Deployment') {
-                steps {
-                    timeout(time: 3, unit: 'MINUTES') {
-                        script {
-                            sh "kubectl config unset current-context || true"
-                            sh """
-                                # Attempt clean helm uninstall first (triggers hook-based cleanup)
-                                helm --kube-context=minikube uninstall ma -n ma || true
-
-                                # Delete kyverno webhooks in case helm uninstall didn't run cleanly
-                                kubectl --context=minikube delete mutatingwebhookconfigurations -l app.kubernetes.io/instance=kyverno --ignore-not-found || true
-                                kubectl --context=minikube delete validatingwebhookconfigurations -l app.kubernetes.io/instance=kyverno --ignore-not-found || true
-
-                                # Force-delete namespaces if they still exist
-                                kubectl --context=minikube delete namespace kyverno-ma --ignore-not-found --grace-period=0 || true
-                                kubectl --context=minikube delete namespace ma --ignore-not-found --grace-period=0 --force || true
-                            """
                         }
                     }
                 }


### PR DESCRIPTION
## Problem

The `Build Docker Images (BuildKit)` stage in `k8sLocalDeployment.groovy` fails when stale Kyverno webhook configurations exist from a previous MA deployment:

```
Error: INSTALLATION FAILED: 1 error occurred:
  * Internal error occurred: failed calling webhook "mutate.kyverno.svc-fail":
    failed to call webhook: Post "https://kyverno-svc.kyverno-ma.svc:443/mutate/fail?timeout=10s":
    service "kyverno-svc" not found
```

Three issues compound to make this a persistent failure loop:

1. **Stage ordering** — `Cleanup Previous MA Deployment` runs *after* `Build Docker Images (BuildKit)`. When BuildKit fails, cleanup is skipped (`Stage skipped due to earlier failure(s)`).

2. **Label selector misses webhooks** — Cleanup uses `-l app.kubernetes.io/instance=kyverno` but the stale webhooks lack this label, so they are never deleted.

3. **Helm hooks fail on terminating namespaces** — `helm uninstall` runs pre-delete hooks that try to create jobs in a namespace that is already terminating, causing the uninstall to error out.

## Fix

1. **Reorder stages** — Move `Cleanup Previous MA Deployment` before `Build Docker Images (BuildKit)`.

2. **Delete all webhooks first** — Use `--all` instead of a label selector. This is a local minikube test cluster where removing all webhook configurations is safe. Deleting webhooks first also prevents them from blocking the subsequent helm uninstall.

3. **Skip hooks on uninstall** — Use `helm uninstall --no-hooks` to avoid failing pre-delete hooks when the namespace is already terminating.