### PR TITLE
Fix race condition in CancelConnectionDrainTest

### DIFF
--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/kafka/CancelConnectionDrainTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/kafka/CancelConnectionDrainTest.java
@@ -56,6 +56,7 @@ class CancelConnectionDrainTest extends InstrumentationTest {
      * scheduleSequencer.isEmpty() stays false indefinitely.
      */
     @Test
+    @org.junit.jupiter.api.Timeout(10)
     void cancelConnection_drainsSorterSlots() throws Exception {
         var onCloseFired = new CountDownLatch(1);
         pool.setGlobalOnSessionClose(session -> onCloseFired.countDown());
@@ -79,8 +80,10 @@ class CancelConnectionDrainTest extends InstrumentationTest {
             );
         }
 
-        // Let the event loop process the submissions
-        Thread.sleep(50);
+        // Wait for the event loop to process all submissions by submitting a
+        // barrier task — once it completes, all prior scheduleRequest submissions
+        // have been processed and the sorter has been populated.
+        session.eventLoop.submit(() -> {}).sync();
         Assertions.assertFalse(session.scheduleSequencer.isEmpty(),
             "sorter should have queued work before cancel");
 
@@ -88,13 +91,12 @@ class CancelConnectionDrainTest extends InstrumentationTest {
         pool.cancelConnection(channelKeyCtx, 0);
 
         // onClose fires (null-channel path completes immediately)
-        boolean fired = onCloseFired.await(5, TimeUnit.SECONDS);
+        boolean fired = onCloseFired.await(10, TimeUnit.SECONDS);
         Assertions.assertTrue(fired, "onClose callback must fire after cancelConnection");
 
-        // After cancel, the sorter must drain — poll with timeout
+        // After cancel, the sorter must drain
         // Before fix: orphaned scheduleFuture entries leave sorter slots pending indefinitely
-        var deadline = System.currentTimeMillis() + 5000;
-        while (!session.scheduleSequencer.isEmpty() && System.currentTimeMillis() < deadline) {
+        while (!session.scheduleSequencer.isEmpty()) {
             Thread.sleep(10);
         }
         Assertions.assertTrue(session.scheduleSequencer.isEmpty(),


### PR DESCRIPTION
## Problem

`CancelConnectionDrainTest.cancelConnection_drainsSorterSlots()` fails intermittently with:

```
sorter should have queued work before cancel ==> expected: <false> but was: <true>
```

## Root Cause

The test calls `orchestrator.scheduleRequest()` 3 times, then uses `Thread.sleep(50)` before asserting the sorter is non-empty. Each `scheduleRequest` submits a task to the Netty event loop, and `addFutureForWork()` only runs when the event loop processes those tasks. Under CI load, 50ms may not be enough time for the event loop to process all submissions, so the sorter is still empty when the assertion runs.

## Fix

Replace `Thread.sleep(50)` with a deterministic event loop barrier: `session.eventLoop.submit(() -> {}).sync()`. Since the event loop processes tasks in FIFO order, once this no-op barrier completes, all prior `scheduleRequest` submissions are guaranteed to have been processed and the sorter populated.

Verified with 5 consecutive runs — all pass.