### PR TITLE
Remove unnecessary Thread.sleep in ResultsToLogsConsumerTest

### DIFF
--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/ResultsToLogsConsumerTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/ResultsToLogsConsumerTest.java
@@ -419,11 +419,6 @@ class ResultsToLogsConsumerTest extends InstrumentationTest {
             log.info("Output=" + contents);
             Assertions.assertEquals(normalizeJson(expected), normalizeJson(contents));
         }
-        try {
-            Thread.sleep(500);
-        } catch (InterruptedException e) {
-            throw new RuntimeException(e);
-        }
         var allMetricData = rootContext.inMemoryInstrumentationBundle.getFinishedMetrics();
         var filteredMetrics = allMetricData.stream()
             .filter(md -> md.getName().startsWith("tupleResult"))


### PR DESCRIPTION
## Problem
`ResultsToLogsConsumerTest` has a `Thread.sleep(500)` before calling `getFinishedMetrics()`, adding 500ms of unnecessary test time.

## Root Cause
`getFinishedMetrics()` already calls `testMetricReader.forceFlush()` internally before collecting metrics, so the sleep is redundant.

## Fix
Remove the `Thread.sleep(500)` and its try/catch block.