### PR TITLE
Remove unnecessary Thread.sleep in NettyPacketToHttpConsumerTest

### DIFF
--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/datahandlers/NettyPacketToHttpConsumerTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/datahandlers/NettyPacketToHttpConsumerTest.java
@@ -357,7 +357,6 @@ public class NettyPacketToHttpConsumerTest extends InstrumentationTest {
     @Tag("longTest")
     public void testMetricCountsFor_testThatConnectionsAreKeptAliveAndShared(boolean useTls) throws Exception {
         testThatConnectionsAreKeptAliveAndShared(useTls, false);
-        Thread.sleep(200); // let metrics settle down
         var allMetricData = rootContext.inMemoryInstrumentationBundle.getFinishedMetrics();
         long tcpOpenConnectionCount = allMetricData.stream()
             .filter(md -> md.getName().startsWith("tcpConnectionCount"))


### PR DESCRIPTION
## Problem
`NettyPacketToHttpConsumerTest.testMetricCountsFor_testThatConnectionsAreKeptAliveAndShared` has a `Thread.sleep(200)` before calling `getFinishedMetrics()`.

## Root Cause
`getFinishedMetrics()` already calls `testMetricReader.forceFlush()` internally before collecting metrics, making the sleep redundant.

## Fix
Remove the `Thread.sleep(200)`.