### PR TITLE
Remove unnecessary Thread.sleep in RestClientTest

### DIFF
--- a/RFS/src/test/java/org/opensearch/migrations/bulkload/common/RestClientTest.java
+++ b/RFS/src/test/java/org/opensearch/migrations/bulkload/common/RestClientTest.java
@@ -70,7 +70,6 @@ class RestClientTest {
             }
         }
 
-        Thread.sleep(200);
         var allMetricData = rootContext.inMemoryInstrumentationBundle.getFinishedMetrics();
 
         for (var kvp : Map.of(


### PR DESCRIPTION
## Problem
`RestClientTest.testGetEmitsInstrumentation` has a `Thread.sleep(200)` before calling `getFinishedMetrics()`.

## Root Cause
`getFinishedMetrics()` already calls `testMetricReader.forceFlush()` internally before collecting metrics, making the sleep redundant.

## Fix
Remove the `Thread.sleep(200)`.