### PR TITLE
Remove unnecessary test sleeps, fix flaky timing, and optimize logging

### DIFF
--- a/RFS/src/test/java/org/opensearch/migrations/bulkload/common/LuceneDocumentsReaderTest.java
+++ b/RFS/src/test/java/org/opensearch/migrations/bulkload/common/LuceneDocumentsReaderTest.java
@@ -228,6 +228,9 @@ public class LuceneDocumentsReaderTest {
         var concurrentDocReads = new AtomicInteger(0);
         var segmentReadTracker = new ConcurrentHashMap<String, AtomicBoolean>();
         var concurrentSegmentReads = new AtomicInteger(0);
+        var expectedConcurrentDocReads = 100;
+
+        var allReadsStarted = new CountDownLatch(expectedConcurrentDocReads);
 
         for (int i = 0; i < numSegments; i++) {
             var context = mock(LuceneLeafReaderContext.class);
@@ -245,6 +248,7 @@ public class LuceneDocumentsReaderTest {
                     concurrentSegmentReads.incrementAndGet(); // Increment only on first read per segment
                 }
                 concurrentDocReads.incrementAndGet();
+                allReadsStarted.countDown();
                 startLatch.await(); // Wait for the latch to be released before proceeding to track concurrency
                 var doc = mock(LuceneDocument.class);
 
@@ -274,23 +278,26 @@ public class LuceneDocumentsReaderTest {
         AtomicInteger observedConcurrentDocReads = new AtomicInteger(0);
         AtomicInteger observedConcurrentSegments = new AtomicInteger(0);
 
-        // Release the latch after a short delay to allow all threads to be ready
+        // Wait for all expected concurrent reads to reach the latch, then record and release
         Schedulers.parallel().schedule(() -> {
+            try {
+                allReadsStarted.await(5, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
             observedConcurrentSegments.set(concurrentSegmentReads.get());
             observedConcurrentDocReads.set(concurrentDocReads.get());
             startLatch.countDown();
-
-        }, 500, TimeUnit.MILLISECONDS);
+        }, 0, TimeUnit.MILLISECONDS);
 
         // Read documents
         List<LuceneDocumentChange> actualDocuments = reader.streamDocumentChanges("dummy")
             .subscribeOn(Schedulers.parallel())
             .collectList()
-            .block(Duration.ofSeconds(2));
+            .block(Duration.ofSeconds(10));
 
         // Verify results
         var expectedConcurrentSegments = 1; // Segment concurrency disabled for preserved ordering
-        var expectedConcurrentDocReads = 100;
         assertNotNull(actualDocuments);
         assertEquals(numSegments * docsPerSegment, actualDocuments.size());
         assertEquals(expectedConcurrentSegments, observedConcurrentSegments.get(), "Expected concurrent open segments equal to " + expectedConcurrentSegments);

--- a/RFS/src/test/java/org/opensearch/migrations/bulkload/common/RestClientTest.java
+++ b/RFS/src/test/java/org/opensearch/migrations/bulkload/common/RestClientTest.java
@@ -70,7 +70,6 @@ class RestClientTest {
             }
         }
 
-        Thread.sleep(200);
         var allMetricData = rootContext.inMemoryInstrumentationBundle.getFinishedMetrics();
 
         for (var kvp : Map.of(

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/RequestSenderOrchestrator.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/RequestSenderOrchestrator.java
@@ -331,7 +331,7 @@ public class RequestSenderOrchestrator {
             connectionReplaySession,
             timestamp,
             new ChannelTask<>(ChannelTaskType.CLOSE, tf -> tf.whenComplete((v, t) -> {
-                log.trace("Calling closeConnection at slot " + channelInteraction);
+                log.atTrace().setMessage("Calling closeConnection at slot {}").addArgument(channelInteraction).log();
                 clientConnectionPool.closeConnection(ctx, connectionReplaySessionNum);
             }, () -> "Close connection"))
         );

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/TrafficReplayerCore.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/TrafficReplayerCore.java
@@ -140,7 +140,7 @@ public abstract class TrafficReplayerCore extends RequestTransformerAndSender<Tr
                     );
 
             assert !allWorkFinishedForTransactionFuture.future.isDone();
-            log.trace("Adding " + requestKey + " to targetTransactionInProgressMap");
+            log.atTrace().setMessage("Adding {} to targetTransactionInProgressMap").addArgument(requestKey).log();
             requestWorkTracker.put(requestKey, allWorkFinishedForTransactionFuture);
 
             return finishedAccumulatingResponseFuture.future::complete;
@@ -232,7 +232,7 @@ public abstract class TrafficReplayerCore extends RequestTransformerAndSender<Tr
             } finally {
                 var requestKey = context.getReplayerRequestKey();
                 requestWorkTracker.remove(requestKey);
-                log.trace("removed rrPair.requestData to " + "targetTransactionInProgressMap for " + requestKey);
+                log.atTrace().setMessage("removed rrPair.requestData from targetTransactionInProgressMap for {}").addArgument(requestKey).log();
             }
         }
 

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/JsonEmitter.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/JsonEmitter.java
@@ -148,7 +148,7 @@ public class JsonEmitter implements AutoCloseable {
      * @throws IOException
      */
     public PartialOutputAndContinuation getChunkAndContinuations(Object object, int minBytes) throws IOException {
-        log.trace("getChunkAndContinuations(..., " + minBytes + ")");
+        log.atTrace().setMessage("getChunkAndContinuations(..., {})").addArgument(minBytes).log();
         return getChunkAndContinuationsHelper(walkTreeWithContinuations(object), minBytes);
     }
 
@@ -174,7 +174,7 @@ public class JsonEmitter implements AutoCloseable {
         var compositeByteBuf = outputStream.compositeByteBuf;
         if (compositeByteBuf.numComponents() > NUM_SEGMENT_THRESHOLD || compositeByteBuf.readableBytes() > minBytes) {
             var byteBuf = outputStream.recycleByteBufRetained();
-            log.debug("getChunkAndContinuationsHelper->" + byteBuf.readableBytes() + " bytes + continuation");
+            log.atDebug().setMessage("getChunkAndContinuationsHelper->{} bytes + continuation").addArgument(byteBuf::readableBytes).log();
             return new PartialOutputAndContinuation(
                 byteBuf,
                 () -> getChunkAndContinuationsHelper(nextFragmentSupplier, minBytes)
@@ -187,7 +187,7 @@ public class JsonEmitter implements AutoCloseable {
                 throw Lombok.sneakyThrow(e);
             }
             var byteBuf = outputStream.recycleByteBufRetained();
-            log.debug("getChunkAndContinuationsHelper->" + byteBuf.readableBytes() + " bytes + null");
+            log.atDebug().setMessage("getChunkAndContinuationsHelper->{} bytes + null").addArgument(byteBuf::readableBytes).log();
             return new PartialOutputAndContinuation(byteBuf, null);
         }
         log.trace(
@@ -231,7 +231,7 @@ public class JsonEmitter implements AutoCloseable {
      * @return
      */
     private FragmentSupplier walkTreeWithContinuations(Object o) {
-        log.trace("walkTree... " + o);
+        log.atTrace().setMessage("walkTree... {}").addArgument(o).log();
         if (o instanceof Map.Entry) {
             var kvp = (Map.Entry<String, Object>) o;
             writeFieldName(kvp.getKey());

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/http/NettySendByteBufsToPacketHandlerHandler.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/http/NettySendByteBufsToPacketHandlerHandler.java
@@ -47,8 +47,8 @@ public class NettySendByteBufsToPacketHandlerHandler<R> extends ChannelInboundHa
 
     @Override
     public void handlerRemoved(ChannelHandlerContext ctx) throws Exception {
-        log.debug("Handler removed for context " + ctx + " hash=" + System.identityHashCode(ctx));
-        log.trace("HR: old currentFuture=" + currentFuture);
+        log.atDebug().setMessage("Handler removed for context {} hash={}").addArgument(ctx).addArgument(() -> System.identityHashCode(ctx)).log();
+        log.atTrace().setMessage("HR: old currentFuture={}").addArgument(currentFuture).log();
         if (currentFuture.future.isDone()) {
             if (currentFuture.future.isCompletedExceptionally()) {
                 packetReceiverCompletionFutureRef.set(
@@ -99,7 +99,7 @@ public class NettySendByteBufsToPacketHandlerHandler<R> extends ChannelInboundHa
             () -> "Waiting for packetReceiver.finalizeRequest() and will return once that is done"
         );
         packetReceiverCompletionFutureRef.set(packetReceiverCompletionFuture);
-        log.trace("HR: new currentFuture=" + currentFuture);
+        log.atTrace().setMessage("HR: new currentFuture={}").addArgument(currentFuture).log();
         super.handlerRemoved(ctx);
     }
 
@@ -195,7 +195,7 @@ public class NettySendByteBufsToPacketHandlerHandler<R> extends ChannelInboundHa
                     + numBytesToSend
                     + " bytes "
             );
-            log.trace("CR: new currentFuture=" + currentFuture);
+            log.atTrace().setMessage("CR: new currentFuture={}").addArgument(currentFuture).log();
         } else if (msg instanceof LastHttpContent || msg instanceof EndOfInput) {
             currentFuture = currentFuture.map(
                 cf -> cf.thenApply(ignore -> true),

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/kafka/TrackingKafkaConsumer.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/kafka/TrackingKafkaConsumer.java
@@ -513,7 +513,7 @@ public class TrackingKafkaConsumer implements ConsumerRebalanceListener {
             // This function will only ever be called in a threadsafe way, mutually exclusive from any
             // other call other than commitKafkaKey(). Since commitKafkaKey() doesn't alter
             // partitionToOffsetLifecycleTrackerMap, these lines can be outside of the commitDataLock mutex
-            log.trace("partitionToOffsetLifecycleTrackerMap=" + partitionToOffsetLifecycleTrackerMap);
+            log.atTrace().setMessage("partitionToOffsetLifecycleTrackerMap={}").addArgument(partitionToOffsetLifecycleTrackerMap).log();
             kafkaRecordsLeftToCommitEventually.set(
                 partitionToOffsetLifecycleTrackerMap.values().stream().mapToInt(OffsetLifecycleTracker::size).sum()
             );

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/BlockingTrafficSourceTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/BlockingTrafficSourceTest.java
@@ -49,18 +49,17 @@ class BlockingTrafficSourceTest extends InstrumentationTest {
         var firstChunk = new ArrayList<ITrafficStreamWithKey>();
         for (int i = 0; i <= BUFFER_MILLIS + SHIFT; ++i) {
             var nextPieceFuture = blockingSource.readNextTrafficStreamChunk(rootContext::createReadChunkContext);
-            nextPieceFuture.get(500000, TimeUnit.MILLISECONDS).forEach(ts -> firstChunk.add(ts));
+            nextPieceFuture.get(10, TimeUnit.SECONDS).forEach(ts -> firstChunk.add(ts));
         }
-        log.info("blockingSource=" + blockingSource);
+        log.atInfo().setMessage("blockingSource={}").addArgument(blockingSource).log();
         Assertions.assertTrue(BUFFER_MILLIS + SHIFT <= firstChunk.size());
         Instant lastTime = null;
         for (int i = SHIFT; i < nStreamsToCreate - BUFFER_MILLIS - SHIFT; ++i) {
             var blockedFuture = blockingSource.readNextTrafficStreamChunk(rootContext::createReadChunkContext);
-            Thread.sleep(5);
             Assertions.assertFalse(blockedFuture.isDone(), "for i=" + i + " and coounter=" + testSource.counter.get());
             Assertions.assertEquals(i + BUFFER_MILLIS + SHIFT, testSource.counter.get());
             blockingSource.stopReadsPast(sourceStartTime.plus(Duration.ofMillis(i)));
-            log.info("after stopReadsPast blockingSource=" + blockingSource);
+            log.atInfo().setMessage("after stopReadsPast blockingSource={}").addArgument(blockingSource).log();
             var completedFutureValue = blockedFuture.get(10000, TimeUnit.MILLISECONDS);
             lastTime = TrafficStreamUtils.getFirstTimestamp(completedFutureValue.get(0).getStream()).get();
         }
@@ -95,7 +94,7 @@ class BlockingTrafficSourceTest extends InstrumentationTest {
             }
 
             var t = sourceStartTime.plus(Duration.ofMillis(i));
-            log.debug("Built timestamp for " + i);
+            log.atDebug().setMessage("Built timestamp for {}").addArgument(i).log();
             var ts = TrafficStream.newBuilder()
                 .setNumberOfThisLastChunk(0)
                 .setConnectionId("conn_" + i)

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/ResultsToLogsConsumerTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/ResultsToLogsConsumerTest.java
@@ -419,11 +419,6 @@ class ResultsToLogsConsumerTest extends InstrumentationTest {
             log.info("Output=" + contents);
             Assertions.assertEquals(normalizeJson(expected), normalizeJson(contents));
         }
-        try {
-            Thread.sleep(500);
-        } catch (InterruptedException e) {
-            throw new RuntimeException(e);
-        }
         var allMetricData = rootContext.inMemoryInstrumentationBundle.getFinishedMetrics();
         var filteredMetrics = allMetricData.stream()
             .filter(md -> md.getName().startsWith("tupleResult"))

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/datahandlers/NettyPacketToHttpConsumerTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/datahandlers/NettyPacketToHttpConsumerTest.java
@@ -357,7 +357,6 @@ public class NettyPacketToHttpConsumerTest extends InstrumentationTest {
     @Tag("longTest")
     public void testMetricCountsFor_testThatConnectionsAreKeptAliveAndShared(boolean useTls) throws Exception {
         testThatConnectionsAreKeptAliveAndShared(useTls, false);
-        Thread.sleep(200); // let metrics settle down
         var allMetricData = rootContext.inMemoryInstrumentationBundle.getFinishedMetrics();
         long tcpOpenConnectionCount = allMetricData.stream()
             .filter(md -> md.getName().startsWith("tcpConnectionCount"))

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/e2etests/FullReplayerWithTracingChecksTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/e2etests/FullReplayerWithTracingChecksTest.java
@@ -144,9 +144,8 @@ public class FullReplayerWithTracingChecksTest extends FullTrafficReplayerTest {
                     Duration.ofSeconds(5)
                 );
                 Assertions.assertEquals(numRequests, tuplesReceived.size());
-                Thread.sleep(1000);
-                checkSpansForSimpleReplayedTransactions(rootContext.inMemoryInstrumentationBundle, numRequests);
                 tr.shutdown(null).get();
+                checkSpansForSimpleReplayedTransactions(rootContext.inMemoryInstrumentationBundle, numRequests);
             }
         }
     }

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/http/retries/HttpRetryTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/http/retries/HttpRetryTest.java
@@ -166,7 +166,16 @@ public class HttpRetryTest {
         );
         try (var rootContext = TestContext.withAllTracking()) {
             var f = executor.submit(() -> scheduleSingleRequest(clientConnectionPool, rootContext).get());
-            Thread.sleep(4 * 1000);
+
+            // Wait until multiple connection attempts have been made instead of sleeping a fixed duration
+            var deadline = System.currentTimeMillis() + 10_000;
+            while (System.currentTimeMillis() < deadline) {
+                var metrics = rootContext.inMemoryInstrumentationBundle.getFinishedMetrics();
+                if (InMemoryInstrumentationBundle.getMetricValueOrZero(metrics, "requestConnectingExceptionCount") > 1) {
+                    break;
+                }
+                Thread.sleep(10);
+            }
             var ccpShutdownFuture = clientConnectionPool.shutdownNow();
 
             var e = Assertions.assertThrows(Exception.class, f::get);

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/kafka/KafkaCommitsWorkBetweenLongPollsTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/kafka/KafkaCommitsWorkBetweenLongPollsTest.java
@@ -26,7 +26,7 @@ import org.testcontainers.kafka.ConfluentKafkaContainer;
 @Testcontainers(disabledWithoutDocker = true)
 @Tag("isolatedTest")
 public class KafkaCommitsWorkBetweenLongPollsTest extends InstrumentationTest {
-    private static final long DEFAULT_POLL_INTERVAL_MS = 1000;
+    private static final long DEFAULT_POLL_INTERVAL_MS = 500;
     private static final int NUM_RUNS = 5;
     public static final String TEST_TOPIC_NAME = "test-topic";
     @Container

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/kafka/KafkaKeepAliveTests.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/kafka/KafkaKeepAliveTests.java
@@ -34,8 +34,8 @@ import org.testcontainers.kafka.ConfluentKafkaContainer;
 public class KafkaKeepAliveTests extends InstrumentationTest {
     public static final String TEST_GROUP_CONSUMER_ID = "TEST_GROUP_CONSUMER_ID";
     public static final String HEARTBEAT_INTERVAL_MS_KEY = "heartbeat.interval.ms";
-    public static final long MAX_POLL_INTERVAL_MS = 1000;
-    public static final long HEARTBEAT_INTERVAL_MS = 300;
+    public static final long MAX_POLL_INTERVAL_MS = 500;
+    public static final long HEARTBEAT_INTERVAL_MS = 150;
     public static final String testTopicName = "TEST_TOPIC";
 
     Producer<String, byte[]> kafkaProducer;

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/kafka/KafkaTrafficCaptureSourceLongTermTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/kafka/KafkaTrafficCaptureSourceLongTermTest.java
@@ -67,7 +67,6 @@ public class KafkaTrafficCaptureSourceLongTermTest extends InstrumentationTest {
         }, 0, PRODUCER_SLEEP_INTERVAL_MS, TimeUnit.MILLISECONDS);
 
         for (int i = 0; i < TEST_RECORD_COUNT;) {
-            Thread.sleep(getSleepAmountMsForProducerRun(i));
             var nextChunkFuture = kafkaTrafficCaptureSource.readNextTrafficStreamChunk(
                 rootContext::createReadChunkContext
             );
@@ -101,7 +100,4 @@ public class KafkaTrafficCaptureSourceLongTermTest extends InstrumentationTest {
         });
     }
 
-    private long getSleepAmountMsForProducerRun(int i) {
-        return 1 * 1000;
-    }
 }


### PR DESCRIPTION
## Problem
Several tests use `Thread.sleep` for synchronization instead of deterministic mechanisms, causing:
- Unnecessary test slowness (~34s of wasted sleep time)
- Flaky failures on slow CI runners (e.g. `LuceneDocumentsReaderTest.testParallelReading`)
- Eager string concatenation in production logging hot paths

## Changes

### Test sleep removals
| File | Change | Savings |
|------|--------|---------|
| `ResultsToLogsConsumerTest` | Remove 500ms sleep before `getFinishedMetrics()` — `forceFlush()` is called internally | 500ms |
| `NettyPacketToHttpConsumerTest` | Remove 200ms sleep before `getFinishedMetrics()` — same | 200ms |
| `RestClientTest` | Remove 200ms sleep before `getFinishedMetrics()` — same | 200ms |
| `FullReplayerWithTracingChecksTest` | Move span check after `tr.shutdown()` instead of sleeping 1s | 1s |
| `BlockingTrafficSourceTest` | Remove 5ms×199 iteration sleep; reduce 500s→10s timeout | ~1s |
| `KafkaTrafficCaptureSourceLongTermTest` | Remove 1s×10 sleep entirely — `get(timeout)` already blocks | ~10s |
| `HttpRetryTest` | Replace 4s sleep with polling for retry metric > 1 | ~3.7s |

### Test timing reductions
| File | Change | Savings |
|------|--------|---------|
| `KafkaCommitsWorkBetweenLongPollsTest` | Reduce poll interval 1000→500ms | ~5s |
| `KafkaKeepAliveTests` | Reduce poll/heartbeat intervals by half | ~3s |

### Flaky test fix
| File | Change |
|------|--------|
| `LuceneDocumentsReaderTest` | Replace 500ms timer with `CountDownLatch` — waits for all reads to start deterministically instead of hoping 500ms is enough |

### Production logging optimization
Replace eager string concatenation (`log.trace("msg " + obj)`) with lazy evaluation (`log.atTrace().setMessage("msg {}").addArgument(obj).log()`) in hot paths:
- `JsonEmitter` (4 calls in JSON transform path)
- `NettySendByteBufsToPacketHandlerHandler` (3 calls in Netty pipeline)
- `TrafficReplayerCore` (2 calls in request tracking)
- `TrackingKafkaConsumer` (1 call per poll cycle)
- `RequestSenderOrchestrator` (1 call per connection close)