### PR TITLE
Adding request translator for standard query parser

### DIFF
--- a/TrafficCapture/SolrTransformations/transforms/package-lock.json
+++ b/TrafficCapture/SolrTransformations/transforms/package-lock.json
@@ -7,7 +7,11 @@
     "": {
       "name": "@transformation-shim/transforms",
       "version": "1.0.0",
+      "dependencies": {
+        "lucene": "^2.1.1"
+      },
       "devDependencies": {
+        "@types/lucene": "^2.1.7",
         "@typescript-eslint/eslint-plugin": "^8.56.1",
         "@typescript-eslint/parser": "^8.56.1",
         "@typescript/native-preview": "7.0.0-dev.20251210.1",
@@ -1068,6 +1072,13 @@
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/lucene": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@types/lucene/-/lucene-2.1.7.tgz",
+      "integrity": "sha512-i3J0OV0RoJSskOJUa76Hgz09deabWwfJajsUxc1M05HryjPpPEKqtRklKe0+O0XVhdrFIiFO1/SInXpDCacfNA==",
       "dev": true,
       "license": "MIT"
     },
@@ -2262,6 +2273,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lucene": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/lucene/-/lucene-2.1.1.tgz",
+      "integrity": "sha512-l0qCX+pgXEZh/7sYQNG+vzhOIFRPjlJJkQ/irk9n7Ak3d+1MrU6F7IV31KILwFkUn153oLK8a2AIt48DzLdVPg==",
+      "license": "MIT"
     },
     "node_modules/magic-string": {
       "version": "0.30.21",
@@ -3965,6 +3982,12 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true
     },
+    "@types/lucene": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@types/lucene/-/lucene-2.1.7.tgz",
+      "integrity": "sha512-i3J0OV0RoJSskOJUa76Hgz09deabWwfJajsUxc1M05HryjPpPEKqtRklKe0+O0XVhdrFIiFO1/SInXpDCacfNA==",
+      "dev": true
+    },
     "@typescript-eslint/eslint-plugin": {
       "version": "8.56.1",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.56.1.tgz",
@@ -4712,6 +4735,11 @@
       "requires": {
         "p-locate": "^5.0.0"
       }
+    },
+    "lucene": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/lucene/-/lucene-2.1.1.tgz",
+      "integrity": "sha512-l0qCX+pgXEZh/7sYQNG+vzhOIFRPjlJJkQ/irk9n7Ak3d+1MrU6F7IV31KILwFkUn153oLK8a2AIt48DzLdVPg=="
     },
     "magic-string": {
       "version": "0.30.21",

--- a/TrafficCapture/SolrTransformations/transforms/package.json
+++ b/TrafficCapture/SolrTransformations/transforms/package.json
@@ -15,6 +15,7 @@
     "clean": "rm -rf dist"
   },
   "devDependencies": {
+    "@types/lucene": "^2.1.7",
     "@typescript-eslint/eslint-plugin": "^8.56.1",
     "@typescript-eslint/parser": "^8.56.1",
     "@typescript/native-preview": "7.0.0-dev.20251210.1",
@@ -29,5 +30,8 @@
     "@typescript/native-preview-darwin-arm64": "7.0.0-dev.20251210.1",
     "@typescript/native-preview-darwin-x64": "7.0.0-dev.20251210.1",
     "@typescript/native-preview-linux-x64": "7.0.0-dev.20251210.1"
+  },
+  "dependencies": {
+    "lucene": "^2.1.1"
   }
 }

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/cases.testcase.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/cases.testcase.ts
@@ -202,4 +202,155 @@ export const testCases: TestCase[] = [
       },
     },
   }),
+
+  // ───────────────────────────────────────────────────────────
+  // Query parser tests — Standard Query Parser (lucene syntax)
+  // ───────────────────────────────────────────────────────────
+
+  solrTest('query-term-single-field', {
+    description: 'Simple term query on a keyword field',
+    documents: [
+      { id: '1', title: 'laptop', category: 'electronics' },
+      { id: '2', title: 'phone', category: 'electronics' },
+      { id: '3', title: 'shirt', category: 'clothing' },
+    ],
+    requestPath: '/solr/testcollection/select?q=category:electronics&wt=json',
+    solrSchema: {
+      fields: {
+        title: { type: 'text_general' },
+        category: { type: 'text_general' },
+      },
+    },
+    opensearchMapping: {
+      properties: {
+        title: { type: 'text' },
+        category: { type: 'text' },
+      },
+    },
+  }),
+
+  solrTest('query-range-inclusive-exclusive', {
+    description: 'Range queries with inclusive and exclusive bounds',
+    documents: [
+      { id: '1', title: 'cheap low stock', price: 10, stock: 5 },
+      { id: '2', title: 'mid good stock', price: 50, stock: 25 },
+      { id: '3', title: 'expensive high stock', price: 100, stock: 50 },
+      { id: '4', title: 'luxury item', price: 500, stock: 10 },
+      { id: '5', title: 'free item', price: 0, stock: 100 },
+    ],
+    // price:[10 TO 100] AND stock:{0 TO 50}
+    requestPath: '/solr/testcollection/select?q=' + encodeURIComponent('price:[10 TO 100] AND stock:{0 TO 50}') + '&wt=json',
+    solrSchema: {
+      fields: {
+        title: { type: 'text_general' },
+        price: { type: 'pint' },
+        stock: { type: 'pint' },
+      },
+    },
+    opensearchMapping: {
+      properties: {
+        title: { type: 'text' },
+        price: { type: 'integer' },
+        stock: { type: 'integer' },
+      },
+    },
+  }),
+
+  solrTest('query-boolean-operators', {
+    description: 'Combined AND, OR, NOT boolean operators',
+    // Query: (category:electronics OR category:clothing) AND brand:nike NOT status:discontinued
+    documents: [
+      { id: '1', title: 'laptop', category: 'electronics', brand: 'apple', status: 'active' },
+      { id: '2', title: 'phone', category: 'electronics', brand: 'samsung', status: 'active' },
+      { id: '3', title: 'tablet', category: 'electronics', brand: 'nike', status: 'discontinued' },
+      { id: '4', title: 'shirt', category: 'clothing', brand: 'nike', status: 'active' },
+      { id: '5', title: 'shoes', category: 'electronics', brand: 'nike', status: 'active' },
+      { id: '6', title: 'apple', category: 'food', brand: 'organic', status: 'active' },
+    ],
+    requestPath: '/solr/testcollection/select?q=' + encodeURIComponent('(category:electronics OR category:clothing) AND brand:nike NOT status:discontinued') + '&wt=json',
+    solrSchema: {
+      fields: {
+        title: { type: 'text_general' },
+        category: { type: 'text_general' },
+        brand: { type: 'text_general' },
+        status: { type: 'text_general' },
+      },
+    },
+    opensearchMapping: {
+      properties: {
+        title: { type: 'text' },
+        category: { type: 'text' },
+        brand: { type: 'text' },
+        status: { type: 'text' },
+      },
+    },
+  }),
+
+  solrTest('query-phrase', {
+    description: 'Phrase query matching exact sequence',
+    documents: [
+      { id: '1', title: 'hello world', content: 'greeting message' },
+      { id: '2', title: 'world hello', content: 'reversed greeting' },
+      { id: '3', title: 'hello there world', content: 'split greeting' },
+    ],
+    requestPath: '/solr/testcollection/select?q=' + encodeURIComponent('title:"hello world"') + '&wt=json',
+    solrSchema: {
+      fields: {
+        title: { type: 'text_general' },
+        content: { type: 'text_general' },
+      },
+    },
+    opensearchMapping: {
+      properties: {
+        title: { type: 'text' },
+        content: { type: 'text' },
+      },
+    },
+  }),
+
+  solrTest('query-prefix-operators', {
+    description: 'Required (+) and prohibited (-) prefix operators',
+    documents: [
+      { id: '1', title: 'laptop', category: 'electronics', status: 'active' },
+      { id: '2', title: 'phone', category: 'electronics', status: 'discontinued' },
+      { id: '3', title: 'shirt', category: 'clothing', status: 'active' },
+    ],
+    requestPath: '/solr/testcollection/select?q=' + encodeURIComponent('+category:electronics -status:discontinued') + '&wt=json',
+    solrSchema: {
+      fields: {
+        title: { type: 'text_general' },
+        category: { type: 'text_general' },
+        status: { type: 'text_general' },
+      },
+    },
+    opensearchMapping: {
+      properties: {
+        title: { type: 'text' },
+        category: { type: 'text' },
+        status: { type: 'text' },
+      },
+    },
+  }),
+
+  solrTest('query-boost', {
+    description: 'Boosted term query to influence relevance scoring',
+    documents: [
+      { id: '1', title: 'laptop computer', category: 'electronics' },
+      { id: '2', title: 'laptop bag', category: 'accessories' },
+      { id: '3', title: 'computer desk', category: 'furniture' },
+    ],
+    requestPath: '/solr/testcollection/select?q=' + encodeURIComponent('title:laptop^2 OR title:computer') + '&wt=json',
+    solrSchema: {
+      fields: {
+        title: { type: 'text_general' },
+        category: { type: 'text_general' },
+      },
+    },
+    opensearchMapping: {
+      properties: {
+        title: { type: 'text' },
+        category: { type: 'text' },
+      },
+    },
+  }),
 ];

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/query-q.test.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/query-q.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect } from 'vitest';
+import { request } from './query-q';
+import type { RequestContext, JavaMap } from '../context';
+
+function createMockContext(params: Record<string, string>): RequestContext {
+  const urlParams = new URLSearchParams();
+  for (const [k, v] of Object.entries(params)) {
+    urlParams.set(k, v);
+  }
+  return {
+    endpoint: 'select',
+    collection: 'test',
+    params: urlParams,
+    body: new Map() as unknown as JavaMap,
+    msg: new Map() as unknown as JavaMap,
+  };
+}
+
+function mapToObject(map: JavaMap): unknown {
+  if (!(map instanceof Map)) return map;
+  const obj: Record<string, unknown> = {};
+  for (const [k, v] of map.entries()) {
+    if (v instanceof Map) {
+      obj[k] = mapToObject(v);
+    } else if (Array.isArray(v)) {
+      obj[k] = v.map((item) => (item instanceof Map ? mapToObject(item) : item));
+    } else {
+      obj[k] = v;
+    }
+  }
+  return obj;
+}
+
+function applyAndGetQuery(q: string): unknown {
+  const ctx = createMockContext({ q });
+  request.apply(ctx);
+  return mapToObject(ctx.body.get('query') as JavaMap);
+}
+
+function applyAndGetBody(params: Record<string, string>): Record<string, unknown> {
+  const ctx = createMockContext(params);
+  request.apply(ctx);
+  const result: Record<string, unknown> = {};
+  for (const [k, v] of (ctx.body as unknown as Map<string, unknown>).entries()) {
+    result[k] = v instanceof Map ? mapToObject(v as JavaMap) : v;
+  }
+  return result;
+}
+
+describe('query-q', () => {
+  // Query parsing tests
+  it('match_all for *:*', () => {
+    expect(applyAndGetQuery('*:*')).toEqual({ match_all: {} });
+  });
+
+  it('match_all for empty query', () => {
+    expect(applyAndGetQuery('')).toEqual({ match_all: {} });
+  });
+
+  it('simple term query', () => {
+    expect(applyAndGetQuery('title:search')).toEqual({ term: { title: 'search' } });
+  });
+
+  it('implicit field query', () => {
+    expect(applyAndGetQuery('java')).toEqual({ query_string: { query: 'java' } });
+  });
+
+  it('AND boolean query', () => {
+    expect(applyAndGetQuery('title:search AND author:john')).toEqual({
+      bool: {
+        must: [{ term: { title: 'search' } }, { term: { author: 'john' } }],
+      },
+    });
+  });
+
+  it('OR boolean query', () => {
+    expect(applyAndGetQuery('title:test OR content:example')).toEqual({
+      bool: {
+        should: [{ term: { title: 'test' } }, { term: { content: 'example' } }],
+      },
+    });
+  });
+
+  it('NOT boolean query', () => {
+    expect(applyAndGetQuery('title:search NOT status:draft')).toEqual({
+      bool: {
+        must: [{ term: { title: 'search' } }],
+        must_not: [{ term: { status: 'draft' } }],
+      },
+    });
+  });
+
+  it('inclusive range query', () => {
+    expect(applyAndGetQuery('price:[10 TO 100]')).toEqual({
+      range: { price: { gte: '10', lte: '100' } },
+    });
+  });
+
+  it('exclusive range query', () => {
+    expect(applyAndGetQuery('price:{10 TO 100}')).toEqual({
+      range: { price: { gt: '10', lt: '100' } },
+    });
+  });
+
+  it('phrase query', () => {
+    expect(applyAndGetQuery('title:"hello world"')).toEqual({
+      match_phrase: { title: 'hello world' },
+    });
+  });
+
+  it('boosted term query', () => {
+    expect(applyAndGetQuery('title:search^2')).toEqual({
+      term: { title: { value: 'search', boost: 2 } },
+    });
+  });
+
+  it('boosted implicit field query', () => {
+    expect(applyAndGetQuery('java^3')).toEqual({
+      query_string: { query: 'java', boost: 3 },
+    });
+  });
+
+  it('boosted phrase query', () => {
+    expect(applyAndGetQuery('title:"hello world"^2')).toEqual({
+      match_phrase: { title: { query: 'hello world', boost: 2 } },
+    });
+  });
+
+  it('required prefix (+)', () => {
+    expect(applyAndGetQuery('+title:required -status:excluded')).toEqual({
+      bool: {
+        must: [{ term: { title: 'required' } }],
+        must_not: [{ term: { status: 'excluded' } }],
+      },
+    });
+  });
+
+  it('prefix on implicit field (+foo -bar)', () => {
+    expect(applyAndGetQuery('+foo -bar')).toEqual({
+      bool: {
+        must: [{ query_string: { query: 'foo' } }],
+        must_not: [{ query_string: { query: 'bar' } }],
+      },
+    });
+  });
+
+  // Pagination tests (rows/start)
+  it('rows param converts to size', () => {
+    const body = applyAndGetBody({ q: '*:*', rows: '25' });
+    expect(body.size).toBe(25);
+  });
+
+  it('start param converts to from', () => {
+    const body = applyAndGetBody({ q: '*:*', start: '10' });
+    expect(body.from).toBe(10);
+  });
+
+  it('rows and start together', () => {
+    const body = applyAndGetBody({ q: '*:*', rows: '50', start: '100' });
+    expect(body.size).toBe(50);
+    expect(body.from).toBe(100);
+  });
+});

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/query-q.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/query-q.ts
@@ -1,34 +1,226 @@
 /**
  * Query q parameter — convert Solr q param to OpenSearch query DSL.
  *
- * Handles:
+ * Uses the lucene parser library for full query syntax support:
  *   - *:* → match_all
  *   - field:value → term query
- *   - Anything else → query_string passthrough (lets OpenSearch parse it)
+ *   - field:"phrase" → match_phrase query
+ *   - field:[min TO max] → range query
+ *   - Boolean operators: AND, OR, NOT
+ *   - Prefix operators: +required -excluded
+ *   - Boost: field:value^2
+ *   - Implicit field → query_string (lets OpenSearch handle default field)
  *
  * Request-only. All output is Maps for zero-serialization GraalVM interop.
  */
+import * as lucene from 'lucene';
 import type { MicroTransform } from '../pipeline';
-import type { RequestContext, JavaMap } from '../context';
+import type { RequestContext } from '../context';
 
-function parseSolrQuery(q: string): JavaMap {
-  if (!q || q === '*:*') return new Map([['match_all', new Map()]]);
+type QueryMap = Map<string, unknown>;
 
-  const fieldMatch = /^([^:]+):(.+)$/.exec(q);
-  if (fieldMatch) {
-    const [, field, value] = fieldMatch;
-    if (field === '*' && value === '*') return new Map([['match_all', new Map()]]);
-    return new Map([['term', new Map([[field, value]])]]);
+/** Term node: field:value or field:"phrase" */
+interface TermNode {
+  field: string;
+  term: string;
+  quoted: boolean;
+  boost: number | null;
+  prefix: '+' | '-' | null;
+}
+
+/** Range node: field:[min TO max] or field:{min TO max} */
+interface RangeNode {
+  field: string;
+  term_min: string;
+  term_max: string;
+  inclusive: 'both' | 'none' | 'left' | 'right';
+}
+
+/** Binary expression: left OP right */
+interface BinaryNode {
+  left: LuceneNode;
+  operator: 'AND' | 'OR' | 'NOT' | 'AND NOT' | '<implicit>';
+  right: LuceneNode;
+}
+
+/** Wrapper node: { left: node } with no operator */
+interface WrapperNode {
+  left: TermNode | RangeNode;
+}
+
+type LuceneNode = TermNode | RangeNode | BinaryNode | WrapperNode;
+
+function isRange(node: LuceneNode): node is RangeNode {
+  return 'term_min' in node;
+}
+
+function isBool(node: LuceneNode): node is BinaryNode {
+  return 'operator' in node;
+}
+
+function isWrapper(node: LuceneNode): node is WrapperNode {
+  return 'left' in node && !('operator' in node);
+}
+
+/**
+ * Converts a Lucene range node to OpenSearch range query.
+ * 
+ * Examples:
+ *   - price:[10 TO 100] → { range: { price: { gte: '10', lte: '100' } } }
+ *   - price:{10 TO 100} → { range: { price: { gt: '10', lt: '100' } } }
+ *   - price:[* TO 100] → { range: { price: { lte: '100' } } }
+ */
+function convertRangeNode(node: RangeNode): QueryMap {
+  const range = new Map<string, string>();
+  const gteOp = node.inclusive === 'both' || node.inclusive === 'left';
+  const lteOp = node.inclusive === 'both' || node.inclusive === 'right';
+  if (node.term_min !== '*') range.set(gteOp ? 'gte' : 'gt', node.term_min);
+  if (node.term_max !== '*') range.set(lteOp ? 'lte' : 'lt', node.term_max);
+  return new Map([['range', new Map([[node.field, range]])]]);
+}
+
+/**
+ * Converts a Lucene term node to OpenSearch query clause.
+ * Handles prefix operators (+/-), implicit fields, phrases, and boosts.
+ * 
+ * Examples:
+ *   - title:search → { term: { title: 'search' } }
+ *   - title:"hello world" → { match_phrase: { title: 'hello world' } }
+ *   - java (implicit field) → { query_string: { query: 'java' } }
+ *   - title:search^2 → { term: { title: { value: 'search', boost: 2 } } }
+ *   - +title:foo → prefix='+', clause={ term: { title: 'foo' } }
+ */
+function convertTerm(node: TermNode): { clause: QueryMap; prefix: string } {
+  let field = node.field;
+  let prefix = '';
+
+  // Check prefix property first (used when field is implicit)
+  if (node.prefix) {
+    prefix = node.prefix;
+  }
+  // Lucene parser puts +/- prefix in field name when field is explicit
+  else if (field.startsWith('+') || field.startsWith('-')) {
+    prefix = field[0];
+    field = field.slice(1);
   }
 
-  return new Map([['query_string', new Map([['query', q]])]]);
+  // Match all
+  if (field === '*' && node.term === '*') {
+    return { clause: new Map([['match_all', new Map()]]), prefix };
+  }
+
+  // Implicit field - use query_string to let OpenSearch handle default field
+  if (field === '<implicit>') {
+    const clause = node.boost
+      ? new Map([['query_string', new Map<string, unknown>([['query', node.term], ['boost', node.boost]])]])
+      : new Map([['query_string', new Map([['query', node.term]])]]);
+    return { clause, prefix };
+  }
+
+  // Phrase query
+  if (node.quoted) {
+    const clause = node.boost
+      ? new Map([['match_phrase', new Map([[field, new Map<string, unknown>([['query', node.term], ['boost', node.boost]])]])]])
+      : new Map([['match_phrase', new Map([[field, node.term]])]]);
+    return { clause, prefix };
+  }
+
+  // Term query
+  const clause = node.boost
+    ? new Map([['term', new Map([[field, new Map<string, unknown>([['value', node.term], ['boost', node.boost]])]])]])
+    : new Map([['term', new Map([[field, node.term]])]]);
+  return { clause, prefix };
+}
+
+/**
+ * Converts a Lucene binary node (AND, OR, NOT, implicit) to OpenSearch bool query.
+ * 
+ * Examples:
+ *   - foo AND bar → { bool: { must: [left, right] } }
+ *   - foo OR bar → { bool: { should: [left, right] } }
+ *   - foo NOT bar → { bool: { must: [left], must_not: [right] } }
+ *   - +foo -bar (implicit) → merges bool clauses: { bool: { must: [...], must_not: [...] } }
+ *   - foo bar (implicit, no prefix) → { bool: { should: [left, right] } }
+ */
+function convertBoolNode(node: BinaryNode, convert: (n: LuceneNode) => QueryMap): QueryMap {
+  const left = convert(node.left);
+  const right = convert(node.right);
+
+  switch (node.operator) {
+    case 'AND':
+      return new Map([['bool', new Map([['must', [left, right]]])]]);
+    case 'OR':
+      return new Map([['bool', new Map([['should', [left, right]]])]]);
+    case 'NOT':
+    case 'AND NOT':
+      return new Map([['bool', new Map([['must', [left]], ['must_not', [right]]])]]);
+    case '<implicit>': {
+      // Merge bool clauses from prefix operators (+/-)
+      const lBool = left.get('bool') as Map<string, QueryMap[]> | undefined;
+      const rBool = right.get('bool') as Map<string, QueryMap[]> | undefined;
+      if (lBool || rBool) {
+        return new Map([['bool', new Map([
+          ['must', [...(lBool?.get('must') || []), ...(rBool?.get('must') || [])]],
+          ['must_not', [...(lBool?.get('must_not') || []), ...(rBool?.get('must_not') || [])]],
+        ])]]);
+      }
+      return new Map([['bool', new Map([['should', [left, right]]])]]);
+    }
+  }
+}
+
+/**
+ * Wraps a term clause with bool must/must_not based on prefix operator.
+ * 
+ * Examples:
+ *   - +foo → { bool: { must: [clause] } }
+ *   - -foo → { bool: { must_not: [clause] } }
+ *   - foo (no prefix) → clause as-is
+ */
+function convertTermNode(node: TermNode): QueryMap {
+  const { clause, prefix } = convertTerm(node);
+  if (prefix === '+') return new Map([['bool', new Map([['must', [clause]]])]]);
+  if (prefix === '-') return new Map([['bool', new Map([['must_not', [clause]]])]]);
+  return clause;
+}
+
+/**
+ * Main entry point for converting a Lucene AST node to OpenSearch query.
+ * Dispatches to the appropriate converter based on node type.
+ */
+function convert(node: LuceneNode): QueryMap {
+  // Unwrap { left: ... } wrapper
+  if (isWrapper(node)) {
+    return convert(node.left);
+  }
+
+  // Range query
+  if (isRange(node)) {
+    return convertRangeNode(node);
+  }
+
+  // Binary operator
+  if (isBool(node)) {
+    return convertBoolNode(node, convert);
+  }
+
+  // Term node with possible prefix
+  return convertTermNode(node as TermNode);
 }
 
 export const request: MicroTransform<RequestContext> = {
   name: 'query-q',
   apply: (ctx) => {
     const q = ctx.params.get('q') || '*:*';
-    ctx.body.set('query', parseSolrQuery(q));
+    if (!q || q === '*:*') {
+      ctx.body.set('query', new Map([['match_all', new Map()]]));
+    } else {
+      try {
+        ctx.body.set('query', convert(lucene.parse(q) as LuceneNode));
+      } catch {
+        ctx.body.set('query', new Map([['query_string', new Map([['query', q]])]]));
+      }
+    }
 
     // rows → size, start → from
     const rows = ctx.params.get('rows');

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/registry.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/registry.ts
@@ -25,6 +25,7 @@ export const requestRegistry: TransformRegistry<RequestContext> = {
       queryQ.request, // q=... → query DSL
       jsonFacets.request, // json.facet → aggs,
       fieldList.request, // fl=... → _source
+      jsonFacets.request, // json.facet → aggs
     ],
   },
 };


### PR DESCRIPTION
### Description
This translates [Solr standard query parser](https://solr.apache.org/guide/solr/latest/query-guide/standard-query-parser.html) to OpenSearch equivalent
- Term queries
- Range queries
- Phrase queries
- Boolean operators
- Boosting expressions

### Issues Resolved
<!-- List any GitHub or Jira issues this PR will resolve -->

### Testing
<!-- Please provide details of testing done: unit testing, integration testing and manual testing -->

### Check List
- [ ] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
