### PR TITLE
feat(solr-transforms): Add transformer stage of the query translation engine

### DIFF
--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/transformer/astToOpenSearch.test.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/transformer/astToOpenSearch.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { transformNode } from './astToOpenSearch';
+import type { ASTNode, BoolNode } from '../ast/nodes';
+
+describe('transformNode', () => {
+  it('recursively transforms nested registered nodes', () => {
+    const inner: BoolNode = { type: 'bool', and: [], or: [], not: [] };
+    const outer: BoolNode = { type: 'bool', and: [inner], or: [], not: [] };
+    const result = transformNode(outer);
+
+    const mustArray = (result.get('bool') as Map<string, any>).get('must') as Map<string, any>[];
+    expect(mustArray).toHaveLength(1);
+    expect(mustArray[0].get('bool')).toBeDefined();
+  });
+
+  it('throws for an unregistered node type', () => {
+    const node: ASTNode = { type: 'field', field: 'title', value: 'java' };
+    expect(() => transformNode(node)).toThrow(
+      'No transform rule registered for node type: field',
+    );
+  });
+});

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/transformer/astToOpenSearch.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/transformer/astToOpenSearch.ts
@@ -36,6 +36,20 @@
  */
 
 import type { ASTNode } from '../ast/nodes';
+import type { TransformRuleFn } from './types';
+import { boolRule } from './rules/boolRule';
+
+/**
+ * Registry of transform functions, keyed by AST node type.
+ *
+ * To add support for a new AST node type:
+ *   1. Create a TransformRuleFn in transformer/rules/
+ *   2. Register it here with the node's `type` discriminant as the key
+ */
+const rules: Record<string, TransformRuleFn> = {
+  bool: boolRule,
+  // TODO: register remaining rules as they are implemented
+};
 
 /**
  * Transform an AST node into an OpenSearch DSL Map.
@@ -47,14 +61,15 @@ import type { ASTNode } from '../ast/nodes';
  *
  * @param node - The AST node to transform
  * @returns A nested Map structure representing OpenSearch Query DSL
+ * @throws Error if no rule is registered for the node type — the orchestrator
+ *         catches this and handles it based on the translation mode:
+ *         - passthrough-on-error: returns query_string passthrough + warning
+ *         - partial: skips the node, adds a warning, continues translating
  */
 export function transformNode(node: ASTNode): Map<string, any> {
-  // TODO: implement
-  // 1. Look up TransformRuleFn by node.type from the rules registry
-  // 2. Call rule(node, transformNode) for recursive dispatch
-  // 3. Throw if no rule registered for the node type — the orchestrator
-  //    catches this and handles it based on the translation mode:
-  //    - passthrough-on-error: returns query_string passthrough + warning
-  //    - partial: skips the node, adds a warning, continues translating
-  throw new Error('Not implemented');
+  const rule = rules[node.type];
+  if (!rule) {
+    throw new Error(`No transform rule registered for node type: ${node.type}`);
+  }
+  return rule(node, transformNode);
 }

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/transformer/rules/boolRule.test.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/transformer/rules/boolRule.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest';
+import { boolRule } from './boolRule';
+import type { ASTNode, BoolNode, FieldNode } from '../../ast/nodes';
+import type { TransformChild } from '../types';
+
+/** Stub transformChild that wraps each node in a Map with its type as key. */
+const stubTransformChild: TransformChild = (child: ASTNode): Map<string, any> =>
+  new Map([[child.type, child]]);
+
+const titleJava: FieldNode = { type: 'field', field: 'title', value: 'java' };
+const authorSmith: FieldNode = { type: 'field', field: 'author', value: 'smith' };
+const statusDraft: FieldNode = { type: 'field', field: 'status', value: 'draft' };
+
+/** Extract the inner bool Map and verify only the expected keys are present. */
+function expectBoolKeys(result: Map<string, any>, expectedKeys: string[]): Map<string, any> {
+  const boolMap = result.get('bool') as Map<string, any>;
+  expect(boolMap).toBeDefined();
+  expect(boolMap.size).toBe(expectedKeys.length);
+  expect([...boolMap.keys()]).toEqual(expect.arrayContaining(expectedKeys));
+  return boolMap;
+}
+
+describe('boolRule', () => {
+  it('transforms AND clauses to must', () => {
+    const node: BoolNode = { type: 'bool', and: [titleJava, authorSmith], or: [], not: [] };
+    const boolMap = expectBoolKeys(boolRule(node, stubTransformChild), ['must']);
+    expect(boolMap.get('must')).toHaveLength(2);
+  });
+
+  it('transforms OR clauses to should', () => {
+    const node: BoolNode = { type: 'bool', and: [], or: [titleJava, authorSmith], not: [] };
+    const boolMap = expectBoolKeys(boolRule(node, stubTransformChild), ['should']);
+    expect(boolMap.get('should')).toHaveLength(2);
+  });
+
+  it('transforms NOT clauses to must_not', () => {
+    const node: BoolNode = { type: 'bool', and: [], or: [], not: [statusDraft] };
+    const boolMap = expectBoolKeys(boolRule(node, stubTransformChild), ['must_not']);
+    expect(boolMap.get('must_not')).toHaveLength(1);
+  });
+
+  it('transforms all three clause types together', () => {
+    const node: BoolNode = { type: 'bool', and: [titleJava], or: [authorSmith], not: [statusDraft] };
+    const boolMap = expectBoolKeys(boolRule(node, stubTransformChild), ['must', 'should', 'must_not']);
+    expect(boolMap.get('must')).toHaveLength(1);
+    expect(boolMap.get('should')).toHaveLength(1);
+    expect(boolMap.get('must_not')).toHaveLength(1);
+  });
+
+  it('omits all clauses when all arrays are empty', () => {
+    const node: BoolNode = { type: 'bool', and: [], or: [], not: [] };
+    expectBoolKeys(boolRule(node, stubTransformChild), []);
+  });
+
+  it('calls transformChild for each child node', () => {
+    const calls: ASTNode[] = [];
+    const trackingTransformChild: TransformChild = (child) => {
+      calls.push(child);
+      return new Map([[child.type, child]]);
+    };
+
+    const node: BoolNode = { type: 'bool', and: [titleJava], or: [authorSmith], not: [statusDraft] };
+    boolRule(node, trackingTransformChild);
+
+    expect(calls).toEqual([titleJava, authorSmith, statusDraft]);
+  });
+
+  it('passes transformChild output directly into clause arrays', () => {
+    const node: BoolNode = { type: 'bool', and: [titleJava], or: [], not: [] };
+    const result = boolRule(node, stubTransformChild);
+
+    const mustArray = (result.get('bool') as Map<string, any>).get('must');
+    expect(mustArray[0]).toEqual(new Map([['field', titleJava]]));
+  });
+
+  it('throws when called with wrong node type', () => {
+    const wrongNode: FieldNode = { type: 'field', field: 'title', value: 'java' };
+    expect(() => boolRule(wrongNode, stubTransformChild)).toThrow(
+      'boolRule called with wrong node type: field',
+    );
+  });
+});

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/transformer/rules/boolRule.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/transformer/rules/boolRule.ts
@@ -26,9 +26,21 @@ export const boolRule: TransformRuleFn = (
   node: ASTNode,
   transformChild: TransformChild,
 ): Map<string, any> => {
-  // TODO: implement
-  // 1. Transform each child in and/or/not via transformChild
-  // 2. Build Map{"bool" → Map{"must" → [...], "should" → [...], "must_not" → [...]}}
-  // 3. Omit empty clause arrays from the output
-  throw new Error('Not implemented');
+  if (node.type !== 'bool') {
+    throw new Error(`boolRule called with wrong node type: ${node.type}`);
+  }
+  const { and, or, not } = node;
+  const boolMap = new Map<string, any>();
+
+  if (and.length > 0) {
+    boolMap.set('must', and.map(transformChild));
+  }
+  if (or.length > 0) {
+    boolMap.set('should', or.map(transformChild));
+  }
+  if (not.length > 0) {
+    boolMap.set('must_not', not.map(transformChild));
+  }
+
+  return new Map([['bool', boolMap]]);
 };


### PR DESCRIPTION
Implement the transformer stage of the query translation pipeline:
  - astToOpenSearch.ts: dispatcher with registry-based rule lookup
  - boolRule.ts: BoolNode → OpenSearch bool query (must/should/must_not)
  - transformer/types.ts: TransformRuleFn and TransformChild type aliases

The dispatcher looks up a TransformRuleFn by node.type and calls it. Unregistered node types throw, which the orchestrator catches and handles based on the translation mode. Only boolRule with basic functionality is registered; remaining rules will be added in follow-up PRs.

### Description
<!-- Describe what this change achieves -->

### Issues Resolved
<!-- List any GitHub or Jira issues this PR will resolve -->

### Testing
<!-- Please provide details of testing done: unit testing, integration testing and manual testing -->

### Check List
- [ ] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
