### PR TITLE
Skip Jib digest resolution for ECR registries

### DIFF
--- a/buildSrc/src/main/groovy/org/opensearch/migrations/image/RegistryImageBuildUtils.groovy
+++ b/buildSrc/src/main/groovy/org/opensearch/migrations/image/RegistryImageBuildUtils.groovy
@@ -141,7 +141,7 @@ class RegistryImageBuildUtils {
 
                     // For intermediate images (built in the same pipeline), resolve the
                     // digest at execution time to ensure reproducible builds.
-                    if (baseEndpoint == intermediateRegistry.hostUrl) {
+                    if (baseEndpoint == intermediateRegistry.hostUrl && !intermediateRegistry.isEcr()) {
                         project.tasks.named("jib").configure {
                             doFirst {
                                 project.jib.from.image = RegistryImageBuildUtils.resolveDigest(baseImage, project.jib.allowInsecureRegistries)


### PR DESCRIPTION
### Description

The `resolveDigest()` method introduced in 4d671a79 makes unauthenticated HTTP HEAD requests to the registry v2 API to pin base image digests for reproducible Jib builds. This works for local registries (e.g. `localhost:5001`) but fails on ECR, which requires authentication for all API calls.

The 5-second connect timeout expires, producing a `SocketTimeoutException` that fails the `:TrafficCapture:trafficCaptureProxyServer:jib` task. This has broken `main-eks-integ-test` consistently since build #327 (every build since the commit was merged).

### Fix

Skip digest resolution when the intermediate registry is ECR. The `Registry.isEcr()` method already exists. ECR provides content-addressable storage guarantees, so digest pinning for reproducibility is not needed there — it's only useful for local dev registries where tags can be mutable.

### Testing

- Verified the one-line change compiles
- `main-eks-integ-test` builds #327–#331 all fail with the same `SocketTimeoutException` on the jib task; #326 (before this commit) was the last success

### Issues Resolved

Fixes consistent `main-eks-integ-test` failures since 4d671a79.