### PR TITLE
Potential fix for code scanning alert no. 56: Clear-text logging of sensitive information

### DIFF
--- a/migrationConsole/lib/console_link/console_link/workflow/models/secret_store.py
+++ b/migrationConsole/lib/console_link/console_link/workflow/models/secret_store.py
@@ -118,7 +118,7 @@ class SecretStore:
                 logger.info(f"Created secret: {basic_creds_resource_name}")
                 return f"Secret created: {basic_creds_resource_name}"
             else:
-                logger.error(f"Kubernetes API error saving secret {basic_creds_resource_name}: {e}")
+                logger.error("Kubernetes API error saving secret", exc_info=True)
                 raise
 
     def load_secret(


### PR DESCRIPTION
Potential fix for [https://github.com/opensearch-project/opensearch-migrations/security/code-scanning/56](https://github.com/opensearch-project/opensearch-migrations/security/code-scanning/56)

In general, to fix clear-text logging of sensitive information, avoid including sensitive or potentially sensitive values in log messages. Instead, log only high-level context (such as operation type and status code) or use opaque identifiers that are not secrets. Exception objects should be logged in a way that does not leak sensitive payloads (for example, log only status codes or use `logger.exception` with a generic message, relying on stack traces rather than interpolated data).

For this specific case, the problematic log statement is in `SecretStore.save_secret` in `secret_store.py`:

```python
logger.error(f"Kubernetes API error saving secret {basic_creds_resource_name}: {e}")
```

The safest change that preserves observability is to remove `basic_creds_resource_name` and the formatted `e` from the log message, and instead log a generic error while still raising the exception. If we want to preserve some debuggability without exposing secret identifiers, we can use a structured log with `exc_info=True` so the traceback is captured, but the message itself stays generic. Given we cannot change surrounding code and we should keep behavior similar, a straightforward fix is:

```python
logger.error("Kubernetes API error saving secret", exc_info=True)
```

This keeps an error log at the same point, maintains the exception information for debugging, but no longer includes the secret name or stringified exception in the log message. No new imports or helpers are needed; we only adjust the existing line in `secret_store.py`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
