### PR TITLE
Added support for date range facets

### DIFF
--- a/TrafficCapture/SolrTransformations/docs/LIMITATIONS.md
+++ b/TrafficCapture/SolrTransformations/docs/LIMITATIONS.md
@@ -11,6 +11,7 @@ the root cause, and provides a workaround where one exists.
 | Shortcode | Summary |
 |-----------|---------|
 | [TERMS-OFFSET](#terms-offset) | Terms facet `offset` not natively supported in OpenSearch |
+| [DATE-RANGE-GAP](#date-range-gap) | Multi-unit date range gaps approximated as fixed intervals |
 
 ---
 
@@ -54,3 +55,65 @@ response on the client side.
 * **Client changes required** – Any application code that previously consumed
   the Solr response directly must be updated to trim the leading buckets,
   since the transformer can only adjust the *request*, not the response.
+
+---
+
+## DATE-RANGE-GAP
+
+**Feature:** Date range facet with multi-unit calendar gaps (e.g. `+2MONTHS`, `+3YEARS`)
+
+**Solr behaviour:**
+Solr's range facet accepts date-math gap strings such as `+1MONTH`, `+2MONTHS`,
+or `+3YEARS`. These are calendar-aware — `+1MONTH` starting from January 31
+lands on February 28/29, and `+1YEAR` correctly handles leap years.
+
+**OpenSearch behaviour:**
+OpenSearch's `date_histogram` aggregation offers two interval parameters:
+
+* **`calendar_interval`** — calendar-aware, but only accepts a **single unit**
+  (e.g. `1M`, `1y`, `1d`). Multi-unit values like `2M` or `3y` are rejected.
+* **`fixed_interval`** — accepts any multiple (e.g. `5m`, `3h`, `48h`), but
+  uses **fixed durations** that do not account for variable-length calendar
+  periods.
+
+**Cause:**
+There is no OpenSearch interval mode that combines calendar-awareness with
+arbitrary multiples. A gap like `+2MONTHS` cannot be directly expressed
+because `calendar_interval` rejects `2M` and `fixed_interval` cannot
+represent the variable length of months.
+
+**Current workaround (applied automatically by the transformer):**
+
+| Solr gap pattern | OpenSearch mapping | Notes |
+|------------------|--------------------|-------|
+| Single-unit, any (`+1MONTH`, `+1DAY`, `+1HOUR`, …) | `calendar_interval` (`1M`, `1d`, `1h`, …) | Exact match — no approximation |
+| Multi-unit, fixed-duration (`+5MINUTES`, `+3HOURS`, `+90SECONDS`) | `fixed_interval` (`5m`, `3h`, `90s`) | Exact match — these units have constant length |
+| Multi-unit, calendar (`+2MONTHS`, `+3YEARS`, `+2DAYS`) | `fixed_interval` with approximation | Approximated using 30 days/month, 365 days/year, 24 hours/day |
+
+For the approximated cases, the transformer converts the gap to a
+`fixed_interval` using the largest whole unit (hours, minutes, or seconds)
+that divides evenly. For example, `+2MONTHS` becomes `1440h`
+(2 × 30 × 24). A console warning is emitted when this approximation is
+applied.
+
+**Compound gaps** (e.g. `+1MONTH+2DAYS`, `+1YEAR+6MONTHS`) are also
+supported. All components are summed into a total number of seconds using the
+same approximation constants, then expressed in the largest whole unit.
+For example, `+1MONTH+2DAYS` becomes `768h` (720 + 48). Compound gaps
+always use `fixed_interval` since they cannot be expressed as a single
+`calendar_interval`.
+
+**Residual impact:**
+
+* **Bucket boundary drift** — Approximated intervals do not align with
+  calendar boundaries. A "2-month" bucket starting February 1 would end on
+  April 2 (60 days later) instead of April 1. The drift accumulates over
+  longer date ranges.
+* **Leap year / DST mismatch** — Years are approximated as 365 days (missing
+  leap days) and days as 24 hours (missing DST transitions of ±1 hour).
+* **Different bucket counts** — The total number of buckets may differ
+  slightly from Solr's output because fixed-duration buckets divide the
+  date range differently than calendar-aware ones.
+* **Compound gap drift** — Compound gaps combining calendar and fixed units
+  (e.g. `+1MONTH+2DAYS`) accumulate approximation error from each calendar
+  component.

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/cases.testcase.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/cases.testcase.ts
@@ -261,6 +261,50 @@ export const testCases: TestCase[] = [
     ],
   }),
 
+  solrTest('facet-date-range', {
+    description: 'Date range facet using start/end/gap with +1MONTH calendar interval',
+    documents: [
+      { id: '1', title: 'jan event', event_date: '2024-01-15T00:00:00Z' },
+      { id: '2', title: 'feb event', event_date: '2024-02-10T00:00:00Z' },
+      { id: '3', title: 'mar event', event_date: '2024-03-20T00:00:00Z' },
+      { id: '4', title: 'mar event 2', event_date: '2024-03-25T00:00:00Z' },
+      { id: '5', title: 'apr event', event_date: '2024-04-05T00:00:00Z' },
+    ],
+    requestPath:
+      '/solr/testcollection/select?q=*:*&wt=json&json.facet=' +
+      encodeURIComponent(
+        JSON.stringify({
+          monthly: {
+            type: 'range',
+            field: 'event_date',
+            start: '2024-01-01T00:00:00Z',
+            end: '2024-05-01T00:00:00Z',
+            gap: '+1MONTH',
+          },
+        }),
+      ),
+    solrSchema: {
+      fields: {
+        title: { type: 'text_general' },
+        event_date: { type: 'pdate' },
+      },
+    },
+    opensearchMapping: {
+      properties: {
+        title: { type: 'text' },
+        event_date: { type: 'date' },
+      },
+    },
+    assertionRules: [
+      ...SOLR_INTERNAL_RULES,
+      {
+        path: '$.response',
+        rule: 'ignore',
+        reason: 'Facet test — only validating $.facets, not hits',
+      },
+    ],
+  }),
+
   // ───────────────────────────────────────────────────────────
   // Field list (fl) tests — _source filtering
   // ───────────────────────────────────────────────────────────

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/aggs-to-facets.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/aggs-to-facets.ts
@@ -17,13 +17,18 @@ import type { ResponseContext, JavaMap } from '../context';
 import { isMapLike } from './utils';
 
 /**
- * Convert a single OpenSearch terms aggregation bucket to a Solr facet bucket.
+ * Convert a single OpenSearch aggregation bucket to a Solr facet bucket.
  *
- * Maps: key → val, doc_count → count
+ * Maps: key → val, doc_count → count.
+ *
+ * For date_histogram buckets, OpenSearch returns `key` as epoch millis and
+ * `key_as_string` as the formatted date string. Solr returns ISO-8601 strings,
+ * so we prefer `key_as_string` when present.
  */
 function convertBucket(osBucket: JavaMap): JavaMap {
   const solrBucket = new Map<string, any>();
-  solrBucket.set('val', osBucket.get('key'));
+  const keyAsString = osBucket.get('key_as_string');
+  solrBucket.set('val', keyAsString ?? osBucket.get('key'));
   solrBucket.set('count', osBucket.get('doc_count'));
   return solrBucket;
 }

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/json-facets.test.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/json-facets.test.ts
@@ -55,6 +55,11 @@ function histogramInner(aggs: JavaMap): JavaMap {
   return aggs.get(FACET_NAME).get('histogram');
 }
 
+/** Extract the inner "date_histogram" map from the aggs result for the default facet name. */
+function dateHistogramInner(aggs: JavaMap): JavaMap {
+  return aggs.get(FACET_NAME).get('date_histogram');
+}
+
 /** Extract the inner "range" map from the aggs result for the default facet name. */
 function rangeInner(aggs: JavaMap): JavaMap {
   return aggs.get(FACET_NAME).get('range');
@@ -73,6 +78,11 @@ function applyBodyHistogram(obj: Record<string, any>): JavaMap {
 /** Build a range facet context (with ranges), apply the transform, and return the inner range map. */
 function applyBodyRange(obj: Record<string, any>): JavaMap {
   return rangeInner(applyAndGetAggs(ctxWithBodyFacet({ type: 'range', ...obj })));
+}
+
+/** Build a date range facet context, apply the transform, and return the inner date_histogram map. */
+function applyBodyDateHistogram(obj: Record<string, any>): JavaMap {
+  return dateHistogramInner(applyAndGetAggs(ctxWithBodyFacet({ type: 'range', ...obj })));
 }
 
 // endregion
@@ -523,6 +533,191 @@ describe('arbitrary range facet conversion (range)', () => {
     expect(ranges[0].get('to')).toBe(50);
     expect(ranges[1].get('from')).toBe(50);
     expect(ranges[1].has('to')).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Date uniform range facet (date gap) → OpenSearch date_histogram aggregation
+// ---------------------------------------------------------------------------
+
+describe('date uniform range facet conversion (date_histogram)', () => {
+  it('should produce a date_histogram with calendar_interval for +1MONTH gap', () => {
+    const inner = applyBodyDateHistogram({
+      field: 'created_at',
+      start: '2024-01-01T00:00:00Z',
+      end: '2024-12-31T00:00:00Z',
+      gap: '+1MONTH',
+    });
+    expect(inner.get('field')).toBe('created_at');
+    expect(inner.get('calendar_interval')).toBe('1M');
+    expect(inner.has('fixed_interval')).toBe(false);
+    expect(inner.has('interval')).toBe(false);
+  });
+
+  it('should produce a date_histogram with calendar_interval for +1DAY gap', () => {
+    const inner = applyBodyDateHistogram({
+      field: 'timestamp',
+      start: '2024-01-01T00:00:00Z',
+      end: '2024-01-31T00:00:00Z',
+      gap: '+1DAY',
+    });
+    expect(inner.get('calendar_interval')).toBe('1d');
+  });
+
+  it('should produce a date_histogram with calendar_interval for +1YEAR gap', () => {
+    const inner = applyBodyDateHistogram({
+      field: 'timestamp',
+      start: '2020-01-01T00:00:00Z',
+      end: '2025-01-01T00:00:00Z',
+      gap: '+1YEAR',
+    });
+    expect(inner.get('calendar_interval')).toBe('1y');
+  });
+
+  it('should produce a date_histogram with fixed_interval for +5MINUTES gap', () => {
+    const inner = applyBodyDateHistogram({
+      field: 'event_time',
+      start: '2024-01-01T00:00:00Z',
+      end: '2024-01-01T01:00:00Z',
+      gap: '+5MINUTES',
+    });
+    expect(inner.get('fixed_interval')).toBe('5m');
+    expect(inner.has('calendar_interval')).toBe(false);
+  });
+
+  it('should produce a date_histogram with fixed_interval for +3HOURS gap', () => {
+    const inner = applyBodyDateHistogram({
+      field: 'event_time',
+      start: '2024-01-01T00:00:00Z',
+      end: '2024-01-02T00:00:00Z',
+      gap: '+3HOURS',
+    });
+    expect(inner.get('fixed_interval')).toBe('3h');
+  });
+
+  it('should return a Map with exactly one top-level "date_histogram" key', () => {
+    const aggs = applyAndGetAggs(
+      ctxWithBodyFacet({
+        type: 'range',
+        field: 'created_at',
+        start: '2024-01-01T00:00:00Z',
+        end: '2024-12-31T00:00:00Z',
+        gap: '+1MONTH',
+      }),
+    );
+    const agg = aggs.get(FACET_NAME);
+    expect(agg.size).toBe(1);
+    expect(agg.has('date_histogram')).toBe(true);
+    expect(agg.has('histogram')).toBe(false);
+  });
+
+  it('should set extended_bounds.min from start and omit max (end is exclusive)', () => {
+    const inner = applyBodyDateHistogram({
+      field: 'created_at',
+      start: '2024-01-01T00:00:00Z',
+      end: '2024-12-31T00:00:00Z',
+      gap: '+1MONTH',
+    });
+    const bounds = inner.get('extended_bounds');
+    expect(bounds).toBeDefined();
+    expect(bounds.get('min')).toBe('2024-01-01T00:00:00Z');
+    // Solr's end is exclusive — setting max=end would create an extra bucket
+    expect(bounds.has('max')).toBe(false);
+  });
+
+  it('should set format to strict_date_time_no_millis for ISO date output', () => {
+    const inner = applyBodyDateHistogram({
+      field: 'created_at',
+      start: '2024-01-01T00:00:00Z',
+      end: '2024-12-31T00:00:00Z',
+      gap: '+1MONTH',
+    });
+    expect(inner.get('format')).toBe('strict_date_time_no_millis');
+  });
+
+  it('should set only extended_bounds.min when end is absent', () => {
+    const inner = applyBodyDateHistogram({
+      field: 'created_at',
+      start: '2024-01-01T00:00:00Z',
+      gap: '+1MONTH',
+    });
+    const bounds = inner.get('extended_bounds');
+    expect(bounds.get('min')).toBe('2024-01-01T00:00:00Z');
+    expect(bounds.has('max')).toBe(false);
+  });
+
+  it('should not set extended_bounds when start and end are both absent', () => {
+    const inner = applyBodyDateHistogram({
+      field: 'created_at',
+      gap: '+1MONTH',
+    });
+    expect(inner.has('extended_bounds')).toBe(false);
+  });
+
+  it('should map mincount to min_doc_count', () => {
+    const inner = applyBodyDateHistogram({
+      field: 'created_at',
+      start: '2024-01-01T00:00:00Z',
+      end: '2024-12-31T00:00:00Z',
+      gap: '+1MONTH',
+      mincount: 1,
+    });
+    expect(inner.get('min_doc_count')).toBe(1);
+  });
+
+  it('should still produce numeric histogram for a numeric gap (regression)', () => {
+    const inner = applyBodyHistogram({ field: 'price', start: 0, end: 100, gap: 10 });
+    expect(inner.get('field')).toBe('price');
+    expect(inner.get('interval')).toBe(10);
+    expect(inner.has('calendar_interval')).toBe(false);
+    expect(inner.has('fixed_interval')).toBe(false);
+  });
+
+  it('should work from a query-string param with date gap', () => {
+    const ctx = ctxWithParamFacet({
+      type: 'range',
+      field: 'created_at',
+      start: '2024-01-01T00:00:00Z',
+      end: '2024-06-01T00:00:00Z',
+      gap: '+1MONTH',
+    });
+    request.apply(ctx);
+    const inner = dateHistogramInner(ctx.body.get('aggs'));
+    expect(inner.get('field')).toBe('created_at');
+    expect(inner.get('calendar_interval')).toBe('1M');
+  });
+
+  it('should warn about unsupported range params on date_histogram too', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    applyBodyDateHistogram({
+      field: 'created_at',
+      start: '2024-01-01T00:00:00Z',
+      end: '2024-12-31T00:00:00Z',
+      gap: '+1MONTH',
+      hardend: true,
+      include: 'lower',
+      other: 'before',
+    });
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('no direct OpenSearch histogram equivalent'),
+    );
+    warnSpy.mockRestore();
+  });
+
+  it('should produce date_histogram with fixed_interval for compound gap +1MONTH+2DAYS', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const inner = applyBodyDateHistogram({
+      field: 'created_at',
+      start: '2024-01-01T00:00:00Z',
+      end: '2024-12-31T00:00:00Z',
+      gap: '+1MONTH+2DAYS',
+    });
+    expect(inner.get('field')).toBe('created_at');
+    // 1 month (720h) + 2 days (48h) = 768h
+    expect(inner.get('fixed_interval')).toBe('768h');
+    expect(inner.has('calendar_interval')).toBe(false);
+    expect(inner.has('interval')).toBe(false);
+    warnSpy.mockRestore();
   });
 });
 

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/json-facets.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/json-facets.ts
@@ -9,7 +9,7 @@
  */
 import type { MicroTransform } from '../pipeline';
 import type { RequestContext, JavaMap } from '../context';
-import { convertSort, isMapLike } from './utils';
+import { convertSort, isMapLike, isSolrDateMathGap, convertSolrDateGap } from './utils';
 
 const FEATURE_NAME = 'json-facets';
 
@@ -211,9 +211,41 @@ function convertArbitraryRangeFacet(def: JavaMap, ranges: any): JavaMap {
 }
 
 /**
- * Convert Solr uniform range (start/end/gap) to an OpenSearch `histogram` aggregation.
+ * Determine whether a uniform range facet targets a date or numeric field.
+ *
+ * Current strategy: inspect the `gap` value for Solr date-math patterns
+ * (e.g. "+1MONTH", "+5MINUTES").
+ *
+ * Future: this function can be extended to accept explicit schema / field-type
+ * metadata when that support becomes available.
+ */
+type FieldTypeHint = 'numeric' | 'date';
+
+function detectFieldType(def: JavaMap): FieldTypeHint {
+  const gap = def.get('gap');
+  if (gap != null && typeof gap === 'string' && isSolrDateMathGap(gap)) {
+    return 'date';
+  }
+  return 'numeric';
+}
+
+/**
+ * Convert Solr uniform range (start/end/gap) to the appropriate OpenSearch
+ * aggregation — either `histogram` (numeric) or `date_histogram` (date).
  */
 function convertUniformRangeFacet(def: JavaMap): JavaMap {
+  const fieldType = detectFieldType(def);
+  if (fieldType === 'date') {
+    return convertDateHistogramFacet(def);
+  }
+  return convertNumericHistogramFacet(def);
+}
+
+/**
+ * Convert Solr uniform range (start/end/gap) to an OpenSearch `histogram` aggregation
+ * for numeric fields.
+ */
+function convertNumericHistogramFacet(def: JavaMap): JavaMap {
   const histogramInner = new Map<string, any>();
   histogramInner.set('field', def.get('field'));
 
@@ -239,7 +271,54 @@ function convertUniformRangeFacet(def: JavaMap): JavaMap {
   const mincount = def.get('mincount');
   if (mincount != null) histogramInner.set('min_doc_count', mincount);
 
-  // These Solr parameters have no direct OpenSearch histogram equivalent — warn if present.
+  warnUnsupportedRangeParams(def);
+  warnUnknownRangeKeys(def);
+
+  return new Map<string, any>([['histogram', histogramInner]]);
+}
+
+/**
+ * Convert Solr uniform range (start/end/gap) to an OpenSearch `date_histogram`
+ * aggregation for date fields.
+ *
+ * Unlike the numeric path, date extended_bounds pass through the raw start/end
+ * strings (no arithmetic), and the gap is translated via convertSolrDateGap().
+ */
+function convertDateHistogramFacet(def: JavaMap): JavaMap {
+  const dateHistInner = new Map<string, any>();
+  dateHistInner.set('field', def.get('field'));
+
+  const gap = def.get('gap');
+  if (gap != null) {
+    const interval = convertSolrDateGap(gap);
+    dateHistInner.set(interval.type, interval.value);
+  }
+
+  // Return ISO-8601 date strings (like Solr) instead of epoch millis
+  dateHistInner.set('format', 'strict_date_time_no_millis');
+
+  const start = def.get('start');
+  if (start != null) {
+    // Only set extended_bounds.min (start).
+    // Solr's "end" is exclusive — the last bucket starts *before* end.
+    // Setting extended_bounds.max = end would create an extra empty bucket
+    // at the end boundary, so we omit it.
+    const bounds = new Map<string, any>();
+    bounds.set('min', start);
+    dateHistInner.set('extended_bounds', bounds);
+  }
+
+  const mincount = def.get('mincount');
+  if (mincount != null) dateHistInner.set('min_doc_count', mincount);
+
+  warnUnsupportedRangeParams(def);
+  warnUnknownRangeKeys(def);
+
+  return new Map<string, any>([['date_histogram', dateHistInner]]);
+}
+
+/** Warn about Solr range parameters that have no direct OpenSearch histogram equivalent. */
+function warnUnsupportedRangeParams(def: JavaMap): void {
   const unsupportedParams: string[] = [];
   const hardend = def.get('hardend');
   if (hardend != null) unsupportedParams.push(`hardend=${hardend}`);
@@ -255,7 +334,10 @@ function convertUniformRangeFacet(def: JavaMap): JavaMap {
       `[${FEATURE_NAME}] Range facet parameters with no direct OpenSearch histogram equivalent: ${unsupportedParams.join(', ')}`,
     );
   }
+}
 
+/** Warn about unknown keys in a uniform range facet definition. */
+function warnUnknownRangeKeys(def: JavaMap): void {
   const knownKeys = new Set([
     'type',
     'field',
@@ -268,8 +350,6 @@ function convertUniformRangeFacet(def: JavaMap): JavaMap {
     'other',
   ]);
   warnUnknownKeys(def, knownKeys, 'range');
-
-  return new Map<string, any>([['histogram', histogramInner]]);
 }
 
 // endregion

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/utils.test.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/utils.test.ts
@@ -1,0 +1,257 @@
+import { describe, it, expect, vi } from 'vitest';
+import { convertSort, isSolrDateMathGap, convertSolrDateGap } from './utils';
+import type { JavaMap } from '../context';
+
+// ---------------------------------------------------------------------------
+// isSolrDateMathGap
+// ---------------------------------------------------------------------------
+
+describe('isSolrDateMathGap', () => {
+  it.each([
+    '+1MONTH',
+    '+1MONTHS',
+    '+1YEAR',
+    '+1YEARS',
+    '+1DAY',
+    '+1DAYS',
+    '+1HOUR',
+    '+1HOURS',
+    '+1MINUTE',
+    '+1MINUTES',
+    '+1SECOND',
+    '+1SECONDS',
+    '+5MINUTES',
+    '+12HOURS',
+    '+30DAYS',
+  ])('should return true for "%s"', (gap) => {
+    expect(isSolrDateMathGap(gap)).toBe(true);
+  });
+
+  it('should be case-insensitive', () => {
+    expect(isSolrDateMathGap('+1month')).toBe(true);
+    expect(isSolrDateMathGap('+1Month')).toBe(true);
+  });
+
+  it.each([
+    '+1MONTH+2DAYS',
+    '+1YEAR+6MONTHS',
+    '+1DAY+12HOURS',
+    '+1HOUR+30MINUTES',
+    '+1YEAR+1MONTH+1DAY',
+  ])('should return true for compound gap "%s"', (gap) => {
+    expect(isSolrDateMathGap(gap)).toBe(true);
+  });
+
+  it.each([
+    '10',
+    '1MONTH',       // missing +
+    '+MONTH',       // missing count
+    '+0.5MONTH',    // decimal count
+    'abc',
+    '',
+    '+1WEEK',       // unsupported unit
+    '+1',           // missing unit
+    '+1MONTH2DAYS', // missing + between components
+  ])('should return false for "%s"', (gap) => {
+    expect(isSolrDateMathGap(gap)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// convertSolrDateGap — calendar_interval (count = 1)
+// ---------------------------------------------------------------------------
+
+describe('convertSolrDateGap', () => {
+  describe('single-unit → calendar_interval', () => {
+    it.each([
+      ['+1YEAR', '1y'],
+      ['+1MONTH', '1M'],
+      ['+1DAY', '1d'],
+      ['+1HOUR', '1h'],
+      ['+1MINUTE', '1m'],
+      ['+1SECOND', '1s'],
+    ])('should convert "%s" to calendar_interval "%s"', (gap, expected) => {
+      const result = convertSolrDateGap(gap);
+      expect(result.type).toBe('calendar_interval');
+      expect(result.value).toBe(expected);
+    });
+
+    it('should accept plural forms for count=1', () => {
+      expect(convertSolrDateGap('+1MONTHS')).toEqual({ type: 'calendar_interval', value: '1M' });
+      expect(convertSolrDateGap('+1YEARS')).toEqual({ type: 'calendar_interval', value: '1y' });
+      expect(convertSolrDateGap('+1DAYS')).toEqual({ type: 'calendar_interval', value: '1d' });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // convertSolrDateGap — fixed_interval (count > 1, fixed-duration units)
+  // ---------------------------------------------------------------------------
+
+  describe('multi-unit fixed-duration → fixed_interval', () => {
+    it.each([
+      ['+5MINUTES', '5m'],
+      ['+3HOURS', '3h'],
+      ['+90SECONDS', '90s'],
+      ['+12HOURS', '12h'],
+      ['+30MINUTES', '30m'],
+    ])('should convert "%s" to fixed_interval "%s"', (gap, expected) => {
+      const result = convertSolrDateGap(gap);
+      expect(result.type).toBe('fixed_interval');
+      expect(result.value).toBe(expected);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // convertSolrDateGap — fixed_interval approximation (count > 1, calendar units)
+  // ---------------------------------------------------------------------------
+
+  describe('multi-unit calendar → fixed_interval approximation', () => {
+    it('should approximate +2MONTHS as 1440h and warn', () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const result = convertSolrDateGap('+2MONTHS');
+      expect(result.type).toBe('fixed_interval');
+      // 2 × 720h = 1440h
+      expect(result.value).toBe('1440h');
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('approximated'));
+      warnSpy.mockRestore();
+    });
+
+    it('should approximate +3YEARS as 26280h and warn', () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const result = convertSolrDateGap('+3YEARS');
+      expect(result.type).toBe('fixed_interval');
+      // 3 × 8760h = 26280h
+      expect(result.value).toBe('26280h');
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('approximated'));
+      warnSpy.mockRestore();
+    });
+
+    it('should approximate +2DAYS as 48h and warn', () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const result = convertSolrDateGap('+2DAYS');
+      expect(result.type).toBe('fixed_interval');
+      // 2 × 24h = 48h
+      expect(result.value).toBe('48h');
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('approximated'));
+      warnSpy.mockRestore();
+    });
+
+    it('should approximate +6MONTHS as 4320h', () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const result = convertSolrDateGap('+6MONTHS');
+      expect(result.type).toBe('fixed_interval');
+      // 6 × 720h = 4320h
+      expect(result.value).toBe('4320h');
+      warnSpy.mockRestore();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // convertSolrDateGap — compound gaps (e.g. +1MONTH+2DAYS)
+  // ---------------------------------------------------------------------------
+
+  describe('compound gaps → fixed_interval approximation', () => {
+    it('should convert +1MONTH+2DAYS to fixed_interval and warn', () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const result = convertSolrDateGap('+1MONTH+2DAYS');
+      expect(result.type).toBe('fixed_interval');
+      // 1 month (720h) + 2 days (48h) = 768h
+      expect(result.value).toBe('768h');
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Compound'));
+      warnSpy.mockRestore();
+    });
+
+    it('should convert +1YEAR+6MONTHS to fixed_interval and warn', () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const result = convertSolrDateGap('+1YEAR+6MONTHS');
+      expect(result.type).toBe('fixed_interval');
+      // 1 year (8760h) + 6 months (4320h) = 13080h
+      expect(result.value).toBe('13080h');
+      warnSpy.mockRestore();
+    });
+
+    it('should convert +1DAY+12HOURS to fixed_interval and warn', () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const result = convertSolrDateGap('+1DAY+12HOURS');
+      expect(result.type).toBe('fixed_interval');
+      // 1 day (24h) + 12 hours = 36h
+      expect(result.value).toBe('36h');
+      warnSpy.mockRestore();
+    });
+
+    it('should convert +1HOUR+30MINUTES to fixed_interval using minutes', () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const result = convertSolrDateGap('+1HOUR+30MINUTES');
+      expect(result.type).toBe('fixed_interval');
+      // 1 hour (60m) + 30 minutes = 90m
+      expect(result.value).toBe('90m');
+      warnSpy.mockRestore();
+    });
+
+    it('should convert +1MINUTE+30SECONDS to fixed_interval using seconds', () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const result = convertSolrDateGap('+1MINUTE+30SECONDS');
+      expect(result.type).toBe('fixed_interval');
+      // 1 minute (60s) + 30 seconds = 90s
+      expect(result.value).toBe('90s');
+      warnSpy.mockRestore();
+    });
+
+    it('should handle three-component compound gap', () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const result = convertSolrDateGap('+1YEAR+1MONTH+1DAY');
+      expect(result.type).toBe('fixed_interval');
+      // 1 year (8760h) + 1 month (720h) + 1 day (24h) = 9504h
+      expect(result.value).toBe('9504h');
+      warnSpy.mockRestore();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // convertSolrDateGap — error cases
+  // ---------------------------------------------------------------------------
+
+  describe('error handling', () => {
+    it('should throw for an unrecognised gap string', () => {
+      expect(() => convertSolrDateGap('10')).toThrow('Unrecognised Solr date gap');
+    });
+
+    it('should throw for a gap with an unknown unit', () => {
+      expect(() => convertSolrDateGap('+1WEEK')).toThrow('Unrecognised Solr date gap');
+    });
+
+    it('should throw for an empty string', () => {
+      expect(() => convertSolrDateGap('')).toThrow('Unrecognised Solr date gap');
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// convertSort (moved from json-facets.test.ts for co-location with utils.ts)
+// ---------------------------------------------------------------------------
+
+describe('convertSort with Map input', () => {
+  it('should convert a Map with count key to _count', () => {
+    const sortMap = new Map([['count', 'desc']]) as unknown as JavaMap;
+    const order = convertSort(sortMap);
+    expect(order.get('_count')).toBe('desc');
+  });
+
+  it('should convert a Map with index key to _key', () => {
+    const sortMap = new Map([['index', 'asc']]) as unknown as JavaMap;
+    const order = convertSort(sortMap);
+    expect(order.get('_key')).toBe('asc');
+  });
+
+  it('should default to desc when Map value is falsy', () => {
+    const sortMap = new Map([['count', '']]) as unknown as JavaMap;
+    const order = convertSort(sortMap);
+    expect(order.get('_count')).toBe('desc');
+  });
+
+  it('should pass through unknown sort keys from a Map', () => {
+    const sortMap = new Map([['my_stat', 'ASC']]) as unknown as JavaMap;
+    const order = convertSort(sortMap);
+    expect(order.get('my_stat')).toBe('asc');
+  });
+});

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/utils.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/utils.ts
@@ -1,5 +1,204 @@
 import { JavaMap } from '../context';
 
+// region Solr date math gap detection and conversion
+
+/**
+ * Solr date-math unit → OpenSearch interval suffix.
+ *
+ * Note: OpenSearch uses lowercase for all units except 'M' (month) to
+ * distinguish it from 'm' (minute).
+ */
+const SOLR_UNIT_TO_OS: Record<string, string> = {
+  YEAR: 'y',
+  YEARS: 'y',
+  MONTH: 'M',
+  MONTHS: 'M',
+  DAY: 'd',
+  DAYS: 'd',
+  HOUR: 'h',
+  HOURS: 'h',
+  MINUTE: 'm',
+  MINUTES: 'm',
+  SECOND: 's',
+  SECONDS: 's',
+};
+
+/**
+ * Units whose length varies with the calendar and therefore **cannot** be
+ * expressed as a fixed duration when the count is greater than 1.
+ *
+ * When the count is 1 we use `calendar_interval`; when > 1 we approximate
+ * with a `fixed_interval` and emit a warning.
+ */
+const CALENDAR_ONLY_UNITS = new Set(['YEAR', 'YEARS', 'MONTH', 'MONTHS', 'DAY', 'DAYS']);
+
+/** Approximate number of seconds in one calendar unit (used for fixed-interval fallback). */
+const APPROX_SECONDS: Record<string, number> = {
+  YEAR: 31536000,   // 365 × 24 × 3600
+  YEARS: 31536000,
+  MONTH: 2592000,   // 30 × 24 × 3600
+  MONTHS: 2592000,
+  DAY: 86400,       // 24 × 3600
+  DAYS: 86400,
+};
+
+/** Matches a single date-math component like "+1MONTH" or "+2DAYS".
+ *  Plural forms listed first so the regex engine doesn't short-circuit on the singular. */
+const SOLR_DATE_COMPONENT_RE = /\+(\d+)(YEARS|YEAR|MONTHS|MONTH|DAYS|DAY|HOURS|HOUR|MINUTES|MINUTE|SECONDS|SECOND)/gi;
+
+/** Matches the entire gap string — one or more components with nothing else. */
+const SOLR_DATE_GAP_SINGLE_RE = /^\+(\d+)(YEAR|YEARS|MONTH|MONTHS|DAY|DAYS|HOUR|HOURS|MINUTE|MINUTES|SECOND|SECONDS)$/i;
+
+/**
+ * Return `true` if `gap` looks like a Solr date-math gap string.
+ *
+ * Supports both simple gaps ("+1MONTH") and compound gaps ("+1MONTH+2DAYS").
+ */
+export function isSolrDateMathGap(gap: string): boolean {
+  // Build the full string from all matched components; if it equals the
+  // original then the entire string is valid date math.
+  const matches = gap.match(SOLR_DATE_COMPONENT_RE);
+  if (!matches) return false;
+  return matches.join('') === gap;
+}
+
+/** Result of converting a Solr date gap to an OpenSearch interval parameter. */
+export interface DateGapInterval {
+  /** The OpenSearch date-histogram parameter name to use. */
+  type: 'calendar_interval' | 'fixed_interval';
+  /** The interval value (e.g. "1M", "5m", "720h"). */
+  value: string;
+}
+
+/** Exact number of seconds in one fixed-duration Solr date math unit. */
+const EXACT_SECONDS: Record<string, number> = {
+  HOUR: 3600,
+  HOURS: 3600,
+  MINUTE: 60,
+  MINUTES: 60,
+  SECOND: 1,
+  SECONDS: 1,
+};
+
+/**
+ * Convert a total number of seconds to the most natural OpenSearch
+ * fixed_interval string: prefer hours if evenly divisible, then minutes,
+ * then seconds.
+ */
+function secondsToFixedInterval(totalSeconds: number): string {
+  if (totalSeconds % 3600 === 0) {
+    return `${totalSeconds / 3600}h`;
+  }
+  if (totalSeconds % 60 === 0) {
+    return `${totalSeconds / 60}m`;
+  }
+  return `${totalSeconds}s`;
+}
+
+/**
+ * Convert a Solr date-math gap string to an OpenSearch date-histogram
+ * interval specification.
+ *
+ * Supports simple gaps ("+1MONTH") and compound gaps ("+1MONTH+2DAYS").
+ *
+ * Rules for **simple** (single-component) gaps:
+ *   • count = 1 for any unit → `calendar_interval` (e.g. "1M", "1d")
+ *   • count > 1 for fixed-duration units (h/m/s) → `fixed_interval`
+ *   • count > 1 for calendar units (y/M/d) → `fixed_interval` with an
+ *     approximation (30 d/month, 365 d/year, 24 h/day) and a console warning
+ *
+ * **Compound** gaps are always converted to `fixed_interval` by summing
+ * all components into total seconds, with calendar units approximated.
+ *
+ * @throws Error if the gap string does not match the expected pattern.
+ */
+export function convertSolrDateGap(gap: string): DateGapInterval {
+  // Try simple (single-component) path first for the common case
+  const singleMatch = SOLR_DATE_GAP_SINGLE_RE.exec(gap);
+  if (singleMatch) {
+    return convertSimpleDateGap(gap, Number(singleMatch[1]), singleMatch[2].toUpperCase());
+  }
+
+  // Try compound path
+  return convertCompoundDateGap(gap);
+}
+
+/** Handle a single-component gap like "+1MONTH" or "+5MINUTES". */
+function convertSimpleDateGap(gap: string, count: number, solrUnit: string): DateGapInterval {
+  const osUnit = SOLR_UNIT_TO_OS[solrUnit];
+  if (!osUnit) {
+    throw new Error(`Unknown Solr date unit: "${solrUnit}"`);
+  }
+
+  // Single-unit → always calendar_interval
+  if (count === 1) {
+    return { type: 'calendar_interval', value: `1${osUnit}` };
+  }
+
+  // Multi-count, fixed-duration (h/m/s) → fixed_interval directly
+  if (!CALENDAR_ONLY_UNITS.has(solrUnit)) {
+    return { type: 'fixed_interval', value: `${count}${osUnit}` };
+  }
+
+  // Multi-count, calendar unit (y/M/d) → approximate as fixed duration
+  const totalSeconds = count * APPROX_SECONDS[solrUnit];
+  const value = secondsToFixedInterval(totalSeconds);
+  console.warn(
+    `[solr-date-gap] Solr gap "${gap}" approximated as fixed_interval "${value}" — bucket boundaries may not align with calendar ${solrUnit.toLowerCase()} boundaries.`,
+  );
+  return { type: 'fixed_interval', value };
+}
+
+/**
+ * Handle a compound gap like "+1MONTH+2DAYS" or "+1YEAR+6MONTHS".
+ *
+ * All components are summed into total seconds. Calendar units are
+ * approximated. A warning is always emitted because compound gaps
+ * cannot be represented as a single calendar_interval.
+ */
+function convertCompoundDateGap(gap: string): DateGapInterval {
+  // Use a fresh regex instance to avoid lastIndex issues with the global flag
+  // Plural forms listed first so the regex engine doesn't short-circuit on the singular
+  const re = /\+(\d+)(YEARS|YEAR|MONTHS|MONTH|DAYS|DAY|HOURS|HOUR|MINUTES|MINUTE|SECONDS|SECOND)/gi;
+  const components: Array<{ count: number; unit: string }> = [];
+  let reconstructed = '';
+  let m: RegExpExecArray | null;
+
+  while ((m = re.exec(gap)) !== null) {
+    components.push({ count: Number(m[1]), unit: m[2].toUpperCase() });
+    reconstructed += m[0];
+  }
+
+  if (components.length === 0 || reconstructed !== gap) {
+    throw new Error(`Unrecognised Solr date gap: "${gap}"`);
+  }
+
+  // Sum all components into total seconds
+  let totalSeconds = 0;
+  for (const { count, unit } of components) {
+    const approx = APPROX_SECONDS[unit];
+    if (approx == null) {
+      const exact = EXACT_SECONDS[unit];
+      if (exact == null) {
+        throw new Error(`Unknown Solr date unit in compound gap: "${unit}"`);
+      } else {
+        totalSeconds += count * exact;
+      }
+    } else {
+      totalSeconds += count * approx;
+    }
+  }
+
+  const value = secondsToFixedInterval(totalSeconds);
+
+  console.warn(
+    `[solr-date-gap] Compound Solr gap "${gap}" approximated as fixed_interval "${value}" — bucket boundaries may not align with calendar boundaries.`,
+  );
+  return { type: 'fixed_interval', value };
+}
+
+// endregion
+
 const SORT_KEY_MAP: Record<string, string> = {
   count: '_count',
   index: '_key',


### PR DESCRIPTION
### Description
Transforms Solr date range facets (e.g. gap: "+1MONTH") into OpenSearch date_histogram aggregations. Single-unit gaps use calendar_interval for exact calendar alignment; multi-unit and compound gaps (e.g. +2MONTHS, +1MONTH+2DAYS) fall back to an approximated fixed_interval with a warning.

### Testing
- Unit tests
- End to end tests

### Check List
- [x] New functionality includes testing
- [x] Limitations file updated.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
