### PR TITLE
feat(solr-transforms): Implement orchestrator for query translation engine

### DIFF
--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/orchestrator/translateQ.test.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/orchestrator/translateQ.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { translateQ } from './translateQ';
+import type { ASTNode } from '../ast/nodes';
+
+// vi.mock must come before importing the mocked modules —
+// vitest hoists these calls to the top of the file.
+vi.mock('../parser/parser', () => ({
+  parseSolrQuery: vi.fn(),
+}));
+vi.mock('../transformer/astToOpenSearch', () => ({
+  transformNode: vi.fn(),
+}));
+
+import { parseSolrQuery } from '../parser/parser';
+import { transformNode } from '../transformer/astToOpenSearch';
+
+const mockParse = vi.mocked(parseSolrQuery);
+const mockTransform = vi.mocked(transformNode);
+
+const params = (...entries: [string, string][]) => new Map(entries);
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+describe('translateQ', () => {
+  describe('successful translation', () => {
+    it('passes q and params to parser, then AST to transformer', () => {
+      const fakeAst: ASTNode = { type: 'matchAll' };
+      const fakeDsl = new Map([['match_all', new Map()]]);
+      mockParse.mockReturnValue({ ast: fakeAst, errors: [] });
+      mockTransform.mockReturnValue(fakeDsl);
+
+      const result = translateQ(params(['q', 'title:java'], ['df', 'content']));
+
+      expect(mockParse).toHaveBeenCalledWith('title:java', params(['q', 'title:java'], ['df', 'content']));
+      expect(mockTransform).toHaveBeenCalledWith(fakeAst);
+      expect(result.dsl).toBe(fakeDsl);
+      expect(result.warnings).toEqual([]);
+    });
+
+    it('defaults q to *:* when not provided', () => {
+      mockParse.mockReturnValue({ ast: { type: 'matchAll' }, errors: [] });
+      mockTransform.mockReturnValue(new Map([['match_all', new Map()]]));
+
+      translateQ(params(['df', 'content']));
+
+      expect(mockParse).toHaveBeenCalledWith('*:*', expect.any(Map));
+    });
+  });
+
+  describe('parse failure', () => {
+    it('returns passthrough with parse_error warnings', () => {
+      mockParse.mockReturnValue({
+        ast: null,
+        errors: [{ message: 'Unexpected )', position: 16 }],
+      });
+
+      const result = translateQ(params(['q', 'title:java AND )']));
+
+      expect(mockTransform).not.toHaveBeenCalled();
+      expect(result.dsl.has('query_string')).toBe(true);
+      expect((result.dsl.get('query_string') as Map<string, any>).get('query'))
+        .toBe('title:java AND )');
+      expect(result.warnings).toEqual([
+        { construct: 'parse_error', position: 16, message: 'Unexpected )' },
+      ]);
+    });
+
+    it('returns passthrough in partial mode on parse failure', () => {
+      mockParse.mockReturnValue({
+        ast: null,
+        errors: [{ message: 'Parse error', position: 0 }],
+      });
+
+      const result = translateQ(params(['q', ')']), 'partial');
+
+      expect(result.dsl.has('query_string')).toBe(true);
+      expect(result.warnings[0].construct).toBe('parse_error');
+    });
+  });
+
+  describe('transform failure', () => {
+    it('returns passthrough in passthrough-on-error mode', () => {
+      mockParse.mockReturnValue({ ast: { type: 'field', field: 'title', value: 'java' }, errors: [] });
+      mockTransform.mockImplementation(() => { throw new Error('No transform rule registered for node type: field'); });
+
+      const result = translateQ(params(['q', 'title:java']));
+
+      expect(result.dsl.has('query_string')).toBe(true);
+      expect((result.dsl.get('query_string') as Map<string, any>).get('query'))
+        .toBe('title:java');
+      expect(result.warnings).toEqual([
+        { construct: 'transform_error', message: 'No transform rule registered for node type: field' },
+      ]);
+    });
+
+    it('returns passthrough in partial mode', () => {
+      mockParse.mockReturnValue({ ast: { type: 'field', field: 'title', value: 'java' }, errors: [] });
+      mockTransform.mockImplementation(() => { throw new Error('No rule'); });
+
+      const result = translateQ(params(['q', 'title:java']), 'partial');
+
+      expect(result.dsl.has('query_string')).toBe(true);
+      expect(result.warnings[0].construct).toBe('transform_error');
+    });
+
+  });
+});

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/orchestrator/translateQ.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/orchestrator/translateQ.ts
@@ -23,6 +23,9 @@
  *     and attaches warnings for unsupported parts.
  */
 
+import { parseSolrQuery } from '../parser/parser';
+import { transformNode } from '../transformer/astToOpenSearch';
+
 export interface TranslateResult {
   /**
    * The OpenSearch Query DSL as a nested Map structure.
@@ -59,6 +62,16 @@ export interface TranslationWarning {
 export type TranslationMode = 'partial' | 'passthrough-on-error';
 
 /**
+ * Build a query_string passthrough DSL Map.
+ * Wraps the raw Solr query so OpenSearch can attempt to execute it as-is.
+ */
+function passthroughDsl(query: string): Map<string, any> {
+  return new Map([
+    ['query_string', new Map([['query', query]])],
+  ]);
+}
+
+/**
  * Translate a Solr query into OpenSearch Query DSL.
  *
  * @param params - All Solr request parameters. The orchestrator reads `q`
@@ -72,16 +85,42 @@ export type TranslationMode = 'partial' | 'passthrough-on-error';
  */
 export function translateQ(
   params: ReadonlyMap<string, string>,
-  mode?: TranslationMode,
+  mode: TranslationMode = 'passthrough-on-error',
 ): TranslateResult {
-  // TODO: implement
-  // 1. Read q from params (default to '*:*')
-  // 2. Call parseSolrQuery(q, params) from ../parser/parser
-  // 3. If ast is null (parse failure): return query_string passthrough
-  //    + warnings (same behavior for both modes — no AST to work with)
-  // 4. Call transformNode(ast) from ../transformer/astToOpenSearch
-  //    - In passthrough-on-error mode: abort on first unsupported construct, return passthrough
-  //    - In partial mode: translate supported parts, collect warnings
-  // 5. Return { dsl, warnings }
-  throw new Error('Not implemented');
+  const query = params.get('q') || '*:*';
+
+  // Stage 1: Parse
+  const { ast, errors } = parseSolrQuery(query, params);
+
+  // Parse failure — passthrough regardless of mode (no AST to work with)
+  if (ast === null) {
+    const warnings: TranslationWarning[] = errors.map((e) => ({
+      construct: 'parse_error',
+      position: e.position,
+      message: e.message,
+    }));
+    return { dsl: passthroughDsl(query), warnings };
+  }
+
+  // Stage 2: Transform
+  try {
+    const dsl = transformNode(ast);
+    return { dsl, warnings: [] };
+  } catch (err: unknown) {
+    // Transform failure — unsupported node type or unexpected error
+    const message = (err as Error).message;
+    const warning: TranslationWarning = {
+      construct: 'transform_error',
+      message,
+    };
+
+    if (mode === 'passthrough-on-error') {
+      return { dsl: passthroughDsl(query), warnings: [warning] };
+    }
+
+    // Partial mode: return what we have (passthrough for now)
+    // TODO: implement partial translation of subtrees when more rules exist —
+    // walk the AST, translate supported nodes, passthrough unsupported ones.
+    return { dsl: passthroughDsl(query), warnings: [warning] };
+  }
 }


### PR DESCRIPTION
Wire the parser → transformer pipeline in translateQ. Reads q from params, parses into AST, transforms to OpenSearch DSL Maps.

On parse failure, returns query_string passthrough with parse_error warnings (same for both modes).

On transform failure:
  - passthrough-on-error (default): returns passthrough + warning
  - partial: returns passthrough + warning (partial subtree translation to be implemented when more rules are registered)

Never throws — always returns { dsl, warnings }.

### Description
<!-- Describe what this change achieves -->

### Issues Resolved
<!-- List any GitHub or Jira issues this PR will resolve -->

### Testing
<!-- Please provide details of testing done: unit testing, integration testing and manual testing -->

### Check List
- [ ] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
