### PR TITLE
Add ignore-error=true to BuildKit cache-to to prevent transient cache export failures

### DIFF
--- a/buildSrc/src/main/groovy/org/opensearch/migrations/image/RegistryImageBuildUtils.groovy
+++ b/buildSrc/src/main/groovy/org/opensearch/migrations/image/RegistryImageBuildUtils.groovy
@@ -352,7 +352,7 @@ class RegistryImageBuildUtils {
                             "-t ${primaryDest}",
                             *(versionTaggedDest ? ["-t", "${versionTaggedDest}"] : []),
                             "--push",
-                            "--cache-to=type=registry,ref=${cacheDestination}${suffix},mode=max",
+                            "--cache-to=type=registry,ref=${cacheDestination}${suffix},mode=max,ignore-error=true",
                             "--cache-from=type=registry,ref=${cacheDestination}${suffix}"
                     ]
                     buildArgFlags.each { fullArgs.add(it) }
@@ -382,7 +382,7 @@ class RegistryImageBuildUtils {
                         "-t ${primaryDest}",
                         *(versionTaggedDest ? ["-t", "${versionTaggedDest}"] : []),
                         "--push",
-                        "--cache-to=type=registry,ref=${cacheDestination},mode=max",
+                        "--cache-to=type=registry,ref=${cacheDestination},mode=max,ignore-error=true",
                         "--cache-from=type=registry,ref=${cacheDestination}",
                         "--cache-from=type=registry,ref=${cacheDestination}_amd64",
                         "--cache-from=type=registry,ref=${cacheDestination}_arm64"


### PR DESCRIPTION
## Description

BuildKit multi-platform builds can intermittently fail with `400 Bad Request` when exporting cache layers to Docker Hub. This happens due to concurrent blob upload race conditions during multi-arch builds — when both platform builds try to commit the same shared base layer, the second PUT gets rejected because the blob was already committed.

This failure occurs during the cache export phase, not the actual image push, so the images themselves are fine. Adding `ignore-error=true` to the `--cache-to` flag ensures cache export errors are non-fatal, preventing these transient failures from breaking release builds.

## Changes

- Added `ignore-error=true` to `--cache-to` flags in both single-platform and multi-arch BuildKit tasks in `RegistryImageBuildUtils.groovy`

## Testing

- No functional change to image builds — only affects error handling for cache export
- Cache will still be exported when possible; failures are simply tolerated instead of fatal

## References

- [BuildKit `ignore-error` docs](https://docs.docker.com/build/cache/backends/registry/#ignore-error)
