### PR TITLE
fix: support output generation from transformed config

### DIFF
--- a/orchestrationSpecs/packages/config-processor/src/migrationInitializer.ts
+++ b/orchestrationSpecs/packages/config-processor/src/migrationInitializer.ts
@@ -25,7 +25,12 @@ export class MigrationInitializer {
      * Generate output files including workflow config, approval ConfigMaps, and concurrency ConfigMaps with semaphores
      */
     async generateOutputFiles(workflows: ARGO_WORKFLOW_SCHEMA, outputDir: string, userConfig: any): Promise<void> {
-        const bundle = await this.generateMigrationBundle(userConfig);
+        const bundle = userConfig == null ? {
+            workflows,
+            approvalConfigMaps: this.generateApprovalConfigMaps(userConfig),
+            concurrencyConfigMaps: this.generateConcurrencyConfigMaps(userConfig),
+            crdResources: this.generateCRDResources(workflows)
+        } : await this.generateMigrationBundle(userConfig);
         await this.writeBundleToFiles(bundle, outputDir);
     }
 

--- a/orchestrationSpecs/packages/config-processor/tests/generateOutputFiles.test.ts
+++ b/orchestrationSpecs/packages/config-processor/tests/generateOutputFiles.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from '@jest/globals';
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+// Use require here to avoid type-only export resolution issues under ts-jest/workspace mapping.
+const { MigrationInitializer } = require('../src/migrationInitializer');
+
+describe('generateOutputFiles', () => {
+    it('writes transformed workflows even when only transformed-config input is available', async () => {
+        const outputDir = await fs.mkdtemp(path.join(os.tmpdir(), 'config-processor-output-'));
+        const workflows = [{ hello: 'world' }] as any;
+        const initializer = Object.create(MigrationInitializer.prototype);
+
+        try {
+            await initializer.generateOutputFiles(workflows, outputDir, null);
+
+            await expect(fs.readFile(path.join(outputDir, 'workflowMigration.config.yaml'), 'utf-8'))
+                .resolves.toBe(JSON.stringify(workflows, null, 2));
+
+            await expect(fs.readFile(path.join(outputDir, 'approvalConfigMaps.yaml'), 'utf-8'))
+                .resolves.toContain('kind: List');
+            await expect(fs.readFile(path.join(outputDir, 'concurrencyConfigMaps.yaml'), 'utf-8'))
+                .resolves.toContain('kind: List');
+            await expect(fs.readFile(path.join(outputDir, 'crdResources.yaml'), 'utf-8'))
+                .resolves.toContain('kind: List');
+        } finally {
+            await fs.rm(outputDir, { recursive: true, force: true });
+        }
+    });
+});


### PR DESCRIPTION
## Summary
- allow `generateOutputFiles` to reuse already-transformed workflows when no user config is available
- still emit the auxiliary ConfigMap/CRD files in that path
- add a regression test covering transformed-config + output-dir usage

## Why
The CLI accepts `--transformed-config`, but when `--output-dir` is also provided it tried to re-transform `userConfig` even though that input is null on the transformed-config path. That caused output generation to fail instead of writing the expected files.

## Validation
- added a regression test for `generateOutputFiles(workflows, outputDir, null)`
- reran `npm test -- --runInBand` in `orchestrationSpecs/packages/config-processor`
