### PR TITLE
Widen cleanup stack matching from 'OpenSearchDomain' to 'OpenSearch'

### DIFF
--- a/test/cleanupDeployment/cleanup_deployment.py
+++ b/test/cleanupDeployment/cleanup_deployment.py
@@ -12,7 +12,8 @@ logger = logging.getLogger(__name__)
 
 INDEPENDENT_STACKS = ['MigrationConsole', 'ReindexFromSnapshot', 'TrafficReplayer', 'TargetClusterProxy',
                       'CaptureProxy', 'KafkaBroker', 'OpenSearchContainer', 'CaptureProxyES', 'Elasticsearch']
-CORE_STACKS_ORDERED = ['MigrationInfra', 'OpenSearchDomain', 'NetworkInfra', 'infra-stack', 'network-stack']
+CORE_STACKS_ORDERED = ['MigrationInfra', 'OpenSearchDomain', 'OpenSearch',
+                       'NetworkInfra', 'infra-stack', 'network-stack']
 CFN_INITIAL_STATUS_SKIP = ['DELETE_IN_PROGRESS', 'DELETE_COMPLETE']
 MAX_DELETE_STACK_RETRIES = 3
 MAX_WAIT_MINUTES = 45


### PR DESCRIPTION
## Problem

Stacks like `OpenSearch-eks-integ-1-us-east-1` were not being cleaned up because `CORE_STACKS_ORDERED` in `cleanup_deployment.py` only matched `OpenSearchDomain`.

## Solution

Shorten the match string from `OpenSearchDomain` to `OpenSearch` so it matches both `OpenSearchDomain-*` and `OpenSearch-*` stacks.

Note: `OpenSearchContainer` is already handled separately in `INDEPENDENT_STACKS`, and the substring match is checked via `core_id in stack_name`, so `OpenSearch` correctly matches any stack containing that prefix.