### PR TITLE
Adding translator for range query

### DIFF
--- a/TrafficCapture/SolrTransformations/transforms/build.mjs
+++ b/TrafficCapture/SolrTransformations/transforms/build.mjs
@@ -92,6 +92,7 @@ for (const entry of transforms) {
     format: 'esm',
     target: 'es2020',
     treeShaking: true,
+    loader: { '.pegjs': 'text' },
     outfile: outPath,
     plugins: [graalvmWrapPlugin()],
   };
@@ -121,6 +122,7 @@ for (const entry of testCaseFiles) {
     format: 'esm',
     target: 'es2020',
     treeShaking: true,
+    loader: { '.pegjs': 'text' },
     outfile: outPath,
     plugins: [testCaseExtractPlugin()],
   };
@@ -150,6 +152,7 @@ for (const entry of configFiles) {
     format: 'esm',
     target: 'es2020',
     treeShaking: true,
+    loader: { '.pegjs': 'text' },
     outfile: outPath,
     plugins: [{
       name: 'config-extract',

--- a/TrafficCapture/SolrTransformations/transforms/src/pegjs.d.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/pegjs.d.ts
@@ -1,0 +1,4 @@
+declare module '*.pegjs' {
+  const grammar: string;
+  export default grammar;
+}

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/query-q.test.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/query-q.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import { request } from './query-q';
+import type { RequestContext, JavaMap } from '../context';
+
+/** Create a mock RequestContext for testing. */
+function createMockContext(params: Record<string, string>): RequestContext {
+  const body = new Map<string, any>();
+  return {
+    msg: new Map() as JavaMap,
+    endpoint: 'select',
+    collection: 'test',
+    params: new URLSearchParams(params),
+    body: body as JavaMap,
+  };
+}
+
+describe('query-q request transform', () => {
+  it('has correct name', () => {
+    expect(request.name).toBe('query-q');
+  });
+
+  it('sets query from translateQ result', () => {
+    const ctx = createMockContext({ q: '*:*' });
+    request.apply(ctx);
+    expect(ctx.body.has('query')).toBe(true);
+  });
+
+  it('converts rows param to size', () => {
+    const ctx = createMockContext({ q: '*:*', rows: '25' });
+    request.apply(ctx);
+    expect(ctx.body.get('size')).toBe(25);
+  });
+
+  it('converts start param to from', () => {
+    const ctx = createMockContext({ q: '*:*', start: '10' });
+    request.apply(ctx);
+    expect(ctx.body.get('from')).toBe(10);
+  });
+
+  it('handles both rows and start together', () => {
+    const ctx = createMockContext({ q: '*:*', rows: '50', start: '100' });
+    request.apply(ctx);
+    expect(ctx.body.get('size')).toBe(50);
+    expect(ctx.body.get('from')).toBe(100);
+  });
+
+  it('does not set size when rows is absent', () => {
+    const ctx = createMockContext({ q: '*:*' });
+    request.apply(ctx);
+    expect(ctx.body.has('size')).toBe(false);
+  });
+
+  it('does not set from when start is absent', () => {
+    const ctx = createMockContext({ q: '*:*' });
+    request.apply(ctx);
+    expect(ctx.body.has('from')).toBe(false);
+  });
+
+  it('defaults to *:* when q is missing', () => {
+    const ctx = createMockContext({});
+    request.apply(ctx);
+    // translateQ defaults to *:* which should produce some query
+    expect(ctx.body.has('query')).toBe(true);
+  });
+});

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/query-q.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/query-q.ts
@@ -10,6 +10,7 @@
  */
 import type { MicroTransform } from '../pipeline';
 import type { RequestContext, JavaMap } from '../context';
+import { translateQ } from '../query-engine/orchestrator/translateQ';
 
 export function parseSolrQuery(q: string): JavaMap {
   if (!q || q === '*:*') return new Map([['match_all', new Map()]]);
@@ -24,11 +25,22 @@ export function parseSolrQuery(q: string): JavaMap {
   return new Map([['query_string', new Map([['query', q]])]]);
 }
 
+/** Convert URLSearchParams to a Map for translateQ. */
+function paramsToMap(params: URLSearchParams): Map<string, string> {
+  const map = new Map<string, string>();
+  for (const [key, value] of params.entries()) {
+    map.set(key, value);
+  }
+  return map;
+}
+
 export const request: MicroTransform<RequestContext> = {
   name: 'query-q',
   apply: (ctx) => {
-    const q = ctx.params.get('q') || '*:*';
-    ctx.body.set('query', parseSolrQuery(q));
+    const result = translateQ(paramsToMap(ctx.params));
+    ctx.body.set('query', result.dsl);
+
+    // TODO: expose result.warnings to caller for observability
 
     // rows → size, start → from
     const rows = ctx.params.get('rows');

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/integration-tests/standard-query-parser/range-query.testcase.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/integration-tests/standard-query-parser/range-query.testcase.ts
@@ -1,0 +1,122 @@
+/**
+ * Test cases for Solr Standard Query Parser (Lucene) → OpenSearch transformation.
+ *
+ * These tests validate the query-engine's ability to parse and transform
+ * Solr's standard query parser syntax into OpenSearch Query DSL.
+ *
+ * Adding a new test: just add a solrTest() entry below.
+ * It automatically runs against every Solr version in matrix.config.ts.
+ *
+ * Each test case defines:
+ * - solrSchema: the Solr collection's field types (applied via Schema API)
+ * - opensearchMapping: the corresponding OpenSearch index mapping
+ * - documents: data seeded into both backends
+ * - requestPath: the Solr query to test
+ * - assertionRules: expected differences from Solr (everything else must match exactly)
+ */
+import { solrTest } from '../../../test-types';
+import type { TestCase } from '../../../test-types';
+
+export const testCases: TestCase[] = [
+  // ───────────────────────────────────────────────────────────
+  // Range queries
+  // ───────────────────────────────────────────────────────────
+
+  solrTest('query-range-inclusive-exclusive', {
+    description: 'Range queries with inclusive and exclusive bounds',
+    documents: [
+      { id: '1', title: 'cheap low stock', price: 10, stock: 5 },
+      { id: '2', title: 'mid good stock', price: 50, stock: 25 },
+      { id: '3', title: 'expensive high stock', price: 100, stock: 50 },
+      { id: '4', title: 'luxury item', price: 500, stock: 10 },
+      { id: '5', title: 'free item', price: 0, stock: 100 },
+    ],
+    // price:[10 TO 100] AND stock:{0 TO 50}
+    requestPath: '/solr/testcollection/select?q=' + encodeURIComponent('price:[10 TO 100] AND stock:{0 TO 50}') + '&wt=json',
+    solrSchema: {
+      fields: {
+        title: { type: 'text_general' },
+        price: { type: 'pint' },
+        stock: { type: 'pint' },
+      },
+    },
+    opensearchMapping: {
+      properties: {
+        title: { type: 'text' },
+        price: { type: 'integer' },
+        stock: { type: 'integer' },
+      },
+    },
+  }),
+
+  solrTest('query-range-mixed-inclusive-exclusive', {
+    description: 'Range query with inclusive lower and exclusive upper bound [10 TO 100}',
+    documents: [
+      { id: '1', title: 'item at lower bound', price: 10 },
+      { id: '2', title: 'item in middle', price: 50 },
+      { id: '3', title: 'item at upper bound', price: 100 },
+      { id: '4', title: 'item above upper', price: 150 },
+    ],
+    // price:[10 TO 100} — includes 10, excludes 100
+    requestPath: '/solr/testcollection/select?q=' + encodeURIComponent('price:[10 TO 100}') + '&wt=json',
+    solrSchema: {
+      fields: {
+        title: { type: 'text_general' },
+        price: { type: 'pint' },
+      },
+    },
+    opensearchMapping: {
+      properties: {
+        title: { type: 'text' },
+        price: { type: 'integer' },
+      },
+    },
+  }),
+
+  solrTest('query-range-unbounded-upper', {
+    description: 'Range query with unbounded upper bound [10 TO *]',
+    documents: [
+      { id: '1', title: 'below threshold', price: 5 },
+      { id: '2', title: 'at threshold', price: 10 },
+      { id: '3', title: 'above threshold', price: 100 },
+      { id: '4', title: 'way above', price: 1000 },
+    ],
+    // price:[10 TO *] — 10 and above
+    requestPath: '/solr/testcollection/select?q=' + encodeURIComponent('price:[10 TO *]') + '&wt=json',
+    solrSchema: {
+      fields: {
+        title: { type: 'text_general' },
+        price: { type: 'pint' },
+      },
+    },
+    opensearchMapping: {
+      properties: {
+        title: { type: 'text' },
+        price: { type: 'integer' },
+      },
+    },
+  }),
+
+  solrTest('query-range-fully-unbounded-exists', {
+    description: 'Range query [* TO *] matches documents where field exists',
+    documents: [
+      { id: '1', title: 'has price', price: 50 },
+      { id: '2', title: 'also has price', price: 0 },
+      { id: '3', title: 'no price field' },
+    ],
+    // price:[* TO *] — field exists check
+    requestPath: '/solr/testcollection/select?q=' + encodeURIComponent('price:[* TO *]') + '&wt=json',
+    solrSchema: {
+      fields: {
+        title: { type: 'text_general' },
+        price: { type: 'pint' },
+      },
+    },
+    opensearchMapping: {
+      properties: {
+        title: { type: 'text' },
+        price: { type: 'integer' },
+      },
+    },
+  }),
+];

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/parser/parser.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/parser/parser.ts
@@ -38,22 +38,17 @@
  */
 
 import * as peggy from 'peggy';
-import { readFileSync } from 'node:fs';
+import grammar from './solr.pegjs';
 import type { ASTNode } from '../ast/nodes';
 import type { ParseResult, ParseError } from './types';
 
-// Lazily compiled parser — the grammar is read from disk and compiled
+// Lazily compiled parser — the grammar is inlined at build time and compiled
 // on the first call to parseSolrQuery, then cached for all subsequent calls.
-// This avoids paying the compile cost at module import time.
 let parserInstance: peggy.Parser | null = null;
-
-// Path to the grammar file, co-located with this module.
-const GRAMMAR_PATH = new URL('solr.pegjs', import.meta.url);
 
 /** Return the cached parser, compiling the grammar on first call. */
 function getParser(): peggy.Parser {
   if (parserInstance) return parserInstance;
-  const grammar = readFileSync(GRAMMAR_PATH, 'utf-8');
   parserInstance = peggy.generate(grammar);
   return parserInstance;
 }

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/transformer/astToOpenSearch.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/transformer/astToOpenSearch.ts
@@ -38,6 +38,7 @@
 import type { ASTNode } from '../ast/nodes';
 import type { TransformRuleFn } from './types';
 import { boolRule } from './rules/boolRule';
+import { rangeRule } from './rules/rangeRule';
 
 /**
  * Registry of transform functions, keyed by AST node type.
@@ -47,8 +48,9 @@ import { boolRule } from './rules/boolRule';
  *   2. Register it here with the node's `type` discriminant as the key
  */
 const rules: Record<string, TransformRuleFn> = {
-  bool: boolRule,
   // TODO: register remaining rules as they are implemented
+  bool: boolRule,
+  range: rangeRule,
 };
 
 /**

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/transformer/rules/rangeRule.test.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/transformer/rules/rangeRule.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect } from 'vitest';
+import { rangeRule } from './rangeRule';
+import type { RangeNode, FieldNode } from '../../ast/nodes';
+
+/** Stub transformChild — not used by rangeRule but required by signature. */
+const stubTransformChild = () => new Map();
+
+describe('rangeRule', () => {
+  it('transforms inclusive range [10 TO 100] to gte/lte', () => {
+    const node: RangeNode = {
+      type: 'range',
+      field: 'price',
+      lower: '10',
+      upper: '100',
+      lowerInclusive: true,
+      upperInclusive: true,
+    };
+
+    const result = rangeRule(node, stubTransformChild);
+
+    expect(result).toEqual(
+      new Map([['range', new Map([['price', new Map([['gte', '10'], ['lte', '100']])]])]]),
+    );
+  });
+
+  it('transforms exclusive range {10 TO 100} to gt/lt', () => {
+    const node: RangeNode = {
+      type: 'range',
+      field: 'price',
+      lower: '10',
+      upper: '100',
+      lowerInclusive: false,
+      upperInclusive: false,
+    };
+
+    const result = rangeRule(node, stubTransformChild);
+
+    expect(result).toEqual(
+      new Map([['range', new Map([['price', new Map([['gt', '10'], ['lt', '100']])]])]]),
+    );
+  });
+
+  it('transforms mixed range [10 TO 100} to gte/lt', () => {
+    const node: RangeNode = {
+      type: 'range',
+      field: 'price',
+      lower: '10',
+      upper: '100',
+      lowerInclusive: true,
+      upperInclusive: false,
+    };
+
+    const result = rangeRule(node, stubTransformChild);
+
+    expect(result).toEqual(
+      new Map([['range', new Map([['price', new Map([['gte', '10'], ['lt', '100']])]])]]),
+    );
+  });
+
+  it('transforms mixed range {10 TO 100] to gt/lte', () => {
+    const node: RangeNode = {
+      type: 'range',
+      field: 'price',
+      lower: '10',
+      upper: '100',
+      lowerInclusive: false,
+      upperInclusive: true,
+    };
+
+    const result = rangeRule(node, stubTransformChild);
+
+    expect(result).toEqual(
+      new Map([['range', new Map([['price', new Map([['gt', '10'], ['lte', '100']])]])]]),
+    );
+  });
+
+  it('omits lower bound when unbounded [* TO 100]', () => {
+    const node: RangeNode = {
+      type: 'range',
+      field: 'price',
+      lower: '*',
+      upper: '100',
+      lowerInclusive: true,
+      upperInclusive: true,
+    };
+
+    const result = rangeRule(node, stubTransformChild);
+
+    expect(result).toEqual(
+      new Map([['range', new Map([['price', new Map([['lte', '100']])]])]]),
+    );
+  });
+
+  it('omits upper bound when unbounded [10 TO *]', () => {
+    const node: RangeNode = {
+      type: 'range',
+      field: 'price',
+      lower: '10',
+      upper: '*',
+      lowerInclusive: true,
+      upperInclusive: true,
+    };
+
+    const result = rangeRule(node, stubTransformChild);
+
+    expect(result).toEqual(
+      new Map([['range', new Map([['price', new Map([['gte', '10']])]])]]),
+    );
+  });
+
+  it('converts fully unbounded [* TO *] to exists query', () => {
+    const node: RangeNode = {
+      type: 'range',
+      field: 'price',
+      lower: '*',
+      upper: '*',
+      lowerInclusive: true,
+      upperInclusive: true,
+    };
+
+    const result = rangeRule(node, stubTransformChild);
+
+    expect(result).toEqual(
+      new Map([['exists', new Map([['field', 'price']])]]),
+    );
+  });
+
+  it('preserves field name in output', () => {
+    const node: RangeNode = {
+      type: 'range',
+      field: 'created_at',
+      lower: '2024-01-01',
+      upper: '2024-12-31',
+      lowerInclusive: true,
+      upperInclusive: true,
+    };
+
+    const result = rangeRule(node, stubTransformChild);
+    const rangeMap = result.get('range') as Map<string, any>;
+
+    expect(rangeMap.has('created_at')).toBe(true);
+  });
+
+  it('throws when called with wrong node type', () => {
+    const wrongNode: FieldNode = { type: 'field', field: 'title', value: 'java' };
+    expect(() => rangeRule(wrongNode, stubTransformChild)).toThrow(
+      'rangeRule called with wrong node type: field',
+    );
+  });
+});

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/transformer/rules/rangeRule.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/transformer/rules/rangeRule.ts
@@ -1,0 +1,51 @@
+/**
+ * Transformation rule for RangeNode → OpenSearch `range` query.
+ *
+ * Maps Solr's range syntax to OpenSearch's range query:
+ *   RangeNode.lowerInclusive=true  → gte (greater than or equal)
+ *   RangeNode.lowerInclusive=false → gt  (greater than)
+ *   RangeNode.upperInclusive=true  → lte (less than or equal)
+ *   RangeNode.upperInclusive=false → lt  (less than)
+ *
+ * Unbounded ranges use `*` which is omitted from the output.
+ *
+ * Examples:
+ *   `price:[10 TO 100]` → Map{"range" → Map{"price" → Map{"gte" → "10", "lte" → "100"}}}
+ *   `price:{10 TO 100}` → Map{"range" → Map{"price" → Map{"gt" → "10", "lt" → "100"}}}
+ *   `price:[10 TO 100}` → Map{"range" → Map{"price" → Map{"gte" → "10", "lt" → "100"}}}
+ *   `price:[* TO 100]`  → Map{"range" → Map{"price" → Map{"lte" → "100"}}}
+ *   `price:[10 TO *]`   → Map{"range" → Map{"price" → Map{"gte" → "10"}}}
+ */
+
+import type { ASTNode } from '../../ast/nodes';
+import type { TransformRuleFn } from '../types';
+
+export const rangeRule: TransformRuleFn = (
+  node: ASTNode,
+  // Range is a leaf node — transformChild not used
+  _transformChild,
+): Map<string, any> => {
+  if (node.type !== 'range') {
+    console.error(`rangeRule called with wrong node type: ${node.type}`);
+    throw new Error(`rangeRule called with wrong node type: ${node.type}`);
+  }
+
+  const { field, lower, upper, lowerInclusive, upperInclusive } = node;
+
+  // [* TO *] means "field exists" in Solr — convert to exists query
+  if (lower === '*' && upper === '*') {
+    return new Map([['exists', new Map([['field', field]])]]);
+  }
+
+  const bounds = new Map<string, string>();
+
+  // Only include bounds that are not unbounded (*)
+  if (lower !== '*') {
+    bounds.set(lowerInclusive ? 'gte' : 'gt', lower);
+  }
+  if (upper !== '*') {
+    bounds.set(upperInclusive ? 'lte' : 'lt', upper);
+  }
+
+  return new Map([['range', new Map([[field, bounds]])]]);
+};

--- a/TrafficCapture/SolrTransformations/transforms/vitest.config.ts
+++ b/TrafficCapture/SolrTransformations/transforms/vitest.config.ts
@@ -1,6 +1,22 @@
 import { defineConfig } from "vitest/config";
+import { readFileSync } from "node:fs";
+import { Plugin } from "vite";
+
+/** Vite plugin that loads solr.pegjs as a raw text string for the parser module. */
+function pegJsRawPlugin(): Plugin {
+  return {
+    name: "pegjs-raw",
+    transform(_code, id) {
+      if (id.endsWith("query-engine/parser/solr.pegjs")) {
+        const text = readFileSync(id, "utf-8");
+        return { code: `export default ${JSON.stringify(text)};` };
+      }
+    },
+  };
+}
 
 export default defineConfig({
+  plugins: [pegJsRawPlugin()],
   test: {
     coverage: {
       provider: "v8",


### PR DESCRIPTION
### Description
This translates [Solr range query](https://solr.apache.org/guide/solr/latest/query-guide/standard-query-parser.html#range-searches) param to OpenSearch equivalent

This also address parsing errors of PEG grammer
Problem - 
```
The issue is that esbuild doesn't know it's bundling code for Node.js.

By default, esbuild assumes it's bundling for the browser. When it encounters import { readFileSync } from 'node:fs' in parser.ts, it tries to find node:fs as a package on disk — which doesn't exist as a file, it's a Node.js built-in module. So esbuild 
throws:

│ Could not resolve "node:fs" ... The package "node:fs" wasn't found on the file system but is built into node.
```

Fixes
```
1. parser.ts — replaced the runtime readFileSync + import.meta.url approach with a static import grammar from './solr.pegjs' that esbuild inlines as a string at build time
2. build.mjs — removed platform: 'node' (wrong for GraalVM target), added loader: { '.pegjs': 'text' } to all three build configs so esbuild treats .pegjs files as raw text
3. src/pegjs.d.ts — new type declaration so TypeScript understands .pegjs imports

The grammar is now embedded directly in the bundle as a string constant — no filesystem access needed at runtime, which is exactly what GraalVM requires.
```
### Testing
Unit tests

### Check List
- [x] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
