### PR TITLE
Reverse some Kyverno commits from PR 2443

### DIFF
--- a/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/templates/childrenChartInstaller/installJob.yaml
+++ b/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/templates/childrenChartInstaller/installJob.yaml
@@ -12,7 +12,7 @@ metadata:
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
-  backoffLimit: 3
+  backoffLimit: 1
   ttlSecondsAfterFinished: 600
   template:
     metadata:
@@ -26,10 +26,6 @@ spec:
         - name: helm-installer
           image: {{ .Values.images.installer.repository }}:{{ .Values.images.installer.tag }}
           imagePullPolicy: {{ .Values.images.installer.pullPolicy }}
-          {{- with .Values.installer.resources }}
-          resources:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
           command:
             - /bin/sh
             - -c
@@ -123,8 +119,6 @@ spec:
                         - resources:
                             kinds:
                               - Pod
-                            operations:
-                              - CREATE
                     mutate:
                       patchStrategicMerge:
                         metadata:

--- a/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/templates/childrenChartInstaller/uninstallJob.yaml
+++ b/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/templates/childrenChartInstaller/uninstallJob.yaml
@@ -12,7 +12,7 @@ metadata:
     "helm.sh/hook-weight": "-10"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
-  backoffLimit: 3
+  backoffLimit: 1
   ttlSecondsAfterFinished: 600
   template:
     metadata:
@@ -26,10 +26,6 @@ spec:
         - name: helm-uninstaller
           image: {{ .Values.images.installer.repository}}:{{ .Values.images.installer.tag }}
           imagePullPolicy: {{ .Values.images.installer.pullPolicy }}
-          {{- with .Values.installer.resources }}
-          resources:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
           command:
             - /bin/sh
             - -c
@@ -60,7 +56,7 @@ metadata:
     "helm.sh/hook-weight": "10"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
-  backoffLimit: 3
+  backoffLimit: 1
   ttlSecondsAfterFinished: 600
   template:
     metadata:

--- a/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/values.yaml
+++ b/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/values.yaml
@@ -124,13 +124,6 @@ installer:
     name: "migrations-service-account"
   rbac:
     create: true
-  resources:
-    requests:
-      cpu: "250m"
-      memory: "512Mi"
-    limits:
-      cpu: "1000m"
-      memory: "1Gi"
 
 # For OTEL Operator
 extraOtelConfiguration:

--- a/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/valuesForLocalK8s.yaml
+++ b/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/valuesForLocalK8s.yaml
@@ -27,17 +27,6 @@ images:
     repository: localhost:5000/migrations/migration_console
     pullPolicy: Always
 
-# Zero out installer resources to match Kyverno zero-resource-requests policy.
-# Prevents Kyverno from mutating the pod spec, which breaks job finalizer removal.
-installer:
-  resources:
-    requests:
-      cpu: "0"
-      memory: "0"
-    limits:
-      cpu: "0"
-      memory: "0"
-
 # Kyverno chart configuration
 charts:
   kyverno:

--- a/libraries/testAutomation/testAutomation/k8s_service.py
+++ b/libraries/testAutomation/testAutomation/k8s_service.py
@@ -318,7 +318,7 @@ class K8sService:
             return True
         logger.info(f"Installing {release_name} from {chart_path} with values {values_file}")
         command = self._helm_base() + ["install", release_name, chart_path, "-n", self.namespace, "--create-namespace",
-                                       "--wait", "--timeout", "5m"]
+                                       "--wait", "--timeout", "20m"]
         if values_file:
             command.extend(["-f", values_file])
         if values:
@@ -334,26 +334,15 @@ class K8sService:
         """Dump detailed debug info when helm install fails."""
         logger.error("=== BEGIN HELM INSTALL DEBUG INFO ===")
         debug_commands = [
-            ("All pods", self._kubectl_base() + ["get", "pods", "--all-namespaces", "-o", "wide"]),
-            ("All events", self._kubectl_base() + ["get", "events", "--all-namespaces", "--sort-by=.lastTimestamp"]),
-            ("kube-system pod logs", self._kubectl_base() + [
-                "logs", "-n", "kube-system", "--all-containers", "--prefix", "--tail=200",
-                "-l", "tier=control-plane"]),
-        ]
-        debug_commands.extend([
+            (f"Pods in {self.namespace}", self._kubectl_base() + ["get", "pods", "-n", self.namespace, "-o", "wide"]),
+            ("Pods in kyverno-ma", self._kubectl_base() + ["get", "pods", "-n", "kyverno-ma", "-o", "wide"]),
             (f"Jobs in {self.namespace}", self._kubectl_base() + ["get", "jobs", "-n", self.namespace, "-o", "wide"]),
-            ("Job status detail", self._kubectl_base() + [
-                "get", "jobs", "-n", self.namespace, "-l", f"app.kubernetes.io/instance={release_name}",
-                "-o", "jsonpath={range .items[*]}name={.metadata.name} succeeded={.status.succeeded} "
-                "failed={.status.failed} conditions={.status.conditions[*].type} "
-                "uncountedSucceeded={.status.uncountedTerminatedPods.succeeded} "
-                "uncountedFailed={.status.uncountedTerminatedPods.failed}{\"\\n\"}{end}"]),
-            ("Pod finalizers", self._kubectl_base() + [
-                "get", "pods", "-n", self.namespace, "-l", f"app.kubernetes.io/instance={release_name}",
-                "-o", "jsonpath={range .items[*]}name={.metadata.name} phase={.status.phase} "
-                "finalizers={.metadata.finalizers}{\"\\n\"}{end}"]),
+            (f"Events in {self.namespace}", self._kubectl_base() + [
+                "get", "events", "-n", self.namespace, "--sort-by=.lastTimestamp"]),
+            ("Events in kyverno-ma", self._kubectl_base() + [
+                "get", "events", "-n", "kyverno-ma", "--sort-by=.lastTimestamp"]),
             ("Helm list all namespaces", self._helm_base() + ["list", "--all-namespaces"]),
-        ])
+        ]
         for label, cmd in debug_commands:
             try:
                 result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)


### PR DESCRIPTION
### Description
Reverts the following 15 commits:
- d53f6c0 Restrict Kyverno zero-resource policy to CREATE operations only
- e2b410c Add installer pod resources to fix Kyverno mutation breaking job finalizer
- 5d0c846 Use label selector for control-plane logs instead of hardcoded pod name
- 2b4c84d Add kube-controller-manager logs to debug dump
- 3fe9800 Dump all-namespaces pods and events in debug info
- f7cf7c3 Fix unclosed paren in debug info dump
- afbe8cc Add kube-system to helm debug info dump
- 5901a4f Reduce helm install timeout from 20m to 5m
- 9f32908 Revert pipeline to original - remove feature gate changes
- bedde18 Increase backoffLimit to 3 for helm hook Jobs
- 00b3d97 Revert helm hooks back to Job (was incorrectly left as Pod)
- be79f54 Fix flake8 F541: remove unnecessary f-string prefixes
- 4becd1f Add diagnostic logging for Job finalizer-tracking state
- 938c2a4 Convert helm hooks from Job to Pod for K8s 1.31+ compatibility
- f5a24bc Increase helm job backoffLimit to fix SuccessCriteriaMet race condition

The next PR will replace those with what should be direct fixes to kyverno's ClusterPolicy.

### Testing
Installation job still fails, but that's expected since it had failed at a7f1db6c2f5e2447de138f66b5bd552a3ecf7e66.

### Check List
- [ ] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
