### PR TITLE
Fix 'Version id must contain OpenSearch mask' error when migrating ES 8.x to OS 3.4+

### DIFF
--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/common/InvalidResponse.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/common/InvalidResponse.java
@@ -18,6 +18,7 @@ import lombok.extern.slf4j.Slf4j;
 public class InvalidResponse extends RfsException {
     private static final Pattern UNKNOWN_SETTING = Pattern.compile("unknown setting \\[([a-zA-Z0-9_.-]+)\\].+");
     private static final Pattern PRIVATE_SETTING = Pattern.compile(".*private index setting \\[([a-zA-Z0-9_.-]+)\\] can not be set explicitly.*");
+    private static final Pattern VERSION_MASK_ERROR = Pattern.compile("Version id \\d+ must contain OpenSearch mask");
     private static final Pattern UNSUPPORTED_MAPPING_PARAM = Pattern.compile("unsupported parameters:\\s+(.+)");
     private static final Pattern MAPPING_PARAM_NAME = Pattern.compile("\\[([a-zA-Z0-9_.]+)\\s*:");
     private static final Pattern AWARENESS_ATTRIBUTE_EXCEPTION = Pattern.compile("expected total copies needs to be a multiple of total awareness attributes");
@@ -144,6 +145,13 @@ public class InvalidResponse extends RfsException {
             matcher = PRIVATE_SETTING.matcher(reason);
             if (matcher.matches()) {
                 return Map.entry(type, matcher.group(1));
+            }
+
+            // Try matching "Version id N must contain OpenSearch mask" — caused by ES 8.x
+            // IndexVersion IDs in index.version.created that lack the OpenSearch MASK bit
+            matcher = VERSION_MASK_ERROR.matcher(reason);
+            if (matcher.matches()) {
+                return Map.entry(type, "index.version.created");
             }
 
             return null;

--- a/RFS/src/test/java/org/opensearch/migrations/bulkload/common/InvalidResponseTest.java
+++ b/RFS/src/test/java/org/opensearch/migrations/bulkload/common/InvalidResponseTest.java
@@ -199,6 +199,29 @@ class InvalidResponseTest {
     }
 
     @Test
+    void testGetIllegalArguments_versionMaskError() {
+        var errorBody = "{\r\n" +
+            "  \"error\": {\r\n" +
+            "    \"root_cause\": [\r\n" +
+            "      {\r\n" +
+            "        \"type\": \"illegal_argument_exception\",\r\n" +
+            "        \"reason\": \"Version id 8521000 must contain OpenSearch mask\"\r\n" +
+            "      }\r\n" +
+            "    ],\r\n" +
+            "    \"type\": \"illegal_argument_exception\",\r\n" +
+            "    \"reason\": \"Version id 8521000 must contain OpenSearch mask\"\r\n" +
+            "  },\r\n" +
+            "  \"status\": 400\r\n" +
+            "}";
+        var response = new HttpResponse(400, "Bad Request", Map.of(), errorBody);
+        var iar = new InvalidResponse("ignored", response);
+
+        var result = iar.getIllegalArguments();
+
+        assertThat(result, containsInAnyOrder("index.version.created"));
+    }
+
+    @Test
     void testGetUnsupportedMappingParameters_singleParam() {
         var errorBody = "{\r\n" +
             "  \"error\": {\r\n" +


### PR DESCRIPTION
## Description

Fixes index creation failures when migrating from Elasticsearch 8.17+ to OpenSearch 3.4+.

### Problem

ES 8.17+ writes decoupled IndexVersion IDs (e.g. `8521000`) into `index.version.created` instead of release-derived version IDs. On OpenSearch 3.4+, sending this value triggers:

```
{"type":"illegal_argument_exception","reason":"Version id 8521000 must contain OpenSearch mask"}
```

This differs from OS 3.0 which rejects `version.created` as a private setting (already handled by the retry loop). OS 3.4+ actually attempts to parse the version ID and fails because it lacks the MASK bit (`0x08000000`).

### Fix

Added a `VERSION_MASK_ERROR` regex pattern in `InvalidResponse` to recognize `"Version id N must contain OpenSearch mask"` and map it to `index.version.created`. This lets the existing retry loop in `IndexCreator_OS_2_11` strip the setting and retry index creation successfully.

### Testing

- Unit test in `InvalidResponseTest` verifying the new pattern extracts `index.version.created`
- E2e test (`VersionCreatedSettingTest`) migrating ES 8.17 and ES 8.19 → OS 3.4.0 via snapshot
  - Fails without the fix (exit code 1)
  - Passes with the fix
- Also adds `OS_V3_4_0` container version