### PR TITLE
Fix deploy cluster script failing on dirty checkout

### DIFF
--- a/deployment/migration-assistant-solution/package-artifacts.sh
+++ b/deployment/migration-assistant-solution/package-artifacts.sh
@@ -24,7 +24,7 @@ mkdir -p "${TEMP_DIR}/deployment/open-source"
 export CODE_BUCKET SOLUTION_NAME CODE_VERSION
 
 cd "${SCRIPT_DIR}"
-npm install
+npm ci
 
 echo "Synthesizing CloudFormation templates..."
 npx cdk synth --asset-metadata false --path-metadata false --quiet

--- a/test/awsDeployCluster.sh
+++ b/test/awsDeployCluster.sh
@@ -130,7 +130,7 @@ else
   echo "Repo already exists, skipping clone."
 fi
 cd amazon-opensearch-service-sample-cdk && git checkout -- . && git fetch --tags && git checkout "$SAMPLE_CDK_VERSION"
-npm install
+npm ci
 
 cd ..
 cp -f "$PROVIDED_CONTEXT_FILE_PATH" "$CLUSTER_CDK_CONTEXT_FILE_PATH"

--- a/test/awsE2ESolutionSetup.sh
+++ b/test/awsE2ESolutionSetup.sh
@@ -245,7 +245,7 @@ else
   echo "Repo already exists, skipping clone."
 fi
 cd opensearch-cluster-cdk && git pull && git checkout migration-es && git pull
-npm install
+npm ci
 if [ "$BOOTSTRAP_REGION" = true ] ; then
   bootstrap_region
 fi
@@ -280,7 +280,7 @@ if [ "$SKIP_MIGRATION_DEPLOY" = false ] ; then
     echo "Error: building docker images failed, exiting."
     exit 1
   fi
-  npm install
+  npm ci
   cdk deploy "*" --c contextFile="$MIGRATION_GEN_CONTEXT_FILE" --c contextId="$MIGRATION_CONTEXT_ID" --require-approval never --concurrency 3
   if [ $? -ne 0 ]; then
     echo "Error: deploying migration stacks failed, exiting."


### PR DESCRIPTION
When the sample CDK repo already exists from a previous run, `npm install` leaves `package-lock.json` modified. The subsequent `git checkout` of the tag version fails because of these uncommitted changes.

**Fix:** Add `git checkout -- .` before the tag checkout to discard leftover modifications from the previous run.

**Error:**
```
error: Your local changes to the following files would be overwritten by checkout:
	package-lock.json
Please commit your changes or stash them before you switch branches.
Aborting
```