### PR TITLE
Remove redundant virtualenv activation in migration console Dockerfile

### DIFF
--- a/migrationConsole/Dockerfile
+++ b/migrationConsole/Dockerfile
@@ -133,7 +133,6 @@ RUN echo '. /.venv/bin/activate' >> /etc/profile.d/venv.sh && \
     echo '. /etc/profile.d/venv.sh' >> ~/.bashrc && \
     echo 'echo Welcome to the Migration Assistant Console' >> ~/.bashrc && \
     echo 'eval "$(register-python-argcomplete cluster_tools)"' >> ~/.bashrc && \
-    echo 'source /.venv/bin/activate' >> ~/.bashrc && \
     echo 'console completion bash 2> /dev/null > /usr/share/bash-completion/completions/console' >> ~/.bashrc && \
     echo 'workflow util completions bash > /usr/share/bash-completion/completions/workflow' >> ~/.bashrc && \
     echo 'PS1="(\\t) \\[\\e[92m\\]migration-console \\[\\e[0m\\](\\w) -> "'>> ~/.bashrc


### PR DESCRIPTION
## Description

The migration console Dockerfile sets up Python virtualenv activation via two paths in `~/.bashrc`:

1. **`/etc/profile.d/venv.sh`** — sourced from `~/.bashrc`, which in turn sources `/.venv/bin/activate`
2. **Direct `source /.venv/bin/activate`** — also appended to `~/.bashrc`

This causes the virtualenv to be activated twice every time an interactive shell starts. The second activation is redundant since `/etc/profile.d/venv.sh` already handles it.

## Changes

Removed the redundant `source /.venv/bin/activate` line from the `~/.bashrc` setup in the Dockerfile. The single activation path through `/etc/profile.d/venv.sh` is preserved.

## Testing

- No behavioral change — the virtualenv is still activated on every interactive shell session
- The only difference is it activates once instead of twice

## Diff

```diff
-    echo 'source /.venv/bin/activate' >> ~/.bashrc && \
```