### PR TITLE
Added Support for Query Facets Translation

### DIFF
--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/cases.testcase.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/cases.testcase.ts
@@ -261,6 +261,49 @@ export const testCases: TestCase[] = [
     ],
   }),
 
+  solrTest('facet-query', {
+    description: 'Query facet counting documents matching specific queries',
+    documents: [
+      { id: '1', title: 'laptop', category: 'electronics', price: 999 },
+      { id: '2', title: 'phone', category: 'electronics', price: 699 },
+      { id: '3', title: 'shirt', category: 'clothing', price: 29 },
+      { id: '4', title: 'pants', category: 'clothing', price: 59 },
+      { id: '5', title: 'apple', category: 'food', price: 3 },
+      { id: '6', title: 'banana', category: 'food', price: 2 },
+    ],
+    requestPath:
+      '/solr/testcollection/select?q=*:*&wt=json&json.facet=' +
+      encodeURIComponent(
+        JSON.stringify({
+          expensive: { type: 'query', q: 'price:[100 TO *]' },
+          cheap: { type: 'query', q: 'price:[* TO 50]' },
+          electronics: { type: 'query', q: 'category:electronics' },
+        }),
+      ),
+    solrSchema: {
+      fields: {
+        title: { type: 'text_general' },
+        category: { type: 'string' },
+        price: { type: 'pfloat' },
+      },
+    },
+    opensearchMapping: {
+      properties: {
+        title: { type: 'text' },
+        category: { type: 'keyword' },
+        price: { type: 'float' },
+      },
+    },
+    assertionRules: [
+      ...SOLR_INTERNAL_RULES,
+      {
+        path: '$.response',
+        rule: 'ignore',
+        reason: 'Facet test — only validating $.facets, not hits',
+      },
+    ],
+  }),
+
   solrTest('facet-date-range', {
     description: 'Date range facet using start/end/gap with +1MONTH calendar interval',
     documents: [

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/aggs-to-facets.test.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/aggs-to-facets.test.ts
@@ -180,6 +180,36 @@ describe('aggs-to-facets MicroTransform', () => {
     });
   });
 
+  describe('filter aggregation (query facet) conversion', () => {
+    it('should convert doc_count to count for a filter aggregation (no buckets)', () => {
+      const filterAgg = new Map<string, any>([['doc_count', 17]]);
+      const aggs = new Map([['expensive', filterAgg]]);
+      const body = new Map<string, any>([['aggregations', aggs]]);
+      const ctx = buildCtx(body, { hitsTotal: 100 });
+      response.apply(ctx);
+
+      const facets: JavaMap = ctx.responseBody.get('facets');
+      const expensive: JavaMap = facets.get('expensive');
+      expect(expensive.get('count')).toBe(17);
+      expect(expensive.has('buckets')).toBe(false);
+    });
+
+    it('should handle filter aggregations alongside terms aggregations', () => {
+      const filterAgg = new Map<string, any>([['doc_count', 5]]);
+      const aggs = new Map<string, any>([
+        ['cheap', filterAgg],
+        ['categories', osTermsAgg([{ key: 'food', doc_count: 3 }])],
+      ]);
+      const body = new Map<string, any>([['aggregations', aggs]]);
+      const ctx = buildCtx(body, { hitsTotal: 50 });
+      response.apply(ctx);
+
+      const facets: JavaMap = ctx.responseBody.get('facets');
+      expect(facets.get('cheap').get('count')).toBe(5);
+      expect(facets.get('categories').get('buckets')).toHaveLength(1);
+    });
+  });
+
   describe('error handling', () => {
     it('should throw when an aggregation result is not a Map', () => {
       const aggs = new Map([['myFacet', 'not-a-map']]);

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/aggs-to-facets.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/aggs-to-facets.ts
@@ -47,6 +47,7 @@ function convertSingleAgg(aggResult: any): JavaMap {
 
   const buckets: any[] = aggResult.get('buckets');
   if (Array.isArray(buckets)) {
+    // Terms / range / histogram aggregations — convert each bucket
     const solrBuckets: JavaMap[] = [];
     for (const bucket of buckets) {
       if (!isMapLike(bucket)) {
@@ -55,6 +56,9 @@ function convertSingleAgg(aggResult: any): JavaMap {
       solrBuckets.push(convertBucket(bucket));
     }
     facetResult.set('buckets', solrBuckets);
+  } else if (aggResult.has('doc_count')) {
+    // Filter aggregation (from query facet) — just has doc_count, no buckets
+    facetResult.set('count', aggResult.get('doc_count'));
   }
 
   return facetResult;

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/json-facets.test.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/json-facets.test.ts
@@ -65,6 +65,11 @@ function rangeInner(aggs: JavaMap): JavaMap {
   return aggs.get(FACET_NAME).get('range');
 }
 
+/** Extract the inner "filter" map from the aggs result for the default facet name. */
+function filterInner(aggs: JavaMap): JavaMap {
+  return aggs.get(FACET_NAME).get('filter');
+}
+
 /** Build a terms facet context, apply the transform, and return the inner terms map. */
 function applyBodyTerms(obj: Record<string, any>): JavaMap {
   return termsInner(applyAndGetAggs(ctxWithBodyFacet({ type: 'terms', ...obj })));
@@ -83,6 +88,11 @@ function applyBodyRange(obj: Record<string, any>): JavaMap {
 /** Build a date range facet context, apply the transform, and return the inner date_histogram map. */
 function applyBodyDateHistogram(obj: Record<string, any>): JavaMap {
   return dateHistogramInner(applyAndGetAggs(ctxWithBodyFacet({ type: 'range', ...obj })));
+}
+
+/** Build a query facet context, apply the transform, and return the inner filter map. */
+function applyBodyQuery(obj: Record<string, any>): JavaMap {
+  return filterInner(applyAndGetAggs(ctxWithBodyFacet({ type: 'query', ...obj })));
 }
 
 // endregion
@@ -752,6 +762,66 @@ describe('convertSort with Map input', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Query facet → OpenSearch filter aggregation
+// ---------------------------------------------------------------------------
+
+describe('query facet conversion (filter)', () => {
+  it('should produce a filter aggregation with a query_string for a free-text query', () => {
+    const inner = applyBodyQuery({ q: 'hello world' });
+    expect(inner.get('query_string')).toBeDefined();
+    expect(inner.get('query_string').get('query')).toBe('hello world');
+  });
+
+  it('should produce a filter aggregation with query_string for a Lucene range query', () => {
+    const inner = applyBodyQuery({ q: 'popularity:[100 TO *]' });
+    expect(inner.get('query_string')).toBeDefined();
+    expect(inner.get('query_string').get('query')).toBe('popularity:[100 TO *]');
+  });
+
+  it('should return a Map with exactly one top-level "filter" key', () => {
+    const aggs = applyAndGetAggs(
+      ctxWithBodyFacet({ type: 'query', q: 'status:active' }),
+    );
+    const agg = aggs.get(FACET_NAME);
+    expect(agg.size).toBe(1);
+    expect(agg.has('filter')).toBe(true);
+  });
+
+  it('should produce match_all for q: "*:*"', () => {
+    const inner = applyBodyQuery({ q: '*:*' });
+    expect(inner.get('match_all')).toBeDefined();
+  });
+
+  it('should produce a query_string for q: "field:value"', () => {
+    const inner = applyBodyQuery({ q: 'status:active' });
+    expect(inner.get('query_string')).toBeDefined();
+    expect(inner.get('query_string').get('query')).toBe('status:active');
+  });
+
+  it('should default to match_all when q is absent', () => {
+    const inner = applyBodyQuery({});
+    expect(inner.get('match_all')).toBeDefined();
+  });
+
+  it('should work from a query-string param', () => {
+    const ctx = ctxWithParamFacet({ type: 'query', q: 'hello world' });
+    request.apply(ctx);
+    const inner = filterInner(ctx.body.get('aggs'));
+    expect(inner.get('query_string')).toBeDefined();
+    expect(inner.get('query_string').get('query')).toBe('hello world');
+  });
+
+  it('should warn about unknown keys in a query facet definition', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    applyBodyQuery({ q: '*:*', unknownParam: 'bar' });
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Unprocessed keys in query facet'),
+    );
+    warnSpy.mockRestore();
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Edge cases and warning paths (json-facets.ts coverage gaps)
 // ---------------------------------------------------------------------------
 
@@ -831,8 +901,8 @@ describe('edge cases and warning paths', () => {
 
   it('should throw for an unimplemented facet type', () => {
     expect(() => {
-      applyAndGetAggs(ctxWithBodyFacet({ type: 'query', field: 'x' }));
-    }).toThrow("Facet type 'query' is not implemented");
+      applyAndGetAggs(ctxWithBodyFacet({ type: 'heatmap', field: 'x' }));
+    }).toThrow("Facet type 'heatmap' is not implemented");
   });
 
   it('should return empty map for non-map facet definition', () => {

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/json-facets.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/json-facets.ts
@@ -354,6 +354,36 @@ function warnUnknownRangeKeys(def: JavaMap): void {
 
 // endregion
 
+// region Query facet
+
+/**
+ * Convert a Solr query facet to an OpenSearch `filter` aggregation.
+ *
+ * Solr query facet:
+ *   { "type": "query", "q": "popularity:[100 TO *]" }
+ *
+ * OpenSearch filter aggregation:
+ *   { "filter": { "query_string": { "query": "popularity:[100 TO *]" } } }
+ *
+ * The `q` parameter is converted as follows:
+ *   - `*:*` (or absent) → `match_all`
+ *   - Everything else → `query_string` passthrough, which lets OpenSearch
+ *     parse the full Lucene query syntax (ranges, booleans, wildcards, etc.)
+ */
+function convertQueryFacet(def: JavaMap): JavaMap {
+  const q = (def.get('q') || '*:*').toString();
+  const query: JavaMap = (!q || q === '*:*')
+    ? new Map([['match_all', new Map()]])
+    : new Map([['query_string', new Map([['query', q]])]]);
+
+  const knownKeys = new Set(['type', 'q']);
+  warnUnknownKeys(def, knownKeys, 'query');
+
+  return new Map<string, any>([['filter', query]]);
+}
+
+// endregion
+
 /** Log a warning for any keys in a facet definition that are not in the known set. */
 function warnUnknownKeys(def: JavaMap, knownKeys: Set<string>, facetType: string): void {
   const unknownKeys: string[] = [];
@@ -384,6 +414,8 @@ function convertSingleFacet(facetDef: any): JavaMap {
       return convertTermsFacet(facetDef);
     case 'range':
       return convertRangeFacet(facetDef);
+    case 'query':
+      return convertQueryFacet(facetDef);
     default:
       throw new Error(`Facet type '${type}' is not implemented`);
   }


### PR DESCRIPTION
### Description
Converts Solr `type: "query"` JSON facets to OpenSearch `filter` aggregations using `query_string` passthrough (`*:*` → `match_all`). Response path maps `doc_count` back to Solr's `count`. Includes unit and integration tests.


### Testing
- Unit tests
- E2E tests

### Check List
- [x] New functionality includes testing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
