### PR TITLE
Integrated OTel. Added one sample metric instrument.

### DIFF
--- a/TrafficCapture/transformationShim/build.gradle
+++ b/TrafficCapture/transformationShim/build.gradle
@@ -5,6 +5,7 @@ plugins {
 }
 
 dependencies {
+    implementation project(':coreUtilities')
     implementation project(':transformation:transformationPlugins:jsonMessageTransformers:jsonMessageTransformerInterface')
     implementation project(':transformation:transformationPlugins:jsonMessageTransformers:jsonJSTransformer')
     implementation project(':transformation:transformationPlugins:jsonMessageTransformers:jsonMessageTransformerLoaders')
@@ -23,6 +24,7 @@ dependencies {
     runtimeOnly project(':transformation:transformationPlugins:jsonMessageTransformers:jsonJSTransformerProvider')
 
     testImplementation libs.junit.jupiter.api
+    testImplementation testFixtures(project(':coreUtilities'))
     testRuntimeOnly libs.junit.jupiter.engine
 }
 

--- a/TrafficCapture/transformationShim/src/main/java/org/opensearch/migrations/transform/shim/ShimMain.java
+++ b/TrafficCapture/transformationShim/src/main/java/org/opensearch/migrations/transform/shim/ShimMain.java
@@ -15,10 +15,15 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Supplier;
 
+import org.opensearch.migrations.tracing.ActiveContextTracker;
+import org.opensearch.migrations.tracing.ActiveContextTrackerByActivityType;
+import org.opensearch.migrations.tracing.CompositeContextTracker;
+import org.opensearch.migrations.tracing.RootOtelContext;
 import org.opensearch.migrations.transform.IJsonTransformer;
 import org.opensearch.migrations.transform.JavascriptTransformer;
 import org.opensearch.migrations.transform.shim.netty.BasicAuthSigningHandler;
 import org.opensearch.migrations.transform.shim.netty.SigV4SigningHandler;
+import org.opensearch.migrations.transform.shim.tracing.RootShimProxyContext;
 import org.opensearch.migrations.transform.shim.validation.DocCountValidator;
 import org.opensearch.migrations.transform.shim.validation.DocIdValidator;
 import org.opensearch.migrations.transform.shim.validation.FieldIgnoringEquality;
@@ -110,6 +115,11 @@ public class ShimMain {
             description = "Port for the health check endpoint. If not set, no health server is started.")
         public int healthPort = -1;
 
+        @Parameter(names = {"--otelCollectorEndpoint"},
+            description = "OpenTelemetry Collector endpoint URL (e.g. http://localhost:4317). "
+                + "If not set, instrumentation runs in no-op mode.")
+        public String otelCollectorEndpoint;
+
         @Parameter(names = {"--watchTransforms"},
             description = "Watch transform JS files for changes and hot-reload them.")
         public boolean watchTransforms;
@@ -139,9 +149,15 @@ public class ShimMain {
         Set<String> activeTargets = parseActiveTargets(params, targets);
         List<ValidationRule> validators = parseValidators(params);
 
+        var otelSdk = RootOtelContext.initializeOpenTelemetryWithCollectorOrAsNoop(
+            params.otelCollectorEndpoint, "shimProxy", "shim-" + params.listenPort);
+        var rootContext = new RootShimProxyContext(otelSdk,
+            new CompositeContextTracker(new ActiveContextTracker(), new ActiveContextTrackerByActivityType()));
+
         var proxy = new ShimProxy(
             params.listenPort, targets, params.primary, activeTargets, validators,
-            null, params.insecureBackend, Duration.ofMillis(params.timeoutMs), params.maxContentLength);
+            null, params.insecureBackend, Duration.ofMillis(params.timeoutMs), params.maxContentLength,
+            rootContext);
 
         TransformFileWatcher watcher = null;
         if (params.watchTransforms && !watchedTransforms.isEmpty()) {

--- a/TrafficCapture/transformationShim/src/main/java/org/opensearch/migrations/transform/shim/ShimProxy.java
+++ b/TrafficCapture/transformationShim/src/main/java/org/opensearch/migrations/transform/shim/ShimProxy.java
@@ -12,6 +12,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.opensearch.migrations.transform.shim.netty.MultiTargetRoutingHandler;
+import org.opensearch.migrations.transform.shim.tracing.RootShimProxyContext;
 import org.opensearch.migrations.transform.shim.validation.Target;
 import org.opensearch.migrations.transform.shim.validation.ValidationRule;
 
@@ -71,6 +72,7 @@ public class ShimProxy {
     private final SslContext backendSslContext;
     private final Duration secondaryTimeout;
     private final int maxContentLength;
+    private final RootShimProxyContext rootShimProxyContext;
 
     private Channel serverChannel;
     private Channel healthChannel;
@@ -87,7 +89,8 @@ public class ShimProxy {
         java.util.function.Supplier<SSLEngine> sslEngineSupplier,
         boolean allowInsecureBackend,
         Duration secondaryTimeout,
-        int maxContentLength
+        int maxContentLength,
+        RootShimProxyContext rootShimProxyContext
     ) {
         this.port = port;
         this.targets = new LinkedHashMap<>(targets);
@@ -98,6 +101,7 @@ public class ShimProxy {
         this.secondaryTimeout = secondaryTimeout != null ? secondaryTimeout : DEFAULT_TIMEOUT;
         this.maxContentLength = maxContentLength > 0 ? maxContentLength : DEFAULT_MAX_CONTENT_LENGTH;
         this.backendSslContext = buildBackendSslContext(allowInsecureBackend);
+        this.rootShimProxyContext = rootShimProxyContext;
 
         if (!this.targets.containsKey(primaryTarget)) {
             throw new IllegalArgumentException("Primary target '" + primaryTarget + "' not in targets");
@@ -114,7 +118,7 @@ public class ShimProxy {
         String primaryTarget,
         List<ValidationRule> validators
     ) {
-        this(port, targets, primaryTarget, null, validators, null, false, null, DEFAULT_MAX_CONTENT_LENGTH);
+        this(port, targets, primaryTarget, null, validators, null, false, null, DEFAULT_MAX_CONTENT_LENGTH, null);
     }
 
     /** Convenience constructor — no max content length override. */
@@ -129,7 +133,7 @@ public class ShimProxy {
         Duration secondaryTimeout
     ) {
         this(port, targets, primaryTarget, activeTargets, validators, sslEngineSupplier,
-            allowInsecureBackend, secondaryTimeout, DEFAULT_MAX_CONTENT_LENGTH);
+            allowInsecureBackend, secondaryTimeout, DEFAULT_MAX_CONTENT_LENGTH, null);
     }
 
     private SslContext buildBackendSslContext(boolean allowInsecure) {
@@ -218,7 +222,7 @@ public class ShimProxy {
 
         pipeline.addLast("multiTargetRouter", new MultiTargetRoutingHandler(
             targets, primaryTarget, activeTargets, validators, secondaryTimeout,
-            backendSslContext, maxContentLength, activeRequests));
+            backendSslContext, maxContentLength, activeRequests, rootShimProxyContext));
         addLoggingHandler(pipeline, "E");
     }
 

--- a/TrafficCapture/transformationShim/src/main/java/org/opensearch/migrations/transform/shim/netty/MultiTargetRoutingHandler.java
+++ b/TrafficCapture/transformationShim/src/main/java/org/opensearch/migrations/transform/shim/netty/MultiTargetRoutingHandler.java
@@ -16,6 +16,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 
+import org.opensearch.migrations.transform.shim.tracing.RootShimProxyContext;
+import org.opensearch.migrations.transform.shim.tracing.ShimRequestContext;
 import org.opensearch.migrations.transform.shim.validation.Target;
 import org.opensearch.migrations.transform.shim.validation.TargetResponse;
 import org.opensearch.migrations.transform.shim.validation.ValidationResult;
@@ -78,6 +80,7 @@ public class MultiTargetRoutingHandler extends SimpleChannelInboundHandler<FullH
     private final int maxContentLength;
     private final AtomicInteger activeRequests;
     private final AtomicLong requestCounter = new AtomicLong(0);
+    private final RootShimProxyContext rootContext;
 
     /** Connection pools keyed by target name. Lazily initialized on first use. */
     private volatile AbstractChannelPoolMap<String, FixedChannelPool> poolMap;
@@ -90,7 +93,8 @@ public class MultiTargetRoutingHandler extends SimpleChannelInboundHandler<FullH
         Duration secondaryTimeout,
         SslContext backendSslContext,
         int maxContentLength,
-        AtomicInteger activeRequests
+        AtomicInteger activeRequests,
+        RootShimProxyContext rootContext
     ) {
         super(false);
         this.targets = targets;
@@ -101,6 +105,22 @@ public class MultiTargetRoutingHandler extends SimpleChannelInboundHandler<FullH
         this.backendSslContext = backendSslContext;
         this.maxContentLength = maxContentLength;
         this.activeRequests = activeRequests;
+        this.rootContext = rootContext;
+    }
+
+    /** Backward-compatible constructor without RootShimProxyContext. */
+    public MultiTargetRoutingHandler(
+        Map<String, Target> targets,
+        String primaryTarget,
+        Set<String> activeTargets,
+        List<ValidationRule> validators,
+        Duration secondaryTimeout,
+        SslContext backendSslContext,
+        int maxContentLength,
+        AtomicInteger activeRequests
+    ) {
+        this(targets, primaryTarget, activeTargets, validators, secondaryTimeout,
+            backendSslContext, maxContentLength, activeRequests, null);
     }
 
     @Override
@@ -138,8 +158,13 @@ public class MultiTargetRoutingHandler extends SimpleChannelInboundHandler<FullH
 
     @Override
     protected void channelRead0(ChannelHandlerContext ctx, FullHttpRequest request) {
-        // TODO: enable if latency headers matter
-        // long shimStartNanos = System.nanoTime();
+        String httpMethod = request.method().name();
+        String httpUri = request.uri();
+
+        ShimRequestContext requestCtx = rootContext != null
+            ? new ShimRequestContext(rootContext, httpMethod, httpUri)
+            : null;
+
         activeRequests.incrementAndGet();
         boolean keepAlive = Boolean.TRUE.equals(
             ctx.channel().attr(ShimChannelAttributes.KEEP_ALIVE).get());
@@ -149,7 +174,7 @@ public class MultiTargetRoutingHandler extends SimpleChannelInboundHandler<FullH
 
         long requestId = requestCounter.getAndIncrement();
         var futures = dispatchAll(requestMap);
-        handlePrimaryCompletion(ctx, futures, keepAlive, requestMap, requestId);
+        handlePrimaryCompletion(ctx, futures, keepAlive, requestMap, requestId, requestCtx);
     }
 
     private Map<String, CompletableFuture<TargetResponse>> dispatchAll(
@@ -170,7 +195,8 @@ public class MultiTargetRoutingHandler extends SimpleChannelInboundHandler<FullH
         Map<String, CompletableFuture<TargetResponse>> futures,
         boolean keepAlive,
         Map<String, Object> requestMap,
-        long requestId
+        long requestId,
+        ShimRequestContext requestCtx
     ) {
         futures.get(primaryTarget).whenComplete((primaryResp, primaryEx) ->
             ctx.channel().eventLoop().execute(() -> {
@@ -181,18 +207,21 @@ public class MultiTargetRoutingHandler extends SimpleChannelInboundHandler<FullH
                     Map<String, TargetResponse> allResponses = collectResponses(futures);
                     List<ValidationResult> results = runValidators(allResponses);
                     FullHttpResponse response = buildFinalResponse(primary, allResponses, results);
-                    // TODO: enable if latency headers matter
-                    // response.headers().set("X-Shim-Latency",
-                    //     Duration.ofNanos(System.nanoTime() - shimStartNanos).toMillis());
                     HttpMessageUtil.writeResponse(ctx, response, keepAlive);
 
                     logTuple(requestId, requestMap, allResponses, results);
                 } catch (Exception e) {
                     log.error("Error building validation response", e);
+                    if (requestCtx != null) {
+                        requestCtx.addTraceException(e, true);
+                    }
                     HttpMessageUtil.writeResponse(ctx, HttpMessageUtil.errorResponse(
                         HttpResponseStatus.INTERNAL_SERVER_ERROR, "Validation shim error"), keepAlive);
                 } finally {
                     activeRequests.decrementAndGet();
+                    if (requestCtx != null) {
+                        requestCtx.close();
+                    }
                 }
             })
         );

--- a/TrafficCapture/transformationShim/src/main/java/org/opensearch/migrations/transform/shim/tracing/IShimProxyContexts.java
+++ b/TrafficCapture/transformationShim/src/main/java/org/opensearch/migrations/transform/shim/tracing/IShimProxyContexts.java
@@ -1,0 +1,15 @@
+package org.opensearch.migrations.transform.shim.tracing;
+
+import org.opensearch.migrations.tracing.IScopedInstrumentationAttributes;
+
+public interface IShimProxyContexts {
+
+    class ActivityNames {
+        private ActivityNames() {}
+        public static final String SHIM_REQUEST = "shimRequest";
+    }
+
+    interface IRequestContext extends IScopedInstrumentationAttributes {
+        String ACTIVITY_NAME = ActivityNames.SHIM_REQUEST;
+    }
+}

--- a/TrafficCapture/transformationShim/src/main/java/org/opensearch/migrations/transform/shim/tracing/RootShimProxyContext.java
+++ b/TrafficCapture/transformationShim/src/main/java/org/opensearch/migrations/transform/shim/tracing/RootShimProxyContext.java
@@ -1,0 +1,19 @@
+package org.opensearch.migrations.transform.shim.tracing;
+
+import org.opensearch.migrations.tracing.IContextTracker;
+import org.opensearch.migrations.tracing.RootOtelContext;
+
+import io.opentelemetry.api.OpenTelemetry;
+import lombok.NonNull;
+
+public class RootShimProxyContext extends RootOtelContext {
+    public static final String SCOPE_NAME = "shimProxy";
+
+    public final ShimRequestContext.MetricInstruments shimRequestInstruments;
+
+    public RootShimProxyContext(@NonNull OpenTelemetry sdk, IContextTracker contextTracker) {
+        super(SCOPE_NAME, contextTracker, sdk);
+        var meter = this.getMeterProvider().get(SCOPE_NAME);
+        shimRequestInstruments = ShimRequestContext.makeMetrics(meter);
+    }
+}

--- a/TrafficCapture/transformationShim/src/main/java/org/opensearch/migrations/transform/shim/tracing/ShimRequestContext.java
+++ b/TrafficCapture/transformationShim/src/main/java/org/opensearch/migrations/transform/shim/tracing/ShimRequestContext.java
@@ -1,0 +1,64 @@
+package org.opensearch.migrations.transform.shim.tracing;
+
+import org.opensearch.migrations.tracing.BaseSpanContext;
+import org.opensearch.migrations.tracing.CommonScopedMetricInstruments;
+import org.opensearch.migrations.tracing.IScopedInstrumentationAttributes;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.AttributesBuilder;
+import io.opentelemetry.api.metrics.Meter;
+import lombok.NonNull;
+
+public class ShimRequestContext extends BaseSpanContext<RootShimProxyContext>
+    implements IShimProxyContexts.IRequestContext {
+
+    public static final AttributeKey<String> HTTP_METHOD_ATTR = AttributeKey.stringKey("http.method");
+    public static final AttributeKey<String> HTTP_URL_ATTR = AttributeKey.stringKey("http.url");
+
+    private final String httpMethod;
+    private final String httpUrl;
+
+    public ShimRequestContext(@NonNull RootShimProxyContext rootScope, String httpMethod, String httpUrl) {
+        super(rootScope);
+        this.httpMethod = httpMethod;
+        this.httpUrl = httpUrl;
+        initializeSpan(rootScope);
+    }
+
+    @Override
+    public String getActivityName() {
+        return ACTIVITY_NAME;
+    }
+
+    @Override
+    public IScopedInstrumentationAttributes getEnclosingScope() {
+        return null;
+    }
+
+    public static class MetricInstruments extends CommonScopedMetricInstruments {
+        private MetricInstruments(Meter meter, String activityName) {
+            super(meter, activityName);
+        }
+    }
+
+    public static MetricInstruments makeMetrics(Meter meter) {
+        return new MetricInstruments(meter, ACTIVITY_NAME);
+    }
+
+    @Override
+    public MetricInstruments getMetrics() {
+        return getRootInstrumentationScope().shimRequestInstruments;
+    }
+
+    @Override
+    public AttributesBuilder fillAttributesForSpansBelow(AttributesBuilder builder) {
+        return builder.put(HTTP_METHOD_ATTR, httpMethod).put(HTTP_URL_ATTR, httpUrl);
+    }
+
+    @Override
+    public AttributesBuilder fillExtraAttributesForThisSpan(AttributesBuilder builder) {
+        return super.fillExtraAttributesForThisSpan(builder)
+            .put(HTTP_METHOD_ATTR, httpMethod)
+            .put(HTTP_URL_ATTR, httpUrl);
+    }
+}

--- a/TrafficCapture/transformationShim/src/test/java/org/opensearch/migrations/transform/shim/tracing/ShimProxyInstrumentationTest.java
+++ b/TrafficCapture/transformationShim/src/test/java/org/opensearch/migrations/transform/shim/tracing/ShimProxyInstrumentationTest.java
@@ -1,0 +1,183 @@
+package org.opensearch.migrations.transform.shim.tracing;
+
+import java.net.ServerSocket;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.opensearch.migrations.tracing.IContextTracker;
+import org.opensearch.migrations.tracing.InMemoryInstrumentationBundle;
+import org.opensearch.migrations.transform.shim.ShimProxy;
+import org.opensearch.migrations.transform.shim.validation.Target;
+
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.channel.socket.nio.NioServerSocketChannel;
+import io.netty.handler.codec.http.DefaultFullHttpResponse;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpObjectAggregator;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpServerCodec;
+import io.netty.handler.codec.http.HttpVersion;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Integration test verifying OTel spans are emitted through the full ShimProxy request path.
+ */
+class ShimProxyInstrumentationTest {
+
+    private static final HttpClient HTTP = HttpClient.newBuilder()
+        .connectTimeout(Duration.ofSeconds(5)).build();
+
+    private InMemoryInstrumentationBundle bundle;
+    private RootShimProxyContext rootContext;
+    private NioEventLoopGroup backendGroup;
+    private Channel backendChannel;
+    private ShimProxy proxy;
+    private int backendPort;
+    private int proxyPort;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        bundle = new InMemoryInstrumentationBundle(true, true);
+        rootContext = new RootShimProxyContext(bundle.openTelemetrySdk, IContextTracker.DO_NOTHING_TRACKER);
+        backendPort = findFreePort();
+        proxyPort = findFreePort();
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        if (proxy != null) proxy.stop();
+        if (backendChannel != null) backendChannel.close().sync();
+        if (backendGroup != null) backendGroup.shutdownGracefully().sync();
+        bundle.close();
+    }
+
+    @Test
+    void requestThroughProxy_emitsShimRequestSpan() throws Exception {
+        startBackend(backendPort, "{\"status\":\"ok\"}");
+
+        Map<String, Target> targets = new LinkedHashMap<>();
+        targets.put("alpha", new Target("alpha", URI.create("http://localhost:" + backendPort)));
+
+        proxy = new ShimProxy(proxyPort, targets, "alpha", null, List.of(),
+            null, false, Duration.ofSeconds(5), ShimProxy.DEFAULT_MAX_CONTENT_LENGTH, rootContext);
+        proxy.start();
+
+        var resp = httpGet("http://localhost:" + proxyPort + "/test/endpoint");
+        assertEquals(200, resp.statusCode());
+
+        // Wait briefly for async span completion
+        Thread.sleep(200);
+
+        var spans = bundle.getFinishedSpans();
+        assertFalse(spans.isEmpty(), "Expected at least one span");
+
+        SpanData requestSpan = spans.stream()
+            .filter(s -> "shimRequest".equals(s.getName()))
+            .findFirst()
+            .orElseThrow(() -> new AssertionError("No shimRequest span found"));
+
+        assertEquals("GET", requestSpan.getAttributes().get(ShimRequestContext.HTTP_METHOD_ATTR));
+        assertEquals("/test/endpoint", requestSpan.getAttributes().get(ShimRequestContext.HTTP_URL_ATTR));
+    }
+
+    @Test
+    void requestThroughProxy_emitsCountMetric() throws Exception {
+        startBackend(backendPort, "{\"status\":\"ok\"}");
+
+        Map<String, Target> targets = new LinkedHashMap<>();
+        targets.put("alpha", new Target("alpha", URI.create("http://localhost:" + backendPort)));
+
+        proxy = new ShimProxy(proxyPort, targets, "alpha", null, List.of(),
+            null, false, Duration.ofSeconds(5), ShimProxy.DEFAULT_MAX_CONTENT_LENGTH, rootContext);
+        proxy.start();
+
+        httpGet("http://localhost:" + proxyPort + "/metrics-check");
+        Thread.sleep(200);
+
+        var metrics = bundle.getFinishedMetrics();
+        long count = InMemoryInstrumentationBundle.getMetricValueOrZero(metrics, "shimRequestCount");
+        assertTrue(count > 0, "shimRequestCount should be > 0 after a request");
+    }
+
+    @Test
+    void proxyWithoutRootContext_emitsNoSpans() throws Exception {
+        startBackend(backendPort, "{\"status\":\"ok\"}");
+
+        Map<String, Target> targets = new LinkedHashMap<>();
+        targets.put("alpha", new Target("alpha", URI.create("http://localhost:" + backendPort)));
+
+        // Use constructor without rootContext (backward compat)
+        proxy = new ShimProxy(proxyPort, targets, "alpha", List.of());
+        proxy.start();
+
+        httpGet("http://localhost:" + proxyPort + "/no-otel");
+        Thread.sleep(200);
+
+        assertTrue(bundle.getFinishedSpans().isEmpty(), "No spans should be emitted without rootContext");
+    }
+
+    // --- Mock backend ---
+
+    private void startBackend(int port, String responseBody) throws InterruptedException {
+        backendGroup = new NioEventLoopGroup(1);
+        backendChannel = new ServerBootstrap()
+            .group(backendGroup)
+            .channel(NioServerSocketChannel.class)
+            .childHandler(new ChannelInitializer<SocketChannel>() {
+                @Override
+                protected void initChannel(SocketChannel ch) {
+                    ch.pipeline()
+                        .addLast(new HttpServerCodec())
+                        .addLast(new HttpObjectAggregator(1024 * 1024))
+                        .addLast(new SimpleChannelInboundHandler<FullHttpRequest>() {
+                            @Override
+                            protected void channelRead0(ChannelHandlerContext ctx, FullHttpRequest req) {
+                                byte[] body = responseBody.getBytes(StandardCharsets.UTF_8);
+                                var resp = new DefaultFullHttpResponse(
+                                    HttpVersion.HTTP_1_1, HttpResponseStatus.OK,
+                                    Unpooled.wrappedBuffer(body));
+                                resp.headers().set(HttpHeaderNames.CONTENT_TYPE, "application/json");
+                                resp.headers().set(HttpHeaderNames.CONTENT_LENGTH, body.length);
+                                resp.headers().set(HttpHeaderNames.CONNECTION, "close");
+                                ctx.writeAndFlush(resp);
+                            }
+                        });
+                }
+            })
+            .bind(port).sync().channel();
+    }
+
+    private static HttpResponse<String> httpGet(String url) throws Exception {
+        return HTTP.send(
+            HttpRequest.newBuilder().uri(URI.create(url)).GET().build(),
+            HttpResponse.BodyHandlers.ofString());
+    }
+
+    private static int findFreePort() throws Exception {
+        try (var socket = new ServerSocket(0)) {
+            return socket.getLocalPort();
+        }
+    }
+}

--- a/TrafficCapture/transformationShim/src/test/java/org/opensearch/migrations/transform/shim/tracing/ShimRequestContextTest.java
+++ b/TrafficCapture/transformationShim/src/test/java/org/opensearch/migrations/transform/shim/tracing/ShimRequestContextTest.java
@@ -1,0 +1,111 @@
+package org.opensearch.migrations.transform.shim.tracing;
+
+import java.util.List;
+
+import org.opensearch.migrations.tracing.IContextTracker;
+import org.opensearch.migrations.tracing.InMemoryInstrumentationBundle;
+
+import io.opentelemetry.sdk.trace.data.SpanData;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ShimRequestContextTest {
+
+    private InMemoryInstrumentationBundle bundle;
+    private RootShimProxyContext rootContext;
+
+    @BeforeEach
+    void setUp() {
+        bundle = new InMemoryInstrumentationBundle(true, true);
+        rootContext = new RootShimProxyContext(bundle.openTelemetrySdk, IContextTracker.DO_NOTHING_TRACKER);
+    }
+
+    @AfterEach
+    void tearDown() {
+        bundle.close();
+    }
+
+    @Test
+    void shimRequestSpan_emittedWithCorrectAttributes() {
+        try (var ctx = new ShimRequestContext(rootContext, "GET", "/test/path")) {
+            assertEquals("shimRequest", ctx.getActivityName());
+        }
+
+        List<SpanData> spans = bundle.getFinishedSpans();
+        assertEquals(1, spans.size());
+
+        SpanData span = spans.get(0);
+        assertEquals("shimRequest", span.getName());
+        assertEquals("GET", span.getAttributes().get(ShimRequestContext.HTTP_METHOD_ATTR));
+        assertEquals("/test/path", span.getAttributes().get(ShimRequestContext.HTTP_URL_ATTR));
+    }
+
+    @Test
+    void shimRequestSpan_emittedForPostMethod() {
+        try (var ctx = new ShimRequestContext(rootContext, "POST", "/api/update")) {
+            // span is open
+        }
+
+        SpanData span = bundle.getFinishedSpans().get(0);
+        assertEquals("POST", span.getAttributes().get(ShimRequestContext.HTTP_METHOD_ATTR));
+        assertEquals("/api/update", span.getAttributes().get(ShimRequestContext.HTTP_URL_ATTR));
+    }
+
+    @Test
+    void shimRequestMetrics_countAndDurationEmitted() {
+        try (var ctx = new ShimRequestContext(rootContext, "GET", "/metrics-test")) {
+            // simulate some work
+        }
+
+        var metrics = bundle.getFinishedMetrics();
+        assertFalse(metrics.isEmpty(), "Expected metrics to be emitted");
+
+        long count = InMemoryInstrumentationBundle.getMetricValueOrZero(metrics, "shimRequestCount");
+        assertTrue(count > 0, "shimRequestCount should be > 0, got: " + count);
+    }
+
+    @Test
+    void shimRequestSpan_recordsException() {
+        var exception = new RuntimeException("test error");
+        try (var ctx = new ShimRequestContext(rootContext, "GET", "/error")) {
+            ctx.addTraceException(exception, true);
+        }
+
+        SpanData span = bundle.getFinishedSpans().get(0);
+        assertFalse(span.getEvents().isEmpty(), "Expected exception event on span");
+
+        var metrics = bundle.getFinishedMetrics();
+        long exceptionCount = InMemoryInstrumentationBundle.getMetricValueOrZero(
+            metrics, "shimRequestExceptionCount");
+        assertTrue(exceptionCount > 0, "Exception counter should be > 0");
+    }
+
+    @Test
+    void shimRequestSpan_enclosingScopeIsNull() {
+        try (var ctx = new ShimRequestContext(rootContext, "GET", "/")) {
+            assertNotNull(ctx.getCurrentSpan());
+            assertEquals(null, ctx.getEnclosingScope());
+        }
+    }
+
+    @Test
+    void multipleRequests_eachProducesSpan() {
+        for (int i = 0; i < 3; i++) {
+            try (var ctx = new ShimRequestContext(rootContext, "GET", "/req-" + i)) {
+                // each request
+            }
+        }
+
+        assertEquals(3, bundle.getFinishedSpans().size());
+
+        var metrics = bundle.getFinishedMetrics();
+        long count = InMemoryInstrumentationBundle.getMetricValueOrZero(metrics, "shimRequestCount");
+        assertEquals(3, count);
+    }
+}


### PR DESCRIPTION
### Description
Adds request-level OpenTelemetry tracing to the ShimProxy using the coreUtilities instrumentation framework. Each incoming HTTP request produces a shimRequest span with http.method and http.url attributes, plus auto-emitted count, duration, and exception metrics. Controlled via --otelCollectorEndpoint CLI flag — no-op when unset, zero overhead.


### Testing
- Unit tests
- Manual tests - tried emitting metrics with a sample LGTM container.

### Check List
- [x] New functionality includes testing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
