### PR TITLE
[Update] Remove unnecessary 600s timeout override for OSB backfill test

### DIFF
--- a/migrationConsole/lib/integ_test/integ_test/test_cases/backfill_tests.py
+++ b/migrationConsole/lib/integ_test/integ_test/test_cases/backfill_tests.py
@@ -46,9 +46,6 @@ class Test0006OpenSearchBenchmarkBackfill(MATestBase):
         # Run OSB workloads against source cluster
         self.source_operations.run_test_benchmarks(cluster=self.source_cluster)
 
-    def workflow_perform_migrations(self, timeout_seconds: int = 600):
-        super().workflow_perform_migrations(timeout_seconds=timeout_seconds)
-
     def verify_clusters(self):
         self.target_operations.check_doc_counts_match(cluster=self.target_cluster,
                                                       expected_index_details=full_indices,


### PR DESCRIPTION
### Description
Remove the `workflow_perform_migrations` override in `Test0006OpenSearchBenchmarkBackfill` that reduced the suspend-wait timeout from the base class default of 1000s to 600s.

### Problem

`Test0006OpenSearchBenchmarkBackfill` has been failing intermittently in `main-k8s-matrix-test`
since `build #49 (Mar 24)` with:
```
TimeoutError: Workflow did not reach suspended state in timeout of 600 seconds
```

The override existed only to lower the timeout — it called `super()` with no other logic. OSB backfill workflows on minikube routinely take 650–770s to reach the suspend checkpoint (observed in builds 45–50), so the 600s limit was always marginal and became consistently insufficient as test durations naturally drifted upward.

### Fix
Delete the 3-line override. The base class `MATestBase.workflow_perform_migrations()` already defaults to 1000s, which provides sufficient headroom for the observed durations.

## Issues Resolved
Fixes `main-k8s-matrix-test` builds 49, 50 and `main-k8s-local-integ-test` builds 119–124.


### Check List
- [x] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
