### PR TITLE
Use ECR pull-through cache for crane image mirroring

### DIFF
--- a/deployment/k8s/aws/aws-bootstrap.sh
+++ b/deployment/k8s/aws/aws-bootstrap.sh
@@ -989,14 +989,21 @@ migration_console|console"
         crane_copy_retry "$src" "$dst"
       done
     else
-      # Copy from public ECR using release image names
-      aws ecr-public get-login-password --region us-east-1 2>/dev/null | \
-        crane auth login public.ecr.aws -u AWS --password-stdin 2>/dev/null || true
+      # Copy from public ECR, trying pull-through cache first when available
+      _ecr_public_authed=false
       echo "$MA_IMAGES" | while IFS='|' read -r build_name public_suffix; do
-        src="public.ecr.aws/opensearchproject/opensearch-migrations-${public_suffix}:${RELEASE_VERSION}"
         dst="${MIGRATIONS_ECR_REGISTRY}:migrations_${build_name}_latest"
         echo "  $public_suffix → $dst"
-        crane_copy_retry "$src" "$dst"
+        if [[ -n "${ECR_PULL_THROUGH_ENDPOINT:-}" ]] && \
+           crane_copy_retry "${ECR_PULL_THROUGH_ENDPOINT}/ecr-public/opensearchproject/opensearch-migrations-${public_suffix}:${RELEASE_VERSION}" "$dst" 2>/dev/null; then
+          continue
+        fi
+        if [[ "$_ecr_public_authed" != "true" ]]; then
+          aws ecr-public get-login-password --region us-east-1 2>/dev/null | \
+            crane auth login public.ecr.aws -u AWS --password-stdin 2>/dev/null || true
+          _ecr_public_authed=true
+        fi
+        crane_copy_retry "public.ecr.aws/opensearchproject/opensearch-migrations-${public_suffix}:${RELEASE_VERSION}" "$dst"
       done
     fi
     # Tag mirrored images with the immutable IMAGE_TAG

--- a/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/scripts/mirrorToEcr.sh
+++ b/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/scripts/mirrorToEcr.sh
@@ -72,7 +72,34 @@ aws ecr-public get-login-password --region us-east-1 2>/dev/null | \
 # Override: DOCKERHUB_MIRRORS="mirror.gcr.io docker.io public.ecr.aws" ./mirrorToEcr.sh ...
 DOCKERHUB_MIRRORS="${DOCKERHUB_MIRRORS:-mirror.gcr.io docker.io public.ecr.aws}"
 
-# Copies a single image to ECR, trying mirror sources for mirror.gcr.io/* images.
+# --- ECR pull-through cache (optional, from Jenkins host environment) ---
+# When set, images from mapped registries are tried via pull-through cache first.
+PTC="${ECR_PULL_THROUGH_ENDPOINT:-}"
+if [ -n "$PTC" ]; then
+  echo "ECR pull-through cache enabled: $PTC"
+  # Authenticate with pull-through cache ECR (may be a different account than ECR_HOST)
+  aws ecr get-login-password --region "$REGION" 2>/dev/null | \
+    crane auth login "$PTC" -u AWS --password-stdin 2>/dev/null || true
+fi
+
+# Registry hostname → ECR pull-through cache prefix (matches PullThroughCacheHelper.groovy)
+ptc_rewrite() {
+  [ -z "$PTC" ] && return 1
+  local image="$1" registry path prefix
+  case "$image" in
+    docker.io/*)            prefix="docker-hub";          path="${image#docker.io/}" ;;
+    registry-1.docker.io/*) prefix="docker-hub";          path="${image#registry-1.docker.io/}" ;;
+    mirror.gcr.io/*)        prefix="docker-hub";          path="${image#mirror.gcr.io/}" ;;
+    public.ecr.aws/*)       prefix="ecr-public";          path="${image#public.ecr.aws/}" ;;
+    ghcr.io/*)              prefix="github-container-registry"; path="${image#ghcr.io/}" ;;
+    registry.k8s.io/*)      prefix="k8s";                 path="${image#registry.k8s.io/}" ;;
+    quay.io/*)              prefix="quay";                path="${image#quay.io/}" ;;
+    *) return 1 ;;
+  esac
+  echo "${PTC}/${prefix}/${path}"
+}
+
+# Copies a single image to ECR, trying pull-through cache then mirror sources.
 copy_image() {
   local image="$1" image_no_tag="${image%%:*}" tag="${image##*:}"
   local ecr_repo="mirrored/${image_no_tag}"
@@ -93,6 +120,11 @@ copy_image() {
   ;; esac
 
   aws ecr create-repository --repository-name "$ecr_repo" --region "$REGION" 2>/dev/null || true
+
+  # Prepend pull-through cache source if available (fastest path — same-region ECR to ECR)
+  local ptc_src
+  ptc_src=$(ptc_rewrite "$image") && sources="$ptc_src ${sources}"
+
   for src in $sources; do
     for attempt in 1 2 3; do
       if crane copy "$src" "$dest" 2>/dev/null; then


### PR DESCRIPTION
## Problem

All crane image copies in `aws-bootstrap.sh` and `mirrorToEcr.sh` pull directly from public registries (public.ecr.aws, quay.io, ghcr.io, registry.k8s.io, docker.io/mirror.gcr.io), bypassing the ECR pull-through cache configured on Jenkins hosts.

## Fix

When `ECR_PULL_THROUGH_ENDPOINT` is set (Jenkins hosts via `/etc/profile.d/ecr-pull-through.sh`), try the pull-through cache path first for crane copies. Falls back to direct pulls on cache miss or when the env var isn't set.

### `mirrorToEcr.sh`
- Add `ptc_rewrite()` function that maps registry hostnames to pull-through cache prefixes (same mapping as `PullThroughCacheHelper.groovy`):
  - `docker.io` / `mirror.gcr.io` → `docker-hub`
  - `public.ecr.aws` → `ecr-public`
  - `quay.io` → `quay`
  - `ghcr.io` → `github-container-registry`
  - `registry.k8s.io` → `k8s`
- `copy_image()` tries pull-through cache before existing mirror/direct sources
- Images from unmapped registries (`cr.fluentbit.io`, `reg.kyverno.io`) fall through to direct pull as before

### `aws-bootstrap.sh`
- MA release image copies from `public.ecr.aws` try `ECR_PULL_THROUGH_ENDPOINT/ecr-public/...` first