### PR TITLE
Adding translator for term query

### DIFF
--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/integration-tests/standard-query-parser/term-query.testcase.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/integration-tests/standard-query-parser/term-query.testcase.ts
@@ -1,0 +1,63 @@
+/**
+ * Test cases for Solr Standard Query Parser field queries → OpenSearch transformation.
+ *
+ * These tests validate the query-engine's ability to parse and transform
+ * Solr's field:value syntax into OpenSearch match and exists queries.
+ *
+ * Adding a new test: just add a solrTest() entry below.
+ * It automatically runs against every Solr version in matrix.config.ts.
+ */
+import { solrTest } from '../../../test-types';
+import type { TestCase } from '../../../test-types';
+
+export const testCases: TestCase[] = [
+  // ───────────────────────────────────────────────────────────
+  // Field queries (field:value → match query)
+  // ───────────────────────────────────────────────────────────
+    solrTest('query-term-single-field', {
+        description: 'Simple field query on a text field',
+        documents: [
+            { id: '1', title: 'laptop', category: 'electronics' },
+            { id: '2', title: 'phone', category: 'electronics' },
+            { id: '3', title: 'shirt', category: 'clothing' },
+        ],
+        requestPath: '/solr/testcollection/select?q=category:electronics&wt=json',
+        solrSchema: {
+            fields: {
+                title: { type: 'text_general' },
+                category: { type: 'text_general' },
+            },
+        },
+        opensearchMapping: {
+            properties: {
+                title: { type: 'text' },
+                category: { type: 'text' },
+            },
+        },
+    }),
+
+  // ───────────────────────────────────────────────────────────
+  // Existence queries (field:*)
+  // ───────────────────────────────────────────────────────────
+    solrTest('query-existence-field-exists', {
+        description: 'Existence query matches documents where field has any value',
+        documents: [
+            { id: '1', title: 'laptop', category: 'electronics' },
+            { id: '2', title: 'phone' },
+            { id: '3', title: 'shirt', category: 'clothing' },
+        ],
+        requestPath: '/solr/testcollection/select?q=category:*&wt=json',
+        solrSchema: {
+            fields: {
+                title: { type: 'text_general' },
+                category: { type: 'text_general' },
+            },
+        },
+        opensearchMapping: {
+            properties: {
+                title: { type: 'text' },
+                category: { type: 'text' },
+            },
+        },
+    }),
+];

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/orchestrator/translateQ.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/orchestrator/translateQ.ts
@@ -81,7 +81,7 @@ function passthroughDsl(query: string): Map<string, any> {
  *
  * Example:
  *   translateQ(new Map([['q', 'title:java'], ['df', 'content']]))
- *   → { dsl: Map{"term" → Map{"title" → "java"}}, warnings: [] }
+ *   → { dsl: Map{"match" → Map{"title" → "java"}}, warnings: [] }
  */
 export function translateQ(
   params: ReadonlyMap<string, string>,

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/parser/solr.pegjs
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/parser/solr.pegjs
@@ -176,8 +176,9 @@ rangeVal
 
 // Unquoted value characters: letters, digits, and common special chars.
 // Determines what can appear in unquoted field values.
+// Includes ~ to parse fuzzy syntax (roam~, roam~1) so we can throw a clear error.
 valueChars
-  = $[a-zA-Z0-9._\-*#$@?+/]+
+  = $[a-zA-Z0-9._\-*#$@?+/~]+
 
 // Field name identifier: starts with a letter or underscore, followed by
 // value characters. More restrictive first character prevents numbers from

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/transformer/astToOpenSearch.test.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/transformer/astToOpenSearch.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { transformNode } from './astToOpenSearch';
-import type { ASTNode, BoolNode } from '../ast/nodes';
+import type { BoolNode } from '../ast/nodes';
 
 describe('transformNode', () => {
   it('recursively transforms nested registered nodes', () => {
@@ -11,12 +11,5 @@ describe('transformNode', () => {
     const mustArray = (result.get('bool') as Map<string, any>).get('must') as Map<string, any>[];
     expect(mustArray).toHaveLength(1);
     expect(mustArray[0].get('bool')).toBeDefined();
-  });
-
-  it('throws for an unregistered node type', () => {
-    const node: ASTNode = { type: 'field', field: 'title', value: 'java' };
-    expect(() => transformNode(node)).toThrow(
-      'No transform rule registered for node type: field',
-    );
   });
 });

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/transformer/astToOpenSearch.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/transformer/astToOpenSearch.ts
@@ -17,7 +17,7 @@
  *     MatchAllNode → Map{"match_all" → Map{}}
  *
  *   `title:java`
- *     FieldNode(title, java) → Map{"term" → Map{"title" → "java"}}
+ *     FieldNode(title, java) → Map{"match" → Map{"title" → "java"}}
  *
  *   `"hello world"` (with df="content")
  *     PhraseNode(hello world) → Map{"match_phrase" → Map{"content" → "hello world"}}
@@ -29,7 +29,7 @@
  *     RangeNode(price, 10, 100) → Map{"range" → Map{"price" → Map{"gte" → "10", "lte" → "100"}}}
  *
  *   `title:java^2`
- *     BoostNode(FieldNode, 2) → Map{"term" → Map{"title" → "java", "boost" → 2}}
+ *     BoostNode(FieldNode, 2) → Map{"match" → Map{"title" → Map{"query" → "java", "boost" → 2}}}
  *
  *   `(a OR b)`
  *     GroupNode → transparent, recurses into child
@@ -39,6 +39,8 @@ import type { ASTNode } from '../ast/nodes';
 import type { TransformRuleFn } from './types';
 import { bareRule } from './rules/bareRule';
 import { boolRule } from './rules/boolRule';
+import { fieldRule } from './rules/fieldRule';
+import { matchAllRule } from './rules/matchAllRule';
 import { phraseRule } from './rules/phraseRule';
 import { rangeRule } from './rules/rangeRule';
 
@@ -53,6 +55,8 @@ const rules: Record<string, TransformRuleFn> = {
   // TODO: register remaining rules as they are implemented
   bare: bareRule,
   bool: boolRule,
+  field: fieldRule,
+  matchAll: matchAllRule,
   phrase: phraseRule,
   range: rangeRule,
 };

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/transformer/rules/boolRule.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/transformer/rules/boolRule.ts
@@ -8,7 +8,7 @@
  *
  * Example:
  *   Input: BoolNode { and: [FieldNode(title,java), RangeNode(price,10,100)], or: [], not: [] }
- *   Output: Map{"bool" → Map{"must" → [Map{"term"→...}, Map{"range"→...}]}}
+ *   Output: Map{"bool" → Map{"must" → [Map{"match"→...}, Map{"range"→...}]}}
  *
  * Empty clause arrays are omitted from the output Map — only clauses with
  * children are included. For example, `title:java AND author:smith` has

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/transformer/rules/fieldRule.test.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/transformer/rules/fieldRule.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi } from 'vitest';
+import { fieldRule } from './fieldRule';
+import type { FieldNode } from '../../ast/nodes';
+
+/** Stub transformChild — not used by fieldRule but required by signature. */
+const stubTransformChild = () => new Map();
+
+describe('fieldRule', () => {
+  it.each([
+    { field: 'title', value: 'java', desc: 'simple field:value' },
+    { field: 'author', value: 'smith', desc: 'simple field name' },
+    { field: '_text_', value: 'search', desc: 'underscore field name' },
+    { field: 'metadata.author', value: 'doe', desc: 'dotted field name' },
+    { field: 'title', value: 'foo-bar_baz.v1@test#123', desc: 'multiple special chars' },
+  ])('transforms $desc to match query', ({ field, value }) => {
+    const node: FieldNode = { type: 'field', field, value };
+
+    const result = fieldRule(node, stubTransformChild);
+
+    expect(result).toEqual(
+      new Map([['match', new Map([[field, value]])]]),
+    );
+  });
+
+  it('transforms existence search field:* to exists query', () => {
+    const node: FieldNode = {
+      type: 'field',
+      field: 'title',
+      value: '*',
+    };
+
+    const result = fieldRule(node, stubTransformChild);
+
+    expect(result).toEqual(
+      new Map([['exists', new Map([['field', 'title']])]]),
+    );
+  });
+
+  it.each([
+    { value: 'te?t', desc: 'single char wildcard (?)' },
+    { value: 'tes*ing', desc: '* in middle' },
+    { value: 'test*', desc: 'trailing *' },
+    { value: '*a', desc: 'leading *' },
+    { value: '**', desc: 'double *' },
+  ])('throws for wildcard pattern: $desc ($value)', ({ value }) => {
+    const node: FieldNode = { type: 'field', field: 'title', value };
+
+    expect(() => fieldRule(node, stubTransformChild)).toThrow(
+      `[fieldRule] Wildcard queries aren't supported yet. Query: title:${value}`,
+    );
+  });
+
+  it('throws for fuzzy search pattern', () => {
+    const node: FieldNode = {
+      type: 'field',
+      field: 'title',
+      value: 'roam~',
+    };
+
+    expect(() => fieldRule(node, stubTransformChild)).toThrow(
+      "[fieldRule] Fuzzy queries aren't supported yet. Query: title:roam~",
+    );
+  });
+
+  it('throws for fuzzy search with distance', () => {
+    const node: FieldNode = {
+      type: 'field',
+      field: 'title',
+      value: 'roam~1',
+    };
+
+    expect(() => fieldRule(node, stubTransformChild)).toThrow(
+      "[fieldRule] Fuzzy queries aren't supported yet. Query: title:roam~1",
+    );
+  });
+
+  it.each([
+    { value: 'roam~', desc: 'bare tilde' },
+    { value: 'roam~1', desc: 'tilde with 1' },
+  ])('throws for fuzzy pattern: $desc ($value)', ({ value }) => {
+    const node: FieldNode = { type: 'field', field: 'title', value };
+
+    expect(() => fieldRule(node, stubTransformChild)).toThrow(
+      `[fieldRule] Fuzzy queries aren't supported yet. Query: title:${value}`,
+    );
+  });
+
+  it.each([
+    { value: 'test~ing', desc: 'tilde in middle' },
+    { value: '~test', desc: 'tilde at start' },
+    { value: 'a~b~c', desc: 'multiple tildes' },
+  ])('does not treat as fuzzy: $desc ($value)', ({ value }) => {
+    const node: FieldNode = { type: 'field', field: 'title', value };
+
+    // These should not throw fuzzy error (may throw wildcard or succeed)
+    expect(() => fieldRule(node, stubTransformChild)).not.toThrow(/Fuzzy/);
+  });
+
+  it('never recurses into children because field is a leaf node', () => {
+    const node: FieldNode = { type: 'field', field: 'title', value: 'java' };
+    const spy = vi.fn();
+
+    fieldRule(node, spy);
+
+    expect(spy).not.toHaveBeenCalled();
+  });
+});

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/transformer/rules/fieldRule.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/transformer/rules/fieldRule.ts
@@ -1,0 +1,62 @@
+/**
+ * Transformation rule for FieldNode → OpenSearch `match` or `exists` query.
+ *
+ * Maps Solr's field:value syntax to OpenSearch's match query.
+ * Special case: field:* (existence search) maps to exists query.
+ *
+ * We use `match` instead of `term` because Solr's standard query parser
+ * analyzes field values at query time, matching OpenSearch's match behavior.
+ * Using `term` would require exact matches against the indexed tokens,
+ * which could fail for analyzed fields (e.g., case differences).
+ *
+ * Examples:
+ *   `title:java` → Map{"match" → Map{"title" → Map{"query" → "java"}}}
+ *   `title:*` → Map{"exists" → Map{"field" → "title"}}
+ *
+ * Unsupported (throws error):
+ *   - Wildcards (te?t, tes*) - throws error
+ *   - Fuzzy searches (roam~, roam~1) - throws error
+ *
+ * Note: Boosts are handled separately by BoostNode.
+ */
+
+import type { ASTNode } from '../../ast/nodes';
+import type { TransformRuleFn } from '../types';
+
+/** Regex to detect wildcard patterns (contains * or ?) */
+const WILDCARD_PATTERN = /[*?]/;
+
+/** Regex to detect fuzzy search patterns (term~ or term~N at end) */
+const FUZZY_PATTERN = /~\d?$/;
+
+export const fieldRule: TransformRuleFn = (
+  node: ASTNode,
+  // Field is a leaf node — transformChild not used
+  _transformChild,
+): Map<string, any> => {
+  const { field, value } = node;
+
+  // Existence search (field:*) → exists query
+  // TODO: Add support for fuzzy queries
+  if (value === '*') {
+    return new Map([['exists', new Map([['field', field]])]]);
+  }
+
+  // Detect unsupported fuzzy patterns (check before wildcard since ~ is more specific)
+  // TODO: Add support for wildcard queries
+  if (FUZZY_PATTERN.test(value)) {
+    const msg = `[fieldRule] Fuzzy queries aren't supported yet. Query: ${field}:${value}`;
+    console.error(msg);
+    throw new Error(msg);
+  }
+
+  // Detect unsupported wildcard patterns
+  // TODO: Add support for wildcard queries
+  if (WILDCARD_PATTERN.test(value)) {
+    const msg = `[fieldRule] Wildcard queries aren't supported yet. Query: ${field}:${value}`;
+    console.error(msg);
+    throw new Error(msg);
+  }
+
+  return new Map([['match', new Map([[field, value]])]]);
+};

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/transformer/rules/matchAllRule.test.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/transformer/rules/matchAllRule.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi } from 'vitest';
+import { matchAllRule } from './matchAllRule';
+import type { MatchAllNode } from '../../ast/nodes';
+
+/** Stub transformChild — not used by matchAllRule but required by signature. */
+const stubTransformChild = () => new Map();
+
+describe('matchAllRule', () => {
+  it('transforms matchAll to match_all query', () => {
+    const node: MatchAllNode = { type: 'matchAll' };
+
+    const result = matchAllRule(node, stubTransformChild);
+
+    expect(result).toEqual(new Map([['match_all', new Map()]]));
+  });
+
+  it('produces match_all even when node contains extra properties', () => {
+    const node = { type: 'matchAll', extra: 'ignored' } as MatchAllNode;
+
+    const result = matchAllRule(node, stubTransformChild);
+
+    expect(result.has('match_all')).toBe(true);
+  });
+
+  it('never recurses into children because matchAll is a leaf node', () => {
+    const node: MatchAllNode = { type: 'matchAll' };
+    const spy = vi.fn();
+
+    matchAllRule(node, spy);
+
+    expect(spy).not.toHaveBeenCalled();
+  });
+});

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/transformer/rules/matchAllRule.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/transformer/rules/matchAllRule.ts
@@ -1,0 +1,19 @@
+/**
+ * Transformation rule for MatchAllNode → OpenSearch `match_all` query.
+ *
+ * Maps Solr's *:* syntax to OpenSearch's match_all query.
+ *
+ * Examples:
+ *   `*:*` → Map{"match_all" → Map{}}
+ */
+
+import type { ASTNode } from '../../ast/nodes';
+import type { TransformRuleFn } from '../types';
+
+export const matchAllRule: TransformRuleFn = (
+  node: ASTNode,
+  // MatchAll is a leaf node — transformChild not used
+  _transformChild,
+): Map<string, any> => {
+  return new Map([['match_all', new Map()]]);
+};

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/transformer/rules/rangeRule.test.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/transformer/rules/rangeRule.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { rangeRule } from './rangeRule';
-import type { RangeNode, FieldNode } from '../../ast/nodes';
+import type { RangeNode } from '../../ast/nodes';
 
 /** Stub transformChild — not used by rangeRule but required by signature. */
 const stubTransformChild = () => new Map();
@@ -139,12 +139,5 @@ describe('rangeRule', () => {
     const rangeMap = result.get('range') as Map<string, any>;
 
     expect(rangeMap.has('created_at')).toBe(true);
-  });
-
-  it('throws when called with wrong node type', () => {
-    const wrongNode: FieldNode = { type: 'field', field: 'title', value: 'java' };
-    expect(() => rangeRule(wrongNode, stubTransformChild)).toThrow(
-      'rangeRule called with wrong node type: field',
-    );
   });
 });

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/transformer/rules/rangeRule.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/transformer/rules/rangeRule.ts
@@ -25,11 +25,6 @@ export const rangeRule: TransformRuleFn = (
   // Range is a leaf node — transformChild not used
   _transformChild,
 ): Map<string, any> => {
-  if (node.type !== 'range') {
-    console.error(`rangeRule called with wrong node type: ${node.type}`);
-    throw new Error(`rangeRule called with wrong node type: ${node.type}`);
-  }
-
   const { field, lower, upper, lowerInclusive, upperInclusive } = node;
 
   // [* TO *] means "field exists" in Solr — convert to exists query

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/transformer/types.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/transformer/types.ts
@@ -23,7 +23,7 @@ export type TransformChild = (child: ASTNode) => Map<string, any>;
  *
  * Example (leaf rule):
  *   (FieldNode { field: "title", value: "java" }, _)
- *   → Map{"term" → Map{"title" → "java"}}
+ *   → Map{"match" → Map{"title" → "java"}}
  *
  * Example (composite rule):
  *   (BoolNode { and: [FieldNode, RangeNode], ... }, transformChild)


### PR DESCRIPTION
### Description
This translates [Solr term query](https://solr.apache.org/guide/solr/latest/query-guide/standard-query-parser.html) param to OpenSearch equivalent

### Issues Resolved
<!-- List any GitHub or Jira issues this PR will resolve -->

### Testing
<!-- Please provide details of testing done: unit testing, integration testing and manual testing -->

### Check List
- [ ] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
