### PR TITLE
Adding translator for phrase and bare query

### DIFF
--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/integration-tests/standard-query-parser/bare-query.testcase.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/integration-tests/standard-query-parser/bare-query.testcase.ts
@@ -1,0 +1,80 @@
+/**
+ * Test cases for Solr Standard Query Parser bare queries → OpenSearch transformation.
+ *
+ * These tests validate the query-engine's ability to parse and transform
+ * Solr's bare term/phrase syntax (without field prefix) into OpenSearch query_string queries.
+ *
+ * Adding a new test: just add a solrTest() entry below.
+ * It automatically runs against every Solr version in matrix.config.ts.
+ */
+import { solrTest } from '../../../test-types';
+import type { TestCase } from '../../../test-types';
+
+export const testCases: TestCase[] = [
+  // ───────────────────────────────────────────────────────────
+  // Bare queries (no field prefix)
+  // ───────────────────────────────────────────────────────────
+
+  solrTest('query-bare-term-with-df', {
+    description: 'Bare term with df parameter searches specified field',
+    documents: [
+      { id: '1', title: 'laptop', description: 'computer' },
+      { id: '2', title: 'computer', description: 'laptop' },
+      { id: '3', title: 'phone', description: 'device' },
+    ],
+    requestPath: '/solr/testcollection/select?q=laptop&df=title&wt=json',
+    solrSchema: {
+      fields: {
+        title: { type: 'text_general' },
+        description: { type: 'text_general' },
+      },
+    },
+    opensearchMapping: {
+      properties: {
+        title: { type: 'text' },
+        description: { type: 'text' },
+      },
+    },
+  }),
+
+  solrTest('query-bare-phrase-with-df', {
+    description: 'Bare phrase with df parameter',
+    documents: [
+      { id: '1', title: 'hello world', description: 'greeting message' },
+      { id: '2', title: 'world hello', description: 'hello world' },
+      { id: '3', title: 'goodbye world', description: 'farewell' },
+    ],
+    requestPath: '/solr/testcollection/select?q=' + encodeURIComponent('"hello world"') + '&df=title&wt=json',
+    solrSchema: {
+      fields: {
+        title: { type: 'text_general' },
+        description: { type: 'text_general' },
+      },
+    },
+    opensearchMapping: {
+      properties: {
+        title: { type: 'text' },
+        description: { type: 'text' },
+      },
+    },
+  }),
+
+  solrTest('query-bare-term-no-match', {
+    description: 'Bare term that matches no documents',
+    documents: [
+      { id: '1', title: 'apple' },
+      { id: '2', title: 'banana' },
+    ],
+    requestPath: '/solr/testcollection/select?q=orange&wt=json',
+    solrSchema: {
+      fields: {
+        title: { type: 'text_general' },
+      },
+    },
+    opensearchMapping: {
+      properties: {
+        title: { type: 'text' },
+      },
+    },
+  }),
+];

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/integration-tests/standard-query-parser/phrase-query.testcase.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/integration-tests/standard-query-parser/phrase-query.testcase.ts
@@ -1,0 +1,56 @@
+/**
+ * Test cases for Solr Standard Query Parser phrase queries → OpenSearch transformation.
+ *
+ * These tests validate the query-engine's ability to parse and transform
+ * Solr's field:"phrase" syntax into OpenSearch match_phrase queries.
+ *
+ * Adding a new test: just add a solrTest() entry below.
+ * It automatically runs against every Solr version in matrix.config.ts.
+ */
+import { solrTest } from '../../../test-types';
+import type { TestCase } from '../../../test-types';
+
+export const testCases: TestCase[] = [
+  // ───────────────────────────────────────────────────────────
+  // Phrase queries
+  // ───────────────────────────────────────────────────────────
+
+  solrTest('query-phrase-simple', {
+    description: 'Simple phrase query on a text field',
+    documents: [
+      { id: '1', title: 'the quick brown fox' },
+      { id: '2', title: 'quick fox brown' },
+      { id: '3', title: 'the slow brown dog' },
+    ],
+    requestPath: '/solr/testcollection/select?q=' + encodeURIComponent('title:"quick brown"') + '&wt=json',
+    solrSchema: {
+      fields: {
+        title: { type: 'text_general' },
+      },
+    },
+    opensearchMapping: {
+      properties: {
+        title: { type: 'text' },
+      },
+    },
+  }),
+
+  solrTest('query-phrase-no-match', {
+    description: 'Phrase query that matches no documents',
+    documents: [
+      { id: '1', title: 'the quick brown fox' },
+      { id: '2', title: 'brown quick fox' },
+    ],
+    requestPath: '/solr/testcollection/select?q=' + encodeURIComponent('title:"fox brown quick"') + '&wt=json',
+    solrSchema: {
+      fields: {
+        title: { type: 'text_general' },
+      },
+    },
+    opensearchMapping: {
+      properties: {
+        title: { type: 'text' },
+      },
+    },
+  }),
+];

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/ast/nodes.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/ast/nodes.ts
@@ -31,6 +31,9 @@ export interface BoolNode {
  * Field-value query node — a `field:value` expression in Solr syntax.
  *
  * Example: `title:java` → field="title", value="java"
+ *
+ * Only used for explicit field:value syntax. Bare values like `java`
+ * produce a BareNode instead.
  */
 export interface FieldNode {
   type: 'field';
@@ -39,21 +42,44 @@ export interface FieldNode {
 }
 
 /**
- * Phrase query node — a quoted phrase search.
+ * Phrase query node — a quoted phrase search with explicit field.
  *
- * Examples:
- *   `title:"hello world"` → text="hello world", field="title"
- *   `"hello world"` with df="content" → text="hello world", field="content"
+ * Example: `title:"hello world"` → text="hello world", field="title"
+ *
+ * Only used for explicit field:"phrase" syntax. Bare phrases like `"hello world"`
+ * produce a BareNode instead.
  */
 export interface PhraseNode {
   type: 'phrase';
   /** The phrase text without quotes. */
   text: string;
-  /**
-   * The target field. The parser sets this to the explicit field (e.g., `title:"..."`)
-   * or the default field (df) for bare phrases like `"hello world"`.
-   */
+  /** The target field (always explicit, e.g., `title:"..."`). */
   field: string;
+}
+
+/**
+ * Bare query node — a term or phrase without explicit field prefix.
+ *
+ * Used for queries like `java` or `"hello world"` where no field is specified.
+ * The transformer converts this to OpenSearch's query_string query, which
+ * searches across the default field (or all fields if df is not set).
+ *
+ * For phrases (isPhrase=true), the transformer wraps the query in quotes
+ * so OpenSearch's query_string treats it as a phrase search.
+ *
+ * Examples:
+ *   `java` → BareNode { query: "java", isPhrase: false }
+ *   `"hello world"` → BareNode { query: "hello world", isPhrase: true }
+ *   `java` with df="content" → BareNode { query: "java", isPhrase: false, defaultField: "content" }
+ */
+export interface BareNode {
+  type: 'bare';
+  /** The search value (term or phrase text, without quotes). */
+  value: string;
+  /** Whether this is a phrase query (originally quoted). */
+  isPhrase: boolean;
+  /** The default field from df parameter, or undefined if not set. */
+  defaultField?: string;
 }
 
 /**
@@ -107,6 +133,7 @@ export interface BoostNode {
 
 /** Union of all AST node types. Every node in the parsed Solr query tree is one of these variants. */
 export type ASTNode =
+  | BareNode
   | BoolNode
   | FieldNode
   | PhraseNode

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/parser/parser.test.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/parser/parser.test.ts
@@ -35,17 +35,33 @@ describe('parseSolrQuery', () => {
       expect(errors).toEqual([]);
       expect(ast).toEqual({ type: 'field', field: 'title', value: 'java' });
     });
+  });
 
-    it('resolves bare value to df', () => {
-      const { ast, errors } = parseSolrQuery('java', paramsWithDf('title'));
-      expect(errors).toEqual([]);
-      expect(ast).toEqual({ type: 'field', field: 'title', value: 'java' });
-    });
+  // ─── BareNode ───────────────────────────────────────────────────────
 
-    it('defaults df to _text_ when not provided', () => {
+  describe('BareNode', () => {
+    it('parses bare term without df', () => {
       const { ast, errors } = parseSolrQuery('java', emptyParams);
       expect(errors).toEqual([]);
-      expect(ast).toEqual({ type: 'field', field: '_text_', value: 'java' });
+      expect(ast).toEqual({ type: 'bare', value: 'java', isPhrase: false });
+    });
+
+    it('parses bare term with df', () => {
+      const { ast, errors } = parseSolrQuery('java', paramsWithDf('title'));
+      expect(errors).toEqual([]);
+      expect(ast).toEqual({ type: 'bare', value: 'java', isPhrase: false, defaultField: 'title' });
+    });
+
+    it('parses bare phrase without df', () => {
+      const { ast, errors } = parseSolrQuery('"hello world"', emptyParams);
+      expect(errors).toEqual([]);
+      expect(ast).toEqual({ type: 'bare', value: 'hello world', isPhrase: true });
+    });
+
+    it('parses bare phrase with df', () => {
+      const { ast, errors } = parseSolrQuery('"hello world"', paramsWithDf('content'));
+      expect(errors).toEqual([]);
+      expect(ast).toEqual({ type: 'bare', value: 'hello world', isPhrase: true, defaultField: 'content' });
     });
   });
 
@@ -56,12 +72,6 @@ describe('parseSolrQuery', () => {
       const { ast, errors } = parseSolrQuery('title:"hello world"', emptyParams);
       expect(errors).toEqual([]);
       expect(ast).toEqual({ type: 'phrase', text: 'hello world', field: 'title' });
-    });
-
-    it('resolves bare phrase to df', () => {
-      const { ast, errors } = parseSolrQuery('"hello world"', paramsWithDf('content'));
-      expect(errors).toEqual([]);
-      expect(ast).toEqual({ type: 'phrase', text: 'hello world', field: 'content' });
     });
   });
 
@@ -403,7 +413,17 @@ describe('parseSolrQuery', () => {
       expect(errors).toEqual([]);
       expect(ast).toEqual({
         type: 'boost',
-        child: { type: 'field', field: 'title', value: 'java' },
+        child: { type: 'bare', value: 'java', isPhrase: false, defaultField: 'title' },
+        value: 2,
+      });
+    });
+
+    it('parses boost on bare phrase', () => {
+      const { ast, errors } = parseSolrQuery('"hello world"^2', paramsWithDf('content'));
+      expect(errors).toEqual([]);
+      expect(ast).toEqual({
+        type: 'boost',
+        child: { type: 'bare', value: 'hello world', isPhrase: true, defaultField: 'content' },
         value: 2,
       });
     });
@@ -434,7 +454,7 @@ describe('parseSolrQuery', () => {
           },
           {
             type: 'bool', and: [], or: [], not: [
-              { type: 'phrase', text: 'hello world', field: 'content' },
+              { type: 'bare', value: 'hello world', isPhrase: true, defaultField: 'content' },
             ],
           },
         ],

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/parser/parser.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/parser/parser.ts
@@ -13,8 +13,8 @@
  *   orExpr / andExpr / unaryExpr → BoolNode
  *   fieldExpr (field:value)      → FieldNode
  *   fieldExpr (field:"text")     → PhraseNode
- *   barePhrase ("text")          → PhraseNode (field="" → resolved to df)
- *   bareValue (text)             → FieldNode  (field="" → resolved to df)
+ *   barePhrase ("text")          → BareNode (isPhrase=true)
+ *   bareValue (text)             → BareNode (isPhrase=false)
  *   fieldExpr (field:[range])    → RangeNode
  *   matchAll / empty query       → MatchAllNode
  *   group                        → GroupNode
@@ -33,7 +33,7 @@
  *
  * Responsibilities:
  *   - Parse the query string into an AST
- *   - Apply the default field (df) from params to bare values and phrases
+ *   - Apply the default field (df) from params to BareNode nodes
  *   - Return parse errors as ParseError (never throws)
  */
 
@@ -112,12 +112,11 @@ export function toParseError(err: unknown): ParseError {
   };
 }
 
-/** Walk the AST and replace empty field strings with the default field.
+/** Walk the AST and resolve BareNode default fields.
  *
- * This handles the Lucene parser's single `df` parameter. For eDisMax's
- * multi-field `qf` (e.g., `qf=title^2 content^1`), bare terms need to be
- * expanded into a BoolNode with one clause per qf field — that's a separate
- * post-parse AST transformation, not handled here.
+ * For BareNode (bare terms/phrases), sets the defaultField property
+ * based on the df parameter. When df is '_text_' (Solr's default catch-all),
+ * leaves defaultField undefined so the transformer omits it from the output.
  *
  * Uses an explicit switch over node types instead of duck-typing ('field' in node)
  * to keep full type safety — the compiler catches missing cases when new node
@@ -128,7 +127,13 @@ function resolveDefaultFields(node: ASTNode, df: string): void {
     case 'field':
     case 'phrase':
     case 'range':
-      if (node.field === '') node.field = df;
+      // These nodes have explicit fields from the grammar, nothing to resolve
+      break;
+    case 'bare':
+      // Set defaultField only if df is not the Solr catch-all
+      if (df !== '_text_') {
+        node.defaultField = df;
+      }
       break;
     case 'bool':
       // Clean up grammar artifact — implicit flag shouldn't leak into AST
@@ -186,6 +191,7 @@ function applyDefaultOperator(node: ASTNode): void {
     case 'group':
       applyDefaultOperator(node.child);
       break;
+    case 'bare':
     case 'field':
     case 'phrase':
     case 'range':

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/parser/solr.pegjs
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/parser/solr.pegjs
@@ -141,28 +141,28 @@ fieldExpr
     }
 
 // ─── Bare expressions (no field prefix) ──────────────────────────────────────
-// These produce nodes with field=''. The parser.ts wrapper resolves the
-// empty field to the default field (df) from the params map after parsing.
+// These produce BareNode. The parser.ts wrapper sets the defaultField
+// property based on the df parameter.
 
-// PhraseNode (bare): "hello world" without a field prefix.
-// `"hello world"` → PhraseNode { text: "hello world", field: "" }
-// field is resolved to df by parser.ts after parsing.
+// BareNode (bare phrase): "hello world" without a field prefix.
+// `"hello world"` → BareNode { query: "hello world", isPhrase: true }
+// defaultField is set by parser.ts based on df parameter.
 barePhrase
   = "\"" text:$[^"]* "\"" boost:boost? {
-      const node = { type: 'phrase', text: text, field: '' };
+      const node = { type: 'bare', value: text, isPhrase: true };
       if (boost !== null) return { type: 'boost', child: node, value: boost };
       return node;
     }
 
-// FieldNode (bare): a search term without a field prefix.
-// `java` → FieldNode { field: "", value: "java" }
-// field is resolved to df by parser.ts after parsing.
+// BareNode (bare term): a search term without a field prefix.
+// `java` → BareNode { query: "java", isPhrase: false }
+// defaultField is set by parser.ts based on df parameter.
 // Keywords (AND, OR, NOT, TO) are excluded to prevent them from being
 // consumed as values — they return undefined so peggy backtracks.
 bareValue
   = val:valueChars boost:boost? {
       if (['AND','OR','NOT','TO'].includes(val)) return undefined;
-      const node = { type: 'field', field: '', value: val };
+      const node = { type: 'bare', value: val, isPhrase: false };
       if (boost !== null) return { type: 'boost', child: node, value: boost };
       return node;
     }

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/transformer/astToOpenSearch.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/transformer/astToOpenSearch.ts
@@ -37,7 +37,9 @@
 
 import type { ASTNode } from '../ast/nodes';
 import type { TransformRuleFn } from './types';
+import { bareRule } from './rules/bareRule';
 import { boolRule } from './rules/boolRule';
+import { phraseRule } from './rules/phraseRule';
 import { rangeRule } from './rules/rangeRule';
 
 /**
@@ -49,7 +51,9 @@ import { rangeRule } from './rules/rangeRule';
  */
 const rules: Record<string, TransformRuleFn> = {
   // TODO: register remaining rules as they are implemented
+  bare: bareRule,
   bool: boolRule,
+  phrase: phraseRule,
   range: rangeRule,
 };
 

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/transformer/rules/bareRule.test.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/transformer/rules/bareRule.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi } from 'vitest';
+import { bareRule } from './bareRule';
+import type { BareNode } from '../../ast/nodes';
+
+/** Stub transformChild — not used by bareRule but required by signature. */
+const stubTransformChild = () => new Map();
+
+describe('bareRule', () => {
+  it('transforms bare term without defaultField to query_string', () => {
+    const node: BareNode = {
+      type: 'bare',
+      value: 'java',
+      isPhrase: false,
+    };
+
+    const result = bareRule(node, stubTransformChild);
+
+    expect(result).toEqual(
+      new Map([['query_string', new Map([['query', 'java']])]]),
+    );
+  });
+
+  it('transforms bare term with defaultField to query_string with default_field', () => {
+    const node: BareNode = {
+      type: 'bare',
+      value: 'java',
+      isPhrase: false,
+      defaultField: 'content',
+    };
+
+    const result = bareRule(node, stubTransformChild);
+
+    expect(result).toEqual(
+      new Map([['query_string', new Map([['query', 'java'], ['default_field', 'content']])]]),
+    );
+  });
+
+  it('transforms bare phrase without defaultField to query_string with quotes', () => {
+    const node: BareNode = {
+      type: 'bare',
+      value: 'hello world',
+      isPhrase: true,
+    };
+
+    const result = bareRule(node, stubTransformChild);
+
+    expect(result).toEqual(
+      new Map([['query_string', new Map([['query', '"hello world"']])]]),
+    );
+  });
+
+  it('transforms bare phrase with defaultField to query_string with quotes and default_field', () => {
+    const node: BareNode = {
+      type: 'bare',
+      value: 'hello world',
+      isPhrase: true,
+      defaultField: 'title',
+    };
+
+    const result = bareRule(node, stubTransformChild);
+
+    expect(result).toEqual(
+      new Map([['query_string', new Map([['query', '"hello world"'], ['default_field', 'title']])]]),
+    );
+  });
+
+  describe('escapes special characters', () => {
+    const escapeTestCases: Array<{ input: string; expected: string; description: string }> = [
+      { input: 'foo:bar', expected: String.raw`foo\:bar`, description: 'colon (field separator)' },
+      { input: 'a+b', expected: String.raw`a\+b`, description: 'plus (required term)' },
+      { input: 'a-b', expected: String.raw`a\-b`, description: 'minus (excluded term)' },
+      { input: 'wild*card', expected: String.raw`wild\*card`, description: 'asterisk (wildcard)' },
+      { input: 'single?char', expected: String.raw`single\?char`, description: 'question mark (single char wildcard)' },
+      { input: '(group)', expected: String.raw`\(group\)`, description: 'parentheses (grouping)' },
+      { input: '[range]', expected: String.raw`\[range\]`, description: 'square brackets (range)' },
+      { input: '{exclusive}', expected: String.raw`\{exclusive\}`, description: 'curly braces (exclusive range)' },
+      { input: 'boost^2', expected: String.raw`boost\^2`, description: 'caret (boost)' },
+      { input: '"quoted"', expected: String.raw`\"quoted\"`, description: 'double quotes (phrase)' },
+      { input: 'fuzzy~2', expected: String.raw`fuzzy\~2`, description: 'tilde (fuzzy/proximity)' },
+      { input: 'path/to', expected: String.raw`path\/to`, description: 'forward slash (regex delimiter)' },
+      { input: String.raw`back\slash`, expected: String.raw`back\\slash`, description: 'backslash (escape char)' },
+      { input: 'a&&b', expected: String.raw`a\&\&b`, description: 'double ampersand (AND)' },
+      { input: 'a||b', expected: String.raw`a\|\|b`, description: 'double pipe (OR)' },
+      { input: 'a<b', expected: String.raw`a\<b`, description: 'less than (range)' },
+      { input: 'a>b', expected: String.raw`a\>b`, description: 'greater than (range)' },
+      { input: '!negated', expected: String.raw`\!negated`, description: 'exclamation (NOT)' },
+      { input: 'a=b', expected: String.raw`a\=b`, description: 'equals sign' },
+    ];
+
+    it.each(escapeTestCases)('escapes $description: "$input" → "$expected"', ({ input, expected }) => {
+      const node: BareNode = {
+        type: 'bare',
+        value: input,
+        isPhrase: false,
+      };
+
+      const result = bareRule(node, stubTransformChild);
+
+      expect(result).toEqual(
+        new Map([['query_string', new Map([['query', expected]])]]),
+      );
+    });
+
+    it.each(escapeTestCases)('escapes $description in phrase: "$input"', ({ input, expected }) => {
+      const node: BareNode = {
+        type: 'bare',
+        value: input,
+        isPhrase: true,
+      };
+
+      const result = bareRule(node, stubTransformChild);
+
+      expect(result).toEqual(
+        new Map([['query_string', new Map([['query', `"${expected}"`]])]]),
+      );
+    });
+  });
+
+  it('never recurses into children because bare is a leaf node', () => {
+    const node: BareNode = {
+      type: 'bare',
+      value: 'test',
+      isPhrase: false,
+    };
+    const spy = vi.fn();
+
+    bareRule(node, spy);
+
+    expect(spy).not.toHaveBeenCalled();
+  });
+});

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/transformer/rules/bareRule.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/transformer/rules/bareRule.ts
@@ -1,0 +1,64 @@
+/**
+ * Transformation rule for BareNode → OpenSearch `query_string` query.
+ *
+ * Maps bare Solr terms/phrases (without field prefix) to OpenSearch's query_string.
+ * When defaultField is set, includes it in the output; otherwise omits it to let
+ * OpenSearch use its default behavior.
+ *
+ * For phrases (isPhrase=true), wraps the query in quotes so OpenSearch's
+ * query_string treats it as a phrase search matching words in order.
+ *
+ * Special characters are escaped to prevent query_string from interpreting them
+ * as operators (e.g., foo:bar would be treated as a field query without escaping).
+ *
+ * Examples:
+ *   `java` (no df) → Map{"query_string" → Map{"query" → "java"}}
+ *   `java` (df="content") → Map{"query_string" → Map{"query" → "java", "default_field" → "content"}}
+ *   `"hello world"` (no df) → Map{"query_string" → Map{"query" → "\"hello world\""}}
+ *   `"hello world"` (df="title") → Map{"query_string" → Map{"query" → "\"hello world\"", "default_field" → "title"}}
+ *   `foo:bar` (no df) → Map{"query_string" → Map{"query" → "foo\\:bar"}}
+ *
+ * Note: Boosts are handled separately by BoostNode.
+ */
+
+import type { ASTNode } from '../../ast/nodes';
+import type { TransformRuleFn } from '../types';
+
+/**
+ * Characters that have special meaning in OpenSearch query_string syntax.
+ * These must be escaped with a backslash to be treated as literals.
+ * Reserved: + - = && || > < ! ( ) { } [ ] ^ " ~ * ? : \ /
+ * @see https://docs.opensearch.org/latest/query-dsl/full-text/query-string/#reserved-characters
+ */
+const QUERY_STRING_SPECIAL_CHARS = /[+\-=&|><!(){}[\]^"~*?:\\/]/g;
+
+/**
+ * Escapes special characters in a query string to prevent them from being
+ * interpreted as query_string operators.
+ */
+function escapeQueryString(text: string): string {
+  // NOSONAR: Using replace() with global regex is equivalent to replaceAll() and avoids ES2021 lib dependency
+  return text.replace(QUERY_STRING_SPECIAL_CHARS, String.raw`\$&`); // NOSONAR
+}
+
+export const bareRule: TransformRuleFn = (
+  node: ASTNode,
+  // Bare is a leaf node — transformChild not used
+  _transformChild,
+): Map<string, any> => {
+  const { value, isPhrase, defaultField } = node;
+
+  // Escape special characters to prevent query_string from interpreting them as operators
+  const escapedQuery = escapeQueryString(value);
+
+  // Wrap phrases in quotes for query_string to treat as phrase search
+  const queryText = isPhrase ? `"${escapedQuery}"` : escapedQuery;
+
+  // Include default_field only when explicitly set
+  // TODO: Evaluate match query vs query string based on validation dataset
+  if (defaultField) {
+    return new Map([['query_string', new Map([['query', queryText], ['default_field', defaultField]])]]);
+  }
+
+  return new Map([['query_string', new Map([['query', queryText]])]]);
+};

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/transformer/rules/phraseRule.test.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/transformer/rules/phraseRule.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi } from 'vitest';
+import { phraseRule } from './phraseRule';
+import type { PhraseNode } from '../../ast/nodes';
+
+/** Stub transformChild — not used by phraseRule but required by signature. */
+const stubTransformChild = () => new Map();
+
+describe('phraseRule', () => {
+  const phraseTestCases: Array<{ field: string; text: string; description: string }> = [
+    { field: 'title', text: 'hello world', description: 'basic phrase' },
+    { field: 'description', text: 'search engine', description: 'different field' },
+    { field: 'content', text: '', description: 'empty phrase' },
+    { field: 'body', text: 'foo:bar baz', description: 'colon in phrase' },
+  ];
+
+  it.each(phraseTestCases)(
+    'transforms $description: $field:"$text" → match_phrase',
+    ({ field, text }) => {
+      const node: PhraseNode = {
+        type: 'phrase',
+        field,
+        text,
+      };
+
+      const result = phraseRule(node, stubTransformChild);
+
+      expect(result).toEqual(
+        new Map([['match_phrase', new Map([[field, new Map([['query', text]])]])]]),
+      );
+    },
+  );
+
+  it('never recurses into children because phrase is a leaf node', () => {
+    const node: PhraseNode = {
+      type: 'phrase',
+      field: 'title',
+      text: 'hello world',
+    };
+    const spy = vi.fn();
+
+    phraseRule(node, spy);
+
+    expect(spy).not.toHaveBeenCalled();
+  });
+});

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/transformer/rules/phraseRule.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/transformer/rules/phraseRule.ts
@@ -1,0 +1,26 @@
+/**
+ * Transformation rule for PhraseNode → OpenSearch `match_phrase` query.
+ *
+ * Maps Solr's explicit field:"phrase" syntax to OpenSearch's match_phrase query.
+ * Bare phrases (without field prefix) are handled by bareRule instead.
+ *
+ * Examples:
+ *   `title:"hello world"` → Map{"match_phrase" → Map{"title" → Map{"query" → "hello world"}}}
+ *   `description:"search engine"` → Map{"match_phrase" → Map{"description" → Map{"query" → "search engine"}}}
+ *
+ * Note: Boosts are handled separately by BoostNode.
+ */
+
+import type { ASTNode } from '../../ast/nodes';
+import type { TransformRuleFn } from '../types';
+
+export const phraseRule: TransformRuleFn = (
+  node: ASTNode,
+  // Phrase is a leaf node — transformChild not used
+  _transformChild,
+): Map<string, any> => {
+  const { field, text } = node;
+
+  // Explicit field → use match_phrase query
+  return new Map([['match_phrase', new Map([[field, new Map([['query', text]])]])]]);
+};


### PR DESCRIPTION
### Description
This translates [Solr phrase query](https://solr.apache.org/guide/solr/latest/query-guide/standard-query-parser.html) param and bare queries to OpenSearch equivalent

### Testing
UTs and Integ

### Check List
- [x] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
