### PR TITLE
Increase Jib HTTP timeout to 60s

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -5,3 +5,5 @@ org.gradle.configuration-cache.problems=warn
 org.gradle.daemon.idletimeout=1800000
 org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 org.gradle.parallel=true
+# Increase Jib HTTP connection timeout from default 20s to 60s for transient network delays
+jib.httpTimeout=60000


### PR DESCRIPTION
## Problem

Intermittent `ConnectTimeoutException` when Jib pulls base images from ECR pull-through cache:

```
Connect to 730335467872.dkr.ecr.us-east-1.amazonaws.com:443 failed: Connect timed out
```

Jib's default connection timeout is 20 seconds, which can be too short when routing through NAT gateway to ECR.

## Fix

Set `jib.httpTimeout=60000` (60s) in `gradle.properties`. Jib already retries failed requests up to 3 times by default, so this just gives each attempt more time to succeed.

One-line change in `gradle.properties`.