### PR TITLE
Fix BYOS Jenkins trigger job_name mismatch

### DIFF
--- a/.github/workflows/jenkins_tests.yml
+++ b/.github/workflows/jenkins_tests.yml
@@ -181,7 +181,7 @@ jobs:
         uses: ./.github/actions/jenkins-trigger
         with:
           jenkins_url: "https://migrations.ci.opensearch.org"
-          job_name: ${{ github.event_name == 'push' && 'main-eks-byos-integ-test' || 'pr-eks-byos-integ-test' }}
+          job_name: ${{ github.event_name == 'push' && 'main-byos-eks-integ-test' || 'byos-eks-integ-test' }}
           api_token: "${{ secrets.JENKINS_MIGRATIONS_GENERIC_WEBHOOK_TOKEN }}"
           job_params: "GIT_REPO_URL=${{ needs.sanitize-input.outputs.pr_repo_url }},GIT_BRANCH=${{ needs.sanitize-input.outputs.branch_name }},GIT_COMMIT=${{ needs.sanitize-input.outputs.commit_hash }}"
           jenkins_user: "${{ secrets.JENKINS_MIGRATIONS_USER }}"


### PR DESCRIPTION
## Description

The BYOS EKS integ test Jenkins job was never being triggered from GitHub Actions because the `job_name` values didn't match the `regexpFilterExpression` configured on the Jenkins side.

**What was happening:**
- GitHub sent `job_name: main-eks-byos-integ-test` (push) / `pr-eks-byos-integ-test` (PR)
- Jenkins `regexpFilterExpression`: `^main-byos-eks-integ-test$` / `^byos-eks-integ-test$`
- The webhook returned 200 but `triggered: false` for all jobs → `NO_JOBS_TRIGGERED` → exit code 1

**Fix:** Update the `job_name` values to match what Jenkins expects (`main-byos-eks-integ-test` / `byos-eks-integ-test`).

## Testing

Verified by inspecting the Jenkins webhook response which shows the exact `regexpFilterExpression` and `regexpFilterText` for each job.