### PR TITLE
Adding translator for boost query

### DIFF
--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/integration-tests/standard-query-parser/boost-query.testcase.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/integration-tests/standard-query-parser/boost-query.testcase.ts
@@ -1,0 +1,166 @@
+/**
+ * Test cases for Solr Standard Query Parser boost queries → OpenSearch transformation.
+ *
+ * These tests validate the query-engine's ability to parse and transform
+ * Solr's boost syntax (^N) into OpenSearch queries with boost parameters.
+ *
+ * Boost only affects scoring/ranking, not which documents match. Therefore,
+ * meaningful boost tests require multiple terms where boost affects the
+ * relative ordering of results.
+ *
+ * Solr boost syntax: https://solr.apache.org/guide/solr/latest/query-guide/standard-query-parser.html#boosting-a-term-with
+ *
+ * Adding a new test: just add a solrTest() entry below.
+ * It automatically runs against every Solr version in matrix.config.ts.
+ */
+import { solrTest } from '../../../test-types';
+import type { TestCase } from '../../../test-types';
+
+export const testCases: TestCase[] = [
+  // ───────────────────────────────────────────────────────────
+  // Multi-term boost queries (where boost affects ranking)
+  // ───────────────────────────────────────────────────────────
+
+  solrTest('query-boost-or-terms', {
+    description: 'OR query with different boosts affects result ordering',
+    documents: [
+      { id: '1', title: 'java programming guide' },
+      { id: '2', title: 'python programming guide' },
+      { id: '3', title: 'java and python together' },
+    ],
+    requestPath: '/solr/testcollection/select?q=' + encodeURIComponent('title:java^2 OR title:python^1') + '&wt=json',
+    solrSchema: {
+      fields: {
+        title: { type: 'text_general' },
+      },
+    },
+    opensearchMapping: {
+      properties: {
+        title: { type: 'text' },
+      },
+    },
+  }),
+
+  solrTest('query-boost-or-phrases', {
+    description: 'OR query with boosted phrases',
+    documents: [
+      { id: '1', title: 'hello world greeting' },
+      { id: '2', title: 'goodbye world farewell' },
+      { id: '3', title: 'hello world goodbye world' },
+    ],
+    requestPath: '/solr/testcollection/select?q=' + encodeURIComponent('title:"hello world"^2 OR title:"goodbye world"^1') + '&wt=json',
+    solrSchema: {
+      fields: {
+        title: { type: 'text_general' },
+      },
+    },
+    opensearchMapping: {
+      properties: {
+        title: { type: 'text' },
+      },
+    },
+  }),
+
+  solrTest('query-boost-mixed-term-phrase', {
+    description: 'Mixed term and phrase with different boosts',
+    documents: [
+      { id: '1', title: 'java programming language' },
+      { id: '2', title: 'learn java basics' },
+      { id: '3', title: 'java programming for beginners' },
+    ],
+    requestPath: '/solr/testcollection/select?q=' + encodeURIComponent('title:"java programming"^2 OR title:java^1') + '&wt=json',
+    solrSchema: {
+      fields: {
+        title: { type: 'text_general' },
+      },
+    },
+    opensearchMapping: {
+      properties: {
+        title: { type: 'text' },
+      },
+    },
+  }),
+
+  solrTest('query-boost-decimal', {
+    description: 'Decimal boost values in OR query',
+    documents: [
+      { id: '1', title: 'java tutorial' },
+      { id: '2', title: 'python tutorial' },
+    ],
+    requestPath: '/solr/testcollection/select?q=' + encodeURIComponent('title:java^1.5 OR title:python^0.5') + '&wt=json',
+    solrSchema: {
+      fields: {
+        title: { type: 'text_general' },
+      },
+    },
+    opensearchMapping: {
+      properties: {
+        title: { type: 'text' },
+      },
+    },
+  }),
+
+  solrTest('query-boost-grouped', {
+    description: 'Boosted group combined with another term',
+    documents: [
+      { id: '1', title: 'java programming', category: 'tech' },
+      { id: '2', title: 'python programming', category: 'tech' },
+      { id: '3', title: 'cooking recipes', category: 'food' },
+    ],
+    requestPath: '/solr/testcollection/select?q=' + encodeURIComponent('(title:java OR title:python)^2 OR category:food^1') + '&wt=json',
+    solrSchema: {
+      fields: {
+        title: { type: 'text_general' },
+        category: { type: 'text_general' },
+      },
+    },
+    opensearchMapping: {
+      properties: {
+        title: { type: 'text' },
+        category: { type: 'text' },
+      },
+    },
+  }),
+
+  solrTest('query-boost-bare-terms', {
+    description: 'Bare terms with boosts and df parameter',
+    documents: [
+      { id: '1', title: 'java programming' },
+      { id: '2', title: 'python programming' },
+      { id: '3', title: 'java and python' },
+    ],
+    requestPath: '/solr/testcollection/select?q=' + encodeURIComponent('java^2 OR python^1') + '&df=title&wt=json',
+    solrSchema: {
+      fields: {
+        title: { type: 'text_general' },
+      },
+    },
+    opensearchMapping: {
+      properties: {
+        title: { type: 'text' },
+      },
+    },
+  }),
+
+  solrTest('query-boost-range-with-term', {
+    description: 'Boosted range combined with boosted term',
+    documents: [
+      { id: '1', title: 'cheap laptop', price: 50 },
+      { id: '2', title: 'expensive laptop', price: 500 },
+      { id: '3', title: 'mid-range laptop', price: 200 },
+    ],
+    requestPath: '/solr/testcollection/select?q=' + encodeURIComponent('price:[0 TO 100]^2 OR title:laptop^1') + '&wt=json',
+    solrSchema: {
+      fields: {
+        title: { type: 'text_general' },
+        price: { type: 'pint' },
+      },
+    },
+    opensearchMapping: {
+      properties: {
+        title: { type: 'text' },
+        price: { type: 'integer' },
+      },
+    },
+  }),
+];

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/README.md
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/README.md
@@ -269,3 +269,49 @@ Map { "query_string" → Map { "query" → "the original solr query" } }
 - **The AST is Solr-specific** — represents what the user wrote, not how it maps to any target system.
 - **The parser handles all Solr parser types** — Lucene, eDisMax, DisMax share the same core syntax. Parser-specific behavior (e.g., eDisMax qf distribution) is a post-parse AST transformation.
 - **The caller provides configuration** — `df`, `qf`, `pf` etc. come from the params map. The query engine does not read config files.
+
+
+## Output Format Requirements
+
+All transformer rules MUST return `Map<string, any>` objects (not plain JS objects). This is a GraalVM requirement for Java interop.
+
+### Boost Compatibility
+
+When creating rules that may be boosted (wrapped in BoostNode), the output MUST follow one of these two patterns:
+
+#### 1. Field-Level Pattern
+
+For queries that target a specific field (match, match_phrase, range, term, etc.):
+
+```typescript
+// Structure: {"queryType": {"fieldName": {"param": "value"}}}
+return new Map([
+  ['match', new Map([
+    ['title', new Map([['query', 'java']])]  // ← Field params in nested Map
+  ])]
+]);
+```
+
+**WRONG** (boost will be applied at wrong level):
+```typescript
+return new Map([
+  ['match', new Map([['title', 'java']])]  // ← String value, not Map!
+]);
+```
+
+#### 2. Query-Level Pattern
+
+For queries without a specific field (query_string, bool, match_all, exists):
+
+```typescript
+// Structure: {"queryType": {"param": "value"}}
+return new Map([
+  ['query_string', new Map([['query', 'java']])]
+]);
+```
+
+### How boostRule Detects the Pattern
+
+The `boostRule` checks if the first value in the query body is a `Map`:
+- If `Map` → field-level pattern, boost added inside field params
+- If primitive (string/number/array) → query-level pattern, boost added at query body level

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/parser/parser.test.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/parser/parser.test.ts
@@ -273,6 +273,22 @@ describe('parseSolrQuery', () => {
         value: 2,
       });
     });
+
+    it('parses boost on match all *:*^2', () => {
+      const { ast, errors } = parseSolrQuery('*:*^2', emptyParams);
+      expect(errors).toEqual([]);
+      expect(ast).toEqual({
+        type: 'boost',
+        child: { type: 'matchAll' },
+        value: 2,
+      });
+    });
+
+    it('fails to parse non-numeric boost value (^abc)', () => {
+      const { ast, errors } = parseSolrQuery('title:java^abc', emptyParams);
+      expect(ast).toBeNull();
+      expect(errors).toHaveLength(1);
+    });
   });
 
   // ─── Combined query ──────────────────────────────────────────────────────

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/parser/solr.pegjs
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/parser/solr.pegjs
@@ -113,8 +113,13 @@ group
 
 // MatchAllNode: `*:*` matches every document.
 // Must be checked before fieldExpr to prevent `*` being parsed as a field name.
+// Supports optional boost: `*:*^2` → BoostNode wrapping MatchAllNode.
 matchAll
-  = "*:*" { return { type: 'matchAll' }; }
+  = "*:*" boost:boost? {
+      const node = { type: 'matchAll' };
+      if (boost !== null) return { type: 'boost', child: node, value: boost };
+      return node;
+    }
 
 // ─── Field expressions ───────────────────────────────────────────────────────
 // Matches field:value, field:"phrase", and field:[range] / field:{range}.

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/transformer/astToOpenSearch.test.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/transformer/astToOpenSearch.test.ts
@@ -25,8 +25,9 @@ describe('transformNode – GroupNode handling', () => {
       child: { type: 'field', field: 'title', value: 'java' },
     });
 
+    // fieldRule produces expanded form: {"match": {"field": {"query": "value"}}}
     expect(result).toEqual(new Map([
-      ['match', new Map([['title', 'java']])],
+      ['match', new Map([['title', new Map([['query', 'java']])]])],
     ]));
   });
 
@@ -60,8 +61,9 @@ describe('transformNode – GroupNode handling', () => {
       },
     });
 
+    // fieldRule produces expanded form: {"match": {"field": {"query": "value"}}}
     expect(result).toEqual(new Map([
-      ['match', new Map([['title', 'java']])],
+      ['match', new Map([['title', new Map([['query', 'java']])]])],
     ]));
   });
 });

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/transformer/astToOpenSearch.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/transformer/astToOpenSearch.ts
@@ -42,6 +42,7 @@ import { boolRule } from './rules/boolRule';
 import { fieldRule } from './rules/fieldRule';
 import { matchAllRule } from './rules/matchAllRule';
 import { phraseRule } from './rules/phraseRule';
+import { boostRule } from './rules/boostRule';
 import { rangeRule } from './rules/rangeRule';
 
 /**
@@ -63,6 +64,7 @@ const rules: Record<string, TransformRuleFn> = {
   matchAll: matchAllRule,
   phrase: phraseRule,
   range: rangeRule,
+  boost: boostRule,
 };
 
 /**

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/transformer/rules/boostRule.test.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/transformer/rules/boostRule.test.ts
@@ -1,0 +1,280 @@
+import { describe, it, expect } from 'vitest';
+import { transformNode } from '../astToOpenSearch';
+import { boostRule } from './boostRule';
+import type { ASTNode, BoostNode, FieldNode, PhraseNode, RangeNode, BareNode, BoolNode, MatchAllNode, GroupNode } from '../../ast/nodes';
+import type { TransformChild } from '../types';
+
+/** Helper to create Map<string, any> with mixed value types */
+const m = (entries: [string, any][]): Map<string, any> => new Map(entries);
+
+describe('boostRule', () => {
+  describe('field-level boost (match, match_phrase, range)', () => {
+    it('adds boost to match query', () => {
+      const node: BoostNode = {
+        type: 'boost',
+        value: 2,
+        child: { type: 'field', field: 'title', value: 'java' } as FieldNode,
+      };
+
+      const result = transformNode(node);
+
+      // fieldRule produces expanded form: {"match": {"title": {"query": "java"}}}
+      // boostRule adds boost inside the field object
+      expect(result).toEqual(m([['match', m([['title', m([['query', 'java'], ['boost', 2]])]])]]));
+    });
+
+    it('adds boost to match_phrase query', () => {
+      const node: BoostNode = {
+        type: 'boost',
+        value: 1.5,
+        child: { type: 'phrase', field: 'title', text: 'hello world' } as PhraseNode,
+      };
+
+      const result = transformNode(node);
+
+      expect(result).toEqual(m([['match_phrase', m([['title', m([['query', 'hello world'], ['boost', 1.5]])]])]]));
+    });
+
+    it('adds boost to range query', () => {
+      const node: BoostNode = {
+        type: 'boost',
+        value: 2,
+        child: {
+          type: 'range',
+          field: 'price',
+          lower: '10',
+          upper: '100',
+          lowerInclusive: true,
+          upperInclusive: true,
+        } as RangeNode,
+      };
+
+      const result = transformNode(node);
+
+      expect(result).toEqual(m([['range', m([['price', m([['gte', '10'], ['lte', '100'], ['boost', 2]])]])]]));
+    });
+  });
+
+  describe('query-level boost (query_string, bool, exists, match_all)', () => {
+    it('adds boost to query_string (bare term)', () => {
+      const node: BoostNode = {
+        type: 'boost',
+        value: 2,
+        child: { type: 'bare', value: 'java', isPhrase: false } as BareNode,
+      };
+
+      const result = transformNode(node);
+
+      expect(result).toEqual(m([['query_string', m([['query', 'java'], ['boost', 2]])]]));
+    });
+
+    it('adds boost to bool query', () => {
+      const node: BoostNode = {
+        type: 'boost',
+        value: 2,
+        child: {
+          type: 'bool',
+          and: [{ type: 'field', field: 'title', value: 'java' } as FieldNode],
+          or: [],
+          not: [],
+        } as BoolNode,
+      };
+
+      const result = transformNode(node);
+      const boolMap = result.get('bool') as Map<string, any>;
+
+      expect(boolMap.get('boost')).toBe(2);
+      expect(boolMap.has('must')).toBe(true);
+    });
+
+    it('adds boost to exists query (field:*)', () => {
+      const node: BoostNode = {
+        type: 'boost',
+        value: 2,
+        child: { type: 'field', field: 'title', value: '*' } as FieldNode,
+      };
+
+      const result = transformNode(node);
+
+      expect(result).toEqual(m([['exists', m([['field', 'title'], ['boost', 2]])]]));
+    });
+
+    it('adds boost to match_all query', () => {
+      const node: BoostNode = {
+        type: 'boost',
+        value: 2,
+        child: { type: 'matchAll' } as MatchAllNode,
+      };
+
+      const result = transformNode(node);
+
+      expect(result).toEqual(m([['match_all', m([['boost', 2]])]]));
+    });
+  });
+
+  describe('edge cases', () => {
+    it('handles decimal boost values', () => {
+      const node: BoostNode = {
+        type: 'boost',
+        value: 0.5,
+        child: { type: 'field', field: 'title', value: 'java' } as FieldNode,
+      };
+
+      const result = transformNode(node);
+      const matchMap = result.get('match') as Map<string, any>;
+      const fieldMap = matchMap.get('title') as Map<string, any>;
+
+      expect(fieldMap.get('boost')).toBe(0.5);
+    });
+
+    it('preserves default_field when boosting bare query', () => {
+      const node: BoostNode = {
+        type: 'boost',
+        value: 2,
+        child: { type: 'bare', value: 'java', isPhrase: false, defaultField: 'content' } as BareNode,
+      };
+
+      const result = transformNode(node);
+
+      expect(result).toEqual(m([['query_string', m([['query', 'java'], ['default_field', 'content'], ['boost', 2]])]]));
+    });
+
+    it('calls transformChild exactly once', () => {
+      const calls: ASTNode[] = [];
+      const trackingTransformChild: TransformChild = (child) => {
+        calls.push(child);
+        // Return expanded form that fieldRule now produces
+        return m([['match', m([['title', m([['query', 'java']])]])]]);
+      };
+
+      const childNode: FieldNode = { type: 'field', field: 'title', value: 'java' };
+      const node: BoostNode = { type: 'boost', value: 2, child: childNode };
+
+      boostRule(node, trackingTransformChild);
+
+      expect(calls).toHaveLength(1);
+      expect(calls[0]).toBe(childNode);
+    });
+
+    it('throws when called with wrong node type', () => {
+      const stubTransformChild: TransformChild = () => m([]);
+      const wrongNode: FieldNode = { type: 'field', field: 'title', value: 'java' };
+
+      expect(() => boostRule(wrongNode, stubTransformChild)).toThrow(
+        '[boostRule] Called with wrong node type: field',
+      );
+    });
+
+    it('handles nested boost (boost wrapping boosted term)', () => {
+      // Represents ((title:java^2)^3) - outer boost wrapping inner boosted term
+      const node: BoostNode = {
+        type: 'boost',
+        value: 3,
+        child: {
+          type: 'boost',
+          value: 2,
+          child: { type: 'field', field: 'title', value: 'java' } as FieldNode,
+        } as BoostNode,
+      };
+
+      const result = transformNode(node);
+
+      // Inner boost produces: match.title.boost = 2
+      // Outer boost overwrites: match.title.boost = 3
+      const matchMap = result.get('match') as Map<string, any>;
+      const fieldMap = matchMap.get('title') as Map<string, any>;
+      expect(fieldMap.get('boost')).toBe(3); // Outer boost overwrites inner
+    });
+
+    it('handles boost on group containing boosted terms', () => {
+      // Represents (title:java^2 OR author:smith^1)^3
+      const node: BoostNode = {
+        type: 'boost',
+        value: 3,
+        child: {
+          type: 'group',
+          child: {
+            type: 'bool',
+            and: [],
+            or: [
+              { type: 'boost', value: 2, child: { type: 'field', field: 'title', value: 'java' } as FieldNode } as BoostNode,
+              { type: 'boost', value: 1, child: { type: 'field', field: 'author', value: 'smith' } as FieldNode } as BoostNode,
+            ],
+            not: [],
+          } as BoolNode,
+        } as GroupNode,
+      };
+
+      const result = transformNode(node);
+
+      // Outer boost goes on the bool query
+      const boolMap = result.get('bool') as Map<string, any>;
+      expect(boolMap.get('boost')).toBe(3);
+
+      // Inner boosts are preserved on individual match queries (inside field object)
+      const shouldClauses = boolMap.get('should') as Map<string, any>[];
+      const titleMatch = shouldClauses[0].get('match') as Map<string, any>;
+      const authorMatch = shouldClauses[1].get('match') as Map<string, any>;
+      expect(titleMatch.get('title').get('boost')).toBe(2);
+      expect(authorMatch.get('author').get('boost')).toBe(1);
+    });
+
+    it('throws when child returns non-Map result', () => {
+      const stubTransformChild: TransformChild = () => null as any;
+
+      const node: BoostNode = { type: 'boost', value: 2, child: { type: 'matchAll' } as MatchAllNode };
+
+      expect(() => boostRule(node, stubTransformChild)).toThrow(
+        '[boostRule] Child transformer returned invalid result: expected non-empty Map',
+      );
+    });
+
+    it('throws when child returns empty Map', () => {
+      const stubTransformChild: TransformChild = () => m([]);
+
+      const node: BoostNode = { type: 'boost', value: 2, child: { type: 'matchAll' } as MatchAllNode };
+
+      expect(() => boostRule(node, stubTransformChild)).toThrow(
+        '[boostRule] Child transformer returned invalid result: expected non-empty Map',
+      );
+    });
+
+    it('throws when query body is not a Map', () => {
+      const stubTransformChild: TransformChild = () => m([['custom_query', 'not a map']]);
+
+      const node: BoostNode = { type: 'boost', value: 2, child: { type: 'matchAll' } as MatchAllNode };
+
+      expect(() => boostRule(node, stubTransformChild)).toThrow(
+        "[boostRule] Query body for type 'custom_query' is not a Map",
+      );
+    });
+
+    it('handles child returning empty query body (falls back to query-level boost)', () => {
+      // Edge case: child transformer returns a query with empty body
+      // This shouldn't happen in practice but tests defensive behavior
+      const stubTransformChild: TransformChild = () => m([['custom_query', m([])]]);
+
+      const node: BoostNode = { type: 'boost', value: 2, child: { type: 'matchAll' } as MatchAllNode };
+
+      const result = boostRule(node, stubTransformChild);
+
+      // With empty body, firstValue is undefined (not a Map), so boost goes at query level
+      expect(result.get('custom_query').get('boost')).toBe(2);
+    });
+
+    it('handles child returning unexpected structure with array value', () => {
+      // Edge case: child returns a query where first value is an array (not Map or primitive)
+      // This tests the else branch where firstValue is not instanceof Map
+      const stubTransformChild: TransformChild = () => m([['ids', m([['values', ['id1', 'id2']]])]]);
+
+      const node: BoostNode = { type: 'boost', value: 2, child: { type: 'matchAll' } as MatchAllNode };
+
+      const result = boostRule(node, stubTransformChild);
+
+      // Array is not a Map, so boost goes at query body level
+      const idsBody = result.get('ids') as Map<string, any>;
+      expect(idsBody.get('boost')).toBe(2);
+      expect(idsBody.get('values')).toEqual(['id1', 'id2']);
+    });
+  });
+});

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/transformer/rules/boostRule.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/transformer/rules/boostRule.ts
@@ -1,0 +1,72 @@
+/**
+ * Transformation rule for BoostNode → OpenSearch query with `boost` parameter.
+ *
+ * Applies Solr's boost modifier (^N) to any query type by adding the `boost`
+ * parameter to the child query's OpenSearch DSL output.
+ *
+ * IMPORTANT: Child transformers must return output in one of two patterns
+ * (field-level or query-level). See @link {../../README.md} for details.
+ */
+
+import type { ASTNode } from '../../ast/nodes';
+import type { TransformRuleFn, TransformChild } from '../types';
+
+export const boostRule: TransformRuleFn = (
+  node: ASTNode,
+  transformChild: TransformChild,
+): Map<string, any> => {
+  if (node.type !== 'boost') {
+    const msg = `[boostRule] Called with wrong node type: ${node.type}`;
+    console.error(msg);
+    throw new Error(msg);
+  }
+
+  const { child, value: boostValue } = node;
+
+  // Transform the child node first
+  const childResult = transformChild(child);
+
+  // validation: child must return a non-empty Map
+  if (!(childResult instanceof Map) || childResult.size === 0) {
+    const msg = `[boostRule] Child transformer returned invalid result: expected non-empty Map`;
+    console.error(msg);
+    throw new Error(msg);
+  }
+
+  // Get the query type and body
+  // e.g., for {"term": {"title": {"value": "java"}}}
+  //       queryType = "term", queryBody = Map{"title" → Map{...}}
+  const queryType = childResult.keys().next().value as string;
+  const queryBody = childResult.get(queryType);
+
+  // Basic validation: query body must be a Map
+  if (!(queryBody instanceof Map)) {
+    const msg = `[boostRule] Query body for type '${queryType}' is not a Map`;
+    console.error(msg);
+    throw new Error(msg);
+  }
+
+  // Detect structure by checking if the first value is a Map (field-level)
+  // or a primitive like string/array (query-level).
+  //
+  // Field-level example: {"term": {"title": {"value": "java"}}}
+  //   queryBody = Map{"title" → Map{"value" → "java"}}
+  //   firstValue = Map{"value" → "java"} → instanceof Map = true
+  //   → Add boost to firstValue: Map{"value" → "java", "boost" → 2}
+  //
+  // Query-level example: {"query_string": {"query": "java"}}
+  //   queryBody = Map{"query" → "java"}
+  //   firstValue = "java" → instanceof Map = false
+  //   → Add boost to queryBody: Map{"query" → "java", "boost" → 2}
+  const firstValue = queryBody.values().next().value;
+
+  if (firstValue instanceof Map) {
+    // Field-level: boost goes inside the field params Map
+    firstValue.set('boost', boostValue);
+  } else {
+    // Query-level: boost goes at the query body level
+    queryBody.set('boost', boostValue);
+  }
+
+  return childResult;
+};

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/transformer/rules/fieldRule.test.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/transformer/rules/fieldRule.test.ts
@@ -17,8 +17,9 @@ describe('fieldRule', () => {
 
     const result = fieldRule(node, stubTransformChild);
 
+    // Uses expanded form: {"match": {"field": {"query": "value"}}}
     expect(result).toEqual(
-      new Map([['match', new Map([[field, value]])]]),
+      new Map([['match', new Map([[field, new Map([['query', value]])]])]]),
     );
   });
 

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/transformer/rules/fieldRule.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/transformer/rules/fieldRule.ts
@@ -9,6 +9,11 @@
  * Using `term` would require exact matches against the indexed tokens,
  * which could fail for analyzed fields (e.g., case differences).
  *
+ * Output uses the expanded match query form with nested field object:
+ *   `{"match": {"field": {"query": "value"}}}`
+ * This allows boostRule to add boost inside the field object:
+ *   `{"match": {"field": {"query": "value", "boost": 2}}}`
+ *
  * Examples:
  *   `title:java` → Map{"match" → Map{"title" → Map{"query" → "java"}}}
  *   `title:*` → Map{"exists" → Map{"field" → "title"}}
@@ -58,5 +63,7 @@ export const fieldRule: TransformRuleFn = (
     throw new Error(msg);
   }
 
-  return new Map([['match', new Map([[field, value]])]]);
+  // Use expanded form: {"match": {"field": {"query": "value"}}}
+  // This allows boostRule to add boost inside the field object
+  return new Map([['match', new Map([[field, new Map([['query', value]])]])]]);
 };


### PR DESCRIPTION
### Description
This translates [Solr boost query](https://solr.apache.org/guide/solr/latest/query-guide/standard-query-parser.html#boosting-a-term-with) to OpenSearch equivalent

### Testing
UT and Integ

### Check List
- [x] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
