### PR TITLE
Add Jenkins trigger for CDC-only integration test

### DIFF
--- a/.github/workflows/jenkins_tests.yml
+++ b/.github/workflows/jenkins_tests.yml
@@ -188,6 +188,30 @@ jobs:
           jenkins_api_token: "${{ secrets.JENKINS_MIGRATIONS_API_TOKEN }}"
           job_timeout_minutes: "1080"
 
+  eks-cdc-only-integ-test:
+    if: |
+      (github.event.action == 'labeled' && github.event.label.name == 'run-cdc-tests') ||
+      (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'run-cdc-tests'))
+    needs: [get-require-approval, sanitize-input]
+    environment: ${{ needs.get-require-approval.outputs.is-require-approval }}
+    runs-on: ubuntu-22.04
+    timeout-minutes: 180
+    concurrency:
+      group: ${{ github.workflow }}-eks-cdc-only-integ-test-${{ github.event.pull_request.number || github.run_id }}
+      cancel-in-progress: true
+    steps:
+      - uses: actions/checkout@v6
+      - name: Jenkins Job Trigger and Monitor
+        uses: ./.github/actions/jenkins-trigger
+        with:
+          jenkins_url: "https://migrations.ci.opensearch.org"
+          job_name: "pr-eks-cdc-only-integ-test"
+          api_token: "${{ secrets.JENKINS_MIGRATIONS_GENERIC_WEBHOOK_TOKEN }}"
+          job_params: "GIT_REPO_URL=${{ needs.sanitize-input.outputs.pr_repo_url }},GIT_BRANCH=${{ needs.sanitize-input.outputs.branch_name }},GIT_COMMIT=${{ needs.sanitize-input.outputs.commit_hash }}"
+          jenkins_user: "${{ secrets.JENKINS_MIGRATIONS_USER }}"
+          jenkins_api_token: "${{ secrets.JENKINS_MIGRATIONS_API_TOKEN }}"
+          job_timeout_minutes: "180"
+
   eks-cfn-create-vpc-test:
     if: |
       github.event_name == 'push' ||


### PR DESCRIPTION
### Description
Adds a new GitHub Actions job `eks-cdc-only-integ-test` to `jenkins_tests.yml` that triggers the `pr-eks-cdc-only-integ-test` Jenkins pipeline on PRs with the `run-cdc-tests` label.

This job will run on PR-only mode for now. Follow up #2563 will add the `main-*` condition to be consistent with other jobs.

### Issues Resolved
N/A

### Testing
N/A

### Check List
- [ ] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
