### PR TITLE
Bump wait pod memory to 64Mi for both limit and request

### DIFF
--- a/orchestrationSpecs/packages/argo-workflow-builders/src/models/waitForResourceBuilder.ts
+++ b/orchestrationSpecs/packages/argo-workflow-builders/src/models/waitForResourceBuilder.ts
@@ -120,8 +120,8 @@ export class WaitForNewResourceBuilder<
             (typeof waitOpts.maxDurationSeconds === "number" ? waitOpts.maxDurationSeconds : DEFAULT_WAIT_DURATION);
         const maxDurationSeconds = waitOpts.maxDurationSeconds ?? maxKubeWaitDuration;
         const resources = waitOpts.kubectlPodResources ?? {
-            limits: { cpu: "50m", memory: "32Mi" },
-            requests: { cpu: "50m", memory: "32Mi" }
+            limits: { cpu: "50m", memory: "64Mi" },
+            requests: { cpu: "50m", memory: "64Mi" }
         };
 
         const namespaceArgs =

--- a/orchestrationSpecs/packages/migration-workflow-templates/tests/__snapshots__/resourceManagement.snap.json
+++ b/orchestrationSpecs/packages/migration-workflow-templates/tests/__snapshots__/resourceManagement.snap.json
@@ -55,11 +55,11 @@
           "resources": {
             "limits": {
               "cpu": "50m",
-              "memory": "32Mi"
+              "memory": "64Mi"
             },
             "requests": {
               "cpu": "50m",
-              "memory": "32Mi"
+              "memory": "64Mi"
             }
           }
         },
@@ -202,11 +202,11 @@
           "resources": {
             "limits": {
               "cpu": "50m",
-              "memory": "32Mi"
+              "memory": "64Mi"
             },
             "requests": {
               "cpu": "50m",
-              "memory": "32Mi"
+              "memory": "64Mi"
             }
           }
         },


### PR DESCRIPTION
### Description
Getting OOMKilled on wait pods pretty consistently when running workflow in local testing setup. Double wait pod memory to 64Mi from 32Mi. 

Keep requests=limits which makes kubernetes set a "guaranteed" pod class over "burstable" when they don't equal.

### Issues Resolved
N/A

### Testing
- Run capture and replay workflows locally. No longer see OOMKills after memory bump.

### Check List
- [ ] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
