### PR TITLE
Packaging Claude Agent in Container

### DIFF
--- a/AIAdvisor/skills/solr-opensearch-migration-advisor/setup/docker/claude/Dockerfile
+++ b/AIAdvisor/skills/solr-opensearch-migration-advisor/setup/docker/claude/Dockerfile
@@ -1,8 +1,6 @@
-FROM ubuntu:24.04
+FROM public.ecr.aws/amazonlinux/amazonlinux:2023
 
-ENV DEBIAN_FRONTEND=noninteractive
-
-RUN apt-get update && apt-get install -y ca-certificates curl jq && && rm -rf /var/lib/apt/lists/*
+RUN dnf install -y jq shadow-utils && dnf clean all
 
 RUN useradd -m -s /bin/bash user && \
     mkdir -p /home/user/claude/.claude/skills/solr-opensearch-migration-advisor && \

--- a/AIAdvisor/skills/solr-opensearch-migration-advisor/setup/docker/claude/Dockerfile
+++ b/AIAdvisor/skills/solr-opensearch-migration-advisor/setup/docker/claude/Dockerfile
@@ -2,10 +2,7 @@ FROM ubuntu:24.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update && apt-get install -y \
-    curl \
-    ca-certificates \
-    jq
+RUN apt-get update && apt-get install -y ca-certificates curl jq && && rm -rf /var/lib/apt/lists/*
 
 RUN useradd -m -s /bin/bash user && \
     mkdir -p /home/user/claude/.claude/skills/solr-opensearch-migration-advisor && \

--- a/AIAdvisor/skills/solr-opensearch-migration-advisor/setup/docker/claude/Dockerfile
+++ b/AIAdvisor/skills/solr-opensearch-migration-advisor/setup/docker/claude/Dockerfile
@@ -1,0 +1,41 @@
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y \
+    curl \
+    ca-certificates \
+    jq
+
+RUN useradd -m -s /bin/bash user && \
+    mkdir -p /home/user/claude/.claude/skills/migration-advisor && \
+    mkdir -p /home/user/claude/processing/.claude/skills
+
+# we copy only entrypoint.sh to the main folder, which will switch cwd to
+# the claude/processing subfolder before starting claude, to which we also mount the host volume to
+# preserve work.
+# To avoid ownership and thus visibility conflicts between host and container,
+# we copy all relevant agent files to /home/user/claude and use symlinks in entrypoint.sh
+# to make them visible in the claude/processing for the agent to consume.
+# Rather than mounting directly to /home/user/claude.
+# NOTE that the docker build assumes we are in the solr-opensearch-migration-advisor root to be
+# able to copy agent files, thus we need to add the path to entrypoint.sh in the below.
+COPY ./setup/docker/claude/entrypoint.sh /home/user/entrypoint.sh
+COPY SKILL.md /home/user/claude/.claude/skills/migration-advisor/SKILL.md
+COPY references /home/user/claude/references
+COPY scripts /home/user/claude/scripts
+COPY steering /home/user/claude/steering
+RUN chmod +x /home/user/entrypoint.sh
+RUN chown user /home/user/entrypoint.sh
+RUN chown -R user /home/user/claude
+
+USER user
+WORKDIR /home/user
+
+RUN curl -fsSL https://claude.ai/install.sh | bash
+
+ENV PATH="/home/user/.local/bin:${PATH}"
+
+RUN claude --version
+
+CMD ["tail", "-f", "/dev/null"]

--- a/AIAdvisor/skills/solr-opensearch-migration-advisor/setup/docker/claude/Dockerfile
+++ b/AIAdvisor/skills/solr-opensearch-migration-advisor/setup/docker/claude/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update && apt-get install -y \
     jq
 
 RUN useradd -m -s /bin/bash user && \
-    mkdir -p /home/user/claude/.claude/skills/migration-advisor && \
+    mkdir -p /home/user/claude/.claude/skills/solr-opensearch-migration-advisor && \
     mkdir -p /home/user/claude/processing/.claude/skills
 
 # we copy only entrypoint.sh to the main folder, which will switch cwd to
@@ -21,7 +21,7 @@ RUN useradd -m -s /bin/bash user && \
 # NOTE that the docker build assumes we are in the solr-opensearch-migration-advisor root to be
 # able to copy agent files, thus we need to add the path to entrypoint.sh in the below.
 COPY ./setup/docker/claude/entrypoint.sh /home/user/entrypoint.sh
-COPY SKILL.md /home/user/claude/.claude/skills/migration-advisor/SKILL.md
+COPY SKILL.md /home/user/claude/.claude/skills/solr-opensearch-migration-advisor/SKILL.md
 COPY references /home/user/claude/references
 COPY scripts /home/user/claude/scripts
 COPY steering /home/user/claude/steering

--- a/AIAdvisor/skills/solr-opensearch-migration-advisor/setup/docker/claude/README.md
+++ b/AIAdvisor/skills/solr-opensearch-migration-advisor/setup/docker/claude/README.md
@@ -1,0 +1,15 @@
+### Claude Agent packaging
+
+The container-packaged claude agent provides an isolated setup with claude installation 
+and startup script to build the image, start up the container, switch into container shell and start up claude.
+The container already contains all needed files.
+
+- Image needs initial build and rebuild after content changes: `build_image.sh`
+  - To build the image, we change the working dir to `solr-opensearch-migration-advisor` root since docker build needs 
+    to be in hierarchy of needed files, not in deeper subdirectories.
+- simply run `start_container.sh` for startup of container and claude session
+  within container from host shell. After running it you find yourself directly in the container shell with 
+  a running claude code session and migration agent skills discoverable.
+  - make sure env var `CLAUDE_CODE_OAUTH_TOKEN` is set in `solr-opensearch-migration-advisor/.env`
+  - in case you dont have such a token yet, you can generate it via `claude setup-token`. This allows you to use
+    your existing claude code subscription rather than needing another api token.

--- a/AIAdvisor/skills/solr-opensearch-migration-advisor/setup/docker/claude/build_image.sh
+++ b/AIAdvisor/skills/solr-opensearch-migration-advisor/setup/docker/claude/build_image.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -eo pipefail
+
+SCRIPT_DIR="$(dirname "$0")"
+CWD=$(pwd)
+# we jump into the solr-opensearch-migration-advisor root to build docker image from there,
+# to allow file copy from root within the docker file.
+# Docker does not allow file copy to image from parent folders
+cd "$SCRIPT_DIR"/../../.. || exit
+
+echo "Building docker image"
+docker build . -t claude_image:0.0.1 -f ./setup/docker/claude/Dockerfile
+
+cd "$CWD" || exit

--- a/AIAdvisor/skills/solr-opensearch-migration-advisor/setup/docker/claude/entrypoint.sh
+++ b/AIAdvisor/skills/solr-opensearch-migration-advisor/setup/docker/claude/entrypoint.sh
@@ -1,0 +1,12 @@
+# see here: https://github.com/anthropics/claude-code/issues/8938; needed to adjust to allow
+# circumventing intro instructions when passing outh key to enable direct start without
+# answering setup questions
+echo "$(jq '. += {"hasCompletedOnboarding": true}' ~/.claude.json)" > ~/.claude.json
+
+ln -s /home/user/claude/.claude/skills/migration-advisor /home/user/claude/processing/.claude/skills/migration-advisor 2>/dev/null
+ln -s /home/user/claude/references /home/user/claude/processing/references 2>/dev/null
+ln -s /home/user/claude/references /home/user/claude/processing/scripts 2>/dev/null
+ln -s /home/user/claude/references /home/user/claude/processing/steering 2>/dev/null
+
+cd claude/processing || exit
+claude

--- a/AIAdvisor/skills/solr-opensearch-migration-advisor/setup/docker/claude/start_container.sh
+++ b/AIAdvisor/skills/solr-opensearch-migration-advisor/setup/docker/claude/start_container.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -eo pipefail
+
+SCRIPT_DIR="$(dirname "$0")"
+AGENT_VOLUME_DIR="$SCRIPT_DIR"/CLAUDE_ADVISOR_VOLUME
+source "$SCRIPT_DIR"/../../../.env
+mkdir -p "$AGENT_VOLUME_DIR"
+
+echo "Starting up claude container"
+docker run -d --rm  \
+  --name claude-container \
+  -v "$AGENT_VOLUME_DIR":/home/user/claude/processing \
+  -e CLAUDE_CODE_OAUTH_TOKEN="$CLAUDE_CODE_OAUTH_TOKEN" \
+  claude_image:0.0.1
+
+echo "Switching shell into container and starting up claude"
+docker exec -it claude-container bash ./entrypoint.sh
+
+
+
+
+


### PR DESCRIPTION
### Description
Packaging knowledge base / skills and isolated claude installation in docker container. Script provided do dive into claude session within the container.

### Issues Resolved
<!-- List any GitHub or Jira issues this PR will resolve -->

### Testing
<!-- Please provide details of testing done: unit testing, integration testing and manual testing -->

### Check List
- [ ] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
