### PR TITLE
[Fix] Treat expected=0 version pairs as skipped, not failed in test runner

### DIFF
--- a/libraries/testAutomation/testAutomation/test_runner.py
+++ b/libraries/testAutomation/testAutomation/test_runner.py
@@ -297,22 +297,27 @@ class TestRunner:
                                              reuse_clusters=reuse_clusters,
                                              test_reports_dir=test_reports_dir)
                 test_reports.append(test_report)
-                tests_failed = test_report.summary.failed > 0 or test_report.summary.passed == 0
 
                 expected = test_report.summary.expected
-                if expected is not None and test_report.summary.passed != expected:
-                    logger.warning(f"Expected {test_report.summary.expected} tests but only "
-                                   f"{test_report.summary.passed} passed "
-                                   f"({test_report.summary.failed} failed)")
-                    tests_failed = True
-
-                if tests_failed:
-                    logger.warning(f"Tests failed (or no tests executed) for migrations "
-                                   f"from {source_version} to {target_version}.")
-                    combos_with_failures.append(f"{source_version} -> {target_version}")
+                # Version pairs with no compatible tests (expected==0) are not failures
+                if expected is not None and expected == 0 and test_report.summary.failed == 0:
+                    logger.info(f"No compatible tests for {source_version} → {target_version}, skipping")
                 else:
-                    logger.info(f"Tests passed successfully for migrations "
-                                f"from {source_version} to {target_version}.")
+                    tests_failed = test_report.summary.failed > 0 or test_report.summary.passed == 0
+
+                    if expected is not None and test_report.summary.passed != expected:
+                        logger.warning(f"Expected {test_report.summary.expected} tests but only "
+                                       f"{test_report.summary.passed} passed "
+                                       f"({test_report.summary.failed} failed)")
+                        tests_failed = True
+
+                    if tests_failed:
+                        logger.warning(f"Tests failed (or no tests executed) for migrations "
+                                       f"from {source_version} to {target_version}.")
+                        combos_with_failures.append(f"{source_version} -> {target_version}")
+                    else:
+                        logger.info(f"Tests passed successfully for migrations "
+                                    f"from {source_version} to {target_version}.")
             except HelmCommandFailed as helmError:
                 logger.error(f"Helm command failed with error: {helmError}. Testing may be incomplete")
                 combos_with_failures.append(f"{source_version} -> {target_version}")
@@ -329,10 +334,14 @@ class TestRunner:
 
         self._print_summary_table(reports=test_reports)
         total_tests = sum(len(r.tests) for r in test_reports)
+        all_expected_zero = all(
+            r.summary.expected is not None and r.summary.expected == 0
+            for r in test_reports
+        ) if test_reports else False
         if combos_with_failures:
             raise TestsFailed(f"The following combinations had test failures (or no test cases executed): "
                               f"{combos_with_failures}")
-        if total_tests == 0:
+        if total_tests == 0 and not all_expected_zero:
             raise TestsFailed("No tests were executed. This likely indicates a configuration error "
                               "(empty version matrix, missing test IDs, or infrastructure failure).")
         logger.info("Test execution completed.")

--- a/libraries/testAutomation/tests/test_test_runner.py
+++ b/libraries/testAutomation/tests/test_test_runner.py
@@ -105,6 +105,18 @@ class TestFailureDetection:
         with patch.object(runner, "run_tests", return_value=_make_report(passed=3, failed=0, expected=None)):
             runner.run()  # Should not raise
 
+    def test_zero_expected_tests_succeeds(self):
+        """Version pair with no compatible tests (expected=0) should not fail.
+
+        Reproduces the OS_1.3 → OS_2.19 Jenkins failure: conftest.py reports
+        expected=0, passed=0, failed=0 — this is a legitimately empty version
+        pair, not a test failure.
+        """
+        runner = _make_runner(combinations=[("OS_1.3", "OS_2.19")])
+        with patch.object(runner, "run_tests", return_value=_make_report(
+                passed=0, failed=0, expected=0, source="OS_1.3", target="OS_2.19")):
+            runner.run()  # Should not raise
+
 
 from test_runner import get_version_combinations, TargetType, VALID_SOURCE_VERSIONS
 

--- a/migrationConsole/lib/integ_test/integ_test/conftest.py
+++ b/migrationConsole/lib/integ_test/integ_test/conftest.py
@@ -154,16 +154,16 @@ def pytest_runtest_makereport(item, call):
 
 
 def pytest_sessionfinish(session, exitstatus):
-    # If no compatible tests were found, record it as a failure in the report
+    # If no compatible tests were found, record it in the report as a skip (not a failure).
+    # Version pairs with zero compatible tests (e.g. OS_1.3 → OS_2.19) are expected —
+    # the outer test_runner.py uses the expected==0 field to handle this gracefully.
     error = session.config.test_summary.get("error")
     if error:
-        session.config.test_summary["failed"] += 1
         session.config.collected_data.append({
             "name": "test_compatibility_check",
             "description": error,
-            "result": "failed",
+            "result": "skipped",
             "duration": 0.0,
-            "error": error,
         })
 
     # Write test report file at end of test session


### PR DESCRIPTION
### Description
Jenkins runs for `OS_1.3 → OS_2.19` were failing with "Tests failed (or no tests executed)" even though no tests were supposed to run. (Link to view failed Jenkins job is [here](https://migrations.ci.opensearch.org/job/main/job/main-k8s-matrix-test/74/))

- OS_1.3 is a valid source version but has no compatible tests against OS_2.19. 
- `conftest.py` was correctly reporting expected=0, passed=0, failed=0, but `test_runner.py` treated passed=0 as a failure 
unconditionally
- Additionally, conftest.py was incrementing failed and recording a "failed" result when no compatible tests were found, which compounded the issue

The bug had no test coverage. There was no test case for the expected=0 scenario in PR #2656 , which is the reason we did not catch this earlier.

#### Fix

1. Added a test test_zero_expected_tests_succeeds to reproduce the failure. It broke immediately, confirming the bug.
2. `test_runner.py` : skip the pass/fail check entirely when `expected==0 and failed==0`; also skip the "no tests executed" guard when all version pairs legitimately have `expected==0`.
3. `conftest.py` : record empty version pairs as "skipped" instead of "failed", and stop incrementing the failed counter.


### Issues Resolved
N/A

### Testing
- Added test_zero_expected_tests_succeeds = was failing before fix, passes after
- All 15 existing tests continue to pass
- Waiting on K8s-matirx-test to pass : https://migrations.ci.opensearch.org/job/pr-checks/job/pr-k8s-matrix-test/29/

### Check List
- [x] New functionality includes testing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
