### PR TITLE
refactor(shim): use replayer's TransformerProvider pattern with SolrTransformerProvider

### DIFF
--- a/TrafficCapture/SolrTransformations/docs/LIMITATIONS.md
+++ b/TrafficCapture/SolrTransformations/docs/LIMITATIONS.md
@@ -178,9 +178,24 @@ The traffic replayer uses `JsonJSTransformerProvider` which does not have
 access to `SolrConfigProvider` for XML parsing. The solrConfig must be
 provided as pre-built JSON in the `bindingsObject` of `--transformerConfig`.
 
-**Note:** The shim proxy supports both XML and JSON via explicit CLI params:
-- `--solr-config-path /path/to/solrconfig.xml` (or `.json`)
-- `--solr-config-inline '{"solrConfig":{...}}'`
+Both the shim proxy and the traffic replayer accept `--transformerConfig`
+(or `--transformerConfigEncoded` / `--transformerConfigFile`) following the
+same pattern. The shim interprets the config as a bindings object directly:
+
+**Example (shim proxy — inline JSON):**
+```
+--transformerConfig '{"solrConfig":{"/select":{"defaults":{"df":"title"}}}}'
+```
+
+**Example (shim proxy — base64 encoded):**
+```
+--transformerConfigEncoded 'eyJzb2xyQ29uZmlnIjp7Ii9zZWxlY3QiOnsiZGVmYXVsdHMiOnsiZGYiOiJ0aXRsZSJ9fX19'
+```
+
+**Example (shim proxy — XML file, auto-parsed):**
+```
+--transformerConfigFile /path/to/solrconfig.xml
+```
 
 **Example (traffic replayer):**
 ```

--- a/TrafficCapture/SolrTransformations/docs/LIMITATIONS.md
+++ b/TrafficCapture/SolrTransformations/docs/LIMITATIONS.md
@@ -178,26 +178,29 @@ The traffic replayer uses `JsonJSTransformerProvider` which does not have
 access to `SolrConfigProvider` for XML parsing. The solrConfig must be
 provided as pre-built JSON in the `bindingsObject` of `--transformerConfig`.
 
-Both the shim proxy and the traffic replayer accept `--transformerConfig`
-(or `--transformerConfigEncoded` / `--transformerConfigFile`) following the
-same pattern. The shim interprets the config as a bindings object directly:
+Both the shim proxy and the traffic replayer use `--transformerConfig`
+with the same provider-based JSON array format. The shim uses
+`SolrTransformerProvider` which auto-prepends the GraalVM polyfill and
+supports `solrConfigXmlFile` for automatic XML parsing.
 
-**Example (shim proxy — inline JSON):**
+**Example (shim proxy — with solrconfig.xml auto-parsing):**
 ```
---transformerConfig '{"solrConfig":{"/select":{"defaults":{"df":"title"}}}}'
-```
-
-**Example (shim proxy — base64 encoded):**
-```
---transformerConfigEncoded 'eyJzb2xyQ29uZmlnIjp7Ii9zZWxlY3QiOnsiZGVmYXVsdHMiOnsiZGYiOiJ0aXRsZSJ9fX19'
-```
-
-**Example (shim proxy — XML file, auto-parsed):**
-```
---transformerConfigFile /path/to/solrconfig.xml
+--transformerConfig '[{"SolrTransformerProvider": {
+  "initializationScriptFile": "/path/to/request.js",
+  "bindingsObject": "{}",
+  "solrConfigXmlFile": "/path/to/solrconfig.xml"
+}}]'
 ```
 
-**Example (traffic replayer):**
+**Example (shim proxy — with inline solrConfig JSON in bindings):**
+```
+--transformerConfig '[{"SolrTransformerProvider": {
+  "initializationScriptFile": "/path/to/request.js",
+  "bindingsObject": "{\"solrConfig\": {\"/select\": {\"defaults\": {\"df\": \"title\"}}}}"
+}}]'
+```
+
+**Example (traffic replayer — uses JsonJSTransformerProvider):**
 ```
 --transformerConfig '[{"JsonJSTransformerProvider": {
   "initializationScriptFile": "/path/to/request.js",
@@ -205,7 +208,6 @@ same pattern. The shim interprets the config as a bindings object directly:
 }}]'
 ```
 
-**Cause:**
-`SolrConfigProvider` lives in the `transformationShim` module. Adding it
-as a dependency to `JsonJSTransformerProvider` would create a circular
-dependency. A future PR can move it to a shared module.
+**Note:** The traffic replayer cannot use `SolrTransformerProvider` directly
+because `SolrConfigProvider` lives in the `transformationShim` module.
+A future PR can move it to a shared module.

--- a/TrafficCapture/SolrTransformations/docs/LIMITATIONS.md
+++ b/TrafficCapture/SolrTransformations/docs/LIMITATIONS.md
@@ -14,6 +14,7 @@ the root cause, and provides a workaround where one exists.
 | [DATE-RANGE-GAP](#date-range-gap) | Multi-unit date range gaps approximated as fixed intervals |
 | [CURSOR-UNIQUEKEY](#cursor-uniquekey) | Cursor pagination assumes `id` as Solr's uniqueKey field |
 | [CURSOR-REPLAY](#cursor-replay) | Traffic replay with cursorMark not supported |
+| [SOLRCONFIG-REPLAYER](#solrconfig-replayer) | Traffic replayer requires manual solrConfig in bindingsObject |
 
 ---
 
@@ -164,3 +165,32 @@ works during replay.
 **Current workaround:**
 This applies only to offline traffic replay. The live shim proxy handles
 cursor pagination correctly using its own base64-encoded tokens.
+
+
+---
+
+## SOLRCONFIG-REPLAYER
+
+**Feature:** Solrconfig defaults in traffic replayer mode
+
+**Limitation:**
+The traffic replayer uses `JsonJSTransformerProvider` which does not have
+access to `SolrConfigProvider` for XML parsing. The solrConfig must be
+provided as pre-built JSON in the `bindingsObject` of `--transformerConfig`.
+
+**Note:** The shim proxy supports both XML and JSON via explicit CLI params:
+- `--solr-config-path /path/to/solrconfig.xml` (or `.json`)
+- `--solr-config-inline '{"solrConfig":{...}}'`
+
+**Example (traffic replayer):**
+```
+--transformerConfig '[{"JsonJSTransformerProvider": {
+  "initializationScriptFile": "/path/to/request.js",
+  "bindingsObject": "{\"solrConfig\": {\"/select\": {\"defaults\": {\"df\": \"title\"}}}}"
+}}]'
+```
+
+**Cause:**
+`SolrConfigProvider` lives in the `transformationShim` module. Adding it
+as a dependency to `JsonJSTransformerProvider` would create a circular
+dependency. A future PR can move it to a shared module.

--- a/TrafficCapture/SolrTransformations/src/test/java/org/opensearch/migrations/transform/solr/TestCaseDefinition.java
+++ b/TrafficCapture/SolrTransformations/src/test/java/org/opensearch/migrations/transform/solr/TestCaseDefinition.java
@@ -36,7 +36,8 @@ record TestCaseDefinition(
     Map<String, Object> solrSchema,
     Map<String, Object> opensearchMapping,
     List<String> solrVersions,
-    List<String> plugins
+    List<String> plugins,
+    Map<String, Object> transformBindings
 ) {
     /** A per-path assertion rule controlling how diffs are handled. */
     @JsonIgnoreProperties(ignoreUnknown = true)

--- a/TrafficCapture/SolrTransformations/src/test/java/org/opensearch/migrations/transform/solr/TransformationShimE2ETest.java
+++ b/TrafficCapture/SolrTransformations/src/test/java/org/opensearch/migrations/transform/solr/TransformationShimE2ETest.java
@@ -82,35 +82,43 @@ class TransformationShimE2ETest {
         });
     }
 
-    /** Run all test cases for a single Solr version using one shared fixture. */
+    /** Run all test cases for a single Solr version, grouping by transform bindings. */
     private void runAllTestsForVersion(
             List<TestCaseDefinition> testCases, String solrImage,
             OpensearchContainer<?> sharedOpenSearch) throws Exception {
         if (testCases.isEmpty()) return;
 
-        var firstTc = testCases.get(0);
-        var requestTransform = composeTransforms(firstTc.requestTransforms());
-        var responseTransform = composeTransforms(firstTc.responseTransforms());
-        var plugins = firstTc.plugins() != null ? firstTc.plugins() : List.<String>of();
+        var groups = new java.util.LinkedHashMap<String, List<TestCaseDefinition>>();
+        for (var tc : testCases) {
+            String key = tc.transformBindings() != null ? tc.transformBindings().toString() : "";
+            groups.computeIfAbsent(key, k -> new ArrayList<>()).add(tc);
+        }
 
-        try (var fixture = new ShimTestFixture(solrImage, sharedOpenSearch, requestTransform, responseTransform)) {
-            fixture.start(plugins);
-            var failures = new ArrayList<String>();
+        var allFailures = new ArrayList<String>();
+        for (var group : groups.values()) {
+            var firstTc = group.get(0);
+            var bindings = firstTc.transformBindings() != null ? firstTc.transformBindings() : EMPTY_BINDINGS;
+            var requestTransform = composeTransforms(firstTc.requestTransforms(), bindings);
+            var responseTransform = composeTransforms(firstTc.responseTransforms());
+            var plugins = firstTc.plugins() != null ? firstTc.plugins() : List.<String>of();
 
-            for (var tc : testCases) {
-                try {
-                    executeTestCase(fixture, tc, solrImage);
-                } catch (Throwable e) {
-                    log.error("FAILED: {} [{}]: {}", tc.name(), solrImage, e.getMessage());
-                    failures.add(tc.name() + ": " + e.getMessage());
-                } finally {
-                    cleanupData(fixture, tc);
+            try (var fixture = new ShimTestFixture(solrImage, sharedOpenSearch, requestTransform, responseTransform)) {
+                fixture.start(plugins);
+                for (var tc : group) {
+                    try {
+                        executeTestCase(fixture, tc, solrImage);
+                    } catch (Throwable e) {
+                        log.error("FAILED: {} [{}]: {}", tc.name(), solrImage, e.getMessage());
+                        allFailures.add(tc.name() + ": " + e.getMessage());
+                    } finally {
+                        cleanupData(fixture, tc);
+                    }
                 }
             }
+        }
 
-            if (!failures.isEmpty()) {
-                fail(failures.size() + " test(s) failed for " + solrImage + ":\n" + String.join("\n", failures));
-            }
+        if (!allFailures.isEmpty()) {
+            fail(allFailures.size() + " test(s) failed for " + solrImage + ":\n" + String.join("\n", allFailures));
         }
     }
 
@@ -245,6 +253,7 @@ class TransformationShimE2ETest {
 
         if (seedSolr) {
             fixture.createSolrCore(tc.collection(), tc.solrSchema());
+            applySolrConfigDefaults(fixture, tc);
             fixture.httpPost(
                 fixture.getSolrBaseUrl() + "/solr/" + tc.collection() + "/update/json/docs?commit=true",
                 MAPPER.writeValueAsString(tc.documents()));
@@ -268,14 +277,43 @@ class TransformationShimE2ETest {
 
     // --- Transform loading ---
 
+    /** Apply solrconfig defaults to the running Solr instance via Config API. */
+    @SuppressWarnings("unchecked")
+    private void applySolrConfigDefaults(ShimTestFixture fixture, TestCaseDefinition tc) throws Exception {
+        if (tc.transformBindings() == null) return;
+        var solrConfig = (Map<String, Object>) tc.transformBindings().get("solrConfig");
+        if (solrConfig == null) return;
+
+        var selectConfig = (Map<String, Object>) solrConfig.get("/select");
+        if (selectConfig == null) return;
+
+        var handlerDef = new java.util.LinkedHashMap<String, Object>();
+        handlerDef.put("name", "/select");
+        handlerDef.put("class", "solr.SearchHandler");
+        if (selectConfig.containsKey("defaults")) {
+            handlerDef.put("defaults", selectConfig.get("defaults"));
+        }
+        if (selectConfig.containsKey("invariants")) {
+            handlerDef.put("invariants", selectConfig.get("invariants"));
+        }
+
+        var configUrl = fixture.getSolrBaseUrl() + "/solr/" + tc.collection() + "/config";
+        fixture.httpPost(configUrl, MAPPER.writeValueAsString(Map.of("update-requesthandler", handlerDef)));
+        log.info("Applied solrconfig defaults to Solr collection '{}'", tc.collection());
+    }
+
     private static IJsonTransformer composeTransforms(List<String> names) throws IOException {
+        return composeTransforms(names, EMPTY_BINDINGS);
+    }
+
+    private static IJsonTransformer composeTransforms(List<String> names, Map<?, ?> bindings) throws IOException {
         if (names == null || names.isEmpty()) {
             return new JavascriptTransformer(IDENTITY_JS, EMPTY_BINDINGS);
         }
         var transformers = new IJsonTransformer[names.size()];
         for (int i = 0; i < names.size(); i++) {
             transformers[i] = new JavascriptTransformer(
-                ShimMain.JS_POLYFILL + loadTransformJs(names.get(i) + ".js"), EMPTY_BINDINGS);
+                ShimMain.JS_POLYFILL + loadTransformJs(names.get(i) + ".js"), bindings);
         }
         return transformers.length == 1 ? transformers[0] : new JsonCompositeTransformer(transformers);
     }

--- a/TrafficCapture/SolrTransformations/src/test/java/org/opensearch/migrations/transform/solr/TransformationShimE2ETest.java
+++ b/TrafficCapture/SolrTransformations/src/test/java/org/opensearch/migrations/transform/solr/TransformationShimE2ETest.java
@@ -17,7 +17,7 @@ import java.util.stream.Stream;
 import org.opensearch.migrations.transform.IJsonTransformer;
 import org.opensearch.migrations.transform.JavascriptTransformer;
 import org.opensearch.migrations.transform.JsonCompositeTransformer;
-import org.opensearch.migrations.transform.shim.ShimMain;
+import org.opensearch.migrations.transform.shim.SolrTransformerProvider;
 import org.opensearch.testcontainers.OpensearchContainer;
 
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -313,7 +313,7 @@ class TransformationShimE2ETest {
         var transformers = new IJsonTransformer[names.size()];
         for (int i = 0; i < names.size(); i++) {
             transformers[i] = new JavascriptTransformer(
-                ShimMain.JS_POLYFILL + loadTransformJs(names.get(i) + ".js"), bindings);
+                SolrTransformerProvider.JS_POLYFILL + loadTransformJs(names.get(i) + ".js"), bindings);
         }
         return transformers.length == 1 ? transformers[0] : new JsonCompositeTransformer(transformers);
     }

--- a/TrafficCapture/SolrTransformations/transforms/package-lock.json
+++ b/TrafficCapture/SolrTransformations/transforms/package-lock.json
@@ -1119,6 +1119,7 @@
       "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.1",
         "@typescript-eslint/types": "8.56.1",
@@ -1571,6 +1572,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1776,6 +1778,7 @@
       "integrity": "sha512-uYixubwmqJZH+KLVYIVKY1JQt7tysXhtj21WSvjcSmU5SVNzMus1bgLe+pAt816yQ8opKfheVVoPLqvVMGejYw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -2490,6 +2493,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2797,6 +2801,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
       "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -3313,6 +3318,7 @@
       "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.18",
         "@vitest/mocker": "4.0.18",
@@ -4017,6 +4023,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.56.1.tgz",
       "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@typescript-eslint/scope-manager": "8.56.1",
         "@typescript-eslint/types": "8.56.1",
@@ -4273,7 +4280,8 @@
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "acorn-jsx": {
       "version": "5.3.2",
@@ -4414,6 +4422,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.0.2.tgz",
       "integrity": "sha512-uYixubwmqJZH+KLVYIVKY1JQt7tysXhtj21WSvjcSmU5SVNzMus1bgLe+pAt816yQ8opKfheVVoPLqvVMGejYw==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -4883,7 +4892,8 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "postcss": {
       "version": "8.5.8",
@@ -5074,6 +5084,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
       "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
+      "peer": true,
       "requires": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -5300,6 +5311,7 @@
       "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.18.tgz",
       "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@vitest/expect": "4.0.18",
         "@vitest/mocker": "4.0.18",

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/context.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/context.ts
@@ -36,6 +36,12 @@ export interface RequestContext {
   targetName?: string;
   /** Routing mode — 'single' or 'dual'. Set by the shim proxy. */
   mode?: string;
+  /**
+   * Solr requestHandler config (defaults/invariants/appends) from solrconfig.xml.
+   * Injected from bindings at init, set per-context so transforms access it via ctx.
+   * Uses Record (plain object) because GraalVM exposes Java Maps as JS objects via allowMapAccess.
+   */
+  solrConfig?: Record<string, { defaults?: Record<string, string>; invariants?: Record<string, string>; appends?: Record<string, string> }>;
 }
 
 /** Parsed once from the bundled {request, response}. Shared across all response micro-transforms. */

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/solrconfig-defaults.test.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/solrconfig-defaults.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect } from 'vitest';
+import { request } from './solrconfig-defaults';
+import { buildRequestContext, type RequestContext, type JavaMap } from '../context';
+import { runPipeline } from '../pipeline';
+import { requestRegistry } from '../registry';
+
+function makeCtx(endpoint: string, params: Record<string, string>,
+    solrConfig?: RequestContext['solrConfig']): RequestContext {
+  const p = new URLSearchParams();
+  for (const [k, v] of Object.entries(params)) p.set(k, v);
+  return {
+    msg: new Map(),
+    endpoint: endpoint as any,
+    collection: 'test',
+    params: p,
+    body: new Map(),
+    solrConfig,
+  };
+}
+
+describe('solrconfig-defaults', () => {
+  it('is a no-op when solrConfig is not set', () => {
+    const ctx = makeCtx('select', { q: 'laptop' });
+    expect(request.match!(ctx)).toBe(false);
+  });
+
+  it('applies defaults when param is missing', () => {
+    const ctx = makeCtx('select', { q: 'laptop' },
+      { '/select': { defaults: { df: 'title', rows: '20' } } });
+    request.apply(ctx);
+    expect(ctx.params.get('df')).toBe('title');
+    expect(ctx.params.get('rows')).toBe('20');
+  });
+
+  it('does not override existing params with defaults', () => {
+    const ctx = makeCtx('select', { q: 'laptop', df: 'description', rows: '5' },
+      { '/select': { defaults: { df: 'title', rows: '20' } } });
+    request.apply(ctx);
+    expect(ctx.params.get('df')).toBe('description');
+    expect(ctx.params.get('rows')).toBe('5');
+  });
+
+  it('invariants always override request params', () => {
+    const ctx = makeCtx('select', { q: 'laptop', 'facet.field': 'brand' },
+      { '/select': { invariants: { 'facet.field': 'cat' } } });
+    request.apply(ctx);
+    expect(ctx.params.get('facet.field')).toBe('cat');
+  });
+
+  it('applies both defaults and invariants', () => {
+    const ctx = makeCtx('select', { q: 'laptop', wt: 'xml' }, {
+      '/select': {
+        defaults: { df: 'title' },
+        invariants: { wt: 'json' },
+      },
+    });
+    request.apply(ctx);
+    expect(ctx.params.get('df')).toBe('title');
+    expect(ctx.params.get('wt')).toBe('json'); // invariant overrides
+  });
+
+  it('skips when endpoint has no handler config', () => {
+    const ctx = makeCtx('update', { q: 'laptop' },
+      { '/select': { defaults: { df: 'title' } } });
+    request.apply(ctx);
+    expect(ctx.params.has('df')).toBe(false);
+  });
+
+  it('handles empty defaults and invariants', () => {
+    const ctx = makeCtx('select', { q: 'laptop' }, { '/select': {} });
+    request.apply(ctx);
+    expect(ctx.params.get('q')).toBe('laptop');
+  });
+
+  it('handles multiple handlers — matches correct endpoint', () => {
+    const ctx = makeCtx('select', { q: 'test' }, {
+      '/select': { defaults: { df: 'title' } },
+      '/query': { defaults: { df: 'content' } },
+    });
+    request.apply(ctx);
+    expect(ctx.params.get('df')).toBe('title');
+  });
+
+  it('invariants override even when param matches default', () => {
+    const ctx = makeCtx('select', { q: 'test' }, {
+      '/select': {
+        defaults: { df: 'title' },
+        invariants: { df: 'forced_field' },
+      },
+    });
+    request.apply(ctx);
+    expect(ctx.params.get('df')).toBe('forced_field');
+  });
+
+  it('appends adds alongside existing param values', () => {
+    const ctx = makeCtx('select', { q: '*:*', fq: 'category:books' },
+      { '/select': { appends: { fq: 'inStock:true' } } });
+    request.apply(ctx);
+    expect(ctx.params.getAll('fq')).toEqual(['category:books', 'inStock:true']);
+  });
+
+  it('appends adds param when not present in request', () => {
+    const ctx = makeCtx('select', { q: '*:*' },
+      { '/select': { appends: { fq: 'inStock:true' } } });
+    request.apply(ctx);
+    expect(ctx.params.getAll('fq')).toEqual(['inStock:true']);
+  });
+
+  it('defaults + appends + invariants all applied together', () => {
+    const ctx = makeCtx('select', { q: 'test', wt: 'xml' }, {
+      '/select': {
+        defaults: { df: 'title', rows: '10' },
+        appends: { fq: 'inStock:true' },
+        invariants: { wt: 'json' },
+      },
+    });
+    request.apply(ctx);
+    expect(ctx.params.get('df')).toBe('title');
+    expect(ctx.params.get('rows')).toBe('10');
+    expect(ctx.params.getAll('fq')).toEqual(['inStock:true']);
+    expect(ctx.params.get('wt')).toBe('json');
+  });
+});
+
+function makeRequestMsg(uri: string): JavaMap {
+  const map = new Map<string, any>();
+  map.set('URI', uri);
+  return map as unknown as JavaMap;
+}
+
+describe('solrconfig-defaults pipeline integration', () => {
+  it('pipeline applies defaults when ctx.solrConfig is set', () => {
+    const msg = makeRequestMsg('/solr/testcollection/select?q=laptop&wt=json');
+    const ctx = buildRequestContext(msg);
+    ctx.solrConfig = { '/select': { defaults: { df: 'content', rows: '15' } } };
+
+    runPipeline(requestRegistry, ctx);
+
+    expect(ctx.params.get('df')).toBe('content');
+    expect(ctx.params.get('rows')).toBe('15');
+  });
+
+  it('pipeline skips solrconfig-defaults when ctx.solrConfig is undefined', () => {
+    const msg = makeRequestMsg('/solr/testcollection/select?q=laptop&wt=json');
+    const ctx = buildRequestContext(msg);
+
+    runPipeline(requestRegistry, ctx);
+
+    expect(ctx.params.has('df')).toBe(false);
+  });
+
+  it('pipeline applies solrConfig before other transforms', () => {
+    const msg = makeRequestMsg('/solr/testcollection/select?q=laptop');
+    const ctx = buildRequestContext(msg);
+    ctx.solrConfig = { '/select': { defaults: { df: 'title' } } };
+
+    runPipeline(requestRegistry, ctx);
+
+    // df=title should be set by solrconfig-defaults (runs first),
+    // then downstream transforms (query-q etc.) see it
+    expect(ctx.params.get('df')).toBe('title');
+  });
+});

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/solrconfig-defaults.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/solrconfig-defaults.ts
@@ -1,0 +1,46 @@
+/**
+ * Solrconfig defaults — apply requestHandler defaults, invariants, and appends
+ * from solrconfig.xml.
+ *
+ * These three categories are defined by the Solr spec:
+ * @see https://solr.apache.org/guide/solr/latest/configuration-guide/requesthandlers-searchcomponents.html
+ *
+ * Per request:
+ *   - defaults: set param only if NOT already in the request
+ *   - invariants: always override, regardless of request params
+ *   - appends: add alongside existing values (e.g., multiple fq)
+ *
+ * Config is read from ctx.solrConfig (set per-request from bindings in request.transform.ts).
+ * Must run FIRST in the select pipeline so all downstream transforms see merged params.
+ */
+import type { MicroTransform } from '../pipeline';
+import type { RequestContext } from '../context';
+
+export const request: MicroTransform<RequestContext> = {
+  name: 'solrconfig-defaults',
+  match: (ctx) => ctx.solrConfig != null,
+  apply: (ctx) => {
+    const handler = ctx.solrConfig?.['/' + ctx.endpoint];
+    if (!handler) return;
+
+    if (handler.defaults) {
+      for (const key in handler.defaults) {
+        if (!ctx.params.has(key)) {
+          ctx.params.set(key, handler.defaults[key]);
+        }
+      }
+    }
+
+    if (handler.invariants) {
+      for (const key in handler.invariants) {
+        ctx.params.set(key, handler.invariants[key]);
+      }
+    }
+
+    if (handler.appends) {
+      for (const key in handler.appends) {
+        ctx.params.append(key, handler.appends[key]);
+      }
+    }
+  },
+};

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/registry.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/registry.ts
@@ -9,6 +9,7 @@
 import type { TransformRegistry } from './pipeline';
 import type { RequestContext, ResponseContext } from './context';
 
+import * as solrconfigDefaults from './features/solrconfig-defaults';
 import * as selectUri from './features/select-uri';
 import * as queryQ from './features/query-q';
 import * as cursorPagination from './features/cursor-pagination';
@@ -24,7 +25,8 @@ export const requestRegistry: TransformRegistry<RequestContext> = {
   global: [],
   byEndpoint: {
     select: [
-      selectUri.request, // URI rewrite — must be first
+      solrconfigDefaults.request, // Apply solrconfig.xml defaults/invariants — must be before all others
+      selectUri.request, // URI rewrite
       queryQ.request, // q=... → query DSL
       cursorPagination.request, // cursorMark → search_after (after query-q sets from)
       jsonFacets.request, // json.facet → aggs

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/request.transform.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/request.transform.ts
@@ -10,9 +10,17 @@ import type { JavaMap } from './context';
 import { runPipeline } from './pipeline';
 import { requestRegistry } from './registry';
 
+// Read solrConfig from bindings once at init (closure, not global mutable state).
+// bindings is injected by Java via JavascriptTransformer's bindingsObject.
+declare const bindings: any;
+const solrConfig = (typeof bindings !== 'undefined' && bindings?.solrConfig) //NOSONAR — typeof required for undeclared closure var
+  ? bindings.solrConfig
+  : undefined;
+
 export function transform(msg: JavaMap): JavaMap {
   const ctx = buildRequestContext(msg);
   if (ctx.endpoint === 'unknown') return msg;
+  ctx.solrConfig = solrConfig;
   runPipeline(requestRegistry, ctx);
   if (ctx.body.size > 0) {
     let payload = msg.get('payload');

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/solrconfig-defaults.testcase.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/solrconfig-defaults.testcase.ts
@@ -1,0 +1,194 @@
+/**
+ * E2E test cases for solrconfig.xml defaults integration.
+ * Tests that handler defaults (df) are applied during query translation.
+ *
+ * All test cases in this file share the same transform bindings (one fixture per file).
+ * Shared solrConfig: df=title, rows=10
+ */
+import { solrTest, SOLR_INTERNAL_RULES } from '../test-types';
+
+/** Shared bindings for all tests in this file. */
+const SOLR_CONFIG_BINDINGS = {
+  solrConfig: {
+    '/select': {
+      defaults: { df: 'title', rows: '10', wt: 'json' },
+    },
+  },
+};
+
+/**
+ * Bindings in the same JSON format as --solr-config-path with a .json file
+ * or --solr-config-inline. Verifies the JSON-based config path works end-to-end.
+ */
+const SOLR_CONFIG_JSON_BINDINGS = {
+  solrConfig: {
+    '/select': {
+      defaults: { df: 'content', rows: '2' },
+    },
+  },
+};
+
+export const testCases = [
+  solrTest('solrconfig-default-df-applied', {
+    description: 'Bare query without df uses df=title from solrconfig defaults — matches Solr behavior',
+    documents: [
+      { id: '1', title: 'Java Programming', content: 'Learn Java basics' },
+      { id: '2', title: 'Python Cookbook', content: 'Recipes for Python devs' },
+      { id: '3', title: 'Go in Action', content: 'Concurrency in Go' },
+    ],
+    requestPath: '/solr/testcollection/select?q=Java&fl=id,title&wt=json',
+    solrSchema: {
+      fields: {
+        title: { type: 'text_general' },
+        content: { type: 'text_general' },
+      },
+    },
+    opensearchMapping: {
+      properties: {
+        title: { type: 'text' },
+        content: { type: 'text' },
+      },
+    },
+    assertionRules: SOLR_INTERNAL_RULES,
+    transformBindings: SOLR_CONFIG_BINDINGS,
+  }),
+
+  solrTest('solrconfig-explicit-df-overrides-default', {
+    description: 'Explicit df=content overrides solrconfig default df=title',
+    documents: [
+      { id: '1', title: 'Java Programming', content: 'Learn Java basics' },
+      { id: '2', title: 'Python Cookbook', content: 'Java recipes for Python devs' },
+    ],
+    requestPath: '/solr/testcollection/select?q=Java&df=content&fl=id,title&wt=json',
+    solrSchema: {
+      fields: {
+        title: { type: 'text_general' },
+        content: { type: 'text_general' },
+      },
+    },
+    opensearchMapping: {
+      properties: {
+        title: { type: 'text' },
+        content: { type: 'text' },
+      },
+    },
+    assertionRules: SOLR_INTERNAL_RULES,
+    transformBindings: SOLR_CONFIG_BINDINGS,
+  }),
+
+  solrTest('solrconfig-default-rows-not-overridden-by-explicit', {
+    description: 'Explicit rows=1 overrides solrconfig default rows=10',
+    documents: [
+      { id: '1', title: 'Doc One' },
+      { id: '2', title: 'Doc Two' },
+      { id: '3', title: 'Doc Three' },
+    ],
+    requestPath: '/solr/testcollection/select?q=*:*&rows=1&fl=id,title&wt=json',
+    solrSchema: {
+      fields: { title: { type: 'text_general' } },
+    },
+    opensearchMapping: {
+      properties: { title: { type: 'text' } },
+    },
+    assertionRules: SOLR_INTERNAL_RULES,
+    transformBindings: SOLR_CONFIG_BINDINGS,
+  }),
+
+  solrTest('solrconfig-df-does-not-affect-field-specific-query', {
+    description: 'Field-specific query title:Java is unaffected by df default',
+    documents: [
+      { id: '1', title: 'Java Programming', content: 'Learn basics' },
+      { id: '2', title: 'Python Cookbook', content: 'Java recipes' },
+    ],
+    requestPath: '/solr/testcollection/select?q=title:Java&fl=id,title&wt=json',
+    solrSchema: {
+      fields: {
+        title: { type: 'text_general' },
+        content: { type: 'text_general' },
+      },
+    },
+    opensearchMapping: {
+      properties: {
+        title: { type: 'text' },
+        content: { type: 'text' },
+      },
+    },
+    assertionRules: SOLR_INTERNAL_RULES,
+    transformBindings: SOLR_CONFIG_BINDINGS,
+  }),
+
+  solrTest('solrconfig-defaults-with-highlighting', {
+    description: 'Default df=title works correctly combined with highlighting',
+    documents: [
+      { id: '1', title: 'Java Basics', content: 'Introduction to Java' },
+      { id: '2', title: 'Java Advanced', content: 'Deep dive into Java' },
+      { id: '3', title: 'Go in Action', content: 'Concurrency in Go' },
+    ],
+    requestPath: '/solr/testcollection/select?q=Java&hl=true&hl.fl=title&fl=id,title&wt=json',
+    solrSchema: {
+      fields: {
+        title: { type: 'text_general' },
+        content: { type: 'text_general' },
+      },
+    },
+    opensearchMapping: {
+      properties: {
+        title: { type: 'text' },
+        content: { type: 'text' },
+      },
+    },
+    assertionRules: [
+      ...SOLR_INTERNAL_RULES,
+      { path: '$.highlighting[*][*][*]', rule: 'regex', expected: '.*<em>.*</em>.*', reason: 'Highlight fragment text may differ' },
+    ],
+    transformBindings: SOLR_CONFIG_BINDINGS,
+  }),
+
+  solrTest('solrconfig-json-bindings-df-applied', {
+    description: 'JSON-format solrConfig bindings (as from --solr-config-path .json or --solr-config-inline) — df=content applied',
+    documents: [
+      { id: '1', title: 'Java Programming', content: 'Learn Java basics' },
+      { id: '2', title: 'Python Cookbook', content: 'Java recipes for Python devs' },
+    ],
+    requestPath: '/solr/testcollection/select?q=Java&fl=id,title,content&wt=json',
+    solrSchema: {
+      fields: {
+        title: { type: 'text_general' },
+        content: { type: 'text_general' },
+      },
+    },
+    opensearchMapping: {
+      properties: {
+        title: { type: 'text' },
+        content: { type: 'text' },
+      },
+    },
+    assertionRules: SOLR_INTERNAL_RULES,
+    transformBindings: SOLR_CONFIG_JSON_BINDINGS,
+  }),
+
+  solrTest('solrconfig-rows-default-applied-when-absent', {
+    description: 'Default rows=2 from solrConfig is applied when rows is not in the URL — verifies URLSearchParams.set() works in GraalVM polyfill',
+    documents: [
+      { id: '1', title: 'Doc A', content: 'first' },
+      { id: '2', title: 'Doc B', content: 'second' },
+      { id: '3', title: 'Doc C', content: 'third' },
+      { id: '4', title: 'Doc D', content: 'fourth' },
+    ],
+    requestPath: '/solr/testcollection/select?q=*:*&fl=id,title&wt=json',
+    solrSchema: {
+      fields: {
+        title: { type: 'text_general' },
+        content: { type: 'text_general' },
+      },
+    },
+    opensearchMapping: {
+      properties: {
+        title: { type: 'text' },
+        content: { type: 'text' },
+      },
+    },
+    assertionRules: SOLR_INTERNAL_RULES,
+    transformBindings: SOLR_CONFIG_JSON_BINDINGS,
+  }),
+];

--- a/TrafficCapture/SolrTransformations/transforms/src/test-types.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/test-types.ts
@@ -200,6 +200,8 @@ export interface TestCase {
   opensearchMapping?: OpenSearchMapping;
   solrVersions?: string[];
   plugins?: string[];
+  /** Optional bindings passed to transforms at init (e.g., solrConfig defaults from solrconfig.xml). */
+  transformBindings?: Record<string, unknown>;
 }
 
 /** Solr-internal fields that OpenSearch doesn't have — always safe to ignore. */

--- a/TrafficCapture/transformationShim/build.gradle
+++ b/TrafficCapture/transformationShim/build.gradle
@@ -8,6 +8,7 @@ dependencies {
     implementation project(':coreUtilities')
     implementation project(':transformation:transformationPlugins:jsonMessageTransformers:jsonMessageTransformerInterface')
     implementation project(':transformation:transformationPlugins:jsonMessageTransformers:jsonJSTransformer')
+    implementation project(':transformation:transformationPlugins:jsonMessageTransformers:jsonGraalTransformerBase')
     implementation project(':transformation:transformationPlugins:jsonMessageTransformers:jsonMessageTransformerLoaders')
     implementation project(':awsUtilities')
 

--- a/TrafficCapture/transformationShim/src/main/java/org/opensearch/migrations/transform/shim/ShimMain.java
+++ b/TrafficCapture/transformationShim/src/main/java/org/opensearch/migrations/transform/shim/ShimMain.java
@@ -124,6 +124,16 @@ public class ShimMain {
             description = "Watch transform JS files for changes and hot-reload them.")
         public boolean watchTransforms;
 
+        @Parameter(names = {"--solr-config-path", "--solrConfigPath"},
+            description = "Path to solrconfig file. Supports solrconfig.xml (parsed for requestHandler "
+                + "defaults/invariants/appends) or a JSON file with pre-built solrConfig bindings.")
+        public String solrConfigPath;
+
+        @Parameter(names = {"--solr-config-inline", "--solrConfigInline"},
+            description = "Inline JSON string for solrConfig transform bindings. "
+                + "Format: '{\"solrConfig\":{\"/select\":{\"defaults\":{\"df\":\"title\"}}}}'")
+        public String solrConfigInline;
+
         @Parameter(names = {"--help", "-h"}, help = true, description = "Show usage.")
         public boolean help;
     }
@@ -196,6 +206,8 @@ public class ShimMain {
             uris.put(spec.substring(0, eq), URI.create(spec.substring(eq + 1)));
         }
 
+        Map<String, Object> bindings = buildTransformBindings(params);
+
         // Parse per-target transforms
         Map<String, IJsonTransformer> reqTransforms = new LinkedHashMap<>();
         Map<String, IJsonTransformer> respTransforms = new LinkedHashMap<>();
@@ -207,10 +219,10 @@ public class ShimMain {
             for (String part : spec.substring(eq + 1).split(",")) {
                 if (part.startsWith("request:")) {
                     reqTransforms.put(name, loadTransformer(
-                        part.substring("request:".length()), params.watchTransforms, watchedTransforms));
+                        part.substring("request:".length()), params.watchTransforms, watchedTransforms, bindings));
                 } else if (part.startsWith("response:")) {
                     respTransforms.put(name, loadTransformer(
-                        part.substring("response:".length()), params.watchTransforms, watchedTransforms));
+                        part.substring("response:".length()), params.watchTransforms, watchedTransforms, bindings));
                 } else {
                     throw new ParameterException("Invalid transform part: " + part + " (expected request:file or response:file)");
                 }
@@ -358,6 +370,8 @@ public class ShimMain {
         "  };\n" +
         "  URLSearchParams.prototype.get = function(k) { return this._map[k] ? this._map[k][0] : null; };\n" +
         "  URLSearchParams.prototype.has = function(k) { return k in this._map; };\n" +
+        "  URLSearchParams.prototype.set = function(k, v) { this._map[k] = [String(v)]; };\n" +
+        "  URLSearchParams.prototype.append = function(k, v) { if (!this._map[k]) this._map[k] = []; this._map[k].push(String(v)); };\n" +
         "  URLSearchParams.prototype.getAll = function(k) { return this._map[k] || []; };\n" +
         "  URLSearchParams.prototype.forEach = function(cb) { for (var k in this._map) { this._map[k].forEach(function(v) { cb(v, k); }); } };\n" +
         "  URLSearchParams.prototype.keys = function() { return Object.keys(this._map); };\n" +
@@ -368,15 +382,59 @@ public class ShimMain {
         "}\n";
 
     private static IJsonTransformer loadTransformer(String pathStr, boolean watch,
-            Map<Path, ReloadableTransformer> watchedTransforms) throws IOException {
+            Map<Path, ReloadableTransformer> watchedTransforms,
+            Map<String, Object> bindings) throws IOException {
         Path path = Path.of(pathStr).toAbsolutePath();
         String script = JS_POLYFILL + Files.readString(path);
         if (watch) {
             var reloadable = new ReloadableTransformer(
-                () -> new JavascriptTransformer(script, new java.util.LinkedHashMap<>()));
+                () -> new JavascriptTransformer(script, bindings));
             watchedTransforms.put(path, reloadable);
             return reloadable;
         }
-        return new JavascriptTransformer(script, new java.util.LinkedHashMap<>());
+        return new JavascriptTransformer(script, bindings);
+    }
+
+    /**
+     * Build transform bindings from explicit CLI params.
+     * Supports --solr-config-path (XML or JSON file) and --solr-config-inline (JSON string).
+     * Returns empty bindings if neither is provided (no-op for transforms).
+     */
+    @SuppressWarnings("unchecked")
+    static Map<String, Object> buildTransformBindings(Parameters params) {
+        if (params.solrConfigPath != null && params.solrConfigInline != null) {
+            throw new ParameterException(
+                "Specify only one of --solr-config-path or --solr-config-inline, not both.");
+        }
+        Map<String, Object> bindings = new LinkedHashMap<>();
+        if (params.solrConfigPath != null) {
+            Path path = Path.of(params.solrConfigPath);
+            if (params.solrConfigPath.endsWith(".xml")) {
+                var solrConfig = SolrConfigProvider.fromXmlFile(path);
+                if (!solrConfig.isEmpty()) {
+                    bindings.put("solrConfig", solrConfig);
+                }
+            } else {
+                try {
+                    var json = Files.readString(path);
+                    var parsed = new com.fasterxml.jackson.databind.ObjectMapper()
+                        .readValue(json, Map.class);
+                    bindings.putAll(parsed);
+                } catch (Exception e) {
+                    throw new ParameterException("Failed to read JSON from " + path + ": " + e.getMessage());
+                }
+            }
+            log.info("Loaded solrconfig from {}", params.solrConfigPath);
+        } else if (params.solrConfigInline != null) {
+            try {
+                var parsed = new com.fasterxml.jackson.databind.ObjectMapper()
+                    .readValue(params.solrConfigInline, Map.class);
+                bindings.putAll(parsed);
+                log.info("Loaded solrconfig from inline JSON");
+            } catch (Exception e) {
+                throw new ParameterException("Invalid JSON in --solr-config-inline: " + e.getMessage());
+            }
+        }
+        return bindings;
     }
 }

--- a/TrafficCapture/transformationShim/src/main/java/org/opensearch/migrations/transform/shim/ShimMain.java
+++ b/TrafficCapture/transformationShim/src/main/java/org/opensearch/migrations/transform/shim/ShimMain.java
@@ -21,6 +21,8 @@ import org.opensearch.migrations.tracing.CompositeContextTracker;
 import org.opensearch.migrations.tracing.RootOtelContext;
 import org.opensearch.migrations.transform.IJsonTransformer;
 import org.opensearch.migrations.transform.JavascriptTransformer;
+import org.opensearch.migrations.transform.TransformerConfigUtils;
+import org.opensearch.migrations.transform.TransformerParams;
 import org.opensearch.migrations.transform.shim.netty.BasicAuthSigningHandler;
 import org.opensearch.migrations.transform.shim.netty.SigV4SigningHandler;
 import org.opensearch.migrations.transform.shim.tracing.RootShimProxyContext;
@@ -35,7 +37,9 @@ import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.ParameterException;
 import com.beust.jcommander.converters.IParameterSplitter;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.netty.channel.ChannelHandler;
+import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 
@@ -50,12 +54,15 @@ import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
  * --targetTransform opensearch=request:req.js,response:resp.js \
  * --targetAuth opensearch=sigv4:es,us-east-1 \
  * --primary solr \
+ * --transformerConfig '{"solrConfig":{"/select":{"defaults":{"df":"title"}}}}' \
  * --validator field-equality:solr,opensearch:ignore=responseHeader.QTime \
  * --timeout 5000
  * }</pre>
  */
 @Slf4j
 public class ShimMain {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
 
     /** Prevents JCommander from splitting parameter values on commas. */
     public static class NoSplitter implements IParameterSplitter {
@@ -124,15 +131,22 @@ public class ShimMain {
             description = "Watch transform JS files for changes and hot-reload them.")
         public boolean watchTransforms;
 
-        @Parameter(names = {"--solr-config-path", "--solrConfigPath"},
-            description = "Path to solrconfig file. Supports solrconfig.xml (parsed for requestHandler "
-                + "defaults/invariants/appends) or a JSON file with pre-built solrConfig bindings.")
-        public String solrConfigPath;
+        @Getter
+        @Parameter(names = {"--transformer-config", "--transformerConfig"},
+            description = "JSON bindings object for transforms (e.g. solrConfig). "
+                + "Same content as the replayer's bindingsObject in --transformerConfig.")
+        String transformerConfig;
 
-        @Parameter(names = {"--solr-config-inline", "--solrConfigInline"},
-            description = "Inline JSON string for solrConfig transform bindings. "
-                + "Format: '{\"solrConfig\":{\"/select\":{\"defaults\":{\"df\":\"title\"}}}}'")
-        public String solrConfigInline;
+        @Getter
+        @Parameter(names = {"--transformer-config-encoded", "--transformerConfigEncoded"},
+            description = "Base64-encoded JSON bindings object for transforms.")
+        String transformerConfigEncoded;
+
+        @Getter
+        @Parameter(names = {"--transformer-config-file", "--transformerConfigFile"},
+            description = "Path to a JSON file containing the bindings object for transforms. "
+                + "Supports .json (parsed as bindings) or .xml (parsed as solrconfig.xml).")
+        String transformerConfigFile;
 
         @Parameter(names = {"--help", "-h"}, help = true, description = "Show usage.")
         public boolean help;
@@ -206,7 +220,7 @@ public class ShimMain {
             uris.put(spec.substring(0, eq), URI.create(spec.substring(eq + 1)));
         }
 
-        Map<String, Object> bindings = buildTransformBindings(params);
+        Map<String, Object> bindings = resolveTransformBindings(params);
 
         // Parse per-target transforms
         Map<String, IJsonTransformer> reqTransforms = new LinkedHashMap<>();
@@ -396,45 +410,46 @@ public class ShimMain {
     }
 
     /**
-     * Build transform bindings from explicit CLI params.
-     * Supports --solr-config-path (XML or JSON file) and --solr-config-inline (JSON string).
-     * Returns empty bindings if neither is provided (no-op for transforms).
+     * Resolve transform bindings from --transformerConfig, --transformerConfigEncoded,
+     * or --transformerConfigFile. Follows the same pattern as the traffic replayer's
+     * {@link TransformerConfigUtils}. The config file may be .xml (parsed via
+     * {@link SolrConfigProvider}) or .json (parsed as bindings directly).
+     *
+     * @return parsed bindings map, or empty map if no config is provided
      */
     @SuppressWarnings("unchecked")
-    static Map<String, Object> buildTransformBindings(Parameters params) {
-        if (params.solrConfigPath != null && params.solrConfigInline != null) {
-            throw new ParameterException(
-                "Specify only one of --solr-config-path or --solr-config-inline, not both.");
-        }
-        Map<String, Object> bindings = new LinkedHashMap<>();
-        if (params.solrConfigPath != null) {
-            Path path = Path.of(params.solrConfigPath);
-            if (params.solrConfigPath.endsWith(".xml")) {
-                var solrConfig = SolrConfigProvider.fromXmlFile(path);
-                if (!solrConfig.isEmpty()) {
-                    bindings.put("solrConfig", solrConfig);
-                }
-            } else {
-                try {
-                    var json = Files.readString(path);
-                    var parsed = new com.fasterxml.jackson.databind.ObjectMapper()
-                        .readValue(json, Map.class);
-                    bindings.putAll(parsed);
-                } catch (Exception e) {
-                    throw new ParameterException("Failed to read JSON from " + path + ": " + e.getMessage());
-                }
+    static Map<String, Object> resolveTransformBindings(Parameters params) {
+        // Handle .xml files specially before delegating to TransformerConfigUtils
+        if (params.transformerConfigFile != null && params.transformerConfigFile.endsWith(".xml")) {
+            var solrConfig = SolrConfigProvider.fromXmlFile(Path.of(params.transformerConfigFile));
+            if (solrConfig.isEmpty()) {
+                return new LinkedHashMap<>();
             }
-            log.info("Loaded solrconfig from {}", params.solrConfigPath);
-        } else if (params.solrConfigInline != null) {
-            try {
-                var parsed = new com.fasterxml.jackson.databind.ObjectMapper()
-                    .readValue(params.solrConfigInline, Map.class);
-                bindings.putAll(parsed);
-                log.info("Loaded solrconfig from inline JSON");
-            } catch (Exception e) {
-                throw new ParameterException("Invalid JSON in --solr-config-inline: " + e.getMessage());
-            }
+            var bindings = new LinkedHashMap<String, Object>();
+            bindings.put("solrConfig", solrConfig);
+            log.info("Loaded solrconfig from XML file {}", params.transformerConfigFile);
+            return bindings;
         }
-        return bindings;
+
+        // Use TransformerConfigUtils for JSON/base64/file resolution (same as replayer)
+        var transformerParams = new TransformerParams() {
+            @Override public String getTransformerConfigParameterArgPrefix() { return ""; }
+            @Override public String getTransformerConfigEncoded() { return params.transformerConfigEncoded; }
+            @Override public String getTransformerConfig() { return params.transformerConfig; }
+            @Override public String getTransformerConfigFile() { return params.transformerConfigFile; }
+        };
+
+        String configJson = TransformerConfigUtils.getTransformerConfig(transformerParams);
+        if (configJson == null) {
+            return new LinkedHashMap<>();
+        }
+
+        try {
+            var parsed = MAPPER.readValue(configJson, Map.class);
+            log.info("Loaded transformer config bindings");
+            return parsed;
+        } catch (Exception e) {
+            throw new ParameterException("Invalid JSON in transformer config: " + e.getMessage());
+        }
     }
 }

--- a/TrafficCapture/transformationShim/src/main/java/org/opensearch/migrations/transform/shim/ShimMain.java
+++ b/TrafficCapture/transformationShim/src/main/java/org/opensearch/migrations/transform/shim/ShimMain.java
@@ -20,7 +20,7 @@ import org.opensearch.migrations.tracing.ActiveContextTrackerByActivityType;
 import org.opensearch.migrations.tracing.CompositeContextTracker;
 import org.opensearch.migrations.tracing.RootOtelContext;
 import org.opensearch.migrations.transform.IJsonTransformer;
-import org.opensearch.migrations.transform.JavascriptTransformer;
+import org.opensearch.migrations.transform.TransformationLoader;
 import org.opensearch.migrations.transform.TransformerConfigUtils;
 import org.opensearch.migrations.transform.TransformerParams;
 import org.opensearch.migrations.transform.shim.netty.BasicAuthSigningHandler;
@@ -37,7 +37,6 @@ import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.ParameterException;
 import com.beust.jcommander.converters.IParameterSplitter;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.netty.channel.ChannelHandler;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
@@ -46,15 +45,19 @@ import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 /**
  * CLI entry point for the multi-target validation shim proxy.
  *
+ * <p>Uses the same {@code --transformerConfig} pattern as the traffic replayer.
+ * Transforms are created via {@link TransformationLoader} and ServiceLoader-discovered
+ * providers (e.g. {@link SolrTransformerProvider}).
+ *
  * <p>Example usage:
  * <pre>{@code
  * --listenPort 8080 \
  * --target solr=http://solr:8983 \
  * --target opensearch=https://opensearch:9200 \
- * --targetTransform opensearch=request:req.js,response:resp.js \
- * --targetAuth opensearch=sigv4:es,us-east-1 \
  * --primary solr \
- * --transformerConfig '{"solrConfig":{"/select":{"defaults":{"df":"title"}}}}' \
+ * --transformerConfig '[{"SolrTransformerProvider":{"initializationScriptFile":"/transforms/request.js","bindingsObject":"{}"}}]' \
+ * --responseTransformerConfig '[{"SolrTransformerProvider":{"initializationScriptFile":"/transforms/response.js","bindingsObject":"{}"}}]' \
+ * --targetAuth opensearch=sigv4:es,us-east-1 \
  * --validator field-equality:solr,opensearch:ignore=responseHeader.QTime \
  * --timeout 5000
  * }</pre>
@@ -62,14 +65,52 @@ import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 @Slf4j
 public class ShimMain {
 
-    private static final ObjectMapper MAPPER = new ObjectMapper();
-
     /** Prevents JCommander from splitting parameter values on commas. */
     public static class NoSplitter implements IParameterSplitter {
         @Override
         public List<String> split(String value) {
             return List.of(value);
         }
+    }
+
+    @Getter
+    public static class RequestTransformationParams implements TransformerParams {
+        @Override
+        public String getTransformerConfigParameterArgPrefix() { return ""; }
+
+        @Parameter(names = {"--transformer-config", "--transformerConfig"},
+            description = "Request transformer config JSON array (same format as traffic replayer). "
+                + "Example: '[{\"SolrTransformerProvider\":{\"initializationScriptFile\":\"/path/to/request.js\",\"bindingsObject\":\"{}\"}}]'")
+        String transformerConfig;
+
+        @Parameter(names = {"--transformer-config-encoded", "--transformerConfigEncoded"},
+            description = "Base64-encoded request transformer config.")
+        String transformerConfigEncoded;
+
+        @Parameter(names = {"--transformer-config-file", "--transformerConfigFile"},
+            description = "Path to JSON file containing request transformer config.")
+        String transformerConfigFile;
+    }
+
+    @Getter
+    public static class ResponseTransformationParams implements TransformerParams {
+        private static final String PREFIX = "response-";
+        private static final String CAMEL_PREFIX = "response";
+
+        @Override
+        public String getTransformerConfigParameterArgPrefix() { return PREFIX; }
+
+        @Parameter(names = {"--" + PREFIX + "transformer-config", "--" + CAMEL_PREFIX + "TransformerConfig"},
+            description = "Response transformer config JSON array (same format as request transformer config).")
+        String transformerConfig;
+
+        @Parameter(names = {"--" + PREFIX + "transformer-config-encoded", "--" + CAMEL_PREFIX + "TransformerConfigEncoded"},
+            description = "Base64-encoded response transformer config.")
+        String transformerConfigEncoded;
+
+        @Parameter(names = {"--" + PREFIX + "transformer-config-file", "--" + CAMEL_PREFIX + "TransformerConfigFile"},
+            description = "Path to JSON file containing response transformer config.")
+        String transformerConfigFile;
     }
 
     public static class Parameters {
@@ -89,9 +130,9 @@ public class ShimMain {
             description = "Comma-separated list of active targets. Defaults to all defined targets.")
         public String active;
 
-        @Parameter(names = {"--targetTransform"}, splitter = NoSplitter.class,
-            description = "Per-target transforms: name=request:file.js,response:file.js. Repeatable.")
-        public List<String> targetTransforms = new ArrayList<>();
+        @Parameter(names = {"--transformTarget"},
+            description = "Name of the target to apply transforms to. Defaults to all non-primary targets.")
+        public String transformTarget;
 
         @Parameter(names = {"--targetAuth"}, splitter = NoSplitter.class,
             description = "Per-target auth: name=sigv4:service,region | name=basic:user:pass | "
@@ -127,34 +168,20 @@ public class ShimMain {
                 + "If not set, instrumentation runs in no-op mode.")
         public String otelCollectorEndpoint;
 
-        @Parameter(names = {"--watchTransforms"},
-            description = "Watch transform JS files for changes and hot-reload them.")
-        public boolean watchTransforms;
-
-        @Getter
-        @Parameter(names = {"--transformer-config", "--transformerConfig"},
-            description = "JSON bindings object for transforms (e.g. solrConfig). "
-                + "Same content as the replayer's bindingsObject in --transformerConfig.")
-        String transformerConfig;
-
-        @Getter
-        @Parameter(names = {"--transformer-config-encoded", "--transformerConfigEncoded"},
-            description = "Base64-encoded JSON bindings object for transforms.")
-        String transformerConfigEncoded;
-
-        @Getter
-        @Parameter(names = {"--transformer-config-file", "--transformerConfigFile"},
-            description = "Path to a JSON file containing the bindings object for transforms. "
-                + "Supports .json (parsed as bindings) or .xml (parsed as solrconfig.xml).")
-        String transformerConfigFile;
-
         @Parameter(names = {"--help", "-h"}, help = true, description = "Show usage.")
         public boolean help;
+
+        public RequestTransformationParams requestTransformationParams = new RequestTransformationParams();
+        public ResponseTransformationParams responseTransformationParams = new ResponseTransformationParams();
     }
 
     public static void main(String[] args) throws Exception {
         var params = new Parameters();
-        var jCommander = JCommander.newBuilder().addObject(params).build();
+        var jCommander = JCommander.newBuilder()
+            .addObject(params)
+            .addObject(params.requestTransformationParams)
+            .addObject(params.responseTransformationParams)
+            .build();
         jCommander.setProgramName("Shim");
         try {
             jCommander.parse(args);
@@ -168,8 +195,7 @@ public class ShimMain {
             return;
         }
 
-        Map<Path, ReloadableTransformer> watchedTransforms = new LinkedHashMap<>();
-        Map<String, Target> targets = parseTargets(params, watchedTransforms);
+        Map<String, Target> targets = parseTargets(params);
         Set<String> activeTargets = parseActiveTargets(params, targets);
         List<ValidationRule> validators = parseValidators(params);
 
@@ -183,19 +209,9 @@ public class ShimMain {
             null, params.insecureBackend, Duration.ofMillis(params.timeoutMs), params.maxContentLength,
             rootContext);
 
-        TransformFileWatcher watcher = null;
-        if (params.watchTransforms && !watchedTransforms.isEmpty()) {
-            watcher = new TransformFileWatcher(watchedTransforms);
-            var watcherThread = new Thread(watcher, "transform-file-watcher");
-            watcherThread.setDaemon(true);
-            watcherThread.start();
-        }
-
-        final TransformFileWatcher watcherRef = watcher;
         Runtime.getRuntime().addShutdownHook(new Thread(() -> {
             try {
                 log.info("Shutdown signal received, stopping proxy...");
-                if (watcherRef != null) watcherRef.close();
                 proxy.stop();
             } catch (Exception e) {
                 if (e instanceof InterruptedException) Thread.currentThread().interrupt();
@@ -210,8 +226,20 @@ public class ShimMain {
         proxy.waitForClose();
     }
 
-    static Map<String, Target> parseTargets(Parameters params,
-            Map<Path, ReloadableTransformer> watchedTransforms) throws IOException {
+    /**
+     * Create a transformer from a TransformerParams config using TransformationLoader.
+     * This is the same mechanism the traffic replayer uses.
+     */
+    static IJsonTransformer createTransformer(TransformerParams transformerParams) {
+        String configStr = TransformerConfigUtils.getTransformerConfig(transformerParams);
+        if (configStr == null) {
+            return null;
+        }
+        log.info("Creating transformer from config: {}", configStr);
+        return new TransformationLoader().getTransformerFactoryLoader(configStr);
+    }
+
+    static Map<String, Target> parseTargets(Parameters params) {
         // Parse base targets: name=uri
         Map<String, URI> uris = new LinkedHashMap<>();
         for (String spec : params.targets) {
@@ -220,27 +248,20 @@ public class ShimMain {
             uris.put(spec.substring(0, eq), URI.create(spec.substring(eq + 1)));
         }
 
-        Map<String, Object> bindings = resolveTransformBindings(params);
+        // Create transformers via TransformationLoader (same as replayer)
+        IJsonTransformer requestTransform = createTransformer(params.requestTransformationParams);
+        IJsonTransformer responseTransform = createTransformer(params.responseTransformationParams);
 
-        // Parse per-target transforms
-        Map<String, IJsonTransformer> reqTransforms = new LinkedHashMap<>();
-        Map<String, IJsonTransformer> respTransforms = new LinkedHashMap<>();
-        for (String spec : params.targetTransforms) {
-            int eq = spec.indexOf('=');
-            if (eq <= 0) throw new ParameterException("Invalid --targetTransform: " + spec);
-            String name = spec.substring(0, eq);
-            if (!uris.containsKey(name)) throw new ParameterException("Unknown target in --targetTransform: " + name);
-            for (String part : spec.substring(eq + 1).split(",")) {
-                if (part.startsWith("request:")) {
-                    reqTransforms.put(name, loadTransformer(
-                        part.substring("request:".length()), params.watchTransforms, watchedTransforms, bindings));
-                } else if (part.startsWith("response:")) {
-                    respTransforms.put(name, loadTransformer(
-                        part.substring("response:".length()), params.watchTransforms, watchedTransforms, bindings));
-                } else {
-                    throw new ParameterException("Invalid transform part: " + part + " (expected request:file or response:file)");
-                }
-            }
+        // Determine which target gets transforms
+        String transformTargetName = params.transformTarget;
+        if (transformTargetName == null) {
+            // Default: apply to all non-primary targets
+            transformTargetName = uris.keySet().stream()
+                .filter(name -> !name.equals(params.primary))
+                .findFirst().orElse(null);
+        }
+        if (transformTargetName != null && !uris.containsKey(transformTargetName)) {
+            throw new ParameterException("Unknown target in --transformTarget: " + transformTargetName);
         }
 
         // Parse per-target auth
@@ -257,8 +278,11 @@ public class ShimMain {
         Map<String, Target> targets = new LinkedHashMap<>();
         for (var entry : uris.entrySet()) {
             String name = entry.getKey();
+            boolean isTransformTarget = name.equals(transformTargetName);
             targets.put(name, new Target(name, entry.getValue(),
-                reqTransforms.get(name), respTransforms.get(name), authHandlers.get(name)));
+                isTransformTarget ? requestTransform : null,
+                isTransformTarget ? responseTransform : null,
+                authHandlers.get(name)));
         }
         return targets;
     }
@@ -282,15 +306,6 @@ public class ShimMain {
         return rules;
     }
 
-    /**
-     * Parse a validator spec string. Formats:
-     * <ul>
-     *   <li>field-equality:targetA,targetB:ignore=path1,path2</li>
-     *   <li>doc-count:targetA,targetB:assert=a&lt;=b</li>
-     *   <li>doc-ids:targetA,targetB[:ordered]</li>
-     *   <li>js:targetA,targetB:script=file.js</li>
-     * </ul>
-     */
     static ValidationRule parseValidatorSpec(String spec) throws IOException {
         String[] parts = spec.split(":", 3);
         if (parts.length < 2) throw new ParameterException("Invalid --validator: " + spec);
@@ -366,90 +381,5 @@ public class ShimMain {
             return () -> new BasicAuthSigningHandler(headerValue);
         }
         throw new ParameterException("Unknown auth type: " + authSpec);
-    }
-
-    public static final String JS_POLYFILL =
-        "if (typeof URLSearchParams === 'undefined') {\n" +
-        "  globalThis.URLSearchParams = function(qs) {\n" +
-        "    this._map = {};\n" +
-        "    if (!qs) return;\n" +
-        "    qs.split('&').forEach(function(pair) {\n" +
-        "      var idx = pair.indexOf('=');\n" +
-        "      if (idx < 0) return;\n" +
-        "      var k = decodeURIComponent(pair.slice(0, idx));\n" +
-        "      var v = decodeURIComponent(pair.slice(idx + 1));\n" +
-        "      if (!this._map[k]) this._map[k] = [];\n" +
-        "      this._map[k].push(v);\n" +
-        "    }.bind(this));\n" +
-        "  };\n" +
-        "  URLSearchParams.prototype.get = function(k) { return this._map[k] ? this._map[k][0] : null; };\n" +
-        "  URLSearchParams.prototype.has = function(k) { return k in this._map; };\n" +
-        "  URLSearchParams.prototype.set = function(k, v) { this._map[k] = [String(v)]; };\n" +
-        "  URLSearchParams.prototype.append = function(k, v) { if (!this._map[k]) this._map[k] = []; this._map[k].push(String(v)); };\n" +
-        "  URLSearchParams.prototype.getAll = function(k) { return this._map[k] || []; };\n" +
-        "  URLSearchParams.prototype.forEach = function(cb) { for (var k in this._map) { this._map[k].forEach(function(v) { cb(v, k); }); } };\n" +
-        "  URLSearchParams.prototype.keys = function() { return Object.keys(this._map); };\n" +
-        "  URLSearchParams.prototype.values = function() { var r = []; for (var k in this._map) { this._map[k].forEach(function(v) { r.push(v); }); } return r; };\n" +
-        "  URLSearchParams.prototype.entries = function() { var r = []; for (var k in this._map) { this._map[k].forEach(function(v) { r.push([k, v]); }); } return r; };\n" +
-        "  URLSearchParams.prototype.delete = function(k) { delete this._map[k]; };\n" +
-        "  URLSearchParams.prototype.toString = function() { var r = []; for (var k in this._map) { this._map[k].forEach(function(v) { r.push(encodeURIComponent(k) + '=' + encodeURIComponent(v)); }); } return r.join('&'); };\n" +
-        "}\n";
-
-    private static IJsonTransformer loadTransformer(String pathStr, boolean watch,
-            Map<Path, ReloadableTransformer> watchedTransforms,
-            Map<String, Object> bindings) throws IOException {
-        Path path = Path.of(pathStr).toAbsolutePath();
-        String script = JS_POLYFILL + Files.readString(path);
-        if (watch) {
-            var reloadable = new ReloadableTransformer(
-                () -> new JavascriptTransformer(script, bindings));
-            watchedTransforms.put(path, reloadable);
-            return reloadable;
-        }
-        return new JavascriptTransformer(script, bindings);
-    }
-
-    /**
-     * Resolve transform bindings from --transformerConfig, --transformerConfigEncoded,
-     * or --transformerConfigFile. Follows the same pattern as the traffic replayer's
-     * {@link TransformerConfigUtils}. The config file may be .xml (parsed via
-     * {@link SolrConfigProvider}) or .json (parsed as bindings directly).
-     *
-     * @return parsed bindings map, or empty map if no config is provided
-     */
-    @SuppressWarnings("unchecked")
-    static Map<String, Object> resolveTransformBindings(Parameters params) {
-        // Handle .xml files specially before delegating to TransformerConfigUtils
-        if (params.transformerConfigFile != null && params.transformerConfigFile.endsWith(".xml")) {
-            var solrConfig = SolrConfigProvider.fromXmlFile(Path.of(params.transformerConfigFile));
-            if (solrConfig.isEmpty()) {
-                return new LinkedHashMap<>();
-            }
-            var bindings = new LinkedHashMap<String, Object>();
-            bindings.put("solrConfig", solrConfig);
-            log.info("Loaded solrconfig from XML file {}", params.transformerConfigFile);
-            return bindings;
-        }
-
-        // Use TransformerConfigUtils for JSON/base64/file resolution (same as replayer)
-        var transformerParams = new TransformerParams() {
-            @Override public String getTransformerConfigParameterArgPrefix() { return ""; }
-            @Override public String getTransformerConfigEncoded() { return params.transformerConfigEncoded; }
-            @Override public String getTransformerConfig() { return params.transformerConfig; }
-            @Override public String getTransformerConfigFile() { return params.transformerConfigFile; }
-        };
-
-        String configJson = TransformerConfigUtils.getTransformerConfig(transformerParams);
-        if (configJson == null) {
-            return new LinkedHashMap<>();
-        }
-
-        try {
-            var parsed = MAPPER.readValue(configJson, Map.class);
-            log.info("Loaded transformer config bindings");
-            return parsed;
-        } catch (Exception e) {
-            throw new ParameterException("Invalid JSON in transformer config: " + e.getMessage());
-        }
     }
 }

--- a/TrafficCapture/transformationShim/src/main/java/org/opensearch/migrations/transform/shim/SolrConfigProvider.java
+++ b/TrafficCapture/transformationShim/src/main/java/org/opensearch/migrations/transform/shim/SolrConfigProvider.java
@@ -1,0 +1,101 @@
+package org.opensearch.migrations.transform.shim;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import lombok.extern.slf4j.Slf4j;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+
+/**
+ * Parses Solr's solrconfig.xml to extract requestHandler defaults and invariants.
+ *
+ * Output format (JSON-compatible Map):
+ * <pre>
+ * {
+ *   "/select": {
+ *     "defaults": { "df": "title", "rows": "10" },
+ *     "invariants": { "facet.field": "cat" }
+ *   }
+ * }
+ * </pre>
+ *
+ * Used by all modes (shim, replayer, standalone) via bindingsObject injection.
+ */
+@Slf4j
+public class SolrConfigProvider {
+
+    private SolrConfigProvider() {}
+
+    /**
+     * Parse solrconfig.xml and extract requestHandler defaults/invariants.
+     * Returns empty map if path is null, file doesn't exist, or parsing fails.
+     */
+    public static Map<String, Object> fromXmlFile(Path path) {
+        if (path == null || !Files.exists(path)) {
+            log.debug("solrconfig.xml not found at {}, skipping defaults", path);
+            return Map.of();
+        }
+        try {
+            var factory = DocumentBuilderFactory.newInstance();
+            factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            Document doc = factory.newDocumentBuilder().parse(path.toFile());
+            return parseRequestHandlers(doc);
+        } catch (Exception e) {
+            log.warn("Failed to parse solrconfig.xml at {}: {}", path, e.getMessage());
+            return Map.of();
+        }
+    }
+
+    private static Map<String, Object> parseRequestHandlers(Document doc) {
+        Map<String, Object> result = new LinkedHashMap<>();
+        NodeList handlers = doc.getElementsByTagName("requestHandler");
+        for (int i = 0; i < handlers.getLength(); i++) {
+            Element handler = (Element) handlers.item(i);
+            String name = handler.getAttribute("name");
+            if (name.isEmpty()) continue;
+
+            Map<String, Object> handlerConfig = parseLstEntries(handler);
+            if (!handlerConfig.isEmpty()) result.put(name, handlerConfig);
+        }
+        return result;
+    }
+
+    /** Single-pass extraction of defaults, invariants, and appends from <lst> children. */
+    private static Map<String, Object> parseLstEntries(Element parent) {
+        Map<String, String> defaults = new LinkedHashMap<>();
+        Map<String, String> invariants = new LinkedHashMap<>();
+        Map<String, String> appends = new LinkedHashMap<>();
+
+        NodeList lsts = parent.getElementsByTagName("lst");
+        for (int i = 0; i < lsts.getLength(); i++) {
+            Element lst = (Element) lsts.item(i);
+            String lstName = lst.getAttribute("name");
+            Map<String, String> target = switch (lstName) {
+                case "defaults" -> defaults;
+                case "invariants" -> invariants;
+                case "appends" -> appends;
+                default -> null;
+            };
+            if (target == null) continue;
+            for (var child = lst.getFirstChild(); child != null; child = child.getNextSibling()) {
+                if (child instanceof Element el) {
+                    String paramName = el.getAttribute("name");
+                    String paramValue = el.getTextContent().trim();
+                    if (!paramName.isEmpty()) target.put(paramName, paramValue);
+                }
+            }
+        }
+
+        Map<String, Object> handlerConfig = new LinkedHashMap<>();
+        if (!defaults.isEmpty()) handlerConfig.put("defaults", defaults);
+        if (!invariants.isEmpty()) handlerConfig.put("invariants", invariants);
+        if (!appends.isEmpty()) handlerConfig.put("appends", appends);
+        return handlerConfig;
+    }
+}

--- a/TrafficCapture/transformationShim/src/main/java/org/opensearch/migrations/transform/shim/SolrTransformerProvider.java
+++ b/TrafficCapture/transformationShim/src/main/java/org/opensearch/migrations/transform/shim/SolrTransformerProvider.java
@@ -1,0 +1,115 @@
+package org.opensearch.migrations.transform.shim;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.opensearch.migrations.transform.IJsonTransformer;
+import org.opensearch.migrations.transform.JavascriptTransformer;
+import org.opensearch.migrations.transform.ScriptTransformerProvider;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Transformer provider for Solr→OpenSearch query translation.
+ *
+ * <p>Extends {@link ScriptTransformerProvider} (same base as {@code JsonJSTransformerProvider})
+ * with two Solr-specific features:
+ * <ul>
+ *   <li>Auto-prepends the GraalVM URLSearchParams polyfill to all scripts</li>
+ *   <li>Supports {@code solrConfigXmlFile} to auto-parse solrconfig.xml into bindingsObject</li>
+ * </ul>
+ *
+ * <p>Config format (same structure as JsonJSTransformerProvider):
+ * <pre>{@code
+ * [{"SolrTransformerProvider": {
+ *     "initializationScriptFile": "/path/to/request.js",
+ *     "bindingsObject": "{}",
+ *     "solrConfigXmlFile": "/path/to/solrconfig.xml"
+ * }}]
+ * }</pre>
+ *
+ * <p>Registered via ServiceLoader in META-INF/services.
+ */
+@Slf4j
+public class SolrTransformerProvider extends ScriptTransformerProvider {
+
+    public static final String SOLR_CONFIG_XML_FILE_KEY = "solrConfigXmlFile";
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    /**
+     * GraalVM URLSearchParams polyfill — required because GraalVM's JS engine
+     * doesn't include browser/Node APIs. Prepended to every script.
+     */
+    public static final String JS_POLYFILL =
+        "if (typeof URLSearchParams === 'undefined') {\n" +
+        "  globalThis.URLSearchParams = function(qs) {\n" +
+        "    this._map = {};\n" +
+        "    if (!qs) return;\n" +
+        "    qs.split('&').forEach(function(pair) {\n" +
+        "      var idx = pair.indexOf('=');\n" +
+        "      if (idx < 0) return;\n" +
+        "      var k = decodeURIComponent(pair.slice(0, idx));\n" +
+        "      var v = decodeURIComponent(pair.slice(idx + 1));\n" +
+        "      if (!this._map[k]) this._map[k] = [];\n" +
+        "      this._map[k].push(v);\n" +
+        "    }.bind(this));\n" +
+        "  };\n" +
+        "  URLSearchParams.prototype.get = function(k) { return this._map[k] ? this._map[k][0] : null; };\n" +
+        "  URLSearchParams.prototype.has = function(k) { return k in this._map; };\n" +
+        "  URLSearchParams.prototype.set = function(k, v) { this._map[k] = [String(v)]; };\n" +
+        "  URLSearchParams.prototype.append = function(k, v) { if (!this._map[k]) this._map[k] = []; this._map[k].push(String(v)); };\n" +
+        "  URLSearchParams.prototype.getAll = function(k) { return this._map[k] || []; };\n" +
+        "  URLSearchParams.prototype.forEach = function(cb) { for (var k in this._map) { this._map[k].forEach(function(v) { cb(v, k); }); } };\n" +
+        "  URLSearchParams.prototype.keys = function() { return Object.keys(this._map); };\n" +
+        "  URLSearchParams.prototype.values = function() { var r = []; for (var k in this._map) { this._map[k].forEach(function(v) { r.push(v); }); } return r; };\n" +
+        "  URLSearchParams.prototype.entries = function() { var r = []; for (var k in this._map) { this._map[k].forEach(function(v) { r.push([k, v]); }); } return r; };\n" +
+        "  URLSearchParams.prototype.delete = function(k) { delete this._map[k]; };\n" +
+        "  URLSearchParams.prototype.toString = function() { var r = []; for (var k in this._map) { this._map[k].forEach(function(v) { r.push(encodeURIComponent(k) + '=' + encodeURIComponent(v)); }); } return r.join('&'); };\n" +
+        "}\n";
+
+    @Override
+    protected String getLanguageName() {
+        return "JavaScript";
+    }
+
+    @Override
+    protected IJsonTransformer buildTransformer(
+            String script, Object bindingsObject, Map<String, Object> config) throws IOException {
+        // Merge solrConfig from XML file into bindings if specified
+        var mergedBindings = mergeSolrConfigXml(bindingsObject, config);
+        return new JavascriptTransformer(JS_POLYFILL + script, mergedBindings);
+    }
+
+    /**
+     * If {@code solrConfigXmlFile} is present in config, parse it and merge
+     * the resulting solrConfig into the bindings object.
+     */
+    @SuppressWarnings("unchecked")
+    private Object mergeSolrConfigXml(Object bindingsObject, Map<String, Object> config) throws IOException {
+        var xmlFile = (String) config.getOrDefault(SOLR_CONFIG_XML_FILE_KEY, null);
+        if (xmlFile == null) {
+            return bindingsObject;
+        }
+
+        var solrConfig = SolrConfigProvider.fromXmlFile(Path.of(xmlFile));
+        if (solrConfig.isEmpty()) {
+            return bindingsObject;
+        }
+
+        // Merge into bindings — bindings is a Map from parseBindingsObject
+        Map<String, Object> merged;
+        if (bindingsObject instanceof Map) {
+            merged = new LinkedHashMap<>((Map<String, Object>) bindingsObject);
+        } else {
+            merged = new LinkedHashMap<>();
+        }
+        merged.put("solrConfig", solrConfig);
+        log.info("Merged solrconfig.xml from {} into bindings", xmlFile);
+        return merged;
+    }
+}

--- a/TrafficCapture/transformationShim/src/main/java/org/opensearch/migrations/transform/shim/TransformFileWatcher.java
+++ b/TrafficCapture/transformationShim/src/main/java/org/opensearch/migrations/transform/shim/TransformFileWatcher.java
@@ -89,7 +89,7 @@ public class TransformFileWatcher implements Runnable, AutoCloseable {
 
     private void reloadTransformer(Path path, ReloadableTransformer transformer) {
         try {
-            String script = ShimMain.JS_POLYFILL + Files.readString(path);
+            String script = SolrTransformerProvider.JS_POLYFILL + Files.readString(path);
             transformer.reload(
                 () -> new JavascriptTransformer(script, new LinkedHashMap<>()));
             log.info("Hot-reloaded transform: {}", path);

--- a/TrafficCapture/transformationShim/src/main/resources/META-INF/services/org.opensearch.migrations.transform.IJsonTransformerProvider
+++ b/TrafficCapture/transformationShim/src/main/resources/META-INF/services/org.opensearch.migrations.transform.IJsonTransformerProvider
@@ -1,0 +1,1 @@
+org.opensearch.migrations.transform.shim.SolrTransformerProvider

--- a/TrafficCapture/transformationShim/src/test/java/org/opensearch/migrations/transform/shim/ShimMainTest.java
+++ b/TrafficCapture/transformationShim/src/test/java/org/opensearch/migrations/transform/shim/ShimMainTest.java
@@ -1,0 +1,152 @@
+package org.opensearch.migrations.transform.shim;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
+import com.beust.jcommander.ParameterException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ShimMainTest {
+
+    @TempDir
+    Path tempDir;
+
+    private static ShimMain.Parameters paramsWithPath(String path) {
+        var p = new ShimMain.Parameters();
+        p.solrConfigPath = path;
+        return p;
+    }
+
+    private static ShimMain.Parameters paramsWithInline(String json) {
+        var p = new ShimMain.Parameters();
+        p.solrConfigInline = json;
+        return p;
+    }
+
+    @Test
+    void buildTransformBindings_xmlPath() throws Exception {
+        Path xml = tempDir.resolve("solrconfig.xml");
+        Files.writeString(xml, """
+            <?xml version="1.0" encoding="UTF-8" ?>
+            <config>
+              <requestHandler name="/select" class="solr.SearchHandler">
+                <lst name="defaults">
+                  <str name="df">title</str>
+                </lst>
+              </requestHandler>
+            </config>
+            """);
+
+        var bindings = ShimMain.buildTransformBindings(paramsWithPath(xml.toString()));
+        assertTrue(bindings.containsKey("solrConfig"));
+        @SuppressWarnings("unchecked")
+        var solrConfig = (Map<String, Object>) bindings.get("solrConfig");
+        assertNotNull(solrConfig.get("/select"));
+    }
+
+    @Test
+    void buildTransformBindings_jsonFilePath() throws Exception {
+        Path json = tempDir.resolve("solrconfig.json");
+        Files.writeString(json, """
+            {"solrConfig":{"/select":{"defaults":{"df":"content"}}}}
+            """);
+
+        var bindings = ShimMain.buildTransformBindings(paramsWithPath(json.toString()));
+        assertTrue(bindings.containsKey("solrConfig"));
+        @SuppressWarnings("unchecked")
+        var solrConfig = (Map<String, Object>) bindings.get("solrConfig");
+        assertNotNull(solrConfig.get("/select"));
+    }
+
+    @Test
+    void buildTransformBindings_inlineJson() {
+        var bindings = ShimMain.buildTransformBindings(paramsWithInline(
+            "{\"solrConfig\":{\"/select\":{\"defaults\":{\"df\":\"title\"}}}}"));
+        assertTrue(bindings.containsKey("solrConfig"));
+        @SuppressWarnings("unchecked")
+        var solrConfig = (Map<String, Object>) bindings.get("solrConfig");
+        assertNotNull(solrConfig.get("/select"));
+    }
+
+    @Test
+    void buildTransformBindings_returnsEmptyWhenNeitherProvided() {
+        var bindings = ShimMain.buildTransformBindings(new ShimMain.Parameters());
+        assertTrue(bindings.isEmpty());
+    }
+
+    @Test
+    void buildTransformBindings_throwsWhenBothProvided() {
+        var p = new ShimMain.Parameters();
+        p.solrConfigPath = "/some/path.xml";
+        p.solrConfigInline = "{\"solrConfig\":{}}";
+        assertThrows(ParameterException.class, () -> ShimMain.buildTransformBindings(p));
+    }
+
+    @Test
+    void buildTransformBindings_throwsOnInvalidInlineJson() {
+        assertThrows(ParameterException.class,
+            () -> ShimMain.buildTransformBindings(paramsWithInline("not valid json")));
+    }
+
+    @Test
+    void buildTransformBindings_throwsOnMissingJsonFile() {
+        assertThrows(ParameterException.class,
+            () -> ShimMain.buildTransformBindings(paramsWithPath("/nonexistent/config.json")));
+    }
+
+    // --- JCommander CLI param wiring tests ---
+
+    @Test
+    void jcommander_parsesSolrConfigPath() {
+        var params = new ShimMain.Parameters();
+        var jc = com.beust.jcommander.JCommander.newBuilder().addObject(params).build();
+        jc.parse("--listenPort", "8080", "--target", "solr=http://localhost:8983",
+            "--primary", "solr", "--solr-config-path", "/path/to/solrconfig.xml");
+        assertEquals("/path/to/solrconfig.xml", params.solrConfigPath);
+    }
+
+    @Test
+    void jcommander_parsesSolrConfigPathCamelCase() {
+        var params = new ShimMain.Parameters();
+        var jc = com.beust.jcommander.JCommander.newBuilder().addObject(params).build();
+        jc.parse("--listenPort", "8080", "--target", "solr=http://localhost:8983",
+            "--primary", "solr", "--solrConfigPath", "/path/to/solrconfig.xml");
+        assertEquals("/path/to/solrconfig.xml", params.solrConfigPath);
+    }
+
+    @Test
+    void jcommander_parsesSolrConfigInline() {
+        var params = new ShimMain.Parameters();
+        var jc = com.beust.jcommander.JCommander.newBuilder().addObject(params).build();
+        jc.parse("--listenPort", "8080", "--target", "solr=http://localhost:8983",
+            "--primary", "solr", "--solr-config-inline", "{\"solrConfig\":{}}");
+        assertEquals("{\"solrConfig\":{}}", params.solrConfigInline);
+    }
+
+    @Test
+    void jcommander_parsesSolrConfigInlineCamelCase() {
+        var params = new ShimMain.Parameters();
+        var jc = com.beust.jcommander.JCommander.newBuilder().addObject(params).build();
+        jc.parse("--listenPort", "8080", "--target", "solr=http://localhost:8983",
+            "--primary", "solr", "--solrConfigInline", "{\"solrConfig\":{}}");
+        assertEquals("{\"solrConfig\":{}}", params.solrConfigInline);
+    }
+
+    @Test
+    void jcommander_neitherSolrConfigParam_leavesNull() {
+        var params = new ShimMain.Parameters();
+        var jc = com.beust.jcommander.JCommander.newBuilder().addObject(params).build();
+        jc.parse("--listenPort", "8080", "--target", "solr=http://localhost:8983",
+            "--primary", "solr");
+        assertNull(params.solrConfigPath);
+        assertNull(params.solrConfigInline);
+    }
+}

--- a/TrafficCapture/transformationShim/src/test/java/org/opensearch/migrations/transform/shim/ShimMainTest.java
+++ b/TrafficCapture/transformationShim/src/test/java/org/opensearch/migrations/transform/shim/ShimMainTest.java
@@ -2,61 +2,109 @@ package org.opensearch.migrations.transform.shim;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Base64;
+import java.util.HashMap;
 import java.util.Map;
 
-import com.beust.jcommander.ParameterException;
+import com.beust.jcommander.JCommander;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
-import org.opensearch.migrations.transform.TransformerConfigUtils;
+import org.opensearch.migrations.transform.IJsonTransformer;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+/**
+ * Tests that ShimMain correctly wires --transformerConfig through TransformationLoader
+ * and ServiceLoader to instantiate SolrTransformerProvider-based transformers.
+ */
 class ShimMainTest {
 
     @TempDir
     Path tempDir;
 
-    private static final String SOLR_CONFIG_JSON =
-        "{\"solrConfig\":{\"/select\":{\"defaults\":{\"df\":\"title\"}}}}";
+    private static final ObjectMapper MAPPER = new ObjectMapper();
 
-    // --- resolveTransformBindings tests ---
+    /** Minimal JS transform that sets a "transformed" flag on the message. */
+    private static final String SIMPLE_TRANSFORM_JS =
+        "(function(bindings) { return function(msg) { msg.set('transformed', true); return msg; }; })";
+
+    /** Build a --transformerConfig JSON string for SolrTransformerProvider. */
+    private static String buildConfig(Map<String, Object> providerConfig) {
+        try {
+            return MAPPER.writeValueAsString(new Object[]{Map.of("SolrTransformerProvider", providerConfig)});
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    // --- createTransformer via --transformerConfig (full provider pattern) ---
 
     @Test
-    void resolveBindings_transformerConfig_inlineJson() {
-        var p = new ShimMain.Parameters();
-        p.transformerConfig = SOLR_CONFIG_JSON;
-        var bindings = ShimMain.resolveTransformBindings(p);
-        assertSolrConfigPresent(bindings);
+    void createTransformer_withSolrTransformerProvider_inlineScript() {
+        var params = new ShimMain.RequestTransformationParams();
+        params.transformerConfig = buildConfig(Map.of(
+            "initializationScript", SIMPLE_TRANSFORM_JS,
+            "bindingsObject", "{}"));
+
+        var transformer = ShimMain.createTransformer(params);
+        assertNotNull(transformer);
+        var result = (Map<?, ?>) transformer.transformJson(new HashMap<>(Map.of("key", "value")));
+        assertEquals(true, result.get("transformed"));
     }
 
     @Test
-    void resolveBindings_transformerConfigEncoded_base64() {
-        var p = new ShimMain.Parameters();
-        p.transformerConfigEncoded = Base64.getEncoder().encodeToString(SOLR_CONFIG_JSON.getBytes());
-        var bindings = ShimMain.resolveTransformBindings(p);
-        assertSolrConfigPresent(bindings);
+    void createTransformer_withSolrTransformerProvider_scriptFile() throws Exception {
+        Path jsFile = tempDir.resolve("transform.js");
+        Files.writeString(jsFile, SIMPLE_TRANSFORM_JS);
+
+        var params = new ShimMain.RequestTransformationParams();
+        params.transformerConfig = buildConfig(Map.of(
+            "initializationScriptFile", jsFile.toAbsolutePath().toString(),
+            "bindingsObject", "{}"));
+
+        var transformer = ShimMain.createTransformer(params);
+        assertNotNull(transformer);
+        var result = (Map<?, ?>) transformer.transformJson(new HashMap<>(Map.of("key", "value")));
+        assertEquals(true, result.get("transformed"));
     }
 
     @Test
-    void resolveBindings_transformerConfigFile_jsonFile() throws Exception {
-        Path json = tempDir.resolve("config.json");
-        Files.writeString(json, SOLR_CONFIG_JSON);
+    void createTransformer_withSolrTransformerProvider_bindingsPassedToScript() throws Exception {
+        // Script that reads bindings.testKey and sets it on the message
+        String script =
+            "(function(bindings) { return function(msg) { msg.set('fromBindings', bindings.testKey); return msg; }; })";
+        Path jsFile = tempDir.resolve("bindings-test.js");
+        Files.writeString(jsFile, script);
 
-        var p = new ShimMain.Parameters();
-        p.transformerConfigFile = json.toString();
-        var bindings = ShimMain.resolveTransformBindings(p);
-        assertSolrConfigPresent(bindings);
+        var params = new ShimMain.RequestTransformationParams();
+        params.transformerConfig = buildConfig(Map.of(
+            "initializationScriptFile", jsFile.toAbsolutePath().toString(),
+            "bindingsObject", "{\"testKey\":\"hello\"}"));
+
+        var transformer = ShimMain.createTransformer(params);
+        var result = (Map<?, ?>) transformer.transformJson(new HashMap<>(Map.of("key", "value")));
+        assertEquals("hello", result.get("fromBindings"));
     }
 
     @Test
-    void resolveBindings_transformerConfigFile_xmlFile() throws Exception {
-        Path xml = tempDir.resolve("solrconfig.xml");
-        Files.writeString(xml, """
+    void createTransformer_withSolrConfigXmlFile() throws Exception {
+        // Script that reads bindings.solrConfig and sets it on the message
+        String script =
+            "(function(bindings) { return function(msg) {" +
+            "  if (bindings.solrConfig) {" +
+            "    var select = bindings.solrConfig['/select'];" +
+            "    if (select && select.defaults) { msg.set('df', select.defaults.df); }" +
+            "  }" +
+            "  return msg;" +
+            "}; })";
+        Path jsFile = tempDir.resolve("solrconfig-test.js");
+        Files.writeString(jsFile, script);
+
+        Path xmlFile = tempDir.resolve("solrconfig.xml");
+        Files.writeString(xmlFile, """
             <?xml version="1.0" encoding="UTF-8" ?>
             <config>
               <requestHandler name="/select" class="solr.SearchHandler">
@@ -67,115 +115,134 @@ class ShimMainTest {
             </config>
             """);
 
-        var p = new ShimMain.Parameters();
-        p.transformerConfigFile = xml.toString();
-        var bindings = ShimMain.resolveTransformBindings(p);
-        assertSolrConfigPresent(bindings);
+        var params = new ShimMain.RequestTransformationParams();
+        params.transformerConfig = buildConfig(Map.of(
+            "initializationScriptFile", jsFile.toAbsolutePath().toString(),
+            "bindingsObject", "{}",
+            "solrConfigXmlFile", xmlFile.toAbsolutePath().toString()));
+
+        var transformer = ShimMain.createTransformer(params);
+        var result = (Map<?, ?>) transformer.transformJson(new HashMap<>(Map.of("key", "value")));
+        assertEquals("title", result.get("df"));
     }
 
     @Test
-    void resolveBindings_returnsEmptyWhenNoneProvided() {
-        var bindings = ShimMain.resolveTransformBindings(new ShimMain.Parameters());
-        assertTrue(bindings.isEmpty());
+    void createTransformer_withUrlSearchParamsPolyfill() throws Exception {
+        // Script that uses URLSearchParams — verifies polyfill is auto-prepended
+        String script =
+            "(function(bindings) { return function(msg) {" +
+            "  var params = new URLSearchParams('q=hello&rows=10');" +
+            "  msg.set('q', params.get('q'));" +
+            "  msg.set('rows', params.get('rows'));" +
+            "  return msg;" +
+            "}; })";
+        Path jsFile = tempDir.resolve("polyfill-test.js");
+        Files.writeString(jsFile, script);
+
+        var params = new ShimMain.RequestTransformationParams();
+        params.transformerConfig = buildConfig(Map.of(
+            "initializationScriptFile", jsFile.toAbsolutePath().toString(),
+            "bindingsObject", "{}"));
+
+        var transformer = ShimMain.createTransformer(params);
+        var result = (Map<?, ?>) transformer.transformJson(new HashMap<>(Map.of("key", "value")));
+        assertEquals("hello", result.get("q"));
+        assertEquals("10", result.get("rows"));
     }
 
     @Test
-    void resolveBindings_throwsWhenMultipleProvided() {
-        var p = new ShimMain.Parameters();
-        p.transformerConfig = SOLR_CONFIG_JSON;
-        p.transformerConfigEncoded = Base64.getEncoder().encodeToString(SOLR_CONFIG_JSON.getBytes());
-        assertThrows(TransformerConfigUtils.TooManyTransformationConfigSourcesException.class,
-            () -> ShimMain.resolveTransformBindings(p));
+    void createTransformer_returnsNullWhenNoConfig() {
+        var params = new ShimMain.RequestTransformationParams();
+        assertNull(ShimMain.createTransformer(params));
     }
 
-    @Test
-    void resolveBindings_throwsOnInvalidJson() {
-        var p = new ShimMain.Parameters();
-        p.transformerConfig = "not valid json";
-        assertThrows(ParameterException.class, () -> ShimMain.resolveTransformBindings(p));
-    }
-
-    @Test
-    void resolveBindings_throwsOnMissingJsonFile() {
-        var p = new ShimMain.Parameters();
-        p.transformerConfigFile = "/nonexistent/config.json";
-        assertThrows(TransformerConfigUtils.UnableToReadTransformationConfigException.class,
-            () -> ShimMain.resolveTransformBindings(p));
-    }
-
-    // --- JCommander CLI param wiring tests ---
+    // --- JCommander CLI wiring tests ---
 
     @Test
     void jcommander_parsesTransformerConfig() {
         var params = new ShimMain.Parameters();
-        var jc = com.beust.jcommander.JCommander.newBuilder().addObject(params).build();
+        var jc = buildJCommander(params);
+        String config = "[{\"SolrTransformerProvider\":{\"initializationScript\":\"x\",\"bindingsObject\":\"{}\"}}]";
         jc.parse("--listenPort", "8080", "--target", "solr=http://localhost:8983",
-            "--primary", "solr", "--transformerConfig", SOLR_CONFIG_JSON);
-        assertEquals(SOLR_CONFIG_JSON, params.transformerConfig);
+            "--primary", "solr", "--transformerConfig", config);
+        assertEquals(config, params.requestTransformationParams.transformerConfig);
     }
 
     @Test
     void jcommander_parsesTransformerConfigKebab() {
         var params = new ShimMain.Parameters();
-        var jc = com.beust.jcommander.JCommander.newBuilder().addObject(params).build();
+        var jc = buildJCommander(params);
+        String config = "[{\"SolrTransformerProvider\":{\"initializationScript\":\"x\",\"bindingsObject\":\"{}\"}}]";
         jc.parse("--listenPort", "8080", "--target", "solr=http://localhost:8983",
-            "--primary", "solr", "--transformer-config", SOLR_CONFIG_JSON);
-        assertEquals(SOLR_CONFIG_JSON, params.transformerConfig);
+            "--primary", "solr", "--transformer-config", config);
+        assertEquals(config, params.requestTransformationParams.transformerConfig);
     }
 
     @Test
-    void jcommander_parsesTransformerConfigEncoded() {
-        var encoded = Base64.getEncoder().encodeToString(SOLR_CONFIG_JSON.getBytes());
+    void jcommander_parsesResponseTransformerConfig() {
         var params = new ShimMain.Parameters();
-        var jc = com.beust.jcommander.JCommander.newBuilder().addObject(params).build();
+        var jc = buildJCommander(params);
+        String config = "[{\"SolrTransformerProvider\":{\"initializationScript\":\"x\",\"bindingsObject\":\"{}\"}}]";
         jc.parse("--listenPort", "8080", "--target", "solr=http://localhost:8983",
-            "--primary", "solr", "--transformerConfigEncoded", encoded);
-        assertEquals(encoded, params.transformerConfigEncoded);
+            "--primary", "solr", "--responseTransformerConfig", config);
+        assertEquals(config, params.responseTransformationParams.transformerConfig);
     }
 
     @Test
-    void jcommander_parsesTransformerConfigEncodedKebab() {
-        var encoded = Base64.getEncoder().encodeToString(SOLR_CONFIG_JSON.getBytes());
+    void jcommander_parsesResponseTransformerConfigKebab() {
         var params = new ShimMain.Parameters();
-        var jc = com.beust.jcommander.JCommander.newBuilder().addObject(params).build();
+        var jc = buildJCommander(params);
+        String config = "[{\"SolrTransformerProvider\":{\"initializationScript\":\"x\",\"bindingsObject\":\"{}\"}}]";
         jc.parse("--listenPort", "8080", "--target", "solr=http://localhost:8983",
-            "--primary", "solr", "--transformer-config-encoded", encoded);
-        assertEquals(encoded, params.transformerConfigEncoded);
+            "--primary", "solr", "--response-transformer-config", config);
+        assertEquals(config, params.responseTransformationParams.transformerConfig);
     }
 
     @Test
     void jcommander_parsesTransformerConfigFile() {
         var params = new ShimMain.Parameters();
-        var jc = com.beust.jcommander.JCommander.newBuilder().addObject(params).build();
+        var jc = buildJCommander(params);
         jc.parse("--listenPort", "8080", "--target", "solr=http://localhost:8983",
             "--primary", "solr", "--transformerConfigFile", "/path/to/config.json");
-        assertEquals("/path/to/config.json", params.transformerConfigFile);
+        assertEquals("/path/to/config.json", params.requestTransformationParams.transformerConfigFile);
     }
 
     @Test
-    void jcommander_parsesTransformerConfigFileKebab() {
+    void jcommander_parsesTransformerConfigEncoded() {
         var params = new ShimMain.Parameters();
-        var jc = com.beust.jcommander.JCommander.newBuilder().addObject(params).build();
+        var jc = buildJCommander(params);
         jc.parse("--listenPort", "8080", "--target", "solr=http://localhost:8983",
-            "--primary", "solr", "--transformer-config-file", "/path/to/config.json");
-        assertEquals("/path/to/config.json", params.transformerConfigFile);
+            "--primary", "solr", "--transformerConfigEncoded", "abc123");
+        assertEquals("abc123", params.requestTransformationParams.transformerConfigEncoded);
     }
 
     @Test
     void jcommander_noTransformerConfig_leavesNull() {
         var params = new ShimMain.Parameters();
-        var jc = com.beust.jcommander.JCommander.newBuilder().addObject(params).build();
+        var jc = buildJCommander(params);
         jc.parse("--listenPort", "8080", "--target", "solr=http://localhost:8983",
             "--primary", "solr");
-        assertNull(params.transformerConfig);
-        assertNull(params.transformerConfigEncoded);
-        assertNull(params.transformerConfigFile);
+        assertNull(params.requestTransformationParams.transformerConfig);
+        assertNull(params.requestTransformationParams.transformerConfigEncoded);
+        assertNull(params.requestTransformationParams.transformerConfigFile);
+        assertNull(params.responseTransformationParams.transformerConfig);
     }
 
-    @SuppressWarnings("unchecked")
-    private void assertSolrConfigPresent(Map<String, Object> bindings) {
-        assertTrue(bindings.containsKey("solrConfig"));
-        var solrConfig = (Map<String, Object>) bindings.get("solrConfig");
-        assertNotNull(solrConfig.get("/select"));
+    @Test
+    void jcommander_parsesTransformTarget() {
+        var params = new ShimMain.Parameters();
+        var jc = buildJCommander(params);
+        jc.parse("--listenPort", "8080", "--target", "solr=http://localhost:8983",
+            "--target", "os=http://localhost:9200",
+            "--primary", "solr", "--transformTarget", "os");
+        assertEquals("os", params.transformTarget);
+    }
+
+    private static JCommander buildJCommander(ShimMain.Parameters params) {
+        return JCommander.newBuilder()
+            .addObject(params)
+            .addObject(params.requestTransformationParams)
+            .addObject(params.responseTransformationParams)
+            .build();
     }
 }

--- a/TrafficCapture/transformationShim/src/test/java/org/opensearch/migrations/transform/shim/ShimMainTest.java
+++ b/TrafficCapture/transformationShim/src/test/java/org/opensearch/migrations/transform/shim/ShimMainTest.java
@@ -2,11 +2,13 @@ package org.opensearch.migrations.transform.shim;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Base64;
 import java.util.Map;
 
 import com.beust.jcommander.ParameterException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.opensearch.migrations.transform.TransformerConfigUtils;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -19,20 +21,40 @@ class ShimMainTest {
     @TempDir
     Path tempDir;
 
-    private static ShimMain.Parameters paramsWithPath(String path) {
-        var p = new ShimMain.Parameters();
-        p.solrConfigPath = path;
-        return p;
-    }
+    private static final String SOLR_CONFIG_JSON =
+        "{\"solrConfig\":{\"/select\":{\"defaults\":{\"df\":\"title\"}}}}";
 
-    private static ShimMain.Parameters paramsWithInline(String json) {
+    // --- resolveTransformBindings tests ---
+
+    @Test
+    void resolveBindings_transformerConfig_inlineJson() {
         var p = new ShimMain.Parameters();
-        p.solrConfigInline = json;
-        return p;
+        p.transformerConfig = SOLR_CONFIG_JSON;
+        var bindings = ShimMain.resolveTransformBindings(p);
+        assertSolrConfigPresent(bindings);
     }
 
     @Test
-    void buildTransformBindings_xmlPath() throws Exception {
+    void resolveBindings_transformerConfigEncoded_base64() {
+        var p = new ShimMain.Parameters();
+        p.transformerConfigEncoded = Base64.getEncoder().encodeToString(SOLR_CONFIG_JSON.getBytes());
+        var bindings = ShimMain.resolveTransformBindings(p);
+        assertSolrConfigPresent(bindings);
+    }
+
+    @Test
+    void resolveBindings_transformerConfigFile_jsonFile() throws Exception {
+        Path json = tempDir.resolve("config.json");
+        Files.writeString(json, SOLR_CONFIG_JSON);
+
+        var p = new ShimMain.Parameters();
+        p.transformerConfigFile = json.toString();
+        var bindings = ShimMain.resolveTransformBindings(p);
+        assertSolrConfigPresent(bindings);
+    }
+
+    @Test
+    void resolveBindings_transformerConfigFile_xmlFile() throws Exception {
         Path xml = tempDir.resolve("solrconfig.xml");
         Files.writeString(xml, """
             <?xml version="1.0" encoding="UTF-8" ?>
@@ -45,108 +67,115 @@ class ShimMainTest {
             </config>
             """);
 
-        var bindings = ShimMain.buildTransformBindings(paramsWithPath(xml.toString()));
-        assertTrue(bindings.containsKey("solrConfig"));
-        @SuppressWarnings("unchecked")
-        var solrConfig = (Map<String, Object>) bindings.get("solrConfig");
-        assertNotNull(solrConfig.get("/select"));
+        var p = new ShimMain.Parameters();
+        p.transformerConfigFile = xml.toString();
+        var bindings = ShimMain.resolveTransformBindings(p);
+        assertSolrConfigPresent(bindings);
     }
 
     @Test
-    void buildTransformBindings_jsonFilePath() throws Exception {
-        Path json = tempDir.resolve("solrconfig.json");
-        Files.writeString(json, """
-            {"solrConfig":{"/select":{"defaults":{"df":"content"}}}}
-            """);
-
-        var bindings = ShimMain.buildTransformBindings(paramsWithPath(json.toString()));
-        assertTrue(bindings.containsKey("solrConfig"));
-        @SuppressWarnings("unchecked")
-        var solrConfig = (Map<String, Object>) bindings.get("solrConfig");
-        assertNotNull(solrConfig.get("/select"));
-    }
-
-    @Test
-    void buildTransformBindings_inlineJson() {
-        var bindings = ShimMain.buildTransformBindings(paramsWithInline(
-            "{\"solrConfig\":{\"/select\":{\"defaults\":{\"df\":\"title\"}}}}"));
-        assertTrue(bindings.containsKey("solrConfig"));
-        @SuppressWarnings("unchecked")
-        var solrConfig = (Map<String, Object>) bindings.get("solrConfig");
-        assertNotNull(solrConfig.get("/select"));
-    }
-
-    @Test
-    void buildTransformBindings_returnsEmptyWhenNeitherProvided() {
-        var bindings = ShimMain.buildTransformBindings(new ShimMain.Parameters());
+    void resolveBindings_returnsEmptyWhenNoneProvided() {
+        var bindings = ShimMain.resolveTransformBindings(new ShimMain.Parameters());
         assertTrue(bindings.isEmpty());
     }
 
     @Test
-    void buildTransformBindings_throwsWhenBothProvided() {
+    void resolveBindings_throwsWhenMultipleProvided() {
         var p = new ShimMain.Parameters();
-        p.solrConfigPath = "/some/path.xml";
-        p.solrConfigInline = "{\"solrConfig\":{}}";
-        assertThrows(ParameterException.class, () -> ShimMain.buildTransformBindings(p));
+        p.transformerConfig = SOLR_CONFIG_JSON;
+        p.transformerConfigEncoded = Base64.getEncoder().encodeToString(SOLR_CONFIG_JSON.getBytes());
+        assertThrows(TransformerConfigUtils.TooManyTransformationConfigSourcesException.class,
+            () -> ShimMain.resolveTransformBindings(p));
     }
 
     @Test
-    void buildTransformBindings_throwsOnInvalidInlineJson() {
-        assertThrows(ParameterException.class,
-            () -> ShimMain.buildTransformBindings(paramsWithInline("not valid json")));
+    void resolveBindings_throwsOnInvalidJson() {
+        var p = new ShimMain.Parameters();
+        p.transformerConfig = "not valid json";
+        assertThrows(ParameterException.class, () -> ShimMain.resolveTransformBindings(p));
     }
 
     @Test
-    void buildTransformBindings_throwsOnMissingJsonFile() {
-        assertThrows(ParameterException.class,
-            () -> ShimMain.buildTransformBindings(paramsWithPath("/nonexistent/config.json")));
+    void resolveBindings_throwsOnMissingJsonFile() {
+        var p = new ShimMain.Parameters();
+        p.transformerConfigFile = "/nonexistent/config.json";
+        assertThrows(TransformerConfigUtils.UnableToReadTransformationConfigException.class,
+            () -> ShimMain.resolveTransformBindings(p));
     }
 
     // --- JCommander CLI param wiring tests ---
 
     @Test
-    void jcommander_parsesSolrConfigPath() {
+    void jcommander_parsesTransformerConfig() {
         var params = new ShimMain.Parameters();
         var jc = com.beust.jcommander.JCommander.newBuilder().addObject(params).build();
         jc.parse("--listenPort", "8080", "--target", "solr=http://localhost:8983",
-            "--primary", "solr", "--solr-config-path", "/path/to/solrconfig.xml");
-        assertEquals("/path/to/solrconfig.xml", params.solrConfigPath);
+            "--primary", "solr", "--transformerConfig", SOLR_CONFIG_JSON);
+        assertEquals(SOLR_CONFIG_JSON, params.transformerConfig);
     }
 
     @Test
-    void jcommander_parsesSolrConfigPathCamelCase() {
+    void jcommander_parsesTransformerConfigKebab() {
         var params = new ShimMain.Parameters();
         var jc = com.beust.jcommander.JCommander.newBuilder().addObject(params).build();
         jc.parse("--listenPort", "8080", "--target", "solr=http://localhost:8983",
-            "--primary", "solr", "--solrConfigPath", "/path/to/solrconfig.xml");
-        assertEquals("/path/to/solrconfig.xml", params.solrConfigPath);
+            "--primary", "solr", "--transformer-config", SOLR_CONFIG_JSON);
+        assertEquals(SOLR_CONFIG_JSON, params.transformerConfig);
     }
 
     @Test
-    void jcommander_parsesSolrConfigInline() {
+    void jcommander_parsesTransformerConfigEncoded() {
+        var encoded = Base64.getEncoder().encodeToString(SOLR_CONFIG_JSON.getBytes());
         var params = new ShimMain.Parameters();
         var jc = com.beust.jcommander.JCommander.newBuilder().addObject(params).build();
         jc.parse("--listenPort", "8080", "--target", "solr=http://localhost:8983",
-            "--primary", "solr", "--solr-config-inline", "{\"solrConfig\":{}}");
-        assertEquals("{\"solrConfig\":{}}", params.solrConfigInline);
+            "--primary", "solr", "--transformerConfigEncoded", encoded);
+        assertEquals(encoded, params.transformerConfigEncoded);
     }
 
     @Test
-    void jcommander_parsesSolrConfigInlineCamelCase() {
+    void jcommander_parsesTransformerConfigEncodedKebab() {
+        var encoded = Base64.getEncoder().encodeToString(SOLR_CONFIG_JSON.getBytes());
         var params = new ShimMain.Parameters();
         var jc = com.beust.jcommander.JCommander.newBuilder().addObject(params).build();
         jc.parse("--listenPort", "8080", "--target", "solr=http://localhost:8983",
-            "--primary", "solr", "--solrConfigInline", "{\"solrConfig\":{}}");
-        assertEquals("{\"solrConfig\":{}}", params.solrConfigInline);
+            "--primary", "solr", "--transformer-config-encoded", encoded);
+        assertEquals(encoded, params.transformerConfigEncoded);
     }
 
     @Test
-    void jcommander_neitherSolrConfigParam_leavesNull() {
+    void jcommander_parsesTransformerConfigFile() {
+        var params = new ShimMain.Parameters();
+        var jc = com.beust.jcommander.JCommander.newBuilder().addObject(params).build();
+        jc.parse("--listenPort", "8080", "--target", "solr=http://localhost:8983",
+            "--primary", "solr", "--transformerConfigFile", "/path/to/config.json");
+        assertEquals("/path/to/config.json", params.transformerConfigFile);
+    }
+
+    @Test
+    void jcommander_parsesTransformerConfigFileKebab() {
+        var params = new ShimMain.Parameters();
+        var jc = com.beust.jcommander.JCommander.newBuilder().addObject(params).build();
+        jc.parse("--listenPort", "8080", "--target", "solr=http://localhost:8983",
+            "--primary", "solr", "--transformer-config-file", "/path/to/config.json");
+        assertEquals("/path/to/config.json", params.transformerConfigFile);
+    }
+
+    @Test
+    void jcommander_noTransformerConfig_leavesNull() {
         var params = new ShimMain.Parameters();
         var jc = com.beust.jcommander.JCommander.newBuilder().addObject(params).build();
         jc.parse("--listenPort", "8080", "--target", "solr=http://localhost:8983",
             "--primary", "solr");
-        assertNull(params.solrConfigPath);
-        assertNull(params.solrConfigInline);
+        assertNull(params.transformerConfig);
+        assertNull(params.transformerConfigEncoded);
+        assertNull(params.transformerConfigFile);
+    }
+
+    @SuppressWarnings("unchecked")
+    private void assertSolrConfigPresent(Map<String, Object> bindings) {
+        assertTrue(bindings.containsKey("solrConfig"));
+        var solrConfig = (Map<String, Object>) bindings.get("solrConfig");
+        assertNotNull(solrConfig.get("/select"));
     }
 }

--- a/TrafficCapture/transformationShim/src/test/java/org/opensearch/migrations/transform/shim/SolrConfigProviderTest.java
+++ b/TrafficCapture/transformationShim/src/test/java/org/opensearch/migrations/transform/shim/SolrConfigProviderTest.java
@@ -1,0 +1,217 @@
+package org.opensearch.migrations.transform.shim;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SolrConfigProviderTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void parsesDefaultsAndInvariants() throws Exception {
+        Path xml = tempDir.resolve("solrconfig.xml");
+        Files.writeString(xml, """
+            <?xml version="1.0" encoding="UTF-8" ?>
+            <config>
+              <requestHandler name="/select" class="solr.SearchHandler">
+                <lst name="defaults">
+                  <str name="df">title</str>
+                  <int name="rows">20</int>
+                  <str name="wt">json</str>
+                </lst>
+                <lst name="invariants">
+                  <str name="facet.field">cat</str>
+                </lst>
+              </requestHandler>
+            </config>
+            """);
+
+        var result = SolrConfigProvider.fromXmlFile(xml);
+        @SuppressWarnings("unchecked")
+        var select = (Map<String, Object>) result.get("/select");
+        @SuppressWarnings("unchecked")
+        var defaults = (Map<String, String>) select.get("defaults");
+        @SuppressWarnings("unchecked")
+        var invariants = (Map<String, String>) select.get("invariants");
+
+        assertEquals("title", defaults.get("df"));
+        assertEquals("20", defaults.get("rows"));
+        assertEquals("json", defaults.get("wt"));
+        assertEquals("cat", invariants.get("facet.field"));
+    }
+
+    @Test
+    void skipsHandlersWithNoDefaultsOrInvariants() throws Exception {
+        Path xml = tempDir.resolve("solrconfig.xml");
+        Files.writeString(xml, """
+            <?xml version="1.0" encoding="UTF-8" ?>
+            <config>
+              <requestHandler name="/update" class="solr.UpdateRequestHandler"/>
+              <requestHandler name="/select" class="solr.SearchHandler">
+                <lst name="defaults">
+                  <str name="df">content</str>
+                </lst>
+              </requestHandler>
+            </config>
+            """);
+
+        var result = SolrConfigProvider.fromXmlFile(xml);
+        assertTrue(result.containsKey("/select"));
+        assertTrue(!result.containsKey("/update"));
+    }
+
+    @Test
+    void returnsEmptyForMissingFile() {
+        var result = SolrConfigProvider.fromXmlFile(Path.of("/nonexistent/solrconfig.xml"));
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void returnsEmptyForNullPath() {
+        var result = SolrConfigProvider.fromXmlFile(null);
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void returnsEmptyForMalformedXml() throws Exception {
+        Path xml = tempDir.resolve("bad.xml");
+        Files.writeString(xml, "not xml at all");
+
+        var result = SolrConfigProvider.fromXmlFile(xml);
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void parsesMultipleHandlers() throws Exception {
+        Path xml = tempDir.resolve("solrconfig.xml");
+        Files.writeString(xml, """
+            <?xml version="1.0" encoding="UTF-8" ?>
+            <config>
+              <requestHandler name="/select" class="solr.SearchHandler">
+                <lst name="defaults">
+                  <str name="df">title</str>
+                </lst>
+              </requestHandler>
+              <requestHandler name="/admin/ping" class="solr.PingRequestHandler">
+                <lst name="invariants">
+                  <str name="q">*:*</str>
+                </lst>
+              </requestHandler>
+            </config>
+            """);
+
+        var result = SolrConfigProvider.fromXmlFile(xml);
+        assertEquals(2, result.size());
+        assertTrue(result.containsKey("/select"));
+        assertTrue(result.containsKey("/admin/ping"));
+    }
+
+    @Test
+    void parsesFloatAndBoolTypes() throws Exception {
+        Path xml = tempDir.resolve("solrconfig.xml");
+        Files.writeString(xml, """
+            <?xml version="1.0" encoding="UTF-8" ?>
+            <config>
+              <requestHandler name="/select" class="solr.SearchHandler">
+                <lst name="defaults">
+                  <float name="hl.regex.slop">0.5</float>
+                  <bool name="facet">true</bool>
+                  <str name="df">title</str>
+                  <int name="rows">10</int>
+                </lst>
+              </requestHandler>
+            </config>
+            """);
+
+        var result = SolrConfigProvider.fromXmlFile(xml);
+        @SuppressWarnings("unchecked")
+        var defaults = (Map<String, String>) ((Map<String, Object>) result.get("/select")).get("defaults");
+        assertEquals("0.5", defaults.get("hl.regex.slop"));
+        assertEquals("true", defaults.get("facet"));
+        assertEquals("title", defaults.get("df"));
+        assertEquals("10", defaults.get("rows"));
+    }
+
+    @Test
+    void handlerWithOnlyInvariants() throws Exception {
+        Path xml = tempDir.resolve("solrconfig.xml");
+        Files.writeString(xml, """
+            <?xml version="1.0" encoding="UTF-8" ?>
+            <config>
+              <requestHandler name="/select" class="solr.SearchHandler">
+                <lst name="invariants">
+                  <str name="wt">json</str>
+                </lst>
+              </requestHandler>
+            </config>
+            """);
+
+        var result = SolrConfigProvider.fromXmlFile(xml);
+        @SuppressWarnings("unchecked")
+        var select = (Map<String, Object>) result.get("/select");
+        assertTrue(!select.containsKey("defaults"));
+        @SuppressWarnings("unchecked")
+        var invariants = (Map<String, String>) select.get("invariants");
+        assertEquals("json", invariants.get("wt"));
+    }
+
+    @Test
+    void parsesAppendsSection() throws Exception {
+        Path xml = tempDir.resolve("solrconfig.xml");
+        Files.writeString(xml, """
+            <?xml version="1.0" encoding="UTF-8" ?>
+            <config>
+              <requestHandler name="/select" class="solr.SearchHandler">
+                <lst name="defaults">
+                  <str name="df">title</str>
+                </lst>
+                <lst name="appends">
+                  <str name="fq">inStock:true</str>
+                </lst>
+              </requestHandler>
+            </config>
+            """);
+
+        var result = SolrConfigProvider.fromXmlFile(xml);
+        @SuppressWarnings("unchecked")
+        var select = (Map<String, Object>) result.get("/select");
+        @SuppressWarnings("unchecked")
+        var appends = (Map<String, String>) select.get("appends");
+        assertEquals("inStock:true", appends.get("fq"));
+    }
+
+    @Test
+    void unknownLstNamesAreSkipped() throws Exception {
+        Path xml = tempDir.resolve("solrconfig.xml");
+        Files.writeString(xml, """
+            <?xml version="1.0" encoding="UTF-8" ?>
+            <config>
+              <requestHandler name="/select" class="solr.SearchHandler">
+                <lst name="defaults">
+                  <str name="df">title</str>
+                </lst>
+                <lst name="components">
+                  <str name="search">mySearchComponent</str>
+                </lst>
+                <lst name="custom-stuff">
+                  <str name="foo">bar</str>
+                </lst>
+              </requestHandler>
+            </config>
+            """);
+
+        var result = SolrConfigProvider.fromXmlFile(xml);
+        @SuppressWarnings("unchecked")
+        var select = (Map<String, Object>) result.get("/select");
+        assertEquals(1, select.size());
+        assertTrue(select.containsKey("defaults"));
+    }
+}

--- a/TrafficCapture/transformationShim/src/test/java/org/opensearch/migrations/transform/shim/SolrTransformerProviderTest.java
+++ b/TrafficCapture/transformationShim/src/test/java/org/opensearch/migrations/transform/shim/SolrTransformerProviderTest.java
@@ -1,0 +1,154 @@
+package org.opensearch.migrations.transform.shim;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for SolrTransformerProvider — the ServiceLoader-discovered provider
+ * that creates Solr JS transformers with polyfill and optional solrconfig.xml parsing.
+ */
+class SolrTransformerProviderTest {
+
+    @TempDir
+    Path tempDir;
+
+    private final SolrTransformerProvider provider = new SolrTransformerProvider();
+
+    private static final String IDENTITY_JS =
+        "(function(bindings) { return function(msg) { return msg; }; })";
+
+    @Test
+    void getName_returnsSolrTransformerProvider() {
+        assertEquals("SolrTransformerProvider", provider.getName());
+    }
+
+    @Test
+    void createTransformer_scriptFile_prependsPolyfill() throws Exception {
+        // Script uses URLSearchParams — only works if polyfill is prepended
+        String script =
+            "(function(bindings) {\n" +
+            "  return function(msg) {\n" +
+            "    var p = new URLSearchParams('q=test');\n" +
+            "    msg.set('q', p.get('q'));\n" +
+            "    return msg;\n" +
+            "  };\n" +
+            "})";
+        Path jsFile = tempDir.resolve("test.js");
+        Files.writeString(jsFile, script);
+
+        var config = Map.of(
+            "initializationScriptFile", jsFile.toAbsolutePath().toString(),
+            "bindingsObject", "{}");
+        var transformer = provider.createTransformer(config);
+        var result = (Map<?, ?>) transformer.transformJson(new HashMap<>(Map.of("key", "value")));
+        assertEquals("test", result.get("q"));
+    }
+
+    @Test
+    void createTransformer_inlineScript() {
+        var config = Map.of(
+            "initializationScript", IDENTITY_JS,
+            "bindingsObject", "{}");
+        var transformer = provider.createTransformer(config);
+        assertNotNull(transformer);
+        var result = (Map<?, ?>) transformer.transformJson(new HashMap<>(Map.of("key", "value")));
+        assertEquals("value", result.get("key"));
+    }
+
+    @Test
+    void createTransformer_withSolrConfigXmlFile() throws Exception {
+        String script =
+            "(function(bindings) {\n" +
+            "  return function(msg) {\n" +
+            "    var sc = bindings.solrConfig;\n" +
+            "    if (sc && sc['/select'] && sc['/select'].defaults) {\n" +
+            "      msg.set('df', sc['/select'].defaults.df);\n" +
+            "    }\n" +
+            "    return msg;\n" +
+            "  };\n" +
+            "})";
+        Path jsFile = tempDir.resolve("test.js");
+        Files.writeString(jsFile, script);
+
+        Path xmlFile = tempDir.resolve("solrconfig.xml");
+        Files.writeString(xmlFile, """
+            <?xml version="1.0" encoding="UTF-8" ?>
+            <config>
+              <requestHandler name="/select" class="solr.SearchHandler">
+                <lst name="defaults">
+                  <str name="df">title</str>
+                  <int name="rows">20</int>
+                </lst>
+              </requestHandler>
+            </config>
+            """);
+
+        var config = Map.of(
+            "initializationScriptFile", jsFile.toAbsolutePath().toString(),
+            "bindingsObject", "{}",
+            "solrConfigXmlFile", xmlFile.toAbsolutePath().toString());
+        var transformer = provider.createTransformer(config);
+        var result = (Map<?, ?>) transformer.transformJson(new HashMap<>(Map.of("key", "value")));
+        assertEquals("title", result.get("df"));
+    }
+
+    @Test
+    void createTransformer_solrConfigXmlMergesWithExistingBindings() throws Exception {
+        String script =
+            "(function(bindings) {\n" +
+            "  return function(msg) {\n" +
+            "    msg.set('custom', bindings.customKey);\n" +
+            "    msg.set('hasSolrConfig', bindings.solrConfig != null);\n" +
+            "    return msg;\n" +
+            "  };\n" +
+            "})";
+        Path jsFile = tempDir.resolve("test.js");
+        Files.writeString(jsFile, script);
+
+        Path xmlFile = tempDir.resolve("solrconfig.xml");
+        Files.writeString(xmlFile, """
+            <?xml version="1.0" encoding="UTF-8" ?>
+            <config>
+              <requestHandler name="/select" class="solr.SearchHandler">
+                <lst name="defaults"><str name="df">title</str></lst>
+              </requestHandler>
+            </config>
+            """);
+
+        var config = Map.of(
+            "initializationScriptFile", jsFile.toAbsolutePath().toString(),
+            "bindingsObject", "{\"customKey\":\"customValue\"}",
+            "solrConfigXmlFile", xmlFile.toAbsolutePath().toString());
+        var transformer = provider.createTransformer(config);
+        var result = (Map<?, ?>) transformer.transformJson(new HashMap<>(Map.of("key", "value")));
+        assertEquals("customValue", result.get("custom"));
+        assertEquals(true, result.get("hasSolrConfig"));
+    }
+
+    @Test
+    void createTransformer_missingBindings_throws() {
+        var config = Map.of("initializationScript", IDENTITY_JS);
+        assertThrows(IllegalArgumentException.class, () -> provider.createTransformer(config));
+    }
+
+    @Test
+    void createTransformer_missingScript_throws() {
+        var config = Map.of("bindingsObject", "{}");
+        assertThrows(IllegalArgumentException.class, () -> provider.createTransformer(config));
+    }
+
+    @Test
+    void createTransformer_nullConfig_throws() {
+        assertThrows(IllegalArgumentException.class, () -> provider.createTransformer(null));
+    }
+}

--- a/TrafficCapture/transformationShim/src/test/java/org/opensearch/migrations/transform/shim/bugfixes/URLSearchParamsPolyfillTest.java
+++ b/TrafficCapture/transformationShim/src/test/java/org/opensearch/migrations/transform/shim/bugfixes/URLSearchParamsPolyfillTest.java
@@ -12,8 +12,8 @@ import java.util.List;
 import java.util.Map;
 
 import org.opensearch.migrations.transform.JavascriptTransformer;
-import org.opensearch.migrations.transform.shim.ShimMain;
 import org.opensearch.migrations.transform.shim.ShimProxy;
+import org.opensearch.migrations.transform.shim.SolrTransformerProvider;
 import org.opensearch.migrations.transform.shim.validation.Target;
 
 import io.netty.bootstrap.ServerBootstrap;
@@ -52,10 +52,10 @@ class URLSearchParamsPolyfillTest {
     private static final HttpClient HTTP = HttpClient.newBuilder()
         .connectTimeout(Duration.ofSeconds(5)).build();
 
-    /** Minimal URLSearchParams polyfill — uses the production polyfill from ShimMain. */
+    /** Minimal URLSearchParams polyfill — uses the production polyfill from SolrTransformerProvider. */
 
     /** Transform that parses query params with URLSearchParams and exercises all polyfill methods. */
-    private static final String TRANSFORM = ShimMain.JS_POLYFILL +
+    private static final String TRANSFORM = SolrTransformerProvider.JS_POLYFILL +
         "(function(bindings) {\n" +
         "  return function(request) {\n" +
         "    var uri = request.get('URI');\n" +

--- a/solrMigrationDevSandbox/config/solr/solrconfig.xml
+++ b/solrMigrationDevSandbox/config/solr/solrconfig.xml
@@ -11,6 +11,7 @@
   <requestHandler name="/select" class="solr.SearchHandler">
     <lst name="defaults">
       <str name="echoParams">explicit</str>
+      <str name="df">product_title</str>
       <str name="wt">json</str>
       <int name="rows">10</int>
     </lst>

--- a/solrMigrationDevSandbox/docker-compose.yml
+++ b/solrMigrationDevSandbox/docker-compose.yml
@@ -79,7 +79,7 @@ services:
       - opensearch
       - --targetTransform
       - opensearch=request:/transforms/solr-to-opensearch-request.js,response:/transforms/solr-to-opensearch-response.js
-      - --solr-config-path
+      - --transformerConfigFile
       - /solr-config/solrconfig.xml
       - --otelCollectorEndpoint
       - http://otel-lgtm:4317
@@ -121,7 +121,7 @@ services:
       - doc-count:solr,opensearch:assert=solr==opensearch
       - --timeout
       - "5000"
-      - --solr-config-path
+      - --transformerConfigFile
       - /solr-config/solrconfig.xml
       - --otelCollectorEndpoint
       - http://otel-lgtm:4317
@@ -163,7 +163,7 @@ services:
       - doc-count:solr,opensearch:assert=solr==opensearch
       - --timeout
       - "5000"
-      - --solr-config-path
+      - --transformerConfigFile
       - /solr-config/solrconfig.xml
       - --otelCollectorEndpoint
       - http://otel-lgtm:4317

--- a/solrMigrationDevSandbox/docker-compose.yml
+++ b/solrMigrationDevSandbox/docker-compose.yml
@@ -60,6 +60,7 @@ services:
       - "18080:8080"
     volumes:
       - transform-dist:/transforms:ro
+      - ./config/solr/solrconfig.xml:/solr-config/solrconfig.xml:ro
     depends_on:
       opensearch:
         condition: service_healthy
@@ -78,6 +79,8 @@ services:
       - opensearch
       - --targetTransform
       - opensearch=request:/transforms/solr-to-opensearch-request.js,response:/transforms/solr-to-opensearch-response.js
+      - --solr-config-path
+      - /solr-config/solrconfig.xml
       - --otelCollectorEndpoint
       - http://otel-lgtm:4317
 
@@ -91,6 +94,7 @@ services:
       - "18083:8080"
     volumes:
       - transform-dist:/transforms:ro
+      - ./config/solr/solrconfig.xml:/solr-config/solrconfig.xml:ro
     depends_on:
       solr:
         condition: service_healthy
@@ -117,6 +121,8 @@ services:
       - doc-count:solr,opensearch:assert=solr==opensearch
       - --timeout
       - "5000"
+      - --solr-config-path
+      - /solr-config/solrconfig.xml
       - --otelCollectorEndpoint
       - http://otel-lgtm:4317
 
@@ -130,6 +136,7 @@ services:
       - "18084:8080"
     volumes:
       - transform-dist:/transforms:ro
+      - ./config/solr/solrconfig.xml:/solr-config/solrconfig.xml:ro
     depends_on:
       solr:
         condition: service_healthy
@@ -156,6 +163,8 @@ services:
       - doc-count:solr,opensearch:assert=solr==opensearch
       - --timeout
       - "5000"
+      - --solr-config-path
+      - /solr-config/solrconfig.xml
       - --otelCollectorEndpoint
       - http://otel-lgtm:4317
 

--- a/solrMigrationDevSandbox/docker-compose.yml
+++ b/solrMigrationDevSandbox/docker-compose.yml
@@ -77,10 +77,10 @@ services:
       - opensearch=http://opensearch:9200
       - --primary
       - opensearch
-      - --targetTransform
-      - opensearch=request:/transforms/solr-to-opensearch-request.js,response:/transforms/solr-to-opensearch-response.js
-      - --transformerConfigFile
-      - /solr-config/solrconfig.xml
+      - --transformerConfig
+      - '[{"SolrTransformerProvider":{"initializationScriptFile":"/transforms/solr-to-opensearch-request.js","bindingsObject":"{}","solrConfigXmlFile":"/solr-config/solrconfig.xml"}}]'
+      - --responseTransformerConfig
+      - '[{"SolrTransformerProvider":{"initializationScriptFile":"/transforms/solr-to-opensearch-response.js","bindingsObject":"{}"}}]'
       - --otelCollectorEndpoint
       - http://otel-lgtm:4317
 
@@ -111,18 +111,18 @@ services:
       - solr=http://solr:8983
       - --target
       - opensearch=http://opensearch:9200
-      - --targetTransform
-      - opensearch=request:/transforms/solr-to-opensearch-request.js,response:/transforms/solr-to-opensearch-response.js
       - --primary
       - solr
+      - --transformerConfig
+      - '[{"SolrTransformerProvider":{"initializationScriptFile":"/transforms/solr-to-opensearch-request.js","bindingsObject":"{}","solrConfigXmlFile":"/solr-config/solrconfig.xml"}}]'
+      - --responseTransformerConfig
+      - '[{"SolrTransformerProvider":{"initializationScriptFile":"/transforms/solr-to-opensearch-response.js","bindingsObject":"{}"}}]'
       - --validator
       - field-equality:solr,opensearch:ignore=responseHeader.QTime,responseHeader.params.NOW
       - --validator
       - doc-count:solr,opensearch:assert=solr==opensearch
       - --timeout
       - "5000"
-      - --transformerConfigFile
-      - /solr-config/solrconfig.xml
       - --otelCollectorEndpoint
       - http://otel-lgtm:4317
 
@@ -153,18 +153,18 @@ services:
       - solr=http://solr:8983
       - --target
       - opensearch=http://opensearch:9200
-      - --targetTransform
-      - opensearch=request:/transforms/solr-to-opensearch-request.js,response:/transforms/solr-to-opensearch-response.js
       - --primary
       - opensearch
+      - --transformerConfig
+      - '[{"SolrTransformerProvider":{"initializationScriptFile":"/transforms/solr-to-opensearch-request.js","bindingsObject":"{}","solrConfigXmlFile":"/solr-config/solrconfig.xml"}}]'
+      - --responseTransformerConfig
+      - '[{"SolrTransformerProvider":{"initializationScriptFile":"/transforms/solr-to-opensearch-response.js","bindingsObject":"{}"}}]'
       - --validator
       - field-equality:solr,opensearch:ignore=responseHeader.QTime,responseHeader.params.NOW
       - --validator
       - doc-count:solr,opensearch:assert=solr==opensearch
       - --timeout
       - "5000"
-      - --transformerConfigFile
-      - /solr-config/solrconfig.xml
       - --otelCollectorEndpoint
       - http://otel-lgtm:4317
 

--- a/solrMigrationDevSandbox/queries/queries.json
+++ b/solrMigrationDevSandbox/queries/queries.json
@@ -1432,5 +1432,92 @@
     "category": "pagination_edge",
     "description": "rows=1 single doc",
     "path": "/solr/testharness/select?q=product_title:wireless&rows=1&sort=id+asc&wt=json"
+  },
+  {
+    "id": "solrconfig_default-001",
+    "category": "solrconfig_default",
+    "description": "Bare term query relying on df=product_title from solrconfig defaults",
+    "path": "/solr/testharness/select?q=headphones&rows=5&fl=id,product_title&wt=json",
+    "params": {
+      "q": "headphones",
+      "rows": "5",
+      "fl": "id,product_title",
+      "wt": "json"
+    }
+  },
+  {
+    "id": "solrconfig_default-002",
+    "category": "solrconfig_default",
+    "description": "Multi-term bare query relying on df from solrconfig defaults",
+    "path": "/solr/testharness/select?q=portable+speaker&rows=5&fl=id,product_title&wt=json",
+    "params": {
+      "q": "portable speaker",
+      "rows": "5",
+      "fl": "id,product_title",
+      "wt": "json"
+    }
+  },
+  {
+    "id": "solrconfig_default-003",
+    "category": "solrconfig_default",
+    "description": "Bare phrase query relying on df from solrconfig defaults",
+    "path": "/solr/testharness/select?q=%22wireless+headphones%22&rows=5&fl=id,product_title&wt=json",
+    "params": {
+      "q": "\"wireless headphones\"",
+      "rows": "5",
+      "fl": "id,product_title",
+      "wt": "json"
+    }
+  },
+  {
+    "id": "solrconfig_default-004",
+    "category": "solrconfig_default",
+    "description": "Explicit df overrides solrconfig default df",
+    "path": "/solr/testharness/select?q=laptop&df=review_body&rows=5&fl=id,product_title&wt=json",
+    "params": {
+      "q": "laptop",
+      "df": "review_body",
+      "rows": "5",
+      "fl": "id,product_title",
+      "wt": "json"
+    }
+  },
+  {
+    "id": "solrconfig_default-005",
+    "category": "solrconfig_default",
+    "description": "Bare term with no results verifies df is applied correctly",
+    "path": "/solr/testharness/select?q=nonexistentword&fl=id&wt=json",
+    "params": {
+      "q": "nonexistentword",
+      "fl": "id",
+      "wt": "json"
+    }
+  },
+  {
+    "id": "solrconfig_default-006",
+    "category": "solrconfig_default",
+    "description": "Bare term with pagination using df from solrconfig defaults",
+    "path": "/solr/testharness/select?q=Cable&start=10&rows=2&fl=id,product_title&wt=json",
+    "params": {
+      "q": "Cable",
+      "start": "10",
+      "rows": "2",
+      "fl": "id,product_title",
+      "wt": "json"
+    }
+  },
+  {
+    "id": "solrconfig_default-007",
+    "category": "solrconfig_default",
+    "description": "Bare term with highlighting using df from solrconfig defaults",
+    "path": "/solr/testharness/select?q=Cable&hl=true&hl.fl=product_title&rows=2&fl=id,product_title&wt=json",
+    "params": {
+      "q": "Cable",
+      "hl": "true",
+      "hl.fl": "product_title",
+      "rows": "2",
+      "fl": "id,product_title",
+      "wt": "json"
+    }
   }
 ]


### PR DESCRIPTION
### Description

Refactors PR #2620 to use the replayer's `TransformerProvider` + `ServiceLoader` + `TransformationLoader` architecture in the shim proxy, replacing the custom transform loading with the same pattern used by the traffic replayer.

### Architecture

**New: `SolrTransformerProvider`** — extends `ScriptTransformerProvider` (same base class as `JsonJSTransformerProvider`):
- Auto-prepends the GraalVM `URLSearchParams` polyfill to all scripts
- Supports `solrConfigXmlFile` config key to auto-parse `solrconfig.xml` into bindings
- Registered via `META-INF/services/org.opensearch.migrations.transform.IJsonTransformerProvider` (ServiceLoader)
- Discovered by `TransformationLoader` at runtime, just like `JsonJSTransformerProvider`

**Refactored `ShimMain`** — uses `TransformationLoader` + `--transformerConfig` (identical JSON array format as the traffic replayer):
- `--transformerConfig` / `--transformerConfigEncoded` / `--transformerConfigFile` for request transforms
- `--responseTransformerConfig` / `--responseTransformerConfigEncoded` / `--responseTransformerConfigFile` for response transforms
- `--transformTarget` to specify which target gets transforms (defaults to first non-primary)
- Removed: `--targetTransform`, `--watchTransforms`, `loadTransformer()`, `resolveTransformBindings()`

### Config format (same as replayer)

```bash
# Request transform with solrconfig.xml auto-parsing
--transformerConfig '[{"SolrTransformerProvider": {
  "initializationScriptFile": "/transforms/request.js",
  "bindingsObject": "{}",
  "solrConfigXmlFile": "/solr-config/solrconfig.xml"
}}]'

# Response transform
--responseTransformerConfig '[{"SolrTransformerProvider": {
  "initializationScriptFile": "/transforms/response.js",
  "bindingsObject": "{}"
}}]'

# Or with inline solrConfig in bindings (no XML file needed)
--transformerConfig '[{"SolrTransformerProvider": {
  "initializationScriptFile": "/transforms/request.js",
  "bindingsObject": "{\"solrConfig\":{\"/select\":{\"defaults\":{\"df\":\"title\"}}}}"
}}]'
```

### Testing

- **SolrTransformerProviderTest (Java):** 8 tests — polyfill prepending, inline script, solrConfigXmlFile parsing, XML+bindings merge, missing bindings/script/null config errors
- **ShimMainTest (Java):** 16 tests — full provider pipeline (inline script, script file, bindings, solrConfigXmlFile, URLSearchParams polyfill, null config), JCommander CLI wiring (kebab + camelCase for request/response config, config file, config encoded, transformTarget, neither-set default)
- **SolrConfigProviderTest (Java):** 10 tests — unchanged, all pass
- **All transformationShim tests:** 188 tests pass
- **E2E isolatedTest:** all pass on Solr 8 + 9 (including 7 solrconfig test cases)
- **TypeScript vitest:** 471 tests pass across 20 files

### Breaking changes

- Removed `--targetTransform` (replaced by `--transformerConfig` + `--transformTarget`)
- Removed `--watchTransforms` (hot-reload)
- Removed `--solr-config-path` / `--solr-config-inline` (replaced by `solrConfigXmlFile` in provider config or inline JSON in `bindingsObject`)

### Related

Builds on #2620