### PR TITLE
Add Roadmap section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
     - [Performance Limitations](#performance-limitations)
       - [Test Results](#test-results)
   - [Issue Tracking](#issue-tracking)
+  - [Roadmap](#roadmap)
   - [User Guide Documentation](#user-guide-documentation)
   - [Getting Started](#getting-started)
     - [Local Deployment](#local-deployment)
@@ -118,6 +119,10 @@ We encourage users to open bugs and feature requests in this GitHub repository.
 For issue prioritization and management, the migrations team uses Jira, but uses GitHub issues for community intake:
 
 https://opensearch.atlassian.net/
+
+## Roadmap
+
+For upcoming features, enhancements, and priorities, check out the [OpenSearch Migrations Project Board](https://github.com/orgs/opensearch-project/projects/229/views/1).
 
 ## User Guide Documentation
 


### PR DESCRIPTION
## Description

Adds a **Roadmap** section to the README linking to the [OpenSearch Migrations Project Board](https://github.com/orgs/opensearch-project/projects/229/views/1), giving users visibility into upcoming features, enhancements, and priorities.

### Changes
- Added `## Roadmap` section between Issue Tracking and User Guide Documentation
- Updated Table of Contents with the new section

### Check List
- [x] New functionality includes testing
  - N/A — documentation-only change
- [x] New functionality has been documented
  - This PR is itself a documentation addition
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).