### PR TITLE
Added Facet Comparison Support for KV Based Buckets

### DIFF
--- a/TrafficCapture/transformationShim/src/main/java/org/opensearch/migrations/transform/shim/reporting/FacetComparator.java
+++ b/TrafficCapture/transformationShim/src/main/java/org/opensearch/migrations/transform/shim/reporting/FacetComparator.java
@@ -2,6 +2,7 @@ package org.opensearch.migrations.transform.shim.reporting;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -12,31 +13,47 @@ import org.opensearch.migrations.transform.shim.reporting.ValidationDocument.Val
 
 /**
  * Compares facet/aggregation bucket results between two post-transform
- * Solr-format response bodies. Both targets are expected to be in Solr
- * facet format after the response transform has been applied.
+ * response bodies. Supports both Solr flat facets ({@code facet_counts.facet_fields})
+ * and JSON Facets API responses ({@code facets} with nested bucket objects).
+ *
+ * <p>Both formats are normalised into a common {@code Map<String, Map<String, Number>>}
+ * representation (facet name → bucket key → count) before comparison, so the
+ * downstream diff logic runs exactly once per facet regardless of source format.
  */
 public final class FacetComparator {
 
     private FacetComparator() {}
 
     /**
-     * Compare facets from both parsed bodies and return a list of comparison entries.
-     * Returns empty list when neither response has facets.
+     * Compare all facets (flat and JSON) from both parsed bodies.
+     * Returns empty list when neither response has any facets.
      */
     public static List<ComparisonEntry> compareFacets(
-            Map<String, Object> solrParsedBody, Map<String, Object> osParsedBody) {
-        Map<String, Object> solrFacets = extractFacetFields(solrParsedBody);
-        Map<String, Object> osFacets = extractFacetFields(osParsedBody);
-
-        Set<String> allFieldNames = new LinkedHashSet<>();
-        allFieldNames.addAll(solrFacets.keySet());
-        allFieldNames.addAll(osFacets.keySet());
-
+            Map<String, Object> baselineBody, Map<String, Object> candidateBody) {
         List<ComparisonEntry> entries = new ArrayList<>();
-        for (String fieldName : allFieldNames) {
-            entries.add(compareSingleFacetField(fieldName, solrFacets.get(fieldName), osFacets.get(fieldName)));
-        }
+        entries.addAll(compareFlatFacets(baselineBody, candidateBody));
+        entries.addAll(compareJsonFacets(baselineBody, candidateBody));
         return entries;
+    }
+
+    private static List<ComparisonEntry> compareFlatFacets(
+            Map<String, Object> baselineBody, Map<String, Object> candidateBody) {
+        Map<String, Map<String, Number>> baseline = normaliseFlatFacets(baselineBody);
+        Map<String, Map<String, Number>> candidate = normaliseFlatFacets(candidateBody);
+        return compareNormalisedFacets("facet_field", baseline, candidate);
+    }
+
+    /**
+     * Normalise flat Solr facets into facetName → (bucketKey → count).
+     * Each field value is an alternating [key, count, key, count, ...] array.
+     */
+    private static Map<String, Map<String, Number>> normaliseFlatFacets(Map<String, Object> parsedBody) {
+        Map<String, Object> fields = extractFacetFields(parsedBody);
+        Map<String, Map<String, Number>> normalised = new LinkedHashMap<>();
+        for (Map.Entry<String, Object> e : fields.entrySet()) {
+            normalised.put(e.getKey(), parseFlatBuckets(e.getValue()));
+        }
+        return normalised;
     }
 
     @SuppressWarnings("unchecked")
@@ -50,58 +67,117 @@ public final class FacetComparator {
         return (Map<String, Object>) facetFields;
     }
 
-    /**
-     * Compare a single facet field. Solr facet_fields values are alternating
-     * [key, count, key, count, ...] arrays.
-     */
-    private static ComparisonEntry compareSingleFacetField(
-            String fieldName, Object solrValue, Object osValue) {
-        Map<String, Number> solrBuckets = parseBuckets(solrValue);
-        Map<String, Number> osBuckets = parseBuckets(osValue);
-
-        Set<String> solrKeys = solrBuckets.keySet();
-        Set<String> osKeys = osBuckets.keySet();
-
-        boolean keysMatch = solrKeys.equals(osKeys);
-        Set<String> missingKeys = new LinkedHashSet<>(solrKeys);
-        missingKeys.removeAll(osKeys);
-        Set<String> extraKeys = new LinkedHashSet<>(osKeys);
-        extraKeys.removeAll(solrKeys);
-
-        List<ValueDrift> valueDrifts = new ArrayList<>();
-        for (String key : solrKeys) {
-            if (osBuckets.containsKey(key)) {
-                Number sv = solrBuckets.get(key);
-                Number ov = osBuckets.get(key);
-                Double drift = MetricsExtractor.computeDriftPercentage(
-                        sv != null ? sv.longValue() : null,
-                        ov != null ? ov.longValue() : null);
-                valueDrifts.add(new ValueDrift(key, sv, ov, drift));
-            }
-        }
-
-        return new ComparisonEntry("facet_field", fieldName, keysMatch,
-                missingKeys.isEmpty() ? null : missingKeys,
-                extraKeys.isEmpty() ? null : extraKeys,
-                valueDrifts.isEmpty() ? null : valueDrifts);
-    }
-
-    /**
-     * Parse Solr facet_fields alternating array [key, count, key, count, ...]
-     * into a key→count map. Returns empty map for null/non-list input.
-     */
     @SuppressWarnings("unchecked")
-    private static Map<String, Number> parseBuckets(Object value) {
+    private static Map<String, Number> parseFlatBuckets(Object value) {
         if (!(value instanceof List)) return Collections.emptyMap();
         List<Object> list = (List<Object>) value;
-        Map<String, Number> buckets = new java.util.LinkedHashMap<>();
+        Map<String, Number> buckets = new LinkedHashMap<>();
         for (int i = 0; i + 1 < list.size(); i += 2) {
             Object key = list.get(i);
             Object count = list.get(i + 1);
-            if (key != null && count instanceof Number) {
-                buckets.put(key.toString(), (Number) count);
+            if (key != null && count instanceof Number number) {
+                buckets.put(key.toString(), number);
             }
         }
         return buckets;
+    }
+
+    private static List<ComparisonEntry> compareJsonFacets(
+            Map<String, Object> baselineBody, Map<String, Object> candidateBody) {
+        Map<String, Map<String, Number>> baseline = normaliseJsonFacets(baselineBody);
+        Map<String, Map<String, Number>> candidate = normaliseJsonFacets(candidateBody);
+        return compareNormalisedFacets("json_facet", baseline, candidate);
+    }
+
+    /**
+     * Normalise JSON API facets into facetName → (bucketKey → count).
+     * Excludes the top-level "count" key which is the total match count.
+     */
+    private static Map<String, Map<String, Number>> normaliseJsonFacets(Map<String, Object> parsedBody) {
+        Map<String, Object> facets = extractJsonFacets(parsedBody);
+        Map<String, Map<String, Number>> normalised = new LinkedHashMap<>();
+        for (Map.Entry<String, Object> e : facets.entrySet()) {
+            if ("count".equals(e.getKey())) continue;
+            normalised.put(e.getKey(), parseJsonBuckets(e.getValue()));
+        }
+        return normalised;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> extractJsonFacets(Map<String, Object> parsedBody) {
+        if (parsedBody == null) return Collections.emptyMap();
+        Object facets = parsedBody.get("facets");
+        if (!(facets instanceof Map)) return Collections.emptyMap();
+        return (Map<String, Object>) facets;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Number> parseJsonBuckets(Object facetValue) {
+        if (!(facetValue instanceof Map)) return Collections.emptyMap();
+        Object bucketsObj = ((Map<String, Object>) facetValue).get("buckets");
+        if (!(bucketsObj instanceof List)) return Collections.emptyMap();
+        List<Object> bucketsList = (List<Object>) bucketsObj;
+        Map<String, Number> buckets = new LinkedHashMap<>();
+        for (Object element : bucketsList) {
+            if (!(element instanceof Map)) continue;
+            Map<String, Object> bucket = (Map<String, Object>) element;
+            Object val = bucket.get("val");
+            Object count = bucket.get("count");
+            if (val != null && count instanceof Number number) {
+                buckets.put(val.toString(), number);
+            }
+        }
+        return buckets;
+    }
+
+    /**
+     * Compare two normalised facet maps and produce one {@link ComparisonEntry} per
+     * facet name found in either side.
+     */
+    private static List<ComparisonEntry> compareNormalisedFacets(
+            String type,
+            Map<String, Map<String, Number>> baseline,
+            Map<String, Map<String, Number>> candidate) {
+        Set<String> allNames = new LinkedHashSet<>();
+        allNames.addAll(baseline.keySet());
+        allNames.addAll(candidate.keySet());
+
+        List<ComparisonEntry> entries = new ArrayList<>();
+        for (String name : allNames) {
+            Map<String, Number> bBuckets = baseline.getOrDefault(name, Collections.emptyMap());
+            Map<String, Number> cBuckets = candidate.getOrDefault(name, Collections.emptyMap());
+            entries.add(buildComparisonEntry(type, name, bBuckets, cBuckets));
+        }
+        return entries;
+    }
+
+    private static ComparisonEntry buildComparisonEntry(
+            String type, String name,
+            Map<String, Number> baselineBuckets, Map<String, Number> candidateBuckets) {
+        Set<String> baselineKeys = baselineBuckets.keySet();
+        Set<String> candidateKeys = candidateBuckets.keySet();
+
+        boolean keysMatch = baselineKeys.equals(candidateKeys);
+        Set<String> missingKeys = new LinkedHashSet<>(baselineKeys);
+        missingKeys.removeAll(candidateKeys);
+        Set<String> extraKeys = new LinkedHashSet<>(candidateKeys);
+        extraKeys.removeAll(baselineKeys);
+
+        List<ValueDrift> valueDrifts = new ArrayList<>();
+        for (String key : baselineKeys) {
+            if (candidateBuckets.containsKey(key)) {
+                Number bv = baselineBuckets.get(key);
+                Number cv = candidateBuckets.get(key);
+                Double drift = MetricsExtractor.computeDriftPercentage(
+                        bv != null ? bv.longValue() : null,
+                        cv != null ? cv.longValue() : null);
+                valueDrifts.add(new ValueDrift(key, bv, cv, drift));
+            }
+        }
+
+        return new ComparisonEntry(type, name, keysMatch,
+                missingKeys.isEmpty() ? null : missingKeys,
+                extraKeys.isEmpty() ? null : extraKeys,
+                valueDrifts.isEmpty() ? null : valueDrifts);
     }
 }

--- a/TrafficCapture/transformationShim/src/test/java/org/opensearch/migrations/transform/shim/reporting/FacetComparatorTest.java
+++ b/TrafficCapture/transformationShim/src/test/java/org/opensearch/migrations/transform/shim/reporting/FacetComparatorTest.java
@@ -1,5 +1,7 @@
 package org.opensearch.migrations.transform.shim.reporting;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -127,5 +129,209 @@ class FacetComparatorTest {
         assertEquals(1, results.size());
         assertFalse(results.get(0).keysMatch());
         assertEquals(Set.of("books"), results.get(0).extraKeys());
+    }
+
+    // ---- JSON Facet tests ----
+
+    @SafeVarargs
+    private static Map<String, Object> jsonFacetBody(String facetName, Map<String, Object>... buckets) {
+        List<Map<String, Object>> bucketList = new ArrayList<>();
+        for (Map<String, Object> b : buckets) {
+            bucketList.add(b);
+        }
+        Map<String, Object> facetValue = new HashMap<>();
+        facetValue.put("buckets", bucketList);
+
+        Map<String, Object> facets = new HashMap<>();
+        facets.put("count", 9999);
+        facets.put(facetName, facetValue);
+
+        Map<String, Object> body = new HashMap<>();
+        body.put("facets", facets);
+        return body;
+    }
+
+    private static Map<String, Object> bucket(String val, Number count) {
+        Map<String, Object> m = new HashMap<>();
+        m.put("val", val);
+        m.put("count", count);
+        return m;
+    }
+
+    /** Filter results to only json_facet entries. */
+    private static List<ComparisonEntry> jsonFacetEntries(List<ComparisonEntry> all) {
+        return all.stream().filter(e -> "json_facet".equals(e.type())).toList();
+    }
+
+    @Test
+    void compareJsonFacets_matchingBuckets() {
+        var baseline = jsonFacetBody("cat", bucket("books", 100), bucket("music", 50));
+        var candidate = jsonFacetBody("cat", bucket("books", 100), bucket("music", 50));
+        var results = jsonFacetEntries(FacetComparator.compareFacets(baseline, candidate));
+        assertEquals(1, results.size());
+        ComparisonEntry entry = results.get(0);
+        assertEquals("json_facet", entry.type());
+        assertTrue(entry.keysMatch());
+        assertNull(entry.missingKeys());
+        assertNull(entry.extraKeys());
+    }
+
+    @Test
+    void compareJsonFacets_missingBuckets() {
+        var baseline = jsonFacetBody("cat", bucket("books", 100), bucket("music", 50));
+        var candidate = jsonFacetBody("cat", bucket("books", 100));
+        var results = jsonFacetEntries(FacetComparator.compareFacets(baseline, candidate));
+        ComparisonEntry entry = results.get(0);
+        assertFalse(entry.keysMatch());
+        assertEquals(Set.of("music"), entry.missingKeys());
+        assertNull(entry.extraKeys());
+    }
+
+    @Test
+    void compareJsonFacets_extraBuckets() {
+        var baseline = jsonFacetBody("cat", bucket("books", 100));
+        var candidate = jsonFacetBody("cat", bucket("books", 100), bucket("music", 50));
+        var results = jsonFacetEntries(FacetComparator.compareFacets(baseline, candidate));
+        ComparisonEntry entry = results.get(0);
+        assertFalse(entry.keysMatch());
+        assertNull(entry.missingKeys());
+        assertEquals(Set.of("music"), entry.extraKeys());
+    }
+
+    @Test
+    void compareJsonFacets_valueDrift() {
+        var baseline = jsonFacetBody("cat", bucket("books", 100));
+        var candidate = jsonFacetBody("cat", bucket("books", 90));
+        var results = jsonFacetEntries(FacetComparator.compareFacets(baseline, candidate));
+        var drifts = results.get(0).valueDrifts();
+        assertNotNull(drifts);
+        assertEquals(1, drifts.size());
+        assertEquals("books", drifts.get(0).key());
+        assertEquals(10.0, drifts.get(0).driftPercentage());
+    }
+
+    @Test
+    void compareJsonFacets_multipleNamedFacets() {
+        Map<String, Object> facets = new HashMap<>();
+        facets.put("count", 500);
+        facets.put("cat", Map.of("buckets", List.of(bucket("books", 10))));
+        facets.put("author", Map.of("buckets", List.of(bucket("Smith", 5))));
+        Map<String, Object> body = Map.of("facets", facets);
+
+        var results = jsonFacetEntries(FacetComparator.compareFacets(body, body));
+        assertEquals(2, results.size());
+        assertTrue(results.stream().allMatch(e -> "json_facet".equals(e.type())));
+        var names = results.stream().map(ComparisonEntry::name).toList();
+        assertTrue(names.contains("cat"));
+        assertTrue(names.contains("author"));
+    }
+
+    @Test
+    void compareJsonFacets_countKeyExcluded() {
+        var body = jsonFacetBody("cat", bucket("books", 10));
+        var results = jsonFacetEntries(FacetComparator.compareFacets(body, body));
+        assertEquals(1, results.size());
+        assertEquals("cat", results.get(0).name());
+    }
+
+    @Test
+    void compareJsonFacets_nullFacetsKey() {
+        var results = jsonFacetEntries(FacetComparator.compareFacets(Map.of(), Map.of()));
+        assertTrue(results.isEmpty());
+    }
+
+    @Test
+    void compareJsonFacets_facetsNotAMap() {
+        var body = Map.<String, Object>of("facets", "not-a-map");
+        var results = jsonFacetEntries(FacetComparator.compareFacets(body, body));
+        assertTrue(results.isEmpty());
+    }
+
+    @Test
+    void compareJsonFacets_noBucketsKey() {
+        Map<String, Object> facets = new HashMap<>();
+        facets.put("cat", Map.of("something", "else"));
+        Map<String, Object> body = Map.of("facets", facets);
+
+        var results = jsonFacetEntries(FacetComparator.compareFacets(body, body));
+        assertEquals(1, results.size());
+        assertTrue(results.get(0).keysMatch());
+        assertNull(results.get(0).missingKeys());
+        assertNull(results.get(0).extraKeys());
+    }
+
+    @Test
+    void compareJsonFacets_bucketsNotAList() {
+        Map<String, Object> facets = new HashMap<>();
+        facets.put("cat", Map.of("buckets", "not-a-list"));
+        Map<String, Object> body = Map.of("facets", facets);
+
+        var results = jsonFacetEntries(FacetComparator.compareFacets(body, body));
+        assertEquals(1, results.size());
+        assertTrue(results.get(0).keysMatch());
+    }
+
+    @Test
+    void compareJsonFacets_bucketMissingVal() {
+        Map<String, Object> badBucket = new HashMap<>();
+        badBucket.put("count", 10);
+
+        Map<String, Object> facets = new HashMap<>();
+        facets.put("cat", Map.of("buckets", List.of(badBucket)));
+        Map<String, Object> body = Map.of("facets", facets);
+
+        var results = jsonFacetEntries(FacetComparator.compareFacets(body, body));
+        assertEquals(1, results.size());
+        assertTrue(results.get(0).keysMatch());
+    }
+
+    @Test
+    void compareJsonFacets_bucketCountNotNumber() {
+        Map<String, Object> badBucket = new HashMap<>();
+        badBucket.put("val", "books");
+        badBucket.put("count", "not-a-number");
+
+        Map<String, Object> facets = new HashMap<>();
+        facets.put("cat", Map.of("buckets", List.of(badBucket)));
+        Map<String, Object> body = Map.of("facets", facets);
+
+        var results = jsonFacetEntries(FacetComparator.compareFacets(body, body));
+        assertEquals(1, results.size());
+        assertTrue(results.get(0).keysMatch());
+    }
+
+    @Test
+    void compareJsonFacets_emptyBucketsArray() {
+        Map<String, Object> facets = new HashMap<>();
+        facets.put("cat", Map.of("buckets", List.of()));
+        Map<String, Object> body = Map.of("facets", facets);
+
+        var results = jsonFacetEntries(FacetComparator.compareFacets(body, body));
+        assertEquals(1, results.size());
+        assertTrue(results.get(0).keysMatch());
+        assertNull(results.get(0).valueDrifts());
+    }
+
+    @Test
+    void compareJsonFacets_onlyBaselineHasJsonFacets() {
+        var baseline = jsonFacetBody("cat", bucket("books", 10), bucket("music", 5));
+        var results = jsonFacetEntries(FacetComparator.compareFacets(baseline, Map.of()));
+        assertEquals(1, results.size());
+        assertFalse(results.get(0).keysMatch());
+        assertEquals(Set.of("books", "music"), results.get(0).missingKeys());
+    }
+
+    @Test
+    void compareJsonFacets_onlyCandidateHasJsonFacets() {
+        var candidate = jsonFacetBody("cat", bucket("books", 10), bucket("music", 5));
+        var results = jsonFacetEntries(FacetComparator.compareFacets(Map.of(), candidate));
+        assertEquals(1, results.size());
+        assertFalse(results.get(0).keysMatch());
+        assertEquals(Set.of("books", "music"), results.get(0).extraKeys());
+    }
+
+    @Test
+    void compareJsonFacets_bothBodiesNull() {
+        assertTrue(FacetComparator.compareFacets(null, null).isEmpty());
     }
 }


### PR DESCRIPTION
### Description
## Add JSON Facets API support to FacetComparator

Extends `compareFacets()` to handle the JSON Facets API format alongside the existing flat format. Both are normalised to a common bucket map before shared comparison logic. No changes to callers.

Previously only supported flat facets:
```json
{"facet_counts": {"facet_fields": {"category": ["books", 10, "music", 5]}}}
```

Now also supports JSON facets:
```json
{"facets": {"count": 200000, "cat": {"buckets": [{"val": "books", "count": 100}, {"val": "music", "count": 50}]}}}
```

### Testing
Unit tests

### Check List
- [x] New functionality includes testing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
