### PR TITLE
fix: Jenkins workflow jobs skip when multiple test labels added simultaneously

### DIFF
--- a/.github/workflows/jenkins_tests.yml
+++ b/.github/workflows/jenkins_tests.yml
@@ -67,8 +67,7 @@ jobs:
   eks-integ-test:
     if: |
       github.event_name == 'push' ||
-      (github.event.action == 'labeled' && github.event.label.name == 'run-eks-tests') ||
-      (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'run-eks-tests'))
+      contains(github.event.pull_request.labels.*.name, 'run-eks-tests')
     needs: [get-require-approval, sanitize-input]
     environment: ${{ needs.get-require-approval.outputs.is-require-approval }}
     runs-on: ubuntu-22.04
@@ -92,8 +91,7 @@ jobs:
   eks-aoss-search-integ-test:
     if: |
       github.event_name == 'push' ||
-      (github.event.action == 'labeled' && github.event.label.name == 'run-aoss-tests') ||
-      (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'run-aoss-tests'))
+      contains(github.event.pull_request.labels.*.name, 'run-aoss-tests')
     needs: [get-require-approval, sanitize-input]
     environment: ${{ needs.get-require-approval.outputs.is-require-approval }}
     runs-on: ubuntu-22.04
@@ -117,8 +115,7 @@ jobs:
   eks-aoss-timeseries-integ-test:
     if: |
       github.event_name == 'push' ||
-      (github.event.action == 'labeled' && github.event.label.name == 'run-aoss-tests') ||
-      (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'run-aoss-tests'))
+      contains(github.event.pull_request.labels.*.name, 'run-aoss-tests')
     needs: [get-require-approval, sanitize-input]
     environment: ${{ needs.get-require-approval.outputs.is-require-approval }}
     runs-on: ubuntu-22.04
@@ -142,8 +139,7 @@ jobs:
   eks-aoss-vector-integ-test:
     if: |
       github.event_name == 'push' ||
-      (github.event.action == 'labeled' && github.event.label.name == 'run-aoss-tests') ||
-      (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'run-aoss-tests'))
+      contains(github.event.pull_request.labels.*.name, 'run-aoss-tests')
     needs: [get-require-approval, sanitize-input]
     environment: ${{ needs.get-require-approval.outputs.is-require-approval }}
     runs-on: ubuntu-22.04
@@ -167,8 +163,7 @@ jobs:
   eks-byos-integ-test:
     if: |
       github.event_name == 'push' ||
-      (github.event.action == 'labeled' && github.event.label.name == 'run-eks-byos-tests') ||
-      (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'run-eks-byos-tests'))
+      contains(github.event.pull_request.labels.*.name, 'run-eks-byos-tests')
     needs: [get-require-approval, sanitize-input]
     environment: ${{ needs.get-require-approval.outputs.is-require-approval }}
     runs-on: ubuntu-22.04
@@ -191,8 +186,7 @@ jobs:
 
   eks-cdc-only-integ-test:
     if: |
-      (github.event.action == 'labeled' && github.event.label.name == 'run-cdc-tests') ||
-      (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'run-cdc-tests'))
+      contains(github.event.pull_request.labels.*.name, 'run-cdc-tests')
     needs: [get-require-approval, sanitize-input]
     environment: ${{ needs.get-require-approval.outputs.is-require-approval }}
     runs-on: ubuntu-22.04
@@ -216,8 +210,7 @@ jobs:
   eks-cfn-create-vpc-test:
     if: |
       github.event_name == 'push' ||
-      (github.event.action == 'labeled' && github.event.label.name == 'run-cfn-tests') ||
-      (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'run-cfn-tests'))
+      contains(github.event.pull_request.labels.*.name, 'run-cfn-tests')
     needs: [get-require-approval, sanitize-input]
     environment: ${{ needs.get-require-approval.outputs.is-require-approval }}
     runs-on: ubuntu-22.04
@@ -241,8 +234,7 @@ jobs:
   eks-cfn-import-vpc-test:
     if: |
       github.event_name == 'push' ||
-      (github.event.action == 'labeled' && github.event.label.name == 'run-cfn-tests') ||
-      (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'run-cfn-tests'))
+      contains(github.event.pull_request.labels.*.name, 'run-cfn-tests')
     needs: [get-require-approval, sanitize-input]
     environment: ${{ needs.get-require-approval.outputs.is-require-approval }}
     runs-on: ubuntu-22.04

--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,4 @@ frontend/
 .factorypath
 deployment/k8s/aws/dist/
 .scannerwork/
+.sisyphus/


### PR DESCRIPTION
## Problem

When multiple test labels are added to a PR (e.g. `run-eks-tests` + `run-aoss-tests` + `run-cfn-tests` + `run-eks-byos-tests`), most Jenkins jobs skip instead of running.

## Root Cause

GitHub fires a separate `labeled` event for each label added. Each workflow run only sees the triggering label in `github.event.label.name`. The old `if` conditions had:

```yaml
if: |
  (github.event.action == 'labeled' && github.event.label.name == 'run-eks-tests') ||
  (github.event.action != 'labeled' && contains(...labels..., 'run-eks-tests'))
```

When the `run-aoss-tests` label triggers the run, `github.event.label.name` is `run-aoss-tests`, so:
- First branch: `'run-aoss-tests' == 'run-eks-tests'` → false
- Second branch: `action != 'labeled'` → false (it IS a labeled event)
- Result: **skipped**

## Fix

Simplify all conditions to just check the PR's full label list:

```yaml
if: |
  github.event_name == 'push' ||
  contains(github.event.pull_request.labels.*.name, 'run-eks-tests')
```

This works for all trigger types (`labeled`, `synchronize`, `reopened`) because `github.event.pull_request.labels` always contains the complete label list.

## Jobs Fixed

| Job | Label |
|-----|-------|
| `eks-integ-test` | `run-eks-tests` |
| `eks-aoss-search-integ-test` | `run-aoss-tests` |
| `eks-aoss-timeseries-integ-test` | `run-aoss-tests` |
| `eks-aoss-vector-integ-test` | `run-aoss-tests` |
| `eks-byos-integ-test` | `run-eks-byos-tests` |
| `eks-cdc-only-integ-test` | `run-cdc-tests` |
| `eks-cfn-create-vpc-test` | `run-cfn-tests` |
| `eks-cfn-import-vpc-test` | `run-cfn-tests` |