### PR TITLE
Add solr-8x-k8s-local-test GHA job to jenkins_tests.yml

### DIFF
--- a/.github/workflows/jenkins_tests.yml
+++ b/.github/workflows/jenkins_tests.yml
@@ -64,6 +64,26 @@ jobs:
           jenkins_api_token: "${{ secrets.JENKINS_MIGRATIONS_API_TOKEN }}"
           job_timeout_minutes: "120"
 
+  solr-8x-k8s-local-test:
+    needs: [get-require-approval, sanitize-input]
+    environment: ${{ needs.get-require-approval.outputs.is-require-approval }}
+    runs-on: ubuntu-22.04
+    concurrency:
+      group: ${{ github.workflow }}-solr-8x-k8s-local-test-${{ github.event.pull_request.number || github.run_id }}
+      cancel-in-progress: ${{ github.event_name != 'push' }}
+    steps:
+      - uses: actions/checkout@v6
+      - name: Jenkins Job Trigger and Monitor
+        uses: ./.github/actions/jenkins-trigger
+        with:
+          jenkins_url: "https://migrations.ci.opensearch.org"
+          job_name: ${{ github.event_name == 'push' && 'main-solr-8x-k8s-local-test' || 'pr-solr-8x-k8s-local-test' }}
+          api_token: "${{ secrets.JENKINS_MIGRATIONS_GENERIC_WEBHOOK_TOKEN }}"
+          job_params: "GIT_REPO_URL=${{ needs.sanitize-input.outputs.pr_repo_url }},GIT_BRANCH=${{ needs.sanitize-input.outputs.branch_name }},GIT_COMMIT=${{ needs.sanitize-input.outputs.commit_hash }}"
+          jenkins_user: "${{ secrets.JENKINS_MIGRATIONS_USER }}"
+          jenkins_api_token: "${{ secrets.JENKINS_MIGRATIONS_API_TOKEN }}"
+          job_timeout_minutes: "120"
+
   eks-integ-test:
     if: |
       github.event_name == 'push' ||
@@ -259,6 +279,7 @@ jobs:
     needs:
       - full-es68-e2e-aws-test
       - elasticsearch-5x-k8s-local-test
+      - solr-8x-k8s-local-test
       - eks-integ-test
       - eks-aoss-search-integ-test
       - eks-aoss-timeseries-integ-test


### PR DESCRIPTION
Adds a dedicated GHA job for the Solr 8.x K8s local integration test, wired to Jenkins via `vars/solr8xK8sLocalTest.groovy`.

This is scaffolding to support the Solr backfill integ test PR.