### PR TITLE
fix(shim): deep-copy request map in dual mode to prevent race condition

### DIFF
--- a/TrafficCapture/transformationShim/src/main/java/org/opensearch/migrations/transform/shim/netty/MultiTargetRoutingHandler.java
+++ b/TrafficCapture/transformationShim/src/main/java/org/opensearch/migrations/transform/shim/netty/MultiTargetRoutingHandler.java
@@ -211,7 +211,7 @@ public class MultiTargetRoutingHandler extends SimpleChannelInboundHandler<FullH
 
         for (String name : activeTargets) {
             Target target = targets.get(name);
-            Map<String, Object> targetRequestMap = (target.requestTransform() != null || hasCursorMark)
+            Map<String, Object> targetRequestMap = (dualMode || target.requestTransform() != null)
                 ? deepCopyMap(requestMap) : requestMap;
             targetRequestMap.put("_targetName", name);
             targetRequestMap.put("_mode", dualMode ? "dual" : "single");


### PR DESCRIPTION
## Description

Fix flaky `ShimProxyTest.dualTarget_validationPass` failure caused by a race condition in `MultiTargetRoutingHandler.dispatchAll()`.

### Root Cause

In dual mode, when neither target had a request transform and the request had no `cursorMark`, both targets shared the **same** `requestMap` reference. The loop mutated it (`_targetName`, `_mode`) and passed it to async connection pool handlers, causing a race on a non-thread-safe `LinkedHashMap`. This intermittently corrupted the request state, leading to validation failures.

### Fix

Changed the deep-copy condition from `(target.requestTransform() != null || hasCursorMark)` to `(dualMode || target.requestTransform() != null)`, ensuring each target always gets its own copy of the request map in dual mode.

### Testing

- All shim tests pass consistently across multiple runs
- No testcontainer usage found in any shim tests (no tagging changes needed)

### Audit Summary

Audited all 19 shim test classes:
- **No testcontainers** found anywhere in the shim module
- Network-based tests use `findFreePort()` with mock Netty backends
- No other race conditions identified