### PR TITLE
feat(solr-transforms): Add Input Validation for Supported/Unsupported Params, Null/Empty Handling & Fix URL + Decoding

### DIFF
--- a/TrafficCapture/SolrTransformations/docs/TRANSFORMS.md
+++ b/TrafficCapture/SolrTransformations/docs/TRANSFORMS.md
@@ -181,6 +181,48 @@ graph LR
 
 ---
 
+## Input Validation
+
+Validation runs before any endpoint-specific transforms, rejecting invalid requests early with clear error messages.
+
+### Declaring Supported Params
+
+Each feature module can export three optional fields that the validation system auto-discovers:
+
+```typescript
+// features/my-feature.ts
+export const params = ['myParam'];                    // exact param names
+export const paramPrefixes = ['myParam.'];            // prefix matching (e.g., hl.fl, json.facet)
+export const paramRules: ParamRule[] = [
+  { name: 'myParam', type: 'integer' },               // type validation
+  { name: 'q', type: 'rejectPattern',                 // regex rejection
+    pattern: String.raw`^\{!`,
+    reason: 'Local params ({!...}) syntax not supported' },
+];
+```
+
+Register the module in `FEATURE_MODULES` in `registry.ts` so validation discovers its params.
+
+### Validation Order
+
+1. **Unsupported param detection** — any param not declared by any feature (and not in `COMMON_PARAMS`) is rejected
+2. **Param type checks** — rules run in declaration order:
+   - `integer` — must match `/^-?\d+$/` (rejects `10abc`)
+   - `boolean` — must be `'true'` or `'false'`
+   - `json` — must parse via `JSON.parse()`
+   - `rejectPattern` — must NOT match the given regex
+
+### Available ParamRule Types
+
+| Type | Validates | Example |
+|------|-----------|---------|
+| `integer` | Strict integer string | `{ name: 'rows', type: 'integer' }` |
+| `boolean` | `'true'` or `'false'` only | `{ name: 'hl', type: 'boolean' }` |
+| `json` | Valid JSON | `{ name: 'json.facet', type: 'json' }` |
+| `rejectPattern` | Value must NOT match regex | `{ name: 'sort', type: 'rejectPattern', pattern: String.raw`\{!`, reason: '...' }` |
+
+---
+
 ## Type System
 
 The TypeScript types mirror the Java-side `JsonKeysForHttpMessage` schema:

--- a/TrafficCapture/SolrTransformations/src/test/java/org/opensearch/migrations/transform/solr/ShimTestFixture.java
+++ b/TrafficCapture/SolrTransformations/src/test/java/org/opensearch/migrations/transform/solr/ShimTestFixture.java
@@ -170,6 +170,14 @@ public class ShimTestFixture implements AutoCloseable {
         ).body();
     }
 
+    /** Returns the full HTTP response (status code + body) for error-path testing. */
+    public HttpResponse<String> httpGetRaw(String url) throws Exception {
+        return HTTP.send(
+            HttpRequest.newBuilder().uri(URI.create(url)).GET().build(),
+            HttpResponse.BodyHandlers.ofString()
+        );
+    }
+
     public String httpPost(String url, String body) throws Exception {
         var resp = HTTP.send(
             HttpRequest.newBuilder().uri(URI.create(url))

--- a/TrafficCapture/SolrTransformations/src/test/java/org/opensearch/migrations/transform/solr/TestCaseDefinition.java
+++ b/TrafficCapture/SolrTransformations/src/test/java/org/opensearch/migrations/transform/solr/TestCaseDefinition.java
@@ -37,7 +37,9 @@ record TestCaseDefinition(
     Map<String, Object> opensearchMapping,
     List<String> solrVersions,
     List<String> plugins,
-    Map<String, Object> transformBindings
+    Map<String, Object> transformBindings,
+    Integer expectedStatusCode,
+    String expectedErrorContains
 ) {
     /** A per-path assertion rule controlling how diffs are handled. */
     @JsonIgnoreProperties(ignoreUnknown = true)

--- a/TrafficCapture/SolrTransformations/src/test/java/org/opensearch/migrations/transform/solr/TransformationShimE2ETest.java
+++ b/TrafficCapture/SolrTransformations/src/test/java/org/opensearch/migrations/transform/solr/TransformationShimE2ETest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.TestFactory;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -125,6 +126,20 @@ class TransformationShimE2ETest {
     private void executeTestCase(
             ShimTestFixture fixture, TestCaseDefinition tc, String solrImage) throws Exception {
         seedData(fixture, tc);
+
+        // Error-path test: assert status code and error message, skip Solr comparison
+        if (tc.expectedStatusCode() != null) {
+            var resp = fixture.httpGetRaw(fixture.getProxyBaseUrl() + tc.requestPath());
+            assertEquals(tc.expectedStatusCode().intValue(), resp.statusCode(),
+                tc.name() + ": expected HTTP " + tc.expectedStatusCode() + " but got " + resp.statusCode());
+            if (tc.expectedErrorContains() != null) {
+                assertTrue(resp.body().contains(tc.expectedErrorContains()),
+                    tc.name() + ": expected error body to contain '" + tc.expectedErrorContains()
+                        + "' but got: " + resp.body());
+            }
+            log.info("PASSED (error-path): {} [{}] → HTTP {}", tc.name(), solrImage, resp.statusCode());
+            return;
+        }
 
         var proxyResponse = sendRequest(fixture, fixture.getProxyBaseUrl() + tc.requestPath(), tc);
         var proxyJson = MAPPER.readValue(proxyResponse, new TypeReference<Map<String, Object>>() {});

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/cases.testcase.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/cases.testcase.ts
@@ -646,4 +646,144 @@ export const testCases: TestCase[] = [
       { path: '$.highlighting[*][*][*]', rule: 'regex', expected: '.*<em>.*</em>.*', reason: 'Fragment text may differ between Solr and OpenSearch highlighters' },
     ],
   }),
+
+  // ───────────────────────────────────────────────────────────
+  // Validation tests — error-path (expectedStatusCode)
+  // ───────────────────────────────────────────────────────────
+
+  solrTest('validation-unsupported-param-fq', {
+    description: 'Unsupported param fq should return 500',
+    documents: [{ id: '1', title: 'test' }],
+    requestPath: '/solr/testcollection/select?q=*:*&fq=title:test&wt=json',
+    expectedStatusCode: 500,
+    expectedErrorContains: 'Request transform failed',
+  }),
+
+  solrTest('validation-unsupported-param-facet', {
+    description: 'Unsupported legacy facet params should return 500',
+    documents: [{ id: '1', title: 'test' }],
+    requestPath: '/solr/testcollection/select?q=*:*&facet=true&facet.field=title&wt=json',
+    expectedStatusCode: 500,
+    expectedErrorContains: 'Request transform failed',
+  }),
+
+  solrTest('validation-unsupported-param-defType', {
+    description: 'Unsupported defType param should return 500',
+    documents: [{ id: '1', title: 'test' }],
+    requestPath: '/solr/testcollection/select?q=test&defType=dismax&qf=title&wt=json',
+    expectedStatusCode: 500,
+    expectedErrorContains: 'Request transform failed',
+  }),
+
+  solrTest('validation-invalid-rows-non-numeric', {
+    description: 'Non-numeric rows should return 500',
+    documents: [{ id: '1', title: 'test' }],
+    requestPath: '/solr/testcollection/select?q=*:*&rows=abc&wt=json',
+    expectedStatusCode: 500,
+    expectedErrorContains: 'Request transform failed',
+  }),
+
+  solrTest('validation-invalid-start-non-numeric', {
+    description: 'Non-numeric start should return 500',
+    documents: [{ id: '1', title: 'test' }],
+    requestPath: '/solr/testcollection/select?q=*:*&start=xyz&wt=json',
+    expectedStatusCode: 500,
+    expectedErrorContains: 'Request transform failed',
+  }),
+
+  solrTest('validation-invalid-hl-boolean', {
+    description: 'Invalid boolean value for hl should return 500',
+    documents: [{ id: '1', title: 'test' }],
+    requestPath: '/solr/testcollection/select?q=*:*&hl=yes&wt=json',
+    expectedStatusCode: 500,
+    expectedErrorContains: 'Request transform failed',
+  }),
+
+  solrTest('validation-local-params-in-q', {
+    description: 'Local params syntax in q should return 500',
+    documents: [{ id: '1', title: 'test' }],
+    requestPath: '/solr/testcollection/select?q=' + encodeURIComponent('{!dismax qf=title}hello') + '&wt=json',
+    expectedStatusCode: 500,
+    expectedErrorContains: 'Request transform failed',
+  }),
+
+  solrTest('validation-invalid-sort-no-direction', {
+    description: 'Sort without direction should return 500',
+    documents: [{ id: '1', title: 'test' }],
+    requestPath: '/solr/testcollection/select?q=*:*&sort=price&wt=json',
+    expectedStatusCode: 500,
+    expectedErrorContains: 'Request transform failed',
+  }),
+
+  solrTest('url-plus-decoding-in-sort', {
+    description: 'Sort with + as space (e.g. sort=price+asc) should decode correctly and return sorted results',
+    documents: [
+      { id: '1', title: 'alpha', price: 30 },
+      { id: '2', title: 'beta', price: 10 },
+      { id: '3', title: 'gamma', price: 20 },
+    ],
+    requestPath: '/solr/testcollection/select?q=*:*&sort=price+asc&wt=json',
+    solrSchema: {
+      fields: {
+        title: { type: 'text_general' },
+        price: { type: 'pfloat' },
+      },
+    },
+    opensearchMapping: {
+      properties: {
+        id: { type: 'keyword' },
+        title: { type: 'text' },
+        price: { type: 'float' },
+      },
+    },
+    assertionRules: SOLR_INTERNAL_RULES,
+  }),
+
+  solrTest('validation-invalid-json-facet', {
+    description: 'Malformed json.facet should return 500',
+    documents: [{ id: '1', title: 'test' }],
+    requestPath: '/solr/testcollection/select?q=*:*&json.facet=' + encodeURIComponent('{bad json}') + '&wt=json',
+    expectedStatusCode: 500,
+    expectedErrorContains: 'Request transform failed',
+  }),
+
+  solrTest('validation-local-params-in-fl', {
+    description: 'Local params syntax in fl should return 500',
+    documents: [{ id: '1', title: 'test' }],
+    requestPath: '/solr/testcollection/select?q=*:*&fl=' + encodeURIComponent('id,{!func}div(price,2)') + '&wt=json',
+    expectedStatusCode: 500,
+    expectedErrorContains: 'Request transform failed',
+  }),
+
+  solrTest('validation-empty-rows', {
+    description: 'Empty rows value should return 500',
+    documents: [{ id: '1', title: 'test' }],
+    requestPath: '/solr/testcollection/select?q=*:*&rows=&wt=json',
+    expectedStatusCode: 500,
+    expectedErrorContains: 'Request transform failed',
+  }),
+
+  solrTest('validation-empty-start', {
+    description: 'Empty start value should return 500',
+    documents: [{ id: '1', title: 'test' }],
+    requestPath: '/solr/testcollection/select?q=*:*&start=&wt=json',
+    expectedStatusCode: 500,
+    expectedErrorContains: 'Request transform failed',
+  }),
+
+  solrTest('validation-valid-request-passes', {
+    description: 'Valid request with supported params should pass through normally',
+    documents: [{ id: '1', title: 'test document' }],
+    requestPath: '/solr/testcollection/select?q=*:*&rows=10&start=0&fl=id,title&wt=json',
+    solrSchema: {
+      fields: {
+        title: { type: 'text_general' },
+      },
+    },
+    opensearchMapping: {
+      properties: {
+        title: { type: 'text' },
+      },
+    },
+  }),
 ];

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/context.test.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/context.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Unit tests for context.ts — parseParams URL decoding and endpoint detection.
+ *
+ * These tests run in Node (which has correct URLSearchParams), so they verify
+ * the parseParams logic itself. The GraalVM polyfill + decoding is tested
+ * separately in URLSearchParamsPolyfillTest.java.
+ */
+import { describe, it, expect } from 'vitest';
+import { buildRequestContext } from './context';
+import type { JavaMap } from './context';
+
+/** Minimal JavaMap stub for testing. */
+function mockMsg(uri: string): JavaMap {
+  const data = new Map<string, any>([['URI', uri]]);
+  return data as unknown as JavaMap;
+}
+
+describe('buildRequestContext', () => {
+  describe('parseParams URL decoding', () => {
+    it('decodes + as space in param values', () => {
+      const ctx = buildRequestContext(mockMsg('/solr/test/select?sort=price+asc'));
+      expect(ctx.params.get('sort')).toBe('price asc');
+    });
+
+    it('decodes + as space in multiple params', () => {
+      const ctx = buildRequestContext(mockMsg('/solr/test/select?q=hello+world&sort=price+asc'));
+      expect(ctx.params.get('q')).toBe('hello world');
+      expect(ctx.params.get('sort')).toBe('price asc');
+    });
+
+    it('decodes %2B as literal +', () => {
+      const ctx = buildRequestContext(mockMsg('/solr/test/select?q=1%2B2'));
+      expect(ctx.params.get('q')).toBe('1+2');
+    });
+
+    it('handles mixed + and %2B correctly', () => {
+      const ctx = buildRequestContext(mockMsg('/solr/test/select?q=%2B1+555+0100'));
+      expect(ctx.params.get('q')).toBe('+1 555 0100');
+    });
+
+    it('decodes %20 as space', () => {
+      const ctx = buildRequestContext(mockMsg('/solr/test/select?sort=price%20asc'));
+      expect(ctx.params.get('sort')).toBe('price asc');
+    });
+
+    it('returns empty params when no query string', () => {
+      const ctx = buildRequestContext(mockMsg('/solr/test/select'));
+      expect(ctx.params.get('q')).toBeNull();
+    });
+  });
+
+  describe('endpoint detection', () => {
+    it('detects select endpoint', () => {
+      const ctx = buildRequestContext(mockMsg('/solr/test/select?q=*:*'));
+      expect(ctx.endpoint).toBe('select');
+    });
+
+    it('detects update endpoint', () => {
+      const ctx = buildRequestContext(mockMsg('/solr/test/update'));
+      expect(ctx.endpoint).toBe('update');
+    });
+
+    it('returns unknown for unrecognized paths', () => {
+      const ctx = buildRequestContext(mockMsg('/other/path'));
+      expect(ctx.endpoint).toBe('unknown');
+    });
+  });
+
+  describe('collection extraction', () => {
+    it('extracts collection from URI', () => {
+      const ctx = buildRequestContext(mockMsg('/solr/mycore/select?q=*:*'));
+      expect(ctx.collection).toBe('mycore');
+    });
+
+    it('returns undefined when no collection in URI', () => {
+      const ctx = buildRequestContext(mockMsg('/other/path'));
+      expect(ctx.collection).toBeUndefined();
+    });
+  });
+});

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/cursor-pagination.test.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/cursor-pagination.test.ts
@@ -92,8 +92,8 @@ describe('parseSolrSort', () => {
     expect(result[0].has(SOLR_UNIQUE_KEY)).toBe(false);
   });
 
-  it('handles + as space', () => {
-    const result = parseSolrSort('price+asc,id+desc');
+  it('handles space-separated sort (+ decoded by parseParams)', () => {
+    const result = parseSolrSort('price asc,id desc');
     expect(result[0].get('price')).toBe('asc');
     expect(result[1].get('_id')).toBe('desc');
   });

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/cursor-pagination.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/cursor-pagination.ts
@@ -11,6 +11,9 @@
 import type { MicroTransform } from '../pipeline';
 import type { RequestContext, ResponseContext, JavaMap } from '../context';
 
+/** Solr query params this feature handles. */
+export const params = ['cursorMark'];
+
 const CURSOR_MARK_START = '*';
 
 /** Solr uniqueKey field name — maps to OpenSearch's _id. */
@@ -99,9 +102,9 @@ function decodeCursorMark(token: string): any[] {
  * Maps Solr's uniqueKey field "id" to OpenSearch's "_id".
  */
 function parseSolrSort(sortStr: string): JavaMap[] {
-  // Handle + as space — URL-encoded sort params (e.g. "price+asc") use + for spaces.
-  // Solr field names cannot contain spaces, so this is safe.
-  return sortStr.replaceAll('+', ' ').split(',').map((clause) => {
+  // parseParams() in context.ts already decodes + as space, so no manual
+  // replacement needed here.
+  return sortStr.split(',').map((clause) => {
     const [field, dir] = clause.trim().split(/\s+/);
     const osField = field === SOLR_UNIQUE_KEY ? OS_UNIQUE_KEY : field;
     return new Map([[osField, (dir || 'asc').toLowerCase()]]);

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/field-list.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/field-list.ts
@@ -12,7 +12,13 @@
  */
 import type { MicroTransform } from '../pipeline';
 import type { RequestContext } from '../context';
+import type { ParamRule } from './validation';
 
+/** Solr query params this feature handles. */
+export const params = ['fl'];
+export const paramRules: ParamRule[] = [
+  { name: 'fl', type: 'rejectPattern', pattern: String.raw`\{!`, reason: 'Local params ({!...}) syntax in fl is not supported' },
+];
 // Pseudo-fields that don't exist in _source (standalone * means all fields)
 const PSEUDO_FIELDS = new Set(['score', '*']);
 

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/highlighting.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/highlighting.ts
@@ -15,7 +15,19 @@
  */
 import type { MicroTransform } from '../pipeline';
 import type { RequestContext, ResponseContext, JavaMap } from '../context';
+import type { ParamRule } from './validation';
 import { parseSolrQuery } from './query-q';
+
+/** Solr query params this feature handles. */
+export const params = ['hl'];
+export const paramPrefixes = ['hl.'];
+export const paramRules: ParamRule[] = [
+  { name: 'hl', type: 'boolean' },
+  { name: 'hl.snippets', type: 'integer' },
+  { name: 'hl.fragsize', type: 'integer' },
+  { name: 'hl.maxAnalyzedChars', type: 'integer' },
+  { name: 'hl.requireFieldMatch', type: 'boolean' },
+];
 
 // Solr hl params with no OpenSearch equivalent — warn and skip
 const UNSUPPORTED_PARAMS = [

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/json-facets.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/json-facets.ts
@@ -9,7 +9,15 @@
  */
 import type { MicroTransform } from '../pipeline';
 import type { RequestContext, JavaMap } from '../context';
+import type { ParamRule } from './validation';
 import { convertSort, isMapLike, isSolrDateMathGap, convertSolrDateGap } from './utils';
+
+/** Solr query params this feature handles. */
+export const params = ['json.facet'];
+export const paramPrefixes = ['json.facet.'];
+export const paramRules: ParamRule[] = [
+  { name: 'json.facet', type: 'json' },
+];
 
 const FEATURE_NAME = 'json-facets';
 

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/query-q.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/query-q.ts
@@ -10,7 +10,16 @@
  */
 import type { MicroTransform } from '../pipeline';
 import type { RequestContext, JavaMap } from '../context';
+import type { ParamRule } from './validation';
 import { translateQ } from '../query-engine/orchestrator/translateQ';
+
+/** Solr query params this feature handles. */
+export const params = ['q', 'rows', 'start', 'q.op'];
+export const paramRules: ParamRule[] = [
+  { name: 'rows', type: 'integer' },
+  { name: 'start', type: 'integer' },
+  { name: 'q', type: 'rejectPattern', pattern: String.raw`^\{!`, reason: 'Local params ({!...}) syntax in q is not supported' },
+];
 
 export function parseSolrQuery(q: string): JavaMap {
   if (!q || q === '*:*') return new Map([['match_all', new Map()]]);

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/select-uri.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/select-uri.ts
@@ -9,6 +9,9 @@
 import type { MicroTransform } from '../pipeline';
 import type { RequestContext } from '../context';
 
+/** Solr query params this feature handles. */
+export const params: string[] = [];
+
 export const request: MicroTransform<RequestContext> = {
   name: 'select-uri',
   apply: (ctx) => {

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/sort.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/sort.ts
@@ -11,7 +11,13 @@
  */
 import type { MicroTransform } from '../pipeline';
 import type { RequestContext } from '../context';
+import type { ParamRule } from './validation';
 
+/** Solr query params this feature handles. */
+export const params = ['sort'];
+export const paramRules: ParamRule[] = [
+  { name: 'sort', type: 'rejectPattern', pattern: String.raw`\{!`, reason: 'Local params ({!...}) syntax in sort is not supported' },
+];
 function parseSortClause(clause: string): Map<string, any> {
   const parts = clause.trim().split(/\s+/);
   if (parts.length < 2 || !parts[0]) {

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/validation.test.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/validation.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { request, initValidation } from './validation';
+import type { RequestContext, JavaMap } from '../context';
+
+beforeAll(() => {
+  initValidation(
+    new Set(['q', 'rows', 'start', 'sort', 'fl', 'cursorMark', 'hl', 'json.facet', 'wt', 'indent', 'echoParams', 'df']),
+    ['hl.', 'json.facet.'],
+    [
+      { name: 'rows', type: 'integer' },
+      { name: 'start', type: 'integer' },
+      { name: 'hl', type: 'boolean' },
+      { name: 'hl.snippets', type: 'integer' },
+      { name: 'hl.fragsize', type: 'integer' },
+      { name: 'hl.maxAnalyzedChars', type: 'integer' },
+      { name: 'hl.requireFieldMatch', type: 'boolean' },
+      { name: 'json.facet', type: 'json' },
+      { name: 'q', type: 'rejectPattern', pattern: String.raw`^\{!`, reason: 'Local params ({!...}) syntax in q is not supported' },
+      { name: 'sort', type: 'rejectPattern', pattern: String.raw`\{!`, reason: 'Local params ({!...}) syntax in sort is not supported' },
+      { name: 'fl', type: 'rejectPattern', pattern: String.raw`\{!`, reason: 'Local params ({!...}) syntax in fl is not supported' },
+    ],
+  );
+});
+
+function buildCtx(params: string): RequestContext {
+  return {
+    msg: new Map() as unknown as JavaMap,
+    endpoint: 'select',
+    collection: 'testcollection',
+    params: new URLSearchParams(params),
+    body: new Map() as unknown as JavaMap,
+  };
+}
+
+describe('validation MicroTransform', () => {
+  describe('match', () => {
+    it('matches select endpoint', () => {
+      expect(request.match!(buildCtx('q=*:*'))).toBe(true);
+    });
+
+    it('does not match non-select endpoints', () => {
+      const ctx = buildCtx('q=*:*');
+      ctx.endpoint = 'update';
+      expect(request.match!(ctx)).toBe(false);
+    });
+  });
+
+  describe('integer param validation', () => {
+    it('passes with valid rows and start', () => {
+      expect(() => request.apply(buildCtx('q=*:*&rows=10&start=0'))).not.toThrow();
+    });
+
+    it('throws when rows is non-numeric', () => {
+      expect(() => request.apply(buildCtx('q=*:*&rows=abc'))).toThrow("'rows' must be a valid integer, got 'abc'");
+    });
+
+    it('throws when start is non-numeric', () => {
+      expect(() => request.apply(buildCtx('q=*:*&start=xyz'))).toThrow("'start' must be a valid integer, got 'xyz'");
+    });
+
+    it('throws when rows is empty', () => {
+      expect(() => request.apply(buildCtx('q=*:*&rows='))).toThrow("'rows' must be a valid integer, got ''");
+    });
+
+    it('passes when integer params are absent', () => {
+      expect(() => request.apply(buildCtx('q=*:*'))).not.toThrow();
+    });
+
+    it('throws when hl.snippets is non-numeric', () => {
+      expect(() => request.apply(buildCtx('q=*:*&hl=true&hl.snippets=many'))).toThrow("'hl.snippets' must be a valid integer");
+    });
+
+    it('throws when hl.fragsize is non-numeric', () => {
+      expect(() => request.apply(buildCtx('q=*:*&hl=true&hl.fragsize=big'))).toThrow("'hl.fragsize' must be a valid integer");
+    });
+
+    it('throws when hl.maxAnalyzedChars is non-numeric', () => {
+      expect(() => request.apply(buildCtx('q=*:*&hl=true&hl.maxAnalyzedChars=lots'))).toThrow("'hl.maxAnalyzedChars' must be a valid integer");
+    });
+  });
+
+  describe('boolean param validation', () => {
+    it('passes with hl=true', () => {
+      expect(() => request.apply(buildCtx('q=*:*&hl=true'))).not.toThrow();
+    });
+
+    it('passes with hl=false', () => {
+      expect(() => request.apply(buildCtx('q=*:*&hl=false'))).not.toThrow();
+    });
+
+    it('throws when hl has invalid boolean value', () => {
+      expect(() => request.apply(buildCtx('q=*:*&hl=yes'))).toThrow("'hl' must be 'true' or 'false', got 'yes'");
+    });
+
+    it('throws when hl=1', () => {
+      expect(() => request.apply(buildCtx('q=*:*&hl=1'))).toThrow("'hl' must be 'true' or 'false', got '1'");
+    });
+
+    it('throws when hl.requireFieldMatch is invalid', () => {
+      expect(() => request.apply(buildCtx('q=*:*&hl=true&hl.requireFieldMatch=yes'))).toThrow("'hl.requireFieldMatch' must be 'true' or 'false'");
+    });
+
+    it('passes with hl.requireFieldMatch=true', () => {
+      expect(() => request.apply(buildCtx('q=*:*&hl=true&hl.requireFieldMatch=true'))).not.toThrow();
+    });
+  });
+
+  describe('json param validation', () => {
+    it('passes with valid json.facet', () => {
+      expect(() => request.apply(buildCtx('q=*:*&json.facet={"categories":{"type":"terms","field":"cat"}}'))).not.toThrow();
+    });
+
+    it('throws when json.facet is invalid JSON', () => {
+      expect(() => request.apply(buildCtx('q=*:*&json.facet={bad json}'))).toThrow("'json.facet' must be valid JSON");
+    });
+
+    it('throws when json.facet is empty', () => {
+      expect(() => request.apply(buildCtx('q=*:*&json.facet='))).toThrow("'json.facet' must be valid JSON, got empty value");
+    });
+  });
+
+  describe('rejectPattern — local params detection', () => {
+    it('throws when q uses local params', () => {
+      expect(() => request.apply(buildCtx('q={!dismax qf=title}hello'))).toThrow('Local params ({!...}) syntax in q is not supported');
+    });
+
+    it('throws when q uses func local params', () => {
+      expect(() => request.apply(buildCtx('q={!func}popularity'))).toThrow('Local params ({!...}) syntax in q is not supported');
+    });
+
+    it('passes when q is a normal query', () => {
+      expect(() => request.apply(buildCtx('q=title:hello'))).not.toThrow();
+    });
+
+    it('throws when sort uses local params', () => {
+      expect(() => request.apply(buildCtx('q=*:*&sort={!func}popularity desc'))).toThrow('Local params ({!...}) syntax in sort is not supported');
+    });
+
+    it('passes when sort is normal', () => {
+      expect(() => request.apply(buildCtx('q=*:*&sort=price asc'))).not.toThrow();
+    });
+
+    it('throws when fl uses local params', () => {
+      expect(() => request.apply(buildCtx('q=*:*&fl=id,{!func}div(price,2)'))).toThrow('Local params ({!...}) syntax in fl is not supported');
+    });
+
+    it('passes when fl is normal', () => {
+      expect(() => request.apply(buildCtx('q=*:*&fl=id,title,price'))).not.toThrow();
+    });
+  });
+
+  describe('unsupported param detection', () => {
+    it('passes with all supported params', () => {
+      expect(() => request.apply(buildCtx('q=*:*&rows=10&start=0&sort=price+asc&fl=id,title&wt=json'))).not.toThrow();
+    });
+
+    it('passes with hl prefix params', () => {
+      expect(() => request.apply(buildCtx('q=*:*&hl=true&hl.fl=title&hl.snippets=3'))).not.toThrow();
+    });
+
+    it('passes with json.facet prefix params', () => {
+      expect(() => request.apply(buildCtx('q=*:*&json.facet={"categories":{"type":"terms","field":"cat"}}'))).not.toThrow();
+    });
+
+    it('throws on unsupported param fq', () => {
+      expect(() => request.apply(buildCtx('q=*:*&fq=inStock:true'))).toThrow('Unsupported Solr parameters: fq');
+    });
+
+    it('throws on multiple unsupported params', () => {
+      expect(() => request.apply(buildCtx('q=*:*&fq=inStock:true&facet=true'))).toThrow('Unsupported Solr parameters: fq, facet');
+    });
+
+    it('skips internal _ prefixed params', () => {
+      expect(() => request.apply(buildCtx('q=*:*&_=1234567890'))).not.toThrow();
+    });
+
+    it('passes with cursorMark', () => {
+      expect(() => request.apply(buildCtx('q=*:*&cursorMark=*&sort=id+asc'))).not.toThrow();
+    });
+
+    it('passes with common params df, indent, echoParams', () => {
+      expect(() => request.apply(buildCtx('q=*:*&df=title&indent=true&echoParams=all'))).not.toThrow();
+    });
+  });
+});

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/validation.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/validation.ts
@@ -1,0 +1,119 @@
+/**
+ * Validation — fail fast on null/empty inputs and unsupported Solr features.
+ *
+ * Runs as a global request transform (before endpoint-specific transforms).
+ * All validation rules are generic and injected by registry.ts via initValidation().
+ *
+ * Features declare:
+ *   - params / paramPrefixes — for supported param discovery
+ *   - paramRules — for param type validation (integer, boolean, json)
+ */
+import type { MicroTransform } from '../pipeline';
+import type { RequestContext } from '../context';
+
+export type ParamType = 'integer' | 'boolean' | 'json' | 'rejectPattern';
+
+/** Data validation rule — checks value format. @example `{ name: 'rows', type: 'integer' }` */
+interface DataRule {
+  /** Solr param name this rule validates. Example: `'rows'`, `'hl'`, `'json.facet'` */
+  name: string;
+  /** `'integer'` — must be a valid integer | `'boolean'` — `'true'`/`'false'` | `'json'` — valid JSON */
+  type: 'integer' | 'boolean' | 'json';
+}
+
+/** Pattern rejection rule — rejects values matching a regex. @example `{ name: 'q', type: 'rejectPattern', pattern: String.raw`^\{!`, reason: 'Local params not supported' }` */
+interface RejectRule {
+  /** Solr param name this rule validates. Example: `'q'`, `'sort'`, `'fl'` */
+  name: string;
+  type: 'rejectPattern';
+  /** Regex pattern — rejects if value matches. Example: `String.raw`^\{!`` */
+  pattern: string;
+  /** Human-readable error shown when pattern matches. Example: `'Local params ({!...}) syntax in q is not supported'` */
+  reason: string;
+}
+
+/** Discriminated union — use `type` to distinguish between data checks and pattern rejections. */
+export type ParamRule = DataRule | RejectRule;
+
+let supportedParams: Set<string> = new Set();
+let supportedPrefixes: string[] = [];
+let paramRules: ParamRule[] = [];
+/** Pre-compiled regexes keyed by pattern string — built once in initValidation(). */
+const compiledPatterns = new Map<string, RegExp>();
+
+/** Called by registry.ts after aggregating from all features. */
+export function initValidation(
+  params: Set<string>,
+  prefixes: string[],
+  rules: ParamRule[],
+): void {
+  supportedParams = params;
+  supportedPrefixes = prefixes;
+  paramRules = rules;
+  compiledPatterns.clear();
+  for (const rule of rules) {
+    if (rule.type === 'rejectPattern' && rule.pattern) {
+      compiledPatterns.set(rule.pattern, new RegExp(rule.pattern));
+    }
+  }
+}
+
+function isSupported(key: string): boolean {
+  if (supportedParams.has(key)) return true;
+  return supportedPrefixes.some((p) => key.startsWith(p));
+}
+
+const TYPE_VALIDATORS: Record<ParamType, (val: string, name: string, rule: ParamRule) => string | null> = {
+  integer: (val, name) => {
+    const trimmed = val.trim();
+    return trimmed === '' || !/^-?\d+$/.test(trimmed)
+      ? `'${name}' must be a valid integer, got '${val}'`
+      : null;
+  },
+  boolean: (val, name) =>
+    val !== 'true' && val !== 'false'
+      ? `'${name}' must be 'true' or 'false', got '${val}'`
+      : null,
+  json: (val, name) => {
+    if (!val.trim()) return `'${name}' must be valid JSON, got empty value`;
+    try {
+      JSON.parse(val);
+      return null;
+    } catch {
+      return `'${name}' must be valid JSON, got '${val.length > 50 ? val.slice(0, 50) + '...' : val}'`;
+    }
+  },
+  rejectPattern: (val, name, rule) => {
+    const re = rule.pattern ? compiledPatterns.get(rule.pattern) : undefined;
+    if (re?.test(val)) {
+      return rule.reason || `'${name}' contains unsupported syntax`;
+    }
+    return null;
+  },
+};
+
+export const request: MicroTransform<RequestContext> = {
+  name: 'validation',
+  match: (ctx) => ctx.endpoint === 'select',
+  apply: (ctx) => {
+    // Unsupported param detection (fail fast on unknown params)
+    const unsupported: string[] = [];
+    for (const key of ctx.params.keys()) {
+      if (!isSupported(key) && !key.startsWith('_')) {
+        unsupported.push(key);
+      }
+    }
+    if (unsupported.length > 0) {
+      throw new Error(`Unsupported Solr parameters: ${unsupported.join(', ')}`);
+    }
+
+    // Param type checks (auto-discovered from features)
+    for (const rule of paramRules) {
+      const val = ctx.params.get(rule.name);
+      if (val != null) {
+        const error = TYPE_VALIDATORS[rule.type](val, rule.name, rule);
+        if (error) throw new Error(`Validation failed: ${error}`);
+      }
+    }
+  },
+};

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/registry.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/registry.ts
@@ -2,9 +2,10 @@
  * Transform registry — single source of truth for all feature registrations.
  *
  * To add a new feature:
- *   1. Create features/my-feature.ts exporting { request?, response? }
+ *   1. Create features/my-feature.ts exporting { request?, response?, params?, paramPrefixes? }
  *   2. Import it here
  *   3. Add to the appropriate endpoint group
+ *   4. Add to FEATURE_MODULES so validation auto-discovers its params
  */
 import type { TransformRegistry } from './pipeline';
 import type { RequestContext, ResponseContext } from './context';
@@ -20,9 +21,53 @@ import * as highlighting from './features/highlighting';
 import * as hitsToDocs from './features/hits-to-docs';
 import * as aggsToFacets from './features/aggs-to-facets';
 import * as responseHeader from './features/response-header';
+import * as validation from './features/validation';
+import { initValidation } from './features/validation';
+import type { ParamRule } from './features/validation';
+
+/** Shape of a feature module that declares supported params for validation. */
+interface FeatureModule {
+  params?: string[];
+  paramPrefixes?: string[];
+  paramRules?: ParamRule[];
+}
+
+/**
+ * All feature modules — used to auto-aggregate supported params and rules.
+ * hitsToDocs and aggsToFacets are response-only transforms with no request
+ * params, so they don't need to be listed here for validation discovery.
+ */
+const FEATURE_MODULES: FeatureModule[] = [
+  selectUri, queryQ, cursorPagination, fieldList,
+  sort, jsonFacets, highlighting,
+];
+
+/**
+ * Common Solr params allowlisted for validation — not rejected as unsupported.
+ * - wt: only json is returned; other formats (xml, csv) are not translated
+ * - indent: pretty-print flag, ignored by the shim
+ * - echoParams: param echo in response header, not implemented
+ * - df: actively used by the query parser as the default field
+ */
+const COMMON_PARAMS = ['wt', 'indent', 'echoParams', 'df'];
+
+/** Auto-aggregated from all feature modules. */
+export const supportedParams = new Set<string>(COMMON_PARAMS);
+export const supportedPrefixes: string[] = [];
+const aggregatedRules: ParamRule[] = [];
+
+for (const mod of FEATURE_MODULES) {
+  mod.params?.forEach((p) => supportedParams.add(p));
+  if (mod.paramPrefixes) supportedPrefixes.push(...mod.paramPrefixes);
+  if (mod.paramRules) aggregatedRules.push(...mod.paramRules);
+}
+
+initValidation(supportedParams, supportedPrefixes, aggregatedRules);
 
 export const requestRegistry: TransformRegistry<RequestContext> = {
-  global: [],
+  global: [
+    validation.request, // Fail fast on null/empty inputs and unsupported params
+  ],
   byEndpoint: {
     select: [
       solrconfigDefaults.request, // Apply solrconfig.xml defaults/invariants — must be before all others
@@ -33,7 +78,6 @@ export const requestRegistry: TransformRegistry<RequestContext> = {
       fieldList.request, // fl=... → _source
       highlighting.request, // hl=true → highlight block
       sort.request, // sort=... → sort DSL
-      jsonFacets.request, // json.facet → aggs
     ],
   },
 };

--- a/TrafficCapture/SolrTransformations/transforms/src/test-types.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/test-types.ts
@@ -202,6 +202,10 @@ export interface TestCase {
   plugins?: string[];
   /** Optional bindings passed to transforms at init (e.g., solrConfig defaults from solrconfig.xml). */
   transformBindings?: Record<string, unknown>;
+  /** Expected HTTP status code from the proxy. When set, skips Solr comparison and asserts status + error message. */
+  expectedStatusCode?: number;
+  /** Expected substring in the error response body. Only used with expectedStatusCode. */
+  expectedErrorContains?: string;
 }
 
 /** Solr-internal fields that OpenSearch doesn't have — always safe to ignore. */

--- a/TrafficCapture/transformationShim/src/main/java/org/opensearch/migrations/transform/shim/ShimMain.java
+++ b/TrafficCapture/transformationShim/src/main/java/org/opensearch/migrations/transform/shim/ShimMain.java
@@ -570,5 +570,4 @@ public class ShimMain {
         }
         throw new ParameterException("Unknown auth type: " + authSpec);
     }
-
 }

--- a/TrafficCapture/transformationShim/src/main/java/org/opensearch/migrations/transform/shim/SolrTransformerProvider.java
+++ b/TrafficCapture/transformationShim/src/main/java/org/opensearch/migrations/transform/shim/SolrTransformerProvider.java
@@ -51,8 +51,8 @@ public class SolrTransformerProvider extends ScriptTransformerProvider {
         "    qs.split('&').forEach(function(pair) {\n" +
         "      var idx = pair.indexOf('=');\n" +
         "      if (idx < 0) return;\n" +
-        "      var k = decodeURIComponent(pair.slice(0, idx));\n" +
-        "      var v = decodeURIComponent(pair.slice(idx + 1));\n" +
+        "      var k = decodeURIComponent(pair.slice(0, idx).replace(/\\+/g, ' '));\n" +
+        "      var v = decodeURIComponent(pair.slice(idx + 1).replace(/\\+/g, ' '));\n" +
         "      if (!this._map[k]) this._map[k] = [];\n" +
         "      this._map[k].push(v);\n" +
         "    }.bind(this));\n" +

--- a/TrafficCapture/transformationShim/src/main/java/org/opensearch/migrations/transform/shim/netty/MultiTargetRoutingHandler.java
+++ b/TrafficCapture/transformationShim/src/main/java/org/opensearch/migrations/transform/shim/netty/MultiTargetRoutingHandler.java
@@ -256,8 +256,10 @@ public class MultiTargetRoutingHandler extends SimpleChannelInboundHandler<FullH
                 ? (TargetDispatchContext) requestCtx.createTargetDispatchContext(name)
                 : null;
 
-            // Response transform needs per-target URI (with rewritten cursorMark)
-            Map<String, Object> responseRequestMap = hasCursorMark ? targetRequestMap : requestMap;
+            // Snapshot the request before the request transform rewrites the URI (e.g., to /_search).
+            // The response transform needs the original Solr URI to detect params like cursorMark, sort, etc.
+            Map<String, Object> responseRequestMap = target.requestTransform() != null
+                ? deepCopyMap(targetRequestMap) : targetRequestMap;
             futures.put(name, dispatchToTarget(target, targetRequestMap, responseRequestMap, dispatchCtx));
 
             collectTransformData(target, name, targetRequestMap,

--- a/TrafficCapture/transformationShim/src/test/java/org/opensearch/migrations/transform/shim/bugfixes/URLSearchParamsPolyfillTest.java
+++ b/TrafficCapture/transformationShim/src/test/java/org/opensearch/migrations/transform/shim/bugfixes/URLSearchParamsPolyfillTest.java
@@ -158,6 +158,55 @@ class URLSearchParamsPolyfillTest {
         assertTrue(body.contains("\"hasRowsAfter\":false"), "has('rows') should be false after delete: " + body);
     }
 
+    @Test
+    void urlSearchParams_decodesPlus_asSpace() throws Exception {
+        int backendPort = findFreePort();
+        int proxyPort = findFreePort();
+
+        startEchoBackend(backendPort);
+
+        // Transform that extracts q param to verify + decoding
+        var plusTransform = new JavascriptTransformer(SolrTransformerProvider.JS_POLYFILL +
+            "(function(bindings) {\n" +
+            "  return function(request) {\n" +
+            "    var uri = request.get('URI');\n" +
+            "    var qIdx = uri.indexOf('?');\n" +
+            "    if (qIdx >= 0) {\n" +
+            "      var params = new URLSearchParams(uri.substring(qIdx + 1));\n" +
+            "      request.set('URI', '/parsed');\n" +
+            "      request.set('method', 'POST');\n" +
+            "      var payload = new Map();\n" +
+            "      var body = new Map();\n" +
+            "      body.set('q', params.get('q'));\n" +
+            "      body.set('sort', params.get('sort'));\n" +
+            "      body.set('literal', params.get('literal'));\n" +
+            "      payload.set('inlinedJsonBody', body);\n" +
+            "      request.set('payload', payload);\n" +
+            "    }\n" +
+            "    return request;\n" +
+            "  };\n" +
+            "})", new LinkedHashMap<>());
+
+        var targets = Map.of("backend",
+            new Target("backend", URI.create("http://localhost:" + backendPort), plusTransform, null, null));
+        proxy = new ShimProxy(proxyPort, targets, "backend", List.of());
+        proxy.start();
+
+        // + should decode as space, %2B should decode as literal +
+        var resp = HTTP.send(
+            HttpRequest.newBuilder()
+                .uri(URI.create("http://localhost:" + proxyPort
+                    + "/search?q=hello+world&sort=price+asc&literal=1%2B2"))
+                .GET().build(),
+            HttpResponse.BodyHandlers.ofString());
+
+        assertEquals(200, resp.statusCode());
+        var body = resp.body();
+        assertTrue(body.contains("\"q\":\"hello world\""), "+ should decode as space: " + body);
+        assertTrue(body.contains("\"sort\":\"price asc\""), "+ in sort should decode as space: " + body);
+        assertTrue(body.contains("\"literal\":\"1+2\""), "%2B should decode as literal +: " + body);
+    }
+
     private void startEchoBackend(int port) throws InterruptedException {
         backendGroup = new NioEventLoopGroup(1);
         backendChannel = new ServerBootstrap()


### PR DESCRIPTION
### Summary

   Adds request-level input validation that detects unsupported Solr params, validates param types (integer, boolean, json), rejects null/empty values, and enforces pattern rules — all before endpoint transforms run. Also fixes the `+` as space
   URL decoding bug at the root cause — the GraalVM URLSearchParams polyfill now correctly decodes `+` as space per the WHATWG URL spec, eliminating the need for workarounds in application code.

   Additionally fixes a pre-existing bug where the response transform in dual-target mode received the post-transform request (with URI rewritten to `/_search`), preventing response transforms from detecting original Solr params like
   `cursorMark`. The response transform now receives a snapshot of the request before the request transform runs.

   ### Files Changed (21)

   **New:**
   - `features/validation.ts` — validation transform + types
   - `features/validation.test.ts` — 34 unit tests
   - `context.test.ts` — 11 unit tests for URL decoding, endpoint detection, collection extraction

   **Modified (TS):**
   - `context.ts`, `registry.ts`, `cursor-pagination.ts`, `cursor-pagination.test.ts`
   - `query-q.ts`, `field-list.ts`, `sort.ts`, `highlighting.ts`, `json-facets.ts`, `select-uri.ts`
   - `cases.testcase.ts`, `test-types.ts`

   **Modified (Java):**
   - `SolrTransformerProvider.java` — `+` decoding fix in URLSearchParams polyfill
   - `MultiTargetRoutingHandler.java` — response transform receives pre-transform request snapshot
   - `TestCaseDefinition.java`, `ShimTestFixture.java`, `TransformationShimE2ETest.java`
   - `URLSearchParamsPolyfillTest.java` — updated reference from `ShimMain` to `SolrTransformerProvider`

   ### Changes

   **Input Validation (`validation.ts`, `registry.ts`)**
   - Features self-declare supported params via `params[]`, `paramPrefixes[]`, and `paramRules[]`
   - Unsupported param detection with fail-fast error responses
   - Four param type validators: `integer`, `boolean`, `json`, `rejectPattern`
   - Pre-compiled regex patterns for reject rules

   **URLSearchParams Polyfill Fix (`SolrTransformerProvider.java`, `context.ts`)**
   - Root cause fix: polyfill now calls `.replace(/\+/g, ' ')` before `decodeURIComponent` per WHATWG URL spec
   - `+` decodes as space, `%2B` decodes as literal `+` — matches browser-native behavior
   - Removed the `replaceAll('+', '%20')` workaround from `parseParams()` in `context.ts` — no custom decoding logic needed
   - Removed per-feature `replaceAll('+', ' ')` workaround in cursor-pagination
   - Any code using `new URLSearchParams()` now gets correct `+` decoding automatically

   **Response Transform Request Context Fix (`MultiTargetRoutingHandler.java`)**
   - Response transform now receives a snapshot of the request taken after cursor rewrite but before the request transform rewrites the URI to `/_search`
   - Fixes cursor pagination in dual-target mode — response transform can now detect `cursorMark` and produce `nextCursorMark`
   - Generic fix that benefits all response transforms, not just cursor — any response transform can now inspect original Solr params
   - Cursor pagination now works correctly on all 3 sandbox modes (single 18080, dual-solr 18083, dual-os 18084)

   **Bug Fixes**
   - Removed duplicate `jsonFacets.request` in `registry.ts`
   - Integer validator rejects `10abc` (was silently accepted by `parseInt`)

   **E2E Error-Path Testing**
   - Java harness extended with `httpGetRaw()`, `expectedStatusCode`, `expectedErrorContains`
   - 13 validation e2e test cases covering unsupported params, invalid types, local params, empty values
   - E2E test for `+` decoding in sort params (`url-plus-decoding-in-sort`)
   - Java integration test for polyfill `+` decoding and `%2B` literal plus

   ### Testing

   | Layer | Result |
   |-------|--------|
   | Unit tests (vitest) | 23 files, 526 tests ✅ |
   | E2E integration (Solr 8 + 9) | All passed ✅ |
   | SonarQube | 0 issues in changed files ✅ |
   | Sandbox single mode (167 queries) | 88/167 pass, 79 correctly rejected ✅ |
   | Sandbox dual mode (167 queries) | 167/167 pass ✅ |

   ### Sandbox Results

   **Mainline baseline: 112/167 pass** — but ~30 of those return silently wrong results (filters ignored, facets missing, stats dropped).

   **Feature branch: 88/167 pass** — all 88 return correct results, zero silent failures. The `+` URL decoding fix resolved 28 additional failures (sort, cursor, boolean queries) compared to pre-fix.

   The 79 rejections break down as:
   - `fq` filter queries (30) — not yet implemented
   - Legacy `facet.*` API (18) — only `json.facet` supported
   - `defType`/dismax/edismax (5)
   - Wildcard/fuzzy/proximity (6) — parser gap
   - `stats`, `group`, `spellcheck`, `mlt`, `bf` (8)
   - Non-select endpoints (6) — stream, get, schema, admin
   - ISO date colons in `q` (2) — parser gap
   - Local params `{!...}` (2)
   - Function sort, nested facet `avg()` (2)