### PR TITLE
Skip solr-8x-k8s-local-test unless PR has 'run-solr-tests' label

### DIFF
--- a/.github/workflows/jenkins_tests.yml
+++ b/.github/workflows/jenkins_tests.yml
@@ -65,6 +65,8 @@ jobs:
           job_timeout_minutes: "120"
 
   solr-8x-k8s-local-test:
+    if: |
+      contains(github.event.pull_request.labels.*.name, 'run-solr-tests')
     needs: [get-require-approval, sanitize-input]
     environment: ${{ needs.get-require-approval.outputs.is-require-approval }}
     runs-on: ubuntu-22.04


### PR DESCRIPTION
The solr-8x-k8s-local-test Jenkins job is currently failing on every PR. This gates it behind the `run-solr-tests` label, following the same pattern used by eks-integ-test and other label-gated jobs.

This prevents the failing test from blocking unrelated PRs while the Solr test issue is being investigated.

### Changes
- Added `if` condition to `solr-8x-k8s-local-test` job to only run on push to main or when the PR has the `run-solr-tests` label
- The `all-jenkins-checks-pass` job already handles skipped jobs correctly (uses `always()` and only fails on cancelled/failure, not skipped)