### PR TITLE
Revert: Re-enable solr-8x-k8s-local-test on all PRs

### DIFF
--- a/.github/workflows/jenkins_tests.yml
+++ b/.github/workflows/jenkins_tests.yml
@@ -65,8 +65,6 @@ jobs:
           job_timeout_minutes: "120"
 
   solr-8x-k8s-local-test:
-    if: |
-      contains(github.event.pull_request.labels.*.name, 'run-solr-tests')
     needs: [get-require-approval, sanitize-input]
     environment: ${{ needs.get-require-approval.outputs.is-require-approval }}
     runs-on: ubuntu-22.04

--- a/migrationConsole/lib/integ_test/integ_test/test_cases/solr_tests.py
+++ b/migrationConsole/lib/integ_test/integ_test/test_cases/solr_tests.py
@@ -38,3 +38,8 @@ class TestSolr0001SingleDocumentBackfill(MATestBase):
         self.source_operations.get_document(
             cluster=self.source_cluster, index_name=self.index_name,
             doc_id=self.doc_id)
+
+    def verify_clusters(self):
+        self.target_operations.get_document(
+            cluster=self.target_cluster, index_name=self.index_name,
+            doc_id=self.doc_id, max_attempts=10, delay=3.0)


### PR DESCRIPTION
Reverts the label-gating of solr-8x-k8s-local-test introduced in #2698.

This restores the test to run on all PRs and pushes to main, removing the `run-solr-tests` label requirement.

### Context
PR #2698 temporarily gates the solr test behind a label while the test failure is being investigated. This revert PR is ready to merge once the underlying issue is resolved.