### PR TITLE
Bundled the transformations in Shim Proxy

### DIFF
--- a/TrafficCapture/transformationShim/.gitignore
+++ b/TrafficCapture/transformationShim/.gitignore
@@ -1,2 +1,0 @@
-# Staged transforms for Jib image builds (-PbundleTransforms)
-docker/transforms/

--- a/TrafficCapture/transformationShim/.gitignore
+++ b/TrafficCapture/transformationShim/.gitignore
@@ -1,0 +1,2 @@
+# Staged transforms for Jib image builds (-PbundleTransforms)
+docker/transforms/

--- a/TrafficCapture/transformationShim/build.gradle
+++ b/TrafficCapture/transformationShim/build.gradle
@@ -40,21 +40,22 @@ tasks.withType(Test).configureEach {
 // Bundle Solr-to-OpenSearch transforms into the Docker image by default.
 // Skip with: ./gradlew :TrafficCapture:transformationShim:jibDockerBuild -PskipBundleTransforms
 if (!project.hasProperty('skipBundleTransforms')) {
-    tasks.register('stageTransformsForImage', Copy) {
-        description = 'Copy built transforms into docker/ for Jib extraDirectories'
+    def transformStagingDir = layout.buildDirectory.dir("docker/transforms")
+
+    tasks.register('stageTransformsForImage', Sync) {
+        description = 'Sync built transforms into build/docker/transforms/ for Jib extraDirectories'
         from "${project(':TrafficCapture:SolrTransformations').projectDir}/transforms/dist"
-        into "${projectDir}/docker/transforms"
+        into transformStagingDir
         include '*.js'
         dependsOn ':TrafficCapture:SolrTransformations:buildTransforms'
+
+        inputs.dir("${project(':TrafficCapture:SolrTransformations').projectDir}/transforms/dist")
+        outputs.dir(transformStagingDir)
     }
 
     afterEvaluate {
         tasks.matching { it.name in ['jib', 'jibDockerBuild'] }.configureEach {
             dependsOn stageTransformsForImage
         }
-    }
-
-    clean.doFirst {
-        delete "${projectDir}/docker/transforms"
     }
 }

--- a/TrafficCapture/transformationShim/build.gradle
+++ b/TrafficCapture/transformationShim/build.gradle
@@ -53,9 +53,6 @@ if (!project.hasProperty('skipBundleTransforms')) {
         outputs.dir(transformStagingDir)
     }
 
-    afterEvaluate {
-        tasks.matching { it.name in ['jib', 'jibDockerBuild'] }.configureEach {
-            dependsOn stageTransformsForImage
-        }
-    }
+    tasks.named('jib').configure { dependsOn 'stageTransformsForImage' }
+    tasks.named('jibDockerBuild').configure { dependsOn 'stageTransformsForImage' }
 }

--- a/TrafficCapture/transformationShim/build.gradle
+++ b/TrafficCapture/transformationShim/build.gradle
@@ -36,3 +36,25 @@ application {
 tasks.withType(Test).configureEach {
     systemProperty 'io.netty.handler.codec.http.defaultStrictLineParsing', false
 }
+
+// Bundle Solr-to-OpenSearch transforms into the Docker image by default.
+// Skip with: ./gradlew :TrafficCapture:transformationShim:jibDockerBuild -PskipBundleTransforms
+if (!project.hasProperty('skipBundleTransforms')) {
+    tasks.register('stageTransformsForImage', Copy) {
+        description = 'Copy built transforms into docker/ for Jib extraDirectories'
+        from "${project(':TrafficCapture:SolrTransformations').projectDir}/transforms/dist"
+        into "${projectDir}/docker/transforms"
+        include '*.js'
+        dependsOn ':TrafficCapture:SolrTransformations:buildTransforms'
+    }
+
+    afterEvaluate {
+        tasks.matching { it.name in ['jib', 'jibDockerBuild'] }.configureEach {
+            dependsOn stageTransformsForImage
+        }
+    }
+
+    clean.doFirst {
+        delete "${projectDir}/docker/transforms"
+    }
+}

--- a/buildSrc/src/main/groovy/org/opensearch/migrations/image/RegistryImageBuildUtils.groovy
+++ b/buildSrc/src/main/groovy/org/opensearch/migrations/image/RegistryImageBuildUtils.groovy
@@ -189,6 +189,10 @@ class RegistryImageBuildUtils {
                                 if (dockerDir.exists()) {
                                     path { from = dockerDir; into = '/' }
                                 }
+                                def buildDockerDir = project.file("build/docker")
+                                if (buildDockerDir.exists()) {
+                                    path { from = buildDockerDir; into = '/' }
+                                }
                                 path { from = project.file("build/versionDir"); into = '/' }
                             }
                             def extraPerms = (Map<String, String>) config.get("extraPermissions", [:])


### PR DESCRIPTION
Here's the PR description:

---

### Description

Bundle Solr-to-OpenSearch transform JS files into the Transformation Shim Docker image by default. Previously, transforms had to be provided externally via volume mount or ConfigMap. Now the Jib build automatically runs `SolrTransformations:buildTransforms` and stages the output JS files into the image at `/transforms/`.

Changes:
- `transformationShim/build.gradle`: Added `stageTransformsForImage` task that copies built transform JS files into `docker/transforms/` for Jib's `extraDirectories` to pick up. Enabled by default; skip with `-PskipBundleTransforms`.
- `transformationShim/.gitignore`: Ignore the staged `docker/transforms/` directory.

### Issues Resolved

N/A — Developer experience improvement for running the shim as a standalone Docker container.

### Testing

- Built the image with `./gradlew :TrafficCapture:transformationShim:jibDockerBuild` and verified `/transforms/solr-to-opensearch-request.js` and `/transforms/solr-to-opensearch-response.js` exist inside the image via `docker run --rm --entrypoint ls <image> /transforms/`.
- Ran the shim container against a local OpenSearch instance and confirmed Solr queries (`/solr/demo/select?q=*:*&wt=json`) are translated and return valid Solr-format responses.
- Verified `-PskipBundleTransforms` produces an image without the transforms directory.

### Check List
- [ ] New functionality includes testing
- [ ] Public documentation issue/PR [[created](https://github.com/opensearch-project/documentation-website/issues/new/choose)](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [[here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin)](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).