### PR TITLE
Add searchguard and sg7- to index deny list prefixes

### DIFF
--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/common/FilterScheme.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/common/FilterScheme.java
@@ -31,6 +31,8 @@ public class FilterScheme {
             "metrics-metadata-",
             "metrics-system.",
             "profiling-",
+            "searchguard",
+            "sg7-",
             "synthetics-"
     );
 

--- a/RFS/src/test/java/org/opensearch/migrations/bulkload/common/FilterSchemeTest.java
+++ b/RFS/src/test/java/org/opensearch/migrations/bulkload/common/FilterSchemeTest.java
@@ -15,6 +15,9 @@ public class FilterSchemeTest {
         // Should be excluded due to prefix
         assertThat(filter.test("apm-test"), equalTo(false));
         assertThat(filter.test(".hidden"), equalTo(false));
+        assertThat(filter.test("searchguard"), equalTo(false));
+        assertThat(filter.test("searchguard_config"), equalTo(false));
+        assertThat(filter.test("sg7-auditlog-2026.04.10"), equalTo(false));
         
         // Should not be excluded (no matching prefix)
         assertThat(filter.test("myindex"), equalTo(true));


### PR DESCRIPTION
### Description

Adds `searchguard` and `sg7-` to `EXCLUDED_PREFIXES` in `FilterScheme` so that SearchGuard configuration and audit log indices are automatically excluded from migration when no explicit allowlist is provided.

These indices are internal to the source cluster's SearchGuard security plugin and should not be migrated to the target cluster.

### Issues Resolved

[MIGRATIONS-3033](https://opensearch.atlassian.net/browse/MIGRATIONS-3033)

### Testing

- Added test assertions for `searchguard`, `searchguard_config`, and `sg7-auditlog-2026.04.10` to `FilterSchemeTest.testExcludedByPrefix()`
- All existing `FilterSchemeTest` tests pass

### Check List
- [x] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).