### PR TITLE
Add transformation shim to release pipeline

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -136,11 +136,13 @@ jobs:
           docker pull opensearchstaging/opensearch-migrations-traffic-replayer:${{ steps.get_data.outputs.version }}
           docker pull opensearchstaging/opensearch-migrations-traffic-capture-proxy:${{ steps.get_data.outputs.version }}
           docker pull opensearchstaging/opensearch-migrations-reindex-from-snapshot:${{ steps.get_data.outputs.version }}
+          docker pull opensearchstaging/opensearch-migrations-transformation-shim:${{ steps.get_data.outputs.version }}
           # Tag them with the expected names for SBOM scanning
           docker tag opensearchstaging/opensearch-migrations-console:${{ steps.get_data.outputs.version }} migrations/migration_console:latest
           docker tag opensearchstaging/opensearch-migrations-traffic-replayer:${{ steps.get_data.outputs.version }} migrations/traffic_replayer:latest
           docker tag opensearchstaging/opensearch-migrations-traffic-capture-proxy:${{ steps.get_data.outputs.version }} migrations/capture_proxy:latest
           docker tag opensearchstaging/opensearch-migrations-reindex-from-snapshot:${{ steps.get_data.outputs.version }} migrations/reindex_from_snapshot:latest
+          docker tag opensearchstaging/opensearch-migrations-transformation-shim:${{ steps.get_data.outputs.version }} migrations/transformation_shim:latest
       - name: Generate SBOM for migration_console
         uses: anchore/sbom-action@v0.24.0
         with:
@@ -161,6 +163,11 @@ jobs:
         with:
           image: migrations/reindex_from_snapshot:latest
           output-file: opensearch-migrations-reindex-from-snapshot-sbom.spdx.json
+      - name: Generate SBOM for transformation_shim
+        uses: anchore/sbom-action@v0.24.0
+        with:
+          image: migrations/transformation_shim:latest
+          output-file: opensearch-migrations-transformation-shim-sbom.spdx.json
       - name: Generate SBOM for artifacts
         uses: anchore/sbom-action@v0.24.0
         with:

--- a/jenkins/release.jenkinsFile
+++ b/jenkins/release.jenkinsFile
@@ -109,6 +109,7 @@ pipeline {
                         copyDockerImage('opensearch-migrations-traffic-replayer');
                         copyDockerImage('opensearch-migrations-traffic-capture-proxy');
                         copyDockerImage('opensearch-migrations-reindex-from-snapshot');
+                        copyDockerImage('opensearch-migrations-transformation-shim');
                     }
                 }
             }


### PR DESCRIPTION
## Description

The `transformation_shim` Docker image is already built via Jib in `buildImages/build.gradle` (with published repo name `opensearch-migrations-transformation-shim`), but it was not included in the release pipeline. This PR adds it to both release paths:

### Changes

**`.github/workflows/release-drafter.yml`**
- Pull the shim image from DockerHub staging after build
- Tag it for SBOM scanning
- Generate SBOM (SPDX) for the shim image

**`jenkins/release.jenkinsFile`**
- Copy the shim image from DockerHub staging to public ECR

### Testing

No functional changes to the shim itself — this only adds it to the existing release image pipeline that already handles console, replayer, capture proxy, and reindex-from-snapshot.