### PR TITLE
Fix Gradle buildSrc compilation failure on JRE-only systems

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -7,6 +7,13 @@ plugins {
     id 'groovy-gradle-plugin'
 }
 
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(17))
+        vendor.set(JvmVendorSpec.AMAZON)
+    }
+}
+
 repositories {
     // Use the plugin portal to apply community plugins in convention plugins.
     gradlePluginPortal()

--- a/buildSrc/settings.gradle
+++ b/buildSrc/settings.gradle
@@ -4,4 +4,8 @@
  * This settings file is used to specify which projects to include in your build-logic build.
  */
 
+plugins {
+    id 'org.gradle.toolchains.foojay-resolver-convention'
+}
+
 rootProject.name = 'buildSrc'


### PR DESCRIPTION
## Description

On systems where the only Java installation is a JRE without `javac` (e.g. `/usr/lib/jvm/java-21-amazon-corretto.x86_64` with only the runtime), Gradle's toolchain auto-detection finds it but fails during `buildSrc` compilation:

```
Failed to calculate the value of task ':buildSrc:compileJava' property 'javaCompiler'.
  > Toolchain installation '/usr/lib/jvm/java-21-amazon-corretto.x86_64' does not provide the required capabilities: [JAVA_COMPILER]
```

### Root Cause

`buildSrc` is compiled as a completely independent build **before** the root `settings.gradle` is evaluated. This means the `foojay-resolver` plugin (which enables JDK auto-provisioning) configured in the root `settings.gradle` is **not available** during `buildSrc` compilation. Without it, Gradle cannot fall back to downloading a proper JDK when the local installation lacks a compiler.

### Fix

1. Add the `foojay-resolver` plugin to `buildSrc/settings.gradle` so `buildSrc` can auto-provision JDKs independently
2. Add an explicit Java 17 Amazon toolchain configuration to `buildSrc/build.gradle` to match the main project

This is unavoidable duplication — Gradle's architecture requires `buildSrc` to have its own build configuration since it runs before the root project.

### Testing

Reproduced on a fresh environment with only Corretto 21 JRE installed. After this fix, Gradle successfully auto-provisions a JDK 17 via foojay and `buildSrc` compiles without error.