### PR TITLE
Fix event loop deadlock in MultiTargetRoutingHandler

### DIFF
--- a/TrafficCapture/transformationShim/src/main/java/org/opensearch/migrations/transform/shim/netty/MultiTargetRoutingHandler.java
+++ b/TrafficCapture/transformationShim/src/main/java/org/opensearch/migrations/transform/shim/netty/MultiTargetRoutingHandler.java
@@ -240,13 +240,22 @@ public class MultiTargetRoutingHandler extends SimpleChannelInboundHandler<FullH
         long requestId,
         ShimRequestContext requestCtx
     ) {
+        // When the primary completes, collect all responses (including blocking on
+        // secondary futures with timeout) on a worker thread — NOT the Netty event loop.
+        // The secondary FixedChannelPools share the same NioEventLoopGroup, so calling
+        // join() on the event loop thread can deadlock when a pooled channel's response
+        // handler needs that same thread to fire channelRead0.
         futures.get(primaryTarget).whenComplete((primaryResp, primaryEx) ->
-            ctx.channel().eventLoop().execute(() -> {
+            CompletableFuture.supplyAsync(() -> {
+                TargetResponse primary = primaryEx != null
+                    ? TargetResponse.error(primaryTarget, Duration.ZERO, primaryEx)
+                    : primaryResp;
+                Map<String, TargetResponse> allResponses = collectResponses(futures);
+                return Map.entry(primary, allResponses);
+            }).thenAcceptAsync(result -> {
                 try {
-                    TargetResponse primary = primaryEx != null
-                        ? TargetResponse.error(primaryTarget, Duration.ZERO, primaryEx)
-                        : primaryResp;
-                    Map<String, TargetResponse> allResponses = collectResponses(futures);
+                    var primary = result.getKey();
+                    var allResponses = result.getValue();
 
                     List<ValidationResult> results = runValidators(allResponses);
                     FullHttpResponse response = buildFinalResponse(primary, allResponses, results, requestMap);
@@ -266,7 +275,7 @@ public class MultiTargetRoutingHandler extends SimpleChannelInboundHandler<FullH
                         requestCtx.close();
                     }
                 }
-            })
+            }, ctx.channel().eventLoop())
         );
     }
 


### PR DESCRIPTION
## Description

Fixes flaky `ShimProxyTest` dual-target tests (`dualTarget_validationPass`, `dualTarget_cursorMarkMerge`) which intermittently fail with `TimeoutException` on the secondary target.

### Root Cause

**Event loop deadlock in `MultiTargetRoutingHandler`.**

`handlePrimaryCompletion()` attached a `whenComplete` callback to the primary future, then ran on the inbound channel's event loop thread via `ctx.channel().eventLoop().execute(...)`. Inside that callback, `collectSingleResponse()` called `future.join()` — a **blocking** call on the event loop thread.

The backend connection pool (`FixedChannelPool`) shares the same `NioEventLoopGroup` as the proxy's inbound channels. When the secondary target's pooled channel happened to be assigned to the **same** event loop thread as the inbound channel, its `PooledTargetResponseHandler.channelRead0()` could never fire because the thread was blocked in `join()` — a classic Netty deadlock that manifested as a `TimeoutException`.

### Fix

Move the blocking `collectResponses()` call off the Netty event loop thread via `CompletableFuture.supplyAsync()`, then write the response back on the event loop via `thenAcceptAsync(_, ctx.channel().eventLoop())`.

This preserves the original behavior: response triggers as soon as the primary completes, secondaries are collected with their existing timeout on a ForkJoinPool worker thread, and the response is written on the event loop thread for thread safety.

### Changes

- `MultiTargetRoutingHandler.java` — 1 file changed, +15/-6 lines. No test changes, no new methods, no removed methods.

Signed-off-by: Andre Kurait <akurait@amazon.com>