### PR TITLE
Jenkins ecs release version test support

### DIFF
--- a/jenkins/migrationIntegPipelines/eksAOSSSearchIntegTestCover.groovy
+++ b/jenkins/migrationIntegPipelines/eksAOSSSearchIntegTestCover.groovy
@@ -4,9 +4,21 @@
 def gitBranch = params.GIT_BRANCH ?: 'main'
 def gitUrl = params.GIT_REPO_URL ?: 'https://github.com/opensearch-project/opensearch-migrations.git'
 
+// For release canary jobs (release-*), resolve the latest release tag
+// and load the library from that version so pipeline code matches the release.
+if (env.JOB_BASE_NAME?.startsWith('release-')) {
+    node('Jenkins-Default-Agent-X64-C5xlarge-Single-Host') {
+        gitBranch = sh(
+            script: "git ls-remote --tags --sort=-v:refname '${gitUrl}' | grep -oP 'refs/tags/\\K[0-9]+\\.[0-9]+\\.[0-9]+\$' | head -1",
+            returnStdout: true
+        ).trim()
+        echo "Release canary: resolved latest tag ${gitBranch}"
+    }
+}
+
 library identifier: "migrations-lib@${gitBranch}", retriever: modernSCM(
         [$class: 'GitSCMSource',
          remote: "${gitUrl}"])
 
 def jobNameOverride = params.JOB_NAME_OVERRIDE ?: env.JOB_BASE_NAME ?: ''
-eksAOSSIntegPipeline(collectionType: 'SEARCH', defaultStageId: 'aosss', jobName: jobNameOverride ?: 'pr-eks-aoss-search-integ-test')
+eksAOSSIntegPipeline(gitBranchDefault: gitBranch, collectionType: 'SEARCH', defaultStageId: 'aosss', jobName: jobNameOverride ?: 'pr-eks-aoss-search-integ-test')

--- a/jenkins/migrationIntegPipelines/eksAOSSTimeSeriesIntegTestCover.groovy
+++ b/jenkins/migrationIntegPipelines/eksAOSSTimeSeriesIntegTestCover.groovy
@@ -4,9 +4,21 @@
 def gitBranch = params.GIT_BRANCH ?: 'main'
 def gitUrl = params.GIT_REPO_URL ?: 'https://github.com/opensearch-project/opensearch-migrations.git'
 
+// For release canary jobs (release-*), resolve the latest release tag
+// and load the library from that version so pipeline code matches the release.
+if (env.JOB_BASE_NAME?.startsWith('release-')) {
+    node('Jenkins-Default-Agent-X64-C5xlarge-Single-Host') {
+        gitBranch = sh(
+            script: "git ls-remote --tags --sort=-v:refname '${gitUrl}' | grep -oP 'refs/tags/\\K[0-9]+\\.[0-9]+\\.[0-9]+\$' | head -1",
+            returnStdout: true
+        ).trim()
+        echo "Release canary: resolved latest tag ${gitBranch}"
+    }
+}
+
 library identifier: "migrations-lib@${gitBranch}", retriever: modernSCM(
         [$class: 'GitSCMSource',
          remote: "${gitUrl}"])
 
 def jobNameOverride = params.JOB_NAME_OVERRIDE ?: env.JOB_BASE_NAME ?: ''
-eksAOSSIntegPipeline(collectionType: 'TIMESERIES', defaultStageId: 'aosst', jobName: jobNameOverride ?: 'pr-eks-aoss-timeseries-integ-test')
+eksAOSSIntegPipeline(gitBranchDefault: gitBranch, collectionType: 'TIMESERIES', defaultStageId: 'aosst', jobName: jobNameOverride ?: 'pr-eks-aoss-timeseries-integ-test')

--- a/jenkins/migrationIntegPipelines/eksAOSSVectorIntegTestCover.groovy
+++ b/jenkins/migrationIntegPipelines/eksAOSSVectorIntegTestCover.groovy
@@ -4,9 +4,21 @@
 def gitBranch = params.GIT_BRANCH ?: 'main'
 def gitUrl = params.GIT_REPO_URL ?: 'https://github.com/opensearch-project/opensearch-migrations.git'
 
+// For release canary jobs (release-*), resolve the latest release tag
+// and load the library from that version so pipeline code matches the release.
+if (env.JOB_BASE_NAME?.startsWith('release-')) {
+    node('Jenkins-Default-Agent-X64-C5xlarge-Single-Host') {
+        gitBranch = sh(
+            script: "git ls-remote --tags --sort=-v:refname '${gitUrl}' | grep -oP 'refs/tags/\\K[0-9]+\\.[0-9]+\\.[0-9]+\$' | head -1",
+            returnStdout: true
+        ).trim()
+        echo "Release canary: resolved latest tag ${gitBranch}"
+    }
+}
+
 library identifier: "migrations-lib@${gitBranch}", retriever: modernSCM(
         [$class: 'GitSCMSource',
          remote: "${gitUrl}"])
 
 def jobNameOverride = params.JOB_NAME_OVERRIDE ?: env.JOB_BASE_NAME ?: ''
-eksAOSSIntegPipeline(collectionType: 'VECTORSEARCH', defaultStageId: 'aossv', jobName: jobNameOverride ?: 'pr-eks-aoss-vector-integ-test')
+eksAOSSIntegPipeline(gitBranchDefault: gitBranch, collectionType: 'VECTORSEARCH', defaultStageId: 'aossv', jobName: jobNameOverride ?: 'pr-eks-aoss-vector-integ-test')

--- a/jenkins/migrationIntegPipelines/eksBYOSIntegTestCover.groovy
+++ b/jenkins/migrationIntegPipelines/eksBYOSIntegTestCover.groovy
@@ -5,6 +5,18 @@
 def gitBranch = params.GIT_BRANCH ?: 'main'
 def gitUrl = params.GIT_REPO_URL ?: 'https://github.com/opensearch-project/opensearch-migrations.git'
 
+// For release canary jobs (release-*), resolve the latest release tag
+// and load the library from that version so pipeline code matches the release.
+if (env.JOB_BASE_NAME?.startsWith('release-')) {
+    node('Jenkins-Default-Agent-X64-C5xlarge-Single-Host') {
+        gitBranch = sh(
+            script: "git ls-remote --tags --sort=-v:refname '${gitUrl}' | grep -oP 'refs/tags/\\K[0-9]+\\.[0-9]+\\.[0-9]+\$' | head -1",
+            returnStdout: true
+        ).trim()
+        echo "Release canary: resolved latest tag ${gitBranch}"
+    }
+}
+
 library identifier: "migrations-lib@${gitBranch}", retriever: modernSCM(
         [$class: 'GitSCMSource',
          remote: "${gitUrl}"])
@@ -13,4 +25,4 @@ library identifier: "migrations-lib@${gitBranch}", retriever: modernSCM(
 // This ensures the GenericTrigger regex stays in sync with the actual job name
 // (e.g., main-* vs pr-*) across runs.
 def jobNameOverride = params.JOB_NAME_OVERRIDE ?: env.JOB_BASE_NAME ?: ''
-eksBYOSIntegPipeline(jobName: jobNameOverride ?: null)
+eksBYOSIntegPipeline(jobName: jobNameOverride ?: null, gitBranchDefault: gitBranch)

--- a/jenkins/migrationIntegPipelines/eksCreateVPCSolutionsCFNTestCover.groovy
+++ b/jenkins/migrationIntegPipelines/eksCreateVPCSolutionsCFNTestCover.groovy
@@ -1,13 +1,25 @@
 def gitBranch = params.GIT_BRANCH ?: 'main'
 def gitUrl = params.GIT_REPO_URL ?: 'https://github.com/opensearch-project/opensearch-migrations.git'
 
+// For release canary jobs (release-*), resolve the latest release tag
+// and load the library from that version so pipeline code matches the release.
+if (env.JOB_BASE_NAME?.startsWith('release-')) {
+    node('Jenkins-Default-Agent-X64-C5xlarge-Single-Host') {
+        gitBranch = sh(
+            script: "git ls-remote --tags --sort=-v:refname '${gitUrl}' | grep -oP 'refs/tags/\\K[0-9]+\\.[0-9]+\\.[0-9]+\$' | head -1",
+            returnStdout: true
+        ).trim()
+        echo "Release canary: resolved latest tag ${gitBranch}"
+    }
+}
+
 library identifier: "migrations-lib@${gitBranch}", retriever: modernSCM(
         [$class: 'GitSCMSource',
          remote: "${gitUrl}"])
 
 // Shared library function (location from root: vars/eksSolutionsCFNTest.groovy)
 def jobNameOverride = params.JOB_NAME_OVERRIDE ?: env.JOB_BASE_NAME ?: ''
-eksSolutionsCFNTest(
+eksSolutionsCFNTest(defaultGitBranch: gitBranch, 
     vpcMode: 'create',
     defaultStage: 'ekscvpc',
     defaultGitUrl: 'https://github.com/opensearch-project/opensearch-migrations.git',

--- a/jenkins/migrationIntegPipelines/eksImportVPCSolutionsCFNTestCover.groovy
+++ b/jenkins/migrationIntegPipelines/eksImportVPCSolutionsCFNTestCover.groovy
@@ -1,13 +1,25 @@
 def gitBranch = params.GIT_BRANCH ?: 'main'
 def gitUrl = params.GIT_REPO_URL ?: 'https://github.com/opensearch-project/opensearch-migrations.git'
 
+// For release canary jobs (release-*), resolve the latest release tag
+// and load the library from that version so pipeline code matches the release.
+if (env.JOB_BASE_NAME?.startsWith('release-')) {
+    node('Jenkins-Default-Agent-X64-C5xlarge-Single-Host') {
+        gitBranch = sh(
+            script: "git ls-remote --tags --sort=-v:refname '${gitUrl}' | grep -oP 'refs/tags/\\K[0-9]+\\.[0-9]+\\.[0-9]+\$' | head -1",
+            returnStdout: true
+        ).trim()
+        echo "Release canary: resolved latest tag ${gitBranch}"
+    }
+}
+
 library identifier: "migrations-lib@${gitBranch}", retriever: modernSCM(
         [$class: 'GitSCMSource',
          remote: "${gitUrl}"])
 
 // Shared library function (location from root: vars/eksSolutionsCFNTest.groovy)
 def jobNameOverride = params.JOB_NAME_OVERRIDE ?: env.JOB_BASE_NAME ?: ''
-eksSolutionsCFNTest(
+eksSolutionsCFNTest(defaultGitBranch: gitBranch, 
     vpcMode: 'import',
     defaultStage: 'eksivpc',
     defaultGitUrl: 'https://github.com/opensearch-project/opensearch-migrations.git',

--- a/jenkins/migrationIntegPipelines/eksIntegTestCover.groovy
+++ b/jenkins/migrationIntegPipelines/eksIntegTestCover.groovy
@@ -1,6 +1,18 @@
 def gitBranch = params.GIT_BRANCH ?: 'main'
 def gitUrl = params.GIT_REPO_URL ?: 'https://github.com/opensearch-project/opensearch-migrations.git'
 
+// For release canary jobs (release-*), resolve the latest release tag
+// and load the library from that version so pipeline code matches the release.
+if (env.JOB_BASE_NAME?.startsWith('release-')) {
+    node('Jenkins-Default-Agent-X64-C5xlarge-Single-Host') {
+        gitBranch = sh(
+            script: "git ls-remote --tags --sort=-v:refname '${gitUrl}' | grep -oP 'refs/tags/\\K[0-9]+\\.[0-9]+\\.[0-9]+\$' | head -1",
+            returnStdout: true
+        ).trim()
+        echo "Release canary: resolved latest tag ${gitBranch}"
+    }
+}
+
 library identifier: "migrations-lib@${gitBranch}", retriever: modernSCM(
         [$class: 'GitSCMSource',
          remote: "${gitUrl}"])
@@ -9,5 +21,5 @@ library identifier: "migrations-lib@${gitBranch}", retriever: modernSCM(
 // This ensures the GenericTrigger regex stays in sync with the actual job name
 // (e.g., main-* vs pr-*) across runs.
 def jobNameOverride = params.JOB_NAME_OVERRIDE ?: env.JOB_BASE_NAME ?: ''
-eksIntegPipeline(jobName: jobNameOverride ?: null)
+eksIntegPipeline(jobName: jobNameOverride ?: null, gitBranchDefault: gitBranch)
 

--- a/jenkins/migrationIntegPipelines/fullES68SourceE2ETestCover.groovy
+++ b/jenkins/migrationIntegPipelines/fullES68SourceE2ETestCover.groovy
@@ -1,6 +1,18 @@
 def gitBranch = params.GIT_BRANCH ?: 'main'
 def gitUrl = params.GIT_REPO_URL ?: 'https://github.com/opensearch-project/opensearch-migrations.git'
 
+// For release canary jobs (release-*), resolve the latest release tag
+// and load the library from that version so pipeline code matches the release.
+if (env.JOB_BASE_NAME?.startsWith('release-')) {
+    node('Jenkins-Default-Agent-X64-C5xlarge-Single-Host') {
+        gitBranch = sh(
+            script: "git ls-remote --tags --sort=-v:refname '${gitUrl}' | grep -oP 'refs/tags/\\K[0-9]+\\.[0-9]+\\.[0-9]+\$' | head -1",
+            returnStdout: true
+        ).trim()
+        echo "Release canary: resolved latest tag ${gitBranch}"
+    }
+}
+
 library identifier: "migrations-lib@${gitBranch}", retriever: modernSCM(
         [$class: 'GitSCMSource',
          remote: "${gitUrl}"])
@@ -9,4 +21,4 @@ library identifier: "migrations-lib@${gitBranch}", retriever: modernSCM(
 // This ensures the GenericTrigger regex stays in sync with the actual job name
 // (e.g., main-* vs pr-*) across runs.
 def jobNameOverride = params.JOB_NAME_OVERRIDE ?: env.JOB_BASE_NAME ?: ''
-fullES68SourceE2ETest(jobName: jobNameOverride ?: null)
+fullES68SourceE2ETest(jobName: jobNameOverride ?: null, defaultGitBranch: gitBranch)

--- a/jenkins/migrationIntegPipelines/rfsDefaultE2ETestCover.groovy
+++ b/jenkins/migrationIntegPipelines/rfsDefaultE2ETestCover.groovy
@@ -1,6 +1,18 @@
 def gitBranch = params.GIT_BRANCH ?: 'main'
 def gitUrl = params.GIT_REPO_URL ?: 'https://github.com/opensearch-project/opensearch-migrations.git'
 
+// For release canary jobs (release-*), resolve the latest release tag
+// and load the library from that version so pipeline code matches the release.
+if (env.JOB_BASE_NAME?.startsWith('release-')) {
+    node('Jenkins-Default-Agent-X64-C5xlarge-Single-Host') {
+        gitBranch = sh(
+            script: "git ls-remote --tags --sort=-v:refname '${gitUrl}' | grep -oP 'refs/tags/\\K[0-9]+\\.[0-9]+\\.[0-9]+\$' | head -1",
+            returnStdout: true
+        ).trim()
+        echo "Release canary: resolved latest tag ${gitBranch}"
+    }
+}
+
 library identifier: "migrations-lib@${gitBranch}", retriever: modernSCM(
         [$class: 'GitSCMSource',
          remote: "${gitUrl}"])
@@ -9,4 +21,4 @@ library identifier: "migrations-lib@${gitBranch}", retriever: modernSCM(
 // This ensures the GenericTrigger regex stays in sync with the actual job name
 // (e.g., main-* vs pr-*) across runs.
 def jobNameOverride = params.JOB_NAME_OVERRIDE ?: env.JOB_BASE_NAME ?: ''
-rfsDefaultE2ETest(jobName: jobNameOverride ?: null)
+rfsDefaultE2ETest(jobName: jobNameOverride ?: null, defaultGitBranch: gitBranch)

--- a/jenkins/migrationIntegPipelines/solutionsCFNTestCover.groovy
+++ b/jenkins/migrationIntegPipelines/solutionsCFNTestCover.groovy
@@ -1,6 +1,18 @@
 def gitBranch = params.GIT_BRANCH ?: 'main'
 def gitUrl = params.GIT_REPO_URL ?: 'https://github.com/opensearch-project/opensearch-migrations.git'
 
+// For release canary jobs (release-*), resolve the latest release tag
+// and load the library from that version so pipeline code matches the release.
+if (env.JOB_BASE_NAME?.startsWith('release-')) {
+    node('Jenkins-Default-Agent-X64-C5xlarge-Single-Host') {
+        gitBranch = sh(
+            script: "git ls-remote --tags --sort=-v:refname '${gitUrl}' | grep -oP 'refs/tags/\\K[0-9]+\\.[0-9]+\\.[0-9]+\$' | head -1",
+            returnStdout: true
+        ).trim()
+        echo "Release canary: resolved latest tag ${gitBranch}"
+    }
+}
+
 library identifier: "migrations-lib@${gitBranch}", retriever: modernSCM(
         [$class: 'GitSCMSource',
          remote: "${gitUrl}"])
@@ -9,4 +21,4 @@ library identifier: "migrations-lib@${gitBranch}", retriever: modernSCM(
 // This ensures the GenericTrigger regex stays in sync with the actual job name
 // (e.g., main-* vs pr-*) across runs.
 def jobNameOverride = params.JOB_NAME_OVERRIDE ?: env.JOB_BASE_NAME ?: ''
-solutionsCFNTest(jobName: jobNameOverride ?: null)
+solutionsCFNTest(jobName: jobNameOverride ?: null, defaultGitBranch: gitBranch)

--- a/jenkins/migrationIntegPipelines/trafficReplayDefaultE2ETestCover.groovy
+++ b/jenkins/migrationIntegPipelines/trafficReplayDefaultE2ETestCover.groovy
@@ -1,6 +1,18 @@
 def gitBranch = params.GIT_BRANCH ?: 'main'
 def gitUrl = params.GIT_REPO_URL ?: 'https://github.com/opensearch-project/opensearch-migrations.git'
 
+// For release canary jobs (release-*), resolve the latest release tag
+// and load the library from that version so pipeline code matches the release.
+if (env.JOB_BASE_NAME?.startsWith('release-')) {
+    node('Jenkins-Default-Agent-X64-C5xlarge-Single-Host') {
+        gitBranch = sh(
+            script: "git ls-remote --tags --sort=-v:refname '${gitUrl}' | grep -oP 'refs/tags/\\K[0-9]+\\.[0-9]+\\.[0-9]+\$' | head -1",
+            returnStdout: true
+        ).trim()
+        echo "Release canary: resolved latest tag ${gitBranch}"
+    }
+}
+
 library identifier: "migrations-lib@${gitBranch}", retriever: modernSCM(
         [$class: 'GitSCMSource',
          remote: "${gitUrl}"])
@@ -9,4 +21,4 @@ library identifier: "migrations-lib@${gitBranch}", retriever: modernSCM(
 // This ensures the GenericTrigger regex stays in sync with the actual job name
 // (e.g., main-* vs pr-*) across runs.
 def jobNameOverride = params.JOB_NAME_OVERRIDE ?: env.JOB_BASE_NAME ?: ''
-trafficReplayDefaultE2ETest(jobName: jobNameOverride ?: null)
+trafficReplayDefaultE2ETest(jobName: jobNameOverride ?: null, defaultGitBranch: gitBranch)

--- a/vars/checkoutStep.groovy
+++ b/vars/checkoutStep.groovy
@@ -19,6 +19,16 @@ def call(Map config = [:]) {
             sh "git remote set-url origin '${repoUrl}' || git remote add origin '${repoUrl}'"
             sh "git fetch origin '${branch}'"
             sh "git checkout '${commit}'"
+        } else if (branch.startsWith('refs/tags/') || branch ==~ /^\d+\.\d+\.\d+$/) {
+            // Tags cannot be resolved by the Jenkins git step (it only fetches refs/heads/*).
+            // Use git CLI to fetch tags and checkout the tag directly.
+            // Always fetch tags from the canonical repo since forks may not have them.
+            def tag = branch.startsWith('refs/tags/') ? branch.replaceFirst('refs/tags/', '') : branch
+            def canonicalRepo = 'https://github.com/opensearch-project/opensearch-migrations.git'
+            sh "git init"
+            sh "git remote set-url origin '${canonicalRepo}' || git remote add origin '${canonicalRepo}'"
+            sh "git fetch origin --tags"
+            sh "git checkout 'tags/${tag}'"
         } else {
             git branch: branch, url: repoUrl
         }

--- a/vars/defaultIntegPipeline.groovy
+++ b/vars/defaultIntegPipeline.groovy
@@ -15,6 +15,7 @@ def call(Map config = [:]) {
     if(jobName == null || jobName.isEmpty()){
         throw new RuntimeException("The jobName argument must be provided");
     }
+    def defaultGitBranch = config.defaultGitBranch ?: 'main'
     def source_context_id = config.sourceContextId ?: 'source-single-node-ec2'
     def migration_context_id = config.migrationContextId ?: 'migration-default'
     def source_context_file_name = 'sourceJenkinsContext.json'
@@ -29,9 +30,10 @@ def call(Map config = [:]) {
 
         parameters {
             string(name: 'GIT_REPO_URL', defaultValue: 'https://github.com/opensearch-project/opensearch-migrations.git', description: 'Git repository url')
-            string(name: 'GIT_BRANCH', defaultValue: 'main', description: 'Git branch to use for repository')
+            string(name: 'GIT_BRANCH', defaultValue: defaultGitBranch, description: 'Git branch to use for repository')
             string(name: 'GIT_COMMIT', defaultValue: '', description: '(Optional) Specific commit to checkout after cloning branch')
             string(name: 'STAGE', defaultValue: "${defaultStageId}", description: 'Stage name for deployment environment')
+            string(name: 'VERSION', defaultValue: '', description: 'Release version to deploy (e.g. "2.9.0"). When set, checks out the release tag instead of GIT_BRANCH.')
         }
 
         options {
@@ -61,11 +63,22 @@ def call(Map config = [:]) {
             stage('Checkout') {
                 steps {
                     script {
+                        def checkoutBranch = params.VERSION?.trim() ? params.VERSION : params.GIT_BRANCH
+                        env.CHECKOUT_BRANCH = checkoutBranch
+                        echo """
+                            ================================================================
+                            Default Integration Pipeline
+                            ================================================================
+                            Git:                    ${params.GIT_REPO_URL} @ ${checkoutBranch}
+                            Stage:                  ${params.STAGE}
+                            Version:                ${params.VERSION ?: 'N/A (using GIT_BRANCH)'}
+                            ================================================================
+                        """
                         // Allow overwriting this step
                         if (config.checkoutStep) {
                             config.checkoutStep()
                         } else {
-                            checkoutStep(branch: params.GIT_BRANCH, repo: params.GIT_REPO_URL, commit: params.GIT_COMMIT)
+                            checkoutStep(branch: checkoutBranch, repo: params.GIT_REPO_URL, commit: params.GIT_COMMIT)
                         }
                     }
                 }
@@ -131,7 +144,7 @@ def call(Map config = [:]) {
                                             "--migration-context-id $migration_context_id " +
                                             "--stage ${stage} " +
                                             "--migrations-git-url ${params.GIT_REPO_URL} " +
-                                            "--migrations-git-branch ${params.GIT_BRANCH}"
+                                            "--migrations-git-branch ${env.CHECKOUT_BRANCH}"
                                     if (skipCaptureProxyOnNodeSetup) {
                                         baseCommand += " --skip-capture-proxy"
                                     }

--- a/vars/eksAOSSIntegPipeline.groovy
+++ b/vars/eksAOSSIntegPipeline.groovy
@@ -1,5 +1,6 @@
 def call(Map config = [:]) {
     def collectionType = config.collectionType ?: 'SEARCH'
+    def gitBranchDefault = config.gitBranchDefault ?: 'main'
     def testIdMap = ['SEARCH': '0021', 'TIMESERIES': '0022', 'VECTORSEARCH': '0023']
     def envVarMap = ['SEARCH': 'AOSS_SEARCH_ENDPOINT', 'TIMESERIES': 'AOSS_TIMESERIES_ENDPOINT', 'VECTORSEARCH': 'AOSS_VECTOR_ENDPOINT']
     def testId = testIdMap[collectionType]
@@ -14,7 +15,7 @@ def call(Map config = [:]) {
 
         parameters {
             string(name: 'GIT_REPO_URL', defaultValue: 'https://github.com/opensearch-project/opensearch-migrations.git', description: 'Git repository url')
-            string(name: 'GIT_BRANCH', defaultValue: 'main', description: 'Git branch to use for repository')
+            string(name: 'GIT_BRANCH', defaultValue: gitBranchDefault, description: 'Git branch to use for repository')
             string(name: 'STAGE', defaultValue: "${defaultStageId}", description: 'Stage name for deployment environment')
             string(name: 'REGION', defaultValue: 'us-east-1', description: 'AWS region for deployment')
             choice(name: 'SOURCE_VERSION', choices: ['OS_1.3'], description: 'Version of the cluster that created the snapshot')

--- a/vars/eksBYOSIntegPipeline.groovy
+++ b/vars/eksBYOSIntegPipeline.groovy
@@ -15,6 +15,7 @@ import groovy.json.JsonOutput
 
 def call(Map config = [:]) {
     def defaultStageId = config.defaultStageId ?: "eksbyos"
+    def gitBranchDefault = config.gitBranchDefault ?: 'main'
     def jobName = config.jobName ?: "eks-byos-integ-test"
     def lockLabel = config.lockLabel ?: (jobName.startsWith("pr-") ? "aws-pr-slot" : "aws-main-slot")
     def clusterContextFilePath = "tmp/cluster-context-byos-${currentBuild.number}.json"
@@ -55,7 +56,7 @@ def call(Map config = [:]) {
 <b>custom</b> — uses the parameter fields below as-is'''
             )
             string(name: 'GIT_REPO_URL', defaultValue: 'https://github.com/opensearch-project/opensearch-migrations.git', description: 'Git repository url')
-            string(name: 'GIT_BRANCH', defaultValue: 'main', description: 'Git branch to use for repository')
+            string(name: 'GIT_BRANCH', defaultValue: gitBranchDefault, description: 'Git branch to use for repository')
             string(name: 'GIT_COMMIT', defaultValue: '', description: '(Optional) Specific commit to checkout after cloning branch')
             string(name: 'STAGE', defaultValue: "${defaultStageId}", description: 'Stage name for deployment environment')
             string(name: 'RFS_WORKERS', defaultValue: '1', description: 'Number of RFS worker pods for document backfill (podReplicas)')

--- a/vars/eksIntegPipeline.groovy
+++ b/vars/eksIntegPipeline.groovy
@@ -7,13 +7,14 @@ def call(Map config = [:]) {
     def sourceClusterType = config.sourceClusterType ?: ""
     def targetClusterType = config.targetClusterType ?: ""
     def testIds = config.testIds ?: "0001,0002"
+    def gitBranchDefault = config.gitBranchDefault ?: 'main'
     def clusterContextFilePath = "tmp/cluster-context-integ-${currentBuild.number}.json"
     pipeline {
         agent { label config.workerAgent ?: 'Jenkins-Default-Agent-X64-C5xlarge-Single-Host' }
 
         parameters {
             string(name: 'GIT_REPO_URL', defaultValue: 'https://github.com/opensearch-project/opensearch-migrations.git', description: 'Git repository url')
-            string(name: 'GIT_BRANCH', defaultValue: 'main', description: 'Git branch to use for repository')
+            string(name: 'GIT_BRANCH', defaultValue: gitBranchDefault, description: 'Git branch to use for repository')
             string(name: 'GIT_COMMIT', defaultValue: '', description: '(Optional) Specific commit to checkout after cloning branch')
             string(name: 'STAGE', defaultValue: "${defaultStageId}", description: 'Stage name for deployment environment')
             choice(

--- a/vars/solutionsCFNTest.groovy
+++ b/vars/solutionsCFNTest.groovy
@@ -10,6 +10,7 @@ def call(Map config = [:]) {
             string(name: 'GIT_COMMIT', defaultValue: '', description: '(Optional) Specific commit to checkout after cloning branch')
             string(name: 'STAGE', defaultValue: "sol-integ", description: 'Stage name for deployment environment')
             string(name: 'REGION', defaultValue: 'us-east-1', description: 'AWS region for deployment')
+            string(name: 'VERSION', defaultValue: '', description: 'Release version to deploy (e.g. "2.9.0"). When set, checks out the release tag instead of GIT_BRANCH.')
         }
 
         options {
@@ -38,7 +39,20 @@ def call(Map config = [:]) {
         stages {
             stage('Checkout') {
                 steps {
-                    checkoutStep(branch: params.GIT_BRANCH, repo: params.GIT_REPO_URL, commit: params.GIT_COMMIT)
+                    script {
+                        def checkoutBranch = params.VERSION?.trim() ? params.VERSION : params.GIT_BRANCH
+                        echo """
+                            ================================================================
+                            Solutions CFN Test
+                            ================================================================
+                            Git:                    ${params.GIT_REPO_URL} @ ${checkoutBranch}
+                            Stage:                  ${params.STAGE}
+                            Region:                 ${params.REGION}
+                            Version:                ${params.VERSION ?: 'N/A (using GIT_BRANCH)'}
+                            ================================================================
+                        """
+                        checkoutStep(branch: checkoutBranch, repo: params.GIT_REPO_URL, commit: params.GIT_COMMIT)
+                    }
                 }
             }
 


### PR DESCRIPTION
### Description

Add release canary support to Jenkins pipeline cover files. Each EKS and ECS cover file now detects `release-*` job names and dynamically resolves the latest release tag from GitHub, loading the shared library from that version so pipeline code matches the release being tested. No manual parameter overrides needed — fully compatible with cron-triggered builds.

Changes:
- 11 cover files — add release tag resolution block for `release-*` jobs
- `checkoutStep.groovy` — add tag-aware checkout (fetches tags from canonical upstream repo)
- `defaultIntegPipeline.groovy` / `solutionsCFNTest.groovy` — add `VERSION` param and info banners for ECS pipeline release testing
- 4 EKS pipelines — add `gitBranchDefault` config to override `GIT_BRANCH` default from cover files
- 7 EKS cover files — pass resolved tag as `gitBranchDefault` so checkout matches the release

**Note:** The `gitBranchDefault` checkout override only takes effect for releases that include this PR. For `3.0.0` (released before this PR), the library loads from the tag but the checkout falls back to `main`. Starting from the next release, both library and checkout will use the tag automatically.

### Issues Resolved
[MIGRATIONS-3035](https://opensearch.atlassian.net/browse/MIGRATIONS-3035)

### Testing

All release canary jobs use the same cover files as `main-*` pipelines — the `release-` prefix in the job name triggers automatic tag resolution. No Build with Parameters overrides needed.

**EKS:**
- [`release-eks-integ-test-mimic` #3](https://migrations.ci.opensearch.org/job/pr-checks/job/release-eks-integ-test-mimic/) — resolved `3.0.0`, library loaded from tag, `gitBranchDefault` passed to pipeline
- [`release-eks-integ-test` #17](https://migrations.ci.opensearch.org/job/release-canaries/job/release-eks-integ-test/) — resolved `2.9.0`, full E2E test
- [`release-eks-aoss-search-integ-test` #8](https://migrations.ci.opensearch.org/job/release-canaries/job/release-eks-aoss-search-integ-test/) — resolved `2.9.0`

**ECS:**
- [`release-solutions-cfn-create-vpc-test` #7](https://migrations.ci.opensearch.org/job/pr-checks/job/release-solutions-cfn-create-vpc-test/) — resolved `2.9.0`, CDK deploy/destroy passed
- [`release-full-es68source-e2e-test` #4](https://migrations.ci.opensearch.org/job/pr-checks/job/release-full-es68source-e2e-test/) — resolved `2.9.0`, full E2E test

Existing `main-*` and `pr-*` pipelines are unaffected — all defaults preserved.

### Check List
- [x] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).