### PR TITLE
Limit crane copy parallelism to 4 concurrent jobs in ECR mirroring

### DIFF
--- a/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/scripts/mirrorToEcr.sh
+++ b/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/scripts/mirrorToEcr.sh
@@ -113,10 +113,14 @@ mirror_images_to_ecr() {
 
   echo ""
   echo "=== Mirroring container images ==="
-  local _imglist
+  local _imglist _max_jobs=4
   _imglist=$(mktemp)
   echo "$images" | sed 's/^[[:space:]]*//' | sed 's/[[:space:]]*$//' | grep -v '^#' | grep -v '^$' > "$_imglist"
   while IFS= read -r image; do
+    # Throttle to $_max_jobs concurrent copies
+    while [ "$(jobs -rp | wc -l)" -ge "$_max_jobs" ]; do
+      wait -n 2>/dev/null || true
+    done
     copy_image "$ecr_host" "$region" "$dockerhub_mirrors" "$ptc" "$image" &
   done < "$_imglist"
   rm -f "$_imglist"


### PR DESCRIPTION
## Summary

The `mirror_images_to_ecr` function in `mirrorToEcr.sh` previously launched all `crane copy` operations as background jobs simultaneously with no concurrency limit. This was observed to cause OOM (out of memory) failures when running in AWS CloudShell, and could also overwhelm ECR API rate limits when mirroring many images.

## Changes

Adds a semaphore pattern that caps concurrent `crane copy` operations at 4. Before launching each background job, the loop checks the number of running background processes (`jobs -rp`) and blocks with `wait -n` if the limit is reached.

## Test Plan

- Manual testing of the mirroring script with a representative image list
- Verified the throttling logic works correctly with bash job control