### PR TITLE
fix: correct ECR public registry namespace for mountpoint-s3 CSI driver image

### DIFF
--- a/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/scripts/privateEcrManifest.sh
+++ b/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/scripts/privateEcrManifest.sh
@@ -118,7 +118,7 @@ mirror.gcr.io/amazon/aws-cli:2.25.11
 mirror.gcr.io/opensearchproject/opensearch:3.1.0
 
 # --- mountpoint-s3 CSI driver ---
-public.ecr.aws/mountpoint-s3/aws-mountpoint-s3-csi-driver:v2.5.0
+public.ecr.aws/mountpoint-s3-csi-driver/aws-mountpoint-s3-csi-driver:v2.5.0
 public.ecr.aws/csi-components/csi-node-driver-registrar:v2.16.0-eksbuild.3
 public.ecr.aws/csi-components/livenessprobe:v2.18.0-eksbuild.3
 


### PR DESCRIPTION
## Summary

The image mirror for the mountpoint-s3 CSI driver was failing during `mirrorToEcr.sh` because the ECR public registry namespace was wrong:

| | Registry path |
|---|---|
| **Wrong** | `public.ecr.aws/mountpoint-s3/aws-mountpoint-s3-csi-driver:v2.5.0` |
| **Correct** | `public.ecr.aws/mountpoint-s3-csi-driver/aws-mountpoint-s3-csi-driver:v2.5.0` |

The `mountpoint-s3` registry does not exist on ECR public (`NAME_UNKNOWN`). The actual registry namespace is `mountpoint-s3-csi-driver`, which matches:
- The helm chart's own `image.repository` default value
- `generatePrivateEcrValues.sh` (which already had the correct path)

## Impact

This is a **bootstrap blocker**. Since `push_images_to_ecr=true` is the default, `mirror_images_to_ecr` hits `exit 1` when this image fails to copy, aborting the entire bootstrap before helm install.

## Test

Verified with crane:
```
# Wrong path - NAME_UNKNOWN
crane manifest public.ecr.aws/mountpoint-s3/aws-mountpoint-s3-csi-driver:v2.5.0
# Error: NAME_UNKNOWN: The repository does not exist in the registry with id 'mountpoint-s3'

# Correct path - works
crane manifest public.ecr.aws/mountpoint-s3-csi-driver/aws-mountpoint-s3-csi-driver:v2.5.0
# Returns valid manifest
```

---

If you encounter issues with the Migration Assistant bootstrap, please [open an issue](https://github.com/opensearch-project/opensearch-migrations/issues/new) with logs and your configuration so we can help.