### PR TITLE
Fix image mirror failures silently swallowed during bootstrap

### DIFF
--- a/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/scripts/mirrorToEcr.sh
+++ b/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/scripts/mirrorToEcr.sh
@@ -113,18 +113,30 @@ mirror_images_to_ecr() {
 
   echo ""
   echo "=== Mirroring container images ==="
-  local _imglist _max_jobs=4
+  local _imglist _max_jobs=4 _failfile
   _imglist=$(mktemp)
+  _failfile=$(mktemp)
   echo "$images" | sed 's/^[[:space:]]*//' | sed 's/[[:space:]]*$//' | grep -v '^#' | grep -v '^$' > "$_imglist"
   while IFS= read -r image; do
     # Throttle to $_max_jobs concurrent copies
     while [ "$(jobs -rp | wc -l)" -ge "$_max_jobs" ]; do
       wait -n 2>/dev/null || true
     done
-    copy_image "$ecr_host" "$region" "$dockerhub_mirrors" "$ptc" "$image" &
+    ( copy_image "$ecr_host" "$region" "$dockerhub_mirrors" "$ptc" "$image" || echo "$image" >> "$_failfile" ) &
   done < "$_imglist"
   rm -f "$_imglist"
-  wait || { echo "❌ Some image copies failed" >&2; exit 1; }
+  wait
+  if [ -s "$_failfile" ]; then
+    echo "" >&2
+    echo "❌ The following image copies failed:" >&2
+    sed 's/^/  - /' "$_failfile" >&2
+    echo "" >&2
+    echo "If this is unexpected, please open an issue at:" >&2
+    echo "  https://github.com/opensearch-project/opensearch-migrations/issues/new" >&2
+    rm -f "$_failfile"
+    exit 1
+  fi
+  rm -f "$_failfile"
 }
 
 # Mirror helm charts to ECR as OCI artifacts.

--- a/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/scripts/privateEcrManifest.sh
+++ b/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/scripts/privateEcrManifest.sh
@@ -118,7 +118,7 @@ mirror.gcr.io/amazon/aws-cli:2.25.11
 mirror.gcr.io/opensearchproject/opensearch:3.1.0
 
 # --- mountpoint-s3 CSI driver ---
-public.ecr.aws/mountpoint-s3/aws-mountpoint-s3-csi-driver:v2.5.0
+public.ecr.aws/mountpoint-s3-csi-driver/aws-mountpoint-s3-csi-driver:v2.5.0
 public.ecr.aws/csi-components/csi-node-driver-registrar:v2.16.0-eksbuild.3
 public.ecr.aws/csi-components/livenessprobe:v2.18.0-eksbuild.3
 


### PR DESCRIPTION
## Problem

When a container image fails to copy during `mirror_images_to_ecr` (e.g. wrong ECR namespace for mountpoint-s3 CSI driver), the bootstrap script **continues to completion** instead of aborting. This means the cluster deploys with missing images and fails at runtime rather than at bootstrap time.

This was observed in the Jenkins log where `[51/56] ❌ public.ecr.aws/mountpoint-s3/aws-mountpoint-s3-csi-driver:v2.5.0` failed but bootstrap continued through helm chart mirroring, value generation, and buildkit setup.

Since `push_images_to_ecr=true` is the **default**, this is a hard blocker for anyone running the standard bootstrap — including the EKS integ tests that run on every push to main.

## Root Cause

Two bash `wait` bugs in `mirrorToEcr.sh`:

1. **Bare `wait` returns last job's exit code, not all jobs.** When background jobs run in parallel, `wait` (no arguments) returns the exit status of the *last* process to finish. If the failed job finishes before another successful job, the failure is silently lost.

2. **`wait -n || true` in throttle loop eats failures.** The concurrency throttle loop uses `wait -n 2>/dev/null || true` to reap finished jobs — this swallows any non-zero exit from completed jobs.

## Fix

- Wrap each background `copy_image` call in a subshell that appends the image name to a temp file on failure
- After all jobs complete, check the failure file to detect any failed copies
- Print a clear summary listing **which specific images failed** and a link to file an issue
- Also fixes the mountpoint-s3 CSI driver ECR namespace: `public.ecr.aws/mountpoint-s3/` → `public.ecr.aws/mountpoint-s3-csi-driver/` (the registry that actually exists)

Example failure output:
```
❌ The following image copies failed:
  - public.ecr.aws/mountpoint-s3-csi-driver/aws-mountpoint-s3-csi-driver:v2.5.0

If this is unexpected, please open an issue at:
  https://github.com/opensearch-project/opensearch-migrations/issues/new
```

Supersedes #2728 which only fixed the namespace typo but not the silent failure.

## Testing

Verified with local bash simulation that:
- Old code: failure swallowed, exit 0
- New code: failure detected, exit 1, failed images listed

If you encounter bootstrap failures related to image mirroring, please [open an issue](https://github.com/opensearch-project/opensearch-migrations/issues/new).