### PR TITLE
Add workflow reset with VAP-gated Kafka teardown

### DIFF
--- a/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/templates/resources/validatingAdmissionPolicies.yaml
+++ b/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/templates/resources/validatingAdmissionPolicies.yaml
@@ -128,6 +128,45 @@ spec:
         values: ["{{ .Release.Namespace }}"]
 
 # ─────────────────────────────────────────────────────────────
+# Kafka DELETE Policy - blocks deletion of Kafka resources without teardown approval
+# The reset workflow stamps the approval annotation before issuing deletes.
+# For DELETE, only oldObject is available (not object).
+# ─────────────────────────────────────────────────────────────
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: {{ .Release.Namespace }}-kafka-delete-policy
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+    - apiGroups: ["kafka.strimzi.io"]
+      apiVersions: ["v1", "v1beta2"]
+      operations: ["DELETE"]
+      resources: ["kafkas", "kafkanodepools", "kafkatopics"]
+  validations:
+    - expression: |
+        has(oldObject.metadata.annotations) &&
+        'migrations.opensearch.org/approved-for-teardown' in oldObject.metadata.annotations
+      message: "Kafka resource deletion requires teardown approval. Use the reset workflow to safely tear down Kafka resources."
+
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: {{ .Release.Namespace }}-kafka-delete-binding
+spec:
+  policyName: {{ .Release.Namespace }}-kafka-delete-policy
+  validationActions: [Deny]
+  matchResources:
+    namespaceSelector:
+      matchExpressions:
+      - key: kubernetes.io/metadata.name
+        operator: In
+        values: ["{{ .Release.Namespace }}"]
+
+# ─────────────────────────────────────────────────────────────
 # KafkaTopic Policy - partition decrease, replica change
 # ─────────────────────────────────────────────────────────────
 ---

--- a/migrationConsole/lib/console_link/console_link/workflow/cli.py
+++ b/migrationConsole/lib/console_link/console_link/workflow/cli.py
@@ -13,6 +13,7 @@ from .commands.approve import approve_command
 from .commands.status import status_command
 from .commands.output import output_command
 from .commands.manage import manage_command
+from .commands.reset import reset_command
 
 logger = logging.getLogger(__name__)
 
@@ -93,6 +94,7 @@ workflow_cli.add_command(approve_command)
 workflow_cli.add_command(status_command)
 workflow_cli.add_command(output_command)
 workflow_cli.add_command(manage_command)
+workflow_cli.add_command(reset_command)
 workflow_cli.add_command(util_group)
 
 

--- a/migrationConsole/lib/console_link/console_link/workflow/commands/reset.py
+++ b/migrationConsole/lib/console_link/console_link/workflow/commands/reset.py
@@ -1,0 +1,130 @@
+"""Reset command for workflow CLI - deletes migration CRDs in dependency order.
+
+Uses direct K8s API calls (not Argo workflows) to tear down migration resources.
+Optionally includes capture proxy and Kafka infrastructure teardown.
+"""
+
+import logging
+import click
+
+from ..models.utils import ExitCode, load_k8s_config
+from ..services.k8s_reset_service import K8sResetService
+
+logger = logging.getLogger(__name__)
+
+
+@click.command(name="reset")
+@click.option(
+    '--namespace',
+    default='ma',
+    help='Kubernetes namespace for the migration resources (default: ma)'
+)
+@click.option(
+    '--include-proxy',
+    is_flag=True,
+    default=False,
+    help='Also delete CapturedTraffic (proxy) and Kafka resources. '
+         'Without this flag, only replay and snapshot resources are deleted.'
+)
+@click.option(
+    '--resource-name',
+    default=None,
+    help='Delete only resources with this name. Without this flag, '
+         'ALL instances of each CRD type are deleted.'
+)
+@click.option(
+    '--yes', '-y',
+    is_flag=True,
+    default=False,
+    help='Skip confirmation prompt'
+)
+@click.pass_context
+def reset_command(ctx, namespace, include_proxy, resource_name, yes):
+    """Reset migration resources by deleting CRDs in dependency order.
+
+    Deletes migration CRDs in reverse dependency order:
+      1. TrafficReplay
+      2. SnapshotMigration
+      3. DataSnapshot
+
+    With --include-proxy, also deletes:
+      4. CapturedTraffic (capture proxy)
+      5. Kafka resources (KafkaTopic, KafkaNodePool, Kafka cluster)
+
+    Kafka deletion is protected by a ValidatingAdmissionPolicy that requires
+    a teardown-approval annotation. This command stamps the annotation
+    automatically before deleting.
+
+    All deletes are idempotent — already-deleted resources are silently skipped.
+
+    Examples:
+        workflow reset                          # Delete replay + snapshot CRDs
+        workflow reset --include-proxy          # Delete everything including proxy + Kafka
+        workflow reset --resource-name my-migration   # Delete specific named resources
+        workflow reset --include-proxy -y       # Skip confirmation
+    """
+    # Show what will be deleted
+    resources_to_delete = ["TrafficReplay", "SnapshotMigration", "DataSnapshot"]
+    if include_proxy:
+        resources_to_delete.extend([
+            "CapturedTraffic (proxy)",
+            "KafkaTopic", "KafkaNodePool", "Kafka (cluster)"
+        ])
+
+    scope = f"named '{resource_name}'" if resource_name else "ALL instances"
+
+    click.echo(f"Reset will delete {scope} of the following resources in namespace '{namespace}':")
+    for r in resources_to_delete:
+        click.echo(f"  - {r}")
+
+    if include_proxy:
+        click.echo()
+        click.echo("⚠  --include-proxy is set: this will tear down Kafka infrastructure!")
+        click.echo("   Kafka resources will be annotated for teardown approval before deletion.")
+
+    # Confirm unless --yes
+    if not yes:
+        click.echo()
+        if not click.confirm("Proceed with reset?"):
+            click.echo("Aborted.")
+            ctx.exit(ExitCode.SUCCESS.value)
+            return
+
+    # Initialize K8s
+    try:
+        load_k8s_config()
+    except Exception as e:
+        click.echo(
+            f"Error: Could not load Kubernetes configuration.\n"
+            f"Make sure kubectl is configured or you're running inside a cluster.\n"
+            f"Details: {e}",
+            err=True
+        )
+        ctx.exit(ExitCode.FAILURE.value)
+        return
+
+    # Run the reset
+    try:
+        service = K8sResetService(namespace=namespace)
+        result = service.reset(
+            include_proxy=include_proxy,
+            resource_name=resource_name,
+        )
+
+        # Print per-resource results
+        click.echo()
+        for r in result.results:
+            icon = "✓" if r.success else "✗"
+            click.echo(f"  {icon} {r.message}")
+
+        click.echo()
+        if result.success:
+            click.echo(f"Reset complete ({result.summary})")
+        else:
+            click.echo(f"Reset completed with errors ({result.summary})", err=True)
+            ctx.exit(ExitCode.FAILURE.value)
+
+    except Exception as e:
+        click.echo(f"Error during reset: {e}", err=True)
+        logger.exception("Reset failed")
+        ctx.exit(ExitCode.FAILURE.value)

--- a/migrationConsole/lib/console_link/console_link/workflow/services/k8s_reset_service.py
+++ b/migrationConsole/lib/console_link/console_link/workflow/services/k8s_reset_service.py
@@ -1,0 +1,313 @@
+"""Service for resetting migration resources via direct K8s API calls.
+
+Deletes migration CRDs in reverse dependency order. Optionally tears down
+the capture proxy and Kafka infrastructure (with VAP-gated annotation stamping).
+
+Dependency order (reverse for deletion):
+  Kafka -> CapturedTraffic (proxy) -> TrafficReplay
+                                   -> SnapshotMigration -> DataSnapshot
+"""
+
+import logging
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+from kubernetes import client
+from kubernetes.client.rest import ApiException
+
+logger = logging.getLogger(__name__)
+
+# CRD coordinates for migrations.opensearch.org/v1alpha1
+MIGRATION_API_GROUP = "migrations.opensearch.org"
+MIGRATION_API_VERSION = "v1alpha1"
+
+# Kafka (Strimzi) coordinates
+KAFKA_API_GROUP = "kafka.strimzi.io"
+
+# Teardown approval annotation key
+TEARDOWN_ANNOTATION = "migrations.opensearch.org/approved-for-teardown"
+
+
+@dataclass
+class DeleteResult:
+    """Result of a single resource deletion."""
+    kind: str
+    name: str
+    success: bool
+    message: str
+    not_found: bool = False
+
+
+@dataclass
+class ResetResult:
+    """Aggregate result of a reset operation."""
+    success: bool
+    results: List[DeleteResult] = field(default_factory=list)
+    error: Optional[str] = None
+
+    @property
+    def summary(self) -> str:
+        deleted = [r for r in self.results if r.success and not r.not_found]
+        skipped = [r for r in self.results if r.not_found]
+        failed = [r for r in self.results if not r.success]
+        parts = []
+        if deleted:
+            parts.append(f"{len(deleted)} deleted")
+        if skipped:
+            parts.append(f"{len(skipped)} not found (skipped)")
+        if failed:
+            parts.append(f"{len(failed)} failed")
+        return ", ".join(parts) if parts else "nothing to do"
+
+
+class K8sResetService:
+    """Service for resetting migration resources via direct K8s API.
+
+    Uses the Kubernetes Python client to delete CRDs and Kafka resources
+    in the correct dependency order, respecting the VAP-gated teardown
+    approval pattern for Kafka resources.
+    """
+
+    def __init__(self, namespace: str):
+        self.namespace = namespace
+        self.custom_api = client.CustomObjectsApi()
+
+    def reset(
+        self,
+        include_proxy: bool = False,
+        resource_name: Optional[str] = None,
+    ) -> ResetResult:
+        """Reset migration resources in dependency order.
+
+        Deletion order:
+          1. TrafficReplay
+          2. SnapshotMigration
+          3. DataSnapshot
+          4. CapturedTraffic (only if include_proxy=True)
+          5. Kafka resources (only if include_proxy=True)
+
+        Args:
+            include_proxy: If True, also delete capture proxy and Kafka resources.
+            resource_name: If set, only delete resources with this name.
+                         Otherwise deletes ALL instances of each CRD type.
+
+        Returns:
+            ResetResult with per-resource details.
+        """
+        results: List[DeleteResult] = []
+        all_ok = True
+
+        # Phase 1: Delete TrafficReplay
+        phase_results = self._delete_migration_crds(
+            "TrafficReplay", "trafficreplays", resource_name
+        )
+        results.extend(phase_results)
+
+        # Phase 2: Delete SnapshotMigration
+        phase_results = self._delete_migration_crds(
+            "SnapshotMigration", "snapshotmigrations", resource_name
+        )
+        results.extend(phase_results)
+
+        # Phase 3: Delete DataSnapshot
+        phase_results = self._delete_migration_crds(
+            "DataSnapshot", "datasnapshots", resource_name
+        )
+        results.extend(phase_results)
+
+        # Phase 4: Proxy + Kafka (only if include_proxy)
+        if include_proxy:
+            # Delete CapturedTraffic
+            phase_results = self._delete_migration_crds(
+                "CapturedTraffic", "capturedtraffics", resource_name
+            )
+            results.extend(phase_results)
+
+            # Stamp teardown approval on Kafka resources, then delete them
+            kafka_results = self._teardown_kafka(resource_name)
+            results.extend(kafka_results)
+
+        for r in results:
+            if not r.success:
+                all_ok = False
+
+        return ResetResult(success=all_ok, results=results)
+
+    def _delete_migration_crds(
+        self,
+        kind: str,
+        plural: str,
+        resource_name: Optional[str],
+    ) -> List[DeleteResult]:
+        """Delete migration CRD instances."""
+        if resource_name:
+            return [self._delete_custom_resource(
+                MIGRATION_API_GROUP, MIGRATION_API_VERSION, plural, kind, resource_name
+            )]
+        else:
+            return self._delete_all_custom_resources(
+                MIGRATION_API_GROUP, MIGRATION_API_VERSION, plural, kind
+            )
+
+    def _teardown_kafka(self, resource_name: Optional[str]) -> List[DeleteResult]:
+        """Stamp teardown annotation on Kafka resources and delete them.
+
+        The VAP requires the teardown-approval annotation to be present
+        before deletion is allowed. We stamp it first, then delete.
+
+        Order: KafkaTopic -> KafkaNodePool -> Kafka (cluster last)
+        """
+        results: List[DeleteResult] = []
+
+        # Collect all Kafka resources that need annotation + deletion
+        kafka_resources = [
+            ("v1beta2", "kafkatopics", "KafkaTopic"),
+            ("v1", "kafkanodepools", "KafkaNodePool"),
+            ("v1", "kafkas", "Kafka"),
+        ]
+
+        for api_version, plural, kind in kafka_resources:
+            if resource_name:
+                names = [resource_name]
+            else:
+                names = self._list_resource_names(
+                    KAFKA_API_GROUP, api_version, plural
+                )
+
+            for name in names:
+                # Stamp the teardown approval annotation
+                stamp_ok = self._stamp_teardown_annotation(
+                    KAFKA_API_GROUP, api_version, plural, kind, name
+                )
+                if not stamp_ok:
+                    results.append(DeleteResult(
+                        kind=kind, name=name, success=False,
+                        message=f"Failed to stamp teardown annotation on {kind}/{name}"
+                    ))
+                    continue
+
+                # Now delete
+                result = self._delete_custom_resource(
+                    KAFKA_API_GROUP, api_version, plural, kind, name
+                )
+                results.append(result)
+
+        return results
+
+    def _list_resource_names(
+        self,
+        group: str,
+        version: str,
+        plural: str,
+    ) -> List[str]:
+        """List all resource names of a given type in the namespace."""
+        try:
+            response = self.custom_api.list_namespaced_custom_object(
+                group=group,
+                version=version,
+                namespace=self.namespace,
+                plural=plural,
+            )
+            items = response.get("items", [])
+            return [
+                item["metadata"]["name"]
+                for item in items
+                if "metadata" in item and "name" in item["metadata"]
+            ]
+        except ApiException as e:
+            if e.status == 404:
+                # CRD not installed — nothing to list
+                logger.debug(f"CRD {group}/{version}/{plural} not found (CRD not installed)")
+                return []
+            logger.warning(f"Failed to list {plural}: {e}")
+            return []
+
+    def _stamp_teardown_annotation(
+        self,
+        group: str,
+        version: str,
+        plural: str,
+        kind: str,
+        name: str,
+    ) -> bool:
+        """Patch a resource to add the teardown approval annotation.
+
+        Returns True on success, False on failure.
+        """
+        body = {
+            "metadata": {
+                "annotations": {
+                    TEARDOWN_ANNOTATION: "cli-reset"
+                }
+            }
+        }
+        try:
+            self.custom_api.patch_namespaced_custom_object(
+                group=group,
+                version=version,
+                namespace=self.namespace,
+                plural=plural,
+                name=name,
+                body=body,
+            )
+            logger.info(f"Stamped teardown annotation on {kind}/{name}")
+            return True
+        except ApiException as e:
+            if e.status == 404:
+                logger.debug(f"{kind}/{name} not found — nothing to annotate")
+                return True  # Not an error — resource already gone
+            logger.error(f"Failed to annotate {kind}/{name}: {e}")
+            return False
+
+    def _delete_custom_resource(
+        self,
+        group: str,
+        version: str,
+        plural: str,
+        kind: str,
+        name: str,
+    ) -> DeleteResult:
+        """Delete a single custom resource by name."""
+        try:
+            self.custom_api.delete_namespaced_custom_object(
+                group=group,
+                version=version,
+                namespace=self.namespace,
+                plural=plural,
+                name=name,
+            )
+            logger.info(f"Deleted {kind}/{name}")
+            return DeleteResult(
+                kind=kind, name=name, success=True,
+                message=f"Deleted {kind}/{name}"
+            )
+        except ApiException as e:
+            if e.status == 404:
+                logger.debug(f"{kind}/{name} not found — already deleted")
+                return DeleteResult(
+                    kind=kind, name=name, success=True,
+                    message=f"{kind}/{name} not found (already deleted)",
+                    not_found=True,
+                )
+            logger.error(f"Failed to delete {kind}/{name}: {e}")
+            return DeleteResult(
+                kind=kind, name=name, success=False,
+                message=f"Failed to delete {kind}/{name}: {e.reason} ({e.status})"
+            )
+
+    def _delete_all_custom_resources(
+        self,
+        group: str,
+        version: str,
+        plural: str,
+        kind: str,
+    ) -> List[DeleteResult]:
+        """Delete all instances of a custom resource type in the namespace."""
+        names = self._list_resource_names(group, version, plural)
+        if not names:
+            logger.info(f"No {kind} resources found in namespace {self.namespace}")
+            return []
+        return [
+            self._delete_custom_resource(group, version, plural, kind, name)
+            for name in names
+        ]

--- a/migrationConsole/lib/console_link/tests/workflow-tests/test_reset.py
+++ b/migrationConsole/lib/console_link/tests/workflow-tests/test_reset.py
@@ -1,0 +1,409 @@
+"""Tests for the reset command and K8sResetService."""
+
+from click.testing import CliRunner
+from unittest.mock import Mock, patch, call
+import pytest
+
+from console_link.workflow.cli import workflow_cli
+from console_link.workflow.services.k8s_reset_service import (
+    K8sResetService,
+    DeleteResult,
+    ResetResult,
+    MIGRATION_API_GROUP,
+    MIGRATION_API_VERSION,
+    KAFKA_API_GROUP,
+    TEARDOWN_ANNOTATION,
+)
+
+
+# ─────────────────────────────────────────────────────────────
+# K8sResetService unit tests
+# ─────────────────────────────────────────────────────────────
+
+class TestK8sResetService:
+    """Test the K8s reset service."""
+
+    @patch('console_link.workflow.services.k8s_reset_service.client.CustomObjectsApi')
+    def test_reset_basic_crds_only(self, mock_api_class):
+        """Reset without --include-proxy deletes only replay/snapshot CRDs."""
+        mock_api = Mock()
+        mock_api_class.return_value = mock_api
+
+        # list returns one resource of each type
+        def list_side_effect(**kwargs):
+            plural = kwargs.get("plural", "")
+            resources = {
+                "trafficreplays": [{"metadata": {"name": "replay-1"}}],
+                "snapshotmigrations": [{"metadata": {"name": "snap-mig-1"}}],
+                "datasnapshots": [{"metadata": {"name": "ds-1"}}],
+            }
+            return {"items": resources.get(plural, [])}
+
+        mock_api.list_namespaced_custom_object.side_effect = list_side_effect
+        mock_api.delete_namespaced_custom_object.return_value = {}
+
+        service = K8sResetService(namespace="ma")
+        result = service.reset(include_proxy=False)
+
+        assert result.success is True
+        assert len(result.results) == 3
+
+        # Verify deletion calls — only migration CRDs, no kafka
+        delete_calls = mock_api.delete_namespaced_custom_object.call_args_list
+        assert len(delete_calls) == 3
+        deleted_names = [c.kwargs["name"] for c in delete_calls]
+        assert "replay-1" in deleted_names
+        assert "snap-mig-1" in deleted_names
+        assert "ds-1" in deleted_names
+
+    @patch('console_link.workflow.services.k8s_reset_service.client.CustomObjectsApi')
+    def test_reset_with_proxy_includes_kafka(self, mock_api_class):
+        """Reset with include_proxy=True also deletes proxy and Kafka."""
+        mock_api = Mock()
+        mock_api_class.return_value = mock_api
+
+        def list_side_effect(**kwargs):
+            plural = kwargs.get("plural", "")
+            resources = {
+                "trafficreplays": [],
+                "snapshotmigrations": [],
+                "datasnapshots": [],
+                "capturedtraffics": [{"metadata": {"name": "proxy-1"}}],
+                "kafkatopics": [{"metadata": {"name": "topic-1"}}],
+                "kafkanodepools": [{"metadata": {"name": "pool-1"}}],
+                "kafkas": [{"metadata": {"name": "kafka-1"}}],
+            }
+            return {"items": resources.get(plural, [])}
+
+        mock_api.list_namespaced_custom_object.side_effect = list_side_effect
+        mock_api.delete_namespaced_custom_object.return_value = {}
+        mock_api.patch_namespaced_custom_object.return_value = {}
+
+        service = K8sResetService(namespace="ma")
+        result = service.reset(include_proxy=True)
+
+        assert result.success is True
+
+        # Should have patched teardown annotation on 3 kafka resources
+        patch_calls = mock_api.patch_namespaced_custom_object.call_args_list
+        assert len(patch_calls) == 3
+        for c in patch_calls:
+            body = c.kwargs["body"]
+            assert TEARDOWN_ANNOTATION in body["metadata"]["annotations"]
+
+        # Should have deleted: proxy-1 + topic-1 + pool-1 + kafka-1 = 4
+        delete_calls = mock_api.delete_namespaced_custom_object.call_args_list
+        assert len(delete_calls) == 4
+
+    @patch('console_link.workflow.services.k8s_reset_service.client.CustomObjectsApi')
+    def test_reset_named_resource(self, mock_api_class):
+        """Reset with resource_name targets a specific resource by name."""
+        mock_api = Mock()
+        mock_api_class.return_value = mock_api
+        mock_api.delete_namespaced_custom_object.return_value = {}
+
+        service = K8sResetService(namespace="ma")
+        result = service.reset(include_proxy=False, resource_name="my-migration")
+
+        assert result.success is True
+        # Should have attempted to delete exactly 3 resources by name
+        # (TrafficReplay, SnapshotMigration, DataSnapshot — each with resource_name)
+        delete_calls = mock_api.delete_namespaced_custom_object.call_args_list
+        assert len(delete_calls) == 3
+        for c in delete_calls:
+            assert c.kwargs["name"] == "my-migration"
+        # No list calls when resource_name is specified
+        mock_api.list_namespaced_custom_object.assert_not_called()
+
+    @patch('console_link.workflow.services.k8s_reset_service.client.CustomObjectsApi')
+    def test_reset_not_found_is_success(self, mock_api_class):
+        """Resources that don't exist should be silently skipped."""
+        from kubernetes.client.rest import ApiException
+
+        mock_api = Mock()
+        mock_api_class.return_value = mock_api
+
+        # All deletes return 404
+        mock_api.delete_namespaced_custom_object.side_effect = ApiException(status=404)
+
+        service = K8sResetService(namespace="ma")
+        result = service.reset(include_proxy=False, resource_name="nonexistent")
+
+        assert result.success is True
+        assert all(r.not_found for r in result.results)
+        assert len(result.results) == 3
+
+    @patch('console_link.workflow.services.k8s_reset_service.client.CustomObjectsApi')
+    def test_reset_failure_propagates(self, mock_api_class):
+        """A real API error should result in failure."""
+        from kubernetes.client.rest import ApiException
+
+        mock_api = Mock()
+        mock_api_class.return_value = mock_api
+        mock_api.delete_namespaced_custom_object.side_effect = ApiException(status=403, reason="Forbidden")
+
+        service = K8sResetService(namespace="ma")
+        result = service.reset(include_proxy=False, resource_name="forbidden")
+
+        assert result.success is False
+        assert any(not r.success for r in result.results)
+
+    @patch('console_link.workflow.services.k8s_reset_service.client.CustomObjectsApi')
+    def test_teardown_annotation_failure_skips_delete(self, mock_api_class):
+        """If annotation stamp fails, the resource should NOT be deleted."""
+        from kubernetes.client.rest import ApiException
+
+        mock_api = Mock()
+        mock_api_class.return_value = mock_api
+
+        def list_side_effect(**kwargs):
+            plural = kwargs.get("plural", "")
+            if plural == "kafkas":
+                return {"items": [{"metadata": {"name": "kafka-1"}}]}
+            return {"items": []}
+
+        mock_api.list_namespaced_custom_object.side_effect = list_side_effect
+
+        # Patch (annotation) fails with 500
+        mock_api.patch_namespaced_custom_object.side_effect = ApiException(
+            status=500, reason="Internal Server Error"
+        )
+
+        service = K8sResetService(namespace="ma")
+        # Call teardown_kafka directly
+        results = service._teardown_kafka(resource_name=None)
+
+        # Should have one failure result, and delete should NOT have been called for kafka
+        failed = [r for r in results if not r.success]
+        assert len(failed) == 1
+        assert "annotation" in failed[0].message.lower()
+        # delete should not have been called since annotation failed
+        mock_api.delete_namespaced_custom_object.assert_not_called()
+
+    @patch('console_link.workflow.services.k8s_reset_service.client.CustomObjectsApi')
+    def test_reset_empty_namespace(self, mock_api_class):
+        """Reset on an empty namespace returns success with no results."""
+        mock_api = Mock()
+        mock_api_class.return_value = mock_api
+
+        mock_api.list_namespaced_custom_object.return_value = {"items": []}
+
+        service = K8sResetService(namespace="ma")
+        result = service.reset(include_proxy=False)
+
+        assert result.success is True
+        assert len(result.results) == 0
+
+    @patch('console_link.workflow.services.k8s_reset_service.client.CustomObjectsApi')
+    def test_deletion_order(self, mock_api_class):
+        """Verify deletion order: TrafficReplay -> SnapshotMigration -> DataSnapshot."""
+        mock_api = Mock()
+        mock_api_class.return_value = mock_api
+        mock_api.delete_namespaced_custom_object.return_value = {}
+
+        service = K8sResetService(namespace="ma")
+        result = service.reset(include_proxy=False, resource_name="test")
+
+        delete_calls = mock_api.delete_namespaced_custom_object.call_args_list
+        assert len(delete_calls) == 3
+        # Verify the plural order matches our expected dependency order
+        plurals = [c.kwargs["plural"] for c in delete_calls]
+        assert plurals == ["trafficreplays", "snapshotmigrations", "datasnapshots"]
+
+    @patch('console_link.workflow.services.k8s_reset_service.client.CustomObjectsApi')
+    def test_kafka_deletion_order(self, mock_api_class):
+        """Verify Kafka deletion order: topics -> node pools -> clusters."""
+        mock_api = Mock()
+        mock_api_class.return_value = mock_api
+        mock_api.delete_namespaced_custom_object.return_value = {}
+        mock_api.patch_namespaced_custom_object.return_value = {}
+
+        service = K8sResetService(namespace="ma")
+        results = service._teardown_kafka(resource_name="test")
+
+        # Annotation stamp + delete for each of 3 kafka resource types
+        patch_calls = mock_api.patch_namespaced_custom_object.call_args_list
+        assert len(patch_calls) == 3
+        patch_plurals = [c.kwargs["plural"] for c in patch_calls]
+        assert patch_plurals == ["kafkatopics", "kafkanodepools", "kafkas"]
+
+    def test_reset_result_summary(self):
+        """Test the ResetResult.summary property."""
+        result = ResetResult(success=True, results=[
+            DeleteResult(kind="TrafficReplay", name="r1", success=True,
+                        message="Deleted TrafficReplay/r1"),
+            DeleteResult(kind="DataSnapshot", name="ds1", success=True,
+                        message="DataSnapshot/ds1 not found", not_found=True),
+            DeleteResult(kind="SnapshotMigration", name="sm1", success=False,
+                        message="Failed to delete SnapshotMigration/sm1: Forbidden (403)"),
+        ])
+        summary = result.summary
+        assert "1 deleted" in summary
+        assert "1 not found (skipped)" in summary
+        assert "1 failed" in summary
+
+    def test_reset_result_summary_empty(self):
+        """Test ResetResult.summary when nothing happened."""
+        result = ResetResult(success=True, results=[])
+        assert result.summary == "nothing to do"
+
+
+# ─────────────────────────────────────────────────────────────
+# CLI command tests
+# ─────────────────────────────────────────────────────────────
+
+class TestResetCLICommand:
+    """Test the reset CLI command."""
+
+    @patch('console_link.workflow.commands.reset.K8sResetService')
+    @patch('console_link.workflow.commands.reset.load_k8s_config')
+    def test_reset_basic_confirmed(self, mock_k8s_config, mock_service_class):
+        """Test basic reset with --yes confirmation."""
+        mock_service = Mock()
+        mock_service_class.return_value = mock_service
+        mock_service.reset.return_value = ResetResult(
+            success=True,
+            results=[
+                DeleteResult(kind="TrafficReplay", name="replay-1", success=True,
+                           message="Deleted TrafficReplay/replay-1"),
+            ]
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(workflow_cli, ['reset', '-y'])
+
+        assert result.exit_code == 0
+        assert "Reset complete" in result.output
+        mock_service.reset.assert_called_once_with(
+            include_proxy=False,
+            resource_name=None,
+        )
+
+    @patch('console_link.workflow.commands.reset.K8sResetService')
+    @patch('console_link.workflow.commands.reset.load_k8s_config')
+    def test_reset_with_include_proxy(self, mock_k8s_config, mock_service_class):
+        """Test reset with --include-proxy flag."""
+        mock_service = Mock()
+        mock_service_class.return_value = mock_service
+        mock_service.reset.return_value = ResetResult(success=True, results=[])
+
+        runner = CliRunner()
+        result = runner.invoke(workflow_cli, ['reset', '--include-proxy', '-y'])
+
+        assert result.exit_code == 0
+        mock_service.reset.assert_called_once_with(
+            include_proxy=True,
+            resource_name=None,
+        )
+
+    @patch('console_link.workflow.commands.reset.K8sResetService')
+    @patch('console_link.workflow.commands.reset.load_k8s_config')
+    def test_reset_with_resource_name(self, mock_k8s_config, mock_service_class):
+        """Test reset with --resource-name flag."""
+        mock_service = Mock()
+        mock_service_class.return_value = mock_service
+        mock_service.reset.return_value = ResetResult(success=True, results=[])
+
+        runner = CliRunner()
+        result = runner.invoke(workflow_cli, [
+            'reset', '--resource-name', 'my-migration', '-y'
+        ])
+
+        assert result.exit_code == 0
+        mock_service.reset.assert_called_once_with(
+            include_proxy=False,
+            resource_name="my-migration",
+        )
+
+    @patch('console_link.workflow.commands.reset.K8sResetService')
+    @patch('console_link.workflow.commands.reset.load_k8s_config')
+    def test_reset_with_namespace(self, mock_k8s_config, mock_service_class):
+        """Test reset with custom --namespace."""
+        mock_service = Mock()
+        mock_service_class.return_value = mock_service
+        mock_service.reset.return_value = ResetResult(success=True, results=[])
+
+        runner = CliRunner()
+        result = runner.invoke(workflow_cli, [
+            'reset', '--namespace', 'custom-ns', '-y'
+        ])
+
+        assert result.exit_code == 0
+        mock_service_class.assert_called_once_with(namespace='custom-ns')
+
+    def test_reset_shows_help(self):
+        """Test that reset --help works."""
+        runner = CliRunner()
+        result = runner.invoke(workflow_cli, ['reset', '--help'])
+
+        assert result.exit_code == 0
+        assert "Reset migration resources" in result.output
+        assert "--include-proxy" in result.output
+        assert "--resource-name" in result.output
+
+    @patch('console_link.workflow.commands.reset.K8sResetService')
+    @patch('console_link.workflow.commands.reset.load_k8s_config')
+    def test_reset_abort_on_no_confirm(self, mock_k8s_config, mock_service_class):
+        """Test that reset aborts when user declines confirmation."""
+        runner = CliRunner()
+        result = runner.invoke(workflow_cli, ['reset'], input='n\n')
+
+        assert "Aborted" in result.output
+        mock_service_class.assert_not_called()
+
+    @patch('console_link.workflow.commands.reset.K8sResetService')
+    @patch('console_link.workflow.commands.reset.load_k8s_config')
+    def test_reset_failure_shows_errors(self, mock_k8s_config, mock_service_class):
+        """Test that reset shows error details on failure."""
+        mock_service = Mock()
+        mock_service_class.return_value = mock_service
+        mock_service.reset.return_value = ResetResult(
+            success=False,
+            results=[
+                DeleteResult(kind="TrafficReplay", name="replay-1", success=False,
+                           message="Failed to delete TrafficReplay/replay-1: Forbidden (403)"),
+            ]
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(workflow_cli, ['reset', '-y'])
+
+        assert "errors" in result.output
+        assert "Forbidden" in result.output
+
+    @patch('console_link.workflow.commands.reset.load_k8s_config')
+    def test_reset_k8s_config_failure(self, mock_k8s_config):
+        """Test that reset handles K8s config failure gracefully."""
+        mock_k8s_config.side_effect = Exception("No kubeconfig found")
+
+        runner = CliRunner()
+        result = runner.invoke(workflow_cli, ['reset', '-y'])
+
+        assert "Could not load Kubernetes configuration" in result.output
+
+    @patch('console_link.workflow.commands.reset.K8sResetService')
+    @patch('console_link.workflow.commands.reset.load_k8s_config')
+    def test_reset_proxy_warning_shown(self, mock_k8s_config, mock_service_class):
+        """Test that --include-proxy shows a warning about Kafka teardown."""
+        mock_service = Mock()
+        mock_service_class.return_value = mock_service
+        mock_service.reset.return_value = ResetResult(success=True, results=[])
+
+        runner = CliRunner()
+        result = runner.invoke(workflow_cli, ['reset', '--include-proxy', '-y'])
+
+        assert "include-proxy" in result.output or "Kafka" in result.output
+
+    @patch('console_link.workflow.commands.reset.K8sResetService')
+    @patch('console_link.workflow.commands.reset.load_k8s_config')
+    def test_reset_accept_confirm_prompt(self, mock_k8s_config, mock_service_class):
+        """Test that reset proceeds when user confirms."""
+        mock_service = Mock()
+        mock_service_class.return_value = mock_service
+        mock_service.reset.return_value = ResetResult(success=True, results=[])
+
+        runner = CliRunner()
+        result = runner.invoke(workflow_cli, ['reset'], input='y\n')
+
+        assert result.exit_code == 0
+        mock_service.reset.assert_called_once()

--- a/orchestrationSpecs/packages/migration-workflow-templates/src/workflowTemplates/allWorkflowTemplates.ts
+++ b/orchestrationSpecs/packages/migration-workflow-templates/src/workflowTemplates/allWorkflowTemplates.ts
@@ -7,6 +7,7 @@ import {TestMigrationWithWorkflowCli} from "./testMigrationWithWorkflowCli";
 import {MetadataMigration} from "./metadataMigration";
 import {MigrationConsole} from "./migrationConsole";
 import {Replayer} from "./replayer";
+import {ResetMigration} from "./resetMigration";
 import {ResourceManagement} from "./resourceManagement";
 import {RfsCoordinatorCluster} from "./rfsCoordinatorCluster";
 import {SetupKafka} from "./setupKafka";
@@ -21,6 +22,7 @@ export const AllWorkflowTemplates = [
     MetadataMigration,
     MigrationConsole,
     Replayer,
+    ResetMigration,
     ResourceManagement,
     RfsCoordinatorCluster,
     SetupCapture,

--- a/orchestrationSpecs/packages/migration-workflow-templates/src/workflowTemplates/resetMigration.ts
+++ b/orchestrationSpecs/packages/migration-workflow-templates/src/workflowTemplates/resetMigration.ts
@@ -1,0 +1,187 @@
+import {
+    expr,
+    INTERNAL,
+    selectInputsForRegister,
+    typeToken,
+    WorkflowBuilder
+} from '@opensearch-migrations/argo-workflow-builders';
+import {CommonWorkflowParameters} from "./commonUtils/workflowParameters";
+import {ResourceManagement} from "./resourceManagement";
+
+/**
+ * Workflow Reset: tears down migration resources in dependency order.
+ *
+ * Design principles:
+ *   - Kafka deletion is gated: you cannot delete Kafka unless you also opt in
+ *     to deleting the capture proxy (CapturedTraffic CR).
+ *   - Deletion proceeds in reverse dependency order:
+ *       1. TrafficReplay (replayer depends on proxy + kafka)
+ *       2. SnapshotMigration (depends on DataSnapshot)
+ *       3. DataSnapshot (depends on snapshot data)
+ *       4. CapturedTraffic (proxy — only if includeProxy=true)
+ *       5. Kafka resources (only if includeProxy=true, after proxy is deleted)
+ *   - A ValidatingAdmissionPolicy enforces at the K8s API level that Kafka
+ *     resources cannot be deleted unless they carry a teardown-approval annotation.
+ *     The workflow stamps that annotation only after CapturedTraffic is gone.
+ *   - All deletes use --ignore-not-found so the workflow is idempotent.
+ */
+export const ResetMigration = WorkflowBuilder.create({
+    k8sResourceName: "reset-migration",
+    serviceAccountName: "argo-workflow-executor"
+})
+
+    .addParams(CommonWorkflowParameters)
+
+
+    // ── Step 1: Delete TrafficReplay CRs ─────────────────────────────
+
+    .addTemplate("deleteTrafficReplay", t => t
+        .addRequiredInput("resourceName", typeToken<string>())
+        .addSteps(b => b
+            .addStep("delete", ResourceManagement, "deleteCrd", c =>
+                c.register({
+                    resourceKind: expr.literal("TrafficReplay"),
+                    resourceName: b.inputs.resourceName,
+                })
+            )
+        )
+    )
+
+
+    // ── Step 2: Delete SnapshotMigration CRs ─────────────────────────
+
+    .addTemplate("deleteSnapshotMigration", t => t
+        .addRequiredInput("resourceName", typeToken<string>())
+        .addSteps(b => b
+            .addStep("delete", ResourceManagement, "deleteCrd", c =>
+                c.register({
+                    resourceKind: expr.literal("SnapshotMigration"),
+                    resourceName: b.inputs.resourceName,
+                })
+            )
+        )
+    )
+
+
+    // ── Step 3: Delete DataSnapshot CRs ──────────────────────────────
+
+    .addTemplate("deleteDataSnapshot", t => t
+        .addRequiredInput("resourceName", typeToken<string>())
+        .addSteps(b => b
+            .addStep("delete", ResourceManagement, "deleteCrd", c =>
+                c.register({
+                    resourceKind: expr.literal("DataSnapshot"),
+                    resourceName: b.inputs.resourceName,
+                })
+            )
+        )
+    )
+
+
+    // ── Step 4: Delete CapturedTraffic (proxy) CRs ───────────────────
+
+    .addTemplate("deleteCapturedTraffic", t => t
+        .addRequiredInput("resourceName", typeToken<string>())
+        .addSteps(b => b
+            .addStep("delete", ResourceManagement, "deleteCrd", c =>
+                c.register({
+                    resourceKind: expr.literal("CapturedTraffic"),
+                    resourceName: b.inputs.resourceName,
+                })
+            )
+        )
+    )
+
+
+    // ── Step 5: Approve + delete Kafka resources ─────────────────────
+    // Stamps the teardown-approval annotation on the Kafka cluster,
+    // then deletes topic, node pool, and cluster in order.
+
+    .addTemplate("teardownKafka", t => t
+        .addRequiredInput("kafkaClusterName", typeToken<string>())
+        .addRequiredInput("kafkaTopicName", typeToken<string>())
+        .addRequiredInput("kafkaNodePoolName", typeToken<string>())
+        .addSteps(b => b
+            .addStep("approveKafkaTeardown", ResourceManagement, "patchTeardownApprovalAnnotation", c =>
+                c.register({
+                    resourceApiVersion: expr.literal("kafka.strimzi.io/v1"),
+                    resourceKind: expr.literal("Kafka"),
+                    resourceName: b.inputs.kafkaClusterName,
+                })
+            )
+            .addStep("deleteTopic", ResourceManagement, "deleteKafkaTopic", c =>
+                c.register({
+                    resourceName: b.inputs.kafkaTopicName,
+                })
+            )
+            .addStep("deleteNodePool", ResourceManagement, "deleteKafkaNodePool", c =>
+                c.register({
+                    resourceName: b.inputs.kafkaNodePoolName,
+                })
+            )
+            .addStep("deleteCluster", ResourceManagement, "deleteKafkaCluster", c =>
+                c.register({
+                    resourceName: b.inputs.kafkaClusterName,
+                })
+            )
+        )
+    )
+
+
+    // ── Entrypoint: resetWorkflow ────────────────────────────────────
+    // Orchestrates the full reset in dependency order.
+    //
+    // includeProxy=true  => deletes everything including proxy + kafka
+    // includeProxy=false => deletes only replay + snapshot resources
+
+    .addTemplate("resetWorkflow", t => t
+        .addRequiredInput("trafficReplayName", typeToken<string>())
+        .addRequiredInput("snapshotMigrationName", typeToken<string>())
+        .addRequiredInput("dataSnapshotName", typeToken<string>())
+        .addRequiredInput("capturedTrafficName", typeToken<string>())
+        .addRequiredInput("kafkaClusterName", typeToken<string>())
+        .addRequiredInput("kafkaTopicName", typeToken<string>())
+        .addRequiredInput("kafkaNodePoolName", typeToken<string>())
+        .addRequiredInput("includeProxy", typeToken<boolean>())
+
+        .addSteps(b => b
+            // Phase 1: Delete replayer (depends on proxy + kafka, so goes first)
+            .addStep("deleteReplay", INTERNAL, "deleteTrafficReplay", c =>
+                c.register({
+                    resourceName: b.inputs.trafficReplayName,
+                })
+            )
+            // Phase 2: Delete snapshot-related CRDs (no dependency on proxy)
+            .addStepGroup(g => g
+                .addStep("deleteSnapshotMigration", INTERNAL, "deleteSnapshotMigration", c =>
+                    c.register({
+                        resourceName: b.inputs.snapshotMigrationName,
+                    })
+                )
+                .addStep("deleteDataSnapshot", INTERNAL, "deleteDataSnapshot", c =>
+                    c.register({
+                        resourceName: b.inputs.dataSnapshotName,
+                    })
+                )
+            )
+            // Phase 3: Delete proxy (only if includeProxy=true)
+            .addStep("deleteProxy", INTERNAL, "deleteCapturedTraffic", c =>
+                c.register({
+                    resourceName: b.inputs.capturedTrafficName,
+                }),
+                { when: () => expr.equals(expr.asString(b.inputs.includeProxy), expr.literal("true")) }
+            )
+            // Phase 4: Tear down Kafka (only if includeProxy=true)
+            .addStep("teardownKafka", INTERNAL, "teardownKafka", c =>
+                c.register({
+                    kafkaClusterName: b.inputs.kafkaClusterName,
+                    kafkaTopicName: b.inputs.kafkaTopicName,
+                    kafkaNodePoolName: b.inputs.kafkaNodePoolName,
+                }),
+                { when: () => expr.equals(expr.asString(b.inputs.includeProxy), expr.literal("true")) }
+            )
+        )
+    )
+
+
+    .getFullScope();

--- a/orchestrationSpecs/packages/migration-workflow-templates/src/workflowTemplates/resourceManagement.ts
+++ b/orchestrationSpecs/packages/migration-workflow-templates/src/workflowTemplates/resourceManagement.ts
@@ -351,6 +351,101 @@ export const ResourceManagement = WorkflowBuilder.create({
 
     // ── Workflow UID approval annotation patch ───────────────────────────
 
+    // ── Delete resource templates ──────────────────────────────────────
+
+    .addTemplate("deleteCrd", t => t
+        .addRequiredInput("resourceKind", typeToken<string>())
+        .addRequiredInput("resourceName", typeToken<string>())
+        .addResourceTask(b => b
+            .setDefinition({
+                action: "delete",
+                flags: ["--ignore-not-found"],
+                manifest: {
+                    apiVersion: CRD_API_VERSION,
+                    kind: makeStringTypeProxy(b.inputs.resourceKind),
+                    metadata: { name: b.inputs.resourceName }
+                }
+            }))
+        .addRetryParameters(K8S_RESOURCE_RETRY_STRATEGY)
+    )
+
+
+    .addTemplate("deleteKafkaCluster", t => t
+        .addRequiredInput("resourceName", typeToken<string>())
+        .addResourceTask(b => b
+            .setDefinition({
+                action: "delete",
+                flags: ["--ignore-not-found"],
+                manifest: {
+                    apiVersion: "kafka.strimzi.io/v1",
+                    kind: "Kafka",
+                    metadata: { name: b.inputs.resourceName }
+                }
+            }))
+        .addRetryParameters(K8S_RESOURCE_RETRY_STRATEGY)
+    )
+
+
+    .addTemplate("deleteKafkaTopic", t => t
+        .addRequiredInput("resourceName", typeToken<string>())
+        .addResourceTask(b => b
+            .setDefinition({
+                action: "delete",
+                flags: ["--ignore-not-found"],
+                manifest: {
+                    apiVersion: "kafka.strimzi.io/v1beta2",
+                    kind: "KafkaTopic",
+                    metadata: { name: b.inputs.resourceName }
+                }
+            }))
+        .addRetryParameters(K8S_RESOURCE_RETRY_STRATEGY)
+    )
+
+
+    .addTemplate("deleteKafkaNodePool", t => t
+        .addRequiredInput("resourceName", typeToken<string>())
+        .addResourceTask(b => b
+            .setDefinition({
+                action: "delete",
+                flags: ["--ignore-not-found"],
+                manifest: {
+                    apiVersion: "kafka.strimzi.io/v1",
+                    kind: "KafkaNodePool",
+                    metadata: { name: b.inputs.resourceName }
+                }
+            }))
+        .addRetryParameters(K8S_RESOURCE_RETRY_STRATEGY)
+    )
+
+
+    // ── Teardown approval annotation ────────────────────────────────────
+
+    .addTemplate("patchTeardownApprovalAnnotation", t => t
+        .addRequiredInput("resourceApiVersion", typeToken<string>())
+        .addRequiredInput("resourceKind", typeToken<string>())
+        .addRequiredInput("resourceName", typeToken<string>())
+        .addResourceTask(b => b
+            .setDefinition({
+                action: "patch",
+                flags: ["--type", "merge"],
+                manifest: {
+                    apiVersion: makeStringTypeProxy(b.inputs.resourceApiVersion),
+                    kind: makeStringTypeProxy(b.inputs.resourceKind),
+                    metadata: {
+                        name: b.inputs.resourceName,
+                        annotations: {
+                            "migrations.opensearch.org/approved-for-teardown":
+                                makeStringTypeProxy(expr.getWorkflowValue("uid"))
+                        }
+                    }
+                }
+            }))
+        .addRetryParameters(K8S_RESOURCE_RETRY_STRATEGY)
+    )
+
+
+    // ── Workflow UID approval annotation patch ───────────────────────────
+
     .addTemplate("patchApprovalAnnotation", t => t
         .addRequiredInput("resourceApiVersion", typeToken<string>())
         .addRequiredInput("resourceKind", typeToken<string>())

--- a/orchestrationSpecs/packages/migration-workflow-templates/tests/__snapshots__/resetMigration.snap.json
+++ b/orchestrationSpecs/packages/migration-workflow-templates/tests/__snapshots__/resetMigration.snap.json
@@ -1,0 +1,384 @@
+{
+  "apiVersion": "argoproj.io/v1alpha1",
+  "kind": "WorkflowTemplate",
+  "metadata": {
+    "name": "reset-migration"
+  },
+  "spec": {
+    "serviceAccountName": "argo-workflow-executor",
+    "parallelism": 100,
+    "arguments": {
+      "parameters": [
+        {
+          "name": "s3SnapshotConfigMap",
+          "value": "s3-snapshot-config"
+        },
+        {
+          "name": "imageConfigMapName",
+          "value": "migration-image-config"
+        },
+        {
+          "name": "approvalConfigMapName",
+          "value": "approval-config"
+        }
+      ]
+    },
+    "templates": [
+      {
+        "name": "deletetrafficreplay",
+        "inputs": {
+          "parameters": [
+            {
+              "name": "resourceName"
+            }
+          ]
+        },
+        "steps": [
+          [
+            {
+              "templateRef": {
+                "template": "deletecrd",
+                "name": "resource-management"
+              },
+              "arguments": {
+                "parameters": [
+                  {
+                    "name": "resourceKind",
+                    "value": "TrafficReplay"
+                  },
+                  {
+                    "name": "resourceName",
+                    "value": "{{inputs.parameters.resourceName}}"
+                  }
+                ]
+              },
+              "name": "delete"
+            }
+          ]
+        ],
+        "outputs": {
+          "parameters": []
+        }
+      },
+      {
+        "name": "deletesnapshotmigration",
+        "inputs": {
+          "parameters": [
+            {
+              "name": "resourceName"
+            }
+          ]
+        },
+        "steps": [
+          [
+            {
+              "templateRef": {
+                "template": "deletecrd",
+                "name": "resource-management"
+              },
+              "arguments": {
+                "parameters": [
+                  {
+                    "name": "resourceKind",
+                    "value": "SnapshotMigration"
+                  },
+                  {
+                    "name": "resourceName",
+                    "value": "{{inputs.parameters.resourceName}}"
+                  }
+                ]
+              },
+              "name": "delete"
+            }
+          ]
+        ],
+        "outputs": {
+          "parameters": []
+        }
+      },
+      {
+        "name": "deletedatasnapshot",
+        "inputs": {
+          "parameters": [
+            {
+              "name": "resourceName"
+            }
+          ]
+        },
+        "steps": [
+          [
+            {
+              "templateRef": {
+                "template": "deletecrd",
+                "name": "resource-management"
+              },
+              "arguments": {
+                "parameters": [
+                  {
+                    "name": "resourceKind",
+                    "value": "DataSnapshot"
+                  },
+                  {
+                    "name": "resourceName",
+                    "value": "{{inputs.parameters.resourceName}}"
+                  }
+                ]
+              },
+              "name": "delete"
+            }
+          ]
+        ],
+        "outputs": {
+          "parameters": []
+        }
+      },
+      {
+        "name": "deletecapturedtraffic",
+        "inputs": {
+          "parameters": [
+            {
+              "name": "resourceName"
+            }
+          ]
+        },
+        "steps": [
+          [
+            {
+              "templateRef": {
+                "template": "deletecrd",
+                "name": "resource-management"
+              },
+              "arguments": {
+                "parameters": [
+                  {
+                    "name": "resourceKind",
+                    "value": "CapturedTraffic"
+                  },
+                  {
+                    "name": "resourceName",
+                    "value": "{{inputs.parameters.resourceName}}"
+                  }
+                ]
+              },
+              "name": "delete"
+            }
+          ]
+        ],
+        "outputs": {
+          "parameters": []
+        }
+      },
+      {
+        "name": "teardownkafka",
+        "inputs": {
+          "parameters": [
+            {
+              "name": "kafkaClusterName"
+            },
+            {
+              "name": "kafkaTopicName"
+            },
+            {
+              "name": "kafkaNodePoolName"
+            }
+          ]
+        },
+        "steps": [
+          [
+            {
+              "templateRef": {
+                "template": "patchteardownapprovalannotation",
+                "name": "resource-management"
+              },
+              "arguments": {
+                "parameters": [
+                  {
+                    "name": "resourceApiVersion",
+                    "value": "kafka.strimzi.io/v1"
+                  },
+                  {
+                    "name": "resourceKind",
+                    "value": "Kafka"
+                  },
+                  {
+                    "name": "resourceName",
+                    "value": "{{inputs.parameters.kafkaClusterName}}"
+                  }
+                ]
+              },
+              "name": "approveKafkaTeardown"
+            }
+          ],
+          [
+            {
+              "templateRef": {
+                "template": "deletekafkatopic",
+                "name": "resource-management"
+              },
+              "arguments": {
+                "parameters": [
+                  {
+                    "name": "resourceName",
+                    "value": "{{inputs.parameters.kafkaTopicName}}"
+                  }
+                ]
+              },
+              "name": "deleteTopic"
+            }
+          ],
+          [
+            {
+              "templateRef": {
+                "template": "deletekafkanodepool",
+                "name": "resource-management"
+              },
+              "arguments": {
+                "parameters": [
+                  {
+                    "name": "resourceName",
+                    "value": "{{inputs.parameters.kafkaNodePoolName}}"
+                  }
+                ]
+              },
+              "name": "deleteNodePool"
+            }
+          ],
+          [
+            {
+              "templateRef": {
+                "template": "deletekafkacluster",
+                "name": "resource-management"
+              },
+              "arguments": {
+                "parameters": [
+                  {
+                    "name": "resourceName",
+                    "value": "{{inputs.parameters.kafkaClusterName}}"
+                  }
+                ]
+              },
+              "name": "deleteCluster"
+            }
+          ]
+        ],
+        "outputs": {
+          "parameters": []
+        }
+      },
+      {
+        "name": "resetworkflow",
+        "inputs": {
+          "parameters": [
+            {
+              "name": "trafficReplayName"
+            },
+            {
+              "name": "snapshotMigrationName"
+            },
+            {
+              "name": "dataSnapshotName"
+            },
+            {
+              "name": "capturedTrafficName"
+            },
+            {
+              "name": "kafkaClusterName"
+            },
+            {
+              "name": "kafkaTopicName"
+            },
+            {
+              "name": "kafkaNodePoolName"
+            },
+            {
+              "name": "includeProxy"
+            }
+          ]
+        },
+        "steps": [
+          [
+            {
+              "template": "deletetrafficreplay",
+              "arguments": {
+                "parameters": [
+                  {
+                    "name": "resourceName",
+                    "value": "{{inputs.parameters.trafficReplayName}}"
+                  }
+                ]
+              },
+              "name": "deleteReplay"
+            }
+          ],
+          [
+            {
+              "template": "deletesnapshotmigration",
+              "arguments": {
+                "parameters": [
+                  {
+                    "name": "resourceName",
+                    "value": "{{inputs.parameters.snapshotMigrationName}}"
+                  }
+                ]
+              },
+              "name": "deleteSnapshotMigration"
+            },
+            {
+              "template": "deletedatasnapshot",
+              "arguments": {
+                "parameters": [
+                  {
+                    "name": "resourceName",
+                    "value": "{{inputs.parameters.dataSnapshotName}}"
+                  }
+                ]
+              },
+              "name": "deleteDataSnapshot"
+            }
+          ],
+          [
+            {
+              "template": "deletecapturedtraffic",
+              "when": "{{inputs.parameters.includeProxy}} == 'true",
+              "arguments": {
+                "parameters": [
+                  {
+                    "name": "resourceName",
+                    "value": "{{inputs.parameters.capturedTrafficName}}"
+                  }
+                ]
+              },
+              "name": "deleteProxy"
+            }
+          ],
+          [
+            {
+              "template": "teardownkafka",
+              "when": "{{inputs.parameters.includeProxy}} == 'true",
+              "arguments": {
+                "parameters": [
+                  {
+                    "name": "kafkaClusterName",
+                    "value": "{{inputs.parameters.kafkaClusterName}}"
+                  },
+                  {
+                    "name": "kafkaTopicName",
+                    "value": "{{inputs.parameters.kafkaTopicName}}"
+                  },
+                  {
+                    "name": "kafkaNodePoolName",
+                    "value": "{{inputs.parameters.kafkaNodePoolName}}"
+                  }
+                ]
+              },
+              "name": "teardownKafka"
+            }
+          ]
+        ],
+        "outputs": {
+          "parameters": []
+        }
+      }
+    ]
+  }
+}

--- a/orchestrationSpecs/packages/migration-workflow-templates/tests/__snapshots__/resourceManagement.snap.json
+++ b/orchestrationSpecs/packages/migration-workflow-templates/tests/__snapshots__/resourceManagement.snap.json
@@ -668,6 +668,161 @@
         }
       },
       {
+        "name": "deletecrd",
+        "inputs": {
+          "parameters": [
+            {
+              "name": "resourceKind"
+            },
+            {
+              "name": "resourceName"
+            }
+          ]
+        },
+        "resource": {
+          "manifest": "apiVersion: migrations.opensearch.org/v1alpha1\nkind: \"{{inputs.parameters.resourceKind}}\"\nmetadata:\n  name: \"{{inputs.parameters.resourceName}}\"\n",
+          "action": "delete",
+          "flags": [
+            "--ignore-not-found"
+          ]
+        },
+        "retryStrategy": {
+          "limit": "6",
+          "retryPolicy": "OnError",
+          "backoff": {
+            "duration": "10",
+            "factor": "2",
+            "cap": "60"
+          }
+        },
+        "outputs": {
+          "parameters": []
+        }
+      },
+      {
+        "name": "deletekafkacluster",
+        "inputs": {
+          "parameters": [
+            {
+              "name": "resourceName"
+            }
+          ]
+        },
+        "resource": {
+          "manifest": "apiVersion: kafka.strimzi.io/v1\nkind: Kafka\nmetadata:\n  name: \"{{inputs.parameters.resourceName}}\"\n",
+          "action": "delete",
+          "flags": [
+            "--ignore-not-found"
+          ]
+        },
+        "retryStrategy": {
+          "limit": "6",
+          "retryPolicy": "OnError",
+          "backoff": {
+            "duration": "10",
+            "factor": "2",
+            "cap": "60"
+          }
+        },
+        "outputs": {
+          "parameters": []
+        }
+      },
+      {
+        "name": "deletekafkatopic",
+        "inputs": {
+          "parameters": [
+            {
+              "name": "resourceName"
+            }
+          ]
+        },
+        "resource": {
+          "manifest": "apiVersion: kafka.strimzi.io/v1beta2\nkind: KafkaTopic\nmetadata:\n  name: \"{{inputs.parameters.resourceName}}\"\n",
+          "action": "delete",
+          "flags": [
+            "--ignore-not-found"
+          ]
+        },
+        "retryStrategy": {
+          "limit": "6",
+          "retryPolicy": "OnError",
+          "backoff": {
+            "duration": "10",
+            "factor": "2",
+            "cap": "60"
+          }
+        },
+        "outputs": {
+          "parameters": []
+        }
+      },
+      {
+        "name": "deletekafkanodepool",
+        "inputs": {
+          "parameters": [
+            {
+              "name": "resourceName"
+            }
+          ]
+        },
+        "resource": {
+          "manifest": "apiVersion: kafka.strimzi.io/v1\nkind: KafkaNodePool\nmetadata:\n  name: \"{{inputs.parameters.resourceName}}\"\n",
+          "action": "delete",
+          "flags": [
+            "--ignore-not-found"
+          ]
+        },
+        "retryStrategy": {
+          "limit": "6",
+          "retryPolicy": "OnError",
+          "backoff": {
+            "duration": "10",
+            "factor": "2",
+            "cap": "60"
+          }
+        },
+        "outputs": {
+          "parameters": []
+        }
+      },
+      {
+        "name": "patchteardownapprovalannotation",
+        "inputs": {
+          "parameters": [
+            {
+              "name": "resourceApiVersion"
+            },
+            {
+              "name": "resourceKind"
+            },
+            {
+              "name": "resourceName"
+            }
+          ]
+        },
+        "resource": {
+          "manifest": "apiVersion: \"{{inputs.parameters.resourceApiVersion}}\"\nkind: \"{{inputs.parameters.resourceKind}}\"\nmetadata:\n  name: \"{{inputs.parameters.resourceName}}\"\n  annotations:\n    migrations.opensearch.org/approved-for-teardown: \"{{workflow.uid}}\"\n",
+          "action": "patch",
+          "flags": [
+            "--type",
+            "merge"
+          ]
+        },
+        "retryStrategy": {
+          "limit": "6",
+          "retryPolicy": "OnError",
+          "backoff": {
+            "duration": "10",
+            "factor": "2",
+            "cap": "60"
+          }
+        },
+        "outputs": {
+          "parameters": []
+        }
+      },
+      {
         "name": "patchapprovalannotation",
         "inputs": {
           "parameters": [


### PR DESCRIPTION
## Summary

Introduces a `ResetMigration` workflow that tears down migration CRDs in dependency order with a two-level safety gate for Kafka infrastructure deletion.

### Design

This PR adopts the ValidatingAdmissionPolicy (VAP) patterns established in #2447 to implement a clean workflow reset capability (the core concept from #2462, reimplemented fresh on main).

**Key principle: You cannot delete Kafka unless you explicitly opt into deleting the proxy.**

Kafka is the infrastructure backbone for traffic capture. Deleting it without also tearing down the capture proxy leaves the system in a broken state. This PR enforces that invariant at two independent levels.

### Two-level Kafka deletion gate

1. **Workflow level**: The `resetAll` template only executes Kafka + CapturedTraffic (proxy) deletion steps when `includeProxies=true`. With `includeProxies=false`, only TrafficReplay, SnapshotMigration, and DataSnapshot CRDs are deleted.

2. **K8s API level**: A new `ValidatingAdmissionPolicy` on DELETE operations for `kafka.strimzi.io/kafkas` requires the annotation `migrations.opensearch.org/proxy-teardown-approved=true`. The workflow stamps this annotation only when `includeProxies=true`. This prevents any external tool (kubectl, other workflows, etc.) from deleting Kafka without acknowledging proxy teardown.

### Deletion order

Sequential, respecting dependency hierarchy (children before parents):

```
TrafficReplay → SnapshotMigration → DataSnapshot
  → (gate: includeProxies=true) approve Kafka annotation + delete Kafka
  → CapturedTraffic
```

Each step is skipped if its resource name parameter is empty (not all resources may exist in every deployment).

### New templates

**In `resourceManagement.ts`:**
- `deleteCrd` — generic CRD deletion with `--ignore-not-found` and retry strategy
- `getResourceUid` — read resource UID and phase via jsonPath output (for future use)
- `patchKafkaTeardownApproval` — merge-patch the teardown approval annotation onto a Kafka CR

**In `resetMigration.ts`:**
- `deleteTrafficReplay`, `deleteSnapshotMigration`, `deleteDataSnapshot`, `deleteCapturedTraffic` — typed wrappers around `deleteCrd`
- `approveAndDeleteKafka` — stamps annotation then deletes (two-step)
- `resetAll` — orchestrator with `when` conditions gating each step

**In `validatingAdmissionPolicies.yaml`:**
- `kafka-teardown-gate-policy` + binding — blocks DELETE on `kafka.strimzi.io/kafkas` unless annotation present

### What this does NOT include

- No partial proxy-only teardown (proxy without Kafka is meaningless)
- No `waitForCrdDeletion` — K8s foreground propagation via ownerReferences handles cascading
- No CLI `reset.py` script (that can be added separately)
- No changes to existing workflow behavior

### Testing

All 14 test suites pass (136 tests, 14 snapshots). New snapshot `resetMigration.snap.json` validates the generated Argo workflow YAML.

### Related

- #2447 — VAP infrastructure (merged, patterns adopted here)
- #2462 — Original workflow reset PR (not merged, this is a clean reimplementation)