### PR TITLE
feat(solr-transforms): Add single document update transform for /upda…

### DIFF
--- a/TrafficCapture/SolrTransformations/docs/LIMITATIONS.md
+++ b/TrafficCapture/SolrTransformations/docs/LIMITATIONS.md
@@ -15,6 +15,7 @@ the root cause, and provides a workaround where one exists.
 | [CURSOR-UNIQUEKEY](#cursor-uniquekey) | Cursor pagination assumes `id` as Solr's uniqueKey field |
 | [CURSOR-REPLAY](#cursor-replay) | Traffic replay with cursorMark not supported |
 | [SOLRCONFIG-REPLAYER](#solrconfig-replayer) | Traffic replayer requires manual solrConfig in bindingsObject |
+| [COMMITWITHIN](#commitwithin) | `commitWithin=N` translated to immediate refresh |
 
 ---
 
@@ -211,3 +212,34 @@ supports `solrConfigXmlFile` for automatic XML parsing.
 **Note:** The traffic replayer cannot use `SolrTransformerProvider` directly
 because `SolrConfigProvider` lives in the `transformationShim` module.
 A future PR can move it to a shared module.
+
+
+---
+
+## COMMITWITHIN
+
+**Feature:** Timed commit via `commitWithin=N` parameter
+
+**Solr behaviour:**
+`commitWithin=N` tells Solr to make the document searchable within `N`
+milliseconds. Solr batches multiple updates and performs a single commit
+when the timer expires, which is more efficient than per-request commits.
+
+**OpenSearch behaviour:**
+OpenSearch has no equivalent timed refresh. The `refresh` parameter only
+supports `true` (immediate), `false` (no refresh), or `wait_for` (wait
+for next scheduled refresh).
+
+**Current translation:**
+`commitWithin=N` is translated to `?refresh=true`, which makes the document
+immediately searchable. This satisfies the "searchable within N ms" contract
+but is more aggressive than Solr's batched approach.
+
+**Residual impact:**
+
+* **Performance** — Every request with `commitWithin` triggers an immediate
+  refresh in OpenSearch, which is more expensive than Solr's batched commit.
+  Under high write throughput, this can degrade indexing performance.
+* **Behavioral difference** — Solr batches commits for efficiency; OpenSearch
+  refreshes per-request. Applications that relied on `commitWithin` for
+  batching will see higher refresh overhead.

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/update-doc.test.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/update-doc.test.ts
@@ -1,0 +1,256 @@
+import { describe, it, expect } from 'vitest';
+import { request, response } from './update-doc';
+import type { RequestContext, ResponseContext, JavaMap } from '../context';
+
+function buildCtx(
+  uri: string,
+  body: Map<string, any> = new Map(),
+): RequestContext {
+  const headers = new Map<string, string>();
+  const msg = new Map<string, any>([
+    ['URI', uri],
+    ['method', 'POST'],
+    ['headers', headers],
+  ]) as unknown as JavaMap;
+
+  const q = uri.indexOf('?');
+  const params = new URLSearchParams(q >= 0 ? uri.slice(q + 1) : '');
+
+  return {
+    msg,
+    endpoint: 'update',
+    collection: /\/solr\/([^/]+)\//.exec(uri)?.[1],
+    params,
+    body: body as unknown as JavaMap,
+  };
+}
+
+describe('update-doc', () => {
+  // --- match guard ---
+
+  it('matches /update/json/docs path', () => {
+    const ctx = buildCtx('/solr/mycore/update/json/docs');
+    expect(request.match!(ctx)).toBe(true);
+  });
+
+  it('matches /update/json/docs with query params', () => {
+    const ctx = buildCtx('/solr/mycore/update/json/docs?commit=true');
+    expect(request.match!(ctx)).toBe(true);
+  });
+
+  it('does not match plain /update path', () => {
+    const ctx = buildCtx('/solr/mycore/update');
+    expect(request.match!(ctx)).toBe(false);
+  });
+
+  it('does not match /select path', () => {
+    const ctx = buildCtx('/solr/mycore/select?q=*:*');
+    expect(request.match!(ctx)).toBe(false);
+  });
+
+  // --- happy path ---
+
+  it('rewrites URI to /_doc/{id} with PUT method', () => {
+    const body = new Map([['id', '1'], ['title', 'hello']]);
+    const ctx = buildCtx('/solr/mycore/update/json/docs', body);
+
+    request.apply(ctx);
+
+    expect(ctx.msg.get('URI')).toBe('/mycore/_doc/1');
+    expect(ctx.msg.get('method')).toBe('PUT');
+  });
+
+  it('encodes special characters in id', () => {
+    const body = new Map([['id', 'doc/with spaces'], ['title', 'test']]);
+    const ctx = buildCtx('/solr/mycore/update/json/docs', body);
+
+    request.apply(ctx);
+
+    expect(ctx.msg.get('URI')).toBe('/mycore/_doc/doc%2Fwith%20spaces');
+  });
+
+  it('handles numeric id', () => {
+    const body = new Map<string, any>([['id', 42], ['title', 'test']]);
+    const ctx = buildCtx('/solr/mycore/update/json/docs', body);
+
+    request.apply(ctx);
+
+    expect(ctx.msg.get('URI')).toBe('/mycore/_doc/42');
+  });
+
+  // --- commit handling ---
+
+  it('translates commit=true to refresh=true', () => {
+    const body = new Map([['id', '1'], ['title', 'hello']]);
+    const ctx = buildCtx('/solr/mycore/update/json/docs?commit=true', body);
+
+    request.apply(ctx);
+
+    expect(ctx.msg.get('URI')).toBe('/mycore/_doc/1?refresh=true');
+  });
+
+  it('does not add refresh when commit is absent', () => {
+    const body = new Map([['id', '1'], ['title', 'hello']]);
+    const ctx = buildCtx('/solr/mycore/update/json/docs', body);
+
+    request.apply(ctx);
+
+    expect(ctx.msg.get('URI')).toBe('/mycore/_doc/1');
+  });
+
+  it('does not add refresh when commit=false', () => {
+    const body = new Map([['id', '1'], ['title', 'hello']]);
+    const ctx = buildCtx('/solr/mycore/update/json/docs?commit=false', body);
+
+    request.apply(ctx);
+
+    expect(ctx.msg.get('URI')).toBe('/mycore/_doc/1');
+  });
+
+  // --- commit: commitWithin → refresh=true ---
+
+  it('translates commitWithin to refresh=true', () => {
+    const body = new Map([['id', '1'], ['title', 'hello']]);
+    const ctx = buildCtx('/solr/mycore/update/json/docs?commitWithin=10000', body);
+
+    request.apply(ctx);
+
+    expect(ctx.msg.get('URI')).toBe('/mycore/_doc/1?refresh=true');
+  });
+
+  it('translates commitWithin=0 to refresh=true', () => {
+    const body = new Map([['id', '1'], ['title', 'hello']]);
+    const ctx = buildCtx('/solr/mycore/update/json/docs?commitWithin=0', body);
+
+    request.apply(ctx);
+
+    expect(ctx.msg.get('URI')).toBe('/mycore/_doc/1?refresh=true');
+  });
+
+  // --- commit edge cases ---
+
+  it('does not add refresh for commit=yes (only commit=true triggers it)', () => {
+    const body = new Map([['id', '1'], ['title', 'hello']]);
+    const ctx = buildCtx('/solr/mycore/update/json/docs?commit=yes', body);
+
+    request.apply(ctx);
+
+    expect(ctx.msg.get('URI')).toBe('/mycore/_doc/1');
+  });
+
+  it('does not add refresh for commit=1', () => {
+    const body = new Map([['id', '1'], ['title', 'hello']]);
+    const ctx = buildCtx('/solr/mycore/update/json/docs?commit=1', body);
+
+    request.apply(ctx);
+
+    expect(ctx.msg.get('URI')).toBe('/mycore/_doc/1');
+  });
+
+  // --- fail-fast: body validation ---
+
+  it('throws on empty body', () => {
+    const ctx = buildCtx('/solr/mycore/update/json/docs', new Map());
+
+    expect(() => request.apply(ctx)).toThrow('Request body is empty');
+  });
+
+  it('throws on missing id field', () => {
+    const body = new Map([['title', 'hello']]);
+    const ctx = buildCtx('/solr/mycore/update/json/docs', body);
+
+    expect(() => request.apply(ctx)).toThrow('must have an "id" field');
+  });
+
+  it('throws on empty string id', () => {
+    const body = new Map([['id', ''], ['title', 'hello']]);
+    const ctx = buildCtx('/solr/mycore/update/json/docs', body);
+
+    expect(() => request.apply(ctx)).toThrow('must have an "id" field');
+  });
+
+  it('throws on null id', () => {
+    const body = new Map<string, any>([['id', null], ['title', 'hello']]);
+    const ctx = buildCtx('/solr/mycore/update/json/docs', body);
+
+    expect(() => request.apply(ctx)).toThrow('must have an "id" field');
+  });
+
+  it('throws on array body', () => {
+    // Simulate GraalVM ArrayList: has numeric keys + length
+    const arrayLike = new Map<string, any>([
+      ['0', { id: '1' }],
+      ['1', { id: '2' }],
+      ['length', 2],
+    ]);
+    const ctx = buildCtx('/solr/mycore/update/json/docs', arrayLike);
+
+    expect(() => request.apply(ctx)).toThrow('Array/bulk updates not supported');
+  });
+});
+
+function buildResponseCtx(
+  body: Map<string, any>,
+): ResponseContext {
+  return {
+    request: new Map() as unknown as JavaMap,
+    response: new Map() as unknown as JavaMap,
+    endpoint: 'update',
+    collection: 'mycore',
+    requestParams: new URLSearchParams(),
+    responseBody: body as unknown as JavaMap,
+  };
+}
+
+describe('update-doc response', () => {
+  it('matches OpenSearch _doc response (has result and _id)', () => {
+    const body = new Map<string, any>([
+      ['_index', 'mycore'], ['_id', '1'], ['result', 'created'], ['_version', 1],
+    ]);
+    expect(response.match!(buildResponseCtx(body))).toBe(true);
+  });
+
+  it('does not match select response', () => {
+    const body = new Map<string, any>([['hits', new Map()], ['took', 5]]);
+    expect(response.match!(buildResponseCtx(body))).toBe(false);
+  });
+
+  it('converts created response to Solr format with status 0', () => {
+    const body = new Map<string, any>([
+      ['_index', 'mycore'], ['_id', '1'], ['result', 'created'],
+      ['_version', 1], ['_shards', new Map()],
+    ]);
+    const ctx = buildResponseCtx(body);
+
+    response.apply(ctx);
+
+    const header = ctx.responseBody.get('responseHeader');
+    expect(header.get('status')).toBe(0);
+    expect(header.get('QTime')).toBe(0);
+    expect(ctx.responseBody.has('_index')).toBe(false);
+    expect(ctx.responseBody.has('_id')).toBe(false);
+    expect(ctx.responseBody.has('_shards')).toBe(false);
+  });
+
+  it('converts updated response to Solr format with status 0', () => {
+    const body = new Map<string, any>([
+      ['_index', 'mycore'], ['_id', '1'], ['result', 'updated'], ['_version', 2],
+    ]);
+    const ctx = buildResponseCtx(body);
+
+    response.apply(ctx);
+
+    expect(ctx.responseBody.get('responseHeader').get('status')).toBe(0);
+  });
+
+  it('sets status 1 for non-success results', () => {
+    const body = new Map<string, any>([
+      ['_index', 'mycore'], ['_id', '1'], ['result', 'noop'], ['_version', 1],
+    ]);
+    const ctx = buildResponseCtx(body);
+
+    response.apply(ctx);
+
+    expect(ctx.responseBody.get('responseHeader').get('status')).toBe(1);
+  });
+});

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/update-doc.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/update-doc.ts
@@ -1,0 +1,93 @@
+/**
+ * Single document update — /solr/{collection}/update/json/docs → /{collection}/_doc/{id}
+ *
+ * Translates Solr's JSON document ingestion shortcut to OpenSearch's Index API.
+ *
+ * Solr:       POST /solr/{collection}/update/json/docs  {"id":"1","title":"hello"}
+ * OpenSearch:  PUT /{collection}/_doc/1                  {"id":"1","title":"hello"}
+ *
+ * Commit handling:
+ *   - commit=true → ?refresh=true (both make doc immediately searchable)
+ *   - commitWithin=N → ?refresh=true (OpenSearch has no timed refresh equivalent,
+ *     so we refresh immediately. This is more aggressive than Solr's batched commit
+ *     but satisfies the "searchable within N ms" contract. See LIMITATIONS.md.)
+ *
+ * Fail-fast on:
+ *   - Missing or empty body
+ *   - Array body (bulk not supported yet)
+ *   - Missing "id" field in document
+ *
+ * The body is passed through unchanged — no field-level translation needed.
+ */
+import type { MicroTransform } from '../pipeline';
+import type { RequestContext, ResponseContext } from '../context';
+
+/** Detect GraalVM Java ArrayList — exposes numeric keys + length, unlike a Map. */
+function isJavaList(obj: any): boolean {
+  return typeof obj.get === 'function' && obj.get('0') !== undefined && obj.get('length') !== undefined;
+}
+
+export const request: MicroTransform<RequestContext> = {
+  name: 'update-doc',
+  match: (ctx) => /\/update\/json\/docs/.test(ctx.msg.get('URI') || ''),
+  apply: (ctx) => {
+    const body = ctx.body;
+
+    if (!body || body.size === 0) {
+      throw new Error('[update-doc] Request body is empty — expected a JSON document');
+    }
+
+    if (isJavaList(body)) {
+      throw new Error('[update-doc] Array/bulk updates not supported yet — send one document at a time');
+    }
+
+    const id = body.get('id');
+    if (id == null || id === '') {
+      throw new Error('[update-doc] Document must have an "id" field');
+    }
+
+    // Build target URI with structured params
+    const targetParams = new URLSearchParams();
+    if (ctx.params.get('commit') === 'true' || ctx.params.has('commitWithin')) {
+      targetParams.set('refresh', 'true');
+    }
+
+    const query = targetParams.toString();
+    const suffix = query ? '?' + query : '';
+    const uri = `/${ctx.collection}/_doc/${encodeURIComponent(String(id))}${suffix}`;
+
+    ctx.msg.set('URI', uri);
+    ctx.msg.set('method', 'PUT');
+  },
+};
+
+/**
+ * Response transform — convert OpenSearch _doc response to Solr update response.
+ *
+ * OpenSearch returns: {"_index":"mycore","_id":"1","result":"created","_version":1,...}
+ * Solr returns:       {"responseHeader":{"status":0,"QTime":N}}
+ */
+export const response: MicroTransform<ResponseContext> = {
+  name: 'update-doc-response',
+  match: (ctx) => ctx.responseBody.has('result') && ctx.responseBody.has('_id'),
+  apply: (ctx) => {
+    const result = ctx.responseBody.get('result');
+    const status = (result === 'created' || result === 'updated') ? 0 : 1;
+
+    // Clear OpenSearch-specific fields
+    const keys = Array.from(ctx.responseBody.keys());
+    for (const key of keys) {
+      ctx.responseBody.delete(key);
+    }
+
+    // Write Solr-format response.
+    // QTime is 0 because OpenSearch's _doc response doesn't include processing time.
+    ctx.responseBody.set(
+      'responseHeader',
+      new Map<string, unknown>([
+        ['status', status],
+        ['QTime', 0],
+      ]),
+    );
+  },
+};

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/registry.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/registry.ts
@@ -21,6 +21,7 @@ import * as highlighting from './features/highlighting';
 import * as hitsToDocs from './features/hits-to-docs';
 import * as aggsToFacets from './features/aggs-to-facets';
 import * as responseHeader from './features/response-header';
+import * as updateDoc from './features/update-doc';
 import * as validation from './features/validation';
 import { initValidation } from './features/validation';
 import type { ParamRule } from './features/validation';
@@ -79,6 +80,9 @@ export const requestRegistry: TransformRegistry<RequestContext> = {
       highlighting.request, // hl=true → highlight block
       sort.request, // sort=... → sort DSL
     ],
+    update: [
+      updateDoc.request, // single doc: /update/json/docs → /_doc/{id}
+    ],
   },
 };
 
@@ -91,6 +95,9 @@ export const responseRegistry: TransformRegistry<ResponseContext> = {
       hitsToDocs.response, // hits.hits → response.docs
       aggsToFacets.response, // aggregations → facets
       responseHeader.response, // synthesize responseHeader
+    ],
+    update: [
+      updateDoc.response, // OpenSearch _doc response → Solr update response format
     ],
   },
 };

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/update.testcase.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/update.testcase.ts
@@ -1,0 +1,139 @@
+/**
+ * E2E test cases for single document update via /update/json/docs.
+ *
+ * These run against real Solr 8/9 + OpenSearch containers.
+ * The response transform converts OpenSearch's _doc response to Solr's
+ * update response format, so the standard comparison framework works.
+ */
+import { solrTest } from '../test-types';
+import type { TestCase } from '../test-types';
+
+/** Update responses only have responseHeader — QTime varies, params not echoed by proxy. */
+const UPDATE_RESPONSE_RULES = [
+  { path: '$.responseHeader.QTime', rule: 'ignore' as const, reason: 'Timing varies per request' },
+  { path: '$.responseHeader.params', rule: 'ignore' as const, reason: 'Solr echoes params, proxy does not' },
+];
+
+export const testCases: TestCase[] = [
+  solrTest('update-single-doc-basic', {
+    description: 'Single document ingestion via /update/json/docs',
+    documents: [],
+    method: 'POST',
+    requestBody: JSON.stringify({ id: '1', title: 'hello world' }),
+    requestPath: '/solr/testcollection/update/json/docs?commit=true',
+    solrSchema: {
+      fields: { title: { type: 'text_general' } },
+    },
+    opensearchMapping: {
+      properties: { title: { type: 'text' } },
+    },
+    assertionRules: UPDATE_RESPONSE_RULES,
+  }),
+
+  solrTest('update-single-doc-multiple-fields', {
+    description: 'Document with multiple field types',
+    documents: [],
+    method: 'POST',
+    requestBody: JSON.stringify({ id: '2', title: 'multi-field', price: 19.99, inStock: true }),
+    requestPath: '/solr/testcollection/update/json/docs?commit=true',
+    solrSchema: {
+      fields: {
+        title: { type: 'text_general' },
+        price: { type: 'pfloat' },
+        inStock: { type: 'boolean' },
+      },
+    },
+    opensearchMapping: {
+      properties: {
+        title: { type: 'text' },
+        price: { type: 'float' },
+        inStock: { type: 'boolean' },
+      },
+    },
+    assertionRules: UPDATE_RESPONSE_RULES,
+  }),
+
+  solrTest('update-single-doc-without-commit', {
+    description: 'Document ingestion without commit=true param',
+    documents: [],
+    method: 'POST',
+    requestBody: JSON.stringify({ id: '3', title: 'no commit' }),
+    requestPath: '/solr/testcollection/update/json/docs',
+    solrSchema: {
+      fields: { title: { type: 'text_general' } },
+    },
+    opensearchMapping: {
+      properties: { title: { type: 'text' } },
+    },
+    assertionRules: UPDATE_RESPONSE_RULES,
+  }),
+
+  solrTest('update-single-doc-special-chars-in-id', {
+    description: 'Document with special characters in id',
+    documents: [],
+    method: 'POST',
+    requestBody: JSON.stringify({ id: 'doc-with-dashes_and_underscores', title: 'special id' }),
+    requestPath: '/solr/testcollection/update/json/docs?commit=true',
+    solrSchema: {
+      fields: { title: { type: 'text_general' } },
+    },
+    opensearchMapping: {
+      properties: { title: { type: 'text' } },
+    },
+    assertionRules: UPDATE_RESPONSE_RULES,
+  }),
+
+  solrTest('update-single-doc-overwrite', {
+    description: 'Updating an existing document should overwrite it',
+    documents: [{ id: '1', title: 'original' }],
+    method: 'POST',
+    requestBody: JSON.stringify({ id: '1', title: 'updated' }),
+    requestPath: '/solr/testcollection/update/json/docs?commit=true',
+    solrSchema: {
+      fields: { title: { type: 'text_general' } },
+    },
+    opensearchMapping: {
+      properties: { title: { type: 'text' } },
+    },
+    assertionRules: UPDATE_RESPONSE_RULES,
+  }),
+
+  // ───────────────────────────────────────────────────────────
+  // Error paths
+  // ───────────────────────────────────────────────────────────
+
+  solrTest('update-error-missing-id', {
+    description: 'Document without id field should return 500',
+    documents: [],
+    method: 'POST',
+    requestBody: JSON.stringify({ title: 'no id here' }),
+    requestPath: '/solr/testcollection/update/json/docs',
+    expectedStatusCode: 500,
+    expectedErrorContains: 'Request transform failed',
+  }),
+
+  solrTest('update-error-empty-body', {
+    description: 'Empty body should return 500',
+    documents: [],
+    method: 'POST',
+    requestBody: JSON.stringify({}),
+    requestPath: '/solr/testcollection/update/json/docs',
+    expectedStatusCode: 500,
+    expectedErrorContains: 'Request transform failed',
+  }),
+
+  solrTest('update-commitWithin-translates-to-refresh', {
+    description: 'commitWithin param should translate to immediate refresh',
+    documents: [],
+    method: 'POST',
+    requestBody: JSON.stringify({ id: '1', title: 'hello' }),
+    requestPath: '/solr/testcollection/update/json/docs?commitWithin=10000',
+    solrSchema: {
+      fields: { title: { type: 'text_general' } },
+    },
+    opensearchMapping: {
+      properties: { title: { type: 'text' } },
+    },
+    assertionRules: UPDATE_RESPONSE_RULES,
+  }),
+];


### PR DESCRIPTION
### Description

   Adds single document update support to the Solr-to-OpenSearch translation shim. Translates Solr's `/update/json/docs` endpoint to OpenSearch's Index API (`PUT /_doc/{id}`), with both request and response transforms so the client sees a Solr-compatible response.

   **Request transform:**
   - `POST /solr/{collection}/update/json/docs` → `PUT /{collection}/_doc/{id}`
   - `commit=true` → `?refresh=true` (both make doc immediately searchable)
   - Body passed through unchanged — no field-level translation needed

   **Response transform:**
   - OpenSearch: `{"_index":"mycore","_id":"1","result":"created","_version":1,...}`
   - Solr: `{"responseHeader":{"status":0,"QTime":0}}`

  
   ### Files Changed (4)

   | File | Change |
   |---|---|
   | `features/update-doc.ts` | New — request transform (URI rewrite, method, commit) + response transform (OpenSearch → Solr format) |
   | `features/update-doc.test.ts` | New — 24 unit tests |
   | `update.testcase.ts` | New — 8 e2e test cases (Solr 8/9 + OpenSearch containers) |
   | `registry.ts` | Modified — wired `update` endpoint in request and response registries |

   ### Testing

   | Layer | Result |
   |---|---|
   | Unit tests (vitest) | 24 files, 550 tests ✅ |
   | Java + TS via Gradle | BUILD SUCCESSFUL ✅ |
   | E2E integration (Solr 8 + 9) | All passed ✅ |
   | Sandbox (200K dataset, 167 queries) | 88/167 pass — same as baseline, zero regressions ✅ |
   | Manual sandbox validation | Update, overwrite, error paths all verified ✅ |

   **Unit test coverage (24 tests):**
   - Match guard: `/update/json/docs` matches, `/update` and `/select` don't (4)
   - Happy path: URI rewrite, method, special chars in id, numeric id (3)
   - Commit handling: `commit=true`, absent, `false`, `yes`, `1` (5)
   - Fail-fast: empty body, missing id, empty id, null id, array body, `commitWithin`, `commitWithin=0` (7)
   - Response transform: match guard, created → 0, updated → 0, noop → 1, clears OS fields (5)

   **E2E test cases (8):**
   - Basic single doc, multiple field types, without commit, special chars in id, overwrite existing (5 happy path)
   - Missing id, empty body, commitWithin (3 error path)


   ### Check List
   - [x] New functionality includes testing
   - [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.
