### PR TITLE
feat(solr-transforms): Add JSON request body format support for Solr to OpenSearch migration

### DIFF
--- a/TrafficCapture/SolrTransformations/docs/LIMITATIONS.md
+++ b/TrafficCapture/SolrTransformations/docs/LIMITATIONS.md
@@ -19,6 +19,8 @@ the root cause, and provides a workaround where one exists.
 | [COMMITWITHIN](#commitwithin)                   | `commitWithin=N` translated to immediate refresh |
 | [FQ-LOCAL-PARAMS](#filter-queries-local-params) | Filter query local params (`cache`, `cost`) and post filters not supported |
 | [FQ-CACHING](#fq-caching)                       | Filter query caching granularity differs between Solr and OpenSearch |
+| [JSON-QUERIES](#json-queries)                   | JSON Request API `queries` key not supported |
+| [JSON-PARAM-PREFIX](#json-param-prefix)         | JSON Request API `json.<param>` prefix passthrough not supported |
 
 ---
 
@@ -410,3 +412,52 @@ internal heuristics.
   OpenSearch caches warm up through live traffic.
 * **Potential performance variance** — Workloads relying heavily on repeated
   `fq` reuse may observe different latency characteristics after migration.
+
+---
+
+---
+
+## JSON-QUERIES
+
+**Feature:** Named sub-queries via `queries` key in JSON Request API
+
+**Solr behaviour:**
+The JSON Request API supports a `queries` key for defining named sub-queries
+that can be referenced elsewhere in the request using local params syntax
+(`{!v=$query_name}`):
+```json
+{
+  "query": "*:*",
+  "queries": {
+    "electronics": "category:electronics"
+  },
+  "filter": ["{!v=$electronics}"]
+}
+```
+
+**Current status:**
+Not supported. The `queries` key depends on local params (`{!...}`) syntax
+which is also not supported. The `queries` key in the JSON body is silently
+ignored.
+
+**Reference:** https://solr.apache.org/guide/solr/latest/query-guide/json-query-dsl.html#additional-queries
+
+---
+
+## JSON-PARAM-PREFIX
+
+**Feature:** `json.<param_name>` URL parameter prefix
+
+**Solr behaviour:**
+Solr allows JSON body properties to be specified as URL query parameters
+using the `json.` prefix. For example, `json.limit=5` is equivalent to
+`{"limit": 5}` in the JSON body. This enables overriding JSON body values
+from the URL.
+
+**Current status:**
+Not supported. The `json.` prefix passthrough is a URL-to-JSON-body bridge
+(opposite direction from what the `json-request` transform handles). URL
+parameters with the `json.` prefix are treated as unsupported params and
+rejected by validation.
+
+**Reference:** https://solr.apache.org/guide/solr/latest/query-guide/json-request-api.html#json-parameter-merging

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/json-request.test.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/json-request.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect } from 'vitest';
+import { request } from './json-request';
+import type { RequestContext, JavaMap } from '../context';
+
+function buildCtx(
+  body: Record<string, any> = {},
+  urlParams: Record<string, string> = {},
+): RequestContext {
+  const bodyMap = new Map(Object.entries(body)) as unknown as JavaMap;
+  return {
+    msg: new Map() as unknown as JavaMap,
+    endpoint: 'select',
+    collection: 'test',
+    params: new URLSearchParams(urlParams),
+    body: bodyMap,
+  };
+}
+
+describe('json-request', () => {
+  // --- match guard ---
+
+  it('matches when body has "query" key', () => {
+    const ctx = buildCtx({ query: '*:*' });
+    expect(request.match!(ctx)).toBe(true);
+  });
+
+  it('does not match empty body', () => {
+    const ctx = buildCtx({});
+    expect(request.match!(ctx)).toBe(false);
+  });
+
+  it('does not match body without "query" key', () => {
+    const ctx = buildCtx({ limit: 10 });
+    expect(request.match!(ctx)).toBe(false);
+  });
+
+  // --- key mapping ---
+
+  it('maps query → q', () => {
+    const ctx = buildCtx({ query: 'title:java' });
+    request.apply(ctx);
+    expect(ctx.params.get('q')).toBe('title:java');
+  });
+
+  it('maps limit → rows', () => {
+    const ctx = buildCtx({ query: '*:*', limit: 10 });
+    request.apply(ctx);
+    expect(ctx.params.get('rows')).toBe('10');
+  });
+
+  it('maps offset → start', () => {
+    const ctx = buildCtx({ query: '*:*', offset: 20 });
+    request.apply(ctx);
+    expect(ctx.params.get('start')).toBe('20');
+  });
+
+  it('maps sort → sort', () => {
+    const ctx = buildCtx({ query: '*:*', sort: 'price asc' });
+    request.apply(ctx);
+    expect(ctx.params.get('sort')).toBe('price asc');
+  });
+
+  it('maps filter → fq', () => {
+    const ctx = buildCtx({ query: '*:*', filter: 'category:electronics' });
+    request.apply(ctx);
+    expect(ctx.params.get('fq')).toBe('category:electronics');
+  });
+
+  it('maps fields → fl', () => {
+    const ctx = buildCtx({ query: '*:*', fields: 'id,title,price' });
+    request.apply(ctx);
+    expect(ctx.params.get('fl')).toBe('id,title,price');
+  });
+
+  it('maps fields array to comma-separated fl', () => {
+    const ctx = buildCtx({ query: '*:*', fields: ['id', 'title', 'price'] });
+    request.apply(ctx);
+    expect(ctx.params.get('fl')).toBe('id,title,price');
+  });
+
+  it('maps all keys together', () => {
+    const ctx = buildCtx({
+      query: 'title:java',
+      limit: 5,
+      offset: 10,
+      sort: 'price desc',
+      fields: ['id', 'title'],
+    });
+    request.apply(ctx);
+    expect(ctx.params.get('q')).toBe('title:java');
+    expect(ctx.params.get('rows')).toBe('5');
+    expect(ctx.params.get('start')).toBe('10');
+    expect(ctx.params.get('sort')).toBe('price desc');
+    expect(ctx.params.get('fl')).toBe('id,title');
+  });
+
+  // --- JSON body takes precedence over URL params ---
+
+  it('overwrites existing URL param q with JSON body query', () => {
+    const ctx = buildCtx({ query: 'from-body' }, { q: 'from-url' });
+    request.apply(ctx);
+    expect(ctx.params.get('q')).toBe('from-body');
+  });
+
+  it('overwrites existing URL param rows with JSON body limit', () => {
+    const ctx = buildCtx({ query: '*:*', limit: 99 }, { rows: '5' });
+    request.apply(ctx);
+    expect(ctx.params.get('rows')).toBe('99');
+  });
+
+  // --- params object ---
+
+  it('merges params object into ctx.params', () => {
+    const ctx = buildCtx({
+      query: '*:*',
+      params: new Map([['df', 'title'], ['wt', 'json']]),
+    });
+    request.apply(ctx);
+    expect(ctx.params.get('df')).toBe('title');
+    expect(ctx.params.get('wt')).toBe('json');
+  });
+
+  it('params object does not overwrite existing URL params', () => {
+    const ctx = buildCtx(
+      { query: '*:*', params: new Map([['wt', 'xml']]) },
+      { wt: 'json' },
+    );
+    request.apply(ctx);
+    expect(ctx.params.get('wt')).toBe('json');
+  });
+
+  // --- facet handling ---
+
+  it('moves facet to json.facet key in body for downstream transform', () => {
+    const facetObj = new Map([['categories', new Map([['type', 'terms'], ['field', 'cat']])]]);
+    const ctx = buildCtx({ query: '*:*', facet: facetObj });
+    request.apply(ctx);
+    expect(ctx.body.has('json.facet')).toBe(true);
+    expect(ctx.body.has('facet')).toBe(false);
+  });
+
+  // --- cleanup ---
+
+  it('clears mapped keys from body after processing', () => {
+    const ctx = buildCtx({
+      query: 'title:java',
+      limit: 10,
+      offset: 0,
+      sort: 'price asc',
+      fields: 'id',
+    });
+    request.apply(ctx);
+    expect(ctx.body.has('query')).toBe(false);
+    expect(ctx.body.has('limit')).toBe(false);
+    expect(ctx.body.has('offset')).toBe(false);
+    expect(ctx.body.has('sort')).toBe(false);
+    expect(ctx.body.has('fields')).toBe(false);
+  });
+});

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/json-request.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/json-request.ts
@@ -1,0 +1,83 @@
+/**
+ * JSON request body — normalize Solr JSON body format into URL params.
+ *
+ * Solr accepts queries as either URL params or a JSON request body:
+ *   GET  /select?q=title:java&rows=10
+ *   POST /select  {"query":"title:java","limit":10}
+ *
+ * The JSON body uses different key names than URL params:
+ *   query  → q        limit  → rows      offset → start
+ *   sort   → sort     filter → fq        fields → fl
+ *   params → merged into ctx.params (arbitrary key-value pairs)
+ *
+ * This pre-processor runs first in the select pipeline. It reads the
+ * incoming JSON body, maps keys to URL param equivalents, merges them
+ * into ctx.params, and clears the body so downstream transforms can
+ * write the OpenSearch request body fresh.
+ *
+ * JSON body keys take precedence over URL params (verified against Solr 8/9).
+ */
+import type { MicroTransform } from '../pipeline';
+import type { RequestContext, JavaMap } from '../context';
+
+/**
+ * Solr JSON body key → URL param name.
+ *
+ * Complete mapping per Solr's JSON Request API:
+ * https://solr.apache.org/guide/solr/latest/query-guide/json-request-api.html#supported-properties-and-syntax
+ *
+ * Not yet supported:
+ *   - json.<param_name> generic passthrough (URL-param-to-JSON bridge, opposite direction)
+ *   - queries (JSON Query DSL additional named queries, depends on local params {!v=$...})
+ */
+const KEY_MAP: Record<string, string> = {
+  query: 'q',
+  limit: 'rows',
+  offset: 'start',
+  sort: 'sort',
+  filter: 'fq',
+  fields: 'fl',
+};
+
+/** Map JSON body keys to URL params. JSON body takes precedence over URL params (verified against Solr 8/9). */
+function mapBodyKeysToParams(body: JavaMap, params: URLSearchParams): void {
+  for (const [jsonKey, paramKey] of Object.entries(KEY_MAP)) {
+    if (!body.has(jsonKey)) continue;
+    const val = body.get(jsonKey);
+    params.set(paramKey, Array.isArray(val) ? val.join(',') : String(val));
+  }
+}
+
+/** Merge the "params" object from JSON body into URL params. */
+function mergeParamsObject(body: JavaMap, params: URLSearchParams): void {
+  const paramsObj = body.get('params');
+  if (!paramsObj || typeof paramsObj.entries !== 'function') return;
+  for (const [key, val] of paramsObj.entries()) {
+    if (!params.has(key)) params.set(key, String(val));
+  }
+}
+
+/** Move "facet" to "json.facet" key for downstream json-facets transform. */
+function moveFacetKey(body: JavaMap, params: URLSearchParams): void {
+  if (body.has('facet') && !params.has('json.facet')) {
+    body.set('json.facet', body.get('facet'));
+  }
+}
+
+/** Remove all JSON body keys that were mapped to params. */
+function clearMappedKeys(body: JavaMap): void {
+  for (const jsonKey of Object.keys(KEY_MAP)) body.delete(jsonKey);
+  body.delete('params');
+  body.delete('facet');
+}
+
+export const request: MicroTransform<RequestContext> = {
+  name: 'json-request',
+  match: (ctx) => ctx.body.size > 0 && ctx.body.has('query'),
+  apply: (ctx) => {
+    mapBodyKeysToParams(ctx.body, ctx.params);
+    mergeParamsObject(ctx.body, ctx.params);
+    moveFacetKey(ctx.body, ctx.params);
+    clearMappedKeys(ctx.body);
+  },
+};

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/select-uri.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/select-uri.ts
@@ -19,6 +19,9 @@ export const request: MicroTransform<RequestContext> = {
     ctx.msg.set('method', 'POST');
     const headers = ctx.msg.get('headers');
     if (headers) {
+      // Remove original Content-Type (may differ in casing) to avoid duplicate headers.
+      // The Java proxy uses headers.add() which would create two Content-Type entries.
+      headers.delete('Content-Type');
       headers.set('content-type', 'application/json');
     }
   },

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/json-request.testcase.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/json-request.testcase.ts
@@ -1,0 +1,135 @@
+/**
+ * E2E test cases for JSON request body format on /select.
+ *
+ * Solr accepts queries as POST with JSON body using different key names
+ * (query, limit, offset, etc.). The json-request transform normalizes
+ * these to URL params before the rest of the pipeline runs.
+ */
+import { solrTest, SOLR_INTERNAL_RULES } from '../test-types';
+import type { TestCase } from '../test-types';
+
+export const testCases: TestCase[] = [
+  solrTest('json-request-basic-query', {
+    description: 'JSON body with query key should work like q= URL param',
+    documents: [
+      { id: '1', title: 'hello world' },
+      { id: '2', title: 'goodbye world' },
+    ],
+    method: 'POST',
+    requestBody: JSON.stringify({ query: '*:*' }),
+    requestPath: '/solr/testcollection/select?wt=json',
+    solrSchema: {
+      fields: { title: { type: 'text_general' } },
+    },
+    opensearchMapping: {
+      properties: { title: { type: 'text' } },
+    },
+    assertionRules: SOLR_INTERNAL_RULES,
+  }),
+
+  solrTest('json-request-with-limit-and-offset', {
+    description: 'JSON body limit/offset should map to rows/start',
+    documents: [
+      { id: '1', title: 'doc one' },
+      { id: '2', title: 'doc two' },
+      { id: '3', title: 'doc three' },
+    ],
+    method: 'POST',
+    requestBody: JSON.stringify({ query: '*:*', limit: 2, offset: 0 }),
+    requestPath: '/solr/testcollection/select?wt=json',
+    solrSchema: {
+      fields: { title: { type: 'text_general' } },
+    },
+    opensearchMapping: {
+      properties: { title: { type: 'text' } },
+    },
+    assertionRules: SOLR_INTERNAL_RULES,
+  }),
+
+  solrTest('json-request-with-fields', {
+    description: 'JSON body fields should map to fl',
+    documents: [
+      { id: '1', title: 'hello', price: 10 },
+      { id: '2', title: 'world', price: 20 },
+    ],
+    method: 'POST',
+    requestBody: JSON.stringify({ query: '*:*', fields: 'id,title' }),
+    requestPath: '/solr/testcollection/select?wt=json',
+    solrSchema: {
+      fields: {
+        title: { type: 'text_general' },
+        price: { type: 'pfloat' },
+      },
+    },
+    opensearchMapping: {
+      properties: {
+        title: { type: 'text' },
+        price: { type: 'float' },
+      },
+    },
+    assertionRules: SOLR_INTERNAL_RULES,
+  }),
+
+  solrTest('json-request-with-sort', {
+    description: 'JSON body sort should map to sort param',
+    documents: [
+      { id: '1', title: 'alpha', price: 30 },
+      { id: '2', title: 'beta', price: 10 },
+      { id: '3', title: 'gamma', price: 20 },
+    ],
+    method: 'POST',
+    requestBody: JSON.stringify({ query: '*:*', sort: 'price asc' }),
+    requestPath: '/solr/testcollection/select?wt=json',
+    solrSchema: {
+      fields: {
+        title: { type: 'text_general' },
+        price: { type: 'pfloat' },
+      },
+    },
+    opensearchMapping: {
+      properties: {
+        title: { type: 'text' },
+        price: { type: 'float' },
+      },
+    },
+    assertionRules: SOLR_INTERNAL_RULES,
+  }),
+
+  solrTest('json-request-url-params-precedence', {
+    description: 'URL params should take precedence over JSON body keys',
+    documents: [
+      { id: '1', title: 'doc one' },
+      { id: '2', title: 'doc two' },
+      { id: '3', title: 'doc three' },
+    ],
+    method: 'POST',
+    // URL has rows=1, body has limit=99 — rows=1 should win
+    requestBody: JSON.stringify({ query: '*:*', limit: 99 }),
+    requestPath: '/solr/testcollection/select?rows=1&wt=json',
+    solrSchema: {
+      fields: { title: { type: 'text_general' } },
+    },
+    opensearchMapping: {
+      properties: { title: { type: 'text' } },
+    },
+    assertionRules: SOLR_INTERNAL_RULES,
+  }),
+
+  solrTest('json-request-with-params-object', {
+    description: 'JSON body params object should be merged into URL params',
+    documents: [
+      { id: '1', title: 'hello world' },
+      { id: '2', title: 'goodbye world' },
+    ],
+    method: 'POST',
+    requestBody: JSON.stringify({ query: '*:*', params: { rows: '1' } }),
+    requestPath: '/solr/testcollection/select?wt=json',
+    solrSchema: {
+      fields: { title: { type: 'text_general' } },
+    },
+    opensearchMapping: {
+      properties: { title: { type: 'text' } },
+    },
+    assertionRules: SOLR_INTERNAL_RULES,
+  }),
+];

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/registry.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/registry.ts
@@ -11,6 +11,7 @@ import type { TransformRegistry } from './pipeline';
 import type { RequestContext, ResponseContext } from './context';
 
 import * as solrconfigDefaults from './features/solrconfig-defaults';
+import * as jsonRequest from './features/json-request';
 import * as selectUri from './features/select-uri';
 import * as queryQ from './features/query-q';
 import * as filterQueryFq from './features/filter-query-fq';
@@ -72,7 +73,8 @@ export const requestRegistry: TransformRegistry<RequestContext> = {
   ],
   byEndpoint: {
     select: [
-      solrconfigDefaults.request, // Apply solrconfig.xml defaults/invariants — must be before all others
+      jsonRequest.request, // JSON body → URL params (before defaults so body values are visible)
+      solrconfigDefaults.request, // Apply solrconfig.xml defaults/invariants
       selectUri.request, // URI rewrite
       queryQ.request, // q=... → query DSL
       filterQueryFq.request, // fq=... → bool.filter (after query-q)


### PR DESCRIPTION
### Description

Adds support for Solr's JSON request body format on the `/select` endpoint. Solr accepts queries as either URL params or a POST with JSON body using different key names. This PR adds a pre-processing transform that normalizes JSON body keys into URL params so all downstream transforms work unchanged.

**Solr JSON body format:**

    POST /solr/{collection}/select
    {"query": "title:java", "limit": 10, "offset": 0, "sort": "price asc", "fields": "id,title"}

**Key mapping ([Solr JSON Request API spec](https://solr.apache.org/guide/solr/latest/query-guide/json-request-api.html#supported-properties-and-syntax)):**

| JSON body key | URL param | Notes |
|---|---|---|
| `query` | `q` | |
| `limit` | `rows` | |
| `offset` | `start` | |
| `sort` | `sort` | |
| `filter` | `fq` | String or array |
| `fields` | `fl` | String or array (joined with comma) |
| `facet` | `json.facet` | Moved in body for downstream json-facets transform |
| `params` | merged | Arbitrary key-value pairs merged into ctx.params |

JSON body keys take precedence over URL params (verified against Solr 8/9).

**Not yet supported (documented in LIMITATIONS.md):**
- `queries` — named sub-queries for JSON Query DSL (depends on local params `{!v=$...}`)
- `json.<param_name>` — URL parameter prefix passthrough
- `json=` — entire JSON body as single URL param


### Files Changed (6)

| File | Change |
|---|---|
| `features/json-request.ts` | New — pre-processor that maps JSON body keys to URL params |
| `features/json-request.test.ts` | New — 17 unit tests |
| `json-request.testcase.ts` | New — 6 e2e test cases (Solr 8/9 + OpenSearch) |
| `registry.ts` | Modified — wired `json-request` as first transform in select pipeline |
| `features/select-uri.ts` | Modified — fix duplicate Content-Type header on POST requests |
| `docs/LIMITATIONS.md` | Modified — added JSON-QUERIES and JSON-PARAM-PREFIX limitations |

### Pipeline Order

    global:  validation
    select:  jsonRequest → solrconfigDefaults → selectUri → queryQ → cursorPagination → jsonFacets → fieldList → highlighting → sort

`json-request` runs first so JSON body keys are available as URL params before defaults fill in gaps and before other transforms consume them.

### Testing

| Layer | Result |
|---|---|
| Unit tests (vitest) | 28 files, 638 tests ✅ |
| E2E integration (Solr 8 + 9) | 6/6 passed ✅ |


### Check List
- [x] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
