### PR TITLE
Add Apache Solr 8.x-9.x to supported migration paths in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,10 @@ OpenSearch Migration Assistant is a comprehensive set of tools designed to facil
 <tr><td>OpenSearch 1.x</td><td>✅</td><td>✅</td><td>✅</td></tr>
 <tr><td>OpenSearch 2.x</td><td></td><td>✅</td><td>✅</td></tr>
 <tr><td>OpenSearch 3.x</td><td></td><td></td><td>🔜 <a href="https://github.com/orgs/opensearch-project/projects/229?pane=issue&itemId=117495207">link</a></td></tr>
+<tr><td>Apache Solr 8.x–9.x*</td><td></td><td></td><td>✅</td></tr>
 </table>
+
+\* Backfill only — Capture and Replay is not supported for Solr sources.
 
 Note that testing is done on specific minor versions, but any minor versions within a listed major version are expected to work.
 


### PR DESCRIPTION
Adds Apache Solr 8.x–9.x → OpenSearch 3.x to the migration paths table in the README.

Marked with asterisk (*) indicating backfill only — Capture and Replay is not supported for Solr sources.

Signed-off-by: Brian Presley <bjpres@amazon.com>