### PR TITLE
Fix missing RBAC permission for TrafficReplay CRD

### DIFF
--- a/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/templates/resources/migrationConsole.yaml
+++ b/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/templates/resources/migrationConsole.yaml
@@ -23,8 +23,8 @@ rules:
     resources: ["workflows", "workflows/finalizers", "workflowtemplates", "workflowtemplates/finalizers", "workflowtaskresults" ]
     verbs: ["create", "get", "list", "watch", "update", "patch", "delete"]
   - apiGroups: ["migrations.opensearch.org"]
-    resources: ["capturedtraffics", "datasnapshots", "snapshotmigrations",
-                "capturedtraffics/status", "datasnapshots/status", "snapshotmigrations/status"]
+    resources: ["capturedtraffics", "datasnapshots", "snapshotmigrations", "trafficreplays",
+                "capturedtraffics/status", "datasnapshots/status", "snapshotmigrations/status", "trafficreplays/status"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 
 ---

--- a/orchestrationSpecs/packages/config-processor/scripts/createMigrationWorkflowFromUserConfiguration.sh
+++ b/orchestrationSpecs/packages/config-processor/scripts/createMigrationWorkflowFromUserConfiguration.sh
@@ -35,14 +35,14 @@ echo "Applying Kubernetes resources..."
 # Apply CRD resources
 if [ -f "$TEMP_DIR/crdResources.yaml" ]; then
     echo "Applying CRD resources..."
-    if kubectl create -f "$TEMP_DIR/crdResources.yaml" 2>/dev/null; then
+    if CREATE_OUTPUT=$(kubectl create -f "$TEMP_DIR/crdResources.yaml" 2>&1); then
         # Patch status subresource (kubectl create ignores status)
         if [ -f "$TEMP_DIR/patchCrdStatus.sh" ]; then
             echo "Patching CRD status subresources..."
             sh "$TEMP_DIR/patchCrdStatus.sh"
         fi
     else
-        echo "CRD resources already exist, skipping."
+        echo "CRD create failed with: $CREATE_OUTPUT"
     fi
 fi
 


### PR DESCRIPTION
### Description

The `migration-console-access-role` RBAC Role was missing permissions for `trafficreplays` and `trafficreplays/status` resources. This caused `workflow submit` from the migration console to silently fail when creating the `TrafficReplay` CRD, which in turn caused the Argo workflow traffic replayer `checkPhase` and `markReady` steps to fail with `NotFound` errors.

The `argo-workflow-executor` role already had these permissions, so the issue only affected the user-facing `workflow submit` path (not the Jenkins CI test path which runs inside an Argo workflow step using the executor service account).

Additionally, the CRD creation script was suppressing all stderr with `2>/dev/null`. This change surfaces the actual `kubectl create` error output. This was how the permission error was caught:

```
CRD create failed with: 
  Error from server (AlreadyExists): capturedtraffics.migrations.opensearch.org "capture-proxy" already exists
  Error from server (AlreadyExists): datasnapshots.migrations.opensearch.org "source-backfill-snapshot" already exists  
  Error from server (AlreadyExists): snapshotmigrations.migrations.opensearch.org "source-target-backfill-snapshot" already exists
  Error from server (Forbidden): trafficreplays.migrations.opensearch.org is forbidden: 
    User "system:serviceaccount:ma:migration-console-access-role" cannot create resource "trafficreplays"
```

### Issues Resolved
N/A

### Testing
- Deployed to EKS dev environment
- Verified `TrafficReplay` CRD is created successfully during `workflow submit`
- Full end-to-end workflow completed with `Phase: Succeeded` (backfill + CDC to AOSS)
- Confirmed live traffic replayed to AOSS target

### Check List
- [ ] New functionality includes testing
- [ ] Public documentation issue/PR created, if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.