### PR TITLE
feat(solr-transforms): Add delete-by-id and /update command dispatcher

### DIFF
--- a/TrafficCapture/SolrTransformations/docs/LIMITATIONS.md
+++ b/TrafficCapture/SolrTransformations/docs/LIMITATIONS.md
@@ -21,6 +21,7 @@ the root cause, and provides a workaround where one exists.
 | [FQ-CACHING](#fq-caching)                       | Filter query caching granularity differs between Solr and OpenSearch |
 | [JSON-QUERIES](#json-queries)                   | JSON Request API `queries` key not supported |
 | [JSON-PARAM-PREFIX](#json-param-prefix)         | JSON Request API `json.<param>` prefix passthrough not supported |
+| [UPDATE-COMMANDS](#update-commands)             | Only `add` and `delete-by-id` commands supported; JSON only |
 
 ---
 
@@ -461,3 +462,35 @@ parameters with the `json.` prefix are treated as unsupported params and
 rejected by validation.
 
 **Reference:** https://solr.apache.org/guide/solr/latest/query-guide/json-request-api.html#json-parameter-merging
+
+---
+
+## UPDATE-COMMANDS
+
+**Feature:** Solr `/update` endpoint command support
+
+**Solr behaviour:**
+The `/update` endpoint accepts JSON or XML bodies with multiple command types:
+`add`, `delete` (by id or query), `commit`, `optimize`, `rollback`. Commands
+can be mixed in a single request and can use arrays for bulk operations.
+Both JSON and XML content types are supported.
+
+**Current support:**
+
+| Command | Status |
+|---|---|
+| `add` (single doc) | ✅ Supported — `{"add":{"doc":{...}}}` |
+| `add` with `boost` | ❌ Not supported — fails fast (OpenSearch has no document-level boost) |
+| `add` with `overwrite: false` | ❌ Not supported — fails fast (OpenSearch always overwrites) |
+| `delete` by id | ✅ Supported — `{"delete":{"id":"..."}}` |
+| `delete` by query | ❌ Not supported — fails fast |
+| `commit` | ❌ Not supported — fails fast |
+| `optimize` / `rollback` | ❌ Not supported — fails fast |
+| Mixed commands | ❌ Not supported — fails fast |
+| Array/bulk operations | ❌ Not supported — fails fast |
+| XML content type | ❌ Not supported — fails fast (JSON only) |
+
+**Content type:**
+Only `application/json` request bodies are supported. XML bodies
+(`text/xml`, `application/xml`) cannot be parsed by the shim and will
+fail with an error. Clients using XML format must switch to JSON.

--- a/TrafficCapture/SolrTransformations/docs/TRANSFORMS.md
+++ b/TrafficCapture/SolrTransformations/docs/TRANSFORMS.md
@@ -181,6 +181,50 @@ graph LR
 
 ---
 
+## Update Router
+
+Routes all `/update/*` requests through a single entry point that dispatches by path and body shape.
+
+```mermaid
+graph TD
+    subgraph Input["Solr /update Request"]
+        A1["POST /update/json/docs<br/>{id:1, title:'hello'}"]
+        A2["POST /update<br/>{delete:{id:'1'}}"]
+        A3["POST /update<br/>{add:{doc:{id:1,...}}}"]
+    end
+
+    subgraph Router["update-router.ts"]
+        R["Detect path + body shape"]
+    end
+
+    subgraph Handlers["Handlers"]
+        H1["update-doc.ts<br/>PUT /_doc/{id}"]
+        H2["delete-doc.ts<br/>DELETE /_doc/{id}"]
+    end
+
+    subgraph Response["update-router.ts (response)"]
+        Resp["Generic _doc response<br/>→ Solr responseHeader"]
+    end
+
+    A1 --> R -->|/json/docs| H1
+    A2 --> R -->|delete command| H2
+    A3 --> R -->|add command, unwrap doc| H1
+    H1 --> Resp
+    H2 --> Resp
+```
+
+### Adding New Commands
+
+To add support for a new command (e.g., `commit`, `delete-by-query`, bulk):
+
+1. Create a handler file (e.g., `features/commit-handler.ts`)
+2. Add a case in `update-router.ts` `dispatchCommand()` switch
+3. No pipeline or registry changes needed
+
+See `docs/LIMITATIONS.md` → `UPDATE-COMMANDS` for the full list of supported and unsupported commands.
+
+---
+
 ## Input Validation
 
 Validation runs before any endpoint-specific transforms, rejecting invalid requests early with clear error messages.

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/delete-doc.test.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/delete-doc.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from 'vitest';
+import { request } from './delete-doc';
+import type { RequestContext, JavaMap } from '../context';
+
+function buildCtx(id: any, collection: string | undefined = 'mycore'): RequestContext {
+  const body = new Map<string, any>([['id', id]]);
+  const msg = new Map<string, any>([
+    ['URI', '/solr/mycore/update'],
+    ['method', 'POST'],
+  ]) as unknown as JavaMap;
+  return {
+    msg,
+    endpoint: 'update',
+    collection,
+    params: new URLSearchParams(),
+    body: body as unknown as JavaMap,
+  };
+}
+
+describe('delete-doc', () => {
+  // --- happy path ---
+
+  it('rewrites URI to DELETE /_doc/{id}', () => {
+    const ctx = buildCtx('1');
+    request.apply(ctx);
+    expect(ctx.msg.get('URI')).toBe('/mycore/_doc/1');
+    expect(ctx.msg.get('method')).toBe('DELETE');
+  });
+
+  it('encodes special characters in id', () => {
+    const ctx = buildCtx('doc/with spaces');
+    request.apply(ctx);
+    expect(ctx.msg.get('URI')).toBe('/mycore/_doc/doc%2Fwith%20spaces');
+  });
+
+  it('handles numeric id', () => {
+    const ctx = buildCtx(42);
+    request.apply(ctx);
+    expect(ctx.msg.get('URI')).toBe('/mycore/_doc/42');
+  });
+
+  it('handles id with dashes and underscores', () => {
+    const ctx = buildCtx('doc-with-dashes_and_underscores');
+    request.apply(ctx);
+    expect(ctx.msg.get('URI')).toBe('/mycore/_doc/doc-with-dashes_and_underscores');
+  });
+
+  it('trims whitespace from id', () => {
+    const ctx = buildCtx('  doc1  ');
+    request.apply(ctx);
+    expect(ctx.msg.get('URI')).toBe('/mycore/_doc/doc1');
+  });
+
+  it('translates commit=true to refresh=true', () => {
+    const body = new Map<string, any>([['id', '1']]);
+    const msg = new Map<string, any>([['URI', '/solr/mycore/update'], ['method', 'POST']]) as unknown as JavaMap;
+    const ctx: RequestContext = {
+      msg, endpoint: 'update', collection: 'mycore',
+      params: new URLSearchParams('commit=true'), body: body as unknown as JavaMap,
+    };
+    request.apply(ctx);
+    expect(ctx.msg.get('URI')).toBe('/mycore/_doc/1?refresh=true');
+  });
+
+  it('does not add refresh when commit is absent', () => {
+    const ctx = buildCtx('1');
+    request.apply(ctx);
+    expect(ctx.msg.get('URI')).toBe('/mycore/_doc/1');
+  });
+
+  // --- error cases ---
+
+  it('throws on empty id', () => {
+    const ctx = buildCtx('');
+    expect(() => request.apply(ctx)).toThrow('non-empty "id"');
+  });
+
+  it('throws on null id', () => {
+    const ctx = buildCtx(null);
+    expect(() => request.apply(ctx)).toThrow('non-empty "id"');
+  });
+
+  it('throws on whitespace-only id', () => {
+    const ctx = buildCtx('   ');
+    expect(() => request.apply(ctx)).toThrow('non-empty "id"');
+  });
+
+  it('throws on undefined id', () => {
+    const body = new Map<string, any>();
+    const msg = new Map<string, any>([
+      ['URI', '/solr/mycore/update'],
+      ['method', 'POST'],
+    ]) as unknown as JavaMap;
+    const ctx: RequestContext = {
+      msg, endpoint: 'update', collection: 'mycore',
+      params: new URLSearchParams(), body: body as unknown as JavaMap,
+    };
+    expect(() => request.apply(ctx)).toThrow('non-empty "id"');
+  });
+
+  it('throws when collection is undefined', () => {
+    const body = new Map<string, any>([['id', '1']]);
+    const msg = new Map<string, any>([['URI', '/update'], ['method', 'POST']]) as unknown as JavaMap;
+    const ctx: RequestContext = {
+      msg, endpoint: 'update', collection: undefined,
+      params: new URLSearchParams(), body: body as unknown as JavaMap,
+    };
+    expect(() => request.apply(ctx)).toThrow('collection could not be determined');
+  });
+});

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/delete-doc.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/delete-doc.ts
@@ -1,0 +1,36 @@
+/**
+ * Single document delete by ID — DELETE /{collection}/_doc/{id}
+ *
+ * Called by update-router.ts after extracting the delete command data.
+ * Expects ctx.body to be the normalized delete data: {"id": "..."}
+ *
+ * Solr:       POST /solr/{collection}/update  {"delete":{"id":"1"}}
+ * OpenSearch:  DELETE /{collection}/_doc/1
+ */
+import type { MicroTransform } from '../pipeline';
+import type { RequestContext } from '../context';
+
+export const request: MicroTransform<RequestContext> = {
+  name: 'delete-doc',
+  apply: (ctx) => {
+    if (!ctx.collection) {
+      throw new Error('[delete-doc] delete: collection could not be determined from URI');
+    }
+
+    const rawId = ctx.body.get('id');
+    const id = rawId != null ? String(rawId).trim() : '';
+    if (!id) {
+      throw new Error('[delete-doc] delete: document must have a non-empty "id" field');
+    }
+
+    const targetParams = new URLSearchParams();
+    if (ctx.params.get('commit') === 'true' || ctx.params.has('commitWithin')) {
+      targetParams.set('refresh', 'true');
+    }
+
+    const query = targetParams.toString();
+    const suffix = query ? '?' + query : '';
+    ctx.msg.set('URI', `/${ctx.collection}/_doc/${encodeURIComponent(id)}${suffix}`);
+    ctx.msg.set('method', 'DELETE');
+  },
+};

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/update-doc.test.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/update-doc.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { request, response } from './update-doc';
-import type { RequestContext, ResponseContext, JavaMap } from '../context';
+import { request } from './update-doc';
+import type { RequestContext, JavaMap } from '../context';
 
 function buildCtx(
   uri: string,
@@ -26,28 +26,6 @@ function buildCtx(
 }
 
 describe('update-doc', () => {
-  // --- match guard ---
-
-  it('matches /update/json/docs path', () => {
-    const ctx = buildCtx('/solr/mycore/update/json/docs');
-    expect(request.match!(ctx)).toBe(true);
-  });
-
-  it('matches /update/json/docs with query params', () => {
-    const ctx = buildCtx('/solr/mycore/update/json/docs?commit=true');
-    expect(request.match!(ctx)).toBe(true);
-  });
-
-  it('does not match plain /update path', () => {
-    const ctx = buildCtx('/solr/mycore/update');
-    expect(request.match!(ctx)).toBe(false);
-  });
-
-  it('does not match /select path', () => {
-    const ctx = buildCtx('/solr/mycore/select?q=*:*');
-    expect(request.match!(ctx)).toBe(false);
-  });
-
   // --- happy path ---
 
   it('rewrites URI to /_doc/{id} with PUT method', () => {
@@ -186,71 +164,5 @@ describe('update-doc', () => {
     const ctx = buildCtx('/solr/mycore/update/json/docs', arrayLike);
 
     expect(() => request.apply(ctx)).toThrow('Array/bulk updates not supported');
-  });
-});
-
-function buildResponseCtx(
-  body: Map<string, any>,
-): ResponseContext {
-  return {
-    request: new Map() as unknown as JavaMap,
-    response: new Map() as unknown as JavaMap,
-    endpoint: 'update',
-    collection: 'mycore',
-    requestParams: new URLSearchParams(),
-    responseBody: body as unknown as JavaMap,
-  };
-}
-
-describe('update-doc response', () => {
-  it('matches OpenSearch _doc response (has result and _id)', () => {
-    const body = new Map<string, any>([
-      ['_index', 'mycore'], ['_id', '1'], ['result', 'created'], ['_version', 1],
-    ]);
-    expect(response.match!(buildResponseCtx(body))).toBe(true);
-  });
-
-  it('does not match select response', () => {
-    const body = new Map<string, any>([['hits', new Map()], ['took', 5]]);
-    expect(response.match!(buildResponseCtx(body))).toBe(false);
-  });
-
-  it('converts created response to Solr format with status 0', () => {
-    const body = new Map<string, any>([
-      ['_index', 'mycore'], ['_id', '1'], ['result', 'created'],
-      ['_version', 1], ['_shards', new Map()],
-    ]);
-    const ctx = buildResponseCtx(body);
-
-    response.apply(ctx);
-
-    const header = ctx.responseBody.get('responseHeader');
-    expect(header.get('status')).toBe(0);
-    expect(header.get('QTime')).toBe(0);
-    expect(ctx.responseBody.has('_index')).toBe(false);
-    expect(ctx.responseBody.has('_id')).toBe(false);
-    expect(ctx.responseBody.has('_shards')).toBe(false);
-  });
-
-  it('converts updated response to Solr format with status 0', () => {
-    const body = new Map<string, any>([
-      ['_index', 'mycore'], ['_id', '1'], ['result', 'updated'], ['_version', 2],
-    ]);
-    const ctx = buildResponseCtx(body);
-
-    response.apply(ctx);
-
-    expect(ctx.responseBody.get('responseHeader').get('status')).toBe(0);
-  });
-
-  it('sets status 1 for non-success results', () => {
-    const body = new Map<string, any>([
-      ['_index', 'mycore'], ['_id', '1'], ['result', 'noop'], ['_version', 1],
-    ]);
-    const ctx = buildResponseCtx(body);
-
-    response.apply(ctx);
-
-    expect(ctx.responseBody.get('responseHeader').get('status')).toBe(1);
   });
 });

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/update-doc.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/update-doc.ts
@@ -20,7 +20,7 @@
  * The body is passed through unchanged — no field-level translation needed.
  */
 import type { MicroTransform } from '../pipeline';
-import type { RequestContext, ResponseContext } from '../context';
+import type { RequestContext } from '../context';
 
 /** Detect GraalVM Java ArrayList — exposes numeric keys + length, unlike a Map. */
 function isJavaList(obj: any): boolean {
@@ -29,7 +29,6 @@ function isJavaList(obj: any): boolean {
 
 export const request: MicroTransform<RequestContext> = {
   name: 'update-doc',
-  match: (ctx) => /\/update\/json\/docs/.test(ctx.msg.get('URI') || ''),
   apply: (ctx) => {
     const body = ctx.body;
 
@@ -58,36 +57,5 @@ export const request: MicroTransform<RequestContext> = {
 
     ctx.msg.set('URI', uri);
     ctx.msg.set('method', 'PUT');
-  },
-};
-
-/**
- * Response transform — convert OpenSearch _doc response to Solr update response.
- *
- * OpenSearch returns: {"_index":"mycore","_id":"1","result":"created","_version":1,...}
- * Solr returns:       {"responseHeader":{"status":0,"QTime":N}}
- */
-export const response: MicroTransform<ResponseContext> = {
-  name: 'update-doc-response',
-  match: (ctx) => ctx.responseBody.has('result') && ctx.responseBody.has('_id'),
-  apply: (ctx) => {
-    const result = ctx.responseBody.get('result');
-    const status = (result === 'created' || result === 'updated') ? 0 : 1;
-
-    // Clear OpenSearch-specific fields
-    const keys = Array.from(ctx.responseBody.keys());
-    for (const key of keys) {
-      ctx.responseBody.delete(key);
-    }
-
-    // Write Solr-format response.
-    // QTime is 0 because OpenSearch's _doc response doesn't include processing time.
-    ctx.responseBody.set(
-      'responseHeader',
-      new Map<string, unknown>([
-        ['status', status],
-        ['QTime', 0],
-      ]),
-    );
   },
 };

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/update-router.test.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/update-router.test.ts
@@ -1,0 +1,390 @@
+import { describe, it, expect } from 'vitest';
+import { request, response } from './update-router';
+import type { RequestContext, ResponseContext, JavaMap } from '../context';
+
+function buildCtx(uri: string, body: Map<string, any>): RequestContext {
+  const msg = new Map<string, any>([
+    ['URI', uri],
+    ['method', 'POST'],
+    ['headers', new Map()],
+  ]) as unknown as JavaMap;
+  return {
+    msg,
+    endpoint: 'update',
+    collection: /\/solr\/([^/]+)\//.exec(uri)?.[1],
+    params: new URLSearchParams(),
+    body: body as unknown as JavaMap,
+  };
+}
+
+function deleteBody(id: any): Map<string, any> {
+  return new Map([['delete', new Map([['id', id]])]]);
+}
+
+function deleteByQueryBody(query: string): Map<string, any> {
+  return new Map([['delete', new Map([['query', query]])]]);
+}
+
+function addBody(doc: Record<string, any>): Map<string, any> {
+  return new Map([['add', new Map([['doc', new Map(Object.entries(doc))]])]]);
+}
+
+describe('update-router request', () => {
+  // --- routing ---
+
+  it('routes /update/json/docs to update-doc handler', () => {
+    const body = new Map<string, any>([['id', '1'], ['title', 'hello']]);
+    const msg = new Map<string, any>([
+      ['URI', '/solr/mycore/update/json/docs'],
+      ['method', 'POST'],
+      ['headers', new Map()],
+    ]) as unknown as JavaMap;
+    const ctx: RequestContext = {
+      msg, endpoint: 'update', collection: 'mycore',
+      params: new URLSearchParams(), body: body as unknown as JavaMap,
+    };
+    request.apply(ctx);
+    expect(ctx.msg.get('URI')).toBe('/mycore/_doc/1');
+    expect(ctx.msg.get('method')).toBe('PUT');
+  });
+
+  it('preserves body fields when routing /update/json/docs', () => {
+    const body = new Map<string, any>([['id', '1'], ['title', 'hello'], ['price', 9.99]]);
+    const msg = new Map<string, any>([
+      ['URI', '/solr/mycore/update/json/docs'],
+      ['method', 'POST'],
+      ['headers', new Map()],
+    ]) as unknown as JavaMap;
+    const ctx: RequestContext = {
+      msg, endpoint: 'update', collection: 'mycore',
+      params: new URLSearchParams(), body: body as unknown as JavaMap,
+    };
+    request.apply(ctx);
+    expect(ctx.body.get('title')).toBe('hello');
+    expect(ctx.body.get('price')).toBe(9.99);
+  });
+
+  it('does not match /foo/update/json/docs123 as json docs path', () => {
+    const body = new Map<string, any>([['id', '1']]);
+    const msg = new Map<string, any>([
+      ['URI', '/solr/mycore/update/json/docs123'],
+      ['method', 'POST'],
+      ['headers', new Map()],
+    ]) as unknown as JavaMap;
+    const ctx: RequestContext = {
+      msg, endpoint: 'update', collection: 'mycore',
+      params: new URLSearchParams(), body: body as unknown as JavaMap,
+    };
+    // Should go through dispatchCommand, not json docs path — will throw since body has no command
+    expect(() => request.apply(ctx)).toThrow('no recognized command');
+  });
+
+  it('throws on XML content type', () => {
+    const body = new Map<string, any>([['delete', new Map([['id', '1']])]]);
+    const msg = new Map<string, any>([
+      ['URI', '/solr/mycore/update'],
+      ['method', 'POST'],
+      ['headers', new Map([['Content-Type', 'text/xml']])],
+    ]) as unknown as JavaMap;
+    const ctx: RequestContext = {
+      msg, endpoint: 'update', collection: 'mycore',
+      params: new URLSearchParams(), body: body as unknown as JavaMap,
+    };
+    expect(() => request.apply(ctx)).toThrow('only JSON content type is supported');
+  });
+
+  it('throws on non-POST method', () => {
+    const body = new Map<string, any>([['delete', new Map([['id', '1']])]]);
+    const msg = new Map<string, any>([
+      ['URI', '/solr/mycore/update'],
+      ['method', 'GET'],
+      ['headers', new Map()],
+    ]) as unknown as JavaMap;
+    const ctx: RequestContext = {
+      msg, endpoint: 'update', collection: 'mycore',
+      params: new URLSearchParams(), body: body as unknown as JavaMap,
+    };
+    expect(() => request.apply(ctx)).toThrow('only POST method is accepted');
+  });
+
+  // --- delete: happy path ---
+
+  it('dispatches delete to DELETE /_doc/{id}', () => {
+    const ctx = buildCtx('/solr/mycore/update', deleteBody('1'));
+    request.apply(ctx);
+    expect(ctx.msg.get('URI')).toBe('/mycore/_doc/1');
+    expect(ctx.msg.get('method')).toBe('DELETE');
+  });
+
+  it('handles delete with special chars in id', () => {
+    const ctx = buildCtx('/solr/mycore/update', deleteBody('doc/with spaces'));
+    request.apply(ctx);
+    expect(ctx.msg.get('URI')).toBe('/mycore/_doc/doc%2Fwith%20spaces');
+  });
+
+  it('handles delete with numeric id', () => {
+    const ctx = buildCtx('/solr/mycore/update', deleteBody(42));
+    request.apply(ctx);
+    expect(ctx.msg.get('URI')).toBe('/mycore/_doc/42');
+  });
+
+  // --- delete: error cases ---
+
+  it('throws on delete with empty id', () => {
+    const ctx = buildCtx('/solr/mycore/update', deleteBody(''));
+    expect(() => request.apply(ctx)).toThrow('non-empty "id"');
+  });
+
+  it('throws on delete with null id', () => {
+    const ctx = buildCtx('/solr/mycore/update', deleteBody(null));
+    expect(() => request.apply(ctx)).toThrow('non-empty "id"');
+  });
+
+  it('throws on delete with whitespace-only id', () => {
+    const ctx = buildCtx('/solr/mycore/update', deleteBody('   '));
+    expect(() => request.apply(ctx)).toThrow('non-empty "id"');
+  });
+
+  it('throws on delete with unsupported _route_ field', () => {
+    const body = new Map([['delete', new Map<string, any>([['id', '1'], ['_route_', 'shard1']])]]);
+    const ctx = buildCtx('/solr/mycore/update', body);
+    expect(() => request.apply(ctx)).toThrow("unsupported field '_route_'");
+  });
+
+  it('throws on delete with unsupported version field', () => {
+    const body = new Map([['delete', new Map<string, any>([['id', '1'], ['version', 123]])]]);
+    const ctx = buildCtx('/solr/mycore/update', body);
+    expect(() => request.apply(ctx)).toThrow("unsupported field 'version'");
+  });
+
+  it('handles delete with id containing reserved chars (/, ?, #)', () => {
+    const ctx = buildCtx('/solr/mycore/update', deleteBody('doc/1?q=x#frag'));
+    request.apply(ctx);
+    expect(ctx.msg.get('URI')).toBe('/mycore/_doc/doc%2F1%3Fq%3Dx%23frag');
+  });
+
+  it('handles delete with very long id', () => {
+    const longId = 'a'.repeat(500);
+    const ctx = buildCtx('/solr/mycore/update', deleteBody(longId));
+    request.apply(ctx);
+    expect(ctx.msg.get('URI')).toBe(`/mycore/_doc/${longId}`);
+  });
+
+  it('throws on delete-by-query', () => {
+    const ctx = buildCtx('/solr/mycore/update', deleteByQueryBody('title:old'));
+    expect(() => request.apply(ctx)).toThrow('delete-by-query is not supported');
+  });
+
+  it('throws on invalid delete format (not a Map)', () => {
+    const ctx = buildCtx('/solr/mycore/update', new Map([['delete', 'invalid']]));
+    expect(() => request.apply(ctx)).toThrow('invalid command format');
+  });
+
+  // --- add: happy path ---
+
+  it('dispatches add to PUT /_doc/{id}', () => {
+    const ctx = buildCtx('/solr/mycore/update', addBody({ id: '1', title: 'hello' }));
+    request.apply(ctx);
+    expect(ctx.msg.get('URI')).toBe('/mycore/_doc/1');
+    expect(ctx.msg.get('method')).toBe('PUT');
+  });
+
+  it('handles add with multiple fields', () => {
+    const ctx = buildCtx('/solr/mycore/update', addBody({ id: '1', title: 'hi', price: 9.99 }));
+    request.apply(ctx);
+    expect(ctx.msg.get('URI')).toBe('/mycore/_doc/1');
+  });
+
+  it('handles add with numeric id', () => {
+    const ctx = buildCtx('/solr/mycore/update', addBody({ id: 42, title: 'test' }));
+    request.apply(ctx);
+    expect(ctx.msg.get('URI')).toBe('/mycore/_doc/42');
+  });
+
+  // --- add: error cases ---
+
+  it('throws on add without doc field', () => {
+    const body = new Map<string, any>([['add', new Map([['id', '1']])]]);
+    const ctx = buildCtx('/solr/mycore/update', body);
+    expect(() => request.apply(ctx)).toThrow('must contain a "doc" field');
+  });
+
+  it('throws on invalid add format (not a Map)', () => {
+    const body = new Map<string, any>([['add', 'invalid']]);
+    const ctx = buildCtx('/solr/mycore/update', body);
+    expect(() => request.apply(ctx)).toThrow('invalid command format');
+  });
+
+  it('throws on add with doc missing id', () => {
+    const ctx = buildCtx('/solr/mycore/update', addBody({ title: 'no id' }));
+    expect(() => request.apply(ctx)).toThrow('must have an "id" field');
+  });
+
+  it('throws on add with boost', () => {
+    const body = new Map<string, any>([
+      ['add', new Map<string, any>([['doc', new Map([['id', '1']])], ['boost', 2]])],
+    ]);
+    const ctx = buildCtx('/solr/mycore/update', body);
+    expect(() => request.apply(ctx)).toThrow('document-level boost is not supported');
+  });
+
+  it('throws on add with overwrite=false', () => {
+    const body = new Map<string, any>([
+      ['add', new Map<string, any>([['doc', new Map([['id', '1']])], ['overwrite', false]])],
+    ]);
+    const ctx = buildCtx('/solr/mycore/update', body);
+    expect(() => request.apply(ctx)).toThrow('overwrite=false is not supported');
+  });
+
+  it('allows add with overwrite=true (default behavior)', () => {
+    const body = new Map<string, any>([
+      ['add', new Map<string, any>([['doc', new Map([['id', '1'], ['title', 'test']])], ['overwrite', true]])],
+    ]);
+    const ctx = buildCtx('/solr/mycore/update', body);
+    request.apply(ctx);
+    expect(ctx.msg.get('URI')).toBe('/mycore/_doc/1');
+  });
+
+  // --- general error cases ---
+
+  it('throws on empty body', () => {
+    const ctx = buildCtx('/solr/mycore/update', new Map());
+    expect(() => request.apply(ctx)).toThrow('request body is empty or not JSON');
+  });
+
+  it('throws on unrecognized command with keys in message', () => {
+    const ctx = buildCtx('/solr/mycore/update', new Map([['unknown', new Map()]]));
+    expect(() => request.apply(ctx)).toThrow(/no recognized command.*keys:.*unknown/);
+  });
+
+  it('throws on valid JSON body with no command keys', () => {
+    const ctx = buildCtx('/solr/mycore/update', new Map([['foo', 'bar'], ['baz', 123]]));
+    expect(() => request.apply(ctx)).toThrow(/no recognized command.*keys:.*foo.*baz/);
+  });
+
+  it('throws on mixed commands (delete + add)', () => {
+    const body = new Map<string, any>([
+      ['delete', new Map([['id', '1']])],
+      ['add', new Map([['doc', new Map([['id', '2']])]])],
+    ]);
+    const ctx = buildCtx('/solr/mycore/update', body);
+    expect(() => request.apply(ctx)).toThrow('mixed commands');
+  });
+
+  it('throws on unsupported commit command', () => {
+    const ctx = buildCtx('/solr/mycore/update', new Map([['commit', new Map()]]));
+    expect(() => request.apply(ctx)).toThrow('command is not supported yet');
+  });
+
+  it('throws on unsupported optimize command', () => {
+    const ctx = buildCtx('/solr/mycore/update', new Map([['optimize', new Map()]]));
+    expect(() => request.apply(ctx)).toThrow('command is not supported yet');
+  });
+
+  it('throws on array of deletes (JS array)', () => {
+    // Use a real JS array wrapped in a Map
+    const body = new Map<string, any>([['delete', [{ id: '1' }, { id: '2' }]]]);
+    const ctx = buildCtx('/solr/mycore/update', body);
+    expect(() => request.apply(ctx)).toThrow('array/bulk operations are not supported');
+  });
+});
+
+// --- Response transform ---
+
+function buildResponseCtx(body: Map<string, any>): ResponseContext {
+  return {
+    request: new Map() as unknown as JavaMap,
+    response: new Map() as unknown as JavaMap,
+    endpoint: 'update',
+    collection: 'mycore',
+    requestParams: new URLSearchParams(),
+    responseBody: body as unknown as JavaMap,
+  };
+}
+
+describe('update-router response', () => {
+  it('matches OpenSearch _doc response', () => {
+    const body = new Map<string, any>([['_id', '1'], ['result', 'created']]);
+    expect(response.match!(buildResponseCtx(body))).toBe(true);
+  });
+
+  it('does not match select response', () => {
+    const body = new Map<string, any>([['hits', new Map()], ['took', 5]]);
+    expect(response.match!(buildResponseCtx(body))).toBe(false);
+  });
+
+  it('does not match response missing _id', () => {
+    const body = new Map<string, any>([['result', 'created']]);
+    expect(response.match!(buildResponseCtx(body))).toBe(false);
+  });
+
+  it('does not match response missing result', () => {
+    const body = new Map<string, any>([['_id', '1']]);
+    expect(response.match!(buildResponseCtx(body))).toBe(false);
+  });
+
+  it('converts created to status 0', () => {
+    const body = new Map<string, any>([['_id', '1'], ['result', 'created'], ['_index', 'x'], ['_shards', new Map()]]);
+    const ctx = buildResponseCtx(body);
+    response.apply(ctx);
+    expect(ctx.responseBody.get('responseHeader').get('status')).toBe(0);
+    expect(ctx.responseBody.has('_index')).toBe(false);
+    expect(ctx.responseBody.has('_shards')).toBe(false);
+    expect(ctx.responseBody.has('_id')).toBe(false);
+    expect(ctx.responseBody.has('result')).toBe(false);
+  });
+
+  it('converts updated to status 0', () => {
+    const body = new Map<string, any>([['_id', '1'], ['result', 'updated']]);
+    const ctx = buildResponseCtx(body);
+    response.apply(ctx);
+    expect(ctx.responseBody.get('responseHeader').get('status')).toBe(0);
+  });
+
+  it('converts deleted to status 0', () => {
+    const body = new Map<string, any>([['_id', '1'], ['result', 'deleted']]);
+    const ctx = buildResponseCtx(body);
+    response.apply(ctx);
+    expect(ctx.responseBody.get('responseHeader').get('status')).toBe(0);
+  });
+
+  it('converts not_found to status 0', () => {
+    const body = new Map<string, any>([['_id', '1'], ['result', 'not_found']]);
+    const ctx = buildResponseCtx(body);
+    response.apply(ctx);
+    expect(ctx.responseBody.get('responseHeader').get('status')).toBe(0);
+  });
+
+  it('sets status 1 for noop result', () => {
+    const body = new Map<string, any>([['_id', '1'], ['result', 'noop']]);
+    const ctx = buildResponseCtx(body);
+    response.apply(ctx);
+    expect(ctx.responseBody.get('responseHeader').get('status')).toBe(1);
+  });
+
+  it('sets status 1 for unexpected result value', () => {
+    const body = new Map<string, any>([['_id', '1'], ['result', 'something_unexpected']]);
+    const ctx = buildResponseCtx(body);
+    response.apply(ctx);
+    expect(ctx.responseBody.get('responseHeader').get('status')).toBe(1);
+  });
+
+  it('sets QTime to 0', () => {
+    const body = new Map<string, any>([['_id', '1'], ['result', 'deleted']]);
+    const ctx = buildResponseCtx(body);
+    response.apply(ctx);
+    expect(ctx.responseBody.get('responseHeader').get('QTime')).toBe(0);
+  });
+
+  it('clears all OpenSearch fields from response', () => {
+    const body = new Map<string, any>([
+      ['_id', '1'], ['result', 'created'], ['_index', 'x'],
+      ['_version', 1], ['_shards', new Map()], ['_seq_no', 0], ['_primary_term', 1],
+    ]);
+    const ctx = buildResponseCtx(body);
+    response.apply(ctx);
+    // Only responseHeader should remain
+    expect(ctx.responseBody.size).toBe(1);
+    expect(ctx.responseBody.has('responseHeader')).toBe(true);
+  });
+});

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/update-router.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/update-router.ts
@@ -1,0 +1,217 @@
+/**
+ * Update router — single entry point for all /update/* paths.
+ *
+ * Routes requests based on path and body shape:
+ *
+ * Supported:
+ *   /update/json/docs                  → update-doc (body IS the document)
+ *   /update  {"add":{"doc":{...}}}     → update-doc (unwraps add.doc)
+ *   /update  {"delete":{"id":"1"}}     → delete-doc
+ *
+ * Not supported (fail fast):
+ *   /update  {"delete":{"query":"..."}} → delete-by-query
+ *   /update  {"add":{"doc":{...},"boost":N}} → document-level boost
+ *   /update  {"add":{"doc":{...},"overwrite":false}} → conditional write
+ *   /update  {"commit":{}}              → commit
+ *   /update  {"optimize":{}}            → optimize
+ *   /update  {"rollback":{}}            → rollback
+ *   /update  {"add":[...]}              → bulk add (array)
+ *   /update  {"delete":[...]}           → bulk delete (array)
+ *   /update  mixed commands             → multiple commands in one request
+ *   /update  XML body                   → only JSON supported
+ *
+ * Future handlers are added as new cases in dispatchCommand() —
+ * no pipeline or registry changes needed.
+ *
+ * Response transform is also here — generic for all _doc API responses
+ * (create, update, delete). Converts OpenSearch format to Solr format.
+ */
+import type { MicroTransform } from '../pipeline';
+import type { RequestContext, ResponseContext } from '../context';
+import { request as deleteDocRequest } from './delete-doc';
+import { request as updateDocRequest } from './update-doc';
+
+/** Known Solr update command keys. */
+const KNOWN_COMMANDS = ['delete', 'add', 'commit', 'optimize', 'rollback'];
+
+/** Identify the command type from the body. Returns null if no command found. */
+function identifyCommand(body: any): string | null {
+  if (!body || typeof body.has !== 'function') return null;
+  for (const cmd of KNOWN_COMMANDS) {
+    if (body.has(cmd)) return cmd;
+  }
+  return null;
+}
+
+/** Check if body has multiple commands. */
+function hasMultipleCommands(body: any): boolean {
+  let count = 0;
+  for (const cmd of KNOWN_COMMANDS) {
+    if (body.has(cmd)) count++;
+    if (count > 1) return true;
+  }
+  return false;
+}
+
+/** Detect arrays — works for both JS arrays and GraalVM Java ArrayLists. */
+function isArrayLike(val: any): boolean {
+  if (val == null || typeof val === 'string') return false;
+  return Array.isArray(val) || (typeof val[Symbol.iterator] === 'function' && typeof val.get !== 'function');
+}
+
+/** Extract body keys for error messages. */
+function bodyKeys(body: any): string {
+  try {
+    return Array.from(body.keys()).join(', ');
+  } catch {
+    return '<unknown>';
+  }
+}
+
+/** Check if the path is the /update/json/docs shortcut. */
+function isJsonDocsPath(uri: string): boolean {
+  return /\/update\/json\/docs(\?|$)/.test(uri);
+}
+
+export const request: MicroTransform<RequestContext> = {
+  name: 'update-router',
+  apply: (ctx) => {
+    // Fail fast on non-JSON content types (XML not supported)
+    const headers = ctx.msg.get('headers');
+    const contentType = headers?.get?.('Content-Type') || headers?.get?.('content-type') || '';
+    if (contentType && !String(contentType).includes('json')) {
+      throw new Error(`[update-router] dispatch: only JSON content type is supported, got '${contentType}'`);
+    }
+
+    // Solr's /update only accepts POST
+    const method = ctx.msg.get('method');
+    if (method && method !== 'POST') {
+      throw new Error(`[update-router] dispatch: only POST method is accepted for /update, got '${method}'`);
+    }
+
+    const uri = ctx.msg.get('URI') || '';
+
+    // /update/json/docs — body IS the document.
+    // Basic validation before delegating to update-doc handler.
+    if (isJsonDocsPath(uri)) {
+      if (!ctx.body || ctx.body.size === 0) {
+        throw new Error('[update-router] json-docs: request body is empty — expected a JSON document');
+      }
+      updateDocRequest.apply(ctx);
+      return;
+    }
+
+    // /update — parse command from body and dispatch
+    dispatchCommand(ctx);
+  },
+};
+
+function dispatchCommand(ctx: RequestContext): void {
+  const body = ctx.body;
+
+  if (!body || body.size === 0) {
+    throw new Error('[update-router] dispatch: request body is empty or not JSON — only JSON content type is supported');
+  }
+
+  if (hasMultipleCommands(body)) {
+    throw new Error('[update-router] dispatch: mixed commands in a single request are not supported yet');
+  }
+
+  const command = identifyCommand(body);
+  if (!command) {
+    throw new Error(`[update-router] dispatch: no recognized command in request body (keys: ${bodyKeys(body)})`);
+  }
+
+  const commandData = body.get(command);
+
+  if (isArrayLike(commandData)) {
+    throw new Error(`[update-router] ${command}: array/bulk operations are not supported yet — send one command at a time`);
+  }
+
+  const handler = COMMAND_HANDLERS[command];
+  if (!handler) {
+    throw new Error(`[update-router] ${command}: command is not supported yet`);
+  }
+  handler(ctx, commandData);
+}
+
+/** Handler registry — add new command handlers here. */
+const COMMAND_HANDLERS: Record<string, (ctx: RequestContext, data: any) => void> = {
+  delete: handleDelete,
+  add: handleAdd,
+};
+
+function handleDelete(ctx: RequestContext, data: any): void {
+  if (!data || typeof data.has !== 'function') {
+    throw new Error('[update-router] delete: invalid command format — expected JSON object');
+  }
+  if (data.has('query')) {
+    throw new Error('[update-router] delete: delete-by-query is not supported yet');
+  }
+  // Fail fast on unsupported Solr delete fields
+  const SUPPORTED_DELETE_FIELDS = new Set(['id']);
+  for (const key of data.keys()) {
+    if (!SUPPORTED_DELETE_FIELDS.has(key)) {
+      throw new Error(`[update-router] delete: unsupported field '${key}' — only 'id' is supported`);
+    }
+  }
+  ctx.body = data;
+  deleteDocRequest.apply(ctx);
+}
+
+function handleAdd(ctx: RequestContext, data: any): void {
+  if (!data || typeof data.get !== 'function') {
+    throw new Error('[update-router] add: invalid command format — expected JSON object');
+  }
+  if (data.has('boost')) {
+    throw new Error('[update-router] add: document-level boost is not supported — OpenSearch has no equivalent');
+  }
+  if (data.has('overwrite') && data.get('overwrite') === false) {
+    throw new Error('[update-router] add: overwrite=false is not supported — OpenSearch always overwrites');
+  }
+  const doc = data.get('doc');
+  if (!doc || typeof doc.get !== 'function') {
+    throw new Error('[update-router] add: command must contain a "doc" field with a JSON object');
+  }
+  ctx.body = doc;
+  updateDocRequest.apply(ctx);
+}
+
+/**
+ * Response transform — convert OpenSearch _doc response to Solr update response.
+ *
+ * Generic for all _doc API operations (create, update, delete).
+ * OpenSearch returns: {"_index":"mycore","_id":"1","result":"created|updated|deleted",...}
+ * Solr returns:       {"responseHeader":{"status":0,"QTime":N}}
+ *
+ * Result mapping:
+ *   created/updated/deleted → status 0 (success)
+ *   not_found → status 0 (Solr treats delete of missing doc as success — verified against Solr 8/9)
+ *   anything else → status 1 (error)
+ *
+ * QTime is set to 0 because OpenSearch's _doc response does not include processing time.
+ * This is a known approximation — monitoring tools should not rely on this value for
+ * update operations through the shim.
+ */
+export const response: MicroTransform<ResponseContext> = {
+  name: 'update-response',
+  match: (ctx) => ctx.responseBody.has('result') && ctx.responseBody.has('_id'),
+  apply: (ctx) => {
+    const result = ctx.responseBody.get('result');
+    const status = (result === 'created' || result === 'updated' || result === 'deleted' || result === 'not_found') ? 0 : 1;
+
+    const keys = Array.from(ctx.responseBody.keys());
+    for (const key of keys) {
+      ctx.responseBody.delete(key);
+    }
+
+    // QTime is 0 because OpenSearch's _doc response doesn't include processing time.
+    ctx.responseBody.set(
+      'responseHeader',
+      new Map<string, unknown>([
+        ['status', status],
+        ['QTime', 0],
+      ]),
+    );
+  },
+};

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/registry.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/registry.ts
@@ -23,7 +23,7 @@ import * as highlighting from './features/highlighting';
 import * as hitsToDocs from './features/hits-to-docs';
 import * as aggsToFacets from './features/aggs-to-facets';
 import * as responseHeader from './features/response-header';
-import * as updateDoc from './features/update-doc';
+import * as updateRouter from './features/update-router';
 import * as validation from './features/validation';
 import { initValidation } from './features/validation';
 import type { ParamRule } from './features/validation';
@@ -85,7 +85,7 @@ export const requestRegistry: TransformRegistry<RequestContext> = {
       sort.request, // sort=... → sort DSL
     ],
     update: [
-      updateDoc.request, // single doc: /update/json/docs → /_doc/{id}
+      updateRouter.request,   // single entry point: routes /update/* by path and body shape
     ],
   },
 };
@@ -101,7 +101,7 @@ export const responseRegistry: TransformRegistry<ResponseContext> = {
       responseHeader.response, // synthesize responseHeader
     ],
     update: [
-      updateDoc.response, // OpenSearch _doc response → Solr update response format
+      updateRouter.response,  // generic _doc response → Solr format (create/update/delete)
     ],
   },
 };

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/update-router.testcase.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/update-router.testcase.ts
@@ -1,0 +1,239 @@
+/**
+ * E2E test cases for /update command dispatcher — delete-by-id and add-via-update.
+ */
+import { solrTest, SOLR_INTERNAL_RULES } from '../test-types';
+import type { TestCase } from '../test-types';
+
+const UPDATE_RESPONSE_RULES = [
+  { path: '$.responseHeader.QTime', rule: 'ignore' as const, reason: 'Timing varies' },
+  { path: '$.responseHeader.params', rule: 'ignore' as const, reason: 'Solr echoes params, proxy does not' },
+];
+
+export const testCases: TestCase[] = [
+  // --- delete-by-id: happy path ---
+
+  solrTest('update-cmd-delete-by-id', {
+    description: 'Delete existing document via /update with delete command',
+    documents: [{ id: '1', title: 'to be deleted' }],
+    method: 'POST',
+    requestBody: JSON.stringify({ delete: { id: '1' } }),
+    requestPath: '/solr/testcollection/update?commit=true',
+    solrSchema: {
+      fields: { title: { type: 'text_general' } },
+    },
+    opensearchMapping: {
+      properties: { title: { type: 'text' } },
+    },
+    assertionRules: UPDATE_RESPONSE_RULES,
+  }),
+
+  solrTest('update-cmd-delete-special-chars-id', {
+    description: 'Delete document with special characters in id',
+    documents: [{ id: 'doc-with-dashes', title: 'special' }],
+    method: 'POST',
+    requestBody: JSON.stringify({ delete: { id: 'doc-with-dashes' } }),
+    requestPath: '/solr/testcollection/update?commit=true',
+    solrSchema: {
+      fields: { title: { type: 'text_general' } },
+    },
+    opensearchMapping: {
+      properties: { title: { type: 'text' } },
+    },
+    assertionRules: UPDATE_RESPONSE_RULES,
+  }),
+
+  solrTest('update-cmd-delete-nonexistent', {
+    description: 'Delete non-existent document should still return success',
+    documents: [{ id: '1', title: 'keep this' }],
+    method: 'POST',
+    requestBody: JSON.stringify({ delete: { id: 'does-not-exist' } }),
+    requestPath: '/solr/testcollection/update?commit=true',
+    solrSchema: {
+      fields: { title: { type: 'text_general' } },
+    },
+    opensearchMapping: {
+      properties: { title: { type: 'text' } },
+    },
+    assertionRules: UPDATE_RESPONSE_RULES,
+  }),
+
+  // --- add via /update: happy path ---
+
+  solrTest('update-cmd-add-single-doc', {
+    description: 'Add document via /update with add command',
+    documents: [],
+    method: 'POST',
+    requestBody: JSON.stringify({ add: { doc: { id: '1', title: 'added via update' } } }),
+    requestPath: '/solr/testcollection/update?commit=true',
+    solrSchema: {
+      fields: { title: { type: 'text_general' } },
+    },
+    opensearchMapping: {
+      properties: { title: { type: 'text' } },
+    },
+    assertionRules: UPDATE_RESPONSE_RULES,
+  }),
+
+  solrTest('update-cmd-add-multiple-fields', {
+    description: 'Add document with multiple field types via /update',
+    documents: [],
+    method: 'POST',
+    requestBody: JSON.stringify({ add: { doc: { id: '2', title: 'multi', price: 19.99, inStock: true } } }),
+    requestPath: '/solr/testcollection/update?commit=true',
+    solrSchema: {
+      fields: {
+        title: { type: 'text_general' },
+        price: { type: 'pfloat' },
+        inStock: { type: 'boolean' },
+      },
+    },
+    opensearchMapping: {
+      properties: {
+        title: { type: 'text' },
+        price: { type: 'float' },
+        inStock: { type: 'boolean' },
+      },
+    },
+    assertionRules: UPDATE_RESPONSE_RULES,
+  }),
+
+  // --- error paths ---
+
+  solrTest('update-cmd-error-delete-by-query', {
+    description: 'Delete-by-query should return 500',
+    documents: [{ id: '1', title: 'test' }],
+    method: 'POST',
+    requestBody: JSON.stringify({ delete: { query: 'title:test' } }),
+    requestPath: '/solr/testcollection/update',
+    expectedStatusCode: 500,
+    expectedErrorContains: 'Request transform failed',
+  }),
+
+  solrTest('update-cmd-error-mixed-commands', {
+    description: 'Mixed commands should return 500',
+    documents: [],
+    method: 'POST',
+    requestBody: JSON.stringify({ delete: { id: '1' }, add: { doc: { id: '2', title: 'x' } } }),
+    requestPath: '/solr/testcollection/update',
+    expectedStatusCode: 500,
+    expectedErrorContains: 'Request transform failed',
+  }),
+
+  solrTest('update-cmd-error-unsupported-commit', {
+    description: 'Standalone commit command should return 500',
+    documents: [],
+    method: 'POST',
+    requestBody: JSON.stringify({ commit: {} }),
+    requestPath: '/solr/testcollection/update',
+    expectedStatusCode: 500,
+    expectedErrorContains: 'Request transform failed',
+  }),
+
+  solrTest('update-cmd-error-empty-body', {
+    description: 'Empty body on /update should return 500',
+    documents: [],
+    method: 'POST',
+    requestBody: JSON.stringify({}),
+    requestPath: '/solr/testcollection/update',
+    expectedStatusCode: 500,
+    expectedErrorContains: 'Request transform failed',
+  }),
+
+  solrTest('update-cmd-error-delete-missing-id', {
+    description: 'Delete without id field should return 500',
+    documents: [],
+    method: 'POST',
+    requestBody: JSON.stringify({ delete: {} }),
+    requestPath: '/solr/testcollection/update',
+    expectedStatusCode: 500,
+    expectedErrorContains: 'Request transform failed',
+  }),
+
+  solrTest('update-cmd-error-array-deletes', {
+    description: 'Array of deletes should return 500 (bulk not supported)',
+    documents: [],
+    method: 'POST',
+    requestBody: JSON.stringify({ delete: [{ id: '1' }, { id: '2' }] }),
+    requestPath: '/solr/testcollection/update',
+    expectedStatusCode: 500,
+    expectedErrorContains: 'Request transform failed',
+  }),
+
+  solrTest('update-cmd-error-add-with-boost', {
+    description: 'Add with document-level boost should return 500',
+    documents: [],
+    method: 'POST',
+    requestBody: JSON.stringify({ add: { doc: { id: '1', title: 'test' }, boost: 2 } }),
+    requestPath: '/solr/testcollection/update',
+    expectedStatusCode: 500,
+    expectedErrorContains: 'Request transform failed',
+  }),
+
+  solrTest('update-cmd-error-add-overwrite-false', {
+    description: 'Add with overwrite=false should return 500',
+    documents: [],
+    method: 'POST',
+    requestBody: JSON.stringify({ add: { doc: { id: '1', title: 'test' }, overwrite: false } }),
+    requestPath: '/solr/testcollection/update',
+    expectedStatusCode: 500,
+    expectedErrorContains: 'Request transform failed',
+  }),
+
+  solrTest('update-cmd-error-delete-with-route', {
+    description: 'Delete with _route_ field should return 500',
+    documents: [],
+    method: 'POST',
+    requestBody: JSON.stringify({ delete: { id: '1', _route_: 'shard1' } }),
+    requestPath: '/solr/testcollection/update',
+    expectedStatusCode: 500,
+    expectedErrorContains: 'Request transform failed',
+  }),
+
+  // --- Side-effect verification tests ---
+
+  solrTest('update-cmd-add-then-query', {
+    description: 'Add a doc via /update, then verify it exists via select',
+    documents: [],
+    method: 'POST',
+    requestBody: JSON.stringify({ add: { doc: { id: 'verify-add-1', title: 'added and verified' } } }),
+    requestPath: '/solr/testcollection/update?commit=true',
+    solrSchema: {
+      fields: { title: { type: 'text_general' } },
+    },
+    opensearchMapping: {
+      properties: { title: { type: 'text' } },
+    },
+    assertionRules: UPDATE_RESPONSE_RULES,
+    requestSequence: [
+      {
+        requestPath: '/solr/testcollection/select?q=id:verify-add-1&wt=json',
+        assertionRules: [
+          ...SOLR_INTERNAL_RULES,
+        ],
+      },
+    ],
+  }),
+
+  solrTest('update-cmd-delete-then-query', {
+    description: 'Delete a doc via /update, then verify it is gone via select',
+    documents: [{ id: 'verify-del-1', title: 'to be deleted' }],
+    method: 'POST',
+    requestBody: JSON.stringify({ delete: { id: 'verify-del-1' } }),
+    requestPath: '/solr/testcollection/update?commit=true',
+    solrSchema: {
+      fields: { title: { type: 'text_general' } },
+    },
+    opensearchMapping: {
+      properties: { title: { type: 'text' } },
+    },
+    assertionRules: UPDATE_RESPONSE_RULES,
+    requestSequence: [
+      {
+        requestPath: '/solr/testcollection/select?q=id:verify-del-1&wt=json',
+        assertionRules: [
+          ...SOLR_INTERNAL_RULES,
+        ],
+      },
+    ],
+  }),
+];


### PR DESCRIPTION
### Description

Adds a command dispatcher for Solr's `/update` endpoint and single document delete-by-id support. The dispatcher parses the JSON body, identifies the command type, and delegates to the appropriate handler. Also refactors the response transform from `update-doc.ts` into a generic handler that supports create, update, and delete responses.

**Supported commands on `/update`:**

| Solr command | OpenSearch translation | Status |
|---|---|---|
| `{"delete": {"id": "1"}}` | `DELETE /{collection}/_doc/1` | ✅ New |
| `{"add": {"doc": {...}}}` | `PUT /{collection}/_doc/{id}` (delegates to update-doc) | ✅ New |
| `{"delete": {"query": "..."}}` | — | ❌ Fail fast |
| `{"commit": {}}` | — | ❌ Fail fast |
| Mixed commands | — | ❌ Fail fast |
| Array/bulk operations | — | ❌ Fail fast |
| XML content type | — | ❌ Fail fast |

**Architecture:**

```
POST /solr/{collection}/update
        │
        ▼
  update-command.ts (dispatcher)
        │
        ├── "delete" with "id"  →  delete-doc.ts  →  DELETE /_doc/{id}
        ├── "add" with "doc"    →  update-doc.ts   →  PUT /_doc/{id}
        └── unknown/mixed       →  fail fast
```

```
Pipeline order:
  update: [
    updateDoc.request,      // /update/json/docs (direct path, unchanged)
    updateCommand.request,  // /update (command dispatcher)
  ]
  response: [
    updateCommand.response, // generic _doc response → Solr format
  ]
```

**Response transform refactoring:**
- Moved from `update-doc.ts` to `update-command.ts` since it's generic for all `_doc` API operations
- Now handles `created`, `updated`, `deleted`, and `not_found` results (previously only `created`/`updated`)
- `not_found` maps to status 0 (matching Solr's idempotent delete behavior)

### Files Changed (9)

| File | Change |
|---|---|
| `features/update-command.ts` | New — command dispatcher + generic response transform |
| `features/update-command.test.ts` | New — 30 unit tests |
| `features/delete-doc.ts` | New — delete-by-id handler |
| `features/delete-doc.test.ts` | New — 7 unit tests |
| `update-command.testcase.ts` | New — 10 e2e test cases (5 happy + 5 error) |
| `features/update-doc.ts` | Modified — removed response transform (moved to update-command) |
| `features/update-doc.test.ts` | Modified — removed response transform tests (moved to update-command) |
| `registry.ts` | Modified — wired update-command into update endpoint pipeline |
| `docs/LIMITATIONS.md` | Modified — added UPDATE-COMMANDS section |

### Testing

| Layer | Result |
|---|---|
| Unit tests (vitest) | 26 files, 581 tests ✅ |
| E2E integration (Solr 8 + 9) | 10/10 passed ✅ |
| Sandbox (200K dataset, 167 queries) | 88/167 — same baseline, zero regressions ✅ |
| Manual sandbox validation | 14/14 tests passed ✅ |


### Check List
- [x] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
