### PR TITLE
BugFix for prefix sequence queries

### DIFF
--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/integration-tests/standard-query-parser/bool-query.testcase.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/integration-tests/standard-query-parser/bool-query.testcase.ts
@@ -295,4 +295,91 @@ export const testCases: TestCase[] = [
     solrSchema: threeFieldSchema,
     opensearchMapping: threeFieldMapping,
   }),
+
+  // ───────────────────────────────────────────────────────────
+  // Prefix sequences (+foo -bar +baz)
+  // ───────────────────────────────────────────────────────────
+
+  solrTest('query-bool-prefix-sequence-two', {
+    description: 'Prefix sequence with two terms: +A -B',
+    documents: electronicsClothingDocs,
+    // +category:electronics -status:draft
+    // Expected: electronics that are NOT draft → id 1, 3
+    requestPath: '/solr/testcollection/select?q=' + encodeURIComponent('+category:electronics -status:draft') + '&wt=json',
+    solrSchema: threeFieldSchema,
+    opensearchMapping: threeFieldMapping,
+  }),
+
+  solrTest('query-bool-prefix-sequence-three', {
+    description: 'Prefix sequence with three terms: +A +B -C',
+    documents: electronicsClothingDocs,
+    // +category:electronics +status:active -title:tablet
+    // Expected: electronics AND active AND NOT tablet → id 1 (laptop)
+    requestPath: '/solr/testcollection/select?q=' + encodeURIComponent('+category:electronics +status:active -title:tablet') + '&wt=json',
+    solrSchema: threeFieldSchema,
+    opensearchMapping: threeFieldMapping,
+  }),
+
+  solrTest('query-bool-prefix-sequence-all-required', {
+    description: 'Prefix sequence with all required: +A +B +C',
+    documents: electronicsClothingDocs,
+    // +category:electronics +status:active +title:laptop
+    // Expected: all three must match → id 1
+    requestPath: '/solr/testcollection/select?q=' + encodeURIComponent('+category:electronics +status:active +title:laptop') + '&wt=json',
+    solrSchema: threeFieldSchema,
+    opensearchMapping: threeFieldMapping,
+  }),
+
+  solrTest('query-bool-prefix-sequence-all-prohibited', {
+    description: 'Prefix sequence with all prohibited: -A -B (matches everything except)',
+    documents: electronicsClothingDocs,
+    // -category:electronics -category:clothing
+    // Expected: NOT electronics AND NOT clothing → id 5 (tools)
+    requestPath: '/solr/testcollection/select?q=' + encodeURIComponent('-category:electronics -category:clothing') + '&wt=json',
+    solrSchema: threeFieldSchema,
+    opensearchMapping: threeFieldMapping,
+  }),
+
+  solrTest('query-bool-prefix-sequence-bare-terms', {
+    description: 'Prefix sequence with bare terms: +foo -bar +baz',
+    documents: [
+      { id: '1', title: 'foo bar baz', content: 'all three' },
+      { id: '2', title: 'foo baz', content: 'no bar' },
+      { id: '3', title: 'foo bar', content: 'no baz' },
+      { id: '4', title: 'bar baz', content: 'no foo' },
+    ],
+    // +foo -bar +baz → must have foo AND baz, must NOT have bar
+    // Expected: id 2 (foo baz, no bar)
+    requestPath: '/solr/testcollection/select?q=' + encodeURIComponent('+foo -bar +baz') + '&df=title&wt=json',
+    solrSchema: { fields: { title: { type: 'text_general' }, content: { type: 'text_general' } } },
+    opensearchMapping: { properties: { title: { type: 'text' }, content: { type: 'text' } } },
+  }),
+
+  solrTest('query-bool-prefix-sequence-mixed-field-bare', {
+    description: 'Prefix sequence mixing field:value and bare terms',
+    documents: [
+      { id: '1', title: 'laptop computer', category: 'electronics', status: 'active' },
+      { id: '2', title: 'laptop bag', category: 'accessories', status: 'active' },
+      { id: '3', title: 'phone charger', category: 'electronics', status: 'active' },
+    ],
+    // +laptop +category:electronics -title:bag
+    // Expected: must have "laptop" in df, must be electronics, must NOT have "bag" in title → id 1
+    requestPath: '/solr/testcollection/select?q=' + encodeURIComponent('+laptop +category:electronics -title:bag') + '&df=title&wt=json',
+    solrSchema: threeFieldSchema,
+    opensearchMapping: threeFieldMapping,
+  }),
+
+  solrTest('query-bool-prefix-sequence-with-phrases', {
+    description: 'Prefix sequence with phrase queries: +"hello world" -"goodbye world"',
+    documents: [
+      { id: '1', title: 'hello world today', content: 'greeting' },
+      { id: '2', title: 'hello world goodbye world', content: 'both' },
+      { id: '3', title: 'goodbye world', content: 'farewell' },
+    ],
+    // +"hello world" -"goodbye world"
+    // Expected: must have "hello world", must NOT have "goodbye world" → id 1
+    requestPath: '/solr/testcollection/select?q=' + encodeURIComponent('+"hello world" -"goodbye world"') + '&df=title&wt=json',
+    solrSchema: { fields: { title: { type: 'text_general' }, content: { type: 'text_general' } } },
+    opensearchMapping: { properties: { title: { type: 'text' }, content: { type: 'text' } } },
+  }),
 ];

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/parser/boolNode.parser.test.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/parser/boolNode.parser.test.ts
@@ -241,15 +241,13 @@ describe('parseSolrQuery – BoolNode', () => {
   it('parses mixed + and - prefixes', () => {
     const { ast, errors } = parseSolrQuery('+title:java -status:draft', emptyParams);
     expect(errors).toEqual([]);
-    // Two adjacent terms → implicit OR
+    // Consecutive prefix operators are merged: +A -B → { and: [A], not: [B] }
+    // This matches Solr semantics where +/- prefixed terms form an AND relationship
     expect(ast).toEqual({
       type: 'bool',
-      and: [],
-      or: [
-        { type: 'bool', and: [{ type: 'field', field: 'title', value: 'java' }], or: [], not: [] },
-        { type: 'bool', and: [], or: [], not: [{ type: 'field', field: 'status', value: 'draft' }] },
-      ],
-      not: [],
+      and: [{ type: 'field', field: 'title', value: 'java' }],
+      or: [],
+      not: [{ type: 'field', field: 'status', value: 'draft' }],
     });
   });
 
@@ -309,6 +307,238 @@ describe('parseSolrQuery – BoolNode', () => {
       and: [],
       or: [],
       not: [{ type: 'bare', value: 'draft', isPhrase: false, defaultField: 'status' }],
+    });
+  });
+
+  // ─── Prefix sequence merging ───────────────────────────────────────────
+  // Consecutive +/- prefixed terms form an AND relationship in Solr.
+  // This is correct parsing of Solr syntax, not a transformation.
+
+  // Fallback path: single prefix still routes correctly through prefixExpr
+  it('single +A falls through to prefixExpr (not prefixSequence)', () => {
+    const { ast, errors } = parseSolrQuery('+title:java', emptyParams);
+    expect(errors).toEqual([]);
+    expect(ast).toEqual({
+      type: 'bool',
+      and: [{ type: 'field', field: 'title', value: 'java' }],
+      or: [],
+      not: [],
+    });
+  });
+
+  it('single -A falls through to prefixExpr (not prefixSequence)', () => {
+    const { ast, errors } = parseSolrQuery('-status:draft', emptyParams);
+    expect(errors).toEqual([]);
+    expect(ast).toEqual({
+      type: 'bool',
+      and: [],
+      or: [],
+      not: [{ type: 'field', field: 'status', value: 'draft' }],
+    });
+  });
+
+  it('parses +A +B as merged must clauses', () => {
+    const { ast, errors } = parseSolrQuery('+title:java +author:smith', emptyParams);
+    expect(errors).toEqual([]);
+    expect(ast).toEqual({
+      type: 'bool',
+      and: [
+        { type: 'field', field: 'title', value: 'java' },
+        { type: 'field', field: 'author', value: 'smith' },
+      ],
+      or: [],
+      not: [],
+    });
+  });
+
+  it('parses -A -B as merged must_not clauses', () => {
+    const { ast, errors } = parseSolrQuery('-status:draft -status:archived', emptyParams);
+    expect(errors).toEqual([]);
+    expect(ast).toEqual({
+      type: 'bool',
+      and: [],
+      or: [],
+      not: [
+        { type: 'field', field: 'status', value: 'draft' },
+        { type: 'field', field: 'status', value: 'archived' },
+      ],
+    });
+  });
+
+  it('parses +A +B +C as merged must clauses (three terms)', () => {
+    const { ast, errors } = parseSolrQuery('+title:java +author:smith +year:2024', emptyParams);
+    expect(errors).toEqual([]);
+    expect(ast).toEqual({
+      type: 'bool',
+      and: [
+        { type: 'field', field: 'title', value: 'java' },
+        { type: 'field', field: 'author', value: 'smith' },
+        { type: 'field', field: 'year', value: '2024' },
+      ],
+      or: [],
+      not: [],
+    });
+  });
+
+  it('parses +A +B -C as mixed must/must_not', () => {
+    const { ast, errors } = parseSolrQuery('+title:java +author:smith -status:draft', emptyParams);
+    expect(errors).toEqual([]);
+    expect(ast).toEqual({
+      type: 'bool',
+      and: [
+        { type: 'field', field: 'title', value: 'java' },
+        { type: 'field', field: 'author', value: 'smith' },
+      ],
+      or: [],
+      not: [
+        { type: 'field', field: 'status', value: 'draft' },
+      ],
+    });
+  });
+
+  // Non-consecutive prefixes: bare term breaks the sequence — each run is separate
+  it('non-consecutive +A B +C — bare term breaks prefix sequence into separate OR groups', () => {
+    // +A and +C are separate prefixExpr nodes joined by implicit OR via orExpr
+    // B is a bare term, also in the implicit OR
+    const { ast, errors } = parseSolrQuery('+title:java author:smith +year:2024', emptyParams);
+    expect(errors).toEqual([]);
+    expect(ast).toEqual({
+      type: 'bool',
+      and: [],
+      or: [
+        { type: 'bool', and: [{ type: 'field', field: 'title', value: 'java' }], or: [], not: [] },
+        { type: 'field', field: 'author', value: 'smith' },
+        { type: 'bool', and: [{ type: 'field', field: 'year', value: '2024' }], or: [], not: [] },
+      ],
+      not: [],
+    });
+  });
+
+  // Precedence: prefixSequence binds tighter than AND/OR
+  it('prefixSequence precedence — +A +B AND C treats +A +B as one unit', () => {
+    // (+A +B) AND C — the prefix sequence is one operand of AND
+    const { ast, errors } = parseSolrQuery('+title:java +author:smith AND category:tech', emptyParams);
+    expect(errors).toEqual([]);
+    expect(ast).toEqual({
+      type: 'bool',
+      and: [
+        { type: 'bool', and: [{ type: 'field', field: 'title', value: 'java' }, { type: 'field', field: 'author', value: 'smith' }], or: [], not: [] },
+        { type: 'field', field: 'category', value: 'tech' },
+      ],
+      or: [],
+      not: [],
+    });
+  });
+
+  // Explicit OR overrides prefix merging — +A OR +B is two separate OR branches
+  it('explicit OR between prefixed terms — +A OR +B is NOT merged', () => {
+    const { ast, errors } = parseSolrQuery('+title:java OR +author:smith', emptyParams);
+    expect(errors).toEqual([]);
+    expect(ast).toEqual({
+      type: 'bool',
+      and: [],
+      or: [
+        { type: 'bool', and: [{ type: 'field', field: 'title', value: 'java' }], or: [], not: [] },
+        { type: 'bool', and: [{ type: 'field', field: 'author', value: 'smith' }], or: [], not: [] },
+      ],
+      not: [],
+    });
+  });
+
+  // ─── Grouped/nested expressions inside prefix operators ───────────────────
+  // prefixWithType delegates to `primary`, and `primary` includes `group`,
+  // so +(A OR B), -(A AND B), etc. are all valid.
+
+  it('parses +(A OR B) — required group', () => {
+    const { ast, errors } = parseSolrQuery('+(title:java OR title:python)', emptyParams);
+    expect(errors).toEqual([]);
+    expect(ast).toEqual({
+      type: 'bool',
+      and: [{
+        type: 'group',
+        child: {
+          type: 'bool',
+          and: [],
+          or: [
+            { type: 'field', field: 'title', value: 'java' },
+            { type: 'field', field: 'title', value: 'python' },
+          ],
+          not: [],
+        },
+      }],
+      or: [],
+      not: [],
+    });
+  });
+
+  it('parses -(A OR B) — prohibited group', () => {
+    const { ast, errors } = parseSolrQuery('-(status:draft OR status:archived)', emptyParams);
+    expect(errors).toEqual([]);
+    expect(ast).toEqual({
+      type: 'bool',
+      and: [],
+      or: [],
+      not: [{
+        type: 'group',
+        child: {
+          type: 'bool',
+          and: [],
+          or: [
+            { type: 'field', field: 'status', value: 'draft' },
+            { type: 'field', field: 'status', value: 'archived' },
+          ],
+          not: [],
+        },
+      }],
+    });
+  });
+
+  it('parses +A +(B OR C) — required field and required group', () => {
+    const { ast, errors } = parseSolrQuery('+title:java +(author:smith OR author:doe)', emptyParams);
+    expect(errors).toEqual([]);
+    expect(ast).toEqual({
+      type: 'bool',
+      and: [
+        { type: 'field', field: 'title', value: 'java' },
+        {
+          type: 'group',
+          child: {
+            type: 'bool',
+            and: [],
+            or: [
+              { type: 'field', field: 'author', value: 'smith' },
+              { type: 'field', field: 'author', value: 'doe' },
+            ],
+            not: [],
+          },
+        },
+      ],
+      or: [],
+      not: [],
+    });
+  });
+
+  it('parses +A -(B AND C) — required field and prohibited nested AND group', () => {
+    const { ast, errors } = parseSolrQuery('+title:java -(status:draft AND category:test)', emptyParams);
+    expect(errors).toEqual([]);
+    expect(ast).toEqual({
+      type: 'bool',
+      and: [
+        { type: 'field', field: 'title', value: 'java' },
+      ],
+      or: [],
+      not: [{
+        type: 'group',
+        child: {
+          type: 'bool',
+          and: [
+            { type: 'field', field: 'status', value: 'draft' },
+            { type: 'field', field: 'category', value: 'test' },
+          ],
+          or: [],
+          not: [],
+        },
+      }],
     });
   });
 });

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/parser/filterNode.parser.test.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/parser/filterNode.parser.test.ts
@@ -522,34 +522,21 @@ describe('FilterNode parsing', () => {
       expect(errors).toEqual([]);
       expect(ast).toEqual({
         type: 'bool',
-        and: [],
-        or: [
+        and: [
           {
-            type: 'bool',
-            and: [
-              {
-                type: 'boost',
-                child: { type: 'filter', child: { type: 'field', field: 'a', value: '1' } },
-                value: 2,
-              },
-            ],
-            or: [],
-            not: [],
-          },
-          {
-            type: 'bool',
-            and: [],
-            or: [],
-            not: [
-              {
-                type: 'boost',
-                child: { type: 'filter', child: { type: 'field', field: 'b', value: '2' } },
-                value: 0.5,
-              },
-            ],
+            type: 'boost',
+            child: { type: 'filter', child: { type: 'field', field: 'a', value: '1' } },
+            value: 2,
           },
         ],
-        not: [],
+        or: [],
+        not: [
+          {
+            type: 'boost',
+            child: { type: 'filter', child: { type: 'field', field: 'b', value: '2' } },
+            value: 0.5,
+          },
+        ],
       });
     });
 

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/parser/solr.pegjs
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/parser/solr.pegjs
@@ -71,10 +71,32 @@ unaryExpr
   = notOp _ expr:unaryExpr {
       return { type: 'bool', and: [], or: [], not: [expr] };
     }
-  / prefixExpr
+  / prefixSequence
 
 // NOT operator: "NOT" (requires trailing whitespace) or "!" (no whitespace needed)
 notOp = "NOT" __ / "!"
+
+// Prefix sequence: consecutive +/- prefixed terms form an AND relationship.
+// In Solr, `+A +B` means "A required AND B required", not "(+A) OR (+B)".
+// This rule directly builds a BoolNode with and/not arrays from the prefix operators.
+//
+// Examples:
+//   `+A +B` → BoolNode { and: [A, B], or: [], not: [] }
+//   `-A -B` → BoolNode { and: [], or: [], not: [A, B] }
+//   `+A -B` → BoolNode { and: [A], or: [], not: [B] }
+prefixSequence
+  = head:prefixWithType tail:(__ prefixWithType)+ {
+      const all = [head, ...tail.map(t => t[1])];
+      const and = all.filter(p => p.op === '+').map(p => p.expr);
+      const not = all.filter(p => p.op === '-').map(p => p.expr);
+      return { type: 'bool', and, or: [], not, implicit: false };
+    }
+  / prefixExpr
+
+// Returns { op: '+' or '-', expr: node } for use by prefixSequence
+prefixWithType
+  = "+" _ expr:primary { return { op: '+', expr }; }
+  / "-" _ expr:primary { return { op: '-', expr }; }
 
 // Prefix expressions: +term (required) and -term (prohibited)
 // `+title:java` → BoolNode { and: [FieldNode] } (must match)

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/transformer/rules/boolRule.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/transformer/rules/boolRule.ts
@@ -19,14 +19,14 @@
  * This produces cleaner DSL matching what OpenSearch clients typically generate.
  */
 
-import type { ASTNode } from '../../ast/nodes';
+import type { ASTNode, BoolNode } from '../../ast/nodes';
 import type { TransformRuleFn, TransformChild } from '../types';
 
 export const boolRule: TransformRuleFn = (
   node: ASTNode,
   transformChild: TransformChild,
 ): Map<string, any> => {
-  const { and, or, not } = node;
+  const { and, or, not } = node as BoolNode;
   const boolMap = new Map<string, any>();
 
   // TODO: Flattening will help in query optimizations


### PR DESCRIPTION
### Description
When we have prefix terms like `+`, `-` ex: `+jakarta +lucene` => it means to search for documents that must contain "jakarta" and  "lucene,". When we don't have prefix terms ex: `jakarta lucene` => we search for docs that contain either jakarta or lucene or both. By default space works like OR operator but when we've prefix operators it is implicit AND. Fixing bug to consider as implicit AND when we've prefix operators

Sample -
| Query | Before | After |
|-------|--------|-------|
| `+A +B` | A OR B | A AND B |
| `+A -B` | A OR (NOT B) | A AND NOT B |

### Testing
UTs and Integ

### Check List
-  [x] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
