### PR TITLE
Emitting Limitation Metrics from Transforms

### DIFF
--- a/TrafficCapture/SolrTransformations/docs/LIMITATIONS.md
+++ b/TrafficCapture/SolrTransformations/docs/LIMITATIONS.md
@@ -12,6 +12,7 @@ the root cause, and provides a workaround where one exists.
 |-------------------------------------------------|---------|
 | [TERMS-OFFSET](#terms-offset)                   | Terms facet `offset` not natively supported in OpenSearch |
 | [DATE-RANGE-GAP](#date-range-gap)               | Multi-unit date range gaps approximated as fixed intervals |
+| [RANGE-BOUNDARY](#range-boundary)               | Range facet boundary types not fully expressible in OpenSearch |
 | [CURSOR-UNIQUEKEY](#cursor-uniquekey)           | Cursor pagination assumes `id` as Solr's uniqueKey field |
 | [CURSOR-REPLAY](#cursor-replay)                 | Traffic replay with cursorMark not supported |
 | [SOLRCONFIG-REPLAYER](#solrconfig-replayer)     | Traffic replayer requires manual solrConfig in bindingsObject |
@@ -123,6 +124,47 @@ always use `fixed_interval` since they cannot be expressed as a single
 * **Compound gap drift** — Compound gaps combining calendar and fixed units
   (e.g. `+1MONTH+2DAYS`) accumulate approximation error from each calendar
   component.
+
+---
+
+## RANGE-BOUNDARY
+
+**Feature:** Range facet with non-default boundary inclusivity
+
+**Solr behaviour:**
+Solr's range facet syntax supports four bracket combinations to control
+boundary inclusivity on each range: `[from, to)` (default), `(from, to)`,
+`[from, to]`, and `(from, to]`. The JSON Facets API `range` type also
+accepts explicit `include` options (`lower`, `upper`, `edge`, `outer`, `all`)
+that fine-tune which boundaries are inclusive.
+
+**OpenSearch behaviour:**
+OpenSearch's `range` aggregation defines each bucket with `from` (inclusive)
+and `to` (exclusive). There is no per-bucket option to flip a boundary
+between inclusive and exclusive.
+
+**Cause:**
+The `range` aggregation hardcodes `[from, to)` semantics. A Solr range
+expressed as `(10, 20]` (exclusive start, inclusive end) cannot be
+represented exactly — the transformer would need to adjust the numeric
+boundary values, which requires knowledge of the field's precision and
+data type.
+
+**Current workaround (applied automatically by the transformer):**
+The transformer parses the bracket notation and emits a console warning
+when the boundaries differ from OpenSearch's default `[from, to)`. The
+`from` and `to` values are passed through as-is, so the resulting bucket
+boundaries are approximate.
+
+**Residual impact:**
+
+* **Off-by-one at boundaries** — Documents exactly at a boundary value may
+  be included or excluded differently than in Solr. For example, a Solr
+  range `(10, 20]` excludes 10 and includes 20, but OpenSearch's
+  `[10, 20)` includes 10 and excludes 20.
+* **Floating-point edge cases** — For decimal fields the mismatch is
+  typically negligible, but for integer fields a single-value difference
+  at the boundary can change bucket counts.
 
 ---
 

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/context.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/context.ts
@@ -8,6 +8,9 @@
  * This matches the replayer/document transform pattern in backfill.
  */
 
+import type { MetricsAccumulator, TransformMetricName } from './metrics';
+import { createMetrics, incrementMetric } from './metrics';
+
 export type SolrEndpoint = 'select' | 'update' | 'admin' | 'schema' | 'config' | 'unknown';
 
 /**
@@ -42,6 +45,10 @@ export interface RequestContext {
    * Uses Record (plain object) because GraalVM exposes Java Maps as JS objects via allowMapAccess.
    */
   solrConfig?: Record<string, { defaults?: Record<string, string>; invariants?: Record<string, string>; appends?: Record<string, string> }>;
+  /** Record a limitation metric occurrence. */
+  emitMetric(metric: TransformMetricName): void;
+  /** Internal accumulator — use {@link emitMetric} instead. */
+  readonly _metrics: MetricsAccumulator;
 }
 
 /** Parsed once from the bundled {request, response}. Shared across all response micro-transforms. */
@@ -90,6 +97,7 @@ function getBodyMap(payload: JavaMap): JavaMap {
 
 export function buildRequestContext(msg: JavaMap): RequestContext {
   const uri: string = msg.get('URI') || '';
+  const metrics = createMetrics();
   return {
     msg,
     endpoint: detectEndpoint(uri),
@@ -98,6 +106,8 @@ export function buildRequestContext(msg: JavaMap): RequestContext {
     body: getBodyMap(msg.get('payload')),
     targetName: msg.get('_targetName') || 'opensearch',
     mode: msg.get('_mode') || 'single',
+    emitMetric: (metric: TransformMetricName) => incrementMetric(metrics, metric),
+    _metrics: metrics,
   };
 }
 

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/json-facets.test.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/json-facets.test.ts
@@ -21,6 +21,8 @@ function ctxWithBodyFacet(obj: Record<string, any>): RequestContext {
     collection: 'testcollection',
     params: new URLSearchParams(),
     body,
+    emitMetric: () => {},
+    _metrics: new Map(),
   };
 }
 
@@ -36,6 +38,8 @@ function ctxWithParamFacet(obj: Record<string, any>): RequestContext {
     collection: 'testcollection',
     params: new URLSearchParams({ 'json.facet': facetJson }),
     body: new Map() as unknown as JavaMap,
+    emitMetric: () => {},
+    _metrics: new Map(),
   };
 }
 

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/json-facets.test.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/json-facets.test.ts
@@ -122,6 +122,8 @@ describe('json-facets MicroTransform', () => {
         collection: 'testcollection',
         params: new URLSearchParams(),
         body: new Map() as unknown as JavaMap,
+        emitMetric: () => {},
+        _metrics: new Map(),
       };
       expect(request.match!(ctx)).toBe(false);
     });
@@ -929,6 +931,8 @@ describe('edge cases and warning paths', () => {
       collection: 'testcollection',
       params: new URLSearchParams(),
       body,
+      emitMetric: () => {},
+      _metrics: new Map(),
     };
     request.apply(ctx);
     const agg = ctx.body.get('aggs').get(FACET_NAME);
@@ -944,6 +948,8 @@ describe('edge cases and warning paths', () => {
       collection: 'testcollection',
       params: new URLSearchParams(),
       body,
+      emitMetric: () => {},
+      _metrics: new Map(),
     };
     request.apply(ctx);
     expect(ctx.body.has('aggs')).toBe(false);
@@ -1228,5 +1234,68 @@ describe('nested facets (sub-facets)', () => {
       expect(subAggs.get('brands').get('terms').get('field')).toBe('brand');
       expect(subAggs.get('brands').get('terms').get('size')).toBe(3);
     });
+  });
+});
+
+function ctxWithSpy(obj: Record<string, any>): { ctx: RequestContext; spy: ReturnType<typeof vi.fn> } {
+  const def = new Map(Object.entries(obj)) as unknown as JavaMap;
+  const jsonFacet = new Map([[FACET_NAME, def]]) as unknown as JavaMap;
+  const body = new Map([['json.facet', jsonFacet]]) as unknown as JavaMap;
+  const spy = vi.fn();
+  const ctx: RequestContext = {
+    msg: new Map() as unknown as JavaMap,
+    endpoint: 'select',
+    collection: 'testcollection',
+    params: new URLSearchParams(),
+    body,
+    emitMetric: spy,
+    _metrics: new Map(),
+  };
+  return { ctx, spy };
+}
+
+describe('limitation metrics emission', () => {
+
+  it('should emit terms_offset when offset > 0', () => {
+    const { ctx, spy } = ctxWithSpy({ type: 'terms', field: 'color', offset: 5 });
+    request.apply(ctx);
+    expect(spy).toHaveBeenCalledWith('terms_offset');
+  });
+
+  it('should not emit terms_offset when offset is 0', () => {
+    const { ctx, spy } = ctxWithSpy({ type: 'terms', field: 'color', offset: 0 });
+    request.apply(ctx);
+    expect(spy).not.toHaveBeenCalledWith('terms_offset');
+  });
+
+  it('should emit date_range_gap for approximated single-unit gap', () => {
+    const { ctx, spy } = ctxWithSpy({ type: 'range', field: 'date', start: '2020-01-01T00:00:00Z', end: '2021-01-01T00:00:00Z', gap: '+2MONTHS' });
+    request.apply(ctx);
+    expect(spy).toHaveBeenCalledWith('date_range_gap');
+  });
+
+  it('should emit date_range_gap_compound for compound gap', () => {
+    const { ctx, spy } = ctxWithSpy({ type: 'range', field: 'date', start: '2020-01-01T00:00:00Z', end: '2021-01-01T00:00:00Z', gap: '+1MONTH+2DAYS' });
+    request.apply(ctx);
+    expect(spy).toHaveBeenCalledWith('date_range_gap_compound');
+  });
+
+  it('should not emit date_range_gap for exact calendar_interval', () => {
+    const { ctx, spy } = ctxWithSpy({ type: 'range', field: 'date', start: '2020-01-01T00:00:00Z', end: '2021-01-01T00:00:00Z', gap: '+1MONTH' });
+    request.apply(ctx);
+    expect(spy).not.toHaveBeenCalledWith('date_range_gap');
+    expect(spy).not.toHaveBeenCalledWith('date_range_gap_compound');
+  });
+
+  it('should emit range_boundary for non-standard bracket semantics', () => {
+    const { ctx, spy } = ctxWithSpy({ type: 'range', field: 'price', ranges: ['(10,20]'] });
+    request.apply(ctx);
+    expect(spy).toHaveBeenCalledWith('range_boundary');
+  });
+
+  it('should not emit range_boundary for standard [from,to) brackets', () => {
+    const { ctx, spy } = ctxWithSpy({ type: 'range', field: 'price', ranges: ['[10,20)'] });
+    request.apply(ctx);
+    expect(spy).not.toHaveBeenCalledWith('range_boundary');
   });
 });

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/json-facets.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/json-facets.ts
@@ -23,7 +23,7 @@ const FEATURE_NAME = 'json-facets';
 
 // region Terms facet
 
-function convertTermsFacet(def: JavaMap): JavaMap {
+function convertTermsFacet(def: JavaMap, ctx: RequestContext): JavaMap {
   const termsInner = new Map<string, any>();
   termsInner.set('field', def.get('field'));
 
@@ -32,11 +32,13 @@ function convertTermsFacet(def: JavaMap): JavaMap {
 
   // OpenSearch has no concept of offset. So, return a large result and
   // expect the client to take the last `limit` results.
-  // TODO: emit a metric when validation framework is ready.
   if (offset != null || limit != null) {
     offset ??= 0;
     limit ??= 10;
     termsInner.set('size', offset + limit);
+    if (offset > 0) {
+      ctx.emitMetric('terms_offset');
+    }
   }
 
   const mincount = def.get('mincount');
@@ -81,7 +83,7 @@ function convertTermsFacet(def: JavaMap): JavaMap {
  * Solr range syntax: [inclusive or (exclusive for boundaries, * for unbounded.
  * OpenSearch range agg: `from` is inclusive, `to` is exclusive by default.
  */
-function parseSolrRange(rangeStr: string): JavaMap {
+function parseSolrRange(rangeStr: string, ctx: RequestContext): JavaMap {
   const range = new Map<string, any>();
 
   // Always preserve the original Solr range string as the bucket key
@@ -112,6 +114,7 @@ function parseSolrRange(rangeStr: string): JavaMap {
     console.warn(
       `[${FEATURE_NAME}] Range boundary "${rangeStr}" may not map exactly to OpenSearch (default: from=inclusive, to=exclusive)`,
     );
+    ctx.emitMetric('range_boundary');
   }
 
   return range;
@@ -132,31 +135,31 @@ function parseSolrRange(rangeStr: string): JavaMap {
  *   - include (lower/upper/edge/outer/all) → No direct OpenSearch equivalent
  *   - other (before/after/between/none/all) → No direct OpenSearch equivalent
  */
-function convertRangeFacet(def: JavaMap): JavaMap {
+function convertRangeFacet(def: JavaMap, ctx: RequestContext): JavaMap {
   const ranges = def.get('ranges');
 
   // Arbitrary ranges → OpenSearch `range` aggregation
   if (ranges != null) {
-    return convertArbitraryRangeFacet(def, ranges);
+    return convertArbitraryRangeFacet(def, ranges, ctx);
   }
 
   // Uniform ranges → OpenSearch `histogram` aggregation
-  return convertUniformRangeFacet(def);
+  return convertUniformRangeFacet(def, ctx);
 }
 
 /**
  * Convert a single range item (string, Map-like, or plain object) to an OpenSearch range entry.
  * Returns null if the item type is unrecognised.
  */
-function convertRangeItem(item: any): JavaMap | null {
+function convertRangeItem(item: any, ctx: RequestContext): JavaMap | null {
   if (typeof item === 'string') {
-    return parseSolrRange(item);
+    return parseSolrRange(item, ctx);
   }
   if (isMapLike(item)) {
-    return convertMapLikeRangeItem(item);
+    return convertMapLikeRangeItem(item, ctx);
   }
   if (item && typeof item === 'object') {
-    return convertPlainObjectRangeItem(item);
+    return convertPlainObjectRangeItem(item, ctx);
   }
   console.warn(
     `[${FEATURE_NAME}] Skipping unrecognised range item of type "${typeof item}": ${JSON.stringify(item)}`,
@@ -165,10 +168,10 @@ function convertRangeItem(item: any): JavaMap | null {
 }
 
 /** Convert a Map-like range item (from Jackson / GraalVM interop) to an OpenSearch range entry. */
-function convertMapLikeRangeItem(item: JavaMap): JavaMap {
+function convertMapLikeRangeItem(item: JavaMap, ctx: RequestContext): JavaMap {
   const rangeStr = item.get('range');
   if (rangeStr && typeof rangeStr === 'string') {
-    return parseSolrRange(rangeStr);
+    return parseSolrRange(rangeStr, ctx);
   }
   const osRange = new Map<string, any>();
   const from = item.get('from');
@@ -181,10 +184,10 @@ function convertMapLikeRangeItem(item: JavaMap): JavaMap {
 }
 
 /** Convert a plain JS object range item (from query-string JSON parse) to an OpenSearch range entry. */
-function convertPlainObjectRangeItem(item: Record<string, any>): JavaMap {
+function convertPlainObjectRangeItem(item: Record<string, any>, ctx: RequestContext): JavaMap {
   const rangeStr = item.range;
   if (rangeStr && typeof rangeStr === 'string') {
-    return parseSolrRange(rangeStr);
+    return parseSolrRange(rangeStr, ctx);
   }
   const osRange = new Map<string, any>();
   if (item.from != null) osRange.set('from', item.from);
@@ -196,7 +199,7 @@ function convertPlainObjectRangeItem(item: Record<string, any>): JavaMap {
 /**
  * Convert Solr arbitrary ranges to an OpenSearch `range` aggregation.
  */
-function convertArbitraryRangeFacet(def: JavaMap, ranges: any): JavaMap {
+function convertArbitraryRangeFacet(def: JavaMap, ranges: any, ctx: RequestContext): JavaMap {
   const rangeInner = new Map<string, any>();
   rangeInner.set('field', def.get('field'));
 
@@ -205,7 +208,7 @@ function convertArbitraryRangeFacet(def: JavaMap, ranges: any): JavaMap {
   const osRanges: JavaMap[] = [];
 
   for (const item of rangeItems) {
-    const converted = convertRangeItem(item);
+    const converted = convertRangeItem(item, ctx);
     if (converted) {
       osRanges.push(converted);
     }
@@ -242,10 +245,10 @@ function detectFieldType(def: JavaMap): FieldTypeHint {
  * Convert Solr uniform range (start/end/gap) to the appropriate OpenSearch
  * aggregation — either `histogram` (numeric) or `date_histogram` (date).
  */
-function convertUniformRangeFacet(def: JavaMap): JavaMap {
+function convertUniformRangeFacet(def: JavaMap, ctx: RequestContext): JavaMap {
   const fieldType = detectFieldType(def);
   if (fieldType === 'date') {
-    return convertDateHistogramFacet(def);
+    return convertDateHistogramFacet(def, ctx);
   }
   return convertNumericHistogramFacet(def);
 }
@@ -305,7 +308,7 @@ function convertNumericHistogramFacet(def: JavaMap): JavaMap {
  * Unlike the numeric path, date extended_bounds pass through the raw start/end
  * strings (no arithmetic), and the gap is translated via convertSolrDateGap().
  */
-function convertDateHistogramFacet(def: JavaMap): JavaMap {
+function convertDateHistogramFacet(def: JavaMap, ctx: RequestContext): JavaMap {
   const dateHistInner = new Map<string, any>();
   dateHistInner.set('field', def.get('field'));
 
@@ -313,6 +316,11 @@ function convertDateHistogramFacet(def: JavaMap): JavaMap {
   if (gap != null) {
     const interval = convertSolrDateGap(gap);
     dateHistInner.set(interval.type, interval.value);
+    if (interval.approximation) {
+      ctx.emitMetric(interval.approximation === 'compound'
+        ? 'date_range_gap_compound'
+        : 'date_range_gap');
+    }
   }
 
   // Return ISO-8601 date strings (like Solr) instead of epoch millis
@@ -449,7 +457,7 @@ function warnUnknownKeys(def: JavaMap, knownKeys: Set<string>, facetType: string
  * they are recursively converted and attached as a sibling `aggs` key
  * on the returned aggregation Map.
  */
-function convertSingleFacet(facetDef: any): JavaMap {
+function convertSingleFacet(facetDef: any, ctx: RequestContext): JavaMap {
   if (!isMapLike(facetDef)) {
     return new Map();
   }
@@ -459,10 +467,10 @@ function convertSingleFacet(facetDef: any): JavaMap {
   let result: JavaMap;
   switch (type) {
     case 'terms':
-      result = convertTermsFacet(facetDef);
+      result = convertTermsFacet(facetDef, ctx);
       break;
     case 'range':
-      result = convertRangeFacet(facetDef);
+      result = convertRangeFacet(facetDef, ctx);
       break;
     case 'query':
       result = convertQueryFacet(facetDef);
@@ -474,7 +482,7 @@ function convertSingleFacet(facetDef: any): JavaMap {
   // Handle nested sub-facets: Solr's `facet` key → OpenSearch's `aggs` key
   const subFacets = facetDef.get('facet');
   if (subFacets && isMapLike(subFacets) && subFacets.size > 0) {
-    result.set('aggs', convertJsonFacets(subFacets));
+    result.set('aggs', convertJsonFacets(subFacets, ctx));
   }
 
   return result;
@@ -486,11 +494,11 @@ function convertSingleFacet(facetDef: any): JavaMap {
  * @param solrJsonFacet - The Solr json.facet Map (keys are facet names, values are facet definitions)
  * @returns An OpenSearch aggs Map ready to set on the request body
  */
-export function convertJsonFacets(solrJsonFacet: JavaMap): JavaMap {
+export function convertJsonFacets(solrJsonFacet: JavaMap, ctx: RequestContext): JavaMap {
   const aggs = new Map<string, any>();
   for (const name of solrJsonFacet.keys()) {
     const facetDef = solrJsonFacet.get(name);
-    aggs.set(name, convertSingleFacet(facetDef));
+    aggs.set(name, convertSingleFacet(facetDef, ctx));
   }
   return aggs;
 }
@@ -515,7 +523,7 @@ export const request: MicroTransform<RequestContext> = {
     }
 
     if (facetMap && facetMap.size > 0) {
-      ctx.body.set('aggs', convertJsonFacets(facetMap));
+      ctx.body.set('aggs', convertJsonFacets(facetMap, ctx));
     }
   },
 };

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/utils.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/utils.ts
@@ -68,6 +68,8 @@ export interface DateGapInterval {
   type: 'calendar_interval' | 'fixed_interval';
   /** The interval value (e.g. "1M", "5m", "720h"). */
   value: string;
+  /** Set when a calendar unit was approximated as a fixed interval. */
+  approximation?: 'single' | 'compound';
 }
 
 /** Exact number of seconds in one fixed-duration Solr date math unit. */
@@ -146,7 +148,7 @@ function convertSimpleDateGap(gap: string, count: number, solrUnit: string): Dat
   console.warn(
     `[solr-date-gap] Solr gap "${gap}" approximated as fixed_interval "${value}" — bucket boundaries may not align with calendar ${solrUnit.toLowerCase()} boundaries.`,
   );
-  return { type: 'fixed_interval', value };
+  return { type: 'fixed_interval', value, approximation: 'single' };
 }
 
 /**
@@ -194,7 +196,7 @@ function convertCompoundDateGap(gap: string): DateGapInterval {
   console.warn(
     `[solr-date-gap] Compound Solr gap "${gap}" approximated as fixed_interval "${value}" — bucket boundaries may not align with calendar boundaries.`,
   );
-  return { type: 'fixed_interval', value };
+  return { type: 'fixed_interval', value, approximation: 'compound' };
 }
 
 // endregion

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/metrics.test.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/metrics.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { createMetrics, incrementMetric, flushMetrics } from './metrics';
+
+describe('metrics', () => {
+  it('createMetrics returns an empty map', () => {
+    const acc = createMetrics();
+    expect(acc.size).toBe(0);
+  });
+
+  it('incrementMetric sets count to 1 on first call', () => {
+    const acc = createMetrics();
+    incrementMetric(acc, 'terms_offset');
+    expect(acc.get('terms_offset')).toBe(1);
+  });
+
+  it('incrementMetric increments on repeated calls', () => {
+    const acc = createMetrics();
+    incrementMetric(acc, 'range_boundary');
+    incrementMetric(acc, 'range_boundary');
+    incrementMetric(acc, 'range_boundary');
+    expect(acc.get('range_boundary')).toBe(3);
+  });
+
+  it('incrementMetric tracks multiple metrics independently', () => {
+    const acc = createMetrics();
+    incrementMetric(acc, 'terms_offset');
+    incrementMetric(acc, 'date_range_gap');
+    incrementMetric(acc, 'terms_offset');
+    expect(acc.get('terms_offset')).toBe(2);
+    expect(acc.get('date_range_gap')).toBe(1);
+  });
+
+  it('flushMetrics does nothing when accumulator is empty', () => {
+    const acc = createMetrics();
+    const msg = new Map<string, any>();
+    flushMetrics(acc, msg);
+    expect(msg.has('_metrics')).toBe(false);
+  });
+
+  it('flushMetrics writes accumulated metrics onto the message map', () => {
+    const acc = createMetrics();
+    incrementMetric(acc, 'terms_offset');
+    incrementMetric(acc, 'date_range_gap_compound');
+    const msg = new Map<string, any>();
+    flushMetrics(acc, msg);
+    const metrics = msg.get('_metrics');
+    expect(metrics).toBeDefined();
+    expect(metrics.get('terms_offset')).toBe(1);
+    expect(metrics.get('date_range_gap_compound')).toBe(1);
+  });
+});

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/metrics.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/metrics.ts
@@ -1,0 +1,37 @@
+/**
+ * Limitation metrics — lightweight counters for known Solr→OpenSearch gaps.
+ *
+ * Each metric maps 1-to-1 to a limitation shortcode in LIMITATIONS.md.
+ * Context objects expose {@link emitMetric} so transforms can record
+ * occurrences without importing the accumulator directly.
+ */
+
+/** All recognised limitation metric names (match LIMITATIONS.md shortcodes). */
+export type TransformMetricName =
+  | 'terms_offset'
+  | 'date_range_gap'
+  | 'date_range_gap_compound'
+  | 'range_boundary';
+
+/** Per-request accumulator — metric name → count. */
+export type MetricsAccumulator = Map<TransformMetricName, number>;
+
+/** Create a fresh accumulator for a new request context. */
+export function createMetrics(): MetricsAccumulator {
+  return new Map();
+}
+
+/** Increment a limitation counter by 1. */
+export function incrementMetric(acc: MetricsAccumulator, metric: TransformMetricName): void {
+  acc.set(metric, (acc.get(metric) ?? 0) + 1);
+}
+
+/** Write accumulated metrics onto the message map as `_metrics`. */
+export function flushMetrics(acc: MetricsAccumulator, msg: { set(key: string, value: any): void }): void {
+  if (acc.size === 0) return;
+  const metricsObj = new Map<string, any>();
+  for (const [key, value] of acc.entries()) {
+    metricsObj.set(key, value);
+  }
+  msg.set('_metrics', metricsObj);
+}

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/request.transform.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/request.transform.ts
@@ -9,6 +9,7 @@ import { buildRequestContext } from './context';
 import type { JavaMap } from './context';
 import { runPipeline } from './pipeline';
 import { requestRegistry } from './registry';
+import { flushMetrics } from './metrics';
 
 // Read solrConfig from bindings once at init (closure, not global mutable state).
 // bindings is injected by Java via JavascriptTransformer's bindingsObject.
@@ -30,5 +31,6 @@ export function transform(msg: JavaMap): JavaMap {
     }
     payload.set('inlinedJsonBody', ctx.body);
   }
+  flushMetrics(ctx._metrics, msg);
   return msg;
 }


### PR DESCRIPTION
### Description
## Emit limitation metrics from Solr→OpenSearch transforms

When the TS transforms hit a known Solr→OpenSearch gap at runtime, they now record it as a structured metric on the message map (`_metrics`). The Java side already picks this up via `collectTransformData` and includes it in the `ValidationDocument`.

Four metrics are emitted, each named after its LIMITATIONS.md shortcode: `terms_offset`, `date_range_gap`, `date_range_gap_compound`, and `range_boundary`.

Also adds a new RANGE-BOUNDARY entry to LIMITATIONS.md for the range facet bracket inclusivity gap, which was previously only a `console.warn`.

### Testing
- Unit tests.

### Check List
- [x] New functionality includes testing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
