### PR TITLE
Add default-container annotation to migration console pod template

### DIFF
--- a/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/templates/resources/migrationConsole.yaml
+++ b/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/templates/resources/migrationConsole.yaml
@@ -127,6 +127,8 @@ spec:
       app: migration-console
   template:
     metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: console
       labels:
         app: migration-console
         env: v1


### PR DESCRIPTION
### Description
When running `kubectl exec` against the migration console pod, users see an extra line due to the new `workflow-schema-generator` container added to the console pod recently:

```
$ kubectl -n ma exec -it migration-console-0 -- /bin/bash
Defaulted container "console" out of: console, workflow-schema-generator (init)
Welcome to the Migration Assistant Console
(16:36:59) migration-console (~) -> 
```

This PR adds a `kubectl.kubernetes.io/default-container: console` annotation to the migration console pod template, which tells kubectl which container to target by default and suppresses the message.

### Issues Resolved
N/A

### Testing
Patched a running migration console StatefulSet and verified `kubectl exec -it migration-console-0 -- /bin/bash` no longer prints the default container warning.

### Check List
- [ ] New functionality includes testing
- [ ] Public documentation issue/PR created, if applicable.

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.