### PR TITLE
Fix duplicate defaultGitBranch parameter in EKS CFN tests

### DIFF
--- a/jenkins/migrationIntegPipelines/eksCreateVPCSolutionsCFNTestCover.groovy
+++ b/jenkins/migrationIntegPipelines/eksCreateVPCSolutionsCFNTestCover.groovy
@@ -23,6 +23,5 @@ eksSolutionsCFNTest(defaultGitBranch: gitBranch,
     vpcMode: 'create',
     defaultStage: 'ekscvpc',
     defaultGitUrl: 'https://github.com/opensearch-project/opensearch-migrations.git',
-    defaultGitBranch: 'main',
     jobName: jobNameOverride ?: null
 )

--- a/jenkins/migrationIntegPipelines/eksImportVPCSolutionsCFNTestCover.groovy
+++ b/jenkins/migrationIntegPipelines/eksImportVPCSolutionsCFNTestCover.groovy
@@ -23,6 +23,5 @@ eksSolutionsCFNTest(defaultGitBranch: gitBranch,
     vpcMode: 'import',
     defaultStage: 'eksivpc',
     defaultGitUrl: 'https://github.com/opensearch-project/opensearch-migrations.git',
-    defaultGitBranch: 'main',
     jobName: jobNameOverride ?: null
 )


### PR DESCRIPTION
### Description
Removes duplicate `defaultGitBranch` named parameter in the `eksSolutionsCFNTest` call that causes a Groovy compilation error in Jenkins

### Issues Resolved
N/A

### Testing

Added `run-cfn-tests` label
- https://migrations.ci.opensearch.org/job/pr-checks/job/pr-deploy-eks-cfn-create-vpc/45/console
- https://migrations.ci.opensearch.org/job/pr-checks/job/pr-deploy-eks-cfn-import-vpc/43/

### Check List
- [x] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
