### PR TITLE
Fix duplicate defaultGitBranch key in EKS Solutions CFN cover files

### DIFF
--- a/jenkins/migrationIntegPipelines/eksCreateVPCSolutionsCFNTestCover.groovy
+++ b/jenkins/migrationIntegPipelines/eksCreateVPCSolutionsCFNTestCover.groovy
@@ -23,6 +23,5 @@ eksSolutionsCFNTest(defaultGitBranch: gitBranch,
     vpcMode: 'create',
     defaultStage: 'ekscvpc',
     defaultGitUrl: 'https://github.com/opensearch-project/opensearch-migrations.git',
-    defaultGitBranch: 'main',
     jobName: jobNameOverride ?: null
 )

--- a/jenkins/migrationIntegPipelines/eksImportVPCSolutionsCFNTestCover.groovy
+++ b/jenkins/migrationIntegPipelines/eksImportVPCSolutionsCFNTestCover.groovy
@@ -23,6 +23,5 @@ eksSolutionsCFNTest(defaultGitBranch: gitBranch,
     vpcMode: 'import',
     defaultStage: 'eksivpc',
     defaultGitUrl: 'https://github.com/opensearch-project/opensearch-migrations.git',
-    defaultGitBranch: 'main',
     jobName: jobNameOverride ?: null
 )


### PR DESCRIPTION
### Description

Fix duplicate `defaultGitBranch` key in `eksCreateVPCSolutionsCFNTestCover.groovy` and `eksImportVPCSolutionsCFNTestCover.groovy`. The duplicate was introduced in #2720 where `defaultGitBranch: gitBranch` was added without removing the existing `defaultGitBranch: 'main'`, causing a Groovy compilation error that breaks the pipeline.

### Issues Resolved

Fixes pipeline failure introduced by #2720:
```
Duplicate named parameter 'defaultGitBranch' found
```

### Testing

- Verified both cover files now have a single `defaultGitBranch` key
- No functional change — `defaultGitBranch: gitBranch` replaces the hardcoded `defaultGitBranch: 'main'` (which defaults to `'main'` for non-release jobs anyway)

### Check List
- [x] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).