### PR TITLE
Add orchestrationSpecs CI job with type-check and tests

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -323,11 +323,6 @@ jobs:
           - ./deployment/cdk/opensearch-service-migration
           - ./deployment/migration-assistant-solution
           - ./TrafficCapture/SolrTransformations/transforms
-          # TODO - get these enabled
-#          - ./orchestrationSpecs/packages/argo-workflow-builders
-#          - ./orchestrationSpecs/packages/config-processor
-#          - ./orchestrationSpecs/packages/migration-workflow-templates
-#          - ./orchestrationSpecs/packages/schemas
     defaults:
       run:
         working-directory: ${{ matrix.npm-project }}
@@ -337,6 +332,30 @@ jobs:
       - name: Install NPM dependencies
         run: npm ci
       - name: Run CDK Jest Tests (using mocked images)
+        run: npm run test
+      - name: Upload coverage to Codecov
+        if: always()
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2
+        with:
+          fail_ci_if_error: true
+          flags: node
+          skip_validation: true
+          token: ${{ secrets.CODECOV_TOKEN }}
+          verbose: true
+
+  orchestration-specs-tests:
+    runs-on: ubuntu-22.04
+    defaults:
+      run:
+        working-directory: ./orchestrationSpecs
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup-env
+      - name: Install NPM dependencies
+        run: npm ci
+      - name: Type check
+        run: npm run type-check
+      - name: Build and run tests
         run: npm run test
       - name: Upload coverage to Codecov
         if: always()
@@ -486,6 +505,7 @@ jobs:
       - gradle-tests
       - link-checker
       - node-tests
+      - orchestration-specs-tests
       - python-e2e-tests
       - python-lint
       - gradle-extended-check

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -323,6 +323,7 @@ jobs:
           - ./deployment/cdk/opensearch-service-migration
           - ./deployment/migration-assistant-solution
           - ./TrafficCapture/SolrTransformations/transforms
+          - ./orchestrationSpecs
     defaults:
       run:
         working-directory: ${{ matrix.npm-project }}
@@ -332,30 +333,6 @@ jobs:
       - name: Install NPM dependencies
         run: npm ci
       - name: Run CDK Jest Tests (using mocked images)
-        run: npm run test
-      - name: Upload coverage to Codecov
-        if: always()
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2
-        with:
-          fail_ci_if_error: true
-          flags: node
-          skip_validation: true
-          token: ${{ secrets.CODECOV_TOKEN }}
-          verbose: true
-
-  orchestration-specs-tests:
-    runs-on: ubuntu-22.04
-    defaults:
-      run:
-        working-directory: ./orchestrationSpecs
-    steps:
-      - uses: actions/checkout@v6
-      - uses: ./.github/actions/setup-env
-      - name: Install NPM dependencies
-        run: npm ci
-      - name: Type check
-        run: npm run type-check
-      - name: Build and run tests
         run: npm run test
       - name: Upload coverage to Codecov
         if: always()
@@ -505,7 +482,6 @@ jobs:
       - gradle-tests
       - link-checker
       - node-tests
-      - orchestration-specs-tests
       - python-e2e-tests
       - python-lint
       - gradle-extended-check

--- a/orchestrationSpecs/package-lock.json
+++ b/orchestrationSpecs/package-lock.json
@@ -3080,7 +3080,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4409,7 +4411,9 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.0.2",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6275,9 +6279,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
-      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.5.tgz",
+      "integrity": "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
@@ -6367,9 +6371,9 @@
       }
     },
     "node_modules/readdir-glob/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8235,7 +8239,8 @@
       },
       "devDependencies": {
         "@types/jest": "*",
-        "expect-type": "*"
+        "expect-type": "*",
+        "testcontainers": "^11.12.0"
       }
     },
     "packages/schemas/node_modules/ajv": {

--- a/orchestrationSpecs/packages/argo-workflow-builders/package.json
+++ b/orchestrationSpecs/packages/argo-workflow-builders/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "build": "echo 'argo-workflow-builders: no build step needed (exports .ts directly)'",
     "type-check": "tsc --noEmit",
-    "test": "jest",
+    "test": "jest --coverage",
     "test:integ": "NODE_OPTIONS=--experimental-vm-modules jest --config jest.integ.config.mjs",
     "test:integ:existing": "NODE_OPTIONS=--experimental-vm-modules jest --config jest.integ.existing.config.mjs",
     "test:parity": "NODE_OPTIONS=--experimental-vm-modules jest --config jest.integ.config.mjs -- parity/",

--- a/orchestrationSpecs/packages/config-processor/package.json
+++ b/orchestrationSpecs/packages/config-processor/package.json
@@ -16,7 +16,7 @@
     "dev-transform": "tsx src/runMigrationConfigTransformer.ts",
     "bundle": "node makeBundle.js",
     "check-and-bundle": "npm run type-check && npm run test && npm run bundle",
-    "test": "jest --config ./jest.config.js"
+    "test": "jest --coverage --config ./jest.config.js"
   },
   "dependencies": {
     "@opensearch-migrations/schemas": "*",

--- a/orchestrationSpecs/packages/migration-workflow-templates/package.json
+++ b/orchestrationSpecs/packages/migration-workflow-templates/package.json
@@ -8,7 +8,7 @@
     "type-check-deps": "npm run -w @opensearch-migrations/argo-workflow-builders type-check && npm run -w @opensearch-migrations/schemas type-check",
     "type-check": "npx tsgo -p ../../tsconfig.typecheck.templates.json --noEmit",
     "type-check-all": "npm run type-check && npm run type-check-deps",
-    "test": "jest --config ./jest.config.js",
+    "test": "jest --coverage --config ./jest.config.js",
     "test-all": "npm run test && npm run -w @opensearch-migrations/argo-workflow-builders test && npm run -w @opensearch-migrations/schemas test",
     "check-and-make-templates": "npm run type-check-all && npm run test-all && tsx makeTemplates.cjs"
   },

--- a/orchestrationSpecs/packages/schemas/package.json
+++ b/orchestrationSpecs/packages/schemas/package.json
@@ -18,7 +18,7 @@
     "schema": "tsx src/showUserSchema.ts",
     "argo-schema": "tsx src/showArgoSchema.ts",
     "make-sample": "tsx src/makeSample.ts",
-    "test": "jest"
+    "test": "jest --coverage"
   },
   "dependencies": {
     "ajv": "^8.17.1",


### PR DESCRIPTION
### Description
Adds a dedicated `orchestration-specs-tests` CI job for the `orchestrationSpecs/` packages, replacing the commented-out TODO in the `node-tests` matrix. The new job runs type-checking (`tsgo`) and jest tests across all orchestrationSpecs workspace packages.

### Changes

- Remove TODO and commented-out orchestrationSpecs entries from `node-tests` matrix
- Add `orchestration-specs-tests` job: `npm ci` → `npm run type-check` → `npm run test` with Codecov upload
- Add to `all-ci-checks-pass` gate
- Fix 2 npm audit vulnerabilities in `orchestrationSpecs/package-lock.json`

#### Why a separate job instead of adding to node-tests matrix?

The orchestrationSpecs monorepo uses a workspace-level `npm run test` that builds and tests all packages together (with inter-package dependencies), unlike the independent CDK/Solr projects in the `node-tests` matrix which each have self-contained `npm run test` scripts.

### Issues Resolved
N/A

### Testing
Existing GHA

### Check List
- [x] New functionality includes testing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
