### PR TITLE
Adding translator for query-fields param

### DIFF
--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/cases.testcase.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/cases.testcase.ts
@@ -659,14 +659,6 @@ export const testCases: TestCase[] = [
     expectedErrorContains: 'Request transform failed',
   }),
 
-  solrTest('validation-unsupported-param-defType', {
-    description: 'Unsupported defType param should return 500',
-    documents: [{ id: '1', title: 'test' }],
-    requestPath: '/solr/testcollection/select?q=test&defType=dismax&qf=title&wt=json',
-    expectedStatusCode: 500,
-    expectedErrorContains: 'Request transform failed',
-  }),
-
   solrTest('validation-invalid-rows-non-numeric', {
     description: 'Non-numeric rows should return 500',
     documents: [{ id: '1', title: 'test' }],

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/query-q.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/query-q.ts
@@ -14,7 +14,7 @@ import type { ParamRule } from './validation';
 import { translateQ } from '../query-engine/orchestrator/translateQ';
 
 /** Solr query params this feature handles. */
-export const params = ['q', 'rows', 'start', 'q.op'];
+export const params = ['q', 'rows', 'start', 'q.op', 'defType', 'qf'];
 export const paramRules: ParamRule[] = [
   { name: 'rows', type: 'integer' },
   { name: 'start', type: 'integer' },

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/integration-tests/query-fields.testcase.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/integration-tests/query-fields.testcase.ts
@@ -1,0 +1,109 @@
+/**
+ * Integration test cases for qf (query fields) parameter — eDisMax and DisMax.
+ *
+ * Both parsers support the same qf syntax and multi-field expansion behavior
+ * for bare terms. Test cases are generated for both defType values to avoid
+ * duplication. eDisMax-specific cases (field:value syntax) are appended at the end.
+ */
+import { solrTest } from '../../test-types';
+import type { TestCase } from '../../test-types';
+
+const twoFieldSchema = {
+  fields: {
+    title: { type: 'text_general' as const },
+    body: { type: 'text_general' as const },
+  },
+};
+
+const twoFieldMapping = {
+  properties: {
+    title: { type: 'text' as const },
+    body: { type: 'text' as const },
+  },
+};
+
+function qfPath(q: string, defType: string, qf: string): string {
+  return '/solr/testcollection/select?q=' + encodeURIComponent(q)
+    + '&defType=' + defType
+    + '&qf=' + encodeURIComponent(qf)
+    + '&wt=json';
+}
+
+function makeQfCases(defType: 'edismax' | 'dismax'): TestCase[] {
+  return [
+    solrTest(`${defType}-bare-term-single-qf`, {
+      description: 'Bare term with single qf field matches that field',
+      documents: [
+        { id: '1', title: 'java programming', body: 'unrelated' },
+        { id: '2', title: 'python programming', body: 'java tutorial' },
+        { id: '3', title: 'unrelated', body: 'unrelated' },
+      ],
+      requestPath: qfPath('java', defType, 'title'),
+      solrSchema: twoFieldSchema,
+      opensearchMapping: twoFieldMapping,
+    }),
+
+    solrTest(`${defType}-bare-term-multi-qf`, {
+      description: 'Bare term with multiple qf fields matches across all of them',
+      documents: [
+        { id: '1', title: 'java programming', body: 'unrelated' },
+        { id: '2', title: 'unrelated', body: 'java tutorial' },
+        { id: '3', title: 'python', body: 'python' },
+      ],
+      requestPath: qfPath('java', defType, 'title body'),
+      solrSchema: twoFieldSchema,
+      opensearchMapping: twoFieldMapping,
+    }),
+
+    solrTest(`${defType}-bare-term-qf-with-boost`, {
+      description: 'Bare term with one boosted qf field — title match scores higher than body',
+      documents: [
+        { id: '1', title: 'java programming', body: 'unrelated' },
+        { id: '2', title: 'unrelated', body: 'java tutorial' },
+      ],
+      requestPath: qfPath('java', defType, 'title^2 body'),
+      solrSchema: twoFieldSchema,
+      opensearchMapping: twoFieldMapping,
+    }),
+
+    solrTest(`${defType}-bare-term-qf-all-boosted`, {
+      description: 'Bare term with all qf fields having boost values',
+      documents: [
+        { id: '1', title: 'java programming', body: 'unrelated' },
+        { id: '2', title: 'unrelated', body: 'java tutorial' },
+      ],
+      requestPath: qfPath('java', defType, 'title^2 body^1'),
+      solrSchema: twoFieldSchema,
+      opensearchMapping: twoFieldMapping,
+    }),
+
+    solrTest(`${defType}-bare-phrase-qf`, {
+      description: 'Bare phrase with qf fields uses phrase matching',
+      documents: [
+        { id: '1', title: 'hello world greeting', body: 'unrelated' },
+        { id: '2', title: 'world hello reversed', body: 'unrelated' },
+        { id: '3', title: 'unrelated', body: 'hello world message' },
+      ],
+      requestPath: qfPath('"hello world"', defType, 'title body'),
+      solrSchema: twoFieldSchema,
+      opensearchMapping: twoFieldMapping,
+    }),
+  ];
+}
+
+export const testCases: TestCase[] = [
+  ...makeQfCases('edismax'),
+  ...makeQfCases('dismax'),
+
+  // edismax only — explicit field:value syntax is supported (in dismax it's treated as a literal string)
+  solrTest('edismax-field-query-still-works', {
+    description: 'Explicit field:value syntax still works in edismax (unlike dismax)',
+    documents: [
+      { id: '1', title: 'java', body: 'unrelated' },
+      { id: '2', title: 'unrelated', body: 'java' },
+    ],
+    requestPath: '/solr/testcollection/select?q=' + encodeURIComponent('title:java') + '&defType=edismax&qf=' + encodeURIComponent('title body') + '&wt=json',
+    solrSchema: twoFieldSchema,
+    opensearchMapping: twoFieldMapping,
+  }),
+];

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/ast/nodes.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/ast/nodes.ts
@@ -64,13 +64,20 @@ export interface PhraseNode {
  * The transformer converts this to OpenSearch's query_string query, which
  * searches across the default field (or all fields if df is not set).
  *
- * For phrases (isPhrase=true), the transformer wraps the query in quotes
- * so OpenSearch's query_string treats it as a phrase search.
+ * When queryFields is set (edismax/dismax with qf param), the transformer
+ * emits a multi_match across those fields. Each entry is a raw OpenSearch
+ * field spec — either "fieldName" or "fieldName^boost" — matching the qf
+ * param format directly, since OpenSearch multi_match fields use the same
+ * syntax. Takes precedence over defaultField when set.
+ *
+ * When defaultField is set (df param, standard parser), the transformer
+ * emits a query_string with default_field.
  *
  * Examples:
- *   `java` → BareNode { query: "java", isPhrase: false }
- *   `"hello world"` → BareNode { query: "hello world", isPhrase: true }
- *   `java` with df="content" → BareNode { query: "java", isPhrase: false, defaultField: "content" }
+ *   `java` → BareNode { value: "java", isPhrase: false }
+ *   `"hello world"` → BareNode { value: "hello world", isPhrase: true }
+ *   `java` with df="content" → BareNode { ..., defaultField: "content" }
+ *   `java` with qf="title^2 body" → BareNode { ..., queryFields: ["title^2", "body"] }
  */
 export interface BareNode {
   type: 'bare';
@@ -80,6 +87,12 @@ export interface BareNode {
   isPhrase: boolean;
   /** The default field from df parameter, or undefined if not set. */
   defaultField?: string;
+  /**
+   * Query fields from the `qf` parameter (edismax/dismax).
+   * Raw field specs in OpenSearch multi_match format: "field" or "field^boost".
+   * Takes precedence over defaultField when set.
+   */
+  queryFields?: string[];
 }
 
 /**

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/parser/parser.test.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/parser/parser.test.ts
@@ -454,6 +454,66 @@ describe('parseSolrQuery', () => {
     });
   });
 
+  // ─── defType + qf (edismax/dismax) ──────────────────────────────────────
+
+  describe('defType + qf', () => {
+    it('stamps queryFields on BareNode when defType=edismax and qf is set', () => {
+      const params = new Map([['defType', 'edismax'], ['qf', 'title^2 body']]);
+      const { ast, errors } = parseSolrQuery('java', params);
+      expect(errors).toEqual([]);
+      expect(ast).toEqual({ type: 'bare', value: 'java', isPhrase: false, queryFields: ['title^2', 'body'] });
+    });
+
+    it('stamps queryFields on BareNode when defType=dismax and qf is set', () => {
+      const params = new Map([['defType', 'dismax'], ['qf', 'title body']]);
+      const { ast, errors } = parseSolrQuery('java', params);
+      expect(errors).toEqual([]);
+      expect(ast).toEqual({ type: 'bare', value: 'java', isPhrase: false, queryFields: ['title', 'body'] });
+    });
+
+    it('queryFields takes precedence over df on BareNode', () => {
+      const params = new Map([['defType', 'edismax'], ['qf', 'title body'], ['df', 'content']]);
+      const { ast, errors } = parseSolrQuery('java', params);
+      expect(errors).toEqual([]);
+      // queryFields set, defaultField should not be set
+      expect(ast).toEqual({ type: 'bare', value: 'java', isPhrase: false, queryFields: ['title', 'body'] });
+    });
+
+    it('does not stamp queryFields when defType is standard (no defType param)', () => {
+      const params = new Map([['qf', 'title body']]);
+      const { ast, errors } = parseSolrQuery('java', params);
+      expect(errors).toEqual([]);
+      expect(ast).toEqual({ type: 'bare', value: 'java', isPhrase: false });
+    });
+
+    it('does not stamp queryFields when qf is absent', () => {
+      const params = new Map([['defType', 'edismax']]);
+      const { ast, errors } = parseSolrQuery('java', params);
+      expect(errors).toEqual([]);
+      expect(ast).toEqual({ type: 'bare', value: 'java', isPhrase: false });
+    });
+
+    it('stamps queryFields on all BareNodes in a bool query', () => {
+      const params = new Map([['defType', 'edismax'], ['qf', 'title body']]);
+      const { ast, errors } = parseSolrQuery('java python', params);
+      expect(errors).toEqual([]);
+      expect(ast).toEqual({
+        type: 'bool', and: [], not: [],
+        or: [
+          { type: 'bare', value: 'java', isPhrase: false, queryFields: ['title', 'body'] },
+          { type: 'bare', value: 'python', isPhrase: false, queryFields: ['title', 'body'] },
+        ],
+      });
+    });
+
+    it('does not stamp queryFields on FieldNode (explicit field syntax)', () => {
+      const params = new Map([['defType', 'edismax'], ['qf', 'title body']]);
+      const { ast, errors } = parseSolrQuery('title:java', params);
+      expect(errors).toEqual([]);
+      expect(ast).toEqual({ type: 'field', field: 'title', value: 'java' });
+    });
+  });
+
   // ─── toParseError ────────────────────────────────────────────────────────
 
   describe('toParseError', () => {

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/parser/parser.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/parser/parser.ts
@@ -19,7 +19,7 @@
  *   matchAll / empty query       → MatchAllNode
  *   group                        → GroupNode
  *   boost suffix (^N)            → BoostNode wrapping the boosted node
- *
+
  * Trace example for `title:java AND price:[10 TO 100]`:
  *   1. query → orExpr → andExpr
  *   2. andExpr matches: head "AND" tail
@@ -31,9 +31,14 @@
  *   3. andExpr action returns
  *        → { type:'bool', and:[FieldNode, RangeNode], or:[], not:[] }   (BoolNode)
  *
+ * Post-parse passes (applied in order):
+ *   1. applyDefaultOperator  — q.op=AND: convert implicit-OR BoolNodes to AND
+ *   2. resolveDefaultFields  — df → BareNode.defaultField
+ *   3. applyQueryFields      — qf → BareNode.queryFields (edismax/dismax only)
+ *
  * Responsibilities:
  *   - Parse the query string into an AST
- *   - Apply the default field (df) from params to BareNode nodes
+ *   - Orchestrate post-parse AST normalization passes
  *   - Return parse errors as ParseError (never throws)
  */
 
@@ -41,6 +46,7 @@ import * as peggy from 'peggy';
 import grammar from './solr.pegjs';
 import type { ASTNode } from '../ast/nodes';
 import type { ParseResult, ParseError } from './types';
+import { parseQueryFields, applyQueryFields } from './qf';
 
 // Lazily compiled parser — the grammar is inlined at build time and compiled
 // on the first call to parseSolrQuery, then cached for all subsequent calls.
@@ -57,8 +63,7 @@ function getParser(): peggy.Parser {
  * Parse a Solr query string into an AST.
  *
  * @param query - The raw Solr query string (the `q` parameter value)
- * @param params - Request parameters. Reads `df` to resolve bare
- *                 values and unfielded phrases to a default field.
+ * @param params - Request parameters. Reads `df`, `q.op`, `defType`, `qf`.
  * @returns ParseResult with the AST and any errors
  *
  * Examples:
@@ -66,7 +71,10 @@ function getParser(): peggy.Parser {
  *   → { ast: BoolNode { and: [FieldNode, RangeNode] }, errors: [] }
  *
  *   parseSolrQuery("java", new Map([["df", "title"]]))
- *   → { ast: FieldNode { field: "title", value: "java" }, errors: [] }
+ *   → { ast: BareNode { value: "java", defaultField: "title" }, errors: [] }
+ *
+ *   parseSolrQuery("java", new Map([["defType", "edismax"], ["qf", "title^2 body"]]))
+ *   → { ast: BareNode { value: "java", queryFields: [{field:"title",boost:2},{field:"body"}] }, errors: [] }
  *
  *   parseSolrQuery("title:java AND )", new Map())
  *   → { ast: null, errors: [{ message: "...", position: 16 }] }
@@ -85,6 +93,9 @@ export function parseSolrQuery(
   // Solr accepts both "AND" and "and", so we normalize to uppercase.
   const qOp = params.get('q.op')?.toUpperCase();
 
+  // defType selects edismax/dismax semantics for the qf pass.
+  const defType = params.get('defType')?.toLowerCase();
+
   try {
     const ast = getParser().parse(query) as ASTNode;
     // Apply q.op before resolveDefaultFields — applyDefaultOperator reads
@@ -93,6 +104,15 @@ export function parseSolrQuery(
       applyDefaultOperator(ast);
     }
     resolveDefaultFields(ast, df);
+
+    // qf → BareNode.queryFields (edismax/dismax only)
+    if (defType === 'edismax' || defType === 'dismax') {
+      const queryFields = parseQueryFields(params.get('qf'));
+      if (queryFields) {
+        applyQueryFields(ast, queryFields);
+      }
+    }
+
     return { ast, errors: [] };
   } catch (err: unknown) {
     return { ast: null, errors: [toParseError(err)] };
@@ -206,4 +226,3 @@ function applyDefaultOperator(node: ASTNode): void {
     }
   }
 }
-

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/parser/qf.test.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/parser/qf.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from 'vitest';
+import { parseQueryFields, applyQueryFields } from './qf';
+import type { ASTNode, BareNode } from '../ast/nodes';
+
+// ─── parseQueryFields ─────────────────────────────────────────────────────────
+
+describe('parseQueryFields', () => {
+  it('returns undefined for undefined input', () => {
+    expect(parseQueryFields(undefined)).toBeUndefined();
+  });
+
+  it('returns undefined for empty string', () => {
+    expect(parseQueryFields('')).toBeUndefined();
+  });
+
+  it('returns undefined for whitespace-only string', () => {
+    expect(parseQueryFields('   ')).toBeUndefined();
+  });
+
+  it('parses a single field without boost', () => {
+    expect(parseQueryFields('title')).toEqual(['title']);
+  });
+
+  it('passes through field^boost token as-is', () => {
+    expect(parseQueryFields('title^2')).toEqual(['title^2']);
+  });
+
+  it('passes through decimal boost as-is', () => {
+    expect(parseQueryFields('title^0.5')).toEqual(['title^0.5']);
+  });
+
+  it('splits multiple fields', () => {
+    expect(parseQueryFields('title^2 body description^0.5')).toEqual([
+      'title^2', 'body', 'description^0.5',
+    ]);
+  });
+
+  it('passes through all fields with boost values', () => {
+    expect(parseQueryFields('title^2 body^1')).toEqual(['title^2', 'body^1']);
+  });
+
+  it('handles extra whitespace between fields', () => {
+    expect(parseQueryFields('title^2   body')).toEqual(['title^2', 'body']);
+  });
+
+  it('handles dotted field names', () => {
+    expect(parseQueryFields('metadata.title^3')).toEqual(['metadata.title^3']);
+  });
+});
+
+// ─── applyQueryFields ─────────────────────────────────────────────────────────
+
+describe('applyQueryFields', () => {
+  const qf = ['title^2', 'body'];
+
+  it('stamps queryFields onto a BareNode', () => {
+    const node: BareNode = { type: 'bare', value: 'java', isPhrase: false };
+    applyQueryFields(node, qf);
+    expect(node.queryFields).toEqual(qf);
+  });
+
+  it('clears defaultField when stamping queryFields', () => {
+    const node: BareNode = { type: 'bare', value: 'java', isPhrase: false, defaultField: 'content' };
+    applyQueryFields(node, qf);
+    expect(node.queryFields).toEqual(qf);
+    expect(node.defaultField).toBeUndefined();
+  });
+
+  it('stamps queryFields onto all BareNodes in a BoolNode', () => {
+    const a: BareNode = { type: 'bare', value: 'java', isPhrase: false };
+    const b: BareNode = { type: 'bare', value: 'python', isPhrase: false };
+    const node: ASTNode = { type: 'bool', and: [a], or: [b], not: [] };
+    applyQueryFields(node, qf);
+    expect(a.queryFields).toEqual(qf);
+    expect(b.queryFields).toEqual(qf);
+  });
+
+  it('recurses into boost node child', () => {
+    const bare: BareNode = { type: 'bare', value: 'java', isPhrase: false };
+    const node: ASTNode = { type: 'boost', child: bare, value: 2 };
+    applyQueryFields(node, qf);
+    expect(bare.queryFields).toEqual(qf);
+  });
+
+  it('recurses into group node child', () => {
+    const bare: BareNode = { type: 'bare', value: 'java', isPhrase: false };
+    const node: ASTNode = { type: 'group', child: bare };
+    applyQueryFields(node, qf);
+    expect(bare.queryFields).toEqual(qf);
+  });
+
+  it('does not touch FieldNode', () => {
+    const node: ASTNode = { type: 'field', field: 'title', value: 'java' };
+    applyQueryFields(node, qf);
+  });
+
+  it('does not touch MatchAllNode', () => {
+    const node: ASTNode = { type: 'matchAll' };
+    applyQueryFields(node, qf);
+  });
+});

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/parser/qf.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/parser/qf.ts
@@ -1,0 +1,78 @@
+/**
+ * Query Fields (qf/pf) parameter parsing and AST annotation.
+ *
+ * The `qf` and `pf` parameters are used by eDisMax and DisMax query parsers
+ * to specify which fields to search and their relative boost weights.
+ *
+ * Format: `qf=title^2 body description^0.5`
+ *
+ * OpenSearch's multi_match `fields` array uses the exact same format
+ * ("field" or "field^boost"), so tokens are passed through as-is with
+ * no parsing of the boost value needed.
+ *
+ * This module has two responsibilities:
+ *   1. parseQueryFields — split the raw param string into field spec tokens
+ *   2. applyQueryFields — walk the AST and stamp queryFields onto BareNodes
+ */
+
+import type { ASTNode } from '../ast/nodes';
+
+/**
+ * Parse a `qf` or `pf` parameter value into an array of field spec strings.
+ *
+ * Each whitespace-separated token is passed through as-is — either "fieldName"
+ * or "fieldName^boost" — matching OpenSearch multi_match fields format directly.
+ *
+ * Returns undefined when the param is absent or empty.
+ *
+ * Examples:
+ *   "title^2 body"     → ["title^2", "body"]
+ *   "title^2 body^0.5" → ["title^2", "body^0.5"]
+ *   "title"            → ["title"]
+ *   "" / undefined     → undefined
+ */
+export function parseQueryFields(qf: string | undefined): string[] | undefined {
+  if (!qf?.trim()) return undefined;
+  const fields = qf.trim().split(/\s+/);
+  return fields.length > 0 ? fields : undefined;
+}
+
+/**
+ * Walk the AST and stamp queryFields onto every BareNode.
+ *
+ * Called as a post-parse pass when defType is edismax or dismax and qf is set.
+ * BareNodes represent unfielded terms/phrases — in edismax/dismax these are
+ * expanded across all qf fields by the transformer (via multi_match).
+ *
+ * Only BareNodes are annotated — FieldNodes, PhraseNodes, and RangeNodes
+ * already have explicit fields from the query syntax and are left unchanged.
+ */
+export function applyQueryFields(node: ASTNode, queryFields: string[]): void {
+  switch (node.type) {
+    case 'bare':
+      node.queryFields = queryFields;
+      // Clear defaultField — queryFields takes precedence and bareRule uses queryFields first
+      delete node.defaultField;
+      break;
+    case 'bool':
+      node.and.forEach((child) => applyQueryFields(child, queryFields));
+      node.or.forEach((child) => applyQueryFields(child, queryFields));
+      node.not.forEach((child) => applyQueryFields(child, queryFields));
+      break;
+    case 'boost':
+    case 'group':
+    case 'filter':
+      applyQueryFields(node.child, queryFields);
+      break;
+    case 'field':
+    case 'phrase':
+    case 'range':
+    case 'matchAll':
+      break;
+    /* v8 ignore next 3 */
+    default: {
+      const _exhaustive: never = node;
+      throw new Error(`Unhandled node type: ${(_exhaustive as ASTNode).type}`);
+    }
+  }
+}

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/transformer/rules/bareRule.test.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/transformer/rules/bareRule.test.ts
@@ -6,126 +6,140 @@ import type { BareNode } from '../../ast/nodes';
 const stubTransformChild = () => new Map();
 
 describe('bareRule', () => {
+  // ─── query_string path (no queryFields) ───────────────────────────────────
+
   it('transforms bare term without defaultField to query_string', () => {
-    const node: BareNode = {
-      type: 'bare',
-      value: 'java',
-      isPhrase: false,
-    };
-
-    const result = bareRule(node, stubTransformChild);
-
-    expect(result).toEqual(
+    const node: BareNode = { type: 'bare', value: 'java', isPhrase: false };
+    expect(bareRule(node, stubTransformChild)).toEqual(
       new Map([['query_string', new Map([['query', 'java']])]]),
     );
   });
 
   it('transforms bare term with defaultField to query_string with default_field', () => {
-    const node: BareNode = {
-      type: 'bare',
-      value: 'java',
-      isPhrase: false,
-      defaultField: 'content',
-    };
-
-    const result = bareRule(node, stubTransformChild);
-
-    expect(result).toEqual(
+    const node: BareNode = { type: 'bare', value: 'java', isPhrase: false, defaultField: 'content' };
+    expect(bareRule(node, stubTransformChild)).toEqual(
       new Map([['query_string', new Map([['query', 'java'], ['default_field', 'content']])]]),
     );
   });
 
   it('transforms bare phrase without defaultField to query_string with quotes', () => {
-    const node: BareNode = {
-      type: 'bare',
-      value: 'hello world',
-      isPhrase: true,
-    };
-
-    const result = bareRule(node, stubTransformChild);
-
-    expect(result).toEqual(
+    const node: BareNode = { type: 'bare', value: 'hello world', isPhrase: true };
+    expect(bareRule(node, stubTransformChild)).toEqual(
       new Map([['query_string', new Map([['query', '"hello world"']])]]),
     );
   });
 
   it('transforms bare phrase with defaultField to query_string with quotes and default_field', () => {
-    const node: BareNode = {
-      type: 'bare',
-      value: 'hello world',
-      isPhrase: true,
-      defaultField: 'title',
-    };
-
-    const result = bareRule(node, stubTransformChild);
-
-    expect(result).toEqual(
+    const node: BareNode = { type: 'bare', value: 'hello world', isPhrase: true, defaultField: 'title' };
+    expect(bareRule(node, stubTransformChild)).toEqual(
       new Map([['query_string', new Map([['query', '"hello world"'], ['default_field', 'title']])]]),
     );
   });
 
-  describe('escapes special characters', () => {
+  // ─── multi_match path (queryFields present) ───────────────────────────────
+
+  it('emits multi_match best_fields for bare term with queryFields', () => {
+    const node: BareNode = {
+      type: 'bare',
+      value: 'java',
+      isPhrase: false,
+      queryFields: ['title^2', 'body'],
+    };
+    expect(bareRule(node, stubTransformChild)).toEqual(
+      new Map([['multi_match', new Map<string, any>([
+        ['query', 'java'],
+        ['fields', ['title^2', 'body']],
+        ['type', 'best_fields'],
+      ])]]),
+    );
+  });
+
+  it('emits multi_match phrase for bare phrase with queryFields', () => {
+    const node: BareNode = {
+      type: 'bare',
+      value: 'hello world',
+      isPhrase: true,
+      queryFields: ['title', 'body'],
+    };
+    expect(bareRule(node, stubTransformChild)).toEqual(
+      new Map([['multi_match', new Map<string, any>([
+        ['query', 'hello world'],
+        ['fields', ['title', 'body']],
+        ['type', 'phrase'],
+      ])]]),
+    );
+  });
+
+  it('passes field^boost tokens through as-is', () => {
+    const node: BareNode = {
+      type: 'bare',
+      value: 'search',
+      isPhrase: false,
+      queryFields: ['title^2.5', 'description^0.5'],
+    };
+    const result = bareRule(node, stubTransformChild);
+    const mm = result.get('multi_match') as Map<string, any>;
+    expect(mm.get('fields')).toEqual(['title^2.5', 'description^0.5']);
+  });
+
+  it('falls back to query_string when queryFields is empty array', () => {
+    const node: BareNode = { type: 'bare', value: 'java', isPhrase: false, queryFields: [] };
+    expect(bareRule(node, stubTransformChild)).toEqual(
+      new Map([['query_string', new Map([['query', 'java']])]]),
+    );
+  });
+
+  it('queryFields takes precedence over defaultField', () => {
+    const node: BareNode = {
+      type: 'bare',
+      value: 'java',
+      isPhrase: false,
+      defaultField: 'content',
+      queryFields: ['title'],
+    };
+    const result = bareRule(node, stubTransformChild);
+    expect(result.has('multi_match')).toBe(true);
+    expect(result.has('query_string')).toBe(false);
+  });
+
+  // ─── escaping (query_string path only) ────────────────────────────────────
+
+  describe('escapes special characters in query_string path', () => {
     const escapeTestCases: Array<{ input: string; expected: string; description: string }> = [
       { input: 'foo:bar', expected: String.raw`foo\:bar`, description: 'colon (field separator)' },
       { input: 'a+b', expected: String.raw`a\+b`, description: 'plus (required term)' },
       { input: 'a-b', expected: String.raw`a\-b`, description: 'minus (excluded term)' },
       { input: 'wild*card', expected: String.raw`wild\*card`, description: 'asterisk (wildcard)' },
-      { input: 'single?char', expected: String.raw`single\?char`, description: 'question mark (single char wildcard)' },
-      { input: '(group)', expected: String.raw`\(group\)`, description: 'parentheses (grouping)' },
-      { input: '[range]', expected: String.raw`\[range\]`, description: 'square brackets (range)' },
-      { input: '{exclusive}', expected: String.raw`\{exclusive\}`, description: 'curly braces (exclusive range)' },
+      { input: 'single?char', expected: String.raw`single\?char`, description: 'question mark' },
+      { input: '(group)', expected: String.raw`\(group\)`, description: 'parentheses' },
+      { input: '[range]', expected: String.raw`\[range\]`, description: 'square brackets' },
+      { input: '{exclusive}', expected: String.raw`\{exclusive\}`, description: 'curly braces' },
       { input: 'boost^2', expected: String.raw`boost\^2`, description: 'caret (boost)' },
-      { input: '"quoted"', expected: String.raw`\"quoted\"`, description: 'double quotes (phrase)' },
-      { input: 'fuzzy~2', expected: String.raw`fuzzy\~2`, description: 'tilde (fuzzy/proximity)' },
-      { input: 'path/to', expected: String.raw`path\/to`, description: 'forward slash (regex delimiter)' },
-      { input: String.raw`back\slash`, expected: String.raw`back\\slash`, description: 'backslash (escape char)' },
+      { input: '"quoted"', expected: String.raw`\"quoted\"`, description: 'double quotes' },
+      { input: 'fuzzy~2', expected: String.raw`fuzzy\~2`, description: 'tilde (fuzzy)' },
+      { input: 'path/to', expected: String.raw`path\/to`, description: 'forward slash' },
+      { input: String.raw`back\slash`, expected: String.raw`back\\slash`, description: 'backslash' },
       { input: 'a&&b', expected: String.raw`a\&\&b`, description: 'double ampersand (AND)' },
       { input: 'a||b', expected: String.raw`a\|\|b`, description: 'double pipe (OR)' },
-      { input: 'a<b', expected: String.raw`a\<b`, description: 'less than (range)' },
-      { input: 'a>b', expected: String.raw`a\>b`, description: 'greater than (range)' },
+      { input: 'a<b', expected: String.raw`a\<b`, description: 'less than' },
+      { input: 'a>b', expected: String.raw`a\>b`, description: 'greater than' },
       { input: '!negated', expected: String.raw`\!negated`, description: 'exclamation (NOT)' },
       { input: 'a=b', expected: String.raw`a\=b`, description: 'equals sign' },
     ];
 
     it.each(escapeTestCases)('escapes $description: "$input" → "$expected"', ({ input, expected }) => {
-      const node: BareNode = {
-        type: 'bare',
-        value: input,
-        isPhrase: false,
-      };
-
+      const node: BareNode = { type: 'bare', value: input, isPhrase: false };
       const result = bareRule(node, stubTransformChild);
-
       expect(result).toEqual(
         new Map([['query_string', new Map([['query', expected]])]]),
-      );
-    });
-
-    it.each(escapeTestCases)('escapes $description in phrase: "$input"', ({ input, expected }) => {
-      const node: BareNode = {
-        type: 'bare',
-        value: input,
-        isPhrase: true,
-      };
-
-      const result = bareRule(node, stubTransformChild);
-
-      expect(result).toEqual(
-        new Map([['query_string', new Map([['query', `"${expected}"`]])]]),
       );
     });
   });
 
   it('never recurses into children because bare is a leaf node', () => {
-    const node: BareNode = {
-      type: 'bare',
-      value: 'test',
-      isPhrase: false,
-    };
+    const node: BareNode = { type: 'bare', value: 'test', isPhrase: false };
     const spy = vi.fn();
-
     bareRule(node, spy);
-
     expect(spy).not.toHaveBeenCalled();
   });
 });

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/transformer/rules/bareRule.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/transformer/rules/bareRule.ts
@@ -1,17 +1,22 @@
 /**
- * Transformation rule for BareNode → OpenSearch `query_string` query.
+ * Transformation rule for BareNode → OpenSearch `multi_match` or `query_string` query.
  *
- * Maps bare Solr terms/phrases (without field prefix) to OpenSearch's query_string.
- * When defaultField is set, includes it in the output; otherwise omits it to let
- * OpenSearch use its default behavior.
+ * When queryFields is set (edismax/dismax with qf param), emits a multi_match
+ * query across those fields. Each field spec is passed through as-is from the
+ * qf param ("field" or "field^boost") since OpenSearch uses the same format.
  *
- * For phrases (isPhrase=true), wraps the query in quotes so OpenSearch's
- * query_string treats it as a phrase search matching words in order.
+ * type "best_fields" matches Solr's dismax behavior for terms (score = max
+ * field score). For phrases (isPhrase=true), uses type "phrase".
  *
- * Special characters are escaped to prevent query_string from interpreting them
- * as operators (e.g., foo:bar would be treated as a field query without escaping).
+ * Falls back to query_string when queryFields is absent (standard parser).
  *
- * Examples:
+ * Examples (multi_match):
+ *   `java` with qf="title^2 body"
+ *     → Map{"multi_match" → Map{"query"→"java", "fields"→["title^2","body"], "type"→"best_fields"}}
+ *   `"hello world"` with qf="title body"
+ *     → Map{"multi_match" → Map{"query"→"hello world", "fields"→["title","body"], "type"→"phrase"}}
+ *
+ * Examples (query_string fallback):
  *   `java` (no df) → Map{"query_string" → Map{"query" → "java"}}
  *   `java` (df="content") → Map{"query_string" → Map{"query" → "java", "default_field" → "content"}}
  *   `"hello world"` (no df) → Map{"query_string" → Map{"query" → "\"hello world\""}}
@@ -46,9 +51,20 @@ export const bareRule: TransformRuleFn = (
   // Bare is a leaf node — transformChild not used
   _transformChild,
 ): Map<string, any> => {
-  const { value, isPhrase, defaultField } = node;
+  const { value, isPhrase, defaultField, queryFields } = node;
 
-  // Escape special characters to prevent query_string from interpreting them as operators
+  // multi_match path: qf fields provided (edismax/dismax)
+  if (queryFields && queryFields.length > 0) {
+    return new Map([
+      ['multi_match', new Map<string, any>([
+        ['query', value],
+        ['fields', queryFields],
+        ['type', isPhrase ? 'phrase' : 'best_fields'],
+      ])],
+    ]);
+  }
+
+  // query_string fallback (standard parser / df only)
   const escapedQuery = escapeQueryString(value);
 
   // Wrap phrases in quotes for query_string to treat as phrase search


### PR DESCRIPTION
### Description
Adding translator for [query-fields](https://solr.apache.org/guide/solr/latest/query-guide/dismax-query-parser.html#qf-query-fields-parameter) param. Dismax and eDismax supports query fields param

### Issues Resolved
<!-- List any GitHub or Jira issues this PR will resolve -->

### Testing
<!-- Please provide details of testing done: unit testing, integration testing and manual testing -->

### Check List
- [ ] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
