### PR TITLE
Pass field metadata to transform rules for query type selection (match vs term)

### DIFF
--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/context.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/context.ts
@@ -42,6 +42,12 @@ export interface RequestContext {
    * Uses Record (plain object) because GraalVM exposes Java Maps as JS objects via allowMapAccess.
    */
   solrConfig?: Record<string, { defaults?: Record<string, string>; invariants?: Record<string, string>; appends?: Record<string, string> }>;
+  /**
+   * Field name → OpenSearch type mappings for query type selection.
+   * When provided, fieldRule uses term query for keyword fields and match for text fields.
+   * Injected from bindings at init.
+   */
+  fieldMappings?: ReadonlyMap<string, string>;
 }
 
 /** Parsed once from the bundled {request, response}. Shared across all response micro-transforms. */

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/query-q.test.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/query-q.test.ts
@@ -62,4 +62,19 @@ describe('query-q request transform', () => {
     // translateQ defaults to *:* which should produce some query
     expect(ctx.body.has('query')).toBe(true);
   });
+
+  it('uses term query for keyword fields when fieldMappings provided', () => {
+    const ctx = createMockContext({ q: 'category:electronics' });
+    ctx.fieldMappings = new Map([['category', 'keyword']]);
+    request.apply(ctx);
+    const query = ctx.body.get('query') as Map<string, any>;
+    expect(query.has('term')).toBe(true);
+  });
+
+  it('uses match query when fieldMappings not provided', () => {
+    const ctx = createMockContext({ q: 'category:electronics' });
+    request.apply(ctx);
+    const query = ctx.body.get('query') as Map<string, any>;
+    expect(query.has('match')).toBe(true);
+  });
 });

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/query-q.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/query-q.ts
@@ -46,7 +46,7 @@ function paramsToMap(params: URLSearchParams): Map<string, string> {
 export const request: MicroTransform<RequestContext> = {
   name: 'query-q',
   apply: (ctx) => {
-    const result = translateQ(paramsToMap(ctx.params));
+    const result = translateQ(paramsToMap(ctx.params), 'fail-fast', ctx.fieldMappings);
     ctx.body.set('query', result.dsl);
 
     // TODO: expose result.warnings to caller for observability

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/query-q.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/query-q.ts
@@ -46,7 +46,7 @@ function paramsToMap(params: URLSearchParams): Map<string, string> {
 export const request: MicroTransform<RequestContext> = {
   name: 'query-q',
   apply: (ctx) => {
-    const result = translateQ(paramsToMap(ctx.params), 'fail-fast', ctx.fieldMappings);
+    const result = translateQ(paramsToMap(ctx.params), undefined, ctx.fieldMappings);
     ctx.body.set('query', result.dsl);
 
     // TODO: expose result.warnings to caller for observability

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/orchestrator/translateQ.test.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/orchestrator/translateQ.test.ts
@@ -39,6 +39,19 @@ describe('translateQ', () => {
       expect(result.warnings).toEqual([]);
     });
 
+    it('passes fieldMappings through to transformNode', () => {
+      const fakeAst: ASTNode = { type: 'matchAll' };
+      const fakeDsl = new Map([['match_all', new Map()]]);
+      mockParse.mockReturnValue({ ast: fakeAst, errors: [] });
+      mockTransform.mockReturnValue(fakeDsl);
+
+      const mappings = new Map([['title', 'text'], ['category', 'keyword']]);
+      const result = translateQ(params(['q', 'title:java']), 'fail-fast', mappings);
+
+      expect(mockTransform).toHaveBeenCalledWith(fakeAst, mappings);
+      expect(result.dsl).toBe(fakeDsl);
+    });
+
     it('defaults q to *:* when not provided', () => {
       mockParse.mockReturnValue({ ast: { type: 'matchAll' }, errors: [] });
       mockTransform.mockReturnValue(new Map([['match_all', new Map()]]));

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/orchestrator/translateQ.test.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/orchestrator/translateQ.test.ts
@@ -34,7 +34,7 @@ describe('translateQ', () => {
       const result = translateQ(params(['q', 'title:java'], ['df', 'content']));
 
       expect(mockParse).toHaveBeenCalledWith('title:java', params(['q', 'title:java'], ['df', 'content']));
-      expect(mockTransform).toHaveBeenCalledWith(fakeAst);
+      expect(mockTransform).toHaveBeenCalledWith(fakeAst, undefined);
       expect(result.dsl).toBe(fakeDsl);
       expect(result.warnings).toEqual([]);
     });

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/orchestrator/translateQ.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/orchestrator/translateQ.ts
@@ -26,6 +26,7 @@
 
 import { parseSolrQuery } from '../parser/parser';
 import { transformNode } from '../transformer/astToOpenSearch';
+import type { FieldMappings } from '../transformer/types';
 
 export interface TranslateResult {
   /**
@@ -87,6 +88,7 @@ function passthroughDsl(query: string): Map<string, any> {
 export function translateQ(
   params: ReadonlyMap<string, string>,
   mode: TranslationMode = 'fail-fast',
+  fieldMappings?: FieldMappings,
 ): TranslateResult {
   const query = params.get('q') || '*:*';
 
@@ -111,7 +113,7 @@ export function translateQ(
 
   // Stage 2: Transform
   try {
-    const dsl = transformNode(ast);
+    const dsl = transformNode(ast, fieldMappings);
     return { dsl, warnings: [] };
   } catch (err: unknown) {
     // Transform failure — unsupported node type or unexpected error

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/transformer/astToOpenSearch.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/transformer/astToOpenSearch.ts
@@ -36,7 +36,7 @@
  */
 
 import type { ASTNode } from '../ast/nodes';
-import type { TransformRuleFn } from './types';
+import type { TransformRuleFn, FieldMappings } from './types';
 import { bareRule } from './rules/bareRule';
 import { boolRule } from './rules/boolRule';
 import { fieldRule } from './rules/fieldRule';
@@ -84,27 +84,14 @@ const rules: Record<string, TransformRuleFn> = {
  *         - passthrough-on-error: returns query_string passthrough + warning
  *         - partial: skips the node, adds a warning, continues translating
  */
-export function transformNode(node: ASTNode): Map<string, any> {
-  /**
-   * GroupNode represents parentheses in Solr syntax, used to override operator
-   * precedence. OpenSearch doesn't have an equivalent concept — precedence is
-   * handled by nesting bool queries. This rule simply unwraps the group and
-   * transforms its child.
-   *
-   * Example:
-   *   Input: GroupNode { child: BoolNode { or: [FieldNode, FieldNode] } }
-   *   Output: Map{"bool" → Map{"should" → [...]}}
-   *
-   * The GroupNode is transparent in the output — it doesn't produce any
-   * OpenSearch DSL structure of its own.
-   */
+export function transformNode(node: ASTNode, fieldMappings?: FieldMappings): Map<string, any> {
   if (node.type === 'group') {
-    return transformNode(node.child);
+    return transformNode(node.child, fieldMappings);
   }
 
   const rule = rules[node.type];
   if (!rule) {
     throw new Error(`No transform rule registered for node type: ${node.type}`);
   }
-  return rule(node, transformNode);
+  return rule(node, (child) => transformNode(child, fieldMappings), fieldMappings);
 }

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/transformer/astToOpenSearch.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/transformer/astToOpenSearch.ts
@@ -85,6 +85,19 @@ const rules: Record<string, TransformRuleFn> = {
  *         - partial: skips the node, adds a warning, continues translating
  */
 export function transformNode(node: ASTNode, fieldMappings?: FieldMappings): Map<string, any> {
+  /**
+   * GroupNode represents parentheses in Solr syntax, used to override operator
+   * precedence. OpenSearch doesn't have an equivalent concept — precedence is
+   * handled by nesting bool queries. This rule simply unwraps the group and
+   * transforms its child.
+   *
+   * Example:
+   *   Input: GroupNode { child: BoolNode { or: [FieldNode, FieldNode] } }
+   *   Output: Map{"bool" → Map{"should" → [...]}}
+   *
+   * The GroupNode is transparent in the output — it doesn't produce any
+   * OpenSearch DSL structure of its own.
+   */
   if (node.type === 'group') {
     return transformNode(node.child, fieldMappings);
   }

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/transformer/rules/fieldRule.test.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/transformer/rules/fieldRule.test.ts
@@ -2,12 +2,10 @@ import { describe, it, expect, vi } from 'vitest';
 import { fieldRule } from './fieldRule';
 import type { FieldNode } from '../../ast/nodes';
 
-/** Stub transformChild — not used by fieldRule but required by signature. */
 const stubTransformChild = () => new Map();
 
 describe('fieldRule', () => {
   // --- Plain match queries ---
-
   it.each([
     { field: 'title', value: 'java', desc: 'simple field:value' },
     { field: 'author', value: 'smith', desc: 'simple field name' },
@@ -16,28 +14,20 @@ describe('fieldRule', () => {
     { field: 'title', value: 'foo-bar_baz.v1@test#123', desc: 'multiple special chars' },
   ])('transforms $desc to match query', ({ field, value }) => {
     const node: FieldNode = { type: 'field', field, value };
-
     const result = fieldRule(node, stubTransformChild);
-
     expect(result).toEqual(
       new Map([['match', new Map([[field, new Map([['query', value]])]])]]),
     );
   });
 
   // --- Existence search ---
-
   it('transforms existence search field:* to exists query', () => {
     const node: FieldNode = { type: 'field', field: 'title', value: '*' };
-
     const result = fieldRule(node, stubTransformChild);
-
-    expect(result).toEqual(
-      new Map([['exists', new Map([['field', 'title']])]]),
-    );
+    expect(result).toEqual(new Map([['exists', new Map([['field', 'title']])]]));
   });
 
   // --- Wildcard queries ---
-
   it.each([
     { value: 'te?t', desc: 'single char wildcard (?)' },
     { value: 'tes*ing', desc: '* in middle' },
@@ -46,31 +36,24 @@ describe('fieldRule', () => {
     { value: 'a?b*c', desc: 'mixed wildcards' },
   ])('transforms wildcard pattern $desc to wildcard query', ({ value }) => {
     const node: FieldNode = { type: 'field', field: 'title', value };
-
     const result = fieldRule(node, stubTransformChild);
-
     expect(result).toEqual(
       new Map([['wildcard', new Map([['title', new Map([['value', value]])]])]]),
     );
   });
 
   // --- Fuzzy queries ---
-
-  it('transforms fuzzy search without distance to fuzzy query', () => {
+  it('transforms fuzzy search without distance', () => {
     const node: FieldNode = { type: 'field', field: 'title', value: 'roam~' };
-
     const result = fieldRule(node, stubTransformChild);
-
     expect(result).toEqual(
       new Map([['fuzzy', new Map([['title', new Map([['value', 'roam']])]])]]),
     );
   });
 
-  it('transforms fuzzy search with distance to fuzzy query with fuzziness', () => {
+  it('transforms fuzzy search with distance 2', () => {
     const node: FieldNode = { type: 'field', field: 'title', value: 'roam~2' };
-
     const result = fieldRule(node, stubTransformChild);
-
     expect(result).toEqual(
       new Map([['fuzzy', new Map([['title', new Map([['value', 'roam'], ['fuzziness', 2]])]])]]),
     );
@@ -78,9 +61,7 @@ describe('fieldRule', () => {
 
   it('transforms fuzzy search with distance 1', () => {
     const node: FieldNode = { type: 'field', field: 'title', value: 'roam~1' };
-
     const result = fieldRule(node, stubTransformChild);
-
     expect(result).toEqual(
       new Map([['fuzzy', new Map([['title', new Map([['value', 'roam'], ['fuzziness', 1]])]])]]),
     );
@@ -88,9 +69,7 @@ describe('fieldRule', () => {
 
   it('transforms fuzzy search with distance 0', () => {
     const node: FieldNode = { type: 'field', field: 'title', value: 'roam~0' };
-
     const result = fieldRule(node, stubTransformChild);
-
     expect(result).toEqual(
       new Map([['fuzzy', new Map([['title', new Map([['value', 'roam'], ['fuzziness', 0]])]])]]),
     );
@@ -98,60 +77,100 @@ describe('fieldRule', () => {
 
   it('clamps fuzziness above 2 to max of 2', () => {
     const node: FieldNode = { type: 'field', field: 'title', value: 'roam~9' };
-
     const result = fieldRule(node, stubTransformChild);
-
     expect(result).toEqual(
       new Map([['fuzzy', new Map([['title', new Map([['value', 'roam'], ['fuzziness', 2]])]])]]),
     );
   });
 
-  // --- Non-fuzzy tilde patterns (should NOT be treated as fuzzy) ---
-
+  // --- Non-fuzzy tilde patterns ---
   it.each([
     { value: 'test~ing', desc: 'tilde in middle' },
     { value: '~test', desc: 'tilde at start' },
     { value: 'a~b~c', desc: 'multiple tildes' },
   ])('does not treat as fuzzy: $desc ($value)', ({ value }) => {
     const node: FieldNode = { type: 'field', field: 'title', value };
-
     const result = fieldRule(node, stubTransformChild);
-
-    // These should produce match queries, not fuzzy
     const queryType = result.keys().next().value;
     expect(queryType).not.toBe('fuzzy');
   });
 
   // --- Boost compatibility ---
-
   it('wildcard output uses expanded form for boost compatibility', () => {
     const node: FieldNode = { type: 'field', field: 'title', value: 'test*' };
     const result = fieldRule(node, stubTransformChild);
-
-    // Verify the structure: {"wildcard": {"title": Map{...}}}
-    // The inner value must be a Map (not a string) so boostRule can inject boost
     const wildcardMap = result.get('wildcard') as Map<string, any>;
-    const fieldParams = wildcardMap.get('title');
-    expect(fieldParams).toBeInstanceOf(Map);
+    expect(wildcardMap.get('title')).toBeInstanceOf(Map);
   });
 
   it('fuzzy output uses expanded form for boost compatibility', () => {
     const node: FieldNode = { type: 'field', field: 'title', value: 'roam~' };
     const result = fieldRule(node, stubTransformChild);
-
     const fuzzyMap = result.get('fuzzy') as Map<string, any>;
-    const fieldParams = fuzzyMap.get('title');
-    expect(fieldParams).toBeInstanceOf(Map);
+    expect(fuzzyMap.get('title')).toBeInstanceOf(Map);
   });
 
   // --- Leaf node behavior ---
-
-  it('never recurses into children because field is a leaf node', () => {
+  it('never recurses into children', () => {
     const node: FieldNode = { type: 'field', field: 'title', value: 'java' };
     const spy = vi.fn();
-
     fieldRule(node, spy);
-
     expect(spy).not.toHaveBeenCalled();
+  });
+
+  // --- Field metadata (fieldMappings) ---
+  it('uses term query for keyword fields', () => {
+    const node: FieldNode = { type: 'field', field: 'category', value: 'electronics' };
+    const result = fieldRule(node, stubTransformChild, new Map([['category', 'keyword']]));
+    expect(result).toEqual(
+      new Map([['term', new Map([['category', new Map([['value', 'electronics']])]])]]),
+    );
+  });
+
+  it('uses match query for text fields', () => {
+    const node: FieldNode = { type: 'field', field: 'title', value: 'java' };
+    const result = fieldRule(node, stubTransformChild, new Map([['title', 'text']]));
+    expect(result).toEqual(
+      new Map([['match', new Map([['title', new Map([['query', 'java']])]])]]),
+    );
+  });
+
+  it('uses term query for integer fields', () => {
+    const node: FieldNode = { type: 'field', field: 'price', value: '100' };
+    const result = fieldRule(node, stubTransformChild, new Map([['price', 'integer']]));
+    expect(result).toEqual(
+      new Map([['term', new Map([['price', new Map([['value', '100']])]])]]),
+    );
+  });
+
+  it('uses term query for date fields', () => {
+    const node: FieldNode = { type: 'field', field: 'created', value: '2025-01-01' };
+    const result = fieldRule(node, stubTransformChild, new Map([['created', 'date']]));
+    expect(result).toEqual(
+      new Map([['term', new Map([['created', new Map([['value', '2025-01-01']])]])]]),
+    );
+  });
+
+  it('falls back to match when field not in mappings', () => {
+    const node: FieldNode = { type: 'field', field: 'unknown', value: 'java' };
+    const result = fieldRule(node, stubTransformChild, new Map([['title', 'text']]));
+    expect(result).toEqual(
+      new Map([['match', new Map([['unknown', new Map([['query', 'java']])]])]]),
+    );
+  });
+
+  it('falls back to match when fieldMappings is undefined', () => {
+    const node: FieldNode = { type: 'field', field: 'title', value: 'java' };
+    const result = fieldRule(node, stubTransformChild, undefined);
+    expect(result).toEqual(
+      new Map([['match', new Map([['title', new Map([['query', 'java']])]])]]),
+    );
+  });
+
+  it('term query uses expanded form for boost compatibility', () => {
+    const node: FieldNode = { type: 'field', field: 'category', value: 'electronics' };
+    const result = fieldRule(node, stubTransformChild, new Map([['category', 'keyword']]));
+    const termMap = result.get('term') as Map<string, any>;
+    expect(termMap.get('category')).toBeInstanceOf(Map);
   });
 });

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/transformer/rules/fieldRule.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/transformer/rules/fieldRule.ts
@@ -5,26 +5,16 @@
  *   - field:* (existence) → exists query
  *   - field:roam~ / field:roam~2 (fuzzy) → fuzzy query
  *   - field:te?t / field:test* (wildcard) → wildcard query
- *   - field:value (plain) → match query
+ *   - field:value (keyword field) → term query (exact match)
+ *   - field:value (text field or unknown) → match query (analyzed)
  *
- * We use `match` for plain values because Solr's standard query parser
- * analyzes field values at query time, matching OpenSearch's match behavior.
- *
- * All output uses the expanded form with nested field object to support
- * boost injection by boostRule:
- *   {"queryType": {"field": {"param": "value"}}}
- *
- * Examples:
- *   `title:java`   → Map{"match" → Map{"title" → Map{"query" → "java"}}}
- *   `title:*`      → Map{"exists" → Map{"field" → "title"}}
- *   `title:te?t`   → Map{"wildcard" → Map{"title" → Map{"value" → "te?t"}}}
- *   `title:test*`  → Map{"wildcard" → Map{"title" → Map{"value" → "test*"}}}
- *   `title:roam~`  → Map{"fuzzy" → Map{"title" → Map{"value" → "roam"}}}
- *   `title:roam~2` → Map{"fuzzy" → Map{"title" → Map{"value" → "roam", "fuzziness" → 2}}}
+ * When fieldMappings are provided, the rule uses the field's OpenSearch type
+ * to choose between term (keyword/numeric/date) and match (text) queries.
+ * Without fieldMappings, defaults to match query for backward compatibility.
  */
 
 import type { ASTNode } from '../../ast/nodes';
-import type { TransformRuleFn } from '../types';
+import type { TransformRuleFn, FieldMappings } from '../types';
 
 /** Detects wildcard patterns: contains * or ? (but not sole *) */
 const WILDCARD_PATTERN = /[*?]/;
@@ -32,9 +22,13 @@ const WILDCARD_PATTERN = /[*?]/;
 /** Detects fuzzy search: term~ or term~N at end of value */
 const FUZZY_PATTERN = /^(.+?)~(\d?)$/;
 
+/** OpenSearch field types that should use term query (exact match, not analyzed) */
+const KEYWORD_TYPES = new Set(['keyword', 'integer', 'long', 'float', 'double', 'boolean', 'date', 'ip']);
+
 export const fieldRule: TransformRuleFn = (
   node: ASTNode,
   _transformChild,
+  fieldMappings?: FieldMappings,
 ): Map<string, any> => {
   const { field, value } = node;
 
@@ -44,7 +38,6 @@ export const fieldRule: TransformRuleFn = (
   }
 
   // Fuzzy search: field:roam~ or field:roam~2 → fuzzy query
-  // Check fuzzy before wildcard since ~ is more specific
   const fuzzyMatch = FUZZY_PATTERN.exec(value);
   if (fuzzyMatch) {
     const term = fuzzyMatch[1];
@@ -52,8 +45,6 @@ export const fieldRule: TransformRuleFn = (
     const fuzzyParams = new Map<string, any>([['value', term]]);
     if (distance !== '') {
       const fuzziness = Number.parseInt(distance, 10);
-      // Both Solr and OpenSearch only support fuzziness 0, 1, or 2.
-      // Clamp to 2 to match Solr's behavior (Solr silently caps at 2).
       fuzzyParams.set('fuzziness', Math.min(fuzziness, 2));
     }
     return new Map([['fuzzy', new Map([[field, fuzzyParams]])]]);
@@ -64,6 +55,12 @@ export const fieldRule: TransformRuleFn = (
     return new Map([['wildcard', new Map([[field, new Map([['value', value]])]])]]);
   }
 
-  // Plain value: field:value → match query (expanded form for boost compatibility)
+  // Choose query type based on field metadata
+  const fieldType = fieldMappings?.get(field);
+  if (fieldType && KEYWORD_TYPES.has(fieldType)) {
+    return new Map([['term', new Map([[field, new Map([['value', value]])]])]]);
+  }
+
+  // Default: text fields or unknown → match query (analyzed)
   return new Map([['match', new Map([[field, new Map([['query', value]])]])]]);
 };

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/transformer/rules/fieldRule.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/transformer/rules/fieldRule.ts
@@ -8,18 +8,36 @@
  *   - field:value (keyword field) → term query (exact match)
  *   - field:value (text field or unknown) → match query (analyzed)
  *
+ * We use `match` for text fields because Solr's standard query parser
+ * analyzes field values at query time, matching OpenSearch's match behavior.
+ * For keyword/numeric/date fields, `term` is used for exact matching.
+ *
  * When fieldMappings are provided, the rule uses the field's OpenSearch type
  * to choose between term (keyword/numeric/date) and match (text) queries.
  * Without fieldMappings, defaults to match query for backward compatibility.
+ *
+ * All output uses the expanded form with nested field object to support
+ * boost injection by boostRule:
+ *   {"queryType": {"field": {"param": "value"}}}
+ *
+ * Examples:
+ *   `title:java`   → Map{"match" → Map{"title" → Map{"query" → "java"}}}
+ *   `title:*`      → Map{"exists" → Map{"field" → "title"}}
+ *   `title:te?t`   → Map{"wildcard" → Map{"title" → Map{"value" → "te?t"}}}
+ *   `title:test*`  → Map{"wildcard" → Map{"title" → Map{"value" → "test*"}}}
+ *   `title:roam~`  → Map{"fuzzy" → Map{"title" → Map{"value" → "roam"}}}
+ *   `title:roam~2` → Map{"fuzzy" → Map{"title" → Map{"value" → "roam", "fuzziness" → 2}}}
+ *
+ * Note: Boosts are handled separately by BoostNode.
  */
 
 import type { ASTNode } from '../../ast/nodes';
 import type { TransformRuleFn, FieldMappings } from '../types';
 
-/** Detects wildcard patterns: contains * or ? (but not sole *) */
+/** Regex to detect wildcard patterns (contains * or ?) */
 const WILDCARD_PATTERN = /[*?]/;
 
-/** Detects fuzzy search: term~ or term~N at end of value */
+/** Regex to detect fuzzy search patterns (term~ or term~N at end) */
 const FUZZY_PATTERN = /^(.+?)~(\d?)$/;
 
 /** OpenSearch field types that should use term query (exact match, not analyzed) */
@@ -27,17 +45,19 @@ const KEYWORD_TYPES = new Set(['keyword', 'integer', 'long', 'float', 'double', 
 
 export const fieldRule: TransformRuleFn = (
   node: ASTNode,
+  // Field is a leaf node — transformChild not used
   _transformChild,
   fieldMappings?: FieldMappings,
 ): Map<string, any> => {
   const { field, value } = node;
 
-  // Existence search: field:* → exists query
+  // Existence search (field:*) → exists query
   if (value === '*') {
     return new Map([['exists', new Map([['field', field]])]]);
   }
 
   // Fuzzy search: field:roam~ or field:roam~2 → fuzzy query
+  // Check fuzzy before wildcard since ~ is more specific
   const fuzzyMatch = FUZZY_PATTERN.exec(value);
   if (fuzzyMatch) {
     const term = fuzzyMatch[1];
@@ -45,6 +65,8 @@ export const fieldRule: TransformRuleFn = (
     const fuzzyParams = new Map<string, any>([['value', term]]);
     if (distance !== '') {
       const fuzziness = Number.parseInt(distance, 10);
+      // Both Solr and OpenSearch only support fuzziness 0, 1, or 2.
+      // Clamp to 2 to match Solr's behavior (Solr silently caps at 2).
       fuzzyParams.set('fuzziness', Math.min(fuzziness, 2));
     }
     return new Map([['fuzzy', new Map([[field, fuzzyParams]])]]);
@@ -58,9 +80,12 @@ export const fieldRule: TransformRuleFn = (
   // Choose query type based on field metadata
   const fieldType = fieldMappings?.get(field);
   if (fieldType && KEYWORD_TYPES.has(fieldType)) {
+    // Keyword/numeric/date fields → term query (exact match, no analysis)
     return new Map([['term', new Map([[field, new Map([['value', value]])]])]]);
   }
 
   // Default: text fields or unknown → match query (analyzed)
+  // Use expanded form: {"match": {"field": {"query": "value"}}}
+  // This allows boostRule to add boost inside the field object
   return new Map([['match', new Map([[field, new Map([['query', value]])]])]]);
 };

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/transformer/types.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/transformer/types.ts
@@ -5,6 +5,13 @@
 import type { ASTNode } from '../ast/nodes';
 
 /**
+ * Field metadata map — field name to OpenSearch field type.
+ * Used by transform rules to choose the correct query type.
+ * Example: { "title": "text", "category": "keyword", "price": "float" }
+ */
+export type FieldMappings = ReadonlyMap<string, string>;
+
+/**
  * A callback that recursively transforms a child AST node into
  * OpenSearch DSL. Provided by the dispatcher to rules that have
  * children (BoolNode, GroupNode, BoostNode).
@@ -14,22 +21,12 @@ export type TransformChild = (child: ASTNode) => Map<string, any>;
 /**
  * A function that transforms an AST node into an OpenSearch DSL Map.
  *
- * Each AST node type has a corresponding TransformRuleFn. The dispatcher
- * looks up the function by `node.type` and calls it.
- *
- * Rules for leaf nodes (FieldNode, PhraseNode, RangeNode, MatchAllNode)
- * can ignore the `transformChild` parameter. Rules for composite nodes
- * (BoolNode, GroupNode, BoostNode) use it to recurse into children.
- *
- * Example (leaf rule):
- *   (FieldNode { field: "title", value: "java" }, _)
- *   → Map{"match" → Map{"title" → "java"}}
- *
- * Example (composite rule):
- *   (BoolNode { and: [FieldNode, RangeNode], ... }, transformChild)
- *   → Map{"bool" → Map{"must" → [transformChild(FieldNode), transformChild(RangeNode)]}}
+ * @param node - The AST node to transform
+ * @param transformChild - Callback for recursive child transformation
+ * @param fieldMappings - Optional field name → OpenSearch type map for query type selection
  */
 export type TransformRuleFn = (
   node: ASTNode,
   transformChild: TransformChild,
+  fieldMappings?: FieldMappings,
 ) => Map<string, any>;

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/transformer/types.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/transformer/types.ts
@@ -21,6 +21,21 @@ export type TransformChild = (child: ASTNode) => Map<string, any>;
 /**
  * A function that transforms an AST node into an OpenSearch DSL Map.
  *
+ * Each AST node type has a corresponding TransformRuleFn. The dispatcher
+ * looks up the function by `node.type` and calls it.
+ *
+ * Rules for leaf nodes (FieldNode, PhraseNode, RangeNode, MatchAllNode)
+ * can ignore the `transformChild` parameter. Rules for composite nodes
+ * (BoolNode, GroupNode, BoostNode) use it to recurse into children.
+ *
+ * Example (leaf rule):
+ *   (FieldNode { field: "title", value: "java" }, _)
+ *   → Map{"match" → Map{"title" → "java"}}
+ *
+ * Example (composite rule):
+ *   (BoolNode { and: [FieldNode, RangeNode], ... }, transformChild)
+ *   → Map{"bool" → Map{"must" → [transformChild(FieldNode), transformChild(RangeNode)]}}
+ *
  * @param node - The AST node to transform
  * @param transformChild - Callback for recursive child transformation
  * @param fieldMappings - Optional field name → OpenSearch type map for query type selection

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/request.transform.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/request.transform.ts
@@ -16,11 +16,15 @@ declare const bindings: any;
 const solrConfig = (typeof bindings !== 'undefined' && bindings?.solrConfig) //NOSONAR — typeof required for undeclared closure var
   ? bindings.solrConfig
   : undefined;
+const fieldMappings = (typeof bindings !== 'undefined' && bindings?.fieldMappings) //NOSONAR
+  ? new Map(Object.entries(bindings.fieldMappings))
+  : undefined;
 
 export function transform(msg: JavaMap): JavaMap {
   const ctx = buildRequestContext(msg);
   if (ctx.endpoint === 'unknown') return msg;
   ctx.solrConfig = solrConfig;
+  ctx.fieldMappings = fieldMappings;
   runPipeline(requestRegistry, ctx);
   if (ctx.body.size > 0) {
     let payload = msg.get('payload');


### PR DESCRIPTION
### Description
Adds field metadata support to the query translation pipeline so transform rules can choose the correct OpenSearch query type based on the target field's type.

### Issues Resolved
Previously, `fieldRule` always produced a `match` query for `field:value`. This works for analyzed text fields but is suboptimal for keyword fields where a `term` query (exact match) is more accurate.

With this change:
- `category:electronics` with `category` mapped as `keyword` → `{"term": {"category": {"value": "electronics"}}}`
- `title:java` with `title` mapped as `text` → `{"match": {"title": {"query": "java"}}}`
- Unknown fields (no mapping) → `match` query (backward compatible)

Field mappings flow through the pipeline: `bindings.fieldMappings` → `RequestContext` → `translateQ()` → `transformNode()` → `fieldRule()`.

Keyword types that produce `term` queries: `keyword`, `integer`, `long`, `float`, `double`, `boolean`, `date`, `ip`.

### Testing
- 7 new unit tests in `fieldRule.test.ts`: keyword→term, text→match, integer, date, unknown field fallback, undefined mappings, boost compatibility
- Updated `translateQ.test.ts` mock assertion for new `fieldMappings` parameter
- All 628 tests pass (`npx vitest run --no-coverage`)
- SonarQube: 0 new issues in changed files

### Check List
- [ ] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
