### PR TITLE
Added Parser Enhancements for Local Params

### DIFF
--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/ast/nodes.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/ast/nodes.ts
@@ -160,6 +160,44 @@ export interface FilterNode {
   child: ASTNode;
 }
 
+/**
+ * A single key-value pair inside a local params block.
+ *
+ * Example: `qf=title` → { key: 'qf', value: 'title', deref: false }
+ * Example: `v=$qq`    → { key: 'v', value: 'qq', deref: true }
+ */
+export interface LocalParamsPair {
+  key: string;
+  value: string;
+  /** True when the value was a $-prefixed parameter dereference. */
+  deref: boolean;
+}
+
+/**
+ * AST node for a query string with a {!...} local params prefix.
+ *
+ * The grammar captures the body as a raw string. The parser (parser.ts)
+ * inspects the `type` param and re-parses the raw body with the appropriate
+ * grammar — e.g., Lucene syntax for lucene/dismax/edismax, or leaves it
+ * raw for unsupported parser types.
+ *
+ * Example: `{!dismax qf=title}java` →
+ *   { type: 'localParams',
+ *     params: [{ key: 'type', value: 'dismax', deref: false },
+ *              { key: 'qf', value: 'title', deref: false }],
+ *     rawBody: 'java',
+ *     body: BareNode { value: 'java', isPhrase: false } }
+ */
+export interface LocalParamsNode {
+  type: 'localParams';
+  /** Parsed key-value pairs from the {!...} block, in order. */
+  params: LocalParamsPair[];
+  /** Raw body text after the closing `}`, before any re-parsing. */
+  rawBody: string | null;
+  /** The query body — parsed from rawBody or the v key value. Null when unresolved (e.g., dereference). */
+  body: ASTNode | null;
+}
+
 /** Union of all AST node types. Every node in the parsed Solr query tree is one of these variants. */
 export type ASTNode =
   | BareNode
@@ -170,4 +208,5 @@ export type ASTNode =
   | RangeNode
   | MatchAllNode
   | GroupNode
-  | BoostNode;
+  | BoostNode
+  | LocalParamsNode;

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/parser/parser.test.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/parser/parser.test.ts
@@ -346,6 +346,185 @@ describe('parseSolrQuery', () => {
     });
   });
 
+  // ─── LocalParamsNode ──────────────────────────────────────────────────────
+
+  describe('LocalParamsNode', () => {
+    it('parses type short form: {!dismax}java', () => {
+      const { ast, errors } = parseSolrQuery('{!dismax}java', emptyParams);
+      expect(errors).toEqual([]);
+      expect(ast).toMatchObject({
+        type: 'localParams',
+        params: [{ key: 'type', value: 'dismax', deref: false }],
+        body: { type: 'bare', value: 'java', isPhrase: false },
+      });
+    });
+
+    it('parses key=value pairs with quoted value', () => {
+      const { ast, errors } = parseSolrQuery("{!edismax qf='title author'}java", emptyParams);
+      expect(errors).toEqual([]);
+      expect(ast).toMatchObject({
+        type: 'localParams',
+        params: [
+          { key: 'type', value: 'edismax', deref: false },
+          { key: 'qf', value: 'title author', deref: false },
+        ],
+        body: { type: 'bare', value: 'java', isPhrase: false },
+      });
+    });
+
+    it('parses empty local params: {!}java', () => {
+      const { ast, errors } = parseSolrQuery('{!}java', emptyParams);
+      expect(errors).toEqual([]);
+      expect(ast).toMatchObject({
+        type: 'localParams',
+        params: [],
+        body: { type: 'bare', value: 'java', isPhrase: false },
+      });
+    });
+
+    it('parses v key and re-parses its value as body', () => {
+      const { ast, errors } = parseSolrQuery("{!dismax qf=title v='solr rocks'}", emptyParams);
+      expect(errors).toEqual([]);
+      expect(ast).toMatchObject({
+        type: 'localParams',
+        params: expect.arrayContaining([
+          { key: 'type', value: 'dismax', deref: false },
+          { key: 'qf', value: 'title', deref: false },
+          { key: 'v', value: 'solr rocks', deref: false },
+        ]),
+      });
+      // v key body is re-parsed: "solr rocks" → two bare terms joined by implicit OR
+      expect(ast).not.toBeNull();
+      expect(ast?.type).toBe('localParams');
+      if (ast?.type === 'localParams') {
+        expect(ast.body).not.toBeNull();
+        expect(ast.body?.type).toBe('bool');
+      }
+    });
+
+    it('parses dereference value: {!dismax v=$qq}', () => {
+      const { ast, errors } = parseSolrQuery('{!dismax v=$qq}', emptyParams);
+      expect(errors).toEqual([]);
+      expect(ast).toMatchObject({
+        type: 'localParams',
+        params: [
+          { key: 'type', value: 'dismax', deref: false },
+          { key: 'v', value: 'qq', deref: true },
+        ],
+        body: null,
+      });
+    });
+
+    it('returns parse error for missing closing }', () => {
+      const { ast, errors } = parseSolrQuery('{!dismax', emptyParams);
+      expect(ast).toBeNull();
+      expect(errors).toHaveLength(1);
+    });
+
+    it('returns parse error for unterminated quoted value', () => {
+      // The grammar treats the unterminated quote as consuming everything to end of input
+      const { ast, errors } = parseSolrQuery("{!dismax qf='unterminated", emptyParams);
+      expect(ast).toBeNull();
+      expect(errors).toHaveLength(1);
+    });
+
+    it('handles backslash escapes in single-quoted values', () => {
+      // Use a key other than 'v' so the value isn't re-parsed as a query.
+      // The grammar should unescape \' inside single-quoted values.
+      const BS = String.fromCodePoint(92);  // backslash
+      const SQ = String.fromCodePoint(39);  // single quote
+      // Input: {!dismax qf='it\'s'}java — qf value contains an escaped quote
+      const input = '{' + '!dismax qf=' + SQ + 'it' + BS + SQ + 's' + SQ + '}java';
+      const { ast, errors } = parseSolrQuery(input, emptyParams);
+      expect(errors).toEqual([]);
+      expect(ast).toMatchObject({
+        type: 'localParams',
+        params: expect.arrayContaining([
+          expect.objectContaining({ key: 'qf', value: "it's" }),
+        ]),
+      });
+    });
+
+    it('backward compat: title:java produces no LocalParamsNode', () => {
+      const { ast, errors } = parseSolrQuery('title:java', emptyParams);
+      expect(errors).toEqual([]);
+      expect(ast?.type).not.toBe('localParams');
+    });
+
+    it('resolves default fields through LocalParamsNode body', () => {
+      const { ast, errors } = parseSolrQuery('{!dismax}java', paramsWithDf('title'));
+      expect(errors).toEqual([]);
+      expect(ast).toMatchObject({
+        type: 'localParams',
+        body: { type: 'bare', value: 'java', isPhrase: false, defaultField: 'title' },
+      });
+    });
+
+    it('applies q.op=AND through LocalParamsNode body', () => {
+      const params = new Map([['q.op', 'AND']]);
+      const { ast, errors } = parseSolrQuery('{!dismax}title:java title:python', params);
+      expect(errors).toEqual([]);
+      expect(ast?.type).toBe('localParams');
+      if (ast?.type === 'localParams' && ast.body?.type === 'bool') {
+        expect(ast.body.and).toHaveLength(2);
+        expect(ast.body.or).toHaveLength(0);
+      }
+    });
+
+    it('v key body override ignores trailing text', () => {
+      const { ast, errors } = parseSolrQuery("{!dismax v='solr rocks'}trailing", emptyParams);
+      expect(errors).toEqual([]);
+      // The body should come from v='solr rocks', not from 'trailing'
+      expect(ast?.type).toBe('localParams');
+      if (ast?.type === 'localParams') {
+        expect(ast.body).not.toBeNull();
+        // "solr rocks" parses to two bare terms
+        expect(ast.body?.type).toBe('bool');
+      }
+    });
+
+    it('parses double-quoted values', () => {
+      const { ast, errors } = parseSolrQuery('{!dismax qf="title author"}java', emptyParams);
+      expect(errors).toEqual([]);
+      expect(ast).toMatchObject({
+        type: 'localParams',
+        params: expect.arrayContaining([
+          { key: 'qf', value: 'title author', deref: false },
+        ]),
+      });
+    });
+
+    it('parses local params with no body', () => {
+      const { ast, errors } = parseSolrQuery('{!dismax}', emptyParams);
+      expect(errors).toEqual([]);
+      expect(ast).toMatchObject({
+        type: 'localParams',
+        params: [{ key: 'type', value: 'dismax', deref: false }],
+        body: null,
+      });
+    });
+
+    it('parses explicit type=dismax key-value pair', () => {
+      const { ast, errors } = parseSolrQuery('{!type=dismax qf=title}java', emptyParams);
+      expect(errors).toEqual([]);
+      expect(ast).toMatchObject({
+        type: 'localParams',
+        params: [
+          { key: 'type', value: 'dismax', deref: false },
+          { key: 'qf', value: 'title', deref: false },
+        ],
+      });
+    });
+
+    it('returns error when v key value fails to re-parse', () => {
+      // v='title:java AND )' is invalid Solr syntax — the re-parse should fail
+      const { ast, errors } = parseSolrQuery("{!dismax v='title:java AND )'}", emptyParams);
+      expect(ast).toBeNull();
+      expect(errors).toHaveLength(1);
+      expect(errors[0].message).toBeDefined();
+    });
+  });
+
   // ─── q.op parameter ──────────────────────────────────────────────────────
 
   describe('q.op=AND', () => {
@@ -446,10 +625,10 @@ describe('parseSolrQuery', () => {
       expect(errors).toEqual([]);
       // All three terms joined by implicit adjacency → converted to AND
       expect(ast).not.toBeNull();
-      expect(ast!.type).toBe('bool');
-      if (ast!.type === 'bool') {
-        expect(ast!.and).toHaveLength(3);
-        expect(ast!.or).toHaveLength(0);
+      expect(ast?.type).toBe('bool');
+      if (ast?.type === 'bool') {
+        expect(ast.and).toHaveLength(3);
+        expect(ast.or).toHaveLength(0);
       }
     });
   });

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/parser/parser.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/parser/parser.ts
@@ -98,6 +98,14 @@ export function parseSolrQuery(
 
   try {
     const ast = getParser().parse(query) as ASTNode;
+
+    // Phase 2: If the grammar produced a LocalParamsNode, re-parse the body
+    // based on the query parser type. The grammar captures the body as raw
+    // text; we parse it here with the appropriate grammar.
+    if (ast.type === 'localParams') {
+      resolveLocalParamsBody(ast);
+    }
+
     // Apply q.op before resolveDefaultFields — applyDefaultOperator reads
     // the `implicit` flag which resolveDefaultFields cleans up.
     if (qOp === 'AND') {
@@ -130,6 +138,60 @@ export function toParseError(err: unknown): ParseError {
     message: e?.message || 'Parse error',
     position: e?.location?.start?.offset ?? 0,
   };
+}
+
+/**
+ * Query parser types whose body uses Lucene/Solr query syntax.
+ * For these types, the raw body is re-parsed using the Solr grammar.
+ * Other types (e.g., func, terms) need their own parsers.
+ */
+const LUCENE_FAMILY_TYPES = new Set([
+  'lucene', 'dismax', 'edismax',
+]);
+
+/**
+ * Resolve the body of a LocalParamsNode.
+ *
+ * The grammar captures the body as raw text. This function determines the
+ * effective body string (from the `v` key or the trailing raw text), then
+ * re-parses it using the appropriate grammar based on the `type` param.
+ *
+ * For Lucene-family types (lucene, dismax, edismax, or no type specified),
+ * the body is parsed with the Solr grammar. For other types, the body is
+ * left as null — future parsers (e.g., function query) will handle them.
+ *
+ * @throws Re-throws parse errors from body re-parsing so the caller can
+ *         convert them to ParseError via toParseError().
+ */
+function resolveLocalParamsBody(node: import('../ast/nodes').LocalParamsNode): void {
+  const vPair = node.params.find((p) => p.key === 'v');
+
+  // Dereference — can't resolve at parse time
+  if (vPair?.deref) {
+    node.body = null;
+    return;
+  }
+
+  // Determine the effective body string: v key takes precedence over raw body
+  const bodyStr = vPair ? vPair.value : node.rawBody;
+  if (!bodyStr) {
+    node.body = null;
+    return;
+  }
+
+  // Determine the parser type (short form or explicit type= pair)
+  const typePair = node.params.find((p) => p.key === 'type');
+  const parserType = typePair?.value?.toLowerCase();
+
+  // For Lucene-family types (or no type = default Lucene), re-parse with Solr grammar
+  if (!parserType || LUCENE_FAMILY_TYPES.has(parserType)) {
+    node.body = getParser().parse(bodyStr) as import('../ast/nodes').ASTNode;
+    return;
+  }
+
+  // Unknown parser type — leave body null for now.
+  // Future: route to func query parser, terms parser, etc.
+  node.body = null;
 }
 
 /** Walk the AST and resolve BareNode default fields.
@@ -166,6 +228,9 @@ function resolveDefaultFields(node: ASTNode, df: string): void {
     case 'group':
     case 'filter':
       resolveDefaultFields(node.child, df);
+      break;
+    case 'localParams':
+      if (node.body) resolveDefaultFields(node.body, df);
       break;
     case 'matchAll':
       break;
@@ -212,6 +277,9 @@ function applyDefaultOperator(node: ASTNode): void {
     case 'group':
     case 'filter':
       applyDefaultOperator(node.child);
+      break;
+    case 'localParams':
+      if (node.body) applyDefaultOperator(node.body);
       break;
     case 'bare':
     case 'field':

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/parser/qf.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/parser/qf.ts
@@ -64,6 +64,9 @@ export function applyQueryFields(node: ASTNode, queryFields: string[]): void {
     case 'filter':
       applyQueryFields(node.child, queryFields);
       break;
+    case 'localParams':
+      if (node.body) applyQueryFields(node.body, queryFields);
+      break;
     case 'field':
     case 'phrase':
     case 'range':

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/parser/solr.pegjs
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/parser/solr.pegjs
@@ -24,9 +24,51 @@
 
 // A query is an OR expression surrounded by optional whitespace.
 // An empty query (e.g., "") produces a MatchAllNode.
+// When a {!...} local params prefix is present, the body is captured as raw
+// text. The parser (parser.ts) re-parses the body based on the `type` param.
 query
-  = _ expr:orExpr _ { return expr; }
+  = _ lp:localParams body:$(.+)? _ {
+      return { type: 'localParams', params: lp, rawBody: body || null, body: null };
+    }
+  / _ expr:orExpr _ { return expr; }
   / _ { return { type: 'matchAll' }; }
+
+// ─── Local params ─────────────────────────────────────────────────────────────
+// Solr local params prefix: {!key=value ...}query
+// Carries metadata like parser type, default field, query fields.
+
+localParams
+  = "{!" _ shortForm:localParamsShortForm? pairs:(_ localParamsPair)* _ "}" {
+      const result = [];
+      if (shortForm) result.push({ key: 'type', value: shortForm, deref: false });
+      for (const p of pairs) result.push(p[1]);
+      return result;
+    }
+
+localParamsShortForm
+  = id:localParamsKey !("=") { return id; }
+
+localParamsPair
+  = key:localParamsKey "=" val:localParamsValue {
+      return { key: key, value: val.value, deref: val.deref };
+    }
+
+localParamsKey
+  = $([a-zA-Z_][a-zA-Z0-9._]*)
+
+localParamsValue
+  = "'" chars:localParamsSingleQuotedChar* "'" { return { value: chars.join(''), deref: false }; }
+  / "\"" chars:localParamsDoubleQuotedChar* "\"" { return { value: chars.join(''), deref: false }; }
+  / "$" name:localParamsKey { return { value: name, deref: true }; }
+  / val:$[^ \t\n\r}]+ { return { value: val, deref: false }; }
+
+localParamsSingleQuotedChar
+  = "\\" c:. { return c; }
+  / [^'\\]
+
+localParamsDoubleQuotedChar
+  = "\\" c:. { return c; }
+  / [^"\\]
 
 // ─── Boolean operators ────────────────────────────────────────────────────────
 // Precedence is encoded by nesting: orExpr → andExpr → unaryExpr → primary.

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/transformer/astToOpenSearch.test.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/transformer/astToOpenSearch.test.ts
@@ -67,3 +67,29 @@ describe('transformNode – GroupNode handling', () => {
     ]));
   });
 });
+
+describe('transformNode – LocalParamsNode handling', () => {
+  it('transforms LocalParamsNode body', () => {
+    const result = transformNode({
+      type: 'localParams',
+      params: [{ key: 'type', value: 'dismax', deref: false }],
+      rawBody: 'title:java',
+      body: { type: 'field', field: 'title', value: 'java' },
+    });
+
+    expect(result).toEqual(new Map([
+      ['match', new Map([['title', new Map([['query', 'java']])]])],
+    ]));
+  });
+
+  it('returns match_all when LocalParamsNode has no body', () => {
+    const result = transformNode({
+      type: 'localParams',
+      params: [{ key: 'type', value: 'dismax', deref: false }],
+      rawBody: null,
+      body: null,
+    });
+
+    expect(result).toEqual(new Map([['match_all', new Map()]]));
+  });
+});

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/transformer/astToOpenSearch.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/transformer/astToOpenSearch.ts
@@ -102,6 +102,17 @@ export function transformNode(node: ASTNode): Map<string, any> {
     return transformNode(node.child);
   }
 
+  // LocalParamsNode: extract metadata and transform the body.
+  // The local params metadata (type, qf, df, etc.) is available on node.params
+  // for the orchestrator to use. The transformer only handles the body query.
+  if (node.type === 'localParams') {
+    if (node.body) {
+      return transformNode(node.body);
+    }
+    // No body — return match_all as default
+    return new Map([['match_all', new Map()]]);
+  }
+
   const rule = rules[node.type];
   if (!rule) {
     throw new Error(`No transform rule registered for node type: ${node.type}`);


### PR DESCRIPTION
### Description
Adds parser support for local params. In the first pass, local params block alone is parsed. Depending on the parser type defined in the block, the body is parsed in the second pass.

### Testing
- Unit tests

### Check List
- [x] New functionality includes testing


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
