### PR TITLE
Add configurable query translation mode

### DIFF
--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/context.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/context.ts
@@ -42,6 +42,13 @@ export interface RequestContext {
    * Uses Record (plain object) because GraalVM exposes Java Maps as JS objects via allowMapAccess.
    */
   solrConfig?: Record<string, { defaults?: Record<string, string>; invariants?: Record<string, string>; appends?: Record<string, string> }>;
+  /**
+   * Query translation mode — controls behavior when query translation fails.
+   * 'fail-fast': throws on unsupported constructs (default).
+   * 'passthrough-on-error': falls back to query_string passthrough.
+   * Injected from bindings at init.
+   */
+  queryTranslationMode?: 'fail-fast' | 'passthrough-on-error';
 }
 
 /** Parsed once from the bundled {request, response}. Shared across all response micro-transforms. */

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/query-q.test.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/query-q.test.ts
@@ -62,4 +62,27 @@ describe('query-q request transform', () => {
     // translateQ defaults to *:* which should produce some query
     expect(ctx.body.has('query')).toBe(true);
   });
+
+  // --- Translation mode tests ---
+
+  it('fail-fast mode throws on unsupported query constructs', () => {
+    const ctx = createMockContext({ q: '{!join from=id to=parent_id}*:*' });
+    ctx.queryTranslationMode = 'fail-fast';
+    expect(() => request.apply(ctx)).toThrow();
+  });
+
+  it('passthrough-on-error mode falls back to query_string on unsupported constructs', () => {
+    const ctx = createMockContext({ q: 'title:java AND )' });
+    ctx.queryTranslationMode = 'passthrough-on-error';
+    request.apply(ctx);
+    const query = ctx.body.get('query') as Map<string, any>;
+    expect(query.has('query_string')).toBe(true);
+  });
+
+  it('defaults to fail-fast when queryTranslationMode is not set', () => {
+    const ctx = createMockContext({ q: '*:*' });
+    // queryTranslationMode is undefined — should default to fail-fast
+    request.apply(ctx);
+    expect(ctx.body.has('query')).toBe(true);
+  });
 });

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/query-q.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/query-q.ts
@@ -46,7 +46,7 @@ function paramsToMap(params: URLSearchParams): Map<string, string> {
 export const request: MicroTransform<RequestContext> = {
   name: 'query-q',
   apply: (ctx) => {
-    const result = translateQ(paramsToMap(ctx.params));
+    const result = translateQ(paramsToMap(ctx.params), ctx.queryTranslationMode || 'fail-fast');
     ctx.body.set('query', result.dsl);
 
     // TODO: expose result.warnings to caller for observability

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/request.transform.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/request.transform.ts
@@ -16,11 +16,15 @@ declare const bindings: any;
 const solrConfig = (typeof bindings !== 'undefined' && bindings?.solrConfig) //NOSONAR — typeof required for undeclared closure var
   ? bindings.solrConfig
   : undefined;
+const queryTranslationMode = (typeof bindings !== 'undefined' && bindings?.queryTranslationMode) //NOSONAR
+  ? bindings.queryTranslationMode
+  : 'fail-fast';
 
 export function transform(msg: JavaMap): JavaMap {
   const ctx = buildRequestContext(msg);
   if (ctx.endpoint === 'unknown') return msg;
   ctx.solrConfig = solrConfig;
+  ctx.queryTranslationMode = queryTranslationMode;
   runPipeline(requestRegistry, ctx);
   if (ctx.body.size > 0) {
     let payload = msg.get('payload');


### PR DESCRIPTION
### Description
Allows customers to configure how the query translation pipeline handles unsupported Solr query constructs:
- **fail-fast** (default): Throws an error when a query can't be converted to OpenSearch DSL. Requests with unsupported syntax will fail.
- **passthrough-on-error**: Falls back to wrapping the raw Solr query in a `query_string` passthrough, letting OpenSearch attempt to parse it. Requests won't fail but results may differ.

### Issues Resolved
Enables configurable strict and passthrough query translation modes as described in the task requirements.

### Testing
- 3 new unit tests in `query-q.test.ts`:
  - `fail-fast mode throws on unsupported query constructs`
  - `passthrough-on-error mode falls back to query_string on unsupported constructs`
  - `defaults to fail-fast when queryTranslationMode is not set`
  
### Check List
- [ ] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
