### PR TITLE
Docs: document downloading workflow schema from GitHub releases

### DIFF
--- a/kiro-cli/kiro-cli-config/steering/workflow.md
+++ b/kiro-cli/kiro-cli-config/steering/workflow.md
@@ -47,8 +47,13 @@ workflow configure edit --stdin  # Load config from stdin (overwrites existing)
 workflow configure view          # View current config
 workflow configure clear         # Reset config
 
-# View full config schema (JSON Schema)
+# View full config schema (JSON Schema) from the running console pod
 kubectl exec migration-console-0 -n ma -- cat /root/.workflowUser.schema.json
+
+# Or download the versioned schema directly from GitHub releases
+# (works when the migration-console pod is not yet deployed)
+# Replace <VERSION> with the installed release tag, e.g. 3.0.1
+curl -sLO https://github.com/opensearch-project/opensearch-migrations/releases/download/<VERSION>/workflowMigration.schema.json
 ```
 
 ## Load Config Programmatically
@@ -310,11 +315,17 @@ kubectl exec migration-console-0 -n ma -- workflow configure sample
 # Load it as a starting point
 kubectl exec migration-console-0 -n ma -- workflow configure sample --load
 
-# View the JSON Schema
+# View the JSON Schema (from the running console pod)
 kubectl exec migration-console-0 -n ma -- cat /root/.workflowUser.schema.json
+
+# Or download the versioned JSON Schema directly from GitHub releases
+# Use this when the migration-console pod is not yet deployed, or when
+# you need to reference the schema from outside the cluster.
+# Replace <VERSION> with the installed release tag, e.g. 3.0.1
+curl -sLO https://github.com/opensearch-project/opensearch-migrations/releases/download/<VERSION>/workflowMigration.schema.json
 ```
 
-The config schema changes between versions. The sample output is always accurate for the installed version.
+The config schema changes between versions. The sample output is always accurate for the installed version, and the `workflowMigration.schema.json` asset published on each GitHub release corresponds exactly to that release tag.
 
 ### Key Config Concepts
 - **Empty `{}` enables a feature with defaults** — without it, the feature is disabled


### PR DESCRIPTION
## Summary

Updates the workflow steering doc (`kiro-cli/kiro-cli-config/steering/workflow.md`) to document a second way to obtain the `workflowMigration.schema.json` config schema: downloading the versioned asset directly from the corresponding GitHub release. This addresses a recurring failure mode where the migration assistant cannot discover the config schema when the `migration-console` pod is not yet deployed.

## Problem

The existing steering doc points the assistant at exactly one schema source:

```bash
kubectl exec migration-console-0 -n ma -- cat /root/.workflowUser.schema.json
```

That command only works once the migration-console pod is running. Before the pod is deployed — e.g. while the user is still drafting their first config, planning a migration, or working outside the cluster — the assistant has no documented way to reach the authoritative schema. In practice this led to the assistant falling back to wiki docs and hand-wavy reasoning about config shape, then getting details wrong (e.g. confusing where `createSnapshotConfig` lives in the hierarchy).

Each GitHub release under `opensearch-project/opensearch-migrations` already publishes `workflowMigration.schema.json` as a release asset (verified for 3.0.0, 3.0.1, 2.9.0, and earlier as `workflow-user-schema.json` in 2.8.0). The steering doc simply didn't mention it.

## Change

Two spots in `workflow.md` now pair the existing `kubectl exec` instruction with the release-download URL:

- Configuration Commands section (~line 50)
- "NEVER hardcode config" section (~line 304)

Both include a note that the download path is for when the console pod isn't deployed yet, and that the published asset matches the release tag exactly:

```bash
# Replace <VERSION> with the installed release tag, e.g. 3.0.1
curl -sLO https://github.com/opensearch-project/opensearch-migrations/releases/download/<VERSION>/workflowMigration.schema.json
```

## Testing

Verified the URL returns the expected schema JSON for tag `3.0.1`:

```bash
curl -sI https://github.com/opensearch-project/opensearch-migrations/releases/download/3.0.1/workflowMigration.schema.json
# HTTP/2 302 -> follows to schema JSON
```

Docs-only change — no code paths affected.
