### PR TITLE
orchestrationSpecs: add serializeSnapshotCreation override, clarify indexAllowlist descriptions

### DIFF
--- a/orchestrationSpecs/packages/config-processor/src/migrationConfigTransformer.ts
+++ b/orchestrationSpecs/packages/config-processor/src/migrationConfigTransformer.ts
@@ -15,7 +15,7 @@ import {StreamSchemaTransformer} from './streamSchemaTransformer';
 import { z } from 'zod';
 import {promises as dns} from "dns";
 import {createHash} from "crypto";
-import { generateSemaphoreKey } from './semaphoreUtils';
+import { generateSemaphoreKey, resolveSerializeSnapshotCreation } from './semaphoreUtils';
 import {validateInputAgainstUnifiedSchema} from "./unifiedSchemaValidator";
 
 type InputConfig = z.infer<typeof OVERALL_MIGRATION_CONFIG>;
@@ -598,7 +598,12 @@ export class MigrationConfigTransformer extends StreamSchemaTransformer<
                 const proxyDeps = proxyNamesBySource.get(sourceName);
 
                 const { snapshotPrefix: _sp, ...createSnapshotOpts } = snapshotDef.config.createSnapshotConfig;
-                const semaphore = this.generateSemaphoreConfig(sourceCluster.version, sourceName, snapshotName);
+                const semaphore = this.generateSemaphoreConfig(
+                    sourceCluster.version,
+                    sourceName,
+                    snapshotName,
+                    snapshotInfo?.serializeSnapshotCreation
+                );
                 createConfigs.push({
                     label: snapshotName,
                     snapshotPrefix: snapshotDef.config.createSnapshotConfig.snapshotPrefix || snapshotName,
@@ -735,10 +740,16 @@ export class MigrationConfigTransformer extends StreamSchemaTransformer<
         });
     }
 
-    private generateSemaphoreConfig(sourceVersion: string, sourceName: string, snapshotName: string) {
+    private generateSemaphoreConfig(
+        sourceVersion: string,
+        sourceName: string,
+        snapshotName: string,
+        serializeSnapshotCreationOverride: boolean | undefined
+    ) {
+        const serialize = resolveSerializeSnapshotCreation(sourceVersion, serializeSnapshotCreationOverride);
         return {
             semaphoreConfigMapName: 'concurrency-config',
-            semaphoreKey: generateSemaphoreKey(sourceVersion, sourceName, snapshotName)
+            semaphoreKey: generateSemaphoreKey(serialize, sourceName, snapshotName)
         };
     }
 

--- a/orchestrationSpecs/packages/config-processor/src/migrationInitializer.ts
+++ b/orchestrationSpecs/packages/config-processor/src/migrationInitializer.ts
@@ -9,7 +9,7 @@ import * as fs from "fs/promises";
 import * as path from "path";
 import {scrapeApprovals} from "./formatApprovals";
 import {setNamesInUserConfig} from "./migrationConfigTransformer";
-import { generateSemaphoreKey } from './semaphoreUtils';
+import { generateSemaphoreKey, resolveSerializeSnapshotCreation } from './semaphoreUtils';
 
 type WorkflowConfig = z.infer<typeof ARGO_MIGRATION_CONFIG_PRE_ENRICH>;
 type KafkaClusterConfig = NonNullable<WorkflowConfig["kafkaClusters"]>[number];
@@ -613,8 +613,12 @@ export class MigrationInitializer {
 
         for (const [sourceName, sourceCluster] of Object.entries<any>(sourceClusters)) {
             const sourceVersion = sourceCluster.version || "";
+            const serialize = resolveSerializeSnapshotCreation(
+                sourceVersion,
+                sourceCluster.snapshotInfo?.serializeSnapshotCreation
+            );
             for (const snapshotName of Object.keys(sourceCluster.snapshotInfo?.snapshots || {})) {
-                const key = generateSemaphoreKey(sourceVersion, sourceName, snapshotName);
+                const key = generateSemaphoreKey(serialize, sourceName, snapshotName);
                 if (!semaphoreKeys.includes(key)) {
                     semaphoreKeys.push(key);
                 }

--- a/orchestrationSpecs/packages/config-processor/src/semaphoreUtils.ts
+++ b/orchestrationSpecs/packages/config-processor/src/semaphoreUtils.ts
@@ -1,11 +1,46 @@
 const LEGACY_VERSION_REGEX = /^(?:ES [1-7]|OS 1)(?:\.[0-9]+)*$/;
 
+/**
+ * Returns true for source versions that require serialized snapshot creation by default
+ * (ES 1.x–7.x and OS 1.x). These versions do not tolerate concurrent snapshot operations
+ * against the same repository reliably.
+ */
 export function isLegacyVersion(sourceVersion: string): boolean {
     return LEGACY_VERSION_REGEX.test(sourceVersion);
 }
 
-export function generateSemaphoreKey(sourceVersion: string, sourceName: string, snapshotName: string): string {
-    if (isLegacyVersion(sourceVersion)) {
+/**
+ * Returns the default value for serializeSnapshotCreation based on the source version.
+ * Legacy sources (ES 1-7, OS 1) default to serialized; modern sources default to parallel.
+ */
+export function defaultSerializeSnapshotCreation(sourceVersion: string): boolean {
+    return isLegacyVersion(sourceVersion);
+}
+
+/**
+ * Resolves serializeSnapshotCreation: the explicit override wins; otherwise fall back to
+ * the version-based default.
+ */
+export function resolveSerializeSnapshotCreation(
+    sourceVersion: string,
+    override: boolean | undefined
+): boolean {
+    return override ?? defaultSerializeSnapshotCreation(sourceVersion);
+}
+
+/**
+ * Build the Argo semaphore key used to gate concurrent snapshot creation.
+ *
+ * When serializeSnapshotCreation is true, all snapshots for a given source share a single
+ * key (forcing them to run one-at-a-time). When false, each snapshot gets its own key
+ * (allowing parallel execution).
+ */
+export function generateSemaphoreKey(
+    serializeSnapshotCreation: boolean,
+    sourceName: string,
+    snapshotName: string
+): string {
+    if (serializeSnapshotCreation) {
         return `snapshot-legacy-${sourceName}`;
     }
     return `snapshot-modern-${sourceName}-${snapshotName}`;

--- a/orchestrationSpecs/packages/config-processor/tests/semaphore.test.ts
+++ b/orchestrationSpecs/packages/config-processor/tests/semaphore.test.ts
@@ -80,7 +80,7 @@ describe('semaphore configuration', () => {
             ss.createSnapshotConfig.map(config => config.semaphoreKey)
         );
         const uniqueKeys = new Set(semaphoreKeys);
-        
+
         expect(uniqueKeys.size).toBe(1); // Legacy: shared semaphore
     });
 
@@ -158,7 +158,7 @@ describe('semaphore configuration', () => {
             .createSnapshotConfig.map(config => config.semaphoreKey)
         );
         const uniqueKeys = new Set(semaphoreKeys);
-        
+
         expect(uniqueKeys.size).toBe(2); // Modern: unique semaphores
     });
 
@@ -259,10 +259,10 @@ describe('semaphore configuration', () => {
 
         const initializer = new MigrationInitializer();
         const concurrencyConfigMaps = (initializer as any).generateConcurrencyConfigMaps(config);
-        
+
         const concurrencyConfigMap = concurrencyConfigMaps.items[0];
         expect(concurrencyConfigMap.metadata.name).toBe('concurrency-config');
-        
+
         // Should have exactly 2 semaphore keys, each set to '1'
         const semaphoreData = concurrencyConfigMap.data;
         expect(Object.keys(semaphoreData)).toHaveLength(2);
@@ -272,16 +272,176 @@ describe('semaphore configuration', () => {
 
         // Test that initializer produces consistent semaphore keys between workflow and ConfigMap
         const bundle = await initializer.generateMigrationBundle(config);
-        
+
         // Extract semaphore keys from transformed workflow
         const workflowSemaphoreKeys = new Set();
         bundle.workflows.snapshots?.forEach(ss =>
             ss.createSnapshotConfig.forEach(snapshotConfig =>
                 workflowSemaphoreKeys.add(snapshotConfig.semaphoreKey))
         );
-        
+
         // Extract semaphore keys from ConfigMap
         const configMapKeys = new Set(Object.keys(bundle.concurrencyConfigMaps.items[0].data));
         expect(workflowSemaphoreKeys).toEqual(configMapKeys);
+    });
+
+    it('honors serializeSnapshotCreation=false override on a legacy source (parallel semaphores)', async () => {
+        const config: z.infer<typeof OVERALL_MIGRATION_CONFIG> = {
+            sourceClusters: {
+                legacy_source: {
+                    endpoint: "https://legacy.example.com",
+                    allowInsecure: true,
+                    version: "ES 7.10.2",
+                    authConfig: {
+                        basic: {
+                            secretName: "legacy-creds"
+                        }
+                    },
+                    snapshotInfo: {
+                        serializeSnapshotCreation: false,
+                        repos: {
+                            default: {
+                                awsRegion: "us-east-2",
+                                s3RepoPathUri: "s3://bucket/path"
+                            }
+                        },
+                        snapshots: {
+                            snap1: {
+                                repoName: "default",
+                                config: {
+                                    createSnapshotConfig: { snapshotPrefix: "snap1" }
+                                }
+                            },
+                            snap2: {
+                                repoName: "default",
+                                config: {
+                                    createSnapshotConfig: { snapshotPrefix: "snap2" }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            targetClusters: {
+                target: {
+                    endpoint: "https://target.example.com",
+                    allowInsecure: true,
+                    authConfig: {
+                        basic: {
+                            secretName: "target-creds"
+                        }
+                    }
+                }
+            },
+            snapshotMigrationConfigs: [
+                {
+                    fromSource: "legacy_source",
+                    toTarget: "target",
+                    perSnapshotConfig: {
+                        "snap1": [{
+                            metadataMigrationConfig: {
+                                skipEvaluateApproval: true,
+                                skipMigrateApproval: true
+                            }
+                        }],
+                        "snap2": [{
+                            metadataMigrationConfig: {
+                                skipEvaluateApproval: true,
+                                skipMigrateApproval: true
+                            }
+                        }]
+                    }
+                }
+            ]
+        };
+
+        const result = await transformer.processFromObject(config);
+        const semaphoreKeys = result.snapshots!.flatMap(ss =>
+            ss.createSnapshotConfig.map(cfg => cfg.semaphoreKey)
+        );
+
+        // Override forces parallel: every snapshot gets its own key
+        expect(new Set(semaphoreKeys).size).toBe(2);
+        semaphoreKeys.forEach(key => expect(key).toMatch(/^snapshot-modern-/));
+    });
+
+    it('honors serializeSnapshotCreation=true override on a modern source (shared semaphore)', async () => {
+        const config: z.infer<typeof OVERALL_MIGRATION_CONFIG> = {
+            sourceClusters: {
+                modern_source: {
+                    endpoint: "https://modern.example.com",
+                    allowInsecure: true,
+                    version: "OS 2.5.0",
+                    authConfig: {
+                        basic: {
+                            secretName: "modern-creds"
+                        }
+                    },
+                    snapshotInfo: {
+                        serializeSnapshotCreation: true,
+                        repos: {
+                            default: {
+                                awsRegion: "us-east-2",
+                                s3RepoPathUri: "s3://bucket/path"
+                            }
+                        },
+                        snapshots: {
+                            snap1: {
+                                repoName: "default",
+                                config: {
+                                    createSnapshotConfig: { snapshotPrefix: "snap1" }
+                                }
+                            },
+                            snap2: {
+                                repoName: "default",
+                                config: {
+                                    createSnapshotConfig: { snapshotPrefix: "snap2" }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            targetClusters: {
+                target: {
+                    endpoint: "https://target.example.com",
+                    allowInsecure: true,
+                    authConfig: {
+                        basic: {
+                            secretName: "target-creds"
+                        }
+                    }
+                }
+            },
+            snapshotMigrationConfigs: [
+                {
+                    fromSource: "modern_source",
+                    toTarget: "target",
+                    perSnapshotConfig: {
+                        "snap1": [{
+                            metadataMigrationConfig: {
+                                skipEvaluateApproval: true,
+                                skipMigrateApproval: true
+                            }
+                        }],
+                        "snap2": [{
+                            metadataMigrationConfig: {
+                                skipEvaluateApproval: true,
+                                skipMigrateApproval: true
+                            }
+                        }]
+                    }
+                }
+            ]
+        };
+
+        const result = await transformer.processFromObject(config);
+        const semaphoreKeys = result.snapshots!.flatMap(ss =>
+            ss.createSnapshotConfig.map(cfg => cfg.semaphoreKey)
+        );
+
+        // Override forces serialized: all snapshots share one key
+        expect(new Set(semaphoreKeys).size).toBe(1);
+        semaphoreKeys.forEach(key => expect(key).toMatch(/^snapshot-legacy-/));
     });
 });

--- a/orchestrationSpecs/packages/schemas/src/userSchemas.ts
+++ b/orchestrationSpecs/packages/schemas/src/userSchemas.ts
@@ -526,8 +526,13 @@ export const USER_CREATE_SNAPSHOT_WORKFLOW_OPTIONS = z.object({
 
 export const USER_CREATE_SNAPSHOT_PROCESS_OPTIONS = z.object({
     indexAllowlist: z.array(z.string()).default([]).optional()
-        .describe("List of index names to include in the snapshot. " +
-            "Each entry is either an exact index name (e.g. 'logs-2024-01') or a regex pattern prefixed with 'regex:' (e.g. 'regex:logs-.*-2024'). " +
+        .describe("Filters which indices are captured at the snapshot layer — evaluated by the source cluster when the snapshot is created. " +
+            "Entries use the cluster's native multi-index expression syntax (the same format accepted by the _snapshot API's 'indices' field): " +
+            "exact names (e.g. 'logs-2024-01'), wildcards (e.g. 'logs-*'), and exclusions via a leading '-' (e.g. '-*-archive'). " +
+            "The entries are joined with commas and sent verbatim as the 'indices' field of the snapshot creation request; this is NOT a regex. " +
+            "Only the matching indices end up in the snapshot, so downstream stages have no way to recover indices excluded here. " +
+            "To further narrow which indices are migrated after the snapshot is taken (including with 'regex:' patterns), use the metadata or RFS indexAllowlist, " +
+            "which filter client-side on the snapshot contents. " +
             "An empty list includes all indices."),
     maxSnapshotRateMbPerNode: z.number().default(0).optional()
         .describe("Maximum snapshot throughput in MB/s per data node. 0 means no rate limiting. Use to reduce I/O impact on the source cluster during snapshot creation."),
@@ -563,8 +568,9 @@ export const USER_METADATA_PROCESS_OPTIONS = z.object({
             "Each entry is either an exact name or a regex pattern prefixed with 'regex:'. " +
             "An empty list includes all non-system component templates."),
     indexAllowlist: z.array(z.string()).default([]).optional()
-        .describe("List of index names to include in the metadata migration. " +
+        .describe("Filters which indices are migrated at the metadata stage — evaluated client-side on the snapshot contents after the snapshot has been taken. " +
             "Each entry is either an exact index name (e.g. 'my-index') or a regex pattern prefixed with 'regex:' (e.g. 'regex:logs-.*'). " +
+            "Applies only among indices already captured in the snapshot; to exclude an index from the snapshot itself, use the CreateSnapshot indexAllowlist. " +
             "An empty list includes all non-system indices."),
     indexTemplateAllowlist: z.array(z.string()).default([]).optional()
         .describe("List of index template names to include in the metadata migration. " +
@@ -631,8 +637,9 @@ export const USER_RFS_WORKFLOW_OPTIONS = z.object({
 
 export const USER_RFS_PROCESS_OPTIONS = z.object({
     indexAllowlist: z.array(z.string()).default([]).optional()
-        .describe("List of index names to include in the document backfill. " +
+        .describe("Filters which indices are migrated by the document backfill (RFS) — evaluated client-side on the snapshot contents after the snapshot has been taken. " +
             "Each entry is either an exact index name or a regex pattern prefixed with 'regex:' (e.g. 'regex:logs-.*'). " +
+            "Applies only among indices already captured in the snapshot; to exclude an index from the snapshot itself, use the CreateSnapshot indexAllowlist. " +
             "An empty list includes all non-system indices from the snapshot.")
         .checksumFor('replayer')
         .changeRestriction('impossible'),
@@ -900,7 +907,15 @@ export const SNAPSHOT_INFO = z.object({
     repos: SOURCE_CLUSTER_REPOS_RECORD.optional()
         .describe("S3 snapshot repositories registered with the source cluster."),
     snapshots: SNAPSHOT_CONFIGS_MAP
-        .describe("Snapshots to use or create for this source cluster.")
+        .describe("Snapshots to use or create for this source cluster."),
+    serializeSnapshotCreation: z.boolean().optional()
+        .describe("Controls whether snapshot creations for this source run one-at-a-time or in parallel. " +
+            "When true, all snapshot creations share a single semaphore so only one runs at any given time; " +
+            "when false, each snapshot can run in parallel with others for this source. " +
+            "When omitted, defaults to true for legacy sources (ES 1-7, OS 1) and false for modern sources (ES 8+, OS 2+). " +
+            "Set explicitly to override the version-based default. " +
+            "Common reason to force true on a modern source: the cluster only supports one snapshot at a time for the indices being captured " +
+            "(for example, OpenSearch UltraWarm indices, which only allow a single index per snapshot and cannot be snapshotted concurrently).")
 }).describe("Snapshot repository and snapshot configuration for a source cluster.");
 
 const AWS_MANAGED_ENDPOINT_PATTERN = /(?:\.es\.amazonaws\.com|\.aos\.[a-z0-9-]+\.on\.aws)(?::\d+)?(?:\/)?$/i;

--- a/orchestrationSpecs/packages/schemas/tests/__snapshots__/argoSchemaSnapshot.test.ts.snap
+++ b/orchestrationSpecs/packages/schemas/tests/__snapshots__/argoSchemaSnapshot.test.ts.snap
@@ -2041,7 +2041,7 @@ exports[`test schemas matches expected argo user matches expected 1`] = `
                                     "type": "string"
                                   },
                                   "default": [],
-                                  "description": "List of index names to include in the snapshot. Each entry is either an exact index name (e.g. 'logs-2024-01') or a regex pattern prefixed with 'regex:' (e.g. 'regex:logs-.*-2024'). An empty list includes all indices."
+                                  "description": "Filters which indices are captured at the snapshot layer — evaluated by the source cluster when the snapshot is created. Entries use the cluster's native multi-index expression syntax (the same format accepted by the _snapshot API's 'indices' field): exact names (e.g. 'logs-2024-01'), wildcards (e.g. 'logs-*'), and exclusions via a leading '-' (e.g. '-*-archive'). The entries are joined with commas and sent verbatim as the 'indices' field of the snapshot creation request; this is NOT a regex. Only the matching indices end up in the snapshot, so downstream stages have no way to recover indices excluded here. To further narrow which indices are migrated after the snapshot is taken (including with 'regex:' patterns), use the metadata or RFS indexAllowlist, which filter client-side on the snapshot contents. An empty list includes all indices."
                                 },
                                 "maxSnapshotRateMbPerNode": {
                                   "type": "number",
@@ -2082,6 +2082,10 @@ exports[`test schemas matches expected argo user matches expected 1`] = `
                   "description": "A snapshot configuration bound to a specific repository."
                 },
                 "description": "Snapshots to use or create for this source cluster."
+              },
+              "serializeSnapshotCreation": {
+                "type": "boolean",
+                "description": "Controls whether snapshot creations for this source run one-at-a-time or in parallel. When true, all snapshot creations share a single semaphore so only one runs at any given time; when false, each snapshot can run in parallel with others for this source. When omitted, defaults to true for legacy sources (ES 1-7, OS 1) and false for modern sources (ES 8+, OS 2+). Set explicitly to override the version-based default. Common reason to force true on a modern source: the cluster only supports one snapshot at a time for the indices being captured (for example, OpenSearch UltraWarm indices, which only allow a single index per snapshot and cannot be snapshotted concurrently)."
               }
             },
             "required": [
@@ -2266,7 +2270,7 @@ exports[`test schemas matches expected argo user matches expected 1`] = `
                           "type": "string"
                         },
                         "default": [],
-                        "description": "List of index names to include in the metadata migration. Each entry is either an exact index name (e.g. 'my-index') or a regex pattern prefixed with 'regex:' (e.g. 'regex:logs-.*'). An empty list includes all non-system indices."
+                        "description": "Filters which indices are migrated at the metadata stage — evaluated client-side on the snapshot contents after the snapshot has been taken. Each entry is either an exact index name (e.g. 'my-index') or a regex pattern prefixed with 'regex:' (e.g. 'regex:logs-.*'). Applies only among indices already captured in the snapshot; to exclude an index from the snapshot itself, use the CreateSnapshot indexAllowlist. An empty list includes all non-system indices."
                       },
                       "indexTemplateAllowlist": {
                         "type": "array",
@@ -2421,7 +2425,7 @@ exports[`test schemas matches expected argo user matches expected 1`] = `
                           "type": "string"
                         },
                         "default": [],
-                        "description": "List of index names to include in the document backfill. Each entry is either an exact index name or a regex pattern prefixed with 'regex:' (e.g. 'regex:logs-.*'). An empty list includes all non-system indices from the snapshot.",
+                        "description": "Filters which indices are migrated by the document backfill (RFS) — evaluated client-side on the snapshot contents after the snapshot has been taken. Each entry is either an exact index name or a regex pattern prefixed with 'regex:' (e.g. 'regex:logs-.*'). Applies only among indices already captured in the snapshot; to exclude an index from the snapshot itself, use the CreateSnapshot indexAllowlist. An empty list includes all non-system indices from the snapshot.",
                         "checksumFor": [
                           "replayer"
                         ],


### PR DESCRIPTION
## Summary

Turns snapshot serialization into an explicit, overridable config on the source cluster, instead of something implicitly derived from the source version. Also sharpens the documentation on the three `indexAllowlist` fields (CreateSnapshot / Metadata / RFS) so users can tell which one filters server-side vs client-side.

## Background: how snapshot serialization is gated

A `ConfigMap` named `concurrency-config` backs an Argo semaphore attached at the **`snapshotworkflow` template level** — so the lock covers the entire workflow invocation, not just the create step. That means one holder at a time owns:

```
runCreateSnapshot  →  getConsoleConfig  →  waitForCompletion  →  patchDataSnapshotCompleted
```

Including the polling wait. This matters for legacy repos that can't tolerate *any* concurrent snapshot op, not just concurrent starts.

The semaphore key granularity was hardcoded by `isLegacyVersion(sourceVersion)`:

```
serialize=true   →  snapshot-legacy-<sourceName>              (one key shared per source)
serialize=false  →  snapshot-modern-<sourceName>-<snapshotName> (one key per snapshot)
```

Version-based default is usually right but wrong for modern clusters whose repo or indices don't support concurrent snapshots.

## Problems Solved

1. **No opt-in to serialization for modern sources** — e.g. OS 2.x with UltraWarm indices (one index per snapshot, no concurrency) was stuck in the parallel bucket.
2. **No opt-out for legacy sources** — operators who know their ES 6/7 repo tolerates concurrent snapshots were stuck sharing one key.
3. **CreateSnapshot `indexAllowlist` was mis-documented** — the description claimed `regex:` support. It doesn't — entries are comma-joined and sent verbatim as the `_snapshot` API's `indices` field (native multi-index syntax, wildcards, `-` exclusions; no regex). Only RFS/Metadata allowlists support `regex:`.
4. **No framing of where each allowlist applies** — three fields share the same name with no hint whether filtering happens server-side at snapshot time (irreversible) or client-side on snapshot contents (re-narrowable later).

## Key Changes

### New optional flag: `sourceClusters.<name>.snapshotInfo.serializeSnapshotCreation`

Boolean, optional. Omitted = legacy defaults to `true`, modern to `false` (prior behavior preserved). Setting it explicitly overrides in either direction.

### Shared resolver keeps config and workflow in lockstep

`semaphoreUtils.ts` exposes `resolveSerializeSnapshotCreation(version, override)`, and `generateSemaphoreKey()` now takes the resolved boolean rather than the version string. Both the `concurrency-config` builder (`MigrationInitializer`) and the workflow template reference (`MigrationConfigTransformer`) call the resolver, so they can't disagree about what key a workflow will request.

Existing key prefixes (`snapshot-legacy-…`, `snapshot-modern-…`) are unchanged to avoid churning the 7 workflow-template snapshot fixtures.

### `indexAllowlist` descriptions clarified

All three now say explicitly *where* filtering happens and whether `regex:` is supported:

- **CreateSnapshot** — server-side at snapshot time; native `_snapshot` syntax (wildcards, `-` exclusions); no regex. Excluded indices can't be recovered downstream.
- **Metadata** — client-side on snapshot contents; supports `regex:`.
- **RFS** — client-side on snapshot contents; supports `regex:`.

## Testing

- 2 new unit tests in `semaphore.test.ts` covering the override in both directions (modern forced to serialize → one shared key; legacy forced parallel → distinct keys per snapshot).
- Updated `argoSchemaSnapshot.test.ts.snap` for the new schema field + rewritten descriptions.
- Full orchestrationSpecs workspace: 206 passing (+2 skipped) across 4 packages. No workflow-template fixture diffs.

## Migration notes

Fully backward-compatible. To force serialization on a modern source:

```yaml
sourceClusters:
  mySource:
    version: "OS 2.11"
    snapshotInfo:
      serializeSnapshotCreation: true
      snapshots: { ... }
```
