### PR TITLE
Enable TLS by default for Argo Workflows server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,7 +33,7 @@ TrafficCapture/dockerSolution/src/main/docker/migrationConsole/staging
 
 # Directory used to temporarily store snapshots during testing
 DocumentsFromSnapshotMigration/docker/snapshots/
-transformation/standardJavascriptTransforms/coverage/
+**/coverage/
 transformation/standardJavascriptTransforms/node_modules/
 orchestrationSpecs/k8sResources/
 orchestrationSpecs/dist/

--- a/.gitignore
+++ b/.gitignore
@@ -33,7 +33,7 @@ TrafficCapture/dockerSolution/src/main/docker/migrationConsole/staging
 
 # Directory used to temporarily store snapshots during testing
 DocumentsFromSnapshotMigration/docker/snapshots/
-**/coverage/
+transformation/standardJavascriptTransforms/coverage/
 transformation/standardJavascriptTransforms/node_modules/
 orchestrationSpecs/k8sResources/
 orchestrationSpecs/dist/

--- a/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/values.yaml
+++ b/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/values.yaml
@@ -378,6 +378,7 @@ charts:
           - name: RESOURCE_STATE_CHECK_INTERVAL
             value: "1s"
       server:
+        secure: true
         replicas: 2
         resources:
           requests: { cpu: 100m, memory: 512Mi }

--- a/migrationConsole/lib/console_link/console_link/workflow/commands/approve.py
+++ b/migrationConsole/lib/console_link/console_link/workflow/commands/approve.py
@@ -10,6 +10,7 @@ from kubernetes.client.rest import ApiException
 
 from ..models.utils import ExitCode, load_k8s_config
 from .autocomplete_workflows import DEFAULT_WORKFLOW_NAME, get_workflow_completions
+from .argo_utils import DEFAULT_ARGO_SERVER_URL
 from .crd_utils import (
     CRD_GROUP,
     CRD_VERSION,
@@ -61,13 +62,12 @@ def get_approval_task_name_completions(ctx, _, incomplete):
     '--argo-server',
     default=lambda: os.environ.get(
         'ARGO_SERVER',
-        f"http://{os.environ.get('ARGO_SERVER_SERVICE_HOST', 'localhost')}:"
-        f"{os.environ.get('ARGO_SERVER_SERVICE_PORT', '2746')}"
+        DEFAULT_ARGO_SERVER_URL
     ),
     help='Argo Server URL'
 )
 @click.option('--namespace', default='ma')
-@click.option('--insecure', is_flag=True, default=False)
+@click.option('--insecure', is_flag=True, default=True)
 @click.option('--token', help='Bearer token for authentication')
 @click.pass_context
 def approve_command(ctx, task_names, workflow_name, argo_server, namespace, insecure, token):

--- a/migrationConsole/lib/console_link/console_link/workflow/commands/argo_utils.py
+++ b/migrationConsole/lib/console_link/console_link/workflow/commands/argo_utils.py
@@ -1,8 +1,14 @@
 """Shared utilities for Argo workflow lifecycle operations via k8s API."""
 
+import os
 import time
 from kubernetes import client
 from kubernetes.client.rest import ApiException
+
+DEFAULT_ARGO_SERVER_URL = (
+    f"https://{os.environ.get('ARGO_SERVER_SERVICE_HOST', 'localhost')}"
+    f":{os.environ.get('ARGO_SERVER_SERVICE_PORT', '2746')}"
+)
 
 ARGO_GROUP = 'argoproj.io'
 ARGO_VERSION = 'v1alpha1'

--- a/migrationConsole/lib/console_link/console_link/workflow/commands/autocomplete_k8s_labels.py
+++ b/migrationConsole/lib/console_link/console_link/workflow/commands/autocomplete_k8s_labels.py
@@ -10,6 +10,7 @@ import requests
 from pathlib import Path
 
 from console_link.workflow.commands.autocomplete_workflows import DEFAULT_WORKFLOW_NAME
+from console_link.workflow.commands.argo_utils import DEFAULT_ARGO_SERVER_URL
 
 logger = logging.getLogger(__name__)
 
@@ -96,10 +97,7 @@ def _get_cached_label_data(ctx):
 
     try:
         namespace = ctx.params.get('namespace', 'ma')
-        argo_server = ctx.params.get('argo_server') or os.environ.get('ARGO_SERVER') or (
-            f"http://{os.environ.get('ARGO_SERVER_SERVICE_HOST', 'localhost')}"
-            f":{os.environ.get('ARGO_SERVER_SERVICE_PORT', '2746')}"
-        )
+        argo_server = ctx.params.get('argo_server') or os.environ.get('ARGO_SERVER') or DEFAULT_ARGO_SERVER_URL
         token = ctx.params.get('token')
         insecure = ctx.params.get('insecure', False)
 

--- a/migrationConsole/lib/console_link/console_link/workflow/commands/autocomplete_k8s_labels.py
+++ b/migrationConsole/lib/console_link/console_link/workflow/commands/autocomplete_k8s_labels.py
@@ -99,7 +99,7 @@ def _get_cached_label_data(ctx):
         namespace = ctx.params.get('namespace', 'ma')
         argo_server = ctx.params.get('argo_server') or os.environ.get('ARGO_SERVER') or DEFAULT_ARGO_SERVER_URL
         token = ctx.params.get('token')
-        insecure = ctx.params.get('insecure', False)
+        insecure = ctx.params.get('insecure', True)
 
         label_map, valid_combos = _fetch_workflow_labels(workflow_name, namespace, argo_server, token, insecure)
 

--- a/migrationConsole/lib/console_link/console_link/workflow/commands/manage.py
+++ b/migrationConsole/lib/console_link/console_link/workflow/commands/manage.py
@@ -11,6 +11,7 @@ from kubernetes import client
 
 # Internal imports
 from .autocomplete_workflows import DEFAULT_WORKFLOW_NAME, get_workflow_completions
+from .argo_utils import DEFAULT_ARGO_SERVER_URL
 from ..models.utils import ExitCode, load_k8s_config
 from ..tui.manage_injections import make_argo_service, make_k8s_pod_scraper, WaiterInterface
 from ..tui.workflow_manage_app import WorkflowTreeApp
@@ -81,12 +82,11 @@ def _initialize_k8s_client(ctx):
 @click.option('--workflow-name', default=DEFAULT_WORKFLOW_NAME, shell_complete=get_workflow_completions)
 @click.option(
     '--argo-server',
-    default=f"http://{os.environ.get('ARGO_SERVER_SERVICE_HOST', 'localhost')}"
-            f":{os.environ.get('ARGO_SERVER_SERVICE_PORT', '2746')}",
+    default=DEFAULT_ARGO_SERVER_URL,
     help='Argo Server URL (default: ARGO_SERVER env var, or ARGO_SERVER_SERVICE_HOST:ARGO_SERVER_SERVICE_PORT)'
 )
 @click.option('--namespace', default='ma')
-@click.option('--insecure', is_flag=True, default=False)
+@click.option('--insecure', is_flag=True, default=True)
 @click.option('--token')
 @click.pass_context
 def manage_command(ctx, workflow_name, argo_server, namespace, insecure, token):

--- a/migrationConsole/lib/console_link/console_link/workflow/commands/output.py
+++ b/migrationConsole/lib/console_link/console_link/workflow/commands/output.py
@@ -10,6 +10,7 @@ from kubernetes import client
 
 from .autocomplete_k8s_labels import get_label_completions
 from .autocomplete_workflows import DEFAULT_WORKFLOW_NAME, get_workflow_completions
+from .argo_utils import DEFAULT_ARGO_SERVER_URL
 from ..models.utils import load_k8s_config
 
 
@@ -40,12 +41,11 @@ def _get_label_selector(selector_str, prefix, workflow_name):
 @click.option('--all-workflows', is_flag=True, default=False, help='Show output for all workflows')
 @click.option(
     '--argo-server',
-    default=f"http://{os.environ.get('ARGO_SERVER_SERVICE_HOST', 'localhost')}"
-            f":{os.environ.get('ARGO_SERVER_SERVICE_PORT', '2746')}",
+    default=DEFAULT_ARGO_SERVER_URL,
     help='Argo Server URL (default: ARGO_SERVER env var, or ARGO_SERVER_SERVICE_HOST:ARGO_SERVER_SERVICE_PORT)'
 )
 @click.option('--namespace', default='ma')
-@click.option('--insecure', is_flag=True, default=False)
+@click.option('--insecure', is_flag=True, default=True)
 @click.option('--token', help='Bearer token for authentication')
 @click.option('--prefix', default='migrations.opensearch.org/', help='Label prefix for filters')
 @click.option(

--- a/migrationConsole/lib/console_link/console_link/workflow/commands/output.py
+++ b/migrationConsole/lib/console_link/console_link/workflow/commands/output.py
@@ -3,7 +3,6 @@ from contextlib import ExitStack
 
 import click
 import logging
-import os
 import subprocess
 
 from kubernetes import client

--- a/migrationConsole/lib/console_link/console_link/workflow/commands/status.py
+++ b/migrationConsole/lib/console_link/console_link/workflow/commands/status.py
@@ -25,6 +25,7 @@ from ..tree_utils import (
     WorkflowDisplayer
 )
 from .autocomplete_workflows import DEFAULT_WORKFLOW_NAME, get_workflow_completions
+from .argo_utils import DEFAULT_ARGO_SERVER_URL
 from console_link.environment import Environment
 from console_link.middleware import snapshot as snapshot_middleware
 from console_link.middleware import backfill as backfill_middleware
@@ -458,12 +459,11 @@ class LiveCheckProcessor:
 @click.option('--all-workflows', is_flag=True, default=False, help='Show status for all workflows')
 @click.option(
     '--argo-server',
-    default=f"http://{os.environ.get('ARGO_SERVER_SERVICE_HOST', 'localhost')}"
-    f":{os.environ.get('ARGO_SERVER_SERVICE_PORT', '2746')}",
+    default=DEFAULT_ARGO_SERVER_URL,
     help='Argo Server URL (default: ARGO_SERVER env var, or ARGO_SERVER_SERVICE_HOST:ARGO_SERVER_SERVICE_PORT)'
 )
 @click.option('--namespace', default='ma', help='Kubernetes namespace for the workflow (default: ma)')
-@click.option('--insecure', is_flag=True, default=False, help='Skip TLS certificate verification')
+@click.option('--insecure', is_flag=True, default=True, help='Skip TLS certificate verification (default: True)')
 @click.option('--token', help='Bearer token for authentication')
 @click.option('--all', 'show_all', is_flag=True, default=False,
               help='Show all workflows including completed ones (default: only running)')

--- a/migrationConsole/lib/console_link/tests/test_artifact_output.py
+++ b/migrationConsole/lib/console_link/tests/test_artifact_output.py
@@ -134,12 +134,12 @@ class TestWorkflowServiceGetArtifactContent:
             node_id="node-abc",
             artifact_name="statusOutput",
             namespace="ma",
-            argo_server="http://argo:2746"
+            argo_server="https://argo:2746"
         )
 
         assert result == "snapshot completed successfully"
         mock_get.assert_called_once_with(
-            "http://argo:2746/api/v1/workflows/ma/my-wf/artifacts/node-abc/statusOutput",
+            "https://argo:2746/api/v1/workflows/ma/my-wf/artifacts/node-abc/statusOutput",
             headers={"Content-Type": "application/json"},
             verify=True
         )
@@ -154,7 +154,7 @@ class TestWorkflowServiceGetArtifactContent:
             node_id="node-abc",
             artifact_name="statusOutput",
             namespace="ma",
-            argo_server="http://argo:2746"
+            argo_server="https://argo:2746"
         )
 
         assert result is None
@@ -170,7 +170,7 @@ class TestWorkflowServiceGetArtifactContent:
             node_id="node-abc",
             artifact_name="statusOutput",
             namespace="ma",
-            argo_server="http://argo:2746",
+            argo_server="https://argo:2746",
             token="my-token"
         )
 
@@ -189,7 +189,7 @@ class TestWorkflowServiceGetArtifactContent:
             node_id="node-abc",
             artifact_name="statusOutput",
             namespace="ma",
-            argo_server="http://argo:2746",
+            argo_server="https://argo:2746",
             insecure=True
         )
 

--- a/migrationConsole/lib/console_link/tests/workflow-tests/test_manage_injections.py
+++ b/migrationConsole/lib/console_link/tests/workflow-tests/test_manage_injections.py
@@ -257,7 +257,7 @@ class TestArgoServiceFiltering:
         mock_response.raw = io.BytesIO(json.dumps(bloated).encode())
         mock_get.return_value = mock_response
 
-        argo = make_argo_service("http://argo:2746", False, "token")
+        argo = make_argo_service("https://argo:2746", False, "token")
         _, slim_data = argo.get_workflow("my-workflow", "default")
 
         node1 = slim_data["status"]["nodes"]["node-1"]
@@ -295,7 +295,7 @@ class TestArgoServiceFiltering:
         mock_response.raw = io.BytesIO(json.dumps(bloated).encode())
         mock_get.return_value = mock_response
 
-        argo = make_argo_service("http://argo:2746", False, "token")
+        argo = make_argo_service("https://argo:2746", False, "token")
         _, slim_data = argo.get_workflow("my-workflow", "default")
 
         node1 = slim_data["status"]["nodes"]["node-1"]
@@ -320,7 +320,7 @@ class TestArgoServiceFiltering:
         mock_response.raw = io.BytesIO(json.dumps(bloated).encode())
         mock_get.return_value = mock_response
 
-        argo = make_argo_service("http://argo:2746", False, "token")
+        argo = make_argo_service("https://argo:2746", False, "token")
         _, slim_data = argo.get_workflow("my-workflow", "default")
 
         node1_inputs = slim_data["status"]["nodes"]["node-1"]["inputs"]["parameters"]
@@ -360,7 +360,7 @@ class TestArgoServiceFiltering:
         mock_response.raw = io.BytesIO(json.dumps(bloated).encode())
         mock_get.return_value = mock_response
 
-        argo = make_argo_service("http://argo:2746", False, "token")
+        argo = make_argo_service("https://argo:2746", False, "token")
         _, slim_data = argo.get_workflow("my-workflow", "default")
 
         node1_artifacts = slim_data["status"]["nodes"]["node-1"]["outputs"]["artifacts"]
@@ -382,7 +382,7 @@ class TestArgoServiceFiltering:
         mock_response.raw = io.BytesIO(json.dumps(bloated).encode())
         mock_get.return_value = mock_response
 
-        argo = make_argo_service("http://argo:2746", False, "token")
+        argo = make_argo_service("https://argo:2746", False, "token")
         _, slim_data = argo.get_workflow("my-workflow", "default")
 
         node1_outputs = slim_data["status"]["nodes"]["node-1"]["outputs"]["parameters"]
@@ -404,7 +404,7 @@ class TestArgoServiceFiltering:
         mock_response.status_code = 404
         mock_get.return_value = mock_response
 
-        argo = make_argo_service("http://argo:2746", False, "token")
+        argo = make_argo_service("https://argo:2746", False, "token")
 
         with pytest.raises(Exception) as exc_info:
             argo.get_workflow("missing-wf", "default")

--- a/migrationConsole/lib/console_link/tests/workflow-tests/test_status.py
+++ b/migrationConsole/lib/console_link/tests/workflow-tests/test_status.py
@@ -96,7 +96,7 @@ class TestStatusCommand:
         handler.data_fetcher = FakeDataFetcher(workflows, service)
 
         output = capture_output(lambda: handler.handle_status_command(
-            'test-wf', 'http://argo', 'ma', False, False, False))
+            'test-wf', 'https://argo', 'ma', False, False, False))
 
         assert 'test-wf' in output
         assert 'Running' in output
@@ -123,7 +123,7 @@ class TestStatusCommand:
         handler.data_fetcher = FakeDataFetcher(workflows, service)
 
         output = capture_output(lambda: handler.handle_status_command(
-            'test-wf', 'http://argo', 'ma', False, False, False))
+            'test-wf', 'https://argo', 'ma', False, False, False))
 
         assert 'test-wf' in output
         assert 'Succeeded' in output
@@ -134,7 +134,7 @@ class TestStatusCommand:
         handler.data_fetcher = FakeDataFetcher({}, service)
 
         with pytest.raises(Exception):  # click.Abort
-            handler.handle_status_command('nonexistent', 'http://argo', 'ma', False, False, False)
+            handler.handle_status_command('nonexistent', 'https://argo', 'ma', False, False, False)
 
     def test_list_multiple_workflows(self):
         workflows = {
@@ -157,7 +157,7 @@ class TestStatusCommand:
         handler.data_fetcher = FakeDataFetcher(workflows, service)
 
         output = capture_output(lambda: handler.handle_status_command(
-            None, 'http://argo', 'ma', False, False, False))
+            None, 'https://argo', 'ma', False, False, False))
 
         assert 'Found 2 workflow(s)' in output
         assert 'wf-1' in output
@@ -185,7 +185,7 @@ class TestStatusCommand:
         handler.data_fetcher = FakeDataFetcher(workflows, service)
 
         output = capture_output(lambda: handler.handle_status_command(
-            None, 'http://argo', 'ma', False, False, False))
+            None, 'https://argo', 'ma', False, False, False))
 
         assert 'Found 1 workflow(s)' in output
         assert 'wf-running' in output
@@ -197,7 +197,7 @@ class TestStatusCommand:
         handler.data_fetcher = FakeDataFetcher({}, service)
 
         output = capture_output(lambda: handler.handle_status_command(
-            None, 'http://argo', 'ma', False, False, False))
+            None, 'https://argo', 'ma', False, False, False))
 
         assert 'No running workflows found' in output
 
@@ -227,7 +227,7 @@ class TestStatusCommand:
         handler.data_fetcher = FakeDataFetcher(workflows, service)
 
         output = capture_output(lambda: handler.handle_status_command(
-            'test-wf', 'http://argo', 'ma', False, False, False))
+            'test-wf', 'https://argo', 'ma', False, False, False))
 
         assert 'test-wf' in output
         assert 'step1' in output
@@ -249,7 +249,7 @@ class TestStatusCommand:
         handler.data_fetcher = FakeDataFetcher(workflows, service)
 
         output = capture_output(lambda: handler.handle_status_command(
-            None, 'http://argo', 'ma', False, True, False))
+            None, 'https://argo', 'ma', False, True, False))
 
         assert 'Found 1 workflow(s)' in output
         assert 'wf-done' in output
@@ -277,7 +277,7 @@ class TestStatusCommand:
         handler.data_fetcher = FakeDataFetcher(workflows, service)
 
         output = capture_output(lambda: handler.handle_status_command(
-            None, 'http://argo', 'ma', False, False, False))
+            None, 'https://argo', 'ma', False, False, False))
 
         assert 'No running workflows found' in output
         assert 'last completed workflow' in output
@@ -295,7 +295,7 @@ class TestStatusCommand:
         handler.data_fetcher.list_workflows = bad_list
 
         with pytest.raises(Exception):
-            handler.handle_status_command(None, 'http://argo', 'ma', False, False, False)
+            handler.handle_status_command(None, 'https://argo', 'ma', False, False, False)
 
     def test_rfs_coordinator_retry_collapsed_in_status(self):
         """Infrastructure retry nodes (bare leaf Pods) are collapsed; retries with
@@ -355,7 +355,7 @@ class TestStatusCommand:
         handler.data_fetcher = FakeDataFetcher(workflows, service)
 
         output = capture_output(lambda: handler.handle_status_command(
-            'test-wf', 'http://argo', 'ma', False, False, False))
+            'test-wf', 'https://argo', 'ma', False, False, False))
 
         # RFS retry attempts should be collapsed — no (0) or (1) suffixes visible
         assert 'createRfsCoordinatorStatefulSet(0)' not in output
@@ -425,7 +425,7 @@ snapshot:
 
         # This will attempt live checks but fail gracefully without real clusters
         output = capture_output(lambda: handler.handle_status_command(
-            'test-wf', 'http://argo', 'ma', False, False, True))
+            'test-wf', 'https://argo', 'ma', False, False, True))
 
         assert 'test-wf' in output
 
@@ -483,7 +483,7 @@ backfill:
         handler.live_check_processor.config_converter = FakeConverter()
 
         output = capture_output(lambda: handler.handle_status_command(
-            'test-wf', 'http://argo', 'ma', False, False, True))
+            'test-wf', 'https://argo', 'ma', False, False, True))
 
         assert 'test-wf' in output
 
@@ -539,6 +539,6 @@ target_cluster:
 
         # Should handle unknown check type gracefully
         output = capture_output(lambda: handler.handle_status_command(
-            'test-wf', 'http://argo', 'ma', False, False, True))
+            'test-wf', 'https://argo', 'ma', False, False, True))
 
         assert 'test-wf' in output


### PR DESCRIPTION
### Description

Enable TLS on the Argo Workflows server by default using the built-in `--secure` mode. The server generates a self-signed certificate at startup and serves HTTPS. All migration console CLI commands now default to `https://` with TLS verification disabled, since all Argo server communication is internal (migration console to Argo server within the cluster) and server identity verification is not required.

Changes:
- Set `server.secure: true` in the Argo Helm chart values (the chart handles both the `--secure` flag and HTTPS health probe scheme)
- Extract shared `DEFAULT_ARGO_SERVER_URL` constant into `argo_utils.py` to eliminate URL duplication across 5 CLI command files
- Change default URL scheme from `http://` to `https://` in all workflow CLI commands
- Default `--insecure` flag to `True` for Argo server calls
- Fix insecure default in autocomplete_k8s_labels.py
- Update unit tests to reflect new defaults

### Issues Resolved

[MIGRATIONS-3040](https://opensearch.atlassian.net/browse/MIGRATIONS-3040)

### Testing

**Unit tests**: 44 tests updated and passing — URL scheme changed from `http://` to `https://`, `--insecure` default flipped to `True`.

**EKS integration tests** (deployed to dev account, us-east-1):

- `curl -sk https://localhost:2746/api/v1/info` returns valid JSON; `curl http://` rejected with "Client sent an HTTP request to an HTTPS server"
- Deployment args contain `--secure=true` with no conflicting `--secure=false`
- Helm chart automatically sets readiness/liveness probe `scheme: HTTPS` when `server.secure: true`; health endpoint returns 200
- `workflow status` from migration console pod connects to `https://<argo-server>:2746` with `insecure=True`
- `workflow submit` and `workflow status` communicate with Argo API over HTTPS successfully
- `curl https://argo-server:2746` without `-k` fails with exit code 60 (cert verification failed), confirming real TLS with self-signed cert

### Check List
- [x] New functionality includes testing
- [ ] Public documentation issue/PR created, if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
