### PR TITLE
feat(solr-transforms): Add mm (minimum should match) parameter support

### DIFF
--- a/TrafficCapture/SolrTransformations/docs/LIMITATIONS.md
+++ b/TrafficCapture/SolrTransformations/docs/LIMITATIONS.md
@@ -22,6 +22,10 @@ the root cause, and provides a workaround where one exists.
 | [JSON-QUERIES](#json-queries)                   | JSON Request API `queries` key not supported |
 | [JSON-PARAM-PREFIX](#json-param-prefix)         | JSON Request API `json.<param>` prefix passthrough not supported |
 | [UPDATE-COMMANDS](#update-commands)             | Only `add` and `delete-by-id` commands supported; JSON only |
+| [MM-AUTORELAX](#mm-autorelax)                   | eDisMax `mm.autoRelax` parameter not supported |
+| [MM-EDISMAX-OPERATOR-DEFAULT](#mm-edismax-operator-default) | eDisMax `mm` default with explicit operators not fully replicated |
+| [MM-EDISMAX-MIXED-OPERATORS](#mm-edismax-mixed-operators) | eDisMax `mm` with mixed explicit and implicit operators applies to wrong scope |
+| [MM-STOPWORD-MULTIFIELD](#mm-stopword-multifield) | `mm` with per-field stopword removal differs from Solr |
 
 ---
 
@@ -494,3 +498,149 @@ Both JSON and XML content types are supported.
 Only `application/json` request bodies are supported. XML bodies
 (`text/xml`, `application/xml`) cannot be parsed by the shim and will
 fail with an error. Clients using XML format must switch to JSON.
+
+---
+
+## MM-AUTORELAX
+
+**Feature:** eDisMax `mm.autoRelax` parameter
+
+**Solr behaviour:**
+When `mm.autoRelax=true` in eDisMax, Solr automatically relaxes the
+`minimum_should_match` requirement if a query clause is removed by stopword
+filtering in some but not all `qf` fields. This prevents zero-hit results
+caused by uneven stopword removal across fields with different analyzers.
+
+**OpenSearch behaviour:**
+OpenSearch has no equivalent parameter. The `minimum_should_match` value on
+a `bool` query is static — it cannot adapt based on per-field analysis
+differences at query time.
+
+**Cause:**
+This is a Solr query-parser-level optimization that inspects per-field
+analysis results during query construction. The shim operates at the HTTP
+transform layer and has no visibility into field-level analyzer behaviour.
+
+**Current status:**
+Not supported. The `mm.autoRelax` parameter is rejected by validation with
+a clear error message. Users relying on this behaviour should remove the
+parameter and consider aligning stopword lists across `qf` fields, or
+lowering the `mm` value to avoid zero-hit results from uneven stopword
+removal.
+
+**Reference:** https://solr.apache.org/guide/solr/latest/query-guide/edismax-query-parser.html
+
+---
+
+## MM-EDISMAX-OPERATOR-DEFAULT
+
+**Feature:** eDisMax `mm` default when explicit operators are present
+
+**Solr behaviour:**
+In eDisMax, the default `mm` value is `0%` if the query contains any explicit
+operator other than `AND` (such as `+`, `-`, `OR`, `NOT`), even when
+`q.op=AND`. Only when `q.op=AND` and no explicit operators are present does
+`mm` default to `100%`.
+
+**OpenSearch behaviour:**
+The shim's query parser handles `+`/`-`/`AND`/`OR`/`NOT` by placing terms
+into `must`/`must_not`/`should` clauses. The explicit `mm` value is applied
+to the `should` clauses via `minimum_should_match`. However, the nuanced
+default logic — where the *presence* of explicit operators changes the `mm`
+default from `100%` to `0%` — is not replicated.
+
+**Cause:**
+The shim does not track whether the original query string contained explicit
+operators to conditionally adjust the default `mm`. The parser structurally
+handles operators correctly, but the default `mm` inference differs.
+
+**Current status:**
+Partially supported. When `mm` is explicitly set, behaviour matches Solr.
+When `mm` is omitted and the query mixes explicit operators with bare terms
+under `q.op=AND`, the effective default may differ. Users relying on this
+nuance should set `mm` explicitly.
+
+**Reference:** https://solr.apache.org/guide/solr/latest/query-guide/edismax-query-parser.html
+
+---
+
+## MM-EDISMAX-MIXED-OPERATORS
+
+**Feature:** eDisMax `mm` with mixed explicit and implicit operators
+
+**Solr behaviour:**
+In eDisMax, a query like `q=A AND B C D` treats `A` and `B` as mandatory
+(from the explicit `AND`) and `C`, `D` as optional. Solr applies `mm` only
+to the optional clauses (`C`, `D`). Internally, Solr produces a flat boolean
+query: `must: [A, B], should: [C, D], minimum_should_match: <mm>`.
+
+**OpenSearch behaviour:**
+The shim's parser produces a different AST structure for this query. The
+`A AND B` sub-expression becomes a nested `bool.must` inside the top-level
+`should` array:
+```json
+{
+  "bool": {
+    "should": [
+      { "bool": { "must": [A, B] } },
+      C,
+      D
+    ],
+    "minimum_should_match": "<mm>"
+  }
+}
+```
+This means `mm` applies to all 3 top-level `should` entries (the nested
+`A AND B` group, `C`, and `D`) rather than just the optional `C` and `D`.
+
+**Cause:**
+The PEG grammar treats `A AND B` as a sub-expression at the same precedence
+level as the implicit-OR siblings `C D`. The parser wraps `A AND B` into a
+nested bool rather than hoisting the `and` clauses to the parent level. A
+`boolRule.ts` TODO exists for AST flattening which would resolve this.
+
+**Current status:**
+Not supported. This only affects eDisMax queries that mix explicit operators
+(`AND`, `OR`, `+`, `-`) with bare terms and use `mm`. Pure DisMax queries
+(no explicit operators) are unaffected since all terms are flat `should`
+clauses. Users experiencing incorrect results should restructure queries to
+avoid mixing explicit operators with `mm`, or use `+`/`-` prefixes on all
+terms to make intent explicit.
+
+**Reference:** https://solr.apache.org/guide/solr/latest/query-guide/edismax-query-parser.html
+
+---
+
+## MM-STOPWORD-MULTIFIELD
+
+**Feature:** `mm` interaction with per-field stopword removal in multi-field queries
+
+**Solr behaviour:**
+When searching across multiple `qf` fields with different query analyzers,
+the number of optional clauses may differ between fields (e.g., a term is a
+stopword in one field but not another). Solr applies `mm` to the **maximum**
+number of optional clauses across all fields. A query clause removed as a
+stopword in one field does not count as matched for that field, potentially
+causing zero results if `mm=100%`.
+
+**OpenSearch behaviour:**
+OpenSearch applies `minimum_should_match` at the `bool` query level, not
+per-field. When `qf` multi-field expansion produces `dis_max` queries per
+term, the `minimum_should_match` operates on the outer bool across terms,
+not on the inner per-field disjunctions. Stopword handling is delegated to
+each field's analyzer independently.
+
+**Cause:**
+This is a fundamental architectural difference. Solr's DisMax/eDisMax parser
+has visibility into per-field analysis results and adjusts clause counts
+accordingly. OpenSearch's `bool` query treats `minimum_should_match` as a
+flat count over its `should` array without per-field clause awareness.
+
+**Current status:**
+Not supported. In most practical cases the behaviour is equivalent. Edge
+cases arise when fields have significantly different stopword lists and `mm`
+is set to a high value (e.g., `100%`). Users experiencing zero-hit queries
+due to this difference should consider aligning stopword lists across fields
+or lowering the `mm` value.
+
+**Reference:** https://solr.apache.org/guide/solr/latest/query-guide/dismax-query-parser.html#mm-minimum-should-match-parameter

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/minimum-match.test.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/minimum-match.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect } from 'vitest';
+import { request, paramRules } from './minimum-match';
+import type { RequestContext, JavaMap } from '../context';
+
+/** Build a mock context with a pre-built bool query in the body. */
+function createCtx(params: Record<string, string>, query?: Map<string, any>): RequestContext {
+  const body = new Map<string, any>();
+  if (query) body.set('query', query);
+  return {
+    msg: new Map() as JavaMap,
+    endpoint: 'select',
+    collection: 'test',
+    params: new URLSearchParams(params),
+    body: body as JavaMap,
+  };
+}
+
+function boolQuery(shouldCount = 2): Map<string, any> {
+  const should = Array.from({ length: shouldCount }, (_, i) =>
+    new Map([['match', new Map([['title', `term${i}`]])]]),
+  );
+  const boolMap = new Map<string, any>([['should', should]]);
+  return new Map([['bool', boolMap]]);
+}
+
+describe('minimum-match request transform', () => {
+  it('has correct name', () => {
+    expect(request.name).toBe('minimum-match');
+  });
+
+  // --- match guard ---
+
+  it('does not match when mm is absent', () => {
+    const ctx = createCtx({ defType: 'dismax' });
+    expect(request.match!(ctx)).toBe(false);
+  });
+
+  it('does not match when defType is absent (standard parser)', () => {
+    const ctx = createCtx({ mm: '2' });
+    expect(request.match!(ctx)).toBe(false);
+  });
+
+  it('does not match when defType is lucene', () => {
+    const ctx = createCtx({ mm: '2', defType: 'lucene' });
+    expect(request.match!(ctx)).toBe(false);
+  });
+
+  it('matches when defType=dismax and mm is present', () => {
+    const ctx = createCtx({ mm: '2', defType: 'dismax' });
+    expect(request.match!(ctx)).toBe(true);
+  });
+
+  it('matches when defType=edismax and mm is present', () => {
+    const ctx = createCtx({ mm: '75%', defType: 'edismax' });
+    expect(request.match!(ctx)).toBe(true);
+  });
+
+  // --- apply ---
+
+  it('sets minimum_should_match on bool query — integer', () => {
+    const query = boolQuery();
+    const ctx = createCtx({ mm: '2', defType: 'dismax' }, query);
+    request.apply(ctx);
+    expect(query.get('bool').get('minimum_should_match')).toBe('2');
+  });
+
+  it('sets minimum_should_match — negative integer', () => {
+    const query = boolQuery();
+    const ctx = createCtx({ mm: '-1', defType: 'dismax' }, query);
+    request.apply(ctx);
+    expect(query.get('bool').get('minimum_should_match')).toBe('-1');
+  });
+
+  it('sets minimum_should_match — percentage', () => {
+    const query = boolQuery();
+    const ctx = createCtx({ mm: '75%', defType: 'edismax' }, query);
+    request.apply(ctx);
+    expect(query.get('bool').get('minimum_should_match')).toBe('75%');
+  });
+
+  it('sets minimum_should_match — negative percentage', () => {
+    const query = boolQuery();
+    const ctx = createCtx({ mm: '-25%', defType: 'dismax' }, query);
+    request.apply(ctx);
+    expect(query.get('bool').get('minimum_should_match')).toBe('-25%');
+  });
+
+  it('sets minimum_should_match — conditional expression', () => {
+    const query = boolQuery();
+    const ctx = createCtx({ mm: '3<90%', defType: 'dismax' }, query);
+    request.apply(ctx);
+    expect(query.get('bool').get('minimum_should_match')).toBe('3<90%');
+  });
+
+  it('sets minimum_should_match — multiple conditionals', () => {
+    const query = boolQuery();
+    const ctx = createCtx({ mm: '2<-25% 9<-3', defType: 'dismax' }, query);
+    request.apply(ctx);
+    expect(query.get('bool').get('minimum_should_match')).toBe('2<-25% 9<-3');
+  });
+
+  // --- no-op cases ---
+
+  it('no-ops when query is match_all (no bool)', () => {
+    const query = new Map([['match_all', new Map()]]);
+    const ctx = createCtx({ mm: '2', defType: 'dismax' }, query);
+    request.apply(ctx);
+    expect(query.has('bool')).toBe(false);
+  });
+
+  it('no-ops when body has no query', () => {
+    const ctx = createCtx({ mm: '2', defType: 'dismax' });
+    request.apply(ctx);
+    expect(ctx.body.has('query')).toBe(false);
+  });
+});
+
+describe('minimum-match paramRules', () => {
+  const pattern = new RegExp(paramRules[0].pattern);
+
+  it.each(['3', '-2', '75%', '-25%', '3<90%', '2<-25% 9<-3'])(
+    'allows valid mm value: %s',
+    (val) => expect(pattern.test(val)).toBe(false),
+  );
+
+  it.each(['abc', '2a', 'foo%', '75%bar'])(
+    'rejects invalid mm value: %s',
+    (val) => expect(pattern.test(val)).toBe(true),
+  );
+});

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/minimum-match.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/minimum-match.ts
@@ -1,0 +1,41 @@
+/**
+ * Minimum match — translate Solr `mm` param to OpenSearch `minimum_should_match`.
+ *
+ * Solr and OpenSearch share identical syntax for this parameter (integers,
+ * percentages, conditional expressions), so the value is a direct passthrough.
+ *
+ * Only applies when defType is dismax or edismax — the standard (lucene)
+ * query parser ignores mm, and so do we to match Solr behavior.
+ *
+ * Must run AFTER query-q so the query DSL bool is already in ctx.body.
+ */
+import type { MicroTransform } from '../pipeline';
+import type { RequestContext } from '../context';
+import type { ParamRule } from './validation';
+
+export const params = ['mm'];
+
+export const paramRules: ParamRule[] = [
+  {
+    name: 'mm',
+    type: 'rejectPattern',
+    pattern: String.raw`[^-\d%<\s]`,
+    reason: 'Invalid mm syntax — only digits, -, %, <, and spaces are allowed (e.g., "2", "75%", "-1", "3<90%", "2<-25% 9<-3")',
+  },
+];
+
+const DISMAX_TYPES = new Set(['dismax', 'edismax']);
+
+export const request: MicroTransform<RequestContext> = {
+  name: 'minimum-match',
+  match: (ctx) => ctx.params.has('mm') && DISMAX_TYPES.has(ctx.params.get('defType') ?? ''),
+  apply: (ctx) => {
+    const query = ctx.body.get('query');
+    if (!query || typeof query.get !== 'function') return;
+
+    const boolClause = query.get('bool');
+    if (!boolClause || typeof boolClause.set !== 'function') return;
+
+    boolClause.set('minimum_should_match', ctx.params.get('mm'));
+  },
+};

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/integration-tests/minimum-match.testcase.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/integration-tests/minimum-match.testcase.ts
@@ -1,0 +1,121 @@
+/**
+ * Integration test cases for mm (minimum should match) parameter — DisMax and eDisMax.
+ *
+ * The mm parameter controls how many optional (should) clauses must match.
+ * Both defType=dismax and defType=edismax support the same mm syntax.
+ * Tests are generated for both to avoid duplication.
+ */
+import { solrTest } from '../../test-types';
+import type { TestCase } from '../../test-types';
+
+const schema = {
+  fields: {
+    title: { type: 'text_general' as const },
+    body: { type: 'text_general' as const },
+  },
+};
+
+const mapping = {
+  properties: {
+    title: { type: 'text' as const },
+    body: { type: 'text' as const },
+  },
+};
+
+const docs = [
+  { id: '1', title: 'java python ruby', body: 'languages' },
+  { id: '2', title: 'java python', body: 'two languages' },
+  { id: '3', title: 'java', body: 'one language' },
+  { id: '4', title: 'unrelated', body: 'nothing here' },
+];
+
+function mmPath(q: string, defType: string, mm: string, qf = 'title'): string {
+  return '/solr/testcollection/select?q=' + encodeURIComponent(q)
+    + '&defType=' + defType
+    + '&qf=' + encodeURIComponent(qf)
+    + '&mm=' + encodeURIComponent(mm)
+    + '&wt=json';
+}
+
+function makeMmCases(defType: 'dismax' | 'edismax'): TestCase[] {
+  return [
+    solrTest(`${defType}-mm-positive-integer`, {
+      description: 'mm=2 requires at least 2 of 3 terms to match',
+      documents: docs,
+      requestPath: mmPath('java python ruby', defType, '2'),
+      solrSchema: schema,
+      opensearchMapping: mapping,
+    }),
+
+    solrTest(`${defType}-mm-100-percent`, {
+      description: 'mm=100% requires all terms to match',
+      documents: docs,
+      requestPath: mmPath('java python ruby', defType, '100%'),
+      solrSchema: schema,
+      opensearchMapping: mapping,
+    }),
+
+    solrTest(`${defType}-mm-negative-integer`, {
+      description: 'mm=-1 allows one term to be missing',
+      documents: docs,
+      requestPath: mmPath('java python ruby', defType, '-1'),
+      solrSchema: schema,
+      opensearchMapping: mapping,
+    }),
+
+    solrTest(`${defType}-mm-percentage`, {
+      description: 'mm=75% with 3 terms requires floor(3*0.75)=2 to match',
+      documents: docs,
+      requestPath: mmPath('java python ruby', defType, '75%'),
+      solrSchema: schema,
+      opensearchMapping: mapping,
+    }),
+
+    solrTest(`${defType}-mm-single-term`, {
+      description: 'mm with single term — always requires that term',
+      documents: docs,
+      requestPath: mmPath('java', defType, '100%'),
+      solrSchema: schema,
+      opensearchMapping: mapping,
+    }),
+
+    solrTest(`${defType}-mm-conditional`, {
+      description: 'mm=3<90% — if <=3 clauses all required, else 90%',
+      documents: docs,
+      requestPath: mmPath('java python ruby', defType, '3<90%'),
+      solrSchema: schema,
+      opensearchMapping: mapping,
+    }),
+
+    solrTest(`${defType}-mm-multiple-conditionals`, {
+      description: 'mm=2<-25% 9<-3 — tiered conditional expression',
+      documents: docs,
+      requestPath: mmPath('java python ruby', defType, '2<-25% 9<-3'),
+      solrSchema: schema,
+      opensearchMapping: mapping,
+    }),
+  ];
+}
+
+export const testCases: TestCase[] = [
+  ...makeMmCases('dismax'),
+  ...makeMmCases('edismax'),
+
+  // --- Error paths ---
+
+  solrTest('mm-autoRelax-rejected', {
+    description: 'mm.autoRelax is unsupported and should be rejected by validation',
+    documents: [{ id: '1', title: 'test' }],
+    requestPath: '/solr/testcollection/select?q=java%20python&defType=edismax&qf=title&mm=2&mm.autoRelax=true&wt=json',
+    expectedStatusCode: 500,
+    expectedErrorContains: 'Request transform failed',
+  }),
+
+  solrTest('mm-invalid-value-rejected', {
+    description: 'Invalid mm value with alphabetic characters should be rejected',
+    documents: [{ id: '1', title: 'test' }],
+    requestPath: '/solr/testcollection/select?q=java%20python&defType=dismax&qf=title&mm=abc&wt=json',
+    expectedStatusCode: 500,
+    expectedErrorContains: 'Request transform failed',
+  }),
+];

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/registry.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/registry.ts
@@ -19,6 +19,7 @@ import * as cursorPagination from './features/cursor-pagination';
 import * as fieldList from './features/field-list';
 import * as sort from './features/sort';
 import * as jsonFacets from './features/json-facets';
+import * as minimumMatch from './features/minimum-match';
 import * as highlighting from './features/highlighting';
 import * as hitsToDocs from './features/hits-to-docs';
 import * as aggsToFacets from './features/aggs-to-facets';
@@ -42,7 +43,7 @@ export interface FeatureModule {
  */
 const FEATURE_MODULES: FeatureModule[] = [
   selectUri, queryQ, filterQueryFq, cursorPagination, fieldList,
-  sort, jsonFacets, highlighting,
+  sort, jsonFacets, highlighting, minimumMatch,
 ];
 
 /**
@@ -77,6 +78,7 @@ export const requestRegistry: TransformRegistry<RequestContext> = {
       solrconfigDefaults.request, // Apply solrconfig.xml defaults/invariants
       selectUri.request, // URI rewrite
       queryQ.request, // q=... → query DSL
+      minimumMatch.request, // mm → minimum_should_match (after query-q builds bool)
       filterQueryFq.request, // fq=... → bool.filter (after query-q)
       cursorPagination.request, // cursorMark → search_after (after query-q sets from)
       jsonFacets.request, // json.facet → aggs


### PR DESCRIPTION

   ### Summary

   Adds support for Solr's `mm` (minimum should match) parameter, translating it to OpenSearch's `minimum_should_match` on the `bool` query. The `mm` value is a direct passthrough since both Solr and OpenSearch share identical syntax.

   Only applies when `defType=dismax` or `defType=edismax`, matching Solr's behavior where the standard (lucene) query parser ignores `mm`.

   ### Changes

   | File | Description |
   |---|---|
   | `features/minimum-match.ts` | Request transform: reads `mm`, sets `minimum_should_match` on the bool query. Gated on `defType`. Includes `paramRules` for character validation. |
   | `features/minimum-match.test.ts` | 20 unit tests: match guard, apply with all mm formats (int, -int, %, -%, conditional, multi-conditional), no-op cases, paramRules validation |
   | `integration-tests/minimum-match.testcase.ts` | 12 E2E tests: 5 dismax + 5 edismax happy-path, `mm.autoRelax` rejection, invalid value rejection |
   | `registry.ts` | Register transform in `FEATURE_MODULES` and `requestRegistry` (after `queryQ`) |
   | `docs/LIMITATIONS.md` | Document 3 limitations: MM-AUTORELAX, MM-EDISMAX-OPERATOR-DEFAULT, MM-STOPWORD-MULTIFIELD |

   ### Supported mm syntax (all 6 Solr formats)

   | Format | Example | Behavior |
   |---|---|---|
   | Positive integer | `mm=3` | At least 3 clauses must match |
   | Negative integer | `mm=-2` | Total clauses minus 2 must match |
   | Percentage | `mm=75%` | 75% of clauses must match (rounded down) |
   | Negative percentage | `mm=-25%` | 25% of clauses can be missing |
   | Conditional | `mm=3<90%` | If ≤3 clauses all required, else 90% |
   | Multiple conditionals | `mm=2<-25% 9<-3` | Tiered conditions |

   ### Known limitations (documented in LIMITATIONS.md)

   - **MM-AUTORELAX**: `mm.autoRelax` is rejected (fail-fast). No OpenSearch equivalent — requires per-field stopword analysis visibility.
   - **MM-EDISMAX-OPERATOR-DEFAULT**: When `mm` is omitted and query contains explicit operators under `q.op=AND`, the default `mm` inference may differ from eDisMax. Workaround: set `mm` explicitly.
   - **MM-STOPWORD-MULTIFIELD**: Solr applies `mm` to the max optional clause count across fields with different analyzers. OpenSearch applies `minimum_should_match` at the `bool` query level. Edge case with divergent stopword lists.

   ### Testing

   | Layer | Result |
   |---|---|
   | Unit tests (vitest) | 719/719 passed (20 new) |
   | E2E integration (Solr 8 + 9) | All 12 mm tests passed on both versions |
   ### References

   - [Solr DisMax mm parameter](https://solr.apache.org/guide/solr/latest/query-guide/dismax-query-parser.html#mm-minimum-should-match-parameter)
   - [Solr eDisMax mm parameter](https://solr.apache.org/guide/solr/latest/query-guide/edismax-query-parser.html)
   - [OpenSearch minimum_should_match](https://opensearch.org/docs/latest/query-dsl/minimum-should-match/)