### PR TITLE
Remove insecure authHeaderValue replayer option and add auth conflict validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ orchestrationSpecs/dist/
 orchestrationSpecs/node_modules/
 orchestrationSpecs/packages/**/dist/
 orchestrationSpecs/packages/**/node_modules/
+orchestrationSpecs/packages/**/coverage/
 orchestrationSpecs/packages/migration-workflow-templates/k8sResources
 orchestrationSpecs/k8s-schemas
 orchestrationSpecs/packages/argo-workflow-builders/src/generated

--- a/TrafficCapture/dockerSolution/src/main/docker/docker-compose.yml
+++ b/TrafficCapture/dockerSolution/src/main/docker/docker-compose.yml
@@ -78,8 +78,8 @@ services:
         condition: service_started
       opensearchtarget:
         condition: service_started
-#   command: /bin/sh -c "/runJavaWithClasspath.sh org.opensearch.migrations.replay.TrafficReplayer --speedup-factor 2 --target-uri https://opensearchtarget:9200 --auth-header-value Basic\\ YWRtaW46bXlTdHJvbmdQYXNzd29yZDEyMyE= --insecure --kafka-traffic-brokers kafka:9092 --kafka-traffic-topic logging-traffic-topic --kafka-traffic-group-id logging-group-default --otelCollectorEndpoint http://otel-collector:4317  "
-    command: /bin/sh -c "/runJavaWithClasspath.sh org.opensearch.migrations.replay.TrafficReplayer --speedup-factor 2 --target-uri https://opensearchtarget:9200 --auth-header-value Basic\\ YWRtaW46bXlTdHJvbmdQYXNzd29yZDEyMyE= --insecure --kafka-traffic-brokers kafka:9092 --kafka-traffic-topic logging-traffic-topic --kafka-traffic-group-id logging-group-default --otelCollectorEndpoint http://otel-collector:4317 --transformer-config '[{\"TypeMappingSanitizationTransformerProvider\":{\"sourceProperties\":{\"version\":{\"major\":7,\"minor\":10}}}}]'"
+#   command: /bin/sh -c "/runJavaWithClasspath.sh org.opensearch.migrations.replay.TrafficReplayer --speedup-factor 2 --target-uri https://opensearchtarget:9200 --target-username admin --target-password 'myStrongPassword123!' --insecure --kafka-traffic-brokers kafka:9092 --kafka-traffic-topic logging-traffic-topic --kafka-traffic-group-id logging-group-default --otelCollectorEndpoint http://otel-collector:4317  "
+    command: /bin/sh -c "/runJavaWithClasspath.sh org.opensearch.migrations.replay.TrafficReplayer --speedup-factor 2 --target-uri https://opensearchtarget:9200 --target-username admin --target-password 'myStrongPassword123!' --insecure --kafka-traffic-brokers kafka:9092 --kafka-traffic-topic logging-traffic-topic --kafka-traffic-group-id logging-group-default --otelCollectorEndpoint http://otel-collector:4317 --transformer-config '[{\"TypeMappingSanitizationTransformerProvider\":{\"sourceProperties\":{\"version\":{\"major\":7,\"minor\":10}}}}]'"
   opensearchtarget:
     image: 'mirror.gcr.io/opensearchproject/opensearch:2.15.0'
     environment:

--- a/TrafficCapture/trafficReplayer/README.md
+++ b/TrafficCapture/trafficReplayer/README.md
@@ -166,7 +166,7 @@ can be augmented however it may choose.
 ## Authorization Header for Replayed Requests
 
 There is a level of precedence that will determine which or if any Auth header should be added to outgoing Replayer requests, which is listed below.
-1. If the user provides an explicit auth header option to the Replayer, such as providing a static value auth header(--auth-header-value), this mechanism will be used for the auth header of outgoing requests. The options can be found as Parameters [here](src/main/java/org/opensearch/migrations/replay/TrafficReplayer.java)
+1. If the user provides an explicit auth option to the Replayer, such as `--target-username`/`--target-password` for basic auth, `--sigv4-auth-header-service-region` for SigV4, or `--remove-auth-header` to strip auth, this mechanism will be used for the auth header of outgoing requests. The options can be found as Parameters [here](src/main/java/org/opensearch/migrations/replay/TrafficReplayer.java)
 2. If the user provides no auth header option and incoming captured requests have an auth header, this auth header will try to be reused for outgoing requests. **Note**: Reusing existing auth headers has a certain level of risk. Reusing Basic Auth headers may work without issue, but reusing SigV4 headers likely won't unless the content AND headers are NOT reformatted
 3. If the user provides no auth header option and incoming captured requests have no auth header, then no auth header will be used for outgoing requests
 

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/TrafficReplayer.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/TrafficReplayer.java
@@ -57,7 +57,6 @@ public class TrafficReplayer {
     private static final String ALL_ACTIVE_CONTEXTS_MONITOR_LOGGER = "AllActiveWorkMonitor";
 
     public static final String SIGV_4_AUTH_HEADER_SERVICE_REGION_ARG = "--sigv4-auth-header-service-region";
-    public static final String AUTH_HEADER_VALUE_ARG = "--auth-header-value";
     public static final String REMOVE_AUTH_HEADER_VALUE_ARG = "--remove-auth-header";
     public static final String PACKET_TIMEOUT_SECONDS_PARAMETER_NAME = "--packet-timeout-seconds";
     public static final String KAFKA_AUTH_TYPE_NONE = "none";
@@ -173,12 +172,6 @@ public class TrafficReplayer {
             arity = 0, description = "Remove the authorization header if present and do not replace it with anything.  "
                 + "(cannot be used with other auth arguments)")
         boolean removeAuthHeader;
-        @Parameter(
-            required = false,
-            names = { AUTH_HEADER_VALUE_ARG, "--authHeaderValue" },
-            arity = 1, description = "Static value to use for the \"authorization\" header of each request "
-                + "(cannot be used with other auth arguments)")
-        String authHeaderValue;
         @Parameter(
             required = false,
             names = { SIGV_4_AUTH_HEADER_SERVICE_REGION_ARG, "--sigv4AuthHeaderServiceRegion" },
@@ -803,7 +796,6 @@ public class TrafficReplayer {
         return String.join(
             ", ",
             REMOVE_AUTH_HEADER_VALUE_ARG,
-            AUTH_HEADER_VALUE_ARG,
             SIGV_4_AUTH_HEADER_SERVICE_REGION_ARG,
             ArgNameConstants.TARGET_USERNAME_ARG_KEBAB_CASE + " and " + ArgNameConstants.TARGET_PASSWORD_ARG_KEBAB_CASE
 
@@ -813,7 +805,6 @@ public class TrafficReplayer {
     private static IAuthTransformerFactory buildAuthTransformerFactory(Parameters params) {
         long authOptionsSpecified = Stream.of(
             params.removeAuthHeader,
-            params.authHeaderValue != null,
             params.useSigV4ServiceAndRegion != null,
             params.targetUsername != null || params.targetPassword != null
         ).filter(b -> b).count();
@@ -824,16 +815,11 @@ public class TrafficReplayer {
             );
         }
 
-        var authHeaderValue = params.authHeaderValue;
         if (params.targetUsername != null || params.targetPassword != null) {
             if (params.targetUsername == null || params.targetPassword == null) {
                 throw new ParameterException("Both target username and target password must be specified, when using this basic auth option");
             }
-            authHeaderValue = getBasicAuthHeader(params.targetUsername, params.targetPassword);
-        }
-
-        if (authHeaderValue != null) {
-            return new StaticAuthTransformerFactory(authHeaderValue);
+            return new StaticAuthTransformerFactory(getBasicAuthHeader(params.targetUsername, params.targetPassword));
         } else if (params.useSigV4ServiceAndRegion != null) {
             var serviceAndRegion = params.useSigV4ServiceAndRegion.split(",");
             if (serviceAndRegion.length != 2) {

--- a/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/templates/resources/migrationCrds.yaml
+++ b/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/templates/resources/migrationCrds.yaml
@@ -391,8 +391,6 @@ spec:
                   type: object
                   x-kubernetes-preserve-unknown-fields: true
                 # Replayer CLI params
-                authHeaderValue:
-                  type: string
                 kafkaTrafficEnableMSKAuth:
                   type: boolean
                 kafkaTrafficPropertyFile:

--- a/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/templates/resources/validatingAdmissionPolicies.yaml
+++ b/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/templates/resources/validatingAdmissionPolicies.yaml
@@ -343,8 +343,6 @@ spec:
     # Gated: auth, transformer, and tuple transformer fields
     - expression: |
         (
-          (!has(object.spec.authHeaderValue) || !has(oldObject.spec.authHeaderValue) ||
-           object.spec.authHeaderValue == oldObject.spec.authHeaderValue) &&
           (!has(object.spec.removeAuthHeader) || !has(oldObject.spec.removeAuthHeader) ||
            object.spec.removeAuthHeader == oldObject.spec.removeAuthHeader) &&
           (!has(object.spec.transformerConfig) || !has(oldObject.spec.transformerConfig) ||
@@ -369,31 +367,21 @@ spec:
       messageExpression: |
         "Gated changes detected on TrafficReplay fields [" +
         (
-          (has(object.spec.authHeaderValue) && has(oldObject.spec.authHeaderValue) &&
-           object.spec.authHeaderValue != oldObject.spec.authHeaderValue ? "authHeaderValue" : "") +
           (has(object.spec.removeAuthHeader) && has(oldObject.spec.removeAuthHeader) &&
-           object.spec.removeAuthHeader != oldObject.spec.removeAuthHeader ?
-             ((has(object.spec.authHeaderValue) && has(oldObject.spec.authHeaderValue) &&
-               object.spec.authHeaderValue != oldObject.spec.authHeaderValue) ? ", removeAuthHeader" : "removeAuthHeader") : "") +
+           object.spec.removeAuthHeader != oldObject.spec.removeAuthHeader ? "removeAuthHeader" : "") +
           (has(object.spec.transformerConfig) && has(oldObject.spec.transformerConfig) &&
            object.spec.transformerConfig != oldObject.spec.transformerConfig ?
-             (((has(object.spec.authHeaderValue) && has(oldObject.spec.authHeaderValue) &&
-                object.spec.authHeaderValue != oldObject.spec.authHeaderValue) ||
-               (has(object.spec.removeAuthHeader) && has(oldObject.spec.removeAuthHeader) &&
-                object.spec.removeAuthHeader != oldObject.spec.removeAuthHeader)) ? ", transformerConfig" : "transformerConfig") : "") +
+             ((has(object.spec.removeAuthHeader) && has(oldObject.spec.removeAuthHeader) &&
+               object.spec.removeAuthHeader != oldObject.spec.removeAuthHeader) ? ", transformerConfig" : "transformerConfig") : "") +
           (has(object.spec.transformerConfigEncoded) && has(oldObject.spec.transformerConfigEncoded) &&
            object.spec.transformerConfigEncoded != oldObject.spec.transformerConfigEncoded ?
-             (((has(object.spec.authHeaderValue) && has(oldObject.spec.authHeaderValue) &&
-                object.spec.authHeaderValue != oldObject.spec.authHeaderValue) ||
-               (has(object.spec.removeAuthHeader) && has(oldObject.spec.removeAuthHeader) &&
+             (((has(object.spec.removeAuthHeader) && has(oldObject.spec.removeAuthHeader) &&
                 object.spec.removeAuthHeader != oldObject.spec.removeAuthHeader) ||
                (has(object.spec.transformerConfig) && has(oldObject.spec.transformerConfig) &&
                 object.spec.transformerConfig != oldObject.spec.transformerConfig)) ? ", transformerConfigEncoded" : "transformerConfigEncoded") : "") +
           (has(object.spec.transformerConfigFile) && has(oldObject.spec.transformerConfigFile) &&
            object.spec.transformerConfigFile != oldObject.spec.transformerConfigFile ?
-             (((has(object.spec.authHeaderValue) && has(oldObject.spec.authHeaderValue) &&
-                object.spec.authHeaderValue != oldObject.spec.authHeaderValue) ||
-               (has(object.spec.removeAuthHeader) && has(oldObject.spec.removeAuthHeader) &&
+             (((has(object.spec.removeAuthHeader) && has(oldObject.spec.removeAuthHeader) &&
                 object.spec.removeAuthHeader != oldObject.spec.removeAuthHeader) ||
                (has(object.spec.transformerConfig) && has(oldObject.spec.transformerConfig) &&
                 object.spec.transformerConfig != oldObject.spec.transformerConfig) ||
@@ -401,9 +389,7 @@ spec:
                 object.spec.transformerConfigEncoded != oldObject.spec.transformerConfigEncoded)) ? ", transformerConfigFile" : "transformerConfigFile") : "") +
           (has(object.spec.tupleTransformerConfig) && has(oldObject.spec.tupleTransformerConfig) &&
            object.spec.tupleTransformerConfig != oldObject.spec.tupleTransformerConfig ?
-             (((has(object.spec.authHeaderValue) && has(oldObject.spec.authHeaderValue) &&
-                object.spec.authHeaderValue != oldObject.spec.authHeaderValue) ||
-               (has(object.spec.removeAuthHeader) && has(oldObject.spec.removeAuthHeader) &&
+             (((has(object.spec.removeAuthHeader) && has(oldObject.spec.removeAuthHeader) &&
                 object.spec.removeAuthHeader != oldObject.spec.removeAuthHeader) ||
                (has(object.spec.transformerConfig) && has(oldObject.spec.transformerConfig) &&
                 object.spec.transformerConfig != oldObject.spec.transformerConfig) ||
@@ -413,9 +399,7 @@ spec:
                 object.spec.transformerConfigFile != oldObject.spec.transformerConfigFile)) ? ", tupleTransformerConfig" : "tupleTransformerConfig") : "") +
           (has(object.spec.tupleTransformerConfigBase64) && has(oldObject.spec.tupleTransformerConfigBase64) &&
            object.spec.tupleTransformerConfigBase64 != oldObject.spec.tupleTransformerConfigBase64 ?
-             (((has(object.spec.authHeaderValue) && has(oldObject.spec.authHeaderValue) &&
-                object.spec.authHeaderValue != oldObject.spec.authHeaderValue) ||
-               (has(object.spec.removeAuthHeader) && has(oldObject.spec.removeAuthHeader) &&
+             (((has(object.spec.removeAuthHeader) && has(oldObject.spec.removeAuthHeader) &&
                 object.spec.removeAuthHeader != oldObject.spec.removeAuthHeader) ||
                (has(object.spec.transformerConfig) && has(oldObject.spec.transformerConfig) &&
                 object.spec.transformerConfig != oldObject.spec.transformerConfig) ||
@@ -427,9 +411,7 @@ spec:
                 object.spec.tupleTransformerConfig != oldObject.spec.tupleTransformerConfig)) ? ", tupleTransformerConfigBase64" : "tupleTransformerConfigBase64") : "") +
           (has(object.spec.tupleTransformerConfigFile) && has(oldObject.spec.tupleTransformerConfigFile) &&
            object.spec.tupleTransformerConfigFile != oldObject.spec.tupleTransformerConfigFile ?
-             (((has(object.spec.authHeaderValue) && has(oldObject.spec.authHeaderValue) &&
-                object.spec.authHeaderValue != oldObject.spec.authHeaderValue) ||
-               (has(object.spec.removeAuthHeader) && has(oldObject.spec.removeAuthHeader) &&
+             (((has(object.spec.removeAuthHeader) && has(oldObject.spec.removeAuthHeader) &&
                 object.spec.removeAuthHeader != oldObject.spec.removeAuthHeader) ||
                (has(object.spec.transformerConfig) && has(oldObject.spec.transformerConfig) &&
                 object.spec.transformerConfig != oldObject.spec.transformerConfig) ||

--- a/docs/reconfiguringWorkflows.md
+++ b/docs/reconfiguringWorkflows.md
@@ -259,7 +259,6 @@ The replayer has no downstream dependencies — nothing waits on it. The checksu
 | --- | --- | --- | --- | --- |
 | `spec.kafkaTrafficEnableMSKAuth` | Impossible | Kafka auth mode — changing breaks the consumer connection | N/A | ✅ |
 | `spec.kafkaTrafficPropertyFile` | Impossible | Kafka connection properties — fundamental to consumer setup | N/A | ✅ |
-| `spec.authHeaderValue` | **Gated** | Changes auth sent to target cluster | Yes (rolling) | ✅ |
 | `spec.removeAuthHeader` | **Gated** | Toggles auth header stripping | Yes (rolling) | ✅ |
 | `spec.transformerConfig` | **Gated** | Changes traffic transformation — could corrupt replay | Yes (rolling) | ✅ |
 | `spec.transformerConfigEncoded` | **Gated** | Same as above, different encoding | Yes (rolling) | ✅ |

--- a/orchestrationSpecs/packages/schemas/src/userSchemas.ts
+++ b/orchestrationSpecs/packages/schemas/src/userSchemas.ts
@@ -432,9 +432,6 @@ export const USER_REPLAYER_WORKFLOW_OPTIONS = z.object({
 }).describe("Kubernetes deployment-level options for the traffic replayer.");
 
 export const USER_REPLAYER_PROCESS_OPTIONS = z.object({
-    authHeaderValue: z.string().default("").optional()
-        .describe("Static value to use for the \"authorization\" header of each request (cannot be used with other auth arguments)")
-        .changeRestriction('gated'),
     kafkaTrafficEnableMSKAuth: z.boolean().default(false).optional()
         .describe("Enable SASL/IAM authentication for the replayer's Kafka consumer when connecting to Amazon MSK. Uses the pod's IAM role via EKS Pod Identity.")
         .changeRestriction('impossible'),
@@ -1120,6 +1117,23 @@ export const OVERALL_MIGRATION_CONFIG = //validateOptionalDefaultConsistency
                             code: z.ZodIssueCode.custom,
                             message: `Replayer '${replayerName}' dependsOnSnapshotMigrations[${j}] references unknown source '${dep.source}'. Available: ${Object.keys(data.sourceClusters).join(', ')}`,
                             path: ['traffic', 'replayers', replayerName, 'dependsOnSnapshotMigrations', j, 'source']
+                        });
+                    }
+                }
+
+                // When the target has sigv4 or basic auth, the workflow auto-derives the replayer's auth
+                // at deploy time. Setting removeAuthHeader alongside that causes a dual-auth startup crash.
+                const targetCluster = data.targetClusters[rc.toTarget];
+                if (targetCluster && rc.replayerConfig && rc.replayerConfig.removeAuthHeader === true) {
+                    const targetHasSigv4 = targetCluster.authConfig && HTTP_AUTH_SIGV4.safeParse(targetCluster.authConfig).success;
+                    const targetHasBasicAuth = targetCluster.authConfig && HTTP_AUTH_BASIC.safeParse(targetCluster.authConfig).success;
+                    if (targetHasSigv4 || targetHasBasicAuth) {
+                        const targetAuthType = targetHasSigv4 ? 'sigv4' : 'basic';
+                        ctx.addIssue({
+                            code: z.ZodIssueCode.custom,
+                            message: `Replayer '${replayerName}' sets 'removeAuthHeader' but target '${rc.toTarget}' uses ${targetAuthType} auth. ` +
+                                `The replayer cannot use both — the target's auth is applied automatically. Remove 'removeAuthHeader' from replayerConfig.`,
+                            path: ['traffic', 'replayers', replayerName, 'replayerConfig', 'removeAuthHeader']
                         });
                     }
                 }

--- a/orchestrationSpecs/packages/schemas/tests/__snapshots__/argoSchemaSnapshot.test.ts.snap
+++ b/orchestrationSpecs/packages/schemas/tests/__snapshots__/argoSchemaSnapshot.test.ts.snap
@@ -1466,10 +1466,6 @@ exports[`test schemas matches expected argo schema matches expected 1`] = `
                       ],
                       "description": "Kubernetes resource limits and requests for the replayer container. Partial overrides are deep-merged with the built-in defaults. By default, limits equal requests, giving the pod 'Guaranteed' QoS (least likely to be evicted). Setting requests lower than limits results in 'Burstable' QoS, allowing the pod to use less resources when idle but burst up to the limit."
                     },
-                    "authHeaderValue": {
-                      "type": "string",
-                      "default": ""
-                    },
                     "kafkaTrafficEnableMSKAuth": {
                       "type": "boolean",
                       "default": false
@@ -3020,12 +3016,6 @@ exports[`test schemas matches expected argo user matches expected 1`] = `
                       "requests"
                     ],
                     "description": "Kubernetes resource limits and requests for the replayer container. Partial overrides are deep-merged with the built-in defaults. By default, limits equal requests, giving the pod 'Guaranteed' QoS (least likely to be evicted). Setting requests lower than limits results in 'Burstable' QoS, allowing the pod to use less resources when idle but burst up to the limit."
-                  },
-                  "authHeaderValue": {
-                    "type": "string",
-                    "default": "",
-                    "description": "Static value to use for the \\"authorization\\" header of each request (cannot be used with other auth arguments)",
-                    "changeRestriction": "gated"
                   },
                   "kafkaTrafficEnableMSKAuth": {
                     "type": "boolean",

--- a/orchestrationSpecs/packages/schemas/tests/fixtures/invalid/replayer-remove-auth-conflicts-with-target-sigv4.json
+++ b/orchestrationSpecs/packages/schemas/tests/fixtures/invalid/replayer-remove-auth-conflicts-with-target-sigv4.json
@@ -1,0 +1,34 @@
+{
+  "sourceClusters": {
+    "source": {
+      "version": "ES 7.10",
+      "endpoint": "https://source.us-east-1.es.amazonaws.com"
+    }
+  },
+  "targetClusters": {
+    "target": {
+      "endpoint": "https://target.us-east-1.es.amazonaws.com",
+      "authConfig": {
+        "sigv4": { "region": "us-east-1", "service": "es" }
+      }
+    }
+  },
+  "snapshotMigrationConfigs": [],
+  "traffic": {
+    "proxies": {
+      "proxy1": {
+        "source": "source",
+        "proxyConfig": { "listenPort": 9201 }
+      }
+    },
+    "replayers": {
+      "replayer1": {
+        "fromProxy": "proxy1",
+        "toTarget": "target",
+        "replayerConfig": {
+          "removeAuthHeader": true
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
### Problem

The replayer's `authHeaderValue` field in the Zod schema had `.default("")`, causing an empty string to be serialized into the replayer's INLINE-JSON config. When the target cluster used SigV4 auth (auto-derived at deploy time as `sigv4AuthHeaderServiceRegion`), the Java replayer received two auth options and rejected the pod at startup with:

> Cannot specify more than one auth option

This caused `CrashLoopBackOff` on all CDC integration tests

### Solution

Remove `authHeaderValue` entirely. The field was insecure (plaintext credentials in config rather than via a Kubernetes Secret) and predated the `--target-username`/`--target-password` CLI params which load credentials from the environment securely. Users needing custom request auth can use request transformations.

Additionally, add Zod cross-cutting validation to catch `removeAuthHeader: true` conflicting with a target that has SigV4 or basic auth configured — preventing the same class of dual-auth startup crash at config time rather than at pod startup.

### Changes

**Schema & Validation** (`orchestrationSpecs/`)
- Removed `authHeaderValue` from `USER_REPLAYER_PROCESS_OPTIONS`
- Added `OVERALL_MIGRATION_CONFIG` validation: `removeAuthHeader` + sigv4/basic target → config error
- Updated schema snapshots
- Added invalid fixture: `replayer-remove-auth-conflicts-with-target-sigv4.json`

**CRD & Admission Policies** (`deployment/k8s/`)
- Removed `authHeaderValue` from TrafficReplay CRD spec
- Removed all `authHeaderValue` references from ValidatingAdmissionPolicy gated-field rules

**Java CLI** (`TrafficCapture/trafficReplayer/`)
- Removed `--auth-header-value` / `--authHeaderValue` CLI parameter and `AUTH_HEADER_VALUE_ARG` constant
- Simplified `buildAuthTransformerFactory()` — basic auth now goes directly through `targetUsername`/`targetPassword`
- `StaticAuthTransformerFactory` retained (still used by the basic auth path)

**Docker & Docs**
- `docker-compose.yml`: Replaced `--auth-header-value Basic\\...` with `--target-username admin --target-password 'myStrongPassword123!'`
- `trafficReplayer/README.md`: Updated auth documentation to reference current options
- `docs/reconfiguringWorkflows.md`: Removed `authHeaderValue` row from change-restriction table

### Issues Resolved
N/A

### Testing
via Jenkins CDC tests

### Check List
- [x] New functionality includes testing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
