### PR TITLE
Adding translator for phrase fields

### DIFF
--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/query-q.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/query-q.ts
@@ -14,7 +14,7 @@ import type { ParamRule } from './validation';
 import { translateQ } from '../query-engine/orchestrator/translateQ';
 
 /** Solr query params this feature handles. */
-export const params = ['q', 'rows', 'start', 'q.op', 'defType', 'qf'];
+export const params = ['q', 'rows', 'start', 'q.op', 'defType', 'qf', 'pf', 'ps', 'tie'];
 export const paramRules: ParamRule[] = [
   { name: 'rows', type: 'integer' },
   { name: 'start', type: 'integer' },

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/integration-tests/dismax-edismax/phrase-fields.testcase.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/integration-tests/dismax-edismax/phrase-fields.testcase.ts
@@ -1,0 +1,203 @@
+/**
+ * Integration test cases for pf (phrase fields), ps (phrase slop), and tie (tie breaker).
+ *
+ * pf: after matching via qf, documents where all terms appear as a phrase in pf
+ *     fields get an additive score boost. Scoring-only — never affects which docs match.
+ * ps: phrase slop — how far apart terms can be and still qualify for the pf phrase boost.
+ * tie: tie breaker — how much non-best-matching qf fields contribute to the score.
+ *
+ * All cases run for both edismax and dismax since they share the same pf/ps/tie behavior.
+ */
+import { solrTest } from '../../../test-types';
+import type { TestCase } from '../../../test-types';
+
+const twoFieldSchema = {
+  fields: {
+    title: { type: 'text_general' as const },
+    body: { type: 'text_general' as const },
+  },
+};
+
+const twoFieldMapping = {
+  properties: {
+    title: { type: 'text' as const },
+    body: { type: 'text' as const },
+  },
+};
+
+function p(q: string, defType: string, extra: Record<string, string> = {}): string {
+  const base = '/solr/testcollection/select?q=' + encodeURIComponent(q) + '&defType=' + defType;
+  const rest = Object.entries(extra)
+    .map(([k, v]) => `&${k}=${encodeURIComponent(v)}`)
+    .join('');
+  return base + rest + '&wt=json';
+}
+
+function makeSharedCases(defType: 'edismax' | 'dismax'): TestCase[] {
+  return [
+    // ─── pf — phrase boost ──────────────────────────────────────────────────
+
+    solrTest(`${defType}-pf-no-boost`, {
+      description: 'pf without boost value — default boost applies',
+      documents: [
+        { id: '1', title: 'java programming tutorial', body: 'unrelated content' },
+        { id: '2', title: 'programming java tutorial', body: 'unrelated content' },
+        { id: '3', title: 'unrelated content', body: 'java programming guide' },
+      ],
+      requestPath: p('java programming', defType, { qf: 'title body', pf: 'title' }),
+      solrSchema: twoFieldSchema,
+      opensearchMapping: twoFieldMapping,
+    }),
+
+    solrTest(`${defType}-pf-boosts-exact-phrase`, {
+      description: 'pf boosts doc where all terms appear as adjacent phrase',
+      documents: [
+        { id: '1', title: 'java programming tutorial', body: 'unrelated content' },
+        { id: '2', title: 'programming java tutorial', body: 'unrelated content' },
+        { id: '3', title: 'unrelated content', body: 'java programming guide' },
+      ],
+      requestPath: p('java programming', defType, { qf: 'title body', pf: 'title^50' }),
+      solrSchema: twoFieldSchema,
+      opensearchMapping: twoFieldMapping,
+    }),
+
+    solrTest(`${defType}-pf-multi-fields-with-qf`, {
+      description: 'pf across multiple fields — both title and body can contribute phrase boost',
+      documents: [
+        { id: '1', title: 'java programming', body: 'unrelated content' },
+        { id: '2', title: 'unrelated content', body: 'java programming guide' },
+        { id: '3', title: 'java', body: 'programming tutorial' },
+      ],
+      requestPath: p('java programming', defType, { qf: 'title body', pf: 'title^50 body^20' }),
+      solrSchema: twoFieldSchema,
+      opensearchMapping: twoFieldMapping,
+    }),
+
+    solrTest(`${defType}-pf-different-boost-than-qf`, {
+      description: 'pf field boosts differ from qf field boosts independently',
+      documents: [
+        { id: '1', title: 'java programming', body: 'unrelated content' },
+        { id: '2', title: 'unrelated content', body: 'java programming guide' },
+        { id: '3', title: 'java tutorial', body: 'programming basics' },
+      ],
+      requestPath: p('java programming', defType, { qf: 'title^1 body^1', pf: 'title^100 body^5' }),
+      solrSchema: twoFieldSchema,
+      opensearchMapping: twoFieldMapping,
+    }),
+
+    solrTest(`${defType}-pf-high-qf-boost-with-pf`, {
+      description: 'qf with boost > 1 combined with pf — title matches score higher on both axes',
+      documents: [
+        { id: '1', title: 'java programming', body: 'unrelated content' },
+        { id: '2', title: 'unrelated content', body: 'java programming guide' },
+        { id: '3', title: 'java tutorial', body: 'programming reference' },
+      ],
+      requestPath: p('java programming', defType, { qf: 'title^5 body', pf: 'title^50 body^10' }),
+      solrSchema: twoFieldSchema,
+      opensearchMapping: twoFieldMapping,
+    }),
+
+    // ─── ps — phrase slop ───────────────────────────────────────────────────
+
+    solrTest(`${defType}-pf-ps-slop-allows-gap`, {
+      description: 'ps=2 allows up to 2 words between terms and still phrase-boosts',
+      documents: [
+        { id: '1', title: 'java programming', body: 'unrelated content' },
+        { id: '2', title: 'java advanced programming', body: 'unrelated content' },
+        { id: '3', title: 'programming java tutorial', body: 'unrelated content' },
+      ],
+      requestPath: p('java programming', defType, { qf: 'title body', pf: 'title^50', ps: '2' }),
+      solrSchema: twoFieldSchema,
+      opensearchMapping: twoFieldMapping,
+    }),
+
+    solrTest(`${defType}-pf-ps0-strict-adjacency`, {
+      description: 'ps=0 (default) only boosts exact adjacent phrase — gap prevents boost',
+      documents: [
+        { id: '1', title: 'java programming', body: 'unrelated content' },
+        { id: '2', title: 'java advanced programming', body: 'unrelated content' },
+        { id: '3', title: 'unrelated content', body: 'java programming guide' },
+      ],
+      requestPath: p('java programming', defType, { qf: 'title body', pf: 'title^50', ps: '0' }),
+      solrSchema: twoFieldSchema,
+      opensearchMapping: twoFieldMapping,
+    }),
+
+    solrTest(`${defType}-pf-ps-with-multi-pf-fields`, {
+      description: 'ps applies to all pf fields — slop on both title and body phrase queries',
+      documents: [
+        { id: '1', title: 'java great programming', body: 'unrelated content' },
+        { id: '2', title: 'unrelated content', body: 'java best programming guide' },
+        { id: '3', title: 'java programming', body: 'java programming' },
+      ],
+      requestPath: p('java programming', defType, { qf: 'title body', pf: 'title^50 body^20', ps: '3' }),
+      solrSchema: twoFieldSchema,
+      opensearchMapping: twoFieldMapping,
+    }),
+
+    // ─── tie — tie breaker ──────────────────────────────────────────────────
+
+    solrTest(`${defType}-tie-zero-pure-dismax`, {
+      description: 'tie=0 (default) — only best field score counts, no bonus for multi-field match',
+      documents: [
+        { id: '1', title: 'java programming', body: 'java tutorial' },
+        { id: '2', title: 'java programming', body: 'unrelated content' },
+        { id: '3', title: 'unrelated content', body: 'java tutorial guide' },
+      ],
+      requestPath: p('java', defType, { qf: 'title body', tie: '0.0' }),
+      solrSchema: twoFieldSchema,
+      opensearchMapping: twoFieldMapping,
+    }),
+
+    solrTest(`${defType}-tie-moderate`, {
+      description: 'tie=0.3 gives moderate bonus to docs matching in multiple qf fields',
+      documents: [
+        { id: '1', title: 'java programming', body: 'java tutorial' },
+        { id: '2', title: 'java programming', body: 'unrelated content' },
+        { id: '3', title: 'unrelated content', body: 'java tutorial guide' },
+      ],
+      requestPath: p('java', defType, { qf: 'title body', tie: '0.3' }),
+      solrSchema: twoFieldSchema,
+      opensearchMapping: twoFieldMapping,
+    }),
+
+    solrTest(`${defType}-tie-one-pure-sum`, {
+      description: 'tie=1.0 — all field scores summed, equivalent to most_fields behavior',
+      documents: [
+        { id: '1', title: 'java programming', body: 'java tutorial' },
+        { id: '2', title: 'java programming', body: 'unrelated content' },
+        { id: '3', title: 'unrelated content', body: 'java tutorial guide' },
+      ],
+      requestPath: p('java', defType, { qf: 'title body', tie: '1.0' }),
+      solrSchema: twoFieldSchema,
+      opensearchMapping: twoFieldMapping,
+    }),
+
+    // ─── combined pf + ps + tie ─────────────────────────────────────────────
+
+    solrTest(`${defType}-pf-ps-tie-combined`, {
+      description: 'pf, ps, and tie all set together — full dismax/edismax scoring',
+      documents: [
+        { id: '1', title: 'java programming tutorial', body: 'java tutorial' },
+        { id: '2', title: 'java advanced programming', body: 'java tutorial' },
+        { id: '3', title: 'java programming', body: 'unrelated content' },
+        { id: '4', title: 'unrelated content', body: 'java programming guide' },
+        { id: '5', title: 'java tutorial', body: 'programming reference' },
+        { id: '6', title: 'programming basics', body: 'java fundamentals' },
+      ],
+      requestPath: p('java programming', defType, {
+        qf: 'title^2 body',
+        pf: 'title^50 body^20',
+        ps: '2',
+        tie: '0.3',
+      }),
+      solrSchema: twoFieldSchema,
+      opensearchMapping: twoFieldMapping,
+    }),
+  ];
+}
+
+export const testCases: TestCase[] = [
+  ...makeSharedCases('edismax'),
+  ...makeSharedCases('dismax'),
+];

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/integration-tests/dismax-edismax/query-fields.testcase.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/integration-tests/dismax-edismax/query-fields.testcase.ts
@@ -5,8 +5,8 @@
  * for bare terms. Test cases are generated for both defType values to avoid
  * duplication. eDisMax-specific cases (field:value syntax) are appended at the end.
  */
-import { solrTest } from '../../test-types';
-import type { TestCase } from '../../test-types';
+import { solrTest } from '../../../test-types';
+import type { TestCase } from '../../../test-types';
 
 const twoFieldSchema = {
   fields: {

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/ast/nodes.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/ast/nodes.ts
@@ -93,6 +93,13 @@ export interface BareNode {
    * Takes precedence over defaultField when set.
    */
   queryFields?: string[];
+  /**
+   * Tie breaker from the `tie` parameter (edismax/dismax).
+   * Controls how much non-best-matching fields contribute to the score.
+   * Only meaningful when queryFields is set.
+   * 0.0 (default) = pure disjunction max, 1.0 = sum of all fields.
+   */
+  tieBreaker?: number;
 }
 
 /**

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/orchestrator/translateQ.test.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/orchestrator/translateQ.test.ts
@@ -84,6 +84,29 @@ describe('translateQ', () => {
     });
   });
 
+  describe('pf phrase boost', () => {
+    it('wraps dsl in bool when pf is set', () => {
+      const fakeDsl = new Map([['multi_match', new Map()]]);
+      mockParse.mockReturnValue({ ast: { type: 'matchAll' }, errors: [] });
+      mockTransform.mockReturnValue(fakeDsl);
+
+      const result = translateQ(params(['q', 'foo bar'], ['pf', 'title^50']));
+
+      expect(result.dsl.has('bool')).toBe(true);
+      expect((result.dsl.get('bool') as Map<string, any>).get('must')).toBe(fakeDsl);
+    });
+
+    it('returns plain dsl when pf is not set', () => {
+      const fakeDsl = new Map([['match_all', new Map()]]);
+      mockParse.mockReturnValue({ ast: { type: 'matchAll' }, errors: [] });
+      mockTransform.mockReturnValue(fakeDsl);
+
+      const result = translateQ(params(['q', 'foo bar']));
+
+      expect(result.dsl).toBe(fakeDsl);
+    });
+  });
+
   describe('fail-fast mode', () => {
     it('throws on parse failure', () => {
       mockParse.mockReturnValue({

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/orchestrator/translateQ.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/orchestrator/translateQ.ts
@@ -26,6 +26,7 @@
 
 import { parseSolrQuery } from '../parser/parser';
 import { transformNode } from '../transformer/astToOpenSearch';
+import { applyPhraseBoost } from '../transformer/phraseBoost';
 
 export interface TranslateResult {
   /**
@@ -111,7 +112,11 @@ export function translateQ(
 
   // Stage 2: Transform
   try {
-    const dsl = transformNode(ast);
+    const mainDsl = transformNode(ast);
+
+    // Stage 3: pf phrase boost — wraps the main query in bool.must + bool.should
+    // if pf is set. Delegated to phraseBoost.ts (transformer concern).
+    const dsl = applyPhraseBoost(mainDsl, query, params);
     return { dsl, warnings: [] };
   } catch (err: unknown) {
     // Transform failure — unsupported node type or unexpected error

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/parser/parser.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/parser/parser.ts
@@ -46,7 +46,7 @@ import * as peggy from 'peggy';
 import grammar from './solr.pegjs';
 import type { ASTNode } from '../ast/nodes';
 import type { ParseResult, ParseError } from './types';
-import { parseQueryFields, applyQueryFields } from './qf';
+import { applyQueryFields } from './qf';
 
 // Lazily compiled parser — the grammar is inlined at build time and compiled
 // on the first call to parseSolrQuery, then cached for all subsequent calls.
@@ -115,10 +115,7 @@ export function parseSolrQuery(
 
     // qf → BareNode.queryFields (edismax/dismax only)
     if (defType === 'edismax' || defType === 'dismax') {
-      const queryFields = parseQueryFields(params.get('qf'));
-      if (queryFields) {
-        applyQueryFields(ast, queryFields);
-      }
+      applyQueryFields(ast, params);
     }
 
     return { ast, errors: [] };

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/parser/qf.test.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/parser/qf.test.ts
@@ -1,101 +1,125 @@
 import { describe, it, expect } from 'vitest';
-import { parseQueryFields, applyQueryFields } from './qf';
+import { parseFieldSpecs, applyQueryFields } from './qf';
 import type { ASTNode, BareNode } from '../ast/nodes';
 
-// ─── parseQueryFields ─────────────────────────────────────────────────────────
+const p = (...entries: [string, string][]) => new Map(entries);
 
-describe('parseQueryFields', () => {
+// ─── parseFieldSpecs ──────────────────────────────────────────────────────────
+
+describe('parseFieldSpecs', () => {
   it('returns undefined for undefined input', () => {
-    expect(parseQueryFields(undefined)).toBeUndefined();
+    expect(parseFieldSpecs(undefined)).toBeUndefined();
   });
 
   it('returns undefined for empty string', () => {
-    expect(parseQueryFields('')).toBeUndefined();
+    expect(parseFieldSpecs('')).toBeUndefined();
   });
 
   it('returns undefined for whitespace-only string', () => {
-    expect(parseQueryFields('   ')).toBeUndefined();
+    expect(parseFieldSpecs('   ')).toBeUndefined();
   });
 
   it('parses a single field without boost', () => {
-    expect(parseQueryFields('title')).toEqual(['title']);
+    expect(parseFieldSpecs('title')).toEqual(['title']);
   });
 
   it('passes through field^boost token as-is', () => {
-    expect(parseQueryFields('title^2')).toEqual(['title^2']);
+    expect(parseFieldSpecs('title^2')).toEqual(['title^2']);
   });
 
   it('passes through decimal boost as-is', () => {
-    expect(parseQueryFields('title^0.5')).toEqual(['title^0.5']);
+    expect(parseFieldSpecs('title^0.5')).toEqual(['title^0.5']);
   });
 
   it('splits multiple fields', () => {
-    expect(parseQueryFields('title^2 body description^0.5')).toEqual([
+    expect(parseFieldSpecs('title^2 body description^0.5')).toEqual([
       'title^2', 'body', 'description^0.5',
     ]);
   });
 
   it('passes through all fields with boost values', () => {
-    expect(parseQueryFields('title^2 body^1')).toEqual(['title^2', 'body^1']);
+    expect(parseFieldSpecs('title^2 body^1')).toEqual(['title^2', 'body^1']);
   });
 
   it('handles extra whitespace between fields', () => {
-    expect(parseQueryFields('title^2   body')).toEqual(['title^2', 'body']);
+    expect(parseFieldSpecs('title^2   body')).toEqual(['title^2', 'body']);
   });
 
   it('handles dotted field names', () => {
-    expect(parseQueryFields('metadata.title^3')).toEqual(['metadata.title^3']);
+    expect(parseFieldSpecs('metadata.title^3')).toEqual(['metadata.title^3']);
   });
 });
 
 // ─── applyQueryFields ─────────────────────────────────────────────────────────
 
 describe('applyQueryFields', () => {
-  const qf = ['title^2', 'body'];
-
   it('stamps queryFields onto a BareNode', () => {
     const node: BareNode = { type: 'bare', value: 'java', isPhrase: false };
-    applyQueryFields(node, qf);
-    expect(node.queryFields).toEqual(qf);
+    applyQueryFields(node, p(['qf', 'title^2 body']));
+    expect(node.queryFields).toEqual(['title^2', 'body']);
   });
 
   it('clears defaultField when stamping queryFields', () => {
     const node: BareNode = { type: 'bare', value: 'java', isPhrase: false, defaultField: 'content' };
-    applyQueryFields(node, qf);
-    expect(node.queryFields).toEqual(qf);
+    applyQueryFields(node, p(['qf', 'title body']));
+    expect(node.queryFields).toEqual(['title', 'body']);
     expect(node.defaultField).toBeUndefined();
+  });
+
+  it('stamps tieBreaker when tie param is set', () => {
+    const node: BareNode = { type: 'bare', value: 'java', isPhrase: false };
+    applyQueryFields(node, p(['qf', 'title body'], ['tie', '0.1']));
+    expect(node.tieBreaker).toBe(0.1);
+  });
+
+  it('does not stamp tieBreaker when tie is absent', () => {
+    const node: BareNode = { type: 'bare', value: 'java', isPhrase: false };
+    applyQueryFields(node, p(['qf', 'title body']));
+    expect(node.tieBreaker).toBeUndefined();
+  });
+
+  it('does not stamp tieBreaker when tie is NaN', () => {
+    const node: BareNode = { type: 'bare', value: 'java', isPhrase: false };
+    applyQueryFields(node, p(['qf', 'title body'], ['tie', 'abc']));
+    expect(node.tieBreaker).toBeUndefined();
+  });
+
+  it('does nothing when qf is absent', () => {
+    const node: BareNode = { type: 'bare', value: 'java', isPhrase: false };
+    applyQueryFields(node, p());
+    expect(node.queryFields).toBeUndefined();
   });
 
   it('stamps queryFields onto all BareNodes in a BoolNode', () => {
     const a: BareNode = { type: 'bare', value: 'java', isPhrase: false };
     const b: BareNode = { type: 'bare', value: 'python', isPhrase: false };
     const node: ASTNode = { type: 'bool', and: [a], or: [b], not: [] };
-    applyQueryFields(node, qf);
-    expect(a.queryFields).toEqual(qf);
-    expect(b.queryFields).toEqual(qf);
+    applyQueryFields(node, p(['qf', 'title body']));
+    expect(a.queryFields).toEqual(['title', 'body']);
+    expect(b.queryFields).toEqual(['title', 'body']);
   });
 
   it('recurses into boost node child', () => {
     const bare: BareNode = { type: 'bare', value: 'java', isPhrase: false };
     const node: ASTNode = { type: 'boost', child: bare, value: 2 };
-    applyQueryFields(node, qf);
-    expect(bare.queryFields).toEqual(qf);
+    applyQueryFields(node, p(['qf', 'title']));
+    expect(bare.queryFields).toEqual(['title']);
   });
 
   it('recurses into group node child', () => {
     const bare: BareNode = { type: 'bare', value: 'java', isPhrase: false };
     const node: ASTNode = { type: 'group', child: bare };
-    applyQueryFields(node, qf);
-    expect(bare.queryFields).toEqual(qf);
+    applyQueryFields(node, p(['qf', 'title']));
+    expect(bare.queryFields).toEqual(['title']);
   });
 
   it('does not touch FieldNode', () => {
     const node: ASTNode = { type: 'field', field: 'title', value: 'java' };
-    applyQueryFields(node, qf);
+    applyQueryFields(node, p(['qf', 'title']));
   });
 
   it('does not touch MatchAllNode', () => {
     const node: ASTNode = { type: 'matchAll' };
-    applyQueryFields(node, qf);
+    applyQueryFields(node, p(['qf', 'title']));
   });
 });

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/parser/qf.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/parser/qf.ts
@@ -31,14 +31,14 @@ import type { ASTNode } from '../ast/nodes';
  *   "title"            → ["title"]
  *   "" / undefined     → undefined
  */
-export function parseQueryFields(qf: string | undefined): string[] | undefined {
-  if (!qf?.trim()) return undefined;
-  const fields = qf.trim().split(/\s+/);
+export function parseFieldSpecs(fieldSpec: string | undefined): string[] | undefined {
+  if (!fieldSpec?.trim()) return undefined;
+  const fields = fieldSpec.trim().split(/\s+/);
   return fields.length > 0 ? fields : undefined;
 }
 
 /**
- * Walk the AST and stamp queryFields onto every BareNode.
+ * Walk the AST and stamp queryFields (and optionally tieBreaker) onto every BareNode.
  *
  * Called as a post-parse pass when defType is edismax or dismax and qf is set.
  * BareNodes represent unfielded terms/phrases — in edismax/dismax these are
@@ -46,26 +46,41 @@ export function parseQueryFields(qf: string | undefined): string[] | undefined {
  *
  * Only BareNodes are annotated — FieldNodes, PhraseNodes, and RangeNodes
  * already have explicit fields from the query syntax and are left unchanged.
+ *
+ * @param node - The AST node to annotate.
+ * @param params - All request params. Reads `qf` and `tie`.
  */
-export function applyQueryFields(node: ASTNode, queryFields: string[]): void {
+export function applyQueryFields(node: ASTNode, params: ReadonlyMap<string, string>): void {
+  const queryFields = parseFieldSpecs(params.get('qf'));
+  if (!queryFields) return;
+
+  const tieRaw = params.get('tie');
+  const tieBreaker = tieRaw !== undefined ? Number.parseFloat(tieRaw) : undefined;
+  const validTie = tieBreaker !== undefined && !Number.isNaN(tieBreaker) ? tieBreaker : undefined;
+
+  _applyQueryFields(node, queryFields, validTie);
+}
+
+function _applyQueryFields(node: ASTNode, queryFields: string[], tieBreaker: number | undefined): void {
   switch (node.type) {
     case 'bare':
       node.queryFields = queryFields;
+      if (tieBreaker !== undefined) node.tieBreaker = tieBreaker;
       // Clear defaultField — queryFields takes precedence and bareRule uses queryFields first
       delete node.defaultField;
       break;
     case 'bool':
-      node.and.forEach((child) => applyQueryFields(child, queryFields));
-      node.or.forEach((child) => applyQueryFields(child, queryFields));
-      node.not.forEach((child) => applyQueryFields(child, queryFields));
+      node.and.forEach((child) => _applyQueryFields(child, queryFields, tieBreaker));
+      node.or.forEach((child) => _applyQueryFields(child, queryFields, tieBreaker));
+      node.not.forEach((child) => _applyQueryFields(child, queryFields, tieBreaker));
       break;
     case 'boost':
     case 'group':
     case 'filter':
-      applyQueryFields(node.child, queryFields);
+      _applyQueryFields(node.child, queryFields, tieBreaker);
       break;
     case 'localParams':
-      if (node.body) applyQueryFields(node.body, queryFields);
+      if (node.body) _applyQueryFields(node.body, queryFields, tieBreaker);
       break;
     case 'field':
     case 'phrase':

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/transformer/phraseBoost.test.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/transformer/phraseBoost.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest';
+import { buildPhraseBoost, applyPhraseBoost } from './phraseBoost';
+
+const p = (...entries: [string, string][]) => new Map(entries);
+
+// ─── buildPhraseBoost ─────────────────────────────────────────────────────────
+
+describe('buildPhraseBoost', () => {
+  it('returns null when pf is not set', () => {
+    expect(buildPhraseBoost('foo bar', p())).toBeNull();
+  });
+
+  it('returns null when pf is empty', () => {
+    expect(buildPhraseBoost('foo bar', p(['pf', '']))).toBeNull();
+  });
+
+  it('builds multi_match phrase with single field', () => {
+    const result = buildPhraseBoost('foo bar', p(['pf', 'title^50']));
+    const mm = result!.get('multi_match') as Map<string, any>;
+    expect(mm.get('query')).toBe('foo bar');
+    expect(mm.get('fields')).toEqual(['title^50']);
+    expect(mm.get('type')).toBe('phrase');
+    expect(mm.has('slop')).toBe(false);
+  });
+
+  it('builds multi_match phrase with multiple fields', () => {
+    const result = buildPhraseBoost('foo bar', p(['pf', 'title^50 body^20']));
+    const mm = result!.get('multi_match') as Map<string, any>;
+    expect(mm.get('fields')).toEqual(['title^50', 'body^20']);
+  });
+
+  it('includes slop when ps > 0', () => {
+    const result = buildPhraseBoost('foo bar', p(['pf', 'title^50'], ['ps', '10']));
+    const mm = result!.get('multi_match') as Map<string, any>;
+    expect(mm.get('slop')).toBe(10);
+  });
+
+  it('omits slop when ps=0', () => {
+    const result = buildPhraseBoost('foo bar', p(['pf', 'title^50'], ['ps', '0']));
+    const mm = result!.get('multi_match') as Map<string, any>;
+    expect(mm.has('slop')).toBe(false);
+  });
+
+  it('omits slop when ps is absent', () => {
+    const result = buildPhraseBoost('foo bar', p(['pf', 'title^50']));
+    const mm = result!.get('multi_match') as Map<string, any>;
+    expect(mm.has('slop')).toBe(false);
+  });
+
+  it('omits slop when ps is negative', () => {
+    // Negative slop is meaningless — treated same as 0 (no slop)
+    const result = buildPhraseBoost('foo bar', p(['pf', 'title^50'], ['ps', '-5']));
+    const mm = result!.get('multi_match') as Map<string, any>;
+    expect(mm.has('slop')).toBe(false);
+  });
+
+  it('uses the full query string as the phrase text', () => {
+    const result = buildPhraseBoost('hello world java', p(['pf', 'title']));
+    const mm = result!.get('multi_match') as Map<string, any>;
+    expect(mm.get('query')).toBe('hello world java');
+  });
+});
+
+// ─── applyPhraseBoost ─────────────────────────────────────────────────────────
+
+describe('applyPhraseBoost', () => {
+  const mainDsl = new Map([['multi_match', new Map()]]);
+
+  it('returns mainDsl unchanged when pf is not set', () => {
+    const result = applyPhraseBoost(mainDsl, 'foo bar', p());
+    expect(result).toBe(mainDsl);
+  });
+
+  it('wraps in bool.must + bool.should when pf is set', () => {
+    const result = applyPhraseBoost(mainDsl, 'foo bar', p(['pf', 'title^50']));
+    const bool = result.get('bool') as Map<string, any>;
+    expect(bool.get('must')).toBe(mainDsl);
+    const should = bool.get('should') as Map<string, any>;
+    expect(should.get('multi_match')).toBeDefined();
+  });
+
+  it('phrase boost in should has correct query and fields', () => {
+    const result = applyPhraseBoost(mainDsl, 'foo bar', p(['pf', 'title^50 body^20'], ['ps', '5']));
+    const mm = (result.get('bool') as Map<string, any>)
+      .get('should').get('multi_match') as Map<string, any>;
+    expect(mm.get('query')).toBe('foo bar');
+    expect(mm.get('fields')).toEqual(['title^50', 'body^20']);
+    expect(mm.get('type')).toBe('phrase');
+    expect(mm.get('slop')).toBe(5);
+  });
+});

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/transformer/phraseBoost.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/transformer/phraseBoost.ts
@@ -1,0 +1,80 @@
+/**
+ * Phrase boost (pf) — builds the OpenSearch DSL for Solr's pf parameter.
+ *
+ * pf (phrase fields) boosts documents where all terms in the query appear
+ * close together as a phrase in the specified fields. It is scoring-only —
+ * it never affects which documents match, only how they are ranked.
+ *
+ * This is a query-level concern (operates on the full query string, not
+ * per-AST-node), so it lives here as a transformer utility rather than
+ * in the AST or orchestrator.
+ *
+ * Output: a multi_match with type "phrase" intended for bool.should.
+ *
+ * Example: pf=title^50 body^20 ps=10
+ *   → Map{"multi_match" → Map{"query"→q, "fields"→["title^50","body^20"], "type"→"phrase", "slop"→10}}
+ *
+ * @see https://solr.apache.org/guide/solr/latest/query-guide/dismax-query-parser.html#pf-phrase-fields-parameter
+ */
+
+import { parseFieldSpecs } from '../parser/qf';
+
+/**
+ * Build the pf phrase boost DSL, or return null if pf is not set.
+ *
+ * @param query - The raw query string (q param value) used as the phrase text.
+ * @param params - All request params. Reads `pf` (fields) and `ps` (phrase slop).
+ */
+export function buildPhraseBoost(
+  query: string,
+  params: ReadonlyMap<string, string>,
+): Map<string, any> | null {
+  const pfFields = parseFieldSpecs(params.get('pf'));
+  if (!pfFields) return null;
+
+  const slop = Number.parseInt(params.get('ps') ?? '0', 10);
+  const entries: [string, any][] = [
+    ['query', query],
+    ['fields', pfFields],
+    ['type', 'phrase'],
+  ];
+  if (slop > 0) entries.push(['slop', slop]);
+
+  return new Map([['multi_match', new Map<string, any>(entries)]]);
+}
+
+/**
+ * Wrap a main DSL query with a pf phrase boost in a bool query.
+ *
+ * If pf is set, returns bool { must: mainDsl, should: phraseBoostDsl }.
+ * If pf is not set, returns mainDsl unchanged.
+ *
+ * @param mainDsl - The translated main query DSL.
+ * @param query   - The raw query string used as the phrase text for pf.
+ * @param params  - All request params. Reads `pf` and `ps`.
+ */
+export function applyPhraseBoost(
+  mainDsl: Map<string, any>,
+  query: string,
+  params: ReadonlyMap<string, string>,
+): Map<string, any> {
+  const pfDsl = buildPhraseBoost(query, params);
+  if (!pfDsl) return mainDsl;
+
+  // bool — combines two independent scoring clauses into one query.
+  //
+  // must — the main qf query: determines which documents match and contributes
+  //   to the base score. Documents that don't satisfy this clause are excluded.
+  //
+  // should — the pf phrase boost: scoring-only, never filters out documents.
+  //   In OpenSearch, a should clause inside a bool that already has a must
+  //   clause is purely additive — it boosts the score of documents where the
+  //   phrase matches, but documents that don't match the phrase still appear
+  //   in results with their base qf score unchanged.
+  return new Map<string, any>([
+    ['bool', new Map<string, any>([
+      ['must', mainDsl],
+      ['should', pfDsl],
+    ])],
+  ]);
+}

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/transformer/rules/bareRule.test.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/transformer/rules/bareRule.test.ts
@@ -82,6 +82,71 @@ describe('bareRule', () => {
     expect(mm.get('fields')).toEqual(['title^2.5', 'description^0.5']);
   });
 
+  it('includes tie_breaker in multi_match when tieBreaker is set', () => {
+    const node: BareNode = {
+      type: 'bare',
+      value: 'java',
+      isPhrase: false,
+      queryFields: ['title^2', 'body'],
+      tieBreaker: 0.3,
+    };
+    const result = bareRule(node, stubTransformChild);
+    const mm = result.get('multi_match') as Map<string, any>;
+    expect(mm.get('tie_breaker')).toBe(0.3);
+  });
+
+  it('omits tie_breaker when tieBreaker is not set', () => {
+    const node: BareNode = {
+      type: 'bare',
+      value: 'java',
+      isPhrase: false,
+      queryFields: ['title', 'body'],
+    };
+    const result = bareRule(node, stubTransformChild);
+    const mm = result.get('multi_match') as Map<string, any>;
+    expect(mm.has('tie_breaker')).toBe(false);
+  });
+
+  it('includes tie_breaker=0 when tieBreaker is explicitly 0', () => {
+    const node: BareNode = {
+      type: 'bare',
+      value: 'java',
+      isPhrase: false,
+      queryFields: ['title', 'body'],
+      tieBreaker: 0,
+    };
+    const result = bareRule(node, stubTransformChild);
+    const mm = result.get('multi_match') as Map<string, any>;
+    expect(mm.get('tie_breaker')).toBe(0);
+  });
+
+  it('includes tie_breaker=1 for pure sum scoring', () => {
+    const node: BareNode = {
+      type: 'bare',
+      value: 'java',
+      isPhrase: false,
+      queryFields: ['title', 'body'],
+      tieBreaker: 1,
+    };
+    const result = bareRule(node, stubTransformChild);
+    const mm = result.get('multi_match') as Map<string, any>;
+    expect(mm.get('tie_breaker')).toBe(1);
+  });
+
+  it('phrase type with tieBreaker still uses type phrase', () => {
+    const node: BareNode = {
+      type: 'bare',
+      value: 'hello world',
+      isPhrase: true,
+      queryFields: ['title', 'body'],
+      tieBreaker: 0.1,
+    };
+    const result = bareRule(node, stubTransformChild);
+    const mm = result.get('multi_match') as Map<string, any>;
+    expect(mm.get('type')).toBe('phrase');
+    expect(mm.get('tie_breaker')).toBe(0.1);
+  });
+
   it('falls back to query_string when queryFields is empty array', () => {
     const node: BareNode = { type: 'bare', value: 'java', isPhrase: false, queryFields: [] };
     expect(bareRule(node, stubTransformChild)).toEqual(

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/transformer/rules/bareRule.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/transformer/rules/bareRule.ts
@@ -51,17 +51,17 @@ export const bareRule: TransformRuleFn = (
   // Bare is a leaf node — transformChild not used
   _transformChild,
 ): Map<string, any> => {
-  const { value, isPhrase, defaultField, queryFields } = node;
+  const { value, isPhrase, defaultField, queryFields, tieBreaker } = node;
 
   // multi_match path: qf fields provided (edismax/dismax)
   if (queryFields && queryFields.length > 0) {
-    return new Map([
-      ['multi_match', new Map<string, any>([
-        ['query', value],
-        ['fields', queryFields],
-        ['type', isPhrase ? 'phrase' : 'best_fields'],
-      ])],
-    ]);
+    const entries: [string, any][] = [
+      ['query', value],
+      ['fields', queryFields],
+      ['type', isPhrase ? 'phrase' : 'best_fields'],
+    ];
+    if (tieBreaker !== undefined) entries.push(['tie_breaker', tieBreaker]);
+    return new Map([['multi_match', new Map<string, any>(entries)]]);
   }
 
   // query_string fallback (standard parser / df only)


### PR DESCRIPTION
### Description
Adding translation for [phrase query fields](https://solr.apache.org/guide/solr/latest/query-guide/dismax-query-parser.html#pf-phrase-fields-parameter)(pf) to OpenSearch equivalent. It also cover its related fields [phrase slop](https://solr.apache.org/guide/solr/latest/query-guide/dismax-query-parser.html#pf-phrase-fields-parameter)(ps), [tie breaker](https://solr.apache.org/guide/solr/latest/query-guide/dismax-query-parser.html#the-tie-tie-breaker-parameter) (tie) params

### Issues Resolved
<!-- List any GitHub or Jira issues this PR will resolve -->

### Testing
<!-- Please provide details of testing done: unit testing, integration testing and manual testing -->

### Check List
- [ ] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
