### PR TITLE
feat(solr-transforms): Add bq boost query param (bq → bool.should)

### DIFF
--- a/TrafficCapture/SolrTransformations/docs/LIMITATIONS.md
+++ b/TrafficCapture/SolrTransformations/docs/LIMITATIONS.md
@@ -26,6 +26,10 @@ the root cause, and provides a workaround where one exists.
 | [MM-EDISMAX-OPERATOR-DEFAULT](#mm-edismax-operator-default) | eDisMax `mm` default with explicit operators not fully replicated |
 | [MM-EDISMAX-MIXED-OPERATORS](#mm-edismax-mixed-operators) | eDisMax `mm` with mixed explicit and implicit operators applies to wrong scope |
 | [MM-STOPWORD-MULTIFIELD](#mm-stopword-multifield) | `mm` with per-field stopword removal differs from Solr |
+| [DISMAX](#dismax)                                | `defType=dismax` not supported — use `defType=edismax` instead |
+| [BQ-NEG-BOOST](#bq-neg-boost)                   | Negative boost in `bq` (e.g., `^-10`) not supported |
+| [BF](#bf)                                       | `bf` (boost functions) parameter not supported |
+| [BOOST-MULTIPLICATIVE](#boost-multiplicative)   | eDisMax multiplicative `boost` parameter not supported |
 
 ---
 
@@ -644,3 +648,94 @@ due to this difference should consider aligning stopword lists across fields
 or lowering the `mm` value.
 
 **Reference:** https://solr.apache.org/guide/solr/latest/query-guide/dismax-query-parser.html#mm-minimum-should-match-parameter
+
+---
+
+## DISMAX
+
+**Feature:** `defType=dismax` (DisMax query parser)
+
+**Solr behaviour:**
+The DisMax query parser provides a simplified query syntax with multi-field
+search via `qf`, boost queries (`bq`), boost functions (`bf`), and minimum
+match (`mm`). eDisMax (Extended DisMax) is a superset that adds support for
+field:value syntax, boolean operators, and additional parameters.
+
+**Current status:**
+Not supported. Requests with `defType=dismax` are rejected by validation
+with a clear error message. Use `defType=edismax` instead — eDisMax supports
+all DisMax features plus additional capabilities.
+
+**Workaround:**
+Replace `defType=dismax` with `defType=edismax` in all queries. eDisMax is
+backwards-compatible with DisMax for the supported parameter set (`q`, `qf`,
+`bq`, `mm`, `pf`, `ps`, `tie`). The only behavioral difference is that
+eDisMax supports explicit field:value syntax and boolean operators in `q`,
+which DisMax treats as literal text.
+
+**Reference:** https://solr.apache.org/guide/solr/latest/query-guide/dismax-query-parser.html
+
+---
+
+## BQ-NEG-BOOST
+
+**Feature:** Negative boost values in `bq` (e.g., `bq=category:spam^-10`)
+
+**Solr behaviour:**
+Solr accepts negative boost values via Java's `Float.parseFloat()`. A negative
+boost reduces the score contribution of matching documents additively — the
+document is still returned, just ranked lower.
+
+**Current status:**
+Not supported. The shim rejects `bq` values containing `^-` with a fail-fast
+error. OpenSearch does not support negative boost values — they produce
+undefined scoring behavior. Without fail-fast, the PEG grammar would
+reinterpret `category:spam^-10` as `-(category:spam^10)` (negation with
+positive boost), which would **exclude** matching documents instead of
+demoting them — a silent correctness bug.
+
+**Workaround:**
+Remove negative boosts from `bq` params. If score demotion is needed,
+consider restructuring the query to use positive boosts on the preferred
+documents instead.
+
+---
+
+## BF
+
+**Feature:** `bf` (boost functions) parameter
+
+**Solr behaviour:**
+The `bf` parameter in DisMax/eDisMax specifies function expressions with
+optional boosts that are added as scoring clauses. For example:
+`bf=div(1,sum(1,price))^1.5` is shorthand for
+`bq={!func}div(1,sum(1,price))^1.5`. Multiple `bf` values are supported.
+
+**Current status:**
+Not supported. The `bf` parameter is entirely function-based and requires
+a dedicated transform to parse the function shorthand syntax and delegate
+to the query engine. Sending `bf` will be rejected by validation as an
+unsupported parameter.
+
+**Reference:** https://solr.apache.org/guide/solr/latest/query-guide/dismax-query-parser.html#bf-boost-functions-parameter
+
+---
+
+## BOOST-MULTIPLICATIVE
+
+**Feature:** eDisMax multiplicative `boost` parameter
+
+**Solr behaviour:**
+The eDisMax `boost` parameter applies a multiplicative boost to the entire
+query score. Unlike `bq` (additive), `boost` acts as a scaling factor.
+For example: `boost=popularity` multiplies each document's score by its
+`popularity` field value. This is shorthand for wrapping the query in a
+`{!boost}` QParser.
+
+**Current status:**
+Not supported. Multiplicative boosting requires OpenSearch's `function_score`
+query with `script_score` or `field_value_factor`, which is architecturally
+different from additive `bq`/`bf`. Sending `boost` will be rejected by
+validation as an unsupported parameter.
+
+**Reference:** https://solr.apache.org/guide/solr/latest/query-guide/edismax-query-parser.html#extended-dismax-parameters

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/boost-query-bq.test.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/boost-query-bq.test.ts
@@ -1,0 +1,455 @@
+import { describe, it, expect } from 'vitest';
+import { request } from './boost-query-bq';
+import type { RequestContext, JavaMap } from '../context';
+
+/** Create a mock RequestContext for testing. */
+function createCtx(
+  params: Record<string, string | string[]>,
+  existingQuery?: Map<string, any>,
+): RequestContext {
+  const body = new Map<string, any>();
+  if (existingQuery) body.set('query', existingQuery);
+
+  const searchParams = new URLSearchParams();
+  for (const [key, value] of Object.entries(params)) {
+    if (Array.isArray(value)) {
+      for (const v of value) searchParams.append(key, v);
+    } else {
+      searchParams.append(key, value);
+    }
+  }
+
+  return {
+    msg: new Map() as JavaMap,
+    endpoint: 'select',
+    collection: 'test',
+    params: searchParams,
+    body: body as JavaMap,
+  };
+}
+
+/** Convert nested Maps to plain objects for easier assertion. */
+function mapToObj(map: Map<string, any>): any {
+  const obj: any = {};
+  for (const [key, value] of map.entries()) {
+    if (value instanceof Map) {
+      obj[key] = mapToObj(value);
+    } else if (Array.isArray(value)) {
+      obj[key] = value.map((v) => (v instanceof Map ? mapToObj(v) : v));
+    } else {
+      obj[key] = value;
+    }
+  }
+  return obj;
+}
+
+describe('boost-query-bq request transform', () => {
+  it('has correct name', () => {
+    expect(request.name).toBe('boost-query-bq');
+  });
+
+  // --- match guard ---
+
+  describe('match', () => {
+    it('matches when bq is present', () => {
+      const ctx = createCtx({ bq: 'category:food', defType: 'edismax' });
+      expect(request.match!(ctx)).toBe(true);
+    });
+
+    it('does not match when bq is absent', () => {
+      const ctx = createCtx({ defType: 'edismax' });
+      expect(request.match!(ctx)).toBe(false);
+    });
+
+    it('matches when bq is empty string (apply handles the no-op)', () => {
+      const ctx = createCtx({ bq: '', defType: 'edismax' });
+      expect(request.match!(ctx)).toBe(true);
+    });
+  });
+
+  // --- fail-fast on invalid defType ---
+
+  describe('defType validation', () => {
+    it('throws when defType is absent', () => {
+      const ctx = createCtx({ bq: 'category:food' }, new Map([['match_all', new Map()]]));
+      expect(() => request.apply(ctx)).toThrow('[boost-query-bq] bq parameter requires defType=edismax');
+    });
+
+    it('throws when defType is lucene', () => {
+      const ctx = createCtx({ bq: 'category:food', defType: 'lucene' }, new Map([['match_all', new Map()]]));
+      expect(() => request.apply(ctx)).toThrow("got 'lucene'");
+    });
+
+    it('throws for defType=dismax', () => {
+      const ctx = createCtx({ bq: 'category:food', defType: 'dismax' }, new Map([['match_all', new Map()]]));
+      expect(() => request.apply(ctx)).toThrow("got 'dismax'");
+    });
+
+    it('does not throw for defType=edismax', () => {
+      const ctx = createCtx({ bq: 'category:food', defType: 'edismax' }, new Map([['match_all', new Map()]]));
+      expect(() => request.apply(ctx)).not.toThrow();
+    });
+  });
+
+  // --- single bq ---
+
+  describe('single bq', () => {
+    it('wraps existing query in bool.must and adds bq to bool.should', () => {
+      const existingQuery = new Map([['match_all', new Map()]]);
+      const ctx = createCtx({ bq: 'category:food', defType: 'edismax' }, existingQuery);
+
+      request.apply(ctx);
+
+      const result = mapToObj(ctx.body.get('query'));
+      expect(result.bool.must).toHaveLength(1);
+      expect(result.bool.must[0].match_all).toBeDefined();
+      expect(result.bool.should).toHaveLength(1);
+      expect(result.bool.should[0].match.category.query).toBe('food');
+      expect(result.bool.minimum_should_match).toBeUndefined();
+    });
+
+    it('handles boosted bq value', () => {
+      const existingQuery = new Map([['match_all', new Map()]]);
+      const ctx = createCtx({ bq: 'category:food^10', defType: 'edismax' }, existingQuery);
+
+      request.apply(ctx);
+
+      const result = mapToObj(ctx.body.get('query'));
+      expect(result.bool.should).toHaveLength(1);
+      expect(result.bool.should[0].match.category.query).toBe('food');
+      expect(result.bool.should[0].match.category.boost).toBe(10);
+    });
+
+    it('handles phrase bq value', () => {
+      const existingQuery = new Map([['match_all', new Map()]]);
+      const ctx = createCtx({ bq: 'title:"aged cheese"', defType: 'edismax' }, existingQuery);
+
+      request.apply(ctx);
+
+      const result = mapToObj(ctx.body.get('query'));
+      expect(result.bool.should[0].match_phrase.title.query).toBe('aged cheese');
+    });
+
+    it('handles range bq value', () => {
+      const existingQuery = new Map([['match_all', new Map()]]);
+      const ctx = createCtx({ bq: 'price:[10 TO 100]', defType: 'edismax' }, existingQuery);
+
+      request.apply(ctx);
+
+      const result = mapToObj(ctx.body.get('query'));
+      expect(result.bool.should[0].range.price.gte).toBe('10');
+      expect(result.bool.should[0].range.price.lte).toBe('100');
+    });
+  });
+
+  // --- multiple bq ---
+
+  describe('multiple bq', () => {
+    it('adds all bq values as separate should clauses', () => {
+      const existingQuery = new Map([['match_all', new Map()]]);
+      const ctx = createCtx(
+        { bq: ['category:food^10', 'category:deli^5'], defType: 'edismax' },
+        existingQuery,
+      );
+
+      request.apply(ctx);
+
+      const result = mapToObj(ctx.body.get('query'));
+      expect(result.bool.should).toHaveLength(2);
+      expect(result.bool.should[0].match.category.query).toBe('food');
+      expect(result.bool.should[0].match.category.boost).toBe(10);
+      expect(result.bool.should[1].match.category.query).toBe('deli');
+      expect(result.bool.should[1].match.category.boost).toBe(5);
+    });
+
+    it('filters out empty bq values', () => {
+      const existingQuery = new Map([['match_all', new Map()]]);
+      const ctx = createCtx(
+        { bq: ['category:food', '', '   ', 'type:book'], defType: 'edismax' },
+        existingQuery,
+      );
+
+      request.apply(ctx);
+
+      const result = mapToObj(ctx.body.get('query'));
+      expect(result.bool.should).toHaveLength(2);
+    });
+
+    it('returns early when all bq values are empty', () => {
+      const existingQuery = new Map([['match_all', new Map()]]);
+      const ctx = createCtx({ bq: ['', '   '], defType: 'edismax' }, existingQuery);
+
+      request.apply(ctx);
+
+      expect(ctx.body.get('query')).toBe(existingQuery);
+      expect(ctx.body.size).toBe(1);
+      expect(existingQuery.size).toBe(1);
+    });
+  });
+
+  // --- bool query flattening ---
+
+  describe('bool query flattening', () => {
+    it('flattens into existing bool query', () => {
+      const existingBool = new Map<string, any>([
+        ['must', [new Map([['match', new Map([['title', new Map([['query', 'java']])]])]])]],
+      ]);
+      const existingQuery = new Map([['bool', existingBool]]);
+      const ctx = createCtx({ bq: 'category:tech^5', defType: 'edismax' }, existingQuery);
+
+      request.apply(ctx);
+
+      const result = mapToObj(ctx.body.get('query'));
+      expect(result.bool.must).toHaveLength(1);
+      expect(result.bool.must[0].match.title.query).toBe('java');
+      expect(result.bool.should).toHaveLength(1);
+      expect(result.bool.should[0].match.category.query).toBe('tech');
+      expect(result.bool.should[0].match.category.boost).toBe(5);
+    });
+
+    it('merges with existing should clauses', () => {
+      const existingBool = new Map<string, any>([
+        ['must', [new Map([['match_all', new Map()]])]],
+        ['should', [new Map([['match', new Map([['status', new Map([['query', 'featured']])]])]])]],
+      ]);
+      const existingQuery = new Map([['bool', existingBool]]);
+      const ctx = createCtx({ bq: 'category:food^10', defType: 'edismax' }, existingQuery);
+
+      request.apply(ctx);
+
+      const result = mapToObj(ctx.body.get('query'));
+      expect(result.bool.should).toHaveLength(2);
+      expect(result.bool.should[0].match.status.query).toBe('featured');
+      expect(result.bool.should[1].match.category.query).toBe('food');
+      expect(result.bool.should[1].match.category.boost).toBe(10);
+    });
+
+    it('works alongside fq (must + filter + should all present)', () => {
+      const existingBool = new Map<string, any>([
+        ['must', [new Map([['match', new Map([['title', new Map([['query', 'cheese']])]])]])]],
+        ['filter', [new Map([['match', new Map([['inStock', new Map([['query', 'true']])]])]])]],
+      ]);
+      const existingQuery = new Map([['bool', existingBool]]);
+      const ctx = createCtx({ bq: 'category:food^10', defType: 'edismax' }, existingQuery);
+
+      request.apply(ctx);
+
+      const result = mapToObj(ctx.body.get('query'));
+      expect(result.bool.must).toHaveLength(1);
+      expect(result.bool.filter).toHaveLength(1);
+      expect(result.bool.should).toHaveLength(1);
+    });
+  });
+
+  // --- no existing query ---
+
+  describe('no existing query', () => {
+    it('creates bool with match_all must and should when no existing query', () => {
+      const ctx = createCtx({ bq: 'category:food', defType: 'edismax' });
+
+      request.apply(ctx);
+
+      const result = mapToObj(ctx.body.get('query'));
+      expect(result.bool.must).toHaveLength(1);
+      expect(result.bool.must[0].match_all).toBeDefined();
+      expect(result.bool.should).toHaveLength(1);
+      expect(result.bool.minimum_should_match).toBeUndefined();
+    });
+  });
+
+  // --- complex bq expressions ---
+
+  describe('complex bq expressions', () => {
+    it('handles boolean expression in bq', () => {
+      const existingQuery = new Map([['match_all', new Map()]]);
+      const ctx = createCtx(
+        { bq: 'category:food AND inStock:true', defType: 'edismax' },
+        existingQuery,
+      );
+
+      request.apply(ctx);
+
+      const result = mapToObj(ctx.body.get('query'));
+      expect(result.bool.should).toHaveLength(1);
+      expect(result.bool.should[0].bool.must).toHaveLength(2);
+    });
+
+    it('handles match_all bq (*:*)', () => {
+      const existingQuery = new Map([['match', new Map([['title', new Map([['query', 'java']])]])]]);
+      const ctx = createCtx({ bq: '*:*', defType: 'edismax' }, existingQuery);
+
+      request.apply(ctx);
+
+      const result = mapToObj(ctx.body.get('query'));
+      expect(result.bool.should[0].match_all).toBeDefined();
+    });
+
+    it('handles grouped bq expression', () => {
+      const existingQuery = new Map([['match_all', new Map()]]);
+      const ctx = createCtx(
+        { bq: '(category:food OR category:drink)^5', defType: 'edismax' },
+        existingQuery,
+      );
+
+      request.apply(ctx);
+
+      const result = mapToObj(ctx.body.get('query'));
+      expect(result.bool.should).toHaveLength(1);
+    });
+
+    it('handles bare term bq', () => {
+      const existingQuery = new Map([['match_all', new Map()]]);
+      const ctx = createCtx({ bq: 'wireless^5', defType: 'edismax' }, existingQuery);
+
+      request.apply(ctx);
+
+      const result = mapToObj(ctx.body.get('query'));
+      expect(result.bool.should).toHaveLength(1);
+    });
+
+    it('handles negation bq', () => {
+      const existingQuery = new Map([['match_all', new Map()]]);
+      const ctx = createCtx({ bq: '-category:Books', defType: 'edismax' }, existingQuery);
+
+      request.apply(ctx);
+
+      const result = mapToObj(ctx.body.get('query'));
+      expect(result.bool.should).toHaveLength(1);
+    });
+
+    it('handles wildcard bq', () => {
+      const existingQuery = new Map([['match_all', new Map()]]);
+      const ctx = createCtx({ bq: 'title:wire*^5', defType: 'edismax' }, existingQuery);
+
+      request.apply(ctx);
+
+      const result = mapToObj(ctx.body.get('query'));
+      expect(result.bool.should).toHaveLength(1);
+      expect(result.bool.should[0].wildcard).toBeDefined();
+      expect(result.bool.should[0].wildcard.title).toBeDefined();
+    });
+  });
+
+  // --- negative boost fail-fast ---
+
+  describe('negative boost', () => {
+    it('throws on negative boost in bq', () => {
+      const ctx = createCtx({ bq: 'category:spam^-10', defType: 'edismax' }, new Map([['match_all', new Map()]]));
+      expect(() => request.apply(ctx)).toThrow('[boost-query-bq] Negative boost in bq');
+    });
+
+    it('throws when any bq in a list has negative boost', () => {
+      const ctx = createCtx(
+        { bq: ['category:food^10', 'category:spam^-5'], defType: 'edismax' },
+        new Map([['match_all', new Map()]]),
+      );
+      expect(() => request.apply(ctx)).toThrow('Negative boost in bq');
+    });
+
+    it('allows positive boost values', () => {
+      const ctx = createCtx({ bq: 'category:food^10', defType: 'edismax' }, new Map([['match_all', new Map()]]));
+      expect(() => request.apply(ctx)).not.toThrow();
+    });
+
+    it('does not false-positive on quoted values containing ^-', () => {
+      const existingQuery = new Map([['match_all', new Map()]]);
+      const ctx = createCtx({ bq: 'title:"some^-thing"', defType: 'edismax' }, existingQuery);
+      expect(() => request.apply(ctx)).not.toThrow();
+    });
+  });
+
+  // --- boost preservation ---
+
+  describe('boost preservation', () => {
+    it('preserves integer boost on field query', () => {
+      const existingQuery = new Map([['match_all', new Map()]]);
+      const ctx = createCtx({ bq: 'category:food^10', defType: 'edismax' }, existingQuery);
+
+      request.apply(ctx);
+
+      const result = mapToObj(ctx.body.get('query'));
+      expect(result.bool.should[0].match.category.boost).toBe(10);
+    });
+
+    it('preserves decimal boost on field query', () => {
+      const existingQuery = new Map([['match_all', new Map()]]);
+      const ctx = createCtx({ bq: 'category:food^2.5', defType: 'edismax' }, existingQuery);
+
+      request.apply(ctx);
+
+      const result = mapToObj(ctx.body.get('query'));
+      expect(result.bool.should[0].match.category.boost).toBe(2.5);
+    });
+
+    it('preserves boost on phrase query', () => {
+      const existingQuery = new Map([['match_all', new Map()]]);
+      const ctx = createCtx({ bq: 'title:"aged cheese"^3', defType: 'edismax' }, existingQuery);
+
+      request.apply(ctx);
+
+      const result = mapToObj(ctx.body.get('query'));
+      expect(result.bool.should[0].match_phrase.title.boost).toBe(3);
+    });
+
+    it('preserves boost on grouped expression', () => {
+      const existingQuery = new Map([['match_all', new Map()]]);
+      const ctx = createCtx({ bq: '(category:food OR category:drink)^5', defType: 'edismax' }, existingQuery);
+
+      request.apply(ctx);
+
+      const result = mapToObj(ctx.body.get('query'));
+      expect(result.bool.should[0].bool.boost).toBe(5);
+    });
+
+    it('preserves different boosts across multiple bq params', () => {
+      const existingQuery = new Map([['match_all', new Map()]]);
+      const ctx = createCtx(
+        { bq: ['category:food^10', 'category:deli^0.5'], defType: 'edismax' },
+        existingQuery,
+      );
+
+      request.apply(ctx);
+
+      const result = mapToObj(ctx.body.get('query'));
+      expect(result.bool.should[0].match.category.boost).toBe(10);
+      expect(result.bool.should[1].match.category.boost).toBe(0.5);
+    });
+
+    it('preserves zero boost', () => {
+      const existingQuery = new Map([['match_all', new Map()]]);
+      const ctx = createCtx({ bq: 'category:food^0', defType: 'edismax' }, existingQuery);
+
+      request.apply(ctx);
+
+      const result = mapToObj(ctx.body.get('query'));
+      expect(result.bool.should[0].match.category.boost).toBe(0);
+    });
+
+    it('preserves large boost', () => {
+      const existingQuery = new Map([['match_all', new Map()]]);
+      const ctx = createCtx({ bq: 'category:food^99999', defType: 'edismax' }, existingQuery);
+
+      request.apply(ctx);
+
+      const result = mapToObj(ctx.body.get('query'));
+      expect(result.bool.should[0].match.category.boost).toBe(99999);
+    });
+  });
+
+  // --- non-bool existing query (else branch) ---
+
+  describe('non-bool existing query', () => {
+    it('wraps range query in must without nesting', () => {
+      const existingQuery = new Map([['range', new Map([['price', new Map([['gte', '10'], ['lte', '100']])]])]]);
+      const ctx = createCtx({ bq: 'category:food^5', defType: 'edismax' }, existingQuery);
+
+      request.apply(ctx);
+
+      const result = mapToObj(ctx.body.get('query'));
+      expect(result.bool.must).toHaveLength(1);
+      expect(result.bool.must[0].range.price.gte).toBe('10');
+      expect(result.bool.should).toHaveLength(1);
+      expect(result.bool.minimum_should_match).toBeUndefined();
+    });
+  });
+});

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/boost-query-bq.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/boost-query-bq.ts
@@ -1,0 +1,94 @@
+/**
+ * Boost query bq parameter — convert Solr bq params to OpenSearch bool.should.
+ *
+ * Solr's bq (boost query) parameter adds optional query clauses that
+ * additively influence scoring without affecting which documents match.
+ * Available in the eDisMax query parser only (defType=dismax is not supported).
+ *
+ * Multiple bq params are each added as separate optional (should) clauses.
+ *
+ * Mapping:
+ *   Solr: q=cheese&defType=edismax&bq=category:food^10&bq=category:deli^5
+ *   OpenSearch: {
+ *     "query": {
+ *       "bool": {
+ *         "must": [<translated q>],
+ *         "should": [<translated bq1>, <translated bq2>]
+ *       }
+ *     }
+ *   }
+ *
+ * This transform runs AFTER filter-query-fq. If the existing query is already
+ * a bool query (from query-q or fq), we add should clauses directly to avoid
+ * unnecessary nesting.
+ *
+ * bq values are parsed through translateQ() — the same query engine used for
+ * q and fq. Local params syntax ({!...}) in bq values is rejected at
+ * validation time to prevent silent lossy translation.
+ *
+ * Request-only. All output is Maps for zero-serialization GraalVM interop.
+ */
+import type { MicroTransform } from '../pipeline';
+import type { RequestContext } from '../context';
+import type { ParamRule } from './validation';
+import { translateQ } from '../query-engine/orchestrator/translateQ';
+
+/** Solr query params this feature handles. */
+export const params = ['bq'];
+export const paramRules: ParamRule[] = [
+  { name: 'bq', type: 'rejectPattern', pattern: String.raw`^\{!`, reason: 'Local params ({!...}) syntax in bq is not supported' },
+];
+
+const DISMAX_TYPES = new Set(['edismax']);
+
+/**
+ * Parse a single bq value using the same query engine as q and fq.
+ */
+function parseBq(bq: string): Map<string, any> {
+  return translateQ(new Map([['q', bq]])).dsl;
+}
+
+/**
+ * Check if a query is a bool query (has 'bool' as its only key).
+ */
+function isBoolQuery(query: Map<string, any>): boolean {
+  return query.size === 1 && query.has('bool');
+}
+
+export const request: MicroTransform<RequestContext> = {
+  name: 'boost-query-bq',
+  match: (ctx) => ctx.params.has('bq'),
+  apply: (ctx) => {
+    const defType = ctx.params.get('defType') ?? '';
+    if (!DISMAX_TYPES.has(defType)) {
+      throw new Error(
+        `[boost-query-bq] bq parameter requires defType=edismax, got '${defType || '(none)'}'`,
+      );
+    }
+
+    const bqValues = ctx.params.getAll('bq').filter((v) => v.trim() !== '');
+    if (bqValues.length === 0) return;
+
+    if (bqValues.some((v) => /\^-\d/.test(v))) {
+      throw new Error(
+        '[boost-query-bq] Negative boost in bq (e.g., field:value^-N) is not supported — ' +
+        'Solr uses it for score reduction, but OpenSearch has no equivalent additive negative boost',
+      );
+    }
+
+    const shouldClauses = bqValues.map(parseBq);
+
+    const existingQuery = ctx.body.get('query');
+
+    if (existingQuery && isBoolQuery(existingQuery)) {
+      const existingBool = existingQuery.get('bool') as Map<string, any>;
+      const existingShould = existingBool.get('should') || [];
+      existingBool.set('should', [...existingShould, ...shouldClauses]);
+    } else {
+      const boolQuery = new Map<string, any>();
+      boolQuery.set('must', [existingQuery ?? new Map([['match_all', new Map()]])]);
+      boolQuery.set('should', shouldClauses);
+      ctx.body.set('query', new Map([['bool', boolQuery]]));
+    }
+  },
+};

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/validation.test.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/validation.test.ts
@@ -4,7 +4,7 @@ import type { RequestContext, JavaMap } from '../context';
 
 beforeAll(() => {
   initValidation(
-    new Set(['q', 'rows', 'start', 'sort', 'fl', 'cursorMark', 'hl', 'json.facet', 'wt', 'indent', 'echoParams', 'df']),
+    new Set(['q', 'rows', 'start', 'sort', 'fl', 'cursorMark', 'hl', 'json.facet', 'wt', 'indent', 'echoParams', 'df', 'bq', 'defType', 'qf']),
     ['hl.', 'json.facet.'],
     [
       { name: 'rows', type: 'integer' },
@@ -18,6 +18,7 @@ beforeAll(() => {
       { name: 'q', type: 'rejectPattern', pattern: String.raw`^\{!`, reason: 'Local params ({!...}) syntax in q is not supported' },
       { name: 'sort', type: 'rejectPattern', pattern: String.raw`\{!`, reason: 'Local params ({!...}) syntax in sort is not supported' },
       { name: 'fl', type: 'rejectPattern', pattern: String.raw`\{!`, reason: 'Local params ({!...}) syntax in fl is not supported' },
+      { name: 'bq', type: 'rejectPattern', pattern: String.raw`^\{!`, reason: 'Local params ({!...}) syntax in bq is not supported' },
     ],
   );
 });
@@ -146,6 +147,18 @@ describe('validation MicroTransform', () => {
 
     it('passes when fl is normal', () => {
       expect(() => request.apply(buildCtx('q=*:*&fl=id,title,price'))).not.toThrow();
+    });
+
+    it('throws when bq uses local params', () => {
+      expect(() => request.apply(buildCtx('q=*:*&defType=edismax&qf=title&bq={!boost b=2}category:food'))).toThrow('Local params ({!...}) syntax in bq is not supported');
+    });
+
+    it('throws when bq uses func local params', () => {
+      expect(() => request.apply(buildCtx('q=*:*&defType=edismax&qf=title&bq={!func}sum(1,price)'))).toThrow('Local params ({!...}) syntax in bq is not supported');
+    });
+
+    it('passes when bq is a normal boost query', () => {
+      expect(() => request.apply(buildCtx('q=*:*&defType=edismax&qf=title&bq=category:food^10'))).not.toThrow();
     });
   });
 

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/integration-tests/boost-query-bq.testcase.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/integration-tests/boost-query-bq.testcase.ts
@@ -1,0 +1,148 @@
+/**
+ * Integration test cases for bq (boost query) parameter — eDisMax only.
+ *
+ * bq adds optional query clauses that additively influence scoring.
+ * defType=dismax is not supported by the shim — use edismax instead.
+ *
+ * Adding a new test: just add a solrTest() entry below.
+ * It automatically runs against every Solr version in matrix.config.ts.
+ */
+import { solrTest, SOLR_INTERNAL_RULES } from '../../test-types';
+import type { TestCase } from '../../test-types';
+
+const schema = {
+  fields: {
+    title: { type: 'text_general' as const },
+    category: { type: 'text_general' as const },
+    price: { type: 'pint' as const },
+  },
+};
+
+const mapping = {
+  properties: {
+    title: { type: 'text' as const },
+    category: { type: 'text' as const },
+    price: { type: 'integer' as const },
+  },
+};
+
+const docs = [
+  { id: '1', title: 'aged cheese wheel', category: 'food', price: 25 },
+  { id: '2', title: 'cheese slicer tool', category: 'kitchen', price: 15 },
+  { id: '3', title: 'cheese platter deluxe', category: 'food', price: 40 },
+];
+
+const scoreRule = { path: '$.response.docs[*].score', rule: 'loose-type' as const, reason: 'Score precision may differ' };
+
+function bqPath(q: string, bq: string | string[], extra = ''): string {
+  const bqArr = Array.isArray(bq) ? bq : [bq];
+  const bqParams = bqArr.map((v) => '&bq=' + encodeURIComponent(v)).join('');
+  return '/solr/testcollection/select?q=' + encodeURIComponent(q)
+    + '&defType=edismax'
+    + '&qf=' + encodeURIComponent('title')
+    + bqParams
+    + extra
+    + '&wt=json';
+}
+
+export const testCases: TestCase[] = [
+  solrTest('edismax-bq-single', {
+    description: 'Single bq boosts documents matching the boost clause',
+    documents: docs,
+    requestPath: bqPath('cheese', 'category:food^10'),
+    solrSchema: schema,
+    opensearchMapping: mapping,
+    assertionRules: [...SOLR_INTERNAL_RULES, scoreRule],
+  }),
+
+  solrTest('edismax-bq-multiple', {
+    description: 'Multiple bq params each add separate boost clauses',
+    documents: docs,
+    requestPath: bqPath('cheese', ['category:food^10', 'category:kitchen^5']),
+    solrSchema: schema,
+    opensearchMapping: mapping,
+    assertionRules: [...SOLR_INTERNAL_RULES, scoreRule],
+  }),
+
+  solrTest('edismax-bq-phrase', {
+    description: 'bq with phrase boost query',
+    documents: docs,
+    requestPath: bqPath('cheese', 'title:"aged cheese"^5'),
+    solrSchema: schema,
+    opensearchMapping: mapping,
+    assertionRules: [...SOLR_INTERNAL_RULES, scoreRule],
+  }),
+
+  solrTest('edismax-bq-range', {
+    description: 'bq with range boost query',
+    documents: docs,
+    requestPath: bqPath('cheese', 'price:[0 TO 20]^10'),
+    solrSchema: schema,
+    opensearchMapping: mapping,
+    assertionRules: [...SOLR_INTERNAL_RULES, scoreRule],
+  }),
+
+  solrTest('edismax-bq-with-fq', {
+    description: 'bq and fq together — fq filters, bq boosts',
+    documents: docs,
+    requestPath: bqPath('cheese', 'category:food^10', '&fq=' + encodeURIComponent('price:[10 TO 30]')),
+    solrSchema: schema,
+    opensearchMapping: mapping,
+    assertionRules: [...SOLR_INTERNAL_RULES, scoreRule],
+  }),
+
+  solrTest('edismax-bq-grouped', {
+    description: 'bq with grouped OR expression and boost',
+    documents: docs,
+    requestPath: bqPath('cheese', '(category:food OR category:kitchen)^5'),
+    solrSchema: schema,
+    opensearchMapping: mapping,
+    assertionRules: [...SOLR_INTERNAL_RULES, scoreRule],
+  }),
+
+  solrTest('edismax-bq-bare-term', {
+    description: 'bq with bare term (no field prefix)',
+    documents: docs,
+    requestPath: bqPath('cheese', 'aged^5'),
+    solrSchema: schema,
+    opensearchMapping: mapping,
+    assertionRules: [...SOLR_INTERNAL_RULES, scoreRule],
+  }),
+
+  solrTest('edismax-bq-boolean', {
+    description: 'bq with boolean expression (AND)',
+    documents: docs,
+    requestPath: bqPath('cheese', 'category:food AND price:[0 TO 30]'),
+    solrSchema: schema,
+    opensearchMapping: mapping,
+    assertionRules: [...SOLR_INTERNAL_RULES, scoreRule],
+  }),
+
+  solrTest('edismax-bq-negation', {
+    description: 'bq with negation — demote matching docs',
+    documents: docs,
+    requestPath: bqPath('cheese', '-category:food^5'),
+    solrSchema: schema,
+    opensearchMapping: mapping,
+    assertionRules: [...SOLR_INTERNAL_RULES, scoreRule],
+  }),
+
+  solrTest('edismax-bq-duplicate', {
+    description: 'Duplicate bq params each contribute separate scoring — not deduplicated',
+    documents: docs,
+    requestPath: bqPath('cheese', ['category:food^10', 'category:food^10']),
+    solrSchema: schema,
+    opensearchMapping: mapping,
+    assertionRules: [...SOLR_INTERNAL_RULES, scoreRule],
+  }),
+
+  // --- Error paths ---
+
+  solrTest('dismax-bq-rejected', {
+    description: 'bq with defType=dismax is rejected — use edismax instead',
+    documents: [{ id: '1', title: 'cheese', category: 'food', price: 10 }],
+    requestPath: '/solr/testcollection/select?q=cheese&defType=dismax&qf=title&bq=' + encodeURIComponent('category:food^10') + '&wt=json',
+    expectedStatusCode: 500,
+    expectedErrorContains: 'Request transform failed',
+  }),
+];

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/registry.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/registry.ts
@@ -15,6 +15,7 @@ import * as jsonRequest from './features/json-request';
 import * as selectUri from './features/select-uri';
 import * as queryQ from './features/query-q';
 import * as filterQueryFq from './features/filter-query-fq';
+import * as boostQueryBq from './features/boost-query-bq';
 import * as cursorPagination from './features/cursor-pagination';
 import * as fieldList from './features/field-list';
 import * as sort from './features/sort';
@@ -42,7 +43,7 @@ export interface FeatureModule {
  * params, so they don't need to be listed here for validation discovery.
  */
 const FEATURE_MODULES: FeatureModule[] = [
-  selectUri, queryQ, filterQueryFq, cursorPagination, fieldList,
+  selectUri, queryQ, filterQueryFq, boostQueryBq, cursorPagination, fieldList,
   sort, jsonFacets, highlighting, minimumMatch,
 ];
 
@@ -80,6 +81,7 @@ export const requestRegistry: TransformRegistry<RequestContext> = {
       queryQ.request, // q=... → query DSL
       minimumMatch.request, // mm → minimum_should_match (after query-q builds bool)
       filterQueryFq.request, // fq=... → bool.filter (after query-q)
+      boostQueryBq.request, // bq=... → bool.should (after fq, dismax/edismax only)
       cursorPagination.request, // cursorMark → search_after (after query-q sets from)
       jsonFacets.request, // json.facet → aggs
       fieldList.request, // fl=... → _source


### PR DESCRIPTION
## Description

   Add support for the Solr eDisMax `bq` (boost query) parameter. The `bq` parameter adds optional query clauses that additively influence scoring without affecting which documents match.

   ### Mapping

   Solr:  q=cheese&defType=edismax&bq=category:food^10&bq=category:deli^5

```
   OpenSearch:
   {
     "query": {
       "bool": {
         "must": [<translated q>],
         "should": [<translated bq1>, <translated bq2>]
       }
     }
   }
```

   Each `bq` value is parsed through `translateQ()` — the same query engine used for `q` and `fq`. Local params syntax (`{!...}`) in bq values is rejected at validation time to prevent silent lossy translation.

   ### Behavior

   - Multiple `bq` params are each added as separate `bool.should` clauses
   - Duplicate `bq` params are preserved (not deduplicated) — matches Solr's additive scoring behavior
   - Flattens into existing bool query when present (works alongside `fq` filters)
   - Always ensures a `must` clause exists (`match_all` when no base query) so `should` is purely scoring-only
   - Fails fast when `bq` is used without `defType=edismax`
   - Fails fast on negative boosts (`^-N`) and local params (`{!...}`)
   - `defType=dismax` is not supported for `bq` — use `defType=edismax` instead

   ### Files Changed

   | File | Description |
   |---|---|
   | `features/boost-query-bq.ts` | New transform — parse bq via translateQ, add to bool.should (edismax only) |
   | `features/boost-query-bq.test.ts` | 32 unit tests (including boost preservation, negative boost rejection, defType validation) |
   | `features/validation.test.ts` | 3 new tests for bq local params rejection |
   | `integration-tests/boost-query-bq.testcase.ts` | 11 e2e test cases (10 edismax success + 1 dismax rejection, Solr 8 + 9) |
   | `registry.ts` | Register in FEATURE_MODULES and select pipeline after fq |
   | `docs/LIMITATIONS.md` | 4 new entries (DISMAX, BQ-NEG-BOOST, BF, BOOST-MULTIPLICATIVE) |

   ### Testing

   - **Unit tests**: 855/855 passed (32 new bq tests + 3 validation tests)
   - **E2E integration**: 11 bq tests passed on both Solr 8 and Solr 9 (including dismax rejection)

   ### Known Limitations

   | Shortcode | Summary |
   |---|---|
   | DISMAX | `defType=dismax` not supported — use `defType=edismax` instead |
   | BQ-NEG-BOOST | Negative boost in `bq` (e.g., `^-10`) not supported |
   | BF | `bf` (boost functions) parameter — not supported, requires function query support |
   | BOOST-MULTIPLICATIVE | eDisMax multiplicative `boost` parameter — not supported, requires function_score |

   ### References

   - [Solr DisMax bq parameter](https://solr.apache.org/guide/solr/latest/query-guide/dismax-query-parser.html#bq-boost-query-parameter)
   - [Solr eDisMax query parser](https://solr.apache.org/guide/solr/latest/query-guide/edismax-query-parser.html)

   