### PR TITLE
Setting docker version to 1.25 to build

### DIFF
--- a/AIAdvisor/opensearch-pricing-calculator/Dockerfile
+++ b/AIAdvisor/opensearch-pricing-calculator/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24-alpine AS builder
+FROM golang:1.25-alpine AS builder
 
 WORKDIR /build
 


### PR DESCRIPTION
### Description
The current go version in the `Dockerfile` is too old to build the OpenSearch pricing calculator. The error given is:

```
0.125 go: go.mod requires go >= 1.25.0 (running go 1.24.13; GOTOOLCHAIN=local)
------
Dockerfile:10
--------------------
   8 |     # Cache dependencies
   9 |     COPY go.mod go.sum ./
  10 | >>> RUN go mod download
  11 |     
  12 |     # Copy source code
--------------------
ERROR: failed to build: failed to solve: process "/bin/sh -c go mod download" did not complete successfully: exit code: 1
```

This change sets the go version to 1.25.0 which allows for building the Docker image.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
