### PR TITLE
Added Facet Translations for Common Stat Functions

### DIFF
--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/json-facets.test.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/json-facets.test.ts
@@ -838,6 +838,99 @@ describe('query facet conversion (filter)', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Stat (metric) facets — string shorthand like "avg(price)"
+// ---------------------------------------------------------------------------
+
+/** Helper: build a context with a string stat facet and return the agg result. */
+function applyStatFacet(expr: string): JavaMap {
+  const jsonFacet = new Map([[FACET_NAME, expr]]) as unknown as JavaMap;
+  const body = new Map([['json.facet', jsonFacet]]) as unknown as JavaMap;
+  const ctx: RequestContext = {
+    msg: new Map() as unknown as JavaMap,
+    endpoint: 'select',
+    collection: 'testcollection',
+    params: new URLSearchParams(),
+    body,
+    emitMetric: () => {},
+    _metrics: new Map(),
+  };
+  request.apply(ctx);
+  return ctx.body.get('aggs').get(FACET_NAME);
+}
+
+describe('stat facet conversion', () => {
+  it('should convert avg(price) to avg aggregation', () => {
+    const agg = applyStatFacet('avg(price)');
+    expect(agg.get('avg')).toEqual(new Map([['field', 'price']]));
+  });
+
+  it('should convert sum(revenue) to sum aggregation', () => {
+    const agg = applyStatFacet('sum(revenue)');
+    expect(agg.get('sum')).toEqual(new Map([['field', 'revenue']]));
+  });
+
+  it('should convert min(price) to min aggregation', () => {
+    const agg = applyStatFacet('min(price)');
+    expect(agg.get('min')).toEqual(new Map([['field', 'price']]));
+  });
+
+  it('should convert max(price) to max aggregation', () => {
+    const agg = applyStatFacet('max(price)');
+    expect(agg.get('max')).toEqual(new Map([['field', 'price']]));
+  });
+
+  it('should convert unique(author) to cardinality aggregation', () => {
+    const agg = applyStatFacet('unique(author)');
+    expect(agg.get('cardinality')).toEqual(new Map([['field', 'author']]));
+  });
+
+  it('should convert hll(author) to cardinality aggregation', () => {
+    const agg = applyStatFacet('hll(author)');
+    expect(agg.get('cardinality')).toEqual(new Map([['field', 'author']]));
+  });
+
+  it('should convert countvals(status) to value_count aggregation', () => {
+    const agg = applyStatFacet('countvals(status)');
+    expect(agg.get('value_count')).toEqual(new Map([['field', 'status']]));
+  });
+
+  it('should throw for unsupported stat function', () => {
+    expect(() => applyStatFacet('sumsq(price)')).toThrow("Unsupported stat function 'sumsq'");
+  });
+
+  it('should throw for stat function with wrong number of args', () => {
+    expect(() => applyStatFacet('avg(price, weight)')).toThrow('expects exactly 1 argument, got 2');
+  });
+
+  it('should throw for invalid stat expression', () => {
+    expect(() => applyStatFacet('not-a-function')).toThrow();
+  });
+
+  it('should work as nested sub-facet inside terms facet', () => {
+    const def = new Map([
+      ['type', 'terms'],
+      ['field', 'category'],
+      ['facet', new Map([['avg_price', 'avg(price)']])],
+    ]) as unknown as JavaMap;
+    const jsonFacet = new Map([[FACET_NAME, def]]) as unknown as JavaMap;
+    const body = new Map([['json.facet', jsonFacet]]) as unknown as JavaMap;
+    const ctx: RequestContext = {
+      msg: new Map() as unknown as JavaMap,
+      endpoint: 'select',
+      collection: 'testcollection',
+      params: new URLSearchParams(),
+      body,
+      emitMetric: () => {},
+      _metrics: new Map(),
+    };
+    request.apply(ctx);
+    const facetAgg = ctx.body.get('aggs').get(FACET_NAME);
+    const nestedAggs = facetAgg.get('aggs');
+    expect(nestedAggs.get('avg_price').get('avg')).toEqual(new Map([['field', 'price']]));
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Edge cases and warning paths (json-facets.ts coverage gaps)
 // ---------------------------------------------------------------------------
 
@@ -922,8 +1015,8 @@ describe('edge cases and warning paths', () => {
   });
 
   it('should return empty map for non-map facet definition', () => {
-    // Build a context where the facet value is a string instead of a Map
-    const jsonFacet = new Map([[FACET_NAME, 'not-a-map']]) as unknown as JavaMap;
+    // Build a context where the facet value is neither a Map nor a string
+    const jsonFacet = new Map([[FACET_NAME, 42]]) as unknown as JavaMap;
     const body = new Map([['json.facet', jsonFacet]]) as unknown as JavaMap;
     const ctx: RequestContext = {
       msg: new Map() as unknown as JavaMap,

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/json-facets.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/json-facets.ts
@@ -11,6 +11,8 @@ import type { MicroTransform } from '../pipeline';
 import type { RequestContext, JavaMap } from '../context';
 import type { ParamRule } from './validation';
 import { convertSort, isMapLike, isSolrDateMathGap, convertSolrDateGap } from './utils';
+import { parseFuncQuery } from '../query-engine/parser/parser';
+import type { FuncNode } from '../query-engine/ast/nodes';
 
 /** Solr query params this feature handles. */
 export const params = ['json.facet'];
@@ -435,6 +437,56 @@ function convertQueryFacet(def: JavaMap): JavaMap {
 
 // endregion
 
+// region Stat (metric) facets
+
+/**
+ * Solr stat function → OpenSearch metric aggregation mapping.
+ *
+ * Solr's json.facet allows shorthand stat facets as plain strings:
+ *   "avg_price": "avg(price)"
+ * These map to OpenSearch metric aggregations:
+ *   "avg_price": { "avg": { "field": "price" } }
+ */
+const STAT_FUNC_MAP: Record<string, string> = {
+  avg: 'avg',
+  sum: 'sum',
+  min: 'min',
+  max: 'max',
+  unique: 'cardinality',
+  hll: 'cardinality',
+  countvals: 'value_count',
+};
+
+/**
+ * Convert a Solr stat facet string (e.g., "avg(price)") to an OpenSearch metric agg.
+ */
+function convertStatFacet(expr: string): JavaMap {
+  const func = parseFuncQuery(expr);
+  return convertFuncToMetricAgg(func);
+}
+
+function convertFuncToMetricAgg(func: FuncNode): JavaMap {
+  const osAggType = STAT_FUNC_MAP[func.name];
+  if (!osAggType) {
+    throw new Error(`Unsupported stat function '${func.name}' in json.facet`);
+  }
+
+  if (func.args.length !== 1) {
+    throw new Error(`Stat function '${func.name}' expects exactly 1 argument, got ${func.args.length}`);
+  }
+
+  const arg = func.args[0];
+  if (!('kind' in arg) || arg.kind !== 'field') {
+    throw new Error(`Stat function '${func.name}' expects a field reference argument`);
+  }
+
+  const inner = new Map<string, any>();
+  inner.set('field', arg.name);
+  return new Map<string, any>([[osAggType, inner]]);
+}
+
+// endregion
+
 /** Log a warning for any keys in a facet definition that are not in the known set. */
 function warnUnknownKeys(def: JavaMap, knownKeys: Set<string>, facetType: string): void {
   const unknownKeys: string[] = [];
@@ -498,7 +550,11 @@ export function convertJsonFacets(solrJsonFacet: JavaMap, ctx: RequestContext): 
   const aggs = new Map<string, any>();
   for (const name of solrJsonFacet.keys()) {
     const facetDef = solrJsonFacet.get(name);
-    aggs.set(name, convertSingleFacet(facetDef, ctx));
+    if (typeof facetDef === 'string') {
+      aggs.set(name, convertStatFacet(facetDef));
+    } else {
+      aggs.set(name, convertSingleFacet(facetDef, ctx));
+    }
   }
   return aggs;
 }

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/parser/parser.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/parser/parser.ts
@@ -141,6 +141,15 @@ export function toParseError(err: unknown): ParseError {
 }
 
 /**
+ * Parse a Solr function query string (e.g., "avg(price)") into a FuncNode.
+ *
+ * Uses the `funcQuery` start rule. Throws on parse failure.
+ */
+export function parseFuncQuery(input: string): import('../ast/nodes').FuncNode {
+  return getParser().parse(input, { startRule: 'funcQuery' }) as import('../ast/nodes').FuncNode;
+}
+
+/**
  * Query parser types whose body uses Lucene/Solr query syntax.
  * For these types, the raw body is re-parsed using the Solr grammar.
  * Other types (e.g., func, terms) need their own parsers.


### PR DESCRIPTION
### Description

Adds support for Solr stat/metric facet shorthand in `json.facet` conversion. String facet definitions like `"avg(price)"` are now parsed using the function query grammar and mapped to OpenSearch metric aggregations.

Supported mappings:
- `avg`, `sum`, `min`, `max` → direct OpenSearch equivalents
- `unique`, `hll` → `cardinality`
- `countvals` → `value_count`

Unsupported stat functions throw a clear error.

### Testing
- Unit tests

### Check List
- [x] New functionality includes testing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
