### PR TITLE
Pin Grafana image tag to match privateEcrManifest.sh version

### DIFF
--- a/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/values.yaml
+++ b/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/values.yaml
@@ -604,6 +604,8 @@ charts:
           requests: { cpu: 25m, memory: 16Mi }
           limits:   { cpu: 100m, memory: 32Mi }
       grafana:
+        image:
+          tag: "11.6.13"
         resources:
           requests: { cpu: 100m, memory: 128Mi }
           limits:   { cpu: 500m, memory: 256Mi }


### PR DESCRIPTION
### Description
Pin the Grafana image tag in kube-prometheus-stack values to `11.6.13`, matching the version
mirrored in `privateEcrManifest.sh`. Without this pin, the chart defaults to `11.6.1` which
does not exist in the private ECR, causing `ImagePullBackOff` in air-gapped deployments.

### Issues Resolved
N/A (discovered during air-gapped deployment testing)

### Testing
Verified the version mismatch during manual air-gapped integration test — the Grafana pod
was stuck in `ImagePullBackOff` looking for `grafana:11.6.1` while ECR only had `11.6.13`.

### Check List
- [ ] New functionality includes testing
- [ ] Public documentation issue/PR created, if applicable.

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.