### PR TITLE
Add CDC capture proxy load testing with k6

### DIFF
--- a/migrationConsole/lib/integ_test/integ_test/k6/README.md
+++ b/migrationConsole/lib/integ_test/integ_test/k6/README.md
@@ -1,0 +1,170 @@
+# k6 Load Testing for CDC Pipeline
+
+Load testing scripts for the CDC capture proxy using [k6](https://k6.io/).
+
+## What This Tests
+
+k6 sends HTTP requests to the capture proxy at a controlled rate, simulating customer traffic during a CDC migration. It measures:
+
+- **TPS** — actual requests per second achieved
+- **TTFB** — time to first byte (`proxy_ttfb`, proxy processing time)
+- **Response time** — time to receive full response (`proxy_receiving`)
+- **End-to-end latency** — full round trip per request (`http_req_duration`, p50/p90/p95/p99)
+- **Error rate** — percentage of failed requests
+
+k6 does NOT measure Kafka throughput, replayer performance, or data accuracy — those are verified by the existing Python test framework.
+
+## Install k6
+
+**Mac:**
+
+```bash
+brew install k6
+```
+
+**Linux:**
+
+```bash
+wget -O /tmp/k6.tar.gz "https://github.com/grafana/k6/releases/download/v1.7.1/k6-v1.7.1-linux-$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz"
+tar xzf /tmp/k6.tar.gz -C /tmp/
+sudo mv /tmp/k6-*/k6 /usr/local/bin/
+```
+
+## Scripts
+
+### cdc-load-test.js — Basic Auth / No Auth
+
+For local Docker CDC, minikube, or any cluster with basic auth or no auth.
+
+```bash
+# No auth (security disabled)
+k6 run -e PROXY_ENDPOINT=http://localhost:9201 cdc-load-test.js
+
+# Basic auth
+k6 run \
+  -e PROXY_ENDPOINT=https://capture-proxy:9201 \
+  -e USERNAME=admin \
+  -e PASSWORD=admin \
+  cdc-load-test.js
+
+# Custom rate and duration
+k6 run \
+  -e PROXY_ENDPOINT=https://capture-proxy:9201 \
+  -e USERNAME=admin \
+  -e PASSWORD=admin \
+  -e WRITE_RATE=100 \
+  -e DURATION=5m \
+  cdc-load-test.js
+
+# Large documents (10KB)
+k6 run \
+  -e PROXY_ENDPOINT=https://capture-proxy:9201 \
+  -e USERNAME=admin \
+  -e PASSWORD=admin \
+  -e DOC_SIZE=large \
+  cdc-load-test.js
+```
+
+### cdc-load-test-sigv4.js — AWS SigV4 Auth
+
+For AWS-managed OpenSearch domains. Must run from inside the migration console pod (or anywhere with network access to the proxy).
+
+```bash
+# Step 1: Generate credentials file (from migration console pod)
+python3 -c "
+from botocore.session import Session
+import json
+creds = Session().get_credentials().get_frozen_credentials()
+json.dump({
+    'accessKeyId': creds.access_key,
+    'secretAccessKey': creds.secret_key,
+    'sessionToken': creds.token
+}, open('/tmp/aws-creds.json', 'w'))
+"
+
+# Step 2: Run k6
+k6 run \
+  -e PROXY_ENDPOINT=https://capture-proxy.ma.svc.cluster.local:9201 \
+  -e SOURCE_HOST=<source-cluster-hostname> \
+  -e WRITE_RATE=50 \
+  -e DURATION=2m \
+  cdc-load-test-sigv4.js
+```
+
+**Note:** SigV4 credentials expire after ~1 hour. Re-run Step 1 before each test session.
+
+**Key detail:** The script signs requests for the source cluster hostname but sends them to the proxy endpoint. This is required because the proxy forwards requests as-is and the source cluster validates the SigV4 signature against its own hostname.
+
+## Parameters
+
+| Parameter | Required | Default | Description |
+|-----------|----------|---------|-------------|
+| `PROXY_ENDPOINT` | Yes | — | Capture proxy URL (e.g. `https://capture-proxy:9201`) |
+| `WRITE_RATE` | No | 50 | Requests per second |
+| `DURATION` | No | 2m | How long to sustain traffic |
+| `INDEX_NAME` | No | cdc-load-test | Target index name |
+| `USERNAME` | No | — | Basic auth username (omit for no auth) |
+| `PASSWORD` | No | — | Basic auth password |
+| `DOC_SIZE` | No | small | Document size: `small` (~100B), `large` (~10KB), `xlarge` (~100KB) |
+| `SOURCE_HOST` | SigV4 only | — | Source cluster hostname for SigV4 signing |
+| `AWS_CREDS_FILE` | No | /tmp/aws-creds.json | Path to AWS credentials JSON file |
+| `AWS_REGION` | No | us-east-1 | AWS region for SigV4 signing |
+
+## Interpreting Output
+
+```
+  █ THRESHOLDS
+
+    http_req_duration
+    ✓ 'p(95)<2000' p(95)=45ms          ← p95 latency under 2s threshold
+
+    http_req_failed
+    ✓ 'rate==0' rate=0.00%             ← 0% error rate
+
+  █ TOTAL RESULTS
+
+    checks_succeeded...: 100.00%       ← all requests returned 200/201
+    http_req_duration..: p(50)=16ms p(95)=45ms  ← latency percentiles
+    http_reqs..........: 151  5.03/s   ← total requests and throughput
+    proxy_ttfb.........: p(50)=15ms    ← time to first byte
+    proxy_receiving....: p(50)=0.07ms  ← time to receive response body
+```
+
+- **✓** = threshold passed
+- **✗** = threshold breached (k6 exits non-zero — fails CI)
+- **dropped_iterations** = requests k6 wanted to send but couldn't (system too slow)
+
+## After the Run
+
+Verify the full CDC pipeline delivered all documents:
+
+```bash
+# Check source
+curl -k -u admin:admin "https://<proxy-or-source>:9200/<index>/_count"
+
+# Check target (after replayer catches up)
+curl "http://<target>:9200/<index>/_count"
+```
+
+Counts should match.
+
+## Validated Results
+
+| Environment | Auth | Rate | Result | Pipeline |
+|-------------|------|------|--------|----------|
+| EKS (AWS domains) | SigV4 | 5 req/s, 30s | 151/151, p95=45ms ✅ | Source 301 = Target 301 ✅ |
+| Minikube | Basic auth | 5 req/s, 30s | 151/151, p95=501ms ✅ | Source = Target ✅ |
+| Minikube | Basic auth | Multi-scenario PoC | 1210/1210, 0% errors ✅ | Source = Target ✅ |
+
+## Limitations
+
+k6 measures the capture proxy HTTP layer only. For full pipeline observability:
+
+| Dimension | k6? | Alternative |
+|-----------|-----|-------------|
+| Proxy latency, TPS, errors | ✅ | — |
+| Document size impact | ✅ | — |
+| Connection scaling | ✅ | — |
+| Kafka throughput / consumer lag | ❌ | Prometheus (Strimzi metrics) |
+| Replayer performance | ❌ | CloudWatch / Prometheus |
+| Source/target data accuracy | ❌ | Python test framework |

--- a/migrationConsole/lib/integ_test/integ_test/k6/cdc-load-test-sigv4.js
+++ b/migrationConsole/lib/integ_test/integ_test/k6/cdc-load-test-sigv4.js
@@ -1,0 +1,79 @@
+import http from 'k6/http';
+import { check } from 'k6';
+import { Trend } from 'k6/metrics';
+import { Endpoint, SignatureV4 } from 'https://jslib.k6.io/aws/0.13.0/aws.js';
+
+const creds = JSON.parse(open(__ENV.AWS_CREDS_FILE || '/tmp/aws-creds.json'));
+
+const proxyTTFB = new Trend('proxy_ttfb', true);
+const proxyReceiving = new Trend('proxy_receiving', true);
+
+export const options = {
+  scenarios: {
+    cdc_writes: {
+      executor: 'constant-arrival-rate',
+      rate: __ENV.WRITE_RATE ? parseInt(__ENV.WRITE_RATE) : 50,
+      timeUnit: '1s',
+      duration: __ENV.DURATION || '2m',
+      preAllocatedVUs: 20,
+      maxVUs: 50,
+    },
+  },
+  thresholds: {
+    http_req_failed: ['rate==0'],
+    http_req_duration: ['p(95)<2000'],
+  },
+  insecureSkipTLSVerify: true,
+};
+
+const PROXY = __ENV.PROXY_ENDPOINT;
+const SOURCE_HOST = __ENV.SOURCE_HOST;
+const INDEX = __ENV.INDEX_NAME || 'cdc-load-test';
+const REGION = __ENV.AWS_REGION || 'us-east-1';
+
+const signer = new SignatureV4({
+  service: 'es',
+  region: REGION,
+  credentials: {
+    accessKeyId: creds.accessKeyId,
+    secretAccessKey: creds.secretAccessKey,
+    sessionToken: creds.sessionToken,
+  },
+});
+
+export default function () {
+  const docId = `${__VU}-${__ITER}`;
+  const doc = JSON.stringify({
+    title: `doc-${docId}`,
+    content: 'Load test document for CDC pipeline validation',
+    timestamp: new Date().toISOString(),
+  });
+
+  const path = `/${INDEX}/_doc/${docId}`;
+
+  // Sign for the source cluster hostname, send to the proxy endpoint.
+  // The proxy forwards the request with the source-signed headers intact.
+  const signed = signer.sign({
+    method: 'PUT',
+    endpoint: new Endpoint(`https://${SOURCE_HOST}`),
+    path: path,
+    headers: {
+      'Content-Type': 'application/json',
+      'host': SOURCE_HOST,
+    },
+    body: doc,
+  });
+
+  const res = http.put(
+    `${PROXY}${path}`,
+    doc,
+    { headers: signed.headers }
+  );
+
+  proxyTTFB.add(res.timings.waiting);
+  proxyReceiving.add(res.timings.receiving);
+
+  check(res, {
+    'status is 200 or 201': (r) => r.status === 200 || r.status === 201,
+  });
+}

--- a/migrationConsole/lib/integ_test/integ_test/k6/cdc-load-test.js
+++ b/migrationConsole/lib/integ_test/integ_test/k6/cdc-load-test.js
@@ -1,0 +1,69 @@
+import http from 'k6/http';
+import { check } from 'k6';
+import { Trend } from 'k6/metrics';
+import encoding from 'k6/encoding';
+
+const proxyTTFB = new Trend('proxy_ttfb', true);
+const proxyReceiving = new Trend('proxy_receiving', true);
+
+export const options = {
+  scenarios: {
+    cdc_writes: {
+      executor: 'constant-arrival-rate',
+      rate: __ENV.WRITE_RATE ? parseInt(__ENV.WRITE_RATE) : 50,
+      timeUnit: '1s',
+      duration: __ENV.DURATION || '2m',
+      preAllocatedVUs: 20,
+      maxVUs: 50,
+    },
+  },
+  thresholds: {
+    http_req_failed: ['rate==0'],
+    http_req_duration: ['p(95)<2000'],
+  },
+  insecureSkipTLSVerify: true,
+};
+
+const PROXY = __ENV.PROXY_ENDPOINT;
+const INDEX = __ENV.INDEX_NAME || 'cdc-load-test';
+const USERNAME = __ENV.USERNAME || '';
+const PASSWORD = __ENV.PASSWORD || '';
+const DOC_SIZE = __ENV.DOC_SIZE || 'small';
+
+const headers = { 'Content-Type': 'application/json' };
+if (USERNAME) {
+  headers['Authorization'] = `Basic ${encoding.b64encode(`${USERNAME}:${PASSWORD}`)}`;
+}
+
+function makeDoc(id) {
+  const base = {
+    title: `doc-${id}`,
+    timestamp: new Date().toISOString(),
+  };
+  if (DOC_SIZE === 'large') {
+    base.content = 'x'.repeat(9000);
+  } else if (DOC_SIZE === 'xlarge') {
+    base.content = 'x'.repeat(95000);
+  } else {
+    base.content = 'Load test document for CDC pipeline validation';
+  }
+  return JSON.stringify(base);
+}
+
+export default function () {
+  const docId = `${__VU}-${__ITER}`;
+  const doc = makeDoc(docId);
+
+  const res = http.put(
+    `${PROXY}/${INDEX}/_doc/${docId}`,
+    doc,
+    { headers }
+  );
+
+  proxyTTFB.add(res.timings.waiting);
+  proxyReceiving.add(res.timings.receiving);
+
+  check(res, {
+    'status is 200 or 201': (r) => r.status === 200 || r.status === 201,
+  });
+}

--- a/migrationConsole/lib/integ_test/integ_test/k6/design.md
+++ b/migrationConsole/lib/integ_test/integ_test/k6/design.md
@@ -1,0 +1,291 @@
+# k6 Load Testing for CDC Pipeline — Design Doc
+
+**Author:** Siqi Ding  
+**Date:** 2026-04-24  
+**Status:** In Progress (Phase 1 complete, Phase 2 in design)
+
+---
+
+## Background
+
+The CDC (Change Data Capture) pipeline captures live traffic from a source cluster via a capture proxy, writes it to Kafka, and replays it to a target cluster via a traffic replayer. All operations (index, update, delete, search) are standard HTTP requests against the Elasticsearch/OpenSearch REST API.
+
+Current integration tests validate functional correctness — they send a handful of documents and verify they appear on the target. The existing `metric_operations.py` checks that CloudWatch metrics emit data points but does not assert on latency, throughput, or error rates. No test generates sustained traffic at a controlled rate, which means we cannot detect performance regressions in the capture proxy until customers run real workloads during migration.
+
+## What Is k6
+
+[k6](https://k6.io/) is an open-source load testing tool by Grafana Labs.
+
+- **Runtime:** Single Go binary (~30MB), no JVM or external dependencies
+- **Scripts:** Written in JavaScript, with SigV4 and basic auth support via built-in libraries
+- **License:** Open source (AGPL-3.0), free to use — no account or paid service required
+- **Install:** `brew install k6` (Mac) or download binary (Linux)
+- **K8s native:** [k6 Operator](https://grafana.com/docs/k6/latest/set-up/set-up-distributed-k6/) provides a Kubernetes CRD (`TestRun`) for running and managing tests as K8s resources
+- **Outputs:** Built-in support for Prometheus Remote Write, JSON, CSV, InfluxDB, Grafana Cloud
+
+k6 sends HTTP requests at a controlled rate and reports built-in metrics: request latency (p50, p90, p95, p99), error rate, throughput (requests/sec), and active virtual users. It exits non-zero if configurable thresholds are breached, making it CI-friendly.
+
+## Where k6 Fits in the CDC Pipeline
+
+During a CDC migration, client traffic is redirected to the capture proxy (via DNS/LB update). The proxy forwards requests to the source cluster and simultaneously captures them to Kafka. The replayer reads from Kafka and replays to the target.
+
+k6 simulates the customer's application — it sends HTTP requests to the capture proxy, the same way a real application would talk to the proxy during migration. In CI, the k6 Operator manages k6 as a Kubernetes-native `TestRun` resource within the Argo workflow.
+
+```
+                                              ┌─────────────────────┐
+                                              │  Prometheus + Grafana│
+                                              │  (metrics storage)   │
+                                              └──────▲──────────────┘
+                                                     │ remote write
+k6 TestRun (via k6 Operator)                         │
+    │                                                │
+    │  HTTP requests (PUT, POST, DELETE)              │
+    ▼                                                │
+Capture Proxy (:9201) ──── metrics ──────────────────┘
+    │
+    ├──► Source Cluster      (request forwarded)
+    │
+    └──► Kafka               (request captured)
+            │
+            ▼
+      Traffic Replayer       (reads from Kafka)
+            │
+            ▼
+      Target Cluster         (replayed)
+```
+
+### What k6 measures and stores
+
+| Metric | Asserted by k6? | Stored in Prometheus? |
+|--------|-----------------|----------------------|
+| Capture proxy error rate = 0% | ✅ Yes — exits non-zero on breach | ✅ Yes |
+| Capture proxy p95 latency < threshold | ✅ Yes — exits non-zero on breach | ✅ Yes |
+| Throughput (req/s) | Reported | ✅ Yes |
+| Request latency distribution (p50/p90/p95/p99) | Reported | ✅ Yes |
+
+### What k6 does NOT measure
+
+These are measured by the existing Python test framework, Argo workflow, or monitoring tools:
+
+| Metric | Asserted by | When |
+|--------|-------------|------|
+| Source/target document count match | Python test framework | After replayer catches up |
+| Replayer catch-up time | Kafka consumer lag / CloudWatch | During/after traffic |
+| Kafka metrics (e.g. `kafkaCommitCount_total`) | Existing `metric_operations.py` | During/after traffic |
+
+### Results Storage and Regression Detection
+
+k6 outputs metrics to **Prometheus via Remote Write**, which is already deployed in the Migration Assistant stack. This enables:
+
+- **Historical trend tracking** — Grafana dashboards show latency and throughput across runs
+- **Regression detection** — Compare p95 latency across releases; alert on degradation
+- **CI visibility** — Test results are queryable via PromQL, not just console output
+
+```bash
+# k6 outputs to Prometheus (already running in the MA stack)
+k6 run --out experimental-prometheus-rw \
+  -e K6_PROMETHEUS_RW_SERVER_URL=http://prometheus:9090/api/v1/write \
+  cdc-load-test.js
+```
+
+For local/ad-hoc runs, JSON output provides machine-parseable results:
+
+```bash
+k6 run --out json=results.json cdc-load-test.js
+```
+
+## Phases
+
+### Phase 1 — k6 Script + Validation ✅ (Complete)
+
+Delivered a k6 script validated against three auth modes and two environments.
+
+**Deliverables:**
+- `cdc-load-test.js` — Single k6 script supporting no-auth, basic auth, and SigV4
+- `README.md` — Installation, usage, and output interpretation
+- This design doc
+
+**Validation results:**
+
+| Auth Mode | Environment | k6 Result | Pipeline E2E |
+|-----------|-------------|-----------|--------------|
+| SigV4 | EKS + AWS-managed OpenSearch domains | 151/151 ✅ | Source 301 = Target 301 ✅ |
+| Basic auth | Minikube + self-managed OpenSearch | 151/151 ✅ | Source 151 = Target 151 ✅ |
+| No auth | Local Docker (security disabled) | Supported | — |
+
+### Phase 2 — Pipeline Integration via k6 Operator + Rate Profiles
+
+Integrate k6 into the CI pipeline using the [k6 Operator](https://grafana.com/docs/k6/latest/set-up/set-up-distributed-k6/) and define standard rate profiles for regression testing.
+
+**Why the k6 Operator:**
+- **Kubernetes-native** — works on EKS, minikube, GKE, or any K8s cluster
+- **Declarative** — test runs defined as YAML `TestRun` resources
+- **Lifecycle management** — operator creates pods, runs tests, collects results, cleans up
+- **Distributed testing** — scales to multiple k6 pods for high-volume tests
+- **CI-friendly** — integrates with Argo Workflows as a workflow step
+
+**Integration with the existing test framework:**
+
+```
+Argo Workflow: cdc-full-e2e-imported-clusters
+│
+├── Deploy capture proxy + replayer
+│
+├── Create k6 TestRun (via k6 Operator)
+│   │
+│   │  apiVersion: k6.io/v1alpha1
+│   │  kind: TestRun
+│   │  spec:
+│   │    parallelism: 1
+│   │    script:
+│   │      configMap:
+│   │        name: cdc-load-test-script
+│   │    arguments:
+│   │      PROXY_ENDPOINT: https://capture-proxy:9201
+│   │      WRITE_RATE: 50
+│   │      DURATION: 5m
+│   │
+│   └── k6 pod runs cdc-load-test.js against capture proxy
+│       ├── Asserts: proxy error rate = 0%
+│       ├── Asserts: proxy p95 latency < threshold
+│       └── Writes metrics to Prometheus
+│
+├── Wait for replayer to catch up
+│
+└── Python test framework (MATestBase) verifies:
+    ├── Source/target document count match
+    ├── k6 TestRun completed successfully
+    └── Argo workflow succeeds
+```
+
+**k6 Operator deployment:**
+
+```bash
+# Install k6 Operator (works on any K8s cluster)
+helm repo add grafana https://grafana.github.io/helm-charts
+helm install k6-operator grafana/k6-operator -n ma
+```
+
+**Rate profiles:**
+
+| Profile | Write Rate | Duration | Purpose | CI? |
+|---------|-----------|----------|---------|-----|
+| Minimal | 10 req/s | 1m | Quick sanity check | Pre-merge |
+| Standard | 50 req/s | 5m | Default CI test | Post-merge |
+| High volume | 200 req/s | 10m | Validate sustained throughput | Nightly |
+| Stress | 500 req/s | 15m | Find breaking points | On-demand |
+| Soak | 50 req/s | 60m | Check for degradation over time | Weekly |
+
+## Authentication
+
+The k6 script supports three authentication modes in a single script, selected via environment variables:
+
+| Mode | Env vars needed | How it works |
+|------|----------------|--------------|
+| No auth | None | Plain HTTP requests |
+| Basic auth | `USERNAME`, `PASSWORD` | `Authorization: Basic <base64>` header |
+| SigV4 | `AWS_CREDS_FILE`, `SOURCE_HOST` | Sign for source hostname via jslib/aws SignatureV4, send to proxy |
+
+### SigV4 Signing with the Capture Proxy
+
+When the source cluster uses SigV4 authentication, the capture proxy passes requests through as-is — it does not add authentication. The k6 script signs every request using the [k6 AWS jslib](https://grafana.com/docs/k6/latest/javascript-api/jslib/aws/) (v0.13.0).
+
+The key challenge: the SigV4 signature includes the `host` header. Since we send requests to the proxy but the source cluster expects its own hostname in the signature, we must:
+
+1. **Sign** the request for the **source cluster hostname**
+2. **Send** the request to the **proxy endpoint**
+
+```javascript
+import { Endpoint, SignatureV4 } from 'https://jslib.k6.io/aws/0.13.0/aws.js';
+
+const creds = JSON.parse(open(__ENV.AWS_CREDS_FILE || '/tmp/aws-creds.json'));
+
+const signer = new SignatureV4({
+  service: 'es',
+  region: __ENV.AWS_REGION || 'us-east-1',
+  credentials: {
+    accessKeyId: creds.accessKeyId,
+    secretAccessKey: creds.secretAccessKey,
+    sessionToken: creds.sessionToken,
+  },
+});
+
+// Sign for SOURCE host, send to PROXY
+const signed = signer.sign({
+  method: 'PUT',
+  endpoint: new Endpoint(`https://${SOURCE_HOST}`),
+  path: path,
+  headers: { 'Content-Type': 'application/json', host: SOURCE_HOST },
+  body: doc,
+});
+
+http.put(`${PROXY}${path}`, doc, { headers: signed.headers });
+```
+
+**Credential handling on EKS:** The migration console pod uses IRSA (IAM Roles for Service Accounts). Credentials are extracted via Python botocore and written to a JSON file:
+
+```bash
+python3 -c "
+from botocore.session import Session
+import json
+creds = Session().get_credentials().get_frozen_credentials()
+json.dump({'accessKeyId': creds.access_key, 'secretAccessKey': creds.secret_key, 'sessionToken': creds.token}, open('/tmp/aws-creds.json','w'))
+"
+```
+
+For CI (Phase 2), the k6 Operator pod uses the same IRSA role as the migration console — credentials are auto-discovered.
+
+### Basic Auth
+
+```javascript
+import encoding from 'k6/encoding';
+
+const headers = { 'Content-Type': 'application/json' };
+if (__ENV.USERNAME) {
+  headers['Authorization'] = `Basic ${encoding.b64encode(`${__ENV.USERNAME}:${__ENV.PASSWORD}`)}`;
+}
+
+http.put(url, doc, { headers });
+```
+
+## Where k6 Runs
+
+| Environment | How k6 runs | Auth supported | Use case |
+|-------------|-------------|----------------|----------|
+| Developer's Mac | k6 CLI | No auth, basic auth | Local development |
+| Migration console pod | k6 CLI | All (SigV4, basic, none) | Ad-hoc testing on EKS |
+| k6 Operator pod (any K8s) | TestRun CRD | All (SigV4, basic, none) | CI pipeline integration |
+
+## Known Issues
+
+### SigV4 + k6 jslib
+
+- Use jslib version `0.13.0` — version 0.14.0 does not exist, 0.12.3 has a different API
+- Pass credentials directly to `SignatureV4` constructor — `AWSConfig.credentials` returns `undefined`
+- Session tokens break shell `-e` flags — use JSON file with `open()` instead
+- IRSA credentials must be extracted via Python botocore (k6 cannot auto-discover them)
+
+### Replayer Auth Conflict (Migration Assistant 3.0.1)
+
+When both `authHeaderValue` and `TARGET_USERNAME`/`TARGET_PASSWORD` are set, the replayer rejects conflicting auth options. Workaround: disable security on the target cluster or omit target `authConfig`.
+
+### Network Access
+
+- The capture proxy's K8s service is only reachable from inside the cluster
+- On EKS, k6 must run from inside the cluster (migration console pod or k6 Operator pod)
+
+## Why k6 Over Alternatives
+
+| Aspect | k6 | OpenSearch Benchmark | Locust | curl loops |
+|--------|----|--------------------|--------|------------|
+| Controlled request rate | Yes (constant-arrival-rate) | No | No native support | No |
+| Pass/fail thresholds | Built-in, exits non-zero | No | No built-in | No |
+| AWS SigV4 support | Yes (jslib) | Yes (native) | Manual | Manual |
+| K8s native (Operator/CRD) | Yes (k6 Operator) | No | No | No |
+| Distributed testing | Yes (via Operator) | No | No | No |
+| Metrics output | Prometheus, JSON, CSV, Grafana Cloud | Custom | Custom | None |
+| Runtime | Go binary, ~30MB | JVM, heavy | Python + deps | bash |
+| Script language | JavaScript | YAML configs | Python | bash |
+| Resource overhead | Low (goroutines) | High (JVM threads) | Moderate (GIL) | Minimal |
+| Cost | Free, open source | Free, open source | Free, open source | Free |
+| Portable across K8s | Yes (EKS, minikube, GKE) | No | No | No |

--- a/migrationConsole/lib/integ_test/integ_test/k6/k6-operator/testrun.yaml
+++ b/migrationConsole/lib/integ_test/integ_test/k6/k6-operator/testrun.yaml
@@ -1,0 +1,64 @@
+# k6 Operator TestRun for CDC Load Testing
+#
+# Prerequisites:
+#   1. Install k6 Operator:
+#      helm repo add grafana https://grafana.github.io/helm-charts
+#      helm install k6-operator grafana/k6-operator -n ma --set namespace.create=false
+#
+#   2. Create ConfigMap from the k6 script:
+#      kubectl create configmap cdc-load-test-script \
+#        --from-file=cdc-load-test.js=../cdc-load-test.js -n ma
+#
+# Usage:
+#   kubectl apply -n ma -f testrun.yaml
+#
+# Monitor:
+#   kubectl get testrun -n ma
+#   kubectl logs -n ma -l k6_cr=cdc-load-test
+#
+# Cleanup:
+#   kubectl delete testrun cdc-load-test -n ma
+
+---
+# Single runner — baseline test
+apiVersion: k6.io/v1alpha1
+kind: TestRun
+metadata:
+  name: cdc-load-test
+spec:
+  parallelism: 1
+  script:
+    configMap:
+      name: cdc-load-test-script
+      file: cdc-load-test.js
+  arguments: >-
+    -e PROXY_ENDPOINT=https://capture-proxy:9201
+    -e WRITE_RATE=5
+    -e DURATION=30s
+  runner:
+    env:
+    - name: K6_INSECURE_SKIP_TLS_VERIFY
+      value: "true"
+
+---
+# Parallel runners — distributed load test
+# Uncomment and apply separately (delete the single runner first)
+#
+# apiVersion: k6.io/v1alpha1
+# kind: TestRun
+# metadata:
+#   name: cdc-load-test-parallel
+# spec:
+#   parallelism: 2
+#   script:
+#     configMap:
+#       name: cdc-load-test-script
+#       file: cdc-load-test.js
+#   arguments: >-
+#     -e PROXY_ENDPOINT=https://capture-proxy:9201
+#     -e WRITE_RATE=10
+#     -e DURATION=30s
+#   runner:
+#     env:
+#     - name: K6_INSECURE_SKIP_TLS_VERIFY
+#       value: "true"

--- a/migrationConsole/lib/integ_test/integ_test/k6/poc-load-test.js
+++ b/migrationConsole/lib/integ_test/integ_test/k6/poc-load-test.js
@@ -1,0 +1,115 @@
+import http from 'k6/http';
+import { check } from 'k6';
+import { Trend } from 'k6/metrics';
+import encoding from 'k6/encoding';
+
+const proxyTTFB = new Trend('proxy_ttfb', true);
+const proxyReceiving = new Trend('proxy_receiving', true);
+
+export const options = {
+  insecureSkipTLSVerify: true,
+  scenarios: {
+    low_rate: {
+      executor: 'constant-arrival-rate',
+      rate: 10, timeUnit: '1s', duration: '30s',
+      preAllocatedVUs: 10, maxVUs: 20,
+      exec: 'indexSmallDoc',
+      tags: { scenario: 'low_rate_10rps' },
+      startTime: '0s',
+    },
+    medium_rate: {
+      executor: 'constant-arrival-rate',
+      rate: 50, timeUnit: '1s', duration: '30s',
+      preAllocatedVUs: 50, maxVUs: 100,
+      exec: 'indexSmallDoc',
+      tags: { scenario: 'medium_rate_50rps' },
+      startTime: '35s',
+    },
+    high_rate: {
+      executor: 'constant-arrival-rate',
+      rate: 200, timeUnit: '1s', duration: '30s',
+      preAllocatedVUs: 100, maxVUs: 200,
+      exec: 'indexSmallDoc',
+      tags: { scenario: 'high_rate_200rps' },
+      startTime: '70s',
+    },
+    large_docs: {
+      executor: 'constant-arrival-rate',
+      rate: 50, timeUnit: '1s', duration: '30s',
+      preAllocatedVUs: 50, maxVUs: 100,
+      exec: 'indexLargeDoc',
+      tags: { scenario: 'large_docs_10kb' },
+      startTime: '105s',
+    },
+    xlarge_docs: {
+      executor: 'constant-arrival-rate',
+      rate: 10, timeUnit: '1s', duration: '30s',
+      preAllocatedVUs: 20, maxVUs: 40,
+      exec: 'indexXLargeDoc',
+      tags: { scenario: 'xlarge_docs_100kb' },
+      startTime: '140s',
+    },
+  },
+  thresholds: {
+    'http_req_failed{scenario:low_rate_10rps}': ['rate==0'],
+    'http_req_failed{scenario:medium_rate_50rps}': ['rate==0'],
+    'http_req_failed{scenario:high_rate_200rps}': ['rate<0.01'],
+    'http_req_failed{scenario:large_docs_10kb}': ['rate==0'],
+    'http_req_failed{scenario:xlarge_docs_100kb}': ['rate==0'],
+    'http_req_duration{scenario:low_rate_10rps}': ['p(95)<2000'],
+    'http_req_duration{scenario:medium_rate_50rps}': ['p(95)<2000'],
+    'http_req_duration{scenario:large_docs_10kb}': ['p(95)<3000'],
+  },
+};
+
+const PROXY = __ENV.PROXY_ENDPOINT || 'https://capture-proxy:9201';
+const USERNAME = __ENV.USERNAME || '';
+const PASSWORD = __ENV.PASSWORD || '';
+
+const headers = { 'Content-Type': 'application/json' };
+if (USERNAME) {
+  headers['Authorization'] = `Basic ${encoding.b64encode(`${USERNAME}:${PASSWORD}`)}`;
+}
+
+function sendDoc(index, docId, body) {
+  const res = http.put(`${PROXY}/${index}/_doc/${docId}`, body, { headers });
+  proxyTTFB.add(res.timings.waiting);
+  proxyReceiving.add(res.timings.receiving);
+  check(res, {
+    'status is 200 or 201': (r) => r.status === 200 || r.status === 201,
+  });
+}
+
+export function indexSmallDoc() {
+  const id = `${__VU}-${__ITER}`;
+  sendDoc('poc-small', id, JSON.stringify({
+    title: `doc-${id}`,
+    content: 'Load test document for CDC pipeline validation',
+    timestamp: new Date().toISOString(),
+  }));
+}
+
+export function indexLargeDoc() {
+  const id = `${__VU}-${__ITER}`;
+  sendDoc('poc-large', id, JSON.stringify({
+    title: `doc-${id}`,
+    content: 'x'.repeat(9000),
+    timestamp: new Date().toISOString(),
+  }));
+}
+
+export function indexXLargeDoc() {
+  const id = `${__VU}-${__ITER}`;
+  sendDoc('poc-xlarge', id, JSON.stringify({
+    title: `doc-${id}`,
+    content: 'x'.repeat(95000),
+    timestamp: new Date().toISOString(),
+  }));
+}
+
+export function handleSummary(data) {
+  return {
+    stdout: JSON.stringify(data.metrics, null, 2) + '\n',
+    '/tmp/poc-results.json': JSON.stringify(data, null, 2),
+  };
+}


### PR DESCRIPTION
### Description

Add k6 load testing scripts for the CDC pipeline capture proxy as a proof of concept. The scripts generate controlled HTTP traffic through the capture proxy and measure proxy-level performance (latency, throughput, error rate) with support for basic auth, no auth, and AWS SigV4 authentication.

**Scripts:**
- `cdc-load-test.js`: Basic auth and no-auth mode with configurable rate, duration, and document sizes (1KB/10KB/100KB)
- `cdc-load-test-sigv4.js`: SigV4 signing for AWS-managed OpenSearch domains — signs for source hostname and sends to proxy endpoint
- `poc-load-test.js`: Multi-scenario PoC testing rate scaling (10/50/200 req/s) and document size impact (1KB/10KB/100KB)

**k6 Operator:**
- `k6-operator/testrun.yaml`: Example TestRun CRD for running tests via the k6 Kubernetes Operator, with single and parallel runner configs

**Documentation:**
- `README.md`: Installation, usage for all auth modes, parameters, output interpretation, validated results, and limitations
- `design.md`: Architecture, where k6 fits in CDC pipeline, what it measures vs what it does not, CI integration plan via k6 Operator

### Issues Resolved

N/A — This is a PoC for adding load testing capability to the CDC pipeline. No existing issue.

### Testing

Validated on multiple environments and auth modes:

| Environment | Auth | Result | Pipeline E2E |
|-------------|------|--------|--------------|
| EKS + AWS-managed OpenSearch | SigV4 (CLI) | 151/151 requests, 0% errors, p95=45ms ✅ | Source 301 = Target 301 ✅ |
| Minikube + self-managed OpenSearch | Basic auth (CLI) | 151/151 requests, 0% errors, p95=501ms ✅ | Source = Target ✅ |
| Minikube | Basic auth (multi-scenario PoC) | 1210/1210 requests, 0% errors ✅ | Source = Target ✅ |
| EKS | k6 Operator single runner | 151 requests, operator lifecycle ✅ | — |
| EKS | k6 Operator parallel (2 pods) | 75+76 requests across 2 pods ✅ | — |

Full pipeline verified: documents sent through the capture proxy via k6 were captured to Kafka, replayed by the traffic replayer, and appeared on the target cluster with matching counts.

### Check List
- [x] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).