### PR TITLE
Forward defaultGitBranch in ECS release canary pipelines for current fix

### DIFF
--- a/vars/fullES68SourceE2ETest.groovy
+++ b/vars/fullES68SourceE2ETest.groovy
@@ -101,6 +101,7 @@ def call(Map config = [:]) {
             skipCaptureProxyOnNodeSetup: true,
             jobName: config.jobName ?: 'full-es68source-e2e-test',
             testUniqueId: testUniqueId,
+            defaultGitBranch: config.defaultGitBranch ?: 'main',
             integTestCommand: '/root/lib/integ_test/integ_test/full_tests.py --source_proxy_alb_endpoint https://alb.migration.<STAGE>.local:9201 --target_proxy_alb_endpoint https://alb.migration.<STAGE>.local:9202',
             preDeployStep: { Map args ->
                 // Destroy any prior stacks in strict order before redeploying: migration CDK

--- a/vars/rfsDefaultE2ETest.groovy
+++ b/vars/rfsDefaultE2ETest.groovy
@@ -62,6 +62,7 @@ def call(Map config = [:]) {
             defaultStageId: 'rfs-integ',
             skipCaptureProxyOnNodeSetup: true,
             jobName: config.jobName ?: 'rfs-default-e2e-test',
-            integTestCommand: '/root/lib/integ_test/integ_test/backfill_tests.py'
+            integTestCommand: '/root/lib/integ_test/integ_test/backfill_tests.py',
+            defaultGitBranch: config.defaultGitBranch ?: 'main'
     )
 }

--- a/vars/solutionsCFNTest.groovy
+++ b/vars/solutionsCFNTest.groovy
@@ -1,12 +1,13 @@
 def call(Map config = [:]) {
     def jobName = config.jobName ?: "solutionsCFNTest"
+    def defaultGitBranch = config.defaultGitBranch ?: 'main'
 
     pipeline {
         agent { label config.workerAgent ?: 'Jenkins-Default-Agent-X64-C5xlarge-Single-Host' }
 
         parameters {
             string(name: 'GIT_REPO_URL', defaultValue: 'https://github.com/opensearch-project/opensearch-migrations.git', description: 'Git repository url')
-            string(name: 'GIT_BRANCH', defaultValue: 'main', description: 'Git branch to use for repository')
+            string(name: 'GIT_BRANCH', defaultValue: defaultGitBranch, description: 'Git branch to use for repository')
             string(name: 'GIT_COMMIT', defaultValue: '', description: '(Optional) Specific commit to checkout after cloning branch')
             string(name: 'STAGE', defaultValue: "sol-integ", description: 'Stage name for deployment environment')
             string(name: 'REGION', defaultValue: 'us-east-1', description: 'AWS region for deployment')

--- a/vars/trafficReplayDefaultE2ETest.groovy
+++ b/vars/trafficReplayDefaultE2ETest.groovy
@@ -82,6 +82,7 @@ def call(Map config = [:]) {
             migrationContextId: migrationContextId,
             defaultStageId: 'aws-integ',
             jobName: config.jobName ?: 'traffic-replay-default-e2e-test',
+            defaultGitBranch: config.defaultGitBranch ?: 'main',
             //deployStep: {
             //    echo 'Custom Test Step'
             //}


### PR DESCRIPTION
### Description

Release canary pipelines (`release-*`) resolve the latest git tag in the cover file and pass it as `defaultGitBranch`, but the ECS/CDK pipeline definitions were not using it. This caused the Checkout stage to fall back to `main` instead of checking out the release tag, making release canaries test unreleased code from `main`.

**Root cause:** The `defaultGitBranch` parameter was either dropped by intermediate wrapper files or ignored by pipelines that hardcoded `GIT_BRANCH` default to `main`.

This is a follow-up PR with [PR-2720](https://github.com/opensearch-project/opensearch-migrations/pull/2720)

**Affected pipelines:**
- `release-rfs-default-e2e-test`
- `release-full-es68source-e2e-test`
- `release-traffic-replay-default-e2e-test`
- `release-solutions-cfn-create-vpc-test`

**Fix:**
| File | Change |
|------|--------|
| `vars/defaultIntegPipeline.groovy` | Accept `defaultGitBranch` from config, use as `GIT_BRANCH` parameter default |
| `vars/solutionsCFNTest.groovy` | Same — use `config.defaultGitBranch` instead of hardcoded `main` |
| `vars/rfsDefaultE2ETest.groovy` | Forward `defaultGitBranch` to `defaultIntegPipeline()` |
| `vars/fullES68SourceE2ETest.groovy` | Forward `defaultGitBranch` to `defaultIntegPipeline()` |
| `vars/trafficReplayDefaultE2ETest.groovy` | Forward `defaultGitBranch` to `defaultIntegPipeline()` |

This also includes the prior commits on this branch:
- `checkoutStep.groovy`: Tag-aware checkout (detects version strings like `3.0.1` and checks out the tag)
- `defaultIntegPipeline.groovy`: `VERSION` parameter and info banner
- `solutionsCFNTest.groovy`: `VERSION` parameter and info banner

### Testing
- Verified the parameter forwarding chain: cover file → wrapper → pipeline definition → checkoutStep
- `checkoutStep.groovy` already has regex `^\d+\.\d+\.\d+$` to detect version tags and run `git checkout tags/<tag>`
- All defaults preserve existing behavior (`main` when no `defaultGitBranch` is passed)

### Check List
- [x] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).