### PR TITLE
Translating Stat Aggs to Solr Stat Facets Buckets

### DIFF
--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/cases.testcase.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/cases.testcase.ts
@@ -521,6 +521,58 @@ export const testCases: TestCase[] = [
     ],
   }),
 
+  solrTest('facet-stat-functions', {
+    description: 'Stat facet shorthand: avg, sum, min, max, unique, countvals, and count(*) as sub-facets',
+    documents: [
+      { id: '1', title: 'laptop', category: 'electronics', price: 999, rating: 4 },
+      { id: '2', title: 'phone', category: 'electronics', price: 699, rating: 5 },
+      { id: '3', title: 'tablet', category: 'electronics', price: 499, rating: 3 },
+      { id: '4', title: 'shirt', category: 'clothing', price: 29, rating: 4 },
+      { id: '5', title: 'pants', category: 'clothing', price: 59, rating: 2 },
+      { id: '6', title: 'apple', category: 'food', price: 3, rating: 5 },
+    ],
+    requestPath:
+      '/solr/testcollection/select?q=*:*&rows=0&wt=json&json.facet=' +
+      encodeURIComponent(JSON.stringify({
+        avg_price: 'avg(price)',
+        total_price: 'sum(price)',
+        min_price: 'min(price)',
+        max_price: 'max(price)',
+        unique_categories: 'unique(category)',
+        rated_count: 'countvals(rating)',
+        by_category: {
+          type: 'terms',
+          field: 'category',
+          sort: 'count desc',
+          facet: {
+            avg_price: 'avg(price)',
+            max_rating: 'max(rating)',
+          },
+        },
+      })),
+    solrSchema: {
+      fields: {
+        title: { type: 'text_general' },
+        category: { type: 'string' },
+        price: { type: 'pfloat' },
+        rating: { type: 'pint' },
+      },
+    },
+    opensearchMapping: {
+      properties: {
+        title: { type: 'text' },
+        category: { type: 'keyword' },
+        price: { type: 'float' },
+        rating: { type: 'integer' },
+      },
+    },
+    assertionRules: [
+      ...SOLR_INTERNAL_RULES,
+      { path: '$.response', rule: 'ignore', reason: 'Facet test — only validating $.facets, not hits' },
+      { path: '$.terminated_early', rule: 'ignore', reason: 'OpenSearch may return terminated_early with rows=0; Solr does not' },
+    ],
+  }),
+
   solrTest('facet-nested-terms-in-terms', {
     description: 'Nested facet: terms facet with a nested terms sub-facet',
     documents: [

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/aggs-to-facets.test.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/aggs-to-facets.test.ts
@@ -547,4 +547,63 @@ describe('aggs-to-facets MicroTransform', () => {
       expect(catBuckets[1].size).toBe(2);
     });
   });
+
+  describe('metric aggregation (stat facet) response conversion', () => {
+    it('should return scalar value for avg metric agg', () => {
+      const avgAgg = new Map<string, any>([['value', 29.95]]);
+      const aggs = new Map([['avg_price', avgAgg]]);
+      const body = new Map<string, any>([['aggregations', aggs]]);
+      const ctx = buildCtx(body, { hitsTotal: 100 });
+      response.apply(ctx);
+
+      const facets: JavaMap = ctx.responseBody.get('facets');
+      expect(facets.get('avg_price')).toBe(29.95);
+    });
+
+    it('should return scalar value for value_count metric agg', () => {
+      const countAgg = new Map<string, any>([['value', 42]]);
+      const aggs = new Map([['num_products', countAgg]]);
+      const body = new Map<string, any>([['aggregations', aggs]]);
+      const ctx = buildCtx(body, { hitsTotal: 100 });
+      response.apply(ctx);
+
+      const facets: JavaMap = ctx.responseBody.get('facets');
+      expect(facets.get('num_products')).toBe(42);
+    });
+
+    it('should handle metric aggs nested inside bucket aggs', () => {
+      const avgAgg = new Map<string, any>([['value', 15.5]]);
+      const outerBuckets = [
+        new Map<string, any>([
+          ['key', 'electronics'],
+          ['doc_count', 10],
+          ['avg_price', avgAgg],
+        ]),
+      ];
+      const aggs = new Map([
+        ['categories', new Map<string, any>([['buckets', outerBuckets]])],
+      ]);
+      const body = new Map<string, any>([['aggregations', aggs]]);
+      const ctx = buildCtx(body, { hitsTotal: 50 });
+      response.apply(ctx);
+
+      const bucket: JavaMap = ctx.responseBody.get('facets').get('categories').get('buckets')[0];
+      expect(bucket.get('avg_price')).toBe(15.5);
+    });
+
+    it('should handle metric aggs alongside bucket aggs at top level', () => {
+      const avgAgg = new Map<string, any>([['value', 25]]);
+      const aggs = new Map<string, any>([
+        ['categories', osTermsAgg([{ key: 'food', doc_count: 3 }])],
+        ['avg_price', avgAgg],
+      ]);
+      const body = new Map<string, any>([['aggregations', aggs]]);
+      const ctx = buildCtx(body, { hitsTotal: 100 });
+      response.apply(ctx);
+
+      const facets: JavaMap = ctx.responseBody.get('facets');
+      expect(facets.get('avg_price')).toBe(25);
+      expect(facets.get('categories').get('buckets')).toHaveLength(1);
+    });
+  });
 });

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/aggs-to-facets.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/aggs-to-facets.ts
@@ -96,11 +96,16 @@ function convertFilterAgg(aggResult: JavaMap): JavaMap {
  * Supports:
  *   - Terms / range / histogram aggregations (which have a `buckets` array)
  *   - Filter aggregations (from query facets, which have `doc_count`)
+ *   - Metric aggregations (avg, sum, min, max, value_count, cardinality — which have a `value` key)
  *
  * For both bucket-based and filter aggregations, any nested aggregation results
  * are recursively converted.
+ *
+ * Metric aggregations return their scalar value directly, matching Solr's
+ * json.facet response format where stat facets are plain numbers:
+ *   Solr: { "facets": { "count": 100, "avg_price": 29.95 } }
  */
-function convertSingleAgg(aggResult: any): JavaMap {
+function convertSingleAgg(aggResult: any): JavaMap | number {
   if (!isMapLike(aggResult)) {
     throw new Error(`Expected aggregation result to be a Map, got: ${typeof aggResult}`);
   }
@@ -108,6 +113,11 @@ function convertSingleAgg(aggResult: any): JavaMap {
   const buckets: any[] = aggResult.get('buckets');
   if (Array.isArray(buckets)) {
     return convertBucketAgg(buckets);
+  }
+  // Metric aggregations (avg, sum, min, max, value_count, cardinality)
+  // return { "value": <number> }. Solr returns the scalar directly.
+  if (aggResult.has('value') && !aggResult.has('doc_count')) {
+    return aggResult.get('value');
   }
   if (aggResult.has('doc_count')) {
     return convertFilterAgg(aggResult);

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/json-facets.test.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/json-facets.test.ts
@@ -894,6 +894,11 @@ describe('stat facet conversion', () => {
     expect(agg.get('value_count')).toEqual(new Map([['field', 'status']]));
   });
 
+  it('should convert count(*) to value_count on _id', () => {
+    const agg = applyStatFacet('count(*)');
+    expect(agg.get('value_count')).toEqual(new Map([['field', '_id']]));
+  });
+
   it('should throw for unsupported stat function', () => {
     expect(() => applyStatFacet('sumsq(price)')).toThrow("Unsupported stat function 'sumsq'");
   });

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/json-facets.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/json-facets.ts
@@ -466,6 +466,13 @@ function convertStatFacet(expr: string): JavaMap {
 }
 
 function convertFuncToMetricAgg(func: FuncNode): JavaMap {
+  // count(*) → value_count on _id (every doc has one, equivalent to doc count)
+  if (func.name === 'count') {
+    const inner = new Map<string, any>();
+    inner.set('field', '_id');
+    return new Map<string, any>([['value_count', inner]]);
+  }
+
   const osAggType = STAT_FUNC_MAP[func.name];
   if (!osAggType) {
     throw new Error(`Unsupported stat function '${func.name}' in json.facet`);
@@ -550,11 +557,10 @@ export function convertJsonFacets(solrJsonFacet: JavaMap, ctx: RequestContext): 
   const aggs = new Map<string, any>();
   for (const name of solrJsonFacet.keys()) {
     const facetDef = solrJsonFacet.get(name);
-    if (typeof facetDef === 'string') {
-      aggs.set(name, convertStatFacet(facetDef));
-    } else {
-      aggs.set(name, convertSingleFacet(facetDef, ctx));
-    }
+    const converted = typeof facetDef === 'string'
+      ? convertStatFacet(facetDef)
+      : convertSingleFacet(facetDef, ctx);
+    aggs.set(name, converted);
   }
   return aggs;
 }

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/parser/solr.pegjs
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/parser/solr.pegjs
@@ -336,7 +336,11 @@ funcArg
   = funcNumericLiteral
   / funcStringConstant
   / funcCall
+  / funcWildcard
   / funcFieldRef
+
+funcWildcard
+  = "*" { return { kind: 'field', name: '*' }; }
 
 funcNumericLiteral
   = val:$("-"? [0-9]+ ("." [0-9]+)? ([eE] [+\-]? [0-9]+)?) {


### PR DESCRIPTION
### Description

Adds response-side handling for metric aggregations in `aggs-to-facets.ts`. OpenSearch metric agg results (`{ "value": N }`) are now converted to scalar values, matching Solr's json.facet response format where stat facets are plain numbers (e.g., `"avg_price": 29.95`).

Also adds `count(*)` support: the PEG grammar now accepts `*` as a function argument, and `count(*)` maps to `value_count` on `_id` so the named aggregation appears in the OpenSearch response.

### Testing
- Unit tests

### Check List
- [x] New functionality includes testing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
