### PR TITLE
feat(solr-transforms): NDJSON framework and shared _bulk helpers

### DIFF
--- a/TrafficCapture/SolrTransformations/docs/LIMITATIONS.md
+++ b/TrafficCapture/SolrTransformations/docs/LIMITATIONS.md
@@ -22,6 +22,8 @@ the root cause, and provides a workaround where one exists.
 | [JSON-QUERIES](#json-queries)                   | JSON Request API `queries` key not supported |
 | [JSON-PARAM-PREFIX](#json-param-prefix)         | JSON Request API `json.<param>` prefix passthrough not supported |
 | [UPDATE-COMMANDS](#update-commands)             | Only `add` and `delete-by-id` commands supported; JSON only |
+| [BULK-PARTIAL-FAILURE](#bulk-partial-failure)   | `_bulk` partial failures surface as `errors[]`; Solr's default strict mode has no OpenSearch equivalent |
+| [NDJSON-INGEST-PARITY](#ndjson-ingest-parity)   | Shim does not parse NDJSON request bodies on ingress (not exercised by Solr clients, but diverges from replayer) |
 | [MM-AUTORELAX](#mm-autorelax)                   | eDisMax `mm.autoRelax` parameter not supported |
 | [MM-EDISMAX-OPERATOR-DEFAULT](#mm-edismax-operator-default) | eDisMax `mm` default with explicit operators not fully replicated |
 | [MM-EDISMAX-MIXED-OPERATORS](#mm-edismax-mixed-operators) | eDisMax `mm` with mixed explicit and implicit operators applies to wrong scope |
@@ -502,6 +504,111 @@ Both JSON and XML content types are supported.
 Only `application/json` request bodies are supported. XML bodies
 (`text/xml`, `application/xml`) cannot be parsed by the shim and will
 fail with an error. Clients using XML format must switch to JSON.
+
+---
+
+## BULK-PARTIAL-FAILURE
+
+**Feature:** Batch `add` / `delete` request where some documents succeed and
+others fail.
+
+**Solr behaviour:**
+Solr's default `/update` semantics are strict: if any document in a batch
+fails validation or indexing, Solr aborts the whole request with an HTTP 4xx
+error and none of the batch's documents become visible. Successfully-indexed
+docs from earlier in the batch are rolled back.
+
+An opt-in `TolerantUpdateProcessorFactory` (configured per-core in
+`solrconfig.xml`) changes this: Solr continues past individual failures and
+returns HTTP 200 with an `errors[]` array describing the per-document
+failures. This opt-in mode is the closest match to OpenSearch's default
+behaviour.
+
+**OpenSearch behaviour:**
+The `_bulk` API processes actions independently. A single failing item does
+**not** abort the rest. The response is always HTTP 200 and each entry in
+`items[]` carries its own `status` and optional `error` block. There is no
+transactional rollback: successfully-indexed documents from earlier items
+remain in the index even if later items fail.
+
+**Cause:**
+OpenSearch does not support ACID transactions across multiple documents.
+Per-document writes are atomic, but the underlying Lucene segment model has
+no concept of a multi-document rollback. There is no header, setting, or
+API flag that enables all-or-nothing batch semantics — not in OpenSearch,
+not in Elasticsearch, not in any fork of either.
+
+**Current workaround (applied automatically by the transformer):**
+The shim's `_bulk` response aggregator (`features/bulk/bulk-response.ts`)
+walks `items[]` and produces a response shape that matches Solr's
+**tolerant** update-processor output:
+
+* All items succeeded → `{responseHeader:{status:0, QTime:<took>}}`, HTTP 200.
+* Any item failed → `{responseHeader:{status:1, QTime:<took>}, errors:[{index,id,status,type,reason},…]}`,
+  HTTP 200.
+
+HTTP 200 is preserved even on partial failure because returning a 4xx would
+imply *no* documents were indexed, causing well-behaved clients to retry the
+entire batch and create duplicates of the already-indexed subset. The
+tolerant-mode emulation lets clients inspect `errors[]` to retry only the
+failed subset.
+
+**Residual impact:**
+
+* **SolrJ clients expecting strict semantics** — Applications that treat any
+  response with `responseHeader.status != 0` as fatal, without inspecting
+  `errors[]`, will behave differently against the shim than against a
+  strict-mode Solr. Migration checklist for these clients: either inspect
+  the `errors[]` array, or deploy Solr's `TolerantUpdateProcessorFactory`
+  in the source Solr for an apples-to-apples comparison.
+* **No rollback of partial successes** — Documents indexed before a
+  failure remain in OpenSearch. This is inherent to OpenSearch's
+  architecture and cannot be fixed by the translation layer. Applications
+  that previously relied on Solr's "entire batch aborted, nothing visible"
+  guarantee should treat batch requests as idempotent (e.g. by using the
+  `_id` of each doc, which is how Solr batches behave anyway when IDs
+  collide).
+
+---
+
+## NDJSON-INGEST-PARITY
+
+**Feature:** Ingesting a request body that is already NDJSON (multiple
+newline-delimited JSON objects).
+
+**Solr behaviour:**
+Not applicable — Solr clients do not send NDJSON to `/update`. Every Solr
+update format (single-doc `add`, command-object with arrays, mixed commands,
+delete-by-id, delete-by-query, commit) uses a single top-level JSON object
+or a top-level JSON array. There is no Solr client that sends a body like
+`{"a":1}\n{"b":2}\n{"c":3}\n`.
+
+**OpenSearch behaviour:**
+OpenSearch's `_bulk`, `_msearch`, and a few other endpoints accept NDJSON.
+The traffic replayer supports this on both ingress (via
+`NettyJsonBodyAccumulateHandler`, which stores the parsed list under
+`payload.inlinedJsonSequenceBodies`) and egress (via
+`NettyJsonBodySerializeHandler`).
+
+**Cause:**
+The shim's `HttpMessageUtil.parseJsonOrText` currently only parses the first
+top-level JSON value it sees. An NDJSON body beginning with `{...}\n{...}`
+would be partially parsed: the first object becomes `inlinedJsonBody` and
+the remaining lines are silently discarded.
+
+**Current workaround:**
+Egress (emitting NDJSON from the shim to OpenSearch) **is** supported as of
+PR 1 — transforms that produce `payload.inlinedJsonSequenceBodies` are
+materialized as NDJSON on the wire with correct trailing-newline semantics.
+Ingress (parsing NDJSON from a client) is not needed for the Solr→OpenSearch
+translation use case.
+
+**Residual impact:**
+Only relevant if the shim is repurposed as a generic proxy that must accept
+arbitrary OpenSearch `_bulk` traffic from clients. No Solr client exercises
+this path, so the gap is invisible to the intended customer. A follow-up
+change to the ingest side (mirroring `JsonAccumulator` semantics from the
+replayer) would close this gap if needed.
 
 ---
 

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/context.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/context.ts
@@ -86,12 +86,25 @@ function parseParams(uri: string): URLSearchParams {
   return new URLSearchParams(q >= 0 ? uri.slice(q + 1) : '');
 }
 
-/** Extract body Map from a Java Map payload. Returns the inlinedJsonBody Map directly — no parsing. */
+/**
+ * Extract body from a Java Map payload.
+ *
+ * Returns one of:
+ *   - a JavaMap  (JSON object body — the common case)
+ *   - a List-like  (top-level JSON array body — e.g. /update/json/docs bulk ingest,
+ *                   matches replayer JsonAccumulator semantics where a top-level
+ *                   array is a valid single top-level JSON value)
+ *   - an empty Map (no payload, or non-JSON content)
+ *
+ * Transforms that care about the shape should use isMapLike / isJavaList guards.
+ */
 function getBodyMap(payload: JavaMap): JavaMap {
   if (!payload) return new Map();
   const jsonBody = payload.get('inlinedJsonBody');
-  if (jsonBody && typeof jsonBody.get === 'function') return jsonBody;
-  // Fallback: if body is a string (non-JSON content), return empty map
+  if (!jsonBody) return new Map();
+  // Map-shaped (typical JSON object) — return as-is
+  if (typeof jsonBody.get === 'function') return jsonBody;
+  // Fallback: non-Map (e.g. raw string from malformed body) — return empty map
   return new Map();
 }
 

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/bulk/bulk-builder.test.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/bulk/bulk-builder.test.ts
@@ -1,0 +1,240 @@
+import { describe, it, expect } from 'vitest';
+import { buildBulkAction, setBulkRequest } from './bulk-builder';
+import type { RequestContext, JavaMap } from '../../context';
+
+/** Build a minimal RequestContext suitable for exercising setBulkRequest. */
+function buildCtx(uri = '/solr/mycore/update'): RequestContext {
+  const msg = new Map<string, any>([
+    ['URI', uri],
+    ['method', 'POST'],
+    ['headers', new Map<string, any>([['Content-Type', 'application/json']])],
+  ]) as unknown as JavaMap;
+  return {
+    msg,
+    endpoint: 'update',
+    collection: /\/solr\/([^/]+)\//.exec(uri)?.[1],
+    params: new URLSearchParams(),
+    body: new Map() as unknown as JavaMap,
+  } as RequestContext;
+}
+
+describe('buildBulkAction', () => {
+  describe('index', () => {
+    it('returns [action, doc] with _index and _id when id provided', () => {
+      const out = buildBulkAction('index', {
+        index: 'mycore',
+        id: '1',
+        doc: new Map([['title', 'hello']]),
+      });
+      expect(out).toHaveLength(2);
+      const meta = out[0].get('index') as Map<string, unknown>;
+      expect(meta.get('_index')).toBe('mycore');
+      expect(meta.get('_id')).toBe('1');
+      expect((out[1]).get('title')).toBe('hello');
+    });
+
+    it('omits _id when id is absent (OpenSearch auto-generates)', () => {
+      const out = buildBulkAction('index', {
+        index: 'mycore',
+        doc: new Map([['title', 'hello']]),
+      });
+      const meta = out[0].get('index') as Map<string, unknown>;
+      expect(meta.has('_index')).toBe(true);
+      expect(meta.has('_id')).toBe(false);
+    });
+
+    it('coerces numeric id to string for _id metadata', () => {
+      const out = buildBulkAction('index', {
+        index: 'mycore',
+        id: 42,
+        doc: new Map([['title', 'hello']]),
+      });
+      const meta = out[0].get('index') as Map<string, unknown>;
+      expect(meta.get('_id')).toBe('42');
+    });
+
+    it('throws when doc is missing', () => {
+      expect(() => buildBulkAction('index', { index: 'mycore', id: '1' })).toThrow('"doc" is required');
+    });
+
+    it('throws when index is missing', () => {
+      expect(() =>
+        buildBulkAction('index', { index: '', id: '1', doc: new Map([['x', 1]]) }),
+      ).toThrow('"index" is required');
+    });
+  });
+
+  describe('create', () => {
+    it('returns [action, doc] with _id required', () => {
+      const out = buildBulkAction('create', {
+        index: 'mycore',
+        id: '1',
+        doc: new Map([['title', 'hello']]),
+      });
+      expect(out).toHaveLength(2);
+      expect((out[0].get('create') as Map<string, unknown>).get('_id')).toBe('1');
+    });
+
+    it('throws when id is missing', () => {
+      expect(() =>
+        buildBulkAction('create', { index: 'mycore', doc: new Map([['x', 1]]) }),
+      ).toThrow('"id" is required');
+    });
+
+    it('throws when doc is missing', () => {
+      expect(() =>
+        buildBulkAction('create', { index: 'mycore', id: '1' }),
+      ).toThrow('"doc" is required');
+    });
+  });
+
+  describe('update', () => {
+    it('returns [action, updatePayload] with _id required', () => {
+      const updatePayload = new Map<string, unknown>([
+        ['doc', new Map([['title', 'new']])],
+      ]);
+      const out = buildBulkAction('update', {
+        index: 'mycore',
+        id: '1',
+        doc: updatePayload,
+      });
+      expect(out).toHaveLength(2);
+      expect((out[0].get('update') as Map<string, unknown>).get('_id')).toBe('1');
+      expect(out[1]).toBe(updatePayload);
+    });
+
+    it('throws when id is missing', () => {
+      expect(() =>
+        buildBulkAction('update', {
+          index: 'mycore',
+          doc: new Map([['doc', new Map()]]),
+        }),
+      ).toThrow('"id" is required');
+    });
+
+    it('throws when doc is missing', () => {
+      expect(() =>
+        buildBulkAction('update', { index: 'mycore', id: '1' }),
+      ).toThrow('"doc" is required');
+    });
+  });
+
+  describe('delete', () => {
+    it('returns [action] only — no doc', () => {
+      const out = buildBulkAction('delete', { index: 'mycore', id: '1' });
+      expect(out).toHaveLength(1);
+      const meta = out[0].get('delete') as Map<string, unknown>;
+      expect(meta.get('_index')).toBe('mycore');
+      expect(meta.get('_id')).toBe('1');
+    });
+
+    it('throws when id is missing', () => {
+      expect(() => buildBulkAction('delete', { index: 'mycore' })).toThrow('"id" is required');
+    });
+
+    it('throws when doc is accidentally passed', () => {
+      expect(() =>
+        buildBulkAction('delete', {
+          index: 'mycore',
+          id: '1',
+          doc: new Map([['x', 1]]),
+        }),
+      ).toThrow('must not include "doc"');
+    });
+  });
+});
+
+describe('setBulkRequest', () => {
+  it('rewrites URI to /{collection}/_bulk and sets POST', () => {
+    const ctx = buildCtx();
+    const actions = buildBulkAction('index', {
+      index: 'mycore',
+      id: '1',
+      doc: new Map([['title', 'hi']]),
+    });
+    setBulkRequest(ctx, 'mycore', actions);
+    expect(ctx.msg.get('URI')).toBe('/mycore/_bulk');
+    expect(ctx.msg.get('method')).toBe('POST');
+  });
+
+  it('adds ?refresh=true when options.refresh is true', () => {
+    const ctx = buildCtx();
+    const actions = buildBulkAction('delete', { index: 'mycore', id: '1' });
+    setBulkRequest(ctx, 'mycore', actions, { refresh: true });
+    expect(ctx.msg.get('URI')).toBe('/mycore/_bulk?refresh=true');
+  });
+
+  it('replaces Content-Type with application/x-ndjson (case-safe)', () => {
+    const ctx = buildCtx();
+    // Pre-populate with a mixed-case header to mirror real ingress
+    const headers = ctx.msg.get('headers');
+    headers.delete('Content-Type');
+    headers.set('Content-Type', 'application/json');
+    const actions = buildBulkAction('delete', { index: 'mycore', id: '1' });
+    setBulkRequest(ctx, 'mycore', actions);
+    expect(headers.has('Content-Type')).toBe(false);
+    expect(headers.get('content-type')).toBe('application/x-ndjson');
+  });
+
+  it('writes actions to payload.inlinedJsonSequenceBodies', () => {
+    const ctx = buildCtx();
+    const actions = [
+      ...buildBulkAction('index', {
+        index: 'mycore',
+        id: '1',
+        doc: new Map([['title', 'a']]),
+      }),
+      ...buildBulkAction('index', {
+        index: 'mycore',
+        id: '2',
+        doc: new Map([['title', 'b']]),
+      }),
+    ];
+    setBulkRequest(ctx, 'mycore', actions);
+    const payload = ctx.msg.get('payload');
+    const seq = payload.get('inlinedJsonSequenceBodies');
+    expect(seq).toBe(actions);
+    expect(seq).toHaveLength(4); // 2 ops × (action + doc)
+  });
+
+  it('clears sibling inlinedJsonBody to preserve single-body invariant', () => {
+    const ctx = buildCtx();
+    // Pre-populate inlinedJsonBody as if a prior transform wrote it
+    const payload = new Map<string, unknown>([['inlinedJsonBody', new Map([['stale', true]])]]);
+    ctx.msg.set('payload', payload);
+    const actions = buildBulkAction('delete', { index: 'mycore', id: '1' });
+    setBulkRequest(ctx, 'mycore', actions);
+    expect(payload.has('inlinedJsonBody')).toBe(false);
+    expect(payload.has('inlinedJsonSequenceBodies')).toBe(true);
+  });
+
+  it('clears ctx.body so request.transform.ts does not re-populate inlinedJsonBody', () => {
+    const ctx = buildCtx();
+    ctx.body = new Map([['original', 'body']]) as unknown as JavaMap;
+    const actions = buildBulkAction('delete', { index: 'mycore', id: '1' });
+    setBulkRequest(ctx, 'mycore', actions);
+    expect(ctx.body.size).toBe(0);
+  });
+
+  it('creates a payload map when one does not exist yet', () => {
+    const ctx = buildCtx();
+    // Brand-new msg without a payload key
+    expect(ctx.msg.get('payload')).toBeUndefined();
+    const actions = buildBulkAction('delete', { index: 'mycore', id: '1' });
+    setBulkRequest(ctx, 'mycore', actions);
+    const payload = ctx.msg.get('payload');
+    expect(payload).toBeDefined();
+    expect(payload.has('inlinedJsonSequenceBodies')).toBe(true);
+  });
+
+  it('throws when collection is empty', () => {
+    const ctx = buildCtx();
+    const actions = buildBulkAction('delete', { index: 'mycore', id: '1' });
+    expect(() => setBulkRequest(ctx, '', actions)).toThrow('collection is required');
+  });
+
+  it('throws when actions array is empty', () => {
+    const ctx = buildCtx();
+    expect(() => setBulkRequest(ctx, 'mycore', [])).toThrow('non-empty array');
+  });
+});

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/bulk/bulk-builder.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/bulk/bulk-builder.ts
@@ -159,7 +159,8 @@ export function setBulkRequest(
     targetParams.set('refresh', 'true');
   }
   const query = targetParams.toString();
-  ctx.msg.set('URI', `/${collection}/_bulk${query ? `?${query}` : ''}`);
+  const suffix = query ? '?' + query : '';
+  ctx.msg.set('URI', '/' + collection + '/_bulk' + suffix);
   ctx.msg.set('method', 'POST');
 
   // Replace Content-Type case-insensitively. The Java proxy uses headers.add()

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/bulk/bulk-builder.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/bulk/bulk-builder.ts
@@ -1,0 +1,188 @@
+/**
+ * Shared helpers for constructing OpenSearch `_bulk` API requests from Solr
+ * command-level operations (index / create / update / delete).
+ *
+ * ## Framework alignment
+ *
+ * - NDJSON payloads are written under `payload.inlinedJsonSequenceBodies`, the
+ *   canonical key defined in `JsonKeysForHttpMessage.INLINED_NDJSON_BODIES_DOCUMENT_KEY`.
+ * - The Java side (`HttpMessageUtil.extractBodyString`) materializes the list
+ *   as one JSON document per line with a trailing newline — matching both the
+ *   traffic replayer's `NettyJsonBodySerializeHandler` and OpenSearch's `_bulk`
+ *   API contract.
+ * - `Content-Type: application/x-ndjson` is set by case-insensitively removing
+ *   any existing Content-Type header before writing — the shim's Java proxy
+ *   uses `headers.add()` rather than `set()`, so casing-variant duplicates can
+ *   otherwise leak through.
+ */
+import type { RequestContext, JavaMap } from '../../context';
+
+/** Supported OpenSearch `_bulk` operation types. */
+export type BulkOp = 'index' | 'create' | 'update' | 'delete';
+
+/** Document body type — a JavaMap (GraalVM polyglot Map) or a JS Map. */
+type DocBody = JavaMap | Map<string, unknown>;
+
+/** Arguments to {@link buildBulkAction}. */
+export interface BulkActionInput {
+  /** OpenSearch target index — typically derived from `ctx.collection`. */
+  index: string;
+  /** Document id. Required for `create`/`update`/`delete`; optional for `index`. */
+  id?: string | number;
+  /**
+   * Document body — a Map representing the JSON document.
+   *   - `index` / `create`: the full source document (required)
+   *   - `update`: an update payload, e.g. `Map{doc → Map{field → value}}` (required)
+   *   - `delete`: must be omitted
+   */
+  doc?: DocBody;
+}
+
+/**
+ * Build the NDJSON entries for a single `_bulk` operation.
+ *
+ * Returns an array that the caller flattens into the full NDJSON sequence.
+ * Each entry becomes one line in the NDJSON body after Java-side serialization.
+ */
+export function buildBulkAction(op: BulkOp, input: BulkActionInput): Map<string, unknown>[] {
+  if (!input.index) {
+    throw new Error(`[bulk-builder] ${op}: "index" is required`);
+  }
+  const meta = buildMeta(input);
+
+  switch (op) {
+    case 'delete':
+      return buildDelete(meta, input);
+    case 'update':
+      return buildUpdate(meta, input);
+    case 'create':
+      return buildCreate(meta, input);
+    case 'index':
+      return buildIndex(meta, input);
+    default: {
+      const exhaustive: never = op;
+      throw new Error(`[bulk-builder] unsupported op '${exhaustive as string}'`);
+    }
+  }
+}
+
+function buildMeta(input: BulkActionInput): Map<string, unknown> {
+  const meta = new Map<string, unknown>();
+  meta.set('_index', input.index);
+  if (input.id != null && input.id !== '') {
+    meta.set('_id', String(input.id));
+  }
+  return meta;
+}
+
+/** Output: `[{"delete": {"_index": "mycore", "_id": "42"}}]` — one NDJSON line, no doc body. */
+function buildDelete(meta: Map<string, unknown>, input: BulkActionInput): Map<string, unknown>[] {
+  if (!meta.has('_id')) {
+    throw new Error('[bulk-builder] delete: "id" is required');
+  }
+  if (input.doc !== undefined) {
+    throw new Error('[bulk-builder] delete: must not include "doc"');
+  }
+  return [new Map<string, unknown>([['delete', meta]])];
+}
+
+/** Output: `[{"update": {"_index": "mycore", "_id": "1"}}, {"doc": {"title": "new"}}]` — two NDJSON lines. */
+function buildUpdate(meta: Map<string, unknown>, input: BulkActionInput): Map<string, unknown>[] {
+  if (!meta.has('_id')) {
+    throw new Error('[bulk-builder] update: "id" is required');
+  }
+  if (input.doc == null) {
+    throw new Error('[bulk-builder] update: "doc" is required (e.g. { doc: {...} } or { script: ... })');
+  }
+  return [new Map<string, unknown>([['update', meta]]), input.doc as Map<string, unknown>];
+}
+
+/** Output: `[{"create": {"_index": "mycore", "_id": "1"}}, {"id": "1", "title": "hello"}]` — two NDJSON lines. */
+function buildCreate(meta: Map<string, unknown>, input: BulkActionInput): Map<string, unknown>[] {
+  if (!meta.has('_id')) {
+    throw new Error('[bulk-builder] create: "id" is required');
+  }
+  if (input.doc == null) {
+    throw new Error('[bulk-builder] create: "doc" is required');
+  }
+  return [new Map<string, unknown>([['create', meta]]), input.doc as Map<string, unknown>];
+}
+
+/** Output: `[{"index": {"_index": "mycore", "_id": "1"}}, {"id": "1", "title": "hello"}]` — two NDJSON lines. `_id` optional. */
+function buildIndex(meta: Map<string, unknown>, input: BulkActionInput): Map<string, unknown>[] {
+  if (input.doc == null) {
+    throw new Error('[bulk-builder] index: "doc" is required');
+  }
+  return [new Map<string, unknown>([['index', meta]]), input.doc as Map<string, unknown>];
+}
+
+/** Options accepted by {@link setBulkRequest}. */
+export interface SetBulkRequestOptions {
+  /**
+   * When true, appends `?refresh=true` to the `_bulk` URI — used for Solr
+   * `commit=true` / `commitWithin` semantics (immediate visibility).
+   */
+  refresh?: boolean;
+}
+
+/**
+ * Mutate a {@link RequestContext} to emit a `_bulk` request to OpenSearch.
+ *
+ * `actions` is the flattened concatenation of `buildBulkAction(...)` results.
+ *
+ * Example flow:
+ *   Solr input:  POST /solr/mycore/update  {"add":[{"doc":{"id":"1"}},{"doc":{"id":"2"}}]}
+ *   Caller does: actions = [...buildBulkAction('index', {index, id:'1', doc}),
+ *                            ...buildBulkAction('index', {index, id:'2', doc})]
+ *                setBulkRequest(ctx, 'mycore', actions, {refresh: true})
+ *   OS output:   POST /mycore/_bulk?refresh=true
+ *                {"index":{"_index":"mycore","_id":"1"}}
+ *                {"id":"1","title":"hello"}
+ *                {"index":{"_index":"mycore","_id":"2"}}
+ *                {"id":"2","title":"world"}
+ */
+export function setBulkRequest(
+  ctx: RequestContext,
+  collection: string,
+  actions: Map<string, unknown>[],
+  options: SetBulkRequestOptions = {},
+): void {
+  if (!collection) {
+    throw new Error('[bulk-builder] setBulkRequest: collection is required');
+  }
+  if (!Array.isArray(actions) || actions.length === 0) {
+    throw new Error('[bulk-builder] setBulkRequest: actions must be a non-empty array');
+  }
+
+  const targetParams = new URLSearchParams();
+  if (options.refresh) {
+    targetParams.set('refresh', 'true');
+  }
+  const query = targetParams.toString();
+  ctx.msg.set('URI', `/${collection}/_bulk${query ? `?${query}` : ''}`);
+  ctx.msg.set('method', 'POST');
+
+  // Replace Content-Type case-insensitively. The Java proxy uses headers.add()
+  // (not set()), so any surviving casing variant would create a duplicate.
+  const headers = ctx.msg.get('headers');
+  if (headers && typeof headers.keys === 'function') {
+    const toDelete = Array.from(headers.keys() as Iterable<string>)
+      .filter((k: string) => k.toLowerCase() === 'content-type');
+    for (const k of toDelete) {
+      headers.delete(k);
+    }
+    headers.set('content-type', 'application/x-ndjson');
+  }
+
+  if (!ctx.msg.get('payload')) ctx.msg.set('payload', new Map());
+  const payload = ctx.msg.get('payload');
+
+  // Enforce single-body invariant: exactly one of inlinedJsonBody /
+  // inlinedJsonSequenceBodies is set at a time (matches replayer contract).
+  payload.delete('inlinedJsonBody');
+  payload.set('inlinedJsonSequenceBodies', actions);
+
+  // Clear ctx.body so request.transform.ts's post-pipeline write does not
+  // re-populate inlinedJsonBody from an earlier state.
+  ctx.body = new Map();
+}

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/bulk/bulk-response.test.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/bulk/bulk-response.test.ts
@@ -1,0 +1,273 @@
+import { describe, it, expect } from 'vitest';
+import { response, isBulkResponse } from './bulk-response';
+import type { ResponseContext, JavaMap } from '../../context';
+
+/** Build a minimal ResponseContext wrapping the given body. */
+function buildCtx(body: Map<string, any>): ResponseContext {
+  return {
+    request: new Map() as unknown as JavaMap,
+    response: new Map() as unknown as JavaMap,
+    endpoint: 'update',
+    collection: 'mycore',
+    requestParams: new URLSearchParams(),
+    responseBody: body as unknown as JavaMap,
+  } as ResponseContext;
+}
+
+/** Build an items[] entry for operation `op` with the given details. */
+function bulkItem(
+  op: 'index' | 'create' | 'update' | 'delete',
+  details: Record<string, any>,
+): Map<string, any> {
+  return new Map([[op, new Map<string, any>(Object.entries(details))]]);
+}
+
+describe('isBulkResponse', () => {
+  it('matches response with items array', () => {
+    const body = new Map<string, any>([['took', 5], ['errors', false], ['items', []]]);
+    expect(isBulkResponse(body as unknown as JavaMap)).toBe(true);
+  });
+
+  it('does not match _doc response', () => {
+    const body = new Map<string, any>([['_id', '1'], ['result', 'created']]);
+    expect(isBulkResponse(body as unknown as JavaMap)).toBe(false);
+  });
+
+  it('does not match select response', () => {
+    const body = new Map<string, any>([['hits', new Map()], ['took', 3]]);
+    expect(isBulkResponse(body as unknown as JavaMap)).toBe(false);
+  });
+
+  it('does not match null / undefined', () => {
+    expect(isBulkResponse(null as unknown as JavaMap)).toBe(false);
+    expect(isBulkResponse(undefined as unknown as JavaMap)).toBe(false);
+  });
+});
+
+describe('bulk-response.apply', () => {
+  it('maps all-success to status 0 with QTime from took', () => {
+    const body = new Map<string, any>([
+      ['took', 42],
+      ['errors', false],
+      ['items', [
+        bulkItem('index', { _index: 'mycore', _id: '1', status: 201 }),
+        bulkItem('index', { _index: 'mycore', _id: '2', status: 200 }),
+      ]],
+    ]);
+    const ctx = buildCtx(body);
+    response.apply(ctx);
+
+    const header = ctx.responseBody.get('responseHeader');
+    expect(header.get('status')).toBe(0);
+    expect(header.get('QTime')).toBe(42);
+    expect(ctx.responseBody.has('errors')).toBe(false);
+  });
+
+  it('maps any item failure to status 1 with errors array', () => {
+    const body = new Map<string, any>([
+      ['took', 7],
+      ['errors', true],
+      ['items', [
+        bulkItem('index', { _index: 'mycore', _id: '1', status: 201 }),
+        bulkItem('index', {
+          _index: 'mycore',
+          _id: '2',
+          status: 400,
+          error: new Map<string, any>([
+            ['type', 'mapper_parsing_exception'],
+            ['reason', 'failed to parse field [x]'],
+          ]),
+        }),
+      ]],
+    ]);
+    const ctx = buildCtx(body);
+    response.apply(ctx);
+
+    const header = ctx.responseBody.get('responseHeader');
+    expect(header.get('status')).toBe(1);
+    expect(header.get('QTime')).toBe(7);
+    const errors = ctx.responseBody.get('errors');
+    expect(Array.isArray(errors)).toBe(true);
+    expect(errors).toHaveLength(1);
+    const first = errors[0] as Map<string, any>;
+    expect(first.get('id')).toBe('2');
+    expect(first.get('status')).toBe(400);
+    expect(first.get('type')).toBe('mapper_parsing_exception');
+    expect(first.get('reason')).toBe('failed to parse field [x]');
+  });
+
+  it('treats error block without numeric status as failure', () => {
+    const body = new Map<string, any>([
+      ['took', 1],
+      ['errors', true],
+      ['items', [
+        bulkItem('update', {
+          _index: 'mycore',
+          _id: 'x',
+          error: new Map<string, any>([['type', 'version_conflict_engine_exception'], ['reason', 'conflict']]),
+        }),
+      ]],
+    ]);
+    const ctx = buildCtx(body);
+    response.apply(ctx);
+
+    expect(ctx.responseBody.get('responseHeader').get('status')).toBe(1);
+    expect(ctx.responseBody.get('errors')).toHaveLength(1);
+  });
+
+  it('handles all-failure response with multiple errors', () => {
+    const body = new Map<string, any>([
+      ['took', 3],
+      ['errors', true],
+      ['items', [
+        bulkItem('delete', {
+          _index: 'mycore',
+          _id: '1',
+          status: 404,
+          error: new Map<string, any>([['type', 'not_found'], ['reason', 'missing']]),
+        }),
+        bulkItem('delete', {
+          _index: 'mycore',
+          _id: '2',
+          status: 500,
+          error: new Map<string, any>([['type', 'server_error'], ['reason', 'boom']]),
+        }),
+      ]],
+    ]);
+    const ctx = buildCtx(body);
+    response.apply(ctx);
+
+    const errors = ctx.responseBody.get('errors');
+    expect(errors).toHaveLength(2);
+    expect((errors[0] as Map<string, any>).get('status')).toBe(404);
+    expect((errors[1] as Map<string, any>).get('status')).toBe(500);
+  });
+
+  it('handles empty items array as success', () => {
+    const body = new Map<string, any>([
+      ['took', 0],
+      ['errors', false],
+      ['items', []],
+    ]);
+    const ctx = buildCtx(body);
+    response.apply(ctx);
+    expect(ctx.responseBody.get('responseHeader').get('status')).toBe(0);
+    expect(ctx.responseBody.has('errors')).toBe(false);
+  });
+
+  it('defaults QTime to 0 when took is missing', () => {
+    const body = new Map<string, any>([
+      ['errors', false],
+      ['items', []],
+    ]);
+    const ctx = buildCtx(body);
+    response.apply(ctx);
+    expect(ctx.responseBody.get('responseHeader').get('QTime')).toBe(0);
+  });
+
+  it('strips all original OpenSearch fields from the response', () => {
+    const body = new Map<string, any>([
+      ['took', 12],
+      ['errors', false],
+      ['items', [bulkItem('index', { _index: 'mycore', _id: '1', status: 201 })]],
+      ['_shards', new Map()],
+    ]);
+    const ctx = buildCtx(body);
+    response.apply(ctx);
+
+    // Only responseHeader should remain (no errors → no errors key)
+    expect(ctx.responseBody.size).toBe(1);
+    expect(ctx.responseBody.has('responseHeader')).toBe(true);
+    expect(ctx.responseBody.has('took')).toBe(false);
+    expect(ctx.responseBody.has('errors')).toBe(false);
+    expect(ctx.responseBody.has('items')).toBe(false);
+  });
+
+  it('omits fields on per-item error when they are not present in source', () => {
+    const body = new Map<string, any>([
+      ['took', 1],
+      ['errors', true],
+      ['items', [
+        bulkItem('update', {
+          // intentionally no _index, no error block — only a failing status
+          _id: '1',
+          status: 409,
+        }),
+      ]],
+    ]);
+    const ctx = buildCtx(body);
+    response.apply(ctx);
+
+    const errors = ctx.responseBody.get('errors');
+    expect(errors).toHaveLength(1);
+    const first = errors[0] as Map<string, any>;
+    expect(first.has('index')).toBe(false);
+    expect(first.get('id')).toBe('1');
+    expect(first.get('status')).toBe(409);
+    expect(first.has('type')).toBe(false);
+    expect(first.has('reason')).toBe(false);
+  });
+
+  it('skips malformed items without crashing', () => {
+    const body = new Map<string, any>([
+      ['took', 1],
+      ['errors', true],
+      ['items', [
+        null,
+        'not an object',
+        new Map(), // empty item — no op key
+        bulkItem('index', { _index: 'mycore', _id: '1', status: 201 }),
+      ]],
+    ]);
+    const ctx = buildCtx(body);
+    // Should not throw
+    expect(() => response.apply(ctx)).not.toThrow();
+    // And should still report success for the one valid, passing item
+    expect(ctx.responseBody.get('responseHeader').get('status')).toBe(0);
+  });
+
+  it('handles status as string (e.g. from non-standard proxy)', () => {
+    const body = new Map<string, any>([
+      ['took', 1],
+      ['errors', true],
+      ['items', [
+        bulkItem('index', { _index: 'mycore', _id: '1', status: '400' }),
+      ]],
+    ]);
+    const ctx = buildCtx(body);
+    response.apply(ctx);
+    expect(ctx.responseBody.get('responseHeader').get('status')).toBe(1);
+    const errors = ctx.responseBody.get('errors');
+    expect(errors).toHaveLength(1);
+    expect((errors[0] as Map<string, any>).get('status')).toBe(400);
+  });
+
+  it('handles numeric _id and _index in error details', () => {
+    const body = new Map<string, any>([
+      ['took', 1],
+      ['errors', true],
+      ['items', [
+        bulkItem('index', {
+          _index: 123,
+          _id: 456,
+          status: 500,
+          error: new Map<string, any>([['type', 'err'], ['reason', 'boom']]),
+        }),
+      ]],
+    ]);
+    const ctx = buildCtx(body);
+    response.apply(ctx);
+    const errors = ctx.responseBody.get('errors');
+    expect(errors).toHaveLength(1);
+    // numeric values should not crash — toStringOrUndefined converts them
+    const first = errors[0] as Map<string, any>;
+    expect(first.get('index')).toBe('123');
+    expect(first.get('id')).toBe('456');
+  });
+
+  it('match predicate works when called directly on bulk-response export', () => {
+    const body = new Map<string, any>([['took', 1], ['errors', false], ['items', []]]);
+    const ctx = buildCtx(body);
+    expect(response.match!(ctx)).toBe(true);
+  });
+});

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/bulk/bulk-response.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/bulk/bulk-response.ts
@@ -1,0 +1,187 @@
+/**
+ * Aggregate OpenSearch `_bulk` response into a Solr-shaped update response.
+ *
+ * ## Design decisions
+ *
+ * ### Partial-failure mapping (BULK-PARTIAL-FAILURE)
+ *
+ * Solr's default update semantics are strict: if any document in a batch fails,
+ * the entire batch is rejected and no documents are applied. This is effectively
+ * transactional — Solr rolls back the partial state on failure.
+ *
+ * OpenSearch's `_bulk` API has no such rollback. Successfully-indexed documents
+ * remain in the index even if later items fail. See LIMITATIONS.md
+ * BULK-PARTIAL-FAILURE for the full discussion of this behavioral difference.
+ *
+ * OpenSearch's `_bulk` API is always partial-success — the top-level `errors`
+ * flag indicates whether *any* item failed, and each `items[]` entry carries
+ * its own `status` and optional `error` block.
+ *
+ * We map conservatively:
+ *   - All items succeeded (status < 400)  → `responseHeader.status = 0`
+ *   - Any item failed                     → `responseHeader.status = 1`
+ *                                           + `errors` array with per-item details
+ *
+ * The aggregated `errors` array gives clients enough information to retry
+ * individual failures without forcing the shim to synthesize a fake "batch
+ * failed" error for Solr compatibility. See LIMITATIONS shortcode
+ * BULK-PARTIAL-FAILURE for the full discussion.
+ *
+ * ### QTime
+ *
+ * OpenSearch's `_bulk` response includes a `took` field (milliseconds). We
+ * surface this as `QTime` — unlike the `_doc` API, which does not, so
+ * single-doc aggregation uses `QTime: 0`.
+ */
+import type { MicroTransform } from '../../pipeline';
+import type { ResponseContext, JavaMap } from '../../context';
+
+/** Per-item error in the Solr-shaped aggregated response. */
+export interface BulkAggregatedError {
+  index: string | undefined;
+  id: string | undefined;
+  status: number | undefined;
+  type: string | undefined;
+  reason: string | undefined;
+}
+
+/**
+ * Match predicate for the `_bulk` response shape. OpenSearch always returns
+ * `{took, errors, items}` — `items` is the unambiguous marker.
+ */
+export function isBulkResponse(body: JavaMap): boolean {
+  return body != null && typeof body.has === 'function'
+    && body.has('items') && body.has('took');
+}
+
+/**
+ * Walk `items[]` from an OpenSearch `_bulk` response and compute an overall
+ * status plus a flat list of per-item errors.
+ */
+function aggregateItems(items: Iterable<unknown>): { hasFailure: boolean; errors: BulkAggregatedError[] } {
+  const errors: BulkAggregatedError[] = [];
+  let hasFailure = false;
+  for (const raw of items) {
+    const itemError = extractItemError(raw);
+    if (itemError) {
+      hasFailure = true;
+      errors.push(itemError);
+    }
+  }
+  return { hasFailure, errors };
+}
+
+/**
+ * Inspect one `_bulk` items[] entry and return an aggregated-error record if
+ * the item failed; otherwise `null`. Each entry has the shape
+ * `{<op>: {_index, _id, status, error?}}` with exactly one op key.
+ */
+function extractItemError(raw: unknown): BulkAggregatedError | null {
+  const entry = toMapLike(raw);
+  if (!entry) return null;
+  const detail = firstOpDetail(entry);
+  if (!detail) return null;
+  const status = toNumber(detail.get('status'));
+  const errorDetail = toMapLike(detail.get('error'));
+  const failed = (status != null && status >= 400) || errorDetail != null;
+  if (!failed) return null;
+  return {
+    index: toStringOrUndefined(detail.get('_index')),
+    id: toStringOrUndefined(detail.get('_id')),
+    status: status,
+    type: errorDetail ? toStringOrUndefined(errorDetail.get('type')) : undefined,
+    reason: errorDetail ? toStringOrUndefined(errorDetail.get('reason')) : undefined,
+  };
+}
+
+/** Return the detail map for the first (and only) op key in an items[] entry. */
+function firstOpDetail(entry: JavaMap): JavaMap | null {
+  const iter = entry.keys()[Symbol.iterator]();
+  const first = iter.next();
+  if (first.done) return null;
+  return toMapLike(entry.get(first.value));
+}
+
+function toMapLike(v: unknown): JavaMap | null {
+  if (v != null && typeof (v as any).get === 'function' && typeof (v as any).keys === 'function') {
+    return v as JavaMap;
+  }
+  return null;
+}
+
+function toNumber(v: unknown): number | undefined {
+  if (typeof v === 'number') return v;
+  if (typeof v === 'string' && v !== '') {
+    const n = Number(v);
+    return Number.isFinite(n) ? n : undefined;
+  }
+  return undefined;
+}
+
+function toStringOrUndefined(v: unknown): string | undefined {
+  if (v == null) return undefined;
+  // Only convert values with a well-defined string representation. Plain
+  // objects would stringify as "[object Object]", which is never useful here
+  // and is what Sonar's S3854 flags.
+  if (typeof v === 'string') return v !== '' ? v : undefined;
+  if (typeof v === 'number' || typeof v === 'boolean' || typeof v === 'bigint') {
+    return String(v);
+  }
+  return undefined;
+}
+
+/**
+ * Response transform for an OpenSearch `_bulk` API response.
+ *
+ * Rewrites `ctx.responseBody` in place to the Solr-shaped form:
+ *   {
+ *     responseHeader: { status, QTime },
+ *     errors?: [ { index, id, status, type, reason }, ... ]
+ *   }
+ */
+export const response: MicroTransform<ResponseContext> = {
+  name: 'bulk-response',
+  match: (ctx) => isBulkResponse(ctx.responseBody),
+  apply: (ctx) => {
+    const body = ctx.responseBody;
+    const took = toNumber(body.get('took')) ?? 0;
+
+    const itemsRaw = body.get('items');
+    const items: Iterable<unknown> = isIterable(itemsRaw) ? (itemsRaw as Iterable<unknown>) : [];
+    const { hasFailure, errors } = aggregateItems(items);
+
+    // Wipe the OpenSearch shape before writing the Solr one. Snapshot the keys
+    // to avoid mutating-while-iterating on the underlying Java Map.
+    const keys = Array.from(body.keys());
+    for (const key of keys) {
+      body.delete(key);
+    }
+
+    body.set(
+      'responseHeader',
+      new Map<string, unknown>([
+        ['status', hasFailure ? 1 : 0],
+        ['QTime', took],
+      ]),
+    );
+
+    if (errors.length > 0) {
+      body.set('errors', errors.map(serializeError));
+    }
+  },
+};
+
+function isIterable(v: unknown): boolean {
+  return v != null && typeof (v as any)[Symbol.iterator] === 'function';
+}
+
+/** Convert an aggregated-error record to a Map so the result round-trips through Jackson. */
+function serializeError(err: BulkAggregatedError): Map<string, unknown> {
+  const m = new Map<string, unknown>();
+  if (err.index !== undefined) m.set('index', err.index);
+  if (err.id !== undefined) m.set('id', err.id);
+  if (err.status !== undefined) m.set('status', err.status);
+  if (err.type !== undefined) m.set('type', err.type);
+  if (err.reason !== undefined) m.set('reason', err.reason);
+  return m;
+}

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/update-router.test.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/update-router.test.ts
@@ -388,3 +388,103 @@ describe('update-router response', () => {
     expect(ctx.responseBody.has('responseHeader')).toBe(true);
   });
 });
+
+// --- Response dispatch: _bulk branch (added in PR 1 for framework readiness) ---
+
+function bulkItem(
+  op: 'index' | 'create' | 'update' | 'delete',
+  details: Record<string, any>,
+): Map<string, any> {
+  return new Map([[op, new Map<string, any>(Object.entries(details))]]);
+}
+
+describe('update-router response — match-and-dispatch', () => {
+  it('matches _bulk response shape (items present)', () => {
+    const body = new Map<string, any>([['took', 3], ['errors', false], ['items', []]]);
+    expect(response.match!(buildResponseCtx(body))).toBe(true);
+  });
+
+  it('still matches single-doc _doc response shape', () => {
+    const body = new Map<string, any>([['_id', '1'], ['result', 'created']]);
+    expect(response.match!(buildResponseCtx(body))).toBe(true);
+  });
+
+  it('does not match unrelated shape (select response)', () => {
+    const body = new Map<string, any>([['hits', new Map()], ['took', 3]]);
+    expect(response.match!(buildResponseCtx(body))).toBe(false);
+  });
+
+  it('dispatches _bulk all-success response to bulk aggregator', () => {
+    const body = new Map<string, any>([
+      ['took', 5],
+      ['errors', false],
+      ['items', [
+        bulkItem('index', { _index: 'mycore', _id: '1', status: 201 }),
+        bulkItem('index', { _index: 'mycore', _id: '2', status: 200 }),
+      ]],
+    ]);
+    const ctx = buildResponseCtx(body);
+    response.apply(ctx);
+    const header = ctx.responseBody.get('responseHeader');
+    expect(header.get('status')).toBe(0);
+    // Bulk path preserves took as QTime (unlike _doc path which always uses 0)
+    expect(header.get('QTime')).toBe(5);
+    expect(ctx.responseBody.has('errors')).toBe(false);
+  });
+
+  it('dispatches _bulk partial-failure response to bulk aggregator', () => {
+    const body = new Map<string, any>([
+      ['took', 7],
+      ['errors', true],
+      ['items', [
+        bulkItem('index', { _index: 'mycore', _id: '1', status: 201 }),
+        bulkItem('index', {
+          _index: 'mycore',
+          _id: '2',
+          status: 400,
+          error: new Map<string, any>([
+            ['type', 'mapper_parsing_exception'],
+            ['reason', 'failed to parse'],
+          ]),
+        }),
+      ]],
+    ]);
+    const ctx = buildResponseCtx(body);
+    response.apply(ctx);
+    expect(ctx.responseBody.get('responseHeader').get('status')).toBe(1);
+    expect(ctx.responseBody.get('responseHeader').get('QTime')).toBe(7);
+    const errors = ctx.responseBody.get('errors');
+    expect(errors).toHaveLength(1);
+    expect((errors[0] as Map<string, any>).get('id')).toBe('2');
+  });
+
+  it('dispatches _bulk response with mixed ops (index + delete + update)', () => {
+    const body = new Map<string, any>([
+      ['took', 10],
+      ['errors', true],
+      ['items', [
+        bulkItem('index', { _index: 'mycore', _id: '1', status: 201 }),
+        bulkItem('delete', {
+          _index: 'mycore',
+          _id: '2',
+          status: 404,
+          error: new Map<string, any>([['type', 'not_found'], ['reason', 'missing']]),
+        }),
+        bulkItem('update', { _index: 'mycore', _id: '3', status: 200 }),
+      ]],
+    ]);
+    const ctx = buildResponseCtx(body);
+    response.apply(ctx);
+    expect(ctx.responseBody.get('responseHeader').get('status')).toBe(1);
+    const errors = ctx.responseBody.get('errors');
+    expect(errors).toHaveLength(1);
+    expect((errors[0] as Map<string, any>).get('id')).toBe('2');
+  });
+
+  it('single-doc dispatch keeps QTime: 0 (distinct from bulk)', () => {
+    const body = new Map<string, any>([['_id', '1'], ['result', 'created']]);
+    const ctx = buildResponseCtx(body);
+    response.apply(ctx);
+    expect(ctx.responseBody.get('responseHeader').get('QTime')).toBe(0);
+  });
+});

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/update-router.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/update-router.ts
@@ -30,6 +30,7 @@ import type { MicroTransform } from '../pipeline';
 import type { RequestContext, ResponseContext } from '../context';
 import { request as deleteDocRequest } from './delete-doc';
 import { request as updateDocRequest } from './update-doc';
+import { response as bulkResponse, isBulkResponse } from './bulk/bulk-response';
 
 /** Known Solr update command keys. */
 const KNOWN_COMMANDS = ['delete', 'add', 'commit', 'optimize', 'rollback'];
@@ -178,40 +179,62 @@ function handleAdd(ctx: RequestContext, data: any): void {
 }
 
 /**
- * Response transform — convert OpenSearch _doc response to Solr update response.
+ * Response transform — single entry point for all /update/* responses.
  *
- * Generic for all _doc API operations (create, update, delete).
- * OpenSearch returns: {"_index":"mycore","_id":"1","result":"created|updated|deleted",...}
- * Solr returns:       {"responseHeader":{"status":0,"QTime":N}}
+ * Match-and-dispatch between two OpenSearch response shapes:
+ *   - Single-doc: {_id, result, ...}   — from PUT /_doc/{id}, DELETE /_doc/{id}
+ *   - Bulk:       {took, errors, items}— from POST /_bulk (used by PR 2+)
  *
- * Result mapping:
- *   created/updated/deleted → status 0 (success)
- *   not_found → status 0 (Solr treats delete of missing doc as success — verified against Solr 8/9)
- *   anything else → status 1 (error)
+ * Single-doc mapping:
+ *   OpenSearch: {"_index":"mycore","_id":"1","result":"created|updated|deleted",...}
+ *   Solr:       {"responseHeader":{"status":0,"QTime":N}}
  *
- * QTime is set to 0 because OpenSearch's _doc response does not include processing time.
- * This is a known approximation — monitoring tools should not rely on this value for
- * update operations through the shim.
+ *   Result mapping:
+ *     created/updated/deleted → status 0 (success)
+ *     not_found → status 0 (Solr treats delete of missing doc as success —
+ *                           verified against Solr 8/9)
+ *     anything else → status 1 (error)
+ *
+ *   QTime is 0 because OpenSearch's _doc response does not include processing
+ *   time. This is a known approximation — monitoring tools should not rely on
+ *   this value for update operations through the shim.
+ *
+ * Bulk mapping: delegated to bulk-response.apply (preserves `took` as QTime,
+ * aggregates per-item failures into a Solr-shaped errors array). See
+ * LIMITATIONS shortcode BULK-PARTIAL-FAILURE.
  */
+function isSingleDocResponse(ctx: ResponseContext): boolean {
+  return ctx.responseBody.has('result') && ctx.responseBody.has('_id');
+}
+
+function applySingleDocResponse(ctx: ResponseContext): void {
+  const result = ctx.responseBody.get('result');
+  const status = (result === 'created' || result === 'updated' || result === 'deleted' || result === 'not_found') ? 0 : 1;
+
+  const keys = Array.from(ctx.responseBody.keys());
+  for (const key of keys) {
+    ctx.responseBody.delete(key);
+  }
+
+  ctx.responseBody.set(
+    'responseHeader',
+    new Map<string, unknown>([
+      ['status', status],
+      ['QTime', 0],
+    ]),
+  );
+}
+
 export const response: MicroTransform<ResponseContext> = {
   name: 'update-response',
-  match: (ctx) => ctx.responseBody.has('result') && ctx.responseBody.has('_id'),
+  match: (ctx) => isSingleDocResponse(ctx) || isBulkResponse(ctx.responseBody),
   apply: (ctx) => {
-    const result = ctx.responseBody.get('result');
-    const status = (result === 'created' || result === 'updated' || result === 'deleted' || result === 'not_found') ? 0 : 1;
-
-    const keys = Array.from(ctx.responseBody.keys());
-    for (const key of keys) {
-      ctx.responseBody.delete(key);
+    if (isBulkResponse(ctx.responseBody)) {
+      bulkResponse.apply(ctx);
+      return;
     }
-
-    // QTime is 0 because OpenSearch's _doc response doesn't include processing time.
-    ctx.responseBody.set(
-      'responseHeader',
-      new Map<string, unknown>([
-        ['status', status],
-        ['QTime', 0],
-      ]),
-    );
+    if (isSingleDocResponse(ctx)) {
+      applySingleDocResponse(ctx);
+    }
   },
 };

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/request.transform.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/request.transform.ts
@@ -4,6 +4,11 @@
  * Thin entry point — parses context once, runs the pipeline, writes the body
  * Map back as inlinedJsonBody. Zero serialization in JavaScript — Jackson
  * handles JSON on the Java side.
+ *
+ * Bulk requests: when a transform (e.g., the bulk builder) has already populated
+ * `payload.inlinedJsonSequenceBodies`, we do not overwrite with `inlinedJsonBody`.
+ * This mirrors the replayer's invariant that exactly one of the two payload-body
+ * keys is set for a given request. See JsonKeysForHttpMessage.
  */
 import { buildRequestContext } from './context';
 import type { JavaMap } from './context';
@@ -18,19 +23,38 @@ const solrConfig = (typeof bindings !== 'undefined' && bindings?.solrConfig) //N
   ? bindings.solrConfig
   : undefined;
 
+/**
+ * True when the body is a non-empty iterable/collection (Map or List). Guards against
+ * writing empty bodies back to the payload while tolerating the polymorphic shape of
+ * ctx.body after top-level-array ingress (List<Object>) vs. JSON-object ingress (Map).
+ */
+function hasContent(body: any): boolean {
+  if (body == null) return false;
+  if (typeof body.size === 'number') return body.size > 0;
+  // Java List polyglot wrapper — exposes length but not size
+  const len = body.length;
+  if (typeof len === 'number') return len > 0;
+  return false;
+}
+
 export function transform(msg: JavaMap): JavaMap {
   const ctx = buildRequestContext(msg);
   if (ctx.endpoint === 'unknown') return msg;
   ctx.solrConfig = solrConfig;
   runPipeline(requestRegistry, ctx);
-  if (ctx.body.size > 0) {
-    let payload = msg.get('payload');
-    if (!payload) {
-      payload = new Map();
-      msg.set('payload', payload);
-    }
+
+  let payload = msg.get('payload');
+  if (!payload) {
+    payload = new Map();
+    msg.set('payload', payload);
+  }
+
+  // If a transform has already produced an NDJSON sequence (e.g., bulk builder),
+  // respect it as the authoritative body and do not overwrite with inlinedJsonBody.
+  if (!payload.has('inlinedJsonSequenceBodies') && hasContent(ctx.body)) {
     payload.set('inlinedJsonBody', ctx.body);
   }
+
   flushMetrics(ctx._metrics, msg);
   return msg;
 }

--- a/TrafficCapture/transformationShim/src/main/java/org/opensearch/migrations/transform/shim/netty/HttpMessageUtil.java
+++ b/TrafficCapture/transformationShim/src/main/java/org/opensearch/migrations/transform/shim/netty/HttpMessageUtil.java
@@ -32,6 +32,7 @@ public final class HttpMessageUtil {
 
     private static final ObjectMapper MAPPER = new ObjectMapper();
     private static final TypeReference<LinkedHashMap<String, Object>> MAP_TYPE_REF = new TypeReference<>() {};
+    private static final TypeReference<List<Object>> LIST_TYPE_REF = new TypeReference<>() {};
 
     private static final Set<String> RESTRICTED_REQUEST_HEADERS = Set.of(
         "host", "content-length", "transfer-encoding", "connection",
@@ -154,7 +155,15 @@ public final class HttpMessageUtil {
     static String extractBodyString(Map<String, Object> map) {
         var payload = (Map<String, Object>) map.get(JsonKeysForHttpMessage.PAYLOAD_KEY);
         if (payload == null) return null;
-        // Prefer inlinedJsonBody — may be a Map (serialize with Jackson) or a String (passthrough)
+        // Prefer inlinedJsonSequenceBodies (NDJSON) when present — used by _bulk-style requests.
+        // Matches the replayer's NettyJsonBodySerializeHandler semantics: one JSON doc per line
+        // with a trailing newline. See OpenSearch _bulk API which requires the trailing newline.
+        var ndjsonBodies = payload.get(JsonKeysForHttpMessage.INLINED_NDJSON_BODIES_DOCUMENT_KEY);
+        if (ndjsonBodies instanceof List) {
+            return serializeNdjson((List<?>) ndjsonBodies);
+        }
+        // inlinedJsonBody may be a Map, a List (top-level JSON array), or a String (passthrough).
+        // Jackson's ObjectMapper handles both Map and List without additional branching.
         var jsonBody = payload.get(JsonKeysForHttpMessage.INLINED_JSON_BODY_DOCUMENT_KEY);
         if (jsonBody != null) {
             if (jsonBody instanceof String) return (String) jsonBody;
@@ -169,14 +178,48 @@ public final class HttpMessageUtil {
     }
 
     /**
-     * Parse a JSON string into a LinkedHashMap if valid JSON object, otherwise return the raw string.
-     * This allows transforms to work with Maps (fast .get()/.set()) instead of parsing JSON in JS.
-     * Only parses JSON objects (starting with '{') — arrays and other types stay as strings.
+     * Serialize a list of JSON values as NDJSON: one JSON document per line, each followed by '\n'
+     * (including the last one). Matches the OpenSearch _bulk API requirement and is semantically
+     * equivalent to the replayer's NettyJsonBodySerializeHandler.serializePayloadList with
+     * addLastNewline=true (i.e. no sibling binary/text body present).
+     */
+    private static String serializeNdjson(List<?> items) {
+        var sb = new StringBuilder();
+        for (var item : items) {
+            try {
+                sb.append(MAPPER.writeValueAsString(item)).append('\n');
+            } catch (JsonProcessingException e) {
+                throw new IllegalStateException("Failed to serialize inlinedJsonSequenceBodies item", e);
+            }
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Parse a JSON string into a structured value for efficient Map/List access by transforms.
+     * - Objects (starting with '{') → LinkedHashMap
+     * - Arrays (starting with '[')  → List<Object>  (matches replayer JsonAccumulator semantics)
+     * - Anything else or parse failure → raw String (passthrough)
+     *
+     * Storing a top-level array under INLINED_JSON_BODY_DOCUMENT_KEY is aligned with the replayer's
+     * NettyJsonBodyAccumulateHandler, which stores a single top-level JSON value (Map or Object[])
+     * under the same key. Only a stream of multiple top-level JSON values (true NDJSON) maps to
+     * INLINED_NDJSON_BODIES_DOCUMENT_KEY — that ingress path is not handled here (see LIMITATIONS
+     * shortcode NDJSON-INGEST-PARITY).
      */
     private static Object parseJsonOrText(String body) {
-        if (body.isEmpty() || body.charAt(0) != '{') return body;
+        if (body.isEmpty()) return body;
+        var first = body.charAt(0);
+        TypeReference<?> typeRef;
+        if (first == '{') {
+            typeRef = MAP_TYPE_REF;
+        } else if (first == '[') {
+            typeRef = LIST_TYPE_REF;
+        } else {
+            return body;
+        }
         try {
-            return MAPPER.readValue(body, MAP_TYPE_REF);
+            return MAPPER.readValue(body, typeRef);
         } catch (JsonProcessingException ignored) {
             return body;
         }

--- a/TrafficCapture/transformationShim/src/test/java/org/opensearch/migrations/transform/shim/netty/HttpMessageUtilTest.java
+++ b/TrafficCapture/transformationShim/src/test/java/org/opensearch/migrations/transform/shim/netty/HttpMessageUtilTest.java
@@ -1,0 +1,242 @@
+package org.opensearch.migrations.transform.shim.netty;
+
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.opensearch.migrations.transform.JsonKeysForHttpMessage;
+
+import io.netty.buffer.Unpooled;
+import io.netty.handler.codec.http.DefaultFullHttpRequest;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpVersion;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for {@link HttpMessageUtil} focused on the ingest/egress behavior for
+ * JSON objects, top-level JSON arrays, and NDJSON sequence bodies.
+ *
+ * <p>Semantics are intentionally aligned with the traffic replayer's
+ * {@code NettyJsonBodyAccumulateHandler} (ingress) and {@code NettyJsonBodySerializeHandler}
+ * (egress). See {@link JsonKeysForHttpMessage} for key contracts.
+ */
+class HttpMessageUtilTest {
+
+    // --- Ingress: parseJsonOrText (exercised via requestToMap) ---
+
+    @Test
+    void requestToMap_parsesJsonObjectBodyAsMap() {
+        var body = "{\"id\":\"1\",\"title\":\"hello\"}";
+        var request = buildRequest(body);
+
+        var map = HttpMessageUtil.requestToMap(request);
+
+        var payload = payloadOf(map);
+        var inlinedBody = payload.get(JsonKeysForHttpMessage.INLINED_JSON_BODY_DOCUMENT_KEY);
+        assertInstanceOf(Map.class, inlinedBody, "JSON object body should be parsed as a Map");
+        @SuppressWarnings("unchecked")
+        var asMap = (Map<String, Object>) inlinedBody;
+        assertEquals("1", asMap.get("id"));
+        assertEquals("hello", asMap.get("title"));
+    }
+
+    @Test
+    void requestToMap_parsesTopLevelJsonArrayAsList() {
+        // Matches replayer JsonAccumulator behavior: a single top-level JSON array is a
+        // valid top-level value and is stored under INLINED_JSON_BODY_DOCUMENT_KEY.
+        var body = "[{\"id\":\"1\"},{\"id\":\"2\"}]";
+        var request = buildRequest(body);
+
+        var map = HttpMessageUtil.requestToMap(request);
+
+        var payload = payloadOf(map);
+        var inlinedBody = payload.get(JsonKeysForHttpMessage.INLINED_JSON_BODY_DOCUMENT_KEY);
+        assertInstanceOf(List.class, inlinedBody, "Top-level JSON array body should be parsed as a List");
+        @SuppressWarnings("unchecked")
+        var asList = (List<Object>) inlinedBody;
+        assertEquals(2, asList.size());
+        assertInstanceOf(Map.class, asList.get(0));
+        assertInstanceOf(Map.class, asList.get(1));
+    }
+
+    @Test
+    void requestToMap_leavesScalarBodyAsRawString() {
+        var body = "plain text body";
+        var request = buildRequest(body);
+
+        var map = HttpMessageUtil.requestToMap(request);
+
+        var payload = payloadOf(map);
+        var inlinedBody = payload.get(JsonKeysForHttpMessage.INLINED_JSON_BODY_DOCUMENT_KEY);
+        assertEquals("plain text body", inlinedBody);
+    }
+
+    @Test
+    void requestToMap_returnsRawStringWhenJsonObjectMalformed() {
+        var body = "{not valid json";
+        var request = buildRequest(body);
+
+        var map = HttpMessageUtil.requestToMap(request);
+
+        var payload = payloadOf(map);
+        assertEquals("{not valid json",
+            payload.get(JsonKeysForHttpMessage.INLINED_JSON_BODY_DOCUMENT_KEY));
+    }
+
+    @Test
+    void requestToMap_returnsRawStringWhenJsonArrayMalformed() {
+        var body = "[not valid json";
+        var request = buildRequest(body);
+
+        var map = HttpMessageUtil.requestToMap(request);
+
+        var payload = payloadOf(map);
+        assertEquals("[not valid json",
+            payload.get(JsonKeysForHttpMessage.INLINED_JSON_BODY_DOCUMENT_KEY));
+    }
+
+    // --- Egress: extractBodyString ---
+
+    @Test
+    void extractBodyString_returnsNdjsonFromInlinedJsonSequenceBodies() {
+        var indexAction = new LinkedHashMap<String, Object>();
+        indexAction.put("_index", "mycore");
+        indexAction.put("_id", "1");
+        var item1 = new LinkedHashMap<String, Object>();
+        item1.put("index", indexAction);
+        var item2 = new LinkedHashMap<String, Object>();
+        item2.put("title", "hello");
+        var map = buildMessageWithPayload(Map.of(
+            JsonKeysForHttpMessage.INLINED_NDJSON_BODIES_DOCUMENT_KEY,
+            List.of(item1, item2)
+        ));
+
+        var body = HttpMessageUtil.extractBodyString(map);
+
+        assertNotNull(body);
+        assertTrue(body.endsWith("\n"),
+            "NDJSON body must end with a trailing newline for OpenSearch _bulk");
+        var lines = body.split("\n");
+        assertEquals(2, lines.length);
+        // Compare parsed JSON structures (not raw strings) to avoid coupling on field ordering.
+        assertEquals(parse("{\"index\":{\"_index\":\"mycore\",\"_id\":\"1\"}}"), parse(lines[0]));
+        assertEquals(parse("{\"title\":\"hello\"}"), parse(lines[1]));
+    }
+
+    @Test
+    void extractBodyString_ndjsonWithSingleItem_stillHasTrailingNewline() {
+        var onlyItem = new LinkedHashMap<String, Object>();
+        onlyItem.put("delete", Map.of("_id", "1"));
+        var map = buildMessageWithPayload(Map.of(
+            JsonKeysForHttpMessage.INLINED_NDJSON_BODIES_DOCUMENT_KEY,
+            List.of(onlyItem)
+        ));
+
+        var body = HttpMessageUtil.extractBodyString(map);
+
+        assertNotNull(body);
+        assertTrue(body.endsWith("\n"));
+        assertEquals(1, body.split("\n").length);
+    }
+
+    @Test
+    void extractBodyString_ndjsonEmptyListProducesEmptyString() {
+        var map = buildMessageWithPayload(Map.of(
+            JsonKeysForHttpMessage.INLINED_NDJSON_BODIES_DOCUMENT_KEY,
+            List.of()
+        ));
+
+        var body = HttpMessageUtil.extractBodyString(map);
+
+        assertEquals("", body);
+    }
+
+    @Test
+    void extractBodyString_ndjsonPreferredOverInlinedJsonBody() {
+        // Producer invariant: only one of the two keys should be set at a time.
+        // If both are present (e.g., a mis-wired transform), NDJSON takes precedence to
+        // match the intent of the writer that produced the sequence.
+        var ndjsonItem = new LinkedHashMap<String, Object>();
+        ndjsonItem.put("index", Map.of("_id", "1"));
+        var payload = new LinkedHashMap<String, Object>();
+        payload.put(JsonKeysForHttpMessage.INLINED_NDJSON_BODIES_DOCUMENT_KEY, List.of(ndjsonItem));
+        payload.put(JsonKeysForHttpMessage.INLINED_JSON_BODY_DOCUMENT_KEY, Map.of("should", "be_ignored"));
+        var map = buildMessageWithPayload(payload);
+
+        var body = HttpMessageUtil.extractBodyString(map);
+
+        assertNotNull(body);
+        assertTrue(body.contains("\"index\""));
+        assertTrue(!body.contains("should"));
+    }
+
+    @Test
+    void extractBodyString_serializesInlinedJsonBodyList() {
+        // A top-level-array inlinedJsonBody must round-trip through Jackson to a JSON array.
+        var list = List.of(Map.of("id", "1"), Map.of("id", "2"));
+        var map = buildMessageWithPayload(Map.of(
+            JsonKeysForHttpMessage.INLINED_JSON_BODY_DOCUMENT_KEY,
+            list
+        ));
+
+        var body = HttpMessageUtil.extractBodyString(map);
+
+        assertNotNull(body);
+        assertTrue(body.startsWith("["));
+        assertTrue(body.endsWith("]"));
+        assertTrue(body.contains("\"id\":\"1\""));
+        assertTrue(body.contains("\"id\":\"2\""));
+    }
+
+    @Test
+    void extractBodyString_returnsNullWhenNoPayload() {
+        var map = new LinkedHashMap<String, Object>();
+        assertNull(HttpMessageUtil.extractBodyString(map));
+    }
+
+    // --- helpers ---
+
+    private static FullHttpRequest buildRequest(String body) {
+        var bytes = body.getBytes(StandardCharsets.UTF_8);
+        return new DefaultFullHttpRequest(
+            HttpVersion.HTTP_1_1,
+            HttpMethod.POST,
+            "/test",
+            Unpooled.wrappedBuffer(bytes)
+        );
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> payloadOf(Map<String, Object> map) {
+        var payload = (Map<String, Object>) map.get(JsonKeysForHttpMessage.PAYLOAD_KEY);
+        assertNotNull(payload, "payload must be present");
+        return payload;
+    }
+
+    private static Map<String, Object> buildMessageWithPayload(Map<String, Object> payload) {
+        var map = new LinkedHashMap<String, Object>();
+        map.put(JsonKeysForHttpMessage.PAYLOAD_KEY, new LinkedHashMap<>(payload));
+        return map;
+    }
+
+    /**
+     * Parse a JSON string into a structural Map for equality comparisons that are
+     * independent of field-ordering quirks in the producer.
+     */
+    private static Object parse(String json) {
+        try {
+            var mapper = new com.fasterxml.jackson.databind.ObjectMapper();
+            return mapper.readValue(json, Object.class);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

   PR 1 of the Solr→OpenSearch write-request translation series. Pure infrastructure — lays the rails for `_bulk` without changing any customer-visible behavior. No request handler invokes the new helpers yet; that happens in subsequent PRs. The existing pipeline registry is untouched.

   This PR aligns the shim with the traffic replayer's NDJSON framework contract so that subsequent PRs can produce `_bulk`-style requests through the same code path the replayer already uses.

   ## Motivation

   Solr's `/update` endpoint supports batch operations (`{"add":[...]}`, `{"delete":[...]}`, `/update/json/docs` with top-level array bodies, mixed commands). The current shim rejects all of these with a fail-fast. To translate them into OpenSearch's `_bulk` API, the shim needs:

   1. A way to emit NDJSON from a transform (one JSON document per line + trailing newline).
   2. A shared builder that produces valid `_bulk` actions for `index` / `create` / `update` / `delete`.
   3. A response aggregator that maps `_bulk`'s per-item status/error output back into a Solr-shaped response.
   4. The ability to parse top-level JSON-array request bodies on ingress (needed by `/update/json/docs`).

   This PR adds all four without wiring any of them into the active pipeline. 

   ## Framework alignment with the traffic replayer

   The shim previously had no path for NDJSON bodies. The traffic replayer already supports NDJSON on both sides via `NettyJsonBodyAccumulateHandler` (ingress) and `NettyJsonBodySerializeHandler` (egress), using `JsonKeysForHttpMessage.INLINED_NDJSON_BODIES_DOCUMENT_KEY` (`inlinedJsonSequenceBodies`) as the canonical payload key.

   This PR brings the shim to the same contract:

   | Concern | Replayer | Shim (before) | Shim (after PR 1) |
   |---|---|---|---|
   | Canonical batch payload key | `inlinedJsonSequenceBodies` | not used | `inlinedJsonSequenceBodies` |
   | Emit NDJSON from a transform | ✅ streaming | ❌ silently dropped | ✅ synchronous materializer |
   | Top-level JSON array ingress | ✅ as `Object[]` under `inlinedJsonBody` | ❌ raw String | ✅ as `List<Object>` under `inlinedJsonBody` |
   | Trailing newline on emit | ✅ (when no sibling body) | n/a | ✅ always |
   | Mutual exclusion with `inlinedJsonBody` | producer responsibility | n/a | enforced by `setBulkRequest` |

   ## Changes

   ### Java — `HttpMessageUtil.java`
   - `parseJsonOrText`: parses top-level `[...]` bodies into `List<Object>` (replayer parity).
   - `extractBodyString`: new branch for `inlinedJsonSequenceBodies` → NDJSON with trailing newline.

   ### TypeScript — `features/bulk/bulk-builder.ts` (new)
   - `buildBulkAction(op, {index, id?, doc?})` — returns NDJSON entries for `index`/`create`/`update`/`delete`.
   - `setBulkRequest(ctx, collection, actions, {refresh})` — rewrites URI to `/_bulk`, sets POST + `application/x-ndjson`, writes `inlinedJsonSequenceBodies`, clears `inlinedJsonBody`.

   ### TypeScript — `features/bulk/bulk-response.ts` (new)
   - Aggregates `_bulk` `items[]` into Solr-shaped response: `status:0` on all-success, `status:1` + `errors[]` on any failure. Uses `took` as `QTime`. Emulates Solr's `TolerantUpdateProcessorFactory` format.

   ### TypeScript — `features/update-router.ts` (modified)
   - Response transform refactored into match-and-dispatch: single-doc (`_id`+`result`) vs bulk (`items[]`). Existing single-doc behavior preserved exactly.

   ### TypeScript — `request.transform.ts` (modified)
   - Skips overwriting `inlinedJsonBody` when `inlinedJsonSequenceBodies` is already set. Tolerates both Map and List body shapes.

   ### TypeScript — `context.ts` (docstring only)
   - `getBodyMap` docstring updated for polymorphic return. No behavioral change.

   ### Docs — `LIMITATIONS.md`
   - **`BULK-PARTIAL-FAILURE`**: OpenSearch `_bulk` has no transactional rollback; aggregator returns HTTP 200 + `errors[]` to prevent client retry duplicates.
   - **`NDJSON-INGEST-PARITY`**: NDJSON egress works; multi-line NDJSON ingress not yet supported (not exercised by Solr clients).


   ## Tests added

   | Suite | Count | Coverage |
   |---|---|---|
   | `HttpMessageUtilTest.java` | 11 | JSON-object ingress → Map, top-level-array ingress → List, scalar/malformed → raw String, NDJSON egress with trailing newline, NDJSON precedence over `inlinedJsonBody`, List `inlinedJsonBody` serializes as JSON array, empty/null payload. |
   | `bulk-builder.test.ts` | 23 | `index` (happy, no id, numeric id, missing doc, missing index) × `create` × `update` × `delete` (3 each); `setBulkRequest` (URI, refresh, content-type case-safety, payload invariant, body clearing, validation). |
   | `bulk-response.test.ts` | 13 | `isBulkResponse` predicate (match/reject cases); aggregator (all-success, any-failure, error-without-status, all-failure, empty items, missing `took` → QTime 0, strips all OS fields, omits absent optional fields, skips malformed items). |
   | `update-router.test.ts` | +7 | Dispatch: bulk match, single-doc match, reject select, bulk all-success (QTime=took), bulk partial-failure with errors[], mixed-op response (index+delete+update) with delete failing, single-doc QTime=0 distinct from bulk. |

   Total new: **+43 TS tests** (863 total, up from 820) and **+11 Java tests**.

   ## Validation

   | Gate | Result |
   |---|---|
   | TS `vitest` | **863 / 863** passing (36 files) |
   | Gradle `:TrafficCapture:transformationShim:test` | **301 / 301** passing |
   | Gradle `:TrafficCapture:SolrTransformations:test` | green |
   | E2E `:isolatedTest` (Solr 8 + Solr 9 + OpenSearch) | **no regressions** |


   ## What this PR does NOT change

   - **Request registry**: unchanged. The new `features/bulk/*` files are dead code at runtime until until subsequent  imports them.
   - **Existing `/update` behavior**: unchanged. The `update-router` still rejects arrays, multi-commands, `commit`, `optimize`, delete-by-query, and XML with fail-fast. Single-doc add, JSON-command-format add, and delete-by-id work exactly as before.
   - **Select / schema / admin endpoints**: unchanged.
   - **Response for existing `_doc` flows**: byte-identical (same match predicate, same body transformation — verified by the full existing `update-router.test.ts` suite continuing to pass unmodified).

   ## PR sequence

   1. **This PR** — NDJSON framework + `_bulk` plumbing
   2. PR 2 — Batch add + bulk delete + commit (depends on this)
   3. PR 3 — Delete by query ( Independent ) 

   After PR 1+2+3, three of the five remaining Solr write-path gaps in issue #2778 close in one cycle: bulk/batch operations, delete-by-query, and commit.

   ## Commit

   - `feat(solr-transforms): NDJSON framework and shared _bulk helpers` — `1dd9efb08`
   - 11 files changed, 1,448 insertions(+), 45 deletions(-)