### PR TITLE
Fix capture proxy TLS crash by using PKCS8 private key encoding

### DIFF
--- a/orchestrationSpecs/packages/migration-workflow-templates/src/workflowTemplates/setupCapture.ts
+++ b/orchestrationSpecs/packages/migration-workflow-templates/src/workflowTemplates/setupCapture.ts
@@ -288,6 +288,11 @@ function makeCertificateManifest(args: {
             dnsNames: makeDirectTypeProxy(args.dnsNames),
             duration: args.duration,
             renewBefore: args.renewBefore,
+            privateKey: {
+                algorithm: "RSA",
+                encoding: "PKCS8",
+                size: 2048,
+            },
         }
     };
 }

--- a/orchestrationSpecs/packages/migration-workflow-templates/tests/__snapshots__/setupCapture.snap.json
+++ b/orchestrationSpecs/packages/migration-workflow-templates/tests/__snapshots__/setupCapture.snap.json
@@ -254,7 +254,7 @@
           ]
         },
         "resource": {
-          "manifest": "apiVersion: cert-manager.io/v1\nkind: Certificate\nmetadata:\n  name: \"{{inputs.parameters.certName}}\"\n  ownerReferences:\n    - apiVersion: migrations.opensearch.org/v1alpha1\n      kind: CaptureProxy\n      name: {{inputs.parameters.ownerName}}\n      uid: {{inputs.parameters.ownerUid}}\n      controller: true\n      blockOwnerDeletion: true\nspec:\n  secretName: \"{{inputs.parameters.secretName}}\"\n  issuerRef:\n    name: \"{{inputs.parameters.issuerName}}\"\n    kind: \"{{inputs.parameters.issuerKind}}\"\n    group: \"{{inputs.parameters.issuerGroup}}\"\n  dnsNames: {{inputs.parameters.dnsNames}}\n  duration: \"{{inputs.parameters.duration}}\"\n  renewBefore: \"{{inputs.parameters.renewBefore}}\"\n",
+          "manifest": "apiVersion: cert-manager.io/v1\nkind: Certificate\nmetadata:\n  name: \"{{inputs.parameters.certName}}\"\n  ownerReferences:\n    - apiVersion: migrations.opensearch.org/v1alpha1\n      kind: CaptureProxy\n      name: {{inputs.parameters.ownerName}}\n      uid: {{inputs.parameters.ownerUid}}\n      controller: true\n      blockOwnerDeletion: true\nspec:\n  secretName: \"{{inputs.parameters.secretName}}\"\n  issuerRef:\n    name: \"{{inputs.parameters.issuerName}}\"\n    kind: \"{{inputs.parameters.issuerKind}}\"\n    group: \"{{inputs.parameters.issuerGroup}}\"\n  dnsNames: {{inputs.parameters.dnsNames}}\n  duration: \"{{inputs.parameters.duration}}\"\n  renewBefore: \"{{inputs.parameters.renewBefore}}\"\n  privateKey:\n    algorithm: RSA\n    encoding: PKCS8\n    size: 2048\n",
           "action": "apply",
           "setOwnerReference": false
         },


### PR DESCRIPTION
### Description
The capture proxy crashes on startup with:
```
java.lang.IllegalArgumentException: File does not contain valid private key: /etc/proxy-tls/tls.key
Caused by: java.security.spec.InvalidKeySpecException: Neither RSA, DSA nor EC worked
```

`cert-manager` defaults to PKCS#1 format `(`BEGIN RSA PRIVATE KEY`)` when no encoding is specified.
Netty's `SslContextBuilder` only supports `PKCS#8` (`BEGIN PRIVATE KEY`).

#### Fix                                                                                                                                                                           
Add `privateKey: { algorithm: "RSA", encoding: "PKCS8", size: 2048 }` to the Certificate manifest in `setupCapture.ts` so cert-manager issues the key in a format Netty can parse.

### Issues Resolved
N/A

### Testing
- Mnaully tested and confirmed capture proxy does not fail, and workflow successfully completes

### Check List
- [x] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
