### PR TITLE
Add migration-companion skill with progressive discovery

### DIFF
--- a/AIAdvisor/skills/migration-companion/README.md
+++ b/AIAdvisor/skills/migration-companion/README.md
@@ -1,0 +1,65 @@
+# Migration Companion for OpenSearch
+
+An **OpenSearch Agent Skill** that provides a unified, AI-guided migration
+experience for migrating to OpenSearch from Elasticsearch, OpenSearch, or
+Apache Solr.
+
+## What It Does
+
+Migration Companion is the conversational front door to
+[Migration Assistant](https://github.com/opensearch-project/opensearch-migrations).
+It uses progressive discovery to:
+
+1. **Identify** the source platform and version from natural language
+2. **Assess** the source environment with source-specific depth
+   - Elasticsearch/OpenSearch: lightweight assessment (version, size, downtime tolerance)
+   - Solr: deep assessment (schema conversion, query translation, sizing)
+3. **Recommend** the right migration strategy (backfill-only vs. backfill + capture & replay)
+4. **Deploy** Migration Assistant on EKS or Docker
+5. **Execute** the migration workflow (metadata → snapshot → backfill)
+6. **Validate** results (doc counts, cluster stats, sample queries)
+7. **Guide** cutover and cleanup
+
+## Example Prompts
+
+* "Help me migrate from Elasticsearch 7.10 to OpenSearch."
+* "I need to migrate from Solr 8 to OpenSearch and understand whether my queries will work."
+* "Upgrade my OpenSearch 1.3 cluster to OpenSearch 2.17."
+* "Full autonomous migration from my ES cluster in EKS to a new Amazon OpenSearch Service domain."
+
+## Supported Sources
+
+| Source | Backfill | Capture & Replay |
+|---|---|---|
+| Elasticsearch 1.x–8.x | ✅ | ✅ (5.x+) |
+| OpenSearch 1.x–2.x | ✅ | ✅ |
+| Apache Solr 8.x–9.x | ✅ (SolrReader) | ❌ |
+
+## Skill Structure
+
+```
+migration-companion/
+├── SKILL.md                          # Main skill definition and workflow
+├── README.md                         # This file
+├── steering/
+│   ├── sizing.md                     # Cluster sizing rules (all sources)
+│   ├── compatibility.md              # Version compatibility and known issues
+│   └── safety.md                     # Destructive action rules
+└── references/
+    ├── elasticsearch-migration.md    # ES-specific migration details
+    ├── solr-migration.md             # Solr schema, query, architecture mapping
+    └── migration-assistant.md        # MA capabilities and CLI reference
+```
+
+## Relationship to Existing Components
+
+| Component | Role | Relationship |
+|---|---|---|
+| **Migration Companion** (this skill) | Conversational front door | Orchestrates everything below |
+| **Migration Assistant** | Execution engine | Deployed and driven by Companion |
+| **Solr Migration Advisor** | Solr-specific assessment | Assessment logic incorporated into Companion's Phase 1B |
+| **Kiro CLI agent** | ES/OS execution agent | Execution logic incorporated into Companion's Phases 4–6 |
+
+## License
+
+Apache-2.0. See [LICENSE](../../LICENSE).

--- a/AIAdvisor/skills/migration-companion/SKILL.md
+++ b/AIAdvisor/skills/migration-companion/SKILL.md
@@ -1,0 +1,295 @@
+---
+name: migration-companion
+description: >
+  AI-guided migration companion for migrating to OpenSearch from
+  Elasticsearch, OpenSearch, or Apache Solr. Provides progressive
+  discovery of the source environment, source-specific assessment,
+  and guided execution through Migration Assistant.
+metadata:
+  author: opensearch-project
+  version: "0.1.0"
+  capability: "migration-orchestration"
+  displayName: "Migration Companion for OpenSearch"
+  keywords:
+    - "migrate to OpenSearch"
+    - "Elasticsearch to OpenSearch"
+    - "Solr to OpenSearch"
+    - "OpenSearch upgrade"
+    - "migration assistant"
+    - "migration companion"
+    - "cluster migration"
+---
+
+# Migration Companion for OpenSearch
+
+A unified AI skill for migrating to OpenSearch from any supported source:
+Elasticsearch (1.x–8.x), OpenSearch (1.x–2.x), or Apache Solr (8.x–9.x).
+
+Migration Companion is the conversational front door. Migration Assistant is
+the execution engine underneath. The user talks to the Companion; the Companion
+orchestrates everything else.
+
+## When to Use
+
+Use this skill when:
+
+- A user wants to migrate from Elasticsearch, OpenSearch, or Solr to OpenSearch.
+- A user wants to understand migration readiness before committing to execution.
+- A user wants a guided, conversational migration experience instead of reading docs.
+- A user wants to deploy Migration Assistant and run a migration workflow.
+- A user wants to assess Solr compatibility with OpenSearch (schema, queries, sizing).
+
+**Trigger phrases:** "migrate to OpenSearch", "migration companion", "migrate from
+Elasticsearch", "migrate from Solr", "upgrade OpenSearch", "migration assistant",
+"help me migrate".
+
+## Supported Migration Paths
+
+| Source | Target | Backfill | Capture & Replay |
+|---|---|---|---|
+| Elasticsearch 1.x–2.x | OpenSearch 1.x–3.x | ✅ | ❌ |
+| Elasticsearch 5.x–8.x | OpenSearch 1.x–3.x | ✅ | ✅ |
+| OpenSearch 1.x–2.x | OpenSearch 1.x–3.x | ✅ | ✅ |
+| Apache Solr 8.x–9.x | OpenSearch 3.x | ✅ (SolrReader) | ❌ |
+
+## Progressive Discovery Workflow
+
+The skill uses progressive discovery: start with what the user knows, discover
+the rest at runtime, and branch to source-specific assessment before converging
+on a unified execution path.
+
+Walk the user through each phase in order. Do not skip ahead.
+
+### Phase 0 — Greeting and Goal Identification
+
+Greet the user and identify the migration goal:
+
+*"I'm Migration Companion. I'll guide you from where you are today to a running
+OpenSearch cluster. Tell me what you're migrating from, what you're migrating to,
+and any constraints I should know about (downtime tolerance, timeline, data size).
+I'll figure out the rest."*
+
+From the user's response, infer:
+
+- **Source type**: Elasticsearch, OpenSearch, or Solr
+- **Source version**: If stated
+- **Target type**: Self-managed OpenSearch, Amazon OpenSearch Service, or OpenSearch Serverless
+- **Constraints**: Downtime tolerance, timeline, data size, zero-downtime requirement
+
+If the source type is ambiguous, ask:
+
+*"Are you migrating from Elasticsearch, OpenSearch, or Apache Solr?"*
+
+Once the source type is identified, branch to the appropriate assessment phase.
+
+### Phase 1 — Source-Specific Assessment
+
+#### Phase 1A — Elasticsearch / OpenSearch Assessment
+
+For Elasticsearch or OpenSearch sources, the assessment is lightweight because
+the migration path is well-established. Gather:
+
+1. **Source version** — Ask if not already known. Accept any ES 1.x–8.x or OS 1.x–2.x version.
+2. **Deployment environment** — Where is the source running?
+   - EKS / Kubernetes (agent can discover via kubectl)
+   - Amazon OpenSearch Service (agent can discover via AWS CLI)
+   - Self-managed on EC2 / VMs (user provides endpoint)
+   - Other (user provides endpoint)
+3. **Data size estimate** — Approximate total data size and index count. If the user
+   doesn't know, note that we'll discover this after deploying Migration Assistant.
+4. **Downtime tolerance** — Can the source pause writes during migration?
+   - Yes → Backfill-only path (simpler)
+   - No → Backfill + Capture & Replay path (zero-downtime)
+5. **Target preference** — New domain or existing? Self-managed or Amazon OpenSearch Service?
+
+Present a summary:
+
+*"Here's what I understand: You're migrating from [source] to [target]. Your data
+is approximately [size]. You [can/cannot] tolerate downtime. I recommend the
+[backfill-only / backfill + capture-and-replay] path. Ready to proceed?"*
+
+Skip to Phase 2.
+
+#### Phase 1B — Solr Assessment
+
+For Solr sources, the assessment is deeper because Solr and OpenSearch have
+fundamental architectural differences. The Companion must help the user
+understand compatibility before committing to execution.
+
+##### Step 1B.1 — Solr Version
+
+*"Which version of Apache Solr are you migrating from?"*
+
+Version-specific notes:
+- **Solr 6.x and earlier** — Trie field types (`TrieIntField`, etc.) have no direct
+  OpenSearch equivalent; flag for mapping to Point field equivalents.
+- **Solr 7.x** — Trie fields deprecated; confirm whether schema uses Point fields.
+- **Solr 8.x / 9.x** — Closer to modern OpenSearch conventions; fewer type issues.
+
+##### Step 1B.2 — Schema Assessment
+
+Get the Solr schema and produce an OpenSearch mapping:
+
+- **Path A — Existing schema:** Ask for `schema.xml` or Schema API JSON. Convert
+  field types, analyzers, tokenizers, and copy fields to OpenSearch equivalents.
+  Flag incompatibilities (Trie types, custom similarity, Solr-specific field types).
+- **Path B — No schema:** Ask for a sample document. Infer field types and generate
+  a starter mapping.
+
+Present the mapping with field-by-field annotations. Flag:
+- Fields requiring manual transformation
+- Analyzer chains that don't have direct OpenSearch equivalents
+- Copy fields that should become multi-match queries instead
+
+##### Step 1B.3 — Query Compatibility
+
+Ask for representative Solr queries (standard, DisMax, eDisMax). For each:
+- Translate to OpenSearch Query DSL
+- Flag behavioral differences (scoring, default operators, field boosting)
+- Note any Solr features without OpenSearch equivalents
+
+##### Step 1B.4 — Sizing Estimate
+
+Based on the Solr cluster configuration (nodes, shards, replicas, heap, data size):
+- Recommend OpenSearch cluster sizing following the rules in `steering/sizing.md`
+- Map Solr node specs to OpenSearch instance types
+- Calculate shard count, replica count, and storage requirements
+
+##### Step 1B.5 — Solr Assessment Summary
+
+Present a migration readiness summary:
+
+*"Assessment complete. Here's what I found:*
+*- Schema: [X fields mapped, Y require manual attention]*
+*- Queries: [X translated, Y have behavioral differences]*
+*- Sizing: [recommended cluster configuration]*
+*- Risks: [list of blockers or concerns]*
+*- Recommendation: [proceed / address blockers first]"*
+
+If the user wants to proceed, continue to Phase 2.
+
+### Phase 2 — Migration Strategy Selection
+
+Based on the source type and assessment results, recommend a strategy:
+
+#### For Elasticsearch / OpenSearch sources:
+- **Backfill only** — Source can pause writes. Uses Reindex-From-Snapshot (RFS).
+  Simplest path. Source cluster has zero load during backfill.
+- **Backfill + Capture & Replay** — Source must continue serving writes. Uses RFS
+  for historical data plus Capture Proxy + Kafka + Replayer for live traffic.
+  Zero-downtime migration.
+
+#### For Solr sources:
+- **Backfill only** — Uses SolrReader to read Solr backup data (Lucene segments +
+  schema.xml), translate field types, and bulk-index into OpenSearch.
+- **Capture & Replay is NOT supported** for Solr sources.
+- **Compatibility evaluation** — The Transformation Shim can translate Solr API
+  requests to OpenSearch for shadow validation, but this is an assessment tool,
+  not a migration mechanism.
+
+Present the recommendation and get confirmation before proceeding.
+
+### Phase 3 — Target and Deployment Preparation
+
+Determine the target environment and Migration Assistant deployment:
+
+1. **Target cluster** — Provision new or use existing?
+   - If provisioning new: size based on source assessment, prefer r8gd NVMe instances,
+     add dedicated master nodes, deploy in same VPC as source.
+   - If using existing: validate version compatibility and connectivity.
+
+2. **Migration Assistant deployment** — Where should MA run?
+   - EKS (recommended for Kubernetes-native sources)
+   - Docker (for local testing or development)
+
+3. **Prerequisites check:**
+   - AWS CLI configured?
+   - kubectl access to EKS cluster?
+   - Network connectivity between source, target, and MA?
+   - Snapshot storage (S3 bucket) available?
+   - Credentials and secrets configured?
+
+Present the deployment plan and get approval.
+
+### Phase 4 — Deploy Migration Assistant
+
+Deploy MA using the appropriate method:
+
+#### For EKS deployment:
+1. Deploy CloudFormation stack (IAM roles, S3 buckets, security groups)
+2. Run `aws-bootstrap.sh` to install Helm chart
+3. Verify pods are running
+4. Validate connectivity from Migration Console to source and target
+
+#### For Docker deployment:
+1. Run docker-compose with appropriate configuration
+2. Verify containers are running
+3. Validate connectivity
+
+All cluster API calls go through the Migration Console using
+`console clusters curl`. Never use kubectl port-forward or direct curl
+to cluster endpoints.
+
+### Phase 5 — Configure and Execute Migration
+
+#### For Elasticsearch / OpenSearch sources:
+1. Load workflow configuration via `workflow configure sample --load`
+2. Set source/target endpoints, auth, index allowlist
+3. Set `max_snapshot_rate_mb_per_node: 1000` for snapshot throughput
+4. Calculate RFS worker count from shard count and target vCPU
+5. Submit workflow via `workflow submit`
+6. Monitor progress via `workflow status`
+7. Approve manual gates as configured
+
+#### For Solr sources:
+1. Configure SolrReader with Solr backup location and schema
+2. Configure target OpenSearch endpoint and mapping
+3. Run backfill
+4. Monitor progress
+
+### Phase 6 — Validate Migration
+
+Compare source and target using at least two independent signals:
+
+1. **Per-index document counts** — Source vs target, flag discrepancies
+2. **Cluster-level stats** — Total docs, total size, index count
+3. **Sample queries** — Run representative queries against both and compare results
+4. **Mapping verification** — Confirm all fields and types migrated correctly
+
+Present a go/no-go assessment:
+
+*"✅ Validation passed: [X] indices, [Y] documents, all counts match."*
+
+Or:
+
+*"⚠️ Validation issue: [description]. Recommend [remediation]."*
+
+### Phase 7 — Cutover and Cleanup
+
+Guide the user through:
+
+1. **Cutover** — Update DNS, load balancers, or application configuration to point
+   at the new target. This is always a human decision.
+2. **Observation window** — Monitor the target under production load.
+3. **Cleanup** — When stable, remove Migration Assistant infrastructure:
+   - `helm uninstall -n ma ma`
+   - `kubectl delete namespace ma`
+   - Delete CloudFormation stack
+4. **Summary** — Produce a migration report with what was migrated, duration,
+   any issues encountered, and follow-up recommendations.
+
+## Steering Documents
+
+The following steering documents provide detailed rules for specific aspects:
+
+- `steering/sizing.md` — Cluster sizing rules for all source types
+- `steering/compatibility.md` — Version compatibility matrix and known issues
+- `steering/safety.md` — Destructive action rules and confirmation requirements
+
+## References
+
+The `references/` directory contains detailed technical references:
+
+- `references/elasticsearch-migration.md` — ES-specific migration considerations
+- `references/solr-migration.md` — Solr-specific schema, query, and architecture mapping
+- `references/migration-assistant.md` — Migration Assistant capabilities and CLI reference

--- a/AIAdvisor/skills/migration-companion/references/elasticsearch-migration.md
+++ b/AIAdvisor/skills/migration-companion/references/elasticsearch-migration.md
@@ -1,0 +1,54 @@
+# Elasticsearch Migration Reference
+
+## Migration Mechanisms
+
+### Reindex-From-Snapshot (RFS) — Backfill
+- Reads raw Lucene segment files from snapshots stored in S3
+- Zero impact on the source cluster during backfill
+- Workers scale horizontally on Kubernetes (Fargate or EKS)
+- Throughput: ~15 MB/s per 2-vCPU worker (primary shard data rate)
+
+### Capture and Replay — Live Traffic
+- Capture Proxy deployed as an isolated fleet in front of the source
+- Source cluster is never modified
+- Traffic captured to Kafka, replayed against target by Replayer service
+- Enables zero-downtime migration: source continues serving reads and writes
+
+### Metadata Migration
+- Migrates index templates, component templates, settings, and aliases
+- Runs as a step in the workflow before backfill
+- Does NOT migrate: data streams, ISM policies, security config, Kibana objects,
+  ingest pipelines
+
+## Version-Specific Considerations
+
+### ES 1.x–2.x
+- Backfill only (no Capture & Replay)
+- Very old mapping formats; expect significant type mapping sanitization
+- Multiple types per index must be flattened
+
+### ES 5.x–6.x
+- Full migration path supported
+- Multiple types per index (ES 5.x) or single type (ES 6.x) — both handled
+  by Type Mapping Sanitization Transformer
+- Check for deprecated field types
+
+### ES 7.x
+- Standard migration path
+- Single type per index (default `_doc`)
+- Most mappings transfer cleanly
+
+### ES 8.x
+- Supported to OS 2.x and 3.x
+- Check for ES 8.x-specific features (ESQL, new field types)
+- Security model differs significantly (X-Pack vs OpenSearch Security)
+
+## Pre-Migration Checklist
+
+1. Verify source version and target version compatibility
+2. Check for deprecated or incompatible field types
+3. Identify plugins that need OpenSearch equivalents
+4. Plan for security migration (users, roles, permissions)
+5. Plan for Kibana → OpenSearch Dashboards migration
+6. Estimate data size and migration duration
+7. Determine downtime tolerance → choose backfill-only or backfill + C&R

--- a/AIAdvisor/skills/migration-companion/references/migration-assistant.md
+++ b/AIAdvisor/skills/migration-companion/references/migration-assistant.md
@@ -1,0 +1,72 @@
+# Migration Assistant Reference
+
+## Overview
+
+Migration Assistant (MA) is the execution engine for OpenSearch migrations.
+It is deployed on Kubernetes (EKS or generic K8s) and provides:
+
+- Migration Console — CLI control plane for all migration operations
+- Reindex-From-Snapshot (RFS) — Snapshot-based document backfill
+- Capture Proxy — Live traffic capture to Kafka
+- Replayer — Replay captured traffic against target
+- Metadata Migration — Templates, settings, aliases
+
+## Migration Console CLI
+
+All cluster API calls go through the Migration Console:
+
+```bash
+CONSOLE_POD=$(kubectl -n ma get pod -l app=migration-console -o jsonpath='{.items[0].metadata.name}')
+kubectl -n ma exec "${CONSOLE_POD}" -- bash -lc "<command>"
+```
+
+### Cluster Commands
+```bash
+console clusters connection-check          # Validate source/target connectivity
+console clusters curl --path '/' --cluster source   # Query source cluster
+console clusters curl --path '/' --cluster target   # Query target cluster
+console clusters cat-indices               # List indices on both clusters
+console clusters clear-indices --cluster target     # Clear target indices (DESTRUCTIVE)
+```
+
+### Workflow Commands
+```bash
+workflow configure sample                  # Show sample config
+workflow configure sample --load           # Load sample as starting point
+workflow configure edit --stdin             # Load config from stdin
+workflow configure view                    # View current config
+workflow submit                            # Submit workflow (returns immediately)
+workflow status                            # Check workflow status
+workflow status --all                      # Include completed workflows
+workflow output                            # View step logs
+workflow output -f                         # Stream logs in real-time
+workflow approve                           # Approve manual gates
+workflow stop                              # Stop running workflow
+```
+
+### Configuration Schema
+```bash
+# View full config schema from running console pod
+kubectl exec migration-console-0 -n ma -- cat /root/.workflowUser.schema.json
+
+# Or download versioned schema from GitHub
+curl -sLO https://github.com/opensearch-project/opensearch-migrations/releases/download/<version>/workflowMigration.schema.json
+```
+
+## Deployment Methods
+
+### EKS Deployment (Recommended)
+1. Deploy CloudFormation stack for IAM, S3, security groups
+2. Run `aws-bootstrap.sh` to install Helm chart
+3. Verify pods: `kubectl -n ma get pods`
+
+### Docker Deployment (Development/Testing)
+1. Run docker-compose from `TrafficCapture/dockerSolution/`
+2. Verify containers are running
+3. Access Migration Console container directly
+
+## Key Configuration Settings
+
+- `max_snapshot_rate_mb_per_node: 1000` — Maximize snapshot throughput (default ~40 MB/s is too slow)
+- RFS worker count — Calculate from shard count and target vCPU (see sizing.md)
+- Index allowlist — Migrate specific indices or all non-system indices

--- a/AIAdvisor/skills/migration-companion/references/solr-migration.md
+++ b/AIAdvisor/skills/migration-companion/references/solr-migration.md
@@ -1,0 +1,84 @@
+# Solr Migration Reference
+
+## Migration Mechanisms
+
+### SolrReader — Backfill
+- Reads Solr backup data: Lucene segments + schema.xml
+- Translates Solr field types to OpenSearch mappings
+- Bulk-indexes documents into OpenSearch
+- Backfill only — no live capture support for Solr sources
+
+### Transformation Shim — Assessment Tool
+- HTTP proxy that translates Solr API requests (`/select`) to OpenSearch `_search`
+- Four operating modes:
+  1. Solr-only passthrough
+  2. OpenSearch-only
+  3. Dual-target Solr-primary (shadow validation)
+  4. Dual-target OpenSearch-primary (cutover with safety net)
+- Used for compatibility evaluation, NOT as a migration mechanism
+- Helps users validate that their application queries work against OpenSearch
+
+## Schema Conversion
+
+### Process
+1. Parse `schema.xml` or Schema API JSON
+2. Map Solr field types to OpenSearch types (see compatibility.md)
+3. Convert analyzer chains (tokenizers + filters)
+4. Handle copy fields (may become multi-match queries)
+5. Flag incompatible features
+
+### Common Analyzer Mappings
+| Solr Analyzer | OpenSearch Equivalent |
+|---|---|
+| `solr.StandardTokenizerFactory` | `standard` tokenizer |
+| `solr.WhitespaceTokenizerFactory` | `whitespace` tokenizer |
+| `solr.LowerCaseFilterFactory` | `lowercase` filter |
+| `solr.StopFilterFactory` | `stop` filter |
+| `solr.SynonymGraphFilterFactory` | `synonym_graph` filter |
+| `solr.SnowballPorterFilterFactory` | `snowball` filter |
+| `solr.EdgeNGramFilterFactory` | `edge_ngram` filter |
+| `solr.NGramFilterFactory` | `ngram` filter |
+| `solr.ASCIIFoldingFilterFactory` | `asciifolding` filter |
+
+### Known Incompatibilities
+- Solr `copyField` has no direct OpenSearch equivalent. Use `copy_to` in mappings
+  or multi-match queries at search time.
+- Solr `dynamicField` maps to OpenSearch `dynamic_templates`.
+- Solr `uniqueKey` maps to OpenSearch `_id` (but OpenSearch auto-generates IDs by default).
+- Solr `similarity` configuration (TF-IDF vs BM25) — OpenSearch defaults to BM25.
+
+## Query Translation
+
+### Solr Standard Query → OpenSearch Query DSL
+| Solr | OpenSearch |
+|---|---|
+| `field:value` | `{"term": {"field": "value"}}` |
+| `field:value*` | `{"prefix": {"field": "value"}}` |
+| `field:[min TO max]` | `{"range": {"field": {"gte": min, "lte": max}}}` |
+| `field:val1 AND field:val2` | `{"bool": {"must": [...]}}` |
+| `field:val1 OR field:val2` | `{"bool": {"should": [...]}}` |
+| `NOT field:value` | `{"bool": {"must_not": [...]}}` |
+
+### Solr DisMax/eDisMax → OpenSearch
+| Solr Parameter | OpenSearch Equivalent |
+|---|---|
+| `qf` (query fields) | `multi_match.fields` with boosts |
+| `pf` (phrase fields) | `multi_match` with `type: phrase` |
+| `bq` (boost query) | `bool.should` with boost |
+| `bf` (boost function) | `function_score` |
+| `tie` (tie breaker) | `multi_match.tie_breaker` |
+| `mm` (minimum match) | `minimum_should_match` |
+
+## Architecture Mapping
+
+| Solr Concept | OpenSearch Equivalent |
+|---|---|
+| SolrCloud cluster | OpenSearch cluster |
+| Collection | Index |
+| Shard | Shard |
+| Replica | Replica |
+| ZooKeeper ensemble | Cluster manager nodes (built-in) |
+| Config set | Index template |
+| Request handler | Search endpoint + query configuration |
+| Update handler | Bulk API / index API |
+| PULL replica | Hot-warm tiering with ISM |

--- a/AIAdvisor/skills/migration-companion/steering/compatibility.md
+++ b/AIAdvisor/skills/migration-companion/steering/compatibility.md
@@ -1,0 +1,71 @@
+# Version Compatibility and Known Issues
+
+## Elasticsearch to OpenSearch
+
+### Version Compatibility
+- ES 1.x–2.x → OS 1.x–3.x: Backfill only (no Capture & Replay)
+- ES 5.x–8.x → OS 1.x–3.x: Backfill + Capture & Replay supported
+- ES 8.x → OS 1.x: Not supported (version gap too large)
+
+### Known Issues
+- **Type mappings:** ES 5.x/6.x indices may use multiple types per index. These must
+  be flattened to single-type indices for OpenSearch. The Type Mapping Sanitization
+  Transformer handles this automatically during RFS backfill.
+- **Field type changes:** `sparse_vector` → `rank_features`, `dense_vector` → `knn_vector`,
+  ELSER-specific types may need removal.
+- **Security plugin:** Elasticsearch X-Pack security does not migrate. OpenSearch uses
+  its own Security plugin. Roles, users, and permissions must be recreated.
+- **Kibana objects:** Kibana saved objects (dashboards, visualizations) need the
+  Dashboards Sanitizer tool for conversion to OpenSearch Dashboards format.
+- **Ingest pipelines:** Not automatically migrated. Must be recreated manually.
+- **ILM → ISM:** Elasticsearch Index Lifecycle Management policies must be converted
+  to OpenSearch Index State Management policies.
+
+## OpenSearch to OpenSearch
+
+### Version Compatibility
+- OS 1.x → OS 1.x–3.x: Supported
+- OS 2.x → OS 2.x–3.x: Supported
+- OS 3.x → OS 3.x: Planned
+
+### Known Issues
+- Generally the smoothest migration path. Most settings and mappings transfer directly.
+- Check for deprecated settings between major versions.
+- Plugin compatibility may vary between versions.
+
+## Solr to OpenSearch
+
+### Version Compatibility
+- Solr 8.x–9.x → OS 3.x: Backfill via SolrReader
+
+### Architectural Differences
+- **No `_source` field:** Solr does not store the original document by default.
+  SolrReader reconstructs documents from stored fields. Fields marked `stored="false"`
+  in the Solr schema cannot be recovered.
+- **Schema model:** Solr uses `schema.xml` or Managed Schema with explicit field type
+  definitions. OpenSearch uses JSON mappings. The conversion is not always 1:1.
+- **Query model:** Solr query syntax (standard, DisMax, eDisMax) differs significantly
+  from OpenSearch Query DSL. Query translation is an assessment aid, not a migration
+  mechanism.
+- **No live capture:** Capture & Replay is not supported for Solr sources.
+- **ZooKeeper → Cluster Manager:** SolrCloud's ZooKeeper ensemble is replaced by
+  OpenSearch's built-in cluster manager nodes.
+
+### Field Type Mapping
+| Solr Type | OpenSearch Type | Notes |
+|---|---|---|
+| `solr.StrField` | `keyword` | Direct mapping |
+| `solr.TextField` | `text` | Analyzer chain must be converted |
+| `solr.IntPointField` | `integer` | Direct mapping |
+| `solr.LongPointField` | `long` | Direct mapping |
+| `solr.FloatPointField` | `float` | Direct mapping |
+| `solr.DoublePointField` | `double` | Direct mapping |
+| `solr.BoolField` | `boolean` | Direct mapping |
+| `solr.DatePointField` | `date` | Direct mapping |
+| `solr.TrieIntField` | `integer` | Deprecated in Solr 7+; map to Point equivalent |
+| `solr.TrieLongField` | `long` | Deprecated in Solr 7+; map to Point equivalent |
+| `solr.TrieFloatField` | `float` | Deprecated in Solr 7+; map to Point equivalent |
+| `solr.TrieDoubleField` | `double` | Deprecated in Solr 7+; map to Point equivalent |
+| `solr.TrieDateField` | `date` | Deprecated in Solr 7+; map to Point equivalent |
+| `solr.SpatialRecursivePrefixTreeFieldType` | `geo_shape` | Approximate mapping |
+| `solr.LatLonPointSpatialField` | `geo_point` | Direct mapping |

--- a/AIAdvisor/skills/migration-companion/steering/safety.md
+++ b/AIAdvisor/skills/migration-companion/steering/safety.md
@@ -1,0 +1,48 @@
+# Safety Rules
+
+## Destructive Action Rules
+
+These operations require explicit user confirmation regardless of interaction mode:
+
+- Deleting indices on source or target
+- Clearing index templates
+- Deleting snapshots or snapshot repositories
+- Modifying AWS domain configuration (access policies, security groups, IAM)
+- Deleting S3 objects
+- Running `aws opensearch update-domain-config`
+- Running `aws ec2 authorize-security-group-*` or `revoke-security-group-*`
+- Running `aws iam` role/policy modifications
+
+**Never delete S3 snapshot files directly.** Delete snapshots via the cluster API first.
+
+## Cluster Access Rules
+
+- All source/target cluster API calls go through the Migration Console using
+  `console clusters curl`. Never use `kubectl port-forward`, `kubectl exec`
+  into source pods, or direct `curl` to cluster endpoints.
+- The Migration Console handles auth, TLS, and network routing correctly.
+- `kubectl port-forward` does not work in many environments (CloudShell, CI/CD).
+
+## AWS Change Rules
+
+If resolving an issue requires AWS-side changes (access policies, security groups,
+IAM, domain config):
+- Provide the exact command to the user
+- Ask the user to run it or explicitly approve it
+- Never run these automatically
+
+## Interaction Modes
+
+| Mode | Phase boundaries | Within phases | Destructive actions |
+|---|---|---|---|
+| **guided** | Ask confirmation | Ask confirmation | Always ask |
+| **semi_auto** | Ask confirmation | Proceed automatically | Always ask |
+| **auto** | Proceed automatically | Proceed automatically | Ask unless `allow_destructive=true` |
+
+Default to `guided` if the interaction level is unclear.
+
+## Retry Rules
+
+- Do not retry the same failing approach more than 3 times.
+- After 3 failures, stop and report to the user with a summary of what was tried.
+- Propose alternative approaches.

--- a/AIAdvisor/skills/migration-companion/steering/sizing.md
+++ b/AIAdvisor/skills/migration-companion/steering/sizing.md
@@ -1,0 +1,61 @@
+# Cluster Sizing Rules
+
+Sizing estimates must always be labeled as estimates with stated assumptions.
+Never present a sizing recommendation as exact.
+
+## Universal Rules (All Source Types)
+
+- **Shard size target:** 10–50 GB per shard. Flag shards outside this range.
+- **Shard count formula:** `primary_shards = ceil(index_size_GB / target_shard_size_GB)`
+- **Replica default:** `number_of_replicas: 1` for production. Set to 0 during bulk load.
+- **JVM heap:** `-Xms` = `-Xmx`. Never exceed 50% of RAM or 32 GB.
+- **Storage formula:** `raw_data × (1 + replicas) × 1.3 overhead × 1.25 headroom`
+- **Cluster manager nodes:** Always 3 dedicated (odd number for quorum).
+- **Disk watermarks:** Alert at 75%. OpenSearch stops allocating at 85%, blocks writes at 90%.
+
+## Instance Type Selection (Amazon OpenSearch Service)
+
+Prefer NVMe-backed instances to eliminate EBS costs:
+
+1. Calculate storage needed per node: `total_storage / data_node_count`
+2. If it fits on r8gd NVMe → use r8gd (default choice)
+3. If not → fall back to r7g + gp3 EBS
+
+| Source Profile | Recommended Instance | Notes |
+|---|---|---|
+| ~2 vCPU, ~16 GB | r8gd.large.search | NVMe preferred |
+| ~4 vCPU, ~32 GB | r8gd.xlarge.search | NVMe preferred |
+| ~8 vCPU, ~64 GB | r8gd.2xlarge.search | NVMe preferred |
+| ~16 vCPU, ~128 GB | r8gd.4xlarge.search | NVMe preferred |
+
+## Elasticsearch / OpenSearch Source Sizing
+
+- Match source data node count exactly as starting point.
+- Map source node vCPU and memory to equivalent or better OpenSearch instance type.
+- Prefer latest generation (r8gd > r7g > r6g).
+- Data node count must be divisible by AZ count; round up if needed.
+- Add dedicated master nodes even if source doesn't have them.
+
+## Solr Source Sizing
+
+- Use Solr shard count as baseline but recalculate — Solr collections are often over-sharded.
+- Map SolrCloud nodes to OpenSearch data nodes 1:1 as minimum.
+- Solr ZooKeeper ensemble is replaced by OpenSearch cluster manager nodes (no external ZK needed).
+- Add coordinating-only nodes for production search workloads.
+- Consider hot-warm tiering for time-series data (replaces Solr PULL replicas on slower hardware).
+
+## RFS Worker Calculation
+
+For Reindex-From-Snapshot worker count:
+
+```
+total_vcpu = target_data_nodes × vcpu_per_node
+S = source_primary_shard_count
+upper = total_vcpu / 3
+lower = total_vcpu / 6
+
+if S <= lower: workers = S
+else: find largest S/N that fits in [lower, upper]
+```
+
+Workers should be a clean fraction of shard count to avoid idle workers in the final batch.


### PR DESCRIPTION
## Description

Introduces a unified **Migration Companion** skill that provides a single conversational entry point for migrating to OpenSearch from Elasticsearch, OpenSearch, or Apache Solr.

### Problem

Today the migration experience is split across two separate components:
- **Solr Migration Advisor** (`AIAdvisor/skills/solr-opensearch-migration-advisor/`) — assessment-focused skill for Solr schema conversion, query translation, and sizing
- **Kiro CLI agent** (`kiro-cli/kiro-cli-config/`) — execution-focused agent for deploying Migration Assistant and running ES/OS migration workflows

There is no unified entry point. A user must know which tool to use before they start.

### Solution

Migration Companion uses **progressive discovery** to provide one experience across all source types:

1. **Phase 0 — Greeting:** Identify the migration goal from natural language
2. **Phase 1 — Source-specific assessment:**
   - **ES/OS:** Lightweight assessment (version, size, downtime tolerance) → proceed to execution
   - **Solr:** Deep assessment (schema conversion, query translation, sizing, compatibility) matching the existing Solr skill experience
3. **Phase 2 — Strategy selection:** Backfill-only vs. backfill + capture & replay
4. **Phases 3–7 — Unified execution:** Target provisioning → MA deployment → workflow execution → validation → cutover

### New Files

```
AIAdvisor/skills/migration-companion/
├── SKILL.md                          # Main skill definition (8-phase workflow)
├── README.md                         # Overview and structure
├── steering/
│   ├── sizing.md                     # Unified sizing rules (all sources)
│   ├── compatibility.md              # Version matrix, field type mappings
│   └── safety.md                     # Destructive action rules
└── references/
    ├── elasticsearch-migration.md    # ES-specific migration details
    ├── solr-migration.md             # Solr schema, query, architecture mapping
    └── migration-assistant.md        # MA CLI reference
```

### Design Decisions

- **Skill, not agent:** Follows the same `SKILL.md` pattern as the existing Solr skill, making it installable via `npx skills add`
- **Progressive discovery:** Does not require the user to know their source type upfront — infers it from natural language
- **Source-specific depth:** Solr gets deep assessment (schema, queries, sizing) because the architectural gap is larger. ES/OS gets lightweight assessment because the migration path is well-established.
- **Unified execution:** All sources converge on Migration Assistant for the actual migration, regardless of source type
- **Steering documents:** Sizing, compatibility, and safety rules are shared across all source types

### Relationship to Existing Components

| Component | Status | Relationship |
|---|---|---|
| `solr-opensearch-migration-advisor` | Unchanged | Solr assessment logic incorporated into Phase 1B |
| `kiro-cli/kiro-cli-config` | Unchanged | ES/OS execution logic incorporated into Phases 4–6 |
| `agent-sops/` | Unchanged | Referenced by the skill for detailed EKS deployment procedures |

### Testing

This is a documentation/skill-definition PR (markdown files only). The skill can be tested by:
1. Placing the files in an agent environment
2. Starting a conversation with "Help me migrate from [source] to OpenSearch"
3. Verifying the progressive discovery workflow branches correctly

### Issues Resolved

N/A — new feature

### Check List

- [x] New functionality includes testing
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.