### PR TITLE
Fail fast in aws-bootstrap.sh when AWS region is unresolvable

### DIFF
--- a/deployment/k8s/aws/aws-bootstrap.sh
+++ b/deployment/k8s/aws/aws-bootstrap.sh
@@ -364,6 +364,21 @@ validate_args() {
       echo "Error: Unknown --tls-mode: $tls_mode (expected: none, self-signed, pca-existing, pca-create)" >&2
       exit 1 ;;
   esac
+
+  # Early-resolve region and fail fast if unresolvable. Without this, a missing
+  # region only surfaces as "You must specify a region" from the AWS CLI deep
+  # into the run (e.g. after a multi-minute CDK build with --build). We check
+  # --region, then $AWS_CFN_REGION, then `aws configure get region` — mirroring
+  # the fallback used later at deploy time — so the error happens in seconds,
+  # not minutes.
+  if [[ -z "$region" ]]; then
+    region="$(aws configure get region 2>/dev/null || true)"
+  fi
+  if [[ -z "$region" ]]; then
+    echo "Error: AWS region is not set." >&2
+    echo "  Pass --region <region>, set AWS_CFN_REGION, or run 'aws configure'." >&2
+    exit 1
+  fi
 }
 
 validate_args


### PR DESCRIPTION
### Description

`deployment/k8s/aws/aws-bootstrap.sh` previously deferred AWS region validation to the AWS CLI itself. If the user forgot `--region`, didn't set `AWS_CFN_REGION`, and had no default in `aws configure`, the script would still execute every preceding step — including `./gradlew … :cdkSynthMinified` under `--build`, which takes close to a minute — before the first `aws` command that needed a region (`aws cloudformation deploy`) surfaced `"You must specify a region"` and exited.

Real-world repro (user's actual session, lightly trimmed):

```
$ ./opensearch-migrations/deployment/k8s/aws/aws-bootstrap.sh \
    --deploy-create-vpc-cfn --stack-name NEW_TEST --build
...
BUILD SUCCESSFUL in 55s
Deploying CloudFormation stack: NEW_TEST
You must specify a region. You can also configure your region by running "aws configure".
CloudFormation deployment failed for: NEW_TEST
```

### Fix

Resolve the region inside `validate_args()`, using the same precedence the rest of the script already relies on (`--region` flag > `$AWS_CFN_REGION` env > `aws configure get region`), and exit immediately with an actionable message if none are set.

```
Error: AWS region is not set.
  Pass --region <region>, set AWS_CFN_REGION, or run 'aws configure'.
```

### Behavior change

* **Missing region** → fails in under a second with an actionable message, instead of after the build/download phase.
* **Region resolvable** (flag / env / `aws configure`) → no observable change. The same value every downstream `aws` call would have picked up is now set on the shell variable and threaded through via the existing `${region:+--region "$region"}` expansions.

### Testing

* `bash -n` clean.
* Manual: missing region + `--build --deploy-create-vpc-cfn` exits immediately with the new message.
* Manual: `--region us-west-2` still reaches the CFN deploy step (the region flag is not shadowed).

### Issues Resolved

N/A — quality-of-life fix.

### Check List

- [x] New functionality includes testing. (Manual run — bash script, no unit-test harness for this file.)
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
