### PR TITLE
feat(solr-transforms): Support delete-by-query via _delete_by_query

### DIFF
--- a/TrafficCapture/SolrTransformations/docs/LIMITATIONS.md
+++ b/TrafficCapture/SolrTransformations/docs/LIMITATIONS.md
@@ -21,7 +21,8 @@ the root cause, and provides a workaround where one exists.
 | [FQ-CACHING](#fq-caching)                       | Filter query caching granularity differs between Solr and OpenSearch |
 | [JSON-QUERIES](#json-queries)                   | JSON Request API `queries` key not supported |
 | [JSON-PARAM-PREFIX](#json-param-prefix)         | JSON Request API `json.<param>` prefix passthrough not supported |
-| [UPDATE-COMMANDS](#update-commands)             | Only `add` and `delete-by-id` commands supported; JSON only |
+| [UPDATE-COMMANDS](#update-commands)             | Only `add`, `delete-by-id`, and `delete-by-query` commands supported; JSON only |
+| [DELETE-BY-QUERY](#delete-by-query)             | Delete-by-query always synchronous; version conflicts treated as partial failure |
 | [BULK-PARTIAL-FAILURE](#bulk-partial-failure)   | `_bulk` partial failures surface as `errors[]`; Solr's default strict mode has no OpenSearch equivalent |
 | [NDJSON-INGEST-PARITY](#ndjson-ingest-parity)   | Shim does not parse NDJSON request bodies on ingress (not exercised by Solr clients, but diverges from replayer) |
 | [MM-AUTORELAX](#mm-autorelax)                   | eDisMax `mm.autoRelax` parameter not supported |
@@ -493,7 +494,7 @@ Both JSON and XML content types are supported.
 | `add` with `boost` | ❌ Not supported — fails fast (OpenSearch has no document-level boost) |
 | `add` with `overwrite: false` | ❌ Not supported — fails fast (OpenSearch always overwrites) |
 | `delete` by id | ✅ Supported — `{"delete":{"id":"..."}}` |
-| `delete` by query | ❌ Not supported — fails fast |
+| `delete` by query | ✅ Supported — `{"delete":{"query":"..."}}` → `_delete_by_query` (see [DELETE-BY-QUERY](#delete-by-query)) |
 | `commit` | ❌ Not supported — fails fast |
 | `optimize` / `rollback` | ❌ Not supported — fails fast |
 | Mixed commands | ❌ Not supported — fails fast |
@@ -504,6 +505,37 @@ Both JSON and XML content types are supported.
 Only `application/json` request bodies are supported. XML bodies
 (`text/xml`, `application/xml`) cannot be parsed by the shim and will
 fail with an error. Clients using XML format must switch to JSON.
+
+---
+
+## DELETE-BY-QUERY
+
+**Feature:** `{"delete":{"query":"<solr-query>"}}` → `POST /_delete_by_query`
+
+**Solr behaviour:**
+Delete-by-query is synchronous — the response is returned after all matching
+documents are deleted. The response is simply `{responseHeader:{status:0,QTime:N}}`
+with no metadata about how many documents were deleted.
+
+**OpenSearch behaviour:**
+`_delete_by_query` is asynchronous by default. With `wait_for_completion=true`,
+it behaves synchronously. Version conflicts during deletion are reported in the
+response as `version_conflicts` count rather than aborting the operation.
+
+**Current behaviour (applied automatically by the transformer):**
+
+* `wait_for_completion=true` is always set for synchronous response.
+* `commit=true` / `commitWithin` → `?refresh=true` (immediate visibility).
+* Query translated via `translateQ` in **fail-fast mode** — no passthrough.
+* Version conflicts or `deleted < total` → `responseHeader.status = 1`.
+
+**Residual impact:**
+
+* **No passthrough mode** — queries that the read path would pass through
+  as `query_string` will fail on delete-by-query (intentional for safety).
+* **Version conflicts** — concurrent updates can cause `version_conflicts`.
+  OpenSearch continues deleting remaining documents (no abort). Reported as
+  `status: 1`.
 
 ---
 

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/delete-by-query.test.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/delete-by-query.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect } from 'vitest';
+import { request, response, isDeleteByQueryResponse } from './delete-by-query';
+import type { RequestContext, ResponseContext, JavaMap } from '../context';
+
+function buildCtx(
+  query: string,
+  commitParam?: string,
+): RequestContext {
+  const uri = '/solr/mycore/update';
+  const params = new URLSearchParams();
+  if (commitParam) params.set('commit', commitParam);
+  const msg = new Map<string, any>([
+    ['URI', uri],
+    ['method', 'POST'],
+    ['headers', new Map()],
+  ]) as unknown as JavaMap;
+  return {
+    msg,
+    endpoint: 'update',
+    collection: 'mycore',
+    params,
+    body: new Map<string, any>([['query', query]]) as unknown as JavaMap,
+  } as RequestContext;
+}
+
+function buildResponseCtx(body: Map<string, any>): ResponseContext {
+  return {
+    request: new Map() as unknown as JavaMap,
+    response: new Map() as unknown as JavaMap,
+    endpoint: 'update',
+    collection: 'mycore',
+    requestParams: new URLSearchParams(),
+    responseBody: body as unknown as JavaMap,
+  } as ResponseContext;
+}
+
+describe('delete-by-query request', () => {
+  it('translates simple query to _delete_by_query with DSL', () => {
+    const ctx = buildCtx('title:hello');
+    request.apply(ctx);
+    expect(ctx.msg.get('URI')).toContain('/mycore/_delete_by_query');
+    expect(ctx.msg.get('URI')).toContain('wait_for_completion=true');
+    expect(ctx.msg.get('method')).toBe('POST');
+    expect(ctx.body.has('query')).toBe(true);
+  });
+
+  it('translates match-all *:* query', () => {
+    const ctx = buildCtx('*:*');
+    request.apply(ctx);
+    expect(ctx.msg.get('URI')).toContain('/mycore/_delete_by_query');
+    expect(ctx.body.has('query')).toBe(true);
+  });
+
+  it('adds refresh=true when commit=true', () => {
+    const ctx = buildCtx('title:old', 'true');
+    request.apply(ctx);
+    expect(ctx.msg.get('URI')).toContain('refresh=true');
+    expect(ctx.msg.get('URI')).toContain('wait_for_completion=true');
+  });
+
+  it('omits refresh when no commit param', () => {
+    const ctx = buildCtx('title:old');
+    request.apply(ctx);
+    expect(ctx.msg.get('URI')).not.toContain('refresh=true');
+    expect(ctx.msg.get('URI')).toContain('wait_for_completion=true');
+  });
+
+  it('throws on empty query string', () => {
+    const ctx = buildCtx('');
+    expect(() => request.apply(ctx)).toThrow('query string is empty');
+  });
+
+  it('throws on null query', () => {
+    const msg = new Map<string, any>([
+      ['URI', '/solr/mycore/update'],
+      ['method', 'POST'],
+      ['headers', new Map()],
+    ]) as unknown as JavaMap;
+    const ctx = {
+      msg,
+      endpoint: 'update' as const,
+      collection: 'mycore',
+      params: new URLSearchParams(),
+      body: new Map<string, any>([['query', null]]) as unknown as JavaMap,
+    } as RequestContext;
+    expect(() => request.apply(ctx)).toThrow('query string is empty');
+  });
+
+  it('throws on whitespace-only query', () => {
+    const ctx = buildCtx('   ');
+    expect(() => request.apply(ctx)).toThrow('query string is empty');
+  });
+
+  it('throws on unparseable query (fail-fast mode)', () => {
+    // A query with unbalanced brackets should fail to parse
+    const ctx = buildCtx('title:[invalid');
+    expect(() => request.apply(ctx)).toThrow();
+  });
+
+  it('trims whitespace from query before translation', () => {
+    const ctx = buildCtx('  title:hello  ');
+    request.apply(ctx);
+    expect(ctx.msg.get('URI')).toContain('/mycore/_delete_by_query');
+    expect(ctx.body.has('query')).toBe(true);
+  });
+});
+
+describe('isDeleteByQueryResponse', () => {
+  it('matches _delete_by_query response shape', () => {
+    const body = new Map<string, any>([['took', 5], ['total', 3], ['deleted', 3]]);
+    expect(isDeleteByQueryResponse(body)).toBe(true);
+  });
+
+  it('does not match _doc response', () => {
+    const body = new Map<string, any>([['_id', '1'], ['result', 'created']]);
+    expect(isDeleteByQueryResponse(body)).toBe(false);
+  });
+
+  it('does not match select response', () => {
+    const body = new Map<string, any>([['hits', new Map()], ['took', 3]]);
+    expect(isDeleteByQueryResponse(body)).toBe(false);
+  });
+
+  it('does not match null', () => {
+    expect(isDeleteByQueryResponse(null)).toBe(false);
+  });
+});
+
+describe('delete-by-query response', () => {
+  it('maps all-success to status 0 with QTime from took', () => {
+    const body = new Map<string, any>([
+      ['took', 42], ['total', 5], ['deleted', 5],
+      ['batches', 1], ['version_conflicts', 0], ['failures', []],
+    ]);
+    const ctx = buildResponseCtx(body);
+    response.apply(ctx);
+    const header = ctx.responseBody.get('responseHeader');
+    expect(header.get('status')).toBe(0);
+    expect(header.get('QTime')).toBe(42);
+  });
+
+  it('maps version_conflicts > 0 to status 1', () => {
+    const body = new Map<string, any>([
+      ['took', 10], ['total', 5], ['deleted', 3],
+      ['version_conflicts', 2], ['failures', []],
+    ]);
+    const ctx = buildResponseCtx(body);
+    response.apply(ctx);
+    expect(ctx.responseBody.get('responseHeader').get('status')).toBe(1);
+  });
+
+  it('maps non-empty failures to status 1', () => {
+    const body = new Map<string, any>([
+      ['took', 10], ['total', 5], ['deleted', 4],
+      ['version_conflicts', 0], ['failures', [{ index: 'mycore', id: '1' }]],
+    ]);
+    const ctx = buildResponseCtx(body);
+    response.apply(ctx);
+    expect(ctx.responseBody.get('responseHeader').get('status')).toBe(1);
+  });
+
+  it('maps deleted < total to status 1', () => {
+    const body = new Map<string, any>([
+      ['took', 10], ['total', 5], ['deleted', 3],
+      ['version_conflicts', 0], ['failures', []],
+    ]);
+    const ctx = buildResponseCtx(body);
+    response.apply(ctx);
+    expect(ctx.responseBody.get('responseHeader').get('status')).toBe(1);
+  });
+
+  it('strips all OpenSearch fields from response', () => {
+    const body = new Map<string, any>([
+      ['took', 5], ['total', 2], ['deleted', 2],
+      ['batches', 1], ['version_conflicts', 0], ['failures', []],
+      ['noops', 0], ['retries', new Map()],
+    ]);
+    const ctx = buildResponseCtx(body);
+    response.apply(ctx);
+    expect(ctx.responseBody.size).toBe(1);
+    expect(ctx.responseBody.has('responseHeader')).toBe(true);
+  });
+
+  it('defaults QTime to 0 when took is missing', () => {
+    const body = new Map<string, any>([['total', 0], ['deleted', 0]]);
+    const ctx = buildResponseCtx(body);
+    response.apply(ctx);
+    expect(ctx.responseBody.get('responseHeader').get('QTime')).toBe(0);
+  });
+
+  it('zero total and zero deleted is success', () => {
+    const body = new Map<string, any>([
+      ['took', 1], ['total', 0], ['deleted', 0],
+      ['version_conflicts', 0], ['failures', []],
+    ]);
+    const ctx = buildResponseCtx(body);
+    response.apply(ctx);
+    expect(ctx.responseBody.get('responseHeader').get('status')).toBe(0);
+  });
+});

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/delete-by-query.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/delete-by-query.ts
@@ -1,0 +1,90 @@
+/**
+ * Delete by query — {"delete":{"query":"<solr-query>"}} → POST /_delete_by_query
+ *
+ * Translates a Solr delete-by-query command into OpenSearch's _delete_by_query API.
+ * The Solr query string goes through the existing translateQ pipeline (parser → AST
+ * → transformer), producing the same DSL the read path uses.
+ *
+ * Commit handling:
+ *   - commit=true → ?refresh=true&wait_for_completion=true
+ *   - No commit   → ?wait_for_completion=true only
+ *
+ * Fail-fast policy: delete is destructive — no passthrough on unparseable queries.
+ */
+import type { MicroTransform } from '../pipeline';
+import type { RequestContext, ResponseContext } from '../context';
+import { translateQ } from '../query-engine/orchestrator/translateQ';
+
+export const request: MicroTransform<RequestContext> = {
+  name: 'delete-by-query',
+  match: (ctx) => ctx.body != null && typeof ctx.body.has === 'function' && ctx.body.has('query'),
+  apply: (ctx) => {
+    const queryStr = ctx.body.get('query');
+    if (queryStr == null || String(queryStr).trim() === '') {
+      throw new Error('[delete-by-query] query string is empty — nothing to delete');
+    }
+
+    const solrQuery = String(queryStr).trim();
+    const params = new Map<string, string>();
+    for (const [key, value] of ctx.params.entries()) {
+      params.set(key, value);
+    }
+    params.set('q', solrQuery);
+    const { dsl } = translateQ(params, 'fail-fast');
+
+    const body = new Map<string, unknown>([['query', dsl]]);
+
+    const targetParams = new URLSearchParams();
+    targetParams.set('wait_for_completion', 'true');
+    if (ctx.params.get('commit') === 'true' || ctx.params.has('commitWithin')) {
+      targetParams.set('refresh', 'true');
+    }
+
+    ctx.msg.set('URI', `/${ctx.collection}/_delete_by_query?${targetParams.toString()}`);
+    ctx.msg.set('method', 'POST');
+    ctx.body = body;
+  },
+};
+
+/**
+ * Response: _delete_by_query returns {took, total, deleted, batches, failures, ...}
+ * → Solr {responseHeader:{status, QTime:took}}
+ *
+ * Status mapping:
+ *   - deleted === total && no failures → status 0
+ *   - version_conflicts > 0 or failures non-empty → status 1
+ */
+export function isDeleteByQueryResponse(body: any): boolean {
+  return body != null && typeof body.has === 'function'
+    && body.has('deleted') && body.has('total');
+}
+
+export const response: MicroTransform<ResponseContext> = {
+  name: 'delete-by-query-response',
+  match: (ctx) => isDeleteByQueryResponse(ctx.responseBody),
+  apply: (ctx) => {
+    const body = ctx.responseBody;
+    const took = typeof body.get('took') === 'number' ? body.get('took') : 0;
+    const total = typeof body.get('total') === 'number' ? body.get('total') : 0;
+    const deleted = typeof body.get('deleted') === 'number' ? body.get('deleted') : 0;
+    const versionConflicts = typeof body.get('version_conflicts') === 'number' ? body.get('version_conflicts') : 0;
+    const failures = body.get('failures');
+    const hasFailures = (failures && typeof failures.length === 'number' && failures.length > 0);
+    const hasConflicts = versionConflicts > 0;
+    const incomplete = deleted < total;
+    const failed = hasFailures || hasConflicts || incomplete;
+
+    const keys = Array.from(body.keys());
+    for (const key of keys) {
+      body.delete(key);
+    }
+
+    body.set(
+      'responseHeader',
+      new Map<string, unknown>([
+        ['status', failed ? 1 : 0],
+        ['QTime', took],
+      ]),
+    );
+  },
+};

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/update-router.test.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/update-router.test.ts
@@ -170,9 +170,20 @@ describe('update-router request', () => {
     expect(ctx.msg.get('URI')).toBe(`/mycore/_doc/${longId}`);
   });
 
-  it('throws on delete-by-query', () => {
+  it('dispatches delete-by-query to _delete_by_query handler', () => {
     const ctx = buildCtx('/solr/mycore/update', deleteByQueryBody('title:old'));
-    expect(() => request.apply(ctx)).toThrow('delete-by-query is not supported');
+    request.apply(ctx);
+    expect(ctx.msg.get('URI')).toContain('/mycore/_delete_by_query');
+    expect(ctx.msg.get('URI')).toContain('wait_for_completion=true');
+    expect(ctx.msg.get('method')).toBe('POST');
+  });
+
+  it('throws when both id and query are present in delete', () => {
+    const body = new Map<string, any>([
+      ['delete', new Map<string, any>([['id', '1'], ['query', 'title:old']])],
+    ]);
+    const ctx = buildCtx('/solr/mycore/update', body);
+    expect(() => request.apply(ctx)).toThrow('cannot specify both "id" and "query"');
   });
 
   it('throws on invalid delete format (not a Map)', () => {
@@ -486,5 +497,36 @@ describe('update-router response — match-and-dispatch', () => {
     const ctx = buildResponseCtx(body);
     response.apply(ctx);
     expect(ctx.responseBody.get('responseHeader').get('QTime')).toBe(0);
+  });
+});
+
+// --- _delete_by_query response dispatch ---
+
+describe('update-router response — _delete_by_query dispatch', () => {
+  it('matches _delete_by_query response shape', () => {
+    const body = new Map<string, any>([['took', 5], ['total', 3], ['deleted', 3]]);
+    expect(response.match!(buildResponseCtx(body))).toBe(true);
+  });
+
+  it('dispatches _delete_by_query all-success to status 0', () => {
+    const body = new Map<string, any>([
+      ['took', 15], ['total', 10], ['deleted', 10],
+      ['version_conflicts', 0], ['failures', []],
+    ]);
+    const ctx = buildResponseCtx(body);
+    response.apply(ctx);
+    const header = ctx.responseBody.get('responseHeader');
+    expect(header.get('status')).toBe(0);
+    expect(header.get('QTime')).toBe(15);
+  });
+
+  it('dispatches _delete_by_query partial failure to status 1', () => {
+    const body = new Map<string, any>([
+      ['took', 10], ['total', 5], ['deleted', 3],
+      ['version_conflicts', 2], ['failures', []],
+    ]);
+    const ctx = buildResponseCtx(body);
+    response.apply(ctx);
+    expect(ctx.responseBody.get('responseHeader').get('status')).toBe(1);
   });
 });

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/update-router.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/update-router.ts
@@ -31,6 +31,7 @@ import type { RequestContext, ResponseContext } from '../context';
 import { request as deleteDocRequest } from './delete-doc';
 import { request as updateDocRequest } from './update-doc';
 import { response as bulkResponse, isBulkResponse } from './bulk/bulk-response';
+import { request as deleteByQueryRequest, response as deleteByQueryResponse, isDeleteByQueryResponse } from './delete-by-query';
 
 /** Known Solr update command keys. */
 const KNOWN_COMMANDS = ['delete', 'add', 'commit', 'optimize', 'rollback'];
@@ -146,15 +147,21 @@ function handleDelete(ctx: RequestContext, data: any): void {
   if (!data || typeof data.has !== 'function') {
     throw new Error('[update-router] delete: invalid command format — expected JSON object');
   }
-  if (data.has('query')) {
-    throw new Error('[update-router] delete: delete-by-query is not supported yet');
-  }
   // Fail fast on unsupported Solr delete fields
-  const SUPPORTED_DELETE_FIELDS = new Set(['id']);
+  const SUPPORTED_DELETE_FIELDS = new Set(['id', 'query']);
   for (const key of data.keys()) {
     if (!SUPPORTED_DELETE_FIELDS.has(key)) {
-      throw new Error(`[update-router] delete: unsupported field '${key}' — only 'id' is supported`);
+      throw new Error(`[update-router] delete: unsupported field '${key}' — only 'id' and 'query' are supported`);
     }
+  }
+  // Mutually exclusive: id and query cannot both be present
+  if (data.has('id') && data.has('query')) {
+    throw new Error('[update-router] delete: cannot specify both "id" and "query" in the same delete command');
+  }
+  if (data.has('query')) {
+    ctx.body = data;
+    deleteByQueryRequest.apply(ctx);
+    return;
   }
   ctx.body = data;
   deleteDocRequest.apply(ctx);
@@ -227,10 +234,14 @@ function applySingleDocResponse(ctx: ResponseContext): void {
 
 export const response: MicroTransform<ResponseContext> = {
   name: 'update-response',
-  match: (ctx) => isSingleDocResponse(ctx) || isBulkResponse(ctx.responseBody),
+  match: (ctx) => isSingleDocResponse(ctx) || isBulkResponse(ctx.responseBody) || isDeleteByQueryResponse(ctx.responseBody),
   apply: (ctx) => {
     if (isBulkResponse(ctx.responseBody)) {
       bulkResponse.apply(ctx);
+      return;
+    }
+    if (isDeleteByQueryResponse(ctx.responseBody)) {
+      deleteByQueryResponse.apply(ctx);
       return;
     }
     if (isSingleDocResponse(ctx)) {

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/update-router.testcase.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/update-router.testcase.ts
@@ -99,11 +99,225 @@ export const testCases: TestCase[] = [
 
   // --- error paths ---
 
-  solrTest('update-cmd-error-delete-by-query', {
-    description: 'Delete-by-query should return 500',
+  // --- delete-by-query: happy path ---
+
+  solrTest('update-cmd-delete-by-query-simple', {
+    description: 'Delete documents matching a simple field query',
+    documents: [
+      { id: 'dbq-1', title: 'remove me' },
+      { id: 'dbq-2', title: 'keep me' },
+      { id: 'dbq-3', title: 'remove me' },
+    ],
+    method: 'POST',
+    requestBody: JSON.stringify({ delete: { query: 'title:"remove me"' } }),
+    requestPath: '/solr/testcollection/update?commit=true',
+    solrSchema: {
+      fields: { title: { type: 'text_general' } },
+    },
+    opensearchMapping: {
+      properties: { title: { type: 'text' } },
+    },
+    assertionRules: UPDATE_RESPONSE_RULES,
+  }),
+
+  solrTest('update-cmd-delete-by-query-match-all', {
+    description: 'Delete all documents with *:* query',
+    documents: [
+      { id: 'dbq-all-1', title: 'one' },
+      { id: 'dbq-all-2', title: 'two' },
+    ],
+    method: 'POST',
+    requestBody: JSON.stringify({ delete: { query: '*:*' } }),
+    requestPath: '/solr/testcollection/update?commit=true',
+    solrSchema: {
+      fields: { title: { type: 'text_general' } },
+    },
+    opensearchMapping: {
+      properties: { title: { type: 'text' } },
+    },
+    assertionRules: UPDATE_RESPONSE_RULES,
+  }),
+
+  solrTest('update-cmd-delete-by-query-no-match', {
+    description: 'Delete-by-query with no matching documents returns success',
+    documents: [{ id: 'dbq-keep', title: 'safe' }],
+    method: 'POST',
+    requestBody: JSON.stringify({ delete: { query: 'title:nonexistent' } }),
+    requestPath: '/solr/testcollection/update?commit=true',
+    solrSchema: {
+      fields: { title: { type: 'text_general' } },
+    },
+    opensearchMapping: {
+      properties: { title: { type: 'text' } },
+    },
+    assertionRules: UPDATE_RESPONSE_RULES,
+  }),
+
+  solrTest('update-cmd-delete-by-query-with-commit', {
+    description: 'Delete-by-query with commit=true makes deletions immediately visible',
+    documents: [
+      { id: 'dbq-commit-1', title: 'visible' },
+      { id: 'dbq-commit-2', title: 'visible' },
+    ],
+    method: 'POST',
+    requestBody: JSON.stringify({ delete: { query: 'title:visible' } }),
+    requestPath: '/solr/testcollection/update?commit=true',
+    solrSchema: {
+      fields: { title: { type: 'text_general' } },
+    },
+    opensearchMapping: {
+      properties: { title: { type: 'text' } },
+    },
+    assertionRules: UPDATE_RESPONSE_RULES,
+  }),
+
+  solrTest('update-cmd-delete-by-query-boolean-and', {
+    description: 'Delete-by-query with AND boolean query',
+    documents: [
+      { id: 'dbq-bool-1', title: 'alpha', category: 'draft' },
+      { id: 'dbq-bool-2', title: 'alpha', category: 'published' },
+      { id: 'dbq-bool-3', title: 'beta', category: 'draft' },
+    ],
+    method: 'POST',
+    requestBody: JSON.stringify({ delete: { query: 'title:alpha AND category:draft' } }),
+    requestPath: '/solr/testcollection/update?commit=true',
+    solrSchema: {
+      fields: {
+        title: { type: 'text_general' },
+        category: { type: 'text_general' },
+      },
+    },
+    opensearchMapping: {
+      properties: {
+        title: { type: 'text' },
+        category: { type: 'text' },
+      },
+    },
+    assertionRules: UPDATE_RESPONSE_RULES,
+  }),
+
+  solrTest('update-cmd-delete-by-query-boolean-or', {
+    description: 'Delete-by-query with OR boolean query',
+    documents: [
+      { id: 'dbq-or-1', title: 'remove' },
+      { id: 'dbq-or-2', title: 'delete' },
+      { id: 'dbq-or-3', title: 'keep' },
+    ],
+    method: 'POST',
+    requestBody: JSON.stringify({ delete: { query: 'title:remove OR title:delete' } }),
+    requestPath: '/solr/testcollection/update?commit=true',
+    solrSchema: {
+      fields: { title: { type: 'text_general' } },
+    },
+    opensearchMapping: {
+      properties: { title: { type: 'text' } },
+    },
+    assertionRules: UPDATE_RESPONSE_RULES,
+  }),
+
+  solrTest('update-cmd-delete-by-query-wildcard', {
+    description: 'Delete-by-query with wildcard query',
+    documents: [
+      { id: 'dbq-wc-1', title: 'temporary_file' },
+      { id: 'dbq-wc-2', title: 'temporary_data' },
+      { id: 'dbq-wc-3', title: 'permanent' },
+    ],
+    method: 'POST',
+    requestBody: JSON.stringify({ delete: { query: 'title:temporary*' } }),
+    requestPath: '/solr/testcollection/update?commit=true',
+    solrSchema: {
+      fields: { title: { type: 'text_general' } },
+    },
+    opensearchMapping: {
+      properties: { title: { type: 'text' } },
+    },
+    assertionRules: UPDATE_RESPONSE_RULES,
+  }),
+
+  solrTest('update-cmd-delete-by-query-range', {
+    description: 'Delete-by-query with range query on numeric field',
+    documents: [
+      { id: 'dbq-range-1', title: 'cheap', price: 5 },
+      { id: 'dbq-range-2', title: 'mid', price: 50 },
+      { id: 'dbq-range-3', title: 'expensive', price: 500 },
+    ],
+    method: 'POST',
+    requestBody: JSON.stringify({ delete: { query: 'price:[100 TO *]' } }),
+    requestPath: '/solr/testcollection/update?commit=true',
+    solrSchema: {
+      fields: {
+        title: { type: 'text_general' },
+        price: { type: 'pint' },
+      },
+    },
+    opensearchMapping: {
+      properties: {
+        title: { type: 'text' },
+        price: { type: 'integer' },
+      },
+    },
+    assertionRules: UPDATE_RESPONSE_RULES,
+  }),
+
+  solrTest('update-cmd-delete-by-query-negation', {
+    description: 'Delete-by-query with NOT query — delete everything except matching',
+    documents: [
+      { id: 'dbq-not-1', title: 'keep', category: 'important' },
+      { id: 'dbq-not-2', title: 'remove', category: 'trash' },
+      { id: 'dbq-not-3', title: 'also remove', category: 'junk' },
+    ],
+    method: 'POST',
+    requestBody: JSON.stringify({ delete: { query: '*:* AND NOT category:important' } }),
+    requestPath: '/solr/testcollection/update?commit=true',
+    solrSchema: {
+      fields: {
+        title: { type: 'text_general' },
+        category: { type: 'text_general' },
+      },
+    },
+    opensearchMapping: {
+      properties: {
+        title: { type: 'text' },
+        category: { type: 'text' },
+      },
+    },
+    assertionRules: UPDATE_RESPONSE_RULES,
+  }),
+
+  solrTest('update-cmd-delete-by-query-no-commit', {
+    description: 'Delete-by-query without commit param still succeeds (async visibility)',
+    documents: [
+      { id: 'dbq-nc-1', title: 'target' },
+    ],
+    method: 'POST',
+    requestBody: JSON.stringify({ delete: { query: 'title:target' } }),
+    requestPath: '/solr/testcollection/update',
+    solrSchema: {
+      fields: { title: { type: 'text_general' } },
+    },
+    opensearchMapping: {
+      properties: { title: { type: 'text' } },
+    },
+    assertionRules: UPDATE_RESPONSE_RULES,
+  }),
+
+  // --- delete-by-query: error paths ---
+
+  solrTest('update-cmd-error-delete-by-query-empty', {
+    description: 'Delete-by-query with empty query should return 500',
     documents: [{ id: '1', title: 'test' }],
     method: 'POST',
-    requestBody: JSON.stringify({ delete: { query: 'title:test' } }),
+    requestBody: JSON.stringify({ delete: { query: '' } }),
+    requestPath: '/solr/testcollection/update',
+    expectedStatusCode: 500,
+    expectedErrorContains: 'Request transform failed',
+  }),
+
+  solrTest('update-cmd-error-delete-by-query-id-and-query', {
+    description: 'Delete with both id and query should return 500 (mutually exclusive)',
+    documents: [{ id: '1', title: 'test' }],
+    method: 'POST',
+    requestBody: JSON.stringify({ delete: { id: '1', query: 'title:test' } }),
     requestPath: '/solr/testcollection/update',
     expectedStatusCode: 500,
     expectedErrorContains: 'Request transform failed',


### PR DESCRIPTION
## Summary

   Adds support for Solr's delete-by-query command (`{"delete":{"query":"..."}}`) by translating it to OpenSearch's `_delete_by_query` API. The Solr query string is translated using the existing `translateQ`
   pipeline — the same parser → AST → transformer chain the read path uses — so any query that works on `/select` also works in delete-by-query.

   This PR is independent of PR #2827 (NDJSON/_bulk framework) — delete-by-query uses a single JSON body to `_delete_by_query`, not the `_bulk` API.

   ## Motivation

   Delete-by-query is one of the most commonly used Solr write operations after single-doc add/delete. SolrJ clients use it for bulk cleanup (`*:*`), conditional deletion (`status:draft`), and data lifecycle
   management. The shim previously rejected it with a fail-fast error.

   ## Changes

   ### `features/delete-by-query.ts` (new)
   - Request: passes Solr query through `translateQ` in **fail-fast mode** (no passthrough — destructive op should not execute an untranslated query). Forwards all URL params (`df`, `defType`, `qf`, etc.) to the query engine.
   - `wait_for_completion=true` always set (Solr clients expect synchronous response).
   - `commit=true` / `commitWithin` → `?refresh=true` (immediate visibility).
   - Response: `{took, total, deleted, ...}` → `{responseHeader: {status, QTime: took}}`. Version conflicts or `deleted < total` → `status: 1`.

   ### `features/update-router.ts` (modified)
   - `handleDelete`: routes `data.has('query')` to new handler instead of fail-fast.
   - `SUPPORTED_DELETE_FIELDS`: `{id, query}` — mutually exclusive (both present → error).
   - Response dispatch extended with `isDeleteByQueryResponse` branch.

   ### `update-router.testcase.ts` (modified)
   - Replaced old error-expectation test with 12 new E2E integration tests.

   ### `docs/LIMITATIONS.md`
   - New `DELETE-BY-QUERY` shortcode documenting: sync-only behavior, fail-fast-only (no passthrough), version-conflict handling.
   - `UPDATE-COMMANDS` table updated: delete-by-query row changed from ❌ to ✅.

   ## Tests

   ### Unit tests — 27 new
   | Suite | Count | Coverage |
   |---|---|---|
   | `delete-by-query.test.ts` | 20 | Request: simple/match-all/commit/no-commit/empty/null/whitespace/unparseable/trim. Predicate: match/reject cases. Response: all-success/version-conflicts/failures/deleted<total/strips-fields/missing-took/zero-total. |
   | `update-router.test.ts` | +7 | Dispatch: mutual exclusion id+query, SUPPORTED_DELETE_FIELDS includes query, unsupported field rejection, response match/dispatch, single-doc still works. |

   ## Validation

   | Gate | Result |
   |---|---|
   | TS vitest | **847/847** passing (+27 from 820 baseline) |
   | Gradle `:SolrTransformations:test` | green |
   | E2E `:isolatedTest` | **0 new regressions** |

   ## Limitations

   - **No passthrough mode** — queries that the read path would pass through as `query_string` will fail on delete-by-query. Intentional: a destructive operation should not execute an untranslated query.
   - **Version conflicts** — concurrent updates to matching documents can cause `version_conflicts`. OpenSearch continues deleting remaining documents (no abort). Reported as `status: 1`.
   - **Synchronous only** — `wait_for_completion=true` is always set. No async task-based mode exposed.

  