### PR TITLE
Fix aws-bootstrap.sh hangs and CWD-sensitive repo-root lookup

### DIFF
--- a/buildImages/setUpK8sImageBuildServices.sh
+++ b/buildImages/setUpK8sImageBuildServices.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-MIGRATIONS_REPO_ROOT_DIR=$(git rev-parse --show-toplevel)
+MIGRATIONS_REPO_ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && git rev-parse --show-toplevel)
 
 # Use KUBE_CONTEXT env var if set, for explicit context targeting
 CONTEXT_ARGS=()

--- a/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/scripts/mirrorToEcr.sh
+++ b/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/scripts/mirrorToEcr.sh
@@ -150,6 +150,13 @@ mirror_charts_to_ecr() {
   ecr_pass=$(aws ecr get-login-password --region "$region")
   echo "$ecr_pass" | helm registry login "$ecr_host" -u AWS --password-stdin
 
+  # Log helm into public.ecr.aws so pulls of OCI charts hosted there
+  # (e.g. aws-controllers-k8s/acmpca-chart) don't stall on anonymous
+  # rate-limits / credential prompts. Best-effort — anonymous pulls
+  # usually work, but authenticated pulls are more reliable.
+  aws ecr-public get-login-password --region us-east-1 2>/dev/null | \
+    helm registry login public.ecr.aws -u AWS --password-stdin 2>/dev/null || true
+
   echo ""
   echo "=== Mirroring Helm charts ==="
   local _chartlist _chart_fail=0
@@ -162,10 +169,12 @@ mirror_charts_to_ecr() {
     [ -z "$name" ] && continue
 
     echo "  Pulling $name $version from $repo..."
+    # Redirect stdin from /dev/null so helm can never block on a credential
+    # prompt — if auth is missing/expired we want a fast failure, not a hang.
     if echo "$repo" | grep -q '^oci://'; then
-      helm pull "$repo/$name" --version "$version" 2>/dev/null
+      helm pull "$repo/$name" --version "$version" </dev/null 2>/dev/null
     else
-      helm pull "$name" --repo "$repo" --version "$version" 2>/dev/null
+      helm pull "$name" --repo "$repo" --version "$version" </dev/null 2>/dev/null
     fi
 
     local tgz
@@ -177,7 +186,7 @@ mirror_charts_to_ecr() {
 
     aws ecr create-repository --repository-name "charts/${name}" --region "$region" 2>/dev/null || true
     echo "  Pushing $tgz → oci://${ecr_host}/charts"
-    helm push "$tgz" "oci://${ecr_host}/charts" 2>&1 || { echo "  ❌ FAILED to push $name" >&2; _chart_fail=1; }
+    helm push "$tgz" "oci://${ecr_host}/charts" </dev/null 2>&1 || { echo "  ❌ FAILED to push $name" >&2; _chart_fail=1; }
     rm -f "$tgz"
     echo "  ✅ $name $version"
   done < "$_chartlist"

--- a/deployment/k8s/generateWorkflowSchemaArtifact.sh
+++ b/deployment/k8s/generateWorkflowSchemaArtifact.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-MIGRATIONS_REPO_ROOT_DIR=$(git rev-parse --show-toplevel)
+MIGRATIONS_REPO_ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && git rev-parse --show-toplevel)
 
 KUBE_CONTEXT="${KUBE_CONTEXT:-kind-release-schema-verification}"
 NAMESPACE="${NAMESPACE:-ma}"

--- a/deployment/k8s/localTesting.sh
+++ b/deployment/k8s/localTesting.sh
@@ -2,7 +2,7 @@
 
 set -xeuo pipefail
 
-MIGRATIONS_REPO_ROOT_DIR=$(git rev-parse --show-toplevel)
+MIGRATIONS_REPO_ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && git rev-parse --show-toplevel)
 
 wait_for_cluster_dns() {
   echo "Waiting for CoreDNS to become ready..."


### PR DESCRIPTION
## Summary

Two independent bugs that both halted `deployment/k8s/aws/aws-bootstrap.sh --build` runs. Each was hit on the same fresh-machine bootstrap run; fixes are small, local, and do not change behavior when the scripts are run the "normal" way from inside the repo.

## Issues

### 1. `mirror_charts_to_ecr` could hang indefinitely on OCI charts from `public.ecr.aws`

`mirror_images_to_ecr` already logs `crane` into `public.ecr.aws` (so image pulls from there are authenticated and don't hit anonymous rate-limits). `mirror_charts_to_ecr` did not do the equivalent for `helm`, so pulling OCI helm charts hosted on `public.ecr.aws` (e.g. `aws-controllers-k8s/acmpca-chart`, `aws-controllers-k8s/cloudwatch-chart`) could stall. Worse, because helm's stdin was inherited from the terminal, the process silently buffered user keystrokes instead of erroring out — the run looked frozen with no diagnostic output.

Observed symptom (from a real run):
```
Pulling acmpca-chart 1.2.2 from oci://public.ecr.aws/aws-controllers-k8s...
  [hang — no output, no error; typing does nothing visible]
```

Manually running `aws ecr-public get-login-password | helm registry login public.ecr.aws -u AWS --password-stdin` and re-running the bootstrap unblocked it.

### 2. Three helper scripts resolved the repo root from `$PWD` instead of their own path

`buildImages/setUpK8sImageBuildServices.sh`, `deployment/k8s/localTesting.sh`, and `deployment/k8s/generateWorkflowSchemaArtifact.sh` all did:

```bash
MIGRATIONS_REPO_ROOT_DIR=$(git rev-parse --show-toplevel)
```

`git rev-parse --show-toplevel` resolves relative to the caller's CWD, not the script's location. `aws-bootstrap.sh --build` calls `setUpK8sImageBuildServices.sh` with no `cd`, so if the bootstrap was invoked from outside the repo (e.g. `./opensearch-migrations/deployment/k8s/aws/aws-bootstrap.sh …` from `$HOME`), the sub-script died with:

```
fatal: not a git repository (or any of the parent directories): .git
```

…and exited 128 under `set -e`, aborting the bootstrap silently from the user's perspective.

## Fixes

1. **`mirror_charts_to_ecr`**: add a best-effort `helm registry login public.ecr.aws` (mirroring the existing crane login), and redirect `helm pull` stdin from `/dev/null` so an auth issue fails fast instead of hanging on a TTY prompt.

2. **Repo-root lookup**: anchor `git rev-parse --show-toplevel` to `$(dirname "${BASH_SOURCE[0]}")` in all three affected scripts. Same fix applied consistently to avoid divergence.

## Files changed

- `deployment/k8s/charts/aggregates/migrationAssistantWithArgo/scripts/mirrorToEcr.sh` — add public.ecr.aws helm login; redirect helm pull stdin.
- `buildImages/setUpK8sImageBuildServices.sh` — anchor repo-root lookup.
- `deployment/k8s/localTesting.sh` — anchor repo-root lookup.
- `deployment/k8s/generateWorkflowSchemaArtifact.sh` — anchor repo-root lookup.

## Test plan

- `bash -n` passes on all four modified scripts.
- Reproduced the `git rev-parse` CWD failure (`fatal: not a git repository … exit=128`) by running the original one-liner from `/tmp`.
- Verified the patched form resolves correctly to the repo root when invoked from `/tmp`.
- End-to-end: the bootstrap run that hit both issues on a fresh dev-desk completed past these two steps once the equivalent fixes were applied locally.

## Risk / compatibility

- When scripts are invoked from inside the repo (today's normal case and what CI does), behavior is unchanged — `cd "$(dirname "${BASH_SOURCE[0]}")"` always resolves to a directory already in the repo, so `git rev-parse --show-toplevel` returns the same value.
- The public.ecr.aws helm login is wrapped in `2>/dev/null || true`, matching the existing crane-side pattern. If `aws ecr-public` is unavailable or the user lacks permissions, the script continues and falls back to anonymous pulls exactly as before.
- `</dev/null` on `helm pull` only matters when helm would otherwise try to read stdin — a scenario the script was never designed to handle interactively.
