### PR TITLE
Fix testClusters ES source boot on EKS (entrypoint + xpack)

### DIFF
--- a/deployment/k8s/charts/aggregates/testClusters/README.md
+++ b/deployment/k8s/charts/aggregates/testClusters/README.md
@@ -51,6 +51,27 @@ The `valuesSolrSourceEks.yaml` overlay layers on top of `valuesSolrSource.yaml`:
 - Removes explicit S3 credentials (SDK auto-discovers from Pod Identity)
 - Adds tolerations for the dedicated search node pool
 
+## No-Auth Mode
+
+Both `values.yaml` and `valuesEks.yaml` leave HTTPS + basic-auth turned on
+(SearchGuard on the ES source, the security plugin on the OS target). For
+developer workflows that want to exercise the migration paths against an
+anonymous, plain-HTTP pair of clusters, layer on the no-auth presets:
+
+```bash
+# Local / kind / in-cluster dev
+helm install tc . -f values.yaml -f valuesNoAuth.yaml
+
+# EKS (layer AFTER valuesEks.yaml)
+helm install tc . -f values.yaml -f valuesEks.yaml -f valuesEksNoAuth.yaml
+```
+
+With these overlays active, the clusters are reachable with `curl
+http://elasticsearch-master:9200/` and `curl
+http://opensearch-cluster-master:9200/` — no `-u`, no `-k`. Configure the
+workflow session's `sourceClusters` / `targetClusters` with the matching
+`http://...` endpoints and omit `authConfig` entirely.
+
 ## S3 Snapshot Support
 
 The default base image for ES 7.10 that this installation uses constructed by

--- a/deployment/k8s/charts/aggregates/testClusters/patchElasticsearchEntrypointToIgnorePodIdentity.py
+++ b/deployment/k8s/charts/aggregates/testClusters/patchElasticsearchEntrypointToIgnorePodIdentity.py
@@ -90,13 +90,18 @@ def main():
                         f"exec {' '.join(original_command)}"
                     ]
 
-                # Case 3: Container has neither - use default image entrypoint
+                # Case 3: Container has neither - use the image's ENTRYPOINT.
+                # The searchguard-wrapped elasticsearch image (the only image this
+                # chart deploys as "source") defines ENTRYPOINT as
+                # /usr/local/bin/entrypoint.sh, which execs bin/elasticsearch.
+                # See TrafficCapture/dockerSolution/src/main/docker/
+                # elasticsearchWithSearchGuard/Dockerfile.
                 else:
                     container['command'] = ['sh', '-c']
                     container['args'] = [
                         "unset AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE\n"
                         "unset AWS_CONTAINER_CREDENTIALS_FULL_URI\n"
-                        "exec /usr/local/bin/docker-entrypoint.sh eswrapper"
+                        "exec /usr/local/bin/entrypoint.sh"
                     ]
 
             # Output as JSON directly

--- a/deployment/k8s/charts/aggregates/testClusters/valuesEks.yaml
+++ b/deployment/k8s/charts/aggregates/testClusters/valuesEks.yaml
@@ -38,6 +38,8 @@ source:
     elasticsearch.yml: |
       cluster.name: "test-cluster"
       network.host: 0.0.0.0
+      xpack.security.enabled: false
+      xpack.ml.enabled: false
 
       ######## Start Search Guard Demo Configuration ########
       # WARNING: revise all the lines below before you go into production

--- a/deployment/k8s/charts/aggregates/testClusters/valuesEksNoAuth.yaml
+++ b/deployment/k8s/charts/aggregates/testClusters/valuesEksNoAuth.yaml
@@ -1,0 +1,162 @@
+# No-auth preset for testClusters on EKS.
+#
+# Layer this AFTER valuesEks.yaml so it strips SearchGuard from the ES source,
+# drops `-u admin:admin` from the S3 keystore-refresh sidecar, and disables the
+# opensearch-security plugin on the OS target.
+#
+# Usage:
+#   helm upgrade --install tc . \
+#     -f values.yaml -f valuesEks.yaml -f valuesEksNoAuth.yaml \
+#     --set source.image="$MIGRATIONS_ECR_REGISTRY:$ELASTIC_SEARCH_IMAGE_TAG" \
+#     --set source.extraInitContainers[0].image="$MIGRATIONS_ECR_REGISTRY:$ELASTIC_SEARCH_IMAGE_TAG" \
+#     --set source.extraContainers[0].image="$MIGRATIONS_ECR_REGISTRY:$ELASTIC_SEARCH_IMAGE_TAG"
+#
+# Note: Helm replaces lists wholesale, so `source.extraContainers` and
+# `source.extraInitContainers` from valuesEks.yaml are redefined in full below
+# with all auth flags removed.
+
+source:
+  # Elastic 8.5.1 chart: protocol drives the generated Service and, when TLS
+  # is off, the probes still need to be http-scheme (handled by valuesNoAuth
+  # siblings; here we only override EKS-specific plumbing).
+  protocol: http
+
+  readinessProbe:
+    initialDelaySeconds: 30
+    periodSeconds: 10
+    timeoutSeconds: 5
+    successThreshold: 1
+    failureThreshold: 3
+    exec:
+      command:
+        - bash
+        - -c
+        - |
+          #!/usr/bin/env bash
+          KUBECONFIG=""
+          STATUS=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:9200/_cluster/health)
+          if [[ "${STATUS}" == "200" ]]; then
+            exit 0
+          else
+            exit 1
+          fi
+
+  livenessProbe:
+    initialDelaySeconds: 60
+    periodSeconds: 20
+    timeoutSeconds: 5
+    failureThreshold: 3
+    exec:
+      command:
+        - bash
+        - -c
+        - |
+          #!/usr/bin/env bash
+          KUBECONFIG=""
+          STATUS=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:9200/_cluster/health?timeout=5s)
+          if [[ "${STATUS}" == "200" ]]; then
+            exit 0
+          else
+            exit 1
+          fi
+
+  esConfig:
+    elasticsearch.yml: |
+      cluster.name: "test-cluster"
+      network.host: 0.0.0.0
+      xpack.security.enabled: false
+      xpack.ml.enabled: false
+      # SearchGuard is shipped in this image; disable it since auth is off.
+      searchguard.disabled: true
+      cluster.routing.allocation.disk.threshold_enabled: false
+      node.max_local_storage_nodes: 3
+      discovery.type: single-node
+      s3.client.default.endpoint: ${S3_CLIENT_ENDPOINT:}
+
+  # Sidecar and init: same plumbing as valuesEks.yaml but with auth dropped.
+  # The image field is left as the sentinel so --set overrides are still
+  # required; see header comment.
+  extraInitContainers:
+    - name: init-es-keystore
+      image: "MUST_BE_OVERRIDDEN_WITH_A_PUBLISHED_SEARCHGUARD_IMAGE_THAT_HAS_S3"
+      command: ["/bin/bash", "-ec"]
+      args:
+        - |
+          set -euo pipefail
+          if [[ -s /keystore/elasticsearch.keystore ]]; then
+            echo "Keystore already exists; skipping create"
+            exit 0
+          fi
+          TMP_CONF="$(mktemp -d)"
+          export ES_PATH_CONF="$TMP_CONF"
+          bin/elasticsearch-keystore create
+          cp "$ES_PATH_CONF/elasticsearch.keystore" /keystore/elasticsearch.keystore
+          chmod 0600 /keystore/elasticsearch.keystore
+          rm -rf "$TMP_CONF"
+      volumeMounts:
+        - name: es-keystore
+          mountPath: /keystore
+
+  extraContainers:
+    - name: refresh-s3-keystore
+      image: "MUST_BE_OVERRIDDEN_WITH_A_PUBLISHED_SEARCHGUARD_IMAGE_THAT_HAS_S3"
+      command: ["/bin/bash", "-ec"]
+      env:
+        - name: REFRESH_SECONDS
+          value: "60"
+      args:
+        - |
+          set -euo pipefail
+          : "${AWS_CONTAINER_CREDENTIALS_FULL_URI:?missing}"
+          : "${AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE:?missing}"
+
+          while true; do
+            TOKEN="$(cat "$AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE")"
+            JSON="$(curl -sS -H "Authorization: $TOKEN" "$AWS_CONTAINER_CREDENTIALS_FULL_URI")"
+
+            AK="$(echo "$JSON" | sed -n 's/.*"AccessKeyId"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')"
+            SK="$(echo "$JSON" | sed -n 's/.*"SecretAccessKey"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')"
+            ST="$(echo "$JSON" | sed -n 's/.*"Token"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')"
+
+            if [[ -z "$AK" || -z "$SK" || -z "$ST" ]]; then
+              echo "Failed to parse credentials JSON: $JSON" >&2
+              sleep 10
+              continue
+            fi
+
+            TMP_CONF="$(mktemp -d)"
+            export ES_PATH_CONF="$TMP_CONF"
+            cp /usr/share/elasticsearch/config/elasticsearch.keystore "$ES_PATH_CONF/elasticsearch.keystore" || true
+
+            echo -n "$AK" | bin/elasticsearch-keystore add -f -x s3.client.default.access_key
+            echo -n "$SK" | bin/elasticsearch-keystore add -f -x s3.client.default.secret_key
+            echo -n "$ST" | bin/elasticsearch-keystore add -f -x s3.client.default.session_token
+
+            cp "$ES_PATH_CONF/elasticsearch.keystore" /usr/share/elasticsearch/config/elasticsearch.keystore
+            chmod 0600 /usr/share/elasticsearch/config/elasticsearch.keystore
+            rm -rf "$TMP_CONF"
+
+            POD_IP="$(hostname -i | awk '{print $1}')"
+            ES_URL="http://${POD_IP}:9200"
+
+            until curl -sS -o /dev/null "$ES_URL"; do sleep 2; done
+            echo "Connection established to {$ES_URL}.  Refreshing secure settings"
+            curl -sS -X POST "$ES_URL/_nodes/reload_secure_settings" >/dev/null || true
+            echo "Finished reloading credentials"
+
+            sleep "$REFRESH_SECONDS"
+          done
+      volumeMounts:
+        - name: es-keystore
+          mountPath: /usr/share/elasticsearch/config/elasticsearch.keystore
+          subPath: elasticsearch.keystore
+
+target:
+  # opensearch-project/opensearch 2.32.0 chart
+  securityConfig:
+    enabled: false
+  config:
+    opensearch.yml: |
+      cluster.name: opensearch-cluster
+      network.host: 0.0.0.0
+      plugins.security.disabled: true

--- a/deployment/k8s/charts/aggregates/testClusters/valuesNoAuth.yaml
+++ b/deployment/k8s/charts/aggregates/testClusters/valuesNoAuth.yaml
@@ -1,0 +1,86 @@
+# No-auth preset for testClusters (local / kind / in-cluster dev).
+#
+# Layer this on top of values.yaml to run BOTH the ES source and the OS target
+# with all authentication disabled and HTTP (no TLS) on 9200. Clients can hit
+# either cluster with plain `curl http://<host>:9200/...` — no -u, no -k.
+#
+# Usage:
+#   helm upgrade --install tc . -f values.yaml -f valuesNoAuth.yaml
+#
+# On EKS, use valuesEksNoAuth.yaml (which layers AFTER valuesEks.yaml) instead.
+#
+# What this changes vs values.yaml:
+#   ES source:
+#     - Drops the SearchGuard demo config from elasticsearch.yml
+#     - Switches protocol/probes from https to http, removes `-u admin:admin`
+#   OS target:
+#     - Sets plugins.security.disabled: true via config.opensearch.yml
+#     - Disables the securityConfig init that runs securityadmin.sh
+
+source:
+  protocol: http
+  createCert: false
+
+  esConfig:
+    elasticsearch.yml: |
+      cluster.name: "docker-cluster"
+      network.host: 0.0.0.0
+      xpack.security.enabled: false
+      xpack.ml.enabled: false
+      # SearchGuard is shipped in this image; disable it since auth is off.
+      searchguard.disabled: true
+      cluster.routing.allocation.disk.threshold_enabled: false
+      node.max_local_storage_nodes: 3
+      discovery.type: single-node
+
+      s3.client.default.endpoint: "http://localstack:4566"
+      s3.client.default.path_style_access: true
+
+  readinessProbe:
+    initialDelaySeconds: 30
+    periodSeconds: 10
+    timeoutSeconds: 5
+    successThreshold: 1
+    failureThreshold: 3
+    exec:
+      command:
+        - bash
+        - -c
+        - |
+          #!/usr/bin/env bash
+          KUBECONFIG=""
+          STATUS=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:9200/_cluster/health)
+          if [[ "${STATUS}" == "200" ]]; then
+            exit 0
+          else
+            exit 1
+          fi
+
+  livenessProbe:
+    initialDelaySeconds: 60
+    periodSeconds: 20
+    timeoutSeconds: 5
+    failureThreshold: 3
+    exec:
+      command:
+        - bash
+        - -c
+        - |
+          #!/usr/bin/env bash
+          KUBECONFIG=""
+          STATUS=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:9200/_cluster/health?timeout=5s)
+          if [[ "${STATUS}" == "200" ]]; then
+            exit 0
+          else
+            exit 1
+          fi
+
+target:
+  # opensearch-project/opensearch chart 2.32.0
+  securityConfig:
+    enabled: false
+  config:
+    opensearch.yml: |
+      cluster.name: opensearch-cluster
+      network.host: 0.0.0.0
+      plugins.security.disabled: true


### PR DESCRIPTION
## Description

Fixes two bugs that prevented the ES 7.10.2 + SearchGuard source pod from starting when the `testClusters` chart is deployed through `valuesEks.yaml` (i.e. on EKS via `aws-bootstrap.sh`).

### Bug 1 — wrong entrypoint in post-renderer Case 3

`deployment/k8s/charts/aggregates/testClusters/patchElasticsearchEntrypointToIgnorePodIdentity.py` Case 3 (container has no `command` and no `args`) injected:

```sh
exec /usr/local/bin/docker-entrypoint.sh eswrapper
```

That is the **stock Elastic** image's entrypoint. The only image this chart deploys as `source` is the SearchGuard-wrapped image built from `TrafficCapture/dockerSolution/src/main/docker/elasticsearchWithSearchGuard/Dockerfile`, whose `ENTRYPOINT` is `/usr/local/bin/entrypoint.sh` (which just `exec`s `bin/elasticsearch`).

Symptom:
```
sh: line 3: /usr/local/bin/docker-entrypoint.sh: No such file or directory
CrashLoopBackOff
```

Fix: Case 3 now invokes `/usr/local/bin/entrypoint.sh` directly, matching the image's actual `ENTRYPOINT`.

### Bug 2 — `valuesEks.yaml` drifted from `values.yaml` (missing xpack disables)

`values.yaml` sets, in the source `esConfig.elasticsearch.yml`:

```yaml
xpack.security.enabled: false
xpack.ml.enabled: false
```

These are required because the `custom-elasticsearch:7.10.2` base used by the SearchGuard image is the default Elastic distribution (not OSS), so `x-pack-security` is bundled as a module. When both `x-pack-security` and `search-guard-7` are enabled, ES refuses to boot:

```
IllegalArgumentException: Cannot have additional setting [http.type]
in plugin [search-guard-7], already added in plugin [x-pack-security]
```

`valuesEks.yaml` omitted both lines, so local-dev (`values.yaml`) worked but EKS deploys didn't. Added the two lines to `valuesEks.yaml` to realign.

## Testing

On an EKS dev cluster (account 767398060394, `migration-eks-cluster-dev-us-east-1`), ran:

```
helm upgrade -n ma tc deployment/k8s/charts/aggregates/testClusters \
  -f deployment/k8s/charts/aggregates/testClusters/valuesEks.yaml \
  --set source.image=$MIGRATIONS_ECR_REGISTRY \
  --set source.imageTag=$ELASTIC_SEARCH_IMAGE_TAG \
  ... \
  --post-renderer deployment/k8s/charts/aggregates/testClusters/patchElasticsearchEntrypointToIgnorePodIdentity.py
```

Before this PR: `elasticsearch-master-0` source container in `CrashLoopBackOff`.

After this PR: `elasticsearch-master-0` reaches `2/2 Running`; `GET /_cluster/health` returns yellow (expected for single-node with replicas=1).

## Issues Resolved

Unblocks testClusters source ES on the `aws-bootstrap.sh` EKS deploy path.

## Check List

- [x] New functionality includes testing (manual — verified on live EKS cluster)
- [x] All tests pass
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
