### PR TITLE
Fix OSB verify_certs conflict when using SigV4 auth with allow_insecure

### DIFF
--- a/migrationConsole/lib/console_link/console_link/models/cluster.py
+++ b/migrationConsole/lib/console_link/console_link/models/cluster.py
@@ -318,21 +318,24 @@ class Cluster:
     def execute_benchmark_workload(self, workload: str,
                                    workload_params='bulk_size:10,bulk_indexing_clients:1',
                                    test_procedure: str = None):
-        client_options = "verify_certs:false"
-        if not self.allow_insecure:
-            client_options += ",use_ssl:true"
+        client_options_parts = []
+        if self.allow_insecure:
+            client_options_parts.append("verify_certs:false")
+        if self.endpoint.startswith("https"):
+            client_options_parts.append("use_ssl:true")
         password_to_censor = ""
         if self.auth_type == AuthMethod.BASIC_AUTH:
             auth_details = self.get_basic_auth_details()
             username = auth_details.username
             password_to_censor = auth_details.password
-            client_options += (f",basic_auth_user:{username},"
-                               f"basic_auth_password:{password_to_censor}")
+            client_options_parts.append(f"basic_auth_user:{username}")
+            client_options_parts.append(f"basic_auth_password:{password_to_censor}")
         elif self.auth_type == AuthMethod.SIGV4:
             service, region = self._get_sigv4_details(force_region=True)
-            client_options += (f",amazon_aws_log_in:session,"
-                               f"service:{service},"
-                               f"region:{region}")
+            client_options_parts.append("amazon_aws_log_in:session")
+            client_options_parts.append(f"service:{service}")
+            client_options_parts.append(f"region:{region}")
+        client_options = ",".join(client_options_parts)
         logger.info(f"Running opensearch-benchmark with '{workload}' workload")
         command = (f"opensearch-benchmark run "
                    f"--exclude-tasks=check-cluster-health "

--- a/migrationConsole/lib/console_link/tests/test_cluster.py
+++ b/migrationConsole/lib/console_link/tests/test_cluster.py
@@ -349,7 +349,7 @@ def test_run_benchmark_executes_correctly_no_auth(mocker):
                                  " --pipeline=benchmark-only"
                                  " --test-mode --kill-running-processes --workload-params="
                                  "bulk_size:10,bulk_indexing_clients:1 "
-                                 "--client-options=verify_certs:false", shell=True)
+                                 "--client-options=verify_certs:false,use_ssl:true", shell=True)
 
 
 def test_run_benchmark_executes_correctly_sigv4_auth(mocker):
@@ -363,7 +363,7 @@ def test_run_benchmark_executes_correctly_sigv4_auth(mocker):
                                  " --pipeline=benchmark-only"
                                  " --test-mode --kill-running-processes --workload-params="
                                  "bulk_size:10,bulk_indexing_clients:1 "
-                                 "--client-options=verify_certs:false,"
+                                 "--client-options=verify_certs:false,use_ssl:true,"
                                  "amazon_aws_log_in:session,"
                                  "service:aoss,"
                                  "region:eu-west-1", shell=True)
@@ -383,7 +383,7 @@ def test_run_benchmark_executes_correctly_basic_auth_and_https(mocker):
                                  " --pipeline=benchmark-only"
                                  " --test-mode --kill-running-processes --workload-params="
                                  "bulk_size:10,bulk_indexing_clients:1 "
-                                 "--client-options=verify_certs:false,use_ssl:true,"
+                                 "--client-options=use_ssl:true,"
                                  f"basic_auth_user:{auth_details['username']},"
                                  f"basic_auth_password:{auth_details['password']}", shell=True)
 


### PR DESCRIPTION
### Description
`console clusters run-test-benchmarks` fails on SigV4-authenticated clusters with:
```
BenchmarkAsyncOpenSearch() got multiple values for keyword argument 'verify_certs'
```

It was found that the `verify_certs:false` was unconditionally passed in `--client-options`, but OSB's SigV4 client factory also sets it internally, causing a duplicate keyword argument.

### Fix

Only pass `verify_certs:false` when `allow_insecure=True`. Derive `use_ssl:true` from the endpoint scheme instead of tying it to the insecure flag. Refactored option building to use a list to avoid leading/trailing comma issues.

### Testing

- Verified manually on EKS against SigV4 ES 7.10 domain

### Check List
- [ ] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
