### PR TITLE
Downgrade workflow status Argo fetch logs to info, improve not-found error message

### DIFF
--- a/migrationConsole/lib/console_link/console_link/workflow/commands/status.py
+++ b/migrationConsole/lib/console_link/console_link/workflow/commands/status.py
@@ -67,7 +67,11 @@ class StatusCommandHandler:
             workflow_name, argo_server, namespace, insecure)
 
         if not workflow_data:
-            click.echo(f"Error: Could not find workflow {workflow_name}", err=True)
+            click.echo(
+                f"No workflow named '{workflow_name}' found in namespace "
+                f"{namespace}. Run `workflow --help` for more help.",
+                err=True,
+            )
             raise click.Abort()
 
         self._display_workflow_with_tree(workflow_data, live_check, argo_server, namespace, insecure)
@@ -166,13 +170,13 @@ class WorkflowDataFetcher:
         headers = {"Authorization": f"Bearer {self.token}"} if self.token else {}
         url = f"{argo_server}/api/v1/workflows/{namespace}/{workflow_name}"
 
-        logger.warning(
+        logger.info(
             "Fetching workflow data from Argo API: workflow=%s namespace=%s url=%s insecure=%s",
             workflow_name, namespace, url, insecure
         )
         response = requests.get(url, headers=headers, verify=not insecure)
         if response.status_code != 200:
-            logger.warning(
+            logger.info(
                 "Argo API workflow fetch failed: status=%s content_type=%s body=%s",
                 response.status_code,
                 response.headers.get("content-type"),
@@ -180,7 +184,7 @@ class WorkflowDataFetcher:
             )
             return {}
 
-        logger.warning(
+        logger.info(
             "Argo API workflow fetch succeeded: status=%s content_type=%s",
             response.status_code,
             response.headers.get("content-type"),


### PR DESCRIPTION
### Description

On every `workflow status` invocation the console emits three WARNING-level lines from the normal, successful code path:

```
(20:04:21) migration-console (~) -> workflow status
WARNING:console_link.workflow.commands.status:Fetching workflow data from Argo API: workflow=migration-workflow namespace=ma url=https://172.20.18.114:2746/api/v1/workflows/ma/migration-workflow insecure=True
WARNING:console_link.workflow.commands.status:Argo API workflow fetch failed: status=404 content_type=application/json body={"code":5,"message":"workflows.argoproj.io \"migration-workflow\" not found"}
Error: Could not find workflow migration-workflow
```

These are informational ("we are about to call the API", "we called the API"), not warnings. They were flagged because `WARNING` is the default root log level, so they surface by default even when nothing is wrong.

This PR:

1. Downgrades the three `Fetching workflow data …` / `Argo API workflow fetch failed` / `Argo API workflow fetch succeeded` messages in `status.py` from `logger.warning` to `logger.info`. They remain available via `--verbose` / log-config but no longer print on every routine status check.
2. Replaces the bare `Error: Could not find workflow <name>` with a clearer hint pointing users at `workflow --help`, which lists the available sub-commands (list / status / submit / approve / …). The user hit this when running `workflow status` with no args because the default workflow name (`migration-workflow`) didn't exist in the namespace; the new message makes the fix discoverable without needing to grep the source.

Other `logger.warning` call sites in the file (surfacing genuinely unexpected conditions — missing Argo config, non-JSON content types, parse failures) are unchanged.

### After

```
(xx:xx:xx) migration-console (~) -> workflow status
No workflow named 'migration-workflow' found in namespace ma. Run `workflow --help` for more help.
```

### Testing

- Full `migrationConsole/lib/console_link/tests/workflow-tests/test_status.py` + `test_workflow_cli_commands.py` suites pass (27/27).
- No tests asserted on the old log strings or the old error message.

### Issues Resolved

N/A — fit-and-finish follow-up to workflow CLI UX.

### Is this a backport? If so, please add backport PR # and/or commits #

No.

### Check List

- [x] New functionality includes testing
  - No behavior change; existing tests cover the affected code paths.
- [x] All tests pass
- [x] New functionality has been documented
  - Self-documenting via the new error hint.
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
