### PR TITLE
Add description for RFS podReplicas field

### DIFF
--- a/orchestrationSpecs/packages/schemas/src/userSchemas.ts
+++ b/orchestrationSpecs/packages/schemas/src/userSchemas.ts
@@ -603,7 +603,8 @@ export const USER_METADATA_OPTIONS = z.object({
 
 export const USER_RFS_WORKFLOW_OPTIONS = z.object({
     podReplicas: z.number().default(1).optional()
-        .describe("Number of RFS (Reindex From Snapshot) pod replicas. Each replica processes shards independently."),
+        .describe("Number of RFS worker pod replicas. Each replica independently acquires and processes snapshot shards in parallel —" + 
+            " throughput scales linearly up to the total number of source shards."),
     jvmArgs: z.string().default("").optional()
         .describe(JVM_ARGS_DESC),
     loggingConfigurationOverrideConfigMap: z.string().default("").optional()

--- a/orchestrationSpecs/packages/schemas/tests/__snapshots__/argoSchemaSnapshot.test.ts.snap
+++ b/orchestrationSpecs/packages/schemas/tests/__snapshots__/argoSchemaSnapshot.test.ts.snap
@@ -2354,7 +2354,7 @@ exports[`test schemas matches expected argo user matches expected 1`] = `
                       "podReplicas": {
                         "type": "number",
                         "default": 1,
-                        "description": "Number of RFS (Reindex From Snapshot) pod replicas. Each replica processes shards independently."
+                        "description": "Number of RFS worker pod replicas. Each replica independently acquires and processes snapshot shards in parallel — throughput scales linearly up to the total number of source shards."
                       },
                       "jvmArgs": {
                         "type": "string",


### PR DESCRIPTION
### Description

Add a description for the RFS `podReplicas` field in `userSchemas.ts`. The previous description ("Number of RFS (Reindex From Snapshot) pod replicas. Each replica processes shards independently.") did not explain the scaling behavior. The updated description clarifies that replicas scale shard-level backfill parallelism and that throughput is bounded by the total number of source shards.

### Issues Resolved

N/A — documentation improvement only.

### Testing

- Schema validation tests pass (no runtime behavior change, description string only).

### Check List
- [x] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).