### PR TITLE
Include workflowMigration.schema.json in Solutions package-artifacts.zip

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -120,9 +120,6 @@ jobs:
       - name: Logout to DockerHub
         if: always()
         run: docker logout
-      - name: Generate Solutions Artifact
-        run: |
-          ./deployment/migration-assistant-solution/package-artifacts.sh
       - name: Build minified CFN templates for GitHub release
         env:
           OS_MIGRATIONS_GRADLE_SCAN_TOS_AGREE_AND_ENABLED: ''
@@ -196,6 +193,9 @@ jobs:
           IMAGE_TAG=${{ steps.get_data.outputs.version }} \
           OUTPUT_PATH="${PWD}/workflowMigration.schema.json" \
           ./deployment/k8s/generateWorkflowSchemaArtifact.sh
+      - name: Generate Solutions Artifact
+        run: |
+          ./deployment/migration-assistant-solution/package-artifacts.sh
       - name: Upload unified schema artifact
         if: ${{ !github.event.act }}
         uses: actions/upload-artifact@v7

--- a/deployment/migration-assistant-solution/package-artifacts.sh
+++ b/deployment/migration-assistant-solution/package-artifacts.sh
@@ -38,6 +38,16 @@ echo "Copying solution-manifest.yaml..."
 cp "${SCRIPT_DIR}/solution-manifest.yaml" "${TEMP_DIR}/solution-manifest.yaml"
 sed -i "s/version: .*/version: ${CODE_VERSION}/" "${TEMP_DIR}/solution-manifest.yaml"
 
+WORKFLOW_SCHEMA_PATH="${WORKFLOW_SCHEMA_PATH:-${PROJECT_ROOT}/workflowMigration.schema.json}"
+if [[ ! -f "${WORKFLOW_SCHEMA_PATH}" ]]; then
+  echo "ERROR: workflow schema not found at ${WORKFLOW_SCHEMA_PATH}." >&2
+  echo "  Generate it first with deployment/k8s/generateWorkflowSchemaArtifact.sh," >&2
+  echo "  or set WORKFLOW_SCHEMA_PATH to an existing workflowMigration.schema.json." >&2
+  exit 1
+fi
+echo "Copying workflow schema from ${WORKFLOW_SCHEMA_PATH}..."
+cp "${WORKFLOW_SCHEMA_PATH}" "${TEMP_DIR}/deployment/global-s3-assets/workflowMigration.schema.json"
+
 touch "${TEMP_DIR}/deployment/regional-s3-assets/test.txt"
 touch "${TEMP_DIR}/deployment/open-source/test.txt"
 


### PR DESCRIPTION
### Description

The Solutions `artifact.zip` packaged by `deployment/migration-assistant-solution/package-artifacts.sh` and uploaded to `s3://cornerstone-amazonaws/SO0290/` did not contain the unified workflow schema. Consumers pulling the Solutions artifact therefore had no access to `workflowMigration.schema.json`.

### Changes

Two small changes across two files:

1. **`deployment/migration-assistant-solution/package-artifacts.sh`** now copies `$WORKFLOW_SCHEMA_PATH` (default: `${PROJECT_ROOT}/workflowMigration.schema.json`) into `deployment/global-s3-assets/` inside the zip. Fails fast with a clear message if the file is missing, so a regression in ordering surfaces immediately instead of silently shipping a zip without the schema.

2. **`.github/workflows/release-drafter.yml`** moves `Generate Solutions Artifact` to run **after** `Deploy Helm chart and copy generated workflow schema`, which is the step that produces `workflowMigration.schema.json` on disk. Pure reorder — no step is added, removed, or otherwise altered.

### Step order in the release-drafter job after this PR

- Build minified CFN templates for GitHub release
- Pull images from DockerHub for SBOM scanning
- (SBOM steps…)
- Install Helm
- Package Helm chart
- Set up Kind cluster for schema verification
- **Deploy Helm chart and copy generated workflow schema**  ← writes the schema file
- **Generate Solutions Artifact**                          ← now packages it into the zip
- Upload unified schema artifact
- Upload Solutions Artifact to S3                          ← uploads the zip that now contains the schema
- Draft a release

### Testing

- `python3 -c 'import yaml; yaml.safe_load(open(".github/workflows/release-drafter.yml"))'` ok
- `bash -n deployment/migration-assistant-solution/package-artifacts.sh` ok
- `actionlint` shows only a pre-existing unrelated warning on line 62 (not from this PR)

### Check List

- [x] New functionality includes testing
  - package-artifacts.sh now fails fast with a clear message when the schema is missing — acts as a regression guard against re-breaking the step order
- [x] All tests pass
- [x] New functionality has been documented
  - Script behavior is self-documenting (echoes the source path and reason on failure)
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
