### PR TITLE
Adding field mappings to shim and using term query for exact fields b…

### DIFF
--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/context.test.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/context.test.ts
@@ -77,4 +77,19 @@ describe('buildRequestContext', () => {
       expect(ctx.collection).toBeUndefined();
     });
   });
+
+  describe('fieldTypes default', () => {
+    it('initializes fieldTypes as empty map', () => {
+      const ctx = buildRequestContext(mockMsg('/solr/test/select?q=*:*'));
+      expect(ctx.fieldTypes).toBeDefined();
+      expect(ctx.fieldTypes.size).toBe(0);
+    });
+
+    it('fieldTypes can be overwritten after construction', () => {
+      const ctx = buildRequestContext(mockMsg('/solr/test/select?q=*:*'));
+      const fieldTypes = new Map([['status', 'solr.StrField']]);
+      ctx.fieldTypes = fieldTypes;
+      expect(ctx.fieldTypes.get('status')).toBe('solr.StrField');
+    });
+  });
 });

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/context.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/context.ts
@@ -45,6 +45,13 @@ export interface RequestContext {
    * Uses Record (plain object) because GraalVM exposes Java Maps as JS objects via allowMapAccess.
    */
   solrConfig?: Record<string, { defaults?: Record<string, string>; invariants?: Record<string, string>; appends?: Record<string, string> }>;
+  /**
+   * Field name → Solr fieldType Java class, resolved from managed-schema.xml at shim startup.
+   * e.g. { "title": "solr.TextField", "id": "solr.StrField" }
+   * fieldRule uses class.includes("TextField") to choose match vs term.
+   * Empty map when solrSchemaXmlFile is not configured — all field:value queries use match.
+   */
+  fieldTypes: ReadonlyMap<string, string>;
   /** Record a limitation metric occurrence. */
   emitMetric(metric: TransformMetricName): void;
   /** Internal accumulator — use {@link emitMetric} instead. */
@@ -108,6 +115,9 @@ function getBodyMap(payload: JavaMap): JavaMap {
   return new Map();
 }
 
+/** Shared empty fieldTypes map — used as the default before request.transform.ts injects the real one. */
+const EMPTY_FIELD_TYPES: ReadonlyMap<string, string> = new Map();
+
 export function buildRequestContext(msg: JavaMap): RequestContext {
   const uri: string = msg.get('URI') || '';
   const metrics = createMetrics();
@@ -119,6 +129,7 @@ export function buildRequestContext(msg: JavaMap): RequestContext {
     body: getBodyMap(msg.get('payload')),
     targetName: msg.get('_targetName') || 'opensearch',
     mode: msg.get('_mode') || 'single',
+    fieldTypes: EMPTY_FIELD_TYPES,
     emitMetric: (metric: TransformMetricName) => incrementMetric(metrics, metric),
     _metrics: metrics,
   };

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/query-q.test.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/query-q.test.ts
@@ -3,7 +3,10 @@ import { request } from './query-q';
 import type { RequestContext, JavaMap } from '../context';
 
 /** Create a mock RequestContext for testing. */
-function createMockContext(params: Record<string, string>): RequestContext {
+function createMockContext(
+  params: Record<string, string>,
+  fieldTypes: ReadonlyMap<string, string> = new Map(),
+): RequestContext {
   const body = new Map<string, any>();
   return {
     msg: new Map() as JavaMap,
@@ -11,6 +14,7 @@ function createMockContext(params: Record<string, string>): RequestContext {
     collection: 'test',
     params: new URLSearchParams(params),
     body: body as JavaMap,
+    fieldTypes,
   };
 }
 
@@ -61,5 +65,46 @@ describe('query-q request transform', () => {
     request.apply(ctx);
     // translateQ defaults to *:* which should produce some query
     expect(ctx.body.has('query')).toBe(true);
+  });
+
+  // --- fieldTypes threading ---
+
+  it('uses match query when fieldTypes is empty (default)', () => {
+    const ctx = createMockContext({ q: 'status:active' });
+    request.apply(ctx);
+
+    const query = ctx.body.get('query') as Map<string, any>;
+    expect(query.has('match')).toBe(true);
+  });
+
+  it('uses term query when ctx.fieldTypes identifies field as non-text', () => {
+    const fieldTypes = new Map([['status', 'solr.StrField']]);
+    const ctx = createMockContext({ q: 'status:active' }, fieldTypes);
+    request.apply(ctx);
+
+    const query = ctx.body.get('query') as Map<string, any>;
+    expect(query.has('term')).toBe(true);
+    expect((query.get('term') as Map<string, any>).get('status')).toEqual(
+      new Map([['value', 'active']]),
+    );
+  });
+
+  it('uses match query when ctx.fieldTypes identifies field as TextField', () => {
+    const fieldTypes = new Map([['title', 'solr.TextField']]);
+    const ctx = createMockContext({ q: 'title:java' }, fieldTypes);
+    request.apply(ctx);
+
+    const query = ctx.body.get('query') as Map<string, any>;
+    expect(query.has('match')).toBe(true);
+  });
+
+  it('uses match for unknown field even when fieldTypes is provided', () => {
+    const fieldTypes = new Map([['other_field', 'solr.StrField']]);
+    const ctx = createMockContext({ q: 'title:java' }, fieldTypes);
+    request.apply(ctx);
+
+    // title not in fieldTypes → safe fallback to match
+    const query = ctx.body.get('query') as Map<string, any>;
+    expect(query.has('match')).toBe(true);
   });
 });

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/query-q.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/features/query-q.ts
@@ -46,7 +46,7 @@ function paramsToMap(params: URLSearchParams): Map<string, string> {
 export const request: MicroTransform<RequestContext> = {
   name: 'query-q',
   apply: (ctx) => {
-    const result = translateQ(paramsToMap(ctx.params));
+    const result = translateQ(paramsToMap(ctx.params), 'fail-fast', ctx.fieldTypes);
     ctx.body.set('query', result.dsl);
 
     // TODO: expose result.warnings to caller for observability

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/orchestrator/translateQ.test.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/orchestrator/translateQ.test.ts
@@ -34,7 +34,7 @@ describe('translateQ', () => {
       const result = translateQ(params(['q', 'title:java'], ['df', 'content']));
 
       expect(mockParse).toHaveBeenCalledWith('title:java', params(['q', 'title:java'], ['df', 'content']));
-      expect(mockTransform).toHaveBeenCalledWith(fakeAst);
+      expect(mockTransform).toHaveBeenCalledWith(fakeAst, new Map());
       expect(result.dsl).toBe(fakeDsl);
       expect(result.warnings).toEqual([]);
     });
@@ -46,6 +46,29 @@ describe('translateQ', () => {
       translateQ(params(['df', 'content']));
 
       expect(mockParse).toHaveBeenCalledWith('*:*', expect.any(Map));
+    });
+
+    it('passes fieldTypes to transformNode when provided', () => {
+      const fakeAst: ASTNode = { type: 'matchAll' };
+      const fakeDsl = new Map([['match_all', new Map()]]);
+      const fieldTypes = new Map([['status', 'solr.StrField'], ['title', 'solr.TextField']]);
+      mockParse.mockReturnValue({ ast: fakeAst, errors: [] });
+      mockTransform.mockReturnValue(fakeDsl);
+
+      translateQ(params(['q', 'status:active']), 'fail-fast', fieldTypes);
+
+      expect(mockTransform).toHaveBeenCalledWith(fakeAst, fieldTypes);
+    });
+
+    it('passes empty fieldTypes to transformNode when not provided', () => {
+      const fakeAst: ASTNode = { type: 'matchAll' };
+      mockParse.mockReturnValue({ ast: fakeAst, errors: [] });
+      mockTransform.mockReturnValue(new Map([['match_all', new Map()]]));
+
+      translateQ(params(['q', '*:*']));
+
+      // Default empty map is passed — transformNode always receives fieldTypes
+      expect(mockTransform).toHaveBeenCalledWith(fakeAst, new Map());
     });
   });
 

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/orchestrator/translateQ.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/orchestrator/translateQ.ts
@@ -80,14 +80,21 @@ function passthroughDsl(query: string): Map<string, any> {
  *                 from this map and passes the full map to the parser
  *                 for configuration (e.g., `df`, `qf`, `pf`).
  * @param mode - 'fail-fast' (default) or 'passthrough-on-error'.
+ * @param fieldTypes - Optional map of field name → Solr type from the schema.
+ *                     Used by fieldRule to choose term vs match. Defaults to empty map
+ *                     (all plain field:value queries use match).
  *
  * Example:
  *   translateQ(new Map([['q', 'title:java'], ['df', 'content']]))
  *   → { dsl: Map{"match" → Map{"title" → "java"}}, warnings: [] }
+ *
+ *   translateQ(new Map([['q', 'status:active']]), 'fail-fast', new Map([['status', 'keyword']]))
+ *   → { dsl: Map{"term" → Map{"status" → "active"}}, warnings: [] }
  */
 export function translateQ(
   params: ReadonlyMap<string, string>,
   mode: TranslationMode = 'fail-fast',
+  fieldTypes: ReadonlyMap<string, string> = new Map(),
 ): TranslateResult {
   const query = params.get('q') || '*:*';
 
@@ -112,7 +119,7 @@ export function translateQ(
 
   // Stage 2: Transform
   try {
-    const mainDsl = transformNode(ast);
+    const mainDsl = transformNode(ast, fieldTypes);
 
     // Stage 3: pf phrase boost — wraps the main query in bool.must + bool.should
     // if pf is set. Delegated to phraseBoost.ts (transformer concern).

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/transformer/astToOpenSearch.test.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/transformer/astToOpenSearch.test.ts
@@ -93,3 +93,77 @@ describe('transformNode – LocalParamsNode handling', () => {
     expect(result).toEqual(new Map([['match_all', new Map()]]));
   });
 });
+
+describe('transformNode – fieldTypes threading', () => {
+  it('uses match for field when fieldTypes is absent (default)', () => {
+    const result = transformNode({ type: 'field', field: 'status', value: 'active' });
+
+    expect(result).toEqual(new Map([
+      ['match', new Map([['status', new Map([['query', 'active']])]])],
+    ]));
+  });
+
+  it('uses term for exact field when fieldTypes identifies it as non-text', () => {
+    const fieldTypes = new Map([['status', 'solr.StrField']]);
+
+    const result = transformNode({ type: 'field', field: 'status', value: 'active' }, fieldTypes);
+
+    expect(result).toEqual(new Map([['term', new Map([['status', new Map([['value', 'active']])]])]]));
+  });
+
+  it('uses match for text field when fieldTypes identifies it as TextField', () => {
+    const fieldTypes = new Map([['title', 'solr.TextField']]);
+
+    const result = transformNode({ type: 'field', field: 'title', value: 'java' }, fieldTypes);
+
+    expect(result).toEqual(new Map([
+      ['match', new Map([['title', new Map([['query', 'java']])]])],
+    ]));
+  });
+
+  it('threads fieldTypes through BoolNode to nested FieldNodes', () => {
+    // a:b AND c:d where both a and c are exact fields
+    const fieldTypes = new Map([
+      ['a', 'solr.StrField'],
+      ['c', 'solr.StrField'],
+    ]);
+
+    const result = transformNode({
+      type: 'bool',
+      and: [
+        { type: 'field', field: 'a', value: 'b' },
+        { type: 'field', field: 'c', value: 'd' },
+      ],
+      or: [],
+      not: [],
+    }, fieldTypes);
+
+    const must = (result.get('bool') as Map<string, any>).get('must') as Map<string, any>[];
+    expect(must[0]).toEqual(new Map([['term', new Map([['a', new Map([['value', 'b']])]])]]));
+    expect(must[1]).toEqual(new Map([['term', new Map([['c', new Map([['value', 'd']])]])]]));
+  });
+
+  it('threads fieldTypes through GroupNode to nested FieldNode', () => {
+    const fieldTypes = new Map([['id', 'solr.StrField']]);
+
+    const result = transformNode({
+      type: 'group',
+      child: { type: 'field', field: 'id', value: '42' },
+    }, fieldTypes);
+
+    expect(result).toEqual(new Map([['term', new Map([['id', new Map([['value', '42']])]])]]));
+  });
+
+  it('threads fieldTypes through LocalParamsNode body', () => {
+    const fieldTypes = new Map([['status', 'solr.StrField']]);
+
+    const result = transformNode({
+      type: 'localParams',
+      params: [],
+      rawBody: 'status:active',
+      body: { type: 'field', field: 'status', value: 'active' },
+    }, fieldTypes);
+
+    expect(result).toEqual(new Map([['term', new Map([['status', new Map([['value', 'active']])]])]]));
+  });
+});

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/transformer/astToOpenSearch.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/transformer/astToOpenSearch.ts
@@ -78,13 +78,24 @@ const rules: Record<string, TransformRuleFn> = {
  * and values.
  *
  * @param node - The AST node to transform
+ * @param fieldTypes - Map of field name → Solr fieldType class from managed-schema.xml.
+ *                     Passed to every rule; currently used by fieldRule to choose
+ *                     term vs match. Empty map = match for all fields (safe default).
  * @returns A nested Map structure representing OpenSearch Query DSL
  * @throws Error if no rule is registered for the node type — the orchestrator
  *         catches this and handles it based on the translation mode:
  *         - passthrough-on-error: returns query_string passthrough + warning
  *         - partial: skips the node, adds a warning, continues translating
  */
-export function transformNode(node: ASTNode): Map<string, any> {
+export function transformNode(
+  node: ASTNode,
+  fieldTypes: ReadonlyMap<string, string> = new Map(),
+): Map<string, any> {
+  // Build a transformChild closure that carries fieldTypes down the tree.
+  // All composite rules (bool, boost, filter, group) call transformChild to
+  // recurse — this ensures fieldTypes propagates to every FieldNode in the tree.
+  const transformChild = (child: ASTNode) => transformNode(child, fieldTypes);
+
   /**
    * GroupNode represents parentheses in Solr syntax, used to override operator
    * precedence. OpenSearch doesn't have an equivalent concept — precedence is
@@ -99,7 +110,7 @@ export function transformNode(node: ASTNode): Map<string, any> {
    * OpenSearch DSL structure of its own.
    */
   if (node.type === 'group') {
-    return transformNode(node.child);
+    return transformNode(node.child, fieldTypes);
   }
 
   // LocalParamsNode: extract metadata and transform the body.
@@ -107,14 +118,13 @@ export function transformNode(node: ASTNode): Map<string, any> {
   // for the orchestrator to use. The transformer only handles the body query.
   if (node.type === 'localParams') {
     if (node.body) {
-      return transformNode(node.body);
+      return transformNode(node.body, fieldTypes);
     }
     // No body — return match_all as default
     return new Map([['match_all', new Map()]]);
   }
 
-  // FuncNode: no transform rule yet — the orchestrator handles this via
-  // existing error modes (passthrough-on-error or partial translation).
+  // FuncNode: no transform rule yet.
   if (node.type === 'func') {
     throw new Error('No transform rule registered for node type: func');
   }
@@ -123,5 +133,5 @@ export function transformNode(node: ASTNode): Map<string, any> {
   if (!rule) {
     throw new Error(`No transform rule registered for node type: ${node.type}`);
   }
-  return rule(node, transformNode);
+  return rule(node, transformChild, fieldTypes);
 }

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/transformer/rules/fieldRule.test.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/transformer/rules/fieldRule.test.ts
@@ -1,12 +1,13 @@
 import { describe, it, expect, vi } from 'vitest';
 import { fieldRule } from './fieldRule';
+import { translateQ } from '../../orchestrator/translateQ';
 import type { FieldNode } from '../../ast/nodes';
 
 /** Stub transformChild — not used by fieldRule but required by signature. */
 const stubTransformChild = () => new Map();
 
 describe('fieldRule', () => {
-  // --- Plain match queries ---
+  // --- Plain match queries (no fieldTypes / unknown field) ---
 
   it.each([
     { field: 'title', value: 'java', desc: 'simple field:value' },
@@ -14,7 +15,7 @@ describe('fieldRule', () => {
     { field: '_text_', value: 'search', desc: 'underscore field name' },
     { field: 'metadata.author', value: 'doe', desc: 'dotted field name' },
     { field: 'title', value: 'foo-bar_baz.v1@test#123', desc: 'multiple special chars' },
-  ])('transforms $desc to match query', ({ field, value }) => {
+  ])('transforms $desc to match query when no fieldTypes provided', ({ field, value }) => {
     const node: FieldNode = { type: 'field', field, value };
 
     const result = fieldRule(node, stubTransformChild);
@@ -22,6 +23,88 @@ describe('fieldRule', () => {
     expect(result).toEqual(
       new Map([['match', new Map([[field, new Map([['query', value]])]])]]),
     );
+  });
+
+  it('uses match query for unknown field even when fieldTypes map is provided', () => {
+    const node: FieldNode = { type: 'field', field: 'unknown_field', value: 'foo' };
+    const fieldTypes = new Map([['status', 'solr.StrField']]);
+
+    const result = fieldRule(node, stubTransformChild, fieldTypes);
+
+    expect(result).toEqual(
+      new Map([['match', new Map([['unknown_field', new Map([['query', 'foo']])]])]]),
+    );
+  });
+
+  // --- term queries when fieldTypes identifies non-text fields ---
+
+  it.each([
+    { fieldTypeClass: 'solr.StrField',         desc: 'StrField (string)' },
+    { fieldTypeClass: 'solr.IntPointField',     desc: 'IntPointField (integer)' },
+    { fieldTypeClass: 'solr.LongPointField',    desc: 'LongPointField (long)' },
+    { fieldTypeClass: 'solr.FloatPointField',   desc: 'FloatPointField (float)' },
+    { fieldTypeClass: 'solr.DoublePointField',  desc: 'DoublePointField (double)' },
+    { fieldTypeClass: 'solr.DatePointField',    desc: 'DatePointField (date)' },
+    { fieldTypeClass: 'solr.BoolField',         desc: 'BoolField (boolean)' },
+    { fieldTypeClass: 'solr.UUIDField',         desc: 'UUIDField (keyword)' },
+    { fieldTypeClass: 'com.example.CustomExactField', desc: 'custom non-text class' },
+  ])('emits term query for $desc', ({ fieldTypeClass }) => {
+    const node: FieldNode = { type: 'field', field: 'status', value: 'active' };
+    const fieldTypes = new Map([['status', fieldTypeClass]]);
+
+    const result = fieldRule(node, stubTransformChild, fieldTypes);
+
+    expect(result).toEqual(
+      new Map([['term', new Map([['status', new Map([['value', 'active']])]])]]),
+    );
+  });
+
+  // --- match queries when fieldTypes identifies text fields ---
+
+  it.each([
+    { fieldTypeClass: 'solr.TextField',                          desc: 'solr.TextField' },
+    { fieldTypeClass: 'org.apache.solr.schema.TextField',        desc: 'fully-qualified TextField' },
+    { fieldTypeClass: 'com.example.CustomTextField',             desc: 'custom class containing TextField' },
+  ])('emits match query for $desc', ({ fieldTypeClass }) => {
+    const node: FieldNode = { type: 'field', field: 'title', value: 'java' };
+    const fieldTypes = new Map([['title', fieldTypeClass]]);
+
+    const result = fieldRule(node, stubTransformChild, fieldTypes);
+
+    expect(result).toEqual(
+      new Map([['match', new Map([['title', new Map([['query', 'java']])]])]]),
+    );
+  });
+
+  it('fieldTypes does not affect existence search — always emits exists', () => {
+    const node: FieldNode = { type: 'field', field: 'status', value: '*' };
+    const fieldTypes = new Map([['status', 'solr.StrField']]);
+
+    const result = fieldRule(node, stubTransformChild, fieldTypes);
+
+    expect(result).toEqual(
+      new Map([['exists', new Map([['field', 'status']])]]),
+    );
+  });
+
+  it('fieldTypes does not affect wildcard search — always emits wildcard', () => {
+    const node: FieldNode = { type: 'field', field: 'status', value: 'act*' };
+    const fieldTypes = new Map([['status', 'solr.StrField']]);
+
+    const result = fieldRule(node, stubTransformChild, fieldTypes);
+
+    expect(result).toEqual(
+      new Map([['wildcard', new Map([['status', new Map([['value', 'act*']])]])]]),
+    );
+  });
+
+  it('fieldTypes does not affect fuzzy search — always emits fuzzy', () => {
+    const node: FieldNode = { type: 'field', field: 'status', value: 'activ~' };
+    const fieldTypes = new Map([['status', 'solr.StrField']]);
+
+    const result = fieldRule(node, stubTransformChild, fieldTypes);
+
+    expect(result.keys().next().value).toBe('fuzzy');
   });
 
   // --- Existence search ---
@@ -72,7 +155,7 @@ describe('fieldRule', () => {
     const result = fieldRule(node, stubTransformChild);
 
     expect(result).toEqual(
-      new Map([['fuzzy', new Map([['title', new Map([['value', 'roam'], ['fuzziness', 2]])]])]]),
+      new Map([['fuzzy', new Map([['title', new Map<string, any>([['value', 'roam'], ['fuzziness', 2]])]])]]),
     );
   });
 
@@ -82,7 +165,7 @@ describe('fieldRule', () => {
     const result = fieldRule(node, stubTransformChild);
 
     expect(result).toEqual(
-      new Map([['fuzzy', new Map([['title', new Map([['value', 'roam'], ['fuzziness', 1]])]])]]),
+      new Map([['fuzzy', new Map([['title', new Map<string, any>([['value', 'roam'], ['fuzziness', 1]])]])]]),
     );
   });
 
@@ -92,7 +175,7 @@ describe('fieldRule', () => {
     const result = fieldRule(node, stubTransformChild);
 
     expect(result).toEqual(
-      new Map([['fuzzy', new Map([['title', new Map([['value', 'roam'], ['fuzziness', 0]])]])]]),
+      new Map([['fuzzy', new Map([['title', new Map<string, any>([['value', 'roam'], ['fuzziness', 0]])]])]]),
     );
   });
 
@@ -102,7 +185,7 @@ describe('fieldRule', () => {
     const result = fieldRule(node, stubTransformChild);
 
     expect(result).toEqual(
-      new Map([['fuzzy', new Map([['title', new Map([['value', 'roam'], ['fuzziness', 2]])]])]]),
+      new Map([['fuzzy', new Map([['title', new Map<string, any>([['value', 'roam'], ['fuzziness', 2]])]])]]),
     );
   });
 
@@ -153,5 +236,63 @@ describe('fieldRule', () => {
     fieldRule(node, spy);
 
     expect(spy).not.toHaveBeenCalled();
+  });
+
+  // --- fieldTypes propagates through bool queries ---
+
+  it.each([
+    { fieldTypeClass: 'solr.StrField',         desc: 'StrField (string)' },
+    { fieldTypeClass: 'solr.IntPointField',     desc: 'IntPointField (integer)' },
+    { fieldTypeClass: 'solr.LongPointField',    desc: 'LongPointField (long)' },
+    { fieldTypeClass: 'solr.FloatPointField',   desc: 'FloatPointField (float)' },
+    { fieldTypeClass: 'solr.DoublePointField',  desc: 'DoublePointField (double)' },
+    { fieldTypeClass: 'solr.DatePointField',    desc: 'DatePointField (date)' },
+    { fieldTypeClass: 'solr.BoolField',         desc: 'BoolField (boolean)' },
+    { fieldTypeClass: 'solr.UUIDField',         desc: 'UUIDField (keyword)' },
+  ])('term query is used for $desc field via translateQ', ({ fieldTypeClass }) => {
+    const fieldTypes = new Map([['status', fieldTypeClass]]);
+    const params = new Map([['q', 'status:active']]);
+
+    const { dsl } = translateQ(params, 'fail-fast', fieldTypes);
+
+    expect(dsl).toEqual(new Map([['term', new Map([['status', new Map([['value', 'active']])]])]]));
+  });
+
+  it('term query propagates through AND bool node', () => {
+    const fieldTypes = new Map([
+      ['status', 'solr.StrField'],
+      ['category', 'solr.StrField'],
+    ]);
+    const params = new Map([['q', 'status:active AND category:books']]);
+
+    const { dsl } = translateQ(params, 'fail-fast', fieldTypes);
+
+    expect(dsl).toEqual(
+      new Map([['bool', new Map([
+        ['must', [
+          new Map([['term', new Map([['status', new Map([['value', 'active']])]])]]),
+          new Map([['term', new Map([['category', new Map([['value', 'books']])]])]]),
+        ]],
+      ])]]),
+    );
+  });
+
+  it('term and match queries mixed in OR bool node', () => {
+    const fieldTypes = new Map([
+      ['status',   'solr.StrField'],   // exact → term
+      ['title',    'solr.TextField'],  // analyzed → match
+    ]);
+    const params = new Map([['q', 'status:active OR title:java']]);
+
+    const { dsl } = translateQ(params, 'fail-fast', fieldTypes);
+
+    expect(dsl).toEqual(
+      new Map([['bool', new Map([
+        ['should', [
+          new Map([['term',  new Map([['status', new Map([['value', 'active']])]])]]),
+          new Map([['match', new Map([['title',  new Map([['query', 'java']])]])]]),
+        ]],
+      ])]]),
+    );
   });
 });

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/transformer/rules/fieldRule.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/transformer/rules/fieldRule.ts
@@ -5,25 +5,35 @@
  *   - field:* (existence) → exists query
  *   - field:roam~ / field:roam~2 (fuzzy) → fuzzy query
  *   - field:te?t / field:test* (wildcard) → wildcard query
- *   - field:value (plain) → match query
+ *   - field:value (plain, text field) → match query
+ *   - field:value (plain, any other type or unknown) → term query
  *
- * We use `match` for plain values because Solr's standard query parser
- * analyzes field values at query time, matching OpenSearch's match behavior.
+ * For plain values, the query type depends on the field's OpenSearch type from
+ * the schema (passed via fieldTypes):
+ *   - `text` → match query (analyzed, full-text search)
+ *   - anything else (keyword, integer, date, boolean, etc.) → term query (exact match)
+ *   - unknown (field not in fieldTypes) → match query (safe default — avoids breaking
+ *     text fields that weren't listed in the schema)
+ 
  *
  * All output uses the expanded form with nested field object to support
  * boost injection by boostRule:
  *   {"queryType": {"field": {"param": "value"}}}
  *
- * Examples:
+ * Examples (text field or unknown):
  *   `title:java`   → Map{"match" → Map{"title" → Map{"query" → "java"}}}
  *   `title:*`      → Map{"exists" → Map{"field" → "title"}}
  *   `title:te?t`   → Map{"wildcard" → Map{"title" → Map{"value" → "te?t"}}}
  *   `title:test*`  → Map{"wildcard" → Map{"title" → Map{"value" → "test*"}}}
  *   `title:roam~`  → Map{"fuzzy" → Map{"title" → Map{"value" → "roam"}}}
  *   `title:roam~2` → Map{"fuzzy" → Map{"title" → Map{"value" → "roam", "fuzziness" → 2}}}
+ *
+ * Examples (with schema, non-text field):
+ *   `status:active` (status=keyword) → Map{"term" → Map{"status" → "active"}}
+ *   `id:42`         (id=keyword)     → Map{"term" → Map{"id" → "42"}}
  */
 
-import type { ASTNode } from '../../ast/nodes';
+import type { ASTNode, FieldNode } from '../../ast/nodes';
 import type { TransformRuleFn } from '../types';
 
 /** Detects wildcard patterns: contains * or ? (but not sole *) */
@@ -32,11 +42,35 @@ const WILDCARD_PATTERN = /[*?]/;
 /** Detects fuzzy search: term~ or term~N at end of value */
 const FUZZY_PATTERN = /^(.+?)~(\d?)$/;
 
+/** Shared empty map used as the default when no fieldTypes are provided. */
+const EMPTY_FIELD_TYPES: ReadonlyMap<string, string> = new Map();
+
+/**
+ * Classify a Solr field as analyzed text or exact based on its fieldType Java class.
+ *
+ * A field is analyzed (text) if its fieldType class contains "TextField"
+ * (e.g. solr.TextField, org.apache.solr.schema.TextField, custom subclasses).
+ * Everything else is exact — regardless of the type name.
+ *
+ * Using the class rather than the type name avoids false positives from
+ * misleadingly-named types (e.g. a type named "text_acs" backed by IntPointField
+ * is exact, not analyzed).
+ */
+function isTextField(fieldTypeClass: string): boolean {
+  return fieldTypeClass.includes('TextField');
+}
+
+/**
+ * TransformRuleFn for FieldNode. Uses the optional `fieldTypes` parameter
+ * (field name → Solr fieldType class) to choose term vs match for plain values.
+ * Falls back to match when fieldTypes is absent or the field is not listed.
+ */
 export const fieldRule: TransformRuleFn = (
   node: ASTNode,
   _transformChild,
+  fieldTypes = EMPTY_FIELD_TYPES,
 ): Map<string, any> => {
-  const { field, value } = node;
+  const { field, value } = node as FieldNode;
 
   // Existence search: field:* → exists query
   if (value === '*') {
@@ -64,6 +98,22 @@ export const fieldRule: TransformRuleFn = (
     return new Map([['wildcard', new Map([[field, new Map([['value', value]])]])]]);
   }
 
-  // Plain value: field:value → match query (expanded form for boost compatibility)
+  // Plain value — choose query type based on field's Solr fieldType class.
+  //
+  // class.includes("TextField") → analyzed → match query.
+  // Everything else (solr.StrField, solr.IntPointField, etc.) → exact → term query.
+  // Unknown fields (not in fieldTypes) fall back to match. Neither match nor term
+  // is universally correct without schema information — match applies whatever
+  // search_analyzer is configured (which may differ from index-time analysis),
+  // while term bypasses analysis entirely. For unknown fields we choose match as
+  // the best-effort default since it matches Solr's query-time analysis behavior
+  // for text fields, which are the most common case when schema metadata is absent.
+  const fieldTypeClass = fieldTypes.get(field);
+  if (fieldTypeClass !== undefined && !isTextField(fieldTypeClass)) {
+    // Known non-text field: term query — exact match, no analysis
+    return new Map([['term', new Map([[field, new Map([['value', value]])]])]]);
+  }
+
+  // text field or unknown type: match query (expanded form for boost compatibility).
   return new Map([['match', new Map([[field, new Map([['query', value]])]])]]);
 };

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/transformer/types.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/transformer/types.ts
@@ -21,8 +21,12 @@ export type TransformChild = (child: ASTNode) => Map<string, any>;
  * can ignore the `transformChild` parameter. Rules for composite nodes
  * (BoolNode, GroupNode, BoostNode) use it to recurse into children.
  *
+ * `fieldTypes` is optional schema metadata (field name → Solr fieldType class).
+ * Currently only `fieldRule` uses it to choose `term` vs `match`. All other
+ * rules can ignore it.
+ *
  * Example (leaf rule):
- *   (FieldNode { field: "title", value: "java" }, _)
+ *   (FieldNode { field: "title", value: "java" }, _transformChild)
  *   → Map{"match" → Map{"title" → "java"}}
  *
  * Example (composite rule):
@@ -32,4 +36,5 @@ export type TransformChild = (child: ASTNode) => Map<string, any>;
 export type TransformRuleFn = (
   node: ASTNode,
   transformChild: TransformChild,
+  fieldTypes?: ReadonlyMap<string, string>,
 ) => Map<string, any>;

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/request.transform.test.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/request.transform.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Unit tests for request.transform.ts.
+ *
+ * resolveFieldTypes() and resolveSolrConfig() are tested directly.
+ * transform() is tested for the behaviors that don't depend on GraalVM bindings
+ * (unknown endpoint passthrough, body writeback, basic query translation).
+ * The fieldTypes → term/match behavior is covered in query-q.test.ts.
+ */
+import { describe, it, expect } from 'vitest';
+import { resolveFieldTypes, resolveSolrConfig, transform } from './request.transform';
+import type { JavaMap } from './context';
+
+/** Build a minimal JavaMap message for a given URI. */
+function mockMsg(uri: string): JavaMap {
+  const data = new Map<string, any>([['URI', uri]]);
+  return data as unknown as JavaMap;
+}
+
+describe('resolveFieldTypes', () => {
+  it('returns empty map when bindings is undefined', () => {
+    const result = resolveFieldTypes(undefined);
+    expect(result.size).toBe(0);
+  });
+
+  it('returns empty map when bindings has no fieldTypes key', () => {
+    const result = resolveFieldTypes({ solrConfig: {} });
+    expect(result.size).toBe(0);
+  });
+
+  it('returns empty map when bindings.fieldTypes is empty object', () => {
+    const result = resolveFieldTypes({ fieldTypes: {} });
+    expect(result.size).toBe(0);
+  });
+
+  it('converts fieldTypes object to a ReadonlyMap', () => {
+    const result = resolveFieldTypes({
+      fieldTypes: {
+        id:       'solr.StrField',
+        title:    'solr.TextField',
+        status:   'solr.StrField',
+      },
+    });
+
+    expect(result.size).toBe(3);
+    expect(result.get('id')).toBe('solr.StrField');
+    expect(result.get('title')).toBe('solr.TextField');
+    expect(result.get('status')).toBe('solr.StrField');
+  });
+
+  it('returns empty map for unknown field', () => {
+    const result = resolveFieldTypes({ fieldTypes: { status: 'solr.StrField' } });
+    expect(result.get('unknown_field')).toBeUndefined();
+  });
+
+  it('returns the same empty map singleton when no fieldTypes (no allocation)', () => {
+    const a = resolveFieldTypes(undefined);
+    const b = resolveFieldTypes({});
+    // Both should be the shared EMPTY_FIELD_TYPES constant
+    expect(a).toBe(b);
+  });
+
+  it('handles fieldTypes with TextField class correctly', () => {
+    const result = resolveFieldTypes({
+      fieldTypes: { body: 'solr.TextField' },
+    });
+    const cls = result.get('body');
+    expect(cls).toBeDefined();
+    expect(cls!.includes('TextField')).toBe(true);
+  });
+
+  it('handles fieldTypes with non-text class correctly', () => {
+    const result = resolveFieldTypes({
+      fieldTypes: { price: 'solr.FloatPointField' },
+    });
+    const cls = result.get('price');
+    expect(cls).toBeDefined();
+    expect(cls!.includes('TextField')).toBe(false);
+  });
+});
+
+describe('resolveSolrConfig', () => {
+  it('returns undefined when bindings is undefined', () => {
+    expect(resolveSolrConfig(undefined)).toBeUndefined();
+  });
+
+  it('returns undefined when bindings has no solrConfig key', () => {
+    expect(resolveSolrConfig({ fieldTypes: {} })).toBeUndefined();
+  });
+
+  it('returns the solrConfig object when present', () => {
+    const config = { '/select': { defaults: { df: 'title' } } };
+    const result = resolveSolrConfig({ solrConfig: config });
+    expect(result).toBe(config);
+  });
+
+  it('returns the same reference (not a copy)', () => {
+    const config = { '/select': { defaults: { df: 'title' } } };
+    const result = resolveSolrConfig({ solrConfig: config });
+    expect(result).toBe(config);
+  });
+
+  it('returns undefined when solrConfig is null', () => {
+    expect(resolveSolrConfig({ solrConfig: null })).toBeUndefined();
+  });
+});
+
+describe('transform', () => {
+  // ─── Unknown endpoint passthrough ────────────────────────────────────────
+
+  it('returns msg unchanged for unknown endpoint', () => {
+    const msg = mockMsg('/unknown/path?q=*:*');
+    const result = transform(msg);
+    expect(result).toBe(msg); // same reference — not modified
+  });
+
+  it('does not write payload for unknown endpoint', () => {
+    const msg = mockMsg('/unknown/path?q=*:*');
+    transform(msg);
+    expect(msg.get('payload')).toBeUndefined();
+  });
+
+  // ─── Select endpoint — body writeback ─────────────────────────────────────
+
+  it('creates payload map when msg has no payload', () => {
+    const msg = mockMsg('/solr/test/select?q=*:*');
+    transform(msg);
+    expect(msg.get('payload')).toBeDefined();
+    expect(msg.get('payload').get('inlinedJsonBody')).toBeDefined();
+  });
+
+  it('writes query to inlinedJsonBody', () => {
+    const msg = mockMsg('/solr/test/select?q=*:*');
+    transform(msg);
+    const body = msg.get('payload').get('inlinedJsonBody');
+    expect(body.has('query')).toBe(true);
+  });
+
+  it('returns msg (same reference) after processing', () => {
+    const msg = mockMsg('/solr/test/select?q=*:*');
+    const result = transform(msg);
+    expect(result).toBe(msg);
+  });
+
+  // ─── rows/start params ────────────────────────────────────────────────────
+
+  it('converts rows param to size', () => {
+    const msg = mockMsg('/solr/test/select?q=*:*&rows=25');
+    transform(msg);
+    const body = msg.get('payload').get('inlinedJsonBody');
+    expect(body.get('size')).toBe(25);
+  });
+
+  it('converts start param to from', () => {
+    const msg = mockMsg('/solr/test/select?q=*:*&start=10');
+    transform(msg);
+    const body = msg.get('payload').get('inlinedJsonBody');
+    expect(body.get('from')).toBe(10);
+  });
+
+  it('does not set size when rows is absent', () => {
+    const msg = mockMsg('/solr/test/select?q=*:*');
+    transform(msg);
+    const body = msg.get('payload').get('inlinedJsonBody');
+    expect(body.has('size')).toBe(false);
+  });
+
+  it('does not set from when start is absent', () => {
+    const msg = mockMsg('/solr/test/select?q=*:*');
+    transform(msg);
+    const body = msg.get('payload').get('inlinedJsonBody');
+    expect(body.has('from')).toBe(false);
+  });
+
+  // ─── match_all for *:* ────────────────────────────────────────────────────
+
+  it('produces match_all query for *:*', () => {
+    const msg = mockMsg('/solr/test/select?q=*:*');
+    transform(msg);
+    const body = msg.get('payload').get('inlinedJsonBody');
+    const query = body.get('query') as Map<string, any>;
+    expect(query.has('match_all')).toBe(true);
+  });
+
+  // ─── match query for plain field:value (no fieldTypes in test env) ────────
+
+  it('produces match query for field:value when no fieldTypes configured', () => {
+    const msg = mockMsg('/solr/test/select?q=status:active');
+    transform(msg);
+    const body = msg.get('payload').get('inlinedJsonBody');
+    const query = body.get('query') as Map<string, any>;
+    // No fieldTypes in test env → falls back to match
+    expect(query.has('match')).toBe(true);
+  });
+});

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/request.transform.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/request.transform.ts
@@ -19,9 +19,20 @@ import { flushMetrics } from './metrics';
 // Read solrConfig from bindings once at init (closure, not global mutable state).
 // bindings is injected by Java via JavascriptTransformer's bindingsObject.
 declare const bindings: any;
-const solrConfig = (typeof bindings !== 'undefined' && bindings?.solrConfig) //NOSONAR — typeof required for undeclared closure var
-  ? bindings.solrConfig
-  : undefined;
+
+/**
+ * Resolve solrConfig from a bindings object.
+ * @param bindingsObj - The bindings object (may be undefined in tests or when
+ *   solrConfigXmlFile is not configured).
+ * @returns The solrConfig object, or undefined when not present in bindings.
+ */
+export function resolveSolrConfig(bindingsObj: any): any {
+  return bindingsObj?.solrConfig ?? undefined;
+}
+
+const solrConfig = resolveSolrConfig(
+  typeof bindings !== 'undefined' ? bindings : undefined, //NOSONAR — typeof required for undeclared closure var
+);
 
 /**
  * True when the body is a non-empty iterable/collection (Map or List). Guards against
@@ -37,10 +48,28 @@ function hasContent(body: any): boolean {
   return false;
 }
 
+// Read fieldTypes from bindings once at init. Java provides a flat map of
+// fieldName → solrTypeClass (e.g. {"title":"solr.TextField","id":"solr.StrField"})
+// resolved from managed-schema.xml via solrSchemaXmlFile config.
+// Empty map when solrSchemaXmlFile is not configured — fieldRule falls back to match.
+const EMPTY_FIELD_TYPES: ReadonlyMap<string, string> = new Map();
+export function resolveFieldTypes(bindingsObj: any): ReadonlyMap<string, string> {
+  if (bindingsObj?.fieldTypes) {
+    return new Map(Object.entries(bindingsObj.fieldTypes as Record<string, string>));
+  }
+  return EMPTY_FIELD_TYPES;
+}
+
+// Read fieldTypes from bindings once at init.
+const fieldTypes = resolveFieldTypes(
+  typeof bindings !== 'undefined' ? bindings : undefined, //NOSONAR — typeof required for undeclared closure var
+);
+
 export function transform(msg: JavaMap): JavaMap {
   const ctx = buildRequestContext(msg);
   if (ctx.endpoint === 'unknown') return msg;
   ctx.solrConfig = solrConfig;
+  ctx.fieldTypes = fieldTypes;
   runPipeline(requestRegistry, ctx);
 
   let payload = msg.get('payload');

--- a/TrafficCapture/transformationShim/src/main/java/org/opensearch/migrations/transform/shim/ShimMain.java
+++ b/TrafficCapture/transformationShim/src/main/java/org/opensearch/migrations/transform/shim/ShimMain.java
@@ -406,6 +406,11 @@ public class ShimMain {
                                 var solrConfig = SolrConfigProvider.fromXmlFile(Path.of(xf));
                                 if (!solrConfig.isEmpty()) bindings.put("solrConfig", solrConfig);
                             }
+                            var schemaFile = pc.get(SolrTransformerProvider.SOLR_SCHEMA_XML_FILE_KEY);
+                            if (schemaFile instanceof String sf && !sf.isBlank()) {
+                                var fieldTypes = SolrSchemaProvider.fromXmlFile(Path.of(sf));
+                                if (!fieldTypes.isEmpty()) bindings.put("fieldTypes", fieldTypes);
+                            }
                         }
                     }
                 }

--- a/TrafficCapture/transformationShim/src/main/java/org/opensearch/migrations/transform/shim/SolrSchemaProvider.java
+++ b/TrafficCapture/transformationShim/src/main/java/org/opensearch/migrations/transform/shim/SolrSchemaProvider.java
@@ -1,0 +1,116 @@
+package org.opensearch.migrations.transform.shim;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import lombok.extern.slf4j.Slf4j;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+
+/**
+ * Reads Solr field metadata from a {@code managed-schema.xml} and emits a flat
+ * {@code fieldName → fieldTypeClass} map for the JS transformer.
+ *
+ * <p>For each {@code <field>} element, resolves its {@code type} attribute to the
+ * Java class of the corresponding {@code <fieldType>} element and emits:
+ * <pre>{@code fieldName → "solr.TextField" | "solr.StrField" | ... }</pre>
+ *
+ * <p>The JS transformer ({@code fieldRule.ts}) applies the classification:
+ * {@code class.includes("TextField")} → analyzed → {@code match} query,
+ * otherwise → exact → {@code term} query.
+ *
+ * <p>Example schema:
+ * <pre>{@code
+ * <fieldType name="text_general"   class="solr.TextField"      .../>
+ * <fieldType name="string"         class="solr.StrField"       .../>
+ * <fieldType name="my_custom_text" class="solr.TextField"      .../>
+ * <field name="title"       type="text_general"   />
+ * <field name="id"          type="string"         />
+ * <field name="description" type="my_custom_text" />
+ * }</pre>
+ *
+ * <p>Output:
+ * <pre>{@code
+ * { "title": "solr.TextField", "id": "solr.StrField", "description": "solr.TextField" }
+ * }</pre>
+ */
+@Slf4j
+public class SolrSchemaProvider {
+
+    private SolrSchemaProvider() {}
+
+    /**
+     * Parse a Solr {@code managed-schema.xml} and return a flat
+     * {@code fieldName → fieldTypeClass} map.
+     *
+     * <p>Returns an empty map if the path is null, the file does not exist, or parsing fails.
+     *
+     * @param path path to {@code managed-schema.xml} or {@code managed-schema}
+     * @return immutable map of field name to Solr fieldType Java class string
+     */
+    public static Map<String, String> fromXmlFile(Path path) {
+        if (path == null) {
+            log.debug("solrSchemaXmlFile not configured, skipping fieldTypes");
+            return Map.of();
+        }
+        if (!Files.exists(path)) {
+            log.debug("managed-schema.xml not found at {}, skipping fieldTypes", path);
+            return Map.of();
+        }
+        try {
+            var factory = DocumentBuilderFactory.newInstance();
+            factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            var doc = factory.newDocumentBuilder().parse(path.toFile());
+            var root = doc.getDocumentElement();
+
+            // Step 1: build typeName → class from <fieldType> elements.
+            var typeNameToClass = buildTypeClassMap(root);
+
+            // Step 2: walk <field> elements and resolve each to its fieldType class.
+            // Fields whose type is not declared in <fieldType> elements are skipped —
+            // the JS transformer treats absent fields as unknown and falls back to match.
+            var result = new LinkedHashMap<String, String>();
+            NodeList fields = root.getElementsByTagName("field");
+            for (int i = 0; i < fields.getLength(); i++) {
+                if (!(fields.item(i) instanceof Element el)) continue;
+                var name = el.getAttribute("name");
+                var type = el.getAttribute("type");
+                if (!name.isEmpty() && !type.isEmpty()) {
+                    var cls = typeNameToClass.get(type);
+                    if (cls != null && !cls.isEmpty()) {
+                        result.put(name, cls);
+                    } else {
+                        log.debug("Field '{}' references unknown fieldType '{}', skipping", name, type);
+                    }
+                }
+            }
+
+            log.info("Loaded {} field class mappings from {}", result.size(), path);
+            return Map.copyOf(result);
+        } catch (Exception e) {
+            log.warn("Failed to parse managed-schema.xml at {}", path, e);
+            return Map.of();
+        }
+    }
+
+    /**
+     * Build a map of Solr fieldType name → Java class from {@code <fieldType>} elements.
+     */
+    private static Map<String, String> buildTypeClassMap(Element root) {
+        var map = new LinkedHashMap<String, String>();
+        NodeList fieldTypes = root.getElementsByTagName("fieldType");
+        for (int i = 0; i < fieldTypes.getLength(); i++) {
+            if (!(fieldTypes.item(i) instanceof Element el)) continue;
+            var name = el.getAttribute("name");
+            var cls  = el.getAttribute("class");
+            if (!name.isEmpty()) {
+                map.put(name, cls);
+            }
+        }
+        return map;
+    }
+}

--- a/TrafficCapture/transformationShim/src/main/java/org/opensearch/migrations/transform/shim/SolrTransformerProvider.java
+++ b/TrafficCapture/transformationShim/src/main/java/org/opensearch/migrations/transform/shim/SolrTransformerProvider.java
@@ -19,6 +19,8 @@ import lombok.extern.slf4j.Slf4j;
  * <ul>
  *   <li>Auto-prepends the GraalVM {@code URLSearchParams} polyfill to all scripts</li>
  *   <li>Supports {@code solrConfigXmlFile} config key to auto-parse solrconfig.xml into bindings</li>
+ *   <li>Supports {@code solrSchemaXmlFile} config key to derive field type metadata from
+ *       managed-schema.xml into bindings, enabling term vs match query selection</li>
  * </ul>
  *
  * <p>Registered via {@code META-INF/services/org.opensearch.migrations.transform.IJsonTransformerProvider}
@@ -29,7 +31,8 @@ import lombok.extern.slf4j.Slf4j;
  * {"SolrTransformerProvider": {
  *   "initializationScriptFile": "/path/to/request.js",
  *   "bindingsObject": "{}",
- *   "solrConfigXmlFile": "/path/to/solrconfig.xml"
+ *   "solrConfigXmlFile": "/path/to/solrconfig.xml",
+ *   "solrSchemaXmlFile": "/path/to/managed-schema.xml"
  * }}
  * }</pre>
  */
@@ -37,6 +40,7 @@ import lombok.extern.slf4j.Slf4j;
 public class SolrTransformerProvider extends ScriptTransformerProvider {
 
     public static final String SOLR_CONFIG_XML_FILE_KEY = "solrConfigXmlFile";
+    public static final String SOLR_SCHEMA_XML_FILE_KEY = "solrSchemaXmlFile";
 
     /**
      * Minimal URLSearchParams polyfill for GraalVM — the engine does not provide
@@ -96,6 +100,15 @@ public class SolrTransformerProvider extends ScriptTransformerProvider {
             if (!solrConfig.isEmpty()) {
                 bindings.put("solrConfig", solrConfig);
                 log.info("Loaded solrConfig from {}", xmlFile);
+            }
+        }
+
+        var schemaFile = (String) config.get(SOLR_SCHEMA_XML_FILE_KEY);
+        if (schemaFile != null && !schemaFile.isBlank()) {
+            var fieldTypes = SolrSchemaProvider.fromXmlFile(Path.of(schemaFile));
+            if (!fieldTypes.isEmpty()) {
+                bindings.put("fieldTypes", fieldTypes);
+                log.info("Loaded {} fieldTypes from {}", fieldTypes.size(), schemaFile);
             }
         }
         return bindings;

--- a/TrafficCapture/transformationShim/src/test/java/org/opensearch/migrations/transform/shim/ShimMainTest.java
+++ b/TrafficCapture/transformationShim/src/test/java/org/opensearch/migrations/transform/shim/ShimMainTest.java
@@ -211,6 +211,40 @@ class ShimMainTest {
 
     @Test
     @SuppressWarnings("unchecked")
+    void extractBindings_withFieldTypesInBindingsObject_extractsIt() {
+        // Operator provides fieldTypes inline in bindingsObject JSON — no schema file needed.
+        // This is the path used by the traffic replayer (JsonJSTransformerProvider) and
+        // any deployment where the schema file is not accessible.
+        var bindings = ShimMain.extractBindings(
+            "[{\"SolrTransformerProvider\":{\"initializationScript\":\"x\"," +
+            "\"bindingsObject\":\"{\\\"fieldTypes\\\":{\\\"id\\\":\\\"solr.StrField\\\"," +
+            "\\\"title\\\":\\\"solr.TextField\\\"}}\"}}]");
+
+        assertTrue(bindings.containsKey("fieldTypes"));
+        var fieldTypes = (java.util.Map<String, String>) bindings.get("fieldTypes");
+        assertEquals("solr.StrField",  fieldTypes.get("id"));
+        assertEquals("solr.TextField", fieldTypes.get("title"));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void extractBindings_withFieldTypesAndSolrConfigBothInBindingsObject_extractsBoth() {
+        // Both fieldTypes and solrConfig can be inlined together in bindingsObject
+        var bindings = ShimMain.extractBindings(
+            "[{\"SolrTransformerProvider\":{\"initializationScript\":\"x\"," +
+            "\"bindingsObject\":\"{" +
+            "\\\"solrConfig\\\":{\\\"/select\\\":{\\\"defaults\\\":{\\\"df\\\":\\\"title\\\"}}}," +
+            "\\\"fieldTypes\\\":{\\\"status\\\":\\\"solr.StrField\\\"}" +
+            "}\"}}]");
+
+        assertTrue(bindings.containsKey("solrConfig"));
+        assertTrue(bindings.containsKey("fieldTypes"));
+        var fieldTypes = (java.util.Map<String, String>) bindings.get("fieldTypes");
+        assertEquals("solr.StrField", fieldTypes.get("status"));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
     void extractBindings_withSolrConfigXmlFile_parsesXml(@TempDir java.nio.file.Path tempDir) throws Exception {
         var xml = tempDir.resolve("solrconfig.xml");
         java.nio.file.Files.writeString(xml, """
@@ -227,6 +261,73 @@ class ShimMainTest {
         assertTrue(bindings.containsKey("solrConfig"));
         var solrConfig = (java.util.Map<String, Object>) bindings.get("solrConfig");
         assertTrue(solrConfig.containsKey("/select"));
+    }
+
+    @Test
+    void extractBindings_withSolrSchemaXmlFile_parsesXml(@TempDir java.nio.file.Path tempDir) throws Exception {
+        var xml = tempDir.resolve("managed-schema.xml");
+        java.nio.file.Files.writeString(xml, """
+            <?xml version="1.0" encoding="UTF-8" ?>
+            <schema name="test" version="1.6">
+              <fieldType name="string"       class="solr.StrField"/>
+              <fieldType name="text_general" class="solr.TextField"/>
+              <field name="id"    type="string"/>
+              <field name="title" type="text_general"/>
+            </schema>
+            """);
+
+        var bindings = ShimMain.extractBindings(
+            "[{\"SolrTransformerProvider\":{\"initializationScript\":\"x\"," +
+            "\"bindingsObject\":\"{}\",\"solrSchemaXmlFile\":\"" + xml.toAbsolutePath() + "\"}}]");
+
+        assertTrue(bindings.containsKey("fieldTypes"));
+        @SuppressWarnings("unchecked")
+        var fieldTypes = (java.util.Map<String, String>) bindings.get("fieldTypes");
+        assertEquals("solr.StrField",  fieldTypes.get("id"));
+        assertEquals("solr.TextField", fieldTypes.get("title"));
+    }
+
+    @Test
+    void extractBindings_withBothSchemaAndConfigXmlFiles_loadsBoth(@TempDir java.nio.file.Path tempDir) throws Exception {
+        var schemaXml = tempDir.resolve("managed-schema.xml");
+        java.nio.file.Files.writeString(schemaXml, """
+            <?xml version="1.0" encoding="UTF-8" ?>
+            <schema name="test" version="1.6">
+              <fieldType name="string" class="solr.StrField"/>
+              <field name="id" type="string"/>
+            </schema>
+            """);
+
+        var configXml = tempDir.resolve("solrconfig.xml");
+        java.nio.file.Files.writeString(configXml, """
+            <?xml version="1.0" encoding="UTF-8" ?>
+            <config>
+              <requestHandler name="/select" class="solr.SearchHandler">
+                <lst name="defaults"><str name="df">title</str></lst>
+              </requestHandler>
+            </config>
+            """);
+
+        var bindings = ShimMain.extractBindings(
+            "[{\"SolrTransformerProvider\":{\"initializationScript\":\"x\"," +
+            "\"bindingsObject\":\"{}\"," +
+            "\"solrConfigXmlFile\":\"" + configXml.toAbsolutePath() + "\"," +
+            "\"solrSchemaXmlFile\":\"" + schemaXml.toAbsolutePath() + "\"}}]");
+
+        assertTrue(bindings.containsKey("solrConfig"),  "solrConfig should be present");
+        assertTrue(bindings.containsKey("fieldTypes"),  "fieldTypes should be present");
+    }
+
+    @Test
+    void extractBindings_withMissingSolrSchemaXmlFile_noFieldTypesKey(@TempDir java.nio.file.Path tempDir) {
+        var bindings = ShimMain.extractBindings(
+            "[{\"SolrTransformerProvider\":{\"initializationScript\":\"x\"," +
+            "\"bindingsObject\":\"{}\"," +
+            "\"solrSchemaXmlFile\":\"/nonexistent/managed-schema.xml\"}}]");
+
+        // Missing file → SolrSchemaProvider returns empty map → not put into bindings
+        assertTrue(!bindings.containsKey("fieldTypes"),
+            "fieldTypes should not be present when schema file is missing");
     }
 
     @Test

--- a/TrafficCapture/transformationShim/src/test/java/org/opensearch/migrations/transform/shim/SolrSchemaProviderTest.java
+++ b/TrafficCapture/transformationShim/src/test/java/org/opensearch/migrations/transform/shim/SolrSchemaProviderTest.java
@@ -1,0 +1,231 @@
+package org.opensearch.migrations.transform.shim;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SolrSchemaProviderTest {
+
+    @TempDir
+    Path tempDir;
+
+    // ─── Basic field resolution ───────────────────────────────────────────────
+
+    @Test
+    void resolvesWellKnownTextFieldToTextFieldClass() throws Exception {
+        var xml = schemaXml(
+            "<fieldType name='text_general' class='solr.TextField'/>",
+            "<field name='title' type='text_general'/>"
+        );
+
+        var result = SolrSchemaProvider.fromXmlFile(xml);
+
+        assertEquals("solr.TextField", result.get("title"));
+    }
+
+    @Test
+    void resolvesStringFieldToStrFieldClass() throws Exception {
+        var xml = schemaXml(
+            "<fieldType name='string' class='solr.StrField'/>",
+            "<field name='id' type='string'/>"
+        );
+
+        var result = SolrSchemaProvider.fromXmlFile(xml);
+
+        assertEquals("solr.StrField", result.get("id"));
+    }
+
+    @Test
+    void resolvesNumericFieldToIntPointFieldClass() throws Exception {
+        var xml = schemaXml(
+            "<fieldType name='pint' class='solr.IntPointField'/>",
+            "<field name='price' type='pint'/>"
+        );
+
+        var result = SolrSchemaProvider.fromXmlFile(xml);
+
+        assertEquals("solr.IntPointField", result.get("price"));
+    }
+
+    @Test
+    void resolvesDateFieldToDatePointFieldClass() throws Exception {
+        var xml = schemaXml(
+            "<fieldType name='pdate' class='solr.DatePointField'/>",
+            "<field name='created' type='pdate'/>"
+        );
+
+        var result = SolrSchemaProvider.fromXmlFile(xml);
+
+        assertEquals("solr.DatePointField", result.get("created"));
+    }
+
+    // ─── Custom fieldType resolution ──────────────────────────────────────────
+
+    @Test
+    void resolvesCustomTextTypeViaClass() throws Exception {
+        // Custom type name that doesn't contain "text" — class is the ground truth
+        var xml = schemaXml(
+            "<fieldType name='my_custom_text' class='solr.TextField'/>",
+            "<field name='description' type='my_custom_text'/>"
+        );
+
+        var result = SolrSchemaProvider.fromXmlFile(xml);
+
+        assertEquals("solr.TextField", result.get("description"));
+    }
+
+    @Test
+    void resolvesCustomExactTypeWithMisleadingName() throws Exception {
+        // Type named "text_acs" but backed by IntPointField — class wins
+        var xml = schemaXml(
+            "<fieldType name='text_acs' class='solr.IntPointField'/>",
+            "<field name='score' type='text_acs'/>"
+        );
+
+        var result = SolrSchemaProvider.fromXmlFile(xml);
+
+        assertEquals("solr.IntPointField", result.get("score"));
+    }
+
+    @Test
+    void resolvesFullyQualifiedClassName() throws Exception {
+        var xml = schemaXml(
+            "<fieldType name='mytext' class='org.apache.solr.schema.TextField'/>",
+            "<field name='body' type='mytext'/>"
+        );
+
+        var result = SolrSchemaProvider.fromXmlFile(xml);
+
+        assertEquals("org.apache.solr.schema.TextField", result.get("body"));
+    }
+
+    // ─── Multiple fields ──────────────────────────────────────────────────────
+
+    @Test
+    void resolvesMultipleFieldsWithDifferentTypes() throws Exception {
+        var xml = schemaXml(
+            "<fieldType name='string'       class='solr.StrField'/>",
+            "<fieldType name='text_general' class='solr.TextField'/>",
+            "<fieldType name='pint'         class='solr.IntPointField'/>",
+            "<field name='id'       type='string'/>",
+            "<field name='title'    type='text_general'/>",
+            "<field name='quantity' type='pint'/>"
+        );
+
+        var result = SolrSchemaProvider.fromXmlFile(xml);
+
+        assertEquals(3, result.size());
+        assertEquals("solr.StrField",      result.get("id"));
+        assertEquals("solr.TextField",     result.get("title"));
+        assertEquals("solr.IntPointField", result.get("quantity"));
+    }
+
+    // ─── Empty class attribute ────────────────────────────────────────────────
+
+    @Test
+    void skipsFieldWhenFieldTypeHasNoClass() throws Exception {
+        // fieldType with no class attribute — field is skipped since we can't classify it.
+        // Falls back to match query in the JS transformer (safe default).
+        var xml = schemaXml(
+            "<fieldType name='mystery'/>",
+            "<field name='x' type='mystery'/>"
+        );
+
+        var result = SolrSchemaProvider.fromXmlFile(xml);
+
+        assertFalse(result.containsKey("x"));
+    }
+
+    @Test
+    void skipsFieldWhenFieldTypeNotFoundInSchema() throws Exception {
+        // Field references a type not declared in <fieldType> elements — skipped entirely.
+        // The JS transformer treats absent fields as unknown and falls back to match query,
+        // which is safer than storing "" which would incorrectly trigger term query.
+        var xml = schemaXml(
+            "<field name='x' type='undeclared_type'/>"
+        );
+
+        var result = SolrSchemaProvider.fromXmlFile(xml);
+
+        // Field is absent — not stored with empty class
+        assertFalse(result.containsKey("x"));
+    }
+
+    // ─── Error handling ───────────────────────────────────────────────────────
+
+    @Test
+    void returnsEmptyForMissingFile() {
+        var result = SolrSchemaProvider.fromXmlFile(Path.of("/nonexistent/managed-schema.xml"));
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void returnsEmptyForNullPath() {
+        var result = SolrSchemaProvider.fromXmlFile(null);
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void returnsEmptyForMalformedXml() throws Exception {
+        var xml = tempDir.resolve("bad.xml");
+        Files.writeString(xml, "not xml at all");
+
+        var result = SolrSchemaProvider.fromXmlFile(xml);
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void skipsFieldsWithEmptyNameOrType() throws Exception {
+        var xml = schemaXml(
+            "<fieldType name='string' class='solr.StrField'/>",
+            "<field name='' type='string'/>",   // empty name — skipped
+            "<field name='id' type=''/>"         // empty type — skipped
+        );
+
+        var result = SolrSchemaProvider.fromXmlFile(xml);
+
+        assertTrue(result.isEmpty());
+    }
+
+    // ─── Result is immutable ──────────────────────────────────────────────────
+
+    @Test
+    void resultMapIsImmutable() throws Exception {
+        var xml = schemaXml(
+            "<fieldType name='string' class='solr.StrField'/>",
+            "<field name='id' type='string'/>"
+        );
+
+        var result = SolrSchemaProvider.fromXmlFile(xml);
+
+        assertFalse(result.isEmpty());
+        org.junit.jupiter.api.Assertions.assertThrows(
+            UnsupportedOperationException.class,
+            () -> result.put("extra", "value")
+        );
+    }
+
+    // ─── Helpers ─────────────────────────────────────────────────────────────
+
+    /**
+     * Write a minimal managed-schema.xml with the given fieldType and field elements
+     * and return the path.
+     */
+    private Path schemaXml(String... elements) throws Exception {
+        var xml = tempDir.resolve("managed-schema.xml");
+        var body = String.join("\n", elements);
+        Files.writeString(xml, """
+            <?xml version="1.0" encoding="UTF-8" ?>
+            <schema name="test" version="1.6">
+            """ + body + """
+            </schema>
+            """);
+        return xml;
+    }
+}

--- a/TrafficCapture/transformationShim/src/test/java/org/opensearch/migrations/transform/shim/SolrTransformerProviderTest.java
+++ b/TrafficCapture/transformationShim/src/test/java/org/opensearch/migrations/transform/shim/SolrTransformerProviderTest.java
@@ -177,4 +177,181 @@ class SolrTransformerProviderTest {
         var provider = new SolrTransformerProvider();
         assertThrows(IllegalArgumentException.class, () -> provider.createTransformer(null));
     }
+
+    // ─── solrSchemaXmlFile tests ──────────────────────────────────────────────
+
+    @Test
+    void createTransformer_withSolrSchemaXmlFile_populatesFieldTypesBinding() throws Exception {
+        var schemaFile = tempDir.resolve("managed-schema.xml");
+        Files.writeString(schemaFile, """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <schema name="test" version="1.6">
+              <fieldType name="string"       class="solr.StrField"/>
+              <fieldType name="text_general" class="solr.TextField"/>
+              <field name="id"    type="string"/>
+              <field name="title" type="text_general"/>
+            </schema>
+            """);
+
+        // Script reads bindings.fieldTypes and exposes the class values for assertion
+        var script = "(function(bindings) { return function(msg) { " +
+            "var ft = bindings.fieldTypes; " +
+            "msg.set('hasFieldTypes', '' + (ft != null)); " +
+            "msg.set('idClass',    ft['id']); " +
+            "msg.set('titleClass', ft['title']); " +
+            "return msg; }; })";
+
+        var config = providerConfig(script, "{}");
+        config.put("solrSchemaXmlFile", schemaFile.toString());
+
+        var provider = new SolrTransformerProvider();
+        var transformer = provider.createTransformer(config);
+
+        var input = new LinkedHashMap<String, Object>();
+        input.put("URI", "/test");
+        @SuppressWarnings("unchecked")
+        var result = (Map<String, Object>) transformer.transformJson(input);
+
+        assertEquals("true",             result.get("hasFieldTypes"));
+        assertEquals("solr.StrField",    result.get("idClass"));
+        assertEquals("solr.TextField",   result.get("titleClass"));
+    }
+
+    @Test
+    void createTransformer_schemaXmlFileMergedWithOtherBindings() throws Exception {
+        var schemaFile = tempDir.resolve("managed-schema.xml");
+        Files.writeString(schemaFile, """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <schema name="test" version="1.6">
+              <fieldType name="string" class="solr.StrField"/>
+              <field name="status" type="string"/>
+            </schema>
+            """);
+
+        // Both customKey (from bindingsObject) and fieldTypes (from schema) should be present
+        var script = "(function(bindings) { return function(msg) { " +
+            "msg.set('customKey',   bindings.customKey); " +
+            "msg.set('statusClass', bindings.fieldTypes['status']); " +
+            "return msg; }; })";
+
+        var config = providerConfig(script, "{\"customKey\":\"myValue\"}");
+        config.put("solrSchemaXmlFile", schemaFile.toString());
+
+        var provider = new SolrTransformerProvider();
+        var transformer = provider.createTransformer(config);
+
+        var input = new LinkedHashMap<String, Object>();
+        input.put("URI", "/test");
+        @SuppressWarnings("unchecked")
+        var result = (Map<String, Object>) transformer.transformJson(input);
+
+        assertEquals("myValue",        result.get("customKey"));
+        assertEquals("solr.StrField",  result.get("statusClass"));
+    }
+
+    @Test
+    void createTransformer_schemaXmlFileAndSolrConfigXmlFileBothLoaded() throws Exception {
+        var schemaFile = tempDir.resolve("managed-schema.xml");
+        Files.writeString(schemaFile, """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <schema name="test" version="1.6">
+              <fieldType name="string" class="solr.StrField"/>
+              <field name="id" type="string"/>
+            </schema>
+            """);
+
+        var configFile = tempDir.resolve("solrconfig.xml");
+        Files.writeString(configFile, """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <config>
+              <requestHandler name="/select" class="solr.SearchHandler">
+                <lst name="defaults"><str name="df">title</str></lst>
+              </requestHandler>
+            </config>
+            """);
+
+        var script = "(function(bindings) { return function(msg) { " +
+            "msg.set('hasSolrConfig',  '' + (bindings.solrConfig != null)); " +
+            "msg.set('hasFieldTypes',  '' + (bindings.fieldTypes != null)); " +
+            "msg.set('idClass',        bindings.fieldTypes['id']); " +
+            "return msg; }; })";
+
+        var config = providerConfig(script, "{}");
+        config.put("solrConfigXmlFile",  configFile.toString());
+        config.put("solrSchemaXmlFile",  schemaFile.toString());
+
+        var provider = new SolrTransformerProvider();
+        var transformer = provider.createTransformer(config);
+
+        var input = new LinkedHashMap<String, Object>();
+        input.put("URI", "/test");
+        @SuppressWarnings("unchecked")
+        var result = (Map<String, Object>) transformer.transformJson(input);
+
+        assertEquals("true",           result.get("hasSolrConfig"));
+        assertEquals("true",           result.get("hasFieldTypes"));
+        assertEquals("solr.StrField",  result.get("idClass"));
+    }
+
+    @Test
+    void createTransformer_missingSchemaXmlFile_noFieldTypesBinding() throws Exception {
+        // When solrSchemaXmlFile points to a non-existent file, fieldTypes is absent
+        var script = "(function(bindings) { return function(msg) { " +
+            "msg.set('hasFieldTypes', '' + (bindings.fieldTypes != null)); " +
+            "return msg; }; })";
+
+        var config = providerConfig(script, "{}");
+        config.put("solrSchemaXmlFile", "/nonexistent/managed-schema.xml");
+
+        var provider = new SolrTransformerProvider();
+        var transformer = provider.createTransformer(config);
+
+        var input = new LinkedHashMap<String, Object>();
+        input.put("URI", "/test");
+        @SuppressWarnings("unchecked")
+        var result = (Map<String, Object>) transformer.transformJson(input);
+
+        // Missing file → SolrSchemaProvider returns empty map → not put into bindings
+        assertEquals("false", result.get("hasFieldTypes"));
+    }
+
+    @Test
+    void createTransformer_blankSchemaXmlFile_noFieldTypesBinding() throws Exception {
+        // Blank string for solrSchemaXmlFile is ignored
+        var script = "(function(bindings) { return function(msg) { " +
+            "msg.set('hasFieldTypes', '' + (bindings.fieldTypes != null)); " +
+            "return msg; }; })";
+
+        var config = providerConfig(script, "{}");
+        config.put("solrSchemaXmlFile", "   ");
+
+        var provider = new SolrTransformerProvider();
+        var transformer = provider.createTransformer(config);
+
+        var input = new LinkedHashMap<String, Object>();
+        input.put("URI", "/test");
+        @SuppressWarnings("unchecked")
+        var result = (Map<String, Object>) transformer.transformJson(input);
+
+        assertEquals("false", result.get("hasFieldTypes"));
+    }
+
+    @Test
+    void createTransformer_inlineFieldTypesInBindings_worksWithoutSchemaFile() {
+        // Operator can provide fieldTypes directly in bindingsObject — no file needed
+        var script = "(function(bindings) { return function(msg) { " +
+            "msg.set('statusClass', bindings.fieldTypes['status']); " +
+            "return msg; }; })";
+
+        var bindingsJson = "{\"fieldTypes\":{\"status\":\"solr.StrField\",\"title\":\"solr.TextField\"}}";
+        var provider = new SolrTransformerProvider();
+        var transformer = provider.createTransformer(providerConfig(script, bindingsJson));
+
+        var input = new LinkedHashMap<String, Object>();
+        input.put("URI", "/test");
+        @SuppressWarnings("unchecked")
+        var result = (Map<String, Object>) transformer.transformJson(input);
+
+        assertEquals("solr.StrField", result.get("statusClass"));
+    }
 }

--- a/solrMigrationDevSandbox/docker-compose.yml
+++ b/solrMigrationDevSandbox/docker-compose.yml
@@ -61,6 +61,7 @@ services:
     volumes:
       - transform-dist:/transforms:ro
       - ./config/solr/solrconfig.xml:/solr-config/solrconfig.xml:ro
+      - ./config/solr/schema.xml:/solr-config/managed-schema.xml:ro
     depends_on:
       opensearch:
         condition: service_healthy
@@ -78,7 +79,7 @@ services:
       - --primary
       - opensearch
       - --transformerConfig
-      - '[{"SolrTransformerProvider":{"initializationScriptFile":"/transforms/solr-to-opensearch-request.js","bindingsObject":"{}","solrConfigXmlFile":"/solr-config/solrconfig.xml"}}]'
+      - '[{"SolrTransformerProvider":{"initializationScriptFile":"/transforms/solr-to-opensearch-request.js","bindingsObject":"{}","solrConfigXmlFile":"/solr-config/solrconfig.xml","solrSchemaXmlFile":"/solr-config/managed-schema.xml"}}]'
       - --responseTransformerConfig
       - '[{"SolrTransformerProvider":{"initializationScriptFile":"/transforms/solr-to-opensearch-response.js","bindingsObject":"{}"}}]'
       - --transformTarget
@@ -97,6 +98,7 @@ services:
     volumes:
       - transform-dist:/transforms:ro
       - ./config/solr/solrconfig.xml:/solr-config/solrconfig.xml:ro
+      - ./config/solr/schema.xml:/solr-config/managed-schema.xml:ro
       - shim-reports-solr:/var/shim/reports
     depends_on:
       solr:
@@ -115,7 +117,7 @@ services:
       - --target
       - opensearch=http://opensearch:9200
       - --transformerConfig
-      - '[{"SolrTransformerProvider":{"initializationScriptFile":"/transforms/solr-to-opensearch-request.js","bindingsObject":"{}","solrConfigXmlFile":"/solr-config/solrconfig.xml"}}]'
+      - '[{"SolrTransformerProvider":{"initializationScriptFile":"/transforms/solr-to-opensearch-request.js","bindingsObject":"{}","solrConfigXmlFile":"/solr-config/solrconfig.xml","solrSchemaXmlFile":"/solr-config/managed-schema.xml"}}]'
       - --responseTransformerConfig
       - '[{"SolrTransformerProvider":{"initializationScriptFile":"/transforms/solr-to-opensearch-response.js","bindingsObject":"{}"}}]'
       - --transformTarget
@@ -144,6 +146,7 @@ services:
     volumes:
       - transform-dist:/transforms:ro
       - ./config/solr/solrconfig.xml:/solr-config/solrconfig.xml:ro
+      - ./config/solr/schema.xml:/solr-config/managed-schema.xml:ro
       - shim-reports-os:/var/shim/reports
     depends_on:
       solr:
@@ -162,7 +165,7 @@ services:
       - --target
       - opensearch=http://opensearch:9200
       - --transformerConfig
-      - '[{"SolrTransformerProvider":{"initializationScriptFile":"/transforms/solr-to-opensearch-request.js","bindingsObject":"{}","solrConfigXmlFile":"/solr-config/solrconfig.xml"}}]'
+      - '[{"SolrTransformerProvider":{"initializationScriptFile":"/transforms/solr-to-opensearch-request.js","bindingsObject":"{}","solrConfigXmlFile":"/solr-config/solrconfig.xml","solrSchemaXmlFile":"/solr-config/managed-schema.xml"}}]'
       - --responseTransformerConfig
       - '[{"SolrTransformerProvider":{"initializationScriptFile":"/transforms/solr-to-opensearch-response.js","bindingsObject":"{}"}}]'
       - --transformTarget


### PR DESCRIPTION
…ased on field mappings

### Description
In the read paths (shim), we don’t have Solr collections field metadata info. Having this info help us to transform certain Solr queries correctly to OpenSearch. Ex: Let’s say we’ve query `q=category:electronics`, if category field is string (keyword in Opensearch) we need to use [term query](https://docs.opensearch.org/latest/query-dsl/term/term/), if it is text_category field then we need to use [match query](https://docs.opensearch.org/latest/query-dsl/full-text/match/). Currently since we don’t have field metadata info we are using match query for all cases as safer option. This can produce search results count difference since match query analyses fields compared to term query. So to solve this problem, we need to have field metadata info in transformation layer to use appropriate query types based on field types. We are Injecting field type metadata via bindings (same pattern as solrConfig): The Java side that configures the shim would need to supply a fieldTypes map in bindings (e.g., { “title”: “text”, “status”: “string”, “id”: “string” }). This will come from the operator providing it as config when setting up the shim

### Check List
- [x] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
