### PR TITLE
Make cat_indices always return str instead of bytes

### DIFF
--- a/migrationConsole/lib/console_link/console_link/middleware/clusters.py
+++ b/migrationConsole/lib/console_link/console_link/middleware/clusters.py
@@ -67,7 +67,7 @@ def cat_indices(cluster: Cluster, refresh=False, as_json=False):
         else:
             cat_indices_path = f"/_cat/indices/_all{as_json_suffix}"
         r = cluster.call_api(cat_indices_path)
-        return r.json() if as_json else r.content
+        return r.json() if as_json else r.content.decode("utf-8")
     except Exception as e:
         logger.debug("Exception occurred when using call_api on cluster: ", exc_info=True)
         return f"Error: Unable to perform cat-indices command with message: {e}"

--- a/migrationConsole/lib/console_link/tests/middleware/test_clusters.py
+++ b/migrationConsole/lib/console_link/tests/middleware/test_clusters.py
@@ -46,6 +46,23 @@ def test_cat_indices_with_error_prints_cleanly():
     assert response_str == f"Error: Unable to perform cat-indices command with message: {error_message}"
 
 
+def test_cat_indices_always_returns_str(requests_mock):
+    """cat_indices must return str in both success and error paths so callers never need .decode()."""
+    # Success path
+    cluster = create_valid_cluster(auth_type=AuthMethod.NO_AUTH)
+    requests_mock.get(f"{cluster.endpoint}/_cat/indices/_all", text="green open my-index 1 0 5 0 10kb 10kb\n")
+    result = clusters_.cat_indices(cluster, refresh=False)
+    assert isinstance(result, str)
+    assert "my-index" in result
+
+    # Error path
+    err_cluster = mock.Mock(spec=Cluster)
+    err_cluster.call_api.side_effect = ConnectionError("cluster unreachable")
+    result = clusters_.cat_indices(err_cluster, refresh=False)
+    assert isinstance(result, str)
+    assert "Error" in result
+
+
 def test_clear_indices(requests_mock):
     cluster = create_valid_cluster(auth_type=AuthMethod.NO_AUTH)
     mock = requests_mock.delete(f"{cluster.endpoint}/*,-.*,-searchguard*,-sg7*,.migrations_working_state*")

--- a/migrationConsole/lib/console_link/tests/test_source_cluster_multiversion.py
+++ b/migrationConsole/lib/console_link/tests/test_source_cluster_multiversion.py
@@ -111,14 +111,14 @@ def test_cluster_cat_indices(env_with_source_container: Environment, json: bool)
     # First, test with refresh enabled.
     result = clusters_.cat_indices(env.source_cluster, refresh=True, as_json=json)
     if not json:
-        result_lines = result.decode('utf-8').split('\n')
+        result_lines = result.split('\n')
         assert any(TEST_INDEX_NAME in line and str(DOC_COUNT) in line for line in result_lines)
     else:
         assert any(item['index'] == TEST_INDEX_NAME and int(item['docs.count']) == DOC_COUNT for item in result)
     # And then test again with refresh disabled. Doing both checks in one test halves the number of container starts
     # and eliminates the need to `sleep` before testing.
     result = clusters_.cat_indices(env.source_cluster, refresh=False, as_json=False)
-    result_lines = result.decode('utf-8').split('\n')
+    result_lines = result.split('\n')
     assert any(TEST_INDEX_NAME in line and str(DOC_COUNT) in line for line in result_lines)
 
 

--- a/migrationConsole/lib/integ_test/integ_test/test_cases/aoss_collection_tests.py
+++ b/migrationConsole/lib/integ_test/integ_test/test_cases/aoss_collection_tests.py
@@ -59,8 +59,6 @@ class AOSSTestBase(MATestBase):
 
     def display_final_cluster_state(self):
         target_response = cat_indices(cluster=self.target_cluster, refresh=True)
-        if isinstance(target_response, bytes):
-            target_response = target_response.decode("utf-8")
         logger.info(f"TARGET CLUSTER (AOSS)\n{target_response}")
 
     def import_existing_clusters(self):

--- a/migrationConsole/lib/integ_test/integ_test/test_cases/ma_argo_test_base.py
+++ b/migrationConsole/lib/integ_test/integ_test/test_cases/ma_argo_test_base.py
@@ -238,8 +238,8 @@ class MATestBase:
         pass
 
     def display_final_cluster_state(self):
-        source_response = cat_indices(cluster=self.source_cluster, refresh=True).decode("utf-8")
-        target_response = cat_indices(cluster=self.target_cluster, refresh=True).decode("utf-8")
+        source_response = cat_indices(cluster=self.source_cluster, refresh=True)
+        target_response = cat_indices(cluster=self.target_cluster, refresh=True)
         logger.info("Printing document counts for source and target clusters:")
         print("SOURCE CLUSTER")
         print(source_response)

--- a/migrationConsole/lib/integ_test/integ_test/test_cases/snapshot_only_tests.py
+++ b/migrationConsole/lib/integ_test/integ_test/test_cases/snapshot_only_tests.py
@@ -127,7 +127,7 @@ class Test0010ExternalSnapshotMigration(MATestBase):
 
     def display_final_cluster_state(self):
         """Display target cluster indices."""
-        target_response = cat_indices(cluster=self.target_cluster, refresh=True).decode("utf-8")
+        target_response = cat_indices(cluster=self.target_cluster, refresh=True)
         logger.info("Target cluster indices after migration:")
         logger.info("TARGET CLUSTER")
         logger.info(target_response)


### PR DESCRIPTION
### Description
Transient Error observed on Jenkins `eks-integ-test` : `cat_indices()` returned `bytes` (via `r.content`) for non-JSON responses, forcing every caller to `.decode("utf-8")` or guard with `isinstance(_, bytes)`.

This change decodes at the source so the function consistently returns `str`
in both success and error paths, and removes all now-unnecessary decode/isinstance
checks from callers.

### Changes
- `clusters.py`: `r.content` → `r.content.decode("utf-8")`
- `test_clusters.py`: Added `test_cat_indices_always_returns_str`
- Removed `.decode("utf-8")` calls from `test_source_cluster_multiversion.py`, `ma_argo_test_base.py`, `snapshot_only_tests.py`
- Removed `isinstance(_, bytes)` guard from `aoss_collection_tests.py`

### Testing
Added unit test verifying `cat_indices` returns `str` for both success and error paths.

### Issues Resolved
N/A

### Check List
- [ ] New functionality includes testing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
