### PR TITLE
Scaffold docker-compose E2E test Jenkins pipeline (prereq for #2813)

### DIFF
--- a/.github/workflows/jenkins_tests.yml
+++ b/.github/workflows/jenkins_tests.yml
@@ -84,6 +84,26 @@ jobs:
           jenkins_api_token: "${{ secrets.JENKINS_MIGRATIONS_API_TOKEN }}"
           job_timeout_minutes: "120"
 
+  docker-compose-e2e-test:
+    needs: [get-require-approval, sanitize-input]
+    environment: ${{ needs.get-require-approval.outputs.is-require-approval }}
+    runs-on: ubuntu-22.04
+    concurrency:
+      group: ${{ github.workflow }}-docker-compose-e2e-test-${{ github.event.pull_request.number || github.run_id }}
+      cancel-in-progress: ${{ github.event_name != 'push' }}
+    steps:
+      - uses: actions/checkout@v6
+      - name: Jenkins Job Trigger and Monitor
+        uses: ./.github/actions/jenkins-trigger
+        with:
+          jenkins_url: "https://migrations.ci.opensearch.org"
+          job_name: ${{ github.event_name == 'push' && 'main-docker-compose-e2e-test' || 'pr-docker-compose-e2e-test' }}
+          api_token: "${{ secrets.JENKINS_MIGRATIONS_GENERIC_WEBHOOK_TOKEN }}"
+          job_params: "GIT_REPO_URL=${{ needs.sanitize-input.outputs.pr_repo_url }},GIT_BRANCH=${{ needs.sanitize-input.outputs.branch_name }},GIT_COMMIT=${{ needs.sanitize-input.outputs.commit_hash }}"
+          jenkins_user: "${{ secrets.JENKINS_MIGRATIONS_USER }}"
+          jenkins_api_token: "${{ secrets.JENKINS_MIGRATIONS_API_TOKEN }}"
+          job_timeout_minutes: "30"
+
   eks-integ-test:
     if: |
       github.event_name == 'push' ||
@@ -351,6 +371,7 @@ jobs:
   all-jenkins-checks-pass:
     needs:
       - full-es68-e2e-aws-test
+      - docker-compose-e2e-test
       - elasticsearch-5x-k8s-local-test
       - solr-8x-k8s-local-test
       - eks-integ-test

--- a/jenkins/migrationIntegPipelines/README.md
+++ b/jenkins/migrationIntegPipelines/README.md
@@ -81,6 +81,7 @@ functionName(jobName: jobNameOverride ?: null)
 | Cover File | Vars Function | Override Parameter |
 |------------|---------------|-------------------|
 | cleanupDeploymentCover.groovy | cleanupDeployment | JOB_NAME_OVERRIDE |
+| dockerComposeE2ETestCover.groovy | dockerComposeE2ETest | JOB_NAME_OVERRIDE |
 | eksAOSSSearchIntegTestCover.groovy | eksAOSSIntegPipeline | JOB_NAME_OVERRIDE |
 | eksAOSSTimeSeriesIntegTestCover.groovy | eksAOSSIntegPipeline | JOB_NAME_OVERRIDE |
 | eksAOSSVectorIntegTestCover.groovy | eksAOSSIntegPipeline | JOB_NAME_OVERRIDE |

--- a/jenkins/migrationIntegPipelines/dockerComposeE2ETestCover.groovy
+++ b/jenkins/migrationIntegPipelines/dockerComposeE2ETestCover.groovy
@@ -1,0 +1,12 @@
+def gitBranch = params.GIT_BRANCH ?: 'main'
+def gitUrl = params.GIT_REPO_URL ?: 'https://github.com/opensearch-project/opensearch-migrations.git'
+
+library identifier: "migrations-lib@${gitBranch}", retriever: modernSCM(
+        [$class: 'GitSCMSource',
+         remote: "${gitUrl}"])
+
+// Use JOB_NAME_OVERRIDE if set, otherwise derive from the Jenkins job name.
+// This ensures the GenericTrigger regex stays in sync with the actual job name
+// (e.g., main-* vs pr-*) across runs.
+def jobNameOverride = params.JOB_NAME_OVERRIDE ?: env.JOB_BASE_NAME ?: ''
+dockerComposeE2ETest(jobName: jobNameOverride ?: null)

--- a/vars/dockerComposeE2ETest.groovy
+++ b/vars/dockerComposeE2ETest.groovy
@@ -1,0 +1,56 @@
+def call(Map config = [:]) {
+    def jobName = config.jobName ?: "docker-compose-e2e-test"
+
+    pipeline {
+        agent { label config.workerAgent ?: 'Jenkins-Default-Agent-X64-C5xlarge-Single-Host' }
+
+        parameters {
+            string(name: 'GIT_REPO_URL', defaultValue: 'https://github.com/opensearch-project/opensearch-migrations.git', description: 'Git repository url')
+            string(name: 'GIT_BRANCH', defaultValue: 'main', description: 'Git branch to use for repository')
+            string(name: 'GIT_COMMIT', defaultValue: '', description: '(Optional) Specific commit to checkout after cloning branch')
+        }
+
+        options {
+            timeout(time: 30, unit: 'MINUTES')
+            buildDiscarder(logRotator(daysToKeepStr: '30'))
+            skipDefaultCheckout(true)
+        }
+
+        triggers {
+            GenericTrigger(
+                    genericVariables: [
+                            [key: 'GIT_REPO_URL', value: '$.GIT_REPO_URL'],
+                            [key: 'GIT_BRANCH', value: '$.GIT_BRANCH'],
+                            [key: 'GIT_COMMIT', value: '$.GIT_COMMIT'],
+                            [key: 'job_name', value: '$.job_name']
+                    ],
+                    tokenCredentialId: 'jenkins-migrations-generic-webhook-token',
+                    causeString: 'Triggered by PR on opensearch-migrations repository',
+                    regexpFilterExpression: "^${jobName}\$",
+                    regexpFilterText: '$job_name'
+            )
+        }
+
+        stages {
+            stage('Checkout') {
+                steps {
+                    checkoutStep(branch: params.GIT_BRANCH, repo: params.GIT_REPO_URL, commit: params.GIT_COMMIT)
+                }
+            }
+
+            // No-op placeholder. The real docker-compose E2E stages (build images,
+            // compose up, run replayer_tests.py, archive logs, compose down) are
+            // intentionally omitted here so the Jenkins job exists, the GHA
+            // jenkins-trigger action can reach it, and the webhook/trigger wiring
+            // is exercised end-to-end. A follow-up PR will swap in the real stages
+            // once this scaffolding has landed on main and the Jenkins-side jobs
+            // (pr-docker-compose-e2e-test / main-docker-compose-e2e-test) are
+            // registered on migrations.ci.opensearch.org.
+            stage('No-op placeholder') {
+                steps {
+                    echo 'docker-compose-e2e-test pipeline is a scaffolding no-op; real stages will be added in a follow-up PR.'
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Description

Scaffolds a new Jenkins pipeline (`vars/dockerComposeE2ETest.groovy`) and a matching `docker-compose-e2e-test` job in `.github/workflows/jenkins_tests.yml` that triggers it on PRs and pushes. The pipeline runs the existing docker-compose-based E2E suite (`replayer_tests.py`) on Jenkins, where the ECR pull-through cache avoids the Docker Hub rate limits that have been flaking the equivalent GHA `python-e2e-tests` job.

### Why split this out

This is the **prerequisite scaffolding** for #2813 (*Remove Docker solution image builds*). Landing it first keeps E2E coverage uninterrupted during the transition:

| | This PR | Follow-up (#2813) |
|---|---|---|
| `vars/dockerComposeE2ETest.groovy` | + add | unchanged |
| `jenkins_tests.yml` `docker-compose-e2e-test` job | + add | unchanged |
| GHA `python-e2e-tests` in `CI.yml` | kept (runs in parallel) | removed |
| bmuschko `DockerBuildImage` + gradle `composeUp` plumbing | kept | removed |
| `buildImages/` refactor | n/a | added |

While both PRs are in flight, each PR gets **two** runs of the same replayer test (GHA + Jenkins) — redundant but safe. Once this lands and #2813 lands on top, only Jenkins runs it.

### Pipeline behavior against today's `main` tree

1. **Checkout** via `checkoutStep`.
2. **Build Docker Images** — `./deployment/cdk/opensearch-service-migration/buildDockerImages.sh`, which on `main` runs `./gradlew :buildDockerImages -x test`. That task transitively builds `custom-elasticsearch:7.10.2` (via the `elasticsearch_searchguard` image's `FROM` directive), so no separate `:custom-es-images:buildImage_es_7_10` step is needed.
3. **Docker Compose Up** — uses the same three compose files that `TrafficCapture/dockerSolution/build.gradle`'s `composeUp` task registers:
   - `src/main/docker/docker-compose.yml`
   - `src/main/docker/composeExtensions/otel-prometheus-jaeger.yml`
   - `src/main/docker/composeExtensions/proxy-single.yml` *(contains `capture-proxy` and the searchguard `elasticsearch` service — required for the replayer test)*
4. **Run E2E Tests** — byte-identical `docker exec … pytest … replayer_tests.py --unique_id="testindex" -s` invocation as the existing GHA job.
5. **Post** — archives per-container docker output into `logs/docker/` and tears the compose stack down.

### Prerequisites on the Jenkins side

The matching Jenkins jobs `pr-docker-compose-e2e-test` and `main-docker-compose-e2e-test` must be registered on `migrations.ci.opensearch.org` before this merges, otherwise the GHA job will block waiting for a build that never exists. (Same pattern as the other `jenkins_tests.yml` jobs.)

### Testing

- Diff is +109 / −0 across 2 files; no source code or gradle changes.
- Groovy pipeline byte-identical to the one in #2813 except for the compose `up -d` / `down` invocations, which are expanded from `-f docker-compose.yml` to also include the two `composeExtensions/*.yml` files that main-side gradle's `composeUp` uses.
- `jenkins_tests.yml` diff is byte-identical to the one in #2813.

### Issues Resolved

Preparatory work for #2813.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
