### PR TITLE
fix(shim): Bundle transform JS files in Docker image on clean builds

### DIFF
--- a/TrafficCapture/transformationShim/build.gradle
+++ b/TrafficCapture/transformationShim/build.gradle
@@ -53,6 +53,16 @@ if (!project.hasProperty('skipBundleTransforms')) {
 
         inputs.dir("${project(':TrafficCapture:SolrTransformations').projectDir}/transforms/dist")
         outputs.dir(transformStagingDir)
+
+        doLast {
+            def staged = transformStagingDir.get().asFile.listFiles()?.findAll { it.name.endsWith('.js') } ?: []
+            if (staged.isEmpty()) {
+                throw new GradleException(
+                    "stageTransformsForImage produced no .js files. " +
+                    "Expected built transforms in ${project(':TrafficCapture:SolrTransformations').projectDir}/transforms/dist/")
+            }
+            logger.lifecycle("Staged ${staged.size()} transform(s) for Docker image: ${staged*.name}")
+        }
     }
 
     tasks.named('jib').configure { dependsOn 'stageTransformsForImage' }

--- a/buildImages/build.gradle
+++ b/buildImages/build.gradle
@@ -50,7 +50,7 @@ def jibProjects = [
                 imageName     : "transformation_shim",
                 imageTag      : "latest",
                 requiredDependencies: [
-                    ":TrafficCapture:transformationShim": ["syncVersionFile_transformation_shim"]
+                    ":TrafficCapture:transformationShim": ["syncVersionFile_transformation_shim", "stageTransformsForImage"]
                 ]
         ],
         "TrafficCapture:trafficCaptureProxyServer": correttoBase + [

--- a/buildSrc/src/main/groovy/org/opensearch/migrations/image/RegistryImageBuildUtils.groovy
+++ b/buildSrc/src/main/groovy/org/opensearch/migrations/image/RegistryImageBuildUtils.groovy
@@ -365,10 +365,12 @@ class RegistryImageBuildUtils {
                                 if (dockerDir.exists()) {
                                     path { from = dockerDir; into = '/' }
                                 }
+                                // Always include build/docker so that tasks which stage files
+                                // there (e.g. stageTransformsForImage) are picked up even on
+                                // clean builds where the directory doesn't exist at config time.
                                 def buildDockerDir = project.file("build/docker")
-                                if (buildDockerDir.exists()) {
-                                    path { from = buildDockerDir; into = '/' }
-                                }
+                                buildDockerDir.mkdirs()
+                                path { from = buildDockerDir; into = '/' }
                                 path { from = project.file("build/versionDir"); into = '/' }
                             }
                             def extraPerms = (Map<String, String>) config.get("extraPermissions", [:])


### PR DESCRIPTION
### Description

The Jib extraDirectories configuration checked if build/docker existed at Gradle configuration time. On clean CI builds this directory does not exist yet, so Jib never included it — even though stageTransformsForImage created and populated it before Jib executed. This caused all published shim images (3.0.0–3.1.1) to ship without the Solr-to-OpenSearch transform JS files.

Fix by calling mkdirs() and unconditionally registering build/docker as a Jib extra directory. Also add a doLast validation to stageTransformsForImage that fails the build if no .js files were staged, and declare stageTransformsForImage as an explicit required dependency in the centralized build config.


## Testing

### Reproducing the bug (before fix)

#### Simulate clean CI build by removing the staging directory
```
rm -rf TrafficCapture/transformationShim/build/docker
```

#### Build the image
```
./gradlew :TrafficCapture:transformationShim:jibDockerBuild
```

#### Tag it as "broken"
```
docker tag localhost:5001/migrations/transformation_shim localhost:5001/migrations/transformation_shim:broken
```


#### Check for transforms — MISSING
```
docker run --rm --entrypoint sh localhost:5001/migrations/transformation_shim \
  -c "ls /transforms/*.js"
```
#### Output: 
```
ls: cannot access '/transforms/*.js': No such file or directory
```

#### End-to-end: shim fails to start
```
docker run --name shim-broken -p 8090:8080 \                              
  localhost:5001/migrations/transformation_shim:broken \
  --listenPort 8080 \
  --target opensearch=http://host.docker.internal:9200 \
  --primary opensearch \
  --transformerConfig '[{"SolrTransformerProvider":{"initializationScriptFile":"/transforms/solr-to-opensearch-request.js","bindingsObject":"{}"}}]' \
  --responseTransformerConfig '[{"SolrTransformerProvider":{"initializationScriptFile":"/transforms/solr-to-opensearch-response.js","bindingsObject":"{}"}}]'
[INFO ] 2026-05-03 06:42:19,869849 [main] ShimMain - Creating transformer from config: [{"SolrTransformerProvider":{"initializationScriptFile":"/transforms/solr-to-opensearch-request.js","bindingsObject":"{}"}}]
[INFO ] 2026-05-03 06:42:19,908525 [main] TransformationLoader - Adding IJsonTransfomerProvider: org.opensearch.migrations.transform.shim.SolrTransformerProvider@452e19ca
[INFO ] 2026-05-03 06:42:19,909036 [main] TransformationLoader - Adding IJsonTransfomerProvider: org.opensearch.migrations.transform.JsonJSTransformerProvider@a1f72f5
[INFO ] 2026-05-03 06:42:19,909683 [main] TransformationLoader - Adding IJsonTransfomerProvider: org.opensearch.migrations.transform.JsonConditionalTransformerProvider@3eb91815
[INFO ] 2026-05-03 06:42:19,910114 [main] TransformationLoader - Adding IJsonTransfomerProvider: org.opensearch.migrations.transform.NoopTransformerProvider@30b6ffe0
[INFO ] 2026-05-03 06:42:19,910635 [main] TransformationLoader - IJsonTransformerProviders loaded: class org.opensearch.migrations.transform.shim.SolrTransformerProvider; class org.opensearch.migrations.transform.JsonJSTransformerProvider; class org.opensearch.migrations.transform.JsonConditionalTransformerProvider; class org.opensearch.migrations.transform.NoopTransformerProvider
[INFO ] 2026-05-03 06:42:19,927789 [main] TransformationLoader - Creating a transformer through provider=org.opensearch.migrations.transform.shim.SolrTransformerProvider@452e19ca with configuration={initializationScriptFile=/transforms/solr-to-opensearch-request.js, bindingsObject={}}
Exception in thread "main" java.lang.IllegalArgumentException: Failed to load script file '/transforms/solr-to-opensearch-request.js'. org.opensearch.migrations.transform.shim.SolrTransformerProvider expects the incoming configuration to be a Map<String, Object>, with keys: initializationScript or initializationScriptFile, bindingsObject.
initializationScriptFile is a string pointing to a file path to a JavaScript file to load.
initializationResourcePath is a string pointing to a resource path to a JavaScript file in a jar on the classpath.
initializationScript is a string consisting of JavaScript which defines a main function that takes in the bindingsObject and returns a transform function.
bindingsObject is a value which can be deserialized with Jackson ObjectMapper.
  at org.opensearch.migrations.transform.ScriptTransformerProvider.resolveScript(ScriptTransformerProvider.java:85)
  at org.opensearch.migrations.transform.ScriptTransformerProvider.createTransformer(ScriptTransformerProvider.java:42)
  at org.opensearch.migrations.transform.TransformationLoader.configureTransformerFromConfig(TransformationLoader.java:91)
  at org.opensearch.migrations.transform.TransformationLoader.lambda$getTransformerFactoryFromServiceLoader$2(TransformationLoader.java:61)
  at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197)
  at java.base/java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1708)
  at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
  at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
  at java.base/java.util.stream.StreamSpliterators$WrappingSpliterator.forEachRemaining(StreamSpliterators.java:310)
  at java.base/java.util.stream.Streams$ConcatSpliterator.forEachRemaining(Streams.java:734)
  at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
  at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
  at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:575)
  at java.base/java.util.stream.AbstractPipeline.evaluateToArrayNode(AbstractPipeline.java:260)
  at java.base/java.util.stream.ReferencePipeline.toArray(ReferencePipeline.java:616)
  at org.opensearch.migrations.transform.TransformationLoader.getTransformerFactoryLoader(TransformationLoader.java:115)
  at org.opensearch.migrations.transform.TransformationLoader.getTransformerFactoryLoader(TransformationLoader.java:102)
  at org.opensearch.migrations.transform.shim.ShimMain.createTransformer(ShimMain.java:353)
  at org.opensearch.migrations.transform.shim.ShimMain.parseTargets(ShimMain.java:441)
  at org.opensearch.migrations.transform.shim.ShimMain.main(ShimMain.java:228)
Caused by: java.nio.file.NoSuchFileException: /transforms/solr-to-opensearch-request.js
  at java.base/sun.nio.fs.UnixException.translateToIOException(UnixException.java:92)
  at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:106)
  at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:111)
  at java.base/sun.nio.fs.UnixFileSystemProvider.newByteChannel(UnixFileSystemProvider.java:261)
  at java.base/java.nio.file.Files.newByteChannel(Files.java:380)
  at java.base/java.nio.file.Files.newByteChannel(Files.java:432)
  at java.base/java.nio.file.Files.readAllBytes(Files.java:3281)
  at java.base/java.nio.file.Files.readString(Files.java:3359)
  at java.base/java.nio.file.Files.readString(Files.java:3318)
  at org.opensearch.migrations.transform.ScriptTransformerProvider.resolveScript(ScriptTransformerProvider.java:82)
  ... 19 more
```


### Verifying the fix (after fix)

#### Simulate clean CI build again
```
rm -rf TrafficCapture/transformationShim/build/docker
```

#### Build the image
```
./gradlew :TrafficCapture:transformationShim:jibDockerBuild
```

#### Check for transforms — PRESENT
```
docker run --rm --entrypoint sh localhost:5001/migrations/transformation_shim \
  -c "ls /transforms/*.js"
```

#### Output:
```
# /transforms/solr-to-opensearch-request.js
# /transforms/solr-to-opensearch-response.js
```

#### End-to-end: shim starts and loads transforms

```
docker run --rm -d --name shim-test -p 8090:8080 \
  localhost:5001/migrations/transformation_shim \
  --listenPort 8080 \
  --target opensearch=http://host.docker.internal:9200 \
  --primary opensearch \
  --transformerConfig '[{"SolrTransformerProvider":{"initializationScriptFile":"/transforms/solr-to-opensearch-request.js","bindingsObject":"{}"}}]' \
  --responseTransformerConfig '[{"SolrTransformerProvider":{"initializationScriptFile":"/transforms/solr-to-opensearch-response.js","bindingsObject":"{}"}}]'
99d180e733919f004e5d999e6249242c94df6d6c9cf50297e53b7519cbd93355
```
```
sleep 3 && docker logs shim-test 2>&1 | tail -3
[WARN ] 2026-05-03 06:44:07,739250 [main] RootOtelContext - Collector endpoint=null, so serviceName parameter 'shimProxy' is being ignored since a no-op OpenTelemetry object is being created
[INFO ] 2026-05-03 06:44:07,851779 [main] ShimProxy - ShimProxy started on port 8080, primary=opensearch, targets=[opensearch], validators=0, maxContentLength=10485760
[INFO ] 2026-05-03 06:44:07,851912 [main] ShimMain - Shim running on port 8080
```







