### PR TITLE
Tag RFS initialLeaseDuration as [Expert] in schema description

### DIFF
--- a/orchestrationSpecs/packages/schemas/src/userSchemas.ts
+++ b/orchestrationSpecs/packages/schemas/src/userSchemas.ts
@@ -663,7 +663,7 @@ export const USER_RFS_PROCESS_OPTIONS = z.object({
     initialLeaseDuration: z.string()
         .regex(/^[-+]?P(?:(\d+)D)?(?:T(?:(\d+)H)?(?:(\d+)M)?(?:(\d+(?:\.\d+)?)S)?)?$/)
         .default("PT1H").optional()
-        .describe("ISO 8601 duration for the initial work item lease in the coordination store (e.g. 'PT1H' = 1 hour, 'PT10M' = 10 minutes). " +
+        .describe("[Expert] ISO 8601 duration for the initial work item lease in the coordination store (e.g. 'PT1H' = 1 hour, 'PT10M' = 10 minutes). " +
             "If a worker fails to complete a shard within this duration, the lease expires and another worker can pick it up, doubling the lease duration on each retry. " +
             "Increase for very large shards (>200GB) to reduce the number of re-downloads per shard needed to complete the migration.")
         .changeRestriction('gated'),

--- a/orchestrationSpecs/packages/schemas/tests/__snapshots__/argoSchemaSnapshot.test.ts.snap
+++ b/orchestrationSpecs/packages/schemas/tests/__snapshots__/argoSchemaSnapshot.test.ts.snap
@@ -2497,7 +2497,7 @@ exports[`test schemas matches expected argo user matches expected 1`] = `
                         "type": "string",
                         "pattern": "^[-+]?P(?:(\\\\d+)D)?(?:T(?:(\\\\d+)H)?(?:(\\\\d+)M)?(?:(\\\\d+(?:\\\\.\\\\d+)?)S)?)?$",
                         "default": "PT1H",
-                        "description": "ISO 8601 duration for the initial work item lease in the coordination store (e.g. 'PT1H' = 1 hour, 'PT10M' = 10 minutes). If a worker fails to complete a shard within this duration, the lease expires and another worker can pick it up, doubling the lease duration on each retry. Increase for very large shards (>200GB) to reduce the number of re-downloads per shard needed to complete the migration.",
+                        "description": "[Expert] ISO 8601 duration for the initial work item lease in the coordination store (e.g. 'PT1H' = 1 hour, 'PT10M' = 10 minutes). If a worker fails to complete a shard within this duration, the lease expires and another worker can pick it up, doubling the lease duration on each retry. Increase for very large shards (>200GB) to reduce the number of re-downloads per shard needed to complete the migration.",
                         "changeRestriction": "gated"
                       },
                       "maxConnections": {


### PR DESCRIPTION
## Summary

Marks the RFS `initialLeaseDuration` field as `[Expert]` in its description so
the generated sample config, CRD docs, and any UI that consumes schema
descriptions can visually demote it alongside other advanced tunables. No
behavior change — the default stays `PT1H` (1 hour), matching what it has
always been.

## Why

`initialLeaseDuration` is a low-level coordination-store knob: the only
scenarios where an operator touches it are very large shards (>200 GB) where
the default lease needs lengthening, or post-mortem debugging of stuck work
items. For the 95% case the default is correct, and surfacing it in basic
config output alongside required fields is noise.

The file already uses a `[Expert]` prefix convention for advanced-audience
fields — e.g. `useTargetClusterForWorkCoordination`, `allowLooseVersionMatching`,
`compressionEnabled`, `includeGlobalState`. This PR just tags `initialLeaseDuration`
the same way so it renders consistently.

## Key Changes

### `orchestrationSpecs/packages/schemas/src/userSchemas.ts`
Prefix the `initialLeaseDuration` description string with `[Expert]`. Default
value (`PT1H`), regex, `.changeRestriction('gated')` — all unchanged.

### Snapshot regen
`orchestrationSpecs/packages/schemas/tests/__snapshots__/argoSchemaSnapshot.test.ts.snap`
— single `description` line updated to match. No other snapshots touched
(config-processor transformer fixtures, migration-workflow-templates
snapshots are all clean, confirming the change is isolated to layer 1 of
the schema).

## Testing

- `npm -w @opensearch-migrations/schemas run test -- -u` — 50/50 tests pass,
  1 snapshot updated (`argoSchemaSnapshot.test.ts.snap`).
- `npm test` (full `orchestrationSpecs` workspace) — 4 suites green:
  schemas (50), argo-workflow-builders (36), config-processor (120 passed
  + 2 skipped), migration-workflow-templates (15). No other snapshot diffs.
