### PR TITLE
FilterScheme: scope built-in exclusion rules per filter context

### DIFF
--- a/MetadataMigration/src/main/java/org/opensearch/migrations/commands/MigratorEvaluatorBase.java
+++ b/MetadataMigration/src/main/java/org/opensearch/migrations/commands/MigratorEvaluatorBase.java
@@ -169,7 +169,7 @@ public abstract class MigratorEvaluatorBase {
     protected void validateSourcelessIndices(Clusters clusters) {
         var metadataFactory = clusters.getSource().getIndexMetadata();
         var repoDataProvider = metadataFactory.getRepoDataProvider();
-        var skipFilter = FilterScheme.filterByAllowList(arguments.dataFilterArgs.indexAllowlist).negate();
+        var skipFilter = FilterScheme.filterByAllowList(arguments.dataFilterArgs.indexAllowlist, FilterScheme.FilterContext.INDEX).negate();
         var sourcelessIndices = new ArrayList<String>();
 
         for (var index : repoDataProvider.getIndicesInSnapshot(arguments.snapshotName)) {

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/common/FilterScheme.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/common/FilterScheme.java
@@ -1,77 +1,171 @@
 package org.opensearch.migrations.bulkload.common;
 
-import java.util.Arrays;
+import java.util.Collections;
+import java.util.EnumSet;
 import java.util.List;
+import java.util.Set;
 import java.util.function.Predicate;
 
+/**
+ * Built-in exclusion rules applied when no user allowlist is supplied.
+ *
+ * <p>Rules are tagged with the set of {@link FilterContext}s in which they apply.
+ * Names like {@code logs} or {@code metrics} are Elastic/Fleet-shipped
+ * <em>template</em> names, so excluding them from template creation is correct,
+ * but excluding them from index migration would silently drop any user index
+ * that happens to share the name. Each rule therefore declares which contexts
+ * it applies to.</p>
+ *
+ * <p>When an allowlist is supplied, built-in exclusions are bypassed entirely and
+ * only the allowlist is consulted.</p>
+ */
 public class FilterScheme {
     private FilterScheme() {}
 
-    private static final List<String> EXCLUDED_PREFIXES = Arrays.asList(
-            ".",
-            "@abc_template@",
-            "apm-",
-            "apm@",
-            "behavioral_analytics-",
-            "data-streams-",
-            "data-streams@",
-            "ecs@",
-            "elastic-connectors-",
-            "elastic_agent.",
-            "ilm-history-",
-            "kibana",
-            "logs-elastic_agent",
-            "logs-endpoint.",
-            "logs-index_pattern",
-            "logs-system.",
-            "metricbeat-",
-            "metrics-elastic_agent",
-            "metrics-endpoint.",
-            "metrics-index_pattern",
-            "metrics-metadata-",
-            "metrics-system.",
-            "profiling-",
-            "searchguard",
-            "sg7-",
-            "synthetics-"
+    /**
+     * What kind of thing is being filtered. Built-in exclusion rules are tagged
+     * with the contexts they apply to so the same name (e.g. {@code logs}) can
+     * be banned as a template but allowed as a user index.
+     */
+    public enum FilterContext {
+        INDEX,
+        LEGACY_INDEX_TEMPLATE,
+        INDEX_TEMPLATE,
+        COMPONENT_TEMPLATE;
+
+        public static final Set<FilterContext> TEMPLATE_CONTEXTS = Collections.unmodifiableSet(EnumSet.of(
+            LEGACY_INDEX_TEMPLATE,
+            INDEX_TEMPLATE,
+            COMPONENT_TEMPLATE
+        ));
+    }
+
+    private enum MatchType { PREFIX, SUFFIX, EXACT }
+
+    private static final class ExclusionRule {
+        final String pattern;
+        final MatchType matchType;
+        final Set<FilterContext> appliesTo;
+
+        ExclusionRule(String pattern, MatchType matchType, Set<FilterContext> appliesTo) {
+            this.pattern = pattern;
+            this.matchType = matchType;
+            this.appliesTo = appliesTo;
+        }
+
+        boolean matches(String item) {
+            switch (matchType) {
+                case PREFIX: return item.startsWith(pattern);
+                case SUFFIX: return item.endsWith(pattern);
+                case EXACT:  return item.equals(pattern);
+                default: throw new IllegalStateException("Unreachable: " + matchType);
+            }
+        }
+    }
+
+    // Shorthand helpers to keep the rule table readable.
+    private static final Set<FilterContext> ALL = EnumSet.allOf(FilterContext.class);
+    private static final Set<FilterContext> TEMPLATES_ONLY = FilterContext.TEMPLATE_CONTEXTS;
+
+    private static ExclusionRule prefix(String p, Set<FilterContext> ctx)  { return new ExclusionRule(p, MatchType.PREFIX, ctx); }
+    private static ExclusionRule suffix(String p, Set<FilterContext> ctx)  { return new ExclusionRule(p, MatchType.SUFFIX, ctx); }
+    private static ExclusionRule exact(String p, Set<FilterContext> ctx)   { return new ExclusionRule(p, MatchType.EXACT,  ctx); }
+
+    /**
+     * Built-in exclusion rules. Each rule declares the contexts in which it applies.
+     *
+     * <p>When adding or adjusting rules, err toward the narrower context set:
+     * a rule that is clearly a template / component-template name (i.e. the
+     * shape of a name users never assign to a real data index) should be
+     * {@link #TEMPLATES_ONLY}, not {@link #ALL}.</p>
+     */
+    private static final List<ExclusionRule> EXCLUSION_RULES = List.of(
+        // Prefixes: system/stack indices that should never be migrated as data OR as templates.
+        prefix(".",                     ALL),
+        prefix("kibana",                ALL),
+        prefix("searchguard",           ALL),
+        prefix("sg7-",                  ALL),
+
+        // Prefixes: Elastic-stack data-stream / integration indices. Data-plane
+        // items with these prefixes are stack-managed, not user data.
+        prefix("apm-",                  ALL),
+        prefix("behavioral_analytics-", ALL),
+        prefix("elastic-connectors-",   ALL),
+        prefix("elastic_agent.",        ALL),
+        prefix("ilm-history-",          ALL),
+        prefix("logs-elastic_agent",    ALL),
+        prefix("logs-endpoint.",        ALL),
+        prefix("logs-index_pattern",    ALL),
+        prefix("logs-system.",          ALL),
+        prefix("metricbeat-",           ALL),
+        prefix("metrics-elastic_agent", ALL),
+        prefix("metrics-endpoint.",     ALL),
+        prefix("metrics-index_pattern", ALL),
+        prefix("metrics-metadata-",     ALL),
+        prefix("metrics-system.",       ALL),
+        prefix("profiling-",            ALL),
+        prefix("synthetics-",           ALL),
+
+        // Prefixes: component-template / index-template name shapes. Indices
+        // can't contain '@' so these are effectively template-only already,
+        // but scoping them explicitly documents intent.
+        prefix("@abc_template@",        TEMPLATES_ONLY),
+        prefix("apm@",                  TEMPLATES_ONLY),
+        prefix("data-streams-",         TEMPLATES_ONLY),
+        prefix("data-streams@",         TEMPLATES_ONLY),
+        prefix("ecs@",                  TEMPLATES_ONLY),
+
+        // Suffixes: all template / component-template naming conventions.
+        // Index names can't contain '@' in Elasticsearch/OpenSearch, so these
+        // never match real indices — scope them to templates.
+        suffix("@ilm",                  TEMPLATES_ONLY),
+        suffix("@lifecycle",            TEMPLATES_ONLY),
+        suffix("@mappings",             TEMPLATES_ONLY),
+        suffix("@package",              TEMPLATES_ONLY),
+        suffix("@settings",             TEMPLATES_ONLY),
+        suffix("@template",             TEMPLATES_ONLY),
+        suffix("@tsdb-settings",        TEMPLATES_ONLY),
+
+        // Exact names: stack-shipped template names. A user index literally
+        // called "logs" / "metrics" / "traces" is unusual but legal; the
+        // template of the same name is stack-managed and should not migrate.
+        exact("agentless",              TEMPLATES_ONLY),
+        exact("elastic-connectors",     TEMPLATES_ONLY),
+        exact("ilm-history",            TEMPLATES_ONLY),
+        exact("logs",                   TEMPLATES_ONLY),
+        exact("logs-mappings",          TEMPLATES_ONLY),
+        exact("logs-settings",          TEMPLATES_ONLY),
+        exact("logs-tsdb-settings",     TEMPLATES_ONLY),
+        exact("metrics",                TEMPLATES_ONLY),
+        exact("metrics-mappings",       TEMPLATES_ONLY),
+        exact("metrics-settings",       TEMPLATES_ONLY),
+        exact("metrics-tsdb-settings",  TEMPLATES_ONLY),
+        exact("profiling",              TEMPLATES_ONLY),
+        exact("search-acl-filter",      TEMPLATES_ONLY),
+        exact("synthetics",             TEMPLATES_ONLY),
+        exact("tenant_template",        TEMPLATES_ONLY),
+        exact("traces",                 TEMPLATES_ONLY),
+        exact("traces-mappings",        TEMPLATES_ONLY),
+        exact("traces-settings",        TEMPLATES_ONLY),
+        exact("traces-tsdb-settings",   TEMPLATES_ONLY),
+
+        // Exact names: X-Pack watcher indices — these are real indices on the
+        // source cluster and should not be migrated as data.
+        exact("triggered_watches",      ALL),
+        exact("watches",                ALL),
+        exact("watch_history_3",        ALL)
     );
 
-    private static final List<String> EXCLUDED_SUFFIXES = Arrays.asList(
-            "@ilm",
-            "@lifecycle",
-            "@mappings",
-            "@package",
-            "@settings",
-            "@template",
-            "@tsdb-settings"
-        );
-
-    private static final List<String> EXCLUDED_NAMES = Arrays.asList(
-            "agentless",
-            "elastic-connectors",
-            "ilm-history",
-            "logs",
-            "logs-mappings",
-            "logs-settings",
-            "logs-tsdb-settings",
-            "metrics",
-            "metrics-mappings",
-            "metrics-settings",
-            "metrics-tsdb-settings",
-            "profiling",
-            "search-acl-filter",
-            "synthetics",
-            "tenant_template",
-            "traces",
-            "traces-mappings",
-            "traces-settings",
-            "traces-tsdb-settings",
-            "triggered_watches",
-            "watches",
-            "watch_history_3"
-    );
-
-    public static Predicate<String> filterByAllowList(List<String> allowlist) {
+    /**
+     * Build a predicate that accepts items the migration should process.
+     *
+     * @param allowlist user-supplied allowlist; when non-empty, built-in
+     *                  exclusions are bypassed and only the allowlist is
+     *                  consulted
+     * @param context   what kind of thing is being filtered; used to select
+     *                  which built-in exclusion rules apply
+     */
+    public static Predicate<String> filterByAllowList(List<String> allowlist, FilterContext context) {
         // Validate and pre-compile all allowlist entries to fail fast on invalid patterns
         final List<AllowlistEntry> compiledEntries;
         if (allowlist != null && !allowlist.isEmpty()) {
@@ -81,10 +175,10 @@ public class FilterScheme {
         } else {
             compiledEntries = null;
         }
-        
+
         return item -> {
             if (compiledEntries == null) {
-                return !isExcluded(item);
+                return !isExcluded(item, context);
             } else {
                 return compiledEntries.stream()
                     .anyMatch(entry -> entry.matches(item));
@@ -92,17 +186,12 @@ public class FilterScheme {
         };
     }
 
-    private static boolean isExcluded(String item) {
-        for (String prefix : EXCLUDED_PREFIXES) {
-            if (item.startsWith(prefix)) {
+    private static boolean isExcluded(String item, FilterContext context) {
+        for (ExclusionRule rule : EXCLUSION_RULES) {
+            if (rule.appliesTo.contains(context) && rule.matches(item)) {
                 return true;
             }
         }
-        for (String suffix : EXCLUDED_SUFFIXES) {
-            if (item.endsWith(suffix)) {
-                return true;
-            }
-        }
-        return EXCLUDED_NAMES.contains(item);
+        return false;
     }
 }

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/version_os_2_11/GlobalMetadataCreator_OS_2_11.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/version_os_2_11/GlobalMetadataCreator_OS_2_11.java
@@ -79,20 +79,24 @@ public class GlobalMetadataCreator_OS_2_11 implements GlobalMetadataCreator {
     enum TemplateTypes {
         INDEX_TEMPLATE(
             (targetClient, name, body, context) -> targetClient.createIndexTemplate(name, body, context.createMigrateTemplateContext()),
-            (targetClient, name) -> targetClient.hasIndexTemplate(name)
+            (targetClient, name) -> targetClient.hasIndexTemplate(name),
+            FilterScheme.FilterContext.INDEX_TEMPLATE
         ),
 
         LEGACY_INDEX_TEMPLATE(
             (targetClient, name, body, context) -> targetClient.createLegacyTemplate(name, body, context.createMigrateLegacyTemplateContext()),
-            (targetClient, name) -> targetClient.hasLegacyTemplate(name)
+            (targetClient, name) -> targetClient.hasLegacyTemplate(name),
+            FilterScheme.FilterContext.LEGACY_INDEX_TEMPLATE
         ),
 
         COMPONENT_TEMPLATE(
             (targetClient, name, body, context) -> targetClient.createComponentTemplate(name, body, context.createComponentTemplateContext()),
-            (targetClient, name) -> targetClient.hasComponentTemplate(name)
+            (targetClient, name) -> targetClient.hasComponentTemplate(name),
+            FilterScheme.FilterContext.COMPONENT_TEMPLATE
         );
         final TemplateCreator creator;
         final TemplateExistsCheck alreadyExistsCheck;
+        final FilterScheme.FilterContext filterContext;
     }
 
     @FunctionalInterface
@@ -144,7 +148,7 @@ public class GlobalMetadataCreator_OS_2_11 implements GlobalMetadataCreator {
             MigrationMode mode,
             IClusterMetadataContext context
         ) {
-        var skipCreation = FilterScheme.filterByAllowList(templateAllowList).negate();
+        var skipCreation = FilterScheme.filterByAllowList(templateAllowList, templateType.filterContext).negate();
 
         return templatesToCreate.entrySet().stream().map(kvp -> {
             var templateName = kvp.getKey();

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/worker/IndexRunner.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/worker/IndexRunner.java
@@ -32,7 +32,7 @@ public class IndexRunner {
     public IndexMetadataResults migrateIndices(MigrationMode mode, ICreateIndexContext context) {
         var repoDataProvider = metadataFactory.getRepoDataProvider();
         var results = IndexMetadataResults.builder();
-        var skipCreation = FilterScheme.filterByAllowList(indexAllowlist).negate();
+        var skipCreation = FilterScheme.filterByAllowList(indexAllowlist, FilterScheme.FilterContext.INDEX).negate();
 
         for (SnapshotRepo.Index index : repoDataProvider.getIndicesInSnapshot(snapshotName)) {
             List<CreationResult> creationResults;

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/worker/ShardWorkPreparer.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/worker/ShardWorkPreparer.java
@@ -102,7 +102,7 @@ public class ShardWorkPreparer {
             .setMessage("Setting up the Documents Work Items...")
             .log();
         SnapshotRepo.Provider repoDataProvider = metadataFactory.getRepoDataProvider();
-        var allowedIndexes = FilterScheme.filterByAllowList(indexAllowlist);
+        var allowedIndexes = FilterScheme.filterByAllowList(indexAllowlist, FilterScheme.FilterContext.INDEX);
         var indicesInSnapshot = repoDataProvider.getIndicesInSnapshot(snapshotName);
         if (indicesInSnapshot.isEmpty()) {
             log.atWarn().setMessage("After filtering the snapshot no indices were found.").log();

--- a/RFS/src/test/java/org/opensearch/migrations/bulkload/common/FilterSchemeTest.java
+++ b/RFS/src/test/java/org/opensearch/migrations/bulkload/common/FilterSchemeTest.java
@@ -2,6 +2,8 @@ package org.opensearch.migrations.bulkload.common;
 
 import java.util.List;
 
+import org.opensearch.migrations.bulkload.common.FilterScheme.FilterContext;
+
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -10,48 +12,114 @@ import static org.hamcrest.MatcherAssert.assertThat;
 public class FilterSchemeTest {
     @Test
     void testExcludedByPrefix() {
-        var filter = FilterScheme.filterByAllowList(null);
-        
+        var filter = FilterScheme.filterByAllowList(null, FilterContext.INDEX);
+
         // Should be excluded due to prefix
         assertThat(filter.test("apm-test"), equalTo(false));
         assertThat(filter.test(".hidden"), equalTo(false));
         assertThat(filter.test("searchguard"), equalTo(false));
         assertThat(filter.test("searchguard_config"), equalTo(false));
         assertThat(filter.test("sg7-auditlog-2026.04.10"), equalTo(false));
-        
+
         // Should not be excluded (no matching prefix)
         assertThat(filter.test("myindex"), equalTo(true));
         assertThat(filter.test("logs-2024"), equalTo(true));
         assertThat(filter.test("metrics-2024"), equalTo(true));
     }
-    
+
     @Test
-    void testExcludedBySuffix() {
-        var filter = FilterScheme.filterByAllowList(null);
-        
-        // Should be excluded due to suffix
+    void testExcludedBySuffix_templateContext() {
+        // Suffixes like @settings / @mappings are template naming conventions;
+        // they only apply to template contexts. Index names can't contain '@'
+        // anyway, so this is a documentation-of-intent change.
+        var filter = FilterScheme.filterByAllowList(null, FilterContext.INDEX_TEMPLATE);
+
         assertThat(filter.test("index@settings"), equalTo(false));
         assertThat(filter.test("test@mappings"), equalTo(false));
-        
+
         // Should not be excluded (no matching suffix)
         assertThat(filter.test("settings"), equalTo(true));
     }
-    
+
     @Test
-    void testExcludedByExactName() {
-        var filter = FilterScheme.filterByAllowList(null);
-        
+    void testExcludedByExactName_templateContext() {
+        var filter = FilterScheme.filterByAllowList(null, FilterContext.INDEX_TEMPLATE);
+
         // Should be excluded due to exact name match
         assertThat(filter.test("logs"), equalTo(false));
         assertThat(filter.test("metrics"), equalTo(false));
-        
+
         // Should not be excluded (no exact name match)
         assertThat(filter.test("metrics_custom"), equalTo(true));
     }
-    
+
+    @Test
+    void testLogsIndex_isMigrated() {
+        // Key behavior of this change: a user index literally named "logs"
+        // (or "metrics", "traces", etc.) must be migrated as data. The name
+        // only excludes the template of the same name.
+        var filter = FilterScheme.filterByAllowList(null, FilterContext.INDEX);
+
+        assertThat(filter.test("logs"), equalTo(true));
+        assertThat(filter.test("metrics"), equalTo(true));
+        assertThat(filter.test("traces"), equalTo(true));
+        assertThat(filter.test("profiling"), equalTo(true));
+        assertThat(filter.test("synthetics"), equalTo(true));
+        assertThat(filter.test("agentless"), equalTo(true));
+        assertThat(filter.test("elastic-connectors"), equalTo(true));
+        assertThat(filter.test("ilm-history"), equalTo(true));
+        assertThat(filter.test("tenant_template"), equalTo(true));
+        assertThat(filter.test("search-acl-filter"), equalTo(true));
+        assertThat(filter.test("logs-mappings"), equalTo(true));
+        assertThat(filter.test("logs-settings"), equalTo(true));
+        assertThat(filter.test("logs-tsdb-settings"), equalTo(true));
+        assertThat(filter.test("metrics-mappings"), equalTo(true));
+        assertThat(filter.test("metrics-settings"), equalTo(true));
+        assertThat(filter.test("metrics-tsdb-settings"), equalTo(true));
+        assertThat(filter.test("traces-mappings"), equalTo(true));
+        assertThat(filter.test("traces-settings"), equalTo(true));
+        assertThat(filter.test("traces-tsdb-settings"), equalTo(true));
+    }
+
+    @Test
+    void testLogsTemplate_isExcluded_inAllTemplateContexts() {
+        // The flip side: a template named "logs" is stack-managed and must
+        // NOT be created on the target in any template context.
+        for (var ctx : FilterContext.TEMPLATE_CONTEXTS) {
+            var filter = FilterScheme.filterByAllowList(null, ctx);
+            assertThat("logs template should be excluded in " + ctx,
+                filter.test("logs"), equalTo(false));
+            assertThat("metrics template should be excluded in " + ctx,
+                filter.test("metrics"), equalTo(false));
+            assertThat("traces template should be excluded in " + ctx,
+                filter.test("traces"), equalTo(false));
+            assertThat("tenant_template should be excluded in " + ctx,
+                filter.test("tenant_template"), equalTo(false));
+        }
+    }
+
+    @Test
+    void testWatcherIndices_excludedInAllContexts() {
+        // X-Pack watcher state lives in real indices on the source, not
+        // templates. They should be excluded in every context.
+        for (var ctx : FilterContext.values()) {
+            var filter = FilterScheme.filterByAllowList(null, ctx);
+            assertThat("triggered_watches should be excluded in " + ctx,
+                filter.test("triggered_watches"), equalTo(false));
+            assertThat("watches should be excluded in " + ctx,
+                filter.test("watches"), equalTo(false));
+            assertThat("watch_history_3 should be excluded in " + ctx,
+                filter.test("watch_history_3"), equalTo(false));
+        }
+
+        // Similar names that shouldn't be excluded
+        var indexFilter = FilterScheme.filterByAllowList(null, FilterContext.INDEX);
+        assertThat(indexFilter.test("watch_custom"), equalTo(true));
+    }
+
     @Test
     void testFilterByAllowList_null() {
-        var filter = FilterScheme.filterByAllowList(null);
+        var filter = FilterScheme.filterByAllowList(null, FilterContext.INDEX);
 
         assertThat(filter.test("test"), equalTo(true));
         assertThat(filter.test("test1"), equalTo(true));
@@ -60,7 +128,7 @@ public class FilterSchemeTest {
 
     @Test
     void testFilterByAllowList_empty() {
-        var filter = FilterScheme.filterByAllowList(List.of());
+        var filter = FilterScheme.filterByAllowList(List.of(), FilterContext.INDEX);
 
         assertThat(filter.test("test"), equalTo(true));
         assertThat(filter.test("test1"), equalTo(true));
@@ -69,7 +137,7 @@ public class FilterSchemeTest {
 
     @Test
     void testFilterByAllowList_matches() {
-        var filter = FilterScheme.filterByAllowList(List.of("test"));
+        var filter = FilterScheme.filterByAllowList(List.of("test"), FilterContext.INDEX);
 
         assertThat(filter.test("test"), equalTo(true));
         assertThat(filter.test("test1"), equalTo(false));
@@ -78,7 +146,7 @@ public class FilterSchemeTest {
 
     @Test
     void testFilterByAllowList_matches_with_period() {
-        var filter = FilterScheme.filterByAllowList(List.of(".test"));
+        var filter = FilterScheme.filterByAllowList(List.of(".test"), FilterContext.INDEX);
 
         assertThat(filter.test("test"), equalTo(false));
         assertThat(filter.test("test1"), equalTo(false));
@@ -86,8 +154,19 @@ public class FilterSchemeTest {
     }
 
     @Test
+    void testAllowlistBypassesBuiltinExclusions() {
+        // When an allowlist is supplied, built-in context-scoped exclusions
+        // are bypassed entirely — the allowlist is the sole filter. This
+        // preserves the prior contract: users can opt-in to stack-managed
+        // templates by naming them explicitly.
+        var filter = FilterScheme.filterByAllowList(List.of("logs"), FilterContext.INDEX_TEMPLATE);
+
+        assertThat(filter.test("logs"), equalTo(true));
+    }
+
+    @Test
     void testExcludedXPackWatchIndices() {
-        var filter = FilterScheme.filterByAllowList(null);
+        var filter = FilterScheme.filterByAllowList(null, FilterContext.INDEX);
 
         // These should all be excluded as xpack creates them by default
         assertThat(filter.test("triggered_watches"), equalTo(false));
@@ -100,7 +179,7 @@ public class FilterSchemeTest {
 
     @Test
     void testExcludedKibanaIndexTemplates() {
-        var filter = FilterScheme.filterByAllowList(null);
+        var filter = FilterScheme.filterByAllowList(null, FilterContext.INDEX);
 
         // Kibana index templates and indices should be excluded
         assertThat(filter.test("kibana_index_template:.kibana"), equalTo(false));
@@ -116,24 +195,24 @@ public class FilterSchemeTest {
 
     @Test
     void testExcludedES717SystemIndices() {
-        var filter = FilterScheme.filterByAllowList(null);
+        var filter = FilterScheme.filterByAllowList(null, FilterContext.INDEX);
 
         // Endpoint logs should be excluded
         assertThat(filter.test("logs-endpoint.alerts"), equalTo(false));
         assertThat(filter.test("logs-endpoint.events.file"), equalTo(false));
-        
+
         // System logs should be excluded
         assertThat(filter.test("logs-system.application"), equalTo(false));
         assertThat(filter.test("logs-system.auth"), equalTo(false));
-        
+
         // System metrics should be excluded
         assertThat(filter.test("metrics-system.cpu"), equalTo(false));
         assertThat(filter.test("metrics-system.memory"), equalTo(false));
-        
+
         // Metadata metrics should be excluded
         assertThat(filter.test("metrics-metadata-current"), equalTo(false));
         assertThat(filter.test("metrics-metadata-united"), equalTo(false));
-        
+
         // Custom indices with similar names should not be excluded
         assertThat(filter.test("logs-myendpoint-custom"), equalTo(true));
         assertThat(filter.test("logs-mysystem-custom"), equalTo(true));
@@ -143,7 +222,7 @@ public class FilterSchemeTest {
 
     @Test
     void testFilterByAllowList_regex_simple() {
-        var filter = FilterScheme.filterByAllowList(List.of("regex:logs-.*"));
+        var filter = FilterScheme.filterByAllowList(List.of("regex:logs-.*"), FilterContext.INDEX);
 
         assertThat(filter.test("logs-app"), equalTo(true));
         assertThat(filter.test("logs-web"), equalTo(true));
@@ -154,7 +233,7 @@ public class FilterSchemeTest {
 
     @Test
     void testFilterByAllowList_regex_withDigits() {
-        var filter = FilterScheme.filterByAllowList(List.of("regex:test-\\d+"));
+        var filter = FilterScheme.filterByAllowList(List.of("regex:test-\\d+"), FilterContext.INDEX);
 
         assertThat(filter.test("test-1"), equalTo(true));
         assertThat(filter.test("test-123"), equalTo(true));
@@ -165,7 +244,7 @@ public class FilterSchemeTest {
 
     @Test
     void testFilterByAllowList_regex_complex() {
-        var filter = FilterScheme.filterByAllowList(List.of("regex:logs-[a-z]+-\\d{4}"));
+        var filter = FilterScheme.filterByAllowList(List.of("regex:logs-[a-z]+-\\d{4}"), FilterContext.INDEX);
 
         assertThat(filter.test("logs-app-2024"), equalTo(true));
         assertThat(filter.test("logs-web-2024"), equalTo(true));
@@ -175,7 +254,7 @@ public class FilterSchemeTest {
 
     @Test
     void testFilterByAllowList_regex_multiplePatterns() {
-        var filter = FilterScheme.filterByAllowList(List.of("regex:logs-.*", "regex:metrics-.*"));
+        var filter = FilterScheme.filterByAllowList(List.of("regex:logs-.*", "regex:metrics-.*"), FilterContext.INDEX);
 
         assertThat(filter.test("logs-app"), equalTo(true));
         assertThat(filter.test("metrics-cpu"), equalTo(true));
@@ -184,12 +263,12 @@ public class FilterSchemeTest {
 
     @Test
     void testFilterByAllowList_mixed_literalAndRegex() {
-        var filter = FilterScheme.filterByAllowList(List.of("exact-index", "regex:logs-.*-2024"));
+        var filter = FilterScheme.filterByAllowList(List.of("exact-index", "regex:logs-.*-2024"), FilterContext.INDEX);
 
         // Literal match
         assertThat(filter.test("exact-index"), equalTo(true));
         assertThat(filter.test("exact-index-2"), equalTo(false));
-        
+
         // Regex match
         assertThat(filter.test("logs-app-2024"), equalTo(true));
         assertThat(filter.test("logs-web-2024"), equalTo(true));
@@ -198,7 +277,7 @@ public class FilterSchemeTest {
 
     @Test
     void testFilterByAllowList_literal_withDotsAndHyphens() {
-        var filter = FilterScheme.filterByAllowList(List.of("my.index-2024", "test-index.v1"));
+        var filter = FilterScheme.filterByAllowList(List.of("my.index-2024", "test-index.v1"), FilterContext.INDEX);
 
         // Dots and hyphens are treated as literal characters
         assertThat(filter.test("my.index-2024"), equalTo(true));
@@ -209,7 +288,7 @@ public class FilterSchemeTest {
 
     @Test
     void testFilterByAllowList_regex_matchesMultipleItems() {
-        var filter = FilterScheme.filterByAllowList(List.of("regex:logs-.*"));
+        var filter = FilterScheme.filterByAllowList(List.of("regex:logs-.*"), FilterContext.INDEX);
 
         // Single pattern matches multiple different indices
         assertThat(filter.test("logs-app"), equalTo(true));
@@ -220,7 +299,7 @@ public class FilterSchemeTest {
 
     @Test
     void testFilterByAllowList_regex_withEscapedDot() {
-        var filter = FilterScheme.filterByAllowList(List.of("regex:logs\\..*"));
+        var filter = FilterScheme.filterByAllowList(List.of("regex:logs\\..*"), FilterContext.INDEX);
 
         // Escaped dot matches only literal dot
         assertThat(filter.test("logs.app"), equalTo(true));
@@ -230,7 +309,7 @@ public class FilterSchemeTest {
 
     @Test
     void testFilterByAllowList_regex_alternation() {
-        var filter = FilterScheme.filterByAllowList(List.of("regex:(logs|metrics)-.*-2024"));
+        var filter = FilterScheme.filterByAllowList(List.of("regex:(logs|metrics)-.*-2024"), FilterContext.INDEX);
 
         assertThat(filter.test("logs-app-2024"), equalTo(true));
         assertThat(filter.test("metrics-cpu-2024"), equalTo(true));
@@ -240,7 +319,7 @@ public class FilterSchemeTest {
     @Test
     void testFilterByAllowList_literal_lookingLikeRegex() {
         // A literal entry that contains regex-like characters but no prefix
-        var filter = FilterScheme.filterByAllowList(List.of("test.*"));
+        var filter = FilterScheme.filterByAllowList(List.of("test.*"), FilterContext.INDEX);
 
         // Should match exactly, not as regex
         assertThat(filter.test("test.*"), equalTo(true));
@@ -252,7 +331,7 @@ public class FilterSchemeTest {
     void testFilterByAllowList_regex_emptyPattern() {
         // Empty pattern after prefix should throw exception
         try {
-            FilterScheme.filterByAllowList(List.of("regex:"));
+            FilterScheme.filterByAllowList(List.of("regex:"), FilterContext.INDEX);
             assertThat("Should have thrown IllegalArgumentException", false);
         } catch (IllegalArgumentException e) {
             assertThat(e.getMessage().contains("empty"), equalTo(true));
@@ -263,7 +342,7 @@ public class FilterSchemeTest {
     void testFilterByAllowList_regex_invalidPattern() {
         // Invalid regex pattern should throw exception
         try {
-            FilterScheme.filterByAllowList(List.of("regex:[invalid"));
+            FilterScheme.filterByAllowList(List.of("regex:[invalid"), FilterContext.INDEX);
             assertThat("Should have thrown IllegalArgumentException", false);
         } catch (IllegalArgumentException e) {
             assertThat(e.getMessage().contains("Invalid regex pattern"), equalTo(true));
@@ -274,7 +353,7 @@ public class FilterSchemeTest {
     void testFilterByAllowList_mixed_withInvalidRegex() {
         // If one entry is invalid, the whole allowlist should fail
         try {
-            FilterScheme.filterByAllowList(List.of("valid-index", "regex:(unclosed"));
+            FilterScheme.filterByAllowList(List.of("valid-index", "regex:(unclosed"), FilterContext.INDEX);
             assertThat("Should have thrown IllegalArgumentException", false);
         } catch (IllegalArgumentException e) {
             assertThat(e.getMessage().contains("Invalid regex pattern"), equalTo(true));


### PR DESCRIPTION
### Description

`FilterScheme.filterByAllowList` applies a single pool of built-in exclusion rules (prefixes, suffixes, exact names) to every callsite. That same pool is consulted when deciding whether to migrate

- indices (`IndexRunner`, `ShardWorkPreparer`, `MigratorEvaluatorBase`)
- legacy index templates, composable index templates, and component templates (`GlobalMetadataCreator_OS_2_11`, called three times with different `TemplateTypes`)

Most of the exact-name entries — `logs`, `metrics`, `traces`, `tenant_template`, `agentless`, etc. — and every `@`-suffix entry — `@settings`, `@mappings`, `@template`, etc. — are Elastic/Fleet-shipped *template* names, not names a user would give a data index. With those rules applied at every callsite, any user index that happens to be named literally `logs` gets silently dropped from the migration even though the source cluster has real data in it.

This PR fixes that by tagging each built-in exclusion rule with the set of contexts in which it applies.

### Changes

Introduces `FilterScheme.FilterContext` with four values — `INDEX`, `LEGACY_INDEX_TEMPLATE`, `INDEX_TEMPLATE`, `COMPONENT_TEMPLATE` — and threads it through `filterByAllowList(List<String>, FilterContext)`. The template callsite derives the context from the existing `TemplateTypes` enum; the three index callsites pass `FilterContext.INDEX` explicitly.

Internally, the three flat `Set<String>` exclusion tables collapse into one ordered list of `ExclusionRule` records, each carrying a pattern, a match type (prefix / suffix / exact), and an `EnumSet<FilterContext>` declaring where it applies.

**Scoped to `TEMPLATES_ONLY`** (`LEGACY_INDEX_TEMPLATE ∪ INDEX_TEMPLATE ∪ COMPONENT_TEMPLATE`):

- all `@`-suffix rules (`@ilm`, `@lifecycle`, `@mappings`, `@package`, `@settings`, `@template`, `@tsdb-settings`) — OpenSearch/Elasticsearch index names cannot contain `@`, so excluding them from the index context was lossless but misleading
- the `@abc_template@`, `apm@`, `data-streams-`, `data-streams@`, `ecs@` prefixes — same reasoning
- exact names that are stack-shipped template names and legitimate user-data index names: `agentless`, `elastic-connectors`, `ilm-history`, `logs`, `logs-mappings`, `logs-settings`, `logs-tsdb-settings`, `metrics`, `metrics-mappings`, `metrics-settings`, `metrics-tsdb-settings`, `profiling`, `search-acl-filter`, `synthetics`, `tenant_template`, `traces`, `traces-mappings`, `traces-settings`, `traces-tsdb-settings`

**Kept at `ALL` contexts** (still excluded everywhere):

- leading-dot system indices (`.`)
- kibana, searchguard, sg7-
- apm-, behavioral_analytics-, elastic-connectors-, elastic_agent., ilm-history-, metricbeat-, profiling-, synthetics-
- logs-elastic_agent, logs-endpoint., logs-index_pattern, logs-system.
- metrics-elastic_agent, metrics-endpoint., metrics-index_pattern, metrics-metadata-, metrics-system.
- the X-Pack watcher exact names (`triggered_watches`, `watches`, `watch_history_3`) — these are real indices on the source, not templates

### Testing

- Extended `FilterSchemeTest` from 22 to 27 tests; the existing cases are re-parameterized with the appropriate `FilterContext` and preserve their original assertions.
- Two new dedicated cases pin the fix down:
  - `testLogsIndex_isMigrated` — every template-only exact name (`logs`, `metrics`, `traces`, `profiling`, `synthetics`, `agentless`, `elastic-connectors`, `ilm-history`, `tenant_template`, `search-acl-filter`, and all the `-mappings`/`-settings`/`-tsdb-settings` variants) now passes the index filter.
  - `testLogsTemplate_isExcluded_inAllTemplateContexts` — those same names are still excluded across all three template contexts.
- One new case (`testAllowlistBypassesBuiltinExclusions`) documents that a user-supplied allowlist overrides built-in exclusions, preserving the prior contract.
- `./gradlew :RFS:test :MetadataMigration:test` passes cleanly.

### Backwards compatibility

`filterByAllowList(List<String>)` is replaced with `filterByAllowList(List<String>, FilterContext)`. All four production callsites are updated in this PR and no tests consumed the old single-arg form outside `FilterSchemeTest`, so no deprecated overload is kept — every caller is required to state which kind of thing is being filtered, which is the point of the change.

### Issues Resolved

N/A — driven by a user-reported regression where an index literally named `logs` was being silently dropped by the metadata filter.

### Is this a backport?

No.

### Testing

- [x] New functionality includes testing
- [x] All tests pass
  - [x] `./gradlew :RFS:test :MetadataMigration:test`

### Check List

- [x] Commits are signed per the DCO using `--signoff`
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
