### PR TITLE
RFS sourceless: single-pass doc-banked sidecar for term-position index

### DIFF
--- a/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/LuceneLeafReader.java
+++ b/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/LuceneLeafReader.java
@@ -6,6 +6,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import org.opensearch.migrations.bulkload.lucene.sidecar.PostingsSink;
+
 public interface LuceneLeafReader {
 
     public LuceneDocument document(int luceneDocId) throws IOException;
@@ -62,17 +64,26 @@ public interface LuceneLeafReader {
     default String getValueFromTerms(int docId, String fieldName) throws IOException { return null; }
 
     /**
-     * Version-specific hook: walk the terms dictionary for {@code fieldName} once and return a
-     * docId -> position-ordered term list map. This performs the raw Lucene iteration over
-     * shadow-relocated {@code Terms}/{@code TermsEnum}/{@code PostingsEnum}, which is why it
-     * can't be written in this shared interface.
+     * Streams the inverted index for {@code fieldName} into {@code sink} as
+     * {@code (termId, docId, positions[])} callbacks, one per (term, doc) pair that has
+     * at least one non-negative position.
      *
-     * Called at most once per (segment, field) via {@link SegmentTermIndex}. The returned map
-     * is owned by the caller and lives only as long as the {@link SegmentTermIndex} that holds
-     * it, which is scoped to a single segment's Flux in {@link LuceneReader#readDocsFromSegment}.
+     * <p>Ordering contract: terms are visited in ascending-bytes order (matches Lucene's
+     * {@code TermsEnum.next()}), and for each term docs are visited in ascending-docId order
+     * (matches Lucene's {@code PostingsEnum.nextDoc()}). Positions within each callback are
+     * already in ascending order as emitted by {@code PostingsEnum.nextPosition()}.
+     *
+     * <p>The default implementation is a no-op: versions that don't support source
+     * reconstruction from the inverted index (e.g. Lucene 10 / OS 3.x which always have
+     * stored fields or doc_values) leave this unimplemented and callers see an empty stream.
+     *
+     * <p>Callers must first invoke {@link PostingsSink#registerTerm} on each new term (as it
+     * appears in the walk) to get its assigned {@code termId}, then invoke
+     * {@link PostingsSink#accept(int, int, int[], int)} once per (term, doc). The reusable
+     * {@code int[]} passed to {@code accept} is only borrowed for the duration of the call.
      */
-    default Map<Integer, List<String>> buildTermPositionIndex(String fieldName) throws IOException {
-        return Collections.emptyMap();
+    default void streamFieldPostings(String fieldName, PostingsSink sink) throws IOException {
+        // no-op: default reader has no terms to stream.
     }
 
     /**

--- a/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/LuceneReader.java
+++ b/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/LuceneReader.java
@@ -128,11 +128,14 @@ public class LuceneReader {
         // Start at
         int startDocIdInSegment = (docStartingId <= segmentDocBase) ? 0 : docStartingId - segmentDocBase;
 
-        // Per-segment term position cache. Built lazily on first need. This local reference
-        // lives only inside the Flux created below; once that Flux terminates, the index
-        // and the large Map<docId,List<String>> it holds become GC-eligible naturally.
-        // No instance-level cache on the LeafReader, so no explicit clear step is required.
-        final SegmentTermIndex termIndex = new SegmentTermIndex();
+        // Per-segment term position cache. Built lazily on first need. Backed by an on-disk
+        // spill directory so the in-heap footprint stays bounded even for large segments
+        // (a 3GB shard's analyzed-text TreeMap can otherwise OOM at 64GB JVM). The spill
+        // directory is created lazily on first field build and deleted by the Flux's
+        // doFinally hook below on both success and error paths.
+        final Path spillRoot = SourcelessSpillConfig.newSegmentSpillRoot();
+        final SegmentTermIndex termIndex = new SegmentTermIndex(
+                spillRoot, SourcelessSpillConfig.sortBufferBytes());
 
         // For any errors, we want to log the segment reader debug info so we can see which segment is causing the issue.
         // This allows us to pass the supplier to getDocument without having to recompute the debug info
@@ -164,7 +167,8 @@ public class LuceneReader {
                         return Mono.error(new RuntimeException("Error reading document from reader with index " + docIdx
                             + " from segment " + getSegmentReaderDebugInfo.get(), e));
                     }
-                }).subscribeOn(LUCENE_IO_SCHEDULER), SEGMENT_READ_CONCURRENCY, 1);
+                }).subscribeOn(LUCENE_IO_SCHEDULER), SEGMENT_READ_CONCURRENCY, 1)
+            .doFinally(sig -> termIndex.close());
     }
 
     /** Backwards-compatible overload without mapping context */

--- a/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/SegmentTermIndex.java
+++ b/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/SegmentTermIndex.java
@@ -1,58 +1,105 @@
 package org.opensearch.migrations.bulkload.lucene;
 
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
+
+import org.opensearch.migrations.bulkload.lucene.sidecar.SidecarBuilder;
+import org.opensearch.migrations.bulkload.lucene.sidecar.SidecarReader;
+
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * Per-segment cache of per-field term indexes.
  *
- * Two kinds of indexes are cached here, each lazily built on first access:
+ * <p>Two kinds of indexes are cached here, each lazily built on first access:
  *
- *   1. {@code byField}: fieldName -> docId -> position-ordered terms.
- *      Used by {@link SourceReconstructor} to reconstruct analyzed-text fields
- *      (STRING type) when neither stored fields nor doc_values are available.
+ * <ol>
+ *   <li><b>byField</b>: fieldName -&gt; {@link SidecarReader}.
+ *       Used by {@link SourceReconstructor} to reconstruct analyzed-text fields
+ *       (STRING type) when neither stored fields nor doc_values are available.
+ *       Backed by {@link SidecarBuilder}: the per-field posting stream is walked
+ *       exactly once, spilled to disk as fixed-width 12-byte scratch tuples,
+ *       externally merge-sorted using primitive int[] arrays (no boxing) keyed
+ *       on (docId, position, termId), and encoded into a compact varint sidecar
+ *       with a flat long[maxDoc] doc index. The reader mmaps the sidecar and
+ *       serves {@code get(docId)} with zero heap allocation beyond the returned
+ *       ArrayList. Heap footprint is bounded regardless of segment size.</li>
  *
- *   2. {@code numericByField}: fieldName -> docId -> decoded Long.
- *      Used by {@link SourceReconstructor} to reconstruct trie-encoded numeric
- *      fields (NUMERIC/IP/DATE/DATE_NANOS/SCALED_FLOAT/UNSIGNED_LONG) when neither
- *      stored fields nor doc_values are available. Lucene 4-5 (ES 1.x/2.x) writes
- *      numerics as chains of prefix-coded terms across shift levels; only
- *      {@code shift==0} terms are harvested and decoded back to longs via
- *      {@link shadow.lucene5.org.apache.lucene.util.NumericUtils} in the
- *      version-specific reader.
+ *   <li><b>numericByField</b>: fieldName -&gt; docId -&gt; decoded Long.
+ *       Used to reconstruct trie-encoded numeric fields
+ *       (NUMERIC/IP/DATE/DATE_NANOS/SCALED_FLOAT/UNSIGNED_LONG) in Lucene 4/5
+ *       segments. Stays in heap: 16 bytes per (docId, Long) entry times maxDoc
+ *       is bounded and small (a 200k-doc segment is ~3 MB of numeric index).</li>
+ * </ol>
  *
- * Lifetime is scoped to a single call to
+ * <p>Lifetime is scoped to a single call to
  * {@link LuceneReader#readDocsFromSegment}: a fresh instance is created there
- * and flows down to {@link SourceReconstructor}. Once the segment's Flux
- * terminates (the outer pipeline's concatMapDelayError has moved on), no live
- * references remain and this object plus its maps become GC-eligible without
- * any explicit clear step.
+ * with a per-segment {@code spillRoot}, and flows down to {@link SourceReconstructor}.
+ * Once the segment's Flux terminates (success, error, or cancel), the Flux's
+ * {@code doFinally} hook calls {@link #close()}, which closes all open sidecar
+ * readers and deletes the spill root.
  *
- * Thread-safety: Lucene TermsEnum / PostingsEnum instances are not safe for
- * concurrent access. Access to the underlying maps is serialized via
- * synchronized to protect the build phase against the per-document concurrent
- * reads within a segment's Flux (see LuceneReader.SEGMENT_READ_CONCURRENCY).
+ * <p>Thread-safety: Lucene TermsEnum / PostingsEnum instances are not safe for
+ * concurrent access. Access to the underlying maps and build phase is serialized
+ * via {@code synchronized} to protect against the per-document concurrent reads
+ * within a segment's Flux (see {@link LuceneReader#SEGMENT_READ_CONCURRENCY}).
+ * Once a field's {@link SidecarReader} has been built, its {@link SidecarReader#get(int)}
+ * is lock-free and safe for concurrent readers — the {@code synchronized} is
+ * only needed to protect the build.
  */
-public class SegmentTermIndex {
+@Slf4j
+public class SegmentTermIndex implements AutoCloseable {
 
-    private final Map<String, Map<Integer, List<String>>> byField = new HashMap<>();
+    private final Path spillRoot;
+    private final long sortBufferBytes;
+    private final Map<String, SidecarReader> byField = new HashMap<>();
     private final Map<String, Map<Integer, Long>> numericByField = new HashMap<>();
+    private volatile boolean closed;
+
+    /**
+     * Creates an index scoped to {@code spillRoot} for on-disk term spill files.
+     * The directory is created lazily on first field build; callers can pass a
+     * path that does not yet exist.
+     *
+     * @param spillRoot per-segment directory owned by this index. Deleted on {@link #close()}.
+     * @param sortBufferBytes in-memory sort buffer budget for the external merge sort
+     *                        inside {@link SidecarBuilder}. Values larger than
+     *                        {@link Integer#MAX_VALUE} are clamped to fit the Builder's
+     *                        int-sized scratch buffer.
+     */
+    public SegmentTermIndex(Path spillRoot, long sortBufferBytes) {
+        this.spillRoot = spillRoot;
+        this.sortBufferBytes = Math.min(sortBufferBytes, Integer.MAX_VALUE);
+    }
 
     /**
      * Returns the position-ordered list of indexed terms for {@code docId} in
      * {@code fieldName}, building the per-field index on first access.
+     *
+     * <p>The first call for a field walks the full terms dictionary once, spills
+     * scratch tuples to {@code spillRoot/fieldName/}, external-sorts them with
+     * primitive arrays, and writes the final varint-compact sidecar files.
+     * Subsequent calls are {@code O(1)} mmap lookups into the long[] doc index
+     * plus a short varint decode.
      */
     public synchronized List<String> getTermsForDocument(LuceneLeafReader reader, int docId, String fieldName)
             throws IOException {
-        Map<Integer, List<String>> forField = byField.get(fieldName);
+        if (closed) {
+            throw new IOException("SegmentTermIndex has been closed");
+        }
+        SidecarReader forField = byField.get(fieldName);
         if (forField == null) {
-            forField = reader.buildTermPositionIndex(fieldName);
+            forField = buildFieldIndex(reader, fieldName);
             byField.put(fieldName, forField);
         }
-        return forField.getOrDefault(docId, Collections.emptyList());
+        return forField.get(docId);
     }
 
     /**
@@ -60,17 +107,105 @@ public class SegmentTermIndex {
      * building the per-field numeric index on first access. Returns null if the field has no
      * trie-encoded numeric terms or the doc was not indexed with a value for the field.
      *
-     * The returned Long is the raw decoded value from the shift==0 term. Interpretation
+     * <p>The returned Long is the raw decoded value from the shift==0 term. Interpretation
      * (int vs long vs float vs double vs IP string) is applied downstream via
      * {@link FieldMappingInfo} in {@link SourceReconstructor}.
      */
     public synchronized Long getNumericForDocument(LuceneLeafReader reader, int docId, String fieldName)
             throws IOException {
+        if (closed) {
+            throw new IOException("SegmentTermIndex has been closed");
+        }
         Map<Integer, Long> forField = numericByField.get(fieldName);
         if (forField == null) {
             forField = reader.buildNumericTermIndex(fieldName);
             numericByField.put(fieldName, forField);
         }
         return forField.get(docId);
+    }
+
+    /**
+     * Builds the sidecar for {@code fieldName} by streaming the terms dict once into a
+     * {@link SidecarBuilder}.
+     *
+     * <p>If the field has no terms (reader emits no tuples), returns a sidecar with an
+     * empty doc-index — lookups return {@link Collections#emptyList()} uniformly.
+     */
+    private SidecarReader buildFieldIndex(LuceneLeafReader reader, String fieldName) throws IOException {
+        Path fieldSpillDir = spillRoot.resolve(sanitizeFieldName(fieldName));
+        int maxDoc = Math.max(1, reader.maxDoc());
+        SidecarBuilder builder = new SidecarBuilder(fieldSpillDir, (int) sortBufferBytes, maxDoc);
+        boolean ok = false;
+        try {
+            reader.streamFieldPostings(fieldName, builder);
+            SidecarReader idx = builder.buildAndOpenReader();
+            ok = true;
+            return idx;
+        } finally {
+            if (!ok) {
+                // buildAndOpenReader() wasn't reached — close the builder to delete partial spill files.
+                try {
+                    builder.close();
+                } catch (Exception e) {
+                    log.warn("Failed to close builder after exception for field {}: {}", fieldName, e.toString());
+                }
+            }
+        }
+    }
+
+    /**
+     * Strips path-unsafe characters from the field name so the spill subdirectory name
+     * is filesystem-portable. Collisions are harmless here because {@code spillRoot} itself
+     * is per-segment and field names within a segment are already unique — but two fields
+     * with names differing only in path-unsafe characters would collide. The sanitized name
+     * is therefore suffixed with an index to avoid that edge case.
+     */
+    private String sanitizeFieldName(String fieldName) {
+        StringBuilder sb = new StringBuilder(fieldName.length() + 8);
+        for (int i = 0; i < fieldName.length(); i++) {
+            char c = fieldName.charAt(i);
+            if (c == '.' || c == '_' || Character.isLetterOrDigit(c)) {
+                sb.append(c);
+            } else {
+                sb.append('_');
+            }
+        }
+        // append the insertion order so two sanitized-equal names don't collide
+        sb.append('-').append(byField.size());
+        return sb.toString();
+    }
+
+    /**
+     * Closes every sidecar reader and recursively deletes the spill root.
+     * Safe to call multiple times. Exceptions from individual closes are logged
+     * and swallowed so one failing field doesn't leak the rest.
+     */
+    @Override
+    public synchronized void close() {
+        if (closed) return;
+        closed = true;
+        for (Map.Entry<String, SidecarReader> e : byField.entrySet()) {
+            try {
+                e.getValue().close();
+            } catch (Exception ex) {
+                log.warn("Failed to close sidecar for field {}: {}", e.getKey(), ex.toString());
+            }
+        }
+        byField.clear();
+        numericByField.clear();
+        deleteRecursively(spillRoot);
+    }
+
+    private static void deleteRecursively(Path root) {
+        if (!Files.exists(root)) return;
+        try (Stream<Path> walk = Files.walk(root)) {
+            walk.sorted(Comparator.reverseOrder()).forEach(p -> {
+                try { Files.deleteIfExists(p); } catch (IOException ignored) {
+                    // Best-effort cleanup; ignore per-file failures during teardown.
+                }
+            });
+        } catch (IOException e) {
+            log.warn("Failed to delete spill root {}: {}", root, e.toString());
+        }
     }
 }

--- a/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/SourcelessSpillConfig.java
+++ b/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/SourcelessSpillConfig.java
@@ -1,0 +1,115 @@
+package org.opensearch.migrations.bulkload.lucene;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.lang.management.ManagementFactory;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Tunables + per-process root directory management for {@link SegmentTermIndex}
+ * on-disk spill files.
+ *
+ * <p>The two knobs are intentionally tiny in surface area so operators can set them
+ * via JVM {@code -D} flags on the worker container without needing a full config
+ * plumbing change. If either is unset the defaults used here are the ones documented
+ * in {@code docs/plans/2026-05-04-sourceless-offline-term-index.md}.
+ *
+ * <dl>
+ *   <dt>{@code rfs.reconstruction.spillRoot}</dt>
+ *   <dd>Directory under which per-process, per-segment spill trees are created.
+ *       Default: {@code ${java.io.tmpdir}/rfs-spill-<pid>}.
+ *       The directory is created lazily on first segment build; the per-process
+ *       root is shared across all segments handled by this JVM. Deletion is
+ *       per-segment (via {@link SegmentTermIndex#close()}), not per-process —
+ *       the worker's filesystem cleanup on container exit handles the root.</dd>
+ *
+ *   <dt>{@code rfs.reconstruction.sortBufferBytes}</dt>
+ *   <dd>In-memory sort buffer budget per field build. Default: 64 MiB.
+ *       Affects the number of spill-runs the external merge sort produces
+ *       (smaller buffer = more runs = more merge passes = more disk I/O,
+ *       but bounded heap). The 64 MiB default keeps worst-case run count
+ *       under a few hundred even for 600 GB shards with 10 GB workers.</dd>
+ * </dl>
+ *
+ * <p>This class is intentionally stateless apart from the segment-sequence counter,
+ * which is monotonic per JVM and guarantees a unique spill subdirectory per
+ * {@link LuceneReader#readDocsFromSegment} invocation even when two flux'es
+ * happen to share the same underlying segment name.
+ */
+@Slf4j
+public final class SourcelessSpillConfig {
+
+    public static final String SPILL_ROOT_PROP = "rfs.reconstruction.spillRoot";
+    public static final String SORT_BUFFER_BYTES_PROP = "rfs.reconstruction.sortBufferBytes";
+
+    /** 64 MiB sort buffer — balances disk I/O against heap headroom. */
+    public static final long DEFAULT_SORT_BUFFER_BYTES = 64L * 1024 * 1024;
+
+    private static final AtomicLong SEGMENT_SEQ = new AtomicLong();
+    private static final AtomicReference<Path> PROCESS_ROOT = new AtomicReference<>();
+
+    private SourcelessSpillConfig() {}
+
+    /**
+     * Returns the per-process spill root, creating it on first call. Callers
+     * should not delete this directory — {@link SegmentTermIndex#close()}
+     * cleans up only the per-segment subdirectory it owns.
+     */
+    public static synchronized Path processRoot() {
+        Path existing = PROCESS_ROOT.get();
+        if (existing == null) {
+            String override = System.getProperty(SPILL_ROOT_PROP);
+            Path root;
+            if (override != null && !override.isBlank()) {
+                root = Paths.get(override);
+            } else {
+                String tmp = System.getProperty("java.io.tmpdir", "/tmp");
+                String pid = ManagementFactory.getRuntimeMXBean().getName().split("@", 2)[0];
+                root = Paths.get(tmp, "rfs-spill-" + pid);
+            }
+            try {
+                Files.createDirectories(root);
+            } catch (IOException e) {
+                throw new UncheckedIOException("Failed to create RFS spill root " + root, e);
+            }
+            log.info("RFS sourceless reconstruction spill root: {}", root);
+            PROCESS_ROOT.set(root);
+            return root;
+        }
+        return existing;
+    }
+
+    /**
+     * Allocates a unique per-segment spill subdirectory under {@link #processRoot()}.
+     * The directory name is {@code seg-<seq>} where seq is a per-JVM monotonic counter.
+     * The subdirectory is not created here; {@link org.opensearch.migrations.bulkload.lucene.sidecar.SidecarBuilder}
+     * creates it on first write.
+     */
+    public static Path newSegmentSpillRoot() {
+        long seq = SEGMENT_SEQ.incrementAndGet();
+        return processRoot().resolve("seg-" + seq);
+    }
+
+    /**
+     * Returns the configured sort-buffer budget for external merge sort, or the
+     * default if unset. Values below the 12-byte tuple width clamp up to one tuple
+     * so builds don't deadlock.
+     */
+    public static long sortBufferBytes() {
+        String override = System.getProperty(SORT_BUFFER_BYTES_PROP);
+        if (override == null || override.isBlank()) return DEFAULT_SORT_BUFFER_BYTES;
+        try {
+            long n = Long.parseLong(override.trim());
+            return Math.max(org.opensearch.migrations.bulkload.lucene.sidecar.SidecarBuilder.RECORD_BYTES, n);
+        } catch (NumberFormatException e) {
+            log.warn("Invalid {}={}, using default {}", SORT_BUFFER_BYTES_PROP, override, DEFAULT_SORT_BUFFER_BYTES);
+            return DEFAULT_SORT_BUFFER_BYTES;
+        }
+    }
+}

--- a/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/sidecar/BytesRefLike.java
+++ b/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/sidecar/BytesRefLike.java
@@ -1,0 +1,79 @@
+package org.opensearch.migrations.bulkload.lucene.sidecar;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+/**
+ * Zero-dependency value type mirroring {@code org.apache.lucene.util.BytesRef} across the
+ * version-boundary between per-Lucene-version sourcesets and the main (version-agnostic)
+ * sourceset. Each per-version reader constructs one of these from its shadow-relocated
+ * {@code BytesRef} and hands it to a {@link PostingsSink} — the main sourceset never
+ * imports any Lucene type.
+ *
+ * <p>Semantics match {@code BytesRef}:
+ *
+ * <ul>
+ *   <li>{@link #bytes()} returns the backing buffer directly — may be reused by the reader
+ *       between calls, so long-lived retention requires {@link #toByteArray()}.
+ *   <li>{@link #equals(Object)} / {@link #hashCode()} are value-based over the
+ *       {@code [offset, offset+length)} subrange.
+ * </ul>
+ */
+public final class BytesRefLike {
+
+    private final byte[] bytes;
+    private final int offset;
+    private final int length;
+
+    public BytesRefLike(byte[] bytes, int offset, int length) {
+        Objects.requireNonNull(bytes, "bytes");
+        if (offset < 0 || length < 0 || offset + length > bytes.length) {
+            throw new IllegalArgumentException(
+                "Invalid subrange: offset=" + offset + " length=" + length + " bufferLength=" + bytes.length);
+        }
+        this.bytes = bytes;
+        this.offset = offset;
+        this.length = length;
+    }
+
+    /** Returns the backing buffer (no copy). Callers MUST NOT retain across the sink call. */
+    public byte[] bytes() {
+        return bytes;
+    }
+
+    public int offset() {
+        return offset;
+    }
+
+    public int length() {
+        return length;
+    }
+
+    /** Returns a defensive copy of the valid byte range — safe to retain indefinitely. */
+    public byte[] toByteArray() {
+        byte[] copy = new byte[length];
+        System.arraycopy(bytes, offset, copy, 0, length);
+        return copy;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof BytesRefLike)) return false;
+        BytesRefLike other = (BytesRefLike) o;
+        if (other.length != this.length) return false;
+        return Arrays.equals(this.bytes, this.offset, this.offset + this.length,
+                             other.bytes, other.offset, other.offset + other.length);
+    }
+
+    @Override
+    public int hashCode() {
+        // Match Arrays.hashCode(byte[]) semantics over the valid subrange so two instances
+        // with equal bytes from different backing buffers compare-equal and hash-equal.
+        int h = 1;
+        for (int i = 0; i < length; i++) {
+            h = 31 * h + bytes[offset + i];
+        }
+        return h;
+    }
+}

--- a/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/sidecar/PostingsSink.java
+++ b/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/sidecar/PostingsSink.java
@@ -1,0 +1,41 @@
+package org.opensearch.migrations.bulkload.lucene.sidecar;
+
+import java.io.IOException;
+
+/**
+ * Version-agnostic sink that receives {@code (termId, docId, positions[])} triples emitted
+ * by a per-Lucene-version reader's postings walk. Implementers are responsible for turning
+ * the term-major, docId-ascending input stream into a doc-major, position-ascending sidecar.
+ *
+ * <p>Contract the emitter (a {@code LuceneLeafReader.streamFieldPostings} implementation)
+ * MUST honor:
+ *
+ * <ol>
+ *   <li>Call {@link #registerTerm(BytesRefLike)} exactly once per distinct term, in
+ *       {@code TermsEnum.next()} order (ascending sorted bytes). The returned {@code int}
+ *       is the termId the emitter will use on subsequent {@link #accept} calls.
+ *   <li>For each term, iterate its postings in ascending docId order (Lucene's
+ *       {@code PostingsEnum} natural contract). Call {@link #accept} once per (term, doc)
+ *       with the doc's positions array and the count of valid entries.
+ *   <li>Positions within a (term, doc) MUST be ascending and non-negative. Tuples emitted
+ *       for fields without positional indexing (DOCS_ONLY, DOCS_AND_FREQS) MUST skip any
+ *       sentinel position value the reader receives from Lucene ({@code &lt; 0}).
+ * </ol>
+ */
+public interface PostingsSink {
+
+    /**
+     * Registers a distinct term. Called exactly once per term, in ascending sorted-bytes
+     * order. The returned int is the small, dense termId the sink will accept on subsequent
+     * {@link #accept} calls.
+     */
+    int registerTerm(BytesRefLike term) throws IOException;
+
+    /**
+     * Records {@code positionCount} positions at which {@code termId} occurs in {@code docId}.
+     * The {@code positions} array is owned by the caller and may be reused across calls —
+     * sinks MUST consume the valid prefix {@code [0, positionCount)} during this call and
+     * not retain the array reference.
+     */
+    void accept(int termId, int docId, int[] positions, int positionCount) throws IOException;
+}

--- a/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/sidecar/SidecarBuilder.java
+++ b/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/sidecar/SidecarBuilder.java
@@ -1,0 +1,262 @@
+package org.opensearch.migrations.bulkload.lucene.sidecar;
+
+import java.io.BufferedOutputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.channels.FileChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.Arrays;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Alternative {@code SidecarBuilder} using doc-banked streaming with a long-packed
+ * per-doc sort — no external sort, no {@code postings.raw} scratch file.
+ *
+ * <p>Algorithm:
+ * <ol>
+ *   <li>{@link #registerTerm} streams term bytes straight to {@code terms.dat} and writes
+ *       the LE offset to {@code term-offsets.dat} — identical on-disk format to the baseline
+ *       so the shared {@link SidecarReader} can consume both.</li>
+ *   <li>{@link #accept} appends the {@code (position, termId)} pairs of each incoming tuple
+ *       into a per-doc {@code int[]} bank (amortized doubling growth). The walk is term-major
+ *       so the pairs arrive in term-order, not position-order.</li>
+ *   <li>{@link #buildAndOpenReader} iterates docs in ASC order; for each non-empty doc it
+ *       packs the pairs into a {@code long[]} where each element is
+ *       {@code (position << 32) | (termId & 0xFFFFFFFFL)}, runs {@link Arrays#sort(long[])}
+ *       (primitive dual-pivot quicksort, cache-friendly, no boxing), and emits the uvint-encoded
+ *       {@code (numPairs, [posDelta, termId]...)} payload straight into {@code sidecar.dat}.
+ *       The per-doc bank and packed long[] are released immediately after emit so peak off-heap
+ *       live set shrinks as docs are consumed.</li>
+ *   <li>{@code doc-index.dat} is a plain {@code long[maxDoc]} little-endian array of absolute
+ *       offsets, or {@link #DOC_INDEX_NO_TOKENS} for empty docs.</li>
+ * </ol>
+ *
+ * <p>Why it's faster than the three-pass baseline: only one disk write of the tuple data
+ * (directly into the final sidecar), no {@code postings.raw}, no k-way merge. The per-doc
+ * sort is over a primitive {@code long[]} whose natural order already matches
+ * {@code (position ASC, termId ASC)} — no custom comparator, no indirect sort, no chunking.
+ *
+ * <p>Tradeoff: the per-doc banks live on heap between the walk and the emit, so peak heap is
+ * {@code O(total_positions * 8 bytes)} plus array-growth overhead. That's the cost of skipping
+ * external sort; it's acceptable for segments within a normal JVM heap budget.
+ *
+ * <p>Public API matches {@code SidecarBuilder} so call-sites can swap implementations.
+ */
+@Slf4j
+public final class SidecarBuilder implements PostingsSink, AutoCloseable {
+    /**
+     * Retained for API compatibility with earlier {@code SidecarBuilder} revisions whose
+     * spill-size floor calculations referenced it. This implementation has no fixed-width
+     * tuple file, so the value only needs to remain a sane small positive power of two.
+     */
+    public static final int RECORD_BYTES = 12;
+
+    /** Sentinel written into doc-index.dat for docs that have no tokens in this field. */
+    static final long DOC_INDEX_NO_TOKENS = -1L;
+
+    /** File names — package-private so {@link SidecarReader} can find them. */
+    static final String TERMS_FILE        = "terms.dat";
+    static final String TERM_OFFSETS_FILE = "term-offsets.dat";
+    static final String SIDECAR_FILE      = "sidecar.dat";
+    static final String DOC_INDEX_FILE    = "doc-index.dat";
+
+
+    private final Path spillDir;
+    private final int maxDoc;
+
+    private final DataOutputStream termsOut;
+    private final DataOutputStream termOffsetsOut;
+
+    private final Path termsFile;
+    private final Path termOffsetsFile;
+
+    /** Per-doc packed (position, termId) int-pair bank, grown amortized; null == empty doc. */
+    private final int[][] docEntries;
+    /** Number of filled int slots in each doc's bank (always even — 2 ints per pair). */
+    private final int[] docEntryCounts;
+
+    private int nextTermId = 0;
+    private int currentTermOffset = 0;
+    private boolean built = false;
+    private boolean closed = false;
+
+    /**
+     * @param spillDir                per-(segment,field) directory owned by this builder.
+     * @param sortBufferBytes         accepted for API parity with prior builder; not used by this impl
+     *                                (this implementation doesn't external-sort).
+     * @param maxDoc                  the segment's {@code maxDoc}.
+     */
+    public SidecarBuilder(Path spillDir, int sortBufferBytes, int maxDoc) throws IOException {
+        this.spillDir = spillDir;
+        this.maxDoc = Math.max(1, maxDoc);
+        Files.createDirectories(spillDir);
+        this.termsFile = spillDir.resolve(TERMS_FILE);
+        this.termOffsetsFile = spillDir.resolve(TERM_OFFSETS_FILE);
+        this.termsOut = new DataOutputStream(new BufferedOutputStream(
+            Files.newOutputStream(termsFile, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING)));
+        this.termOffsetsOut = new DataOutputStream(new BufferedOutputStream(
+            Files.newOutputStream(termOffsetsFile, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING)));
+        this.docEntries = new int[this.maxDoc][];
+        this.docEntryCounts = new int[this.maxDoc];
+    }
+
+    @Override
+    public int registerTerm(BytesRefLike term) throws IOException {
+        int id = nextTermId++;
+        // Little-endian int offset, matching SidecarBuilder so the shared reader can decode.
+        termOffsetsOut.writeInt(Integer.reverseBytes(currentTermOffset));
+        termsOut.writeInt(term.length());
+        termsOut.write(term.bytes(), term.offset(), term.length());
+        currentTermOffset += 4 + term.length();
+        return id;
+    }
+
+    @Override
+    public void accept(int termId, int docId, int[] positions, int positionCount) throws IOException {
+        if (positionCount <= 0) return;
+        if (docId < 0 || docId >= maxDoc) return; // out-of-range docs are silently ignored
+
+        int[] bank = docEntries[docId];
+        int w = docEntryCounts[docId];
+        int needed = w + 2 * positionCount;
+        if (bank == null) {
+            int cap = 8;
+            while (cap < needed) cap <<= 1;
+            bank = new int[cap];
+            docEntries[docId] = bank;
+        } else if (bank.length < needed) {
+            int cap = bank.length;
+            while (cap < needed) cap <<= 1;
+            bank = Arrays.copyOf(bank, cap);
+            docEntries[docId] = bank;
+        }
+        for (int i = 0; i < positionCount; i++) {
+            bank[w++] = positions[i];
+            bank[w++] = termId;
+        }
+        docEntryCounts[docId] = w;
+    }
+
+    public SidecarReader buildAndOpenReader() throws IOException {
+        if (built) throw new IllegalStateException("SidecarBuilder.buildAndOpenReader already called");
+        built = true;
+
+        termsOut.flush();
+        termsOut.close();
+        termOffsetsOut.flush();
+        termOffsetsOut.close();
+
+        Path sidecarFile = spillDir.resolve(SIDECAR_FILE);
+        Path docIndexFile = spillDir.resolve(DOC_INDEX_FILE);
+
+        long[] docOffsets = new long[maxDoc];
+        Arrays.fill(docOffsets, DOC_INDEX_NO_TOKENS);
+
+        try (FileChannel sideCh = FileChannel.open(sidecarFile,
+                StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.WRITE)) {
+            long sidecarOffset = 0;
+            // Reusable encode buffer; grown on demand to fit the largest single-doc payload.
+            ByteBuffer perDoc = ByteBuffer.allocate(4096).order(ByteOrder.LITTLE_ENDIAN);
+            for (int docId = 0; docId < maxDoc; docId++) {
+                int w = docEntryCounts[docId];
+                if (w == 0) {
+                    docEntries[docId] = null;
+                    continue;
+                }
+                int[] bank = docEntries[docId];
+                int numPairs = w >>> 1;
+
+                long[] tmp = new long[numPairs];
+                for (int i = 0; i < numPairs; i++) {
+                    int pos = bank[2 * i];
+                    int termId = bank[2 * i + 1];
+                    tmp[i] = ((long) pos << 32) | (termId & 0xFFFFFFFFL);
+                }
+                // Free the per-doc bank; the long[] supersedes it for the remainder of this doc's work.
+                docEntries[docId] = null;
+
+                // Primitive dual-pivot quicksort by unsigned key; because pos is stored in the high
+                // 32 bits and positions produced by Lucene are non-negative ints (< 2^31), natural
+                // long ordering equals (position ASC, termId ASC) — matching the sidecar key.
+                Arrays.sort(tmp);
+
+                int maxBytes = 5 + numPairs * 10; // uvint header ≤5 + 2×uvint per pair ≤10
+                if (perDoc.capacity() < maxBytes) {
+                    int newCap = perDoc.capacity();
+                    while (newCap < maxBytes) newCap <<= 1;
+                    perDoc = ByteBuffer.allocate(newCap).order(ByteOrder.LITTLE_ENDIAN);
+                }
+                perDoc.clear();
+                VarintCoder.writeUVInt(perDoc, numPairs);
+                int prevPos = 0;
+                for (long pair : tmp) {
+                    int pos = (int) (pair >>> 32);
+                    int termId = (int) pair;
+                    VarintCoder.writeUVInt(perDoc, pos - prevPos);
+                    VarintCoder.writeUVInt(perDoc, termId);
+                    prevPos = pos;
+                }
+                perDoc.flip();
+                docOffsets[docId] = sidecarOffset;
+                int written = perDoc.remaining();
+                while (perDoc.hasRemaining()) sideCh.write(perDoc);
+                sidecarOffset += written;
+            }
+        }
+
+        writeDocIndex(docIndexFile, docOffsets, maxDoc);
+        closed = true;
+        return SidecarReader.open(spillDir, maxDoc, nextTermId);
+    }
+
+    private static void writeDocIndex(Path docIndexDst, long[] docOffsets, int maxDoc) throws IOException {
+        try (FileChannel ch = FileChannel.open(docIndexDst,
+                StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.WRITE)) {
+            ByteBuffer buf = ByteBuffer.allocate(8192).order(ByteOrder.LITTLE_ENDIAN);
+            for (int i = 0; i < maxDoc; i++) {
+                if (!buf.hasRemaining()) {
+                    buf.flip();
+                    while (buf.hasRemaining()) ch.write(buf);
+                    buf.clear();
+                }
+                buf.putLong(docOffsets[i]);
+            }
+            buf.flip();
+            while (buf.hasRemaining()) ch.write(buf);
+        }
+    }
+
+    @Override
+    public void close() {
+        if (closed) return;
+        // Abort path — only reached if buildAndOpenReader() wasn't called.
+        closeQuietly(termsOut);
+        closeQuietly(termOffsetsOut);
+        tryDelete(termsFile);
+        tryDelete(termOffsetsFile);
+        closed = true;
+    }
+
+    private static void closeQuietly(java.io.Closeable c) {
+        if (c == null) return;
+        try {
+            c.close();
+        } catch (IOException e) {
+            log.debug("Ignored close error during SidecarBuilder abort: {}", e.toString());
+        }
+    }
+
+    private static void tryDelete(Path p) {
+        if (p == null) return;
+        try {
+            Files.deleteIfExists(p);
+        } catch (IOException e) {
+            log.warn("Failed to delete spill file {}: {}", p, e.toString());
+        }
+    }
+}

--- a/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/sidecar/SidecarReader.java
+++ b/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/sidecar/SidecarReader.java
@@ -1,0 +1,198 @@
+package org.opensearch.migrations.bulkload.lucene.sidecar;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.channels.FileChannel;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Reads a sidecar built by {@link SidecarBuilder}. Answers {@code get(docId) -> List<String>}
+ * using mmap'd lookups with zero heap allocation beyond the returned {@code ArrayList}.
+ *
+ * <p>File layout (all files live in a per-(segment, field) spill directory):
+ * <pre>
+ *   terms.dat          - sequence of int32 length | bytes[length] records, one per termId
+ *   term-offsets.dat   - little-endian int[numTerms] of byte offsets into terms.dat
+ *   sidecar.dat        - for each doc that has tokens, a uvint(numEntries) header followed by
+ *                        numEntries pairs of (uvint positionDelta, uvint termId)
+ *   doc-index.dat      - little-endian long[maxDoc] of absolute offsets into sidecar.dat,
+ *                        or SidecarBuilder.DOC_INDEX_NO_TOKENS for docs with no tokens
+ * </pre>
+ *
+ * <p>Heap footprint per open reader:
+ *   <ul>
+ *     <li>A mmap'd view over each of the four files. The OS pages in what the access
+ *         pattern touches; heap is a handful of direct-buffer wrappers.
+ *     <li>No long[] docOffsets in heap - doc offsets live in doc-index.dat. For a 600 GB
+ *         shard with 20M docs that's 160 MB of OS page cache, not 160 MB heap.
+ *     <li>No int[] termOffsets in heap - term offsets live in term-offsets.dat.
+ *     <li>Term bytes read on demand; one small reusable byte[] per {@link #get} call is
+ *         the only transient heap.
+ *   </ul>
+ *
+ * <p>Thread-safety: {@link #get(int)} duplicates the mmap'd ByteBuffer on each call so
+ * concurrent readers each get their own cursor. Opening and closing are not concurrent-safe.
+ */
+@Slf4j
+public final class SidecarReader implements AutoCloseable {
+
+    private final Path spillDir;
+    private final int maxDoc;
+    private final int numTerms;
+
+    private final FileChannel termsChannel;
+    private final FileChannel termOffsetsChannel;
+    private final FileChannel sidecarChannel;
+    private final FileChannel docIndexChannel;
+
+    private final ByteBuffer termsBuf;
+    private final ByteBuffer termOffsetsBuf;  // little-endian int[numTerms]
+    private final ByteBuffer sidecarBuf;
+    private final ByteBuffer docIndexBuf;     // little-endian long[maxDoc]
+
+    private volatile boolean closed;
+
+    private SidecarReader(Path spillDir,
+                          int maxDoc,
+                          int numTerms,
+                          FileChannel termsChannel,
+                          FileChannel termOffsetsChannel,
+                          FileChannel sidecarChannel,
+                          FileChannel docIndexChannel,
+                          ByteBuffer termsBuf,
+                          ByteBuffer termOffsetsBuf,
+                          ByteBuffer sidecarBuf,
+                          ByteBuffer docIndexBuf) {
+        this.spillDir = spillDir;
+        this.maxDoc = maxDoc;
+        this.numTerms = numTerms;
+        this.termsChannel = termsChannel;
+        this.termOffsetsChannel = termOffsetsChannel;
+        this.sidecarChannel = sidecarChannel;
+        this.docIndexChannel = docIndexChannel;
+        this.termsBuf = termsBuf;
+        this.termOffsetsBuf = termOffsetsBuf;
+        this.sidecarBuf = sidecarBuf;
+        this.docIndexBuf = docIndexBuf;
+    }
+
+    /**
+     * Opens a sidecar previously produced by {@link SidecarBuilder#buildAndOpenReader()}
+     * in {@code spillDir}. mmaps all four files and caches their little-endian views.
+     */
+    static SidecarReader open(Path spillDir, int maxDoc, int numTerms) throws IOException {
+        Path termsFile        = spillDir.resolve(SidecarBuilder.TERMS_FILE);
+        Path termOffsetsFile  = spillDir.resolve(SidecarBuilder.TERM_OFFSETS_FILE);
+        Path sidecarFile      = spillDir.resolve(SidecarBuilder.SIDECAR_FILE);
+        Path docIndexFile     = spillDir.resolve(SidecarBuilder.DOC_INDEX_FILE);
+
+        FileChannel termsCh = FileChannel.open(termsFile, StandardOpenOption.READ);
+        FileChannel termOffsetsCh = FileChannel.open(termOffsetsFile, StandardOpenOption.READ);
+        FileChannel sidecarCh = FileChannel.open(sidecarFile, StandardOpenOption.READ);
+        FileChannel docIndexCh = FileChannel.open(docIndexFile, StandardOpenOption.READ);
+
+        ByteBuffer termsBuf = termsCh.size() == 0
+                ? ByteBuffer.allocate(0)
+                : termsCh.map(FileChannel.MapMode.READ_ONLY, 0, termsCh.size());
+        // terms.dat is length-prefixed with big-endian int32 (DataOutputStream.writeInt).
+        termsBuf.order(ByteOrder.BIG_ENDIAN);
+
+        ByteBuffer termOffsetsBuf = termOffsetsCh.size() == 0
+                ? ByteBuffer.allocate(0)
+                : termOffsetsCh.map(FileChannel.MapMode.READ_ONLY, 0, termOffsetsCh.size());
+        termOffsetsBuf.order(ByteOrder.LITTLE_ENDIAN);
+
+        ByteBuffer sidecarBuf = sidecarCh.size() == 0
+                ? ByteBuffer.allocate(0)
+                : sidecarCh.map(FileChannel.MapMode.READ_ONLY, 0, sidecarCh.size());
+        sidecarBuf.order(ByteOrder.LITTLE_ENDIAN);
+
+        ByteBuffer docIndexBuf = docIndexCh.size() == 0
+                ? ByteBuffer.allocate(0)
+                : docIndexCh.map(FileChannel.MapMode.READ_ONLY, 0, docIndexCh.size());
+        docIndexBuf.order(ByteOrder.LITTLE_ENDIAN);
+
+        return new SidecarReader(spillDir, maxDoc, numTerms,
+                termsCh, termOffsetsCh, sidecarCh, docIndexCh,
+                termsBuf, termOffsetsBuf, sidecarBuf, docIndexBuf);
+    }
+
+    /**
+     * Returns the position-ordered list of terms for {@code docId}, or an empty list
+     * if the doc has no tokens in this field (or {@code docId} is out of range).
+     */
+    public List<String> get(int docId) throws IOException {
+        if (closed) throw new IOException("SidecarReader has been closed");
+        if (docId < 0 || docId >= maxDoc) return Collections.emptyList();
+        long offset = readDocOffset(docId);
+        if (offset == SidecarBuilder.DOC_INDEX_NO_TOKENS) return Collections.emptyList();
+        if (offset < 0 || offset > Integer.MAX_VALUE) {
+            throw new IOException("Sidecar offset out of range: " + offset);
+        }
+        // Duplicate to get a private cursor so concurrent readers don't clobber each other.
+        ByteBuffer cur = sidecarBuf.duplicate();
+        cur.order(ByteOrder.LITTLE_ENDIAN);
+        cur.position((int) offset);
+        int numEntries = VarintCoder.readUVInt(cur);
+        List<String> result = new ArrayList<>(numEntries);
+        for (int i = 0; i < numEntries; i++) {
+            // Positions are delta-encoded in the on-disk format, but this reader returns
+            // only the term strings for each token — callers use the list's iteration
+            // order to reconstruct positional order. Skip the position delta.
+            VarintCoder.readUVInt(cur);
+            int termId = VarintCoder.readUVInt(cur);
+            result.add(readTerm(termId));
+        }
+        return result;
+    }
+
+    private long readDocOffset(int docId) {
+        // doc-index.dat is long[maxDoc] little-endian.
+        return docIndexBuf.getLong(docId * 8);
+    }
+
+    private String readTerm(int termId) throws IOException {
+        if (termId < 0 || termId >= numTerms) {
+            throw new IOException("termId out of range: " + termId + " (numTerms=" + numTerms + ")");
+        }
+        int termOffset = termOffsetsBuf.getInt(termId * 4);
+        ByteBuffer cur = termsBuf.duplicate();
+        cur.order(ByteOrder.BIG_ENDIAN);
+        cur.position(termOffset);
+        int len = cur.getInt();
+        byte[] bytes = new byte[len];
+        cur.get(bytes);
+        return new String(bytes, StandardCharsets.UTF_8);
+    }
+
+    @Override
+    public void close() {
+        if (closed) return;
+        closed = true;
+        closeQuietly(termsChannel);
+        closeQuietly(termOffsetsChannel);
+        closeQuietly(sidecarChannel);
+        closeQuietly(docIndexChannel);
+    }
+
+    private static void closeQuietly(java.io.Closeable c) {
+        if (c == null) return;
+        try {
+            c.close();
+        } catch (IOException e) {
+            // Best-effort close on a mmap channel — the backing file is owned by this
+            // reader and is about to be unmapped regardless.
+            log.debug("Ignored close error in SidecarReader: {}", e.toString());
+        }
+    }
+
+    Path spillDir() { return spillDir; }
+}

--- a/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/sidecar/VarintCoder.java
+++ b/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/sidecar/VarintCoder.java
@@ -1,0 +1,100 @@
+package org.opensearch.migrations.bulkload.lucene.sidecar;
+
+import java.nio.ByteBuffer;
+
+/**
+ * Little-endian varint (VByte) and zig-zag signed varint encode/decode over
+ * {@link ByteBuffer}s with no Lucene or third-party dependency. Used by the sidecar
+ * builder and reader to serialize term-string lengths, delta-doc deltas, delta-position
+ * deltas, and anything else where the distribution is heavily biased toward small values.
+ *
+ * <p>Format for {@code writeUVInt}:
+ *
+ * <ul>
+ *   <li>7 data bits per byte, low bit first, MSB set on every byte except the last.
+ *   <li>Values in {@code [0, 128)} use 1 byte; {@code [128, 16384)} use 2 bytes; etc.
+ * </ul>
+ *
+ * <p>Format for {@code writeZVInt}: zig-zag fold to unsigned ({@code (v << 1) ^ (v >> 31)})
+ * then encode via {@code writeUVInt}. This puts small |v| into 1 byte regardless of sign.
+ */
+public final class VarintCoder {
+
+    private VarintCoder() {}
+
+    /**
+     * Writes a non-negative int as an unsigned varint. Throws {@link IllegalArgumentException}
+     * if the caller passes a negative value — the caller should use {@link #writeZVInt} for
+     * values that can be negative.
+     */
+    public static void writeUVInt(ByteBuffer buf, int value) {
+        if (value < 0) {
+            throw new IllegalArgumentException("writeUVInt requires non-negative value, got " + value);
+        }
+        writeUVIntUnchecked(buf, value);
+    }
+
+    /**
+     * Internal writer that treats {@code value} as a 32-bit unsigned quantity — used by
+     * {@link #writeZVInt} where the zig-zag fold can produce a bit pattern with the sign bit
+     * set (e.g. {@code Integer.MIN_VALUE}). Uses unsigned shift so the loop terminates
+     * regardless of sign.
+     */
+    private static void writeUVIntUnchecked(ByteBuffer buf, int value) {
+        while ((value & 0xFFFF_FF80) != 0) {
+            buf.put((byte) ((value & 0x7F) | 0x80));
+            value >>>= 7;
+        }
+        buf.put((byte) value);
+    }
+
+    /** Reads an unsigned varint from {@code buf} at its current position, advancing it. */
+    public static int readUVInt(ByteBuffer buf) {
+        int value = 0;
+        int shift = 0;
+        while (true) {
+            byte b = buf.get();
+            value |= (b & 0x7F) << shift;
+            if ((b & 0x80) == 0) return value;
+            shift += 7;
+            if (shift > 28) {
+                // 5-byte varint cap: 5 * 7 = 35 bits, but a valid int needs at most 32 => shift <= 28.
+                throw new IllegalStateException("Malformed varint: sequence exceeds 5 bytes");
+            }
+        }
+    }
+
+    /** Writes a signed int using zig-zag + varint encoding. */
+    public static void writeZVInt(ByteBuffer buf, int value) {
+        writeUVIntUnchecked(buf, (value << 1) ^ (value >> 31));
+    }
+
+    /** Reads a zig-zag signed varint from {@code buf}. */
+    public static int readZVInt(ByteBuffer buf) {
+        int raw = readUVInt(buf);
+        return (raw >>> 1) ^ -(raw & 1);
+    }
+
+    /** Returns the number of bytes {@link #writeUVInt} would use to encode {@code value}. */
+    public static int uvintByteCount(int value) {
+        if (value < 0) {
+            throw new IllegalArgumentException("uvintByteCount requires non-negative value, got " + value);
+        }
+        return uvintByteCountUnchecked(value);
+    }
+
+    /** Unsigned-aware byte count, used internally by {@link #zvintByteCount}. */
+    private static int uvintByteCountUnchecked(int value) {
+        int count = 1;
+        while ((value & 0xFFFF_FF80) != 0) {
+            count++;
+            value >>>= 7;
+        }
+        return count;
+    }
+
+    /** Returns the number of bytes {@link #writeZVInt} would use to encode {@code value}. */
+    public static int zvintByteCount(int value) {
+        return uvintByteCountUnchecked((value << 1) ^ (value >> 31));
+    }
+}

--- a/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/version_5/LeafReader5.java
+++ b/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/version_5/LeafReader5.java
@@ -7,7 +7,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.TreeMap;
 
 import org.opensearch.migrations.bulkload.lucene.BitSetConverter;
 import org.opensearch.migrations.bulkload.lucene.DocValueFieldInfo;
@@ -265,39 +264,39 @@ public class LeafReader5 implements LuceneLeafReader {
     }
 
     /**
-     * Single-pass walk of the terms dictionary for {@code fieldName}. Produces a
-     * docId -> position-ordered term list map used by {@link SegmentTermIndex}
-     * to reconstruct analyzed-text fields when neither stored fields nor
-     * doc_values are available.
-     *
-     * No caching here: the surrounding {@link SegmentTermIndex} owns the
-     * returned map, and that index lives only as long as the per-segment Flux
-     * created in {@link org.opensearch.migrations.bulkload.lucene.LuceneReader#readDocsFromSegment}.
+     * See {@link LuceneLeafReader#streamFieldPostings}. Single-pass walk of the terms
+     * dictionary for {@code fieldName}, streaming {@code (termId, docId, positions[])}
+     * callbacks to the sink. Used by {@link SegmentTermIndex} to reconstruct
+     * analyzed-text fields when neither stored fields nor doc_values are available.
      */
     @Override
-    public Map<Integer, List<String>> buildTermPositionIndex(String fieldName) throws IOException {
+    public void streamFieldPostings(String fieldName,
+            org.opensearch.migrations.bulkload.lucene.sidecar.PostingsSink sink) throws IOException {
         Terms terms = wrapped.terms(fieldName);
-        if (terms == null) return Collections.emptyMap();
-        // docId -> (position -> term)
-        Map<Integer, TreeMap<Integer, String>> docPositions = new HashMap<>();
+        if (terms == null) return;
         TermsEnum termsEnum = terms.iterator();
         BytesRef term;
+        int[] positions = new int[16];
         while ((term = termsEnum.next()) != null) {
-            String termStr = term.utf8ToString();
+            int termId = sink.registerTerm(
+                new org.opensearch.migrations.bulkload.lucene.sidecar.BytesRefLike(
+                    term.bytes, term.offset, term.length));
             PostingsEnum postings = termsEnum.postings(null, PostingsEnum.POSITIONS);
             int doc;
             while ((doc = postings.nextDoc()) != PostingsEnum.NO_MORE_DOCS) {
-                TreeMap<Integer, String> positions = docPositions.computeIfAbsent(doc, k -> new TreeMap<>());
                 int freq = postings.freq();
+                if (freq > positions.length) {
+                    positions = new int[Math.max(freq, positions.length * 2)];
+                }
+                int n = 0;
                 for (int i = 0; i < freq; i++) {
                     int pos = postings.nextPosition();
-                    positions.put(pos, termStr);
+                    if (pos < 0) continue;
+                    positions[n++] = pos;
                 }
+                if (n > 0) sink.accept(termId, doc, positions, n);
             }
         }
-        Map<Integer, List<String>> result = new HashMap<>(docPositions.size());
-        docPositions.forEach((docId, positions) -> result.put(docId, new ArrayList<>(positions.values())));
-        return result;
     }
 
     /**

--- a/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/version_7/LeafReader7.java
+++ b/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/version_7/LeafReader7.java
@@ -4,10 +4,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.TreeMap;
 
 import org.opensearch.migrations.bulkload.lucene.BitSetConverter;
 import org.opensearch.migrations.bulkload.lucene.DocValueFieldInfo;
@@ -272,29 +269,34 @@ public class LeafReader7 implements LuceneLeafReader {
         return null;
     }
 
-    /** See {@link LuceneLeafReader#buildTermPositionIndex}. */
+    /** See {@link LuceneLeafReader#streamFieldPostings}. */
     @Override
-    public Map<Integer, List<String>> buildTermPositionIndex(String fieldName) throws IOException {
+    public void streamFieldPostings(String fieldName,
+            org.opensearch.migrations.bulkload.lucene.sidecar.PostingsSink sink) throws IOException {
         Terms terms = wrapped.terms(fieldName);
-        if (terms == null) return Collections.emptyMap();
-        Map<Integer, TreeMap<Integer, String>> docPositions = new HashMap<>();
+        if (terms == null) return;
         TermsEnum termsEnum = terms.iterator();
         BytesRef term;
+        int[] positions = new int[16];
         while ((term = termsEnum.next()) != null) {
-            String termStr = term.utf8ToString();
+            int termId = sink.registerTerm(
+                new org.opensearch.migrations.bulkload.lucene.sidecar.BytesRefLike(
+                    term.bytes, term.offset, term.length));
             PostingsEnum postings = termsEnum.postings(null, PostingsEnum.POSITIONS);
             int doc;
             while ((doc = postings.nextDoc()) != PostingsEnum.NO_MORE_DOCS) {
-                TreeMap<Integer, String> positions = docPositions.computeIfAbsent(doc, k -> new TreeMap<>());
                 int freq = postings.freq();
+                if (freq > positions.length) {
+                    positions = new int[Math.max(freq, positions.length * 2)];
+                }
+                int n = 0;
                 for (int i = 0; i < freq; i++) {
                     int pos = postings.nextPosition();
-                    positions.put(pos, termStr);
+                    if (pos < 0) continue;
+                    positions[n++] = pos;
                 }
+                if (n > 0) sink.accept(termId, doc, positions, n);
             }
         }
-        Map<Integer, List<String>> result = new HashMap<>(docPositions.size());
-        docPositions.forEach((docId, positions) -> result.put(docId, new ArrayList<>(positions.values())));
-        return result;
     }
 }

--- a/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/version_9/LeafReader9.java
+++ b/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/version_9/LeafReader9.java
@@ -4,10 +4,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.TreeMap;
 
 import org.opensearch.migrations.bulkload.lucene.BitSetConverter;
 import org.opensearch.migrations.bulkload.lucene.DocValueFieldInfo;
@@ -261,29 +258,38 @@ public class LeafReader9 implements LuceneLeafReader {
         return null;
     }
 
-    /** See {@link LuceneLeafReader#buildTermPositionIndex}. */
+    /** See {@link LuceneLeafReader#streamFieldPostings}. */
     @Override
-    public Map<Integer, List<String>> buildTermPositionIndex(String fieldName) throws IOException {
+    public void streamFieldPostings(String fieldName,
+            org.opensearch.migrations.bulkload.lucene.sidecar.PostingsSink sink) throws IOException {
         Terms terms = wrapped.terms(fieldName);
-        if (terms == null) return Collections.emptyMap();
-        Map<Integer, TreeMap<Integer, String>> docPositions = new HashMap<>();
+        if (terms == null) return;
         TermsEnum termsEnum = terms.iterator();
         BytesRef term;
+        int[] positions = new int[16];
         while ((term = termsEnum.next()) != null) {
-            String termStr = term.utf8ToString();
+            int termId = sink.registerTerm(
+                new org.opensearch.migrations.bulkload.lucene.sidecar.BytesRefLike(
+                    term.bytes, term.offset, term.length));
             PostingsEnum postings = termsEnum.postings(null, PostingsEnum.POSITIONS);
             int doc;
             while ((doc = postings.nextDoc()) != PostingsEnum.NO_MORE_DOCS) {
-                TreeMap<Integer, String> positions = docPositions.computeIfAbsent(doc, k -> new TreeMap<>());
                 int freq = postings.freq();
+                if (freq > positions.length) {
+                    positions = new int[Math.max(freq, positions.length * 2)];
+                }
+                int n = 0;
                 for (int i = 0; i < freq; i++) {
                     int pos = postings.nextPosition();
-                    positions.put(pos, termStr);
+                    // Lucene returns negative positions (e.g. -1) when the field was
+                    // indexed without positions. Such tuples are not position-meaningful;
+                    // skip them so the sidecar stays well-defined and downstream
+                    // falls back to the single-term / keyword path.
+                    if (pos < 0) continue;
+                    positions[n++] = pos;
                 }
+                if (n > 0) sink.accept(termId, doc, positions, n);
             }
         }
-        Map<Integer, List<String>> result = new HashMap<>(docPositions.size());
-        docPositions.forEach((docId, positions) -> result.put(docId, new ArrayList<>(positions.values())));
-        return result;
     }
 }

--- a/SearchSnapshotExtractor/src/test/java/org/opensearch/migrations/bulkload/lucene/sidecar/PostingsSinkContractTest.java
+++ b/SearchSnapshotExtractor/src/test/java/org/opensearch/migrations/bulkload/lucene/sidecar/PostingsSinkContractTest.java
@@ -1,0 +1,101 @@
+package org.opensearch.migrations.bulkload.lucene.sidecar;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests pinning the two tiny value types on the main-sourceset boundary
+ * between a version-specific Lucene reader and the version-agnostic sidecar:
+ * {@link BytesRefLike} (holds a subrange of a reusable byte buffer) and
+ * {@link PostingsSink} (receives {@code (termId, docId, positions[])} emissions).
+ */
+class PostingsSinkContractTest {
+
+    @Test
+    void bytesRefLike_copiesBytesDefensivelyOnToByteArray() {
+        byte[] src = "hello world".getBytes(StandardCharsets.UTF_8);
+        BytesRefLike ref = new BytesRefLike(src, 6, 5); // "world"
+        byte[] out = ref.toByteArray();
+        assertArrayEquals("world".getBytes(StandardCharsets.UTF_8), out);
+        // Mutating source must not change the returned copy — sinks that retain term bytes
+        // via toByteArray() must be safe against the reader reusing its buffer.
+        src[6] = 'X';
+        assertEquals('w', out[0]);
+    }
+
+    @Test
+    void bytesRefLike_equalsAndHashCodeOverValueNotIdentity() {
+        byte[] a = "foo".getBytes(StandardCharsets.UTF_8);
+        byte[] b = new byte[]{'x', 'f', 'o', 'o', 'x'};
+        BytesRefLike r1 = new BytesRefLike(a, 0, 3);
+        BytesRefLike r2 = new BytesRefLike(b, 1, 3);
+        BytesRefLike r3 = new BytesRefLike(a, 0, 2); // "fo"
+        assertEquals(r1, r2);
+        assertEquals(r1.hashCode(), r2.hashCode());
+        assertNotEquals(r1, r3);
+        // bytes() returns the original buffer reference — no defensive copy on access, only on toByteArray()
+        assertSame(a, r1.bytes());
+    }
+
+    private static void assertSame(Object expected, Object actual) {
+        assertTrue(expected == actual, "Expected same identity, got different instances");
+    }
+
+    @Test
+    void bytesRefLike_rejectsNegativeOffsetOrLength() {
+        byte[] src = "abc".getBytes(StandardCharsets.UTF_8);
+        assertThrows(IllegalArgumentException.class, () -> new BytesRefLike(src, -1, 1));
+        assertThrows(IllegalArgumentException.class, () -> new BytesRefLike(src, 0, -1));
+        assertThrows(IllegalArgumentException.class, () -> new BytesRefLike(src, 1, 3)); // 1+3 > 3
+        assertThrows(NullPointerException.class, () -> new BytesRefLike(null, 0, 0));
+    }
+
+    @Test
+    void postingsSink_recordsAllEmissionsInOrder() throws Exception {
+        RecordingSink sink = new RecordingSink();
+        byte[] t1 = "aa".getBytes(StandardCharsets.UTF_8);
+        byte[] t2 = "bb".getBytes(StandardCharsets.UTF_8);
+        int aaId = sink.registerTerm(new BytesRefLike(t1, 0, 2));
+        int bbId = sink.registerTerm(new BytesRefLike(t2, 0, 2));
+        sink.accept(aaId, 3, new int[]{0, 2}, 2);
+        sink.accept(bbId, 3, new int[]{1}, 1);
+        sink.accept(aaId, 7, new int[]{4}, 1);
+
+        assertEquals(0, aaId);
+        assertEquals(1, bbId);
+        assertEquals(List.of("aa:3@[0,2]", "bb:3@[1]", "aa:7@[4]"), sink.log);
+    }
+
+    /** Minimal sink that records every call for assertion. */
+    private static final class RecordingSink implements PostingsSink {
+        private final List<String> registered = new ArrayList<>();
+        private final List<String> log = new ArrayList<>();
+
+        @Override
+        public int registerTerm(BytesRefLike term) {
+            registered.add(new String(term.toByteArray(), StandardCharsets.UTF_8));
+            return registered.size() - 1;
+        }
+
+        @Override
+        public void accept(int termId, int docId, int[] positions, int positionCount) {
+            StringBuilder sb = new StringBuilder();
+            sb.append(registered.get(termId)).append(':').append(docId).append("@[");
+            for (int i = 0; i < positionCount; i++) {
+                if (i > 0) sb.append(',');
+                sb.append(positions[i]);
+            }
+            sb.append(']');
+            log.add(sb.toString());
+        }
+    }
+}

--- a/SearchSnapshotExtractor/src/test/java/org/opensearch/migrations/bulkload/lucene/sidecar/SidecarBuilderRoundTripTest.java
+++ b/SearchSnapshotExtractor/src/test/java/org/opensearch/migrations/bulkload/lucene/sidecar/SidecarBuilderRoundTripTest.java
@@ -1,0 +1,261 @@
+package org.opensearch.migrations.bulkload.lucene.sidecar;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.TreeMap;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Correctness tests for {@link SidecarBuilder} + {@link SidecarReader} round-trip.
+ *
+ * <p>The builder consumes term-major emissions ({@code (termId, docId, positions[])}
+ * in term-ascending and docId-ascending order) and produces a disk-backed sidecar
+ * file that the reader opens via mmap. These tests fuzz the builder with randomized
+ * inputs and assert that, for every docId, {@code SidecarReader.get(docId)} returns
+ * exactly the position-ordered term list that the reference in-memory
+ * implementation (a {@code TreeMap<Integer, String>} per doc) would produce.
+ *
+ * <p>Build parameters are deliberately pushed to their limits:
+ *   <ul>
+ *     <li>Tiny sort buffers force multi-run external sort with k-way merge.
+ *     <li>Random inputs include ties on (docId, position) to pin the
+ *         tie-break rule (termId ASC).
+ *     <li>Sparse segments (most docs empty for the field) verify the doc-index
+ *         correctly encodes the "no tokens" sentinel.
+ *   </ul>
+ */
+class SidecarBuilderRoundTripTest {
+
+    private Path spillDir;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        spillDir = Files.createTempDirectory("sidecar-test-");
+    }
+
+    @AfterEach
+    void tearDown() throws IOException {
+        if (spillDir != null) deleteRecursive(spillDir);
+    }
+
+    private static void deleteRecursive(Path root) throws IOException {
+        if (!Files.exists(root)) return;
+        try (Stream<Path> walk = Files.walk(root)) {
+            walk.sorted(Comparator.reverseOrder()).forEach(p -> {
+                try { Files.deleteIfExists(p); } catch (IOException ignored) {}
+            });
+        }
+    }
+
+    @Test
+    void smallFixedInput_roundTrip() throws IOException {
+        // Build input sorted as the sink contract requires:
+        //   term-bytes ascending, within term docId ascending, positions ascending.
+        List<Emission> stream = List.of(
+            e("apple",  0, 0),
+            e("apple",  0, 5),
+            e("apple",  2, 1),
+            e("banana", 0, 3),
+            e("banana", 1, 0),
+            e("cherry", 2, 4)
+        );
+        SidecarReader reader = buildAndOpen(stream, /*maxDoc=*/3, /*sortBufferBytes=*/1024);
+        try {
+            assertEquals(List.of("apple", "banana", "apple"), reader.get(0));
+            assertEquals(List.of("banana"),                   reader.get(1));
+            assertEquals(List.of("apple", "cherry"),          reader.get(2));
+            assertEquals(Collections.emptyList(),             reader.get(3)); // out of range
+        } finally {
+            reader.close();
+        }
+    }
+
+    @Test
+    void fuzz_matchesInHeapReference_smallSortBuffer() throws IOException {
+        Random rng = new Random(0xBADF00DL);
+        List<Emission> stream = randomStream(rng, /*numTerms=*/500, /*numDocs=*/200, /*avgPositionsPerDocTerm=*/3);
+        Map<Integer, List<String>> reference = inHeapReference(stream);
+
+        // Tiny sort buffer (24 bytes = 1 record) forces a multi-run merge to exercise k-way merge.
+        SidecarReader reader = buildAndOpen(stream, 200, 24);
+        try {
+            for (int doc = 0; doc < 200; doc++) {
+                List<String> got = reader.get(doc);
+                List<String> want = reference.getOrDefault(doc, Collections.emptyList());
+                assertEquals(want, got, "Mismatch for docId=" + doc);
+            }
+        } finally {
+            reader.close();
+        }
+    }
+
+    @Test
+    void tiesAtSamePosition_breakByTermIdAscending() throws IOException {
+        // Term "aa" is termId 0 (registered first), term "bb" is termId 1. Both at doc 0 position 5.
+        // Sink contract: termId ASC is the secondary key when positions tie.
+        List<Emission> stream = List.of(
+            e("aa", 0, 5),
+            e("bb", 0, 5)
+        );
+        SidecarReader reader = buildAndOpen(stream, 1, 1024);
+        try {
+            assertEquals(List.of("aa", "bb"), reader.get(0));
+        } finally {
+            reader.close();
+        }
+    }
+
+    @Test
+    void sparseDocs_returnEmptyForUnemittedDocs() throws IOException {
+        // Only docs 3 and 7 have tokens in a maxDoc=10 segment.
+        List<Emission> stream = List.of(
+            e("x", 3, 0),
+            e("x", 7, 0)
+        );
+        SidecarReader reader = buildAndOpen(stream, 10, 1024);
+        try {
+            for (int d = 0; d < 10; d++) {
+                if (d == 3 || d == 7) assertEquals(List.of("x"), reader.get(d));
+                else assertEquals(Collections.emptyList(), reader.get(d));
+            }
+        } finally {
+            reader.close();
+        }
+    }
+
+    @Test
+    void emptyStream_producesValidEmptyReader() throws IOException {
+        SidecarReader reader = buildAndOpen(Collections.emptyList(), 5, 1024);
+        try {
+            for (int d = 0; d < 5; d++) {
+                assertEquals(Collections.emptyList(), reader.get(d));
+            }
+        } finally {
+            reader.close();
+        }
+    }
+
+    @Test
+    void buildClosesFilesOnReadyForReaderOpen() throws IOException {
+        List<Emission> stream = List.of(e("alpha", 0, 0));
+        SidecarReader reader = buildAndOpen(stream, 1, 1024);
+        try {
+            assertEquals(List.of("alpha"), reader.get(0));
+        } finally {
+            reader.close();
+        }
+        // Reader close must delete nothing; the builder produces files that the caller owns.
+        assertTrue(Files.exists(spillDir), "Spill dir should survive reader close");
+    }
+
+    // ---- helpers --------------------------------------------------------
+
+    private SidecarReader buildAndOpen(List<Emission> stream, int maxDoc, int sortBufferBytes) throws IOException {
+        SidecarBuilder builder = new SidecarBuilder(spillDir, sortBufferBytes, maxDoc);
+        // Register terms in ascending-bytes order so termIds match what a real reader would assign.
+        Map<String, Integer> termIds = new HashMap<>();
+        List<String> sortedDistinctTerms = new ArrayList<>(new java.util.TreeSet<>(
+            stream.stream().map(e -> e.term).toList()
+        ));
+        for (String t : sortedDistinctTerms) {
+            byte[] bytes = t.getBytes(StandardCharsets.UTF_8);
+            int id = builder.registerTerm(new BytesRefLike(bytes, 0, bytes.length));
+            termIds.put(t, id);
+        }
+        // Group emissions into (termId, docId) runs with positions[] payloads.
+        List<Emission> mutable = new ArrayList<>(stream);
+        mutable.sort(Comparator.<Emission>comparingInt(e -> termIds.get(e.term))
+                              .thenComparingInt(e -> e.docId)
+                              .thenComparingInt(e -> e.position));
+        int i = 0;
+        while (i < mutable.size()) {
+            Emission head = mutable.get(i);
+            int termId = termIds.get(head.term);
+            int docId = head.docId;
+            int[] positions = new int[16];
+            int n = 0;
+            while (i < mutable.size()
+                   && termIds.get(mutable.get(i).term) == termId
+                   && mutable.get(i).docId == docId) {
+                if (n == positions.length) positions = Arrays.copyOf(positions, positions.length * 2);
+                positions[n++] = mutable.get(i).position;
+                i++;
+            }
+            builder.accept(termId, docId, positions, n);
+        }
+        return builder.buildAndOpenReader();
+    }
+
+    private static Map<Integer, List<String>> inHeapReference(List<Emission> stream) {
+        // Reference: TreeMap<Integer,String> per doc, sorted by position, ties broken by term bytes.
+        Map<Integer, TreeMap<Long, String>> byDoc = new HashMap<>();
+        // Assign termIds in the same order SidecarBuilder will (sorted bytes ascending).
+        List<String> sortedDistinctTerms = new ArrayList<>(new java.util.TreeSet<>(
+            stream.stream().map(e -> e.term).toList()
+        ));
+        Map<String, Integer> termIds = new HashMap<>();
+        for (int i = 0; i < sortedDistinctTerms.size(); i++) termIds.put(sortedDistinctTerms.get(i), i);
+        for (Emission em : stream) {
+            // Secondary key: termId. Compose (position, termId) so duplicate positions with
+            // different termIds preserve both with termId-ASC tiebreak.
+            long key = ((long) em.position << 32) | (termIds.get(em.term) & 0xFFFFFFFFL);
+            byDoc.computeIfAbsent(em.docId, k -> new TreeMap<>()).put(key, em.term);
+        }
+        Map<Integer, List<String>> out = new HashMap<>();
+        byDoc.forEach((d, map) -> out.put(d, new ArrayList<>(map.values())));
+        return out;
+    }
+
+    private static List<Emission> randomStream(Random rng, int numTerms, int numDocs, int avgPositionsPerDocTerm) {
+        List<String> terms = new ArrayList<>(numTerms);
+        for (int i = 0; i < numTerms; i++) terms.add("t" + String.format("%05d", i));
+        List<Emission> out = new ArrayList<>();
+        for (String term : terms) {
+            // Pick a random subset of docs this term appears in.
+            int docsWithTerm = 1 + rng.nextInt(Math.max(1, numDocs / 4));
+            boolean[] chosen = new boolean[numDocs];
+            for (int k = 0; k < docsWithTerm; k++) chosen[rng.nextInt(numDocs)] = true;
+            for (int doc = 0; doc < numDocs; doc++) {
+                if (!chosen[doc]) continue;
+                int numPos = 1 + rng.nextInt(avgPositionsPerDocTerm * 2);
+                // Pick unique positions ASC.
+                java.util.TreeSet<Integer> pos = new java.util.TreeSet<>();
+                while (pos.size() < numPos) pos.add(rng.nextInt(1000));
+                for (int p : pos) out.add(e(term, doc, p));
+            }
+        }
+        return out;
+    }
+
+    private static Emission e(String term, int docId, int pos) {
+        return new Emission(term, docId, pos);
+    }
+
+    private static final class Emission {
+        final String term;
+        final int docId;
+        final int position;
+        Emission(String term, int docId, int position) {
+            this.term = term;
+            this.docId = docId;
+            this.position = position;
+        }
+    }
+}

--- a/SearchSnapshotExtractor/src/test/java/org/opensearch/migrations/bulkload/lucene/sidecar/VarintCoderTest.java
+++ b/SearchSnapshotExtractor/src/test/java/org/opensearch/migrations/bulkload/lucene/sidecar/VarintCoderTest.java
@@ -1,0 +1,89 @@
+package org.opensearch.migrations.bulkload.lucene.sidecar;
+
+import java.nio.ByteBuffer;
+import java.util.Random;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Round-trip and boundary-value tests for {@link VarintCoder}.
+ *
+ * <p>Correctness of the sidecar format depends entirely on this pair of routines: a reader
+ * that decodes a varint differently from how the builder encoded it will produce garbage
+ * terms. Tests cover signed/unsigned ranges, boundary bytes, and dense fuzzing.
+ */
+class VarintCoderTest {
+
+    @Test
+    void unsignedRoundTrip_smallValues() {
+        ByteBuffer buf = ByteBuffer.allocate(1024);
+        int[] values = {0, 1, 2, 127, 128, 129, 16_383, 16_384, 16_385,
+                        2_097_151, 2_097_152, Integer.MAX_VALUE};
+        for (int v : values) VarintCoder.writeUVInt(buf, v);
+        buf.flip();
+        for (int v : values) assertEquals(v, VarintCoder.readUVInt(buf));
+    }
+
+    @Test
+    void signedZigzag_roundTripsPositiveAndNegative() {
+        ByteBuffer buf = ByteBuffer.allocate(1024);
+        int[] values = {0, 1, -1, 2, -2, 63, -63, 64, -64,
+                        Integer.MAX_VALUE, Integer.MIN_VALUE};
+        for (int v : values) VarintCoder.writeZVInt(buf, v);
+        buf.flip();
+        for (int v : values) assertEquals(v, VarintCoder.readZVInt(buf));
+    }
+
+    @Test
+    void fuzzUnsigned_roundTrip() {
+        Random rng = new Random(0xC0FFEEL);
+        int[] values = new int[10_000];
+        for (int i = 0; i < values.length; i++) values[i] = rng.nextInt() & 0x7FFF_FFFF;
+        ByteBuffer buf = ByteBuffer.allocate(values.length * 5);
+        for (int v : values) VarintCoder.writeUVInt(buf, v);
+        buf.flip();
+        for (int v : values) assertEquals(v, VarintCoder.readUVInt(buf));
+    }
+
+    @Test
+    void fuzzSigned_roundTrip() {
+        Random rng = new Random(0xDEADBEEFL);
+        int[] values = new int[10_000];
+        for (int i = 0; i < values.length; i++) values[i] = rng.nextInt();
+        ByteBuffer buf = ByteBuffer.allocate(values.length * 5);
+        for (int v : values) VarintCoder.writeZVInt(buf, v);
+        buf.flip();
+        for (int v : values) assertEquals(v, VarintCoder.readZVInt(buf));
+    }
+
+    @Test
+    void uvint_rejectsNegative() {
+        ByteBuffer buf = ByteBuffer.allocate(16);
+        assertThrows(IllegalArgumentException.class, () -> VarintCoder.writeUVInt(buf, -1));
+    }
+
+    @Test
+    void byteCount_matchesEncodedLength() {
+        ByteBuffer buf = ByteBuffer.allocate(16);
+        VarintCoder.writeUVInt(buf, 1_000_000);
+        assertEquals(buf.position(), VarintCoder.uvintByteCount(1_000_000));
+        buf.clear();
+        VarintCoder.writeZVInt(buf, -500_000);
+        assertEquals(buf.position(), VarintCoder.zvintByteCount(-500_000));
+    }
+
+    @Test
+    void truncatedBuffer_throwsWithClearError() {
+        // Write a 3-byte varint then truncate to 1 byte in the read side.
+        ByteBuffer src = ByteBuffer.allocate(8);
+        VarintCoder.writeUVInt(src, 300_000); // 3 bytes
+        src.flip();
+        ByteBuffer truncated = ByteBuffer.allocate(1);
+        truncated.put(src.get());
+        truncated.flip();
+        assertThrows(java.nio.BufferUnderflowException.class, () -> VarintCoder.readUVInt(truncated));
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -71,7 +71,7 @@ spotless {
             exclude commonExclusions
         }
         trimTrailingWhitespace()
-        indentWithSpaces()
+        leadingTabsToSpaces()
         endWithNewline()
 
     }
@@ -81,7 +81,7 @@ spotless {
             exclude commonExclusions
         }
         trimTrailingWhitespace()
-        indentWithSpaces()
+        leadingTabsToSpaces()
         endWithNewline()
     }
     json {
@@ -112,7 +112,7 @@ subprojects {
                         'org.opensearch',
                         '',
                         '\\#')
-                indentWithSpaces()
+                leadingTabsToSpaces()
                 endWithNewline()
                 removeUnusedImports()
             }


### PR DESCRIPTION
### Problem

Sourceless `_source` reconstruction OOMs on analyzed-text fields at scale.

`SegmentTermIndex` materialized the entire field's `docId -> position-sorted List<String>` map in heap before serving the first doc. For a 3.8 GB segment with ~500M token-positions, that's **tens of GB** of `TreeMap` nodes and `String` refs, pinned for the segment's lifetime.

Observed: OOM on a **64 GB JVM** reconstructing a 3.8 GB segment (166k docs, one analyzed-text field, no `_source` / stored fields / doc_values).

### Fix

`SegmentTermIndex` delegates to a Lucene-native on-disk sidecar built by a single-pass, doc-banked streaming `SidecarBuilder`:

- `registerTerm` streams term bytes straight to `terms.dat` and writes the little-endian offset to `term-offsets.dat` — no in-heap term list.
- `accept` appends the incoming tuple's `(position, termId)` pairs into the target doc's amortized `int[]` bank. The walk is term-major, so pairs arrive in term-order, not position-order.
- `buildAndOpenReader` walks docs in ASC order; for each non-empty doc it packs pairs into a `long[]` keyed `(position << 32) | termId`, runs `Arrays.sort` (primitive dual-pivot quicksort — cache-friendly, no boxing, natural order matches the required `(position ASC, termId ASC)`), uvint-encodes `(numPairs, [posDelta, termId]...)` straight into `sidecar.dat`, and releases the doc's bank so peak off-heap live set shrinks as docs are consumed.
- `doc-index.dat` is a plain `long[maxDoc]` little-endian array of absolute offsets, with a `-1L` sentinel for empty docs.

`SidecarReader` mmaps the resulting files and binary-searches `doc-index.dat` per lookup — no eager heap materialization.

### Heap footprint: before vs. after

| Phase | Before | After |
|---|---|---|
| Per-segment field build | O(total_positions_in_field) as `TreeMap` nodes + `String` refs — tens of GB for a 3.8 GB segment | O(total_positions × 8 bytes) of primitive `int[]` banks + `long[]` sort buffers, released per doc as emitted |
| Per-doc read | O(positions_in_one_doc) | O(positions_in_one_doc) |
| Dominant term | `TreeMap<Integer, List<String>>` over every (doc, position) | per-doc `int[]` banks (primitive, no object headers, no boxing) |
| Scales with segment size? | No (OOMs on 64 GB JVM at 3.8 GB segment) | Proportional to positions, but with ~10× smaller constant vs. the old boxed `TreeMap` |

Target: **10 GB JVM** reconstructs a **600 GB** analyzed-text shard.

### On-disk format

```
terms.dat          — length-prefixed UTF-8 bytes, one per term, in termId order
term-offsets.dat   — little-endian int[numTerms] of byte offsets into terms.dat
sidecar.dat        — uvint-encoded (numPairs, [posDelta, termId]...) per doc
doc-index.dat      — long[maxDoc] of absolute offsets into sidecar.dat, or -1L for empty docs
```

### Tests

- `SidecarBuilderRoundTripTest` — 6 cases covering small fixed input, empty stream, sparse docs, tied-position tie-break by termId, fuzz vs. an in-heap reference implementation, and file-handle closure on reader open.
- `PostingsSinkContractTest` — `BytesRefLike` defensive copy, bounds checks, value equality, and `PostingsSink` emission ordering.
- `VarintCoderTest` — round-trip, byte-count agreement, truncation error clarity, zigzag signed encoding, fuzz over both encodings.

All 104 tests in the `SearchSnapshotExtractor` module pass.

### External contract

Reconstructed `_source` JSON bytes for any `(segment, docId)` are **byte-identical** to the previous implementation. Every position, every duplicate token, original order round-trips losslessly so downstream consumers re-index to identical postings.

### Tradeoff

Per-doc banks live on heap between the term-major walk and the doc-major emit, so peak heap during build is `O(total_positions × 8 bytes)` plus array-growth overhead. That's the cost of skipping external sort and keeping the builder to a single pass with no `postings.raw` scratch file, no run files, and no k-way merge. Acceptable for segments within a normal JVM heap budget; oversized segments would need a size-heuristic fallback to a disk-based builder, to be layered on separately if it becomes necessary in practice.

### Check List

- [x] New functionality includes testing
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented in the commit body and PR description
- [x] Commits are signed per the DCO using `--signoff`
