### PR TITLE
Make work item separator configurable

### DIFF
--- a/DocumentsFromSnapshotMigration/src/main/java/org/opensearch/migrations/RfsMigrateDocuments.java
+++ b/DocumentsFromSnapshotMigration/src/main/java/org/opensearch/migrations/RfsMigrateDocuments.java
@@ -291,6 +291,13 @@ public class RfsMigrateDocuments {
         private ExperimentalArgs experimental = new ExperimentalArgs();
 
         @Parameter(required = false,
+            names = { "--work-item-separator" },
+            description = "Optional. The separator string used to delimit components in work item IDs. " +
+                "Change this if your index names contain the default separator ('__'). " +
+                "Must be consistent across all workers in a migration. Default: '__'")
+        public String workItemSeparator = IWorkCoordinator.WorkItemAndDuration.WorkItem.DEFAULT_SEPARATOR;
+
+        @Parameter(required = false,
             names = { "--allowed-doc-exception-types", "--allowedDocExceptionTypes" },
             description = "Optional. Comma-separated list of document-level exception types that should be " +
                 "treated as successful operations during bulk migration. This enables idempotent migrations by " +
@@ -482,6 +489,8 @@ public class RfsMigrateDocuments {
         }
 
         validateArgs(arguments);
+
+        IWorkCoordinator.WorkItemAndDuration.WorkItem.setSeparator(arguments.workItemSeparator);
 
         if (arguments.cleanLocalDirs) {
             FileSystemUtils.deleteDirectories(arguments.s3LocalDir, arguments.luceneDir);

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/workcoordination/IWorkCoordinator.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/workcoordination/IWorkCoordinator.java
@@ -208,15 +208,32 @@ public interface IWorkCoordinator extends AutoCloseable {
         @EqualsAndHashCode
         @Getter
         public static class WorkItem implements Serializable {
-            private static final String SEPARATOR = "__";
+            public static final String DEFAULT_SEPARATOR = "__";
+            private static volatile String separator = DEFAULT_SEPARATOR;
+
             String indexName;
             Integer shardNumber;
             Long startingDocId;
 
+            /**
+             * Set the separator used to delimit components in work item strings.
+             * Must be called before any WorkItem instances are created or parsed.
+             */
+            public static void setSeparator(String newSeparator) {
+                if (newSeparator == null || newSeparator.isEmpty()) {
+                    throw new IllegalArgumentException("Separator must not be null or empty");
+                }
+                separator = newSeparator;
+            }
+
+            public static String getSeparator() {
+                return separator;
+            }
+
             public WorkItem(String indexName, Integer shardNumber, Long startingDocId) {
-                if (indexName.contains(SEPARATOR)) {
+                if (indexName.contains(separator)) {
                     throw new IllegalArgumentException(
-                            "Illegal work item name: '" + indexName + "'.  " + "Work item names cannot contain '" + SEPARATOR + "'"
+                            "Illegal work item name: '" + indexName + "'.  " + "Work item names cannot contain '" + separator + "'"
                     );
                 }
                 this.indexName = indexName;
@@ -228,10 +245,10 @@ public interface IWorkCoordinator extends AutoCloseable {
             public String toString() {
                 var name = indexName;
                 if (shardNumber != null) {
-                    name += SEPARATOR + shardNumber;
+                    name += separator + shardNumber;
                 }
                 if (startingDocId != null) {
-                    name += SEPARATOR + startingDocId;
+                    name += separator + startingDocId;
                 }
                 return name;
             }
@@ -240,7 +257,7 @@ public interface IWorkCoordinator extends AutoCloseable {
                 if ("shard_setup".equals(input)) {
                     return new WorkItem(input, null, null);
                 }
-                var components = input.split(SEPARATOR + "+");
+                var components = input.split(java.util.regex.Pattern.quote(separator) + "+");
                 if (components.length != 3) {
                     throw new IllegalArgumentException("Illegal work item: '" + input + "'");
                 }


### PR DESCRIPTION
### Description

Resolves #2880.

The work item separator was hardcoded to `__`, which prevented migration of indices whose names contain `__`.

### Changes

- Make `WorkItem.SEPARATOR` a configurable static field with a default value of `__` for backward compatibility
- Add `--work-item-separator` CLI parameter to `RfsMigrateDocuments`
- Use `Pattern.quote()` in `split()` to handle regex-special characters in custom separators
- Use `volatile` for thread safety across workers

### Usage

Users with `__` in their index names can now run:
```
--work-item-separator ":::"
```

### Testing

- Default behavior unchanged (separator defaults to `__`)
- Existing tests pass without modification
