### PR TITLE
Allow '__' in index names for work item parsing

### DIFF
--- a/DocumentsFromSnapshotMigration/src/test/java/org/opensearch/migrations/bulkload/LeaseExpirationTest.java
+++ b/DocumentsFromSnapshotMigration/src/test/java/org/opensearch/migrations/bulkload/LeaseExpirationTest.java
@@ -360,10 +360,16 @@ public class LeaseExpirationTest extends SourceTestBase {
                 var successorItems = parentHits.get(0).path("_source")
                     .path(OpenSearchWorkCoordinator.SUCCESSOR_ITEMS_FIELD_NAME).asText();
 
-                // ASSERT: successor checkpoint doc is in early-trigger range
-                Assertions.assertTrue(successorItems.startsWith("geonames__0__"),
+                // ASSERT: successor checkpoint doc is in early-trigger range.  The work-item id is a
+                // base64url(indexName) + "__" + shard + "__" + docId string (see #2880), so decode it
+                // via the canonical parser rather than string-matching a plaintext prefix.
+                var successor = IWorkCoordinator.WorkItemAndDuration.WorkItem
+                    .valueFromWorkItemString(successorItems);
+                Assertions.assertEquals("geonames", successor.getIndexName(),
+                    "Successor should be for index geonames, got: " + successorItems);
+                Assertions.assertEquals(0, (int) successor.getShardNumber(),
                     "Successor should be for shard 0, got: " + successorItems);
-                var checkpointDoc = Integer.parseInt(successorItems.substring("geonames__0__".length()));
+                var checkpointDoc = successor.getStartingDocId();
                 Assertions.assertTrue(checkpointDoc >= 40 && checkpointDoc <= 44,
                     "Checkpoint doc should be 40-44 (early trigger at ~t=45s); got " + checkpointDoc);
             } finally {

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/workcoordination/IWorkCoordinator.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/workcoordination/IWorkCoordinator.java
@@ -2,9 +2,11 @@ package org.opensearch.migrations.bulkload.workcoordination;
 
 import java.io.IOException;
 import java.io.Serializable;
+import java.nio.charset.StandardCharsets;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.Base64;
 import java.util.List;
 import java.util.function.Supplier;
 
@@ -209,24 +211,33 @@ public interface IWorkCoordinator extends AutoCloseable {
         @Getter
         public static class WorkItem implements Serializable {
             private static final String SEPARATOR = "__";
+            private static final String SHARD_SETUP_SENTINEL = "shard_setup";
+            private static final Base64.Encoder INDEX_NAME_ENCODER = Base64.getUrlEncoder().withoutPadding();
+            private static final Base64.Decoder INDEX_NAME_DECODER = Base64.getUrlDecoder();
+
             String indexName;
             Integer shardNumber;
             Long startingDocId;
 
             public WorkItem(String indexName, Integer shardNumber, Long startingDocId) {
-                if (indexName.contains(SEPARATOR)) {
-                    throw new IllegalArgumentException(
-                            "Illegal work item name: '" + indexName + "'.  " + "Work item names cannot contain '" + SEPARATOR + "'"
-                    );
-                }
                 this.indexName = indexName;
                 this.shardNumber = shardNumber;
                 this.startingDocId = startingDocId;
             }
 
+            /**
+             * Serializes this work item to the id string stored in the work-coordination index.
+             * The index name is base64url-encoded (no padding) so it cannot collide with the
+             * {@link #SEPARATOR} regardless of what characters the source index name contains
+             * (see opensearch-project/opensearch-migrations#2880).  The {@code shard_setup}
+             * sentinel is preserved verbatim so existing bootstrap logic is unaffected.
+             */
             @Override
             public String toString() {
-                var name = indexName;
+                if (SHARD_SETUP_SENTINEL.equals(indexName) && shardNumber == null && startingDocId == null) {
+                    return SHARD_SETUP_SENTINEL;
+                }
+                var name = INDEX_NAME_ENCODER.encodeToString(indexName.getBytes(StandardCharsets.UTF_8));
                 if (shardNumber != null) {
                     name += SEPARATOR + shardNumber;
                 }
@@ -237,14 +248,21 @@ public interface IWorkCoordinator extends AutoCloseable {
             }
 
             public static WorkItem valueFromWorkItemString(String input) {
-                if ("shard_setup".equals(input)) {
+                if (SHARD_SETUP_SENTINEL.equals(input)) {
                     return new WorkItem(input, null, null);
                 }
                 var components = input.split(SEPARATOR + "+");
                 if (components.length != 3) {
                     throw new IllegalArgumentException("Illegal work item: '" + input + "'");
                 }
-                return new WorkItem(components[0], Integer.parseInt(components[1]), Long.parseLong(components[2]));
+                final String indexName;
+                try {
+                    indexName = new String(INDEX_NAME_DECODER.decode(components[0]), StandardCharsets.UTF_8);
+                } catch (IllegalArgumentException e) {
+                    throw new IllegalArgumentException("Illegal work item: '" + input
+                            + "' (index name segment is not valid base64url)", e);
+                }
+                return new WorkItem(indexName, Integer.parseInt(components[1]), Long.parseLong(components[2]));
             }
         }
     }

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/workcoordination/OpenSearchWorkCoordinator.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/workcoordination/OpenSearchWorkCoordinator.java
@@ -69,6 +69,11 @@ public abstract class OpenSearchWorkCoordinator implements IWorkCoordinator {
 
 
     public static final String SCRIPT_VERSION_TEMPLATE = "{SCRIPT_VERSION}";
+    // Bumped to 3.0 alongside the switch to base64url-encoded indexName segments in work-item
+    // ids (opensearch-project/opensearch-migrations#2880).  Work-coordination documents written
+    // by a previous version will fail the scriptVersion check, which is intentional — the
+    // working-state index must be cleared before upgrading across this boundary.
+    public static final String SCRIPT_VERSION = "3.0";
     public static final String WORKER_ID_TEMPLATE = "{WORKER_ID}";
     public static final String CLIENT_TIMESTAMP_TEMPLATE = "{CLIENT_TIMESTAMP}";
     public static final String EXPIRATION_WINDOW_TEMPLATE = "{EXPIRATION_WINDOW}";
@@ -82,6 +87,7 @@ public abstract class OpenSearchWorkCoordinator implements IWorkCoordinator {
     public static final String LEASE_HOLDER_ID_FIELD_NAME = "leaseHolderId";
     public static final String VERSION_CONFLICTS_FIELD_NAME = "version_conflicts";
     public static final String COMPLETED_AT_FIELD_NAME = "completedAt";
+    public static final String INDEX_NAME_FIELD_NAME = "indexName";
     public static final String SOURCE_FIELD_NAME = "_source";
     public static final String SUCCESSOR_ITEMS_FIELD_NAME = "successor_items";
     public static final String SUCCESSOR_ITEM_DELIMITER = ",";
@@ -346,12 +352,28 @@ public abstract class OpenSearchWorkCoordinator implements IWorkCoordinator {
         String workItemId,
         long expirationWindowSeconds
     ) throws IOException {
+        // Store the plaintext index name alongside the lease metadata so operators can audit
+        // the work-coordination index without having to reverse the id encoding.  The id itself
+        // encodes the index name as base64url so indices whose names contain the SEPARATOR
+        // ('__') serialize cleanly (see opensearch-project/opensearch-migrations#2880).
+        String indexNameField = "";
+        try {
+            var parsed = IWorkCoordinator.WorkItemAndDuration.WorkItem.valueFromWorkItemString(workItemId);
+            if (parsed.getShardNumber() != null) {
+                indexNameField = "    \"" + INDEX_NAME_FIELD_NAME + "\": "
+                    + objectMapper.writeValueAsString(parsed.getIndexName()) + ",\n";
+            }
+        } catch (IllegalArgumentException e) {
+            // Not a decodable work-item id (e.g. the shard_setup sentinel or a legacy/test id);
+            // fall through without recording a plaintext indexName.
+        }
         // the notion of 'now' isn't supported with painless scripts
         // https://www.elastic.co/guide/en/elasticsearch/painless/current/painless-datetime.html#_datetime_now
         final var upsertLeaseBodyTemplate = "{\n"
             + "  \"scripted_upsert\": true,\n"
             + "  \"upsert\": {\n"
             + "    \"scriptVersion\": \"" + SCRIPT_VERSION_TEMPLATE + "\",\n"
+            + indexNameField
             + "    \"" + EXPIRATION_FIELD_NAME + "\": 0,\n"
             + "    \"creatorId\": \"" + WORKER_ID_TEMPLATE + "\",\n"
             + "    \"nextAcquisitionLeaseExponent\": 0\n"
@@ -394,7 +416,7 @@ public abstract class OpenSearchWorkCoordinator implements IWorkCoordinator {
             + // close script
             "}"; // close top-level
 
-        var body = upsertLeaseBodyTemplate.replace(SCRIPT_VERSION_TEMPLATE, "2.0")
+        var body = upsertLeaseBodyTemplate.replace(SCRIPT_VERSION_TEMPLATE, SCRIPT_VERSION)
             .replace(WORKER_ID_TEMPLATE, workerId)
             .replace(CLIENT_TIMESTAMP_TEMPLATE, Long.toString(clock.instant().toEpochMilli() / 1000))
             .replace(EXPIRATION_WINDOW_TEMPLATE, Long.toString(expirationWindowSeconds))
@@ -539,7 +561,7 @@ public abstract class OpenSearchWorkCoordinator implements IWorkCoordinator {
                 + "  }\n"
                 + "}";
 
-            var body = markWorkAsCompleteBodyTemplate.replace(SCRIPT_VERSION_TEMPLATE, "2.0")
+            var body = markWorkAsCompleteBodyTemplate.replace(SCRIPT_VERSION_TEMPLATE, SCRIPT_VERSION)
                 .replace(WORKER_ID_TEMPLATE, workerId)
                 .replace(CLIENT_TIMESTAMP_TEMPLATE, Long.toString(clock.instant().toEpochMilli() / 1000));
 
@@ -674,7 +696,7 @@ public abstract class OpenSearchWorkCoordinator implements IWorkCoordinator {
             "}";
 
         final var timestampEpochSeconds = clock.instant().toEpochMilli() / 1000;
-        final var body = queryUpdateTemplate.replace(SCRIPT_VERSION_TEMPLATE, "2.0")
+        final var body = queryUpdateTemplate.replace(SCRIPT_VERSION_TEMPLATE, SCRIPT_VERSION)
             .replace(WORKER_ID_TEMPLATE, workerId)
             .replace(CLIENT_TIMESTAMP_TEMPLATE, Long.toString(timestampEpochSeconds))
             .replace(OLD_EXPIRATION_THRESHOLD_TEMPLATE, Long.toString(timestampEpochSeconds))
@@ -836,7 +858,7 @@ public abstract class OpenSearchWorkCoordinator implements IWorkCoordinator {
                 + "  }\n"
                 + "}";
 
-        var body = updateSuccessorWorkItemsTemplate.replace(SCRIPT_VERSION_TEMPLATE, "2.0")
+        var body = updateSuccessorWorkItemsTemplate.replace(SCRIPT_VERSION_TEMPLATE, SCRIPT_VERSION)
                 .replace(WORKER_ID_TEMPLATE, workerId)
                 .replace(CLIENT_TIMESTAMP_TEMPLATE, Long.toString(clock.instant().toEpochMilli() / 1000))
                 .replace(SUCCESSOR_WORK_ITEM_IDS_TEMPLATE, String.join(SUCCESSOR_ITEM_DELIMITER, successorWorkItemIds));
@@ -883,7 +905,7 @@ public abstract class OpenSearchWorkCoordinator implements IWorkCoordinator {
     private void createUnassignedWorkItemsIfNonexistent(List<String> workItemIds, int nextAcquisitionLeaseExponent) throws IOException, IllegalStateException {
         String workItemBodyTemplate = "{\"nextAcquisitionLeaseExponent\":" + nextAcquisitionLeaseExponent + ", \"scriptVersion\":\"" + SCRIPT_VERSION_TEMPLATE + "\", " +
             "\"creatorId\":\"" + WORKER_ID_TEMPLATE + "\", \"" + EXPIRATION_FIELD_NAME + "\":0 }";
-        String workItemBody = workItemBodyTemplate.replace(SCRIPT_VERSION_TEMPLATE, "2.0").replace(WORKER_ID_TEMPLATE, workerId);
+        String workItemBody = workItemBodyTemplate.replace(SCRIPT_VERSION_TEMPLATE, SCRIPT_VERSION).replace(WORKER_ID_TEMPLATE, workerId);
 
         StringBuilder body = new StringBuilder();
         for (var workItemId : workItemIds) {

--- a/RFS/src/test/java/org/opensearch/migrations/bulkload/workcoordination/WorkCoordinatorTest.java
+++ b/RFS/src/test/java/org/opensearch/migrations/bulkload/workcoordination/WorkCoordinatorTest.java
@@ -336,7 +336,7 @@ public class WorkCoordinatorTest {
         try (var workCoordinator = factory.get(httpClientSupplier.get(), 3600, "docCreatorWorker")) {
             Assertions.assertFalse(workCoordinator.workItemsNotYetComplete(testContext::createItemsPendingContext));
             for (var i = 0; i < NUM_DOCS; ++i) {
-                final var docId = "R__0__" + i;
+                final var docId = workId("R", 0, i);
                 workCoordinator.createUnassignedWorkItem(docId, testContext::createUnassignedWorkContext);
             }
             Assertions.assertTrue(workCoordinator.workItemsNotYetComplete(testContext::createItemsPendingContext));
@@ -499,9 +499,13 @@ public class WorkCoordinatorTest {
                 false
         );
         ArrayList<String> successorWorkItems = new ArrayList<>();
+        var parent = IWorkCoordinator.WorkItemAndDuration.WorkItem.valueFromWorkItemString(workItemId);
         for (int j = 0; j < numSuccessorItems; j++) {
-            // Replace "__" with "_" in workerId to create a unique name
-            successorWorkItems.add(workItemId.replace("__", "_") + "__0__" + j);
+            // Build a unique successor id that incorporates the parent's full identity so
+            // concurrent parents don't collide; route through the production encoder rather
+            // than hand-concatenating the serialized format.
+            var successorIndex = parent.getIndexName() + "-p" + parent.getStartingDocId() + "-s" + j;
+            successorWorkItems.add(workId(successorIndex, 0, j));
         }
         try (var workCoordinator = factory.get(httpClientSupplier.get(), 3600, workerName)) {
             workCoordinator.createSuccessorWorkItemsAndMarkComplete(
@@ -539,7 +543,7 @@ public class WorkCoordinatorTest {
                 3600, workerName
             )
         ) {
-            var doneId = DUMMY_FINISHED_DOC_ID + "__" + nonce.incrementAndGet() + "__0";
+            var doneId = workId(DUMMY_FINISHED_DOC_ID + "-" + nonce.incrementAndGet(), 0, 0);
             if (placeFinishedDoc) {
                 workCoordinator.createOrUpdateLeaseForDocument(doneId, 1);
                 workCoordinator.completeWorkItem(doneId, testContext::createCompleteWorkContext);

--- a/RFS/src/test/java/org/opensearch/migrations/bulkload/workcoordination/WorkCoordinatorTest.java
+++ b/RFS/src/test/java/org/opensearch/migrations/bulkload/workcoordination/WorkCoordinatorTest.java
@@ -61,6 +61,17 @@ public class WorkCoordinatorTest {
 
     public static final String DUMMY_FINISHED_DOC_ID = "dummy_finished_doc";
 
+    /**
+     * Helper that mirrors the production encoding: build a serialized work-item id from a
+     * human-readable (indexName, shardNumber, startingDocId) triple via
+     * {@link IWorkCoordinator.WorkItemAndDuration.WorkItem#toString()}.  Use this in tests
+     * instead of hand-concatenating {@code "name__0__0"} strings so the fixtures survive
+     * changes to the serialization format (see opensearch-project/opensearch-migrations#2880).
+     */
+    private static String workId(String indexName, int shardNumber, long startingDocId) {
+        return new IWorkCoordinator.WorkItemAndDuration.WorkItem(indexName, shardNumber, startingDocId).toString();
+    }
+
     private Supplier<AbstractedHttpClient> httpClientSupplier;
 
     @BeforeEach
@@ -131,8 +142,7 @@ public class WorkCoordinatorTest {
             Assertions.assertFalse(workCoordinator.workItemsNotYetComplete(testContext::createItemsPendingContext));
             for (var i = 0; i < NUM_DOCS; ++i) {
                 final var docId = "R" + i;
-                var newWorkItem = IWorkCoordinator.WorkItemAndDuration.WorkItem.valueFromWorkItemString(docId + "__0__0");
-                workCoordinator.createUnassignedWorkItem(newWorkItem.toString(), testContext::createUnassignedWorkContext);
+                workCoordinator.createUnassignedWorkItem(workId(docId, 0, 0L), testContext::createUnassignedWorkContext);
             }
             Assertions.assertTrue(workCoordinator.workItemsNotYetComplete(testContext::createItemsPendingContext));
         }
@@ -178,7 +188,7 @@ public class WorkCoordinatorTest {
                     IntStream.range(0, NUM_DOCS)
                             .mapToObj(i -> CompletableFuture.supplyAsync(() -> {
                                 try {
-                                    return workCoordinator.createUnassignedWorkItem("R__0__" + i, testContext::createUnassignedWorkContext);
+                                    return workCoordinator.createUnassignedWorkItem(workId("R", 0, i), testContext::createUnassignedWorkContext);
                                 } catch (IOException e) {
                                     throw new RuntimeException(e);
                                 }
@@ -258,8 +268,7 @@ public class WorkCoordinatorTest {
         try (var workCoordinator = factory.get(httpClientSupplier.get(), 3600, "docCreatorWorker")) {
             Assertions.assertFalse(workCoordinator.workItemsNotYetComplete(testContext::createItemsPendingContext));
             for (var i = 0; i < NUM_DOCS; ++i) {
-                final var docId = "R__0__" + i;
-                workCoordinator.createUnassignedWorkItem(docId, testContext::createUnassignedWorkContext);
+                workCoordinator.createUnassignedWorkItem(workId("R", 0, i), testContext::createUnassignedWorkContext);
             }
             Assertions.assertTrue(workCoordinator.workItemsNotYetComplete(testContext::createItemsPendingContext));
         }
@@ -278,7 +287,7 @@ public class WorkCoordinatorTest {
 
                 var successorWorkItems = new ArrayList<String>();
                 for (int j = 0; j < NUM_SUCCESSOR_ITEMS; j++) {
-                    successorWorkItems.add("successor__" + i + "__" + j);
+                    successorWorkItems.add(workId("successor", i, j));
                 }
 
                 workCoordinator.createSuccessorWorkItemsAndMarkComplete(
@@ -360,9 +369,9 @@ public class WorkCoordinatorTest {
         // but not all.  This tests that the coordinator handles this case correctly by continuing to make the originally specific successor items.
         var testContext = WorkCoordinationTestContext.factory().withAllTracking();
         var docId = "R0";
-        var initialWorkItem = docId + "__0__0";
+        var initialWorkItem = workId(docId, 0, 0);
         var N_SUCCESSOR_ITEMS = 3;
-        var successorItems = (ArrayList<String>) IntStream.range(1, N_SUCCESSOR_ITEMS + 1).mapToObj(i -> docId + "__0__" + i).collect(Collectors.toList());
+        var successorItems = (ArrayList<String>) IntStream.range(1, N_SUCCESSOR_ITEMS + 1).mapToObj(i -> workId(docId, 0, i)).collect(Collectors.toList());
 
         var originalWorkItemExpiration = Duration.ofSeconds(5);
         final var seenWorkerItems = new ConcurrentHashMap<String, String>();
@@ -420,7 +429,7 @@ public class WorkCoordinatorTest {
         // but not all.  This tests that the coordinator handles this case correctly by continuing to make the originally specific successor items.
         var testContext = WorkCoordinationTestContext.factory().withAllTracking();
         var docId = "R0";
-        var initialWorkItem = docId + "__0__0";
+        var initialWorkItem = workId(docId, 0, 0);
         var N_SUCCESSOR_ITEMS = 3;
         var successorItems = (ArrayList<String>) IntStream.range(0, N_SUCCESSOR_ITEMS).mapToObj(i -> docId + "_successor_" + i).collect(Collectors.toList());
 
@@ -454,8 +463,8 @@ public class WorkCoordinatorTest {
         // A partially completed successor item will have a `successor_items` field and _some_ of the successor work items will be created
         // but not all.  This tests that the coordinator handles this case correctly by continuing to make the originally specific successor items.
         var testContext = WorkCoordinationTestContext.factory().withAllTracking();
-        var initialWorkItem = "R0__0__0";
-        var successorItems = new ArrayList<>(List.of("R0__0__0", "R1__0__0", "R2__0__0"));
+        var initialWorkItem = workId("R0", 0, 0);
+        var successorItems = new ArrayList<>(List.of(workId("R0", 0, 0), workId("R1", 0, 0), workId("R2", 0, 0)));
 
         try (var workCoordinator = factory.get(httpClientSupplier.get(), 3600, "successorTest")) {
             Assertions.assertFalse(workCoordinator.workItemsNotYetComplete(testContext::createItemsPendingContext));

--- a/RFS/src/test/java/org/opensearch/migrations/bulkload/workcoordination/WorkItemStringParsingTest.java
+++ b/RFS/src/test/java/org/opensearch/migrations/bulkload/workcoordination/WorkItemStringParsingTest.java
@@ -1,0 +1,115 @@
+package org.opensearch.migrations.bulkload.workcoordination;
+
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * Unit coverage for {@link IWorkCoordinator.WorkItemAndDuration.WorkItem#toString()} and
+ * {@link IWorkCoordinator.WorkItemAndDuration.WorkItem#valueFromWorkItemString(String)}.
+ *
+ * <p>Regression for opensearch-project/opensearch-migrations#2880: the previous serialization
+ * simply concatenated {@code indexName + "__" + shard + "__" + docId}, which collided with
+ * any index whose name contained the {@code "__"} separator and caused the migration tool
+ * to misparse real-world indices.  The current implementation base64url-encodes the index
+ * name segment so it can never contain the separator; these tests pin that contract.
+ */
+class WorkItemStringParsingTest {
+
+    private static IWorkCoordinator.WorkItemAndDuration.WorkItem wi(String name, Integer shard, Long docId) {
+        return new IWorkCoordinator.WorkItemAndDuration.WorkItem(name, shard, docId);
+    }
+
+    static Stream<Arguments> roundTripIndexNames() {
+        return Stream.of(
+            // Plain names — the vast majority of real-world indices.
+            Arguments.of("logs-2024"),
+            Arguments.of("my-index"),
+            Arguments.of("simple"),
+            // The bug from #2880: names containing the legacy separator must round-trip cleanly.
+            Arguments.of("my__index"),
+            Arguments.of("__leading"),
+            Arguments.of("trailing__"),
+            Arguments.of("one__two__three"),
+            Arguments.of("a__b__c__d__e"),
+            Arguments.of("________"),
+            // Names that would otherwise confuse a naive left-to-right parser.
+            Arguments.of("contains-0-digits"),
+            Arguments.of("has.dots.and-dashes"),
+            Arguments.of("with spaces"),
+            // Single underscores must survive the base64url alphabet untouched.
+            Arguments.of("_one_under_score_"),
+            // Non-ASCII / unicode characters — base64url handles raw UTF-8 bytes.
+            Arguments.of("índex-ñame"),
+            Arguments.of("日本語"),
+            // Edge cases around length boundaries where base64 padding used to matter.
+            Arguments.of("a"),
+            Arguments.of("ab"),
+            Arguments.of("abc"),
+            Arguments.of("abcd")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("roundTripIndexNames")
+    void toString_then_valueFromWorkItemString_preservesAllFields(String indexName) {
+        var original = wi(indexName, 7, 42L);
+        var serialized = original.toString();
+
+        var parsed = IWorkCoordinator.WorkItemAndDuration.WorkItem.valueFromWorkItemString(serialized);
+
+        Assertions.assertEquals(indexName, parsed.getIndexName(),
+            "index name must round-trip verbatim, got serialized=" + serialized);
+        Assertions.assertEquals(7, parsed.getShardNumber());
+        Assertions.assertEquals(42L, parsed.getStartingDocId());
+        Assertions.assertEquals(original, parsed);
+    }
+
+    @ParameterizedTest
+    @MethodSource("roundTripIndexNames")
+    void serializedForm_containsNoDoubleUnderscoreInsideIndexSegment(String indexName) {
+        var serialized = wi(indexName, 0, 0L).toString();
+
+        // The serialized form is `<base64>__<shard>__<docId>`.  Splitting on the separator
+        // must always yield exactly three components, regardless of the source index name.
+        var parts = serialized.split("__");
+        Assertions.assertEquals(3, parts.length,
+            "serialized work item must split into exactly 3 components on '__', got '"
+                + serialized + "' -> " + parts.length);
+    }
+
+    @Test
+    void shardSetupSentinel_roundTrips() {
+        var sentinel = IWorkCoordinator.WorkItemAndDuration.WorkItem
+            .valueFromWorkItemString("shard_setup");
+        Assertions.assertEquals("shard_setup", sentinel.getIndexName());
+        Assertions.assertNull(sentinel.getShardNumber());
+        Assertions.assertNull(sentinel.getStartingDocId());
+        Assertions.assertEquals("shard_setup", sentinel.toString());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "not enough parts",
+        "only_one_segment",
+        "two__segments",
+        // Index-name segment must decode as base64url; a '!' is outside the alphabet.
+        "not!base64__0__0"
+    })
+    void malformedIds_throwIllegalArgumentException(String malformed) {
+        Assertions.assertThrows(IllegalArgumentException.class,
+            () -> IWorkCoordinator.WorkItemAndDuration.WorkItem.valueFromWorkItemString(malformed));
+    }
+
+    @Test
+    void constructor_acceptsIndexNameContainingSeparator() {
+        // The pre-fix constructor rejected any name containing "__".  The base64 encoding
+        // makes that guard unnecessary; this test pins that the guard is gone.
+        Assertions.assertDoesNotThrow(() -> wi("anything__goes__here", 0, 0L));
+    }
+}

--- a/migrationConsole/lib/integ_test/integ_test/test_cases/basic_tests.py
+++ b/migrationConsole/lib/integ_test/integ_test/test_cases/basic_tests.py
@@ -34,7 +34,11 @@ class Test0001SingleDocumentBackfill(MATestBase):
                          description=description,
                          migrations_required=migrations_required,
                          allow_source_target_combinations=allow_combinations)
-        self.index_name = f"test_0001_{self.unique_id}"
+        # Use an index name containing the work-coordinator separator ('__') to pin the fix
+        # for opensearch-project/opensearch-migrations#2880 — prior to that fix, any index
+        # whose name contained '__' was silently unmigratable because the work-item id
+        # parser split on the first two occurrences of the separator.
+        self.index_name = f"test__0001__{self.unique_id}"
         self.doc_id = "test_0001_doc"
         self.doc_type = "sample_type"
         self.source_cluster = None


### PR DESCRIPTION
### Description

Fixes #2880: the work-coordinator rejected (or silently mishandled) indices whose names contain `__`.

The work-coordinator stores one document per `(index, shard, startingDocId)` triple in `.migrations_working_state`, keyed by a serialized id. Before this change that id was `indexName + "__" + shard + "__" + docId`, and the parser split on the first two `__` — which meant any index name containing `__` was unmigratable. The pre-check in the `WorkItem` constructor also rejected such names outright.

This change base64url-encodes (no padding) the index-name segment of the id:

```
<base64url(indexName)>__<shard>__<docId>
```

The base64url alphabet is `[A-Za-z0-9_-]`, so the encoded segment can never contain two consecutive underscores. The existing `split(SEPARATOR + "+")` parser keeps working as-is, unchanged. The `shard_setup` sentinel is still written verbatim.

For operator auditability, the plaintext index name is also written as an `indexName` keyword field on the work-item document body, so the working-state index is readable via a normal query without having to reverse the id encoding.

### Issues Resolved

Closes #2880

### Testing

- New `WorkItemStringParsingTest` unit test: round-trips plain names, names containing `__`, leading/trailing/repeated `__`, unicode, single-char / 2-char / 3-char / 4-char names (base64 padding boundaries), confirms the `shard_setup` sentinel still round-trips, confirms the serialized form always splits into exactly 3 components on `__`, and asserts that malformed ids throw `IllegalArgumentException`.
- Updated `WorkCoordinatorTest` integration-container fixtures that hand-assembled plaintext `"R0__0__0"`-style ids to go through `WorkItem.toString()` via a small `workId()` helper — this keeps them as readable as before while surviving any future serialization change.
- `Test0001SingleDocumentBackfill` now uses `test__0001__{unique_id}` as its target index name, so every run of the basic backfill integration test exercises an index name the pre-fix work-coordinator would have silently mishandled, across every supported ES→OS pair.

### Compatibility Note

This is a hard cutover: serialized ids are not forward- or backward-compatible with the previous plaintext format. To make the boundary explicit, the work-coordinator painless `scriptVersion` is bumped from `2.0` to `3.0`; the guard at the top of every script throws `IllegalArgumentException` when it encounters a document carrying a different version, so mixing binaries across the boundary fails loudly rather than silently corrupting state. Working-state indices written by an older build are not readable by this version and must be cleared before upgrading. The tool already assumes a fresh working-state index per migration run in normal operation.

### Check List
- [x] New functionality includes testing
- [x] All tests pass
- [x] New functionality has been documented (commit messages + PR body + inline javadoc)
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
