### PR TITLE
Fix Docker Hub rate-limit failures in dockerComposeE2ETest

### DIFF
--- a/buildImages/backends/dockerHostedBuildkit.sh
+++ b/buildImages/backends/dockerHostedBuildkit.sh
@@ -14,9 +14,39 @@ set_docker_hosted_defaults() {
   : "${BUILD_CONTAINER_REGISTRY_ENDPOINT:=${EXTERNAL_REGISTRY_NAME}:5000}"
 }
 
+# Rewrite an image reference through the ECR pull-through cache when
+# ECR_PULL_THROUGH_ENDPOINT is set (e.g. on Jenkins hosts via
+# /etc/profile.d/ecr-pull-through.sh). Mirrors PullThroughCacheHelper.groovy
+# and the ptc_rewrite in deployment/k8s/.../mirrorToEcr.sh. Falls back to the
+# original reference when the endpoint is unset or the registry isn't mapped.
+ptc_rewrite_image() {
+  local image="$1"
+  local ptc="${ECR_PULL_THROUGH_ENDPOINT:-}"
+  [[ -z "$ptc" ]] && { echo "$image"; return; }
+  local prefix path
+  case "$image" in
+    docker.io/*)            prefix="docker-hub";               path="${image#docker.io/}" ;;
+    registry-1.docker.io/*) prefix="docker-hub";               path="${image#registry-1.docker.io/}" ;;
+    public.ecr.aws/*)       prefix="ecr-public";               path="${image#public.ecr.aws/}" ;;
+    ghcr.io/*)              prefix="github-container-registry"; path="${image#ghcr.io/}" ;;
+    registry.k8s.io/*)      prefix="k8s";                      path="${image#registry.k8s.io/}" ;;
+    quay.io/*)              prefix="quay";                     path="${image#quay.io/}" ;;
+    *)
+      # Bare reference (e.g. "registry:2") — implicit Docker Hub library/
+      if [[ "$image" != */* ]]; then
+        prefix="docker-hub"; path="library/${image}"
+      else
+        echo "$image"; return
+      fi
+      ;;
+  esac
+  echo "${ptc}/${prefix}/${path}"
+}
+
 get_docker_network_dns_servers() {
-  local resolv_conf dns_line
-  resolv_conf="$(docker run --rm --network "${EXTERNAL_DOCKER_NETWORK}" registry:2 cat /etc/resolv.conf 2>/dev/null || true)"
+  local resolv_conf dns_line registry_image
+  registry_image="$(ptc_rewrite_image registry:2)"
+  resolv_conf="$(docker run --rm --network "${EXTERNAL_DOCKER_NETWORK}" "${registry_image}" cat /etc/resolv.conf 2>/dev/null || true)"
   dns_line="$(printf '%s\n' "${resolv_conf}" | sed -n 's/^# ExtServers: \[\(.*\)\]$/\1/p' | head -n1)"
 
   if [[ -z "${dns_line}" ]]; then
@@ -67,13 +97,15 @@ ensure_docker_network() {
 
 ensure_registry_container() {
   if ! docker inspect "${EXTERNAL_REGISTRY_NAME}" >/dev/null 2>&1; then
+    local registry_image
+    registry_image="$(ptc_rewrite_image registry:2)"
     docker run -d \
       --name "${EXTERNAL_REGISTRY_NAME}" \
       --network "${EXTERNAL_DOCKER_NETWORK}" \
       -p "127.0.0.1:${EXTERNAL_REGISTRY_PORT}:5000" \
       -v "${EXTERNAL_REGISTRY_VOLUME}:/var/lib/registry" \
       --restart=always \
-      registry:2 >/dev/null
+      "${registry_image}" >/dev/null
   else
     if [[ "$(docker inspect -f '{{.State.Running}}' "${EXTERNAL_REGISTRY_NAME}")" != "true" ]]; then
       docker start "${EXTERNAL_REGISTRY_NAME}" >/dev/null

--- a/buildImages/build.gradle
+++ b/buildImages/build.gradle
@@ -80,8 +80,6 @@ def buildKitProjects = [
                 ]
         ],
         [
-
-
                 serviceName: "reindexFromSnapshot",
                 contextDir: "DocumentsFromSnapshotMigration/docker",
                 imageName:  "reindex_from_snapshot",
@@ -93,12 +91,6 @@ def buildKitProjects = [
                         ":DocumentsFromSnapshotMigration:copyDockerRuntimeJars",
                         ":DocumentsFromSnapshotMigration:syncVersionFile_reindexFromSnapshot"
                 ]
-        ],
-        [
-                serviceName: "elasticsearchTestConsole",
-                contextDir: "TrafficCapture/dockerSolution/src/main/docker/elasticsearchTestConsole",
-                imageName:  "elasticsearch_test_console",
-                imageTag:   "latest"
         ],
         [
                 serviceName: "migrationConsoleBase",

--- a/vars/dockerComposeE2ETest.groovy
+++ b/vars/dockerComposeE2ETest.groovy
@@ -61,7 +61,15 @@ def call(Map config = [:]) {
             stage('Build Docker Images') {
                 steps {
                     timeout(time: 15, unit: 'MINUTES') {
-                        sh './deployment/cdk/opensearch-service-migration/buildDockerImages.sh'
+                        script {
+                            // ECR_PULL_THROUGH_ENDPOINT is exported by /etc/profile.d/ecr-pull-through.sh
+                            // on Jenkins hosts, which only login shells source. Read it via `bash -l`
+                            // so the non-login Jenkins sh step can forward it to buildDockerImages.sh.
+                            def ptcEndpoint = sh(script: 'bash -l -c \'echo -n $ECR_PULL_THROUGH_ENDPOINT\'', returnStdout: true).trim()
+                            withEnv(ptcEndpoint ? ["ECR_PULL_THROUGH_ENDPOINT=${ptcEndpoint}"] : []) {
+                                sh './deployment/cdk/opensearch-service-migration/buildDockerImages.sh'
+                            }
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Problem

`jenkins/migrationIntegPipelines/dockerComposeE2ETestCover.groovy` was failing on shared AL2023 Jenkins agents with `toomanyrequests: You have reached your unauthenticated pull rate limit` from Docker Hub. Two distinct paths were still hitting `docker.io` directly:

1. **`registry:2`** — `buildImages/backends/dockerHostedBuildkit.sh` `docker run`s this to stand up the local registry, and `vars/dockerComposeE2ETest.groovy` invokes that from a non-login `sh` step where `/etc/profile.d/ecr-pull-through.sh` doesn't apply.

2. **`docker.io/library/amazonlinux:2023`** (`elasticsearchTestConsole` target) — `buildImages/build.gradle` declared `serviceName: "elasticsearchTestConsole"` twice: once with PTC-rewritten `BUILDER_IMAGE`/`RUNTIME_IMAGE` buildArgs, once with no buildArgs. `registerBuildKitBakeAggregateTask` keys the included-projects map on `serviceName`, so the second entry overwrote the first and the generated bake spec had no build args — buildx fell back to the Dockerfile `ARG` defaults.

## Fix

- **Commit 1**: `dockerHostedBuildkit.sh` — add `ptc_rewrite_image()` (mirrors the `ptc_rewrite` helper already in `mirrorToEcr.sh` and `PullThroughCacheHelper.groovy`), wrap both `registry:2` call sites. `vars/dockerComposeE2ETest.groovy` — surface `ECR_PULL_THROUGH_ENDPOINT` into the `sh` step via `bash -l -c` and `withEnv`, matching the pattern in `vars/k8sLocalDeployment.groovy`.

- **Commit 2**: Remove the duplicate `elasticsearchTestConsole` entry from `buildKitProjects`.

## Behavior when `ECR_PULL_THROUGH_ENDPOINT` is unset

`ptc_rewrite_image` and `PullThroughCacheHelper.rewrite` both echo input unchanged when the endpoint is empty, so laptops and forks without a configured PTC are unaffected.