### PR TITLE
Update ArgoService default CLI image to v4.0.3

### DIFF
--- a/migrationConsole/lib/console_link/console_link/models/argo_service.py
+++ b/migrationConsole/lib/console_link/console_link/models/argo_service.py
@@ -23,7 +23,7 @@ class WorkflowEndedBeforeSuspend(Exception):
 
 
 class ArgoService:
-    def __init__(self, namespace: str = "ma", argo_image: str = "quay.io/argoproj/argocli:v3.6.5",
+    def __init__(self, namespace: str = "ma", argo_image: str = "quay.io/argoproj/argocli:v4.0.3",
                  service_account: str = "argo-workflow-executor"):
         self.namespace = namespace
         self.argo_image = argo_image


### PR DESCRIPTION
### Description
The ArgoService class hardcodes `quay.io/argoproj/argocli:v3.6.5` as the default CLI image, but the images we mirror are v4.0.3. This causes teardown errors in isolated VPC integration tests because:
1. Only v4.0.3 is mirrored to private ECR — v3.6.5 cannot be pulled
2. v3.6.5 CLI vs v4.0.3 server is a major version mismatch with no compatibility guarantee

This updates the default to match the mirror versions specified in `privateEcrManifest.sh` and `generatePrivateEcrValues.sh`.

### Issues Resolved
Fixes teardown errors in `oeyh-eks-full-e2e-isolated-vpc-test` Jenkins pipeline.

### Testing
- All 35 unit tests in `test_argo_service.py` pass.
- Added test label to trigger isolated vpc test and but still see the error at stopping argo workflow.

### Check List
- [x] New functionality includes testing
- [ ] Public documentation issue/PR created, if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.