### PR TITLE
Stop probing the registry to resolve BuildKit bake digests

### DIFF
--- a/buildSrc/src/main/groovy/org/opensearch/migrations/image/RegistryImageBuildUtils.groovy
+++ b/buildSrc/src/main/groovy/org/opensearch/migrations/image/RegistryImageBuildUtils.groovy
@@ -98,48 +98,6 @@ class RegistryImageBuildUtils {
     }
 
     /**
-     * Query a v2 registry for the digest of an image reference like "host:port/repo:tag"
-     * and return "host:port/repo@sha256:...". Throws if the digest cannot be resolved.
-     */
-    static String resolveDigest(String imageReference) {
-        def atIdx = imageReference.indexOf('@')
-        if (atIdx >= 0) return imageReference // already has a digest
-
-        def colonIdx = imageReference.lastIndexOf(':')
-        def slashIdx = imageReference.lastIndexOf('/')
-        String tag = (colonIdx > slashIdx && colonIdx >= 0) ? imageReference.substring(colonIdx + 1) : "latest"
-        String repoWithHost = (colonIdx > slashIdx && colonIdx >= 0) ? imageReference.substring(0, colonIdx) : imageReference
-
-        def firstSlash = repoWithHost.indexOf('/')
-        if (firstSlash < 0) throw new GradleException("Cannot parse registry host from image reference: ${imageReference}")
-        def registryHost = repoWithHost.substring(0, firstSlash)
-        def repository = repoWithHost.substring(firstSlash + 1)
-
-        def scheme = registryScheme(registryHost)
-        def url = new URL("${scheme}://${registryHost}/v2/${repository}/manifests/${tag}")
-        def conn = (HttpURLConnection) url.openConnection()
-        conn.setRequestMethod("HEAD")
-        conn.setRequestProperty("Accept",
-                "application/vnd.docker.distribution.manifest.list.v2+json, " +
-                "application/vnd.docker.distribution.manifest.v2+json, " +
-                "application/vnd.oci.image.index.v1+json, " +
-                "application/vnd.oci.image.manifest.v1+json")
-        def authHeader = registryAuthHeader(registryHost)
-        if (authHeader) conn.setRequestProperty("Authorization", authHeader)
-        conn.setConnectTimeout(5000)
-        conn.setReadTimeout(5000)
-
-        if (conn.responseCode != 200) {
-            throw new GradleException("Failed to resolve digest for ${imageReference}: registry returned HTTP ${conn.responseCode}")
-        }
-        def digest = conn.getHeaderField("Docker-Content-Digest")
-        if (!digest) {
-            throw new GradleException("Failed to resolve digest for ${imageReference}: registry did not return Docker-Content-Digest header")
-        }
-        return "${repoWithHost}@${digest}"
-    }
-
-    /**
      * Return the path where a BuildKit task should write its --metadata-file output.
      * Convention: {buildDir}/buildkit-metadata/{serviceName}{archSuffix}.json
      */
@@ -712,6 +670,17 @@ class RegistryImageBuildUtils {
             group = "docker"
             description = "Build BuildKit images in dependency-ordered parallel phases using buildx bake (${architecture})"
 
+            // phaseName -> bake --metadata-file output path. Populated in doFirst, consumed
+            // in doLast to derive per-service metadata files without re-probing the registry.
+            def bakePhaseMetadataFiles = [:] as LinkedHashMap<String, File>
+            // serviceName -> phaseName. Populated in doFirst so doLast can find which bake
+            // invocation's metadata JSON contains each target.
+            def serviceToPhase = [:] as Map<String, String>
+            // serviceName -> hostVisibleRef. Captured in doFirst (same ref the bake tag uses,
+            // normalized to the host-visible form) so doLast can record it in the per-service
+            // metadata file without re-computing via the registry formatter.
+            def serviceToHostVisibleRef = [:] as Map<String, String>
+
             doFirst {
                 if (!builderWasExplicit) {
                     throw new GradleException("No -Pbuilder specified and no kube context set. Use -Pbuilder=<name> or set a kube context.")
@@ -749,6 +718,16 @@ class RegistryImageBuildUtils {
 
                         def targetName = cfg.serviceName.toString()
                         targetsForPhase << targetName
+                        serviceToPhase[targetName] = phaseName
+                        // Capture the host-visible tag (same formatter, same registry endpoint)
+                        // for recording in the per-service metadata file.
+                        def hostFormatter = ImageRegistryFormatterFactory.getFormatter(targetRegistry.hostUrl)
+                        serviceToHostVisibleRef[targetName] = hostFormatter.getFullTargetImageIdentifier(
+                                targetRegistry.hostUrl,
+                                imageName,
+                                imageTag,
+                                repoName
+                        )[0].toString()
                         bakeDefinition.target[targetName] = [
                                 context     : project.file(cfg.get("contextDir", ".")).absolutePath,
                                 dockerfile  : "Dockerfile",
@@ -766,12 +745,23 @@ class RegistryImageBuildUtils {
                 outputFile.parentFile.mkdirs()
                 outputFile.text = JsonOutput.prettyPrint(JsonOutput.toJson(bakeDefinition))
 
+                // Allocate one metadata file per phase so consecutive bake invocations don't
+                // overwrite each other's output. Parent dir is created here; bake creates the file.
+                def bakeMetadataDir = project.file("${project.buildDir}/buildkit-metadata/bake/${taskName}")
+                bakeMetadataDir.mkdirs()
+                phaseNames.each { phaseName ->
+                    def pf = new File(bakeMetadataDir, "${phaseName}.json")
+                    if (pf.exists()) pf.delete()
+                    bakePhaseMetadataFiles[phaseName] = pf
+                }
+
                 def commands = phaseNames.collect { phaseName ->
                     def args = [
                             "docker buildx bake",
                             "--progress=plain",
                             "-f \"${outputFile.absolutePath}\"",
                             "--builder ${builder}",
+                            "--metadata-file \"${bakePhaseMetadataFiles[phaseName].absolutePath}\"",
                             "--push",
                             phaseName
                     ]
@@ -781,28 +771,50 @@ class RegistryImageBuildUtils {
             }
 
             doLast {
+                // Bake writes one JSON per phase, keyed by target name. Split that into
+                // per-service metadata files so downstream consumers (jib base-image resolution
+                // in applyJibConfigurations, intermediate-arg resolution in resolveIntermediateArgs)
+                // can read ${serviceName}${archSuffix}.json as they do for the non-bake path.
+                // No outbound HTTP — bake already made the synchronous call to the registry
+                // when it pushed; we're just relaying the digest it recorded.
                 def archSuffix = architecture == "multi" ? "" : "_${architecture}"
+                def jsonSlurper = new groovy.json.JsonSlurper()
+                def phaseJsonCache = [:] as Map<String, Map>
                 includedProjects.each { cfg ->
-                    def repoName = cfg.get("repoName")?.toString()
-                    Registry targetRegistry = repoName ? finalRegistry : intermediateRegistry
-                    def hostFormatter = ImageRegistryFormatterFactory.getFormatter(targetRegistry.hostUrl)
-                    def imageName = cfg.get("imageName").toString()
-                    def imageTag = cfg.get("imageTag", "latest").toString()
-                    def hostVisibleRef = hostFormatter.getFullTargetImageIdentifier(
-                            targetRegistry.hostUrl,
-                            imageName,
-                            imageTag,
-                            repoName
-                    )[0].toString()
-                    def digest = architecture == "multi"
-                            ? resolveDigest(hostVisibleRef)?.split('@')?.last()
-                            : resolvePlatformDigest(hostVisibleRef, architecture)
-                    def metadataFile = RegistryImageBuildUtils.metadataFileFor(project, cfg.serviceName.toString(), archSuffix)
-                    metadataFile.parentFile.mkdirs()
-                    metadataFile.text = JsonOutput.prettyPrint(JsonOutput.toJson([
-                            "image.name"           : hostVisibleRef,
+                    def serviceName = cfg.serviceName.toString()
+                    def phaseName = serviceToPhase[serviceName]
+                    if (!phaseName) {
+                        throw new GradleException("No phase recorded for service ${serviceName}; doFirst did not run?")
+                    }
+                    def bakeMetadataFile = bakePhaseMetadataFiles[phaseName]
+                    if (!bakeMetadataFile?.exists()) {
+                        throw new GradleException("BuildKit bake did not write metadata file ${bakeMetadataFile} " +
+                                "for phase ${phaseName}. Verify the bake command includes --metadata-file.")
+                    }
+                    def phaseJson = phaseJsonCache.computeIfAbsent(phaseName) {
+                        (Map) jsonSlurper.parse(bakeMetadataFile)
+                    }
+                    def targetMeta = phaseJson[serviceName]
+                    if (!(targetMeta instanceof Map)) {
+                        throw new GradleException("Bake metadata file ${bakeMetadataFile} is missing target '${serviceName}'. " +
+                                "Keys present: ${phaseJson.keySet()}")
+                    }
+                    def digest = targetMeta["containerimage.digest"]?.toString()
+                    if (!digest) {
+                        throw new GradleException("No containerimage.digest for target '${serviceName}' in ${bakeMetadataFile}")
+                    }
+                    // Preserve bake's descriptor so readDigestFromMetadataFile can detect
+                    // OCI-index output and resolve per-platform digests when a consumer asks for one.
+                    def perServiceJson = [
+                            "image.name"           : serviceToHostVisibleRef[serviceName] ?: targetMeta["image.name"]?.toString(),
                             "containerimage.digest": digest
-                    ]))
+                    ]
+                    if (targetMeta["containerimage.descriptor"] != null) {
+                        perServiceJson["containerimage.descriptor"] = targetMeta["containerimage.descriptor"]
+                    }
+                    def metadataFile = RegistryImageBuildUtils.metadataFileFor(project, serviceName, archSuffix)
+                    metadataFile.parentFile.mkdirs()
+                    metadataFile.text = JsonOutput.prettyPrint(JsonOutput.toJson(perServiceJson))
                 }
             }
 


### PR DESCRIPTION
### Description

`buildKitBakeAll` was failing the 3.2.0 release-drafter run ([build 25406337260, job 74518036583](https://github.com/opensearch-project/opensearch-migrations/actions/runs/25406337260/job/74518036583)) with:

```
Execution failed for task ':buildKitBakeAll'.
> java.net.UnknownHostException: ***
```

…after bake had already successfully pushed every target, including `docker.io/***/opensearch-migrations-console:3.2.0`. So the build was fine; the post-build step was broken.

### Why it happened

After bake finished, `buildKitBakeAll`'s `doLast` block opened an HTTPS `HEAD` connection to the target registry for each service to recover the digest that bake had just pushed (see [previous `doLast`](https://github.com/opensearch-project/opensearch-migrations/blob/3.2.0/buildSrc/src/main/groovy/org/opensearch/migrations/image/RegistryImageBuildUtils.groovy#L783-L807) and [`resolveDigest`](https://github.com/opensearch-project/opensearch-migrations/blob/3.2.0/buildSrc/src/main/groovy/org/opensearch/migrations/image/RegistryImageBuildUtils.groovy#L104)).

That `HEAD` builds a URL as `https://<registryEndpoint>/v2/<repo>/manifests/<tag>`. The release workflow invokes Gradle with:

```
-PregistryEndpoint=opensearchstaging -PintermediateRegistry=localhost:5000 -PpublishStyle=separateRepos
```

`opensearchstaging` is a bare DockerHub namespace — no host prefix. The Docker CLI tolerates that (it silently prepends `docker.io/`), so bake and push both succeed. `java.net.URL` does not: it treats `opensearchstaging` as a hostname and throws `UnknownHostException`.

Only `migrationConsole` actually triggers it because it is the single BuildKit target whose `repoName` gets populated from `publishedRepoByImageName` under `publishStyle=separateRepos`, flipping its `targetRegistry` from the safe `intermediateRegistry` (`localhost:5000`) to the published one.

### Fix

`docker buildx bake` already writes the pushed digest for every target when invoked with `--metadata-file`. Switch to reading bake's own output instead of re-probing the registry:

1. In `doFirst` of the aggregate task, allocate one metadata file per phase (phases are separate `docker buildx bake` invocations, so one shared file would be overwritten). Append `--metadata-file <path>` to each phase command.
2. In `doLast`, parse each phase's JSON (keyed by target name), pull `containerimage.digest` (and `containerimage.descriptor` when present, so `readDigestFromMetadataFile`'s OCI-index fallback still works), and write the same per-service `${serviceName}${archSuffix}.json` files that downstream consumers already read:
   - `applyJibConfigurations` uses them to resolve jib base-image digests.
   - `resolveIntermediateArgs` uses them to wire intermediate base-image build args.

No outbound HTTP in the post-bake phase → no DNS on whatever the user passed as `-PregistryEndpoint`.

This matches the pattern already used by the single-target `buildKit_<service>` tasks ([here](https://github.com/opensearch-project/opensearch-migrations/blob/main/buildSrc/src/main/groovy/org/opensearch/migrations/image/RegistryImageBuildUtils.groovy#L576) and [here](https://github.com/opensearch-project/opensearch-migrations/blob/main/buildSrc/src/main/groovy/org/opensearch/migrations/image/RegistryImageBuildUtils.groovy#L612)) — the aggregate task just wasn't wired to use it.

### What changed

`buildSrc/src/main/groovy/org/opensearch/migrations/image/RegistryImageBuildUtils.groovy` only.

- `registerBuildKitBakeAggregateTask`:
  - `doFirst` now records a `phaseName → metadata file` map and a `serviceName → phaseName` map, and adds `--metadata-file` to every bake command.
  - `doLast` reads each phase JSON once (cached), extracts each target's entry, and writes the per-service metadata file. Errors explicitly if bake didn't write the file or didn't include the expected target.
- `resolveDigest` is removed. It had one caller (the old `doLast`) and nothing else in the repo uses it.
- `resolvePlatformDigest` stays — it is still reachable via `readDigestFromMetadataFile`'s OCI-index fallback, which runs only on the jib path where the registry is always `intermediateRegistry` (localhost), so it is unaffected by the bug.

### Verification

Local:

- `./gradlew :buildSrc:compileGroovy` — clean.
- `./gradlew buildKitBakeAll -PregistryEndpoint=opensearchstaging -PintermediateRegistry=localhost:5000 -PpublishStyle=separateRepos -Pbuilder=test --dry-run` — task graph configures with the same flags as the failing release job.

Full execution requires a real BuildKit builder + registry credentials, so the authoritative verification is CI on this PR. The next release-drafter run (or any workflow that invokes `buildKitBakeAll` with a bare-namespace `-PregistryEndpoint`) should now complete.

### Check List

- [x] New functionality includes testing — N/A, removing HTTP side-effect and reading an already-generated JSON file. `buildSrc` has no existing test harness; adding Spock/JUnit wiring is out of scope for an unblock PR.
- [x] New functionality has been documented — CHANGELOG lives in the release-drafter config; this is build-internal plumbing with no user-visible API change.
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
