### PR TITLE
fix(rfs): respect copy_to destinations and _source includes/excludes in reconstruction

### DIFF
--- a/RFS/src/test/java/org/opensearch/migrations/bulkload/lucene/FieldMappingContextTest.java
+++ b/RFS/src/test/java/org/opensearch/migrations/bulkload/lucene/FieldMappingContextTest.java
@@ -133,4 +133,94 @@ class FieldMappingContextTest {
 
         assertTrue(context.getFieldNames().isEmpty());
     }
+
+    @Test
+    void testNoFiltersMeansNothingExcluded() throws Exception {
+        String json = """
+            {
+                "properties": {
+                    "title": {"type": "text"}
+                }
+            }
+            """;
+        FieldMappingContext context = new FieldMappingContext(MAPPER.readTree(json));
+        assertFalse(context.isSourceExcluded("title"));
+        assertFalse(context.isSourceExcluded("anything.else"));
+    }
+
+    @Test
+    void testCopyToDestinationExcluded() throws Exception {
+        String json = """
+            {
+                "properties": {
+                    "title": {"type": "text", "copy_to": "all_text"},
+                    "body":  {"type": "text", "copy_to": ["all_text", "combined.text"]},
+                    "all_text": {"type": "text"}
+                }
+            }
+            """;
+        FieldMappingContext context = new FieldMappingContext(MAPPER.readTree(json));
+        assertTrue(context.isSourceExcluded("all_text"), "copy_to destination must be excluded");
+        assertTrue(context.isSourceExcluded("combined.text"), "array-form copy_to entries must be excluded");
+        assertFalse(context.isSourceExcluded("title"), "source fields must not be excluded");
+        assertFalse(context.isSourceExcluded("body"), "source fields must not be excluded");
+    }
+
+    @Test
+    void testSourceExcludes() throws Exception {
+        String json = """
+            {
+                "_source": {"excludes": ["secret", "nested.*"]},
+                "properties": {
+                    "secret":   {"type": "keyword"},
+                    "visible":  {"type": "keyword"},
+                    "nested":   {"properties": {"a": {"type": "keyword"}, "b": {"type": "keyword"}}}
+                }
+            }
+            """;
+        FieldMappingContext context = new FieldMappingContext(MAPPER.readTree(json));
+        assertTrue(context.isSourceExcluded("secret"));
+        assertTrue(context.isSourceExcluded("nested.a"));
+        assertTrue(context.isSourceExcluded("nested.b"));
+        assertTrue(context.isSourceExcluded("nested.deep.path"));
+        assertFalse(context.isSourceExcluded("visible"));
+        assertFalse(context.isSourceExcluded("nested"), "'nested.*' must not match the bare parent");
+    }
+
+    @Test
+    void testSourceIncludes() throws Exception {
+        String json = """
+            {
+                "_source": {"includes": ["keep.*"]},
+                "properties": {
+                    "keep":  {"properties": {"a": {"type": "keyword"}}},
+                    "drop":  {"type": "keyword"}
+                }
+            }
+            """;
+        FieldMappingContext context = new FieldMappingContext(MAPPER.readTree(json));
+        assertFalse(context.isSourceExcluded("keep.a"));
+        assertFalse(context.isSourceExcluded("keep.deep.path"));
+        assertTrue(context.isSourceExcluded("drop"), "outside includes -> excluded");
+        assertTrue(context.isSourceExcluded("keep"), "'keep.*' does not match bare 'keep'");
+    }
+
+    @Test
+    void testSourceExcludesWinsOverIncludes() throws Exception {
+        // ES semantics: excludes is applied after includes, so overlapping entries are dropped.
+        String json = """
+            {
+                "_source": {"includes": ["keep.*"], "excludes": ["keep.secret"]},
+                "properties": {
+                    "keep": {"properties": {
+                        "visible": {"type": "keyword"},
+                        "secret":  {"type": "keyword"}
+                    }}
+                }
+            }
+            """;
+        FieldMappingContext context = new FieldMappingContext(MAPPER.readTree(json));
+        assertFalse(context.isSourceExcluded("keep.visible"), "included and not excluded");
+        assertTrue(context.isSourceExcluded("keep.secret"), "excludes must beat includes on overlap");
+    }
 }

--- a/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/FieldMappingContext.java
+++ b/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/FieldMappingContext.java
@@ -1,49 +1,79 @@
 package org.opensearch.migrations.bulkload.lucene;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.function.Consumer;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import lombok.extern.slf4j.Slf4j;
 
 /**
  * Parses index mappings once and provides field type info for doc_value conversion.
+ * Also tracks {@code copy_to} destinations and {@code _source} include/exclude globs so
+ * the reconstructor can suppress fields that never existed in the origin {@code _source}.
  */
 @Slf4j
 public class FieldMappingContext {
     private static final String PROPERTIES = "properties";
+    private static final String SOURCE = "_source";
     private final Map<String, FieldMappingInfo> fieldMappings = new HashMap<>();
+    // Targets of some other field's copy_to. ES never writes copy_to output into _source,
+    // so reconstruction must treat these paths as absent.
+    private final Set<String> copyToDestinations = new HashSet<>();
+    // _source.includes / _source.excludes glob patterns. This implements a pragmatic subset
+    // of ES source-filter glob semantics sufficient for the common cases:
+    //   "*"              -> matches every path
+    //   "<prefix>.*"     -> matches any path starting with "<prefix>."
+    //   "<prefix>.**"    -> same as "<prefix>.*" for our purposes
+    //   "<literal.path>" -> exact match
+    // Mid-string '*' / '?' fall back to literal match with a debug log so they do not
+    // silently drop matching paths.
+    private final List<String> sourceIncludes = new ArrayList<>();
+    private final List<String> sourceExcludes = new ArrayList<>();
 
     public FieldMappingContext(JsonNode mappingsNode) {
         if (mappingsNode == null) {
             log.debug("Mappings node is null, no field mappings available");
             return;
         }
-        
+
         log.debug("Parsing mappings node of type: {}", mappingsNode.getNodeType());
-        JsonNode properties = extractProperties(mappingsNode);
-        
-        if (properties != null && !properties.isMissingNode()) {
+        JsonNode container = extractMappingContainer(mappingsNode);
+        if (container == null || !container.isObject()) {
+            log.debug("No mapping container found");
+            return;
+        }
+
+        parseSourceFilter(container.path(SOURCE));
+
+        JsonNode properties = container.path(PROPERTIES);
+        if (!properties.isMissingNode() && properties.isObject()) {
             log.debug("Found {} top-level properties", properties.size());
             parseProperties(properties, "");
         } else {
             log.debug("No properties found in mappings");
         }
-        
-        log.debug("Parsed {} field mappings total", fieldMappings.size());
+
+        log.debug("Parsed {} field mappings, {} copy_to destinations, {} include/exclude rules",
+            fieldMappings.size(), copyToDestinations.size(),
+            sourceIncludes.size() + sourceExcludes.size());
     }
 
-    private JsonNode extractProperties(JsonNode mappingsNode) {
+    private JsonNode extractMappingContainer(JsonNode mappingsNode) {
         if (mappingsNode.isArray()) {
-            return extractPropertiesFromArray(mappingsNode);
+            return extractContainerFromArray(mappingsNode);
         }
         if (mappingsNode.isObject()) {
-            return extractPropertiesFromObject(mappingsNode);
+            return extractContainerFromObject(mappingsNode);
         }
         return null;
     }
 
-    private JsonNode extractPropertiesFromArray(JsonNode mappingsNode) {
+    private JsonNode extractContainerFromArray(JsonNode mappingsNode) {
         // Multi-type mappings (ES 1.x-5.x) - take first type
         if (mappingsNode.size() == 0) {
             return null;
@@ -58,16 +88,15 @@ public class FieldMappingContext {
         }
         var typeEntry = fields.next();
         log.debug("Using first mapping type: {}", typeEntry.getKey());
-        return typeEntry.getValue().path(PROPERTIES);
+        return typeEntry.getValue();
     }
 
-    private JsonNode extractPropertiesFromObject(JsonNode mappingsNode) {
-        // Check for direct properties
-        JsonNode properties = mappingsNode.path(PROPERTIES);
-        if (!properties.isMissingNode()) {
-            return properties;
+    private JsonNode extractContainerFromObject(JsonNode mappingsNode) {
+        // Direct style (ES 7+): root has "properties" as a direct child.
+        if (!mappingsNode.path(PROPERTIES).isMissingNode()) {
+            return mappingsNode;
         }
-        // Check for typed mappings (ES 6.x style: {"_doc": {"properties": {...}}})
+        // Typed mappings (ES 6.x style: {"_doc": {"properties": {...}}})
         var fields = mappingsNode.fields();
         if (!fields.hasNext()) {
             return null;
@@ -78,21 +107,48 @@ public class FieldMappingContext {
             return null;
         }
         log.debug("Using mapping type: {}", typeName);
-        return typeEntry.getValue().path(PROPERTIES);
+        return typeEntry.getValue();
+    }
+
+    private void parseSourceFilter(JsonNode sourceNode) {
+        if (sourceNode.isMissingNode() || !sourceNode.isObject()) {
+            return;
+        }
+        collectStrings(sourceNode.path("includes"), sourceIncludes::add);
+        collectStrings(sourceNode.path("excludes"), sourceExcludes::add);
+    }
+
+    private static void collectStrings(JsonNode node, Consumer<String> sink) {
+        if (node.isMissingNode() || node.isNull()) {
+            return;
+        }
+        if (node.isTextual()) {
+            sink.accept(node.asText());
+            return;
+        }
+        if (node.isArray()) {
+            node.forEach(n -> {
+                if (n.isTextual()) {
+                    sink.accept(n.asText());
+                }
+            });
+        }
     }
 
     private void parseProperties(JsonNode properties, String prefix) {
         properties.fieldNames().forEachRemaining(fieldName -> {
             JsonNode fieldDef = properties.get(fieldName);
             String fullPath = prefix.isEmpty() ? fieldName : prefix + "." + fieldName;
-            
+
             if (fieldDef.has("type")) {
                 String type = fieldDef.get("type").asText();
                 FieldMappingInfo info = FieldMappingInfo.from(fieldDef);
                 fieldMappings.put(fullPath, info);
                 log.debug("Field '{}' -> type={}, esType={}", fullPath, type, info.type());
             }
-            
+
+            collectStrings(fieldDef.path("copy_to"), copyToDestinations::add);
+
             // Handle nested properties
             JsonNode nestedProps = fieldDef.path(PROPERTIES);
             if (!nestedProps.isMissingNode()) {
@@ -110,5 +166,52 @@ public class FieldMappingContext {
      */
     public java.util.Set<String> getFieldNames() {
         return fieldMappings.keySet();
+    }
+
+    /**
+     * Returns {@code true} if the given path should be suppressed from a reconstructed
+     * {@code _source}, because it is either (a) a {@code copy_to} destination — ES never
+     * writes copy_to output back into {@code _source}, (b) matches a {@code _source.excludes}
+     * glob, or (c) {@code _source.includes} is set and the path matches no include glob.
+     * Excludes take precedence over includes (ES semantics). Cheap no-op when the mapping
+     * declared neither {@code copy_to} nor a {@code _source} filter.
+     */
+    public boolean isSourceExcluded(String fieldPath) {
+        if (copyToDestinations.isEmpty() && sourceIncludes.isEmpty() && sourceExcludes.isEmpty()) {
+            return false;
+        }
+        if (copyToDestinations.contains(fieldPath)) {
+            return true;
+        }
+        for (String glob : sourceExcludes) {
+            if (matchesGlob(glob, fieldPath)) {
+                return true;
+            }
+        }
+        if (!sourceIncludes.isEmpty()) {
+            for (String glob : sourceIncludes) {
+                if (matchesGlob(glob, fieldPath)) {
+                    return false;
+                }
+            }
+            return true;
+        }
+        return false;
+    }
+
+    private static boolean matchesGlob(String glob, String path) {
+        if ("*".equals(glob)) {
+            return true;
+        }
+        if (glob.endsWith(".**")) {
+            return path.startsWith(glob.substring(0, glob.length() - 2));
+        }
+        if (glob.endsWith(".*")) {
+            return path.startsWith(glob.substring(0, glob.length() - 1));
+        }
+        if (glob.indexOf('*') >= 0 || glob.indexOf('?') >= 0) {
+            log.debug("Unsupported source-filter glob '{}', treating as literal", glob);
+        }
+        return path.equals(glob);
     }
 }

--- a/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/SourceReconstructor.java
+++ b/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/SourceReconstructor.java
@@ -40,11 +40,15 @@ public class SourceReconstructor {
         if (fieldName.startsWith("_")) {
             return true;
         }
-        if (!fieldName.contains(".")) {
-            return false;
+        if (fieldName.contains(".")
+            && (mappingContext == null || mappingContext.getFieldInfo(fieldName) == null)) {
+            // Dotted field the mapping does not recognize as an object subfield (i.e., a
+            // multi-field sub-field like title.keyword).
+            return true;
         }
-        // Dotted field: keep it only if the mapping recognizes it as an object subfield.
-        return mappingContext == null || mappingContext.getFieldInfo(fieldName) == null;
+        // Final gate: respect the origin mapping's copy_to destinations and _source
+        // includes/excludes. Cheap no-op when none are declared.
+        return mappingContext != null && mappingContext.isSourceExcluded(fieldName);
     }
 
     /**

--- a/SearchSnapshotExtractor/src/test/java/org/opensearch/migrations/bulkload/lucene/SourceReconstructorTest.java
+++ b/SearchSnapshotExtractor/src/test/java/org/opensearch/migrations/bulkload/lucene/SourceReconstructorTest.java
@@ -1248,4 +1248,47 @@ class SourceReconstructorTest {
         assertEquals("alice@example.com", tree.path("user").path("email").asText(),
             "dotted subfield from doc_values path must nest: " + json);
     }
+
+    @Test
+    void reconstructSource_respectsCopyToAndSourceExcludes() throws IOException {
+        // REGRESSION: reconstructor used to emit every field it could recover from stored fields /
+        // doc_values / points — including copy_to destinations (which ES never writes to _source)
+        // and fields the origin mapping filtered out via _source.excludes. Stand-in mapping:
+        //   title, body  -> origin _source fields, both copy_to "all_text"
+        //   all_text     -> mapped field, but pure copy_to sink (not in origin _source)
+        //   secret       -> mapped field, but filtered via _source.excludes
+        // The reconstructed _source must contain exactly {title, body}.
+        String mappingJson = """
+            {
+                "_source": {"excludes": ["secret"]},
+                "properties": {
+                    "title":    {"type": "text", "copy_to": "all_text"},
+                    "body":     {"type": "text", "copy_to": "all_text"},
+                    "all_text": {"type": "text"},
+                    "secret":   {"type": "keyword"}
+                }
+            }
+            """;
+        var ctx = new FieldMappingContext(MAPPER.readTree(mappingJson));
+
+        var reader = storedOnlyReader();
+        // Simulate a segment that has stored values for every indexed field — i.e. the path
+        // the reconstructor would otherwise happily serialize for all four.
+        var doc = document(
+            storedString("title", "hello"),
+            storedString("body", "world"),
+            storedString("all_text", "hello world"),
+            storedString("secret", "do-not-emit")
+        );
+
+        String json = SourceReconstructor.reconstructSource(reader, 0, doc, ctx);
+        JsonNode tree = MAPPER.readTree(json);
+
+        assertEquals("hello", tree.path("title").asText(), "title preserved: " + json);
+        assertEquals("world", tree.path("body").asText(), "body preserved: " + json);
+        assertTrue(tree.path("all_text").isMissingNode(),
+            "copy_to destination must not appear in _source: " + json);
+        assertTrue(tree.path("secret").isMissingNode(),
+            "_source.excludes field must not appear in _source: " + json);
+    }
 }


### PR DESCRIPTION
## Problem

The sourceless reconstructor walks every stored field, doc_value, and indexed point it can reach, then serializes all of them into the rebuilt `_source`. That's the wrong shape for two categories of field that exist on the indexed side but never existed in the origin `_source`:

- **`copy_to` destinations.** ES writes `copy_to` output only to the inverted index and doc_values. It never writes it back into `_source`. A mapping with `{title, body, copy_to: "all_text"}` produces a document whose ES `_source` contains `{title, body}` but whose reconstructed OS `_source` (prior to this fix) contained `{title, body, all_text}`.
- **`_source.excludes` / `_source.includes` paths.** If the origin mapping declares `_source.excludes: ["secret"]`, ES never stores `secret` in `_source`, yet the field is typically still indexed — so the reconstructor emitted it.

The practical impact: an extraneous top-level object appears in the reconstructed document whenever the origin mapping funnels many leaves into a shared `copy_to` sink (for example, when an index maps per-bucket sub-fields to an umbrella "all" path for cross-field search).

## Before / after

Mapping:
```json
{
  "_source": {"excludes": ["secret"]},
  "properties": {
    "title":    {"type": "text", "copy_to": "all_text"},
    "body":     {"type": "text", "copy_to": "all_text"},
    "all_text": {"type": "text"},
    "secret":   {"type": "keyword"}
  }
}
```

Indexed document on origin: `{title, body, secret}` (the original `_source` — `all_text` never existed in `_source`; `secret` was filtered out).

| Path     | Origin `_source` | Reconstructed `_source` (before) | Reconstructed `_source` (after) |
|----------|:---:|:---:|:---:|
| title    | ✓ | ✓ | ✓ |
| body     | ✓ | ✓ | ✓ |
| all_text | — | **leaked** | — |
| secret   | — | **leaked** | — |

## Fix

- `FieldMappingContext` now parses `copy_to` at every mapped leaf and the index-level `_source.includes` / `_source.excludes` block, and exposes `isSourceExcluded(path)` as a single gate that combines copy_to-sink detection with include/exclude glob matching. Cheap no-op when neither directive is declared.
- `SourceReconstructor.shouldSkipField` consults that gate as its final decision. All existing call sites (stored fields, doc_values, points, terms) pick up the new behaviour without further changes.

Glob matching is a pragmatic subset sufficient for the common cases: exact paths, `"*"`, trailing `".*"`, trailing `".**"`. Mid-string wildcards fall back to literal match with a debug log so they don't silently drop matches.

## Tests

`RFS/.../FieldMappingContextTest`:
- `testNoFiltersMeansNothingExcluded` — no `copy_to` / `_source` filter declared → `isSourceExcluded` is a no-op.
- `testCopyToDestinationExcluded` — scalar and array-form `copy_to` destinations are excluded; source fields aren't.
- `testSourceExcludes` — exact-path and trailing-`.*` globs.
- `testSourceIncludes` — include-list gate; paths outside are excluded.
- `testSourceExcludesWinsOverIncludes` — ES semantics: excludes is applied after includes.

`SearchSnapshotExtractor/.../SourceReconstructorTest.reconstructSource_respectsCopyToAndSourceExcludes` — end-to-end behavioural test through `reconstructSource`: builds a segment whose stored fields include the `copy_to` sink and the `_source.excludes` field, runs the full reconstruction path, and asserts the rebuilt `_source` is shaped exactly `{title, body}`.

All 14 tests green locally:
```
./gradlew :SearchSnapshotExtractor:test --tests '*FieldMappingContext*' --tests '*SourceReconstructor*' :RFS:test --tests '*FieldMappingContext*'
```

## Scope

No behaviour change when the mapping declares neither `copy_to` nor `_source` filters. No changes outside the two production files and their two tests. No build, config, or unrelated refactors.
