### PR TITLE
(Fix) migrate to explicit clusterName for sample-cdk v0.4.0

### DIFF
--- a/test/awsDeployCluster.sh
+++ b/test/awsDeployCluster.sh
@@ -129,11 +129,16 @@ cp -f "$PROVIDED_CONTEXT_FILE_PATH" "$CLUSTER_CDK_CONTEXT_FILE_PATH"
 # Wait for any leftover OpenSearch domains from a previous run to finish deleting.
 # The CDK VPC-validation Lambda will reject deployment if a domain with the same name
 # still exists in a different VPC (e.g. from a prior run whose cleanup is still in progress).
-# Read clusterName from the context if set (sample-cdk honors it verbatim); otherwise
-# fall back to the sample-cdk default pattern "cluster-<stage>-<clusterId>".
+# Every cluster entry must set `clusterName` explicitly. This keeps the script
+# independent of sample-cdk's internal default naming pattern, which is an
+# implementation detail of the sample-cdk and not part of this script's contract.
 while read -r entry; do
   cid=$(echo "$entry" | jq -r '.clusterId')
-  domain_name=$(echo "$entry" | jq -r --arg stage "$STAGE" --arg cid "$cid" '.clusterName // "cluster-\($stage)-\($cid)"')
+  domain_name=$(echo "$entry" | jq -r '.clusterName // empty')
+  if [[ -z "$domain_name" ]]; then
+    echo "ERROR: cluster '$cid' is missing 'clusterName' in the context file. Set 'clusterName' explicitly for each cluster entry."
+    exit 1
+  fi
   if aws opensearch describe-domain --domain-name "$domain_name" >/dev/null 2>&1; then
     if aws opensearch describe-domain --domain-name "$domain_name" \
          --query 'DomainStatus.Deleted' --output text 2>/dev/null | grep -qi true; then

--- a/test/awsDeployCluster.sh
+++ b/test/awsDeployCluster.sh
@@ -112,7 +112,7 @@ if [[ -z "$PROVIDED_CONTEXT_FILE_PATH" ]]; then
 fi
 
 SAMPLE_CDK_REPO="https://github.com/aws-samples/amazon-opensearch-service-sample-cdk.git"
-SAMPLE_CDK_VERSION="v0.3.10"
+SAMPLE_CDK_VERSION="v0.4.0"
 echo "Using sample CDK version: $SAMPLE_CDK_VERSION"
 if [ ! -d "amazon-opensearch-service-sample-cdk" ]; then
   git clone "$SAMPLE_CDK_REPO"

--- a/test/awsDeployCluster.sh
+++ b/test/awsDeployCluster.sh
@@ -129,9 +129,11 @@ cp -f "$PROVIDED_CONTEXT_FILE_PATH" "$CLUSTER_CDK_CONTEXT_FILE_PATH"
 # Wait for any leftover OpenSearch domains from a previous run to finish deleting.
 # The CDK VPC-validation Lambda will reject deployment if a domain with the same name
 # still exists in a different VPC (e.g. from a prior run whose cleanup is still in progress).
-cluster_ids=$(jq -r '.clusters[].clusterId' "$PROVIDED_CONTEXT_FILE_PATH")
-for cid in $cluster_ids; do
-  domain_name="cluster-${STAGE}-${cid}"
+# Read clusterName from the context if set (sample-cdk honors it verbatim); otherwise
+# fall back to the sample-cdk default pattern "cluster-<stage>-<clusterId>".
+while read -r entry; do
+  cid=$(echo "$entry" | jq -r '.clusterId')
+  domain_name=$(echo "$entry" | jq -r --arg stage "$STAGE" --arg cid "$cid" '.clusterName // "cluster-\($stage)-\($cid)"')
   if aws opensearch describe-domain --domain-name "$domain_name" >/dev/null 2>&1; then
     if aws opensearch describe-domain --domain-name "$domain_name" \
          --query 'DomainStatus.Deleted' --output text 2>/dev/null | grep -qi true; then
@@ -152,7 +154,7 @@ for cid in $cluster_ids; do
       echo "WARNING: Domain '$domain_name' exists and is NOT being deleted. CDK deploy may fail if VPC differs."
     fi
   fi
-done
+done < <(jq -c '.clusters[]' "$PROVIDED_CONTEXT_FILE_PATH")
 
 # Delete any ROLLBACK_COMPLETE stacks from a prior failed deploy — CDK cannot update these.
 rollback_stacks=$(aws cloudformation list-stacks \

--- a/vars/deployClustersStep.groovy
+++ b/vars/deployClustersStep.groovy
@@ -9,6 +9,7 @@ def call(Map config = [:]) {
         if (config.sourceVer) {
             def cluster = [
                     clusterId               : "source",
+                    clusterName             : "${config.stage}-source",
                     clusterVersion          : "${config.sourceVer}",
                     clusterType             : "${config.sourceClusterType}",
                     domainRemovalPolicy     : "DESTROY",
@@ -27,6 +28,7 @@ def call(Map config = [:]) {
         if (config.targetVer) {
             def cluster = [
                     clusterId               : "target",
+                    clusterName             : "${config.stage}-target",
                     clusterVersion          : "${config.targetVer}",
                     clusterType             : "${config.targetClusterType}",
                     domainRemovalPolicy     : "DESTROY",

--- a/vars/deployIsolatedAosClusters.groovy
+++ b/vars/deployIsolatedAosClusters.groovy
@@ -117,7 +117,7 @@ def call(Map config = [:]) {
     }
 
     // 5. Add security group rules: EKS → AOS on port 443
-    // Domain names follow the pattern: cluster-<stage>-<clusterId>
+    // Domain names follow the pattern: <stage>-<clusterId> (clusterName overridden in deployClustersStep)
     withMigrationsTestAccount(region: region) { accountId ->
         def eksSg = sh(script: """
             aws eks describe-cluster --name ${eksClusterName} --region ${region} \
@@ -125,7 +125,7 @@ def call(Map config = [:]) {
         """, returnStdout: true).trim()
 
         for (clusterId in ['source', 'target']) {
-            def domainName = "cluster-${stage}-${clusterId}"
+            def domainName = "${stage}-${clusterId}"
             def sg = sh(script: """
                 aws opensearch describe-domain --domain-name ${domainName} --region ${region} \
                   --query 'DomainStatus.VPCOptions.SecurityGroupIds[0]' --output text 2>/dev/null || echo ''

--- a/vars/eksAOSSIntegPipeline.groovy
+++ b/vars/eksAOSSIntegPipeline.groovy
@@ -143,6 +143,7 @@ def call(Map config = [:]) {
                                         clusters: [
                                             [
                                                 clusterId: "target",
+                                                clusterName: "${maStageName}-target",
                                                 clusterType: "OPENSEARCH_SERVERLESS",
                                                 collectionType: collectionType,
                                                 standbyReplicas: "DISABLED",

--- a/vars/eksBYOSIntegPipeline.groovy
+++ b/vars/eksBYOSIntegPipeline.groovy
@@ -407,6 +407,7 @@ def deployTargetClusterOnly(Map config) {
         vpcId: "${config.vpcId}",
         clusters: [[
             clusterId: "target",
+            clusterName: "${config.stage}-target",
             clusterVersion: "${config.targetVer}",
             clusterType: "OPENSEARCH_MANAGED_SERVICE",
             openAccessPolicyEnabled: true,

--- a/vars/eksCdcAossIntegPipeline.groovy
+++ b/vars/eksCdcAossIntegPipeline.groovy
@@ -138,6 +138,7 @@ def call(Map config = [:]) {
                                         clusters: [
                                             [
                                                 clusterId: "source",
+                                                clusterName: "${maStageName}-source",
                                                 clusterVersion: env.sourceVer,
                                                 clusterType: params.SOURCE_CLUSTER_TYPE,
                                                 domainRemovalPolicy: "DESTROY",
@@ -154,6 +155,7 @@ def call(Map config = [:]) {
                                             ],
                                             [
                                                 clusterId: "target",
+                                                clusterName: "${maStageName}-target",
                                                 clusterType: "OPENSEARCH_SERVERLESS",
                                                 collectionType: "SEARCH",
                                                 standbyReplicas: "DISABLED",


### PR DESCRIPTION
### Description
Three related changes to keep EKS integ pipelines working with [amazon-opensearch-service-sample-cdk v0.4.0](https://github.com/aws-samples/amazon-opensearch-service-sample-cdk/releases/tag/v0.4.0), which: (1) added synth-time validation of AWS resource-name limits on `clusterName` in 0.3.11 (aws-samples/amazon-opensearch-service-sample-cdk#137), and (2) dropped the `cluster-` prefix from the default `clusterName` in 0.4.0 (aws-samples/amazon-opensearch-service-sample-cdk#139).

**1. Override `clusterName` explicitly** in the 4 pipelines that consume sample-cdk. Uses `${stage}-${clusterId}` — matches v0.4.0's new default exactly, and insulates the pipelines from any future default-naming changes. Without this, `eksCdcAossIntegPipeline` would have tripped the AOSS 25-char `clusterName` limit at two-digit build numbers in the 0.3.x era (the `aosscdc` stageId was already 9 chars of fixed overhead).

**2. Update two downstream lookups that assumed the old default naming**:
- `vars/deployIsolatedAosClusters.groovy` — the EKS→AOS security-group authorization step was calling `describe-domain --domain-name "cluster-${stage}-${clusterId}"`; now uses `"${stage}-${clusterId}"` to match what's actually deployed.
- `test/awsDeployCluster.sh` — the "wait for leftover deleting domain" pre-flight check now reads `.clusterName` directly from the context and hard-fails if missing, rather than guessing a sample-cdk default. Addresses @gregschohn's review comment ("do you need the prefix 'cluster'?") — the whole fallback is gone, not just the prefix.

**3. Bump `SAMPLE_CDK_VERSION`** from `v0.3.10` → `v0.4.0` directly, skipping the intermediate 0.3.11 (its only consumer-visible behavior — synth-time validation — is trivially satisfied by the explicit overrides in change 1).

After this PR, all six sample-cdk-consuming pipelines fit comfortably within AWS resource-name limits for 9-digit build numbers:

| Pipeline | Longest clusterName (build=999,999) | Longest derived AOSS policy name | AWS limit |
|---|---|---|---|
| `eksIntegPipeline` | `eksint-p999999-target` = 21 | — | 28 (managed) |
| `eksCdcIntegPipeline` | `esoscdc-p999999-target` = 22 | — | 28 (managed) |
| `eksBYOSIntegPipeline` | `eksbyos-p999999-target`
| `eksAOSSIntegPipeline` | `aosss-p999999-target` = 20 | `-access` → 27 | 32 (AOSS policy) |
| `eksCdcAossIntegPipeline` | `aosscdc-p999999-target` = 22 | `-access` → 29 | 32 (AOSS policy) |
| `eksIsolatedIntegTest` | `isoint-p999999-target` = 21 | — | 28 (managed) |

### Issues Resolved
- Jenkins : [main-eks-cdc-aoss-e2e-test](https://migrations.ci.opensearch.org/job/main/job/main-eks-cdc-aoss-e2e-test/)

### Testing
- Existing GHA and Jenkins

### Check List
- [x] New functionality includes testing
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
