### PR TITLE
Add test to catch groovy/test_runner version drift

### DIFF
--- a/libraries/testAutomation/tests/test_test_runner.py
+++ b/libraries/testAutomation/tests/test_test_runner.py
@@ -138,3 +138,46 @@ class TestVersionCombinations:
         combos = get_version_combinations("all", "OS_2.19", TargetType.AOSS)
         assert all(t == "AOSS" for _, t in combos)
         assert len(combos) == len(VALID_SOURCE_VERSIONS)
+
+
+class TestGroovyVersionConsistency:
+    """Ensure pipeline groovy files only reference versions that test_runner accepts."""
+
+    @staticmethod
+    def _find_repo_root():
+        path = os.path.dirname(__file__)
+        while path != '/':
+            if os.path.isdir(os.path.join(path, '.git')) or os.path.isfile(os.path.join(path, '.git')):
+                return path
+            path = os.path.dirname(path)
+        return None
+
+    def _read_groovy_versions(self, filename):
+        """Extract version strings from a groovy file."""
+        import re
+        repo_root = self._find_repo_root()
+        if not repo_root:
+            pytest.skip("Cannot find repo root")
+        filepath = os.path.join(repo_root, 'vars', filename)
+        if not os.path.exists(filepath):
+            pytest.skip(f"{filepath} not found")
+        content = open(filepath).read()
+        # Match sourceVersion: 'XXX' or sourceVersions: ['XXX', 'YYY']
+        singles = re.findall(r"sourceVersion:\s*'([^']+)'", content)
+        lists = re.findall(r"sourceVersions:\s*\[([^\]]+)\]", content)
+        versions = list(singles)
+        for lst in lists:
+            versions.extend(re.findall(r"'([^']+)'", lst))
+        return versions
+
+    def test_elasticsearch8x_version_in_valid_list(self):
+        versions = self._read_groovy_versions('elasticsearch8xK8sLocalTest.groovy')
+        for v in versions:
+            assert v in VALID_SOURCE_VERSIONS, \
+                f"'{v}' in elasticsearch8xK8sLocalTest.groovy is not in VALID_SOURCE_VERSIONS: {VALID_SOURCE_VERSIONS}"
+
+    def test_migration_versions_in_valid_list(self):
+        versions = self._read_groovy_versions('migrationVersions.groovy')
+        for v in versions:
+            assert v in VALID_SOURCE_VERSIONS, \
+                f"'{v}' in migrationVersions.groovy is not in VALID_SOURCE_VERSIONS: {VALID_SOURCE_VERSIONS}"


### PR DESCRIPTION
## Problem

The `elasticsearch8xK8sLocalTest.groovy` had `sourceVersion: 'ES_8.x'` but `test_runner.py`'s `VALID_SOURCE_VERSIONS` didn't include `ES_8.x`, causing Jenkins failures:
```
error: argument --source-version: invalid choice: 'ES_8.x'
```

This happened because the shared library is loaded from the PR branch (`library identifier: "migrations-lib@${gitBranch}"` in the cover groovy), so both the pipeline definition and the test code come from the same branch. When they drift apart, the test fails with a cryptic argparse error.

The version mismatch was fixed in PR #2847, but there's nothing preventing it from happening again.

## Fix

Add a test that parses the groovy pipeline files and asserts every `sourceVersion` referenced is present in `VALID_SOURCE_VERSIONS`. This catches the drift at PR CI time with a clear assertion message, before it reaches Jenkins.

## Why not fix it in the pipeline itself?

The cover groovy (`elasticsearch8xK8sLocalTestCover.groovy`) is the only file loaded from main — everything else comes from the PR branch. Since the pipeline groovy (`k8sLocalDeployment.groovy`) is loaded from the PR branch, any fix there won't help old PRs that don't have it. The only real fix for currently-broken old PRs is to rebase onto main.