### PR TITLE
Restore default SIGPIPE handling in CLI entry points

### DIFF
--- a/migrationConsole/lib/console_link/console_link/cli.py
+++ b/migrationConsole/lib/console_link/console_link/cli.py
@@ -1,4 +1,5 @@
 # pyright: ignore[reportCallIssue]
+import signal
 from contextlib import contextmanager
 import json
 from pprint import pprint
@@ -6,6 +7,12 @@ import sys
 import time
 from typing import Dict
 import click
+
+# Restore default SIGPIPE handling so piped commands (e.g. `| head`) exit cleanly.
+try:
+    signal.signal(signal.SIGPIPE, signal.SIG_DFL)
+except (AttributeError, ValueError):
+    pass
 
 import console_link.middleware.clusters as clusters_
 import console_link.middleware.metrics as metrics_

--- a/migrationConsole/lib/console_link/console_link/workflow/cli.py
+++ b/migrationConsole/lib/console_link/console_link/workflow/cli.py
@@ -1,9 +1,16 @@
 """Main CLI entry point for the workflow tool."""
 
+import signal
 import sys
 import logging
 import click
 from click.shell_completion import get_completion_class
+
+# Restore default SIGPIPE handling so piped commands (e.g. `| head`) exit cleanly.
+try:
+    signal.signal(signal.SIGPIPE, signal.SIG_DFL)
+except (AttributeError, ValueError):
+    pass
 
 from .models.utils import ExitCode
 from .models.utils import get_current_namespace

--- a/migrationConsole/lib/console_link/tests/test_sigpipe_handling.py
+++ b/migrationConsole/lib/console_link/tests/test_sigpipe_handling.py
@@ -4,6 +4,7 @@ Regression coverage for
 https://github.com/opensearch-project/opensearch-migrations/issues/2803
 """
 
+import shutil
 import subprocess
 import sys
 import textwrap
@@ -13,6 +14,11 @@ import pytest
 skip_on_windows = pytest.mark.skipif(
     sys.platform == "win32",
     reason="SIGPIPE is POSIX-only",
+)
+
+skip_if_not_installed = pytest.mark.skipif(
+    not shutil.which("workflow"),
+    reason="workflow CLI not installed",
 )
 
 
@@ -57,6 +63,7 @@ def test_workflow_cli_import_installs_sigpipe_sig_dfl():
 # ---------- End-to-end: actual bug reproduction ----------
 
 @skip_on_windows
+@skip_if_not_installed
 @pytest.mark.parametrize("consumer", [
     "head -0",
     "head",
@@ -80,6 +87,7 @@ def test_workflow_configure_sample_pipe_no_traceback(consumer):
 
 
 @skip_on_windows
+@skip_if_not_installed
 def test_workflow_configure_sample_full_read_still_works():
     """Sanity check: the fix must not break the happy path (full stdout read)."""
     proc = subprocess.run(

--- a/migrationConsole/lib/console_link/tests/test_sigpipe_handling.py
+++ b/migrationConsole/lib/console_link/tests/test_sigpipe_handling.py
@@ -1,0 +1,91 @@
+"""Tests for SIGPIPE handling in CLI entry points.
+
+Regression coverage for
+https://github.com/opensearch-project/opensearch-migrations/issues/2803
+"""
+
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+skip_on_windows = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="SIGPIPE is POSIX-only",
+)
+
+
+# ---------- Unit tests: verify handler is installed at import time ----------
+
+@skip_on_windows
+def test_console_cli_import_installs_sigpipe_sig_dfl():
+    """Importing console_link.cli must restore default SIGPIPE handling."""
+    script = textwrap.dedent("""
+        import signal
+        import console_link.cli  # noqa: F401
+        handler = signal.getsignal(signal.SIGPIPE)
+        assert handler == signal.SIG_DFL, f"Expected SIG_DFL, got {handler!r}"
+        print("OK")
+    """)
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True, text=True, timeout=30,
+    )
+    assert result.returncode == 0, f"stderr: {result.stderr}"
+    assert "OK" in result.stdout
+
+
+@skip_on_windows
+def test_workflow_cli_import_installs_sigpipe_sig_dfl():
+    """Same guarantee for the workflow CLI entry point."""
+    script = textwrap.dedent("""
+        import signal
+        import console_link.workflow.cli  # noqa: F401
+        handler = signal.getsignal(signal.SIGPIPE)
+        assert handler == signal.SIG_DFL, f"Expected SIG_DFL, got {handler!r}"
+        print("OK")
+    """)
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True, text=True, timeout=30,
+    )
+    assert result.returncode == 0, f"stderr: {result.stderr}"
+    assert "OK" in result.stdout
+
+
+# ---------- End-to-end: actual bug reproduction ----------
+
+@skip_on_windows
+@pytest.mark.parametrize("consumer", [
+    "head -0",
+    "head",
+    "true",
+    ":",
+    "grep -m1 sourceClusters",
+    "sed -n 1p",
+])
+def test_workflow_configure_sample_pipe_no_traceback(consumer):
+    """`workflow configure sample | <consumer>` must not print a Python traceback."""
+    proc = subprocess.run(
+        f"workflow configure sample | {consumer}",
+        shell=True, capture_output=True, text=True, timeout=60,
+    )
+    assert "Traceback" not in proc.stderr, (
+        f"Unexpected traceback for consumer={consumer!r}:\n{proc.stderr}"
+    )
+    assert "Broken pipe" not in proc.stderr, (
+        f"Unexpected BrokenPipe message for consumer={consumer!r}:\n{proc.stderr}"
+    )
+
+
+@skip_on_windows
+def test_workflow_configure_sample_full_read_still_works():
+    """Sanity check: the fix must not break the happy path (full stdout read)."""
+    proc = subprocess.run(
+        "workflow configure sample",
+        shell=True, capture_output=True, text=True, timeout=60,
+    )
+    assert proc.returncode == 0, f"exit={proc.returncode} stderr={proc.stderr}"
+    assert "sourceClusters" in proc.stdout
+    assert "Traceback" not in proc.stderr


### PR DESCRIPTION
### Problem
Running `workflow configure sample | head` (or any early-closing pipe consumer) prints a full Python traceback and `BrokenPipeError` to stderr. This happens because Python's default SIGPIPE handler raises an exception instead of exiting silently.

### Fix
Restore default Unix SIGPIPE handling (`signal.signal(signal.SIGPIPE, signal.SIG_DFL)`) at both CLI entry points (`console` and `workflow`). This is the standard approach used by `aws`, `kubectl`, and other CLI tools.

### Issues Resolved
Fixes https://github.com/opensearch-project/opensearch-migrations/issues/2803

### Testing
Added regression tests covering:
  - Import-time verification that SIG_DFL is installed
  - End-to-end pipe scenarios (`head -0`, `head`, `true`, `grep -m1`, `sed -n 1p`)
  - Happy-path sanity check (full read still works)

### Check List
- [ ] New functionality includes testing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
