### PR TITLE
Solr: preserve dotted field names through migration

### DIFF
--- a/DocumentsFromSnapshotMigration/src/test/java/org/opensearch/migrations/bulkload/SolrSnapshotToOpenSearchTest.java
+++ b/DocumentsFromSnapshotMigration/src/test/java/org/opensearch/migrations/bulkload/SolrSnapshotToOpenSearchTest.java
@@ -12,6 +12,9 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 
+import org.opensearch.migrations.MetadataMigration;
+import org.opensearch.migrations.MigrateOrEvaluateArgs;
+import org.opensearch.migrations.Version;
 import org.opensearch.migrations.bulkload.common.DocumentExceptionAllowlist;
 import org.opensearch.migrations.bulkload.common.OpenSearchClientFactory;
 import org.opensearch.migrations.bulkload.common.RestClient;
@@ -34,6 +37,7 @@ import org.opensearch.migrations.bulkload.workcoordination.WorkCoordinatorFactor
 import org.opensearch.migrations.bulkload.worker.CompletionStatus;
 import org.opensearch.migrations.bulkload.worker.ShardWorkPreparer;
 import org.opensearch.migrations.bulkload.worker.WorkItemCursor;
+import org.opensearch.migrations.metadata.tracing.MetadataMigrationTestContext;
 import org.opensearch.migrations.reindexer.tracing.DocumentMigrationTestContext;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -48,6 +52,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -409,6 +414,129 @@ public class SolrSnapshotToOpenSearchTest {
     }
 
     /**
+     * Backfill E2E regression: Solr fields with dotted names (including names
+     * whose top-level segment matches a default {@code dynamicField} pattern)
+     * survive the full backfill flow — {@code MetadataMigration} pushes the
+     * converted schema, then {@code RfsMigrateDocuments} writes documents.
+     *
+     * <p>SOURCE — Solr collection {@code dotted_collection} (Solr default schema's
+     * dynamic fields) with two explicit dotted-name fields and one document.
+     * <pre>{@code
+     *   schema (explicit dotted fields):
+     *     category.name      string  (→ OS keyword)
+     *     metric.cpu.percent pfloat  (→ OS float)
+     *   schema (default dynamicField patterns exercised):
+     *     attr_*  → text_general,  *_i → pint
+     *   doc1: {
+     *     category.name:"books",                // explicit dotted field
+     *     metric.cpu.percent:42.5,              // explicit 3-segment dotted field
+     *     attr_thing.withdot:"vip",             // attr_*  + dotted leaf (regression case)
+     *     counter.value_i:17                    // *_i     + dotted leaf
+     *   }
+     * }</pre>
+     *
+     * <p>TARGET — OpenSearch index {@code dotted_collection} containing exactly one
+     * doc with all four dotted keys preserved verbatim in {@code _source}, the
+     * declared dotted fields typed in the {@code _mapping}, and dotted-path
+     * queries returning the doc.
+     *
+     * <p>Pre-fix, MetadataMigration emitted dynamic templates with plain
+     * {@code match}, so the {@code attr_*} template fired on the synthesized
+     * parent {@code attr_thing} when the doc was written, and the bulk write
+     * failed with {@code mapper_parsing_exception}, dropping the doc.
+     */
+    @ParameterizedTest(name = "backfill dotted-name fields: {0} → {1}")
+    @MethodSource("solr8ToOpenSearch3Cloud")
+    void backfillsDottedFieldNames(
+        SolrClusterContainer.SolrVersion solrVersion,
+        SearchClusterContainer.ContainerVersion targetVersion
+    ) throws Exception {
+        var collection = "dotted_collection";
+        try (
+            var solr = SolrClusterContainer.cloud(solrVersion);
+            var target = new SearchClusterContainer(targetVersion)
+        ) {
+            solr.start();
+            target.start();
+
+            // ---- SOURCE: Solr collection with explicit dotted fields + 1 doc ----
+            createCollection(solr, collection);
+            addSchemaFields(solr, collection, "["
+                + "{\"name\":\"category.name\",      \"type\":\"string\", \"stored\":true, \"indexed\":true, \"docValues\":true},"
+                + "{\"name\":\"metric.cpu.percent\", \"type\":\"pfloat\", \"stored\":true, \"indexed\":true, \"docValues\":true}"
+                + "]");
+            indexDocs(solr, collection, "[{"
+                + "\"id\":\"doc1\","
+                + "\"category.name\":\"books\","
+                + "\"metric.cpu.percent\":42.5,"
+                + "\"attr_thing.withdot\":\"vip\","
+                + "\"counter.value_i\":17"
+                + "}]");
+
+            // ---- MIGRATE: backup → MetadataMigration (schema) → RfsMigrateDocuments CLI (docs) ----
+            var backupRoot = createBackup(solr, collection);
+
+            // 1. Push the converted Solr schema (with dotted-leaf-safe dynamic templates) to OS.
+            var metadataArgs = new MigrateOrEvaluateArgs();
+            metadataArgs.fileSystemRepoPath = backupRoot.toString();
+            metadataArgs.sourceVersion = Version.fromString("SOLR " + solrVersion.tag());
+            metadataArgs.targetArgs.host = target.getUrl();
+            var metaResult = new MetadataMigration().migrate(metadataArgs)
+                .execute(MetadataMigrationTestContext.factory().noOtelTracking());
+            log.atInfo().setMessage("MetadataMigration result: {}").addArgument(metaResult.asCliOutput()).log();
+            assertEquals(0, metaResult.getExitCode(), "MetadataMigration should succeed");
+
+            // 2. Backfill documents through the CLI.
+            int exitCode = SourceTestBase.runProcessAgainstTarget(new String[]{
+                "--source-version", "SOLR_" + solrVersion.tag(),
+                "--snapshot-local-dir", backupRoot.toString(),
+                "--snapshot-name", "solr-dotted",
+                "--target-host", target.getUrl(),
+                "--coordinator-host", target.getUrl(),
+                "--index-allowlist", collection
+            });
+            assertEquals(0, exitCode, "RfsMigrateDocuments should exit successfully");
+
+            // ---- TARGET: assert metadata, document content, and queries ----
+            verifyDocCount(target, collection, 1);
+
+            var restClient = new RestClient(
+                ConnectionContextTestParams.builder().host(target.getUrl()).build().toConnectionContext()
+            );
+            var ctx = DocumentMigrationTestContext.factory().noOtelTracking();
+            restClient.get("_refresh", ctx.createUnboundRequestContext());
+
+            // Metadata: explicit dotted fields land under their full dotted path with the
+            // OpenSearch type the converter derives from Solr. (Dynamic-leaf types are
+            // covered in SolrToOpenSearchEndToEndTest where the in-process pipeline
+            // exposes the dynamic_templates path directly.)
+            assertTargetFieldType(restClient, ctx, collection, "category.name",       "keyword");
+            assertTargetFieldType(restClient, ctx, collection, "metric.cpu.percent",  "float");
+
+            // Document content: every dotted key preserved verbatim in _source — including
+            // the dynamic-template regression case, which would have been dropped pre-fix.
+            var resp = restClient.get(
+                collection + "/_search?q=id:doc1&size=1", ctx.createUnboundRequestContext()
+            );
+            var hits = MAPPER.readTree(resp.body).path("hits").path("hits");
+            assertThat("Should find doc1", hits.size(), equalTo(1));
+            var src = hits.get(0).path("_source");
+            log.atInfo().setMessage("Backfilled dotted-name _source: {}").addArgument(src).log();
+            assertThat("_source.category.name",      src.path("category.name").asText(),     equalTo("books"));
+            assertThat("_source.metric.cpu.percent",
+                (double) src.path("metric.cpu.percent").floatValue(),                       closeTo(42.5, 0.01));
+            assertThat("_source.attr_thing.withdot", src.path("attr_thing.withdot").asText(), equalTo("vip"));
+            assertThat("_source.counter.value_i",    src.path("counter.value_i").asInt(),     equalTo(17));
+
+            // Queries by dotted path resolve back to the doc — including the regression case.
+            assertQueryHits(restClient, ctx, collection, "category.name:books",       1);
+            assertQueryHits(restClient, ctx, collection, "metric.cpu.percent:42.5",   1);
+            assertQueryHits(restClient, ctx, collection, "attr_thing.withdot:vip",    1);
+            assertQueryHits(restClient, ctx, collection, "counter.value_i:17",        1);
+        }
+    }
+
+    /**
      * Tests migrating multiple Solr collections through the work coordinator.
      * Each collection is a single shard, so migrateOneShard() should be called
      * exactly once per collection (2 total), then return NOTHING_DONE.
@@ -510,6 +638,49 @@ public class SolrSnapshotToOpenSearchTest {
     }
 
     // --- Helpers ---
+
+    /** POST {@code {"add-field":[...]}} to a Solr collection's Schema API. */
+    private static void addSchemaFields(SolrClusterContainer solr, String collection, String addFieldArrayJson)
+        throws Exception {
+        solr.execInContainer(
+            "curl", "-s", "-H", "Content-Type: application/json",
+            "http://localhost:8983/solr/" + collection + "/schema",
+            "-d", "{\"add-field\":" + addFieldArrayJson + "}"
+        );
+    }
+
+    /** POST a JSON document array to a Solr collection's /update endpoint with commit. */
+    private static void indexDocs(SolrClusterContainer solr, String collection, String jsonDocsArray)
+        throws Exception {
+        solr.execInContainer(
+            "curl", "-s", "-H", "Content-Type: application/json",
+            "http://localhost:8983/solr/" + collection + "/update?commit=true",
+            "-d", jsonDocsArray
+        );
+    }
+
+    /** Assert that {@code _field_caps} reports {@code field} on the target index with the given OS type. */
+    private static void assertTargetFieldType(
+        RestClient restClient, DocumentMigrationTestContext ctx,
+        String index, String field, String expectedType
+    ) throws Exception {
+        var resp = restClient.get(index + "/_field_caps?fields=" + field, ctx.createUnboundRequestContext());
+        var typeNode = MAPPER.readTree(resp.body)
+            .path("fields").path(field).path(expectedType).path("type");
+        assertThat(field + " → " + expectedType, typeNode.asText(), equalTo(expectedType));
+    }
+
+    /** Run a Lucene query string against the target and assert the hit count. */
+    private static void assertQueryHits(
+        RestClient restClient, DocumentMigrationTestContext ctx,
+        String index, String luceneQuery, int expectedHits
+    ) throws Exception {
+        var resp = restClient.get(
+            index + "/_search?q=" + luceneQuery + "&size=10", ctx.createUnboundRequestContext()
+        );
+        var hits = MAPPER.readTree(resp.body).path("hits").path("hits");
+        assertThat("query " + luceneQuery + " hit count", hits.size(), equalTo(expectedHits));
+    }
 
     private static SolrClusterContainer createSolr(SolrClusterContainer.SolrVersion version, boolean cloudMode) {
         return cloudMode ? SolrClusterContainer.cloud(version) : new SolrClusterContainer(version);

--- a/SolrReader/src/main/java/org/opensearch/migrations/bulkload/solr/SolrSchemaConverter.java
+++ b/SolrReader/src/main/java/org/opensearch/migrations/bulkload/solr/SolrSchemaConverter.java
@@ -28,21 +28,20 @@ public final class SolrSchemaConverter {
     private static final String OS_KEYWORD = "keyword";
     private static final String OS_TEXT = "text";
     /**
-     * JSON value-shape token for OpenSearch dynamic_template's {@code match_mapping_type}
-     * when the leaf value is a string. Distinct from any OS field-type constant: the
-     * value-shape vocabulary is {@code "string" | "long" | "double" | "boolean" | "date"
-     * | "*"} (see OpenSearch dynamic_templates docs), which only partially overlaps
-     * field-type names. We reuse {@link #OS_LONG} / {@link #OS_DOUBLE} / {@link #OS_BOOLEAN}
-     * where the strings happen to coincide; "string" gets its own constant since no
-     * field-type is named "string".
+     * The literal token {@code "string"}. It serves two unrelated purposes: it's the
+     * name of Solr's {@code StrField}-backed {@code string} fieldType (used as a key
+     * in {@link #SOLR_TO_OS_TYPE}), and it's also the JSON value-shape token used in
+     * OpenSearch dynamic_template's {@code match_mapping_type} ("string" | "long" |
+     * "double" | "boolean" | "date" | "*"). Two callers, same string — kept on one
+     * constant so SonarQube java:S1192 (duplicate string literal) stays clean.
      */
-    private static final String MMT_STRING = "string";
+    private static final String STRING_TOKEN = "string";
     private static final String OS_BINARY = "binary";
     private static final String OS_FORMAT_FIELD = "format";
 
     /** Maps Solr field type names to OpenSearch types. */
     private static final Map<String, String> SOLR_TO_OS_TYPE = Map.ofEntries(
-        Map.entry("string", OS_KEYWORD),
+        Map.entry(STRING_TOKEN, OS_KEYWORD),
         Map.entry("strings", OS_KEYWORD),
         Map.entry("text_general", OS_TEXT),
         Map.entry("text_en", OS_TEXT),
@@ -354,7 +353,7 @@ public final class SolrSchemaConverter {
                 return OS_BOOLEAN;
             case OS_KEYWORD:
             case OS_TEXT:
-                return MMT_STRING;
+                return STRING_TOKEN;
             default:
                 // BINARY and any future types: leave match_mapping_type unset and
                 // rely on path_match alone. Object containers still never match

--- a/SolrReader/src/main/java/org/opensearch/migrations/bulkload/solr/SolrSchemaConverter.java
+++ b/SolrReader/src/main/java/org/opensearch/migrations/bulkload/solr/SolrSchemaConverter.java
@@ -27,6 +27,16 @@ public final class SolrSchemaConverter {
     private static final String OS_BOOLEAN = "boolean";
     private static final String OS_KEYWORD = "keyword";
     private static final String OS_TEXT = "text";
+    /**
+     * JSON value-shape token for OpenSearch dynamic_template's {@code match_mapping_type}
+     * when the leaf value is a string. Distinct from any OS field-type constant: the
+     * value-shape vocabulary is {@code "string" | "long" | "double" | "boolean" | "date"
+     * | "*"} (see OpenSearch dynamic_templates docs), which only partially overlaps
+     * field-type names. We reuse {@link #OS_LONG} / {@link #OS_DOUBLE} / {@link #OS_BOOLEAN}
+     * where the strings happen to coincide; "string" gets its own constant since no
+     * field-type is named "string".
+     */
+    private static final String MMT_STRING = "string";
     private static final String OS_BINARY = "binary";
     private static final String OS_FORMAT_FIELD = "format";
 
@@ -336,15 +346,15 @@ public final class SolrSchemaConverter {
                 // the converted documents present date leaves as JSON longs. Gating
                 // dynamic date templates by "long" matches the actual wire shape and
                 // still excludes object containers (which never carry a value type).
-                return "long";
+                return OS_LONG;
             case OS_FLOAT:
             case OS_DOUBLE:
-                return "double";
+                return OS_DOUBLE;
             case OS_BOOLEAN:
                 return OS_BOOLEAN;
             case OS_KEYWORD:
             case OS_TEXT:
-                return "string";
+                return MMT_STRING;
             default:
                 // BINARY and any future types: leave match_mapping_type unset and
                 // rely on path_match alone. Object containers still never match

--- a/SolrReader/src/main/java/org/opensearch/migrations/bulkload/solr/SolrSchemaConverter.java
+++ b/SolrReader/src/main/java/org/opensearch/migrations/bulkload/solr/SolrSchemaConverter.java
@@ -27,21 +27,12 @@ public final class SolrSchemaConverter {
     private static final String OS_BOOLEAN = "boolean";
     private static final String OS_KEYWORD = "keyword";
     private static final String OS_TEXT = "text";
-    /**
-     * The literal token {@code "string"}. It serves two unrelated purposes: it's the
-     * name of Solr's {@code StrField}-backed {@code string} fieldType (used as a key
-     * in {@link #SOLR_TO_OS_TYPE}), and it's also the JSON value-shape token used in
-     * OpenSearch dynamic_template's {@code match_mapping_type} ("string" | "long" |
-     * "double" | "boolean" | "date" | "*"). Two callers, same string — kept on one
-     * constant so SonarQube java:S1192 (duplicate string literal) stays clean.
-     */
-    private static final String STRING_TOKEN = "string";
     private static final String OS_BINARY = "binary";
     private static final String OS_FORMAT_FIELD = "format";
 
     /** Maps Solr field type names to OpenSearch types. */
     private static final Map<String, String> SOLR_TO_OS_TYPE = Map.ofEntries(
-        Map.entry(STRING_TOKEN, OS_KEYWORD),
+        Map.entry("string", OS_KEYWORD),
         Map.entry("strings", OS_KEYWORD),
         Map.entry("text_general", OS_TEXT),
         Map.entry("text_en", OS_TEXT),
@@ -276,21 +267,16 @@ public final class SolrSchemaConverter {
     }
 
     /**
-     * Build an OpenSearch dynamic_template from a Solr dynamic field pattern.
-     * Solr patterns: "*_s" (suffix), "attr_*" (prefix).
+     * Build an OpenSearch dynamic_template from a Solr dynamic field pattern
+     * ({@code "*_s"} suffix or {@code "attr_*"} prefix).
      *
-     * <p>Uses {@code path_match} (not {@code match}) so the template matches against
-     * the field's full dotted path. This matters for Solr fields whose names contain
-     * dots (e.g. a doc field named {@code attr_field.withdot} under an {@code attr_*}
-     * dynamic template). With plain {@code match}, OpenSearch would only consider the
-     * leaf name segment ({@code withdot}), miss the prefix, fall back to dynamic
-     * mapping for the parent ({@code attr_field}) as the template's target type, and
-     * then fail with {@code mapper_parsing_exception} when the child key is added
-     * because the parent is no longer an object.
-     *
-     * <p>Pairs {@code path_match} with {@code match_mapping_type} so the template
-     * fires only on leaves (which carry a JSON value type), never on intermediate
-     * object containers — preventing the same parent/child collision.
+     * <p>Uses {@code path_match} + {@code match_mapping_type} (not plain {@code match}).
+     * When a Solr doc field has dots in its name (e.g. {@code attr_field.withdot})
+     * OpenSearch auto-expands it into a nested object on write. With plain {@code match},
+     * the {@code attr_*} template would also fire on the synthesized parent
+     * ({@code attr_field}), type it as the target type, and then reject the child key
+     * with {@code mapper_parsing_exception}. {@code match_mapping_type} gates on the
+     * JSON value shape, which intermediate object containers never carry.
      */
     static ObjectNode buildDynamicTemplate(String solrPattern, String osType) {
         String matchPattern;
@@ -326,12 +312,9 @@ public final class SolrSchemaConverter {
     }
 
     /**
-     * Map an OpenSearch field type to the JSON value shape OpenSearch reports for it
-     * during dynamic mapping ({@code match_mapping_type}). Returning a non-null shape
-     * gates the dynamic template to leaf values only — intermediate object containers
-     * never carry a {@code match_mapping_type}, so they can't accidentally trigger
-     * the template when a Solr dynamic-field pattern (e.g. {@code attr_*}) happens
-     * to also prefix-match a parent object name produced by a dotted-name leaf.
+     * Map an OpenSearch field type to its {@code match_mapping_type} JSON-shape token,
+     * or {@code null} when no shape can be confidently asserted. Solr-extracted dates
+     * arrive as epoch-millis longs, so date templates gate on {@code long}.
      */
     private static String osTypeToMatchMappingType(String osType) {
         if (osType == null) {
@@ -341,10 +324,6 @@ public final class SolrSchemaConverter {
             case OS_INTEGER:
             case OS_LONG:
             case OS_DATE:
-                // Solr serializes dates as epoch millis (long) in stored fields, so
-                // the converted documents present date leaves as JSON longs. Gating
-                // dynamic date templates by "long" matches the actual wire shape and
-                // still excludes object containers (which never carry a value type).
                 return OS_LONG;
             case OS_FLOAT:
             case OS_DOUBLE:
@@ -353,11 +332,8 @@ public final class SolrSchemaConverter {
                 return OS_BOOLEAN;
             case OS_KEYWORD:
             case OS_TEXT:
-                return STRING_TOKEN;
+                return "string";
             default:
-                // BINARY and any future types: leave match_mapping_type unset and
-                // rely on path_match alone. Object containers still never match
-                // because OpenSearch only consults dynamic_templates on leaves.
                 return null;
         }
     }

--- a/SolrReader/src/main/java/org/opensearch/migrations/bulkload/solr/SolrSchemaConverter.java
+++ b/SolrReader/src/main/java/org/opensearch/migrations/bulkload/solr/SolrSchemaConverter.java
@@ -315,11 +315,11 @@ public final class SolrSchemaConverter {
      * Map an OpenSearch field type to its {@code match_mapping_type} JSON-shape token,
      * or {@code null} when no shape can be confidently asserted. Solr-extracted dates
      * arrive as epoch-millis longs, so date templates gate on {@code long}.
+     *
+     * <p>{@code osType} is always non-null in practice ({@link #resolveOsType} falls
+     * back to {@code OS_TEXT}), so no defensive null guard is needed.
      */
     private static String osTypeToMatchMappingType(String osType) {
-        if (osType == null) {
-            return null;
-        }
         switch (osType) {
             case OS_INTEGER:
             case OS_LONG:

--- a/SolrReader/src/main/java/org/opensearch/migrations/bulkload/solr/SolrSchemaConverter.java
+++ b/SolrReader/src/main/java/org/opensearch/migrations/bulkload/solr/SolrSchemaConverter.java
@@ -269,6 +269,19 @@ public final class SolrSchemaConverter {
     /**
      * Build an OpenSearch dynamic_template from a Solr dynamic field pattern.
      * Solr patterns: "*_s" (suffix), "attr_*" (prefix).
+     *
+     * <p>Uses {@code path_match} (not {@code match}) so the template matches against
+     * the field's full dotted path. This matters for Solr fields whose names contain
+     * dots (e.g. a doc field named {@code attr_field.withdot} under an {@code attr_*}
+     * dynamic template). With plain {@code match}, OpenSearch would only consider the
+     * leaf name segment ({@code withdot}), miss the prefix, fall back to dynamic
+     * mapping for the parent ({@code attr_field}) as the template's target type, and
+     * then fail with {@code mapper_parsing_exception} when the child key is added
+     * because the parent is no longer an object.
+     *
+     * <p>Pairs {@code path_match} with {@code match_mapping_type} so the template
+     * fires only on leaves (which carry a JSON value type), never on intermediate
+     * object containers — preventing the same parent/child collision.
      */
     static ObjectNode buildDynamicTemplate(String solrPattern, String osType) {
         String matchPattern;
@@ -288,7 +301,11 @@ public final class SolrSchemaConverter {
 
         var template = MAPPER.createObjectNode();
         var inner = MAPPER.createObjectNode();
-        inner.put("match", matchPattern);
+        inner.put("path_match", matchPattern);
+        var jsonShape = osTypeToMatchMappingType(osType);
+        if (jsonShape != null) {
+            inner.put("match_mapping_type", jsonShape);
+        }
         var mapping = MAPPER.createObjectNode();
         mapping.put("type", osType);
         if (OS_DATE.equals(osType)) {
@@ -297,6 +314,43 @@ public final class SolrSchemaConverter {
         inner.set("mapping", mapping);
         template.set(templateName, inner);
         return template;
+    }
+
+    /**
+     * Map an OpenSearch field type to the JSON value shape OpenSearch reports for it
+     * during dynamic mapping ({@code match_mapping_type}). Returning a non-null shape
+     * gates the dynamic template to leaf values only — intermediate object containers
+     * never carry a {@code match_mapping_type}, so they can't accidentally trigger
+     * the template when a Solr dynamic-field pattern (e.g. {@code attr_*}) happens
+     * to also prefix-match a parent object name produced by a dotted-name leaf.
+     */
+    private static String osTypeToMatchMappingType(String osType) {
+        if (osType == null) {
+            return null;
+        }
+        switch (osType) {
+            case OS_INTEGER:
+            case OS_LONG:
+            case OS_DATE:
+                // Solr serializes dates as epoch millis (long) in stored fields, so
+                // the converted documents present date leaves as JSON longs. Gating
+                // dynamic date templates by "long" matches the actual wire shape and
+                // still excludes object containers (which never carry a value type).
+                return "long";
+            case OS_FLOAT:
+            case OS_DOUBLE:
+                return "double";
+            case OS_BOOLEAN:
+                return OS_BOOLEAN;
+            case OS_KEYWORD:
+            case OS_TEXT:
+                return "string";
+            default:
+                // BINARY and any future types: leave match_mapping_type unset and
+                // rely on path_match alone. Object containers still never match
+                // because OpenSearch only consults dynamic_templates on leaves.
+                return null;
+        }
     }
 
     private static boolean isInternalField(String name) {

--- a/SolrReader/src/test/java/org/opensearch/migrations/bulkload/solr/SolrSchemaConverterTest.java
+++ b/SolrReader/src/test/java/org/opensearch/migrations/bulkload/solr/SolrSchemaConverterTest.java
@@ -319,6 +319,59 @@ class SolrSchemaConverterTest {
             "Non-date fields should not have format");
     }
 
+    // --- Dotted field name tests ---
+    //
+    // Solr permits flat field names that contain '.' (e.g. "category.name"). When
+    // the converter emits these as keys under "properties", OpenSearch silently
+    // expands them into nested-object form (properties.category.properties.name)
+    // — a documented OpenSearch behavior, not a bug. Queries written against the
+    // original "category.name" path continue to resolve and the _source preserves
+    // the original key shape, so the migration is intuitive from the customer's
+    // point of view. These tests pin that contract down so it does not regress.
+
+    @Test
+    void preservesDottedFieldNamesAsLiteralKeys() {
+        var fields = MAPPER.createArrayNode();
+        fields.add(field("id", "string"));
+        fields.add(field("category.name", "string"));
+        fields.add(field("metric.cpu.percent", "pfloat"));
+        fields.add(field("event.created", "pdate"));
+
+        var mappings = SolrSchemaConverter.convertToOpenSearchMappings(fields);
+        var properties = mappings.get("properties");
+
+        // Keys stay literal — the converter does NOT pre-split them.
+        assertNotNull(properties.get("category.name"),
+            "dotted field name should be emitted as a literal key");
+        assertThat(properties.get("category.name").get("type").asText(), equalTo("keyword"));
+
+        assertNotNull(properties.get("metric.cpu.percent"),
+            "multi-segment dotted field name should be emitted as a literal key");
+        assertThat(properties.get("metric.cpu.percent").get("type").asText(), equalTo("float"));
+
+        // Date format is propagated even when the field name has dots.
+        var eventCreated = properties.get("event.created");
+        assertNotNull(eventCreated);
+        assertThat(eventCreated.get("type").asText(), equalTo("date"));
+        assertThat(eventCreated.get("format").asText(), equalTo(SolrSchemaConverter.OS_DATE_FORMAT));
+    }
+
+    @Test
+    void dottedFieldNamesCoexistWithFlatFields() {
+        var fields = MAPPER.createArrayNode();
+        fields.add(field("id", "string"));
+        fields.add(field("title", "text_general"));
+        fields.add(field("user.id", "string"));
+        fields.add(field("user.email", "string"));
+
+        var mappings = SolrSchemaConverter.convertToOpenSearchMappings(fields);
+        var properties = mappings.get("properties");
+
+        assertThat(properties.get("title").get("type").asText(), equalTo("text"));
+        assertThat(properties.get("user.id").get("type").asText(), equalTo("keyword"));
+        assertThat(properties.get("user.email").get("type").asText(), equalTo("keyword"));
+    }
+
     // --- Helpers ---
 
     private static ObjectNode field(String name, String type) {

--- a/SolrReader/src/test/java/org/opensearch/migrations/bulkload/solr/SolrSchemaConverterTest.java
+++ b/SolrReader/src/test/java/org/opensearch/migrations/bulkload/solr/SolrSchemaConverterTest.java
@@ -141,6 +141,36 @@ class SolrSchemaConverterTest {
             .fields().next().getValue().get("match_mapping_type").asText(), equalTo("string"));
     }
 
+    @Test
+    void dynamicFieldTemplateOmitsMatchMappingTypeForBinaryAndUnknownOsTypes() {
+        // BINARY (and any future / unrecognized OpenSearch type) has no JSON value
+        // shape we can confidently gate on, so the template falls through to the
+        // default branch and emits no match_mapping_type. path_match alone scopes it.
+        var binaryTemplate = SolrSchemaConverter.buildDynamicTemplate("blob_*", "binary");
+        var binaryInner = binaryTemplate.fields().next().getValue();
+        assertThat(binaryInner.get("path_match").asText(), equalTo("blob_*"));
+        assertThat("BINARY: no match_mapping_type emitted",
+            binaryInner.has("match_mapping_type"), equalTo(false));
+        assertThat(binaryInner.get("mapping").get("type").asText(), equalTo("binary"));
+
+        var unknownTemplate = SolrSchemaConverter.buildDynamicTemplate("x_*", "some_future_type");
+        var unknownInner = unknownTemplate.fields().next().getValue();
+        assertThat("Unknown OS type: no match_mapping_type emitted",
+            unknownInner.has("match_mapping_type"), equalTo(false));
+    }
+
+    @Test
+    void dynamicFieldTemplateOmitsMatchMappingTypeWhenOsTypeIsNull() {
+        // resolveOsType can return null when the Solr fieldType doesn't map to any
+        // known OS type and isn't class-resolvable. The template still emits a
+        // path_match-scoped entry, but with no match_mapping_type gate.
+        var template = SolrSchemaConverter.buildDynamicTemplate("ignore_*", null);
+        var inner = template.fields().next().getValue();
+        assertThat(inner.get("path_match").asText(), equalTo("ignore_*"));
+        assertThat("Null osType: no match_mapping_type emitted",
+            inner.has("match_mapping_type"), equalTo(false));
+    }
+
     // --- CopyField tests ---
 
     @Test

--- a/SolrReader/src/test/java/org/opensearch/migrations/bulkload/solr/SolrSchemaConverterTest.java
+++ b/SolrReader/src/test/java/org/opensearch/migrations/bulkload/solr/SolrSchemaConverterTest.java
@@ -94,9 +94,11 @@ class SolrSchemaConverterTest {
     void dynamicFieldSuffixPatternMapsCorrectly() {
         var template = SolrSchemaConverter.buildDynamicTemplate("*_s", "keyword");
         assertNotNull(template);
-        // Template should have a match pattern
+        // Template should have a path_match pattern (matches full dotted path) gated
+        // by match_mapping_type so it fires only on leaves, never object containers.
         var inner = template.fields().next().getValue();
-        assertThat(inner.get("match").asText(), equalTo("*_s"));
+        assertThat(inner.get("path_match").asText(), equalTo("*_s"));
+        assertThat(inner.get("match_mapping_type").asText(), equalTo("string"));
         assertThat(inner.get("mapping").get("type").asText(), equalTo("keyword"));
     }
 
@@ -105,8 +107,38 @@ class SolrSchemaConverterTest {
         var template = SolrSchemaConverter.buildDynamicTemplate("attr_*", "text");
         assertNotNull(template);
         var inner = template.fields().next().getValue();
-        assertThat(inner.get("match").asText(), equalTo("attr_*"));
+        assertThat(inner.get("path_match").asText(), equalTo("attr_*"));
+        assertThat(inner.get("match_mapping_type").asText(), equalTo("string"));
         assertThat(inner.get("mapping").get("type").asText(), equalTo("text"));
+    }
+
+    @Test
+    void dynamicFieldTemplateGatesByJsonShapeForEachOpenSearchType() {
+        // path_match alone is not enough: an int dynamic-field pattern like attr_*
+        // would otherwise also match an OBJECT container "attr_field" produced by a
+        // dotted-name leaf like attr_field.withdot, causing OpenSearch to try to
+        // make attr_field an integer and then explode when the .withdot child
+        // arrives. match_mapping_type pins each template to the JSON value shape
+        // that OpenSearch reports for that type, so containers (no value shape)
+        // can never trigger it.
+        assertThat(SolrSchemaConverter.buildDynamicTemplate("attr_*", "integer")
+            .fields().next().getValue().get("match_mapping_type").asText(), equalTo("long"));
+        assertThat(SolrSchemaConverter.buildDynamicTemplate("attr_*", "long")
+            .fields().next().getValue().get("match_mapping_type").asText(), equalTo("long"));
+        assertThat(SolrSchemaConverter.buildDynamicTemplate("price_*", "float")
+            .fields().next().getValue().get("match_mapping_type").asText(), equalTo("double"));
+        assertThat(SolrSchemaConverter.buildDynamicTemplate("price_*", "double")
+            .fields().next().getValue().get("match_mapping_type").asText(), equalTo("double"));
+        assertThat(SolrSchemaConverter.buildDynamicTemplate("flag_*", "boolean")
+            .fields().next().getValue().get("match_mapping_type").asText(), equalTo("boolean"));
+        // Date: Solr stores dates as epoch millis (long) in stored fields, so the
+        // converted documents present date leaves as JSON longs — gate accordingly.
+        assertThat(SolrSchemaConverter.buildDynamicTemplate("when_*", "date")
+            .fields().next().getValue().get("match_mapping_type").asText(), equalTo("long"));
+        assertThat(SolrSchemaConverter.buildDynamicTemplate("name_*", "keyword")
+            .fields().next().getValue().get("match_mapping_type").asText(), equalTo("string"));
+        assertThat(SolrSchemaConverter.buildDynamicTemplate("body_*", "text")
+            .fields().next().getValue().get("match_mapping_type").asText(), equalTo("string"));
     }
 
     // --- CopyField tests ---

--- a/SolrReader/src/test/java/org/opensearch/migrations/bulkload/solr/SolrSchemaConverterTest.java
+++ b/SolrReader/src/test/java/org/opensearch/migrations/bulkload/solr/SolrSchemaConverterTest.java
@@ -94,8 +94,6 @@ class SolrSchemaConverterTest {
     void dynamicFieldSuffixPatternMapsCorrectly() {
         var template = SolrSchemaConverter.buildDynamicTemplate("*_s", "keyword");
         assertNotNull(template);
-        // Template should have a path_match pattern (matches full dotted path) gated
-        // by match_mapping_type so it fires only on leaves, never object containers.
         var inner = template.fields().next().getValue();
         assertThat(inner.get("path_match").asText(), equalTo("*_s"));
         assertThat(inner.get("match_mapping_type").asText(), equalTo("string"));
@@ -114,61 +112,39 @@ class SolrSchemaConverterTest {
 
     @Test
     void dynamicFieldTemplateGatesByJsonShapeForEachOpenSearchType() {
-        // path_match alone is not enough: an int dynamic-field pattern like attr_*
-        // would otherwise also match an OBJECT container "attr_field" produced by a
-        // dotted-name leaf like attr_field.withdot, causing OpenSearch to try to
-        // make attr_field an integer and then explode when the .withdot child
-        // arrives. match_mapping_type pins each template to the JSON value shape
-        // that OpenSearch reports for that type, so containers (no value shape)
-        // can never trigger it.
-        assertThat(SolrSchemaConverter.buildDynamicTemplate("attr_*", "integer")
-            .fields().next().getValue().get("match_mapping_type").asText(), equalTo("long"));
-        assertThat(SolrSchemaConverter.buildDynamicTemplate("attr_*", "long")
-            .fields().next().getValue().get("match_mapping_type").asText(), equalTo("long"));
-        assertThat(SolrSchemaConverter.buildDynamicTemplate("price_*", "float")
-            .fields().next().getValue().get("match_mapping_type").asText(), equalTo("double"));
-        assertThat(SolrSchemaConverter.buildDynamicTemplate("price_*", "double")
-            .fields().next().getValue().get("match_mapping_type").asText(), equalTo("double"));
-        assertThat(SolrSchemaConverter.buildDynamicTemplate("flag_*", "boolean")
-            .fields().next().getValue().get("match_mapping_type").asText(), equalTo("boolean"));
-        // Date: Solr stores dates as epoch millis (long) in stored fields, so the
-        // converted documents present date leaves as JSON longs — gate accordingly.
-        assertThat(SolrSchemaConverter.buildDynamicTemplate("when_*", "date")
-            .fields().next().getValue().get("match_mapping_type").asText(), equalTo("long"));
-        assertThat(SolrSchemaConverter.buildDynamicTemplate("name_*", "keyword")
-            .fields().next().getValue().get("match_mapping_type").asText(), equalTo("string"));
-        assertThat(SolrSchemaConverter.buildDynamicTemplate("body_*", "text")
-            .fields().next().getValue().get("match_mapping_type").asText(), equalTo("string"));
+        // match_mapping_type pins each template to the JSON value shape OpenSearch
+        // reports for that type, so intermediate object containers (which have no
+        // value shape) never trigger the template — preventing the parent/child
+        // collision that occurs when a dotted-name leaf synthesizes an object whose
+        // top-level segment also matches the dynamic-field pattern.
+        assertThat(matchMappingType("attr_*", "integer"), equalTo("long"));
+        assertThat(matchMappingType("attr_*", "long"), equalTo("long"));
+        assertThat(matchMappingType("price_*", "float"), equalTo("double"));
+        assertThat(matchMappingType("price_*", "double"), equalTo("double"));
+        assertThat(matchMappingType("flag_*", "boolean"), equalTo("boolean"));
+        // Solr stores dates as epoch millis (JSON long) — gate accordingly.
+        assertThat(matchMappingType("when_*", "date"), equalTo("long"));
+        assertThat(matchMappingType("name_*", "keyword"), equalTo("string"));
+        assertThat(matchMappingType("body_*", "text"), equalTo("string"));
     }
 
     @Test
     void dynamicFieldTemplateOmitsMatchMappingTypeForBinaryAndUnknownOsTypes() {
-        // BINARY (and any future / unrecognized OpenSearch type) has no JSON value
-        // shape we can confidently gate on, so the template falls through to the
-        // default branch and emits no match_mapping_type. path_match alone scopes it.
-        var binaryTemplate = SolrSchemaConverter.buildDynamicTemplate("blob_*", "binary");
-        var binaryInner = binaryTemplate.fields().next().getValue();
+        // No confidently-known JSON shape — fall back to path_match alone.
+        var binaryInner = SolrSchemaConverter.buildDynamicTemplate("blob_*", "binary")
+            .fields().next().getValue();
         assertThat(binaryInner.get("path_match").asText(), equalTo("blob_*"));
-        assertThat("BINARY: no match_mapping_type emitted",
-            binaryInner.has("match_mapping_type"), equalTo(false));
+        assertThat(binaryInner.has("match_mapping_type"), equalTo(false));
         assertThat(binaryInner.get("mapping").get("type").asText(), equalTo("binary"));
 
-        var unknownTemplate = SolrSchemaConverter.buildDynamicTemplate("x_*", "some_future_type");
-        var unknownInner = unknownTemplate.fields().next().getValue();
-        assertThat("Unknown OS type: no match_mapping_type emitted",
-            unknownInner.has("match_mapping_type"), equalTo(false));
+        var unknownInner = SolrSchemaConverter.buildDynamicTemplate("x_*", "some_future_type")
+            .fields().next().getValue();
+        assertThat(unknownInner.has("match_mapping_type"), equalTo(false));
     }
 
-    @Test
-    void dynamicFieldTemplateOmitsMatchMappingTypeWhenOsTypeIsNull() {
-        // resolveOsType can return null when the Solr fieldType doesn't map to any
-        // known OS type and isn't class-resolvable. The template still emits a
-        // path_match-scoped entry, but with no match_mapping_type gate.
-        var template = SolrSchemaConverter.buildDynamicTemplate("ignore_*", null);
-        var inner = template.fields().next().getValue();
-        assertThat(inner.get("path_match").asText(), equalTo("ignore_*"));
-        assertThat("Null osType: no match_mapping_type emitted",
-            inner.has("match_mapping_type"), equalTo(false));
+    private static String matchMappingType(String pattern, String osType) {
+        return SolrSchemaConverter.buildDynamicTemplate(pattern, osType)
+            .fields().next().getValue().get("match_mapping_type").asText();
     }
 
     // --- CopyField tests ---
@@ -382,56 +358,25 @@ class SolrSchemaConverterTest {
     }
 
     // --- Dotted field name tests ---
-    //
-    // Solr permits flat field names that contain '.' (e.g. "category.name"). When
-    // the converter emits these as keys under "properties", OpenSearch silently
-    // expands them into nested-object form (properties.category.properties.name)
-    // — a documented OpenSearch behavior, not a bug. Queries written against the
-    // original "category.name" path continue to resolve and the _source preserves
-    // the original key shape, so the migration is intuitive from the customer's
-    // point of view. These tests pin that contract down so it does not regress.
 
     @Test
     void preservesDottedFieldNamesAsLiteralKeys() {
+        // Solr permits flat field names containing '.'. The converter emits them as
+        // literal keys under "properties"; OpenSearch then auto-expands them into a
+        // nested-object tree at index time. Date format must propagate through.
         var fields = MAPPER.createArrayNode();
         fields.add(field("id", "string"));
         fields.add(field("category.name", "string"));
         fields.add(field("metric.cpu.percent", "pfloat"));
         fields.add(field("event.created", "pdate"));
 
-        var mappings = SolrSchemaConverter.convertToOpenSearchMappings(fields);
-        var properties = mappings.get("properties");
+        var properties = SolrSchemaConverter.convertToOpenSearchMappings(fields).get("properties");
 
-        // Keys stay literal — the converter does NOT pre-split them.
-        assertNotNull(properties.get("category.name"),
-            "dotted field name should be emitted as a literal key");
         assertThat(properties.get("category.name").get("type").asText(), equalTo("keyword"));
-
-        assertNotNull(properties.get("metric.cpu.percent"),
-            "multi-segment dotted field name should be emitted as a literal key");
         assertThat(properties.get("metric.cpu.percent").get("type").asText(), equalTo("float"));
-
-        // Date format is propagated even when the field name has dots.
         var eventCreated = properties.get("event.created");
-        assertNotNull(eventCreated);
         assertThat(eventCreated.get("type").asText(), equalTo("date"));
         assertThat(eventCreated.get("format").asText(), equalTo(SolrSchemaConverter.OS_DATE_FORMAT));
-    }
-
-    @Test
-    void dottedFieldNamesCoexistWithFlatFields() {
-        var fields = MAPPER.createArrayNode();
-        fields.add(field("id", "string"));
-        fields.add(field("title", "text_general"));
-        fields.add(field("user.id", "string"));
-        fields.add(field("user.email", "string"));
-
-        var mappings = SolrSchemaConverter.convertToOpenSearchMappings(fields);
-        var properties = mappings.get("properties");
-
-        assertThat(properties.get("title").get("type").asText(), equalTo("text"));
-        assertThat(properties.get("user.id").get("type").asText(), equalTo("keyword"));
-        assertThat(properties.get("user.email").get("type").asText(), equalTo("keyword"));
     }
 
     // --- Helpers ---

--- a/SolrReader/src/test/java/org/opensearch/migrations/bulkload/solr/SolrToOpenSearchEndToEndTest.java
+++ b/SolrReader/src/test/java/org/opensearch/migrations/bulkload/solr/SolrToOpenSearchEndToEndTest.java
@@ -336,6 +336,118 @@ public class SolrToOpenSearchEndToEndTest {
     }
 
     /**
+     * E2E regression: dotted field names whose top-level segment ALSO matches a Solr
+     * dynamic-field prefix pattern.
+     *
+     * <p>Solr's default schema declares a prefix-style dynamic field {@code attr_*}.
+     * A doc field like {@code attr_field.withdot=42} therefore both (a) belongs to a
+     * dotted path and (b) prefix-matches {@code attr_*}. Without a careful template
+     * spec, OpenSearch will apply the {@code attr_*} template to the parent object
+     * {@code attr_field} (typing it as {@code integer}) and then reject the child
+     * key {@code .withdot} with {@code mapper_parsing_exception}. The bulk request
+     * fails outright — the migrated doc is silently lost.
+     *
+     * <p>Verifies the converter emits dynamic templates that pin to the JSON value
+     * shape ({@code match_mapping_type}) and use {@code path_match}, so the template
+     * fires only on the leaf value and never on intermediate object containers.
+     */
+    @ParameterizedTest(name = "dynamic-field + dotted name: {0} → {1}")
+    @MethodSource("solr8ToOpenSearch")
+    void migratesDynamicFieldsWithDotsInLeafName(
+        SolrClusterContainer.SolrVersion solrVersion,
+        SearchClusterContainer.ContainerVersion targetVersion
+    ) throws Exception {
+        try (
+            var solr = new SolrClusterContainer(solrVersion);
+            var target = new SearchClusterContainer(targetVersion)
+        ) {
+            solr.start();
+            target.start();
+
+            createSolrCollection(solr, COLLECTION_NAME);
+
+            // Solr default schema already has attr_* (text_general) and *_s, *_i, *_b, *_f, *_dt
+            // dynamic fields. Index a doc that uses each of those patterns with a
+            // dotted leaf name so the parent segment also prefix-matches the pattern.
+            var doc = "[{"
+                + "\"id\":\"dyn-dot-1\","
+                + "\"attr_thing.withdot\":\"vip\","        // attr_*  (text_general) + dotted leaf
+                + "\"label.tag_s\":\"alpha\","             // *_s     (string)        + dotted leaf
+                + "\"counter.value_i\":17,"                // *_i     (pint)          + dotted leaf
+                + "\"flag.is.set_b\":true,"                // *_b     (boolean)       + dotted leaf (3 segments)
+                + "\"price.unit_f\":9.99,"                 // *_f     (pfloat)        + dotted leaf
+                + "\"event.created_dt\":\"2024-06-15T12:00:00Z\""  // *_dt (pdate)    + dotted leaf
+                + "}]";
+            solr.execInContainer("curl", "-s", "-H", "Content-Type: application/json",
+                "http://localhost:8983/solr/" + COLLECTION_NAME + "/update?commit=true",
+                "-d", doc);
+
+            var schema = fetchSolrSchema(solr, COLLECTION_NAME);
+            var backupDir = createAndCopyBackup(solr, COLLECTION_NAME);
+
+            var source = new SolrBackupSource(backupDir, COLLECTION_NAME, schema);
+            var targetClient = createOpenSearchClient(target);
+            var sink = new OpenSearchDocumentSink(
+                targetClient, null, false, DocumentExceptionAllowlist.empty(), null
+            );
+            new DocumentMigrationPipeline(source, sink, 100, Long.MAX_VALUE)
+                .migrateAll().collectList().block();
+
+            var restClient = createRestClient(target);
+            var ctx = DocumentMigrationTestContext.factory().noOtelTracking();
+            restClient.get("_refresh", ctx.createUnboundRequestContext());
+
+            // The migrated doc must exist — bulk would have failed if dynamic templates
+            // had collided with the dotted parent segment.
+            var searchResp = restClient.get(
+                COLLECTION_NAME + "/_search?q=id:dyn-dot-1&size=1",
+                ctx.createUnboundRequestContext()
+            );
+            var hits = MAPPER.readTree(searchResp.body).path("hits").path("hits");
+            assertThat("dyn-dot-1 should be present", hits.size(), equalTo(1));
+
+            var src = hits.get(0).path("_source");
+            log.atInfo().setMessage("Migrated dynamic+dotted _source: {}").addArgument(src).log();
+            assertThat(src.path("attr_thing.withdot").asText(), equalTo("vip"));
+            assertThat(src.path("label.tag_s").asText(), equalTo("alpha"));
+            assertThat(src.path("counter.value_i").asInt(), equalTo(17));
+            assertThat(src.path("flag.is.set_b").asBoolean(), equalTo(true));
+            assertThat((double) src.path("price.unit_f").floatValue(), closeTo(9.99, 0.01));
+
+            // Verify dynamic templates produced the right *typed* mapping for the dotted
+            // leaves — proving the path_match + match_mapping_type pair worked.
+            var capsResp = restClient.get(
+                COLLECTION_NAME + "/_field_caps?fields="
+                    + "attr_thing.withdot,label.tag_s,counter.value_i,flag.is.set_b,price.unit_f,event.created_dt",
+                ctx.createUnboundRequestContext()
+            );
+            var fields = MAPPER.readTree(capsResp.body).path("fields");
+            log.atInfo().setMessage("OpenSearch field_caps for dynamic+dotted fields: {}")
+                .addArgument(fields).log();
+
+            assertThat("attr_thing.withdot → text (attr_* template)",
+                fields.path("attr_thing.withdot").path("text").path("type").asText(), equalTo("text"));
+            assertThat("label.tag_s → keyword (*_s template)",
+                fields.path("label.tag_s").path("keyword").path("type").asText(), equalTo("keyword"));
+            assertThat("counter.value_i → integer (*_i template)",
+                fields.path("counter.value_i").path("integer").path("type").asText(), equalTo("integer"));
+            assertThat("flag.is.set_b → boolean (*_b template)",
+                fields.path("flag.is.set_b").path("boolean").path("type").asText(), equalTo("boolean"));
+            assertThat("price.unit_f → float (*_f template)",
+                fields.path("price.unit_f").path("float").path("type").asText(), equalTo("float"));
+            assertThat("event.created_dt → date (*_dt template)",
+                fields.path("event.created_dt").path("date").path("type").asText(), equalTo("date"));
+
+            // And queries by the original dotted path resolve to the doc.
+            var qHits = MAPPER.readTree(restClient.get(
+                COLLECTION_NAME + "/_search?q=counter.value_i:17&size=10",
+                ctx.createUnboundRequestContext()
+            ).body).path("hits").path("hits");
+            assertThat("query counter.value_i:17 matches dyn-dot-1", qHits.size(), equalTo(1));
+        }
+    }
+
+    /**
      * E2E: Multi-shard backup discovery and parallel reading.
      * Creates a simulated multi-shard backup directory structure and verifies
      * all shards are discovered and documents from each shard are migrated.

--- a/SolrReader/src/test/java/org/opensearch/migrations/bulkload/solr/SolrToOpenSearchEndToEndTest.java
+++ b/SolrReader/src/test/java/org/opensearch/migrations/bulkload/solr/SolrToOpenSearchEndToEndTest.java
@@ -509,21 +509,24 @@ public class SolrToOpenSearchEndToEndTest {
                 "dynamic_templates must be an array in OS mapping");
             assertThat("dynamic_templates must be non-empty (Solr default schema has *_s, *_i, *_dt, ...)",
                 dynamicTemplates.size(), greaterThan(0));
-            // Each entry should be a single-key object: { "<name>": { "match": "...", "mapping": { "type": "..." } } }
+            // Each entry is a single-key object:
+            //   { "<name>": { "path_match": "...", "match_mapping_type": "...", "mapping": { "type": "..." } } }
+            // path_match + match_mapping_type scopes the template to leaves only — see
+            // SolrSchemaConverter.buildDynamicTemplate for why plain `match` is unsafe.
             var foundStringSuffix = false;
             for (var template : dynamicTemplates) {
                 var entry = template.fields().next();
                 var spec = entry.getValue();
-                assertTrue(spec.has("match") || spec.has("match_mapping_type"),
-                    "Dynamic template '" + entry.getKey() + "' must have a match clause");
+                assertTrue(spec.has("path_match"),
+                    "Dynamic template '" + entry.getKey() + "' must have a path_match clause");
                 assertTrue(spec.path("mapping").has("type"),
                     "Dynamic template '" + entry.getKey() + "' must specify a mapping type");
-                if (spec.path("match").asText().equals("*_s")) {
+                if (spec.path("path_match").asText().equals("*_s")) {
                     foundStringSuffix = true;
                 }
             }
             assertTrue(foundStringSuffix,
-                "Expected a dynamic_template matching '*_s' (Solr default string suffix)");
+                "Expected a dynamic_template with path_match='*_s' (Solr default string suffix)");
         }
     }
 

--- a/SolrReader/src/test/java/org/opensearch/migrations/bulkload/solr/SolrToOpenSearchEndToEndTest.java
+++ b/SolrReader/src/test/java/org/opensearch/migrations/bulkload/solr/SolrToOpenSearchEndToEndTest.java
@@ -198,9 +198,26 @@ public class SolrToOpenSearchEndToEndTest {
     }
 
     /**
-     * E2E: Solr fields with dots in their names (e.g. {@code category.name}) migrate
-     * with their declared types, {@code _source} preserves the original keys, and
-     * queries against the original dotted path resolve to the migrated docs.
+     * E2E: Solr fields whose names contain '.' migrate with their declared types,
+     * {@code _source} preserves the original dotted keys verbatim, and queries
+     * against the original dotted path resolve.
+     *
+     * <p>SOURCE — Solr 8 collection with five explicitly declared dotted-name fields,
+     * one document.
+     * <pre>{@code
+     *   schema:
+     *     category.name      string  (→ Solr "string"  → OS keyword)
+     *     category.id        pint    (→ Solr "pint"    → OS integer)
+     *     metric.cpu.percent pfloat  (→ Solr "pfloat"  → OS float)
+     *     event.created      pdate   (→ Solr "pdate"   → OS date)
+     *     is.active          boolean (→ Solr "boolean" → OS boolean)
+     *   doc1: {category.name:"books", category.id:7, metric.cpu.percent:42.5,
+     *          event.created:"2024-01-15T10:30:00Z", is.active:true}
+     * }</pre>
+     *
+     * <p>TARGET — OpenSearch 2.19 index "test_collection" with the dotted keys
+     * round-tripped verbatim in {@code _source}, the declared types reflected in
+     * {@code _field_caps}, and queries on the dotted path returning doc1.
      */
     @ParameterizedTest(name = "dotted field names: {0} → {1}")
     @MethodSource("solr8ToOpenSearch")
@@ -215,125 +232,85 @@ public class SolrToOpenSearchEndToEndTest {
             solr.start();
             target.start();
 
+            // ---- SOURCE: Solr collection with explicit dotted-name fields + 1 doc ----
             createSolrCollection(solr, COLLECTION_NAME);
+            addSolrSchemaFields(solr, COLLECTION_NAME, "["
+                + "{\"name\":\"category.name\",       \"type\":\"string\",  \"stored\":true, \"indexed\":true, \"docValues\":true},"
+                + "{\"name\":\"category.id\",         \"type\":\"pint\",    \"stored\":true, \"indexed\":true, \"docValues\":true},"
+                + "{\"name\":\"metric.cpu.percent\",  \"type\":\"pfloat\",  \"stored\":true, \"indexed\":true, \"docValues\":true},"
+                + "{\"name\":\"event.created\",       \"type\":\"pdate\",   \"stored\":true, \"indexed\":true, \"docValues\":true},"
+                + "{\"name\":\"is.active\",           \"type\":\"boolean\", \"stored\":true, \"docValues\":true}"
+                + "]");
+            indexSolrDocs(solr, COLLECTION_NAME, "[{"
+                + "\"id\":\"doc1\","
+                + "\"category.name\":\"books\","
+                + "\"category.id\":7,"
+                + "\"metric.cpu.percent\":42.5,"
+                + "\"event.created\":\"2024-01-15T10:30:00Z\","
+                + "\"is.active\":true"
+                + "}]");
 
-            // Solr permits flat field names with '.'. Declare a few of them with mixed
-            // types so we can verify both the mapping and the round-tripped values.
-            var schemaUpdate = "{"
-                + "\"add-field\": ["
-                + "  {\"name\":\"category.name\",       \"type\":\"string\",  \"stored\":true,  \"indexed\":true,  \"docValues\":true},"
-                + "  {\"name\":\"category.id\",         \"type\":\"pint\",    \"stored\":true,  \"indexed\":true,  \"docValues\":true},"
-                + "  {\"name\":\"metric.cpu.percent\",  \"type\":\"pfloat\",  \"stored\":true,  \"indexed\":true,  \"docValues\":true},"
-                + "  {\"name\":\"event.created\",       \"type\":\"pdate\",   \"stored\":true,  \"indexed\":true,  \"docValues\":true},"
-                + "  {\"name\":\"is.active\",           \"type\":\"boolean\", \"stored\":true,  \"docValues\":true}"
-                + "]}";
-            solr.execInContainer(
-                "curl", "-s", "-H", "Content-Type: application/json",
-                "http://localhost:8983/solr/" + COLLECTION_NAME + "/schema",
-                "-d", schemaUpdate
-            );
+            // ---- MIGRATE: backup → pipeline → OpenSearch ----
+            runPipelineMigration(solr, target, COLLECTION_NAME, solrVersion);
 
-            var doc = "[{"
-                + "\"id\": \"doc1\","
-                + "\"category.name\": \"books\","
-                + "\"category.id\": 7,"
-                + "\"metric.cpu.percent\": 42.5,"
-                + "\"event.created\": \"2024-01-15T10:30:00Z\","
-                + "\"is.active\": true"
-                + "}]";
-            solr.execInContainer(
-                "curl", "-s", "-H", "Content-Type: application/json",
-                "http://localhost:8983/solr/" + COLLECTION_NAME + "/update?commit=true",
-                "-d", doc
-            );
-
-            var schema = fetchSolrSchema(solr, COLLECTION_NAME);
-            var backupDir = createAndCopyBackup(solr, COLLECTION_NAME);
-
-            var source = new SolrBackupSource(backupDir, COLLECTION_NAME, schema);
-            var targetClient = createOpenSearchClient(target);
-            var sink = new OpenSearchDocumentSink(
-                targetClient, null, false, DocumentExceptionAllowlist.empty(), null
-            );
-            new DocumentMigrationPipeline(source, sink, 100, Long.MAX_VALUE)
-                .migrateAll().collectList().block();
-
+            // ---- TARGET: assert metadata (declared types) and document content ----
             var restClient = createRestClient(target);
             var ctx = DocumentMigrationTestContext.factory().noOtelTracking();
             restClient.get("_refresh", ctx.createUnboundRequestContext());
 
-            // --- Verify field_caps reports the original dotted field names with the right types ---
-            var capsResp = restClient.get(
-                COLLECTION_NAME + "/_field_caps?fields=category.name,category.id,metric.cpu.percent,event.created,is.active",
-                ctx.createUnboundRequestContext()
-            );
-            var fields = MAPPER.readTree(capsResp.body).path("fields");
-            log.atInfo().setMessage("OpenSearch field_caps for dotted fields: {}").addArgument(fields).log();
+            // Metadata: each declared dotted field is reachable by its full dotted path
+            // and reports the OpenSearch type that the converter should derive from Solr.
+            assertTargetFieldType(restClient, ctx, COLLECTION_NAME, "category.name",       "keyword");
+            assertTargetFieldType(restClient, ctx, COLLECTION_NAME, "category.id",         "integer");
+            assertTargetFieldType(restClient, ctx, COLLECTION_NAME, "metric.cpu.percent",  "float");
+            assertTargetFieldType(restClient, ctx, COLLECTION_NAME, "event.created",       "date");
+            assertTargetFieldType(restClient, ctx, COLLECTION_NAME, "is.active",           "boolean");
 
-            assertThat("category.name → keyword",
-                fields.path("category.name").path("keyword").path("type").asText(), equalTo("keyword"));
-            assertThat("category.id → integer",
-                fields.path("category.id").path("integer").path("type").asText(), equalTo("integer"));
-            assertThat("metric.cpu.percent → float",
-                fields.path("metric.cpu.percent").path("float").path("type").asText(), equalTo("float"));
-            assertThat("event.created → date",
-                fields.path("event.created").path("date").path("type").asText(), equalTo("date"));
-            assertThat("is.active → boolean",
-                fields.path("is.active").path("boolean").path("type").asText(), equalTo("boolean"));
+            // Document content: _source keeps every dotted key verbatim, with the value as written.
+            var src = fetchTargetSource(restClient, ctx, COLLECTION_NAME, "doc1");
+            assertThat("_source.category.name",
+                src.path("category.name").asText(),                    equalTo("books"));
+            assertThat("_source.category.id",
+                src.path("category.id").asInt(),                       equalTo(7));
+            assertThat("_source.metric.cpu.percent",
+                (double) src.path("metric.cpu.percent").floatValue(),  closeTo(42.5, 0.01));
+            assertThat("_source.is.active",
+                src.path("is.active").asBoolean(),                     equalTo(true));
 
-            // --- Verify _source preserves the dotted keys verbatim ---
-            var searchResp = restClient.get(
-                COLLECTION_NAME + "/_search?q=id:doc1&size=1", ctx.createUnboundRequestContext()
-            );
-            var hits = MAPPER.readTree(searchResp.body).path("hits").path("hits");
-            assertThat("Should find doc1", hits.size(), equalTo(1));
-            var src = hits.get(0).path("_source");
-            log.atInfo().setMessage("Migrated dotted-field doc _source: {}").addArgument(src).log();
-
-            assertThat("_source keeps category.name as-is",
-                src.path("category.name").asText(), equalTo("books"));
-            assertThat("_source keeps category.id as-is",
-                src.path("category.id").asInt(), equalTo(7));
-            assertThat("_source keeps metric.cpu.percent as-is",
-                (double) src.path("metric.cpu.percent").floatValue(), closeTo(42.5, 0.01));
-            assertThat("_source keeps is.active as-is",
-                src.path("is.active").asBoolean(), equalTo(true));
-
-            // --- Verify queries against the original dotted path resolve to this doc ---
-            // Solr customers query like q=category.name:books — the same path must work in OS.
-            var qByDottedKeyword = restClient.get(
-                COLLECTION_NAME + "/_search?q=category.name:books&size=10",
-                ctx.createUnboundRequestContext()
-            );
-            var keywordHits = MAPPER.readTree(qByDottedKeyword.body).path("hits").path("hits");
-            assertThat("category.name:books should match doc1", keywordHits.size(), equalTo(1));
-            assertThat(keywordHits.get(0).path("_id").asText(), equalTo("doc1"));
-
-            // Numeric range query on a dotted-name int field.
-            var qByDottedInt = restClient.get(
-                COLLECTION_NAME + "/_search?q=category.id:7&size=10",
-                ctx.createUnboundRequestContext()
-            );
-            var intHits = MAPPER.readTree(qByDottedInt.body).path("hits").path("hits");
-            assertThat("category.id:7 should match doc1", intHits.size(), equalTo(1));
-
-            // Three-segment dotted field name still resolves as a query path.
-            var qByThreeSegmentFloat = restClient.get(
-                COLLECTION_NAME + "/_search?q=metric.cpu.percent:42.5&size=10",
-                ctx.createUnboundRequestContext()
-            );
-            var floatHits = MAPPER.readTree(qByThreeSegmentFloat.body).path("hits").path("hits");
-            assertThat("query on metric.cpu.percent should match doc1",
-                floatHits.size(), equalTo(1));
+            // Queries by the original dotted path resolve back to doc1 — including a
+            // three-segment field name. This is what Solr customers actually issue.
+            assertQueryReturnsId(restClient, ctx, COLLECTION_NAME, "category.name:books",        "doc1");
+            assertQueryReturnsId(restClient, ctx, COLLECTION_NAME, "category.id:7",              "doc1");
+            assertQueryReturnsId(restClient, ctx, COLLECTION_NAME, "metric.cpu.percent:42.5",    "doc1");
         }
     }
 
     /**
      * E2E regression: a dotted-name field whose top-level segment also matches a
-     * Solr dynamic-field pattern (e.g. {@code attr_thing.withdot} under {@code attr_*}).
-     * Without {@code path_match} + {@code match_mapping_type}, the dynamic template
-     * fires on the synthesized parent object and the bulk write fails with
-     * {@code mapper_parsing_exception}, silently dropping the doc.
+     * Solr {@code dynamicField} pattern. Before the fix, the converter emitted
+     * dynamic templates with plain {@code match}, which fired on the synthesized
+     * parent object on write and failed bulk indexing with
+     * {@code mapper_parsing_exception} — silently dropping the doc.
+     *
+     * <p>SOURCE — Solr 8 collection (default schema's dynamic fields) with one doc
+     * that exercises each of the six default dynamic-field patterns using a dotted
+     * leaf so the parent segment also prefix-matches the pattern.
+     * <pre>{@code
+     *   dynamic fields (default Solr 8 schema):
+     *     attr_*  text_general,  *_s string,  *_i pint,  *_b boolean,  *_f pfloat,  *_dt pdate
+     *   dyn-dot-1: {
+     *     attr_thing.withdot:"vip",       // attr_*  + dotted leaf
+     *     label.tag_s:"alpha",            // *_s     + dotted leaf
+     *     counter.value_i:17,             // *_i     + dotted leaf
+     *     flag.is.set_b:true,             // *_b     + dotted leaf (3 segments)
+     *     price.unit_f:9.99,              // *_f     + dotted leaf
+     *     event.created_dt:"2024-06-15T12:00:00Z"  // *_dt + dotted leaf
+     *   }
+     * }</pre>
+     *
+     * <p>TARGET — OpenSearch 2.19 index "test_collection" with the doc successfully
+     * indexed (no bulk failure), each dotted leaf typed by its dynamic template,
+     * and dotted-path queries returning the doc.
      */
     @ParameterizedTest(name = "dynamic-field + dotted name: {0} → {1}")
     @MethodSource("solr8ToOpenSearch")
@@ -348,86 +325,45 @@ public class SolrToOpenSearchEndToEndTest {
             solr.start();
             target.start();
 
+            // ---- SOURCE: Solr collection (default dynamicFields) + 1 doc with dotted leaves ----
             createSolrCollection(solr, COLLECTION_NAME);
-
-            // Solr default schema already has attr_* (text_general) and *_s, *_i, *_b, *_f, *_dt
-            // dynamic fields. Index a doc that uses each of those patterns with a
-            // dotted leaf name so the parent segment also prefix-matches the pattern.
-            var doc = "[{"
+            indexSolrDocs(solr, COLLECTION_NAME, "[{"
                 + "\"id\":\"dyn-dot-1\","
-                + "\"attr_thing.withdot\":\"vip\","        // attr_*  (text_general) + dotted leaf
-                + "\"label.tag_s\":\"alpha\","             // *_s     (string)        + dotted leaf
-                + "\"counter.value_i\":17,"                // *_i     (pint)          + dotted leaf
-                + "\"flag.is.set_b\":true,"                // *_b     (boolean)       + dotted leaf (3 segments)
-                + "\"price.unit_f\":9.99,"                 // *_f     (pfloat)        + dotted leaf
-                + "\"event.created_dt\":\"2024-06-15T12:00:00Z\""  // *_dt (pdate)    + dotted leaf
-                + "}]";
-            solr.execInContainer("curl", "-s", "-H", "Content-Type: application/json",
-                "http://localhost:8983/solr/" + COLLECTION_NAME + "/update?commit=true",
-                "-d", doc);
+                + "\"attr_thing.withdot\":\"vip\","
+                + "\"label.tag_s\":\"alpha\","
+                + "\"counter.value_i\":17,"
+                + "\"flag.is.set_b\":true,"
+                + "\"price.unit_f\":9.99,"
+                + "\"event.created_dt\":\"2024-06-15T12:00:00Z\""
+                + "}]");
 
-            var schema = fetchSolrSchema(solr, COLLECTION_NAME);
-            var backupDir = createAndCopyBackup(solr, COLLECTION_NAME);
+            // ---- MIGRATE: backup → pipeline → OpenSearch ----
+            runPipelineMigration(solr, target, COLLECTION_NAME, solrVersion);
 
-            var source = new SolrBackupSource(backupDir, COLLECTION_NAME, schema);
-            var targetClient = createOpenSearchClient(target);
-            var sink = new OpenSearchDocumentSink(
-                targetClient, null, false, DocumentExceptionAllowlist.empty(), null
-            );
-            new DocumentMigrationPipeline(source, sink, 100, Long.MAX_VALUE)
-                .migrateAll().collectList().block();
-
+            // ---- TARGET: assert metadata (per-template types) and document content ----
             var restClient = createRestClient(target);
             var ctx = DocumentMigrationTestContext.factory().noOtelTracking();
             restClient.get("_refresh", ctx.createUnboundRequestContext());
 
-            // The migrated doc must exist — bulk would have failed if dynamic templates
-            // had collided with the dotted parent segment.
-            var searchResp = restClient.get(
-                COLLECTION_NAME + "/_search?q=id:dyn-dot-1&size=1",
-                ctx.createUnboundRequestContext()
-            );
-            var hits = MAPPER.readTree(searchResp.body).path("hits").path("hits");
-            assertThat("dyn-dot-1 should be present", hits.size(), equalTo(1));
+            // The doc must exist — pre-fix, bulk would have failed with mapper_parsing_exception.
+            var src = fetchTargetSource(restClient, ctx, COLLECTION_NAME, "dyn-dot-1");
+            assertThat("_source.attr_thing.withdot", src.path("attr_thing.withdot").asText(),         equalTo("vip"));
+            assertThat("_source.label.tag_s",        src.path("label.tag_s").asText(),                equalTo("alpha"));
+            assertThat("_source.counter.value_i",    src.path("counter.value_i").asInt(),             equalTo(17));
+            assertThat("_source.flag.is.set_b",      src.path("flag.is.set_b").asBoolean(),           equalTo(true));
+            assertThat("_source.price.unit_f",       (double) src.path("price.unit_f").floatValue(),  closeTo(9.99, 0.01));
 
-            var src = hits.get(0).path("_source");
-            log.atInfo().setMessage("Migrated dynamic+dotted _source: {}").addArgument(src).log();
-            assertThat(src.path("attr_thing.withdot").asText(), equalTo("vip"));
-            assertThat(src.path("label.tag_s").asText(), equalTo("alpha"));
-            assertThat(src.path("counter.value_i").asInt(), equalTo(17));
-            assertThat(src.path("flag.is.set_b").asBoolean(), equalTo(true));
-            assertThat((double) src.path("price.unit_f").floatValue(), closeTo(9.99, 0.01));
+            // Each dotted leaf got the type its matching dynamic template prescribes —
+            // proves path_match + match_mapping_type targeted only the leaf, not the parent.
+            assertTargetFieldType(restClient, ctx, COLLECTION_NAME, "attr_thing.withdot",  "text");      // attr_* template
+            assertTargetFieldType(restClient, ctx, COLLECTION_NAME, "label.tag_s",         "keyword");   // *_s    template
+            assertTargetFieldType(restClient, ctx, COLLECTION_NAME, "counter.value_i",     "integer");   // *_i    template
+            assertTargetFieldType(restClient, ctx, COLLECTION_NAME, "flag.is.set_b",       "boolean");   // *_b    template
+            assertTargetFieldType(restClient, ctx, COLLECTION_NAME, "price.unit_f",        "float");     // *_f    template
+            assertTargetFieldType(restClient, ctx, COLLECTION_NAME, "event.created_dt",    "date");      // *_dt   template
 
-            // Verify dynamic templates produced the right *typed* mapping for the dotted
-            // leaves — proving the path_match + match_mapping_type pair worked.
-            var capsResp = restClient.get(
-                COLLECTION_NAME + "/_field_caps?fields="
-                    + "attr_thing.withdot,label.tag_s,counter.value_i,flag.is.set_b,price.unit_f,event.created_dt",
-                ctx.createUnboundRequestContext()
-            );
-            var fields = MAPPER.readTree(capsResp.body).path("fields");
-            log.atInfo().setMessage("OpenSearch field_caps for dynamic+dotted fields: {}")
-                .addArgument(fields).log();
-
-            assertThat("attr_thing.withdot → text (attr_* template)",
-                fields.path("attr_thing.withdot").path("text").path("type").asText(), equalTo("text"));
-            assertThat("label.tag_s → keyword (*_s template)",
-                fields.path("label.tag_s").path("keyword").path("type").asText(), equalTo("keyword"));
-            assertThat("counter.value_i → integer (*_i template)",
-                fields.path("counter.value_i").path("integer").path("type").asText(), equalTo("integer"));
-            assertThat("flag.is.set_b → boolean (*_b template)",
-                fields.path("flag.is.set_b").path("boolean").path("type").asText(), equalTo("boolean"));
-            assertThat("price.unit_f → float (*_f template)",
-                fields.path("price.unit_f").path("float").path("type").asText(), equalTo("float"));
-            assertThat("event.created_dt → date (*_dt template)",
-                fields.path("event.created_dt").path("date").path("type").asText(), equalTo("date"));
-
-            // And queries by the original dotted path resolve to the doc.
-            var qHits = MAPPER.readTree(restClient.get(
-                COLLECTION_NAME + "/_search?q=counter.value_i:17&size=10",
-                ctx.createUnboundRequestContext()
-            ).body).path("hits").path("hits");
-            assertThat("query counter.value_i:17 matches dyn-dot-1", qHits.size(), equalTo(1));
+            // Query by the original dotted path resolves to the doc.
+            assertQueryReturnsId(restClient, ctx, COLLECTION_NAME, "counter.value_i:17", "dyn-dot-1");
         }
     }
 
@@ -1127,6 +1063,78 @@ public class SolrToOpenSearchEndToEndTest {
     }
 
     // --- Helpers ---
+
+    /** POST a JSON document array to a Solr collection's /update endpoint with commit. */
+    private static void indexSolrDocs(SolrClusterContainer solr, String collection, String jsonDocsArray)
+        throws Exception {
+        solr.execInContainer(
+            "curl", "-s", "-H", "Content-Type: application/json",
+            "http://localhost:8983/solr/" + collection + "/update?commit=true",
+            "-d", jsonDocsArray
+        );
+    }
+
+    /** POST {@code {"add-field":[...]}} to a Solr collection's Schema API. */
+    private static void addSolrSchemaFields(
+        SolrClusterContainer solr, String collection, String addFieldArrayJson
+    ) throws Exception {
+        solr.execInContainer(
+            "curl", "-s", "-H", "Content-Type: application/json",
+            "http://localhost:8983/solr/" + collection + "/schema",
+            "-d", "{\"add-field\":" + addFieldArrayJson + "}"
+        );
+    }
+
+    /** Snapshot the Solr collection, copy locally, and run the in-process pipeline to OpenSearch. */
+    private void runPipelineMigration(
+        SolrClusterContainer solr, SearchClusterContainer target,
+        String collection, SolrClusterContainer.SolrVersion solrVersion
+    ) throws Exception {
+        var schema = fetchSolrSchema(solr, collection);
+        var backupDir = createAndCopyBackup(solr, collection);
+        var source = new SolrBackupSource(backupDir, collection, schema, solrVersion.major());
+        var sink = new OpenSearchDocumentSink(
+            createOpenSearchClient(target), null, false, DocumentExceptionAllowlist.empty(), null
+        );
+        new DocumentMigrationPipeline(source, sink, 100, Long.MAX_VALUE).migrateAll().collectList().block();
+    }
+
+    /** Assert that {@code _field_caps} reports {@code field} on the target index with the given OS type. */
+    private static void assertTargetFieldType(
+        RestClient restClient, DocumentMigrationTestContext ctx,
+        String index, String field, String expectedType
+    ) throws Exception {
+        var resp = restClient.get(index + "/_field_caps?fields=" + field, ctx.createUnboundRequestContext());
+        var typeNode = MAPPER.readTree(resp.body)
+            .path("fields").path(field).path(expectedType).path("type");
+        assertThat(field + " → " + expectedType, typeNode.asText(), equalTo(expectedType));
+    }
+
+    /** Fetch the {@code _source} of a target doc by id. Asserts the doc exists. */
+    private static JsonNode fetchTargetSource(
+        RestClient restClient, DocumentMigrationTestContext ctx, String index, String id
+    ) throws Exception {
+        var resp = restClient.get(index + "/_search?q=id:" + id + "&size=1", ctx.createUnboundRequestContext());
+        var hits = MAPPER.readTree(resp.body).path("hits").path("hits");
+        assertThat("Should find " + id, hits.size(), equalTo(1));
+        var src = hits.get(0).path("_source");
+        log.atInfo().setMessage("Migrated _source for {}: {}").addArgument(id).addArgument(src).log();
+        return src;
+    }
+
+    /** Run a Lucene query string against the target and assert exactly one hit with the expected id. */
+    private static void assertQueryReturnsId(
+        RestClient restClient, DocumentMigrationTestContext ctx,
+        String index, String luceneQuery, String expectedId
+    ) throws Exception {
+        var resp = restClient.get(
+            index + "/_search?q=" + luceneQuery + "&size=10", ctx.createUnboundRequestContext()
+        );
+        var hits = MAPPER.readTree(resp.body).path("hits").path("hits");
+        assertThat("query " + luceneQuery + " should return one hit", hits.size(), equalTo(1));
+        assertThat("query " + luceneQuery + " should return id=" + expectedId,
+            hits.get(0).path("_id").asText(), equalTo(expectedId));
+    }
 
     /**
      * Polls /solr/admin/collections?action=CLUSTERSTATUS until the collection has the

--- a/SolrReader/src/test/java/org/opensearch/migrations/bulkload/solr/SolrToOpenSearchEndToEndTest.java
+++ b/SolrReader/src/test/java/org/opensearch/migrations/bulkload/solr/SolrToOpenSearchEndToEndTest.java
@@ -198,6 +198,144 @@ public class SolrToOpenSearchEndToEndTest {
     }
 
     /**
+     * E2E: Solr fields whose names contain '.' (e.g. "category.name", "metric.cpu.percent")
+     * migrate to OpenSearch with the original key shape preserved in {@code _source}, the
+     * declared types honored, and queries written against the original dotted field path
+     * still resolving correctly.
+     *
+     * <p>OpenSearch interprets dotted JSON keys as nested-object paths during indexing, so
+     * {@code "category.name": "books"} ends up stored under {@code category.properties.name}
+     * in the mapping tree. {@code _source}, {@code _search} field-path resolution, and
+     * {@code _field_caps} still expose the field by its original {@code "category.name"}
+     * name, which is the customer-visible behavior Solr users expect.</p>
+     */
+    @ParameterizedTest(name = "dotted field names: {0} → {1}")
+    @MethodSource("solr8ToOpenSearch")
+    void migratesFieldsWithDotsInName(
+        SolrClusterContainer.SolrVersion solrVersion,
+        SearchClusterContainer.ContainerVersion targetVersion
+    ) throws Exception {
+        try (
+            var solr = new SolrClusterContainer(solrVersion);
+            var target = new SearchClusterContainer(targetVersion)
+        ) {
+            solr.start();
+            target.start();
+
+            createSolrCollection(solr, COLLECTION_NAME);
+
+            // Solr permits flat field names with '.'. Declare a few of them with mixed
+            // types so we can verify both the mapping and the round-tripped values.
+            var schemaUpdate = "{"
+                + "\"add-field\": ["
+                + "  {\"name\":\"category.name\",       \"type\":\"string\",  \"stored\":true,  \"indexed\":true,  \"docValues\":true},"
+                + "  {\"name\":\"category.id\",         \"type\":\"pint\",    \"stored\":true,  \"indexed\":true,  \"docValues\":true},"
+                + "  {\"name\":\"metric.cpu.percent\",  \"type\":\"pfloat\",  \"stored\":true,  \"indexed\":true,  \"docValues\":true},"
+                + "  {\"name\":\"event.created\",       \"type\":\"pdate\",   \"stored\":true,  \"indexed\":true,  \"docValues\":true},"
+                + "  {\"name\":\"is.active\",           \"type\":\"boolean\", \"stored\":true,  \"docValues\":true}"
+                + "]}";
+            solr.execInContainer(
+                "curl", "-s", "-H", "Content-Type: application/json",
+                "http://localhost:8983/solr/" + COLLECTION_NAME + "/schema",
+                "-d", schemaUpdate
+            );
+
+            var doc = "[{"
+                + "\"id\": \"doc1\","
+                + "\"category.name\": \"books\","
+                + "\"category.id\": 7,"
+                + "\"metric.cpu.percent\": 42.5,"
+                + "\"event.created\": \"2024-01-15T10:30:00Z\","
+                + "\"is.active\": true"
+                + "}]";
+            solr.execInContainer(
+                "curl", "-s", "-H", "Content-Type: application/json",
+                "http://localhost:8983/solr/" + COLLECTION_NAME + "/update?commit=true",
+                "-d", doc
+            );
+
+            var schema = fetchSolrSchema(solr, COLLECTION_NAME);
+            var backupDir = createAndCopyBackup(solr, COLLECTION_NAME);
+
+            var source = new SolrBackupSource(backupDir, COLLECTION_NAME, schema);
+            var targetClient = createOpenSearchClient(target);
+            var sink = new OpenSearchDocumentSink(
+                targetClient, null, false, DocumentExceptionAllowlist.empty(), null
+            );
+            new DocumentMigrationPipeline(source, sink, 100, Long.MAX_VALUE)
+                .migrateAll().collectList().block();
+
+            var restClient = createRestClient(target);
+            var ctx = DocumentMigrationTestContext.factory().noOtelTracking();
+            restClient.get("_refresh", ctx.createUnboundRequestContext());
+
+            // --- Verify field_caps reports the original dotted field names with the right types ---
+            var capsResp = restClient.get(
+                COLLECTION_NAME + "/_field_caps?fields=category.name,category.id,metric.cpu.percent,event.created,is.active",
+                ctx.createUnboundRequestContext()
+            );
+            var fields = MAPPER.readTree(capsResp.body).path("fields");
+            log.atInfo().setMessage("OpenSearch field_caps for dotted fields: {}").addArgument(fields).log();
+
+            assertThat("category.name → keyword",
+                fields.path("category.name").path("keyword").path("type").asText(), equalTo("keyword"));
+            assertThat("category.id → integer",
+                fields.path("category.id").path("integer").path("type").asText(), equalTo("integer"));
+            assertThat("metric.cpu.percent → float",
+                fields.path("metric.cpu.percent").path("float").path("type").asText(), equalTo("float"));
+            assertThat("event.created → date",
+                fields.path("event.created").path("date").path("type").asText(), equalTo("date"));
+            assertThat("is.active → boolean",
+                fields.path("is.active").path("boolean").path("type").asText(), equalTo("boolean"));
+
+            // --- Verify _source preserves the dotted keys verbatim ---
+            var searchResp = restClient.get(
+                COLLECTION_NAME + "/_search?q=id:doc1&size=1", ctx.createUnboundRequestContext()
+            );
+            var hits = MAPPER.readTree(searchResp.body).path("hits").path("hits");
+            assertThat("Should find doc1", hits.size(), equalTo(1));
+            var src = hits.get(0).path("_source");
+            log.atInfo().setMessage("Migrated dotted-field doc _source: {}").addArgument(src).log();
+
+            assertThat("_source keeps category.name as-is",
+                src.path("category.name").asText(), equalTo("books"));
+            assertThat("_source keeps category.id as-is",
+                src.path("category.id").asInt(), equalTo(7));
+            assertThat("_source keeps metric.cpu.percent as-is",
+                (double) src.path("metric.cpu.percent").floatValue(), closeTo(42.5, 0.01));
+            assertThat("_source keeps is.active as-is",
+                src.path("is.active").asBoolean(), equalTo(true));
+
+            // --- Verify queries against the original dotted path resolve to this doc ---
+            // Solr customers query like q=category.name:books — the same path must work in OS.
+            var qByDottedKeyword = restClient.get(
+                COLLECTION_NAME + "/_search?q=category.name:books&size=10",
+                ctx.createUnboundRequestContext()
+            );
+            var keywordHits = MAPPER.readTree(qByDottedKeyword.body).path("hits").path("hits");
+            assertThat("category.name:books should match doc1", keywordHits.size(), equalTo(1));
+            assertThat(keywordHits.get(0).path("_id").asText(), equalTo("doc1"));
+
+            // Numeric range query on a dotted-name int field.
+            var qByDottedInt = restClient.get(
+                COLLECTION_NAME + "/_search?q=category.id:7&size=10",
+                ctx.createUnboundRequestContext()
+            );
+            var intHits = MAPPER.readTree(qByDottedInt.body).path("hits").path("hits");
+            assertThat("category.id:7 should match doc1", intHits.size(), equalTo(1));
+
+            // Three-segment dotted field name still resolves as a query path.
+            var qByThreeSegmentFloat = restClient.get(
+                COLLECTION_NAME + "/_search?q=metric.cpu.percent:42.5&size=10",
+                ctx.createUnboundRequestContext()
+            );
+            var floatHits = MAPPER.readTree(qByThreeSegmentFloat.body).path("hits").path("hits");
+            assertThat("query on metric.cpu.percent should match doc1",
+                floatHits.size(), equalTo(1));
+        }
+    }
+
+    /**
      * E2E: Multi-shard backup discovery and parallel reading.
      * Creates a simulated multi-shard backup directory structure and verifies
      * all shards are discovered and documents from each shard are migrated.

--- a/SolrReader/src/test/java/org/opensearch/migrations/bulkload/solr/SolrToOpenSearchEndToEndTest.java
+++ b/SolrReader/src/test/java/org/opensearch/migrations/bulkload/solr/SolrToOpenSearchEndToEndTest.java
@@ -198,16 +198,9 @@ public class SolrToOpenSearchEndToEndTest {
     }
 
     /**
-     * E2E: Solr fields whose names contain '.' (e.g. "category.name", "metric.cpu.percent")
-     * migrate to OpenSearch with the original key shape preserved in {@code _source}, the
-     * declared types honored, and queries written against the original dotted field path
-     * still resolving correctly.
-     *
-     * <p>OpenSearch interprets dotted JSON keys as nested-object paths during indexing, so
-     * {@code "category.name": "books"} ends up stored under {@code category.properties.name}
-     * in the mapping tree. {@code _source}, {@code _search} field-path resolution, and
-     * {@code _field_caps} still expose the field by its original {@code "category.name"}
-     * name, which is the customer-visible behavior Solr users expect.</p>
+     * E2E: Solr fields with dots in their names (e.g. {@code category.name}) migrate
+     * with their declared types, {@code _source} preserves the original keys, and
+     * queries against the original dotted path resolve to the migrated docs.
      */
     @ParameterizedTest(name = "dotted field names: {0} → {1}")
     @MethodSource("solr8ToOpenSearch")
@@ -336,20 +329,11 @@ public class SolrToOpenSearchEndToEndTest {
     }
 
     /**
-     * E2E regression: dotted field names whose top-level segment ALSO matches a Solr
-     * dynamic-field prefix pattern.
-     *
-     * <p>Solr's default schema declares a prefix-style dynamic field {@code attr_*}.
-     * A doc field like {@code attr_field.withdot=42} therefore both (a) belongs to a
-     * dotted path and (b) prefix-matches {@code attr_*}. Without a careful template
-     * spec, OpenSearch will apply the {@code attr_*} template to the parent object
-     * {@code attr_field} (typing it as {@code integer}) and then reject the child
-     * key {@code .withdot} with {@code mapper_parsing_exception}. The bulk request
-     * fails outright — the migrated doc is silently lost.
-     *
-     * <p>Verifies the converter emits dynamic templates that pin to the JSON value
-     * shape ({@code match_mapping_type}) and use {@code path_match}, so the template
-     * fires only on the leaf value and never on intermediate object containers.
+     * E2E regression: a dotted-name field whose top-level segment also matches a
+     * Solr dynamic-field pattern (e.g. {@code attr_thing.withdot} under {@code attr_*}).
+     * Without {@code path_match} + {@code match_mapping_type}, the dynamic template
+     * fires on the synthesized parent object and the bulk write fails with
+     * {@code mapper_parsing_exception}, silently dropping the doc.
      */
     @ParameterizedTest(name = "dynamic-field + dotted name: {0} → {1}")
     @MethodSource("solr8ToOpenSearch")

--- a/migrationConsole/lib/integ_test/integ_test/test_cases/solr_tests.py
+++ b/migrationConsole/lib/integ_test/integ_test/test_cases/solr_tests.py
@@ -69,11 +69,7 @@ class TestSolr0001SingleDocumentBackfill(MATestBase):
         self.sharded_num_shards = 2
         self.sharded_doc_count = 40
 
-        # Dotted-field collection — exercises migration of flat Solr field names
-        # whose names contain '.' (e.g. 'category.name'). OpenSearch interprets
-        # such keys as nested-object paths during indexing, but _source preserves
-        # the original key shape and queries against the original dotted path
-        # continue to resolve, so the migration is intuitive for Solr users.
+        # Dotted-field collection — exercises Solr field names containing '.'.
         self.dotted_collection = f"dotted_{self._suffix}"
         self.dotted_doc_id = "dotted_doc_0001"
 
@@ -126,11 +122,7 @@ class TestSolr0001SingleDocumentBackfill(MATestBase):
             docs=sharded_docs)
         self._assert_source_count(self.sharded_collection, self.sharded_doc_count)
 
-        # (4) Dotted-field collection — declare explicit Solr schema fields whose
-        # names contain '.' and index a doc that uses them. This is the realistic
-        # customer scenario: Solr permits flat dotted names as a naming
-        # convention; the migration must round-trip them through to OpenSearch
-        # without renaming or dropping data.
+        # (4) Dotted-field collection — explicit schema fields whose names contain '.'.
         logger.info(f"Creating SolrCloud collection '{self.dotted_collection}' "
                     f"with explicit dotted-name fields")
         self.source_operations.create_index(
@@ -154,16 +146,9 @@ class TestSolr0001SingleDocumentBackfill(MATestBase):
         self._assert_source_count(self.dotted_collection, 1)
 
     def _add_solr_schema_fields(self, collection: str, fields: list):
-        """Declare explicit schema fields on a Solr collection via the Schema API.
-
-        Solr's _default configset is dynamic-field-driven; declaring explicit
-        fields with concrete types is what real Solr customers do for
-        production data and is what makes type assertions on the OpenSearch
-        side meaningful.
-        """
+        """Declare explicit schema fields on a Solr collection via the Schema API."""
         url = f"{self.source_cluster.endpoint}/solr/{collection}/schema"
-        body = {"add-field": fields}
-        r = requests.post(url, json=body,
+        r = requests.post(url, json={"add-field": fields},
                           headers={"Content-Type": "application/json"}, timeout=15)
         r.raise_for_status()
         # Solr returns 200 with errors embedded in the body on failure.
@@ -207,67 +192,40 @@ class TestSolr0001SingleDocumentBackfill(MATestBase):
                                       "collectionPreparer to download shard_backup_metadata "
                                       "from S3 before counting)."))
 
-        # (4) Dotted fields: doc-count, _source preservation of dotted keys, and
-        # query-by-dotted-path resolution all matter to customers. If the
-        # migration silently renamed or split the field names, this scenario
-        # would catch it.
+        # (4) Dotted fields: doc-count, _source preservation, and query resolution.
         self._assert_target_count(self.dotted_collection, 1,
                                   regression_hint=(
                                       "Dotted-field collection failed to migrate. Check that "
                                       "SolrSchemaConverter emits dotted field names as literal "
-                                      "keys under 'properties' and that the document indexer "
-                                      "does not collide on a parent key (e.g. both 'category' "
-                                      "as leaf and 'category.id' as object form)."))
+                                      "keys under 'properties'."))
         self._assert_dotted_field_doc_round_trip()
 
     def _assert_dotted_field_doc_round_trip(self):
-        """Verify a dotted-field document round-trips through the migration.
-
-        Asserts:
-          - The exact doc id is retrievable.
-          - _source preserves the original dotted keys (category.name, etc.).
-          - Queries written against the original dotted path
-            (q=category.name:books) resolve to the migrated document.
-        """
-        # _source preservation
+        """Verify _source preserves dotted keys and queries by dotted path resolve."""
         resp = execute_api_call(
             cluster=self.target_cluster,
             path=f"/{self.dotted_collection}/_search?q=id:{self.dotted_doc_id}&size=1")
-        body = resp.json()
-        hits = body.get("hits", {}).get("hits", [])
-        assert len(hits) == 1, (
-            f"Expected to find dotted-field doc by id, got {len(hits)} hits. "
-            f"Body: {body}")
+        hits = resp.json().get("hits", {}).get("hits", [])
+        assert len(hits) == 1, f"Expected to find dotted-field doc by id, got {len(hits)} hits."
         src = hits[0].get("_source", {})
-        assert src.get("category.name") == "books", (
-            f"_source should preserve 'category.name' verbatim, got {src!r}")
-        assert src.get("category.id") == 7, (
-            f"_source should preserve 'category.id' verbatim, got {src!r}")
+        assert src.get("category.name") == "books", f"_source mismatch: {src!r}"
+        assert src.get("category.id") == 7, f"_source mismatch: {src!r}"
         actual_pct = src.get("metric.cpu.percent")
-        assert actual_pct is not None and abs(actual_pct - 42.5) < 0.01, (
-            f"_source should preserve 'metric.cpu.percent' verbatim, got {src!r}")
-        assert src.get("is.active") is True, (
-            f"_source should preserve 'is.active' verbatim, got {src!r}")
+        assert actual_pct is not None and abs(actual_pct - 42.5) < 0.01, f"_source mismatch: {src!r}"
+        assert src.get("is.active") is True, f"_source mismatch: {src!r}"
 
-        # Query against original dotted path resolves to the migrated doc.
-        resp2 = execute_api_call(
+        kw_hits = execute_api_call(
             cluster=self.target_cluster,
-            path=f"/{self.dotted_collection}/_search?q=category.name:books&size=10")
-        kw_hits = resp2.json().get("hits", {}).get("hits", [])
+            path=f"/{self.dotted_collection}/_search?q=category.name:books&size=10",
+        ).json().get("hits", {}).get("hits", [])
         assert len(kw_hits) == 1 and kw_hits[0].get("_id") == self.dotted_doc_id, (
-            f"Query 'category.name:books' should match the migrated dotted-field "
-            f"doc, got: {kw_hits}")
+            f"Query 'category.name:books' should match dotted-field doc, got: {kw_hits}")
 
-        # Exact-match query on a multi-segment dotted field name resolves.
-        resp3 = execute_api_call(
+        flt_hits = execute_api_call(
             cluster=self.target_cluster,
-            path=f"/{self.dotted_collection}/_search?q=metric.cpu.percent:42.5&size=10")
-        flt_hits = resp3.json().get("hits", {}).get("hits", [])
-        assert len(flt_hits) == 1, (
-            f"Query on 'metric.cpu.percent' should match the dotted-field "
-            f"doc, got: {flt_hits}")
-        logger.info("Dotted-field doc round-trip verified: _source preserved + "
-                    "queries by original dotted path resolve correctly.")
+            path=f"/{self.dotted_collection}/_search?q=metric.cpu.percent:42.5&size=10",
+        ).json().get("hits", {}).get("hits", [])
+        assert len(flt_hits) == 1, f"Query on 'metric.cpu.percent' should match, got: {flt_hits}"
 
     def _assert_target_count(self, collection: str, expected: int, regression_hint: str = ""):
         # Retry a few times — bulk migration may not be fully flushed to the target yet.

--- a/migrationConsole/lib/integ_test/integ_test/test_cases/solr_tests.py
+++ b/migrationConsole/lib/integ_test/integ_test/test_cases/solr_tests.py
@@ -137,10 +137,10 @@ class TestSolr0001SingleDocumentBackfill(MATestBase):
             cluster=self.source_cluster, index_name=self.dotted_collection,
             num_shards=1, replication_factor=1)
         self._add_solr_schema_fields(self.dotted_collection, [
-            {"name": "category.name",      "type": "string",  "stored": True, "indexed": True, "docValues": True},
-            {"name": "category.id",        "type": "pint",    "stored": True, "indexed": True, "docValues": True},
-            {"name": "metric.cpu.percent", "type": "pfloat",  "stored": True, "indexed": True, "docValues": True},
-            {"name": "is.active",          "type": "boolean", "stored": True, "docValues": True},
+            {"name": "category.name", "type": "string", "stored": True, "indexed": True, "docValues": True},
+            {"name": "category.id", "type": "pint", "stored": True, "indexed": True, "docValues": True},
+            {"name": "metric.cpu.percent", "type": "pfloat", "stored": True, "indexed": True, "docValues": True},
+            {"name": "is.active", "type": "boolean", "stored": True, "docValues": True},
         ])
         self.source_operations.create_document(
             cluster=self.source_cluster, index_name=self.dotted_collection,

--- a/migrationConsole/lib/integ_test/integ_test/test_cases/solr_tests.py
+++ b/migrationConsole/lib/integ_test/integ_test/test_cases/solr_tests.py
@@ -10,12 +10,16 @@ workflow has non-trivial setup/teardown overhead, the realistic-customer scenari
 is packed into a single test that exercises:
   - Multiple collections (pre-existing 'dummy' + customer-created ones)
   - A multi-shard collection (regression for SolrBackupIndexMetadataFactory)
+  - A collection with flat field names containing '.' (e.g. category.name)
   - Hundreds of documents (bulk indexing path)
   - Full doc-count equivalence + sampled document retrieval on the target
 """
 import logging
 
+import requests
+
 from ..cluster_version import SolrV8_X, OpensearchV2_X, OpensearchV3_X
+from ..common_utils import execute_api_call
 from .ma_argo_test_base import MATestBase, MigrationType, MATestUserArguments
 
 logger = logging.getLogger(__name__)
@@ -64,6 +68,14 @@ class TestSolr0001SingleDocumentBackfill(MATestBase):
         self.sharded_collection = f"sharded_{self._suffix}"
         self.sharded_num_shards = 2
         self.sharded_doc_count = 40
+
+        # Dotted-field collection — exercises migration of flat Solr field names
+        # whose names contain '.' (e.g. 'category.name'). OpenSearch interprets
+        # such keys as nested-object paths during indexing, but _source preserves
+        # the original key shape and queries against the original dotted path
+        # continue to resolve, so the migration is intuitive for Solr users.
+        self.dotted_collection = f"dotted_{self._suffix}"
+        self.dotted_doc_id = "dotted_doc_0001"
 
     def prepare_clusters(self):
         # (1) Pre-existing 'dummy' collection — single smoke document.
@@ -114,6 +126,52 @@ class TestSolr0001SingleDocumentBackfill(MATestBase):
             docs=sharded_docs)
         self._assert_source_count(self.sharded_collection, self.sharded_doc_count)
 
+        # (4) Dotted-field collection — declare explicit Solr schema fields whose
+        # names contain '.' and index a doc that uses them. This is the realistic
+        # customer scenario: Solr permits flat dotted names as a naming
+        # convention; the migration must round-trip them through to OpenSearch
+        # without renaming or dropping data.
+        logger.info(f"Creating SolrCloud collection '{self.dotted_collection}' "
+                    f"with explicit dotted-name fields")
+        self.source_operations.create_index(
+            cluster=self.source_cluster, index_name=self.dotted_collection,
+            num_shards=1, replication_factor=1)
+        self._add_solr_schema_fields(self.dotted_collection, [
+            {"name": "category.name",      "type": "string",  "stored": True, "indexed": True, "docValues": True},
+            {"name": "category.id",        "type": "pint",    "stored": True, "indexed": True, "docValues": True},
+            {"name": "metric.cpu.percent", "type": "pfloat",  "stored": True, "indexed": True, "docValues": True},
+            {"name": "is.active",          "type": "boolean", "stored": True, "docValues": True},
+        ])
+        self.source_operations.create_document(
+            cluster=self.source_cluster, index_name=self.dotted_collection,
+            doc_id=self.dotted_doc_id,
+            data={
+                "category.name": "books",
+                "category.id": 7,
+                "metric.cpu.percent": 42.5,
+                "is.active": True,
+            })
+        self._assert_source_count(self.dotted_collection, 1)
+
+    def _add_solr_schema_fields(self, collection: str, fields: list):
+        """Declare explicit schema fields on a Solr collection via the Schema API.
+
+        Solr's _default configset is dynamic-field-driven; declaring explicit
+        fields with concrete types is what real Solr customers do for
+        production data and is what makes type assertions on the OpenSearch
+        side meaningful.
+        """
+        url = f"{self.source_cluster.endpoint}/solr/{collection}/schema"
+        body = {"add-field": fields}
+        r = requests.post(url, json=body,
+                          headers={"Content-Type": "application/json"}, timeout=15)
+        r.raise_for_status()
+        # Solr returns 200 with errors embedded in the body on failure.
+        result = r.json()
+        if "errors" in result:
+            raise AssertionError(
+                f"Failed to add Solr schema fields for '{collection}': {result['errors']}")
+
     def _assert_source_count(self, collection: str, expected: int):
         actual = self.source_operations.get_doc_count(
             cluster=self.source_cluster, index_name=collection)
@@ -149,12 +207,73 @@ class TestSolr0001SingleDocumentBackfill(MATestBase):
                                       "collectionPreparer to download shard_backup_metadata "
                                       "from S3 before counting)."))
 
+        # (4) Dotted fields: doc-count, _source preservation of dotted keys, and
+        # query-by-dotted-path resolution all matter to customers. If the
+        # migration silently renamed or split the field names, this scenario
+        # would catch it.
+        self._assert_target_count(self.dotted_collection, 1,
+                                  regression_hint=(
+                                      "Dotted-field collection failed to migrate. Check that "
+                                      "SolrSchemaConverter emits dotted field names as literal "
+                                      "keys under 'properties' and that the document indexer "
+                                      "does not collide on a parent key (e.g. both 'category' "
+                                      "as leaf and 'category.id' as object form)."))
+        self._assert_dotted_field_doc_round_trip()
+
+    def _assert_dotted_field_doc_round_trip(self):
+        """Verify a dotted-field document round-trips through the migration.
+
+        Asserts:
+          - The exact doc id is retrievable.
+          - _source preserves the original dotted keys (category.name, etc.).
+          - Queries written against the original dotted path
+            (q=category.name:books) resolve to the migrated document.
+        """
+        # _source preservation
+        resp = execute_api_call(
+            cluster=self.target_cluster,
+            path=f"/{self.dotted_collection}/_search?q=id:{self.dotted_doc_id}&size=1")
+        body = resp.json()
+        hits = body.get("hits", {}).get("hits", [])
+        assert len(hits) == 1, (
+            f"Expected to find dotted-field doc by id, got {len(hits)} hits. "
+            f"Body: {body}")
+        src = hits[0].get("_source", {})
+        assert src.get("category.name") == "books", (
+            f"_source should preserve 'category.name' verbatim, got {src!r}")
+        assert src.get("category.id") == 7, (
+            f"_source should preserve 'category.id' verbatim, got {src!r}")
+        actual_pct = src.get("metric.cpu.percent")
+        assert actual_pct is not None and abs(actual_pct - 42.5) < 0.01, (
+            f"_source should preserve 'metric.cpu.percent' verbatim, got {src!r}")
+        assert src.get("is.active") is True, (
+            f"_source should preserve 'is.active' verbatim, got {src!r}")
+
+        # Query against original dotted path resolves to the migrated doc.
+        resp2 = execute_api_call(
+            cluster=self.target_cluster,
+            path=f"/{self.dotted_collection}/_search?q=category.name:books&size=10")
+        kw_hits = resp2.json().get("hits", {}).get("hits", [])
+        assert len(kw_hits) == 1 and kw_hits[0].get("_id") == self.dotted_doc_id, (
+            f"Query 'category.name:books' should match the migrated dotted-field "
+            f"doc, got: {kw_hits}")
+
+        # Exact-match query on a multi-segment dotted field name resolves.
+        resp3 = execute_api_call(
+            cluster=self.target_cluster,
+            path=f"/{self.dotted_collection}/_search?q=metric.cpu.percent:42.5&size=10")
+        flt_hits = resp3.json().get("hits", {}).get("hits", [])
+        assert len(flt_hits) == 1, (
+            f"Query on 'metric.cpu.percent' should match the dotted-field "
+            f"doc, got: {flt_hits}")
+        logger.info("Dotted-field doc round-trip verified: _source preserved + "
+                    "queries by original dotted path resolve correctly.")
+
     def _assert_target_count(self, collection: str, expected: int, regression_hint: str = ""):
         # Retry a few times — bulk migration may not be fully flushed to the target yet.
         # Uses a direct _count API call per collection rather than get_all_index_details
         # (which crashes when called without index_prefix_ignore_list).
         import time
-        from ..common_utils import execute_api_call
         actual = 0
         for attempt in range(1, 31):
             try:


### PR DESCRIPTION
## Description

Solr permits literal `.` in field names (e.g. `category.name`, `attr_thing.withdot`). This PR makes the Solr→OpenSearch migration handle them correctly.

**Bug fix.** When a dotted-name doc field's top-level segment also matches a Solr `dynamicField` pattern (e.g. `attr_thing.withdot` under `attr_*`), OpenSearch auto-expands the dotted key into a parent object on write. The previous `buildDynamicTemplate` output used a plain `match` clause, which then fired on the synthesized parent — typing it as the template's target type and causing the child write to fail with `mapper_parsing_exception` (`NumberFieldMapper cannot be cast to ObjectMapper`). The bulk request fails and the doc is silently lost.

Fix: emit each `dynamic_template` with `path_match` (matches the field's full dotted path) plus `match_mapping_type` (gates on the JSON value shape, which intermediate object containers never carry). The combination scopes the template to leaves only.

**Test coverage.** Adds:
- Unit tests pinning the new template shape and the per-OS-type → `match_mapping_type` mapping.
- SolrReader E2E `migratesFieldsWithDotsInName` — declared dotted fields of every common Solr type round-trip through `_field_caps`, `_source`, and dotted-path queries.
- SolrReader E2E `migratesDynamicFieldsWithDotsInLeafName` — six dynamic-field patterns (`attr_*`, `*_s`, `*_i`, `*_b`, `*_f`, `*_dt`) each with a dotted leaf, exercising the regression path end-to-end.
- Backfill E2E `SolrSnapshotToOpenSearchTest.backfillsDottedFieldNames` — runs the full production flow (`MetadataMigration` pushes the converted schema, then `RfsMigrateDocuments` CLI writes documents) and verifies dotted-name mappings, `_source` preservation, and dotted-path queries on the target. Pre-fix, the dynamic-leaf doc would have been silently dropped at bulk-write.
- Python integ scenario in `solr_tests.py` covering the same path on the live console workflow.

The two SolrReader E2E tests are also restructured around explicit SOURCE → MIGRATE → TARGET phases with a tabular Javadoc preamble — each test reads top-to-bottom and clearly states what's on Solr vs. what's expected on OpenSearch (mapping types + `_source` + queries).

### Is this a breaking change?

No. `buildDynamicTemplate` is package-private; only its emitted template shape changed. Existing dynamicField behavior (no dotted leaves) is unchanged — `path_match` matches non-dotted leaves with the same wildcard semantics, and `match_mapping_type` accepts the JSON shape OpenSearch reports natively for each target type. All prior E2E fixtures (`dynamicFieldsAndCopyFieldsMigration`, `copyFieldDestinationsResolveTypeFromDynamicFields`, `dateFieldsGetProperFormatMapping`) still pass.

### Issues Resolved

n/a — internal investigation.

### Check List

- [x] New functionality includes testing
- [x] New functionality has been documented
- [x] Commits are signed per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/opensearch-migrations/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).