### PR TITLE
RFS: log bulk response body at INFO on any failure

### DIFF
--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/common/OpenSearchClient.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/common/OpenSearchClient.java
@@ -548,7 +548,11 @@ public abstract class OpenSearchClient {
                     if (!resp.hasBadStatusCode() && !resp.hasFailedOperations()) {
                         return Mono.just(resp);
                     }
-                    log.atDebug().setMessage("Response has some errors...: {}").addArgument(response.body).log();
+                    log.atInfo()
+                        .setMessage("Bulk response on index '{}' contains errors: {}")
+                        .addArgument(indexName)
+                        .addArgument(() -> truncateMessageIfNeeded(response.body, BULK_TRUNCATED_RESPONSE_MAX_LENGTH))
+                        .log();
 
                     // Allow lazy initialization of pendingOps (e.g., raw→ops conversion)
                     preCompactHook.run();


### PR DESCRIPTION
## Summary
- Promote the per-response error log in `OpenSearchClient.executeBulkWithRetry` from `DEBUG` to `INFO` so document migration failures surface immediately on the first attempt, instead of only after retries are exhausted at `WARN`/`ERROR`.
- Truncate the response body to `BULK_TRUNCATED_RESPONSE_MAX_LENGTH` to match the existing WARN log so we don't dump unbounded payloads at INFO.
- Include the index name in the message so the log is useful when many indices are migrating concurrently.

## Why
Previously this was visible at `DEBUG`, which most operators don't run with. As a result the first sign of a failing migration was the WARN/ERROR after retries, by which point a slow failure mode (e.g. version conflict, bad mapping) has already burned ~10 minutes of retry budget. INFO gives immediate visibility on the very first failed bulk response without changing retry semantics.

## Test plan
- [ ] Existing OpenSearchClient tests pass
- [ ] Manually verify INFO log appears on first failure during a doc migration with bad mapping or doc

🤖 Generated with [Claude Code](https://claude.com/claude-code)