### PR TITLE
RFS: release lease on shutdown when no docs were migrated

### DIFF
--- a/DocumentsFromSnapshotMigration/src/main/java/org/opensearch/migrations/RfsMigrateDocuments.java
+++ b/DocumentsFromSnapshotMigration/src/main/java/org/opensearch/migrations/RfsMigrateDocuments.java
@@ -551,7 +551,8 @@ public class RfsMigrateDocuments {
                         arguments.initialLeaseDuration,
                         () -> Optional.ofNullable(cancellationRunnableRef.get()).ifPresent(Runnable::run),
                         cleanShutdownCompleted,
-                        context.getWorkCoordinationContext()::createSuccessorWorkItemsContext),
+                        context.getWorkCoordinationContext()::createSuccessorWorkItemsContext,
+                        context.getWorkCoordinationContext()::createReleaseWorkItemContext),
                 Clock.systemUTC());) {
             // Set up a hook to attempt to shut down cleanly (to mark progress in the worker coordination system) in the
             // event of a SIGTERM signal.
@@ -560,7 +561,8 @@ public class RfsMigrateDocuments {
                 log.atWarn().setMessage("Received shutdown signal. Trying to mark progress and shutdown cleanly.").log();
                 try {
                     executeCleanShutdownProcess(workItemRef, progressCursor, workCoordinator, cleanShutdownCompleted,
-                            context.getWorkCoordinationContext()::createSuccessorWorkItemsContext);
+                            context.getWorkCoordinationContext()::createSuccessorWorkItemsContext,
+                            context.getWorkCoordinationContext()::createReleaseWorkItemContext);
                     log.atInfo().setMessage("Clean shutdown completed.").log();
                 } catch (InterruptedException e) {
                     log.atError().setMessage("Clean exit process was interrupted: {}").addArgument(e).log();
@@ -723,17 +725,27 @@ public class RfsMigrateDocuments {
             AtomicReference<WorkItemCursor> progressCursor,
             IWorkCoordinator coordinator,
             AtomicBoolean cleanShutdownCompleted,
-            Supplier<IWorkCoordinationContexts.ICreateSuccessorWorkItemsContext> contextSupplier
+            Supplier<IWorkCoordinationContexts.ICreateSuccessorWorkItemsContext> contextSupplier,
+            Supplier<IWorkCoordinationContexts.IReleaseWorkItemContext> releaseContextSupplier
     ) throws IOException, InterruptedException {
         if (cleanShutdownCompleted.get())  {
             log.atInfo().setMessage("Clean shutdown already completed").log();
             return;
         }
-        if (workItemRef.get() == null || progressCursor.get() == null) {
-            log.atInfo().setMessage("No work item or progress cursor found. This may indicate that the task is exiting too early to have progress to mark.").log();
+        if (workItemRef.get() == null) {
+            log.atInfo().setMessage("No work item found. This may indicate that the task is exiting too early to have progress to mark.").log();
             return;
         }
         var workItemAndDuration = workItemRef.get();
+        if (progressCursor.get() == null) {
+            // No documents have been migrated yet (the cursor is only populated after the first
+            // successful bulk batch — see DocumentMigrationBootstrap), so there is nothing to
+            // checkpoint and we can't seed a successor.  Releasing the lease here lets another
+            // worker retry the same item immediately instead of waiting for natural expiration.
+            releaseLeaseWithoutProgress(workItemAndDuration, coordinator, releaseContextSupplier);
+            cleanShutdownCompleted.set(true);
+            return;
+        }
         log.atInfo().setMessage("Marking progress: " + workItemAndDuration.getWorkItem().toString() + ", at doc " + progressCursor.get().getProgressCheckpointNum()).log();
         var successorWorkItem = getSuccessorWorkItemIds(workItemAndDuration, progressCursor.get());
 
@@ -741,6 +753,24 @@ public class RfsMigrateDocuments {
                 workItemAndDuration.getWorkItem().toString(), successorWorkItem, 1, contextSupplier
         );
         cleanShutdownCompleted.set(true);
+    }
+
+    /**
+     * Release the lease for a work item that we acquired but made no progress on — the doc
+     * cursor is still null, so there is nothing to checkpoint and no meaningful successor to
+     * create.  Without this, the work item stays leased for the full expiration window and
+     * blocks any other worker from picking it up.
+     */
+    private static void releaseLeaseWithoutProgress(
+            IWorkCoordinator.WorkItemAndDuration workItemAndDuration,
+            IWorkCoordinator coordinator,
+            Supplier<IWorkCoordinationContexts.IReleaseWorkItemContext> releaseContextSupplier
+    ) throws IOException, InterruptedException {
+        var workItemId = workItemAndDuration.getWorkItem().toString();
+        log.atWarn().setMessage("Releasing lease for work item {} because no progress was made before shutdown — letting another worker retry immediately rather than waiting for natural lease expiration.")
+                .addArgument(workItemId)
+                .log();
+        coordinator.releaseWorkItem(workItemId, releaseContextSupplier);
     }
 
     @SneakyThrows
@@ -753,7 +783,8 @@ public class RfsMigrateDocuments {
             Duration initialLeaseDuration,
             Runnable cancellationRunnable,
             AtomicBoolean cleanShutdownCompleted,
-            Supplier<IWorkCoordinationContexts.ICreateSuccessorWorkItemsContext> contextSupplier) {
+            Supplier<IWorkCoordinationContexts.ICreateSuccessorWorkItemsContext> contextSupplier,
+            Supplier<IWorkCoordinationContexts.IReleaseWorkItemContext> releaseContextSupplier) {
         log.atWarn().setMessage("Terminating RfsMigrateDocuments because the lease has expired for {}")
                 .addArgument(workItemId)
                 .log();
@@ -790,10 +821,19 @@ public class RfsMigrateDocuments {
                     );
                 }
             } else {
-                log.atWarn().setMessage("No progress cursor to create successor work items from. This can happen when" +
-                        "downloading and unpacking shard takes longer than the lease").log();
-                log.atWarn().setMessage("Skipping creation of successor work item to retry the existing one with more time")
-                        .log();
+                // We held the lease but never produced a checkpoint — the most common cause is
+                // shard download/unpack outliving the lease window before any docs were migrated.
+                // Release the lease so another worker can immediately retry instead of waiting
+                // for natural expiration.  workItemRef may be null if the trigger fired before
+                // acquisition completed; in that case there's nothing to release.
+                log.atWarn().setMessage("No progress cursor to create successor work items from. This can happen when " +
+                        "downloading and unpacking shard takes longer than the lease.").log();
+                var workItemAndDuration = workItemRef.get();
+                if (workItemAndDuration != null) {
+                    releaseLeaseWithoutProgress(workItemAndDuration, coordinator, releaseContextSupplier);
+                } else {
+                    log.atWarn().setMessage("No work item reference available; skipping lease release.").log();
+                }
             }
         } catch (Exception e) {
             if (e instanceof InterruptedException) {
@@ -932,7 +972,8 @@ public class RfsMigrateDocuments {
                             arguments.initialLeaseDuration,
                             () -> Optional.ofNullable(cancellationRunnableRef.get()).ifPresent(Runnable::run),
                             cleanShutdownCompleted,
-                            context.getWorkCoordinationContext()::createSuccessorWorkItemsContext),
+                            context.getWorkCoordinationContext()::createSuccessorWorkItemsContext,
+                            context.getWorkCoordinationContext()::createReleaseWorkItemContext),
                     Clock.systemUTC())) {
 
                 // Work coordination will naturally short-circuit via ShardWorkPreparer.onAlreadyCompleted
@@ -1048,7 +1089,8 @@ public class RfsMigrateDocuments {
                     log.atWarn().setMessage("Received shutdown signal. Trying to mark progress and shutdown cleanly.").log();
                     try {
                         executeCleanShutdownProcess(workItemRef, progressCursor, workCoordinator, cleanShutdownCompleted,
-                                context.getWorkCoordinationContext()::createSuccessorWorkItemsContext);
+                                context.getWorkCoordinationContext()::createSuccessorWorkItemsContext,
+                                context.getWorkCoordinationContext()::createReleaseWorkItemContext);
                         log.atInfo().setMessage("Clean shutdown completed.").log();
                     } catch (InterruptedException e) {
                         log.atError().setMessage("Clean exit process was interrupted: {}").addArgument(e).log();

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/tracing/IWorkCoordinationContexts.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/tracing/IWorkCoordinationContexts.java
@@ -12,6 +12,7 @@ public interface IWorkCoordinationContexts {
         public static final String SYNC_REFRESH_CLUSTER = "refreshCluster";
         public static final String ACQUIRE_SPECIFIC_WORK = "acquireSpecificWorkItem";
         public static final String COMPLETE_WORK = "completeWork";
+        public static final String RELEASE_WORK = "releaseWork";
         public static final String ACQUIRE_NEXT_WORK = "acquireNextWorkItem";
         public static final String CREATE_SUCCESSOR_WORK_ITEMS = "createSuccessorWorkItems";
 
@@ -80,6 +81,10 @@ public interface IWorkCoordinationContexts {
         String ACTIVITY_NAME = ActivityNames.COMPLETE_WORK;
 
         IRefreshContext getRefreshContext();
+    }
+
+    interface IReleaseWorkItemContext extends IRetryableActivityContext {
+        String ACTIVITY_NAME = ActivityNames.RELEASE_WORK;
     }
 
     interface ICreateSuccessorWorkItemsContext extends IRetryableActivityContext {

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/tracing/RootWorkCoordinationContext.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/tracing/RootWorkCoordinationContext.java
@@ -17,6 +17,7 @@ public class RootWorkCoordinationContext extends RootOtelContext {
     public final WorkCoordinationContexts.PendingItems.MetricInstruments pendingItemsMetrics;
     public final WorkCoordinationContexts.AcquireSpecificWorkContext.MetricInstruments acquireSpecificWorkMetrics;
     public final WorkCoordinationContexts.CompleteWorkItemContext.MetricInstruments completeWorkMetrics;
+    public final WorkCoordinationContexts.ReleaseWorkItemContext.MetricInstruments releaseWorkItemMetrics;
     public final WorkCoordinationContexts.AcquireNextWorkItemContext.MetricInstruments acquireNextWorkMetrics;
     public final WorkCoordinationContexts.CreateSuccessorWorkItemsContext.MetricInstruments createSuccessorWorkItemsMetrics;
 
@@ -38,6 +39,7 @@ public class RootWorkCoordinationContext extends RootOtelContext {
         pendingItemsMetrics = WorkCoordinationContexts.PendingItems.makeMetrics(meter);
         acquireSpecificWorkMetrics = WorkCoordinationContexts.AcquireSpecificWorkContext.makeMetrics(meter);
         completeWorkMetrics = WorkCoordinationContexts.CompleteWorkItemContext.makeMetrics(meter);
+        releaseWorkItemMetrics = WorkCoordinationContexts.ReleaseWorkItemContext.makeMetrics(meter);
         acquireNextWorkMetrics = WorkCoordinationContexts.AcquireNextWorkItemContext.makeMetrics(meter);
         createSuccessorWorkItemsMetrics = WorkCoordinationContexts.CreateSuccessorWorkItemsContext.makeMetrics(meter);
     }
@@ -88,6 +90,16 @@ public class RootWorkCoordinationContext extends RootOtelContext {
         IScopedInstrumentationAttributes enclosingScope
     ) {
         return new WorkCoordinationContexts.CompleteWorkItemContext(this, enclosingScope);
+    }
+
+    public IWorkCoordinationContexts.IReleaseWorkItemContext createReleaseWorkItemContext() {
+        return createReleaseWorkItemContext(null);
+    }
+
+    public IWorkCoordinationContexts.IReleaseWorkItemContext createReleaseWorkItemContext(
+        IScopedInstrumentationAttributes enclosingScope
+    ) {
+        return new WorkCoordinationContexts.ReleaseWorkItemContext(this, enclosingScope);
     }
 
     public IWorkCoordinationContexts.ICreateSuccessorWorkItemsContext createSuccessorWorkItemsContext() {

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/tracing/WorkCoordinationContexts.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/tracing/WorkCoordinationContexts.java
@@ -373,6 +373,43 @@ public interface WorkCoordinationContexts extends IWorkCoordinationContexts {
     }
 
     @Getter
+    class ReleaseWorkItemContext extends BaseSpanContext<RootWorkCoordinationContext>
+        implements
+            IReleaseWorkItemContext,
+            RetryableActivityContextMetricMixin<ReleaseWorkItemContext.MetricInstruments> {
+        final IScopedInstrumentationAttributes enclosingScope;
+
+        ReleaseWorkItemContext(
+            RootWorkCoordinationContext rootScope,
+            IScopedInstrumentationAttributes enclosingScope
+        ) {
+            super(rootScope);
+            this.enclosingScope = enclosingScope;
+            initializeSpan(rootScope);
+        }
+
+        @Override
+        public String getActivityName() {
+            return ACTIVITY_NAME;
+        }
+
+        public static class MetricInstruments extends RetryMetricInstruments {
+            private MetricInstruments(Meter meter, String activityName) {
+                super(meter, autoLabels(activityName));
+            }
+        }
+
+        public static @NonNull MetricInstruments makeMetrics(Meter meter) {
+            return new MetricInstruments(meter, ACTIVITY_NAME);
+        }
+
+        @Override
+        public MetricInstruments getRetryMetrics() {
+            return getRootInstrumentationScope().releaseWorkItemMetrics;
+        }
+    }
+
+    @Getter
     class CreateSuccessorWorkItemsContext extends BaseSpanContext<RootWorkCoordinationContext>
             implements
             ICreateSuccessorWorkItemsContext,

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/workcoordination/IWorkCoordinator.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/workcoordination/IWorkCoordinator.java
@@ -104,6 +104,20 @@ public interface IWorkCoordinator extends AutoCloseable {
     ) throws IOException, InterruptedException;
 
     /**
+     * Release the lease on a work item without marking it complete, so that another worker can
+     * pick it up immediately.  Intended for the case where the current worker is shutting down
+     * before any progress (i.e. no checkpoint cursor) has been made on the item — staying on the
+     * lease until natural expiration would needlessly block the work.  This is a no-op if the
+     * work item is already completed or if the lease has already rolled to a different worker.
+     * The lease exponent is intentionally left untouched: a release implies the work hasn't
+     * been done yet and the next acquirer should still benefit from any prior backoff signal.
+     */
+    void releaseWorkItem(
+        String workItemId,
+        Supplier<IWorkCoordinationContexts.IReleaseWorkItemContext> contextSupplier
+    ) throws IOException, InterruptedException;
+
+    /**
      * Add the list of successor items to the work item, create new work items for each of the successors, and mark the
      * original work item as completed.
      * @param workItemId the work item that is being completed

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/workcoordination/OpenSearchWorkCoordinator.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/workcoordination/OpenSearchWorkCoordinator.java
@@ -585,6 +585,88 @@ public abstract class OpenSearchWorkCoordinator implements IWorkCoordinator {
         }
     }
 
+    @Override
+    public void releaseWorkItem(
+        String workItemId,
+        Supplier<IWorkCoordinationContexts.IReleaseWorkItemContext> contextSupplier
+    ) throws InterruptedException {
+        try (var ctx = contextSupplier.get()) {
+            // Clearing the lease is best-effort: completion is the only durable state, so we
+            // retry transient failures but do not propagate the underlying exception if every
+            // retry fails — the lease will still expire naturally.  Using the same retry shape
+            // as completeWorkItem keeps behavior consistent under coordinator-side load.
+            retryWithExponentialBackoff(
+                () -> releaseWorkItemWithoutRetry(workItemId),
+                completionRetryConfig.maxRetries(),
+                completionRetryConfig.initialDelayMs(),
+                completionRetryConfig.maxDelayMs(),
+                "releaseWorkItem[" + workItemId + "]",
+                e -> ctx.addTraceException(e, true)
+            );
+        } catch (IllegalStateException e) {
+            log.atWarn().setCause(e)
+                .setMessage("Failed to release work item {}; falling back to natural lease expiration")
+                .addArgument(workItemId)
+                .log();
+        }
+    }
+
+    private void releaseWorkItemWithoutRetry(String workItemId) throws IOException {
+        // Painless script:
+        //   - throws on scriptVersion mismatch (matches the rest of the coordinator contract)
+        //   - no-op when the work is already completed (don't clobber a completion)
+        //   - no-op when the lease has rolled to another worker (don't clobber the new owner)
+        //   - otherwise: clear expiration to 0 and leaseHolderId to null so the next
+        //     acquireNextWorkItem call can pick this item up immediately.  We intentionally
+        //     leave nextAcquisitionLeaseExponent as-is — releasing the lease means the work
+        //     hasn't been done, so any prior bump in the exponent is still meaningful.
+        final var releaseLeaseBodyTemplate = "{\n"
+            + "  \"script\": {\n"
+            + "    \"lang\": \"painless\",\n"
+            + "    \"params\": { \n"
+            + "      \"workerId\": \"" + WORKER_ID_TEMPLATE + "\"\n"
+            + "    },\n"
+            + "    \"source\": \""
+            + "      if (ctx._source.scriptVersion != \\\"" + SCRIPT_VERSION_TEMPLATE + "\\\") {"
+            + "        throw new IllegalArgumentException(\\\"scriptVersion mismatch.  Not all participants are using the same script: sourceVersion=\\\" + ctx._source.scriptVersion);"
+            + "      }"
+            + "      if (ctx._source." + COMPLETED_AT_FIELD_NAME + " != null) {"
+            + "        ctx.op = \\\"noop\\\";"
+            + "      } else if (ctx._source." + LEASE_HOLDER_ID_FIELD_NAME + " != params.workerId) {"
+            + "        ctx.op = \\\"noop\\\";"
+            + "      } else {"
+            + "        ctx._source." + EXPIRATION_FIELD_NAME + " = 0;"
+            + "        ctx._source." + LEASE_HOLDER_ID_FIELD_NAME + " = null;"
+            + "      }"
+            + "\"\n"
+            + "  }\n"
+            + "}";
+
+        var body = releaseLeaseBodyTemplate.replace(SCRIPT_VERSION_TEMPLATE, SCRIPT_VERSION)
+            .replace(WORKER_ID_TEMPLATE, workerId);
+
+        var response = httpClient.makeJsonRequest(
+            AbstractedHttpClient.POST_METHOD,
+            getPathForUpdates(workItemId),
+            null,
+            body
+        );
+
+        var result = getResult(response);
+        // Both UPDATED (we cleared the lease) and IGNORED (already completed or owned elsewhere)
+        // are acceptable terminal outcomes; only an unexpected response shape is an error.
+        if (result != DocumentModificationResult.UPDATED && result != DocumentModificationResult.IGNORED) {
+            throw new IllegalStateException(
+                "Unexpected response releasing workItemId: " + workItemId
+                    + ".  Response: " + response.toDiagnosticString()
+            );
+        }
+        log.atInfo().setMessage("Released lease for work item {} (result={})")
+            .addArgument(workItemId)
+            .addArgument(result)
+            .log();
+    }
+
     private int numWorkItemsNotYetCompleteInternal(
         Supplier<IWorkCoordinationContexts.IPendingWorkItemsContext> contextSupplier
     ) throws IOException, InterruptedException {

--- a/RFS/src/test/java/org/opensearch/migrations/bulkload/workcoordination/WorkCoordinatorTest.java
+++ b/RFS/src/test/java/org/opensearch/migrations/bulkload/workcoordination/WorkCoordinatorTest.java
@@ -260,6 +260,105 @@ public class WorkCoordinatorTest {
 
     @ParameterizedTest
     @MethodSource("containerVersions")
+    public void testReleaseWorkItemAllowsImmediateReacquisition(SearchClusterContainer.ContainerVersion version) throws Exception {
+        // Models the "shutdown before any docs migrated" scenario: worker A acquires the
+        // lease, makes no progress (no cursor / no successor possible), and releases the lease
+        // on shutdown.  Worker B should then be able to pick the same work item up immediately
+        // rather than waiting for the original lease to expire.
+        setupOpenSearchContainer(version);
+        var testContext = WorkCoordinationTestContext.factory().withAllTracking();
+        var workItemId = workId("R", 0, 0L);
+
+        try (var creator = factory.get(httpClientSupplier.get(), 3600, "creator")) {
+            creator.createUnassignedWorkItem(workItemId, testContext::createUnassignedWorkContext);
+        }
+
+        // Long lease so that "expires naturally" is clearly not what's letting reacquisition succeed.
+        var longLease = Duration.ofSeconds(600);
+
+        try (var workerA = factory.get(httpClientSupplier.get(), 3600, "workerA")) {
+            var outcome = workerA.acquireNextWorkItem(longLease, testContext::createAcquireNextItemContext);
+            var acquired = Assertions.assertInstanceOf(IWorkCoordinator.WorkItemAndDuration.class, outcome);
+            Assertions.assertEquals(workItemId, acquired.getWorkItem().toString());
+
+            // Sanity: another worker cannot grab this work item while workerA holds the lease.
+            try (var blocked = factory.get(httpClientSupplier.get(), 3600, "blocked")) {
+                var blockedOutcome = blocked.acquireNextWorkItem(longLease, testContext::createAcquireNextItemContext);
+                Assertions.assertInstanceOf(IWorkCoordinator.NoAvailableWorkToBeDone.class, blockedOutcome);
+            }
+
+            workerA.releaseWorkItem(workItemId, testContext::createReleaseWorkItemContext);
+        }
+
+        // workerB should now be able to immediately re-acquire the same work item.
+        try (var workerB = factory.get(httpClientSupplier.get(), 3600, "workerB")) {
+            var outcome = workerB.acquireNextWorkItem(longLease, testContext::createAcquireNextItemContext);
+            var acquired = Assertions.assertInstanceOf(IWorkCoordinator.WorkItemAndDuration.class, outcome);
+            Assertions.assertEquals(workItemId, acquired.getWorkItem().toString());
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("containerVersions")
+    public void testReleaseWorkItemIsNoopIfLeaseRolledOver(SearchClusterContainer.ContainerVersion version) throws Exception {
+        // If workerA's lease has already expired and workerB has picked the item up, a late
+        // releaseWorkItem call from workerA must NOT clobber workerB's lease — otherwise we
+        // could hand the same item to a third worker while workerB is still working on it.
+        setupOpenSearchContainer(version);
+        var testContext = WorkCoordinationTestContext.factory().withAllTracking();
+        var workItemId = workId("R", 0, 0L);
+
+        try (var creator = factory.get(httpClientSupplier.get(), 3600, "creator")) {
+            creator.createUnassignedWorkItem(workItemId, testContext::createUnassignedWorkContext);
+        }
+
+        var shortLease = Duration.ofSeconds(2);
+
+        try (var workerA = factory.get(httpClientSupplier.get(), 3600, "workerA")) {
+            workerA.acquireNextWorkItem(shortLease, testContext::createAcquireNextItemContext);
+            // Wait out the lease so workerB can take over.
+            Thread.sleep(shortLease.plusSeconds(1).toMillis());
+
+            try (var workerB = factory.get(httpClientSupplier.get(), 3600, "workerB")) {
+                var bOutcome = workerB.acquireNextWorkItem(Duration.ofSeconds(600), testContext::createAcquireNextItemContext);
+                Assertions.assertInstanceOf(IWorkCoordinator.WorkItemAndDuration.class, bOutcome);
+
+                // workerA finally tries to release the item it had; should be a no-op.
+                workerA.releaseWorkItem(workItemId, testContext::createReleaseWorkItemContext);
+
+                // A third worker must not be able to acquire — workerB still owns it.
+                try (var workerC = factory.get(httpClientSupplier.get(), 3600, "workerC")) {
+                    var cOutcome = workerC.acquireNextWorkItem(Duration.ofSeconds(600), testContext::createAcquireNextItemContext);
+                    Assertions.assertInstanceOf(IWorkCoordinator.NoAvailableWorkToBeDone.class, cOutcome);
+                }
+            }
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("containerVersions")
+    public void testReleaseWorkItemIsNoopIfAlreadyCompleted(SearchClusterContainer.ContainerVersion version) throws Exception {
+        // Defensive: if a release call races against (or follows) completion, it must not
+        // resurrect a completed work item by clearing fields the script doesn't gate on.
+        setupOpenSearchContainer(version);
+        var testContext = WorkCoordinationTestContext.factory().withAllTracking();
+        var workItemId = workId("R", 0, 0L);
+
+        try (var creator = factory.get(httpClientSupplier.get(), 3600, "creator")) {
+            creator.createUnassignedWorkItem(workItemId, testContext::createUnassignedWorkContext);
+        }
+
+        try (var worker = factory.get(httpClientSupplier.get(), 3600, "worker")) {
+            worker.acquireNextWorkItem(Duration.ofSeconds(600), testContext::createAcquireNextItemContext);
+            worker.completeWorkItem(workItemId, testContext::createCompleteWorkContext);
+            // Release after completion — should be a no-op.
+            worker.releaseWorkItem(workItemId, testContext::createReleaseWorkItemContext);
+            Assertions.assertFalse(worker.workItemsNotYetComplete(testContext::createItemsPendingContext));
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("containerVersions")
     public void testAddSuccessorWorkItems(SearchClusterContainer.ContainerVersion version) throws Exception {
         setupOpenSearchContainer(version);
         var testContext = WorkCoordinationTestContext.factory().withAllTracking();


### PR DESCRIPTION
## Summary
- When a worker exits before checkpointing any documents (slow shard download, k8s pod kill, etc.), the work item used to stay leased until natural expiration, blocking other workers. Both shutdown paths — SIGTERM clean shutdown and the early lease-timeout trigger — hit the same dead end with `progressCursor == null`: no checkpoint to write and no useful successor to seed.
- Add `IWorkCoordinator.releaseWorkItem` that clears `expiration` and `leaseHolderId` via a Painless script, gated on the caller still owning the lease (`leaseHolderId == workerId`) and the item not being completed. Late or racing releases are no-ops, so they can't clobber a new owner or resurrect a completed item.
- `nextAcquisitionLeaseExponent` is intentionally left untouched — the work hasn't been done yet, and any prior backoff bump is still meaningful for the next acquirer.
- Wire the new helper into both `executeCleanShutdownProcess` and `exitOnLeaseTimeout` via a shared `releaseLeaseWithoutProgress` branch, so both shutdown paths follow the same code.

## Why
Doc-zero shutdowns (especially on short-lived migration pods) currently waste an entire lease window before the next worker can retry. With short test leases this can stall a migration end-to-end; with long production leases it can stall it for many minutes per failure.

## Test plan
- [x] New container integration tests in `WorkCoordinatorTest`:
  - `testReleaseWorkItemAllowsImmediateReacquisition` — workerA acquires + releases, workerB picks up the same item with no wait.
  - `testReleaseWorkItemIsNoopIfLeaseRolledOver` — late release from workerA must not steal workerB's active lease.
  - `testReleaseWorkItemIsNoopIfAlreadyCompleted` — release after completion must not resurrect the item.
- [x] Existing coordinator tests unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)