### PR TITLE
RFS: log bulk response body at INFO on any failure

### DIFF
--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/common/OpenSearchClient.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/common/OpenSearchClient.java
@@ -548,7 +548,11 @@ public abstract class OpenSearchClient {
                     if (!resp.hasBadStatusCode() && !resp.hasFailedOperations()) {
                         return Mono.just(resp);
                     }
-                    log.atDebug().setMessage("Response has some errors...: {}").addArgument(response.body).log();
+                    log.atInfo()
+                        .setMessage("Bulk response on index '{}' contains errors: {}")
+                        .addArgument(indexName)
+                        .addArgument(() -> truncateMessageIfNeeded(response.body, BULK_TRUNCATED_RESPONSE_MAX_LENGTH))
+                        .log();
 
                     // Allow lazy initialization of pendingOps (e.g., raw→ops conversion)
                     preCompactHook.run();


### PR DESCRIPTION
## Summary
- Promote per-response error log in `OpenSearchClient.executeBulkWithRetry` from DEBUG to INFO so document migration failures surface immediately on the first attempt, not only after retries are exhausted at WARN/ERROR.
- Truncate the body to `BULK_TRUNCATED_RESPONSE_MAX_LENGTH` to match the existing WARN log.

## Test plan
- [ ] CI green
- [ ] Manual: trigger a bulk index failure and confirm the response body appears at INFO on the first attempt (not just on the final retry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)