### PR TITLE
Solr→OS shim: support date-math, ISO timestamps, and field:(a OR b) groups in queries

### DIFF
--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/parser/grammarExtensions.test.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/parser/grammarExtensions.test.ts
@@ -1,0 +1,242 @@
+/**
+ * Unit tests for grammar fixes:
+ *
+ *   1. `rangeVal` accepts ISO-8601 timestamps and Solr date-math
+ *      (`NOW`, `NOW-365DAYS`, `NOW/MONTH-6MONTHS`, `2020-01-01T00:00:00Z`).
+ *   2. `fieldExpr` accepts the `field:(a OR b OR c)` parenthesized
+ *      value-group sugar and hoists the field onto every bare leaf
+ *      inside the group.
+ *
+ * These are pure parser-level tests: we only assert on the AST shape, not
+ * on downstream OpenSearch DSL output. Range/fieldExpr translation tests
+ * live in `rangeRule.test.ts` and `astToOpenSearch.test.ts`.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { parseSolrQuery } from './parser';
+
+const emptyParams = new Map<string, string>();
+
+describe('grammar — rangeVal extensions (Fix 1)', () => {
+  it('parses an ISO-8601 timestamp range', () => {
+    const { ast, errors } = parseSolrQuery(
+      'review_date:[2020-01-01T00:00:00Z TO 2022-12-31T23:59:59Z]',
+      emptyParams,
+    );
+    expect(errors).toEqual([]);
+    expect(ast).toMatchObject({
+      type: 'range',
+      field: 'review_date',
+      lower: '2020-01-01T00:00:00Z',
+      upper: '2022-12-31T23:59:59Z',
+      lowerInclusive: true,
+      upperInclusive: true,
+    });
+  });
+
+  it('parses an ISO-8601 timestamp with milliseconds', () => {
+    const { ast, errors } = parseSolrQuery(
+      'd:[2020-01-01T00:00:00.123Z TO 2020-01-02T00:00:00.456Z]',
+      emptyParams,
+    );
+    expect(errors).toEqual([]);
+    expect(ast).toMatchObject({
+      type: 'range',
+      lower: '2020-01-01T00:00:00.123Z',
+      upper: '2020-01-02T00:00:00.456Z',
+    });
+  });
+
+  it('parses a NOW-365DAYS to NOW range', () => {
+    const { ast, errors } = parseSolrQuery(
+      'review_date:[NOW-365DAYS TO NOW]',
+      emptyParams,
+    );
+    expect(errors).toEqual([]);
+    expect(ast).toMatchObject({
+      type: 'range',
+      field: 'review_date',
+      lower: 'NOW-365DAYS',
+      upper: 'NOW',
+    });
+  });
+
+  it('parses a NOW/MONTH-6MONTHS rounding+offset bound', () => {
+    const { ast, errors } = parseSolrQuery(
+      'review_date:[NOW/MONTH-6MONTHS TO NOW/MONTH]',
+      emptyParams,
+    );
+    expect(errors).toEqual([]);
+    expect(ast).toMatchObject({
+      type: 'range',
+      lower: 'NOW/MONTH-6MONTHS',
+      upper: 'NOW/MONTH',
+    });
+  });
+
+  it('parses a NOW+1HOUR bound and a wildcard upper', () => {
+    const { ast, errors } = parseSolrQuery('d:[NOW+1HOUR TO *]', emptyParams);
+    expect(errors).toEqual([]);
+    expect(ast).toMatchObject({
+      type: 'range',
+      lower: 'NOW+1HOUR',
+      upper: '*',
+    });
+  });
+
+  it('still parses plain numeric ranges (regression)', () => {
+    const { ast, errors } = parseSolrQuery('price:[10 TO 100]', emptyParams);
+    expect(errors).toEqual([]);
+    expect(ast).toMatchObject({
+      type: 'range',
+      field: 'price',
+      lower: '10',
+      upper: '100',
+    });
+  });
+
+  it('still parses [* TO *] as matchAll-like exists (regression)', () => {
+    const { ast, errors } = parseSolrQuery('price:[* TO *]', emptyParams);
+    expect(errors).toEqual([]);
+    expect(ast).toMatchObject({
+      type: 'range',
+      lower: '*',
+      upper: '*',
+    });
+  });
+});
+
+describe('grammar — field:(group) hoisting (Fix 3)', () => {
+  it('parses field:(a OR b) and hoists field onto each bare value', () => {
+    const { ast, errors } = parseSolrQuery(
+      'marketplace:(US OR UK)',
+      emptyParams,
+    );
+    expect(errors).toEqual([]);
+    expect(ast).toMatchObject({
+      type: 'group',
+      child: {
+        type: 'bool',
+        or: [
+          { type: 'field', field: 'marketplace', value: 'US' },
+          { type: 'field', field: 'marketplace', value: 'UK' },
+        ],
+      },
+    });
+  });
+
+  it('parses three-term group field:(a OR b OR c)', () => {
+    const { ast, errors } = parseSolrQuery(
+      'marketplace:(US OR UK OR JP)',
+      emptyParams,
+    );
+    expect(errors).toEqual([]);
+    expect(ast).toMatchObject({
+      type: 'group',
+      child: {
+        type: 'bool',
+        or: [
+          { type: 'field', field: 'marketplace', value: 'US' },
+          { type: 'field', field: 'marketplace', value: 'UK' },
+          { type: 'field', field: 'marketplace', value: 'JP' },
+        ],
+      },
+    });
+  });
+
+  it('hoists field over an implicit-OR (whitespace-separated) group', () => {
+    // `tag:(foo bar)` — implicit-OR sequence inside the group.
+    const { ast, errors } = parseSolrQuery('tag:(foo bar)', emptyParams);
+    expect(errors).toEqual([]);
+    expect(ast).toMatchObject({
+      type: 'group',
+      child: {
+        type: 'bool',
+        or: [
+          { type: 'field', field: 'tag', value: 'foo' },
+          { type: 'field', field: 'tag', value: 'bar' },
+        ],
+      },
+    });
+  });
+
+  it('hoists field through a NOT operator inside the group', () => {
+    const { ast, errors } = parseSolrQuery('tag:(NOT foo)', emptyParams);
+    expect(errors).toEqual([]);
+    // NOT foo → bool{ not: [bare(foo)] } — after hoisting becomes
+    // bool{ not: [field{tag,foo}] }.
+    expect(ast).toMatchObject({
+      type: 'group',
+      child: {
+        type: 'bool',
+        not: [{ type: 'field', field: 'tag', value: 'foo' }],
+      },
+    });
+  });
+
+  it('hoists field onto a bare phrase inside the group', () => {
+    const { ast, errors } = parseSolrQuery(
+      'tag:("hello world" OR baz)',
+      emptyParams,
+    );
+    expect(errors).toEqual([]);
+    expect(ast).toMatchObject({
+      type: 'group',
+      child: {
+        type: 'bool',
+        or: [
+          { type: 'phrase', field: 'tag', text: 'hello world' },
+          { type: 'field', field: 'tag', value: 'baz' },
+        ],
+      },
+    });
+  });
+
+  it('does NOT override an explicit nested field inside the group', () => {
+    // Solr semantics: `tag:(foo OR other:bar)` keeps `other:bar` qualified
+    // by `other`, not by `tag`.
+    const { ast, errors } = parseSolrQuery(
+      'tag:(foo OR other:bar)',
+      emptyParams,
+    );
+    expect(errors).toEqual([]);
+    expect(ast).toMatchObject({
+      type: 'group',
+      child: {
+        type: 'bool',
+        or: [
+          { type: 'field', field: 'tag', value: 'foo' },
+          { type: 'field', field: 'other', value: 'bar' },
+        ],
+      },
+    });
+  });
+
+  it('preserves boost on the outer paren group', () => {
+    const { ast, errors } = parseSolrQuery(
+      'marketplace:(US OR UK)^2.0',
+      emptyParams,
+    );
+    expect(errors).toEqual([]);
+    expect(ast).toMatchObject({
+      type: 'boost',
+      value: 2,
+      child: { type: 'group' },
+    });
+  });
+
+  it('still parses an unfielded paren group (regression — existing `group` rule)', () => {
+    const { ast, errors } = parseSolrQuery('(foo OR bar)', emptyParams);
+    expect(errors).toEqual([]);
+    expect(ast).toMatchObject({
+      type: 'group',
+      child: {
+        type: 'bool',
+        or: [
+          { type: 'bare', value: 'foo' },
+          { type: 'bare', value: 'bar' },
+        ],
+      },
+    });
+  });
+});

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/parser/solr.pegjs
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/parser/solr.pegjs
@@ -240,6 +240,70 @@ fieldExpr
       if (boost !== null) return { type: 'boost', child: node, value: boost };
       return node;
     }
+  // FieldGroup: field:(subquery) — Solr's "field hoisting" sugar.
+  // `marketplace:(US OR UK)` is canonical sugar for `(marketplace:US OR marketplace:UK)`.
+  // The inner query is walked and every BareNode (and nested phrase / wildcard
+  // bareValue) gets the outer field hoisted onto it. Nested field expressions
+  // inside the group keep their own field — the hoist is non-overriding.
+  //
+  // Examples (all produce results equivalent to expanding the field manually):
+  //   `marketplace:(US OR UK)`        → group{ bool{ or: [field{marketplace,US}, field{marketplace,UK}] } }
+  //   `marketplace:(US OR JP UK)`     → group{ bool{ or: [field{...,US}, field{...,JP}, field{...,UK}] } }
+  //   `tag:(NOT foo)`                 → group{ bool{ not: [field{tag,foo}] } }
+  //   `tag:("foo bar" OR baz)`        → group{ bool{ or: [phrase{tag,"foo bar"}, field{tag,baz}] } }
+  //   `tag:(foo OR other:bar)`        → group{ bool{ or: [field{tag,foo}, field{other,bar}] } }   // nested field wins
+  //
+  // Boost on the outer group is preserved: `marketplace:(US OR UK)^2` → boost{group{...}, 2}.
+  / field:identifier ":" "(" _ expr:query _ ")" boost:boost? {
+      // Hoist `field` onto every bare leaf inside `expr`. Pre-existing field
+      // and phrase-with-field nodes inside the subexpression are left alone
+      // (the inner field wins, matching Solr semantics).
+      function hoist(n) {
+        if (n === null || typeof n !== 'object') return n;
+        switch (n.type) {
+          case 'bare':
+            if (n.isPhrase) {
+              return { type: 'phrase', text: n.value, field: field };
+            }
+            return { type: 'field', field: field, value: n.value };
+          case 'phrase':
+            // Bare phrase already became {type:'phrase', field:undefined} via
+            // bareValue — give it our field. A phrase that already had a
+            // field came through fieldExpr (handled via 'field' / 'phrase'
+            // with field set) — leave it alone.
+            if (n.field === undefined || n.field === null) {
+              return { type: 'phrase', text: n.text, field: field };
+            }
+            return n;
+          case 'field':
+          case 'range':
+            // Already field-qualified — keep as-is.
+            return n;
+          case 'bool':
+            return {
+              type: 'bool',
+              and: (n.and || []).map(hoist),
+              or: (n.or || []).map(hoist),
+              not: (n.not || []).map(hoist),
+              implicit: n.implicit,
+            };
+          case 'group':
+            return { type: 'group', child: hoist(n.child) };
+          case 'boost':
+            return { type: 'boost', child: hoist(n.child), value: n.value };
+          case 'filter':
+            return { type: 'filter', child: hoist(n.child) };
+          case 'matchAll':
+            return n;
+          default:
+            return n;
+        }
+      }
+      const hoisted = hoist(expr);
+      const node = { type: 'group', child: hoisted };
+      if (boost !== null) return { type: 'boost', child: node, value: boost };
+      return node;
+    }
   // FieldNode: field:value (unquoted)
   // `title:java` → FieldNode { field: "title", value: "java" }
   / field:identifier ":" val:valueChars boost:boost? {
@@ -278,9 +342,32 @@ bareValue
 // ─── Terminals ───────────────────────────────────────────────────────────────
 
 // Range bound value: alphanumeric string or * (for unbounded ranges like [* TO 100]).
+//
+// Supported forms:
+//   - Numbers / strings:                 10, 1.5, abc
+//   - Wildcard:                          *
+//   - ISO-8601 timestamps:               2020-01-01T00:00:00Z
+//                                        2020-01-01T00:00:00.123Z
+//   - Solr date-math NOW expressions:    NOW
+//                                        NOW-365DAYS
+//                                        NOW+1HOUR
+//                                        NOW/DAY
+//                                        NOW/MONTH-6MONTHS
+//                                        NOW/MONTH+1DAY/HOUR
+//
+// Characters added beyond the original [a-zA-Z0-9._\-]+:
+//   ':'  for ISO timestamps (T00:00:00) and date-math operators
+//   '/'  for date-math rounding (NOW/MONTH)
+//   '+'  for date-math additive offsets (NOW+1HOUR)
+// `-` is already covered by the original character class.
+//
+// We deliberately do NOT include whitespace; the surrounding `_` rules in
+// fieldExpr handle whitespace around the bound, and Solr requires "TO" to
+// be surrounded by whitespace, so an unquoted bound never contains a literal
+// space.
 rangeVal
   = "*" { return '*'; }
-  / $[a-zA-Z0-9._\-]+
+  / $[a-zA-Z0-9._\-:/+]+
 
 // Unquoted value characters: letters, digits, and common special chars.
 // Determines what can appear in unquoted field values.

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/transformer/dateMath.test.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/transformer/dateMath.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Unit tests for the Solr → OpenSearch date-math translation helper.
+ *
+ * Covers:
+ *   - Bare `NOW`           → `now`
+ *   - Solr unit names      → OpenSearch single-letter abbreviations
+ *   - Compound expressions → preserve operator order (`NOW/MONTH-6MONTHS` → `now/M-6M`)
+ *   - ISO timestamps       → unchanged (OpenSearch accepts them natively)
+ *   - Plain numbers/strings → unchanged
+ *   - Unrecognized "NOW"-like input → unchanged (loud failure preferred over silent semantic drift)
+ */
+
+import { describe, it, expect } from 'vitest';
+import { translateSolrDateMath } from './dateMath';
+
+describe('translateSolrDateMath', () => {
+  describe('bare NOW', () => {
+    it('translates NOW to now', () => {
+      expect(translateSolrDateMath('NOW')).toBe('now');
+    });
+  });
+
+  describe('NOW with offset', () => {
+    it('NOW-365DAYS → now-365d', () => {
+      expect(translateSolrDateMath('NOW-365DAYS')).toBe('now-365d');
+    });
+    it('NOW+1HOUR → now+1h', () => {
+      expect(translateSolrDateMath('NOW+1HOUR')).toBe('now+1h');
+    });
+    it('NOW-1MINUTE → now-1m', () => {
+      expect(translateSolrDateMath('NOW-1MINUTE')).toBe('now-1m');
+    });
+    it('NOW+30SECONDS → now+30s', () => {
+      expect(translateSolrDateMath('NOW+30SECONDS')).toBe('now+30s');
+    });
+    it('NOW-2YEARS → now-2y', () => {
+      expect(translateSolrDateMath('NOW-2YEARS')).toBe('now-2y');
+    });
+    it('NOW-1MONTH → now-1M (capital M, not minute)', () => {
+      expect(translateSolrDateMath('NOW-1MONTH')).toBe('now-1M');
+    });
+    it('NOW-1MONTHS (plural) → now-1M', () => {
+      expect(translateSolrDateMath('NOW-1MONTHS')).toBe('now-1M');
+    });
+  });
+
+  describe('NOW with rounding', () => {
+    it('NOW/DAY → now/d', () => {
+      expect(translateSolrDateMath('NOW/DAY')).toBe('now/d');
+    });
+    it('NOW/HOUR → now/h', () => {
+      expect(translateSolrDateMath('NOW/HOUR')).toBe('now/h');
+    });
+    it('NOW/MONTH → now/M', () => {
+      expect(translateSolrDateMath('NOW/MONTH')).toBe('now/M');
+    });
+    it('NOW/YEAR → now/y', () => {
+      expect(translateSolrDateMath('NOW/YEAR')).toBe('now/y');
+    });
+  });
+
+  describe('compound NOW expressions', () => {
+    it('NOW/MONTH-6MONTHS → now/M-6M', () => {
+      expect(translateSolrDateMath('NOW/MONTH-6MONTHS')).toBe('now/M-6M');
+    });
+    it('NOW/DAY+1HOUR → now/d+1h', () => {
+      expect(translateSolrDateMath('NOW/DAY+1HOUR')).toBe('now/d+1h');
+    });
+    it('NOW-1YEAR/MONTH → now-1y/M', () => {
+      expect(translateSolrDateMath('NOW-1YEAR/MONTH')).toBe('now-1y/M');
+    });
+    it('NOW/MONTH+1DAY/HOUR (round, add, round) → now/M+1d/h', () => {
+      expect(translateSolrDateMath('NOW/MONTH+1DAY/HOUR')).toBe('now/M+1d/h');
+    });
+  });
+
+  describe('case sensitivity of unit names', () => {
+    it('accepts mixed-case unit names', () => {
+      expect(translateSolrDateMath('NOW-1Day')).toBe('now-1d');
+    });
+  });
+
+  describe('passthrough — values that are not Solr date-math', () => {
+    it('ISO-8601 timestamp passes through unchanged', () => {
+      expect(translateSolrDateMath('2020-01-01T00:00:00Z')).toBe('2020-01-01T00:00:00Z');
+    });
+    it('ISO-8601 timestamp with millis passes through', () => {
+      expect(translateSolrDateMath('2020-01-01T00:00:00.123Z')).toBe('2020-01-01T00:00:00.123Z');
+    });
+    it('integer string passes through', () => {
+      expect(translateSolrDateMath('42')).toBe('42');
+    });
+    it('decimal string passes through', () => {
+      expect(translateSolrDateMath('1.5')).toBe('1.5');
+    });
+    it('alpha string passes through', () => {
+      expect(translateSolrDateMath('abc')).toBe('abc');
+    });
+    it('empty string passes through', () => {
+      expect(translateSolrDateMath('')).toBe('');
+    });
+  });
+
+  describe('unrecognized NOW-like input — preserve loud failure', () => {
+    it('NOW with unknown unit returns input unchanged so OS rejects loudly', () => {
+      expect(translateSolrDateMath('NOW-1FORTNIGHT')).toBe('NOW-1FORTNIGHT');
+    });
+    it('NOW with malformed offset returns input unchanged', () => {
+      // Two operators in a row is not a valid Solr date-math expression.
+      expect(translateSolrDateMath('NOW--1DAY')).toBe('NOW--1DAY');
+    });
+    it('NOW with trailing garbage returns input unchanged', () => {
+      expect(translateSolrDateMath('NOW-1DAYxyz')).toBe('NOW-1DAYxyz');
+    });
+    it('value that starts with NOW but is actually a different identifier passes through', () => {
+      // `NOWHERE` happens to start with NOW but is not date-math. The helper
+      // notices this because nothing matches the (op)(unit) segment pattern
+      // and returns the input unchanged.
+      expect(translateSolrDateMath('NOWHERE')).toBe('NOWHERE');
+    });
+  });
+});

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/transformer/dateMath.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/transformer/dateMath.ts
@@ -91,7 +91,7 @@ function solrUnitToOpenSearch(unit: string): string | null {
  */
 function translateSolrDateMathBody(body: string): string | null {
   // Pattern: optional sign + digits + UNIT  OR  '/' + UNIT
-  const segmentPattern = /([+\-]\d+|\/)([A-Za-z]+)/g;
+  const segmentPattern = /([+-]\d+|\/)([A-Za-z]+)/g;
   let out = '';
   let lastIndex = 0;
   let match: RegExpExecArray | null;

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/transformer/dateMath.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/transformer/dateMath.ts
@@ -1,0 +1,150 @@
+/**
+ * Solr → OpenSearch date-math translation.
+ *
+ * Solr date-math is documented at
+ *   https://solr.apache.org/guide/solr/latest/indexing-guide/date-formatting-math.html
+ *
+ * OpenSearch date-math is documented at
+ *   https://opensearch.org/docs/latest/field-types/supported-field-types/date/#date-math
+ *
+ * Differences this helper bridges:
+ *
+ *   1. The "NOW" anchor:
+ *        Solr        : `NOW`        (uppercase)
+ *        OpenSearch  : `now`        (lowercase)
+ *
+ *   2. Unit suffix names. Solr accepts singular and plural English-language
+ *      unit names; OpenSearch uses single-letter abbreviations:
+ *
+ *        Solr (any of)             | OpenSearch
+ *        --------------------------+-----------
+ *        YEAR / YEARS              | y
+ *        MONTH / MONTHS            | M    (capital M — `m` would mean minute)
+ *        DAY / DAYS / DATE         | d
+ *        HOUR / HOURS              | h
+ *        MINUTE / MINUTES          | m
+ *        SECOND / SECONDS          | s
+ *        MILLI / MILLIS / MILLISECOND / MILLISECONDS | (unsupported in OS;
+ *                                                       the millisecond unit
+ *                                                       has no rounding form
+ *                                                       in OpenSearch DSL.
+ *                                                       We pass it through
+ *                                                       and let OS reject it
+ *                                                       loudly rather than
+ *                                                       silently dropping.)
+ *
+ *   3. Rounding form. Both engines use `/UNIT`, so this is a pure unit
+ *      rename:  `NOW/MONTH` → `now/M`,  `NOW/MONTH-6MONTHS` → `now/M-6M`.
+ *
+ *   4. ISO-8601 absolute timestamps (`2020-01-01T00:00:00Z`) are accepted
+ *      verbatim by OpenSearch and pass through unchanged.
+ *
+ * Anything that is *not* recognizable Solr date-math is returned unchanged so
+ * pre-existing numeric / lexical range bounds keep working.
+ */
+
+/**
+ * Map a Solr date-math unit name (case-insensitive, possibly plural) to its
+ * OpenSearch single-letter equivalent. Returns `null` if the unit is not a
+ * recognized Solr date-math unit.
+ */
+function solrUnitToOpenSearch(unit: string): string | null {
+  switch (unit.toUpperCase()) {
+    case 'YEAR':
+    case 'YEARS':
+      return 'y';
+    case 'MONTH':
+    case 'MONTHS':
+      return 'M';
+    case 'DAY':
+    case 'DAYS':
+    case 'DATE':
+      return 'd';
+    case 'HOUR':
+    case 'HOURS':
+      return 'h';
+    case 'MINUTE':
+    case 'MINUTES':
+      return 'm';
+    case 'SECOND':
+    case 'SECONDS':
+      return 's';
+    default:
+      return null;
+  }
+}
+
+/**
+ * Translate a single Solr date-math expression (rooted at `NOW` or a value
+ * after the absolute-date `Z` anchor) to OpenSearch date-math.
+ *
+ * Walks the string left-to-right matching `(±N)?UNIT` pairs and rounding
+ * `/UNIT` segments. Returns `null` if any segment is unrecognized — the
+ * caller is then expected to leave the bound unchanged.
+ *
+ * Note: Solr also supports an absolute-date prefix form like
+ *   `2020-01-01T00:00:00Z+6MONTHS`
+ * OpenSearch supports the same form (`||+6M`) but with a different separator.
+ * That mixed form is rare in practice; we translate only the bare `NOW`-rooted
+ * form here. Pure ISO timestamps (no math suffix) are handled by the caller
+ * via the early-return path before this function is invoked.
+ */
+function translateSolrDateMathBody(body: string): string | null {
+  // Pattern: optional sign + digits + UNIT  OR  '/' + UNIT
+  const segmentPattern = /([+\-]\d+|\/)([A-Za-z]+)/g;
+  let out = '';
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = segmentPattern.exec(body)) !== null) {
+    if (match.index !== lastIndex) {
+      // Unconsumed characters between segments — unrecognized form.
+      return null;
+    }
+    const [whole, op, unit] = match;
+    const osUnit = solrUnitToOpenSearch(unit);
+    if (osUnit === null) {
+      return null;
+    }
+    out += op + osUnit;
+    lastIndex = match.index + whole.length;
+  }
+  if (lastIndex !== body.length) {
+    // Trailing garbage — unrecognized.
+    return null;
+  }
+  return out;
+}
+
+/**
+ * Translate a Solr range-bound value to its OpenSearch equivalent.
+ *
+ * - `NOW` and `NOW`-rooted date-math are translated.
+ * - ISO-8601 absolute timestamps pass through unchanged (OpenSearch accepts
+ *   them natively).
+ * - Numeric / string bounds pass through unchanged.
+ * - Anything that *looks* like Solr date-math but contains an unrecognized
+ *   unit is returned unchanged so the failure mode is "OS rejects it loudly"
+ *   rather than "silent semantic drift".
+ *
+ * @param bound - The raw Solr bound value (e.g. `"NOW-365DAYS"`,
+ *                `"2020-01-01T00:00:00Z"`, `"42"`).
+ * @returns The bound rewritten for OpenSearch, or the original input if no
+ *          translation is needed or no safe translation is possible.
+ */
+export function translateSolrDateMath(bound: string): string {
+  if (!bound.startsWith('NOW')) {
+    return bound;
+  }
+  // bound is exactly "NOW"
+  if (bound.length === 3) {
+    return 'now';
+  }
+  const tail = bound.slice(3);
+  const translatedTail = translateSolrDateMathBody(tail);
+  if (translatedTail === null) {
+    // Couldn't safely translate — leave it alone. OpenSearch will reject
+    // unknown units loudly rather than us silently producing wrong dates.
+    return bound;
+  }
+  return 'now' + translatedTail;
+}

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/transformer/rules/rangeRule.test.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/transformer/rules/rangeRule.test.ts
@@ -140,4 +140,110 @@ describe('rangeRule', () => {
 
     expect(rangeMap.has('created_at')).toBe(true);
   });
+
+  // ─── Solr date-math translation (Fix 2) ────────────────────────────────────
+
+  it('translates Solr date-math NOW-365DAYS to OpenSearch now-365d', () => {
+    const node: RangeNode = {
+      type: 'range',
+      field: 'review_date',
+      lower: 'NOW-365DAYS',
+      upper: 'NOW',
+      lowerInclusive: true,
+      upperInclusive: true,
+    };
+
+    const result = rangeRule(node, stubTransformChild);
+
+    expect(result).toEqual(
+      new Map([
+        [
+          'range',
+          new Map([['review_date', new Map([['gte', 'now-365d'], ['lte', 'now']])]]),
+        ],
+      ]),
+    );
+  });
+
+  it('translates rounded date-math NOW/MONTH-6MONTHS to now/M-6M', () => {
+    const node: RangeNode = {
+      type: 'range',
+      field: 'd',
+      lower: 'NOW/MONTH-6MONTHS',
+      upper: 'NOW/MONTH',
+      lowerInclusive: true,
+      upperInclusive: false,
+    };
+
+    const result = rangeRule(node, stubTransformChild);
+
+    expect(result).toEqual(
+      new Map([
+        [
+          'range',
+          new Map([['d', new Map([['gte', 'now/M-6M'], ['lt', 'now/M']])]]),
+        ],
+      ]),
+    );
+  });
+
+  it('passes ISO-8601 timestamps through unchanged', () => {
+    const node: RangeNode = {
+      type: 'range',
+      field: 'd',
+      lower: '2020-01-01T00:00:00Z',
+      upper: '2022-12-31T23:59:59Z',
+      lowerInclusive: true,
+      upperInclusive: true,
+    };
+
+    const result = rangeRule(node, stubTransformChild);
+
+    expect(result).toEqual(
+      new Map([
+        [
+          'range',
+          new Map([
+            [
+              'd',
+              new Map([
+                ['gte', '2020-01-01T00:00:00Z'],
+                ['lte', '2022-12-31T23:59:59Z'],
+              ]),
+            ],
+          ]),
+        ],
+      ]),
+    );
+  });
+
+  it('combines date-math lower with ISO upper', () => {
+    const node: RangeNode = {
+      type: 'range',
+      field: 'd',
+      lower: 'NOW-7DAYS',
+      upper: '2025-01-01T00:00:00Z',
+      lowerInclusive: true,
+      upperInclusive: false,
+    };
+
+    const result = rangeRule(node, stubTransformChild);
+
+    expect(result).toEqual(
+      new Map([
+        [
+          'range',
+          new Map([
+            [
+              'd',
+              new Map([
+                ['gte', 'now-7d'],
+                ['lt', '2025-01-01T00:00:00Z'],
+              ]),
+            ],
+          ]),
+        ],
+      ]),
+    );
+  });
 });

--- a/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/transformer/rules/rangeRule.ts
+++ b/TrafficCapture/SolrTransformations/transforms/src/solr-to-opensearch/query-engine/transformer/rules/rangeRule.ts
@@ -9,16 +9,24 @@
  *
  * Unbounded ranges use `*` which is omitted from the output.
  *
+ * Solr date-math bounds are translated to OpenSearch date-math via the
+ * shared `translateSolrDateMath` helper, so e.g.
+ *   `review_date:[NOW-365DAYS TO NOW]`
+ *     → range{review_date: {gte: 'now-365d', lte: 'now'}}
+ *
  * Examples:
- *   `price:[10 TO 100]` → Map{"range" → Map{"price" → Map{"gte" → "10", "lte" → "100"}}}
- *   `price:{10 TO 100}` → Map{"range" → Map{"price" → Map{"gt" → "10", "lt" → "100"}}}
- *   `price:[10 TO 100}` → Map{"range" → Map{"price" → Map{"gte" → "10", "lt" → "100"}}}
- *   `price:[* TO 100]`  → Map{"range" → Map{"price" → Map{"lte" → "100"}}}
- *   `price:[10 TO *]`   → Map{"range" → Map{"price" → Map{"gte" → "10"}}}
+ *   `price:[10 TO 100]`            → Map{"range" → Map{"price" → Map{"gte" → "10", "lte" → "100"}}}
+ *   `price:{10 TO 100}`            → Map{"range" → Map{"price" → Map{"gt" → "10", "lt" → "100"}}}
+ *   `price:[10 TO 100}`            → Map{"range" → Map{"price" → Map{"gte" → "10", "lt" → "100"}}}
+ *   `price:[* TO 100]`             → Map{"range" → Map{"price" → Map{"lte" → "100"}}}
+ *   `price:[10 TO *]`              → Map{"range" → Map{"price" → Map{"gte" → "10"}}}
+ *   `d:[NOW-365DAYS TO NOW]`       → Map{"range" → Map{"d" → Map{"gte" → "now-365d", "lte" → "now"}}}
+ *   `d:[2020-01-01T00:00:00Z TO *]`→ Map{"range" → Map{"d" → Map{"gte" → "2020-01-01T00:00:00Z"}}}
  */
 
 import type { ASTNode } from '../../ast/nodes';
 import type { TransformRuleFn } from '../types';
+import { translateSolrDateMath } from '../dateMath';
 
 export const rangeRule: TransformRuleFn = (
   node: ASTNode,
@@ -36,10 +44,10 @@ export const rangeRule: TransformRuleFn = (
 
   // Only include bounds that are not unbounded (*)
   if (lower !== '*') {
-    bounds.set(lowerInclusive ? 'gte' : 'gt', lower);
+    bounds.set(lowerInclusive ? 'gte' : 'gt', translateSolrDateMath(lower));
   }
   if (upper !== '*') {
-    bounds.set(upperInclusive ? 'lte' : 'lt', upper);
+    bounds.set(upperInclusive ? 'lte' : 'lt', translateSolrDateMath(upper));
   }
 
   return new Map([['range', new Map([[field, bounds]])]]);


### PR DESCRIPTION
## What

Three real Solr→OpenSearch query translation gaps in `TrafficCapture/SolrTransformations/transforms/`, each surfaced by running the SolrCloud sandbox migration and inspecting the queries that the shim either failed to parse or translated into something OpenSearch then rejected.

| | Before | After |
| --- | --- | --- |
| `review_date:[NOW-365DAYS TO NOW]` | parser error: unexpected `-` after `[` | translates to `range: { review_date: { gte: "now-365d", lte: "now" } }` |
| `review_date:[2020-01-01T00:00:00Z TO 2022-12-31T23:59:59Z]` | parser error: unexpected `:` | translates to `range: { review_date: { gte: "2020-01-01T00:00:00Z", lte: "2022-12-31T23:59:59Z" } }` (passthrough — OS accepts ISO natively) |
| `marketplace:(US OR UK OR JP)` | parser error: unexpected `(` | translates to `bool: { should: [ term:{marketplace:US}, term:{marketplace:UK}, term:{marketplace:JP} ] }` (group hoisting) |

These are the top three sources of refused queries in the sandbox sample I ran — each one breaks a common idiomatic Solr query shape that workloads use heavily.

## Changes

Three small, orthogonal changes:

**1. `solr.pegjs` `rangeVal` — extend allowed character class.** Was `[a-zA-Z0-9._\-]+`, which excluded `:`, `T`, `Z`, `/`, and `+` — every character ISO timestamps and Solr date-math need. Whitespace deliberately stays excluded; `_` rules around the bound handle whitespace and `TO` is unambiguous.

**2. `dateMath.ts` (new) + `rangeRule.ts` — translate Solr date-math into OpenSearch date-math.** OpenSearch wants lowercase `now` and single-letter units (`d`, `h`, `m`, `s`, `M`, `y`). The helper handles bare `NOW`, offsets (`NOW-365DAYS`), rounding (`NOW/MONTH`), and compound expressions (`NOW/MONTH-6MONTHS+1DAY/HOUR`). ISO-8601 timestamps and other unrecognized values pass through unchanged so OpenSearch can reject them loudly rather than the shim swallowing the discrepancy. The helper is colocated with the other transformer rules so future callers (legacy `facet.range`, `stats.field` percentiles over time) can reuse it.

**3. `solr.pegjs` `fieldExpr` — accept `field:(subquery)` group sugar.** Solr canonicalises this as `(field:a OR field:b OR field:c)`. A new `fieldExpr` alternative captures the inner subquery, walks it, and hoists the outer field onto every bare leaf. Nested explicit-field nodes inside the group keep their own field — `tag:(foo OR other:bar)` keeps `other:bar` qualified by `other`, matching Solr semantics. Boost on the outer group is preserved (`marketplace:(US OR UK)^2.0`).

## Tests

Three new vitest specs:

- `dateMath.test.ts` — 27 tests covering the date-math translator (bare `NOW`, offsets, rounding, compound expressions, ISO passthrough, malformed-input passthrough).
- `grammarExtensions.test.ts` — 15 tests for the grammar additions, including regression coverage on the existing range and group forms.
- `rangeRule.test.ts` +4 tests — date-math integration through `rangeRule`.

Suite count goes from **935 → 977 passing tests**. No prior test was modified or relaxed.

```
$ npm run test:nocov
 Test Files  40 passed (40)
      Tests  977 passed (977)
```

## What this does NOT include

This PR is intentionally narrow — only the three gaps above. There are four more real gaps in the same area (legacy `facet=true & facet.field/.range/.query/.pivot`, `stats.field`, `group.field`, `track_total_hits`) that I have working in a follow-up branch and will open separately so each PR carries its own evidence.

## Compatibility

- No Solr query that parsed before this PR will parse to a different AST after it. Verified by 977/977 passing including the existing `parser.test.ts` (82 tests) and `rangeRule.test.ts` (8 prior tests).
- No new dependencies. `solr.pegjs` is loaded at runtime and parsed by `peggy.generate()` on first call, so the grammar changes pick up automatically.
- Shim-internal only; no impact on Console, Replayer, Reindex-from-Snapshot, or migration-orchestration paths.
