### PR TITLE
Add migration-companion top-level skill for ES/OS → OS migrations

### DIFF
--- a/migration-companion/README.md
+++ b/migration-companion/README.md
@@ -23,7 +23,7 @@ reads `SKILL.md` and follows its phase map.
 migration-companion/
 ├── SKILL.md                          # Entry point. Start here.
 ├── README.md                         # This file.
-├── pitfalls.md                       # Non-discoverable facts (P1..P19).
+├── pitfalls.md                       # Non-discoverable facts (P1..P18).
 ├── steering/
 │   ├── 00-intent.md                  # Pick path: LEARN / POC / ANALYZE / MIGRATE.
 │   ├── 01-interview.md               # Persona + source/target pair.

--- a/migration-companion/README.md
+++ b/migration-companion/README.md
@@ -1,0 +1,93 @@
+# Migration Companion
+
+A minimalist, agent-runnable skill that walks a user end-to-end
+through migrating an **Elasticsearch** or **OpenSearch** cluster to
+**OpenSearch** (self-managed), **Amazon OpenSearch Service** (AOS),
+or **Amazon OpenSearch Serverless** (AOSS).
+
+The skill adapts to the user's starting point — from "I know nothing
+yet" to "here are credentials, do it" — and points the user at this
+repository's existing Migration Assistant tooling (helm chart,
+docker-compose dev sandboxes, `migration-console` CLI) for execution.
+It does **not** ship its own infrastructure.
+
+## How an agent uses this
+
+Point any SKILL.md-aware runner (Claude Code, Kiro, the AIAdvisor
+loader, a custom skill loader, etc.) at this directory. The runner
+reads `SKILL.md` and follows its phase map.
+
+## Layout
+
+```
+migration-companion/
+├── SKILL.md                          # Entry point. Start here.
+├── README.md                         # This file.
+├── pitfalls.md                       # Non-discoverable facts (P1..P19).
+├── steering/
+│   ├── 00-intent.md                  # Pick path: LEARN / POC / ANALYZE / MIGRATE.
+│   ├── 01-interview.md               # Persona + source/target pair.
+│   ├── 02-probe.md                   # Read source cluster (read-only).
+│   ├── 03-evaluate.md                # Pros/cons across 7 approaches → pick one.
+│   ├── 04-execute.md                 # Run via the in-repo MA tooling.
+│   ├── 05-validate.md                # Doc count + sample query parity.
+│   └── 06-report.md                  # Write report.md.
+└── packs/                            # Loaded on demand by phases 2-5.
+    ├── source-elasticsearch.md
+    ├── source-opensearch.md
+    ├── target-self-managed.md
+    ├── target-aws-managed.md
+    └── target-aws-serverless.md
+```
+
+## Four user paths
+
+| Path     | Trigger                                    | Phases run        |
+| -------- | ------------------------------------------ | ----------------- |
+| LEARN    | "What's involved in migrating?"            | 0 → 1 → 6         |
+| POC      | "Show me how it works locally"             | 0 → 1 → 3..6      |
+| ANALYZE  | "Here's a snapshot, tell me what'll break" | 0 → 1 → 2 → 3 → 6 |
+| MIGRATE  | "Here are creds, do the migration"         | 0 → 1 → 2..6      |
+
+## Where execution happens
+
+This skill is the *guide*. The infrastructure lives elsewhere in this
+repo:
+
+| Need                            | Path                                                        |
+| ------------------------------- | ----------------------------------------------------------- |
+| MA on a real / local k8s        | `deployment/k8s/charts/aggregates/migrationAssistantWithArgo/` |
+| Local docker-compose dev loop   | `TrafficCapture/dockerSolution/`                            |
+| Operator CLI (`console …`)      | `migrationConsole/`                                         |
+| Argo workflow templates         | `orchestrationSpecs/`                                       |
+| Solr → OS (sibling skill)       | `AIAdvisor/skills/solr-opensearch-migration-advisor/`       |
+
+## Design notes
+
+- **Single SKILL.md entry point.** ~3.5 KB. Everything else is
+  on-demand.
+- **One question at a time.** No 5-question dumps in Phase 1.
+- **Pull, don't push.** The 5 packs are not loaded until the
+  source/target pair is known (Phase 2+).
+- **Evaluate, don't prescribe.** Phase 3 lays out 7 approaches with
+  honest pros/cons, then narrows to one. The user signs off.
+- **Capability profiles, not parity claims.** Each target pack lists
+  what works and what doesn't. AOSS's `snapshot_restore: false` is
+  the load-bearing example — believe the pack, don't try to be
+  clever.
+- **One-pass validation.** Doc counts + 3-5 sample queries. No
+  N-pass review framework.
+- **No state file.** Working memory plus a final `report.md` is
+  enough.
+- **No bundled POC.** This skill does not duplicate
+  `TrafficCapture/dockerSolution` or the helm chart. It points at
+  them and walks the user through driving the `migration-console`
+  CLI.
+
+## Heritage
+
+Combines a layered source/target packs idea with the stepwise
+persona-tailored interview model from
+`AIAdvisor/skills/solr-opensearch-migration-advisor/`, scoped to the
+ES/OS → OS/AOS/AOSS domain. The Solr → OS workflow stays where it
+already lives.

--- a/migration-companion/README.md
+++ b/migration-companion/README.md
@@ -32,12 +32,13 @@ migration-companion/
 │   ├── 04-execute.md                 # Run via the in-repo MA tooling.
 │   ├── 05-validate.md                # Doc count + sample query parity.
 │   └── 06-report.md                  # Write report.md.
-└── packs/                            # Loaded on demand by phases 2-5.
+└── packs/                            # Loaded on demand by phases 2-5
     ├── source-elasticsearch.md
     ├── source-opensearch.md
     ├── target-self-managed.md
     ├── target-aws-managed.md
-    └── target-aws-serverless.md
+    ├── target-aws-serverless.md
+    └── techniques.md                 # 7 migration approaches reference
 ```
 
 ## Four user paths

--- a/migration-companion/SKILL.md
+++ b/migration-companion/SKILL.md
@@ -71,7 +71,10 @@ mid-run.
 
 ```
 LEARN     "What's involved in migrating?"
-          → 0 → 1 → 6 (planning report only, no clusters touched)
+          → 0 → 1 → techniques.md → 6
+          (planning report only, no clusters touched.
+           Phase 1 is lightweight — see 01-interview.md for the
+           LEARN-specific prompts.)
 
 POC       "Show me how it works locally"
           → 0 → 1 → 3 → 4 → 5 → 6

--- a/migration-companion/SKILL.md
+++ b/migration-companion/SKILL.md
@@ -93,6 +93,14 @@ Source packs (`packs/source-elasticsearch.md`,
 `packs/target-aws-serverless.md`) are pulled by phases 2-5 once the
 source/target pair is known. Don't load them in Phase 0 or 1.
 
+`packs/techniques.md` is a standalone reference for the seven
+migration approaches (snapshot/restore, RFS, `_reindex` from remote,
+capture-and-replay, Logstash, CCR, app dual-write) — pros, cons, when
+to use, and common combinations. Phase 3 is where the agent narrows
+to one; load `techniques.md` if the user wants to compare options
+outside the interview flow (LEARN path) or is asking "what are my
+options" before Phase 2 has run.
+
 ## Pitfalls
 
 `pitfalls.md` is a single flat file of non-discoverable facts (things

--- a/migration-companion/SKILL.md
+++ b/migration-companion/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: migration-companion
+description: >
+  Guides a user end-to-end through migrating an Elasticsearch or
+  OpenSearch cluster to OpenSearch (self-managed, Amazon OpenSearch
+  Service, or Amazon OpenSearch Serverless). Adapts to the user's
+  starting point — from "I know nothing yet" to "here are credentials,
+  do it" — and points at this repository's existing Migration
+  Assistant tooling (helm chart, docker-compose dev sandboxes,
+  migration-console CLI) for execution.
+---
+
+# Migration Companion
+
+You (the agent) are walking the user through a migration. The user's
+starting point determines the path. Don't assume they know what a
+snapshot is, what RFS is, or what the difference between AOS and AOSS
+is. Don't assume they don't, either — ask.
+
+This skill lives inside the opensearch-migrations repo. Execution
+phases reference the repo's existing artifacts directly:
+
+  - Helm chart for k8s installs:
+    `deployment/k8s/charts/aggregates/migrationAssistantWithArgo/`
+  - Docker-compose dev sandboxes for local POCs:
+    `TrafficCapture/dockerSolution/`
+  - Migration console (the operator CLI inside `migration-console`):
+    `migrationConsole/`
+  - Argo workflow specs that drive RFS / metadata / snapshot:
+    `orchestrationSpecs/`
+  - Sibling Solr-specific advisor (out of scope here):
+    `AIAdvisor/skills/solr-opensearch-migration-advisor/`
+
+Don't reimplement these. Point at them.
+
+## Non-negotiables
+
+1. **One question at a time.** Don't dump 5 questions in one message.
+2. **Don't load packs you don't need yet.** SKILL.md and the current
+   phase's steering doc are enough to start. Pull a pack only when the
+   phase tells you to.
+3. **No raw cluster mutations without confirmation.** Probes (GET /,
+   GET /_cat/indices, etc.) are fine. Anything that writes to the
+   target cluster requires the user to say "go".
+4. **Source can be Elasticsearch (5/6/7/8) or OpenSearch (1/2/3).
+   Target can be self-managed OpenSearch, Amazon OpenSearch Service
+   (AOS), or Amazon OpenSearch Serverless (AOSS).** Solr is
+   out-of-scope — it lives in
+   `AIAdvisor/skills/solr-opensearch-migration-advisor/`.
+5. **Don't invent capabilities.** If a target pack says
+   `snapshot_restore: false` (AOSS), believe it. Don't try to be
+   clever.
+
+## Phase map
+
+| Phase | File                              | When                          |
+| ----- | --------------------------------- | ----------------------------- |
+| 0     | `steering/00-intent.md`           | Always first.                 |
+| 1     | `steering/01-interview.md`        | Always.                       |
+| 2     | `steering/02-probe.md`            | Paths ANALYZE, MIGRATE.       |
+| 3     | `steering/03-evaluate.md`         | All paths except LEARN.       |
+| 4     | `steering/04-execute.md`          | Paths POC, MIGRATE.           |
+| 5     | `steering/05-validate.md`         | Paths POC, MIGRATE.           |
+| 6     | `steering/06-report.md`           | All paths.                    |
+
+## Path router (set in Phase 0)
+
+The user's readiness lands them on one of four paths. Set
+`intent_path` in your working memory and don't drift across paths
+mid-run.
+
+```
+LEARN     "What's involved in migrating?"
+          → 0 → 1 → 6 (planning report only, no clusters touched)
+
+POC       "Show me how it works locally"
+          → 0 → 1 → 3 → 4 → 5 → 6
+          (uses TrafficCapture/dockerSolution OR
+           deployment/k8s + Migration Assistant helm chart)
+
+ANALYZE   "Here's a snapshot, tell me what'll break"
+          → 0 → 1 → 2 → 3 → 6 (no execute, no validate)
+
+MIGRATE   "Here are creds, do the migration"
+          → 0 → 1 → 2 → 3 → 4 → 5 → 6
+```
+
+## Pack loading
+
+Source packs (`packs/source-elasticsearch.md`,
+`packs/source-opensearch.md`) and target packs
+(`packs/target-self-managed.md`, `packs/target-aws-managed.md`,
+`packs/target-aws-serverless.md`) are pulled by phases 2-5 once the
+source/target pair is known. Don't load them in Phase 0 or 1.
+
+## Pitfalls
+
+`pitfalls.md` is a single flat file of non-discoverable facts (things
+the docs don't say but bite every run). Skim it before phase 4 on
+MIGRATE / POC paths.
+
+## State
+
+You don't need a JSON state file. Keep `intent_path`, source version,
+target type, and any user-supplied facts in your reply context. If the
+user asks you to write a report (Phase 6), produce a single
+`report.md` in the working directory. That's the only file you write
+unless the user explicitly asks for more.

--- a/migration-companion/packs/source-elasticsearch.md
+++ b/migration-companion/packs/source-elasticsearch.md
@@ -1,0 +1,59 @@
+# Source pack: Elasticsearch (5.x – 8.x)
+
+Things the agent needs to know about Elasticsearch sources that the
+docs won't tell you in one place.
+
+## Version → snapshot compatibility quick check
+
+| Source ES | Target OS 1.x | Target OS 2.x | Target OS 3.x |
+| --------- | ------------- | ------------- | ------------- |
+| 5.x       | RFS only      | RFS only      | RFS only      |
+| 6.x       | restore (compat) | RFS preferred | RFS only   |
+| 7.x       | restore (compat) | restore (compat) | restore (compat) |
+| 8.x       | RFS only      | RFS only      | RFS only      |
+
+ES 8 snapshots use a format that OpenSearch cannot read directly.
+There is no compatibility layer. RFS is the only path.
+
+## Things that don't carry over
+
+- **X-Pack security**: roles/users live in `.security` and don't
+  migrate. Recreate via OpenSearch security plugin (self-managed)
+  or fine-grained access control (AOS). On AOSS, security model
+  is different (data access policies).
+- **Watcher**: not in OpenSearch. Use Alerting plugin instead.
+- **Machine Learning** (X-Pack ML): not in OpenSearch. ML Commons
+  exists but is not a drop-in.
+- **Transforms**: present in OpenSearch but config schema differs.
+- **ILM**: maps to ISM in OpenSearch but JSON shape is different.
+  Not auto-translated by snapshot/restore.
+- **Multi-type mappings (ES 5.x)**: gone since ES 6. Map to single
+  type per index before migrating.
+- **`_all` field**: removed in ES 7, also gone in OpenSearch. Replace
+  with `copy_to` if your queries depend on it.
+- **`include_type_name`**: ignore — OpenSearch never had types.
+
+## Things that look the same but aren't
+
+- **Fielddata on text**: behavior matches up to ES 7.x. Fine.
+- **Date math in field names**: works in OpenSearch.
+- **Painless scripts**: portable. OpenSearch ships Painless.
+- **Index aliases**: portable.
+- **Mapping `flattened` field type** (ES 7.3+): OpenSearch has
+  `flat_object`. Different name, similar behavior, NOT auto-converted.
+
+## Probe quirks
+
+- ES 8 with security on requires `Authorization: ApiKey ...` or basic
+  auth + TLS. Self-signed certs are common; if curl returns a TLS
+  error, ask the user about `--insecure` rather than assuming.
+- `cluster.name` from `GET /` is sometimes `docker-cluster` on
+  containers — not a useful identifier, ask the user what to call it.
+- If the user is on Elastic Cloud, `_cat/plugins` will look very
+  different. That's fine, focus on what the indices use.
+
+## Auth handoff
+
+Source basic-auth → target basic-auth is trivial. Source X-Pack roles
+→ target equivalent must be designed by hand. Capture the role list
+in Phase 2; flag it as a follow-up in the Phase 6 report.

--- a/migration-companion/packs/source-opensearch.md
+++ b/migration-companion/packs/source-opensearch.md
@@ -1,0 +1,56 @@
+# Source pack: OpenSearch (1.x – 3.x)
+
+Things the agent needs to know about OpenSearch sources.
+
+## Version → target compatibility
+
+| Source OS | Target self-managed OS 3 | Target AOS | Target AOSS |
+| --------- | ------------------------ | ---------- | ----------- |
+| 1.x       | snapshot/restore         | snapshot/restore | RFS  |
+| 2.x       | snapshot/restore         | snapshot/restore | RFS  |
+| 3.x       | snapshot/restore         | snapshot/restore | RFS  |
+
+OpenSearch → OpenSearch within the same major or 1 major up is the
+simplest case in this whole skill. Snapshot/restore covers it.
+AOSS is the only awkward leg because it doesn't accept snapshot
+restore at all.
+
+## Things that don't carry over
+
+- **Plugins** that aren't bundled on the target: list with
+  `GET /_cat/plugins` in Phase 2 and check each against the target
+  pack's bundled-plugin list.
+- **k-NN indices**: vector field type and method config carry over,
+  but `space_type`/`engine` defaults changed between OS 1 → 2. Re-read
+  mapping after restore and verify queries return ranked results.
+- **Anomaly Detection / Alerting / ISM** state: stored in dot-prefixed
+  system indices (`.opendistro-anomaly-detector-*`, `.opendistro-alerting-*`,
+  `.opendistro-ism-*`). Not migrated by default — the user has to
+  re-create monitors/detectors/policies, or carry these specific
+  indices in the snapshot scope.
+
+## OS 1 → OS 3 specific gotchas
+
+- Removed in 3.x: `mapper-murmur3` is no longer a separate plugin
+  (now a feature flag). Mappings using it need re-checking.
+- Default password policy on the security plugin tightened in 2.12+.
+  If the user is restoring `.opendistro_security` from an OS < 2.12
+  snapshot to OS 3, expect login failures until they reset.
+
+## Probe quirks
+
+- AOS source: `GET /_cat/plugins` will show AOS-specific plugins
+  (`opensearch-ml`, `opensearch-knn`, `opensearch-security`). Don't
+  count these as "extra" — they're part of the platform.
+- AOS source: snapshots taken by AOS go to S3. The user has the
+  bucket name; they don't always have direct S3 access. If they
+  don't, the path is "have AOS register the snapshot repo on the
+  target" rather than "copy snapshot files".
+
+## Auth handoff
+
+OS-bundled security plugin → same plugin on the target: the
+`.opendistro_security` index can be carried in the snapshot, but
+test before relying on it. AOS uses fine-grained access control
+(maps cleanly). AOSS uses data access policies (does NOT map; design
+from scratch).

--- a/migration-companion/packs/target-aws-managed.md
+++ b/migration-companion/packs/target-aws-managed.md
@@ -1,0 +1,79 @@
+# Target pack: Amazon OpenSearch Service (AOS — managed domains)
+
+AWS runs the cluster. The user gets a domain endpoint, IAM controls
+access, and snapshots go to S3 buckets the user owns.
+
+## Capability profile
+
+| Capability         | Supported | Notes                                      |
+| ------------------ | --------- | ------------------------------------------ |
+| snapshot_restore   | yes       | Manual S3 repo, IAM passrole required.     |
+| snapshot_repo_s3   | yes       | Only S3, only via signed-request register. |
+| snapshot_repo_fs   | no        | No filesystem access.                      |
+| reindex_from_remote| yes       | Source must be allowlisted in domain config. |
+| painless_scripts   | yes       | Inline + stored.                           |
+| custom_analyzers   | partial   | Bundled language plugins; no arbitrary jars. |
+| security_plugin    | partial   | Fine-grained access control (FGAC); not the same UI as the OSS plugin. |
+| ism                | yes       | Bundled.                                   |
+| alerting           | yes       | Bundled.                                   |
+| knn                | yes       | Bundled.                                   |
+| ml_commons         | yes       | On supported instance types.               |
+
+## Pre-flight (before any restore)
+
+1. Domain must allow the user's IAM role to invoke
+   `es:ESHttp*` / `es:HttpPost` on the snapshot endpoints.
+2. An S3 bucket in the same region as the domain.
+3. An IAM role the domain can assume to read the bucket. Trust
+   policy: `es.amazonaws.com`. Permissions: `s3:GetObject`,
+   `s3:ListBucket`, `s3:PutObject`, `s3:DeleteObject` on the bucket.
+4. The user's role needs `iam:PassRole` for that snapshot role.
+
+## Snapshot repo registration (signed)
+
+This is the part that bites everyone. AWS requires the registration
+request itself to be SigV4-signed. Plain curl with basic auth does
+NOT work — you need either:
+
+- The Python `requests-aws4auth` snippet, OR
+- The `awscurl` tool, OR
+- The MA orchestrator (it handles this).
+
+Shape:
+
+```
+PUT https://<domain>/_snapshot/<repo-name>
+{
+  "type": "s3",
+  "settings": {
+    "bucket": "<bucket>",
+    "region": "<region>",
+    "role_arn": "arn:aws:iam::<account>:role/<snapshot-role>"
+  }
+}
+```
+
+After registration, restore is plain HTTPS.
+
+## Restore from a self-managed source
+
+The cross-engine snapshot path requires a "transfer" bucket: take
+snapshot on source's S3, register the same bucket on AOS, restore.
+Both clusters need IAM access to the bucket.
+
+If the source is on-prem with no S3 access, RFS over HTTP is the
+practical choice.
+
+## Pitfalls
+
+- **Major-version-skip restore is rejected.** AOS will refuse to
+  restore a snapshot taken from a cluster more than 1 major version
+  behind the domain. Bridge with an intermediate cluster, or use RFS.
+- **Service-linked roles**: `AmazonOpenSearchServiceRolePolicy` must
+  exist in the account, or domain creation will silently lack
+  permissions. Auto-created on first domain create in modern accounts.
+- **VPC-only domains** can't pull from public source URLs. RFS must
+  run inside the VPC (Fargate, EC2 in the same subnet, etc.).
+- **Index limits**: AOS caps shards-per-node based on instance type.
+  Restoring a source with thousands of small shards will fail. Pre-shrink
+  on the source, or accept reindex into fewer shards.

--- a/migration-companion/packs/target-aws-serverless.md
+++ b/migration-companion/packs/target-aws-serverless.md
@@ -38,22 +38,31 @@ and re-running RFS.
 
 ## Migration path (always RFS)
 
-Because there is no snapshot API:
+Because there is no snapshot API, RFS is the only path. Don't try to
+hand-roll a `docker run` of the RFS image — RFS reads documents from
+a snapshot stored somewhere both the source ES and the RFS pod can
+see (S3 typically), and it expects orchestration via the Migration
+Assistant helm chart, not standalone invocation.
 
-```
-docker run --rm \
-  -e SOURCE_HOST=https://source:9200 \
-  -e SOURCE_USER=... -e SOURCE_PASSWORD=... \
-  -e TARGET_HOST=https://<collection-id>.<region>.aoss.amazonaws.com \
-  -e TARGET_AUTH_TYPE=sigv4 \
-  -e AWS_REGION=<region> \
-  opensearchproject/opensearch-migrations-rfs:latest \
-  --index-allowlist '...'
-```
+The flow:
 
-The RFS image must be on a host that has AWS credentials (env vars,
-instance role, or container task role). SigV4-sign every request to
-the AOSS endpoint.
+  1. Take a snapshot of the source ES into S3 (AOS source: SigV4 +
+     IAM passrole; self-managed source: `repository-s3` plugin or
+     a shared FS repo).
+  2. Deploy MA via the helm chart (or via `aws-bootstrap.sh` for an
+     EKS install pointing at public ECR).
+  3. Configure the AOSS target in `/etc/migration_services.yaml`
+     inside the migration-console pod with `auth.type: sigv4` and
+     `auth.region: <region>`.
+  4. Drive the migration from the console pod:
+     `console metadata migrate` then `console backfill start`.
+     RFS workers spin up as Argo workflow pods; they read from the
+     S3 snapshot and bulk-write to the AOSS endpoint.
+
+The published image (used by the helm chart) is
+`public.ecr.aws/opensearchproject/opensearch-migrations-reindex-from-snapshot`.
+The chart wires its env vars and IAM correctly; standalone
+`docker run` of this image is not a documented use pattern.
 
 ## Data access policy
 

--- a/migration-companion/packs/target-aws-serverless.md
+++ b/migration-companion/packs/target-aws-serverless.md
@@ -1,0 +1,87 @@
+# Target pack: Amazon OpenSearch Serverless (AOSS)
+
+AWS runs everything. There is no cluster, no domain, no shards visible
+to the user — only **collections** (logical groups of indices) and
+**data access policies**. AOSS is the most-restricted target in this
+skill.
+
+## Capability profile (READ THIS BEFORE PLANNING)
+
+| Capability         | Supported | Notes                                      |
+| ------------------ | --------- | ------------------------------------------ |
+| **snapshot_restore** | **NO**  | Hard invariant. There is no snapshot API.  |
+| snapshot_repo_s3   | no        | Not exposed.                               |
+| snapshot_repo_fs   | no        | Not exposed.                               |
+| reindex_from_remote| yes       | RFS is THE migration path.                 |
+| painless_scripts   | partial   | Inline only, limited script context.       |
+| custom_analyzers   | partial   | Built-in language analyzers only; no plugins. |
+| security_plugin    | no        | Replaced by data access policies (IAM-based). |
+| ism                | no        | Not available.                             |
+| alerting           | no        | Not available.                             |
+| knn                | yes       | Vector search collection type.             |
+| ml_commons         | no        | Not available.                             |
+| _all field         | no        | Removed; AOSS rejects mappings that include it. |
+| index renaming     | depends   | Indices live within a collection scope.    |
+
+## Collection types
+
+AOSS forces you to pick a collection type at creation. They are NOT
+interchangeable:
+
+- **TIME_SERIES** — write-heavy, low query concurrency, optimized for
+  logs. Good fit for ES `logs-*` patterns.
+- **SEARCH** — typical search workload, standard balance.
+- **VECTORSEARCH** — k-NN/embeddings.
+
+Pick before Phase 4. Wrong choice means re-creating the collection
+and re-running RFS.
+
+## Migration path (always RFS)
+
+Because there is no snapshot API:
+
+```
+docker run --rm \
+  -e SOURCE_HOST=https://source:9200 \
+  -e SOURCE_USER=... -e SOURCE_PASSWORD=... \
+  -e TARGET_HOST=https://<collection-id>.<region>.aoss.amazonaws.com \
+  -e TARGET_AUTH_TYPE=sigv4 \
+  -e AWS_REGION=<region> \
+  opensearchproject/opensearch-migrations-rfs:latest \
+  --index-allowlist '...'
+```
+
+The RFS image must be on a host that has AWS credentials (env vars,
+instance role, or container task role). SigV4-sign every request to
+the AOSS endpoint.
+
+## Data access policy
+
+Before RFS can write, the IAM principal running RFS needs:
+
+- A **data access policy** on the collection allowing
+  `aoss:CreateIndex`, `aoss:WriteDocument`, `aoss:UpdateIndex`.
+- A **network access policy** allowing the source-of-traffic
+  (VPC, public, etc.).
+- An **encryption policy** (KMS or AWS-owned).
+
+All three are required. Missing any one → 403 with no useful detail.
+
+## Mapping pitfalls
+
+Mappings carry over via RFS but AOSS rejects:
+
+- `_all` — strip from any pre-7.x source mapping.
+- `index.codec: best_compression` if using TIME_SERIES (it's already
+  optimized; the explicit setting can fail).
+- Custom analyzers referencing non-bundled tokenizers/filters.
+
+Validate the mapping by sending it as a `PUT /<index>` to the
+collection BEFORE RFS runs the bulk load. Cheap to do, expensive to
+discover at doc 5,000,000.
+
+## Counts
+
+AOSS caps `hits.total.value` at 10,000 by default. Always pass
+`track_total_hits: true` in Phase 5 parity queries or counts will
+look wrong.

--- a/migration-companion/packs/target-self-managed.md
+++ b/migration-companion/packs/target-self-managed.md
@@ -67,24 +67,34 @@ overwrites your target's templates and cluster settings.
 
 ## RFS (when snapshot/restore won't work)
 
-The `opensearch-migrations-rfs` image reads from a source over HTTP
-and writes docs to the target. Minimal invocation:
+For self-managed OpenSearch targets, RFS is delivered via the
+Migration Assistant helm chart, not as a standalone `docker run`.
+The chart deploys the migration-console pod plus Argo workflows that
+spin up RFS workers as needed. The published image (used by the
+chart) is
+`public.ecr.aws/opensearchproject/opensearch-migrations-reindex-from-snapshot`.
+
+For a kind / minikube / on-prem k8s install, see
+`steering/04-execute.md` "Local-build vs released-image testing"
+for the full helm-install command and image overlay. Once installed,
+drive the migration with:
 
 ```
-docker run --rm \
-  -e SOURCE_HOST=https://source:9200 \
-  -e SOURCE_USER=admin -e SOURCE_PASSWORD=admin \
-  -e TARGET_HOST=https://target:9200 \
-  -e TARGET_USER=admin -e TARGET_PASSWORD=admin \
-  -e SOURCE_INSECURE=true -e TARGET_INSECURE=true \
-  opensearchproject/opensearch-migrations-rfs:latest \
-  --index-allowlist 'logs-*,products'
+kubectl -n ma exec -it migration-console-0 -- /bin/bash
+console snapshot create
+console metadata migrate
+console backfill start
+console backfill scale 1     # then bump as workers prove out
 ```
+
+Self-managed-to-self-managed sources where you don't already run
+k8s and the dataset is modest are usually better served by
+`_reindex` from remote (no MA install needed).
 
 ## Pitfalls
 
-- Default heap on the docker image is 1g. For anything beyond a POC,
-  set `-e OPENSEARCH_JAVA_OPTS="-Xms4g -Xmx4g"` and ensure
-  `vm.max_map_count >= 262144` on the host.
+- Default heap on the OS / ES container is 1g. For anything beyond
+  a POC, set `-e OPENSEARCH_JAVA_OPTS="-Xms4g -Xmx4g"` and ensure
+  `vm.max_map_count >= 262144` on the host (P1, P10).
 - Demo certs: `OPENSEARCH_INITIAL_ADMIN_PASSWORD` is required since
-  2.12. POC compose files in this repo set it.
+  2.12. POC compose files in this repo set it (P9).

--- a/migration-companion/packs/target-self-managed.md
+++ b/migration-companion/packs/target-self-managed.md
@@ -1,0 +1,90 @@
+# Target pack: self-managed OpenSearch (3.x)
+
+The user runs the cluster. Docker, Kubernetes, EC2, bare metal — all
+the same from the migration's perspective.
+
+## Capability profile
+
+| Capability         | Supported | Notes                                      |
+| ------------------ | --------- | ------------------------------------------ |
+| snapshot_restore   | yes       | All snapshot repo types.                   |
+| snapshot_repo_s3   | yes       | `repository-s3` plugin (bundled).          |
+| snapshot_repo_fs   | yes       | Shared filesystem.                         |
+| reindex_from_remote| yes       | RFS works.                                 |
+| painless_scripts   | yes       | Bundled.                                   |
+| custom_analyzers   | yes       | Bundled + plugin-installable (icu, kuromoji, smartcn, phonetic). |
+| security_plugin    | yes       | Bundled. Demo certs by default — replace before prod. |
+| ism                | yes       | Bundled.                                   |
+| alerting           | yes       | Bundled.                                   |
+| knn                | yes       | Bundled `opensearch-knn`.                  |
+| ml_commons         | yes       | Bundled.                                   |
+
+## What you can do
+
+Anything the source could do, basically. This is the most permissive
+target. Snapshot/restore is the default execution strategy unless
+the source is ES 8 (RFS required regardless of target).
+
+## Snapshot repo registration (S3)
+
+```
+PUT /_snapshot/<repo-name>
+{
+  "type": "s3",
+  "settings": {
+    "bucket": "<bucket>",
+    "region": "<region>",
+    "base_path": "<prefix>"
+  }
+}
+```
+
+Credentials: keystore-based. On the OS 3.x docker image, run inside
+the container:
+
+```
+opensearch-keystore add s3.client.default.access_key
+opensearch-keystore add s3.client.default.secret_key
+```
+
+Then `POST /_nodes/reload_secure_settings`.
+
+## Restore
+
+```
+POST /_snapshot/<repo>/<snap>/_restore
+{
+  "indices": "logs-*,products,users",
+  "ignore_unavailable": true,
+  "include_global_state": false,
+  "rename_pattern": "(.+)",
+  "rename_replacement": "$1"
+}
+```
+
+`include_global_state: false` is the safe default. Setting it true
+overwrites your target's templates and cluster settings.
+
+## RFS (when snapshot/restore won't work)
+
+The `opensearch-migrations-rfs` image reads from a source over HTTP
+and writes docs to the target. Minimal invocation:
+
+```
+docker run --rm \
+  -e SOURCE_HOST=https://source:9200 \
+  -e SOURCE_USER=admin -e SOURCE_PASSWORD=admin \
+  -e TARGET_HOST=https://target:9200 \
+  -e TARGET_USER=admin -e TARGET_PASSWORD=admin \
+  -e SOURCE_INSECURE=true -e TARGET_INSECURE=true \
+  opensearchproject/opensearch-migrations-rfs:latest \
+  --index-allowlist 'logs-*,products'
+```
+
+## Pitfalls
+
+- Default heap on the docker image is 1g. For anything beyond a POC,
+  set `-e OPENSEARCH_JAVA_OPTS="-Xms4g -Xmx4g"` and ensure
+  `vm.max_map_count >= 262144` on the host.
+- Demo certs: `OPENSEARCH_INITIAL_ADMIN_PASSWORD` is required since
+  2.12. POC compose files in this repo set it.

--- a/migration-companion/packs/techniques.md
+++ b/migration-companion/packs/techniques.md
@@ -11,19 +11,100 @@ and the "Common combinations" at the bottom.
 
 ## TL;DR matrix
 
-| # | Technique                          | Live cutover? | Transforms? | AOSS target? | ES 8 source? | Setup cost | Per-migration cost |
-|---|------------------------------------|---------------|-------------|--------------|--------------|------------|--------------------|
-| 1 | Snapshot + restore                 | no            | no          | no           | no           | low        | low                |
-| 2 | Reindex-from-Snapshot (RFS) via MA | no¹           | yes         | yes          | yes          | high       | low                |
-| 3 | `_reindex` from remote             | no            | limited     | no           | partial²     | low        | medium             |
-| 4 | Capture-and-replay (MA)            | **yes**       | yes         | yes          | yes          | very high  | medium             |
-| 5 | Logstash / Fluentd dual-write      | yes           | yes         | yes          | yes          | medium     | medium             |
-| 6 | Cross-cluster replication (CCR)    | yes (ongoing) | no          | no           | no           | medium     | low                |
-| 7 | Application-layer dual-write       | yes           | yes         | yes          | yes          | medium³    | medium             |
+| # | Technique                          | Sources supported          | Targets supported              | Live cutover? | Transforms? | Source impact     | Setup cost | Per-migration cost |
+|---|------------------------------------|----------------------------|--------------------------------|---------------|-------------|-------------------|------------|--------------------|
+| 1 | Snapshot + restore                 | ES 6.8, 7.x; OS 1.x, 2.x⁸  | OS 1.x, 2.x, 3.x; AOS          | no            | no          | medium⁴           | low        | low                |
+| 2 | Reindex-from-Snapshot (RFS) via MA | ES 1.x–8.x; OS 1.x, 2.x, 3.x | OS 1.x, 2.x, 3.x; AOS; AOSS  | no¹           | yes         | **none**          | high       | low                |
+| 3 | `_reindex` from remote             | ES 1.x–7.x; OS 1.x, 2.x⁹   | OS 1.x, 2.x, 3.x; AOS          | no            | limited     | **high**⁵         | low        | medium             |
+| 4 | Capture-and-replay (MA)            | ES 6.8–8.x; OS 1.x, 2.x, 3.x | OS 1.x, 2.x, 3.x; AOS; AOSS  | **yes**       | yes         | medium⁶           | very high  | medium             |
+| 5 | Logstash / Fluentd dual-write      | ES 5.x–8.x; OS 1.x, 2.x, 3.x¹⁰ | OS 1.x, 2.x, 3.x; AOS; AOSS | yes        | yes         | variable⁷         | medium     | medium             |
+| 6 | Cross-cluster replication (CCR)    | OS 1.1+, 2.x, 3.x          | OS 1.1+, 2.x, 3.x              | yes (ongoing) | no          | low (ongoing)     | medium     | low                |
+| 7 | Application-layer dual-write       | anything the client lib speaks | anything the client lib speaks | yes      | yes         | **none**          | medium³    | medium             |
 
 ¹ RFS is offline replay; pair with #4 capture-and-replay for zero-downtime.
-² ES 8 source TLS/auth model is not supported by every OS reindex client matrix.
 ³ Low *technical* cost; high *organizational* cost (app teams must change code).
+⁴ Initial snapshot reads every segment from disk — can saturate snapshot-thread-pool and disk I/O on a busy source. Incrementals after the first are cheap.
+⁵ Source serves a continuous scroll/search workload to the target for the whole reindex window. Pressures source's search thread pool, heap (scroll contexts), and network egress. **Can take down an underprovisioned source.**
+⁶ Capture-proxy adds a network hop and CPU cost to every source request. Read path is untouched; write path latency increases.
+⁷ Depends on the Logstash input. `elasticsearch` input doing historical scroll = same pressure as #3. Tap into an existing ingest pipeline = zero source impact.
+⁸ Snapshot/restore opens cross-major (ES 6→OS, ES 7→OS, OS 1→OS 2/3) but the indices keep their original segment format and mapping shape — see the "Snapshot restore tradeoffs vs RFS" section below. ES 1.x/2.x/5.x snapshot formats are too old for any direct OS restore. ES 8 changed snapshot internals and has no compatibility shim into OS. AOSS has no snapshot API at all. **Native-restore is only the unambiguous best path for same-major same-engine upgrades.**
+⁹ `_reindex` from remote with an ES 8.x source is unreliable in practice — TLS/auth handshake mismatches with OS reindex clients fail in ways that depend on the exact patch versions. Treat ES 8 as "use #2 instead."
+¹⁰ Logstash version determines source/target reach. Logstash 8.x inputs/outputs against ES 1.x/2.x have been removed; Logstash 7.x is the broad-compatibility branch. The OpenSearch output plugin (`logstash-output-opensearch`) targets OS 1.x/2.x/3.x and AOS/AOSS via sigv4.
+
+**The "Source impact" column is critical for production migrations.**
+A migration plan that ignores source pressure is how you turn a
+migration into an outage.
+
+## Version compatibility — quick reference
+
+The technique's source/target columns above tell you *whether* a pair
+is supported. They don't tell you *what configuration* you need for
+edge versions. Use this when the user names a specific source/target
+combo.
+
+**Read this before recommending snapshot/restore:** native
+snapshot/restore (#1) is only the unambiguous best path for **same
+major version, same engine** (OS x.y → OS x.z, or like-for-like ES
+upgrades within a major). Anything cross-major or cross-engine
+carries real tradeoffs that RFS (#2) does not — see the "Snapshot
+restore tradeoffs vs RFS" section below before defaulting to #1.
+
+| Pair                                | Notes                                                                                                                                                  |
+|-------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ES 1.x / 2.x → OS                   | **RFS (#2) only.** Snapshot format predates the OS restore path entirely.                                                                              |
+| ES 5.x → OS                         | **RFS (#2) preferred.** Snapshot/restore is technically possible only via an ES 5→6→7→OS chain of intermediate restores — multi-hop, slow, risky. Don't. |
+| ES 6.8 → OS 1.x                     | **RFS (#2) preferred.** Snapshot/restore *can* open the indices, but they retain ES 6 segment format and *type mappings* — you inherit pre-Lucene-8 perf and have to live with `_doc`-style mapping shape. RFS rewrites both. Use #1 only if the user explicitly accepts staying on legacy segment format. |
+| ES 7.x → OS 1.x / 2.x               | **RFS (#2) preferred.** ES 7.10.2 → OS 1.x is the fork point and #1 works mechanically, but you still skip OpenSearch's post-fork segment improvements and don't get a chance to fix mappings. Use #1 only for very-large-data emergency cutovers where you'll re-migrate later. |
+| ES 8.x → OS / AOS / AOSS            | **RFS (#2) or capture-replay (#4).** Snapshot/restore (#1) blocked entirely. `_reindex` (#3) unreliable.                                               |
+| OS 1.x → OS 2.x                     | Cross-major OS upgrade. #1 works, but you skip segment-format improvements and any deprecated mapping warnings carry forward. **#2 if you care about long-term performance; #1 if you need a fast one-shot and accept a future re-migration.** |
+| OS 2.x → OS 3.x                     | Same as above — cross-major. Same tradeoff: #1 fast, #2 clean.                                                                                         |
+| OS 1.x → OS 1.x (minor upgrade)     | **#1 snapshot/restore is the right answer.** Same engine, same major. No tradeoff.                                                                     |
+| OS 2.x → OS 2.x (minor upgrade)     | **#1.** Same.                                                                                                                                          |
+| OS 3.x → OS 3.x (minor upgrade)     | **#1.** Same.                                                                                                                                          |
+| OS 1.x / 2.x / 3.x → AOSS           | RFS (#2), Logstash (#5), or app dual-write (#7) only. AOSS has no snapshot, no `reindex.remote.allowlist`, no CCR.                                     |
+| OS 1.x / 2.x → OS 1.x / 2.x         | CCR (#6) viable for ongoing replication; #1 for same-major one-shot.                                                                                   |
+
+If the user names a version combo not in this table, fall back to the
+matrix above and Phase 3 of the steering flow. The MA version registry
+(`transformation/src/main/java/org/opensearch/migrations/VersionMatchers.java`
+in the same repo) is the source of truth for what RFS actually accepts.
+
+### Snapshot restore tradeoffs vs RFS
+
+When a user (or a tool) reflexively suggests snapshot/restore for a
+cross-major or cross-engine move, these are what they're trading
+away vs running RFS:
+
+- **Segment format stays old.** ES 5 indices on ES 6, ES 6 indices
+  restored to OS 1.x, OS 1.x indices restored to OS 2.x — all keep
+  their original Lucene segment format until force-merged or
+  reindexed. You inherit older codecs, older bkd-tree formats,
+  older docvalues encodings. Performance improvements that
+  shipped *between* the source and target majors do not apply
+  to restored indices. RFS writes fresh segments using the
+  target's current codec.
+- **Mapping shape stays old.** Multi-type mappings from ES 5/6
+  restore as-is; deprecated field types restore as-is; pre-2.x
+  knn fields restore in their old shape. Restored indices may
+  refuse new writes if the target rejects the legacy mapping.
+  RFS applies any configured transforms (type collapses, field
+  drops, keyword↔text rewrites) on the way in.
+- **No transform window.** Snapshot/restore is byte-shuffle; you
+  can't rename indices, drop fields, or rewrite analyzers without
+  a follow-up reindex. RFS does this in flight.
+- **Cluster-state items are lost.** Templates may carry; ISM
+  policies, snapshot policies, index-state objects, security
+  users/roles, and watcher jobs do not transfer. RFS doesn't
+  solve this either, but at least the migration-console gives
+  you a concrete migration path for them.
+- **Force-merge or reindex required afterward** to actually pick
+  up target-version performance improvements. That second pass
+  is more work than just running RFS once.
+
+**Rule of thumb:** if the source and target share both engine
+*and* major version, snapshot/restore is the right call. Anything
+else, default to RFS unless the user has explicitly decided a
+fast restore-now-fix-later cutover is acceptable.
 
 ---
 
@@ -41,6 +122,13 @@ is byte-shuffling, not document-by-document.
 - Preserves shard layout, doc IDs, and `_seq_no` exactly.
 
 **Cons.**
+- **Versions:** Same-major same-engine is the only unambiguous fit (OS 1.x→1.x, 2.x→2.x, 3.x→3.x). Cross-major (ES 6.8→OS, ES 7→OS, OS 1→OS 2 or 3) is *mechanically supported* but trades real things — see "What you give up vs RFS" immediately below. ES 1.x/2.x/5.x: don't (snapshot format too old). ES 8: blocked. AOSS target: blocked (no snapshot API).
+- **What you give up vs RFS** when you pick #1 for a cross-major move:
+  - Restored indices keep the source's Lucene segment format and codec. Performance improvements shipped between the source and target majors do not apply until you force-merge or reindex.
+  - Restored indices keep the source's mapping shape. ES 5/6 multi-type mappings, deprecated field types, and pre-2.x knn shapes carry over verbatim. Some restored indices may refuse new writes against the target's stricter mapping validation.
+  - No transform window — can't rename indices, drop fields, type-collapse, or rewrite analyzers. Anything you'd want changed needs a follow-up reindex pass.
+  - In short: native restore is byte-shuffle. RFS rewrites segments through the target's current codec and lets you fix mappings on the way in. The cost difference is RFS setup time vs an eventual second reindex pass.
+- **Source impact: medium.** Initial snapshot reads every segment off disk — saturates snapshot-thread-pool and disk I/O on a busy source. Incrementals after the first are cheap. Schedule the *first* snapshot during a quiet window if the source is anywhere near its I/O ceiling.
 - No transformation hook. Source mappings/templates land verbatim on
   target. If the target rejects them (deprecated field types,
   unsupported analyzers), the restore fails and you start over.
@@ -51,13 +139,16 @@ is byte-shuffling, not document-by-document.
 - Cluster-state items don't restore (templates can; ISM policies,
   watcher jobs, security users do not).
 
-**Use when.** Same-engine like-for-like upgrade (OS 1.3 → OS 2.x,
-or ES 7.10 → OS 1.x via the OpenSearch compatibility shim), no
-transforms required, multi-TB scale where any other approach would
-take days.
+**Use when.** Same-engine same-major minor upgrade (OS 1.3 → OS 1.5,
+OS 2.7 → OS 2.15). For cross-major moves it's only the right pick
+when the dataset is large enough that RFS setup is genuinely a
+blocker *and* the user has explicitly accepted that they'll later
+need to reindex or force-merge to reclaim the perf improvements.
 
 **Don't use when.** AOSS target. ES 8 source. Anything that needs
-mapping rewrites, index renames, or schema-level changes.
+mapping rewrites, index renames, or schema-level changes. Cross-major
+moves where the user wants the target's full performance profile —
+use RFS instead.
 
 ---
 
@@ -85,6 +176,8 @@ source snapshot  →  RFS worker  →  transform pipeline  →  target /_bulk
   up the same shard's remaining docs.
 
 **Cons.**
+- **Versions:** Widest matrix in this skill. Source ES 1.x through 8.x and OS 1.x/2.x/3.x. Target OS 1.x/2.x/3.x, AOS, AOSS. The version registry that authoritatively decides this lives at `transformation/src/main/java/org/opensearch/migrations/VersionMatchers.java`. If a user is on a version older than ES 1.7 (yes, that ancient), this is still the only viable path — they'll likely need to validate with MA's snapshot fixtures first.
+- **Source impact: none.** RFS reads from a snapshot store (S3, NFS), never connects to the live source. This is the only backfill technique that doesn't pressure source at all. Pair with #4 if the *write* path also needs to be untouched during cutover.
 - Highest setup cost. Requires k8s (or EKS), the MA helm chart,
   Strimzi/Kafka if you're also doing capture-and-replay, plus the
   migration-console and Argo for orchestration.
@@ -122,6 +215,8 @@ POST $TARGET/_reindex?wait_for_completion=false
   intra-VPC link.
 
 **Cons.**
+- **Versions:** Source ES 1.x–7.x, OS 1.x/2.x. ES 8 source is unreliable — TLS/auth handshake mismatches with the OS reindex client matrix fail in ways that depend on exact patch versions; treat ES 8 as "use #2 instead." OS 3.x source works but is unusual. Target must accept `reindex.remote.allowlist`, which AOS does (via UpdateDomainConfig blue-green) and AOSS does **not** at all.
+- **Source impact: high.** This is the technique most likely to take down an underprovisioned source. Target opens a continuous scroll context against source for the entire reindex window — search thread pool pressure, heap consumption (scroll contexts hold segment readers open), and saturated network egress. Throttle with `requests_per_second` or `slices` if source is anywhere near production load. **Don't run unthrottled `_reindex` against a customer-serving source.**
 - Requires `reindex.remote.allowlist` to include source. This is a
   **static** cluster setting on most distributions, meaning a target
   restart. AOS supports it via UpdateDomainConfig (no manual
@@ -170,6 +265,8 @@ clients → capture-proxy → source        (passthrough)
 - Works for any source that's behind a proxy you can insert.
 
 **Cons.**
+- **Versions:** Source ES 6.8 through 8.x, OS 1.x/2.x/3.x. Target OS 1.x/2.x/3.x, AOS, AOSS. Capture-proxy understands the HTTP request shapes from ES 6.8 onward; older ES sources don't have a viable capture path here (use #5 or #7 if you must do live cutover from ES <6.8).
+- **Source impact: medium.** Capture-proxy adds a network hop in front of source for **every** request. CPU cost on the proxy is real; latency cost on the source request path is small but measurable (sub-millisecond on a healthy proxy, 1-5ms on a busy one). Read path is untouched once the proxy is bypassed. The *risk* impact is higher than the steady-state impact: misconfigured proxies can drop traffic.
 - Highest infrastructure cost in this skill. Capture-proxy + Strimzi
   + Kafka cluster + traffic-replayer + everything RFS needs.
 - Capture-proxy is the **only MA image not published on public ECR**
@@ -211,6 +308,8 @@ target clusters. After target steady-state, flip reads.
   target snapshot eras.
 
 **Cons.**
+- **Versions:** Bound by the Logstash version more than by source/target version. Logstash 7.x has the broadest input/output matrix (ES 1.x through 8.x as either side, OS 1.x/2.x/3.x via the `logstash-output-opensearch` plugin). Logstash 8.x dropped support for ES 1.x/2.x as inputs. AOSS as target requires sigv4-aware Logstash output (`logstash-output-opensearch` 2.0+).
+- **Source impact: variable — and this is the column to read carefully.** If Logstash hooks an existing ingest pipeline (Kafka topic, Kinesis stream, app log) and forks writes to both clusters, source impact is **zero**. If Logstash uses the `elasticsearch` input plugin to scroll history off a live source, you're back to #3-level pressure on source. **Pick the input deliberately.**
 - No backfill story. Logstash starts mirroring *now*; everything
   written before "now" needs a separate backfill (#1, #2, or #3).
   This means you're running two techniques simultaneously, which
@@ -243,6 +342,8 @@ flip clients.
 - Sustained replication, so cutover can be deferred indefinitely.
 
 **Cons.**
+- **Versions:** OpenSearch only, both sides. CCR plugin shipped in OS 1.1; supported on 1.1+, 2.x, 3.x. Not in Elasticsearch (ES has its own CCR feature, but it's a different system and not interoperable). Self-managed OS or AOS only — AOSS does not run plugins. Cross-major-version replication (e.g. OS 1.x → OS 3.x) works but is not the recommended bootstrap path; pair with #1 to establish the follower at the right version, then start CCR.
+- **Source impact: low and ongoing.** Follower pulls translog operations from leader continuously. Steady-state cost is modest — proportional to your write rate, not to your data size. Burst cost when establishing a new follower can briefly look like #1 (initial bootstrap reads segments). Once steady, this is the lightest-touch live-replication option.
 - OS → OS only. Any ES source is unsupported.
 - AOSS as either side is unsupported.
 - One-shot migration is overkill — CCR is for ongoing replication
@@ -273,6 +374,8 @@ flip after target is steady.
 - App team has full control over the write semantics during cutover.
 
 **Cons.**
+- **Versions:** Bound by the application's chosen client library, not by MA. Common reach: `opensearch-java` and `opensearch-py` clients target OS 1.x/2.x/3.x and AOS/AOSS; the `elasticsearch` clients (any major) speak to ES 1.x–8.x. If the app is on the official Elasticsearch 8.x client, that client *will not* speak to OpenSearch (license check); use `opensearch-java` or a compatible 7.x client. This is a one-line client swap but worth confirming during planning.
+- **Source impact: none.** App writes to source as it always has, plus an additional write to target. Source sees no extra read pressure, no proxy in the request path, no scroll context. Failure modes are all on the *target* and *application* sides — never source. This is why teams reach for it when the source is a fragile legacy ES 5/6 cluster they're afraid to touch.
 - Highest organizational cost. Every write path in the app must be
   identified and modified, including batch jobs, cron tasks, and
   any internal tooling that bypasses the main service.
@@ -297,20 +400,17 @@ window.
 
 Walk in this order — first match wins:
 
-1. **Target is AOSS** → rule out #1 (no snapshot API), #6 (CCR not
-   supported). Default to **#2 RFS**. Consider **#5 Logstash** if
-   the team already runs Logstash. Consider **#7 app dual-write**
-   only if hard zero-downtime is required.
-2. **Source is ES 8** → rule out #1 (snapshot format incompatible).
-   Default to **#2 RFS**.
-3. **Hard zero-downtime requirement** → **#4 capture-and-replay**
+1. **Source is ES 1.x / 2.x / 5.x** → only **#2 RFS** is viable. Snapshot/restore (#1) snapshot format is too old; capture-replay (#4) capture-proxy doesn't speak the older HTTP shapes; CCR (#6) isn't in ES at all. If the user *also* needs zero-downtime, pair #2 with #5 Logstash or #7 app dual-write.
+2. **Source is ES 8.x** → rule out #1 (snapshot format incompatible) and #3 (handshake unreliable). Default to **#2 RFS**. If zero-downtime is required, **#2 RFS + #4 capture-replay**.
+3. **Target is AOSS** → rule out #1 (no snapshot API), #3 (no `reindex.remote.allowlist`), #6 (CCR not supported). Default to **#2 RFS**. Consider **#5 Logstash** if the team already runs Logstash. Consider **#7 app dual-write** only if hard zero-downtime is required.
+4. **Hard zero-downtime requirement** → **#4 capture-and-replay**
    (if source can be proxied) or **#5 Logstash / #7 app dual-write**
    otherwise. Pair with **#2 RFS** for backfill.
-4. **Dataset < 100 GB, same VPC, no transforms, target accepts
-   `reindex.remote.allowlist`** → **#3 `_reindex` from remote**.
-5. **OS → OS, ongoing replication wanted (not just migration)** →
-   **#6 CCR**.
-6. **Otherwise** → **#2 RFS via MA** is the safe default.
+5. **Dataset < 100 GB, same VPC, no transforms, source is ES 6.8/7.x or OS, target accepts `reindex.remote.allowlist`** → **#3 `_reindex` from remote**.
+6. **OS → OS, ongoing replication wanted (not just migration)** →
+   **#6 CCR**. (Both sides must be OS 1.1+.)
+7. **Same-engine same-major minor upgrade (OS 1.x → 1.x, 2.x → 2.x, 3.x → 3.x), no transforms** → **#1 snapshot/restore** is the simplest path. *Cross-major* OS upgrades (1→2, 2→3) are mechanically supported by #1 but inherit old segment format and mappings — pick #2 RFS unless the user has explicitly accepted a follow-up reindex.
+8. **Otherwise** → **#2 RFS via MA** is the safe default.
 
 LEARN-path users (educational only) should see #1, #2, #3 in detail,
 then a one-line mention of #4-#7 with a "ask if you want to know
@@ -324,9 +424,11 @@ In practice these aren't always one-or-the-other:
   Assistant deployment. RFS does the bulk backfill; capture-replay
   catches everything written during and after backfill. This is what
   the MA helm chart deploys by default.
-- **#1 snapshot/restore + #6 CCR** — bootstrap a brand-new follower
-  with snapshot/restore, then start CCR for ongoing sync. Less wire
-  time than CCR initial sync from empty.
+- **#1 snapshot/restore + #6 CCR** — bootstrap a brand-new OS
+  follower with snapshot/restore, then start CCR for ongoing sync.
+  Less wire time than CCR initial sync from empty. Same-major OS
+  pairs only — for cross-major OS, use #2 RFS as the bootstrap
+  path so the follower starts on the target's segment format.
 - **#5 Logstash + #1 snapshot/restore** — Logstash does live mirror
   going forward; snapshot/restore handles backfill. Common when
   AOSS isn't the target (else #1 isn't available).

--- a/migration-companion/packs/techniques.md
+++ b/migration-companion/packs/techniques.md
@@ -184,7 +184,7 @@ source snapshot  →  RFS worker  →  transform pipeline  →  target /_bulk
 - Doc-level rewrite cost. Unlike snapshot/restore, every document
   goes through `_bulk`, so target indexing CPU is the bottleneck.
 - Snapshot must reach the workers. Cross-account / cross-region /
-  cross-VPC snapshots need wiring (see pitfalls P19).
+  cross-VPC snapshots need wiring (see pitfalls P18).
 
 **Use when.** This is the default for any non-trivial migration. ES
 or OS source, any OS target, transforms needed, dataset large enough

--- a/migration-companion/packs/techniques.md
+++ b/migration-companion/packs/techniques.md
@@ -1,0 +1,344 @@
+# Techniques pack: how migrations actually move data
+
+A reference for the seven approaches a Companion run can pick from.
+Phase 3 (`steering/03-evaluate.md`) is where the agent narrows to one;
+this pack is the longer-form description for users who want to read
+or compare without going through the interview.
+
+If you've never thought about index migration before, read this top
+to bottom. If you're triaging a known case, jump to "When to use what"
+and the "Common combinations" at the bottom.
+
+## TL;DR matrix
+
+| # | Technique                          | Live cutover? | Transforms? | AOSS target? | ES 8 source? | Setup cost | Per-migration cost |
+|---|------------------------------------|---------------|-------------|--------------|--------------|------------|--------------------|
+| 1 | Snapshot + restore                 | no            | no          | no           | no           | low        | low                |
+| 2 | Reindex-from-Snapshot (RFS) via MA | no¹           | yes         | yes          | yes          | high       | low                |
+| 3 | `_reindex` from remote             | no            | limited     | no           | partial²     | low        | medium             |
+| 4 | Capture-and-replay (MA)            | **yes**       | yes         | yes          | yes          | very high  | medium             |
+| 5 | Logstash / Fluentd dual-write      | yes           | yes         | yes          | yes          | medium     | medium             |
+| 6 | Cross-cluster replication (CCR)    | yes (ongoing) | no          | no           | no           | medium     | low                |
+| 7 | Application-layer dual-write       | yes           | yes         | yes          | yes          | medium³    | medium             |
+
+¹ RFS is offline replay; pair with #4 capture-and-replay for zero-downtime.
+² ES 8 source TLS/auth model is not supported by every OS reindex client matrix.
+³ Low *technical* cost; high *organizational* cost (app teams must change code).
+
+---
+
+## 1. Snapshot + restore
+
+**What it does.** Take a snapshot on source via the snapshot API,
+restore it on target via the restore API. Native to both Elasticsearch
+and OpenSearch. The snapshot is a Lucene-segment-level copy; restore
+is byte-shuffling, not document-by-document.
+
+**Pros.**
+- Simplest path. One snapshot + one restore. No moving parts.
+- Fastest at scale. Restore I/O is bounded by your snapshot store
+  bandwidth (S3, NFS), not by the target's indexing throughput.
+- Preserves shard layout, doc IDs, and `_seq_no` exactly.
+
+**Cons.**
+- No transformation hook. Source mappings/templates land verbatim on
+  target. If the target rejects them (deprecated field types,
+  unsupported analyzers), the restore fails and you start over.
+- Tight version compatibility window. Source major must be ≤ target
+  major + 1. ES 8 → any OS is unsupported (different snapshot format
+  internals, no compatibility layer).
+- AOSS as target is unsupported. AOSS has no snapshot API.
+- Cluster-state items don't restore (templates can; ISM policies,
+  watcher jobs, security users do not).
+
+**Use when.** Same-engine like-for-like upgrade (OS 1.3 → OS 2.x,
+or ES 7.10 → OS 1.x via the OpenSearch compatibility shim), no
+transforms required, multi-TB scale where any other approach would
+take days.
+
+**Don't use when.** AOSS target. ES 8 source. Anything that needs
+mapping rewrites, index renames, or schema-level changes.
+
+---
+
+## 2. Reindex-from-Snapshot (RFS) via Migration Assistant
+
+**What it does.** MA reads the source snapshot from a shared S3 or
+filesystem location, parses index metadata, applies any configured
+transforms, and bulk-writes documents into the target via its HTTP
+indexing API. The actual byte stream goes:
+
+```
+source snapshot  →  RFS worker  →  transform pipeline  →  target /_bulk
+```
+
+**Pros.**
+- Widest compatibility matrix in this skill. Every supported source
+  pair (ES 5/6/7/8, OS 1/2/3) works against every supported target
+  (OS self-managed, AOS, AOSS).
+- Transforms are first-class. Mapping rewrites, index renames, type
+  collapses, field exclusions all run in the pipeline.
+- Scales horizontally. Increase the worker fleet (`console backfill
+  scale N`) and you increase indexing throughput linearly until you
+  saturate the target's `_bulk` queue.
+- Resumable. Workers checkpoint per shard; if one dies, another picks
+  up the same shard's remaining docs.
+
+**Cons.**
+- Highest setup cost. Requires k8s (or EKS), the MA helm chart,
+  Strimzi/Kafka if you're also doing capture-and-replay, plus the
+  migration-console and Argo for orchestration.
+- Doc-level rewrite cost. Unlike snapshot/restore, every document
+  goes through `_bulk`, so target indexing CPU is the bottleneck.
+- Snapshot must reach the workers. Cross-account / cross-region /
+  cross-VPC snapshots need wiring (see pitfalls P19).
+
+**Use when.** This is the default for any non-trivial migration. ES
+or OS source, any OS target, transforms needed, dataset large enough
+that `_reindex` from remote would be too slow.
+
+**Don't use when.** Tiny datasets where the helm install takes longer
+than the migration itself. Single-shot homework where #1 or #3 would
+finish in a single command.
+
+---
+
+## 3. `_reindex` from remote (built-in)
+
+**What it does.** The target cluster pulls documents directly from
+the source over HTTP using the built-in `_reindex` API with a
+`source.remote` clause. No intermediate snapshot, no MA.
+
+```
+POST $TARGET/_reindex?wait_for_completion=false
+{ "source": { "remote": {"host": "$SOURCE"}, "index": "*" },
+  "dest":   { "index": "{{index}}" } }
+```
+
+**Pros.**
+- Lowest moving-parts count of any live-data approach. One curl.
+- No snapshot store needed. Target reads source directly.
+- Works fine for hundreds of millions of small documents on a fast
+  intra-VPC link.
+
+**Cons.**
+- Requires `reindex.remote.allowlist` to include source. This is a
+  **static** cluster setting on most distributions, meaning a target
+  restart. AOS supports it via UpdateDomainConfig (no manual
+  restart, but the domain blue-greens). AOSS does **not** expose it
+  at all.
+- Doc-by-doc HTTP. WAN latency multiplies; works poorly across
+  regions or over VPN.
+- Limited transforms. The `script` clause is a Painless one-liner,
+  not a pipeline.
+- ES 8 source is in-and-out depending on the OS reindex client
+  matrix; some combinations fail TLS/auth handshake.
+- No resume. If the task dies, you restart from zero (or hand-craft
+  a `_search_after`-based wrapper).
+
+**Use when.** Dataset < ~100 GB, both clusters in the same VPC, no
+transforms or one trivial Painless rewrite, AOS or self-managed
+target, and you'd rather not stand up MA.
+
+**Don't use when.** AOSS target. WAN-separated clusters. Anything
+that needs to resume after a target restart.
+
+---
+
+## 4. Capture-and-replay (Migration Assistant)
+
+**What it does.** MA's capture-proxy sits in front of the source
+cluster's HTTP endpoint and mirrors all writes into a Kafka topic
+while passing requests through unchanged. Backfill (RFS, #2) runs in
+parallel. After backfill catches up, MA's traffic-replayer drains
+the buffered writes into the target, achieving cutover with no
+write loss.
+
+```
+clients → capture-proxy → source        (passthrough)
+                       ↓
+                     Kafka  →  traffic-replayer  →  target
+   (parallel)
+   source snapshot  →  RFS  →  target
+```
+
+**Pros.**
+- Only approach in this list that gives true zero-downtime cutover
+  with no application change.
+- Replayer dedup logic uses sequence numbers, so write order is
+  preserved.
+- Works for any source that's behind a proxy you can insert.
+
+**Cons.**
+- Highest infrastructure cost in this skill. Capture-proxy + Strimzi
+  + Kafka cluster + traffic-replayer + everything RFS needs.
+- Capture-proxy is the **only MA image not published on public ECR**
+  at the time of writing — see pitfalls P18. You need a private
+  build path.
+- Inserting a proxy in front of the source is operationally
+  invasive. Most managed services (Elastic Cloud, AOS) won't let
+  you do it.
+- If write rate > replayer throughput, Kafka backs up. You can
+  scale, but at some point you've built a streaming system, not a
+  migration.
+- POC scale: way too much infra for a demo. Don't reach for this
+  unless the zero-downtime requirement is real.
+
+**Use when.** Production, regulated workload, source is self-managed
+(or behind your own load balancer), zero-downtime is genuinely
+non-negotiable.
+
+**Don't use when.** POC. Source is a managed service you can't put
+a proxy in front of. The "zero-downtime" requirement is aspirational
+rather than contractual.
+
+---
+
+## 5. Logstash / Fluentd dual-write
+
+**What it does.** A stream processor (Logstash, Fluentd, Vector)
+reads from the application's write path — or from a queue the app
+already publishes to — and forks each event to both source and
+target clusters. After target steady-state, flip reads.
+
+**Pros.**
+- AOSS target works (Logstash has a sigv4 output). #4 capture-replay
+  also reaches AOSS, but Logstash is far less infra.
+- Many shops already have Logstash for ingest — you're adding an
+  output, not a service.
+- Writes go to both clusters as native `_bulk` requests, so target
+  is always seeing real shape — no schema drift between source and
+  target snapshot eras.
+
+**Cons.**
+- No backfill story. Logstash starts mirroring *now*; everything
+  written before "now" needs a separate backfill (#1, #2, or #3).
+  This means you're running two techniques simultaneously, which
+  doubles the operational story.
+- Schema drift between source and Logstash filter config silently
+  corrupts target data. Field whose source mapping is `keyword`
+  but Logstash output config sends as `text` does not error — it
+  indexes wrong.
+- Logstash write failures during cutover window can be missed if
+  retry/DLQ is misconfigured.
+
+**Use when.** App team already runs Logstash, AOSS target, dual-write
+fits the existing ingest topology, willing to combine with a backfill
+technique for history.
+
+**Don't use when.** No existing Logstash. Need a single-tool story.
+Schema is volatile.
+
+---
+
+## 6. Cross-cluster replication (CCR)
+
+**What it does.** OpenSearch's CCR plugin lets a follower index on
+target track a leader index on source. After replication catches up,
+flip clients.
+
+**Pros.**
+- Built into OpenSearch. No external pipeline.
+- Per-index granularity — replicate only what you need.
+- Sustained replication, so cutover can be deferred indefinitely.
+
+**Cons.**
+- OS → OS only. Any ES source is unsupported.
+- AOSS as either side is unsupported.
+- One-shot migration is overkill — CCR is for ongoing replication
+  topologies, not "I need to move data once". For a one-shot move,
+  #1 or #2 is simpler.
+- Cross-cluster trust has its own setup (see opensearch-ccr-shared-
+  ca-trust skill in the broader Hermes corpus). Easy to misconfigure
+  silently.
+
+**Use when.** Both source and target are OpenSearch (self-managed or
+AOS), the user actually wants ongoing replication (DR, geo-redundancy),
+not a one-shot migration. If they say "we want CCR" but mean "we
+want to migrate", redirect them to #1 or #2.
+
+**Don't use when.** Any ES source. AOSS anywhere. One-shot migration.
+
+---
+
+## 7. Application-layer dual-write
+
+**What it does.** Application code writes to both clusters explicitly
+on every write path. Backfill (separate) catches up history. Reads
+flip after target is steady.
+
+**Pros.**
+- No infrastructure introduced — it's all code in the app.
+- Target sees writes in their native, application-canonical shape.
+- App team has full control over the write semantics during cutover.
+
+**Cons.**
+- Highest organizational cost. Every write path in the app must be
+  identified and modified, including batch jobs, cron tasks, and
+  any internal tooling that bypasses the main service.
+- Dual-write failures in app code are easy to miss — partial writes
+  desync the two clusters silently.
+- Engineering time scales with the app's complexity, not the
+  cluster's size.
+- Doesn't help with backfill — pair with #1, #2, or #3 for history.
+
+**Use when.** AOSS target with hard zero-downtime, source can't be
+proxied (so #4 is out), app team owns the change and is willing to
+ship code, or the user explicitly wants migration logic in their
+codebase rather than as a separate system.
+
+**Don't use when.** Many writer paths the central team doesn't
+control. Shadow batch jobs. Schema is changing during the cutover
+window.
+
+---
+
+## When to use what (quick decision)
+
+Walk in this order — first match wins:
+
+1. **Target is AOSS** → rule out #1 (no snapshot API), #6 (CCR not
+   supported). Default to **#2 RFS**. Consider **#5 Logstash** if
+   the team already runs Logstash. Consider **#7 app dual-write**
+   only if hard zero-downtime is required.
+2. **Source is ES 8** → rule out #1 (snapshot format incompatible).
+   Default to **#2 RFS**.
+3. **Hard zero-downtime requirement** → **#4 capture-and-replay**
+   (if source can be proxied) or **#5 Logstash / #7 app dual-write**
+   otherwise. Pair with **#2 RFS** for backfill.
+4. **Dataset < 100 GB, same VPC, no transforms, target accepts
+   `reindex.remote.allowlist`** → **#3 `_reindex` from remote**.
+5. **OS → OS, ongoing replication wanted (not just migration)** →
+   **#6 CCR**.
+6. **Otherwise** → **#2 RFS via MA** is the safe default.
+
+LEARN-path users (educational only) should see #1, #2, #3 in detail,
+then a one-line mention of #4-#7 with a "ask if you want to know
+more" tail.
+
+## Common combinations
+
+In practice these aren't always one-or-the-other:
+
+- **#2 RFS + #4 capture-and-replay** — the canonical Migration
+  Assistant deployment. RFS does the bulk backfill; capture-replay
+  catches everything written during and after backfill. This is what
+  the MA helm chart deploys by default.
+- **#1 snapshot/restore + #6 CCR** — bootstrap a brand-new follower
+  with snapshot/restore, then start CCR for ongoing sync. Less wire
+  time than CCR initial sync from empty.
+- **#5 Logstash + #1 snapshot/restore** — Logstash does live mirror
+  going forward; snapshot/restore handles backfill. Common when
+  AOSS isn't the target (else #1 isn't available).
+- **#2 RFS + #3 `_reindex` from remote** — RFS for the bulk of
+  indices; `_reindex` from remote for a few small indices that
+  weren't worth bringing up in the snapshot path. Edge case, but
+  legitimate.
+
+## What this pack is NOT
+
+This pack does not enumerate the *combinations* exhaustively, nor
+does it prescribe choices for any given user. That's Phase 3's
+job (`steering/03-evaluate.md`), which walks the actual decision
+tree against a known source/target pair. Use this pack as the
+reference; use Phase 3 as the workflow.

--- a/migration-companion/pitfalls.md
+++ b/migration-companion/pitfalls.md
@@ -1,0 +1,195 @@
+# Pitfalls
+
+Non-discoverable facts. The kind of thing that wastes 30 minutes
+before you realize what's happening. Skim once before Phase 4 on
+MIGRATE / POC. Don't memorize.
+
+## P1. `vm.max_map_count` on the host
+
+Both Elasticsearch and OpenSearch refuse to start if
+`/proc/sys/vm/max_map_count` is too low. Symptom: container exits
+during bootstrap with "max virtual memory areas vm.max_map_count
+[65530] is too low".
+
+Fix on Linux host: `sudo sysctl -w vm.max_map_count=262144`.
+
+The POC compose files in this repo set the in-container ulimits, but
+the host setting is not something docker can override — that's on
+the user.
+
+## P2. `hits.total.value` capping (both ES 7+ and AOSS)
+
+`hits.total.value` caps at 10000 unless you pass `track_total_hits: true`
+in the request body. This is true on:
+
+- Elasticsearch 7.x and 8.x sources (default behavior, not a bug).
+- OpenSearch when configured similarly.
+- AOSS targets (always — no opt-out for "real" precision until you
+  pass the flag).
+
+Always pass `track_total_hits: true` in Phase 5 parity queries. Phase 5
+doc count parity uses `_count` (not affected) but query-level parity
+checks must include this flag or top-N matches but `total` looks broken.
+
+## P3. AWS snapshot repo registration needs SigV4
+
+`PUT /_snapshot/<repo>` against an AOS domain MUST be a SigV4-signed
+request. Plain `curl -u user:pass` returns a confusing AccessDenied
+even with correct IAM. Use `awscurl`, `requests-aws4auth`, or the MA
+orchestrator.
+
+## P4. ES 8 → OpenSearch is RFS-only
+
+There is no "OS compatibility layer" for ES 8. Any answer that
+involves "register the snapshot repo and restore" for an ES 8 source
+is wrong. Plan for RFS from the start.
+
+## P5. `include_global_state` defaults differ in restore
+
+`POST /_snapshot/<repo>/<snap>/_restore` with no body restores
+`include_global_state: true` by default — this overwrites the
+target's templates and cluster settings. Always set
+`include_global_state: false` unless the user explicitly wants
+state migrated.
+
+## P6. RFS image needs network paths to BOTH clusters
+
+When source is on-prem and target is AOS-in-VPC (or AOSS), the RFS
+container needs a route to both. Common gotcha: running RFS on the
+user's laptop with VPN to source but no path to AOS endpoint.
+
+Fix: run RFS in the same VPC as the target (Fargate task, EC2
+instance), or peer the networks.
+
+## P7. Self-signed TLS
+
+Elasticsearch's default docker stack ships with self-signed certs
+since 8.x. The OpenSearch security plugin also uses demo certs by
+default. RFS will refuse to connect unless you pass
+`SOURCE_INSECURE=true` / `TARGET_INSECURE=true` (or supply CA bundles).
+
+This is fine for POC. Not fine for real migrations — pin a CA bundle.
+
+## P8. AOSS rejects `_all` mapping field
+
+If migrating from ES 5.x or pre-7.x indices that still carry an
+`_all` field declaration in their mapping (even if disabled), AOSS
+will reject the index create. Strip `_all` from the mapping before
+RFS runs the create.
+
+## P9. Demo passwords on OpenSearch 2.12+
+
+Since 2.12, OpenSearch requires `OPENSEARCH_INITIAL_ADMIN_PASSWORD`
+to be set on first start. POC compose files in this repo set it.
+Real installs need to pick something better.
+
+## P10. Default heap is 1g
+
+The OS / ES docker images default to 1g heap. Anything past a 5k-doc
+POC needs more. Add `-e OPENSEARCH_JAVA_OPTS="-Xms4g -Xmx4g"` (or ES
+equivalent) and bump the container memory ceiling to match.
+
+## P11. Snapshot status polling cadence
+
+`GET /_snapshot/<repo>/<snap>` is fine for "in progress / done".
+For per-shard progress on a large snapshot, use
+`GET /_snapshot/<repo>/<snap>/_status`. Don't poll either more often
+than every 5-10s — it's not free.
+
+## P12. `_index_template` vs `_template`
+
+Composable index templates (`_index_template`) and legacy templates
+(`_template`) both exist. ES 7.8+ and OS 1+ have both. Restoring
+templates from a snapshot only restores the kind that's stored.
+Migrate both explicitly if the source uses both.
+
+## P13. AOS major-version-skip
+
+AOS refuses to restore a snapshot from a cluster more than 1 major
+version older than the domain. ES 6 → AOS OS 2 is rejected. Bridge
+via OS 1, or use RFS.
+
+## P14. The "this can't be right" doc count drift
+
+If counts differ by exactly 0 or by exactly N for some round N, it's
+a scope bug (allowlist excluded something). If they differ by a small
+fraction, it's almost always P2 (AOSS) or `track_total_hits`. If they
+differ by a large unpredictable amount, you have a real problem —
+investigate before reporting "migrated cleanly".
+
+## P15. Reindex setting renamed: whitelist → allowlist
+
+OpenSearch (1.x onward) renamed `reindex.remote.whitelist` (the ES
+key) to `reindex.remote.allowlist`. Setting the old name on an OS
+target is not a deprecation — it is a hard startup failure with
+"unknown setting [reindex.remote.whitelist]". This bites anyone
+copying a docker-compose, helm chart, or terraform module from an ES
+era. Fix: use `reindex.remote.allowlist`.
+
+## P16. The MA release `.tgz` IS the aggregate, not a leaf chart
+
+The artifact at `migration-assistant-<version>.tgz` from the MA
+releases page is the `migrationAssistantWithArgo` aggregate chart
+renamed to `migration-assistant`. It pulls in cert-manager, Argo
+Workflows, Strimzi/Kafka, and so on through an in-cluster
+`helm-installer` Job. There is no separately published "leaf MA
+chart". Every piece of the stack comes from this one tarball.
+
+Implication: a 5-pod MA install isn't a thing. Expect ~30 pods
+across ~5 namespaces after `helm install` settles.
+
+## P17. `valuesForLocalK8s.yaml` assumes a localhost:5000 build
+
+The repo's `valuesForLocalK8s.yaml` (under
+`deployment/k8s/charts/aggregates/migrationAssistantWithArgo/`)
+overrides image refs to `localhost:5000/migrations/<name>` —
+because the MA dev workflow Gradle-builds and pushes to a local
+registry. If you `helm install` with only this values file you'll
+get `ImagePullBackOff` on every MA pod.
+
+When pointing a user at the helm chart for an install that doesn't
+involve a local Gradle build (i.e. most users), they need to either:
+
+  - Use the chart's default `values.yaml` (which references whatever
+    registry the release line publishes to), or
+  - Layer their own image overlay on top of `valuesForLocalK8s.yaml`
+    pointing at a registry they can pull from.
+
+Confirm the image-publication policy of the current release by
+checking the chart's `README.md` and `Chart.yaml` before assuming
+`public.ecr.aws/opensearchproject/...` resolves.
+
+## P18. Only 3 of 5 logical MA roles have published public ECR images
+
+The MA chart references 5 image roles: `migrationConsole`,
+`installer`, `reindexFromSnapshot`, `trafficReplayer`, `captureProxy`.
+Three are published to `public.ecr.aws/opensearchproject/`:
+
+  - `opensearch-migrations-console`
+  - `opensearch-migrations-reindex-from-snapshot`
+  - `opensearch-migrations-traffic-replayer`
+
+The other two:
+
+  - **installer**: the chart's default already maps `installer` to
+    the `migration_console` image (the installer Job is just the
+    console image running a helm-install script). No separate image
+    is published; rebinding the console image is enough.
+  - **capture-proxy**: not published anywhere public. There's no
+    workaround. capture-and-replay is unavailable on a public-ECR-only
+    install. RFS-only POCs are fine; disable the capture-proxy and
+    traffic-replayer Argo-workflow steps in values.
+
+## P19. MA snapshot path needs cross-pod shared storage
+
+RFS reads documents from a snapshot repo path that BOTH source ES
+and the migration-console pod can see. With S3 this is trivial.
+With a filesystem repo on kind, you need a shared PVC mounted at
+the same path in both namespaces — and that's not what the
+default chart values set up. For a kind POC, prefer running source
+ES in the same namespace as MA, or use S3 via localstack.
+
+When walking the user through a kind-based POC, prefer running source
+ES in the same namespace as MA (so they share a PVC trivially), or
+use S3 via localstack. Cross-namespace shared filesystem repos are
+the bit that's environment-specific.

--- a/migration-companion/pitfalls.md
+++ b/migration-companion/pitfalls.md
@@ -138,49 +138,32 @@ chart". Every piece of the stack comes from this one tarball.
 Implication: a 5-pod MA install isn't a thing. Expect ~30 pods
 across ~5 namespaces after `helm install` settles.
 
-## P17. `valuesForLocalK8s.yaml` assumes a localhost:5000 build
+## P17. The chart ships THREE values overlays — pick the right one
 
-The repo's `valuesForLocalK8s.yaml` (under
-`deployment/k8s/charts/aggregates/migrationAssistantWithArgo/`)
-overrides image refs to `localhost:5000/migrations/<name>` —
-because the MA dev workflow Gradle-builds and pushes to a local
-registry. If you `helm install` with only this values file you'll
-get `ImagePullBackOff` on every MA pod.
+`deployment/k8s/charts/aggregates/migrationAssistantWithArgo/`
+contains three values files:
 
-When pointing a user at the helm chart for an install that doesn't
-involve a local Gradle build (i.e. most users), they need to either:
+  - `values.yaml` — chart defaults. Image refs are bare paths like
+    `migrations/capture_proxy:latest` (no registry prefix), which
+    resolves to `docker.io/migrations/...` and won't pull. **Don't
+    `helm install` with only this file.** The defaults exist to be
+    overlaid.
+  - `valuesForLocalK8s.yaml` — overrides image refs to
+    `localhost:5000/migrations/<name>`. Use this only when you've
+    Gradle-built the images and pushed them to a local registry
+    (the MA dev loop). If you use this without that build step,
+    every pod is `ImagePullBackOff`.
+  - `valuesEks.yaml` (and `aws-bootstrap.sh`) — points all five
+    images at `public.ecr.aws/opensearchproject/opensearch-migrations-*`
+    with `--set images.<role>.repository=...` flags.
 
-  - Use the chart's default `values.yaml` (which references whatever
-    registry the release line publishes to), or
-  - Layer their own image overlay on top of `valuesForLocalK8s.yaml`
-    pointing at a registry they can pull from.
+For a normal user who isn't iterating on MA source, the path is
+either (a) run `aws-bootstrap.sh` which sets the public-ECR overrides
+for you, or (b) write a small overlay that hard-codes the public-ECR
+repos. See `steering/04-execute.md` "Local-build vs released-image
+testing" for the explicit commands.
 
-Confirm the image-publication policy of the current release by
-checking the chart's `README.md` and `Chart.yaml` before assuming
-`public.ecr.aws/opensearchproject/...` resolves.
-
-## P18. Only 3 of 5 logical MA roles have published public ECR images
-
-The MA chart references 5 image roles: `migrationConsole`,
-`installer`, `reindexFromSnapshot`, `trafficReplayer`, `captureProxy`.
-Three are published to `public.ecr.aws/opensearchproject/`:
-
-  - `opensearch-migrations-console`
-  - `opensearch-migrations-reindex-from-snapshot`
-  - `opensearch-migrations-traffic-replayer`
-
-The other two:
-
-  - **installer**: the chart's default already maps `installer` to
-    the `migration_console` image (the installer Job is just the
-    console image running a helm-install script). No separate image
-    is published; rebinding the console image is enough.
-  - **capture-proxy**: not published anywhere public. There's no
-    workaround. capture-and-replay is unavailable on a public-ECR-only
-    install. RFS-only POCs are fine; disable the capture-proxy and
-    traffic-replayer Argo-workflow steps in values.
-
-## P19. MA snapshot path needs cross-pod shared storage
+## P18. MA snapshot path needs cross-pod shared storage
 
 RFS reads documents from a snapshot repo path that BOTH source ES
 and the migration-console pod can see. With S3 this is trivial.

--- a/migration-companion/steering/00-intent.md
+++ b/migration-companion/steering/00-intent.md
@@ -1,0 +1,45 @@
+# Phase 0 — Intent Probe
+
+**Goal:** Figure out which of the four paths the user is on. Don't
+ask the source/target pair yet — that's Phase 1. Don't probe any
+cluster — that's Phase 2.
+
+## What you do
+
+Open with this exact question (one message, nothing else):
+
+> Welcome. I can help you migrate to OpenSearch or Amazon OpenSearch.
+> Where are you today — pick one:
+>
+> 1. **Just learning** — I want to understand what a migration involves
+>    before committing to anything.
+> 2. **Local POC** — Spin up a sample source + target in Docker on my
+>    laptop and walk me through a working migration.
+> 3. **Snapshot analysis** — I have a snapshot (or access to one) and
+>    want to know what will break before I migrate.
+> 4. **Real migration** — I have source and target clusters ready and
+>    want to actually move the data.
+
+Wait for their answer. Map it:
+
+| Answer        | `intent_path` |
+| ------------- | ------------- |
+| 1 / "learn"   | `LEARN`       |
+| 2 / "poc"     | `POC`         |
+| 3 / "analyze" | `ANALYZE`     |
+| 4 / "migrate" | `MIGRATE`     |
+
+If they describe something that doesn't fit, say so and ask them to
+pick the closest one.
+
+## What you don't do
+
+- Don't ask for cluster URLs, credentials, or versions.
+- Don't load any packs.
+- Don't read `pitfalls.md`.
+- Don't write any files.
+
+## Exit criteria
+
+You can recite, in one sentence: "User is on the {LEARN,POC,ANALYZE,
+MIGRATE} path." Move to Phase 1.

--- a/migration-companion/steering/01-interview.md
+++ b/migration-companion/steering/01-interview.md
@@ -1,0 +1,61 @@
+# Phase 1 — Interview
+
+**Goal:** Pin down (a) the user's persona, (b) source engine + version,
+(c) target engine + flavor. Stepwise — one question per message.
+
+## Persona
+
+> Are you closer to a **Search Relevance Engineer** (queries,
+> mappings, ranking), a **DevOps / Platform Engineer** (clusters,
+> snapshots, IAM), or a **Business Stakeholder** (timelines, cost,
+> milestones)?
+
+Use it to tune depth, not to gate content:
+- SRE: full DSL / mapping detail, surface analyzer differences.
+- DOP: emphasize snapshots, IAM, networking, sizing.
+- BSH: summarize technical detail as schedule/cost/risk.
+
+## Source engine
+
+If `intent_path == POC`: skip — we'll seed the source for them in
+Phase 4. Tell them which source we'll seed (default ES 7.17, see
+Phase 3 to override) and move on.
+
+Otherwise:
+
+> What are you migrating from — **Elasticsearch** or **OpenSearch**?
+> And which version? (e.g. ES 7.17, OS 2.11)
+
+Validate the version against the source pack's matrix:
+- ES: 5.x, 6.x, 7.x, 8.x
+- OS: 1.x, 2.x, 3.x
+
+If it's something else (Solr, Kibana-only, a fork), stop and ask
+the user to clarify. Solr → point them at
+`AIAdvisor/skills/solr-opensearch-migration-advisor/`.
+
+## Target
+
+> Where are you migrating to?
+>
+> 1. **Self-managed OpenSearch** (you run the cluster).
+> 2. **Amazon OpenSearch Service** (AOS — managed domains).
+> 3. **Amazon OpenSearch Serverless** (AOSS — collections, no cluster
+>    management).
+
+If they say "AWS" without specifying, ask. The difference matters:
+AOSS doesn't support snapshot restore, AOS does.
+
+## Confirm
+
+Echo back what you heard in one short paragraph and ask them to
+confirm. Example:
+
+> So: Elasticsearch 7.17 → Amazon OpenSearch Service, you're on the
+> DevOps side, MIGRATE path. Confirm?
+
+## Exit criteria
+
+You know `persona`, `source_engine`, `source_version`,
+`target_flavor`, and `intent_path`. Move on per the phase map in
+`SKILL.md`.

--- a/migration-companion/steering/01-interview.md
+++ b/migration-companion/steering/01-interview.md
@@ -17,11 +17,25 @@ Use it to tune depth, not to gate content:
 
 ## Source engine
 
-If `intent_path == POC`: skip — we'll seed the source for them in
-Phase 4. Tell them which source we'll seed (default ES 7.17, see
-Phase 3 to override) and move on.
+Path-specific defaults:
 
-Otherwise:
+- `intent_path == POC`: skip the version question. The POC stack
+  seeds the source for them (default ES 7.17 in
+  `TrafficCapture/dockerSolution/`; the helm-chart POC defaults
+  to OS 2.x). Tell them what will be seeded and move on. Phase 3
+  is where they can override.
+- `intent_path == LEARN`: don't require a specific version. Ask
+  for a rough engine + era only ("ES 7-ish", "OS 2", "I'm not
+  sure yet"). LEARN's job is to read `packs/techniques.md` and
+  produce a planning report. A precise version isn't needed.
+- `intent_path == ANALYZE`: if the user only has a snapshot in
+  hand and doesn't know the source version, accept "I'll show
+  you in Phase 2" — Phase 2 reads version off the snapshot
+  metadata. Don't block on a version they don't have.
+- `intent_path == MIGRATE`: ask for the version. Migrations need
+  it pinned before any technique can be picked.
+
+When you ask:
 
 > What are you migrating from — **Elasticsearch** or **OpenSearch**?
 > And which version? (e.g. ES 7.17, OS 2.11)
@@ -45,6 +59,16 @@ the user to clarify. Solr → point them at
 
 If they say "AWS" without specifying, ask. The difference matters:
 AOSS doesn't support snapshot restore, AOS does.
+
+For `intent_path == LEARN`, accept "I haven't decided yet" — that
+*is* the question they're trying to answer. Note it and move on;
+Phase 6 will lay out the trade-offs.
+
+For `intent_path == POC`, default to **self-managed OpenSearch** in
+the same compose / kind stack as the source. POCs that target a
+real AOS domain or AOSS collection are valid but no longer "POC" —
+push back to the user if they pick AOS/AOSS for a POC and check
+they meant it.
 
 ## Confirm
 

--- a/migration-companion/steering/02-probe.md
+++ b/migration-companion/steering/02-probe.md
@@ -20,7 +20,16 @@ don't make up placeholders.
 
 ## What you probe (live cluster)
 
-Run these in order, narrate each one:
+Prefer the console CLI when MA is already deployed (MIGRATE path,
+sometimes ANALYZE):
+
+```
+console clusters connection-check       # source + target reachability
+console clusters cat-indices             # canonical index summary
+```
+
+Falls through to raw HTTP otherwise. Run these in order, narrate
+each one:
 
 ```
 GET /                                 # version, cluster name, lucene
@@ -31,8 +40,15 @@ GET /_cluster/settings?include_defaults=false
 GET /_template, /_index_template      # legacy + composable
 ```
 
-For each user-data index (skip dot-prefixed system indices unless the
-user calls them out):
+If `_cat/indices` returns more than ~200 indices, **don't dump the
+whole list into context.** Summarize: total index count, total doc
+count, top 10 by `store.size`, count of dot-prefixed system
+indices. Then ask the user "which index patterns matter for the
+migration?" before walking per-index mappings. A 10K-index cluster
+hand-walked via `_mapping` will eat the agent's context for nothing.
+
+For each user-data index *the user has flagged* (skip dot-prefixed
+system indices unless the user calls them out):
 
 ```
 GET /<index>/_mapping
@@ -42,13 +58,29 @@ GET /<index>/_count
 
 ## What you probe (snapshot)
 
-Open the snapshot's `index.latest` / `index-N` blob and read:
-- Snapshot UUID, version, indices list.
-- Per-index `meta-<uuid>.dat` for mappings + settings.
+Don't try to hand-parse Lucene snapshot blobs. Use the MA tooling
+that already exists:
 
-If the snapshot was taken on a major version >2 ahead of the target,
-flag it as a hard incompatibility (e.g. ES 8 snapshot → OS 2.x is
-**not** directly restorable; RFS is required).
+  - If MA is deployed: `console snapshot status` and
+    `console metadata evaluate` read the snapshot's index
+    list, mappings, and per-index settings via the same code path
+    the migration uses. `evaluate` is the dry-run that previews
+    what `migrate` would do without writing to the target.
+    This is the source of truth.
+  - If MA isn't deployed yet but you have S3 access: register the
+    snapshot repo on a throwaway OS instance (or the future target,
+    if the version pair allows) and run
+    `GET /_snapshot/<repo>/<snapshot>` for metadata.
+  - If you only have S3 paths: read `index-N` and the per-index
+    `meta-<uuid>.dat` blobs as JSON / SMILE — but this is the path
+    of last resort. Lucene format details aren't part of this
+    skill.
+
+Cross-major incompatibility flag: if the source major is more than
+`target major + 1`, **or** the source is ES 8.x against any
+OpenSearch target, snapshot/restore is blocked. RFS is required.
+(See `packs/techniques.md` "Version compatibility — quick
+reference" for the full table.)
 
 ## Pack loading
 

--- a/migration-companion/steering/02-probe.md
+++ b/migration-companion/steering/02-probe.md
@@ -1,0 +1,72 @@
+# Phase 2 — Probe
+
+**Goal:** Read enough of the source cluster (or snapshot) to know what
+needs to migrate. Read-only. No writes.
+
+Run on paths: `ANALYZE`, `MIGRATE`. Skip on `LEARN` and `POC`.
+
+## What you ask for
+
+For MIGRATE:
+- Source URL + auth (basic / API key / IAM-signed for AOS).
+- (Optionally now, definitely by Phase 5) target URL + auth.
+
+For ANALYZE:
+- Either a snapshot location (S3 bucket + prefix, or filesystem path)
+  OR access to a cluster you can read snapshots from.
+
+If they don't have credentials handy, say so plainly and pause —
+don't make up placeholders.
+
+## What you probe (live cluster)
+
+Run these in order, narrate each one:
+
+```
+GET /                                 # version, cluster name, lucene
+GET /_cluster/health                  # status, node count
+GET /_cat/indices?v&s=index&h=index,docs.count,store.size,pri,rep
+GET /_cat/plugins?v&h=name,component  # security, ism, alerting, etc.
+GET /_cluster/settings?include_defaults=false
+GET /_template, /_index_template      # legacy + composable
+```
+
+For each user-data index (skip dot-prefixed system indices unless the
+user calls them out):
+
+```
+GET /<index>/_mapping
+GET /<index>/_settings
+GET /<index>/_count
+```
+
+## What you probe (snapshot)
+
+Open the snapshot's `index.latest` / `index-N` blob and read:
+- Snapshot UUID, version, indices list.
+- Per-index `meta-<uuid>.dat` for mappings + settings.
+
+If the snapshot was taken on a major version >2 ahead of the target,
+flag it as a hard incompatibility (e.g. ES 8 snapshot → OS 2.x is
+**not** directly restorable; RFS is required).
+
+## Pack loading
+
+Now is the time. Load:
+- `packs/source-{elasticsearch,opensearch}.md` based on Phase 1.
+- `packs/target-{self-managed,aws-managed,aws-serverless}.md` based
+  on Phase 1.
+
+Cross-reference what you found against the source pack's "things
+that don't carry over" list and the target pack's capability profile.
+Build a mental list of incompatibilities. Don't write them to a file
+yet — that's Phase 6.
+
+## Exit criteria
+
+You can answer:
+- How many indices and docs?
+- What plugins / security model is on the source?
+- What features in use have a target-side caveat?
+
+Move to Phase 3.

--- a/migration-companion/steering/03-evaluate.md
+++ b/migration-companion/steering/03-evaluate.md
@@ -15,6 +15,10 @@ Each row: **what it is**, **fits when**, **breaks when**, **complexity**.
 Mention all that apply to the source/target pair. Don't pretend an
 inapplicable option exists.
 
+For a longer-form reference (full pros/cons, common combinations,
+quick decision matrix), see `packs/techniques.md`. This phase is the
+abbreviated decision-time form; the pack is the browse-time form.
+
 ### 1. Snapshot + restore (no transformation)
 
   - What: take a snapshot on source, restore it on target. Native to

--- a/migration-companion/steering/03-evaluate.md
+++ b/migration-companion/steering/03-evaluate.md
@@ -121,10 +121,11 @@ Walk it interactively. Order matters:
      `_reindex` is the simplest live option.
   5. Otherwise default to #2 RFS via MA.
 
-For the LOCAL POC path: default to #2 RFS via MA on kind. The POC's
-job is to teach the *real* tool, not the simplest tool. (See
-`TrafficCapture/dockerSolution/`.) Drop to #3 `_reindex` only if the user is on a
-machine that can't run kind + 12 GB of MA infra.
+For the LOCAL POC path: **default to #2 RFS** but let Phase 4 pick
+the *stack* (compose vs kind+helm). Don't pick the stack here —
+Phase 4 has the selector with resource budgets. Phase 3's job for a
+POC is just to confirm the technique. Drop to #3 `_reindex` only if
+the user is on a machine that can't run docker compose.
 
 ## What to propose to the user
 

--- a/migration-companion/steering/03-evaluate.md
+++ b/migration-companion/steering/03-evaluate.md
@@ -1,0 +1,150 @@
+# Phase 3 — Evaluate
+
+**Goal:** lay out every viable migration approach with honest pros and
+cons, then narrow to one strategy and propose it for sign-off.
+
+Run on paths: POC, ANALYZE, MIGRATE. (LEARN skips this — goes to Phase 6
+report instead.)
+
+The evaluation is consultative, not prescriptive. The Companion knows
+the trade-offs cold; the user picks once they understand them.
+
+## The seven approaches
+
+Each row: **what it is**, **fits when**, **breaks when**, **complexity**.
+Mention all that apply to the source/target pair. Don't pretend an
+inapplicable option exists.
+
+### 1. Snapshot + restore (no transformation)
+
+  - What: take a snapshot on source, restore it on target. Native to
+    Elasticsearch and OpenSearch.
+  - Fits: source major <= target major + 1, both self-managed or AOS,
+    no schema/mapping changes needed, multi-GB to multi-TB scale.
+  - Breaks: AOSS as target (not supported), ES 8.x source (not supported
+    by OS), needs schema translation (no transform hook).
+  - Complexity: lowest. One snapshot + one restore. No infra.
+
+### 2. Reindex-from-Snapshot (RFS) via Migration Assistant
+
+  - What: MA reads the source snapshot from a shared location (S3 or
+    filesystem), reads index metadata, applies transforms if any, and
+    bulk-writes documents into the target via its HTTP API.
+  - Fits: any source/target pair MA supports (ES 5/6/7, OS 1/2/3 source;
+    OS 1/2/3, AOS, AOSS target), needs transforms (mapping rewrites,
+    index renames), needs to migrate to a *different major* than snapshot
+    restore allows, large datasets (RFS scales horizontally with worker
+    fleet).
+  - Breaks: source you can't snapshot (rare), no place to put the
+    snapshot, environment without k8s/EKS for the MA helm release.
+  - Complexity: high one-time setup (helm chart + console + Argo +
+    Kafka + Strimzi), low per-migration cost after that.
+
+### 3. `_reindex` from remote (built-in)
+
+  - What: target opensearch pulls documents directly from source using
+    the built-in `_reindex` API with a remote source clause. No
+    intermediate snapshot.
+  - Fits: small to medium datasets (< 100 GB), source reachable over
+    HTTP from target, you control target's `reindex.remote.allowlist`
+    static setting, simple ES 7 -> OS X migrations.
+  - Breaks: AOSS target (allowlist setting can't be set), wide-area
+    network between source and target (slow, doc-by-doc), needs
+    transforms beyond what reindex `script` can do, ES 8 source (TLS +
+    auth model not supported by OS reindex client in some matrices).
+  - Complexity: low. One curl. But the static `reindex.remote.allowlist`
+    needs a target restart on most managed services.
+
+### 4. Capture-and-replay (Migration Assistant)
+
+  - What: MA capture-proxy sits in front of source, mirrors live writes
+    to Kafka. After backfill, traffic-replayer drains the buffered
+    writes into the target. Lets you cut over with zero data loss while
+    backfill runs in parallel.
+  - Fits: zero-downtime cutover required, can place capture-proxy in
+    the source request path, OK with proxying live traffic.
+  - Breaks: can't add a proxy hop in front of source (most managed ES),
+    write rate exceeds replayer throughput (Kafka backs up), POC scale
+    (way too much infra for a demo).
+  - Complexity: highest. Capture-proxy (the only MA image NOT on public
+    ECR), Kafka via Strimzi, traffic-replayer, plus everything RFS
+    needs.
+
+### 5. Logstash / Fluentd dual-write
+
+  - What: a stream processor reads from source (or sits in app's write
+    path) and writes to both source and target. Cut over once target
+    is steady.
+  - Fits: app teams already have Logstash, willing to redirect writes,
+    AOSS target (Logstash supports AOSS sigv4 output), zero-downtime.
+  - Breaks: there's no clean "starting point" for backfill (Logstash
+    isn't built to replay history at scale), schema drift between
+    source and Logstash output config silently corrupts data.
+  - Complexity: medium. New service, new config, new operational story.
+
+### 6. Cross-cluster replication (CCR)
+
+  - What: native OpenSearch CCR plugin: target is a follower of source.
+  - Fits: OS -> OS only, both self-managed or both AOS in compatible
+    matrix, sustained replication needed (not just one-shot migration),
+    user already has CCR plugin licensed/installed.
+  - Breaks: any ES source (not supported), AOSS as either side (not
+    supported), one-shot migration (CCR is overkill — just reindex).
+  - Complexity: medium. CCR setup is straightforward but follower-index
+    semantics are easy to mis-operate.
+
+### 7. Application-layer dual-write
+
+  - What: app writes to both clusters from the application code, reads
+    from old until target is caught up via separate backfill.
+  - Fits: app team owns the change, controls all writers, can tolerate
+    a careful cut-over week, no other approach will work (e.g. AOSS
+    target with hard zero-downtime constraint and source can't be
+    proxied).
+  - Breaks: many writer paths, batch jobs that bypass app, schema drift
+    in either direction.
+  - Complexity: highest organizationally, lowest technically.
+
+## How to choose
+
+Walk it interactively. Order matters:
+
+  1. Is target AOSS? -> rule out #1, #6. Recommend #2 RFS or #5 Logstash.
+  2. Is source ES 8? -> rule out #1. Recommend #2 RFS.
+  3. Need zero-downtime? -> #4 capture-replay or #5/#7 dual-write.
+     Otherwise drop them — they're a tax you don't owe.
+  4. Total dataset < 100 GB and source reachable from target? -> #3
+     `_reindex` is the simplest live option.
+  5. Otherwise default to #2 RFS via MA.
+
+For the LOCAL POC path: default to #2 RFS via MA on kind. The POC's
+job is to teach the *real* tool, not the simplest tool. (See
+`TrafficCapture/dockerSolution/`.) Drop to #3 `_reindex` only if the user is on a
+machine that can't run kind + 12 GB of MA infra.
+
+## What to propose to the user
+
+After picking one strategy, write 4-7 bullets for sign-off:
+
+  1. Strategy (one of the seven above).
+  2. Execution backend: MA helm release on kind/EKS, raw HTTP, Logstash, …
+  3. Index handling: 1:1 names, renames, filter pattern. Default:
+     migrate everything except `.kibana*`, `.opendistro*`, `.opensearch*`,
+     and other dot-prefixed system indices.
+  4. Mapping/template handling: any translation needed? Cite the target
+     pack capability profile by section.
+  5. Auth model on source and target.
+  6. The hard incompatibilities found in Phase 2 and how this plan
+     handles each.
+  7. What "done" looks like (Phase 5 validation criteria).
+
+Then:
+
+> Look right? Anything you want to change before I start?
+
+Wait for explicit sign-off.
+
+## Exit criteria
+
+User has signed off on a written plan. Move to Phase 4 (POC, MIGRATE)
+or Phase 6 (ANALYZE).

--- a/migration-companion/steering/04-execute.md
+++ b/migration-companion/steering/04-execute.md
@@ -19,17 +19,67 @@ drive it from there.
 | `_reindex` from remote          | Hand-rolled — no infra needed; see below                  |
 | Snapshot/restore (no MA needed) | `awscurl` / `aws cli`, source/target tools directly       |
 
+## POC: pick the stack first
+
+Two POC stacks ship in this repo. Pick deliberately — they teach
+different things, and they have different resource costs.
+
+| Stack                                  | What it teaches                              | Time-to-up | Disk + RAM budget       | When to use                                                                 |
+| -------------------------------------- | -------------------------------------------- | ---------- | ----------------------- | --------------------------------------------------------------------------- |
+| `TrafficCapture/dockerSolution/`       | RFS end-to-end + console CLI ergonomics      | ~3 min     | ~6 GB RAM, ~10 GB disk  | **Default for "show me how it works"**. Laptop-friendly. No k8s required.  |
+| `deployment/k8s/charts/.../migrationAssistantWithArgo/` (kind) | Real MA shape (helm + Argo + console pod)    | ~10 min    | **~16 GB RAM**, ~30 GB disk | User wants to see the production deployment shape; has the headroom.        |
+
+If unsure which the user wants, ask once: "fast end-to-end demo
+(docker compose) or production-shape (kind + helm)?" Default to
+docker compose if they don't pick.
+
+If the host has < 16 GB RAM free, refuse the kind path and route to
+docker compose. Don't pretend a kind+helm POC will work on an 8 GB
+machine — it'll OOM mid-install.
+
+## POC path — TrafficCapture docker-compose dev sandbox (default)
+
+The fastest way to see RFS move data end-to-end. See
+`TrafficCapture/dockerSolution/README.md` for the canonical
+walkthrough. You'll get a source ES container, a target OS
+container, and a `migration-console` container with the same
+`console …` CLI as the helm install.
+
+Steps the agent should narrate:
+
+  1. `cd TrafficCapture/dockerSolution && ./gradlew :composeUp`
+     (or follow the README's current invocation — it changes).
+  2. Tell the user the seeded endpoints: source on
+     `http://localhost:9200` (or whatever the compose file maps),
+     target on `http://localhost:9201`, console at
+     `docker compose exec migration-console bash`.
+  3. From inside the console container, run the same
+     `console clusters connection-check / snapshot create /
+     metadata migrate / backfill start / backfill status`
+     sequence as the helm path.
+
+**Tear-down (record this for Phase 6):**
+`./gradlew :composeDown` (or `docker compose down -v` from the
+sandbox dir, which also removes volumes).
+
 ## POC path — Migration Assistant helm chart on a local k8s
 
-This is the "real" Migration Assistant on a kind/minikube/k3d cluster.
+Use this only when the user has explicitly asked for the
+production shape and has ≥16 GB RAM free.
 
-  1. Create a local k8s cluster (kind is fine for ~16 GB hosts).
+  1. Create a local k8s cluster (kind is fine for ~16 GB hosts;
+     k3d / minikube also work). Confirm `docker stats` shows
+     headroom before installing the chart.
   2. Install the chart from
      `deployment/k8s/charts/aggregates/migrationAssistantWithArgo/`.
      **Always pass an image overlay** — the chart's bare `values.yaml`
      uses unprefixed image refs that don't resolve. See "Local-build
      vs released-image testing" below.
-  3. Drive the migration from the `migration-console` pod:
+  3. Tell the user the seeded endpoints: source/target services
+     resolve in-cluster as `<release>-source` / `<release>-target`;
+     the console pod is `migration-console-0` in the install
+     namespace.
+  4. Drive the migration from the `migration-console` pod:
 
      ```
      kubectl -n ma exec -it migration-console-0 -- /bin/bash
@@ -44,6 +94,10 @@ This is the "real" Migration Assistant on a kind/minikube/k3d cluster.
 If a step takes more than ~30s, tell the user what you're waiting on
 ("waiting for MA helm release to be ready", "polling backfill
 status") instead of going silent.
+
+**Tear-down (record this for Phase 6):**
+`helm -n ma uninstall ma && kind delete cluster` (or your local
+cluster's equivalent: `k3d cluster delete`, `minikube delete`).
 
 ## Local-build vs released-image testing
 
@@ -102,17 +156,6 @@ because `migrations/<name>:latest` resolves to docker.io.
 When walking a user through a POC: pick the released-image path
 unless they've explicitly said they're iterating on MA source.
 
-## POC path — TrafficCapture docker-compose dev sandbox
-
-The fastest way to see RFS move data end-to-end without standing up
-k8s. See `TrafficCapture/dockerSolution/README.md` for the canonical
-walkthrough — bring up the source/target/console containers, seed
-data, and the `migration-console` container exposes the same
-`console …` CLI as the helm install.
-
-This is the right POC if the user just wants to *see* data move from
-one cluster to another in a few minutes.
-
 ## POC path — `_reindex` from remote (lightweight alternative)
 
 If the user can't run kind or compose and just wants the simplest
@@ -120,6 +163,25 @@ possible demo, they can drive `_reindex` from-remote against any two
 clusters they already have — no MA, no helm, no compose. This skill
 doesn't supply a stack for it, but the steps are well-defined; see
 the MIGRATE path below for the curl shape.
+
+## MIGRATE: deploying MA for production
+
+Phase 4 for MIGRATE assumes the user is *not* on a laptop. If they
+don't already have MA running, point them at the right deployment
+artifact for their environment — don't reuse the kind path, which is
+explicitly POC-shaped.
+
+| Environment                 | Deploy via                                          |
+| --------------------------- | --------------------------------------------------- |
+| Existing EKS cluster        | `deployment/k8s/charts/.../migrationAssistantWithArgo/` with the public-ECR overlay above |
+| Greenfield AWS account      | `deployment/k8s/aws/aws-bootstrap.sh` (CDK + EKS bring-up + chart install in one) |
+| Self-hosted on-prem k8s     | Same chart, with whatever image registry the cluster can pull from (use `generatePrivateEcrValues` pattern from P17 in `pitfalls.md`, or mirror the public images into the org registry) |
+| Existing OpenShift / GKE    | Same chart; verify SCC / pod-security-admission compatibility before installing |
+
+If the user wants to *try* MA before committing to deploying it for
+real, route them back to the POC path (compose stack) and explicitly
+say so — don't let a MIGRATE user stand up a kind cluster and call
+it production.
 
 ## MIGRATE path — snapshot + restore
 
@@ -176,6 +238,35 @@ curl -X POST "$TARGET/_reindex?wait_for_completion=false" \
   }'
 # 3. Poll GET /_tasks/<task_id> until "completed": true.
 ```
+
+## When a step fails
+
+Migrations fail mid-flight. Don't retry blindly — capture state
+first, then retry the smallest unit that failed.
+
+  - **`console snapshot create` hung or errored**: read
+    `console snapshot status` (and `--json` for the raw response).
+    On k8s, also `kubectl logs <snapshot-pod>`. Check the source's
+    `_snapshot/_status` directly. Common causes: snapshot repo not
+    registered on source, S3 IAM passrole missing, source disk full.
+  - **`console metadata migrate` errored**: rerun with
+    `--detailed` or read the migration-console log
+    (`kubectl logs migration-console-0 -c migration-console`).
+    Mapping conflicts on the target are the usual cause; surface
+    them and ask the user how to resolve before retrying.
+  - **`console backfill status` shows workers `Failed`**:
+    `kubectl logs <rfs-worker-pod>` for the worker, plus
+    `argo get <workflow>` if Argo is driving the run. Look for
+    target `_bulk` rejections (queue full → scale target;
+    mapping mismatch → fix mapping, requeue the failed shard).
+  - **`_reindex` from remote task hung**:
+    `GET /_tasks/<task_id>` on target, then
+    `POST /_tasks/<task_id>/_cancel` if needed. Restart by
+    re-issuing reindex with a `query` filter that excludes the
+    docs already in target.
+
+Tell the user *what* you captured before suggesting *what* to try
+next. Don't roll up errors into "something went wrong, retrying".
 
 ## Logging + artifacts
 

--- a/migration-companion/steering/04-execute.md
+++ b/migration-companion/steering/04-execute.md
@@ -26,10 +26,9 @@ This is the "real" Migration Assistant on a kind/minikube/k3d cluster.
   1. Create a local k8s cluster (kind is fine for ~16 GB hosts).
   2. Install the chart from
      `deployment/k8s/charts/aggregates/migrationAssistantWithArgo/`.
-     For local installs the repo ships `valuesForLocalK8s.yaml`
-     alongside `values.yaml`. Review the chart's `README.md` and
-     `DEVELOPER_GUIDE.md` first — image-publication policy varies
-     across releases.
+     **Always pass an image overlay** — the chart's bare `values.yaml`
+     uses unprefixed image refs that don't resolve. See "Local-build
+     vs released-image testing" below.
   3. Drive the migration from the `migration-console` pod:
 
      ```
@@ -45,6 +44,63 @@ This is the "real" Migration Assistant on a kind/minikube/k3d cluster.
 If a step takes more than ~30s, tell the user what you're waiting on
 ("waiting for MA helm release to be ready", "polling backfill
 status") instead of going silent.
+
+## Local-build vs released-image testing
+
+The helm chart can be driven from two very different image sources.
+Pick deliberately — they're not interchangeable.
+
+**Released images (public ECR).** Use this when iterating on the
+*skill* or running a POC against a real release. All five MA
+images are published to `public.ecr.aws/opensearchproject/`:
+`opensearch-migrations-{console, traffic-replayer,
+reindex-from-snapshot, traffic-capture-proxy, transformation-shim}`.
+For a kind POC pinned to a release tag, layer this overlay on top
+of the chart's `values.yaml`:
+
+```yaml
+# public-ecr-overlay.yaml
+images:
+  migrationConsole:
+    repository: public.ecr.aws/opensearchproject/opensearch-migrations-console
+    tag: <release-version>      # e.g. 2.5.0; "latest" tracks main.
+  installer:
+    repository: public.ecr.aws/opensearchproject/opensearch-migrations-console
+    tag: <release-version>
+  reindexFromSnapshot:
+    repository: public.ecr.aws/opensearchproject/opensearch-migrations-reindex-from-snapshot
+    tag: <release-version>
+  trafficReplayer:
+    repository: public.ecr.aws/opensearchproject/opensearch-migrations-traffic-replayer
+    tag: <release-version>
+  captureProxy:
+    repository: public.ecr.aws/opensearchproject/opensearch-migrations-traffic-capture-proxy
+    tag: <release-version>
+```
+
+Install: `helm install ma <chart> -f public-ecr-overlay.yaml`.
+On EKS, `deployment/k8s/aws/aws-bootstrap.sh` does the same overrides
+inline via `--set images.<role>.repository=...` flags.
+
+**Locally-built images (this repo's branch).** Use this when iterating
+on MA *source* — when you've changed code in `TrafficCapture/`,
+`migrationConsole/`, etc. and need to test that change end-to-end.
+The repo-supplied path is:
+
+  1. `./gradlew buildImagesToRegistry` — Gradle builds each image
+     (Jib) and pushes to `localhost:5001` (default registry) plus
+     `localhost:5000` (the in-cluster `docker-registry`).
+  2. `helm install ma <chart> -f valuesForLocalK8s.yaml` — that
+     overlay points all five image refs at `localhost:5000/migrations/<name>`,
+     which the kind cluster pulls from the in-cluster registry.
+
+If you `helm install` with `valuesForLocalK8s.yaml` *without* the
+Gradle build first, every pod is `ImagePullBackOff`. If you
+`helm install` with neither overlay, every pod is `ErrImagePull`
+because `migrations/<name>:latest` resolves to docker.io.
+
+When walking a user through a POC: pick the released-image path
+unless they've explicitly said they're iterating on MA source.
 
 ## POC path — TrafficCapture docker-compose dev sandbox
 

--- a/migration-companion/steering/04-execute.md
+++ b/migration-companion/steering/04-execute.md
@@ -1,0 +1,136 @@
+# Phase 4 — Execute
+
+**Goal:** run the plan from Phase 3.
+
+Run on paths: POC, MIGRATE. (ANALYZE skips this.)
+
+This skill does not ship its own POC stack. Pick the existing
+opensearch-migrations artifact that matches the chosen approach and
+drive it from there.
+
+## Pick the right backend
+
+| Approach (from Phase 3)         | Use this from the repo                                    |
+| ------------------------------- | --------------------------------------------------------- |
+| MA RFS / metadata / snapshot    | `deployment/k8s/charts/aggregates/migrationAssistantWithArgo/` |
+| MA capture-and-replay           | `deployment/k8s/...` + `TrafficCapture/`                  |
+| Local sandbox (RFS dev loop)    | `TrafficCapture/dockerSolution/` — see its README         |
+| Solr → OS specifically          | `solrMigrationDevSandbox/` (and the AIAdvisor solr skill) |
+| `_reindex` from remote          | Hand-rolled — no infra needed; see below                  |
+| Snapshot/restore (no MA needed) | `awscurl` / `aws cli`, source/target tools directly       |
+
+## POC path — Migration Assistant helm chart on a local k8s
+
+This is the "real" Migration Assistant on a kind/minikube/k3d cluster.
+
+  1. Create a local k8s cluster (kind is fine for ~16 GB hosts).
+  2. Install the chart from
+     `deployment/k8s/charts/aggregates/migrationAssistantWithArgo/`.
+     For local installs the repo ships `valuesForLocalK8s.yaml`
+     alongside `values.yaml`. Review the chart's `README.md` and
+     `DEVELOPER_GUIDE.md` first — image-publication policy varies
+     across releases.
+  3. Drive the migration from the `migration-console` pod:
+
+     ```
+     kubectl -n ma exec -it migration-console-0 -- /bin/bash
+     console clusters connection-check
+     console snapshot create
+     console metadata migrate
+     console backfill start
+     console backfill scale 1
+     console backfill status        # poll until completed
+     ```
+
+If a step takes more than ~30s, tell the user what you're waiting on
+("waiting for MA helm release to be ready", "polling backfill
+status") instead of going silent.
+
+## POC path — TrafficCapture docker-compose dev sandbox
+
+The fastest way to see RFS move data end-to-end without standing up
+k8s. See `TrafficCapture/dockerSolution/README.md` for the canonical
+walkthrough — bring up the source/target/console containers, seed
+data, and the `migration-console` container exposes the same
+`console …` CLI as the helm install.
+
+This is the right POC if the user just wants to *see* data move from
+one cluster to another in a few minutes.
+
+## POC path — `_reindex` from remote (lightweight alternative)
+
+If the user can't run kind or compose and just wants the simplest
+possible demo, they can drive `_reindex` from-remote against any two
+clusters they already have — no MA, no helm, no compose. This skill
+doesn't supply a stack for it, but the steps are well-defined; see
+the MIGRATE path below for the curl shape.
+
+## MIGRATE path — snapshot + restore
+
+If Phase 3 picked snapshot/restore:
+
+  1. Register the snapshot repository on source (S3 typically; for
+     AOS source, IAM passrole; for self-managed, an `s3` plugin or
+     shared filesystem).
+  2. Take the snapshot. Wait for `SUCCESS` — poll
+     `GET /_snapshot/<repo>/<snapshot>/_status` every 10-30 s.
+  3. Register the same repo on target. For AOS, this means
+     `repository-s3` with an assume-role; pull the exact shape from
+     `packs/target-aws-managed.md`.
+  4. Restore: `POST /_snapshot/<repo>/<snap>/_restore` with the index
+     filter from the plan. Poll `GET /_recovery` until done.
+
+Ask before each step that mutates state. Don't chain.
+
+## MIGRATE path — RFS via Migration Assistant
+
+If Phase 3 picked RFS and the user has MA deployed (or you're
+deploying it for them via the helm chart above):
+
+  - All operational driving happens through the `migration-console`
+    pod. Use the `console …` CLI; don't hand-roll the underlying
+    HTTP calls. Source for the CLI lives in `migrationConsole/`.
+  - Connection settings live in `/etc/migration_services.yaml` inside
+    the console pod. The exact shape is in `packs/target-*.md` for
+    the chosen target.
+  - Worker fleet size: start with `console backfill scale 1`. Only
+    scale up after the first worker completes a few shards cleanly.
+  - The Argo workflow templates that drive backfill / metadata /
+    snapshot live in `orchestrationSpecs/`.
+
+If the user does NOT have MA deployed and the migration is one-shot
+at modest scale, prefer raw `_reindex` from remote (below) over
+spinning up MA from scratch.
+
+## MIGRATE path — `_reindex` from remote
+
+If Phase 3 picked `_reindex` from remote:
+
+```bash
+# 1. Add source URL to target's reindex.remote.allowlist (static
+#    setting — needs target restart on most managed services).
+# 2. Run reindex on the target:
+curl -X POST "$TARGET/_reindex?wait_for_completion=false" \
+  -H 'Content-Type: application/json' -d '{
+    "source": {
+      "remote": {"host": "'"$SOURCE"'"},
+      "index":  "<pattern>"
+    },
+    "dest":   {"index": "<pattern>"}
+  }'
+# 3. Poll GET /_tasks/<task_id> until "completed": true.
+```
+
+## Logging + artifacts
+
+Tell the user where logs are landing.
+  - kind+MA: `kubectl -n ma logs <pod>`; console output streams to
+    the user's terminal directly.
+  - Compose sandbox: `docker compose logs <svc>`.
+  - Raw `_reindex`: capture the task response and stream stdout +
+    stderr to `migration-<timestamp>.log`.
+
+## Exit criteria
+
+Source data is on the target. Don't trust this yet — Phase 5
+verifies. Move to Phase 5.

--- a/migration-companion/steering/05-validate.md
+++ b/migration-companion/steering/05-validate.md
@@ -24,8 +24,17 @@ Both numbers should match. If they don't, the difference is either:
 
 ## Sample query parity
 
-Pick 3-5 representative queries with the user. Don't invent them
-— ask. For each:
+For **MIGRATE**: pick 3-5 representative queries with the user.
+Don't invent them — ask. They know which queries matter for their
+application.
+
+For **POC**: the user didn't bring queries (they're using seeded
+data they've never seen). Use 2-3 queries shaped to the seeded
+dataset — `match_all`, a `range` on a known timestamp field, a
+`term` on a known keyword. The point isn't to validate *their*
+workload; it's to show that data round-tripped intact.
+
+For each:
 
 ```
 POST source/<index>/_search { ...query... }
@@ -35,14 +44,39 @@ POST target/<index>/_search { ...query... }
 Compare:
 - `hits.total.value` (with `track_total_hits=true` on target).
 - Top-10 doc IDs, in order.
-- Top hit's `_score` to within 5% (BM25 scores can drift slightly
-  across engines, that's expected; large drift is a finding).
+- `_score` drift, **per rank**:
+  - Top hit (`hits[0]`): within 5% is normal (BM25 across engines).
+  - Mid-rank (`hits[5]` ish): within 10% is normal.
+  - Tail (`hits[9]`): can drift more — what matters is whether
+    the *same docs* are in the top-10, not their exact scores.
+  - If the top-10 doc IDs diverge **in set** (not just order),
+    that's a finding. Score-only drift on the same set is fine.
+- For ranking-sensitive workloads, compute nDCG@10 against source
+  as the reference; flag any query below 0.9.
 
 ## Spot-check a few docs
 
-Pick 3 random doc IDs. `GET source/<index>/_doc/<id>` vs
-`GET target/<index>/_doc/<id>`. Bytes should be identical except
-for `_seq_no`, `_primary_term`, `_version`.
+Pick a sample with a real method, not "3 random IDs you made up":
+
+```
+# First / last / middle by _doc sort:
+POST <index>/_search { "size":1, "sort":[{"_doc":"asc"}] }
+POST <index>/_search { "size":1, "sort":[{"_doc":"desc"}] }
+# Random sample for billion-doc indices:
+POST <index>/_search {
+  "size": 10,
+  "query": { "function_score": {
+    "query": {"match_all": {}},
+    "random_score": {"seed": 42, "field": "_seq_no"}
+  }}
+}
+```
+
+Take the IDs that come back, then `GET source/<index>/_doc/<id>` vs
+`GET target/<index>/_doc/<id>`. `_source` bytes should be identical
+except for `_seq_no`, `_primary_term`, `_version`. If `_source` is
+disabled on either side, compare via `GET <index>/_search { "query":
+{"ids": {"values":[...]}}, "_source": true }` instead.
 
 ## Don't
 

--- a/migration-companion/steering/05-validate.md
+++ b/migration-companion/steering/05-validate.md
@@ -1,0 +1,58 @@
+# Phase 5 — Validate
+
+**Goal:** Confirm the migration actually moved what it claimed to,
+and that queries return roughly the same results. One pass — don't
+build a 5-pass review framework.
+
+Run on paths: `POC`, `MIGRATE`.
+
+## Doc count parity
+
+For each migrated index:
+
+```
+GET source/<index>/_count
+GET target/<index>/_count
+```
+
+Both numbers should match. If they don't, the difference is either:
+- An index that wasn't part of the migration scope (re-check the
+  index allowlist).
+- AOSS truncating `hits.total.value` at 10000 — pass
+  `track_total_hits=true`.
+- A genuine drop (this is a finding, not a glitch — investigate).
+
+## Sample query parity
+
+Pick 3-5 representative queries with the user. Don't invent them
+— ask. For each:
+
+```
+POST source/<index>/_search { ...query... }
+POST target/<index>/_search { ...query... }
+```
+
+Compare:
+- `hits.total.value` (with `track_total_hits=true` on target).
+- Top-10 doc IDs, in order.
+- Top hit's `_score` to within 5% (BM25 scores can drift slightly
+  across engines, that's expected; large drift is a finding).
+
+## Spot-check a few docs
+
+Pick 3 random doc IDs. `GET source/<index>/_doc/<id>` vs
+`GET target/<index>/_doc/<id>`. Bytes should be identical except
+for `_seq_no`, `_primary_term`, `_version`.
+
+## Don't
+
+- Don't build a "claim-trace footer" unless the user asks.
+- Don't run a 7-pass review.
+- Don't write per-query result files unless something looks wrong
+  and you need to attach evidence.
+
+## Exit criteria
+
+You have a one-paragraph verdict: "doc counts match, top-10 hits
+match on N/N queries, no drift". Or you have a list of findings.
+Either way, move to Phase 6.

--- a/migration-companion/steering/06-report.md
+++ b/migration-companion/steering/06-report.md
@@ -1,0 +1,57 @@
+# Phase 6 — Report
+
+**Goal:** Write `report.md` in the working directory. One file.
+Plain markdown. No spec versioning, no claim-trace, no nested
+`<details>` accordion forest.
+
+Always runs (every path).
+
+## Length target
+
+- LEARN: ~1 page, planning-only.
+- POC: ~1 page, "what we built and how to tear it down".
+- ANALYZE: ~1-2 pages, gap analysis.
+- MIGRATE: 1-2 pages, what happened + what to do next.
+
+If you're past 2 pages on any path, you're padding.
+
+## Sections (use these names verbatim)
+
+1. **Verdict** — One sentence at the top. Examples:
+   - "ES 7.17 → AOS 2.13 migrated cleanly, 12.4M docs, 100% count
+     parity, top-10 query parity on 5/5 sample queries."
+   - "ES 7.17 → AOSS migration is feasible via RFS. One blocker
+     (custom analyzer X uses a plugin not on AOSS)."
+   - "Local POC stood up successfully in 4m32s. Tear-down at the
+     bottom."
+2. **What we did** — bullets. What the user saw, in order.
+3. **Findings** — if any. One row per finding. Severity (block /
+   warn / note), what it is, what to do about it.
+4. **Open items** — anything pending the user's decision.
+5. **Cleanup / next steps** — if POC, the tear-down command. If
+   MIGRATE, the cutover checklist (DNS, app config, monitoring).
+
+## What goes in *Findings*
+
+A finding is anything from Phase 2-5 the user needs to act on:
+- An incompatibility from a target pack (e.g. AOSS doesn't support
+  snapshot restore — restate it once, in plain English).
+- A doc-count mismatch from Phase 5.
+- A plugin on the source that has no target-side equivalent.
+- A query whose top-10 differed from source.
+
+Don't list things that "happen to be different" without consequence.
+A different `_seq_no` is not a finding.
+
+## What does NOT go in this report
+
+- Version numbers of this skill.
+- Self-praise about the rigor of the analysis.
+- A re-statement of the plan from Phase 3 (cite it, don't repeat it).
+- Empirical "we ran this on N=200K docs" claims unless you literally
+  ran it on N=200K docs.
+
+## Exit criteria
+
+`report.md` exists, the user has read it, you've answered any
+follow-up questions. Done.

--- a/migration-companion/steering/06-report.md
+++ b/migration-companion/steering/06-report.md
@@ -17,6 +17,27 @@ If you're past 2 pages on any path, you're padding.
 
 ## Sections (use these names verbatim)
 
+For **LEARN** the report is planning-only — no migration ran. Use
+these sections instead of the default set:
+
+1. **Verdict** — One sentence: where they're starting from, what
+   the most likely path is, whether anything is a hard blocker.
+   Example: "ES 7.17-ish source to AOS 2.x target: RFS via
+   Migration Assistant is the default; no hard blockers."
+2. **What we covered** — bullets, what *concepts* you walked
+   through (which approaches from `techniques.md`, what trade-offs
+   matter most for their pair).
+3. **Trade-offs that matter for them** — the 2-4 rows from the
+   techniques matrix that are decision-relevant given what they
+   told you in Phase 1. Don't dump the whole matrix.
+4. **Open questions** — what they need to find out before they
+   can commit (snapshot access, AOS vs AOSS, source impact
+   tolerance, downtime budget).
+5. **Suggested next step** — usually "come back on the ANALYZE or
+   POC path once you've decided X, Y." Cite the sibling paths.
+
+For **POC**, **ANALYZE**, **MIGRATE** use the default sections:
+
 1. **Verdict** — One sentence at the top. Examples:
    - "ES 7.17 → AOS 2.13 migrated cleanly, 12.4M docs, 100% count
      parity, top-10 query parity on 5/5 sample queries."


### PR DESCRIPTION
### Description

Adds a new top-level `migration-companion/` directory: a minimalist
SKILL.md-based agent skill that walks a user end-to-end through
migrating an Elasticsearch (5/6/7/8) or OpenSearch (1/2/3) cluster
to OpenSearch — self-managed, Amazon OpenSearch Service (AOS), or
Amazon OpenSearch Serverless (AOSS).

It adapts to the user's starting point via four paths:

| Path     | Trigger                                    | Phases run        |
| -------- | ------------------------------------------ | ----------------- |
| LEARN    | "What's involved in migrating?"            | 0 → 1 → 6         |
| POC      | "Show me how it works locally"             | 0 → 1 → 3..6      |
| ANALYZE  | "Here's a snapshot, tell me what'll break" | 0 → 1 → 2 → 3 → 6 |
| MIGRATE  | "Here are creds, do the migration"         | 0 → 1 → 2..6      |

The skill is a **guide, not infrastructure**. Execution phases point
at the repo's existing Migration Assistant tooling rather than
duplicating it:

- `deployment/k8s/charts/aggregates/migrationAssistantWithArgo/` — helm chart for k8s installs
- `TrafficCapture/dockerSolution/` — local docker-compose dev sandbox
- `migrationConsole/` — the `console …` operator CLI
- `orchestrationSpecs/` — Argo workflow templates

#### Layout (15 files, 1,346 lines)

```
migration-companion/
├── SKILL.md                          # Entry point + phase router
├── README.md                         # Top-level overview
├── pitfalls.md                       # Non-discoverable facts (P1..P19)
├── steering/
│   ├── 00-intent.md                  # Pick path: LEARN/POC/ANALYZE/MIGRATE
│   ├── 01-interview.md               # Persona + source/target pair
│   ├── 02-probe.md                   # Read source cluster (read-only)
│   ├── 03-evaluate.md                # 7 approaches with pros/cons → pick one
│   ├── 04-execute.md                 # Drive in-repo MA tooling
│   ├── 05-validate.md                # Doc count + 3-5 sample queries
│   └── 06-report.md                  # Write report.md
└── packs/                            # Loaded on demand by phases 2-5
    ├── source-elasticsearch.md
    ├── source-opensearch.md
    ├── target-self-managed.md
    ├── target-aws-managed.md
    └── target-aws-serverless.md
```

#### Design constraints

- **Single SKILL.md entry.** ~3.5 KB; everything else is lazy-loaded.
- **One question at a time** during the interview phase. No 5-question dumps.
- **Pull, don't push.** Source/target packs are not loaded until the pair is known (Phase 2+).
- **Evaluate, don't prescribe.** Phase 3 lays out 7 migration approaches with honest pros/cons, then narrows to one. The user signs off.
- **Capability profiles, not parity claims.** AOSS's `snapshot_restore: false` is the load-bearing example — believe the pack, don't try to be clever.
- **One-pass validation.** Doc counts + 3-5 sample queries; no N-pass review framework.
- **No state file.** Working memory plus a final `report.md`.

#### Relationship to existing `AIAdvisor/`

This is a sibling, not a replacement. The existing
`AIAdvisor/skills/solr-opensearch-migration-advisor/` covers Solr →
OS specifically and stays where it is. Migration Companion covers
ES/OS → OS/AOS/AOSS, with Solr explicitly out of scope.

It sits at the repo root (peer to `solrMigrationDevSandbox/`,
`AIAdvisor/`, `deployment/`) because it's a top-level user-facing
resource — the same shape `solrMigrationDevSandbox/` already uses.

### Issues Resolved
N/A — new additive resource.

### Testing

This is documentation/agent-instruction content, not executable code.
Verification done:

- File count and total lines within self-imposed budget (≤25 files, ≤2k lines).
- All cross-file links resolve (no orphan references to the dropped POC directory or to the prior `upstream-ma-patches.md` doc).
- All references to in-repo paths (`deployment/k8s/charts/...`, `TrafficCapture/dockerSolution/`, `migrationConsole/`, `orchestrationSpecs/`, `AIAdvisor/skills/solr-opensearch-migration-advisor/`) confirmed to exist on `main`.
- No "parity with Elasticsearch" framing or references to ES internals; "Elasticsearch" appears only as a named source product in user-facing version-compatibility tables.

### Check List
- [x] New functionality includes testing (N/A — docs only; manual link verification done)
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
