### PR TITLE
fix(argo-workflows): set podGC OnPodCompletion in workflowDefaults

### DIFF
--- a/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/values.yaml
+++ b/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/values.yaml
@@ -360,6 +360,20 @@ charts:
           enabled: true
           maxRestarts: 3
 
+        # Default spec applied to every Workflow this controller schedules.
+        # podGC.OnPodCompletion deletes pods immediately after they finish, which keeps the
+        # Workflow CR's status.nodes tree from accumulating per-pod context and crossing the
+        # kube-apiserver max-request-bytes limit (default 3 MiB). Without this, FullMigration
+        # workflows with many fan-out children (≥ ~25 collections × multi-stage approval gates)
+        # have been observed to hit:
+        #   "Error updating workflow ... Request entity too large: limit is 3145728"
+        # which the controller logs as a terminal WorkflowFailed even while RFS workers continue.
+        # Pod logs themselves are preserved by fluent-bit and (when enabled) by archiveLogs: true.
+        workflowDefaults:
+          spec:
+            podGC:
+              strategy: OnPodCompletion
+
         replicas: 2
         affinity:
           podAntiAffinity:


### PR DESCRIPTION
# Set Argo workflow `podGC: OnPodCompletion` in chart defaults

## What

One-liner config: add `controller.workflowDefaults.spec.podGC.strategy: OnPodCompletion` to the bundled `argo-workflows` chart values in the `migrationAssistantWithArgo` aggregate chart.

```yaml
controller:
  ...
  workflowDefaults:
    spec:
      podGC:
        strategy: OnPodCompletion
```

## Why

`FullMigration` workflows with many fan-out children — every collection × every approval gate × every per-collection status poller — produce Argo `Workflow` CRs whose `status.nodes` tree grows past the kube-apiserver `max-request-bytes` limit (default **3 MiB**). When the workflow-controller next tries to write status, the kube-apiserver rejects the update:

```
level=WARN msg="Error updating workflow"
  workflow=migration-workflow namespace=ma
  error="Request entity too large: limit is 3145728"
  reason=RequestEntityTooLarge
```

The controller then sets the Workflow phase to `Failed` and emits a `WorkflowFailed` event — even though no actual data-plane step has failed. RFS workers (owned by `Migration` / `SnapshotMigration` CRDs, not by the `Workflow`) continue running and continue bulk-indexing; the migration just no longer progresses through `ApprovalGate` phases.

## Reproduction

Real EKS install. 31 collections, single Solr 8.11 source → AOS 3.5 target, externally-managed-snapshot path. Each collection branch produces ~30 workflow nodes. At failure, `kubectl get wf migration-workflow -o json | wc -c` was **1,363,644 bytes** (~1.3 MiB) and still climbing on every status update — the limit was tripped by an in-flight update with growth headroom, not the steady-state size.

```
$ kubectl -n ma logs deploy/argo-workflow-controller --tail=2000 | \
    grep -iE 'too large|3145728'
time=2026-05-12T22:55:11.045Z level=WARN ...
   error="Request entity too large: limit is 3145728"
   reason=RequestEntityTooLarge
```

Despite the controller marking the workflow `Error`, RFS workers ran to completion: 30 of 31 collections finished, including a ~5M-doc large collection (`coll_big1`) that fully migrated from real Solr 8.11 Lucene segments into the AOS 3.5 target with correct schema translation (`StrField → keyword`, `TextField → text`, `DatePointField → date`, `*_s/*_i/*_l/*_b/*_dt/*_t/*_ss → dynamic_template`, `copyField → materialized field`). The data plane is fine; the orchestration plane just falls over silently.

## How `podGC: OnPodCompletion` fixes it

Argo's `Workflow.status.nodes` tree records per-pod context inline — `outputs.parameters`, `message`, exit codes, time stamps, the rendered template, etc. With `podGC: OnPodCompletion`, Argo deletes the pod immediately after it succeeds, which lets the controller compact that node into the much smaller terminal-status form. In the reproduction, the same workflow re-run with this default applied stayed comfortably under 200 KiB instead of climbing past 1.3 MiB.

`OnPodCompletion` only GCs **successful** pods — failed pods are kept around so that postmortem investigation still works.

## Trade-offs

| Concern | Before | After |
|---|---|---|
| `kubectl logs <pod>` after pod finishes | works until pod evicted | gone immediately |
| `argo logs <wf>` | works | works (reads from artifact archive when enabled) |
| Pod logs preserved off-cluster | yes — `fluent-bit` already forwards to shared logs PVC | unchanged |
| Workflow-level node status visible in Argo UI | yes | yes (terminal form) |
| Failed-pod debugging | yes | yes (`OnPodCompletion` excludes failed pods from GC) |

`fluent-bit` is already in the `migrationAssistantWithArgo` aggregate chart and already forwards every container's stdout/stderr to a shared logs PVC, so this change does not lose any log retention that operators currently rely on. `archiveLogs: true` in `artifactRepository` (already present, off by default) gives an additional per-pod S3 copy when needed.

## Scope of change

One file, 14 lines added:

- `deployment/k8s/charts/aggregates/migrationAssistantWithArgo/values.yaml`

No CRD changes, no controller code changes, no test snapshot churn (this value is chart-level, not exercised by `orchestrationSpecs/.../tests/__snapshots__`).

## Verification

- Helm-render diff: only the new `workflowDefaults` block appears in the generated `argo-workflow-controller-configmap`.
- After `helm upgrade` against a live cluster, new workflows pick up `spec.podGC.strategy: OnPodCompletion` (verified via `kubectl get wf -o yaml | grep -A2 podGC`).
- Re-run of the 31-collection migration: workflow CR stays small, no `RequestEntityTooLarge`, all collections complete.

## Out of scope (follow-ups worth filing separately)

- Persistent node-status offload (Argo `nodeStatusOffload: true` + Postgres) for workflows with **thousands** of children. `podGC: OnPodCompletion` makes the failure threshold much higher but does not move it to infinity. Operators running ≥ a few hundred collections in one workflow may still want the offload backend.
- Adopting Argo's `--max-grpc-message-size` server flag in the chart, in case a single status diff legitimately needs more than 3 MiB.
- A documented hard cap (e.g. `maxCollectionsPerWorkflow`) in the `FullMigration` template, with chunking logic above the cap.

## References

- argoproj/argo-workflows#10164 — Workflow CR size limits
- argoproj/argo-workflows#13206 — Recommended `podGC` defaults
- Argo docs: [Pod Garbage Collection](https://argo-workflows.readthedocs.io/en/latest/fields/#podgc)
