### PR TITLE
feat(rfs): cap sourceless reconstruction spill bytes with fail-fast budget

### DIFF
--- a/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/SourcelessSpillConfig.java
+++ b/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/SourcelessSpillConfig.java
@@ -1,5 +1,8 @@
 package org.opensearch.migrations.bulkload.lucene;
 
+import java.io.IOException;
+import java.nio.file.FileStore;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -15,23 +18,44 @@ import lombok.extern.slf4j.Slf4j;
  * happens naturally when the worker wipes its Lucene scratch tree on shutdown or via
  * {@code --clear-existing}. No separate {@code /tmp/rfs-spill-<pid>} root is needed.
  *
- * <p>Sort-buffer size is exposed as a single JVM {@code -D} flag so operators can tune
- * it on the worker container without a config plumbing change.
+ * <p>All knobs are exposed as JVM {@code -D} flags so operators can tune
+ * them on the worker container without a config plumbing change.
  *
  * <dl>
  *   <dt>{@code rfs.reconstruction.sortBufferBytes}</dt>
  *   <dd>In-memory sort buffer budget per field build. Default: 256 MiB.
- *       Smaller buffer = more runs = more merge passes = more disk I/O, but bounded heap.
- *       Tune down via {@code -Drfs.reconstruction.sortBufferBytes} on smaller workers.</dd>
+ *       Smaller buffer = more runs = more merge passes = more disk I/O, but bounded heap.</dd>
+ *
+ *   <dt>{@code rfs.reconstruction.maxSpillBytes}</dt>
+ *   <dd>Aggregate ceiling on bytes-in-flight in the per-segment spill across all
+ *       concurrent {@code SidecarBuilder}s in this JVM. When the cap is breached,
+ *       the offending builder throws {@link SpillBudgetExceededException}, which
+ *       propagates as an {@code IOException} and aborts the segment fast and
+ *       clean instead of letting the worker run the disk to ENOSPC.
+ *       Default: {@link Long#MAX_VALUE} (unbounded — opt-in).</dd>
+ *
+ *   <dt>{@code rfs.reconstruction.spillFreeSpaceMinBytes}</dt>
+ *   <dd>If set, builders sample the spill volume's usable space periodically
+ *       and abort early when {@code FileStore.getUsableSpace()} drops below
+ *       this floor. Catches the case where another process (or another shard's
+ *       Lucene tree) is the one filling the disk. Default: {@code 0} (disabled).</dd>
  * </dl>
  */
 @Slf4j
 public final class SourcelessSpillConfig {
 
     public static final String SORT_BUFFER_BYTES_PROP = "rfs.reconstruction.sortBufferBytes";
+    public static final String MAX_SPILL_BYTES_PROP = "rfs.reconstruction.maxSpillBytes";
+    public static final String SPILL_FREE_SPACE_MIN_BYTES_PROP = "rfs.reconstruction.spillFreeSpaceMinBytes";
 
     /** 256 MiB sort buffer — tuned for production 4+ GiB heaps. */
     public static final long DEFAULT_SORT_BUFFER_BYTES = 256L * 1024 * 1024;
+
+    /** Unbounded by default; the cap is opt-in. Operators set it via {@code -D}. */
+    public static final long DEFAULT_MAX_SPILL_BYTES = Long.MAX_VALUE;
+
+    /** Disabled by default. */
+    public static final long DEFAULT_SPILL_FREE_SPACE_MIN_BYTES = 0L;
 
     /** Sub-directory of the shard's Lucene dir where per-segment spill trees live. */
     static final String SPILL_SUBDIR = ".rfs-spill";
@@ -56,14 +80,45 @@ public final class SourcelessSpillConfig {
      * default if unset. Values below one tuple width are clamped up so builds don't deadlock.
      */
     public static long sortBufferBytes() {
-        String override = System.getProperty(SORT_BUFFER_BYTES_PROP);
-        if (override == null || override.isBlank()) return DEFAULT_SORT_BUFFER_BYTES;
+        return parseLongProp(SORT_BUFFER_BYTES_PROP, DEFAULT_SORT_BUFFER_BYTES,
+            n -> Math.max(org.opensearch.migrations.bulkload.lucene.sidecar.SidecarBuilder.RECORD_BYTES, n));
+    }
+
+    /** Aggregate spill-bytes ceiling across all in-flight builders in this JVM. */
+    public static long maxSpillBytes() {
+        return parseLongProp(MAX_SPILL_BYTES_PROP, DEFAULT_MAX_SPILL_BYTES, n -> Math.max(0L, n));
+    }
+
+    /** Minimum usable bytes that must remain on the spill volume mid-build. */
+    public static long spillFreeSpaceMinBytes() {
+        return parseLongProp(SPILL_FREE_SPACE_MIN_BYTES_PROP, DEFAULT_SPILL_FREE_SPACE_MIN_BYTES,
+            n -> Math.max(0L, n));
+    }
+
+    /**
+     * Returns the usable space (in bytes) on the file store that contains
+     * {@code path}, or {@link Long#MAX_VALUE} if the volume can't be probed
+     * (so a probe failure never causes a false positive abort).
+     */
+    public static long usableSpace(Path path) {
         try {
-            long n = Long.parseLong(override.trim());
-            return Math.max(org.opensearch.migrations.bulkload.lucene.sidecar.SidecarBuilder.RECORD_BYTES, n);
+            FileStore fs = Files.getFileStore(path);
+            long n = fs.getUsableSpace();
+            return n > 0 ? n : Long.MAX_VALUE;
+        } catch (IOException e) {
+            log.debug("usableSpace probe failed for {}: {}", path, e.toString());
+            return Long.MAX_VALUE;
+        }
+    }
+
+    private static long parseLongProp(String prop, long defaultValue, java.util.function.LongUnaryOperator clamp) {
+        String override = System.getProperty(prop);
+        if (override == null || override.isBlank()) return defaultValue;
+        try {
+            return clamp.applyAsLong(Long.parseLong(override.trim()));
         } catch (NumberFormatException e) {
-            log.warn("Invalid {}={}, using default {}", SORT_BUFFER_BYTES_PROP, override, DEFAULT_SORT_BUFFER_BYTES);
-            return DEFAULT_SORT_BUFFER_BYTES;
+            log.warn("Invalid {}={}, using default {}", prop, override, defaultValue);
+            return defaultValue;
         }
     }
 }

--- a/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/sidecar/SidecarBuilder.java
+++ b/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/sidecar/SidecarBuilder.java
@@ -93,6 +93,18 @@ public final class SidecarBuilder implements PostingsSink, AutoCloseable {
     private boolean built = false;
     private boolean closed = false;
 
+    /**
+     * Bytes this builder has reserved from {@link SpillBudget}. Tracked here so
+     * {@link #close()} releases exactly what was reserved, even on a half-built
+     * failure path. Updates only on the {@code accept()} / {@code buildAndOpenReader()}
+     * thread; reads from {@code close()} use the same monitor as the writers.
+     */
+    private long reservedBytes = 0L;
+    /** Bytes written to {@code sort-input.bin} since the last volume-headroom probe. */
+    private long bytesSinceVolumeProbe = 0L;
+    /** Probe disk usable-space at most every 64 MiB written. */
+    private static final long VOLUME_PROBE_INTERVAL_BYTES = 64L * 1024 * 1024;
+
     public SidecarBuilder(Path spillDir, long sortBufferBytes, int maxDoc) throws IOException {
         this.spillDir = spillDir;
         this.maxDoc = Math.max(1, maxDoc);
@@ -121,6 +133,21 @@ public final class SidecarBuilder implements PostingsSink, AutoCloseable {
     @Override
     public void accept(int termId, int docId, int[] positions, int[] startOffsets, int[] endOffsets, int positionCount) throws IOException {
         if (positionCount <= 0 || docId < 0 || docId >= maxDoc) return;
+
+        // Reserve before writing so we abort fast (typed exception) instead of running disk to ENOSPC.
+        // Each tuple is RECORD_BYTES on the wire — the builder's full sort-input footprint is
+        // positionCount × RECORD_BYTES summed across every accept() call.
+        long pendingBytes = (long) positionCount * RECORD_BYTES;
+        SpillBudget.tryReserve(pendingBytes);
+        reservedBytes += pendingBytes;
+
+        // Coarse-grained disk-volume probe: avoid syscall-per-record overhead.
+        bytesSinceVolumeProbe += pendingBytes;
+        if (bytesSinceVolumeProbe >= VOLUME_PROBE_INTERVAL_BYTES) {
+            bytesSinceVolumeProbe = 0L;
+            SpillBudget.assertVolumeHeadroom(spillDir);
+        }
+
         byte[] rec = recordScratch;
         VH_BE_INT.set(rec, 0, docId);
         VH_BE_INT.set(rec, 8, termId);
@@ -140,6 +167,14 @@ public final class SidecarBuilder implements PostingsSink, AutoCloseable {
         termsStage.close();
         CodecUtil.writeFooter(sortInputOut);
         sortInputWriter.close();
+
+        // OfflineSorter spills runs to disk and merges them — peak transient cost
+        // is roughly the sort-input size again. Reserve it up front so the segment
+        // fails fast if the merge would push past the cap, instead of mid-merge ENOSPC.
+        long mergeReservation = reservedBytes;
+        SpillBudget.tryReserve(mergeReservation);
+        reservedBytes += mergeReservation;
+        SpillBudget.assertVolumeHeadroom(spillDir);
 
         OfflineSorter sorter = new OfflineSorter(
                 dir, "sort", Comparator.naturalOrder(), sortBufferSize,
@@ -204,6 +239,13 @@ public final class SidecarBuilder implements PostingsSink, AutoCloseable {
             dir.deleteFile(sortedName);
             dir.deleteFile(TERMS_STAGE_FILE);
         }
+
+        // Sort scratch is gone; the only remaining on-disk artifact is sidecar.bin
+        // (compressed final form, materially smaller than the raw record stream).
+        // Release the full reservation back to the JVM-wide budget so other concurrent
+        // builders can proceed.
+        SpillBudget.release(reservedBytes);
+        reservedBytes = 0L;
 
         closed = true;
         return SidecarReader.open(spillDir);
@@ -346,6 +388,12 @@ public final class SidecarBuilder implements PostingsSink, AutoCloseable {
             Files.deleteIfExists(spillDir.resolve(TERMS_STAGE_FILE));
         } catch (IOException e) {
             log.debug("Ignored terms-stage delete error: {}", e.toString());
+        }
+        // Failure path: release any bytes still on the JVM-wide budget so a single
+        // failed segment doesn't permanently shrink headroom for the rest of the worker.
+        if (reservedBytes > 0L) {
+            SpillBudget.release(reservedBytes);
+            reservedBytes = 0L;
         }
     }
 }

--- a/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/sidecar/SpillBudget.java
+++ b/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/sidecar/SpillBudget.java
@@ -1,0 +1,121 @@
+package org.opensearch.migrations.bulkload.lucene.sidecar;
+
+import java.nio.file.Path;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.opensearch.migrations.bulkload.lucene.SourcelessSpillConfig;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * JVM-wide accounting of bytes-in-flight in spill files across all concurrent
+ * {@link SidecarBuilder}s. Singleton because the disk is a single shared
+ * resource: per-builder caps wouldn't catch the case where N fields × M
+ * segments each individually fit but collectively exceed disk.
+ *
+ * <p>The cap is read once on first access from
+ * {@link SourcelessSpillConfig#maxSpillBytes()} and stays fixed for the JVM's
+ * lifetime — operators tune it via {@code -D} at worker startup, not at runtime.
+ *
+ * <p>Reservation is best-effort: a winning {@link #tryReserve(long)} commits
+ * the bytes; subsequent {@link #release(long)} calls (in {@code SidecarBuilder.close()}
+ * and on failure paths) make those bytes available to other builders. The cap
+ * fires before disk fills, surfacing as {@link SpillBudgetExceededException} from
+ * the offending {@code accept()} call. The segment Flux's {@code concatMapDelayError}
+ * propagates that as a per-segment failure, freeing the segment's spill tree on
+ * close — exactly the behavior the worker lease semantics want.
+ */
+@Slf4j
+public final class SpillBudget {
+
+    private static final AtomicLong BYTES_IN_FLIGHT = new AtomicLong();
+    private static volatile long capBytes = -1L; // -1 = uninitialized
+    private static volatile long freeSpaceFloorBytes = -1L;
+
+    private SpillBudget() {}
+
+    private static long cap() {
+        long c = capBytes;
+        if (c < 0L) {
+            c = SourcelessSpillConfig.maxSpillBytes();
+            capBytes = c;
+        }
+        return c;
+    }
+
+    private static long freeSpaceFloor() {
+        long f = freeSpaceFloorBytes;
+        if (f < 0L) {
+            f = SourcelessSpillConfig.spillFreeSpaceMinBytes();
+            freeSpaceFloorBytes = f;
+        }
+        return f;
+    }
+
+    /**
+     * Reserve {@code bytes} from the global budget. Throws
+     * {@link SpillBudgetExceededException} if the reservation would exceed the
+     * configured cap, leaving the counter unchanged so the caller can choose
+     * how to react. Callers MUST balance every successful reservation with a
+     * matching {@link #release(long)} call (typically from {@code close()}).
+     */
+    public static void tryReserve(long bytes) throws SpillBudgetExceededException {
+        if (bytes <= 0L) return;
+        long limit = cap();
+        if (limit == Long.MAX_VALUE) {
+            BYTES_IN_FLIGHT.addAndGet(bytes);
+            return;
+        }
+        long updated = BYTES_IN_FLIGHT.addAndGet(bytes);
+        if (updated > limit) {
+            // Roll back our delta so the in-flight number stays honest, then fail.
+            BYTES_IN_FLIGHT.addAndGet(-bytes);
+            throw new SpillBudgetExceededException(
+                "RFS sourceless reconstruction would exceed configured spill budget"
+                + " (" + SourcelessSpillConfig.MAX_SPILL_BYTES_PROP + "=" + limit
+                + " bytes); aborting field build before disk fills."
+                + " Current in-flight=" + (updated - bytes)
+                + ", attempted reservation=" + bytes);
+        }
+    }
+
+    /**
+     * Probe the spill volume's usable space and abort if it has fallen below
+     * the configured floor. Cheap enough to call at coarse granularity (e.g.
+     * once per N MiB written) but not free — every call is a syscall.
+     */
+    public static void assertVolumeHeadroom(Path spillDir) throws SpillBudgetExceededException {
+        long floor = freeSpaceFloor();
+        if (floor <= 0L) return;
+        long usable = SourcelessSpillConfig.usableSpace(spillDir);
+        if (usable < floor) {
+            throw new SpillBudgetExceededException(
+                "RFS sourceless reconstruction spill volume below floor"
+                + " (" + SourcelessSpillConfig.SPILL_FREE_SPACE_MIN_BYTES_PROP + "=" + floor
+                + " bytes, usable=" + usable + " bytes, dir=" + spillDir
+                + "); aborting field build before disk fills.");
+        }
+    }
+
+    /** Return previously-reserved bytes to the budget. Idempotent on zero/negative input. */
+    public static void release(long bytes) {
+        if (bytes <= 0L) return;
+        BYTES_IN_FLIGHT.addAndGet(-bytes);
+    }
+
+    /** Visible for testing. */
+    public static long bytesInFlight() {
+        return BYTES_IN_FLIGHT.get();
+    }
+
+    /**
+     * Visible for testing. Resets cached config and the counter so a test can
+     * exercise different {@code -D} values inside a single JVM. Production code
+     * never calls this.
+     */
+    static void resetForTest() {
+        BYTES_IN_FLIGHT.set(0L);
+        capBytes = -1L;
+        freeSpaceFloorBytes = -1L;
+    }
+}

--- a/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/sidecar/SpillBudgetExceededException.java
+++ b/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/sidecar/SpillBudgetExceededException.java
@@ -1,0 +1,17 @@
+package org.opensearch.migrations.bulkload.lucene.sidecar;
+
+/**
+ * Thrown when a {@link SidecarBuilder} would exceed the JVM-wide aggregate
+ * spill cap configured by {@code rfs.reconstruction.maxSpillBytes}, or when
+ * the spill volume's usable space drops below
+ * {@code rfs.reconstruction.spillFreeSpaceMinBytes}. Distinct from a generic
+ * {@link java.io.IOException} so callers (and log scrapers) can match the
+ * pre-ENOSPC fail-fast path explicitly.
+ */
+public class SpillBudgetExceededException extends java.io.IOException {
+    private static final long serialVersionUID = 1L;
+
+    public SpillBudgetExceededException(String message) {
+        super(message);
+    }
+}

--- a/SearchSnapshotExtractor/src/test/java/org/opensearch/migrations/bulkload/lucene/SourcelessSpillConfigTest.java
+++ b/SearchSnapshotExtractor/src/test/java/org/opensearch/migrations/bulkload/lucene/SourcelessSpillConfigTest.java
@@ -1,0 +1,75 @@
+package org.opensearch.migrations.bulkload.lucene;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.opensearch.migrations.bulkload.lucene.sidecar.SidecarBuilder;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Pins the system-property contract for {@link SourcelessSpillConfig} — defaults,
+ * parse-failure fallback, and clamp behavior. Operators rely on these props to
+ * tune the sourceless-reconstruction spill budget without a code change, so
+ * silent regressions here would re-open issue #2961's failure mode.
+ */
+class SourcelessSpillConfigTest {
+
+    private String savedSort;
+    private String savedMax;
+    private String savedFloor;
+
+    @BeforeEach
+    void saveProps() {
+        savedSort  = System.getProperty(SourcelessSpillConfig.SORT_BUFFER_BYTES_PROP);
+        savedMax   = System.getProperty(SourcelessSpillConfig.MAX_SPILL_BYTES_PROP);
+        savedFloor = System.getProperty(SourcelessSpillConfig.SPILL_FREE_SPACE_MIN_BYTES_PROP);
+        System.clearProperty(SourcelessSpillConfig.SORT_BUFFER_BYTES_PROP);
+        System.clearProperty(SourcelessSpillConfig.MAX_SPILL_BYTES_PROP);
+        System.clearProperty(SourcelessSpillConfig.SPILL_FREE_SPACE_MIN_BYTES_PROP);
+    }
+
+    @AfterEach
+    void restoreProps() {
+        restore(SourcelessSpillConfig.SORT_BUFFER_BYTES_PROP, savedSort);
+        restore(SourcelessSpillConfig.MAX_SPILL_BYTES_PROP, savedMax);
+        restore(SourcelessSpillConfig.SPILL_FREE_SPACE_MIN_BYTES_PROP, savedFloor);
+    }
+
+    private static void restore(String prop, String value) {
+        if (value == null) System.clearProperty(prop);
+        else System.setProperty(prop, value);
+    }
+
+    @Test
+    void defaults_whenUnset() {
+        assertEquals(SourcelessSpillConfig.DEFAULT_SORT_BUFFER_BYTES, SourcelessSpillConfig.sortBufferBytes());
+        assertEquals(SourcelessSpillConfig.DEFAULT_MAX_SPILL_BYTES, SourcelessSpillConfig.maxSpillBytes());
+        assertEquals(SourcelessSpillConfig.DEFAULT_SPILL_FREE_SPACE_MIN_BYTES, SourcelessSpillConfig.spillFreeSpaceMinBytes());
+    }
+
+    @Test
+    void sortBufferBytes_clampsBelowRecordWidth() {
+        System.setProperty(SourcelessSpillConfig.SORT_BUFFER_BYTES_PROP, "1");
+        assertEquals(SidecarBuilder.RECORD_BYTES, SourcelessSpillConfig.sortBufferBytes());
+    }
+
+    @Test
+    void parseFailure_fallsBackToDefault() {
+        System.setProperty(SourcelessSpillConfig.MAX_SPILL_BYTES_PROP, "not-a-number");
+        assertEquals(SourcelessSpillConfig.DEFAULT_MAX_SPILL_BYTES, SourcelessSpillConfig.maxSpillBytes());
+    }
+
+    @Test
+    void maxSpillBytes_negativeClampsToZero() {
+        System.setProperty(SourcelessSpillConfig.MAX_SPILL_BYTES_PROP, "-1");
+        assertEquals(0L, SourcelessSpillConfig.maxSpillBytes());
+    }
+
+    @Test
+    void spillFreeSpaceMinBytes_acceptsValidValue() {
+        System.setProperty(SourcelessSpillConfig.SPILL_FREE_SPACE_MIN_BYTES_PROP, "1073741824");
+        assertEquals(1073741824L, SourcelessSpillConfig.spillFreeSpaceMinBytes());
+    }
+}

--- a/SearchSnapshotExtractor/src/test/java/org/opensearch/migrations/bulkload/lucene/sidecar/SidecarBuilderBudgetTest.java
+++ b/SearchSnapshotExtractor/src/test/java/org/opensearch/migrations/bulkload/lucene/sidecar/SidecarBuilderBudgetTest.java
@@ -1,0 +1,104 @@
+package org.opensearch.migrations.bulkload.lucene.sidecar;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.opensearch.migrations.bulkload.lucene.SourcelessSpillConfig;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies that {@link SidecarBuilder} fails fast with
+ * {@link SpillBudgetExceededException} when the JVM-wide spill cap configured via
+ * {@code rfs.reconstruction.maxSpillBytes} would be exceeded — exercising the
+ * fail-fast path that replaces ENOSPC at scale (issue #2961).
+ *
+ * <p>The volume-headroom probe ({@code rfs.reconstruction.spillFreeSpaceMinBytes})
+ * is intentionally not asserted here: producing a real ENOSPC inside a unit test
+ * would mean filling the actual test volume, which is hostile to CI. The
+ * arithmetic cap path covers the same fail-fast contract.
+ */
+class SidecarBuilderBudgetTest {
+
+    private Path spillDir;
+    private String savedCap;
+    private String savedFloor;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        spillDir = Files.createTempDirectory("sidecar-budget-test-");
+        savedCap = System.getProperty(SourcelessSpillConfig.MAX_SPILL_BYTES_PROP);
+        savedFloor = System.getProperty(SourcelessSpillConfig.SPILL_FREE_SPACE_MIN_BYTES_PROP);
+        SpillBudget.resetForTest();
+    }
+
+    @AfterEach
+    void tearDown() throws IOException {
+        if (savedCap == null) System.clearProperty(SourcelessSpillConfig.MAX_SPILL_BYTES_PROP);
+        else System.setProperty(SourcelessSpillConfig.MAX_SPILL_BYTES_PROP, savedCap);
+        if (savedFloor == null) System.clearProperty(SourcelessSpillConfig.SPILL_FREE_SPACE_MIN_BYTES_PROP);
+        else System.setProperty(SourcelessSpillConfig.SPILL_FREE_SPACE_MIN_BYTES_PROP, savedFloor);
+        SpillBudget.resetForTest();
+        SidecarTestSupport.rm(spillDir);
+    }
+
+    @Test
+    void unbounded_default_acceptsLargeWrites() throws IOException {
+        // Default cap is unbounded; the builder should accept many records without throwing.
+        try (SidecarBuilder b = new SidecarBuilder(spillDir, /*sortBufferBytes=*/1024, /*maxDoc=*/16)) {
+            int[] positions = new int[]{0, 1, 2, 3, 4, 5, 6, 7};
+            b.accept(/*termId=*/0, /*docId=*/0, positions, positions, positions, positions.length);
+            // 8 positions × RECORD_BYTES = 160 bytes reserved.
+            assertEquals(8L * SidecarBuilder.RECORD_BYTES, SpillBudget.bytesInFlight());
+        }
+        // close() releases the reservation.
+        assertEquals(0L, SpillBudget.bytesInFlight());
+    }
+
+    @Test
+    void cap_breached_throwsTypedException() throws IOException {
+        // Cap of one record. Any non-trivial accept() will exceed it on the first call.
+        System.setProperty(SourcelessSpillConfig.MAX_SPILL_BYTES_PROP,
+            Long.toString(SidecarBuilder.RECORD_BYTES));
+        SpillBudget.resetForTest();
+
+        try (SidecarBuilder b = new SidecarBuilder(spillDir, /*sortBufferBytes=*/1024, /*maxDoc=*/16)) {
+            int[] positions = new int[]{0, 1, 2, 3};
+            SpillBudgetExceededException e = assertThrows(
+                SpillBudgetExceededException.class,
+                () -> b.accept(0, 0, positions, positions, positions, positions.length));
+            assertTrue(e.getMessage().contains(SourcelessSpillConfig.MAX_SPILL_BYTES_PROP),
+                "exception message should name the prop that was breached: " + e.getMessage());
+        }
+        // The failed reservation rolled back, and close() released any remainder. Net zero.
+        assertEquals(0L, SpillBudget.bytesInFlight());
+    }
+
+    @Test
+    void cap_just_below_two_records_partial_progress_then_throws() throws IOException {
+        // Cap that admits one accept() of 1 record but rejects a second of 2 records.
+        long capBytes = 2L * SidecarBuilder.RECORD_BYTES;
+        System.setProperty(SourcelessSpillConfig.MAX_SPILL_BYTES_PROP, Long.toString(capBytes));
+        SpillBudget.resetForTest();
+
+        try (SidecarBuilder b = new SidecarBuilder(spillDir, /*sortBufferBytes=*/1024, /*maxDoc=*/16)) {
+            int[] one = new int[]{0};
+            int[] three = new int[]{0, 1, 2};
+            b.accept(0, 0, one, one, one, 1); // OK: 20 bytes reserved, in-flight=20.
+            assertEquals(SidecarBuilder.RECORD_BYTES, SpillBudget.bytesInFlight());
+            // Second call needs 60 more — would push to 80, over the 40-byte cap. Throws.
+            assertThrows(SpillBudgetExceededException.class,
+                () -> b.accept(0, 1, three, three, three, 3));
+            // First record's reservation is intact (only the failed reservation rolled back).
+            assertEquals(SidecarBuilder.RECORD_BYTES, SpillBudget.bytesInFlight());
+        }
+        assertEquals(0L, SpillBudget.bytesInFlight());
+    }
+}


### PR DESCRIPTION
### Description
Sourceless reconstruction (SearchSnapshotExtractor) writes per-field spill files via `SidecarBuilder` during external merge sort. On hot-loop or large-postings shapes, the spill tree can grow to many multiples of the source segment, eventually filling the worker's disk and surfacing only as a generic `ENOSPC` `IOException` deep in `OfflineSorter` — by which point the worker lease is wedged for minutes (#2961).

This PR is the first of three follow-ups to that issue. It adds a **fail-fast aggregate budget** at the spill write boundary so operators can put a hard ceiling on bytes-in-flight without changing the per-builder algorithm.

Two opt-in JVM-level knobs:

| Property | Default | Effect |
|---|---|---|
| `rfs.reconstruction.maxSpillBytes` | `Long.MAX_VALUE` (unbounded) | Aggregate ceiling on bytes-in-flight in spill files across all concurrent `SidecarBuilder`s in this JVM. |
| `rfs.reconstruction.spillFreeSpaceMinBytes` | `0` (disabled) | Floor on the spill volume's usable space (`FileStore#getUsableSpace`). Coarse-grained probe (every 64 MiB written) catches the case where another process — or another shard's Lucene tree — fills the disk. |

When either limit is breached, `SidecarBuilder.accept()` throws the new `SpillBudgetExceededException` (an `IOException` subclass) instead of letting the write run to ENOSPC. The segment `Flux`'s existing `concatMapDelayError` path treats it as a per-segment failure: the spill tree is freed on `close()`, the worker lease is released cleanly, and neighboring segments keep making progress.

### Issues Resolved
First of three PRs addressing #2961. Follow-ups will land:
- Per-field LRU eviction in `SegmentTermIndex` (PR-2)
- Eager disk-space precheck in `SidecarBuilder` constructor (PR-3)

### Implementation notes
- **Bookkeeping** is a JVM-wide `AtomicLong` in the new `SpillBudget` singleton. Reservation is balanced with release on `close()`, so a failed segment doesn't permanently shrink headroom for the rest of the worker.
- **Reservation points:**
  - `accept()` reserves `positionCount × RECORD_BYTES` per call (the actual bytes that hit `sort-input.bin`).
  - `buildAndOpenReader()` reserves an additional `~peak` for the `OfflineSorter` merge phase (transient runs roughly double the on-disk footprint), then releases the full reservation after the sort scratch is unlinked from disk.
  - `close()` releases any leftover reservation on the failure path.
- **Behavior with both knobs unset is byte-for-byte identical** to the existing default: reservations against an unbounded cap are accounting-only and the volume probe short-circuits.

### Testing
- New `SourcelessSpillConfigTest` (5 cases) — pins `-D` parsing, defaults, clamp, and parse-failure fallback for all three props.
- New `SidecarBuilderBudgetTest` (3 cases) — drives the cap path end-to-end:
  - unbounded default accepts large writes,
  - breach throws the typed exception with the prop name in the message,
  - partial-progress-then-throw leaves bookkeeping consistent (failed reservation rolls back, successful one stays committed until `close()`).
- Existing `SidecarBuilderRoundTripTest` (9 cases) unchanged — all still pass.
- Full `SearchSnapshotExtractor:test` suite green locally.

```text
SourcelessSpillConfigTest                 5/5 PASSED
SidecarBuilderBudgetTest                  3/3 PASSED
SidecarBuilderRoundTripTest               9/9 PASSED
```

### Check List
- [x] New functionality includes testing
- [x] All tests pass
- [x] New functionality has been documented (Javadoc on every new public surface + the three properties block in `SourcelessSpillConfig`)
- [x] Commits are signed per the [DCO](https://github.com/opensearch-project/.github/blob/main/CONTRIBUTING.md) using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
