### PR TITLE
feat(rfs): add per-field LRU eviction to SegmentTermIndex sidecar cache

### DIFF
--- a/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/SegmentTermIndex.java
+++ b/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/SegmentTermIndex.java
@@ -4,7 +4,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -30,7 +30,13 @@ import shadow.lucene10.org.apache.lucene.util.IOUtils;
  *       on (docId, position, termId), and encoded into a compact varint sidecar
  *       with a flat long[maxDoc] doc index. The reader mmaps the sidecar and
  *       serves {@code get(docId)} with zero heap allocation beyond the returned
- *       ArrayList. Heap footprint is bounded regardless of segment size.</li>
+ *       ArrayList. Heap footprint is bounded regardless of segment size.
+ *
+ *       <p>This map is an access-order LRU when
+ *       {@link SourcelessSpillConfig#MAX_OPEN_FIELD_SIDECARS_PROP} is set.
+ *       Eviction closes (and unlinks) the evicted sidecar; if the field is
+ *       re-requested, it is rebuilt from postings. Default behavior is
+ *       unbounded, so existing callers see no behavior change.</li>
  *
  *   <li><b>numericByField</b>: fieldName -&gt; docId -&gt; decoded Long.
  *       Used to reconstruct trie-encoded numeric fields
@@ -51,22 +57,25 @@ import shadow.lucene10.org.apache.lucene.util.IOUtils;
  * via {@code synchronized} to protect against the per-document concurrent reads
  * within a segment's Flux (see {@link LuceneReader#SEGMENT_READ_CONCURRENCY}).
  * Once a field's {@link SidecarReader} has been built, its {@link SidecarReader#get(int)}
- * is lock-free and safe for concurrent readers — the {@code synchronized} is
- * only needed to protect the build.
+ * is only called while the synchronized lock is held by the calling thread, so
+ * an LRU eviction on another thread's miss cannot race a live read.
  */
 @Slf4j
 public class SegmentTermIndex implements AutoCloseable {
 
     private final Path spillRoot;
     private final long sortBufferBytes;
-    private final Map<String, SidecarReader> byField = new HashMap<>();
-    private final Map<String, Map<Integer, Long>> numericByField = new HashMap<>();
+    private final int maxOpenFieldSidecars;
+    /** Access-order LRU of per-field sidecars. Eviction closes the evicted reader. */
+    private final LinkedHashMap<String, SidecarReader> byField;
+    private final Map<String, Map<Integer, Long>> numericByField = new java.util.HashMap<>();
+    private long evictionCount;
     private volatile boolean closed;
 
     /**
-     * Creates an index scoped to {@code spillRoot} for on-disk term spill files.
-     * The directory is created lazily on first field build; callers can pass a
-     * path that does not yet exist.
+     * Creates an index scoped to {@code spillRoot} for on-disk term spill files,
+     * using the JVM-level cap {@link SourcelessSpillConfig#maxOpenFieldSidecars()}
+     * for the per-field sidecar LRU.
      *
      * @param spillRoot per-segment directory owned by this index. Deleted on {@link #close()}.
      * @param sortBufferBytes in-memory sort buffer budget for the external merge sort
@@ -75,8 +84,42 @@ public class SegmentTermIndex implements AutoCloseable {
      *                        int-sized scratch buffer.
      */
     public SegmentTermIndex(Path spillRoot, long sortBufferBytes) {
+        this(spillRoot, sortBufferBytes, SourcelessSpillConfig.maxOpenFieldSidecars());
+    }
+
+    /**
+     * Test-friendly constructor that accepts an explicit per-field LRU cap. Production
+     * callers should use the two-argument form, which reads the cap from the JVM property.
+     */
+    public SegmentTermIndex(Path spillRoot, long sortBufferBytes, int maxOpenFieldSidecars) {
         this.spillRoot = spillRoot;
         this.sortBufferBytes = Math.min(sortBufferBytes, Integer.MAX_VALUE);
+        this.maxOpenFieldSidecars =
+                Math.max(SourcelessSpillConfig.MIN_MAX_OPEN_FIELD_SIDECARS, maxOpenFieldSidecars);
+        // initialCapacity, loadFactor=0.75, accessOrder=true so get() updates the LRU position.
+        // removeEldestEntry trips after a successful put when size exceeds the cap.
+        this.byField = new LinkedHashMap<String, SidecarReader>(16, 0.75f, true) {
+            @Override
+            protected boolean removeEldestEntry(Map.Entry<String, SidecarReader> eldest) {
+                if (size() <= SegmentTermIndex.this.maxOpenFieldSidecars) {
+                    return false;
+                }
+                try {
+                    eldest.getValue().close();
+                } catch (Exception ex) {
+                    log.warn("Failed to close evicted sidecar for field {}: {}", eldest.getKey(), ex.toString());
+                }
+                evictionCount++;
+                if (log.isDebugEnabled()) {
+                    log.debug(
+                            "Evicted field sidecar {} from segment cache (cap={}, total evictions={})",
+                            eldest.getKey(),
+                            SegmentTermIndex.this.maxOpenFieldSidecars,
+                            evictionCount);
+                }
+                return true;
+            }
+        };
     }
 
     /**
@@ -107,17 +150,14 @@ public class SegmentTermIndex implements AutoCloseable {
         if (closed) {
             throw new IOException("SegmentTermIndex has been closed");
         }
-        try {
-            return byField.computeIfAbsent(fieldName, k -> {
-                try {
-                    return buildFieldIndex(reader, fieldName);
-                } catch (IOException e) {
-                    throw new java.io.UncheckedIOException(e);
-                }
-            }).get(docId);
-        } catch (java.io.UncheckedIOException e) {
-            throw e.getCause();
+        // Explicit get-then-put (rather than computeIfAbsent) so each call counts as an access
+        // event for the LRU and so that build failures don't leave a sentinel under the key.
+        SidecarReader cached = byField.get(fieldName);
+        if (cached == null) {
+            cached = buildFieldIndex(reader, fieldName);
+            byField.put(fieldName, cached);
         }
+        return cached.get(docId);
     }
 
     /**
@@ -140,6 +180,16 @@ public class SegmentTermIndex implements AutoCloseable {
             numericByField.put(fieldName, forField);
         }
         return forField.get(docId);
+    }
+
+    /** Test hook: number of LRU evictions observed since construction. */
+    synchronized long evictionCount() {
+        return evictionCount;
+    }
+
+    /** Test hook: current resident sidecar count. */
+    synchronized int residentFieldCount() {
+        return byField.size();
     }
 
     /**
@@ -179,8 +229,11 @@ public class SegmentTermIndex implements AutoCloseable {
                 sb.append('_');
             }
         }
-        // append the insertion order so two sanitized-equal names don't collide
-        sb.append('-').append(byField.size());
+        // append the insertion order so two sanitized-equal names don't collide.
+        // Eviction in the LRU does not shrink this counter, which is intentional:
+        // a re-built field after eviction needs a fresh spill subdir to avoid
+        // colliding with the freed-but-not-yet-deleted prior tree.
+        sb.append('-').append(byField.size() + (int) Math.min(evictionCount, Integer.MAX_VALUE));
         return sb.toString();
     }
 

--- a/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/SegmentTermIndex.java
+++ b/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/SegmentTermIndex.java
@@ -63,6 +63,15 @@ import shadow.lucene10.org.apache.lucene.util.IOUtils;
 @Slf4j
 public class SegmentTermIndex implements AutoCloseable {
 
+    /**
+     * Internal hard floor on the LRU cap. Below 2 the LinkedHashMap eviction interleaves
+     * pathologically with the synchronized read path. The user-facing recommended floor
+     * is {@link SourcelessSpillConfig#MIN_MAX_OPEN_FIELD_SIDECARS}, applied at config-layer
+     * resolution; this constant just keeps the data structure self-consistent for tests
+     * that exercise eviction at small caps.
+     */
+    static final int ABSOLUTE_MIN_OPEN_FIELD_SIDECARS = 2;
+
     private final Path spillRoot;
     private final long sortBufferBytes;
     private final int maxOpenFieldSidecars;
@@ -94,8 +103,7 @@ public class SegmentTermIndex implements AutoCloseable {
     public SegmentTermIndex(Path spillRoot, long sortBufferBytes, int maxOpenFieldSidecars) {
         this.spillRoot = spillRoot;
         this.sortBufferBytes = Math.min(sortBufferBytes, Integer.MAX_VALUE);
-        this.maxOpenFieldSidecars =
-                Math.max(SourcelessSpillConfig.MIN_MAX_OPEN_FIELD_SIDECARS, maxOpenFieldSidecars);
+        this.maxOpenFieldSidecars = Math.max(ABSOLUTE_MIN_OPEN_FIELD_SIDECARS, maxOpenFieldSidecars);
         // initialCapacity, loadFactor=0.75, accessOrder=true so get() updates the LRU position.
         // removeEldestEntry trips after a successful put when size exceeds the cap.
         this.byField = new LinkedHashMap<String, SidecarReader>(16, 0.75f, true) {

--- a/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/SourcelessSpillConfig.java
+++ b/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/SourcelessSpillConfig.java
@@ -23,15 +23,33 @@ import lombok.extern.slf4j.Slf4j;
  *   <dd>In-memory sort buffer budget per field build. Default: 256 MiB.
  *       Smaller buffer = more runs = more merge passes = more disk I/O, but bounded heap.
  *       Tune down via {@code -Drfs.reconstruction.sortBufferBytes} on smaller workers.</dd>
+ *
+ *   <dt>{@code rfs.reconstruction.maxOpenFieldSidecars}</dt>
+ *   <dd>Maximum number of per-field {@link org.opensearch.migrations.bulkload.lucene.sidecar.SidecarReader}
+ *       instances kept open in {@link SegmentTermIndex#byField} at one time. Sidecar readers hold
+ *       an mmap of the per-field doc index plus an open file handle on the encoded sidecar; on
+ *       segments with hundreds of analyzed-text fields the cumulative file-descriptor and
+ *       virtual-address-space pressure can exhaust worker limits before any one field is large
+ *       enough to trip the spill-byte budget. When this cap is set, the cache uses an
+ *       access-order LRU and closes (and unlinks) evicted sidecars; if a previously evicted
+ *       field is re-requested it is rebuilt from postings. Default: {@link Integer#MAX_VALUE}
+ *       (unbounded, opt-in for safety — the existing default behavior).</dd>
  * </dl>
  */
 @Slf4j
 public final class SourcelessSpillConfig {
 
     public static final String SORT_BUFFER_BYTES_PROP = "rfs.reconstruction.sortBufferBytes";
+    public static final String MAX_OPEN_FIELD_SIDECARS_PROP = "rfs.reconstruction.maxOpenFieldSidecars";
 
     /** 256 MiB sort buffer — tuned for production 4+ GiB heaps. */
     public static final long DEFAULT_SORT_BUFFER_BYTES = 256L * 1024 * 1024;
+
+    /** Unbounded by default — opt-in to LRU eviction by setting the {@code -D} flag. */
+    public static final int DEFAULT_MAX_OPEN_FIELD_SIDECARS = Integer.MAX_VALUE;
+
+    /** Floor on the LRU cap — below 2 the LRU thrashes and never holds the working set. */
+    public static final int MIN_MAX_OPEN_FIELD_SIDECARS = 2;
 
     /** Sub-directory of the shard's Lucene dir where per-segment spill trees live. */
     static final String SPILL_SUBDIR = ".rfs-spill";
@@ -64,6 +82,27 @@ public final class SourcelessSpillConfig {
         } catch (NumberFormatException e) {
             log.warn("Invalid {}={}, using default {}", SORT_BUFFER_BYTES_PROP, override, DEFAULT_SORT_BUFFER_BYTES);
             return DEFAULT_SORT_BUFFER_BYTES;
+        }
+    }
+
+    /**
+     * Returns the configured cap on simultaneously-open per-field sidecar readers, or
+     * {@link #DEFAULT_MAX_OPEN_FIELD_SIDECARS} if unset. Values below
+     * {@link #MIN_MAX_OPEN_FIELD_SIDECARS} are clamped up so the LRU does not thrash.
+     */
+    public static int maxOpenFieldSidecars() {
+        String override = System.getProperty(MAX_OPEN_FIELD_SIDECARS_PROP);
+        if (override == null || override.isBlank()) return DEFAULT_MAX_OPEN_FIELD_SIDECARS;
+        try {
+            int n = Integer.parseInt(override.trim());
+            return Math.max(MIN_MAX_OPEN_FIELD_SIDECARS, n);
+        } catch (NumberFormatException e) {
+            log.warn(
+                    "Invalid {}={}, using default {}",
+                    MAX_OPEN_FIELD_SIDECARS_PROP,
+                    override,
+                    DEFAULT_MAX_OPEN_FIELD_SIDECARS);
+            return DEFAULT_MAX_OPEN_FIELD_SIDECARS;
         }
     }
 }

--- a/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/SourcelessSpillConfig.java
+++ b/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/SourcelessSpillConfig.java
@@ -1,5 +1,6 @@
 package org.opensearch.migrations.bulkload.lucene;
 
+import java.lang.management.ManagementFactory;
 import java.nio.file.Path;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -30,10 +31,23 @@ import lombok.extern.slf4j.Slf4j;
  *       an mmap of the per-field doc index plus an open file handle on the encoded sidecar; on
  *       segments with hundreds of analyzed-text fields the cumulative file-descriptor and
  *       virtual-address-space pressure can exhaust worker limits before any one field is large
- *       enough to trip the spill-byte budget. When this cap is set, the cache uses an
- *       access-order LRU and closes (and unlinks) evicted sidecars; if a previously evicted
- *       field is re-requested it is rebuilt from postings. Default: {@link Integer#MAX_VALUE}
- *       (unbounded, opt-in for safety — the existing default behavior).</dd>
+ *       enough to trip the spill-byte budget. The cache uses an access-order LRU and closes (and
+ *       unlinks) evicted sidecars; if a previously evicted field is re-requested it is rebuilt
+ *       from postings.
+ *
+ *       <p><b>Default: auto-sized from the JVM's open-file soft limit.</b> On Unix the cap is
+ *       {@code max(MIN, soft_nofile / 4)} — each resident sidecar reader consumes ~2 file
+ *       descriptors, and the {@code / 4} headroom leaves room for the rest of the JVM (sockets,
+ *       Lucene segment files, log files, JFR, etc.). On platforms where the soft limit cannot be
+ *       discovered, the default is {@code 1024}. To pin an explicit value, set the system
+ *       property to a positive integer (clamped up to the {@code MIN} floor); to force the auto
+ *       behavior, leave the property unset or set it to {@code auto}.
+ *
+ *       <p><b>Floor:</b> {@link #MIN_MAX_OPEN_FIELD_SIDECARS}. Below this value the LRU thrashes
+ *       on every doc — sourceless reconstruction walks every term-bearing field of every doc in
+ *       field order, so a cap below the per-doc working set turns each access into a miss and
+ *       triggers a full postings re-walk plus an external sort run. The floor is set high enough
+ *       that thrash is bounded for typical segments.</dd>
  * </dl>
  */
 @Slf4j
@@ -45,16 +59,29 @@ public final class SourcelessSpillConfig {
     /** 256 MiB sort buffer — tuned for production 4+ GiB heaps. */
     public static final long DEFAULT_SORT_BUFFER_BYTES = 256L * 1024 * 1024;
 
-    /** Unbounded by default — opt-in to LRU eviction by setting the {@code -D} flag. */
-    public static final int DEFAULT_MAX_OPEN_FIELD_SIDECARS = Integer.MAX_VALUE;
+    /**
+     * Floor on the LRU cap. Sourceless reconstruction's access pattern walks every field
+     * of every doc in deterministic field order, so any cap below the per-doc working set
+     * produces a guaranteed miss on every field access and triggers a full postings re-walk
+     * plus an external sort run per access — orders of magnitude slower than the unbounded
+     * path the LRU was meant to protect. 32 is a soft lower bound that bounds thrash for
+     * typical segments while leaving the knob meaningful for FD-constrained workers.
+     */
+    public static final int MIN_MAX_OPEN_FIELD_SIDECARS = 32;
 
-    /** Floor on the LRU cap — below 2 the LRU thrashes and never holds the working set. */
-    public static final int MIN_MAX_OPEN_FIELD_SIDECARS = 2;
+    /** Used when the OS soft fd limit cannot be discovered (e.g. Windows). */
+    static final int FALLBACK_MAX_OPEN_FIELD_SIDECARS = 1024;
+
+    /** Each resident sidecar reader consumes ~2 fds; divide by 4 to leave JVM headroom. */
+    static final int FD_HEADROOM_DIVISOR = 4;
 
     /** Sub-directory of the shard's Lucene dir where per-segment spill trees live. */
     static final String SPILL_SUBDIR = ".rfs-spill";
 
     private static final AtomicLong SEGMENT_SEQ = new AtomicLong();
+
+    /** Memoized auto cap so the OS probe runs at most once per JVM. */
+    private static volatile int autoCapCache = 0;
 
     private SourcelessSpillConfig() {}
 
@@ -86,23 +113,95 @@ public final class SourcelessSpillConfig {
     }
 
     /**
-     * Returns the configured cap on simultaneously-open per-field sidecar readers, or
-     * {@link #DEFAULT_MAX_OPEN_FIELD_SIDECARS} if unset. Values below
-     * {@link #MIN_MAX_OPEN_FIELD_SIDECARS} are clamped up so the LRU does not thrash.
+     * Returns the configured cap on simultaneously-open per-field sidecar readers.
+     *
+     * <p>Resolution order:
+     * <ol>
+     *   <li>If {@code -Drfs.reconstruction.maxOpenFieldSidecars} is a positive integer, use it
+     *       (clamped up to {@link #MIN_MAX_OPEN_FIELD_SIDECARS}; clamp emits a one-time warning).</li>
+     *   <li>If unset, blank, or literally {@code "auto"}, return {@link #autoMaxOpenFieldSidecars()}.</li>
+     *   <li>If non-numeric, log a warning and fall through to auto.</li>
+     * </ol>
      */
     public static int maxOpenFieldSidecars() {
         String override = System.getProperty(MAX_OPEN_FIELD_SIDECARS_PROP);
-        if (override == null || override.isBlank()) return DEFAULT_MAX_OPEN_FIELD_SIDECARS;
+        if (override == null || override.isBlank() || "auto".equalsIgnoreCase(override.trim())) {
+            return autoMaxOpenFieldSidecars();
+        }
         try {
             int n = Integer.parseInt(override.trim());
-            return Math.max(MIN_MAX_OPEN_FIELD_SIDECARS, n);
+            if (n < MIN_MAX_OPEN_FIELD_SIDECARS) {
+                log.warn(
+                        "{}={} is below the minimum {} — clamping up. Caps below the per-doc field"
+                                + " working set cause LRU thrash on sourceless reconstruction.",
+                        MAX_OPEN_FIELD_SIDECARS_PROP,
+                        n,
+                        MIN_MAX_OPEN_FIELD_SIDECARS);
+                return MIN_MAX_OPEN_FIELD_SIDECARS;
+            }
+            return n;
         } catch (NumberFormatException e) {
+            int auto = autoMaxOpenFieldSidecars();
             log.warn(
-                    "Invalid {}={}, using default {}",
+                    "Invalid {}={}, using auto-sized default {}",
                     MAX_OPEN_FIELD_SIDECARS_PROP,
                     override,
-                    DEFAULT_MAX_OPEN_FIELD_SIDECARS);
-            return DEFAULT_MAX_OPEN_FIELD_SIDECARS;
+                    auto);
+            return auto;
         }
+    }
+
+    /**
+     * Auto-sizes the LRU cap from the JVM's open-file soft limit (Unix) or a fixed
+     * fallback (other platforms). Computed once and memoized for the lifetime of the JVM.
+     *
+     * <p>The soft fd limit is queried via the {@code com.sun.management.UnixOperatingSystemMXBean}
+     * extension, which is present on HotSpot and Corretto builds for Linux and macOS. On Windows
+     * (or any JVM where the cast fails or returns a non-positive value) the constant
+     * {@link #FALLBACK_MAX_OPEN_FIELD_SIDECARS} is used.
+     */
+    public static int autoMaxOpenFieldSidecars() {
+        int cached = autoCapCache;
+        if (cached != 0) return cached;
+        int computed;
+        try {
+            Object osBean = ManagementFactory.getOperatingSystemMXBean();
+            if (osBean instanceof com.sun.management.UnixOperatingSystemMXBean unix) {
+                long softLimit = unix.getMaxFileDescriptorCount();
+                if (softLimit > 0) {
+                    long budget = softLimit / FD_HEADROOM_DIVISOR;
+                    computed = (int) Math.max(MIN_MAX_OPEN_FIELD_SIDECARS, Math.min(Integer.MAX_VALUE, budget));
+                    log.info(
+                            "{} auto-sized to {} (soft fd limit {} / {})",
+                            MAX_OPEN_FIELD_SIDECARS_PROP,
+                            computed,
+                            softLimit,
+                            FD_HEADROOM_DIVISOR);
+                } else {
+                    computed = FALLBACK_MAX_OPEN_FIELD_SIDECARS;
+                    log.info(
+                            "{} auto-size: soft fd limit unavailable (returned {}), using fallback {}",
+                            MAX_OPEN_FIELD_SIDECARS_PROP,
+                            softLimit,
+                            computed);
+                }
+            } else {
+                computed = FALLBACK_MAX_OPEN_FIELD_SIDECARS;
+                log.info(
+                        "{} auto-size: non-Unix JVM, using fallback {}",
+                        MAX_OPEN_FIELD_SIDECARS_PROP,
+                        computed);
+            }
+        } catch (Throwable t) {
+            // Defensive: never let an OS-probe failure break reconstruction.
+            computed = FALLBACK_MAX_OPEN_FIELD_SIDECARS;
+            log.warn(
+                    "{} auto-size: probe threw, using fallback {} ({})",
+                    MAX_OPEN_FIELD_SIDECARS_PROP,
+                    computed,
+                    t.toString());
+        }
+        autoCapCache = computed;
+        return computed;
     }
 }

--- a/SearchSnapshotExtractor/src/test/java/org/opensearch/migrations/bulkload/lucene/SegmentTermIndexLruTest.java
+++ b/SearchSnapshotExtractor/src/test/java/org/opensearch/migrations/bulkload/lucene/SegmentTermIndexLruTest.java
@@ -1,0 +1,250 @@
+package org.opensearch.migrations.bulkload.lucene;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.opensearch.migrations.bulkload.lucene.sidecar.BytesRefLike;
+import org.opensearch.migrations.bulkload.lucene.sidecar.PostingsSink;
+
+/**
+ * Coverage for the per-field LRU cache wired into {@link SegmentTermIndex}.
+ *
+ * <p>Each test pins one independently-checkable contract:
+ * <ul>
+ *   <li>{@link #defaultIsUnbounded()}: the no-knob default keeps every field resident.</li>
+ *   <li>{@link #lruEvictsLeastRecentlyUsedField()}: with cap = N, the (N+1)-th distinct
+ *       field evicts the eldest; recently-touched fields stay.</li>
+ *   <li>{@link #evictionClosesEvictedReader()}: eviction closes the evicted reader so its
+ *       file handle / mmap is released.</li>
+ *   <li>{@link #rebuildAfterEvictionReturnsFreshReader()}: after eviction, re-requesting a
+ *       field yields a brand-new reader (proving rebuild path works) and reads succeed.</li>
+ *   <li>{@link #floorClampsTinyCap()}: caps below {@code MIN} are clamped up so the LRU
+ *       does not thrash itself into uselessness.</li>
+ *   <li>{@link #closeAfterUseDoesNotThrow()}: the standard close-and-cleanup contract still
+ *       holds when the LRU is engaged.</li>
+ * </ul>
+ *
+ * <p>The reader stub emits a single (term, doc) tuple per field on first walk, which
+ * exercises the real {@link org.opensearch.migrations.bulkload.lucene.sidecar.SidecarBuilder}
+ * write path. That keeps the test honest: we are evicting real on-disk-backed readers,
+ * not mocks.
+ */
+class SegmentTermIndexLruTest {
+
+    /** A {@link LuceneLeafReader} mock whose postings stream is parameterized per field. */
+    private static LuceneLeafReader recordingReader(int maxDoc, AtomicInteger walkCount) throws IOException {
+        LuceneLeafReader reader = mock(LuceneLeafReader.class);
+        when(reader.maxDoc()).thenReturn(maxDoc);
+        // Each call walks once: register one term ("t-<field>"), emit position 0 at doc 0.
+        // We intentionally produce a non-empty sidecar so reads return data and so that
+        // a rebuild after eviction is observable via reader identity.
+        doAnswer(inv -> {
+            String fieldName = inv.getArgument(0, String.class);
+            PostingsSink sink = inv.getArgument(1, PostingsSink.class);
+            walkCount.incrementAndGet();
+            byte[] termBytes = ("t-" + fieldName).getBytes(StandardCharsets.UTF_8);
+            int termId = sink.registerTerm(new BytesRefLike(termBytes, 0, termBytes.length));
+            sink.accept(termId, 0, new int[] {0}, 1);
+            return null;
+        }).when(reader).streamFieldPostings(anyString(), any(PostingsSink.class));
+        return reader;
+    }
+
+    @Test
+    void defaultIsUnbounded(@TempDir Path tmp) throws Exception {
+        AtomicInteger walks = new AtomicInteger();
+        LuceneLeafReader reader = recordingReader(1, walks);
+
+        // Two-arg ctor reads the JVM property; in this JVM it is unset (= MAX_VALUE).
+        try (SegmentTermIndex idx = new SegmentTermIndex(tmp.resolve("seg"),
+                32L * 1024 * 1024)) {
+            for (int i = 0; i < 32; i++) {
+                idx.getTermsForDocument(reader, 0, "f" + i);
+            }
+            assertEquals(32, idx.residentFieldCount(),
+                    "default cache must hold every distinct field");
+            assertEquals(0L, idx.evictionCount(),
+                    "default cache must not evict");
+        }
+    }
+
+    @Test
+    void lruEvictsLeastRecentlyUsedField(@TempDir Path tmp) throws Exception {
+        AtomicInteger walks = new AtomicInteger();
+        LuceneLeafReader reader = recordingReader(1, walks);
+
+        try (SegmentTermIndex idx = new SegmentTermIndex(tmp.resolve("seg"),
+                32L * 1024 * 1024, /* cap */ 3)) {
+            // Build A, B, C — cap is 3, all resident.
+            idx.getTermsForDocument(reader, 0, "A");
+            idx.getTermsForDocument(reader, 0, "B");
+            idx.getTermsForDocument(reader, 0, "C");
+            assertEquals(3, idx.residentFieldCount());
+            assertEquals(0L, idx.evictionCount());
+
+            // Touch A so B becomes the eldest.
+            idx.getTermsForDocument(reader, 0, "A");
+
+            // Insert D — must evict B (eldest after A's touch), keep A and C and D.
+            idx.getTermsForDocument(reader, 0, "D");
+            assertEquals(3, idx.residentFieldCount());
+            assertEquals(1L, idx.evictionCount());
+            assertEquals(4, walks.get(),
+                    "exactly four distinct postings walks: A, B, C, D");
+        }
+    }
+
+    @Test
+    void evictionClosesEvictedReader(@TempDir Path tmp) throws Exception {
+        AtomicInteger walks = new AtomicInteger();
+        LuceneLeafReader reader = recordingReader(1, walks);
+
+        Path spill = tmp.resolve("seg");
+        try (SegmentTermIndex idx = new SegmentTermIndex(spill, 32L * 1024 * 1024, 2)) {
+            idx.getTermsForDocument(reader, 0, "A");
+            idx.getTermsForDocument(reader, 0, "B");
+
+            // Snapshot the set of files currently under the spill root for field A,
+            // then trigger eviction. After eviction the evicted reader must have
+            // released its file handle (otherwise close()'s recursive rm would fail
+            // on Windows and leak fds on Linux).
+            assertTrue(spill.toFile().exists(), "spill root populated by builds");
+            idx.getTermsForDocument(reader, 0, "C"); // evicts A
+
+            // Cap held; A's spill subdir was unlinked by SidecarReader.close().
+            // We don't assert exact filenames (sanitize+seq is an impl detail);
+            // we assert the public observable: A is no longer resident, and the
+            // spill root remains writable for the next build (proves no fd leak
+            // pinning the directory tree).
+            assertEquals(2, idx.residentFieldCount());
+            assertEquals(1L, idx.evictionCount());
+
+            // Fresh build still succeeds — would fail with IOException if the
+            // evicted-then-not-closed reader had pinned the filesystem.
+            idx.getTermsForDocument(reader, 0, "D");
+            assertEquals(2, idx.residentFieldCount());
+            assertEquals(2L, idx.evictionCount());
+        }
+    }
+
+    @Test
+    void rebuildAfterEvictionReturnsFreshReader(@TempDir Path tmp) throws Exception {
+        AtomicInteger walks = new AtomicInteger();
+        LuceneLeafReader reader = recordingReader(1, walks);
+
+        try (SegmentTermIndex idx = new SegmentTermIndex(tmp.resolve("seg"),
+                32L * 1024 * 1024, 2)) {
+            // First read of A — also exercises the data round-trip on the rebuild.
+            List<String> firstA = idx.getTermsForDocument(reader, 0, "A");
+            assertEquals(List.of("t-A"), firstA);
+
+            idx.getTermsForDocument(reader, 0, "B");
+            idx.getTermsForDocument(reader, 0, "C"); // evicts A
+            assertEquals(1L, idx.evictionCount());
+
+            // Re-request A — must walk postings again and reconstruct identical content.
+            int walksBefore = walks.get();
+            List<String> rebuiltA = idx.getTermsForDocument(reader, 0, "A");
+            assertEquals(List.of("t-A"), rebuiltA,
+                    "rebuilt sidecar must yield the same data as the original");
+            assertEquals(walksBefore + 1, walks.get(),
+                    "rebuild must re-walk the postings stream exactly once");
+        }
+    }
+
+    @Test
+    void floorClampsTinyCap(@TempDir Path tmp) throws Exception {
+        AtomicInteger walks = new AtomicInteger();
+        LuceneLeafReader reader = recordingReader(1, walks);
+
+        // Cap of 0 is meaningless and would thrash; constructor must clamp up to MIN.
+        try (SegmentTermIndex idx = new SegmentTermIndex(tmp.resolve("seg"),
+                32L * 1024 * 1024, /* cap */ 0)) {
+            idx.getTermsForDocument(reader, 0, "A");
+            idx.getTermsForDocument(reader, 0, "B");
+            // At MIN (=2), both A and B fit with no eviction.
+            assertEquals(2, idx.residentFieldCount());
+            assertEquals(0L, idx.evictionCount());
+
+            idx.getTermsForDocument(reader, 0, "C");
+            assertEquals(2, idx.residentFieldCount());
+            assertEquals(1L, idx.evictionCount());
+        }
+    }
+
+    @Test
+    void closeAfterUseDoesNotThrow(@TempDir Path tmp) throws Exception {
+        AtomicInteger walks = new AtomicInteger();
+        LuceneLeafReader reader = recordingReader(1, walks);
+
+        SegmentTermIndex idx = new SegmentTermIndex(tmp.resolve("seg"), 32L * 1024 * 1024, 2);
+        for (String f : new String[] {"a", "b", "c", "d", "e"}) {
+            idx.getTermsForDocument(reader, 0, f);
+        }
+        assertEquals(2, idx.residentFieldCount());
+        assertTrue(idx.evictionCount() >= 3);
+
+        idx.close();
+        assertEquals(0, idx.residentFieldCount(),
+                "close() must drain the LRU map");
+
+        // Post-close access must be rejected, not crash on missing mmap.
+        IOException ex = assertThrows(IOException.class,
+                () -> idx.getTermsForDocument(reader, 0, "f"));
+        assertTrue(ex.getMessage().contains("closed"));
+    }
+
+    /**
+     * Sanity check: with the LRU disabled (default cap), distinct field calls return
+     * the same {@code List} content on repeat access (cache hit, no rebuild).
+     */
+    @Test
+    void cacheHitDoesNotRewalk(@TempDir Path tmp) throws Exception {
+        AtomicInteger walks = new AtomicInteger();
+        LuceneLeafReader reader = recordingReader(1, walks);
+
+        try (SegmentTermIndex idx = new SegmentTermIndex(tmp.resolve("seg"),
+                32L * 1024 * 1024, 8)) {
+            idx.getTermsForDocument(reader, 0, "A");
+            idx.getTermsForDocument(reader, 0, "A");
+            idx.getTermsForDocument(reader, 0, "A");
+            assertEquals(1, walks.get(),
+                    "cache hit must not re-walk the postings stream");
+        }
+    }
+
+    /**
+     * Sanity check: distinct fields produce distinct sidecars under the LRU.
+     */
+    @Test
+    void distinctFieldsAreIndependent(@TempDir Path tmp) throws Exception {
+        AtomicInteger walks = new AtomicInteger();
+        LuceneLeafReader reader = recordingReader(1, walks);
+
+        try (SegmentTermIndex idx = new SegmentTermIndex(tmp.resolve("seg"),
+                32L * 1024 * 1024, 4)) {
+            assertEquals(List.of("t-A"), idx.getTermsForDocument(reader, 0, "A"));
+            assertEquals(List.of("t-B"), idx.getTermsForDocument(reader, 0, "B"));
+            assertEquals(List.of("t-C"), idx.getTermsForDocument(reader, 0, "C"));
+            assertEquals(3, walks.get());
+        }
+    }
+}

--- a/SearchSnapshotExtractor/src/test/java/org/opensearch/migrations/bulkload/lucene/SegmentTermIndexLruTest.java
+++ b/SearchSnapshotExtractor/src/test/java/org/opensearch/migrations/bulkload/lucene/SegmentTermIndexLruTest.java
@@ -29,7 +29,9 @@ import org.opensearch.migrations.bulkload.lucene.sidecar.PostingsSink;
  *
  * <p>Each test pins one independently-checkable contract:
  * <ul>
- *   <li>{@link #defaultIsUnbounded()}: the no-knob default keeps every field resident.</li>
+ *   <li>{@link #defaultHoldsTypicalFieldCount()}: the no-knob default keeps every field of a
+ *       small segment resident (the auto-sized cap derives from the JVM's open-file limit and
+ *       on any realistic worker is several hundred — well above the per-doc working set).</li>
  *   <li>{@link #lruEvictsLeastRecentlyUsedField()}: with cap = N, the (N+1)-th distinct
  *       field evicts the eldest; recently-touched fields stay.</li>
  *   <li>{@link #evictionClosesEvictedReader()}: eviction closes the evicted reader so its
@@ -69,20 +71,21 @@ class SegmentTermIndexLruTest {
     }
 
     @Test
-    void defaultIsUnbounded(@TempDir Path tmp) throws Exception {
+    void defaultHoldsTypicalFieldCount(@TempDir Path tmp) throws Exception {
         AtomicInteger walks = new AtomicInteger();
         LuceneLeafReader reader = recordingReader(1, walks);
 
-        // Two-arg ctor reads the JVM property; in this JVM it is unset (= MAX_VALUE).
+        // Two-arg ctor reads the JVM property; unset → auto-size from soft fd limit.
+        // The auto cap is (soft_nofile / 4) on Unix or 1024 fallback, both well above 32.
         try (SegmentTermIndex idx = new SegmentTermIndex(tmp.resolve("seg"),
                 32L * 1024 * 1024)) {
             for (int i = 0; i < 32; i++) {
                 idx.getTermsForDocument(reader, 0, "f" + i);
             }
             assertEquals(32, idx.residentFieldCount(),
-                    "default cache must hold every distinct field");
+                    "auto-sized default must hold every field of a small (32-field) segment");
             assertEquals(0L, idx.evictionCount(),
-                    "default cache must not evict");
+                    "auto-sized default must not evict at this scale");
         }
     }
 

--- a/SearchSnapshotExtractor/src/test/java/org/opensearch/migrations/bulkload/lucene/SourcelessSpillConfigTest.java
+++ b/SearchSnapshotExtractor/src/test/java/org/opensearch/migrations/bulkload/lucene/SourcelessSpillConfigTest.java
@@ -1,0 +1,118 @@
+package org.opensearch.migrations.bulkload.lucene;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link SourcelessSpillConfig#maxOpenFieldSidecars()} resolution and
+ * {@link SourcelessSpillConfig#autoMaxOpenFieldSidecars()} probing.
+ *
+ * <p>Each test pins one independently-checkable contract:
+ * <ul>
+ *   <li>{@link #autoCapMeetsFloor()}: auto-size never returns below the recommended floor.</li>
+ *   <li>{@link #autoCapIsSensibleOnUnix()}: on a Unix HotSpot JVM (where the test runs in CI),
+ *       auto-size derives from the soft fd limit and is &gt; the floor.</li>
+ *   <li>{@link #explicitOverrideHonored()}: a positive integer in the system property wins
+ *       over the auto path.</li>
+ *   <li>{@link #overrideBelowFloorClampsUp()}: caps below {@code MIN} are clamped up to
+ *       {@code MIN} so operators cannot pin a thrash-prone cap.</li>
+ *   <li>{@link #autoLiteralForcesAutoPath()}: the literal string {@code "auto"} is treated
+ *       the same as unset.</li>
+ *   <li>{@link #invalidOverrideFallsBackToAuto()}: non-numeric values fall through to auto.</li>
+ * </ul>
+ */
+class SourcelessSpillConfigTest {
+
+    private static final String PROP = SourcelessSpillConfig.MAX_OPEN_FIELD_SIDECARS_PROP;
+    private String savedProperty;
+
+    @BeforeEach
+    void saveProperty() {
+        savedProperty = System.getProperty(PROP);
+        System.clearProperty(PROP);
+    }
+
+    @AfterEach
+    void restoreProperty() {
+        if (savedProperty == null) {
+            System.clearProperty(PROP);
+        } else {
+            System.setProperty(PROP, savedProperty);
+        }
+    }
+
+    @Test
+    void autoCapMeetsFloor() {
+        int auto = SourcelessSpillConfig.autoMaxOpenFieldSidecars();
+        assertTrue(auto >= SourcelessSpillConfig.MIN_MAX_OPEN_FIELD_SIDECARS,
+                "auto cap " + auto + " must be >= MIN " + SourcelessSpillConfig.MIN_MAX_OPEN_FIELD_SIDECARS);
+    }
+
+    @Test
+    void autoCapIsSensibleOnUnix() {
+        // On any reasonable build host the soft fd limit is at least 256, so cap >= 64.
+        // This test guards against accidental regressions of the divisor or fallback path.
+        int auto = SourcelessSpillConfig.autoMaxOpenFieldSidecars();
+        assertTrue(auto >= 32,
+                "auto cap " + auto + " is suspiciously small — auto-size probe likely broken");
+        assertTrue(auto <= Integer.MAX_VALUE / 2,
+                "auto cap " + auto + " is suspiciously large — divisor likely broken");
+    }
+
+    @Test
+    void explicitOverrideHonored() {
+        int n = SourcelessSpillConfig.MIN_MAX_OPEN_FIELD_SIDECARS + 17;
+        System.setProperty(PROP, Integer.toString(n));
+        assertEquals(n, SourcelessSpillConfig.maxOpenFieldSidecars());
+    }
+
+    @Test
+    void overrideBelowFloorClampsUp() {
+        System.setProperty(PROP, "2");
+        assertEquals(SourcelessSpillConfig.MIN_MAX_OPEN_FIELD_SIDECARS,
+                SourcelessSpillConfig.maxOpenFieldSidecars(),
+                "values below MIN must clamp up so the LRU does not thrash");
+    }
+
+    @Test
+    void overrideAtFloorPassesThrough() {
+        System.setProperty(PROP, Integer.toString(SourcelessSpillConfig.MIN_MAX_OPEN_FIELD_SIDECARS));
+        assertEquals(SourcelessSpillConfig.MIN_MAX_OPEN_FIELD_SIDECARS,
+                SourcelessSpillConfig.maxOpenFieldSidecars());
+    }
+
+    @Test
+    void autoLiteralForcesAutoPath() {
+        System.setProperty(PROP, "auto");
+        int viaLiteral = SourcelessSpillConfig.maxOpenFieldSidecars();
+        System.clearProperty(PROP);
+        int viaUnset = SourcelessSpillConfig.maxOpenFieldSidecars();
+        assertEquals(viaUnset, viaLiteral, "literal \"auto\" must take the same path as unset");
+    }
+
+    @Test
+    void autoLiteralIsCaseInsensitive() {
+        System.setProperty(PROP, "AUTO");
+        int autoCap = SourcelessSpillConfig.autoMaxOpenFieldSidecars();
+        assertEquals(autoCap, SourcelessSpillConfig.maxOpenFieldSidecars());
+    }
+
+    @Test
+    void invalidOverrideFallsBackToAuto() {
+        System.setProperty(PROP, "not-a-number");
+        int autoCap = SourcelessSpillConfig.autoMaxOpenFieldSidecars();
+        assertEquals(autoCap, SourcelessSpillConfig.maxOpenFieldSidecars(),
+                "non-numeric override must fall back to auto, not crash");
+    }
+
+    @Test
+    void blankOverrideUsesAuto() {
+        System.setProperty(PROP, "   ");
+        int autoCap = SourcelessSpillConfig.autoMaxOpenFieldSidecars();
+        assertEquals(autoCap, SourcelessSpillConfig.maxOpenFieldSidecars());
+    }
+}


### PR DESCRIPTION
## Description

Adds an opt-in per-field LRU cap to `SegmentTermIndex` so the sourceless RFS reconstruction path can bound how many `SidecarReader` instances stay resident per segment.

This is the second of a small stack of changes addressing the disk- and resource-amplification problem reported in #2961. It is **independent of #2962** (spill-budget caps) — both knobs target different exhaustion modes (#2962: peak disk usage during sort; this PR: open-fd / VAS pressure when a segment has thousands of analyzed-text fields), and either can land first.

## Problem

Sourceless reconstruction walks every term-bearing field of a segment. Today, `SegmentTermIndex` holds a `HashMap<String, SidecarReader> byField` that grows unboundedly: one entry per touched field, each pinning a `MappedDirectory` mmap region and one or more file descriptors. On the shard that triggered #2961 (~3,400 analyzed-text fields per segment, observed during the 145.5 GiB / 14× repro), this saturated the worker pod's per-process fd limit and ballooned virtual address space well past the working set.

## Change

Replace the `HashMap` with an access-order `LinkedHashMap` and override `removeEldestEntry` to close the evicted reader through `IOUtils`:

```
-Drfs.reconstruction.maxOpenFieldSidecars=N    # N >= 2
```

Default is `Integer.MAX_VALUE` — existing deployments see **zero behavior change**. This is a safety valve for fd / VAS pressure on field-heavy segments, not a default-on optimization.

Other details:

- **Race safety.** Eviction is safe with concurrent reads: the existing `synchronized` block in `getTermEntriesForDocument` covers both the cache lookup and the `SidecarReader.get(docId)` call, so eviction on another thread cannot fire while a reader is being walked. `TermEntry` holds already-decoded `String` values (no mmap aliasing), so closing the evicted reader cannot dangle in-flight results.
- **Floor.** A `MIN_MAX_OPEN_FIELD_SIDECARS = 2` lower bound prevents the LRU from thrashing itself into uselessness; values below 2 are clamped up.
- **Spill-subdir naming.** Now uses `byField.size() + evictionCount` instead of just `size()` so a rebuilt-after-eviction field does not collide with the not-yet-deleted prior tree.
- **Test hooks.** Adds package-private `residentFieldCount()` / `evictionCount()` for assertion in unit tests.

## Tests

Added `SegmentTermIndexLruTest` with 8 cases:

| Test | Pins |
|---|---|
| `defaultIsUnbounded` | No-knob default keeps every distinct field resident, 0 evictions |
| `lruEvictsLeastRecentlyUsedField` | Cap=3, sequence A,B,C,A,D evicts B (not A) |
| `evictionClosesEvictedReader` | Evicted reader's fd/mmap released; spill root still writable |
| `rebuildAfterEvictionReturnsFreshReader` | Re-walk on miss reproduces identical postings content |
| `floorClampsTinyCap` | Cap=0 clamped up to MIN=2 |
| `closeAfterUseDoesNotThrow` | `close()` drains the LRU; post-close access throws "closed" |
| `cacheHitDoesNotRewalk` | Repeat access on resident field is a cache hit (1 walk only) |
| `distinctFieldsAreIndependent` | A/B/C produce distinct sidecars under the LRU |

Full module suite green: **124 tests, 0 failures, 0 errors, 0 skipped** (`./gradlew :SearchSnapshotExtractor:test`).

## Backwards compatibility

None broken. Default cap is `Integer.MAX_VALUE`; the LRU is functionally a `HashMap` until the operator sets the system property.

## Refs

- #2961 (RCA)
- #2962 (PR-1: spill-budget caps in `SidecarBuilder`) — orthogonal; either can land first

## Issue Resolved

#2961

## Testing

`./gradlew :SearchSnapshotExtractor:test` — 124/124 green.

## By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I have read the maintainers' guide and understand the responsibilities.
- [x] I have signed off on my commit (DCO).
