### PR TITLE
RFS: stop busy-restart loop on idle Solr-source workers

### DIFF
--- a/DocumentsFromSnapshotMigration/docker/runJavaWithClasspathWithRepeat.sh
+++ b/DocumentsFromSnapshotMigration/docker/runJavaWithClasspathWithRepeat.sh
@@ -1,23 +1,51 @@
 #!/bin/sh
 
-# Store our PID for later use
+# Re-runs the RFS Java entrypoint, translating well-known exit codes from
+# RfsMigrateDocuments into orchestrator-friendly behavior:
+#
+#   0 (success)              -> work was migrated; restart immediately to
+#                                acquire the next shard.
+#   3 (NO_WORK_LEFT_EXIT_CODE) -> all work for this run is done. Propagate
+#                                the non-zero code so the orchestrator
+#                                (k8s Deployment / kubelet) applies its
+#                                CrashLoopBackOff backoff between restarts
+#                                while the control plane (Argo / operator)
+#                                observes completion and scales replicas
+#                                to zero. Exiting 0 here would cause the
+#                                Pod's container to be restarted with no
+#                                backoff at all, immediately re-burning a
+#                                ~2.5 s cold-start cycle.
+#   4 (NO_WORK_AVAILABLE_EXIT_CODE) -> work still exists but none is currently
+#                                available to this worker (e.g. all leases
+#                                held by peers). Sleep with jittered
+#                                exponential backoff before re-execing the
+#                                JVM, so we don't burn ~2.5s of cold-start
+#                                per attempt while peers finish.
+#   anything else (real failure) -> propagate so the orchestrator (k8s, Argo,
+#                                ECS, ...) sees the failure and retries
+#                                according to its own policy.
+#
+# These codes are defined in RfsMigrateDocuments.java; keep both in sync.
+
 OUR_PID=$$
 
-# Setup signal handling
+# Backoff configuration for the "no work available right now" case. Override
+# with environment variables if a particular orchestrator wants different
+# behavior (e.g. very small clusters with chatty coordinators).
+NO_WORK_BACKOFF_INITIAL_SECONDS="${NO_WORK_BACKOFF_INITIAL_SECONDS:-5}"
+NO_WORK_BACKOFF_MAX_SECONDS="${NO_WORK_BACKOFF_MAX_SECONDS:-60}"
+
 cleanup() {
     echo "Received termination signal. Forwarding to child processes..."
-    # Find the Java process PID
     JAVA_PID=$(pgrep -P $OUR_PID -f "java")
     if [ -n "$JAVA_PID" ]; then
         echo "Sending SIGTERM to Java process $JAVA_PID"
         kill -TERM "$JAVA_PID"
-        # Wait for Java process to terminate gracefully (up to 30 seconds)
         TIMEOUT=30
         while kill -0 "$JAVA_PID" 2>/dev/null && [ $TIMEOUT -gt 0 ]; do
             sleep 1
             TIMEOUT=$((TIMEOUT-1))
         done
-        # Force kill if needed
         if kill -0 "$JAVA_PID" 2>/dev/null; then
             echo "Java process didn't terminate gracefully, forcing..."
             kill -9 "$JAVA_PID"
@@ -28,17 +56,42 @@ cleanup() {
     exit 0
 }
 
-# Register the trap for SIGTERM and other relevant signals
-trap cleanup SIGTERM SIGINT SIGQUIT
+trap cleanup TERM INT QUIT
 
+backoff_seconds=$NO_WORK_BACKOFF_INITIAL_SECONDS
 while true; do
     /rfs-app/runJavaWithClasspath.sh "$@" &
     JAVA_PID=$!
-    # Wait for the Java process to finish
     wait $JAVA_PID
     EXIT_CODE=$?
-    if [ $EXIT_CODE -ne 0 ]; then
-        exit $EXIT_CODE
-    fi
-    echo "Process exited with code 0, restarting..."
+    case "$EXIT_CODE" in
+        0)
+            echo "Process exited with code 0, restarting..."
+            backoff_seconds=$NO_WORK_BACKOFF_INITIAL_SECONDS
+            ;;
+        3)
+            # Propagate non-zero so the orchestrator's restart policy
+            # applies a backoff (k8s CrashLoopBackOff) between attempts.
+            # The control plane will scale us to zero once it sees the
+            # work is complete; until then, backoff is what we want.
+            echo "Process exited with code 3 (NO_WORK_LEFT). Propagating to orchestrator for backoff."
+            exit 3
+            ;;
+        4)
+            # Add small jitter (0-1s) so 50+ workers don't re-storm the
+            # coordinator in lockstep after they all stalled together.
+            jitter=$(awk 'BEGIN{srand(); print int(rand()*2)}')
+            sleep_for=$((backoff_seconds + jitter))
+            echo "Process exited with code 4 (NO_WORK_AVAILABLE). Sleeping ${sleep_for}s before retry."
+            sleep "$sleep_for"
+            # Exponential backoff capped at NO_WORK_BACKOFF_MAX_SECONDS.
+            backoff_seconds=$((backoff_seconds * 2))
+            if [ "$backoff_seconds" -gt "$NO_WORK_BACKOFF_MAX_SECONDS" ]; then
+                backoff_seconds=$NO_WORK_BACKOFF_MAX_SECONDS
+            fi
+            ;;
+        *)
+            exit $EXIT_CODE
+            ;;
+    esac
 done

--- a/DocumentsFromSnapshotMigration/src/main/java/org/opensearch/migrations/RfsMigrateDocuments.java
+++ b/DocumentsFromSnapshotMigration/src/main/java/org/opensearch/migrations/RfsMigrateDocuments.java
@@ -941,6 +941,7 @@ public class RfsMigrateDocuments {
         boolean useServerGeneratedIds,
         RootDocumentMigrationContext context
     ) {
+        var cleanShutdownCompleted = new AtomicBoolean(false);
         try {
             // Check the coordinator for pending work BEFORE downloading anything from S3.
             // This avoids wasting time/bandwidth downloading schema metadata on every pod restart
@@ -957,7 +958,6 @@ public class RfsMigrateDocuments {
             var completionRetryConfig = buildCompletionRetryConfig(arguments);
             var coordinatorFactory = new WorkCoordinatorFactory(
                 coordinatorInfo.version(), arguments.indexNameSuffix, completionRetryConfig);
-            var cleanShutdownCompleted = new AtomicBoolean(false);
             var allowlist = buildDocumentExceptionAllowlist(arguments);
 
             try (var workCoordinator = coordinatorFactory.get(
@@ -1124,12 +1124,19 @@ public class RfsMigrateDocuments {
                     .cancellationTriggerConsumer(cancellationRunnableRef::set)
                     .build();
 
-                runner.migrateOneShard(context::createReindexContext);
+                var status = runner.migrateOneShard(context::createReindexContext);
                 cleanShutdownCompleted.set(true);
+                if (status == CompletionStatus.NOTHING_DONE) {
+                    log.atInfo().setMessage("Work exists but none available to this worker. Exiting with exit code "
+                            + NO_WORK_AVAILABLE_EXIT_CODE).log();
+                    System.exit(NO_WORK_AVAILABLE_EXIT_CODE);
+                }
             }
             log.atInfo().setMessage("Solr backup document migration completed successfully").log();
         } catch (NoWorkLeftException e) {
             log.atInfo().setMessage("No more Solr work items to process: {}").addArgument(e.getMessage()).log();
+            cleanShutdownCompleted.set(true);
+            System.exit(NO_WORK_LEFT_EXIT_CODE);
         } catch (Exception e) {
             throw new RuntimeException("Failed to migrate Solr backup", e);
         }

--- a/DocumentsFromSnapshotMigration/src/test/java/org/opensearch/migrations/bulkload/RunJavaWithClasspathWithRepeatScriptTest.java
+++ b/DocumentsFromSnapshotMigration/src/test/java/org/opensearch/migrations/bulkload/RunJavaWithClasspathWithRepeatScriptTest.java
@@ -1,0 +1,178 @@
+package org.opensearch.migrations.bulkload;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.attribute.PosixFilePermission;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Behavioral tests for runJavaWithClasspathWithRepeat.sh: the Docker entrypoint
+ * wrapper that re-execs the Java process. The wrapper must translate the
+ * RfsMigrateDocuments exit codes correctly:
+ *
+ *   exit 3 (NO_WORK_LEFT)      -> wrapper exits 0 (Pod Completed, no restart loop)
+ *   exit 4 (NO_WORK_AVAILABLE) -> wrapper sleeps with backoff, then re-execs
+ *   exit 0 (work done)         -> wrapper re-execs immediately
+ *   exit other (real failure)  -> wrapper propagates the code
+ *
+ * Tests run by invoking the real script with a stubbed `runJavaWithClasspath.sh`
+ * child placed on a temp PATH that records each invocation.
+ */
+@DisabledOnOs(OS.WINDOWS) // /bin/sh-based wrapper
+class RunJavaWithClasspathWithRepeatScriptTest {
+
+    private static final Path SCRIPT = locateScript();
+
+    private static Path locateScript() {
+        // Resolve from the project working directory in a robust way: the test
+        // is run from .../DocumentsFromSnapshotMigration so the script lives
+        // at docker/runJavaWithClasspathWithRepeat.sh relative to it.
+        Path candidate = Paths.get("docker", "runJavaWithClasspathWithRepeat.sh").toAbsolutePath();
+        if (Files.exists(candidate)) {
+            return candidate;
+        }
+        // Fallback: walk up one level (in case tests are invoked from repo root).
+        Path alt = Paths.get("DocumentsFromSnapshotMigration", "docker", "runJavaWithClasspathWithRepeat.sh")
+            .toAbsolutePath();
+        if (Files.exists(alt)) {
+            return alt;
+        }
+        throw new IllegalStateException("Cannot locate runJavaWithClasspathWithRepeat.sh; tried "
+            + candidate + " and " + alt);
+    }
+
+    /**
+     * Writes a fake `/rfs-app/runJavaWithClasspath.sh` shim that records each
+     * invocation in a counter file and exits with the next code from a
+     * pre-supplied list. Returns the directory that should be prepended to PATH
+     * (for /rfs-app substitution we rebind via a sed-replaced copy of the
+     * script — see {@link #stagedScript(Path, Path)}).
+     */
+    private static Path writeChildShim(Path tempDir, String exitCodesCsv, Path counterFile) throws IOException {
+        Path child = tempDir.resolve("fake-runJavaWithClasspath.sh");
+        String shim = "#!/bin/sh\n"
+            + "n=$(cat \"" + counterFile.toAbsolutePath() + "\" 2>/dev/null || echo 0)\n"
+            + "n=$((n + 1))\n"
+            + "echo $n > \"" + counterFile.toAbsolutePath() + "\"\n"
+            + "set -- " + exitCodesCsv.replace(",", " ") + "\n"
+            + "i=$n\n"
+            + "while [ $i -gt 1 ]; do shift; i=$((i - 1)); done\n"
+            + "exit ${1:-0}\n";
+        Files.writeString(child, shim);
+        try {
+            Files.setPosixFilePermissions(child, Set.of(
+                PosixFilePermission.OWNER_READ,
+                PosixFilePermission.OWNER_WRITE,
+                PosixFilePermission.OWNER_EXECUTE,
+                PosixFilePermission.GROUP_READ,
+                PosixFilePermission.GROUP_EXECUTE,
+                PosixFilePermission.OTHERS_READ,
+                PosixFilePermission.OTHERS_EXECUTE
+            ));
+        } catch (UnsupportedOperationException ignored) {
+            // not a POSIX file system; chmod handled by sh
+        }
+        return child;
+    }
+
+    /**
+     * Produces a copy of the production script with the hardcoded
+     * /rfs-app/runJavaWithClasspath.sh path rewritten to point at our test
+     * shim. The production script does not parameterize that path, so this
+     * is the cleanest way to test the wrapper without breaking its
+     * production behavior.
+     */
+    private static Path stagedScript(Path tempDir, Path childShim) throws IOException {
+        String original = Files.readString(SCRIPT);
+        String rewritten = original.replace(
+            "/rfs-app/runJavaWithClasspath.sh",
+            childShim.toAbsolutePath().toString()
+        );
+        Path staged = tempDir.resolve("repeat-under-test.sh");
+        Files.writeString(staged, rewritten);
+        try {
+            Files.setPosixFilePermissions(staged, Set.of(
+                PosixFilePermission.OWNER_READ,
+                PosixFilePermission.OWNER_WRITE,
+                PosixFilePermission.OWNER_EXECUTE
+            ));
+        } catch (UnsupportedOperationException ignored) {
+            // not a POSIX file system
+        }
+        return staged;
+    }
+
+    private static int runScript(Path staged) throws IOException, InterruptedException {
+        // Use a tiny backoff to keep the NO_WORK_AVAILABLE test fast.
+        ProcessBuilder pb = new ProcessBuilder("/bin/sh", staged.toAbsolutePath().toString());
+        pb.environment().put("NO_WORK_BACKOFF_INITIAL_SECONDS", "0");
+        pb.environment().put("NO_WORK_BACKOFF_MAX_SECONDS", "0");
+        pb.redirectErrorStream(true);
+        Process p = pb.start();
+        if (!p.waitFor(30, TimeUnit.SECONDS)) {
+            p.destroyForcibly();
+            throw new AssertionError("repeat script did not exit within 30s");
+        }
+        return p.exitValue();
+    }
+
+    @Test
+    void exit3FromChildPropagatesAsThreeWithoutRetry(@TempDir Path tempDir) throws Exception {
+        Path counter = tempDir.resolve("counter");
+        Path shim = writeChildShim(tempDir, "3", counter);
+        Path staged = stagedScript(tempDir, shim);
+
+        assertEquals(3, runScript(staged),
+            "exit 3 from child should be propagated as wrapper exit 3 so the orchestrator can apply backoff");
+        assertEquals("1", Files.readString(counter).trim(), "child should be invoked exactly once");
+    }
+
+    @Test
+    void exit4FromChildBackoffsAndRetries(@TempDir Path tempDir) throws Exception {
+        Path counter = tempDir.resolve("counter");
+        // First call -> 4 (no work available, retry), second call -> 3 (no work left, propagate)
+        Path shim = writeChildShim(tempDir, "4,3", counter);
+        Path staged = stagedScript(tempDir, shim);
+
+        assertEquals(3, runScript(staged),
+            "exit 4 then exit 3 should result in wrapper exit 3 after retry");
+        assertEquals("2", Files.readString(counter).trim(),
+            "child should be invoked twice: once for the 4, once for the 3");
+    }
+
+    @Test
+    void exit0FromChildRestartsImmediatelyUntilTerminalCode(@TempDir Path tempDir) throws Exception {
+        Path counter = tempDir.resolve("counter");
+        // Three "did work, restart" cycles, then a terminal "no work left".
+        Path shim = writeChildShim(tempDir, "0,0,0,3", counter);
+        Path staged = stagedScript(tempDir, shim);
+
+        assertEquals(3, runScript(staged),
+            "exit 0 cycles followed by exit 3 should end with wrapper exit 3");
+        assertEquals("4", Files.readString(counter).trim(),
+            "child should be invoked four times: three exit-0 cycles plus the terminal exit 3");
+    }
+
+    @Test
+    void nonZeroNonTerminalCodePropagates(@TempDir Path tempDir) throws Exception {
+        Path counter = tempDir.resolve("counter");
+        Path shim = writeChildShim(tempDir, "1", counter);
+        Path staged = stagedScript(tempDir, shim);
+
+        int actual = runScript(staged);
+        assertEquals(1, actual, "exit 1 from child should propagate verbatim");
+        assertTrue(Files.exists(counter), "counter file should exist after one invocation");
+        assertEquals("1", Files.readString(counter).trim(), "child should be invoked exactly once on hard failure");
+    }
+}

--- a/DocumentsFromSnapshotMigration/src/test/java/org/opensearch/migrations/bulkload/SolrSnapshotToOpenSearchTest.java
+++ b/DocumentsFromSnapshotMigration/src/test/java/org/opensearch/migrations/bulkload/SolrSnapshotToOpenSearchTest.java
@@ -135,6 +135,68 @@ public class SolrSnapshotToOpenSearchTest {
     }
 
     /**
+     * Regression test for the RFS busy-restart loop on idle Solr-source workers.
+     *
+     * Before the fix, the Solr branch of RfsMigrateDocuments swallowed
+     * NoWorkLeftException and let main() return normally, so the JVM exited 0
+     * even when all work for the snapshot was already complete. The Docker
+     * wrapper script (runJavaWithClasspathWithRepeat.sh) treats exit 0 as
+     * "did some work, restart for the next item", which produced an infinite
+     * cold-start loop on the (very common) case of a worker re-attaching to
+     * a fully-completed migration.
+     *
+     * After the fix, a second invocation against an already-migrated dataset
+     * must exit with NO_WORK_LEFT_EXIT_CODE (3) so that the Docker wrapper
+     * propagates a non-zero status to the orchestrator (kubelet), letting
+     * its CrashLoopBackOff timer pace restarts while the control plane
+     * scales replicas to zero — instead of the JVM busy-restarting on the
+     * coordinator with no backoff.
+     */
+    @org.junit.jupiter.api.Test
+    @Tag("isolatedTest")
+    @Timeout(value = 5, unit = TimeUnit.MINUTES)
+    void secondInvocationExitsWithNoWorkLeftCode() throws Exception {
+        try (
+            var solr = createSolr(SolrClusterContainer.SOLR_8, false);
+            var target = new SearchClusterContainer(SearchClusterContainer.OS_V3_5_0)
+        ) {
+            solr.start();
+            target.start();
+
+            createCollection(solr, COLLECTION_NAME);
+            indexMovieDocuments(solr, COLLECTION_NAME);
+            var backupDir = createBackup(solr, COLLECTION_NAME);
+
+            String[] args = new String[]{
+                "--source-version", "SOLR_" + SolrClusterContainer.SOLR_8.tag(),
+                "--snapshot-local-dir", backupDir.toString(),
+                "--snapshot-name", "solr-migration",
+                "--target-host", target.getUrl(),
+                "--coordinator-host", target.getUrl(),
+                "--index-allowlist", COLLECTION_NAME
+            };
+
+            // First run actually migrates the shard and exits 0 (work completed).
+            int firstExit = SourceTestBase.runProcessAgainstTarget(args);
+            assertEquals(0, firstExit, "First invocation should migrate the shard and exit 0");
+            verifyDocCount(target, COLLECTION_NAME, 5);
+
+            // Second run finds work coordination already complete and must exit 3
+            // After the fix, the second invocation MUST exit with code 3
+            // (NO_WORK_LEFT) so the Docker wrapper propagates non-zero to
+            // the orchestrator and the kubelet's CrashLoopBackOff paces
+            // subsequent restarts instead of busy-spinning on cold-start.
+            int secondExit = SourceTestBase.runProcessAgainstTarget(args);
+            assertEquals(
+                org.opensearch.migrations.RfsMigrateDocuments.NO_WORK_LEFT_EXIT_CODE,
+                secondExit,
+                "Second invocation against a fully-migrated snapshot must exit with NO_WORK_LEFT_EXIT_CODE "
+                    + "so runJavaWithClasspathWithRepeat.sh propagates non-zero and the orchestrator backs off"
+            );
+        }
+    }
+
+    /**
      * Tests the pipeline-level integration directly (no CLI).
      */
     @ParameterizedTest(name = "pipeline: {0} → {1} (cloud={2})")


### PR DESCRIPTION
### Description

The Solr-source RFS path can spin in a busy cold-start loop on idle workers, burning ~20 JVM cold-starts/sec per migration with no progress. This PR stops the loop.

#### Root cause

The Solr branch of `RfsMigrateDocuments.runSolrBackupMigration` caught `NoWorkLeftException` with just an INFO log and let `main()` return normally — so the JVM exited 0 even when all work for the snapshot was already complete cluster-wide.

The Docker entrypoint `runJavaWithClasspathWithRepeat.sh` was a tight `while true` loop that treated **any** exit 0 as "did some work, restart for the next item". Together, the two produced an infinite cold-start loop the moment a worker re-attached to a fully-completed migration:

```
~2.5 s of JVM bootstrap + SPI scanning + S3 metadata download
       + work-coordinator probe per iteration, repeated forever
```

With ~50 workers per migration that's ~20 wasted JVM cold-starts/sec per migration, plus continuous S3 GET / coordinator query traffic, plus a Pod that never reaches `Completed` and so blocks downstream Argo / k8s lifecycle steps.

For comparison, the ES-source branch already does the right thing: it lets `NoWorkLeftException` bubble up to the outer catch which calls `System.exit(NO_WORK_LEFT_EXIT_CODE)` (3), and exits 4 (`NO_WORK_AVAILABLE_EXIT_CODE`) when `migrateOneShard()` returns `NOTHING_DONE`. The exit codes existed but the Solr branch never produced them and the wrapper never translated them.

#### Fix

Two complementary changes:

**1. `RfsMigrateDocuments.runSolrBackupMigration` mirrors the ES branch's exit-code contract**

- `NoWorkLeftException` &rarr; `System.exit(NO_WORK_LEFT_EXIT_CODE)` (3)
- `migrateOneShard()` returning `NOTHING_DONE` &rarr; `System.exit(NO_WORK_AVAILABLE_EXIT_CODE)` (4)
- `cleanShutdownCompleted` is hoisted to the outer-method scope (matching the ES branch) so the existing shutdown hook can observe it from the new catch path.

**2. `runJavaWithClasspathWithRepeat.sh` interprets those exit codes**

| child exit | wrapper behavior |
|---|---|
| `0` | restart immediately (unchanged — worker did real work, grab next shard) |
| `3` (`NO_WORK_LEFT`) | propagate as **exit 3** so the orchestrator's restart policy applies a backoff between attempts. RFS workers run as a `Deployment` (`restartPolicy: Always`), so the kubelet will restart the container regardless of exit code; the only knob the wrapper controls is whether that restart is **immediate** (exit 0) or **paced by `CrashLoopBackOff`** (non-zero). The control plane (Argo / operator) eventually patches the Deployment's `replicas: 0` once it observes work-coordinator completion; until then, `CrashLoopBackOff` is exactly what we want. |
| `4` (`NO_WORK_AVAILABLE`) | sleep with jittered exponential backoff (5 s &rarr; 60 s, env-overridable) before retry. Workers can usefully retry inside the same JVM here because peers may release leases at any time. |
| anything else | propagate (unchanged) |

Backoff for code 4 is env-tunable via `NO_WORK_BACKOFF_INITIAL_SECONDS` and `NO_WORK_BACKOFF_MAX_SECONDS`. The Java exit-code constants and the shell case branches cross-reference each other in comments so future contributors keep them in sync.

#### What this changes operationally

- Workers re-attaching to a completed migration **stop busy-spinning on the JVM cold-start path**. The wrapper still re-execs (it must — the kubelet will restart the container regardless), but each restart is now **paced by CrashLoopBackOff** (10 s → 20 s → 40 s → 80 s → 160 s → 300 s cap) instead of firing every ~2.5 s. The control plane eventually scales the Deployment to zero and the pod terminates entirely.
- Workers blocked on peer leases back off in-process via the wrapper instead of hammering the work coordinator + S3 metadata layer with full cold-starts.
- The "did real work, restart for next shard" path is **unchanged** — important for throughput on multi-shard collections.

### Issues Resolved

None filed; bug was discovered in production from worker logs showing a sub-2-second exit-and-restart cadence on a fully-migrated collection.

### Testing

**New test: `SolrSnapshotToOpenSearchTest#secondInvocationExitsWithNoWorkLeftCode`**

Runs an end-to-end Solr-snapshot &rarr; OpenSearch migration twice and asserts:

1. First invocation exits 0 (work completed, docs visible in target).
2. Second invocation against the same already-completed snapshot exits with `NO_WORK_LEFT_EXIT_CODE` (3) — the regression-guard for this fix.

This test fails on the previous code (the second run logs "No more Solr work items to process" and exits 0).

**New test: `RunJavaWithClasspathWithRepeatScriptTest`**

Behavioral test for the wrapper. Stages a copy of the production script with the hardcoded `/rfs-app/runJavaWithClasspath.sh` rewritten to point at a counter-incrementing test shim. Then asserts wrapper exit code AND number of child invocations across four scenarios:

- exit 3 from child &rarr; wrapper exits **3**, child invoked once (propagation, no retry)
- exit 4 then exit 3 from child &rarr; wrapper exits **3**, child invoked twice (backoff + propagation)
- three exit-0 cycles then exit 3 &rarr; wrapper exits **3**, child invoked four times
- exit 1 from child &rarr; wrapper exits 1, child invoked once

Backoff is short-circuited to 0s in the test harness via the new env vars so the suite runs in <0.2 s. Skipped on Windows since the wrapper is `/bin/sh`-based.

```
> Task :DocumentsFromSnapshotMigration:test
RunJavaWithClasspathWithRepeatScriptTest tests=4 skipped=0 failures=0 errors=0 time=0.103
BUILD SUCCESSFUL
```

The existing `SolrSnapshotToOpenSearchTest#snapshotBasedDocumentMigration` and `SolrSuccessiveBackupsTest` continue to assert exit code 0 and still pass — those tests run a single invocation that actually migrates a shard (the new `WORK_COMPLETED` &rarr; exit 0 path), not a re-attach to a completed migration.

### Check List
- [x] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
