### PR TITLE
Fix workflow show --history S3 prefix to include creationTimestamp

### DIFF
--- a/migrationConsole/lib/console_link/console_link/workflow/commands/show.py
+++ b/migrationConsole/lib/console_link/console_link/workflow/commands/show.py
@@ -205,9 +205,10 @@ def _history_prefix(resource_name: str, resource: Dict[str, Any], output_name: s
     display_type = _resource_display_type(resource_name)
     parsed = parse_resource_path(resource_name)
     uid = _resource_uid(resource)
-    if not display_type or not parsed or not uid:
+    creation_ts = resource.get("metadata", {}).get("creationTimestamp", "")
+    if not display_type or not parsed or not uid or not creation_ts:
         return None
-    return f"{OUTPUT_ROOT}/{display_type}/{parsed[1]}/{uid}/{output_name}/"
+    return f"{OUTPUT_ROOT}/{display_type}/{parsed[1]}/{creation_ts}_{uid}/{output_name}/"
 
 
 def _iso_timestamp(value) -> str:

--- a/migrationConsole/lib/console_link/tests/workflow-tests/test_workflow_cli_commands.py
+++ b/migrationConsole/lib/console_link/tests/workflow-tests/test_workflow_cli_commands.py
@@ -1262,17 +1262,20 @@ class TestWorkflowCLICommands:
         mock_custom = Mock()
         mock_client.CustomObjectsApi.return_value = mock_custom
         mock_custom.get_namespaced_custom_object.return_value = {
-            'metadata': {'uid': 'uid-1'},
+            'metadata': {'uid': 'uid-1', 'creationTimestamp': '2020-01-01T00:00:00Z'},
             'status': {'outputs': {}},
         }
         mock_list_artifacts.return_value = [
             {
-                'key': 'migration-outputs/snapshotmigration/mig/uid-1/metadataMigrate/wf-1.log',
+                'key': 'migration-outputs/snapshotmigration/mig/2020-01-01T00:00:00Z_uid-1/metadataMigrate/wf-1.log',
                 'last_modified': 1710000000.0,
                 'size': 12,
             },
             {
-                'key': 'migration-outputs/snapshotmigration/mig/uid-1/metadataMigrate/wf-1.log.metadata',
+                'key': (
+                    'migration-outputs/snapshotmigration/mig/'
+                    '2020-01-01T00:00:00Z_uid-1/metadataMigrate/wf-1.log.metadata'
+                ),
                 'last_modified': 1710000001.0,
                 'size': 2,
             },
@@ -1285,11 +1288,38 @@ class TestWorkflowCLICommands:
 
         assert result.exit_code == 0
         mock_list_artifacts.assert_called_once_with(
-            'migration-outputs/snapshotmigration/mig/uid-1/metadataMigrate/'
+            'migration-outputs/snapshotmigration/mig/2020-01-01T00:00:00Z_uid-1/metadataMigrate/'
         )
         assert 'metadataMigrate' in result.output
-        assert 's3://bucket/migration-outputs/snapshotmigration/mig/uid-1/metadataMigrate/wf-1.log' in result.output
+        expected_uri = ('s3://bucket/migration-outputs/snapshotmigration/mig/'
+                        '2020-01-01T00:00:00Z_uid-1/metadataMigrate/wf-1.log')
+        assert expected_uri in result.output
         assert '.metadata' not in result.output
+
+    def test_history_prefix_includes_creation_timestamp(self):
+        from console_link.workflow.commands.show import _history_prefix
+
+        resource = {
+            'metadata': {
+                'uid': 'accd2c5a-0e7c-4890-a083-96b3b201e1c9',
+                'creationTimestamp': '2026-05-11T21:23:08Z',
+            },
+        }
+
+        prefix = _history_prefix('snapshotmigration.my-migration-0', resource, 'metadataEvaluate')
+
+        assert prefix == (
+            'migration-outputs/snapshotmigration/my-migration-0/'
+            '2026-05-11T21:23:08Z_accd2c5a-0e7c-4890-a083-96b3b201e1c9/metadataEvaluate/'
+        )
+        # Verify the prefix matches the format used by reset.py's _artifact_output_prefix
+        from console_link.workflow.commands.reset import _artifact_output_prefix
+        reset_prefix = _artifact_output_prefix(
+            'snapshotmigrations', 'my-migration-0',
+            uid='accd2c5a-0e7c-4890-a083-96b3b201e1c9',
+            created_at='2026-05-11T21:23:08Z',
+        )
+        assert prefix.startswith(reset_prefix)
 
     @patch('console_link.workflow.commands.submit.verify_configured_secrets_exist')
     @patch('console_link.workflow.commands.submit.get_credentials_secret_store_for_namespace')


### PR DESCRIPTION
### Description

Include `metadata.creationTimestamp` in the S3 prefix built by `workflow show --history`. The `--history` code path was constructing the prefix using only the resource UID, but the actual S3 layout written by workflow templates uses `<creationTimestamp>_<uid>` as the directory segment. This caused `--history` to find no artifacts even when they exist and `workflow show` (without `--history`) works correctly.

The fix applies to one function:

- `_history_prefix()` in `show.py` — reads `metadata.creationTimestamp` from the CR (already available, no new plumbing) and prepends it to the UID when building the S3 listing prefix

Previously, any user running `workflow show <resource> --history` would see "No retained output artifacts found" despite artifacts being present in S3, making the history feature completely non-functional.

### Issues Resolved

Fixes https://github.com/opensearch-project/opensearch-migrations/issues/2958

### Testing

- Unit test updated to verify the corrected prefix format (all 17 show-related tests passing)
- Reproduced the bug on a live EKS cluster (MA 3.2.0, us-east-1) and verified the fix: `--history` now lists artifacts and `--run` reads them correctly
- No behavioral change for `workflow show` without `--history` (uses the exact `s3Key` from CR status, unaffected)

### Check List

- [x] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).