### PR TITLE
Add approve release step via GitHub environments

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -14,12 +14,20 @@ env:
 permissions:
   id-token: write
   contents: write
-  issues: write
 
 jobs:
+  approve-release:
+    name: Approve release
+    if: ${{ !github.event.act && github.repository == 'opensearch-project/opensearch-migrations' }}
+    runs-on: ubuntu-22.04
+    environment: migrations-cicd-require-approval
+    steps:
+      - run: echo "Release approved"
+
   draft-a-release:
     name: Draft a release
-    if: ${{ github.event.act || github.repository == 'opensearch-project/opensearch-migrations' }}
+    needs: approve-release
+    if: ${{ github.event.act || needs.approve-release.result == 'success' }}
     runs-on: ubuntu-22.04
     services:
       registry:
@@ -38,17 +46,7 @@ jobs:
       - uses: ./.github/actions/setup-env
       - id: get_data
         run: |
-          echo "approvers=$(cat .github/CODEOWNERS | grep @ | tr -d '*\n ' | sed 's/@/,/g' | sed 's/,//1')" >> $GITHUB_OUTPUT
           echo "version=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
-      - uses: trstringer/manual-approval@v1
-        if: ${{ !github.event.act }}
-        with:
-          secret: ${{ github.TOKEN }}
-          approvers: ${{ steps.get_data.outputs.approvers }}
-          minimum-approvals: 1
-          issue-title: 'Release opensearch-migrations version ${{ steps.get_data.outputs.version }}'
-          issue-body: "This release requires approval from at least one reviewer. Please approve or deny the release of opensearch-migrations **TAG**: ${{ github.ref_name }}  **COMMIT**: ${{ github.sha }} **VERSION**: ${{ steps.get_data.outputs.version }}. The published TrafficCapture version will be 0.${{ steps.get_data.outputs.version }}."
-          exclude-workflow-initiator-as-approver: true
       - name: Set up QEMU (for arm64 emulation)
         uses: docker/setup-qemu-action@v4
       - name: Set up Buildx builder (BuildKit)

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -20,7 +20,7 @@ jobs:
     name: Approve release
     if: ${{ !github.event.act && github.repository == 'opensearch-project/opensearch-migrations' }}
     runs-on: ubuntu-22.04
-    environment: migrations-cicd-require-approval
+    environment: release-approval
     steps:
       - run: echo "Release approved"
 


### PR DESCRIPTION
### Description
Reusing existing GitHub environments for approving releases instead of creating issues and approving. This effort makes sure only maintained list of people can approve a given workflow before releasing artifacts. 

Please us know if the list needs to be updated. 

### Issues Resolved
<!-- List any GitHub or Jira issues this PR will resolve -->

### Testing
Sample run: https://github.com/gaiksaya/opensearch-migrations/actions/runs/25832542938

### Check List
- [ ] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
