### PR TITLE
Use chart appVersion for default migration image tags

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -39,7 +39,12 @@ jobs:
       - id: get_data
         run: |
           echo "approvers=$(cat .github/CODEOWNERS | grep @ | tr -d '*\n ' | sed 's/@/,/g' | sed 's/,//1')" >> $GITHUB_OUTPUT
-          echo "version=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+          version="$(tr -d '[:space:]' < VERSION)"
+          if [[ "$GITHUB_REF" == refs/tags/* && "${GITHUB_REF#refs/tags/}" != "$version" ]]; then
+            echo "Release tag '${GITHUB_REF#refs/tags/}' does not match VERSION '${version}'" >&2
+            exit 1
+          fi
+          echo "version=${version}" >> $GITHUB_OUTPUT
       - uses: trstringer/manual-approval@v1
         if: ${{ !github.event.act }}
         with:

--- a/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/Chart.yaml
+++ b/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: migration-assistant
 version: 0.2.0
 type: application
-appVersion: "1.16.0"
+appVersion: "latest"

--- a/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/templates/childrenChartInstaller/installJob.yaml
+++ b/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/templates/childrenChartInstaller/installJob.yaml
@@ -32,7 +32,7 @@ spec:
 {{- end }}
       containers:
         - name: helm-installer
-          image: {{ .Values.images.installer.repository }}:{{ .Values.images.installer.tag }}
+          image: {{ include "migration.image" (dict "root" . "image" .Values.images.installer) }}
           imagePullPolicy: {{ .Values.images.installer.pullPolicy }}
 {{- if and .Values.conditionalPackageInstalls.kyverno .Values.kyvernoPolicies.zeroResourceRequests }}
           volumeMounts:
@@ -120,7 +120,7 @@ spec:
               echo "Waiting for zero-resource-requests policy to be ready..."
               kubectl wait --for=condition=Ready clusterpolicy/zero-resource-requests --timeout=60s
               echo "Verifying policy is actively enforcing via canary pod..."
-              INSTALLER_IMAGE="{{ $.Values.images.installer.repository }}:{{ $.Values.images.installer.tag }}"
+              INSTALLER_IMAGE="{{ include "migration.image" (dict "root" $ "image" $.Values.images.installer) }}"
               until kubectl run kyverno-canary -n {{ $.Release.Namespace }} --image="$INSTALLER_IMAGE" --restart=Never --command -- sleep 999 2>/dev/null \
                 && kubectl get pod -n {{ $.Release.Namespace }} kyverno-canary -o jsonpath='{.metadata.annotations.kyverno\.io/mutated-by}' 2>/dev/null | grep -q zero-resource-requests; do
                 kubectl delete pod kyverno-canary -n {{ $.Release.Namespace }} --ignore-not-found 2>/dev/null

--- a/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/templates/childrenChartInstaller/permissions.yaml
+++ b/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/templates/childrenChartInstaller/permissions.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.installer.serviceAccount.create -}}
+{{- if .Values.installer.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -15,7 +15,7 @@ metadata:
 {{- end }}
 
 ---
-{{- if .Values.installer.rbac.create -}}
+{{- if .Values.installer.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -36,7 +36,7 @@ rules:
 {{- end }}
 
 ---
-{{- if .Values.installer.rbac.create -}}
+{{- if .Values.installer.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/templates/childrenChartInstaller/uninstallJob.yaml
+++ b/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/templates/childrenChartInstaller/uninstallJob.yaml
@@ -26,7 +26,7 @@ spec:
       restartPolicy: Never
       containers:
         - name: helm-uninstaller
-          image: {{ .Values.images.installer.repository}}:{{ .Values.images.installer.tag }}
+          image: {{ include "migration.image" (dict "root" . "image" .Values.images.installer) }}
           imagePullPolicy: {{ .Values.images.installer.pullPolicy }}
           command:
             - /bin/sh
@@ -72,7 +72,7 @@ spec:
       restartPolicy: Never
       containers:
         - name: helm-uninstaller-logging
-          image: {{ .Values.images.installer.repository}}:{{ .Values.images.installer.tag }}
+          image: {{ include "migration.image" (dict "root" . "image" .Values.images.installer) }}
           imagePullPolicy: {{ .Values.images.installer.pullPolicy }}
           command:
             - /bin/sh

--- a/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/templates/helpers/_imageHelper.tpl
+++ b/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/templates/helpers/_imageHelper.tpl
@@ -1,0 +1,7 @@
+{{- define "migration.imageTag" -}}
+{{- default .root.Chart.AppVersion .image.tag -}}
+{{- end -}}
+
+{{- define "migration.image" -}}
+{{- printf "%s:%s" .image.repository (include "migration.imageTag" .) -}}
+{{- end -}}

--- a/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/templates/installWorkflows.yaml
+++ b/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/templates/installWorkflows.yaml
@@ -21,7 +21,7 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: migration-console-for-workflows
-          image: {{ .Values.images.migrationConsole.repository }}:{{ .Values.images.migrationConsole.tag }}
+          image: {{ include "migration.image" (dict "root" . "image" .Values.images.migrationConsole) }}
           imagePullPolicy: {{ .Values.images.migrationConsole.pullPolicy }}
           command:
             - "/bin/sh"
@@ -78,7 +78,7 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: migration-console-for-workflows
-          image: {{ .Values.images.migrationConsole.repository }}:{{ .Values.images.migrationConsole.tag }}
+          image: {{ include "migration.image" (dict "root" . "image" .Values.images.migrationConsole) }}
           imagePullPolicy: {{ .Values.images.migrationConsole.pullPolicy }}
           command:
             - "/bin/sh"

--- a/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/templates/resources/awsPrivateCA.yaml
+++ b/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/templates/resources/awsPrivateCA.yaml
@@ -17,7 +17,7 @@ spec:
       serviceAccountName: {{ .Values.argoWorkflowServiceAccountName | default "argo-workflow-executor" }}
       containers:
       - name: create-issuer
-        image: {{ .Values.images.migrationConsole.repository }}:{{ .Values.images.migrationConsole.tag }}
+        image: {{ include "migration.image" (dict "root" . "image" .Values.images.migrationConsole) }}
         command: ["/bin/sh", "-c"]
         args:
         - |

--- a/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/templates/resources/awsPrivateCaIssuerHook.yaml
+++ b/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/templates/resources/awsPrivateCaIssuerHook.yaml
@@ -17,7 +17,7 @@ spec:
       serviceAccountName: {{ .Values.argoWorkflowServiceAccountName | default "argo-workflow-executor" }}
       containers:
       - name: create-pca-and-issuer
-        image: {{ .Values.images.migrationConsole.repository }}:{{ .Values.images.migrationConsole.tag }}
+        image: {{ include "migration.image" (dict "root" . "image" .Values.images.migrationConsole) }}
         command: ["/bin/sh", "-c"]
         args:
         - |

--- a/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/templates/resources/imageConfigmap.yaml
+++ b/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/templates/resources/imageConfigmap.yaml
@@ -7,13 +7,13 @@ metadata:
     workflows.argoproj.io/configmap-type: Parameter
 
 data:
-  captureProxyImage: "{{ .Values.images.captureProxy.repository }}:{{ .Values.images.captureProxy.tag }}"
+  captureProxyImage: "{{ include "migration.image" (dict "root" . "image" .Values.images.captureProxy) }}"
   captureProxyPullPolicy: "{{ .Values.images.captureProxy.pullPolicy }}"
-  trafficReplayerImage: "{{ .Values.images.trafficReplayer.repository }}:{{ .Values.images.trafficReplayer.tag }}"
+  trafficReplayerImage: "{{ include "migration.image" (dict "root" . "image" .Values.images.trafficReplayer) }}"
   trafficReplayerPullPolicy: "{{ .Values.images.trafficReplayer.pullPolicy }}"
-  reindexFromSnapshotImage: "{{ .Values.images.reindexFromSnapshot.repository }}:{{ .Values.images.reindexFromSnapshot.tag }}"
+  reindexFromSnapshotImage: "{{ include "migration.image" (dict "root" . "image" .Values.images.reindexFromSnapshot) }}"
   reindexFromSnapshotPullPolicy: "{{ .Values.images.reindexFromSnapshot.pullPolicy }}"
-  migrationConsoleImage: "{{ .Values.images.migrationConsole.repository }}:{{ .Values.images.migrationConsole.tag }}"
+  migrationConsoleImage: "{{ include "migration.image" (dict "root" . "image" .Values.images.migrationConsole) }}"
   migrationConsolePullPolicy: "{{ .Values.images.migrationConsole.pullPolicy }}"
   coordinatorClusterImage: "{{ .Values.images.coordinatorCluster.repository }}:{{ .Values.images.coordinatorCluster.tag }}"
   coordinatorClusterPullPolicy: "{{ .Values.images.coordinatorCluster.pullPolicy }}"

--- a/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/templates/resources/kyvernoMountLocalAwsCreds.yaml
+++ b/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/templates/resources/kyvernoMountLocalAwsCreds.yaml
@@ -86,7 +86,7 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: apply-policy
-          image: {{ .Values.images.installer.repository }}:{{ .Values.images.installer.tag }}
+          image: {{ include "migration.image" (dict "root" . "image" .Values.images.installer) }}
           imagePullPolicy: {{ .Values.images.installer.pullPolicy }}
           command:
             - /bin/sh

--- a/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/templates/resources/migrationConsole.yaml
+++ b/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/templates/resources/migrationConsole.yaml
@@ -137,7 +137,7 @@ spec:
       terminationGracePeriodSeconds: 65
       initContainers:
         - name: workflow-schema-generator
-          image: {{ .Values.images.installer.repository }}:{{ .Values.images.installer.tag }}
+          image: {{ include "migration.image" (dict "root" . "image" .Values.images.installer) }}
           imagePullPolicy: {{ .Values.images.installer.pullPolicy }}
           command:
             - /bin/sh
@@ -191,7 +191,7 @@ spec:
       {{- end }}
       containers:
         - name: console
-          image: {{ .Values.images.migrationConsole.repository}}:{{ .Values.images.migrationConsole.tag }}
+          image: {{ include "migration.image" (dict "root" . "image" .Values.images.migrationConsole) }}
           imagePullPolicy: {{ .Values.images.migrationConsole.pullPolicy }}
           # Since the console may be used interactively, try to keep the migration
           # console on the same node so that it can be stable.  Keep the requests

--- a/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/templates/resources/otel/simpleCollectorAsIndependentDaemonset.yaml
+++ b/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/templates/resources/otel/simpleCollectorAsIndependentDaemonset.yaml
@@ -127,7 +127,7 @@ spec:
       serviceAccountName: {{ .Values.argoWorkflowServiceAccountName | default "argo-workflow-executor" }}
       containers:
       - name: apply-monitor
-        image: {{ .Values.images.installer.repository }}:{{ .Values.images.installer.tag }}
+        image: {{ include "migration.image" (dict "root" . "image" .Values.images.installer) }}
         command: ["/bin/sh", "-c"]
         args:
         - |

--- a/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/templates/resources/selfSignedClusterIssuer.yaml
+++ b/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/templates/resources/selfSignedClusterIssuer.yaml
@@ -17,7 +17,7 @@ spec:
       serviceAccountName: {{ .Values.argoWorkflowServiceAccountName | default "argo-workflow-executor" }}
       containers:
       - name: create-ca
-        image: {{ .Values.images.migrationConsole.repository }}:{{ .Values.images.migrationConsole.tag }}
+        image: {{ include "migration.image" (dict "root" . "image" .Values.images.migrationConsole) }}
         imagePullPolicy: {{ .Values.images.migrationConsole.pullPolicy }}
         command: ["/bin/sh", "-c"]
         args:

--- a/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/templates/resources/workerFleets.yaml
+++ b/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/templates/resources/workerFleets.yaml
@@ -20,7 +20,7 @@ spec:
       serviceAccountName: migration-console-access-role
       containers:
         - name: console
-          image: {{ $.Values.images.migrationConsole.repository }}:{{ $.Values.images.migrationConsole.tag }}
+          image: {{ include "migration.image" (dict "root" $ "image" $.Values.images.migrationConsole) }}
           imagePullPolicy: {{ $.Values.images.migrationConsole.pullPolicy }}
           resources:
             requests:

--- a/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/templates/tests/test-vap-kafka.yaml
+++ b/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/templates/tests/test-vap-kafka.yaml
@@ -17,7 +17,7 @@ spec:
   restartPolicy: Never
   containers:
   - name: test
-    image: {{ .Values.images.migrationConsole.repository }}:{{ .Values.images.migrationConsole.tag }}
+    image: {{ include "migration.image" (dict "root" . "image" .Values.images.migrationConsole) }}
     imagePullPolicy: {{ .Values.images.migrationConsole.pullPolicy }}
     command:
     - /bin/bash

--- a/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/values.yaml
+++ b/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/values.yaml
@@ -37,25 +37,27 @@ kyvernoPolicies:
   mountLocalAwsCredsPath: "~/.aws"
 
 images:
+  # Empty project image tags default to Chart.appVersion. Release packaging sets
+  # appVersion from VERSION; source/dev chart renders keep appVersion as "latest".
   captureProxy:
     repository: migrations/capture_proxy
-    tag: latest
+    tag: ""
     pullPolicy: IfNotPresent
   trafficReplayer:
     repository: migrations/traffic_replayer
-    tag: latest
+    tag: ""
     pullPolicy: IfNotPresent
   reindexFromSnapshot:
     repository: migrations/reindex_from_snapshot
-    tag: latest
+    tag: ""
     pullPolicy: IfNotPresent
   migrationConsole:
     repository: migrations/migration_console
-    tag: latest
+    tag: ""
     pullPolicy: IfNotPresent
   installer:
     repository: migrations/migration_console
-    tag: latest
+    tag: ""
     pullPolicy: IfNotPresent
   coordinatorCluster:
     repository: mirror.gcr.io/opensearchproject/opensearch

--- a/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/values.yaml
+++ b/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/values.yaml
@@ -38,7 +38,7 @@ kyvernoPolicies:
 
 images:
   # Empty project image tags default to Chart.appVersion. Release packaging sets
-  # appVersion from VERSION; source/dev chart renders keep appVersion as "latest".
+  # appVersion from the release git tag; source/dev chart renders keep appVersion as "latest".
   captureProxy:
     repository: migrations/capture_proxy
     tag: ""


### PR DESCRIPTION
### Description
Default migration image tags to Chart.appVersion instead of 'latest' when values omit an explicit tag. The default value of appVersion for the Chart.yaml is 'latest' so source/development installs will still use 'latest'. This lets release-packaged Helm charts resolve project images to VERSION via the existing --app-version packaging step.

Make sure that the gha release-drafter validate that release tag pushes match VERSION.

Some helm lint errors popped up, so the templates were tidied up too.

### Issues Resolved
https://github.com/opensearch-project/opensearch-migrations/issues/2947

### Testing
Tested helm installs as a dev (no build) and a helm install after running `helm package deployment/k8s/charts/aggregates/migrationAssistantWithArgo --version 3.2.0 --app-version 3.2.0 `

### Check List
- [ ] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
