### PR TITLE
Fix webhook trigger to pass token as URL query parameter

### DIFF
--- a/.github/actions/jenkins-trigger/webhook-trigger/default_webhook_trigger.py
+++ b/.github/actions/jenkins-trigger/webhook-trigger/default_webhook_trigger.py
@@ -44,14 +44,11 @@ class JenkinsConfig:
 
     @property
     def webhook_url(self) -> str:
-        return f"{self.jenkins_url}/generic-webhook-trigger/invoke"
+        return f"{self.jenkins_url}/generic-webhook-trigger/invoke?token={self.pipeline_token}"
 
     @property
     def auth_headers(self) -> dict[str, str]:
-        return {
-            "Content-Type": "application/json",
-            "Authorization": f"Bearer {self.pipeline_token}",
-        }
+        return {"Content-Type": "application/json"}
 
     @property
     def payload(self) -> dict[str, str]:


### PR DESCRIPTION
## Problem

The Generic Webhook Trigger Jenkins plugin expects the authentication token as a URL query parameter (`?token=XXX`), not as a Bearer Authorization header. The current implementation sends the token as a header, causing Jenkins to respond with:

```
Did not find any jobs with GenericTrigger configured!
A token was supplied.
```

## Fix

Pass `pipeline_token` as a query parameter in the webhook URL instead of as an Authorization header.

## Testing

Verified that Jenkins jobs have GenericTrigger configured with token-based matching. After this fix, the token in the URL will match the job's configured token and trigger correctly.