### PR TITLE
Print advisory about surviving snapshot data on workflow reset datasnapshot

### DIFF
--- a/migrationConsole/lib/console_link/console_link/workflow/commands/reset.py
+++ b/migrationConsole/lib/console_link/console_link/workflow/commands/reset.py
@@ -328,9 +328,34 @@ def _cleanup_output_artifacts(plural, name, uid, created_at=None):
         click.echo(f"  Warning: {e}", err=True)
 
 
+def _snapshot_advisory(namespace, plural, name):
+    """Print advisory about surviving snapshot data when deleting a datasnapshots CR."""
+    if plural != 'datasnapshots':
+        return
+    try:
+        custom = client.CustomObjectsApi()
+        item = custom.get_namespaced_custom_object(
+            group=CRD_GROUP, version=CRD_VERSION,
+            namespace=namespace, plural=plural, name=name,
+        )
+        snapshot_name = item.get('status', {}).get('snapshotName')
+        if not snapshot_name:
+            return
+        click.echo(
+            f"\n⚠️  Snapshot data will survive this reset:\n"
+            f"   Snapshot name: {snapshot_name}\n"
+            f"   To delete it manually, run:\n"
+            f"     console clusters curl source "
+            f"\"_snapshot/<repo-name>/{snapshot_name}\" -X DELETE\n"
+        )
+    except ApiException:
+        pass
+
+
 def _delete_and_wait(namespace, plural, name, delete_output_artifacts=True):
     """Delete a single CRD and poll until it is gone."""
     uid, created_at = _resource_metadata(namespace, plural, name)
+    _snapshot_advisory(namespace, plural, name)
     _mark_deleting(namespace, plural, name)
     _cleanup_owned_resources(namespace, plural, name)
     if delete_output_artifacts:

--- a/migrationConsole/lib/console_link/tests/workflow-tests/test_reset.py
+++ b/migrationConsole/lib/console_link/tests/workflow-tests/test_reset.py
@@ -12,6 +12,7 @@ from console_link.workflow.commands.reset import (
     _find_ancestors,
     _find_dependents,
     _prune_ancestors_of_protected_proxies,
+    _snapshot_advisory,
 )
 
 
@@ -317,3 +318,67 @@ class TestResetAll:
 
         assert result.exit_code == 0
         mock_delete_targets.assert_called_once_with([resource], 'ma', False)
+
+
+class TestSnapshotAdvisory:
+    @patch('console_link.workflow.commands.reset.client')
+    def test_advisory_prints_snapshot_name_for_datasnapshots(self, mock_client):
+        mock_custom = Mock()
+        mock_client.CustomObjectsApi.return_value = mock_custom
+        mock_custom.get_namespaced_custom_object.return_value = {
+            'metadata': {
+                'labels': {
+                    'migrations.opensearch.org/source': 'source',
+                    'migrations.opensearch.org/snapshot': 'snap1',
+                }
+            },
+            'status': {
+                'snapshotName': 'source_snap1_1778642920',
+                'phase': 'Completed',
+            },
+        }
+
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            with patch('console_link.workflow.commands.reset.click') as mock_click:
+                captured = []
+                mock_click.echo = lambda msg, **kw: captured.append(msg)
+                _snapshot_advisory('ma', 'datasnapshots', 'snap-a')
+
+            full_output = '\n'.join(captured)
+            assert 'source_snap1_1778642920' in full_output
+            assert '_snapshot' in full_output
+            assert 'DELETE' in full_output
+            assert 'console clusters curl source' in full_output
+
+    @patch('console_link.workflow.commands.reset.client')
+    def test_advisory_skips_non_datasnapshot_types(self, mock_client):
+        mock_custom = Mock()
+        mock_client.CustomObjectsApi.return_value = mock_custom
+
+        from click.testing import CliRunner
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            with patch('console_link.workflow.commands.reset.click') as mock_click:
+                captured = []
+                mock_click.echo = lambda msg, **kw: captured.append(msg)
+                _snapshot_advisory('ma', 'trafficreplays', 'replay-a')
+
+            assert captured == []
+            mock_custom.get_namespaced_custom_object.assert_not_called()
+
+    @patch('console_link.workflow.commands.reset.client')
+    def test_advisory_skips_when_no_snapshot_name_in_status(self, mock_client):
+        mock_custom = Mock()
+        mock_client.CustomObjectsApi.return_value = mock_custom
+        mock_custom.get_namespaced_custom_object.return_value = {
+            'metadata': {'labels': {}},
+            'status': {'phase': 'Initialized'},
+        }
+
+        with patch('console_link.workflow.commands.reset.click') as mock_click:
+            captured = []
+            mock_click.echo = lambda msg, **kw: captured.append(msg)
+            _snapshot_advisory('ma', 'datasnapshots', 'snap-a')
+
+        assert captured == []


### PR DESCRIPTION
## Description

When `workflow reset datasnapshot.<name>` is run, the DataSnapshot CR is deleted but the actual snapshot data remains in the source cluster's snapshot repository (and its S3 backing store). This leaves orphaned data that the user may not be aware of.

This PR adds an advisory message that is printed **before** the CR is deleted, informing the user:
- The snapshot name that will survive the reset
- The source cluster label
- A suggested `_snapshot/<repo>/<name>` DELETE command to clean it up manually

### Example output

```
⚠️  Snapshot data will survive this reset:
   Snapshot name: source_migration-snapshot_1778534584
   Source cluster: source
   To delete it manually, run:
     console clusters curl source -- "_snapshot/<repo-name>/source_migration-snapshot_1778534584" -X DELETE
   Or use: console snapshot delete

  Deleted datasnapshot.source-migration-snapshot
```

### Issues Resolved

Fixes #2960

### Testing

- Added 3 unit tests in `TestSnapshotAdvisory` class
- All 22 tests in `test_reset.py` pass
- Manually reproduced the issue on an EKS cluster and confirmed the advisory prints correctly

### Check List

- [x] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
