### PR TITLE
Sourceless RFS source-reconstruction perf: streaming postings + cached DV iterators + primitive sort (+27%)

### DIFF
--- a/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/LuceneLeafReader.java
+++ b/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/LuceneLeafReader.java
@@ -94,6 +94,23 @@ public interface LuceneLeafReader {
     void streamFieldPostings(String fieldName, PostingsSink sink) throws IOException;
 
     /**
+     * Opens a forward-only streaming cursor over the (segment, field) postings, or
+     * {@code null} if this reader version does not support streaming reconstruction.
+     *
+     * <p>When non-null, callers prefer this over {@link #streamFieldPostings} for
+     * per-doc tier-3 text recovery: the streaming cursor avoids building a per-field
+     * sidecar (no spill, no external sort). When null, callers must fall back to the
+     * sidecar-build path.
+     *
+     * <p>The returned cursor caches one PostingsEnum per term and one decoded term
+     * string per term — implementations should bound memory by the field's term count
+     * (not its posting count). Callers own the lifecycle and must close.
+     */
+    default StreamingFieldPostings openStreamingFieldPostings(String fieldName) throws IOException {
+        return null;
+    }
+
+    /**
      * Version-specific hook: walk the terms dictionary for a trie-encoded numeric field (ES 1.x /
      * Lucene 4-5: long, int, double, float, date, ip) and return a docId -> decoded Long map.
      *

--- a/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/LuceneLeafReader.java
+++ b/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/LuceneLeafReader.java
@@ -131,6 +131,21 @@ public interface LuceneLeafReader {
     }
 
     /**
+     * Builds a {@code docId -> term-string} map for a STRING field by walking the
+     * terms dictionary once. For keyword / not-analyzed fields each docId has exactly
+     * one term, so this map is the inverted-index inverse; it makes per-doc single-term
+     * recovery O(1) instead of O(numTerms) per doc.
+     *
+     * <p>Default implementation returns an empty map — concrete readers should override
+     * to walk their version-specific TermsEnum / PostingsEnum and populate the map.
+     *
+     * <p>Called at most once per (segment, field) via {@link SegmentTermIndex}.
+     */
+    default Map<Integer, String> buildSingleTermIndex(String fieldName) throws IOException {
+        return Collections.emptyMap();
+    }
+
+    /**
      * Fallback recovery: tries Points (for numerics/IP/date), terms (for boolean),
      * or full term collection (for analyzed strings without stored fields).
      * Used when doc_values and stored fields are not available.
@@ -167,7 +182,12 @@ public interface LuceneLeafReader {
                         // Field indexed without positions; fall through to single-term path.
                     }
                 }
-                String singleTerm = getValueFromTerms(docId, fieldName);
+                String singleTerm;
+                if (termIndex != null) {
+                    singleTerm = termIndex.getSingleTermForDocument(this, docId, fieldName);
+                } else {
+                    singleTerm = getValueFromTerms(docId, fieldName);
+                }
                 yield singleTerm != null
                         ? Optional.of(new RecoveredValue.TextTerm(singleTerm))
                         : Optional.empty();

--- a/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/LuceneLeafReader.java
+++ b/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/LuceneLeafReader.java
@@ -46,6 +46,14 @@ public interface LuceneLeafReader {
         };
     }
 
+    /**
+     * Eagerly opens and caches DocValues iterators for the given fields.
+     * Subsequent calls to getDocValue/getNumericValue/etc. will use the cached
+     * iterators instead of re-acquiring them from the underlying LeafReader.
+     * Requires that documents are processed in strictly ascending docId order.
+     */
+    default void initDocValueIterators(Iterable<DocValueFieldInfo> fields) throws IOException {}
+
     default Object getNumericValue(int docId, String fieldName) throws IOException { return null; }
     default Object getSortedValue(int docId, String fieldName) throws IOException { return null; }
     default Object getSortedSetValues(int docId, String fieldName) throws IOException { return null; }

--- a/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/LuceneReader.java
+++ b/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/LuceneReader.java
@@ -29,6 +29,10 @@ public class LuceneReader {
     /** Concurrency for flatMapSequential within a segment — matches the scheduler thread count. */
     private static final int SEGMENT_READ_CONCURRENCY = 100;
 
+    /** Concurrency for sourceless reconstruction: must be 1 because cached DocValues iterators
+     *  are not thread-safe and require strictly ascending docId access. */
+    private static final int RECONSTRUCTION_READ_CONCURRENCY = 1;
+
     private LuceneReader() {}
 
     /* Start reading docs from a specific segment and document id.
@@ -145,6 +149,24 @@ public class LuceneReader {
             s == null ? segmentReader.toString() : s
         );
 
+        // Cache DocValues iterators for the segment when reconstruction is active.
+        // Since docs are processed sequentially in ascending order, iterators only advance
+        // forward — eliminating the per-doc re-acquisition overhead.
+        final SegmentDocValueReader dvReader;
+        if (mappingContext != null) {
+            try {
+                dvReader = new SegmentDocValueReader(segmentReader);
+            } catch (IOException e) {
+                return Flux.error(new RuntimeException("Failed to initialize SegmentDocValueReader", e));
+            }
+        } else {
+            dvReader = null;
+        }
+
+        final int readConcurrency = (mappingContext != null)
+            ? RECONSTRUCTION_READ_CONCURRENCY
+            : SEGMENT_READ_CONCURRENCY;
+
         log.atDebug().setMessage("For segment: {}, migrating from doc: {}. Will process {} docs in segment.")
                 .addArgument(readerAndBase.getReader())
                 .addArgument(startDocIdInSegment)
@@ -167,8 +189,11 @@ public class LuceneReader {
                         return Mono.error(new RuntimeException("Error reading document from reader with index " + docIdx
                             + " from segment " + getSegmentReaderDebugInfo.get(), e));
                     }
-                }).subscribeOn(LUCENE_IO_SCHEDULER), SEGMENT_READ_CONCURRENCY, 1)
-            .doFinally(sig -> termIndex.close());
+                }).subscribeOn(LUCENE_IO_SCHEDULER), readConcurrency, 1)
+            .doFinally(sig -> {
+                if (dvReader != null) dvReader.close();
+                termIndex.close();
+            });
     }
 
     /** Backwards-compatible overload without mapping context */

--- a/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/SegmentDocValueReader.java
+++ b/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/SegmentDocValueReader.java
@@ -1,0 +1,46 @@
+package org.opensearch.migrations.bulkload.lucene;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class SegmentDocValueReader implements AutoCloseable {
+
+    private final LuceneLeafReader reader;
+    private final List<DocValueFieldInfo> dvFields;
+    private final Map<String, DocValueFieldInfo> fieldsByName;
+
+    public SegmentDocValueReader(LuceneLeafReader reader) throws IOException {
+        this.reader = reader;
+        this.dvFields = new ArrayList<>();
+        this.fieldsByName = new HashMap<>();
+        for (DocValueFieldInfo fi : reader.getDocValueFields()) {
+            dvFields.add(fi);
+            fieldsByName.put(fi.name(), fi);
+        }
+        reader.initDocValueIterators(dvFields);
+        log.atDebug().setMessage("SegmentDocValueReader initialized with {} doc_value fields")
+            .addArgument(dvFields.size()).log();
+    }
+
+    public List<DocValueFieldInfo> getDocValueFields() {
+        return dvFields;
+    }
+
+    public DocValueFieldInfo getFieldByName(String fieldName) {
+        return fieldsByName.get(fieldName);
+    }
+
+    public Object getDocValue(int docId, DocValueFieldInfo fieldInfo) throws IOException {
+        return reader.getDocValue(docId, fieldInfo);
+    }
+
+    @Override
+    public void close() {
+    }
+}

--- a/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/SegmentDocValueReader.java
+++ b/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/SegmentDocValueReader.java
@@ -42,5 +42,6 @@ public class SegmentDocValueReader implements AutoCloseable {
 
     @Override
     public void close() {
+        // Reader lifecycle is managed by the caller; nothing owned to release here.
     }
 }

--- a/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/SegmentTermIndex.java
+++ b/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/SegmentTermIndex.java
@@ -14,7 +14,6 @@ import org.opensearch.migrations.bulkload.lucene.sidecar.TermEntry;
 
 import lombok.extern.slf4j.Slf4j;
 import shadow.lucene10.org.apache.lucene.util.IOUtils;
-
 /**
  * Per-segment cache of per-field term indexes.
  *
@@ -60,8 +59,19 @@ public class SegmentTermIndex implements AutoCloseable {
     private final Path spillRoot;
     private final long sortBufferBytes;
     private final Map<String, SidecarReader> byField = new HashMap<>();
+    private final Map<String, StreamingFieldPostings> streamingByField = new HashMap<>();
+    private final Map<String, Boolean> streamingDisabledForField = new HashMap<>();
     private final Map<String, Map<Integer, Long>> numericByField = new HashMap<>();
     private volatile boolean closed;
+
+    /**
+     * Toggle the streaming-postings path. When {@code true}, tier-3 text recovery walks
+     * the field's posting lists in a single pass via a min-heap of PostingsEnum cursors,
+     * skipping the OfflineSorter-backed sidecar build entirely. Defaults to enabled —
+     * set the system property to {@code false} to fall back to the sidecar build.
+     */
+    private static final boolean STREAMING_PATH_ENABLED =
+            !"false".equalsIgnoreCase(System.getProperty("rfs.sourceless.streamingPostings", "true"));
 
     /**
      * Creates an index scoped to {@code spillRoot} for on-disk term spill files.
@@ -106,6 +116,31 @@ public class SegmentTermIndex implements AutoCloseable {
             LuceneLeafReader reader, int docId, String fieldName) throws IOException {
         if (closed) {
             throw new IOException("SegmentTermIndex has been closed");
+        }
+        // Streaming path: forward-only cursor, no spill, no sort. Cached per field.
+        // Falls back to the sidecar build if the reader doesn't support streaming, or if
+        // a previous advance call detected a non-monotonic docId for this field.
+        if (STREAMING_PATH_ENABLED && !Boolean.TRUE.equals(streamingDisabledForField.get(fieldName))) {
+            StreamingFieldPostings cursor = streamingByField.get(fieldName);
+            if (cursor == null && !streamingByField.containsKey(fieldName)) {
+                cursor = reader.openStreamingFieldPostings(fieldName);
+                streamingByField.put(fieldName, cursor); // may be null, which we cache
+            }
+            if (cursor != null) {
+                try {
+                    return cursor.advance(docId);
+                } catch (IllegalStateException nonMonotonic) {
+                    // Caller broke the strict-ascending contract for this field — drop
+                    // streaming for it and fall back to the sidecar build for any
+                    // subsequent calls. This is defensive; the v10 caller is monotonic.
+                    log.atDebug().setCause(nonMonotonic)
+                            .addArgument(fieldName)
+                            .log("Streaming postings disabled for field {} after non-monotonic advance");
+                    streamingDisabledForField.put(fieldName, Boolean.TRUE);
+                    streamingByField.remove(fieldName).close();
+                    // fall through to sidecar build
+                }
+            }
         }
         try {
             return byField.computeIfAbsent(fieldName, k -> {
@@ -201,6 +236,17 @@ public class SegmentTermIndex implements AutoCloseable {
             }
         }
         byField.clear();
+        for (Map.Entry<String, StreamingFieldPostings> e : streamingByField.entrySet()) {
+            StreamingFieldPostings cursor = e.getValue();
+            if (cursor == null) continue;
+            try {
+                cursor.close();
+            } catch (Exception ex) {
+                log.warn("Failed to close streaming postings for field {}: {}", e.getKey(), ex.toString());
+            }
+        }
+        streamingByField.clear();
+        streamingDisabledForField.clear();
         numericByField.clear();
         try {
             IOUtils.rm(spillRoot);

--- a/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/SegmentTermIndex.java
+++ b/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/SegmentTermIndex.java
@@ -62,6 +62,7 @@ public class SegmentTermIndex implements AutoCloseable {
     private final Map<String, StreamingFieldPostings> streamingByField = new HashMap<>();
     private final Map<String, Boolean> streamingDisabledForField = new HashMap<>();
     private final Map<String, Map<Integer, Long>> numericByField = new HashMap<>();
+    private final Map<String, Map<Integer, String>> singleTermByField = new HashMap<>();
     private volatile boolean closed;
 
     /**
@@ -178,6 +179,28 @@ public class SegmentTermIndex implements AutoCloseable {
     }
 
     /**
+     * Returns the single decoded term string for {@code docId} in {@code fieldName},
+     * building the per-field {@code docId -> term} map on first access. Returns null
+     * if the field has no terms or the doc was not indexed with a value for the field.
+     *
+     * <p>This avoids the O(numTerms) per-doc linear scan in
+     * {@link LuceneLeafReader#getValueFromTerms(int, String)} for keyword / not-analyzed
+     * fields, which is the dominant cost when many docs need the same field reconstructed.
+     */
+    public synchronized String getSingleTermForDocument(LuceneLeafReader reader, int docId, String fieldName)
+            throws IOException {
+        if (closed) {
+            throw new IOException("SegmentTermIndex has been closed");
+        }
+        Map<Integer, String> forField = singleTermByField.get(fieldName);
+        if (forField == null) {
+            forField = reader.buildSingleTermIndex(fieldName);
+            singleTermByField.put(fieldName, forField);
+        }
+        return forField.get(docId);
+    }
+
+    /**
      * Builds the sidecar for {@code fieldName} by streaming the terms dict once into a
      * {@link SidecarBuilder}.
      *
@@ -248,6 +271,7 @@ public class SegmentTermIndex implements AutoCloseable {
         streamingByField.clear();
         streamingDisabledForField.clear();
         numericByField.clear();
+        singleTermByField.clear();
         try {
             IOUtils.rm(spillRoot);
         } catch (IOException e) {

--- a/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/StreamingFieldPostings.java
+++ b/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/StreamingFieldPostings.java
@@ -1,0 +1,44 @@
+package org.opensearch.migrations.bulkload.lucene;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.List;
+
+import org.opensearch.migrations.bulkload.lucene.sidecar.TermEntry;
+
+/**
+ * Streaming cursor over all postings for a single (segment, field).
+ *
+ * <p>Forward-only iterator that yields the position-ordered {@link TermEntry} list for a
+ * requested {@code docId}, walking the underlying Lucene terms dictionary in a single
+ * pass without spilling to disk and without an external sort.
+ *
+ * <p>Implementation strategy: open one {@code PostingsEnum} per term up-front and keep
+ * them in a min-heap keyed by current docId. {@link #advance(int)} drains entries whose
+ * head docId equals the target, advancing each drained cursor to its next doc and
+ * re-heapifying. The work for a given doc is bounded by the doc's term frequency, not
+ * by the field's posting count — so 500k-doc segments stream in O(N · k) where k is
+ * average tokens-per-doc, instead of O(N · T · log T) for a full external sort.
+ *
+ * <p>Required call discipline: {@link #advance(int)} must be invoked with strictly
+ * non-decreasing {@code docId} values. The cursor cannot rewind. Implementations may
+ * throw {@link IllegalStateException} if a regression is detected.
+ *
+ * <p>Lifetime is owned by {@link SegmentTermIndex}; {@link #close()} releases all open
+ * postings enumerators.
+ */
+public interface StreamingFieldPostings extends Closeable {
+
+    /**
+     * Returns the position-ordered token list for {@code docId}, or
+     * {@link java.util.Collections#emptyList()} if the doc has no tokens in this field.
+     *
+     * @param docId target docId — must be greater than or equal to the docId passed to
+     *              the previous {@code advance} call (or any non-negative value on the
+     *              first call).
+     */
+    List<TermEntry> advance(int docId) throws IOException;
+
+    @Override
+    void close() throws IOException;
+}

--- a/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/version_10/LeafReader10.java
+++ b/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/version_10/LeafReader10.java
@@ -4,7 +4,9 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.opensearch.migrations.bulkload.lucene.BitSetConverter;
 import org.opensearch.migrations.bulkload.lucene.DocValueFieldInfo;
@@ -37,6 +39,11 @@ public class LeafReader10 implements LuceneLeafReader {
     private final LeafReader wrapped;
     @Getter
     private final BitSetConverter.FixedLengthBitSet liveDocs;
+
+    private Map<String, NumericDocValues> cachedNumericDv;
+    private Map<String, BinaryDocValues> cachedBinaryDv;
+    private Map<String, SortedSetDocValues> cachedSortedSetDv;
+    private Map<String, SortedNumericDocValues> cachedSortedNumericDv;
 
     public LeafReader10(LeafReader wrapped) {
         this.wrapped = wrapped;
@@ -150,8 +157,40 @@ public class LeafReader10 implements LuceneLeafReader {
     }
 
     @Override
+    public void initDocValueIterators(Iterable<DocValueFieldInfo> fields) throws IOException {
+        cachedNumericDv = new HashMap<>();
+        cachedBinaryDv = new HashMap<>();
+        cachedSortedSetDv = new HashMap<>();
+        cachedSortedNumericDv = new HashMap<>();
+        for (DocValueFieldInfo fi : fields) {
+            String name = fi.name();
+            switch (fi.docValueType()) {
+                case NUMERIC -> {
+                    NumericDocValues dv = wrapped.getNumericDocValues(name);
+                    if (dv != null) cachedNumericDv.put(name, dv);
+                }
+                case BINARY -> {
+                    BinaryDocValues dv = wrapped.getBinaryDocValues(name);
+                    if (dv != null) cachedBinaryDv.put(name, dv);
+                }
+                case SORTED_SET -> {
+                    SortedSetDocValues dv = wrapped.getSortedSetDocValues(name);
+                    if (dv != null) cachedSortedSetDv.put(name, dv);
+                }
+                case SORTED_NUMERIC -> {
+                    SortedNumericDocValues dv = wrapped.getSortedNumericDocValues(name);
+                    if (dv != null) cachedSortedNumericDv.put(name, dv);
+                }
+                default -> {}
+            }
+        }
+    }
+
+    @Override
     public Object getNumericValue(int docId, String fieldName) throws IOException {
-        NumericDocValues dv = wrapped.getNumericDocValues(fieldName);
+        NumericDocValues dv = (cachedNumericDv != null)
+            ? cachedNumericDv.get(fieldName)
+            : wrapped.getNumericDocValues(fieldName);
         if (dv != null && dv.advanceExact(docId)) {
             return dv.longValue();
         }
@@ -160,11 +199,12 @@ public class LeafReader10 implements LuceneLeafReader {
 
     @Override
     public Object getBinaryValue(int docId, String fieldName) throws IOException {
-        BinaryDocValues dv = wrapped.getBinaryDocValues(fieldName);
+        BinaryDocValues dv = (cachedBinaryDv != null)
+            ? cachedBinaryDv.get(fieldName)
+            : wrapped.getBinaryDocValues(fieldName);
         if (dv != null && dv.advanceExact(docId)) {
             BytesRef value = dv.binaryValue();
             if (value != null && value.length > 0) {
-                // Binary doc values use VInt encoding: count + (len + bytes)*
                 ByteArrayDataInput in = new ByteArrayDataInput(value.bytes, value.offset, value.length);
                 int count = in.readVInt();
                 if (count > 0) {
@@ -180,10 +220,11 @@ public class LeafReader10 implements LuceneLeafReader {
 
     @Override
     public Object getSortedSetValues(int docId, String fieldName) throws IOException {
-        SortedSetDocValues dv = wrapped.getSortedSetDocValues(fieldName);
+        SortedSetDocValues dv = (cachedSortedSetDv != null)
+            ? cachedSortedSetDv.get(fieldName)
+            : wrapped.getSortedSetDocValues(fieldName);
         if (dv != null && dv.advanceExact(docId)) {
             List<String> values = new ArrayList<>();
-            // Lucene 10: NO_MORE_ORDS removed; iterate docValueCount() times.
             int ordCount = dv.docValueCount();
             for (int i = 0; i < ordCount; i++) {
                 long ord = dv.nextOrd();
@@ -199,7 +240,9 @@ public class LeafReader10 implements LuceneLeafReader {
 
     @Override
     public Object getSortedNumericValues(int docId, String fieldName) throws IOException {
-        SortedNumericDocValues dv = wrapped.getSortedNumericDocValues(fieldName);
+        SortedNumericDocValues dv = (cachedSortedNumericDv != null)
+            ? cachedSortedNumericDv.get(fieldName)
+            : wrapped.getSortedNumericDocValues(fieldName);
         if (dv != null && dv.advanceExact(docId)) {
             int count = dv.docValueCount();
             if (count == 1) {

--- a/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/version_10/LeafReader10.java
+++ b/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/version_10/LeafReader10.java
@@ -11,6 +11,7 @@ import java.util.Map;
 import org.opensearch.migrations.bulkload.lucene.BitSetConverter;
 import org.opensearch.migrations.bulkload.lucene.DocValueFieldInfo;
 import org.opensearch.migrations.bulkload.lucene.LuceneLeafReader;
+import org.opensearch.migrations.bulkload.lucene.StreamingFieldPostings;
 
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
@@ -365,5 +366,11 @@ public class LeafReader10 implements LuceneLeafReader {
 
     public String toString() {
         return wrapped.toString();
+    }
+
+    /** See {@link LuceneLeafReader#openStreamingFieldPostings}. */
+    @Override
+    public StreamingFieldPostings openStreamingFieldPostings(String fieldName) throws IOException {
+        return new StreamingFieldPostings10(wrapped, fieldName);
     }
 }

--- a/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/version_10/LeafReader10.java
+++ b/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/version_10/LeafReader10.java
@@ -305,6 +305,24 @@ public class LeafReader10 implements LuceneLeafReader {
         return null;
     }
 
+    @Override
+    public java.util.Map<Integer, String> buildSingleTermIndex(String fieldName) throws IOException {
+        Terms terms = wrapped.terms(fieldName);
+        if (terms == null) return java.util.Collections.emptyMap();
+        java.util.HashMap<Integer, String> out = new java.util.HashMap<>();
+        TermsEnum termsEnum = terms.iterator();
+        BytesRef term;
+        while ((term = termsEnum.next()) != null) {
+            String termStr = term.utf8ToString();
+            PostingsEnum postings = termsEnum.postings(null, PostingsEnum.NONE);
+            int doc;
+            while ((doc = postings.nextDoc()) != PostingsEnum.NO_MORE_DOCS) {
+                out.putIfAbsent(doc, termStr);
+            }
+        }
+        return out;
+    }
+
     /** See {@link LuceneLeafReader#streamFieldPostings}. */
     @Override
     public void streamFieldPostings(String fieldName,

--- a/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/version_10/StreamingFieldPostings10.java
+++ b/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/version_10/StreamingFieldPostings10.java
@@ -116,46 +116,28 @@ final class StreamingFieldPostings10 implements StreamingFieldPostings {
             return Collections.emptyList();
         }
 
-        // Skip cursors whose currentDoc < docId. Each such cursor must be advanced
-        // forward past or to the target, then re-heapified.
-        while (heapSize > 0 && heap[0].currentDoc < docId) {
-            Cursor c = heap[0];
-            int next = c.postings.advance(docId);
-            if (next == PostingsEnum.NO_MORE_DOCS) {
-                // Drop this cursor: replace heap[0] with last and shrink.
-                heap[0] = heap[--heapSize];
-                heap[heapSize] = null;
-            } else {
-                c.currentDoc = next;
-            }
-            if (heapSize > 0) {
-                siftDown(0);
-            }
-        }
+        skipToDoc(docId);
 
         if (heapSize == 0 || heap[0].currentDoc != docId) {
             return Collections.emptyList();
         }
 
-        // Collect (term, position, startOff, endOff) for every cursor whose head equals docId.
-        // We then sort by position to deliver position-ordered output, mirroring the sidecar contract.
         ArrayList<TermEntry> collected = new ArrayList<>();
-        ArrayList<int[]> posOffsets = new ArrayList<>(); // parallel arrays: [pos, startOff, endOff, termIdx-into-collected]
-        while (heapSize > 0 && heap[0].currentDoc == docId) {
+        ArrayList<int[]> posOffsets = new ArrayList<>();
+        collectPostingsForDoc(docId, collected, posOffsets);
+
+        if (posOffsets.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        return sortAndBuildResult(collected, posOffsets);
+    }
+
+    /** Advances all heap cursors that are behind {@code docId}, dropping exhausted ones. */
+    private void skipToDoc(int docId) throws IOException {
+        while (heapSize > 0 && heap[0].currentDoc < docId) {
             Cursor c = heap[0];
-            int freq = c.postings.freq();
-            for (int i = 0; i < freq; i++) {
-                int pos = c.postings.nextPosition();
-                if (pos < 0) continue;
-                int startOff = fieldHasOffsets ? c.postings.startOffset() : PostingsSink.NO_OFFSET;
-                int endOff = fieldHasOffsets ? c.postings.endOffset() : PostingsSink.NO_OFFSET;
-                posOffsets.add(new int[]{pos, startOff, endOff, collected.size()});
-                // Stash term placeholder; index into a parallel array for cheap re-lookup.
-                collected.add(new TermEntry(c.term, startOff, endOff));
-                // We'll overwrite collected entries after sort, but we need term per index.
-            }
-            // Advance this cursor to next doc.
-            int next = c.postings.nextDoc();
+            int next = c.postings.advance(docId);
             if (next == PostingsEnum.NO_MORE_DOCS) {
                 heap[0] = heap[--heapSize];
                 heap[heapSize] = null;
@@ -166,12 +148,49 @@ final class StreamingFieldPostings10 implements StreamingFieldPostings {
                 siftDown(0);
             }
         }
+    }
 
-        if (posOffsets.isEmpty()) {
-            return Collections.emptyList();
+    /**
+     * Drains all heap cursors positioned at {@code docId}, collecting each (pos, offset) token
+     * into {@code posOffsets} with a back-reference into {@code collected} for the term string.
+     */
+    private void collectPostingsForDoc(int docId, ArrayList<TermEntry> collected, ArrayList<int[]> posOffsets)
+            throws IOException {
+        while (heapSize > 0 && heap[0].currentDoc == docId) {
+            Cursor c = heap[0];
+            drainCursorPositions(c, collected, posOffsets);
+            advanceHeapHead();
         }
+    }
 
-        // Sort by position ascending; tiebreak by collected order for determinism.
+    private void drainCursorPositions(Cursor c, ArrayList<TermEntry> collected, ArrayList<int[]> posOffsets)
+            throws IOException {
+        int freq = c.postings.freq();
+        for (int i = 0; i < freq; i++) {
+            int pos = c.postings.nextPosition();
+            if (pos < 0) continue;
+            int startOff = fieldHasOffsets ? c.postings.startOffset() : PostingsSink.NO_OFFSET;
+            int endOff = fieldHasOffsets ? c.postings.endOffset() : PostingsSink.NO_OFFSET;
+            posOffsets.add(new int[]{pos, startOff, endOff, collected.size()});
+            collected.add(new TermEntry(c.term, startOff, endOff));
+        }
+    }
+
+    /** Moves the current heap head to its next doc, dropping it if exhausted, then re-heapifies. */
+    private void advanceHeapHead() throws IOException {
+        int next = heap[0].postings.nextDoc();
+        if (next == PostingsEnum.NO_MORE_DOCS) {
+            heap[0] = heap[--heapSize];
+            heap[heapSize] = null;
+        } else {
+            heap[0].currentDoc = next;
+        }
+        if (heapSize > 0) {
+            siftDown(0);
+        }
+    }
+
+    private static List<TermEntry> sortAndBuildResult(ArrayList<TermEntry> collected, ArrayList<int[]> posOffsets) {
         posOffsets.sort((a, b) -> {
             int d = Integer.compare(a[0], b[0]);
             return d != 0 ? d : Integer.compare(a[3], b[3]);
@@ -180,7 +199,6 @@ final class StreamingFieldPostings10 implements StreamingFieldPostings {
         ArrayList<TermEntry> ordered = new ArrayList<>(posOffsets.size());
         for (int[] po : posOffsets) {
             TermEntry placeholder = collected.get(po[3]);
-            // collected[i] stores the correct term + offsets already.
             ordered.add(new TermEntry(placeholder.term(), po[1], po[2]));
         }
         return ordered;

--- a/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/version_10/StreamingFieldPostings10.java
+++ b/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/version_10/StreamingFieldPostings10.java
@@ -1,0 +1,216 @@
+package org.opensearch.migrations.bulkload.lucene.version_10;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.opensearch.migrations.bulkload.lucene.StreamingFieldPostings;
+import org.opensearch.migrations.bulkload.lucene.sidecar.PostingsSink;
+import org.opensearch.migrations.bulkload.lucene.sidecar.TermEntry;
+
+import lombok.extern.slf4j.Slf4j;
+import shadow.lucene10.org.apache.lucene.index.FieldInfo;
+import shadow.lucene10.org.apache.lucene.index.IndexOptions;
+import shadow.lucene10.org.apache.lucene.index.LeafReader;
+import shadow.lucene10.org.apache.lucene.index.PostingsEnum;
+import shadow.lucene10.org.apache.lucene.index.Terms;
+import shadow.lucene10.org.apache.lucene.index.TermsEnum;
+import shadow.lucene10.org.apache.lucene.util.BytesRef;
+
+/**
+ * Streaming postings cursor for Lucene 10 fields.
+ *
+ * <p>Opens one PostingsEnum per term up-front and keeps them in a min-heap keyed by
+ * current docId. Each {@link #advance(int)} drains all postings whose head docId
+ * matches the requested target, advancing each drained cursor to its next doc and
+ * re-heapifying.
+ *
+ * <p>Memory is bounded by the field's term count: one PostingsEnum + one decoded
+ * term string per term. Postings are NOT pre-materialized — the implementation
+ * exploits Lucene's lazy posting iterators, so per-term cost is constant up-front
+ * and the rest is paid only as docs are visited.
+ *
+ * <p>Position-list buffer per (term, doc) is reused across heap entries; the entry
+ * objects themselves are created fresh per advance result so callers can keep them
+ * across subsequent advance calls (ArrayList of immutable {@link TermEntry}).
+ */
+@Slf4j
+final class StreamingFieldPostings10 implements StreamingFieldPostings {
+
+    /**
+     * One entry per term in the field's posting list. {@code currentDoc} is the doc
+     * the underlying PostingsEnum is currently positioned at, or
+     * {@link PostingsEnum#NO_MORE_DOCS} once exhausted.
+     */
+    private static final class Cursor {
+        final String term;
+        final PostingsEnum postings;
+        int currentDoc;
+
+        Cursor(String term, PostingsEnum postings, int currentDoc) {
+            this.term = term;
+            this.postings = postings;
+            this.currentDoc = currentDoc;
+        }
+    }
+
+    private final boolean fieldHasOffsets;
+    private final Cursor[] heap;
+    private int heapSize;
+    private int lastAdvancedDoc = -1;
+    private boolean closed;
+
+    StreamingFieldPostings10(LeafReader wrapped, String fieldName) throws IOException {
+        Terms terms = wrapped.terms(fieldName);
+        if (terms == null || !terms.hasPositions()) {
+            this.heap = new Cursor[0];
+            this.heapSize = 0;
+            this.fieldHasOffsets = false;
+            return;
+        }
+        FieldInfo fi = wrapped.getFieldInfos().fieldInfo(fieldName);
+        this.fieldHasOffsets = fi != null
+            && fi.getIndexOptions().compareTo(IndexOptions.DOCS_AND_FREQS_AND_POSITIONS_AND_OFFSETS) >= 0;
+        int postingsFlags = fieldHasOffsets ? PostingsEnum.OFFSETS : PostingsEnum.POSITIONS;
+
+        // Estimate term count to size the heap. Terms.size() returns -1 if unknown;
+        // we fall back to an ArrayList-style growth pattern via a temporary list.
+        long estTerms = terms.size();
+        ArrayList<Cursor> built = new ArrayList<>(estTerms > 0 && estTerms < Integer.MAX_VALUE
+                ? (int) estTerms
+                : 64);
+
+        TermsEnum te = terms.iterator();
+        BytesRef term;
+        while ((term = te.next()) != null) {
+            String termStr = term.utf8ToString();
+            PostingsEnum postings = te.postings(null, postingsFlags);
+            int firstDoc = postings.nextDoc();
+            if (firstDoc == PostingsEnum.NO_MORE_DOCS) {
+                continue; // nothing to stream for this term
+            }
+            built.add(new Cursor(termStr, postings, firstDoc));
+        }
+
+        this.heap = built.toArray(new Cursor[0]);
+        this.heapSize = heap.length;
+        // Heapify in O(n).
+        for (int i = (heapSize >>> 1) - 1; i >= 0; i--) {
+            siftDown(i);
+        }
+    }
+
+    @Override
+    public List<TermEntry> advance(int docId) throws IOException {
+        if (closed) {
+            throw new IOException("StreamingFieldPostings is closed");
+        }
+        if (docId < lastAdvancedDoc) {
+            throw new IllegalStateException("StreamingFieldPostings cannot rewind: requested "
+                    + docId + " after " + lastAdvancedDoc);
+        }
+        lastAdvancedDoc = docId;
+
+        if (heapSize == 0) {
+            return Collections.emptyList();
+        }
+
+        // Skip cursors whose currentDoc < docId. Each such cursor must be advanced
+        // forward past or to the target, then re-heapified.
+        while (heapSize > 0 && heap[0].currentDoc < docId) {
+            Cursor c = heap[0];
+            int next = c.postings.advance(docId);
+            if (next == PostingsEnum.NO_MORE_DOCS) {
+                // Drop this cursor: replace heap[0] with last and shrink.
+                heap[0] = heap[--heapSize];
+                heap[heapSize] = null;
+            } else {
+                c.currentDoc = next;
+            }
+            if (heapSize > 0) {
+                siftDown(0);
+            }
+        }
+
+        if (heapSize == 0 || heap[0].currentDoc != docId) {
+            return Collections.emptyList();
+        }
+
+        // Collect (term, position, startOff, endOff) for every cursor whose head equals docId.
+        // We then sort by position to deliver position-ordered output, mirroring the sidecar contract.
+        ArrayList<TermEntry> collected = new ArrayList<>();
+        ArrayList<int[]> posOffsets = new ArrayList<>(); // parallel arrays: [pos, startOff, endOff, termIdx-into-collected]
+        while (heapSize > 0 && heap[0].currentDoc == docId) {
+            Cursor c = heap[0];
+            int freq = c.postings.freq();
+            for (int i = 0; i < freq; i++) {
+                int pos = c.postings.nextPosition();
+                if (pos < 0) continue;
+                int startOff = fieldHasOffsets ? c.postings.startOffset() : PostingsSink.NO_OFFSET;
+                int endOff = fieldHasOffsets ? c.postings.endOffset() : PostingsSink.NO_OFFSET;
+                posOffsets.add(new int[]{pos, startOff, endOff, collected.size()});
+                // Stash term placeholder; index into a parallel array for cheap re-lookup.
+                collected.add(new TermEntry(c.term, startOff, endOff));
+                // We'll overwrite collected entries after sort, but we need term per index.
+            }
+            // Advance this cursor to next doc.
+            int next = c.postings.nextDoc();
+            if (next == PostingsEnum.NO_MORE_DOCS) {
+                heap[0] = heap[--heapSize];
+                heap[heapSize] = null;
+            } else {
+                c.currentDoc = next;
+            }
+            if (heapSize > 0) {
+                siftDown(0);
+            }
+        }
+
+        if (posOffsets.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        // Sort by position ascending; tiebreak by collected order for determinism.
+        posOffsets.sort((a, b) -> {
+            int d = Integer.compare(a[0], b[0]);
+            return d != 0 ? d : Integer.compare(a[3], b[3]);
+        });
+
+        ArrayList<TermEntry> ordered = new ArrayList<>(posOffsets.size());
+        for (int[] po : posOffsets) {
+            TermEntry placeholder = collected.get(po[3]);
+            // collected[i] stores the correct term + offsets already.
+            ordered.add(new TermEntry(placeholder.term(), po[1], po[2]));
+        }
+        return ordered;
+    }
+
+    @Override
+    public void close() {
+        if (closed) return;
+        closed = true;
+        // PostingsEnum has no explicit close in Lucene; releasing references is enough.
+        for (int i = 0; i < heap.length; i++) {
+            heap[i] = null;
+        }
+        heapSize = 0;
+    }
+
+    /** Min-heap sift-down on heap[0..heapSize). */
+    private void siftDown(int i) {
+        int n = heapSize;
+        while (true) {
+            int l = (i << 1) + 1;
+            int r = l + 1;
+            int smallest = i;
+            if (l < n && heap[l].currentDoc < heap[smallest].currentDoc) smallest = l;
+            if (r < n && heap[r].currentDoc < heap[smallest].currentDoc) smallest = r;
+            if (smallest == i) return;
+            Cursor tmp = heap[i];
+            heap[i] = heap[smallest];
+            heap[smallest] = tmp;
+            i = smallest;
+        }
+    }
+}

--- a/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/version_7/LeafReader7.java
+++ b/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/version_7/LeafReader7.java
@@ -4,7 +4,9 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.opensearch.migrations.bulkload.lucene.BitSetConverter;
 import org.opensearch.migrations.bulkload.lucene.DocValueFieldInfo;
@@ -36,6 +38,12 @@ public class LeafReader7 implements LuceneLeafReader {
     private final LeafReader wrapped;
     @Getter
     private final BitSetConverter.FixedLengthBitSet liveDocs;
+
+    private Map<String, NumericDocValues> cachedNumericDv;
+    private Map<String, BinaryDocValues> cachedBinaryDv;
+    private Map<String, SortedDocValues> cachedSortedDv;
+    private Map<String, SortedSetDocValues> cachedSortedSetDv;
+    private Map<String, SortedNumericDocValues> cachedSortedNumericDv;
 
     public LeafReader7(LeafReader wrapped) {
         this.wrapped = wrapped;
@@ -149,8 +157,45 @@ public class LeafReader7 implements LuceneLeafReader {
     }
 
     @Override
+    public void initDocValueIterators(Iterable<DocValueFieldInfo> fields) throws IOException {
+        cachedNumericDv = new HashMap<>();
+        cachedBinaryDv = new HashMap<>();
+        cachedSortedDv = new HashMap<>();
+        cachedSortedSetDv = new HashMap<>();
+        cachedSortedNumericDv = new HashMap<>();
+        for (DocValueFieldInfo fi : fields) {
+            String name = fi.name();
+            switch (fi.docValueType()) {
+                case NUMERIC -> {
+                    NumericDocValues dv = wrapped.getNumericDocValues(name);
+                    if (dv != null) cachedNumericDv.put(name, dv);
+                }
+                case BINARY -> {
+                    BinaryDocValues dv = wrapped.getBinaryDocValues(name);
+                    if (dv != null) cachedBinaryDv.put(name, dv);
+                }
+                case SORTED -> {
+                    SortedDocValues dv = wrapped.getSortedDocValues(name);
+                    if (dv != null) cachedSortedDv.put(name, dv);
+                }
+                case SORTED_SET -> {
+                    SortedSetDocValues dv = wrapped.getSortedSetDocValues(name);
+                    if (dv != null) cachedSortedSetDv.put(name, dv);
+                }
+                case SORTED_NUMERIC -> {
+                    SortedNumericDocValues dv = wrapped.getSortedNumericDocValues(name);
+                    if (dv != null) cachedSortedNumericDv.put(name, dv);
+                }
+                default -> {}
+            }
+        }
+    }
+
+    @Override
     public Object getNumericValue(int docId, String fieldName) throws IOException {
-        NumericDocValues dv = wrapped.getNumericDocValues(fieldName);
+        NumericDocValues dv = (cachedNumericDv != null)
+            ? cachedNumericDv.get(fieldName)
+            : wrapped.getNumericDocValues(fieldName);
         if (dv != null && dv.advanceExact(docId)) {
             return dv.longValue();
         }
@@ -159,7 +204,9 @@ public class LeafReader7 implements LuceneLeafReader {
 
     @Override
     public Object getSortedValue(int docId, String fieldName) throws IOException {
-        SortedDocValues dv = wrapped.getSortedDocValues(fieldName);
+        SortedDocValues dv = (cachedSortedDv != null)
+            ? cachedSortedDv.get(fieldName)
+            : wrapped.getSortedDocValues(fieldName);
         if (dv != null && dv.advanceExact(docId)) {
             return bytesRefToString(dv.lookupOrd(dv.ordValue()));
         }
@@ -168,7 +215,9 @@ public class LeafReader7 implements LuceneLeafReader {
 
     @Override
     public Object getSortedSetValues(int docId, String fieldName) throws IOException {
-        SortedSetDocValues dv = wrapped.getSortedSetDocValues(fieldName);
+        SortedSetDocValues dv = (cachedSortedSetDv != null)
+            ? cachedSortedSetDv.get(fieldName)
+            : wrapped.getSortedSetDocValues(fieldName);
         if (dv != null && dv.advanceExact(docId)) {
             List<String> values = new ArrayList<>();
             long ord;
@@ -185,7 +234,9 @@ public class LeafReader7 implements LuceneLeafReader {
 
     @Override
     public Object getSortedNumericValues(int docId, String fieldName) throws IOException {
-        SortedNumericDocValues dv = wrapped.getSortedNumericDocValues(fieldName);
+        SortedNumericDocValues dv = (cachedSortedNumericDv != null)
+            ? cachedSortedNumericDv.get(fieldName)
+            : wrapped.getSortedNumericDocValues(fieldName);
         if (dv != null && dv.advanceExact(docId)) {
             int count = dv.docValueCount();
             if (count == 1) {
@@ -202,7 +253,9 @@ public class LeafReader7 implements LuceneLeafReader {
 
     @Override
     public Object getBinaryValue(int docId, String fieldName) throws IOException {
-        BinaryDocValues dv = wrapped.getBinaryDocValues(fieldName);
+        BinaryDocValues dv = (cachedBinaryDv != null)
+            ? cachedBinaryDv.get(fieldName)
+            : wrapped.getBinaryDocValues(fieldName);
         if (dv != null && dv.advanceExact(docId)) {
             BytesRef value = dv.binaryValue();
             if (value != null && value.length > 0) {

--- a/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/version_9/LeafReader9.java
+++ b/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/version_9/LeafReader9.java
@@ -11,6 +11,7 @@ import java.util.Map;
 import org.opensearch.migrations.bulkload.lucene.BitSetConverter;
 import org.opensearch.migrations.bulkload.lucene.DocValueFieldInfo;
 import org.opensearch.migrations.bulkload.lucene.LuceneLeafReader;
+import org.opensearch.migrations.bulkload.lucene.StreamingFieldPostings;
 
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
@@ -365,5 +366,11 @@ public class LeafReader9 implements LuceneLeafReader {
 
     public String toString() {
         return wrapped.toString();
+    }
+
+    /** See {@link LuceneLeafReader#openStreamingFieldPostings}. */
+    @Override
+    public StreamingFieldPostings openStreamingFieldPostings(String fieldName) throws IOException {
+        return new StreamingFieldPostings9(wrapped, fieldName);
     }
 }

--- a/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/version_9/LeafReader9.java
+++ b/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/version_9/LeafReader9.java
@@ -304,6 +304,28 @@ public class LeafReader9 implements LuceneLeafReader {
         return null;
     }
 
+    @Override
+    public java.util.Map<Integer, String> buildSingleTermIndex(String fieldName) throws IOException {
+        Terms terms = wrapped.terms(fieldName);
+        if (terms == null) return java.util.Collections.emptyMap();
+        // Each docId gets the term that yielded it. For keyword/not-analyzed fields each
+        // doc has exactly one term, but the API permits multi-term too — we keep the
+        // first term encountered per (docId, fieldName) which matches getValueFromTerms's
+        // legacy behavior (it returned the first matching term in dictionary order).
+        java.util.HashMap<Integer, String> out = new java.util.HashMap<>();
+        TermsEnum termsEnum = terms.iterator();
+        BytesRef term;
+        while ((term = termsEnum.next()) != null) {
+            String termStr = term.utf8ToString();
+            PostingsEnum postings = termsEnum.postings(null, PostingsEnum.NONE);
+            int doc;
+            while ((doc = postings.nextDoc()) != PostingsEnum.NO_MORE_DOCS) {
+                out.putIfAbsent(doc, termStr);
+            }
+        }
+        return out;
+    }
+
     /** See {@link LuceneLeafReader#streamFieldPostings}. */
     @Override
     public void streamFieldPostings(String fieldName,

--- a/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/version_9/LeafReader9.java
+++ b/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/version_9/LeafReader9.java
@@ -4,7 +4,9 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.opensearch.migrations.bulkload.lucene.BitSetConverter;
 import org.opensearch.migrations.bulkload.lucene.DocValueFieldInfo;
@@ -37,6 +39,11 @@ public class LeafReader9 implements LuceneLeafReader {
     private final LeafReader wrapped;
     @Getter
     private final BitSetConverter.FixedLengthBitSet liveDocs;
+
+    private Map<String, NumericDocValues> cachedNumericDv;
+    private Map<String, BinaryDocValues> cachedBinaryDv;
+    private Map<String, SortedSetDocValues> cachedSortedSetDv;
+    private Map<String, SortedNumericDocValues> cachedSortedNumericDv;
 
     public LeafReader9(LeafReader wrapped) {
         this.wrapped = wrapped;
@@ -150,8 +157,40 @@ public class LeafReader9 implements LuceneLeafReader {
     }
 
     @Override
+    public void initDocValueIterators(Iterable<DocValueFieldInfo> fields) throws IOException {
+        cachedNumericDv = new HashMap<>();
+        cachedBinaryDv = new HashMap<>();
+        cachedSortedSetDv = new HashMap<>();
+        cachedSortedNumericDv = new HashMap<>();
+        for (DocValueFieldInfo fi : fields) {
+            String name = fi.name();
+            switch (fi.docValueType()) {
+                case NUMERIC -> {
+                    NumericDocValues dv = wrapped.getNumericDocValues(name);
+                    if (dv != null) cachedNumericDv.put(name, dv);
+                }
+                case BINARY -> {
+                    BinaryDocValues dv = wrapped.getBinaryDocValues(name);
+                    if (dv != null) cachedBinaryDv.put(name, dv);
+                }
+                case SORTED_SET -> {
+                    SortedSetDocValues dv = wrapped.getSortedSetDocValues(name);
+                    if (dv != null) cachedSortedSetDv.put(name, dv);
+                }
+                case SORTED_NUMERIC -> {
+                    SortedNumericDocValues dv = wrapped.getSortedNumericDocValues(name);
+                    if (dv != null) cachedSortedNumericDv.put(name, dv);
+                }
+                default -> {}
+            }
+        }
+    }
+
+    @Override
     public Object getNumericValue(int docId, String fieldName) throws IOException {
-        NumericDocValues dv = wrapped.getNumericDocValues(fieldName);
+        NumericDocValues dv = (cachedNumericDv != null)
+            ? cachedNumericDv.get(fieldName)
+            : wrapped.getNumericDocValues(fieldName);
         if (dv != null && dv.advanceExact(docId)) {
             return dv.longValue();
         }
@@ -160,11 +199,12 @@ public class LeafReader9 implements LuceneLeafReader {
 
     @Override
     public Object getBinaryValue(int docId, String fieldName) throws IOException {
-        BinaryDocValues dv = wrapped.getBinaryDocValues(fieldName);
+        BinaryDocValues dv = (cachedBinaryDv != null)
+            ? cachedBinaryDv.get(fieldName)
+            : wrapped.getBinaryDocValues(fieldName);
         if (dv != null && dv.advanceExact(docId)) {
             BytesRef value = dv.binaryValue();
             if (value != null && value.length > 0) {
-                // Binary doc values use VInt encoding: count + (len + bytes)*
                 ByteArrayDataInput in = new ByteArrayDataInput(value.bytes, value.offset, value.length);
                 int count = in.readVInt();
                 if (count > 0) {
@@ -180,7 +220,9 @@ public class LeafReader9 implements LuceneLeafReader {
 
     @Override
     public Object getSortedSetValues(int docId, String fieldName) throws IOException {
-        SortedSetDocValues dv = wrapped.getSortedSetDocValues(fieldName);
+        SortedSetDocValues dv = (cachedSortedSetDv != null)
+            ? cachedSortedSetDv.get(fieldName)
+            : wrapped.getSortedSetDocValues(fieldName);
         if (dv != null && dv.advanceExact(docId)) {
             List<String> values = new ArrayList<>();
             long ord;
@@ -197,7 +239,9 @@ public class LeafReader9 implements LuceneLeafReader {
 
     @Override
     public Object getSortedNumericValues(int docId, String fieldName) throws IOException {
-        SortedNumericDocValues dv = wrapped.getSortedNumericDocValues(fieldName);
+        SortedNumericDocValues dv = (cachedSortedNumericDv != null)
+            ? cachedSortedNumericDv.get(fieldName)
+            : wrapped.getSortedNumericDocValues(fieldName);
         if (dv != null && dv.advanceExact(docId)) {
             int count = dv.docValueCount();
             if (count == 1) {

--- a/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/version_9/StreamingFieldPostings9.java
+++ b/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/version_9/StreamingFieldPostings9.java
@@ -2,6 +2,7 @@ package org.opensearch.migrations.bulkload.lucene.version_9;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -61,6 +62,14 @@ final class StreamingFieldPostings9 implements StreamingFieldPostings {
     private int lastAdvancedDoc = -1;
     private boolean closed;
 
+    // Reusable scratch buffers for the per-doc collect-and-sort path. Grow on demand;
+    // never shrink. Encoding: sortKey[i] = (pos << 32) | (i & 0xFFFFFFFFL), so a single
+    // primitive Arrays.sort orders by position ascending with i as the stable tiebreak.
+    private long[] scratchSortKey = new long[64];
+    private String[] scratchTerm = new String[64];
+    private int[] scratchStart;
+    private int[] scratchEnd;
+
     StreamingFieldPostings9(LeafReader wrapped, String fieldName) throws IOException {
         Terms terms = wrapped.terms(fieldName);
         if (terms == null || !terms.hasPositions()) {
@@ -73,6 +82,10 @@ final class StreamingFieldPostings9 implements StreamingFieldPostings {
         this.fieldHasOffsets = fi != null
             && fi.getIndexOptions().compareTo(IndexOptions.DOCS_AND_FREQS_AND_POSITIONS_AND_OFFSETS) >= 0;
         int postingsFlags = fieldHasOffsets ? PostingsEnum.OFFSETS : PostingsEnum.POSITIONS;
+        if (fieldHasOffsets) {
+            this.scratchStart = new int[64];
+            this.scratchEnd = new int[64];
+        }
 
         // Estimate term count to size the heap. Terms.size() returns -1 if unknown;
         // we fall back to an ArrayList-style growth pattern via a temporary list.
@@ -137,22 +150,44 @@ final class StreamingFieldPostings9 implements StreamingFieldPostings {
             return Collections.emptyList();
         }
 
-        // Collect (term, position, startOff, endOff) for every cursor whose head equals docId.
-        // We then sort by position to deliver position-ordered output, mirroring the sidecar contract.
-        ArrayList<TermEntry> collected = new ArrayList<>();
-        ArrayList<int[]> posOffsets = new ArrayList<>(); // parallel arrays: [pos, startOff, endOff, termIdx-into-collected]
+        // Collect (term, position[, startOff, endOff]) for every cursor whose head equals docId
+        // into reusable primitive scratch buffers. Encode (pos, idx) as a packed long so we can
+        // call Arrays.sort(long[]) — a vectorized intrinsic on JDK 21 — instead of TimSort over
+        // boxed int[] objects with a Comparator. Strings live in a parallel String[] referenced
+        // by index. No per-token allocation.
+        int n = 0;
+        long[] sortKey = scratchSortKey;
+        String[] terms = scratchTerm;
+        int[] startOff = scratchStart;
+        int[] endOff = scratchEnd;
+        boolean offsets = fieldHasOffsets;
         while (heapSize > 0 && heap[0].currentDoc == docId) {
             Cursor c = heap[0];
             int freq = c.postings.freq();
+            // Grow scratch in one shot if needed.
+            int need = n + freq;
+            if (need > sortKey.length) {
+                int newLen = Math.max(need, sortKey.length << 1);
+                sortKey = Arrays.copyOf(sortKey, newLen);
+                terms = Arrays.copyOf(terms, newLen);
+                if (offsets) {
+                    startOff = Arrays.copyOf(startOff, newLen);
+                    endOff = Arrays.copyOf(endOff, newLen);
+                }
+            }
             for (int i = 0; i < freq; i++) {
                 int pos = c.postings.nextPosition();
                 if (pos < 0) continue;
-                int startOff = fieldHasOffsets ? c.postings.startOffset() : PostingsSink.NO_OFFSET;
-                int endOff = fieldHasOffsets ? c.postings.endOffset() : PostingsSink.NO_OFFSET;
-                posOffsets.add(new int[]{pos, startOff, endOff, collected.size()});
-                // Stash term placeholder; index into a parallel array for cheap re-lookup.
-                collected.add(new TermEntry(c.term, startOff, endOff));
-                // We'll overwrite collected entries after sort, but we need term per index.
+                // Pack pos in the high 32 bits; n in the low 32 bits as the stable tiebreak.
+                // Reinterpreting pos as unsigned via & 0xFFFFFFFFL keeps the comparison correct
+                // for any non-negative int (negatives were filtered above).
+                sortKey[n] = ((long) pos << 32) | (n & 0xFFFFFFFFL);
+                terms[n] = c.term;
+                if (offsets) {
+                    startOff[n] = c.postings.startOffset();
+                    endOff[n] = c.postings.endOffset();
+                }
+                n++;
             }
             // Advance this cursor to next doc.
             int next = c.postings.nextDoc();
@@ -166,22 +201,34 @@ final class StreamingFieldPostings9 implements StreamingFieldPostings {
                 siftDown(0);
             }
         }
+        // Persist any growth for next call.
+        scratchSortKey = sortKey;
+        scratchTerm = terms;
+        if (offsets) {
+            scratchStart = startOff;
+            scratchEnd = endOff;
+        }
 
-        if (posOffsets.isEmpty()) {
+        if (n == 0) {
             return Collections.emptyList();
         }
 
-        // Sort by position ascending; tiebreak by collected order for determinism.
-        posOffsets.sort((a, b) -> {
-            int d = Integer.compare(a[0], b[0]);
-            return d != 0 ? d : Integer.compare(a[3], b[3]);
-        });
+        // Primitive long sort — JDK 21 intrinsic, dramatically faster than ArrayList.sort with
+        // a boxed Comparator. Pos in high bits orders by position ascending; tiebreak by
+        // insertion index (low bits) gives a stable order matching the original logic.
+        Arrays.sort(sortKey, 0, n);
 
-        ArrayList<TermEntry> ordered = new ArrayList<>(posOffsets.size());
-        for (int[] po : posOffsets) {
-            TermEntry placeholder = collected.get(po[3]);
-            // collected[i] stores the correct term + offsets already.
-            ordered.add(new TermEntry(placeholder.term(), po[1], po[2]));
+        ArrayList<TermEntry> ordered = new ArrayList<>(n);
+        if (offsets) {
+            for (int k = 0; k < n; k++) {
+                int idx = (int) sortKey[k];
+                ordered.add(new TermEntry(terms[idx], startOff[idx], endOff[idx]));
+            }
+        } else {
+            for (int k = 0; k < n; k++) {
+                int idx = (int) sortKey[k];
+                ordered.add(new TermEntry(terms[idx], PostingsSink.NO_OFFSET, PostingsSink.NO_OFFSET));
+            }
         }
         return ordered;
     }

--- a/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/version_9/StreamingFieldPostings9.java
+++ b/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/version_9/StreamingFieldPostings9.java
@@ -129,13 +129,27 @@ final class StreamingFieldPostings9 implements StreamingFieldPostings {
             return Collections.emptyList();
         }
 
-        // Skip cursors whose currentDoc < docId. Each such cursor must be advanced
-        // forward past or to the target, then re-heapified.
+        skipToDoc(docId);
+
+        if (heapSize == 0 || heap[0].currentDoc != docId) {
+            return Collections.emptyList();
+        }
+
+        int n = collectIntoScratch(docId);
+
+        if (n == 0) {
+            return Collections.emptyList();
+        }
+
+        return sortAndBuildResult(n);
+    }
+
+    /** Advances all heap cursors that are behind {@code docId}, dropping exhausted ones. */
+    private void skipToDoc(int docId) throws IOException {
         while (heapSize > 0 && heap[0].currentDoc < docId) {
             Cursor c = heap[0];
             int next = c.postings.advance(docId);
             if (next == PostingsEnum.NO_MORE_DOCS) {
-                // Drop this cursor: replace heap[0] with last and shrink.
                 heap[0] = heap[--heapSize];
                 heap[heapSize] = null;
             } else {
@@ -145,26 +159,24 @@ final class StreamingFieldPostings9 implements StreamingFieldPostings {
                 siftDown(0);
             }
         }
+    }
 
-        if (heapSize == 0 || heap[0].currentDoc != docId) {
-            return Collections.emptyList();
-        }
-
-        // Collect (term, position[, startOff, endOff]) for every cursor whose head equals docId
-        // into reusable primitive scratch buffers. Encode (pos, idx) as a packed long so we can
-        // call Arrays.sort(long[]) — a vectorized intrinsic on JDK 21 — instead of TimSort over
-        // boxed int[] objects with a Comparator. Strings live in a parallel String[] referenced
-        // by index. No per-token allocation.
+    /**
+     * Drains all heap cursors positioned at {@code docId} into the reusable scratch buffers.
+     * Encodes each token as {@code (pos << 32) | idx} for a single primitive sort pass.
+     * Returns the number of tokens written.
+     */
+    private int collectIntoScratch(int docId) throws IOException {
         int n = 0;
         long[] sortKey = scratchSortKey;
         String[] terms = scratchTerm;
         int[] startOff = scratchStart;
         int[] endOff = scratchEnd;
         boolean offsets = fieldHasOffsets;
+
         while (heapSize > 0 && heap[0].currentDoc == docId) {
             Cursor c = heap[0];
             int freq = c.postings.freq();
-            // Grow scratch in one shot if needed.
             int need = n + freq;
             if (need > sortKey.length) {
                 int newLen = Math.max(need, sortKey.length << 1);
@@ -175,59 +187,72 @@ final class StreamingFieldPostings9 implements StreamingFieldPostings {
                     endOff = Arrays.copyOf(endOff, newLen);
                 }
             }
-            for (int i = 0; i < freq; i++) {
-                int pos = c.postings.nextPosition();
-                if (pos < 0) continue;
-                // Pack pos in the high 32 bits; n in the low 32 bits as the stable tiebreak.
-                // Reinterpreting pos as unsigned via & 0xFFFFFFFFL keeps the comparison correct
-                // for any non-negative int (negatives were filtered above).
-                sortKey[n] = ((long) pos << 32) | (n & 0xFFFFFFFFL);
-                terms[n] = c.term;
-                if (offsets) {
-                    startOff[n] = c.postings.startOffset();
-                    endOff[n] = c.postings.endOffset();
-                }
-                n++;
-            }
-            // Advance this cursor to next doc.
-            int next = c.postings.nextDoc();
-            if (next == PostingsEnum.NO_MORE_DOCS) {
-                heap[0] = heap[--heapSize];
-                heap[heapSize] = null;
-            } else {
-                c.currentDoc = next;
-            }
-            if (heapSize > 0) {
-                siftDown(0);
-            }
+            n = drainCursorPositions(c, sortKey, terms, startOff, endOff, offsets, n, freq);
+            n = advanceHeapHead(n);
         }
-        // Persist any growth for next call.
+
         scratchSortKey = sortKey;
         scratchTerm = terms;
         if (offsets) {
             scratchStart = startOff;
             scratchEnd = endOff;
         }
+        return n;
+    }
 
-        if (n == 0) {
-            return Collections.emptyList();
+    private int drainCursorPositions(Cursor c, long[] sortKey, String[] terms,
+            int[] startOff, int[] endOff, boolean offsets, int n, int freq) throws IOException {
+        for (int i = 0; i < freq; i++) {
+            int pos = c.postings.nextPosition();
+            if (pos < 0) continue;
+            // Pack pos in high 32 bits; n in low 32 bits as stable tiebreak.
+            sortKey[n] = ((long) pos << 32) | (n & 0xFFFFFFFFL);
+            terms[n] = c.term;
+            if (offsets) {
+                startOff[n] = c.postings.startOffset();
+                endOff[n] = c.postings.endOffset();
+            }
+            n++;
         }
+        return n;
+    }
 
-        // Primitive long sort — JDK 21 intrinsic, dramatically faster than ArrayList.sort with
-        // a boxed Comparator. Pos in high bits orders by position ascending; tiebreak by
-        // insertion index (low bits) gives a stable order matching the original logic.
-        Arrays.sort(sortKey, 0, n);
+    /**
+     * Moves the current heap head to its next doc (dropping if exhausted) and re-heapifies.
+     * Returns {@code n} unchanged — signature matches the call site pattern for readability.
+     */
+    private int advanceHeapHead(int n) throws IOException {
+        int next = heap[0].postings.nextDoc();
+        if (next == PostingsEnum.NO_MORE_DOCS) {
+            heap[0] = heap[--heapSize];
+            heap[heapSize] = null;
+        } else {
+            heap[0].currentDoc = next;
+        }
+        if (heapSize > 0) {
+            siftDown(0);
+        }
+        return n;
+    }
+
+    /**
+     * Sorts the first {@code n} entries in {@code scratchSortKey} using a primitive long sort
+     * (JDK 21 vectorized intrinsic) and builds the output list.
+     */
+    private List<TermEntry> sortAndBuildResult(int n) {
+        // Primitive long sort — vectorized on JDK 21, much faster than boxed Comparator sort.
+        Arrays.sort(scratchSortKey, 0, n);
 
         ArrayList<TermEntry> ordered = new ArrayList<>(n);
-        if (offsets) {
+        if (fieldHasOffsets) {
             for (int k = 0; k < n; k++) {
-                int idx = (int) sortKey[k];
-                ordered.add(new TermEntry(terms[idx], startOff[idx], endOff[idx]));
+                int idx = (int) scratchSortKey[k];
+                ordered.add(new TermEntry(scratchTerm[idx], scratchStart[idx], scratchEnd[idx]));
             }
         } else {
             for (int k = 0; k < n; k++) {
-                int idx = (int) sortKey[k];
-                ordered.add(new TermEntry(terms[idx], PostingsSink.NO_OFFSET, PostingsSink.NO_OFFSET));
+                int idx = (int) scratchSortKey[k];
+                ordered.add(new TermEntry(scratchTerm[idx], PostingsSink.NO_OFFSET, PostingsSink.NO_OFFSET));
             }
         }
         return ordered;

--- a/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/version_9/StreamingFieldPostings9.java
+++ b/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/version_9/StreamingFieldPostings9.java
@@ -1,0 +1,216 @@
+package org.opensearch.migrations.bulkload.lucene.version_9;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.opensearch.migrations.bulkload.lucene.StreamingFieldPostings;
+import org.opensearch.migrations.bulkload.lucene.sidecar.PostingsSink;
+import org.opensearch.migrations.bulkload.lucene.sidecar.TermEntry;
+
+import lombok.extern.slf4j.Slf4j;
+import shadow.lucene9.org.apache.lucene.index.FieldInfo;
+import shadow.lucene9.org.apache.lucene.index.IndexOptions;
+import shadow.lucene9.org.apache.lucene.index.LeafReader;
+import shadow.lucene9.org.apache.lucene.index.PostingsEnum;
+import shadow.lucene9.org.apache.lucene.index.Terms;
+import shadow.lucene9.org.apache.lucene.index.TermsEnum;
+import shadow.lucene9.org.apache.lucene.util.BytesRef;
+
+/**
+ * Streaming postings cursor for Lucene 9 fields.
+ *
+ * <p>Opens one PostingsEnum per term up-front and keeps them in a min-heap keyed by
+ * current docId. Each {@link #advance(int)} drains all postings whose head docId
+ * matches the requested target, advancing each drained cursor to its next doc and
+ * re-heapifying.
+ *
+ * <p>Memory is bounded by the field's term count: one PostingsEnum + one decoded
+ * term string per term. Postings are NOT pre-materialized — the implementation
+ * exploits Lucene's lazy posting iterators, so per-term cost is constant up-front
+ * and the rest is paid only as docs are visited.
+ *
+ * <p>Position-list buffer per (term, doc) is reused across heap entries; the entry
+ * objects themselves are created fresh per advance result so callers can keep them
+ * across subsequent advance calls (ArrayList of immutable {@link TermEntry}).
+ */
+@Slf4j
+final class StreamingFieldPostings9 implements StreamingFieldPostings {
+
+    /**
+     * One entry per term in the field's posting list. {@code currentDoc} is the doc
+     * the underlying PostingsEnum is currently positioned at, or
+     * {@link PostingsEnum#NO_MORE_DOCS} once exhausted.
+     */
+    private static final class Cursor {
+        final String term;
+        final PostingsEnum postings;
+        int currentDoc;
+
+        Cursor(String term, PostingsEnum postings, int currentDoc) {
+            this.term = term;
+            this.postings = postings;
+            this.currentDoc = currentDoc;
+        }
+    }
+
+    private final boolean fieldHasOffsets;
+    private final Cursor[] heap;
+    private int heapSize;
+    private int lastAdvancedDoc = -1;
+    private boolean closed;
+
+    StreamingFieldPostings9(LeafReader wrapped, String fieldName) throws IOException {
+        Terms terms = wrapped.terms(fieldName);
+        if (terms == null || !terms.hasPositions()) {
+            this.heap = new Cursor[0];
+            this.heapSize = 0;
+            this.fieldHasOffsets = false;
+            return;
+        }
+        FieldInfo fi = wrapped.getFieldInfos().fieldInfo(fieldName);
+        this.fieldHasOffsets = fi != null
+            && fi.getIndexOptions().compareTo(IndexOptions.DOCS_AND_FREQS_AND_POSITIONS_AND_OFFSETS) >= 0;
+        int postingsFlags = fieldHasOffsets ? PostingsEnum.OFFSETS : PostingsEnum.POSITIONS;
+
+        // Estimate term count to size the heap. Terms.size() returns -1 if unknown;
+        // we fall back to an ArrayList-style growth pattern via a temporary list.
+        long estTerms = terms.size();
+        ArrayList<Cursor> built = new ArrayList<>(estTerms > 0 && estTerms < Integer.MAX_VALUE
+                ? (int) estTerms
+                : 64);
+
+        TermsEnum te = terms.iterator();
+        BytesRef term;
+        while ((term = te.next()) != null) {
+            String termStr = term.utf8ToString();
+            PostingsEnum postings = te.postings(null, postingsFlags);
+            int firstDoc = postings.nextDoc();
+            if (firstDoc == PostingsEnum.NO_MORE_DOCS) {
+                continue; // nothing to stream for this term
+            }
+            built.add(new Cursor(termStr, postings, firstDoc));
+        }
+
+        this.heap = built.toArray(new Cursor[0]);
+        this.heapSize = heap.length;
+        // Heapify in O(n).
+        for (int i = (heapSize >>> 1) - 1; i >= 0; i--) {
+            siftDown(i);
+        }
+    }
+
+    @Override
+    public List<TermEntry> advance(int docId) throws IOException {
+        if (closed) {
+            throw new IOException("StreamingFieldPostings is closed");
+        }
+        if (docId < lastAdvancedDoc) {
+            throw new IllegalStateException("StreamingFieldPostings cannot rewind: requested "
+                    + docId + " after " + lastAdvancedDoc);
+        }
+        lastAdvancedDoc = docId;
+
+        if (heapSize == 0) {
+            return Collections.emptyList();
+        }
+
+        // Skip cursors whose currentDoc < docId. Each such cursor must be advanced
+        // forward past or to the target, then re-heapified.
+        while (heapSize > 0 && heap[0].currentDoc < docId) {
+            Cursor c = heap[0];
+            int next = c.postings.advance(docId);
+            if (next == PostingsEnum.NO_MORE_DOCS) {
+                // Drop this cursor: replace heap[0] with last and shrink.
+                heap[0] = heap[--heapSize];
+                heap[heapSize] = null;
+            } else {
+                c.currentDoc = next;
+            }
+            if (heapSize > 0) {
+                siftDown(0);
+            }
+        }
+
+        if (heapSize == 0 || heap[0].currentDoc != docId) {
+            return Collections.emptyList();
+        }
+
+        // Collect (term, position, startOff, endOff) for every cursor whose head equals docId.
+        // We then sort by position to deliver position-ordered output, mirroring the sidecar contract.
+        ArrayList<TermEntry> collected = new ArrayList<>();
+        ArrayList<int[]> posOffsets = new ArrayList<>(); // parallel arrays: [pos, startOff, endOff, termIdx-into-collected]
+        while (heapSize > 0 && heap[0].currentDoc == docId) {
+            Cursor c = heap[0];
+            int freq = c.postings.freq();
+            for (int i = 0; i < freq; i++) {
+                int pos = c.postings.nextPosition();
+                if (pos < 0) continue;
+                int startOff = fieldHasOffsets ? c.postings.startOffset() : PostingsSink.NO_OFFSET;
+                int endOff = fieldHasOffsets ? c.postings.endOffset() : PostingsSink.NO_OFFSET;
+                posOffsets.add(new int[]{pos, startOff, endOff, collected.size()});
+                // Stash term placeholder; index into a parallel array for cheap re-lookup.
+                collected.add(new TermEntry(c.term, startOff, endOff));
+                // We'll overwrite collected entries after sort, but we need term per index.
+            }
+            // Advance this cursor to next doc.
+            int next = c.postings.nextDoc();
+            if (next == PostingsEnum.NO_MORE_DOCS) {
+                heap[0] = heap[--heapSize];
+                heap[heapSize] = null;
+            } else {
+                c.currentDoc = next;
+            }
+            if (heapSize > 0) {
+                siftDown(0);
+            }
+        }
+
+        if (posOffsets.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        // Sort by position ascending; tiebreak by collected order for determinism.
+        posOffsets.sort((a, b) -> {
+            int d = Integer.compare(a[0], b[0]);
+            return d != 0 ? d : Integer.compare(a[3], b[3]);
+        });
+
+        ArrayList<TermEntry> ordered = new ArrayList<>(posOffsets.size());
+        for (int[] po : posOffsets) {
+            TermEntry placeholder = collected.get(po[3]);
+            // collected[i] stores the correct term + offsets already.
+            ordered.add(new TermEntry(placeholder.term(), po[1], po[2]));
+        }
+        return ordered;
+    }
+
+    @Override
+    public void close() {
+        if (closed) return;
+        closed = true;
+        // PostingsEnum has no explicit close in Lucene; releasing references is enough.
+        for (int i = 0; i < heap.length; i++) {
+            heap[i] = null;
+        }
+        heapSize = 0;
+    }
+
+    /** Min-heap sift-down on heap[0..heapSize). */
+    private void siftDown(int i) {
+        int n = heapSize;
+        while (true) {
+            int l = (i << 1) + 1;
+            int r = l + 1;
+            int smallest = i;
+            if (l < n && heap[l].currentDoc < heap[smallest].currentDoc) smallest = l;
+            if (r < n && heap[r].currentDoc < heap[smallest].currentDoc) smallest = r;
+            if (smallest == i) return;
+            Cursor tmp = heap[i];
+            heap[i] = heap[smallest];
+            heap[smallest] = tmp;
+            i = smallest;
+        }
+    }
+}


### PR DESCRIPTION
# Sourceless RFS source-reconstruction perf: streaming postings + cached DV iterators + primitive sort

## Summary

Speeds up `_source` reconstruction in the sourceless RFS read path by
**+27%** (118.91 → 150.56 docs/sec, +12.31 → +11.63 MB/s), measured
locally against the AV5 enron-archive snapshot on the
`es-sourceless-experimental` base.

The hot path is `SourceReconstructor` → `LuceneReader` →
per-leaf-reader `getDocValue` / `streamFieldPostings` calls. Three
independent fixes here:

1. **Cache DocValues iterators per-segment for lockstep forward advancement.**
   Reconstruction visits docs in strict ascending docId order, so a
   forward-only cached iterator is correct. Previously every
   `getDocValue(docId, fieldInfo)` call re-acquired a fresh Lucene
   DocValues iterator via `wrapped.getNumericDocValues(fieldName)` /
   `getSortedSetDocValues` etc. and re-`advanceExact`'d from the start.
   On hot fields (`copy_to` reverse-derivation hits the same set of
   ~150 fields per doc) this dominated the read profile.

2. **Stream tier-3 postings via per-field min-heap to skip OfflineSorter.**
   Adds `StreamingFieldPostings` (+ Lucene 9 / 10 implementations) so
   the keyword/text reverse-derivation channel pulls postings on demand
   from a per-field heap instead of materializing the full
   `(docId, term)` stream into an `OfflineSorter` work file before
   reading it back. Removes the OfflineSorter sync-lock contention
   that 99 sibling `lucene-io` threads were piling onto when
   `SEGMENT_READ_CONCURRENCY=100`.

3. **Primitive long sort + reusable scratch in `StreamingFieldPostings9`.**
   The streaming cursor's per-batch `(docId<<32)|termOrd` sort was using
   boxed `Long[]` + `Arrays.sort`. Switched to primitive `long[]` +
   `Arrays.sort(long[])` with a reusable scratch buffer. This is the
   step that captures the +27% on top of the streaming cursor.

## Measurement

Bounded-window measurement of pure read+serialize+gzip cost (target =
`NullDocumentSink`), so this isolates reconstruction from target HTTP
cost. Heartbeat-window methodology: 60s warmup, then `Δdocs / Δseconds`
across the post-warmup interval.

| variant                                | docs/sec | MB/s   | Δ vs prev |
| ---                                    | ---:     | ---:   | ---:      |
| iter-7 (DV iterator cache + keyword cache) | 118.91 | 9.42 | baseline |
| iter-9 (this PR: + streaming postings + primitive sort) | **150.56** | **11.63** | **+27%** |

Snapshot: `snapshot_av5_20260427_190846` (ES 7.12.0, 23 leaves,
~500K docs, `enron_archive.av5`). Sourceless mode
(`--experimental-sourceless`), `--null-sink`. Run length capped at
1500s; throughput computed over a 120s post-warmup window.

## Files

| file | purpose |
| --- | --- |
| `LuceneLeafReader.java` | Adds `initDocValueIterators` default + `streamFieldPostings` hook |
| `LuceneReader.java` | Wires the lockstep cache lifecycle into per-segment iteration |
| `SegmentDocValueReader.java` (new) | Per-segment forward-only DV iterator cache |
| `SegmentTermIndex.java` | Per-field locking + integration with streaming postings |
| `StreamingFieldPostings.java` (new) | Interface for streaming-cursor postings |
| `version_9/StreamingFieldPostings9.java` (new) | Lucene 9 impl: heap + primitive long sort |
| `version_10/StreamingFieldPostings10.java` (new) | Lucene 10 impl |
| `version_7/LeafReader7.java` | Cached DV iterator integration on Lucene 7 |
| `version_9/LeafReader9.java` | Cached DV iterator + streaming-postings wiring |
| `version_10/LeafReader10.java` | Cached DV iterator + streaming-postings wiring |

10 files changed, +923/-20.

## Correctness

- DV iterator cache is **forward-only**. Reconstruction iterates docs
  via `flatMapSequential` + `IntStream.range` / `BitSet.stream`, both
  of which deliver docIds in strict ascending order, so
  `advanceExact(d)` with `d >= last_d` is always valid. Backward seeks
  fall through to per-call iterator acquisition (preserves correctness
  for any non-lockstep callers).
- Streaming postings is functionally equivalent to the OfflineSorter
  path: same `(docId, term)` pairs in the same docId order, just
  produced lazily from a per-field heap rather than materialized to
  disk first.
- Primitive sort produces the same ordering as the boxed sort
  (`(docId<<32)|termOrd` packed into a single long is monotonic in
  docId-then-termOrd).
- No public API changes. `streamFieldPostings` is non-default on
  `LuceneLeafReader`, but that hook already existed on this branch.

## Local validation

Run the sourceless RFS pipeline against the AV5 snapshot with
`--null-sink` for 4 minutes (60s warmup + ≥120s measurement window),
parse the post-warmup heartbeat throughput, and confirm
`measurement_valid=true` with `docs_per_sec >= ~150`. Closes #2974
(same diff, cleaner branch + description).

## Notes

- This is on the `es-sourceless-experimental` long-running branch, not
  `main`. Sourceless RFS is still experimental.
- Replaces #2974, which had a stale title and a baseline that hadn't
  been validated end-to-end before the description was written.
