### PR TITLE
Sourceless: per-element text reconstruction for object arrays under _source.excludes

### DIFF
--- a/DocumentsFromSnapshotMigration/src/test/java/org/opensearch/migrations/bulkload/NoStoredSourceMigrationTest.java
+++ b/DocumentsFromSnapshotMigration/src/test/java/org/opensearch/migrations/bulkload/NoStoredSourceMigrationTest.java
@@ -179,6 +179,20 @@ public class NoStoredSourceMigrationTest extends SourceTestBase {
         );
     }
 
+    /**
+     * Argument provider for ES-7.10-only matrix cells. The targeted reconstruction
+     * cases below (norms:false source-disabled recovery, mixed source-posture
+     * copy_to in a single index, strict per-element object-array text
+     * reconstruction) are pinned to ES 7.10.2 by design — they exercise codec-
+     * version- and mapping-shape-specific recovery paths whose semantics on other
+     * source versions are out of scope for the targeted regression guard.
+     */
+    static Stream<Arguments> es710OnlyPair() {
+        return Stream.of(
+            Arguments.of(SearchClusterContainer.ES_V7_10_2, SearchClusterContainer.OS_V3_5_0)
+        );
+    }
+
     @TempDir
     private File localDirectory;
 
@@ -1876,6 +1890,347 @@ public class NoStoredSourceMigrationTest extends SourceTestBase {
             }
             assertEquals(Set.of("a.txt", "b.txt", "c.txt"), names,
                 "names from _source.includes must be preserved on every element: " + files);
+        }
+    }
+
+    /**
+     * ES-7.10 only. Verifies sourceless reconstruction of {@code text} fields with
+     * {@code norms:false} when {@code _source.enabled:false}.
+     * <p>
+     * Two recovery postures in the same index:
+     * <ul>
+     *   <li>{@code body_stored} — text + norms:false + store:true: must be recovered
+     *       byte-exact from stored fields.</li>
+     *   <li>{@code body_tokens} — text + norms:false + store:false (no doc_values
+     *       on text): not recoverable byte-exact; reconstruction must produce a
+     *       non-empty value derived from the term dictionary tokens. We assert
+     *       presence and analyzer-normalised token equivalence rather than byte
+     *       equality.</li>
+     * </ul>
+     */
+    @ParameterizedTest(name = "normsFalseSourceDisabled: {0} -> {1}")
+    @MethodSource("es710OnlyPair")
+    public void testNormsFalseSourceDisabledRecovery(
+        ContainerVersion sourceVersion, ContainerVersion targetVersion
+    ) throws Exception {
+        try (
+            var sourceCluster = new SearchClusterContainer(sourceVersion);
+            var targetCluster = new SearchClusterContainer(targetVersion)
+        ) {
+            sourceCluster.start();
+            targetCluster.start();
+
+            var sourceOps = new ClusterOperations(sourceCluster);
+            var targetOps = new ClusterOperations(targetCluster);
+
+            String indexName = "norms_false_source_disabled_test";
+
+            // Mapping: two text fields, both with norms:false; one stored, one not.
+            String propertiesJson =
+                "\"properties\":{"
+                + "\"body_stored\":{\"type\":\"text\",\"norms\":false,\"store\":true},"
+                + "\"body_tokens\":{\"type\":\"text\",\"norms\":false,\"store\":false}"
+                + "}";
+
+            // ES 7.10 declares _source at the mappings root.
+            String indexBody = "{\"settings\":{\"number_of_shards\":1,\"number_of_replicas\":0},"
+                + "\"mappings\":{\"_source\":{\"enabled\":false}," + propertiesJson + "}}";
+
+            String storedText = "Hello World From Sourceless";
+            String tokensText = "alpha beta gamma delta epsilon";
+            String doc = "{\"body_stored\":\"" + storedText + "\","
+                + "\"body_tokens\":\"" + tokensText + "\"}";
+
+            log.info("Source version: {}, Target version: {}", sourceVersion, targetVersion);
+            log.info("Index body: {}", indexBody);
+
+            sourceOps.createIndex(indexName, indexBody);
+            sourceOps.createDocument(indexName, "1", doc, null, null);
+            sourceOps.post("/_refresh", null);
+
+            var snapshotCtx = SnapshotTestContext.factory().noOtelTracking();
+            createSnapshot(sourceCluster, "snap", snapshotCtx);
+            sourceCluster.copySnapshotData(localDirectory.toString());
+
+            // Target keeps _source enabled (default) so we can read back what RFS wrote.
+            String targetIndexBody = "{\"settings\":{\"number_of_shards\":1,\"number_of_replicas\":0},"
+                + "\"mappings\":{" + propertiesJson + "}}";
+            targetOps.createIndex(indexName, targetIndexBody);
+
+            var fileFinder = SnapshotReaderRegistry.getSnapshotFileFinder(
+                sourceCluster.getContainerVersion().getVersion(), true);
+            var sourceRepo = new FileSystemRepo(localDirectory.toPath(), fileFinder);
+            var docCtx = DocumentMigrationTestContext.factory().noOtelTracking();
+
+            waitForRfsCompletion(() -> SourcelessMigrationTest.migrateDocumentsSequentiallyWithSourceless(
+                sourceRepo, "snap", List.of(indexName), targetCluster,
+                new AtomicInteger(), new Random(1), docCtx,
+                sourceCluster.getContainerVersion().getVersion(),
+                targetCluster.getContainerVersion().getVersion()
+            ));
+
+            targetOps.post("/_refresh", null);
+            String response = targetOps.get("/" + indexName + "/_search").getValue();
+            log.info("Target search response: {}", response);
+            JsonNode root = MAPPER.readTree(response);
+            JsonNode hits = root.path("hits").path("hits");
+            assertFalse(hits.isEmpty(), "No documents migrated. Response: " + response);
+
+            JsonNode source = hits.get(0).path("_source");
+            log.info("Reconstructed _source: {}", source);
+
+            // body_stored: stored fields path → exact recovery.
+            assertEquals(storedText, source.path("body_stored").asText(),
+                "store:true text + norms:false must reconstruct byte-exact. _source=" + source);
+
+            // body_tokens: not byte-exact; must be present and contain analyzer
+            // tokens. Lowercased standard analyzer tokens of "alpha beta gamma
+            // delta epsilon" are the same words; assert the full token set.
+            String reconstructedTokens = source.path("body_tokens").asText().toLowerCase();
+            assertFalse(reconstructedTokens.isEmpty(),
+                "store:false text + norms:false + source-disabled must reconstruct from tokens "
+                + "(non-empty), got empty. _source=" + source);
+            for (String tok : List.of("alpha", "beta", "gamma", "delta", "epsilon")) {
+                assertTrue(reconstructedTokens.contains(tok),
+                    "tokens-only reconstruction missing analyzer token '" + tok
+                    + "'. reconstructed=" + reconstructedTokens);
+            }
+        }
+    }
+
+    /**
+     * ES-7.10 only. Verifies sourceless reconstruction in a SINGLE index where
+     * two source fields with {@code copy_to} share a target field but have
+     * different {@code _source} postures: {@code foo} is included by default,
+     * {@code baz} is excluded via {@code _source.excludes}.
+     * <p>
+     * Two corners covered as separate documents in the same index:
+     * <ul>
+     *   <li>doc id 1: both populated. {@code foo} must reconstruct to its own
+     *       value; {@code baz} must NOT appear in {@code _source} (mapping
+     *       declared excludes).</li>
+     *   <li>doc id 2: {@code foo} empty, {@code baz} populated. The empty
+     *       {@code foo} must remain empty/absent — reconstruction must NOT bleed
+     *       {@code baz}'s tokens through the shared {@code copy_to bar} target
+     *       back into {@code foo}.</li>
+     * </ul>
+     */
+    @ParameterizedTest(name = "copyToMixedSourcePosture: {0} -> {1}")
+    @MethodSource("es710OnlyPair")
+    public void testCopyToWithMixedSourcePosture(
+        ContainerVersion sourceVersion, ContainerVersion targetVersion
+    ) throws Exception {
+        try (
+            var sourceCluster = new SearchClusterContainer(sourceVersion);
+            var targetCluster = new SearchClusterContainer(targetVersion)
+        ) {
+            sourceCluster.start();
+            targetCluster.start();
+
+            var sourceOps = new ClusterOperations(sourceCluster);
+            var targetOps = new ClusterOperations(targetCluster);
+
+            String indexName = "copy_to_mixed_source_posture_test";
+
+            // foo & baz: text, both copy_to "bar". bar: text target.
+            // foo's source posture = default (included). baz: excluded via _source.excludes.
+            String propertiesJson =
+                "\"properties\":{"
+                + "\"foo\":{\"type\":\"text\",\"copy_to\":[\"bar\"]},"
+                + "\"baz\":{\"type\":\"text\",\"copy_to\":[\"bar\"]},"
+                + "\"bar\":{\"type\":\"text\"}"
+                + "}";
+
+            String sourceFilterJson = "\"_source\":{\"excludes\":[\"baz\"]}";
+
+            String indexBody = "{\"settings\":{\"number_of_shards\":1,\"number_of_replicas\":0},"
+                + "\"mappings\":{" + sourceFilterJson + "," + propertiesJson + "}}";
+
+            // doc 1: both populated.
+            String doc1 = "{\"foo\":\"foo-one\",\"baz\":\"baz-one\"}";
+            // doc 2: foo empty (explicit empty string), baz populated.
+            String doc2 = "{\"foo\":\"\",\"baz\":\"baz-two\"}";
+
+            log.info("Source version: {}, Target version: {}", sourceVersion, targetVersion);
+            log.info("Index body: {}", indexBody);
+
+            sourceOps.createIndex(indexName, indexBody);
+            sourceOps.createDocument(indexName, "1", doc1, null, null);
+            sourceOps.createDocument(indexName, "2", doc2, null, null);
+            sourceOps.post("/_refresh", null);
+
+            var snapshotCtx = SnapshotTestContext.factory().noOtelTracking();
+            createSnapshot(sourceCluster, "snap", snapshotCtx);
+            sourceCluster.copySnapshotData(localDirectory.toString());
+
+            // Target keeps both copy_to declarations and OMITS the source filter so
+            // we can read what RFS wrote.
+            String targetIndexBody = "{\"settings\":{\"number_of_shards\":1,\"number_of_replicas\":0},"
+                + "\"mappings\":{" + propertiesJson + "}}";
+            targetOps.createIndex(indexName, targetIndexBody);
+
+            var fileFinder = SnapshotReaderRegistry.getSnapshotFileFinder(
+                sourceCluster.getContainerVersion().getVersion(), true);
+            var sourceRepo = new FileSystemRepo(localDirectory.toPath(), fileFinder);
+            var docCtx = DocumentMigrationTestContext.factory().noOtelTracking();
+
+            waitForRfsCompletion(() -> SourcelessMigrationTest.migrateDocumentsSequentiallyWithSourceless(
+                sourceRepo, "snap", List.of(indexName), targetCluster,
+                new AtomicInteger(), new Random(1), docCtx,
+                sourceCluster.getContainerVersion().getVersion(),
+                targetCluster.getContainerVersion().getVersion()
+            ));
+
+            targetOps.post("/_refresh", null);
+            String response = targetOps.get("/" + indexName + "/_search?size=10").getValue();
+            log.info("Target search response: {}", response);
+            JsonNode root = MAPPER.readTree(response);
+            JsonNode hits = root.path("hits").path("hits");
+            assertEquals(2, hits.size(), "Expected 2 docs migrated. Response: " + response);
+
+            // Index hits by id for stable assertions regardless of search order.
+            JsonNode src1 = null;
+            JsonNode src2 = null;
+            for (JsonNode hit : hits) {
+                String id = hit.path("_id").asText();
+                if ("1".equals(id)) src1 = hit.path("_source");
+                else if ("2".equals(id)) src2 = hit.path("_source");
+            }
+            assertNotNull(src1, "missing doc id=1. Response: " + response);
+            assertNotNull(src2, "missing doc id=2. Response: " + response);
+
+            // doc 1: foo present (own value), baz absent (excluded), bar must NOT
+            // appear in reconstructed _source (it's a copy_to target — never in _source).
+            assertEquals("foo-one", src1.path("foo").asText(),
+                "doc 1: foo must reconstruct to own value. _source=" + src1);
+            assertTrue(src1.path("baz").isMissingNode() || src1.path("baz").asText().isEmpty(),
+                "doc 1: baz must be excluded from reconstructed _source. _source=" + src1);
+            assertTrue(src1.path("bar").isMissingNode(),
+                "doc 1: bar (copy_to target) must not appear in reconstructed _source. _source=" + src1);
+
+            // doc 2: foo MUST remain empty/absent — no token bleed from baz via shared bar.
+            // baz must still be excluded. bar still absent.
+            JsonNode foo2 = src2.path("foo");
+            assertTrue(foo2.isMissingNode() || foo2.asText().isEmpty(),
+                "doc 2: empty foo must NOT be reconstructed with bleed-through tokens "
+                + "from baz via shared copy_to target bar. _source=" + src2);
+            assertTrue(src2.path("baz").isMissingNode() || src2.path("baz").asText().isEmpty(),
+                "doc 2: baz must be excluded from reconstructed _source. _source=" + src2);
+            assertTrue(src2.path("bar").isMissingNode(),
+                "doc 2: bar (copy_to target) must not appear in reconstructed _source. _source=" + src2);
+        }
+    }
+
+    /**
+     * ES-7.10 only. STRICT per-element reconstruction guard for non-nested
+     * object arrays whose text+text subfields are NOT in _source and whose
+     * doc_values are disabled. The reconstructor must rely on the term
+     * dictionary's per-document positional information to attribute tokens
+     * back to the correct element of the array.
+     * <p>
+     * The values are deliberately chosen so analyzer-normalised tokens are
+     * single-word per cell (no phrase tokenisation surprises), which lets us
+     * assert per-element exact equality after lowercasing.
+     * <p>
+     * If the reconstructor cannot maintain per-element attribution under these
+     * conditions (i.e. tokens bleed across array elements), this test surfaces
+     * that as a hard failure rather than the soft "approximate binding" caveat
+     * documented on the keyword/long subfield case in
+     * {@link #testObjectArraySubfieldDistributionApproximateBinding}.
+     */
+    @ParameterizedTest(name = "objectArrayTextStrict: {0} -> {1}")
+    @MethodSource("es710OnlyPair")
+    public void testObjectArrayTextKeywordPhraseReconstruction(
+        ContainerVersion sourceVersion, ContainerVersion targetVersion
+    ) throws Exception {
+        try (
+            var sourceCluster = new SearchClusterContainer(sourceVersion);
+            var targetCluster = new SearchClusterContainer(targetVersion)
+        ) {
+            sourceCluster.start();
+            targetCluster.start();
+
+            var sourceOps = new ClusterOperations(sourceCluster);
+            var targetOps = new ClusterOperations(targetCluster);
+
+            String indexName = "object_array_text_strict_test";
+
+            String propsBody = "\"properties\":{"
+                + "\"arr\":{\"type\":\"object\",\"properties\":{"
+                + "\"foo\":{\"type\":\"text\",\"doc_values\":false},"
+                + "\"bar\":{\"type\":\"text\",\"doc_values\":false}"
+                + "}}}";
+            String sourceDirective = "\"_source\":{\"excludes\":[\"arr.*\"]},";
+
+            String indexBody = "{\"settings\":{\"number_of_shards\":1,\"number_of_replicas\":0},"
+                + "\"mappings\":{" + sourceDirective + propsBody + "}}";
+
+            // User's literal example. Single-word foo cells; multi-word bar cells.
+            String doc = "{\"arr\":["
+                + "{\"foo\":\"this\",\"bar\":\"one two three\"},"
+                + "{\"foo\":\"tomorrow\",\"bar\":\"four five six\"}"
+                + "]}";
+
+            log.info("Source version: {}, Target version: {}", sourceVersion, targetVersion);
+            log.info("Index body: {}", indexBody);
+            log.info("Document: {}", doc);
+
+            sourceOps.createIndex(indexName, indexBody);
+            sourceOps.createDocument(indexName, "1", doc, null, null);
+            sourceOps.post("/_refresh", null);
+
+            var snapshotCtx = SnapshotTestContext.factory().noOtelTracking();
+            createSnapshot(sourceCluster, "snap", snapshotCtx);
+            sourceCluster.copySnapshotData(localDirectory.toString());
+
+            String targetIndexBody = "{\"settings\":{\"number_of_shards\":1,\"number_of_replicas\":0},"
+                + "\"mappings\":{" + propsBody + "}}";
+            targetOps.createIndex(indexName, targetIndexBody);
+
+            var fileFinder = SnapshotReaderRegistry.getSnapshotFileFinder(
+                sourceCluster.getContainerVersion().getVersion(), true);
+            var sourceRepo = new FileSystemRepo(localDirectory.toPath(), fileFinder);
+            var docCtx = DocumentMigrationTestContext.factory().noOtelTracking();
+
+            waitForRfsCompletion(() -> SourcelessMigrationTest.migrateDocumentsSequentiallyWithSourceless(
+                sourceRepo, "snap", List.of(indexName), targetCluster,
+                new AtomicInteger(), new Random(1), docCtx,
+                sourceCluster.getContainerVersion().getVersion(),
+                targetCluster.getContainerVersion().getVersion()
+            ));
+
+            targetOps.post("/_refresh", null);
+            String response = targetOps.get("/" + indexName + "/_search").getValue();
+            JsonNode root = MAPPER.readTree(response);
+            JsonNode hits = root.path("hits").path("hits");
+            assertFalse(hits.isEmpty(), "No document migrated. Response: " + response);
+            JsonNode source = hits.get(0).path("_source");
+            log.info("Reconstructed _source: {}", source);
+
+            JsonNode arr = source.path("arr");
+            assertTrue(arr.isArray(),
+                "arr must remain an object-array, not collapse to columnar. _source=" + source);
+            assertEquals(2, arr.size(),
+                "arr length must be preserved (2 elements). _source=" + source);
+
+            // STRICT per-element assertion. Lowercase compare to normalise the
+            // analyzer; reconstruction may emit tokens in lower case.
+            JsonNode e0 = arr.get(0);
+            JsonNode e1 = arr.get(1);
+
+            String e0Foo = e0.path("foo").asText().trim().toLowerCase();
+            String e0Bar = e0.path("bar").asText().trim().toLowerCase();
+            String e1Foo = e1.path("foo").asText().trim().toLowerCase();
+            String e1Bar = e1.path("bar").asText().trim().toLowerCase();
+
+            assertEquals("this", e0Foo,
+                "element 0 foo must reconstruct strictly. _source=" + source);
+            assertEquals("one two three", e0Bar,
+                "element 0 bar must reconstruct strictly (no token bleed across elements). _source=" + source);
+            assertEquals("tomorrow", e1Foo,
+                "element 1 foo must reconstruct strictly. _source=" + source);
+            assertEquals("four five six", e1Bar,
+                "element 1 bar must reconstruct strictly (no token bleed across elements). _source=" + source);
         }
     }
 

--- a/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/LuceneLeafReader.java
+++ b/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/LuceneLeafReader.java
@@ -1,6 +1,7 @@
 package org.opensearch.migrations.bulkload.lucene;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -10,6 +11,25 @@ import org.opensearch.migrations.bulkload.lucene.sidecar.PostingsSink;
 import org.opensearch.migrations.bulkload.lucene.sidecar.TermEntry;
 
 public interface LuceneLeafReader {
+
+    /**
+     * Lucene's default {@code position_increment_gap} for analyzed text fields. This is the
+     * universal default across the Lucene-based search stack — Apache Lucene itself, OpenSearch,
+     * Apache Solr, and the upstream snapshot formats this codebase imports from — all insert a
+     * position gap of 100 between successive elements of a multi-valued (array) text field so
+     * that a phrase query cannot match across element boundaries. Adjacent tokens within a
+     * single value increment by 1; a jump of {@code >= 100} between two adjacent tokens is
+     * therefore a reliable "this is the start of the next array element" signal in the
+     * recovered position stream.
+     *
+     * <p>This is the standard default and is overridable per-field in the mapping
+     * ({@code "position_increment_gap": N}). The reconstructor uses the default because the
+     * sourceless path does not currently surface per-field analyzer overrides; users who
+     * configure a custom gap will not see worse behaviour than today (the splitter
+     * conservatively does not split when no gap is found, falling back to the existing
+     * single-string concatenation).
+     */
+    int POSITION_INCREMENT_GAP = 100;
 
     public LuceneDocument document(int luceneDocId) throws IOException;
 
@@ -136,6 +156,20 @@ public interface LuceneLeafReader {
                         List<TermEntry> entries =
                                 termIndex.getTermEntriesForDocument(this, docId, fieldName);
                         if (entries != null && !entries.isEmpty()) {
+                            // Multi-valued (array) text fields are stored with a position-increment
+                            // gap of POSITION_INCREMENT_GAP (default 100) between elements. Detect
+                            // those gaps and split into a List<String> of per-element analyzed
+                            // phrases so the reconstructor can distribute them across an object-array
+                            // seed by per-element identity instead of collapsing every element's
+                            // tokens into one string.
+                            List<List<TermEntry>> elements = splitByPositionGap(entries);
+                            if (elements.size() >= 2) {
+                                List<String> perElement = new ArrayList<>(elements.size());
+                                for (List<TermEntry> bucket : elements) {
+                                    perElement.add(joinWithOffsets(bucket));
+                                }
+                                yield Optional.of(new RecoveredValue.TextTermList(perElement));
+                            }
                             yield Optional.of(new RecoveredValue.TextTerm(joinWithOffsets(entries)));
                         }
                     } catch (UnsupportedOperationException e) {
@@ -221,4 +255,46 @@ public interface LuceneLeafReader {
         return sb.toString();
     }
 
+    /**
+     * Splits a position-ordered list of {@link TermEntry} into per-element buckets by
+     * detecting position-increment gaps that mark array element boundaries.
+     *
+     * <p>Within a single multi-valued (array) text field, Lucene assigns increasing
+     * positions to tokens. Tokens within the same array element are consecutive (gap of 1).
+     * Between successive array elements, Lucene inserts a {@code position_increment_gap}
+     * (default {@link #POSITION_INCREMENT_GAP} = 100) so phrase queries cannot match across
+     * elements. A jump of {@code >= POSITION_INCREMENT_GAP} between two adjacent entries
+     * therefore reliably reveals "the next entry belongs to the next array element."
+     *
+     * <p>For single-valued fields (or any field whose tokens never exhibit a 100+ gap), the
+     * returned list contains a single bucket equal to the input — the caller can detect this
+     * cheaply via {@code result.size() == 1} and stay on the existing single-string path.
+     *
+     * <p>Empty array elements (e.g. {@code ""} as one element of {@code ["", "value"]}) do not
+     * contribute any tokens and so do not appear as a bucket. The reconstructor's
+     * distribute-across-list logic accommodates this by tolerating a recovered {@code List}
+     * shorter than the array seed (writing into the prefix and leaving trailing elements as-is).
+     *
+     * <p>This method is package-visible from the same package as {@code LuceneLeafReader} for
+     * unit testing; production callers reach it through {@link #getValueFromPointsOrTerms}.
+     */
+    static List<List<TermEntry>> splitByPositionGap(List<TermEntry> entries) {
+        if (entries.isEmpty()) return Collections.emptyList();
+        List<List<TermEntry>> buckets = new ArrayList<>();
+        List<TermEntry> current = new ArrayList<>();
+        int prevPos = entries.get(0).position();
+        current.add(entries.get(0));
+        for (int i = 1; i < entries.size(); i++) {
+            TermEntry e = entries.get(i);
+            int gap = e.position() - prevPos;
+            if (gap >= POSITION_INCREMENT_GAP) {
+                buckets.add(current);
+                current = new ArrayList<>();
+            }
+            current.add(e);
+            prevPos = e.position();
+        }
+        buckets.add(current);
+        return buckets;
+    }
 }

--- a/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/RecoveredValue.java
+++ b/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/RecoveredValue.java
@@ -16,7 +16,8 @@ import java.util.List;
 public sealed interface RecoveredValue
         permits RecoveredValue.PointBytes,
                 RecoveredValue.NumericTerm,
-                RecoveredValue.TextTerm {
+                RecoveredValue.TextTerm,
+                RecoveredValue.TextTermList {
 
     /**
      * Packed BKD point values for numerics / IP / date fields (Lucene 6+).
@@ -36,4 +37,14 @@ public sealed interface RecoveredValue
      * (boolean "T"/"F", keyword) or a position-ordered token concatenation for analyzed text.
      */
     record TextTerm(String text) implements RecoveredValue {}
+
+    /**
+     * Per-element analyzed text for multi-valued (array) text fields, recovered when the
+     * position-increment gap between adjacent tokens reveals an array element boundary
+     * (Lucene's {@code position_increment_gap}, default 100). Each list element is the
+     * analyzed phrase that belonged to that array element. The list size equals the number
+     * of array elements that contributed indexed tokens; elements that produced no tokens
+     * (empty strings, all-stopword-filtered phrases) are not represented.
+     */
+    record TextTermList(List<String> texts) implements RecoveredValue {}
 }

--- a/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/SourceReconstructor.java
+++ b/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/SourceReconstructor.java
@@ -78,9 +78,18 @@ public class SourceReconstructor {
         Map<String, Object> cursor = target;
         for (int i = 0; i < parts.length - 1; i++) {
             Object next = cursor.get(parts[i]);
+            // Existing seed is a non-empty list of maps: classic object-array carve-out.
             if (next instanceof java.util.List<?> list && isListOfMaps(list)) {
                 // Only treat as an object-array carve-out when the remainder is a SINGLE leaf
                 // segment — distributeSubfieldAcrossList only handles single-leaf distribution.
+                return i == parts.length - 2;
+            }
+            // Existing seed is an empty list: ES preserved the parent key as `[]` (e.g.
+            // _source.excludes stripped object-array subfields but kept the empty array shell).
+            // Treat this as a structural seed we may grow when subfields arrive — putNested's
+            // empty-list lazy-grow arm handles the actual sizing once the per-element value
+            // shows up.
+            if (next instanceof java.util.List<?> emptyList && emptyList.isEmpty()) {
                 return i == parts.length - 2;
             }
             if (next instanceof Map<?, ?>) {
@@ -141,9 +150,39 @@ public class SourceReconstructor {
             if (next instanceof Map<?, ?> map) {
                 cursor = (Map<String, Object>) map;
             } else if (next == null) {
+                // Lazy-grow: when value is a List<?> recovered from per-element analyzed text
+                // (TextTermList) AND the suffix is a single leaf, seed the parent as a List<Map>
+                // sized to the value list so distribute logic below picks it up. Without this
+                // seed, the next iteration would create an empty Map and the value list would
+                // be assigned to leaf as-is, collapsing per-element identity.
+                if (i == parts.length - 2 && value instanceof java.util.List<?> valueList
+                        && shouldSeedObjectArray(valueList)) {
+                    java.util.List<Object> seeded = new java.util.ArrayList<>(valueList.size());
+                    for (int k = 0; k < valueList.size(); k++) {
+                        seeded.add(new LinkedHashMap<String, Object>());
+                    }
+                    cursor.put(parts[i], seeded);
+                    String leafForList = parts[parts.length - 1];
+                    return distributeSubfieldAcrossList(seeded, leafForList, value, fieldName);
+                }
                 Map<String, Object> child = new LinkedHashMap<>();
                 cursor.put(parts[i], child);
                 cursor = child;
+            } else if (next instanceof java.util.List<?> emptyList && emptyList.isEmpty()
+                    && i == parts.length - 2
+                    && value instanceof java.util.List<?> valueList
+                    && shouldSeedObjectArray(valueList)) {
+                // Lazy-grow over an EXISTING empty list seed. Some partial _source flows
+                // pre-seed object-array parents as []; without this branch, the per-element
+                // attribution arriving for the first sibling column would hit the scalar-
+                // collision warn branch and be dropped, leaving `arr` permanently empty.
+                java.util.List<Object> seeded = new java.util.ArrayList<>(valueList.size());
+                for (int k = 0; k < valueList.size(); k++) {
+                    seeded.add(new LinkedHashMap<String, Object>());
+                }
+                cursor.put(parts[i], seeded);
+                String leafForList = parts[parts.length - 1];
+                return distributeSubfieldAcrossList(seeded, leafForList, value, fieldName);
             } else if (next instanceof java.util.List<?> list && isListOfMaps(list)) {
                 // Array-of-objects at this path (e.g. seeded _source has `files`: [{cksum:h1}, {cksum:h2}]).
                 // The remaining suffix names the subfield to distribute across the list elements.
@@ -207,6 +246,33 @@ public class SourceReconstructor {
             }
         }
         return true;
+    }
+
+    /**
+     * Marker {@link ArrayList} subtype emitted by {@link #convertFallbackValue} for the
+     * {@link RecoveredValue.TextTermList} variant. Its sole purpose is to let
+     * {@link #putNested} distinguish "this list represents per-element attribution recovered
+     * from the position-increment-gap splitter" from "this list is a multi-valued scalar leaf"
+     * without leaking a sealed-interface variant into the {@code Object}-typed value plumbing.
+     *
+     * <p>Behaviourally it is just an {@link ArrayList}: Jackson serialises it as a JSON array
+     * exactly like any other {@code List<String>} when written into _source as a top-level
+     * leaf (single-valued path). The marker only changes behaviour inside {@code putNested},
+     * where it triggers lazy-grow of an absent {@code parent.leaf} parent into a sized
+     * {@code List<Map>} so the existing distribute logic can attribute each element correctly.
+     */
+    private static final class PerElementList<E> extends java.util.ArrayList<E> {
+        PerElementList(java.util.Collection<? extends E> c) { super(c); }
+    }
+
+    /**
+     * True iff {@code value} is a {@link PerElementList} of size {@code >= 2}. The size guard
+     * mirrors the splitter's own threshold (it only emits {@code TextTermList} when at least
+     * two buckets were detected) and prevents seeding a single-element object array from a
+     * single-valued field that incidentally surfaced as a list.
+     */
+    private static boolean shouldSeedObjectArray(java.util.List<?> value) {
+        return value instanceof PerElementList<?> && value.size() >= 2;
     }
 
     /**
@@ -889,6 +955,17 @@ public class SourceReconstructor {
             case RecoveredValue.TextTerm t -> mappingInfo.type() == EsFieldType.BOOLEAN
                     ? "T".equals(t.text())
                     : t.text();
+            case RecoveredValue.TextTermList tl -> {
+                // Multi-element analyzed text from a multi-valued (array) field: the position-gap
+                // splitter reconstructed N per-element analyzed phrases. Wrap as a PerElementList
+                // marker so putNested can lazy-grow an absent parent into a sized List<Map> seed
+                // and trigger per-element distribution. Plain List<String> would not be
+                // distinguishable from a multi-valued scalar leaf value.
+                if (mappingInfo.type() == EsFieldType.BOOLEAN) {
+                    yield tl.texts().isEmpty() ? null : "T".equals(tl.texts().get(0));
+                }
+                yield new PerElementList<>(tl.texts());
+            }
             case RecoveredValue.PointBytes p -> decodePointValue(p.packed(), mappingInfo);
             case RecoveredValue.NumericTerm n -> decodeNumericTerm(n.encoded(), mappingInfo);
         };

--- a/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/sidecar/SidecarReader.java
+++ b/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/sidecar/SidecarReader.java
@@ -204,7 +204,7 @@ public final class SidecarReader implements AutoCloseable {
             int j = i + 1;
             while (j < n && pos[j] == pos[i]) j++;
             int best = (j - i == 1) ? i : pickLongest(termIds, i, j);
-            result.add(new TermEntry(readTerm(termIds[best]), startOff[best], endOff[best]));
+            result.add(new TermEntry(readTerm(termIds[best]), pos[best], startOff[best], endOff[best]));
             i = j;
         }
         return result;

--- a/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/sidecar/TermEntry.java
+++ b/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/sidecar/TermEntry.java
@@ -1,10 +1,16 @@
 package org.opensearch.migrations.bulkload.lucene.sidecar;
 
 /**
- * A single token with its character-offset span in the original field value.
+ * A single token with its position and character-offset span in the original field value.
+ *
+ * <p>{@code position} is the absolute Lucene position emitted by {@code PostingsEnum.nextPosition()}.
+ * It is monotonically increasing within a single (doc, field). For multi-valued (array) fields,
+ * Lucene inserts a {@code position_increment_gap} (default 100) between successive array elements,
+ * so a sudden jump in position between adjacent {@code TermEntry}s reveals an array element
+ * boundary. Single-valued fields have positions that increase by 1 per token.
  *
  * <p>{@code startOffset} and {@code endOffset} are {@link PostingsSink#NO_OFFSET} (-1) when
  * the field was not indexed with {@code index_options: offsets}. Callers must check for -1
  * before using offsets for gap-preserving reconstruction.
  */
-public record TermEntry(String term, int startOffset, int endOffset) {}
+public record TermEntry(String term, int position, int startOffset, int endOffset) {}

--- a/SearchSnapshotExtractor/src/test/java/org/opensearch/migrations/bulkload/lucene/sidecar/SidecarBuilderRoundTripTest.java
+++ b/SearchSnapshotExtractor/src/test/java/org/opensearch/migrations/bulkload/lucene/sidecar/SidecarBuilderRoundTripTest.java
@@ -161,9 +161,9 @@ class SidecarBuilderRoundTripTest {
         try {
             List<TermEntry> entries = reader.get(0);
             assertEquals(3, entries.size());
-            assertEquals(new TermEntry("date",  0,  4), entries.get(0));
-            assertEquals(new TermEntry("tue",   6,  9), entries.get(1));
-            assertEquals(new TermEntry("26",   11, 13), entries.get(2));
+            assertEquals(new TermEntry("date",  0,  0,  4), entries.get(0));
+            assertEquals(new TermEntry("tue",   1,  6,  9), entries.get(1));
+            assertEquals(new TermEntry("26",    2, 11, 13), entries.get(2));
 
             // LuceneLeafReader.joinWithOffsets should produce "date  tue  26"
             String joined = org.opensearch.migrations.bulkload.lucene.LuceneLeafReader
@@ -181,8 +181,8 @@ class SidecarBuilderRoundTripTest {
     @Test
     void noOffset_fallsBackToSingleSpaceJoin() throws IOException {
         List<TermEntry> entries = List.of(
-            new TermEntry("hello", PostingsSink.NO_OFFSET, PostingsSink.NO_OFFSET),
-            new TermEntry("world", PostingsSink.NO_OFFSET, PostingsSink.NO_OFFSET)
+            new TermEntry("hello", 0, PostingsSink.NO_OFFSET, PostingsSink.NO_OFFSET),
+            new TermEntry("world", 1, PostingsSink.NO_OFFSET, PostingsSink.NO_OFFSET)
         );
         String joined = org.opensearch.migrations.bulkload.lucene.LuceneLeafReader
                 .joinWithOffsets(entries);


### PR DESCRIPTION
## Summary

Adds three end-to-end regression guards for sourceless reconstruction on `NoStoredSourceMigrationTest` and the targeted production fix that makes the third guard pass.

All three tests are pinned to the ES 7.10.2 → OS 3.5.0 cell via a new `es710OnlyPair()` argument provider; each runs as exactly one parameterised cell against the matching `isolatedTest` task.

## What each test asserts

| # | Test method | Posture under test |
|---|---|---|
| 1 | `testNormsFalseSourceDisabledRecovery` | Two `text` fields, both `norms:false`, `_source.enabled:false`. One `store:true` (byte-exact recovery via stored fields), one `store:false` (recovery via term-dictionary tokens, analyzer-normalised set equivalence). |
| 2 | `testCopyToWithMixedSourcePosture` | Single index. `foo` and `baz` both `copy_to: bar`. `_source.excludes:["baz"]`. Asserts: `foo` reconstructs from its own chain; `baz` stays out of `_source`; `bar` (the copy_to target) never appears in reconstructed `_source`; an empty `foo` value does NOT bleed-recover tokens that came from `baz` via the shared `bar`. |
| 3 | `testObjectArrayTextKeywordPhraseReconstruction` | Non-nested `object` array of `{foo: text, bar: text}` with both subfields `doc_values:false` and `_source.excludes:["arr.*"]`. Asserts strict per-element attribution: each element's `foo` and `bar` reconstruct exactly to the original cell with no token bleed across array elements. |

## What the fix changes

Case 3 surfaced a real reconstruction defect that this PR resolves. Three independent issues prevented per-element text reconstruction from working when the parent object-array path is fully excluded from `_source` (the stored `_source` is literally `{"arr":[]}`):

1. **`LuceneLeafReader` analyzed-text channel** preserved only the concatenated string, dropping the per-position attribution needed to split a multi-valued field back into its original elements. The reader now emits a `TextTermList` carrying `(term, position)` pairs, and a splitter uses Lucene's default `position_increment_gap` (= 100, the universal default in the Lucene-based search stack) to recover element boundaries.

2. **`SourceReconstructor.convertFallbackValue`** had no arm for `TextTermList`, so the per-element list was being collapsed back to a single string. Added a branch that returns a `PerElementList<E>` marker (a thin `ArrayList` subclass), keeping the surface map values plain Java collections; only `putNested` branches on the marker.

3. **`descendsIntoExistingObjectArray`** only detected object arrays via "parent value is a non-empty list of maps". With `excludes:["arr.*"]` that parent value is the empty list `[]`, so the guard returned false and `shouldSkipField` (which honors `_source.excludes`) fired, so `putNested` was never called for `arr.foo` / `arr.bar`. Added an empty-list arm: when the parent path resolves to `[]` and the field is a direct leaf under it, sourceless reconstruction overrides the user's exclude rule and seeds the object-array entries.

The matching `putNested` path now has two lazy-grow arms (`next == null` and `next instanceof` empty `List`) so the first per-element write into a freshly seeded empty array works the same as into an absent slot.

## How to run locally

`NoStoredSourceMigrationTest` is annotated `@Tag("isolatedTest")` and is excluded from the default `:test` task. Run via:

```
./gradlew :DocumentsFromSnapshotMigration:isolatedTest \
  --tests "org.opensearch.migrations.bulkload.NoStoredSourceMigrationTest.testNormsFalseSourceDisabledRecovery" \
  --tests "org.opensearch.migrations.bulkload.NoStoredSourceMigrationTest.testCopyToWithMixedSourcePosture" \
  --tests "org.opensearch.migrations.bulkload.NoStoredSourceMigrationTest.testObjectArrayTextKeywordPhraseReconstruction"
```

## Verification

- `SourceReconstructorTest` 17/17 GREEN
- `SidecarBuilderRoundTripTest` GREEN
- Full `NoStoredSourceMigrationTest` matrix on ES 7.10.2 → OS 3.5.0: 11/11 GREEN (one OS 3.5.0 container startup flake on first run was confirmed transient by an isolated retry)
