### PR TITLE
RFS: unify ES and Solr migration orchestration to prevent exit-code divergence

### DIFF
--- a/DocumentsFromSnapshotMigration/src/main/java/org/opensearch/migrations/RfsMigrateDocuments.java
+++ b/DocumentsFromSnapshotMigration/src/main/java/org/opensearch/migrations/RfsMigrateDocuments.java
@@ -464,11 +464,20 @@ public class RfsMigrateDocuments {
         }
     }
 
+    @FunctionalInterface
+    interface MigrationSourceFactory {
+        CompletionStatus buildAndRun(
+            IWorkCoordinator workCoordinator,
+            LeaseExpireTrigger processManager,
+            AtomicReference<WorkItemCursor> progressCursor,
+            AtomicReference<Runnable> cancellationRunnableRef,
+            WorkItemTimeProvider workItemTimeProvider
+        ) throws IOException, InterruptedException, NoWorkLeftException;
+    }
+
     public static void main(String[] args) throws Exception {
         var workerId = ProcessHelpers.getNodeInstanceName();
         System.err.println("Starting program with: " + String.join(" ", ArgLogUtils.getRedactedArgs(args, ArgNameConstants.CENSORED_ARGS)));
-        // Ensure that log4j2 doesn't execute shutdown hooks until ours have completed. This means that we need to take
-        // responsibility for calling `LogManager.shutdown()` in our own shutdown hook..
         System.setProperty("log4j2.shutdownHookEnabled", "false");
         log.atInfo().setMessage("Starting RfsMigrateDocuments with workerId={}").addArgument(workerId).log();
 
@@ -493,8 +502,7 @@ public class RfsMigrateDocuments {
         var targetClientFactory = new OpenSearchClientFactory(targetConnectionContext, arguments.maxConnections);
         OpenSearchClient targetClient = targetClientFactory.determineVersionAndCreate();
         var targetVersion = targetClient.getClusterVersion();
-        
-        // Determine if server-generated IDs should be used
+
         boolean useServerGeneratedIds = switch (arguments.serverGeneratedIds) {
             case ALWAYS -> true;
             case NEVER -> false;
@@ -515,17 +523,25 @@ public class RfsMigrateDocuments {
         var transformationLoader = new TransformationLoader();
         Supplier<IJsonTransformer> docTransformerSupplier = () -> transformationLoader.getTransformerFactoryLoader(docTransformerConfig);
 
+        MigrationSourceFactory sourceFactory;
         if (arguments.sourceVersion != null && arguments.sourceVersion.getFlavor() == Flavor.SOLR) {
-            runSolrBackupMigration(arguments, targetClient, docTransformerSupplier, useServerGeneratedIds, context);
-            return;
+            sourceFactory = buildSolrSourceFactory(arguments, targetClient, docTransformerSupplier, useServerGeneratedIds, context);
+        } else {
+            sourceFactory = buildElasticsearchSourceFactory(arguments, targetClient,
+                docTransformerSupplier, useServerGeneratedIds, context);
         }
 
-        var luceneDirPath = Paths.get(arguments.luceneDir);
-        var snapshotLocalDirPath = arguments.snapshotLocalDir != null ? Paths.get(arguments.snapshotLocalDir) : null;
-
-        // Determine coordinator connection and version
         var coordinatorInfo = resolveCoordinatorConnection(arguments, targetConnectionContext, targetVersion);
+        runMigration(workerId, arguments, coordinatorInfo, context, sourceFactory);
+    }
 
+    private static void runMigration(
+        String workerId,
+        Args arguments,
+        CoordinatorInfo coordinatorInfo,
+        RootDocumentMigrationContext context,
+        MigrationSourceFactory sourceFactory
+    ) throws Exception {
         var workItemRef = new AtomicReference<IWorkCoordinator.WorkItemAndDuration>();
         var progressCursor = new AtomicReference<WorkItemCursor>();
         var cancellationRunnableRef = new AtomicReference<Runnable>();
@@ -554,8 +570,6 @@ public class RfsMigrateDocuments {
                         context.getWorkCoordinationContext()::createSuccessorWorkItemsContext,
                         context.getWorkCoordinationContext()::createReleaseWorkItemContext),
                 Clock.systemUTC());) {
-            // Set up a hook to attempt to shut down cleanly (to mark progress in the worker coordination system) in the
-            // event of a SIGTERM signal.
             Runtime.getRuntime().addShutdownHook(new Thread(() -> {
                 Thread.currentThread().setName("Cleanup-Hook-Thread");
                 log.atWarn().setMessage("Received shutdown signal. Trying to mark progress and shutdown cleanly.").log();
@@ -566,19 +580,45 @@ public class RfsMigrateDocuments {
                     log.atInfo().setMessage("Clean shutdown completed.").log();
                 } catch (InterruptedException e) {
                     log.atError().setMessage("Clean exit process was interrupted: {}").addArgument(e).log();
-                    // Re-interrupt the thread to maintain interruption state
                     Thread.currentThread().interrupt();
                 } catch (Exception e) {
                     log.atError().setMessage("Could not complete clean exit process: {}").addArgument(e).log();
                 } finally {
-                    // Manually flush logs and shutdown log4j after all logging is done
                     LogManager.shutdown();
                 }
             }));
 
-            MDC.put(LOGGING_MDC_WORKER_ID, workerId); // I don't see a need to clean this up since we're in main
+            MDC.put(LOGGING_MDC_WORKER_ID, workerId);
 
+            var status = sourceFactory.buildAndRun(
+                workCoordinator, processManager, progressCursor, cancellationRunnableRef, workItemTimeProvider);
+            cleanShutdownCompleted.set(true);
+            if (status == CompletionStatus.NOTHING_DONE) {
+                log.atInfo().setMessage("Work exists but none available to this worker. Exiting with exit code " + NO_WORK_AVAILABLE_EXIT_CODE).log();
+                System.exit(NO_WORK_AVAILABLE_EXIT_CODE);
+            }
+        } catch (NoWorkLeftException e) {
+            log.atInfo().setMessage("No work left to acquire. Exiting with exit code " + NO_WORK_LEFT_EXIT_CODE).log();
+            cleanShutdownCompleted.set(true);
+            System.exit(NO_WORK_LEFT_EXIT_CODE);
+        } catch (Exception e) {
+            log.atError().setCause(e).setMessage("Unexpected error running RfsWorker").log();
+            throw e;
+        }
+    }
+
+    private static MigrationSourceFactory buildElasticsearchSourceFactory(
+        Args arguments,
+        OpenSearchClient targetClient,
+        Supplier<IJsonTransformer> docTransformerSupplier,
+        boolean useServerGeneratedIds,
+        RootDocumentMigrationContext context
+    ) {
+        return (workCoordinator, processManager, progressCursor, cancellationRunnableRef, workItemTimeProvider) -> {
             DocumentExceptionAllowlist allowlist = buildDocumentExceptionAllowlist(arguments);
+
+            var luceneDirPath = Paths.get(arguments.luceneDir);
+            var snapshotLocalDirPath = arguments.snapshotLocalDir != null ? Paths.get(arguments.snapshotLocalDir) : null;
 
             var finder = SnapshotReaderRegistry.getSnapshotFileFinder(
                     arguments.sourceVersion,
@@ -593,11 +633,12 @@ public class RfsMigrateDocuments {
                     finder)
                 : new FileSystemRepo(snapshotLocalDirPath, finder);
 
-            var sourceResourceProvider = SnapshotReaderRegistry.getSnapshotReader(arguments.sourceVersion, sourceRepo, arguments.versionStrictness.allowLooseVersionMatches);
+            var sourceResourceProvider = SnapshotReaderRegistry.getSnapshotReader(
+                arguments.sourceVersion, sourceRepo, arguments.versionStrictness.allowLooseVersionMatches);
 
             var extractor = SnapshotExtractor.create(
                 arguments.sourceVersion, sourceResourceProvider, sourceRepo);
-            var status = runWithPipeline(
+            return runWithPipeline(
                 extractor,
                 targetClient,
                 arguments.snapshotName,
@@ -622,19 +663,7 @@ public class RfsMigrateDocuments {
                 arguments.experimental.experimentalDeltaMode,
                 arguments.experimental.enableSourcelessMigrations,
                 arguments.experimental.useRecoverySource);
-            cleanShutdownCompleted.set(true);
-            if (status == CompletionStatus.NOTHING_DONE) {
-                log.atInfo().setMessage("Work exists but none available to this worker. Exiting with exit code " + NO_WORK_AVAILABLE_EXIT_CODE).log();
-                System.exit(NO_WORK_AVAILABLE_EXIT_CODE);
-            }
-        } catch (NoWorkLeftException e) {
-            log.atInfo().setMessage("No work left to acquire.  Exiting with error code to signal that.").log();
-            cleanShutdownCompleted.set(true);
-            System.exit(NO_WORK_LEFT_EXIT_CODE);
-        } catch (Exception e) {
-            log.atError().setCause(e).setMessage("Unexpected error running RfsWorker").log();
-            throw e;
-        }
+        };
     }
 
     @SuppressWarnings({"java:S100", "java:S1172", "java:S1186"})
@@ -934,205 +963,120 @@ public class RfsMigrateDocuments {
     }
 
 
-    private static void runSolrBackupMigration(
+    private static MigrationSourceFactory buildSolrSourceFactory(
         Args arguments,
         OpenSearchClient targetClient,
         Supplier<IJsonTransformer> docTransformerSupplier,
         boolean useServerGeneratedIds,
         RootDocumentMigrationContext context
     ) {
-        try {
-            // Check the coordinator for pending work BEFORE downloading anything from S3.
-            // This avoids wasting time/bandwidth downloading schema metadata on every pod restart
-            // when all work items have already been completed.
-            var targetConnectionContext = arguments.targetArgs.toConnectionContext();
-            var targetVersion = targetClient.getClusterVersion();
-            var coordinatorInfo = resolveCoordinatorConnection(arguments, targetConnectionContext, targetVersion);
+        return (workCoordinator, processManager, progressCursor, cancellationRunnableRef, workItemTimeProvider) -> {
+            DocumentExceptionAllowlist allowlist = buildDocumentExceptionAllowlist(arguments);
 
-            var workerId = ProcessHelpers.getNodeInstanceName();
-            var workItemRef = new AtomicReference<IWorkCoordinator.WorkItemAndDuration>();
-            var progressCursor = new AtomicReference<WorkItemCursor>();
-            var cancellationRunnableRef = new AtomicReference<Runnable>();
-            var workItemTimeProvider = new WorkItemTimeProvider();
-            var completionRetryConfig = buildCompletionRetryConfig(arguments);
-            var coordinatorFactory = new WorkCoordinatorFactory(
-                coordinatorInfo.version(), arguments.indexNameSuffix, completionRetryConfig);
-            var cleanShutdownCompleted = new AtomicBoolean(false);
-            var allowlist = buildDocumentExceptionAllowlist(arguments);
-
-            try (var workCoordinator = coordinatorFactory.get(
-                     new CoordinateWorkHttpClient(coordinatorInfo.connectionContext()),
-                     TOLERABLE_CLIENT_SERVER_CLOCK_DIFFERENCE_SECONDS,
-                     workerId,
-                     Clock.systemUTC(),
-                     workItemRef::set);
-                 var processManager = new LeaseExpireTrigger(
-                    w -> exitOnLeaseTimeout(
-                            workItemRef, workCoordinator, w, progressCursor, workItemTimeProvider,
-                            arguments.initialLeaseDuration,
-                            () -> Optional.ofNullable(cancellationRunnableRef.get()).ifPresent(Runnable::run),
-                            cleanShutdownCompleted,
-                            context.getWorkCoordinationContext()::createSuccessorWorkItemsContext,
-                            context.getWorkCoordinationContext()::createReleaseWorkItemContext),
-                    Clock.systemUTC())) {
-
-                // Work coordination will naturally short-circuit via ShardWorkPreparer.onAlreadyCompleted
-                // and prepareWorkCoordination will throw NoWorkLeftException if there's nothing to do.
-                // Both cases are handled below without any S3 schema downloads thanks to the lazy
-                // collectionPreparer wired into the factory/source.
-
-                // Work is available — now download metadata from S3 / local
-                Path backupDir;
-                S3Repo s3Repo = null;
-                if (arguments.snapshotLocalDir != null) {
-                    backupDir = Paths.get(arguments.snapshotLocalDir);
-                    log.atInfo().setMessage("Starting Solr backup document migration from local dir: {}").addArgument(backupDir).log();
-                } else if (arguments.s3RepoUri != null && arguments.s3Region != null && arguments.s3LocalDir != null) {
-                    // Solr's BACKUP API writes to <location>/<snapshotName>/ where <location> is
-                    // the path portion of s3RepoUri (or / when no subpath is configured).
-                    // Mirror the path-extraction logic so reader & writer land on the same URI.
-                    var backupS3Uri = SolrBackupLayout.buildBackupS3Uri(
-                        new S3Uri(arguments.s3RepoUri), arguments.snapshotName);
-                    log.atInfo().setMessage("Downloading Solr backup metadata from S3: {}").addArgument(backupS3Uri).log();
-                    s3Repo = S3Repo.createRaw(
-                        Paths.get(arguments.s3LocalDir),
-                        new S3Uri(backupS3Uri),
-                        arguments.s3Region,
-                        arguments.s3Endpoint != null ? URI.create(arguments.s3Endpoint) : null
-                    );
-                    backupDir = s3Repo.getRepoRootDir();
-                } else {
-                    throw new ParameterException(
-                        "When source version is SOLR, provide either --snapshot-local-dir or S3 args (--s3-local-dir, --s3-repo-uri, --s3-region)."
-                    );
-                }
-
-                // Discover collection names (cheap: single S3 list-directories call or local dir scan).
-                // The schema XMLs themselves are fetched lazily by the collectionPreparer below -- only
-                // when ShardWorkPreparer actually needs to iterate shards for an uncompleted work item.
-                // If work-coordination already has everything marked complete, ShardWorkPreparer short-
-                // circuits via onAlreadyCompleted and no schema downloads happen at all.
-                var schemas = new LinkedHashMap<String, JsonNode>();
-                final List<String> collections;
-                if (s3Repo != null) {
-                    collections = new ArrayList<>(s3Repo.listTopLevelDirectories());
-                } else {
-                    collections = new ArrayList<>(SolrSnapshotReader.discoverCollections(backupDir));
-                }
-                if (!arguments.indexAllowlist.isEmpty()) {
-                    collections.retainAll(arguments.indexAllowlist);
-                }
-                for (var collection : collections) {
-                    schemas.put(collection, null);  // placeholder; populated lazily by collectionPreparer
-                }
-
-                // collectionPreparer hydrates a collection on first access: resolves the backup
-                // layout (flat vs. two-level), downloads the latest zk_backup_N and
-                // shard_backup_metadata (S3 only), then parses the schema into the schemas map.
-                // Called from SolrBackupIndexMetadataFactory.fromRepo and
-                // SolrMultiCollectionSource.readDocuments, wrapped so it runs at most once per
-                // collection per process.
-                final S3Repo finalS3Repo = s3Repo;
-                final Path finalBackupDir = backupDir;
-                // dataPrefixByCollection caches the resolved layout for each collection so the
-                // collectionPreparer (which downloads metadata) and the shardPreparer
-                // (which downloads shard index files) both use the same prefix, even for the
-                // two-level Solr 8 incremental layout.
-                final Map<String, String> dataPrefixByCollection = new ConcurrentHashMap<>();
-                Consumer<String> collectionPreparer = collection -> {
-                    if (finalS3Repo != null) {
-                        var resolved = SolrBackupLayout.resolveCollectionDataPrefix(
-                            collection, finalS3Repo::listSubDirectories);
-                        if (resolved != null) {
-                            dataPrefixByCollection.put(collection, resolved.dataPrefix());
-                            var dataRoot = resolved.joinWith(collection);
-                            finalS3Repo.downloadPrefix(dataRoot + "/" + resolved.latestZkBackupName());
-                            log.atInfo().setMessage("Downloading shard metadata for collection '{}' from S3").addArgument(collection).log();
-                            finalS3Repo.downloadPrefix(dataRoot + "/shard_backup_metadata");
-                        } else {
-                            log.warn("No zk_backup directories found for collection '{}' in S3", collection);
-                        }
-                    }
-                    var collectionRoot = finalBackupDir.resolve(collection);
-                    var dataPrefix = dataPrefixByCollection.getOrDefault(collection, "");
-                    var dataDir = dataPrefix.isEmpty() ? collectionRoot : collectionRoot.resolve(dataPrefix);
-                    schemas.put(collection, SolrSchemaXmlParser.findAndParse(dataDir));
-                };
-                Consumer<SolrShardPartition> shardPreparer = (finalS3Repo != null) ? partition -> {
-                    var dataPrefix = dataPrefixByCollection.getOrDefault(partition.collection(), "");
-                    var collectionDataPrefix = dataPrefix.isEmpty()
-                        ? partition.collection()
-                        : partition.collection() + "/" + dataPrefix;
-                    var mapping = partition.fileNameMapping();
-                    if (mapping != null) {
-                        // SolrCloud UUID backup: download only the UUID files for this shard
-                        log.atInfo().setMessage("Downloading {} index files for shard '{}/{}' from S3")
-                            .addArgument(mapping.size()).addArgument(partition.collection()).addArgument(partition.shard()).log();
-                        for (var uuid : mapping.values()) {
-                            finalS3Repo.downloadFile(collectionDataPrefix + "/index/" + uuid);
-                        }
-                    } else {
-                        // Non-UUID layout: download the shard's directory
-                        log.atInfo().setMessage("Downloading index data for shard '{}/{}' from S3")
-                            .addArgument(partition.collection()).addArgument(partition.shard()).log();
-                        finalS3Repo.downloadPrefix(collectionDataPrefix + "/index");
-                    }
-                } : null;
-
-                var solrMajor = arguments.sourceVersion.getMajor();
-                var indexMetadataFactory = new SolrBackupIndexMetadataFactory(backupDir, schemas, collectionPreparer, solrMajor);
-                var documentSource = new SolrMultiCollectionSource(backupDir, schemas, collectionPreparer, shardPreparer, solrMajor);
-
-                // Set up a hook to attempt to shut down cleanly (to mark progress in the worker coordination system) in the
-                // event of a SIGTERM signal.
-                Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-                    Thread.currentThread().setName("Cleanup-Hook-Thread");
-                    log.atWarn().setMessage("Received shutdown signal. Trying to mark progress and shutdown cleanly.").log();
-                    try {
-                        executeCleanShutdownProcess(workItemRef, progressCursor, workCoordinator, cleanShutdownCompleted,
-                                context.getWorkCoordinationContext()::createSuccessorWorkItemsContext,
-                                context.getWorkCoordinationContext()::createReleaseWorkItemContext);
-                        log.atInfo().setMessage("Clean shutdown completed.").log();
-                    } catch (InterruptedException e) {
-                        log.atError().setMessage("Clean exit process was interrupted: {}").addArgument(e).log();
-                        Thread.currentThread().interrupt();
-                    } catch (Exception e) {
-                        log.atError().setMessage("Could not complete clean exit process: {}").addArgument(e).log();
-                    } finally {
-                        LogManager.shutdown();
-                    }
-                }));
-
-                var scopedWorkCoordinator = prepareWorkCoordination(
-                    workCoordinator, processManager, indexMetadataFactory,
-                    arguments.snapshotName, arguments.indexAllowlist, context);
-
-                var runner = DocumentMigrationBootstrap.builder()
-                    .targetClient(targetClient)
-                    .snapshotName(arguments.snapshotName)
-                    .maxDocsPerBatch(arguments.numDocsPerBulkRequest)
-                    .maxBytesPerBatch(arguments.numBytesPerBulkRequest)
-                    .batchConcurrency(arguments.maxConnections)
-                    .transformerSupplier(docTransformerSupplier)
-                    .allowServerGeneratedIds(useServerGeneratedIds)
-                    .allowlist(allowlist)
-                    .externalDocumentSource(documentSource)
-                    .workCoordinator(scopedWorkCoordinator)
-                    .workItemTimeProvider(workItemTimeProvider)
-                    .maxInitialLeaseDuration(arguments.initialLeaseDuration)
-                    .cursorConsumer(progressCursor::set)
-                    .cancellationTriggerConsumer(cancellationRunnableRef::set)
-                    .build();
-
-                runner.migrateOneShard(context::createReindexContext);
-                cleanShutdownCompleted.set(true);
+            Path backupDir;
+            S3Repo s3Repo = null;
+            if (arguments.snapshotLocalDir != null) {
+                backupDir = Paths.get(arguments.snapshotLocalDir);
+                log.atInfo().setMessage("Starting Solr backup document migration from local dir: {}").addArgument(backupDir).log();
+            } else if (arguments.s3RepoUri != null && arguments.s3Region != null && arguments.s3LocalDir != null) {
+                var backupS3Uri = SolrBackupLayout.buildBackupS3Uri(
+                    new S3Uri(arguments.s3RepoUri), arguments.snapshotName);
+                log.atInfo().setMessage("Downloading Solr backup metadata from S3: {}").addArgument(backupS3Uri).log();
+                s3Repo = S3Repo.createRaw(
+                    Paths.get(arguments.s3LocalDir),
+                    new S3Uri(backupS3Uri),
+                    arguments.s3Region,
+                    arguments.s3Endpoint != null ? URI.create(arguments.s3Endpoint) : null
+                );
+                backupDir = s3Repo.getRepoRootDir();
+            } else {
+                throw new ParameterException(
+                    "When source version is SOLR, provide either --snapshot-local-dir or S3 args (--s3-local-dir, --s3-repo-uri, --s3-region)."
+                );
             }
-            log.atInfo().setMessage("Solr backup document migration completed successfully").log();
-        } catch (NoWorkLeftException e) {
-            log.atInfo().setMessage("No more Solr work items to process: {}").addArgument(e.getMessage()).log();
-        } catch (Exception e) {
-            throw new RuntimeException("Failed to migrate Solr backup", e);
-        }
+
+            var schemas = new LinkedHashMap<String, JsonNode>();
+            final List<String> collections;
+            if (s3Repo != null) {
+                collections = new ArrayList<>(s3Repo.listTopLevelDirectories());
+            } else {
+                collections = new ArrayList<>(SolrSnapshotReader.discoverCollections(backupDir));
+            }
+            if (!arguments.indexAllowlist.isEmpty()) {
+                collections.retainAll(arguments.indexAllowlist);
+            }
+            for (var collection : collections) {
+                schemas.put(collection, null);
+            }
+
+            final S3Repo finalS3Repo = s3Repo;
+            final Path finalBackupDir = backupDir;
+            final Map<String, String> dataPrefixByCollection = new ConcurrentHashMap<>();
+            Consumer<String> collectionPreparer = collection -> {
+                if (finalS3Repo != null) {
+                    var resolved = SolrBackupLayout.resolveCollectionDataPrefix(
+                        collection, finalS3Repo::listSubDirectories);
+                    if (resolved != null) {
+                        dataPrefixByCollection.put(collection, resolved.dataPrefix());
+                        var dataRoot = resolved.joinWith(collection);
+                        finalS3Repo.downloadPrefix(dataRoot + "/" + resolved.latestZkBackupName());
+                        log.atInfo().setMessage("Downloading shard metadata for collection '{}' from S3").addArgument(collection).log();
+                        finalS3Repo.downloadPrefix(dataRoot + "/shard_backup_metadata");
+                    } else {
+                        log.warn("No zk_backup directories found for collection '{}' in S3", collection);
+                    }
+                }
+                var collectionRoot = finalBackupDir.resolve(collection);
+                var dataPrefix = dataPrefixByCollection.getOrDefault(collection, "");
+                var dataDir = dataPrefix.isEmpty() ? collectionRoot : collectionRoot.resolve(dataPrefix);
+                schemas.put(collection, SolrSchemaXmlParser.findAndParse(dataDir));
+            };
+            Consumer<SolrShardPartition> shardPreparer = (finalS3Repo != null) ? partition -> {
+                var dataPrefix = dataPrefixByCollection.getOrDefault(partition.collection(), "");
+                var collectionDataPrefix = dataPrefix.isEmpty()
+                    ? partition.collection()
+                    : partition.collection() + "/" + dataPrefix;
+                var mapping = partition.fileNameMapping();
+                if (mapping != null) {
+                    log.atInfo().setMessage("Downloading {} index files for shard '{}/{}' from S3")
+                        .addArgument(mapping.size()).addArgument(partition.collection()).addArgument(partition.shard()).log();
+                    for (var uuid : mapping.values()) {
+                        finalS3Repo.downloadFile(collectionDataPrefix + "/index/" + uuid);
+                    }
+                } else {
+                    log.atInfo().setMessage("Downloading index data for shard '{}/{}' from S3")
+                        .addArgument(partition.collection()).addArgument(partition.shard()).log();
+                    finalS3Repo.downloadPrefix(collectionDataPrefix + "/index");
+                }
+            } : null;
+
+            var solrMajor = arguments.sourceVersion.getMajor();
+            var indexMetadataFactory = new SolrBackupIndexMetadataFactory(backupDir, schemas, collectionPreparer, solrMajor);
+            var documentSource = new SolrMultiCollectionSource(backupDir, schemas, collectionPreparer, shardPreparer, solrMajor);
+
+            var scopedWorkCoordinator = prepareWorkCoordination(
+                workCoordinator, processManager, indexMetadataFactory,
+                arguments.snapshotName, arguments.indexAllowlist, context);
+
+            var runner = DocumentMigrationBootstrap.builder()
+                .targetClient(targetClient)
+                .snapshotName(arguments.snapshotName)
+                .maxDocsPerBatch(arguments.numDocsPerBulkRequest)
+                .maxBytesPerBatch(arguments.numBytesPerBulkRequest)
+                .batchConcurrency(arguments.maxConnections)
+                .transformerSupplier(docTransformerSupplier)
+                .allowServerGeneratedIds(useServerGeneratedIds)
+                .allowlist(allowlist)
+                .externalDocumentSource(documentSource)
+                .workCoordinator(scopedWorkCoordinator)
+                .workItemTimeProvider(workItemTimeProvider)
+                .maxInitialLeaseDuration(arguments.initialLeaseDuration)
+                .cursorConsumer(progressCursor::set)
+                .cancellationTriggerConsumer(cancellationRunnableRef::set)
+                .build();
+
+            return runner.migrateOneShard(context::createReindexContext);
+        };
     }
 
     public static CompletionStatus runWithPipeline(

--- a/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/SegmentDocStream.java
+++ b/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/SegmentDocStream.java
@@ -1,0 +1,213 @@
+package org.opensearch.migrations.bulkload.lucene;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.IntStream;
+
+import lombok.extern.slf4j.Slf4j;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Scheduler;
+
+/**
+ * Shared utility for streaming documents from sorted Lucene segments.
+ * Used by both ES snapshot reading (LuceneReader) and Solr backup reading (SolrBackupSource).
+ *
+ * <p>Segments are sorted by {@link SegmentNameSorter#INSTANCE} for deterministic ordering,
+ * and cumulative document bases are computed so that a global document offset can be used
+ * to resume reading from an arbitrary position. Within each segment, live documents are
+ * iterated (using the liveDocs bitset when available) and processed with bounded concurrency
+ * via {@code flatMapSequential}.
+ */
+@Slf4j
+public final class SegmentDocStream {
+
+    private SegmentDocStream() {}
+
+    /**
+     * Stream documents from a list of leaf reader contexts, starting at a global document offset.
+     *
+     * <p>Segments are sorted by name for deterministic ordering. Documents within each segment
+     * are read with bounded concurrency via flatMapSequential.
+     *
+     * @param leaves the leaf reader contexts from a DirectoryReader
+     * @param startDocId global document ID to resume from (0 = start from beginning)
+     * @param concurrency max concurrent document reads within a segment
+     * @param scheduler the scheduler to use for I/O operations
+     * @param documentReader function that takes (reader, docIdx, segmentDocBase) and returns
+     *                       a Mono of the output type T (empty Mono to skip a document)
+     * @param <T> the output element type
+     * @return Flux of documents in segment order
+     */
+    public static <T> Flux<T> fromLeaves(
+        List<? extends LuceneLeafReaderContext> leaves,
+        int startDocId,
+        int concurrency,
+        Scheduler scheduler,
+        DocumentReader<T> documentReader
+    ) {
+        if (leaves.isEmpty()) {
+            return Flux.empty();
+        }
+
+        var readers = leaves.stream()
+            .map(LuceneLeafReaderContext::reader)
+            .sorted(SegmentNameSorter.INSTANCE)
+            .toList();
+
+        return streamFromSortedReaders(readers, startDocId, concurrency, scheduler, documentReader);
+    }
+
+    /**
+     * Simpler overload that takes a list of LuceneLeafReader directly (used by Solr path
+     * which already has readers extracted from contexts).
+     *
+     * @param readers the leaf readers, which will be sorted by segment name
+     * @param startDocId global document ID to resume from (0 = start from beginning)
+     * @param concurrency max concurrent document reads within a segment
+     * @param scheduler the scheduler to use for I/O operations
+     * @param documentReader function that takes (reader, docIdx, segmentDocBase) and returns
+     *                       a Mono of the output type T (empty Mono to skip a document)
+     * @param <T> the output element type
+     * @return Flux of documents in segment order
+     */
+    public static <T> Flux<T> fromReaders(
+        List<? extends LuceneLeafReader> readers,
+        int startDocId,
+        int concurrency,
+        Scheduler scheduler,
+        DocumentReader<T> documentReader
+    ) {
+        if (readers.isEmpty()) {
+            return Flux.empty();
+        }
+
+        var sortedReaders = readers.stream()
+            .sorted(SegmentNameSorter.INSTANCE)
+            .toList();
+
+        return streamFromSortedReaders(sortedReaders, startDocId, concurrency, scheduler, documentReader);
+    }
+
+    /**
+     * Core implementation: given already-sorted readers, build cumulative doc bases,
+     * binary-search to the starting segment, and stream documents sequentially across segments.
+     */
+    private static <T> Flux<T> streamFromSortedReaders(
+        List<? extends LuceneLeafReader> sortedReaders,
+        int startDocId,
+        int concurrency,
+        Scheduler scheduler,
+        DocumentReader<T> documentReader
+    ) {
+        // Build ReaderAndBase list with cumulative document bases
+        var sortedReaderAndBase = new ArrayList<ReaderAndBase>(sortedReaders.size());
+        int cumulativeDocBase = 0;
+        for (var reader : sortedReaders) {
+            sortedReaderAndBase.add(new ReaderAndBase(reader, cumulativeDocBase, reader.getLiveDocs()));
+            cumulativeDocBase += reader.maxDoc();
+        }
+
+        // Binary search to find the starting segment
+        int startIndex = findStartingSegment(sortedReaderAndBase, startDocId);
+
+        log.atDebug().setMessage("Streaming from segment index {} of {} (startDocId={})")
+            .addArgument(startIndex)
+            .addArgument(sortedReaderAndBase.size())
+            .addArgument(startDocId)
+            .log();
+
+        // Stream segments sequentially; within each segment, read docs with bounded concurrency
+        return Flux.fromIterable(sortedReaderAndBase.subList(startIndex, sortedReaderAndBase.size()))
+            .concatMap(readerAndBase -> readSegment(readerAndBase, startDocId, concurrency, scheduler, documentReader));
+    }
+
+    /**
+     * Uses binary search to find the first segment whose cumulative doc base is
+     * less than or equal to the specified startDocId.
+     *
+     * <p>This mirrors the logic in {@code LuceneReader.getSegmentsFromStartingSegment()}.
+     */
+    private static int findStartingSegment(List<ReaderAndBase> sortedReaderAndBase, int startDocId) {
+        if (startDocId <= 0) {
+            return 0;
+        }
+
+        var segmentStartingDocIds = sortedReaderAndBase.stream()
+            .map(ReaderAndBase::getDocBaseInParent)
+            .toArray();
+        int index = Arrays.binarySearch(segmentStartingDocIds, startDocId);
+
+        // If an exact match is found (binarySearch returns non-negative), use that index.
+        // If not found, binarySearch returns -(insertionPoint) - 1, where insertionPoint
+        // is the first position where docBaseInParent > startDocId.
+        // We want the last segment with docBaseInParent <= startDocId.
+        if (index < 0) {
+            int insertionPoint = -(index + 1);
+            index = Math.max(insertionPoint - 1, 0);
+        }
+
+        return index;
+    }
+
+    /**
+     * Read all live documents from a single segment with bounded concurrency.
+     *
+     * <p>If the segment has a liveDocs bitset, only live (non-deleted) document indices
+     * are iterated. If liveDocs is null (no deletions), all document indices are iterated.
+     * The startDocId is used to skip documents within the first segment when resuming.
+     */
+    private static <T> Flux<T> readSegment(
+        ReaderAndBase readerAndBase,
+        int startDocId,
+        int concurrency,
+        Scheduler scheduler,
+        DocumentReader<T> documentReader
+    ) {
+        var segmentReader = readerAndBase.getReader();
+        var liveDocs = readerAndBase.getLiveDocs();
+        int segmentDocBase = readerAndBase.getDocBaseInParent();
+
+        // Within this segment, skip docs that come before startDocId
+        int startDocIdInSegment = (startDocId <= segmentDocBase) ? 0 : startDocId - segmentDocBase;
+
+        log.atDebug().setMessage("Reading segment {}: docBase={}, startInSegment={}, maxDoc={}")
+            .addArgument(segmentReader::getSegmentName)
+            .addArgument(segmentDocBase)
+            .addArgument(startDocIdInSegment)
+            .addArgument(segmentReader::maxDoc)
+            .log();
+
+        // Build the stream of live document indices within this segment
+        IntStream docIdxStream = (liveDocs != null)
+            ? liveDocs.stream().filter(idx -> idx >= startDocIdInSegment)
+            : IntStream.range(startDocIdInSegment, segmentReader.maxDoc());
+
+        return Flux.fromStream(docIdxStream.boxed())
+            .flatMapSequential(
+                docIdx -> Mono.defer(() -> documentReader.read(segmentReader, docIdx, segmentDocBase))
+                    .subscribeOn(scheduler),
+                concurrency,
+                1
+            );
+    }
+
+    /**
+     * Functional interface for reading a single document from a segment.
+     *
+     * @param <T> the output type produced for each document
+     */
+    @FunctionalInterface
+    public interface DocumentReader<T> {
+        /**
+         * Read a document and produce a result.
+         *
+         * @param reader the leaf reader for the segment containing the document
+         * @param docIdx the document index within the segment (segment-local)
+         * @param segmentDocBase the cumulative doc base for this segment (for computing global doc IDs)
+         * @return a Mono emitting the result, or empty Mono to skip the document
+         */
+        Mono<T> read(LuceneLeafReader reader, int docIdx, int segmentDocBase);
+    }
+}

--- a/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/StoredFieldDocReader.java
+++ b/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/StoredFieldDocReader.java
@@ -1,0 +1,280 @@
+package org.opensearch.migrations.bulkload.lucene;
+
+import java.net.InetAddress;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Predicate;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * Shared utility for reading stored fields from Lucene documents and assembling
+ * them into JSON. Used as the foundation for both ES sourceless reconstruction
+ * and Solr document reading (which always reads from stored fields).
+ */
+public final class StoredFieldDocReader {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private StoredFieldDocReader() {}
+
+    /**
+     * Result of reading a document's stored fields.
+     */
+    public record ReadResult(
+        Map<String, Object> fields,
+        String documentId
+    ) {}
+
+    /**
+     * Read stored fields from a Lucene document, filtering out internal fields and
+     * extracting the document ID.
+     *
+     * @param document the Lucene document to read
+     * @param idFieldName the field name that contains the document ID ("_id" for ES, "id" for Solr)
+     * @param internalFieldFilter predicate that returns true for fields that should be skipped
+     * @param mappingContext optional mapping context for type-aware conversion (null for basic conversion)
+     * @return ReadResult with extracted fields and document ID, or null if document has no usable fields
+     */
+    public static ReadResult readStoredFields(
+        LuceneDocument document,
+        String idFieldName,
+        Predicate<String> internalFieldFilter,
+        FieldMappingContext mappingContext
+    ) {
+        String documentId = null;
+        var fields = new LinkedHashMap<String, Object>();
+
+        for (var field : document.getFields()) {
+            String fieldName = field.name();
+
+            if (fieldName.equals(idFieldName)) {
+                // Extract ID - use asUid() for _id (ES Lucene 7+), stringValue() otherwise
+                documentId = "_id".equals(idFieldName) ? field.asUid() : field.stringValue();
+                if (documentId == null) {
+                    documentId = field.stringValue();
+                }
+                continue;
+            }
+
+            if (internalFieldFilter.test(fieldName)) {
+                continue;
+            }
+
+            FieldMappingInfo mappingInfo = (mappingContext != null)
+                ? mappingContext.getFieldInfo(fieldName)
+                : null;
+            Object value = extractFieldValue(field, mappingInfo);
+            if (value != null) {
+                addMultiValue(fields, fieldName, value);
+            }
+        }
+
+        return new ReadResult(fields, documentId);
+    }
+
+    /**
+     * Extract a field value from a LuceneField, with optional mapping-aware type conversion.
+     *
+     * <p>Without mappingInfo (or for unmapped fields):
+     * <ul>
+     *   <li>Numeric values returned as-is</li>
+     *   <li>"T"/"F" converted to boolean true/false</li>
+     *   <li>Other strings returned as-is</li>
+     * </ul>
+     *
+     * <p>With mappingInfo:
+     * <ul>
+     *   <li>Boolean fields: numeric 0/1 or "T"/"F" converted to true/false</li>
+     *   <li>Date fields: epoch millis converted to ISO string (respecting format)</li>
+     *   <li>IP fields: 4-byte or 16-byte conversion to dotted-quad or colon notation</li>
+     *   <li>Scaled float: long / scalingFactor</li>
+     *   <li>Other types: delegates to mapping-aware conversion then falls through to basic</li>
+     * </ul>
+     */
+    public static Object extractFieldValue(LuceneField field, FieldMappingInfo mappingInfo) {
+        Number numValue = field.numericValue();
+        if (numValue != null) {
+            if (mappingInfo != null) {
+                return convertNumericWithMapping(numValue, mappingInfo);
+            }
+            return numValue;
+        }
+
+        byte[] binaryData = field.binaryValue();
+        if (binaryData != null && binaryData.length > 0 && mappingInfo != null) {
+            Object converted = convertBinaryWithMapping(binaryData, mappingInfo);
+            if (converted != null) {
+                return converted;
+            }
+        }
+
+        String value = field.stringValue();
+        if (value == null) {
+            value = field.utf8ToStringValue();
+        }
+        if (value == null) {
+            return null;
+        }
+
+        if (mappingInfo != null) {
+            Object converted = convertStringWithMapping(value, mappingInfo);
+            if (converted != null) {
+                return converted;
+            }
+        }
+
+        // Basic conversion: "T"/"F" to boolean
+        if ("T".equals(value)) {
+            return true;
+        }
+        if ("F".equals(value)) {
+            return false;
+        }
+        return value;
+    }
+
+    /**
+     * Add a field value to the fields map, handling multi-valued fields by
+     * converting scalars to lists when a second value arrives for the same key.
+     */
+    @SuppressWarnings("unchecked")
+    public static void addMultiValue(Map<String, Object> fields, String name, Object value) {
+        var existing = fields.get(name);
+        if (existing == null) {
+            fields.put(name, value);
+        } else if (existing instanceof List) {
+            ((List<Object>) existing).add(value);
+        } else {
+            var list = new ArrayList<>();
+            list.add(existing);
+            list.add(value);
+            fields.put(name, list);
+        }
+    }
+
+    /**
+     * Serialize a fields map to JSON bytes.
+     */
+    public static byte[] toJsonBytes(Map<String, Object> fields) {
+        try {
+            return MAPPER.writeValueAsBytes(fields);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to serialize document fields to JSON", e);
+        }
+    }
+
+    // ---- Mapping-aware conversion helpers ----
+
+    private static Object convertNumericWithMapping(Number numValue, FieldMappingInfo mappingInfo) {
+        switch (mappingInfo.type()) {
+            case BOOLEAN:
+                return numValue.longValue() != 0;
+            case DATE:
+                return formatDate(numValue.longValue(), mappingInfo.format());
+            case DATE_NANOS:
+                return formatDateNanos(numValue.longValue());
+            case IP:
+                // ES 2.x stores IPv4 as 32-bit integer
+                long ipLong = numValue.longValue();
+                return String.format("%d.%d.%d.%d",
+                    (ipLong >> 24) & 0xFF, (ipLong >> 16) & 0xFF,
+                    (ipLong >> 8) & 0xFF, ipLong & 0xFF);
+            case SCALED_FLOAT:
+                if (mappingInfo.scalingFactor() != null) {
+                    return numValue.longValue() / mappingInfo.scalingFactor();
+                }
+                return numValue;
+            default:
+                return numValue;
+        }
+    }
+
+    private static Object convertBinaryWithMapping(byte[] binaryData, FieldMappingInfo mappingInfo) {
+        switch (mappingInfo.type()) {
+            case IP:
+                // ES 5+ stores IP as 16-byte IPv6 format
+                return convertIpBytes(binaryData);
+            case STRING:
+                // STRING fields (keyword/text) in ES 5+ store UTF-8 bytes
+                return new String(binaryData, java.nio.charset.StandardCharsets.UTF_8);
+            default:
+                return null;
+        }
+    }
+
+    private static Object convertStringWithMapping(String value, FieldMappingInfo mappingInfo) {
+        switch (mappingInfo.type()) {
+            case BOOLEAN:
+                if ("T".equals(value)) return true;
+                if ("F".equals(value)) return false;
+                return null; // fall through to basic conversion
+            case DATE:
+                try {
+                    return formatDate(Long.parseLong(value), mappingInfo.format());
+                } catch (NumberFormatException e) {
+                    return value; // Already formatted or custom format
+                }
+            case SCALED_FLOAT:
+                if (mappingInfo.scalingFactor() != null) {
+                    try {
+                        return Long.parseLong(value) / mappingInfo.scalingFactor();
+                    } catch (NumberFormatException e) {
+                        return value;
+                    }
+                }
+                return null;
+            case IP:
+                try {
+                    long ipLong = Long.parseLong(value);
+                    return String.format("%d.%d.%d.%d",
+                        (ipLong >> 24) & 0xFF, (ipLong >> 16) & 0xFF,
+                        (ipLong >> 8) & 0xFF, ipLong & 0xFF);
+                } catch (NumberFormatException e) {
+                    return value; // Already an IP string
+                }
+            default:
+                return null; // fall through to basic conversion
+        }
+    }
+
+    private static Object formatDate(long epochMillis, String format) {
+        if ("epoch_millis".equals(format)) {
+            return epochMillis;
+        }
+        return DateTimeFormatter.ISO_INSTANT.format(Instant.ofEpochMilli(epochMillis));
+    }
+
+    private static Object formatDateNanos(long epochNanos) {
+        long epochSecond = epochNanos / 1_000_000_000L;
+        int nanoAdjustment = (int) (epochNanos % 1_000_000_000L);
+        return DateTimeFormatter.ISO_INSTANT.format(Instant.ofEpochSecond(epochSecond, nanoAdjustment));
+    }
+
+    private static String convertIpBytes(byte[] bytes) {
+        try {
+            if (bytes.length == 16) {
+                // Check for IPv4-mapped IPv6
+                boolean isIpv4Mapped = true;
+                for (int i = 0; i < 10; i++) {
+                    if (bytes[i] != 0) {
+                        isIpv4Mapped = false;
+                        break;
+                    }
+                }
+                if (isIpv4Mapped && bytes[10] == (byte) 0xff && bytes[11] == (byte) 0xff) {
+                    return String.format("%d.%d.%d.%d",
+                        bytes[12] & 0xFF, bytes[13] & 0xFF,
+                        bytes[14] & 0xFF, bytes[15] & 0xFF);
+                }
+            }
+            return InetAddress.getByAddress(bytes).getHostAddress();
+        } catch (Exception e) {
+            return java.util.Base64.getEncoder().encodeToString(bytes);
+        }
+    }
+}

--- a/SolrReader/src/main/java/org/opensearch/migrations/bulkload/solr/SolrBackupSource.java
+++ b/SolrReader/src/main/java/org/opensearch/migrations/bulkload/solr/SolrBackupSource.java
@@ -7,15 +7,13 @@ import java.nio.file.Path;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
-import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import org.opensearch.migrations.bulkload.common.DocumentChangeType;
 import org.opensearch.migrations.bulkload.common.LuceneDocumentChange;
+import org.opensearch.migrations.bulkload.lucene.FieldMappingContext;
 import org.opensearch.migrations.bulkload.lucene.LuceneIndexReader;
-import org.opensearch.migrations.bulkload.lucene.LuceneLeafReaderContext;
-import org.opensearch.migrations.bulkload.lucene.SegmentNameSorter;
+import org.opensearch.migrations.bulkload.lucene.SegmentDocStream;
 import org.opensearch.migrations.bulkload.lucene.version_6.IndexReader6;
 import org.opensearch.migrations.bulkload.lucene.version_7.IndexReader7;
 import org.opensearch.migrations.bulkload.lucene.version_9.IndexReader9;
@@ -29,8 +27,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 import reactor.core.publisher.Flux;
-import reactor.core.publisher.Mono;
-import reactor.core.scheduler.Schedulers;
 import shadow.lucene9.org.apache.lucene.store.FSDirectory;
 
 /**
@@ -58,12 +54,18 @@ public class SolrBackupSource implements DocumentSource {
     private final String collectionName;
     private final JsonNode solrSchema;
     private final int solrMajorVersion;
+    private final FieldMappingContext mappingContext;
 
     public SolrBackupSource(Path backupDir, String collectionName, JsonNode solrSchema, int solrMajorVersion) {
+        this(backupDir, collectionName, solrSchema, solrMajorVersion, null);
+    }
+
+    public SolrBackupSource(Path backupDir, String collectionName, JsonNode solrSchema, int solrMajorVersion, FieldMappingContext mappingContext) {
         this.backupDir = backupDir;
         this.collectionName = collectionName;
         this.solrSchema = solrSchema;
         this.solrMajorVersion = solrMajorVersion;
+        this.mappingContext = mappingContext;
     }
 
     /**
@@ -271,37 +273,18 @@ public class SolrBackupSource implements DocumentSource {
         org.opensearch.migrations.bulkload.lucene.LuceneDirectoryReader directoryReader,
         long startingDocOffset
     ) {
-        var scheduler = Schedulers.newBoundedElastic(10, Integer.MAX_VALUE, "solrReader");
+        var scheduler = reactor.core.scheduler.Schedulers.newBoundedElastic(10, Integer.MAX_VALUE, "solrReader");
 
-        var sortedLeaves = directoryReader.leaves().stream()
-            .map(LuceneLeafReaderContext::reader)
-            .sorted(SegmentNameSorter.INSTANCE)
-            .toList();
-
-        int[] docBases = new int[sortedLeaves.size()];
-        for (int i = 1; i < sortedLeaves.size(); i++) {
-            docBases[i] = docBases[i - 1] + sortedLeaves.get(i - 1).maxDoc();
-        }
-
-        return Flux.range(0, sortedLeaves.size())
-            .concatMap(segIdx -> {
-                var segReader = sortedLeaves.get(segIdx);
-                int segDocBase = docBases[segIdx];
-                var liveDocs = segReader.getLiveDocs();
-                var liveDocStream = (liveDocs != null)
-                    ? liveDocs.stream()
-                    : IntStream.range(0, segReader.maxDoc());
-
-                return Flux.fromStream(liveDocStream.boxed())
-                    .flatMapSequential(docIdx -> Mono.fromCallable(() ->
-                        SolrLuceneDocReader.getDocument(
-                            segReader, docIdx, true, segDocBase,
-                            DocumentChangeType.INDEX
-                        )
-                    ).subscribeOn(scheduler), 10)
-                    .filter(Objects::nonNull);
-            })
-            .skip(startingDocOffset)
+        return SegmentDocStream.<LuceneDocumentChange>fromLeaves(
+                directoryReader.leaves(),
+                (int) startingDocOffset,
+                10,
+                scheduler,
+                (segReader, docIdx, segDocBase) -> {
+                    var doc = SolrLuceneDocReader.getDocument(
+                        segReader, docIdx, true, segDocBase, DocumentChangeType.INDEX, mappingContext);
+                    return reactor.core.publisher.Mono.justOrEmpty(doc);
+                })
             .map(SolrBackupSource::toDocument)
             .doFinally(s -> scheduler.dispose());
     }

--- a/SolrReader/src/main/java/org/opensearch/migrations/bulkload/solr/SolrLuceneDocReader.java
+++ b/SolrReader/src/main/java/org/opensearch/migrations/bulkload/solr/SolrLuceneDocReader.java
@@ -1,33 +1,22 @@
 package org.opensearch.migrations.bulkload.solr;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.LinkedHashMap;
-import java.util.List;
 
 import org.opensearch.migrations.bulkload.common.DocumentChangeType;
 import org.opensearch.migrations.bulkload.common.LuceneDocumentChange;
-import org.opensearch.migrations.bulkload.common.ObjectMapperFactory;
-import org.opensearch.migrations.bulkload.lucene.LuceneField;
+import org.opensearch.migrations.bulkload.lucene.FieldMappingContext;
 import org.opensearch.migrations.bulkload.lucene.LuceneLeafReader;
+import org.opensearch.migrations.bulkload.lucene.StoredFieldDocReader;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 
 /**
- * Reads Solr documents from Lucene segments. Unlike ES, Solr stores the document ID
- * in a field called {@code id} (not {@code _id}), and has no {@code _source} field.
- * This reader reconstructs JSON from stored fields, handling Solr-specific conventions:
- * <ul>
- *   <li>Boolean fields stored as "T"/"F" → converted to true/false</li>
- *   <li>Multi-valued fields → collected into JSON arrays</li>
- *   <li>Internal fields (_version_, _root_, etc.) → skipped</li>
- * </ul>
+ * Reads Solr documents from Lucene segments using the shared {@link StoredFieldDocReader}.
+ * Unlike ES, Solr stores the document ID in a field called {@code id} (not {@code _id}),
+ * and has no {@code _source} field — all documents are reconstructed from stored fields.
  */
 @Slf4j
 final class SolrLuceneDocReader {
-
-    private static final ObjectMapper MAPPER = ObjectMapperFactory.createDefaultMapper();
 
     private SolrLuceneDocReader() {}
 
@@ -36,7 +25,8 @@ final class SolrLuceneDocReader {
         int luceneDocId,
         boolean isLive,
         int segmentDocBase,
-        DocumentChangeType operation
+        DocumentChangeType operation,
+        FieldMappingContext mappingContext
     ) {
         if (!isLive) {
             return null;
@@ -47,25 +37,15 @@ final class SolrLuceneDocReader {
             return null;
         }
 
-        String docId = null;
-        var fields = new LinkedHashMap<String, Object>();
+        var result = StoredFieldDocReader.readStoredFields(
+            document, "id", SolrLuceneDocReader::isInternalField, mappingContext);
 
-        for (var field : document.getFields()) {
-            if (!isInternalField(field.name())) {
-                Object value = extractFieldValue(field);
-                if (value != null) {
-                    if ("id".equals(field.name())) {
-                        docId = value.toString();
-                    }
-                    addFieldValue(fields, field.name(), value);
-                }
-            }
-        }
-
+        String docId = result.documentId();
         if (docId == null) {
             docId = "solr_doc_" + (segmentDocBase + luceneDocId);
         }
 
+        var fields = result.fields();
         if (fields.isEmpty()) {
             log.atWarn()
                 .setMessage("Solr document {} has no stored fields, skipping")
@@ -74,7 +54,8 @@ final class SolrLuceneDocReader {
             return null;
         }
 
-        return serializeDocument(segmentDocBase + luceneDocId, docId, fields, operation);
+        byte[] sourceBytes = StoredFieldDocReader.toJsonBytes(fields);
+        return new LuceneDocumentChange(segmentDocBase + luceneDocId, docId, null, sourceBytes, null, operation);
     }
 
     private static org.opensearch.migrations.bulkload.lucene.LuceneDocument readDocument(
@@ -92,59 +73,7 @@ final class SolrLuceneDocReader {
         }
     }
 
-    @SuppressWarnings("unchecked")
-    private static void addFieldValue(LinkedHashMap<String, Object> fields, String name, Object value) {
-        var existing = fields.get(name);
-        if (existing == null) {
-            fields.put(name, value);
-        } else if (existing instanceof List) {
-            ((List<Object>) existing).add(value);
-        } else {
-            var list = new ArrayList<>();
-            list.add(existing);
-            list.add(value);
-            fields.put(name, list);
-        }
-    }
-
-    private static LuceneDocumentChange serializeDocument(
-        int docNumber, String docId, LinkedHashMap<String, Object> fields, DocumentChangeType operation
-    ) {
-        try {
-            byte[] sourceBytes = MAPPER.writeValueAsBytes(fields);
-            return new LuceneDocumentChange(docNumber, docId, null, sourceBytes, null, operation);
-        } catch (Exception e) {
-            log.atError().setCause(e).setMessage("Failed to serialize Solr document {}").addArgument(docId).log();
-            return null;
-        }
-    }
-
     private static boolean isInternalField(String fieldName) {
         return fieldName.startsWith("_");
-    }
-
-    private static Object extractFieldValue(LuceneField field) {
-        var numValue = field.numericValue();
-        if (numValue != null) {
-            return numValue;
-        }
-
-        String value = field.stringValue();
-        if (value == null) {
-            value = field.utf8ToStringValue();
-        }
-        if (value == null) {
-            return null;
-        }
-
-        // Lucene stores booleans as "T"/"F"
-        if ("T".equals(value)) {
-            return true;
-        }
-        if ("F".equals(value)) {
-            return false;
-        }
-
-        return value;
     }
 }

--- a/SolrReader/src/main/java/org/opensearch/migrations/bulkload/solr/SolrMultiCollectionSource.java
+++ b/SolrReader/src/main/java/org/opensearch/migrations/bulkload/solr/SolrMultiCollectionSource.java
@@ -7,12 +7,14 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 
+import org.opensearch.migrations.bulkload.lucene.FieldMappingContext;
 import org.opensearch.migrations.bulkload.pipeline.model.CollectionMetadata;
 import org.opensearch.migrations.bulkload.pipeline.model.Document;
 import org.opensearch.migrations.bulkload.pipeline.model.Partition;
 import org.opensearch.migrations.bulkload.pipeline.source.DocumentSource;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import lombok.extern.slf4j.Slf4j;
 import reactor.core.publisher.Flux;
 
@@ -78,8 +80,26 @@ public class SolrMultiCollectionSource implements DocumentSource {
             var schema = schemas.get(c);
             var schemaNode = schema != null ? schema.path("schema") : schema;
             var collectionDir = SolrBackupLayout.resolveCollectionDataDir(backupDir.resolve(c));
-            return new SolrBackupSource(collectionDir, c, schemaNode, solrMajorVersion);
+            var mappingContext = buildMappingContext(schemaNode);
+            return new SolrBackupSource(collectionDir, c, schemaNode, solrMajorVersion, mappingContext);
         });
+    }
+
+    private static FieldMappingContext buildMappingContext(JsonNode schemaNode) {
+        if (schemaNode == null) {
+            return null;
+        }
+        try {
+            ObjectNode osMappings = SolrSchemaConverter.convertToOpenSearchMappings(
+                schemaNode.path("fields"),
+                schemaNode.path("dynamicFields"),
+                schemaNode.path("copyFields"),
+                schemaNode.path("fieldTypes"));
+            return new FieldMappingContext(osMappings);
+        } catch (Exception e) {
+            log.atWarn().setCause(e).setMessage("Failed to build mapping context from Solr schema, falling back to basic type conversion").log();
+            return null;
+        }
     }
 
     @Override


### PR DESCRIPTION
## Summary

**Commit 1: Unify orchestration** — Extracts the duplicated orchestration scaffolding (work coordinator, shutdown hook, exit-code handling) from the ES and Solr code paths into a single `runMigration()` method. Introduces `MigrationSourceFactory` functional interface so each source only provides pipeline construction logic.

**Commit 2: Shared Lucene utilities** — Extracts two shared utilities that both the ES and Solr reading paths can use:

- **`SegmentDocStream`**: Shared segment iteration (sort by name, cumulative docBase, binary-search resume, bounded-concurrency flatMapSequential). Replaces the duplicated loop in `LuceneReader` and `SolrBackupSource`.
- **`StoredFieldDocReader`**: Shared stored-field-to-JSON assembly (ID extraction, internal-field filtering, multi-value accumulation, mapping-aware type conversion). Replaces `SolrLuceneDocReader.extractFieldValue()` and the stage-1 path of `SourceReconstructor`.

Additionally wires `FieldMappingContext` into the Solr path: `SolrMultiCollectionSource` now converts the Solr schema into a `FieldMappingContext` (via `SolrSchemaConverter`), so Solr stored-field extraction gets proper type-aware conversion (dates → ISO, booleans, IPs, scaled_float) for free.

## Motivation

The Solr and ES paths had duplicated orchestration and Lucene reading logic. When behavior changed in one path (like the exit-code fix in #2965), the other path would silently diverge. By unifying:
- Exit-code handling is structurally guaranteed consistent (prevents the #2965 class of bug)
- Segment iteration is single-source-of-truth
- Stored-field reading with type conversion is shared (Solr gets richer type handling for free)

## Test plan

- [x] `./gradlew :DocumentsFromSnapshotMigration:compileJava` passes
- [x] `./gradlew :DocumentsFromSnapshotMigration:compileTestJava` passes
- [x] `./gradlew :SolrReader:compileJava` passes
- [x] `./gradlew :SearchSnapshotExtractor:compileJava` passes
- [ ] Existing `SolrSnapshotToOpenSearchTest` integration tests pass (require Docker)
- [ ] Existing ES snapshot integration tests pass (require Docker)
- [ ] Follow-up: migrate `LuceneReader` to use `SegmentDocStream` (left for a separate PR to keep this one focused)