### PR TITLE
Bump jenkins library version to 12.0.0

### DIFF
--- a/jenkins/release.jenkinsFile
+++ b/jenkins/release.jenkinsFile
@@ -1,4 +1,4 @@
-lib = library(identifier: 'jenkins@10.2.2', retriever: modernSCM([
+lib = library(identifier: 'jenkins@12.0.0', retriever: modernSCM([
     $class: 'GitSCMSource',
     remote: 'https://github.com/opensearch-project/opensearch-build-libraries.git',
 ]))


### PR DESCRIPTION
## Summary
- Bumps the `opensearch-build-libraries` jenkins library version from `10.2.2` to `12.0.0` in `jenkins/release.jenkinsFile`

## Test plan
- [ ] Verify release pipeline runs successfully with the updated library version