### PR TITLE
Check for missing dependencies in the bootstrap script

### DIFF
--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/common/OpenSearchClient.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/common/OpenSearchClient.java
@@ -548,7 +548,11 @@ public abstract class OpenSearchClient {
                     if (!resp.hasBadStatusCode() && !resp.hasFailedOperations()) {
                         return Mono.just(resp);
                     }
-                    log.atDebug().setMessage("Response has some errors...: {}").addArgument(response.body).log();
+                    log.atInfo()
+                        .setMessage("Bulk response on index '{}' contains errors: {}")
+                        .addArgument(indexName)
+                        .addArgument(() -> truncateMessageIfNeeded(response.body, BULK_TRUNCATED_RESPONSE_MAX_LENGTH))
+                        .log();
 
                     // Allow lazy initialization of pendingOps (e.g., raw→ops conversion)
                     preCompactHook.run();

--- a/deployment/k8s/aws/aws-bootstrap.sh
+++ b/deployment/k8s/aws/aws-bootstrap.sh
@@ -640,6 +640,7 @@ if [[ "$deploy_cfn" == "true" ]]; then
     seen_file=$(mktemp)
     trap "rm -f '$seen_file'" RETURN
     while true; do
+      # awk reverses the event list (oldest-first) — portable substitute for `tac`, which isn't in the BSD userland on macOS.
       aws cloudformation describe-stack-events --stack-name "$cfn_stack_name" ${region:+--region "$region"} \
         --query 'StackEvents[].[EventId,Timestamp,ResourceStatus,ResourceType,LogicalResourceId,ResourceStatusReason]' \
         --output text 2>/dev/null | awk '{a[NR]=$0} END{for(i=NR;i;i--) print a[i]}' | while IFS=$'\t' read -r eid ts status rtype logical reason; do

--- a/deployment/k8s/aws/aws-bootstrap.sh
+++ b/deployment/k8s/aws/aws-bootstrap.sh
@@ -533,7 +533,7 @@ check_existing_ma_release() {
 
 # Check required tools
 missing=0
-for cmd in jq kubectl tac aws curl; do
+for cmd in jq kubectl aws curl; do
   if ! command -v $cmd &>/dev/null; then
     echo "Missing required tool: $cmd"
     missing=1
@@ -551,6 +551,12 @@ fi
 
 # --- CFN deployment (optional) ---
 if [[ "$deploy_cfn" == "true" ]]; then
+  if ! command -v tac &>/dev/null; then
+    echo "Missing required tool: tac (used for CloudFormation event streaming)" >&2
+    echo "On macOS, install with: brew install coreutils" >&2
+    exit 1
+  fi
+
   # Determine template source
   if [[ "$build" == "true" ]]; then
     echo "Building CloudFormation templates from source..."

--- a/deployment/k8s/aws/aws-bootstrap.sh
+++ b/deployment/k8s/aws/aws-bootstrap.sh
@@ -533,7 +533,7 @@ check_existing_ma_release() {
 
 # Check required tools
 missing=0
-for cmd in jq kubectl; do
+for cmd in jq kubectl tac aws curl; do
   if ! command -v $cmd &>/dev/null; then
     echo "Missing required tool: $cmd"
     missing=1

--- a/deployment/k8s/aws/aws-bootstrap.sh
+++ b/deployment/k8s/aws/aws-bootstrap.sh
@@ -551,12 +551,6 @@ fi
 
 # --- CFN deployment (optional) ---
 if [[ "$deploy_cfn" == "true" ]]; then
-  if ! command -v tac &>/dev/null; then
-    echo "Missing required tool: tac (used for CloudFormation event streaming)" >&2
-    echo "On macOS, install with: brew install coreutils" >&2
-    exit 1
-  fi
-
   # Determine template source
   if [[ "$build" == "true" ]]; then
     echo "Building CloudFormation templates from source..."
@@ -648,7 +642,7 @@ if [[ "$deploy_cfn" == "true" ]]; then
     while true; do
       aws cloudformation describe-stack-events --stack-name "$cfn_stack_name" ${region:+--region "$region"} \
         --query 'StackEvents[].[EventId,Timestamp,ResourceStatus,ResourceType,LogicalResourceId,ResourceStatusReason]' \
-        --output text 2>/dev/null | tac | while IFS=$'\t' read -r eid ts status rtype logical reason; do
+        --output text 2>/dev/null | awk '{a[NR]=$0} END{for(i=NR;i;i--) print a[i]}' | while IFS=$'\t' read -r eid ts status rtype logical reason; do
           grep -qxF "$eid" "$seen_file" 2>/dev/null && continue
           echo "$eid" >> "$seen_file"
           [[ "$reason" == "None" ]] && reason=""


### PR DESCRIPTION
### Description
For folks running this script for the first time, they may not have the dependencies like `tac`, `aws` or `curl` installed locally.  `tac` is one that osx folks aren't likely to have.

Obviously after you run through things once you will have it!   

I was trying to not just list every command needed, like `docker` or `gradlew`....

### Issues Resolved

### Testing
manual testing.

### Check List
- [ ] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
