### PR TITLE
Fix a GHA build errors - bump the version of kind node image to use k8s 1.35

### DIFF
--- a/.github/workflows/generate-workflow-schema.yaml
+++ b/.github/workflows/generate-workflow-schema.yaml
@@ -127,7 +127,14 @@ jobs:
       - name: Dump schema generation diagnostics
         if: ${{ failure() }}
         run: |
-          kubectl --context kind-generate-workflow-schema get pods -A
+          kubectl --context kind-generate-workflow-schema get nodes -o wide || true
+          kubectl --context kind-generate-workflow-schema get pods -A -o wide || true
+          helm --kube-context kind-generate-workflow-schema -n ma list --all || true
+          helm --kube-context kind-generate-workflow-schema -n ma status ma || true
+          kubectl --context kind-generate-workflow-schema -n ma get jobs,pods,events || true
+          kubectl --context kind-generate-workflow-schema -n ma describe job ma-helm-installer || true
+          kubectl --context kind-generate-workflow-schema -n ma logs job/ma-helm-installer --all-containers --tail=-1 || true
+          kubectl --context kind-generate-workflow-schema -n ma get configmap ma-installation-notes -o yaml || true
           kubectl --context kind-generate-workflow-schema -n ma describe statefulset migration-console || true
           kubectl --context kind-generate-workflow-schema -n ma describe pod migration-console-0 || true
           kubectl --context kind-generate-workflow-schema -n ma logs migration-console-0 -c workflow-schema-generator || true

--- a/.github/workflows/generate-workflow-schema.yaml
+++ b/.github/workflows/generate-workflow-schema.yaml
@@ -80,7 +80,7 @@ jobs:
         uses: helm/kind-action@v1.14.0
         with:
           cluster_name: generate-workflow-schema
-          node_image: kindest/node:v1.33.1
+          node_image: kindest/node:v1.35.0
 
       - name: Build migration console image to local registry
         run: |

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -181,7 +181,7 @@ jobs:
         uses: helm/kind-action@v1.14.0
         with:
           cluster_name: release-schema-verification
-          node_image: kindest/node:v1.33.1
+          node_image: kindest/node:v1.35.0
       - name: Deploy Helm chart and copy generated workflow schema
         if: ${{ !github.event.act }}
         run: |

--- a/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/templates/childrenChartInstaller/installJob.yaml
+++ b/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/templates/childrenChartInstaller/installJob.yaml
@@ -224,9 +224,11 @@ spec:
           {{- if eq $name "ack-cloudwatch-controller" }}
                     --set aws.region="{{ $.Values.aws.region }}" \
           {{- end }}
-                    $VALUE_PARAM \
           {{- if $chart.waitForInstallation }}
+                    $VALUE_PARAM \
                     --wait
+          {{- else }}
+                    $VALUE_PARAM
           {{- end }}
                 }
                 retry 2 15 "helm upgrade --install {{ $name }}" -- do_install_{{ $name | replace "-" "_" }}

--- a/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/templates/helpers/_installHelper.tpl
+++ b/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/templates/helpers/_installHelper.tpl
@@ -26,9 +26,11 @@
 {{- end }}
                   --timeout {{ default "300" $chart.timeout }}s \
                   --set global.managedBy="{{ $root.Release.Name }}" \
-                  $VALUE_PARAM \
 {{- if or $chart.waitForInstallation $forceWait }}
+                  $VALUE_PARAM \
                   --wait
+{{- else }}
+                  $VALUE_PARAM
 {{- end }}
               }
               retry 2 15 "helm upgrade --install {{ $name }}" -- do_install_{{ $name | replace "-" "_" }}


### PR DESCRIPTION
### Description
Fix a GHA build errors - bump the version of kind node image to use k8s 1.35

### Issues Resolved
This should fix this issue
https://github.com/opensearch-project/opensearch-migrations/actions/runs/25943274896/job/76265726220?pr=2829

### Check List
- [ ] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
