### PR TITLE
fix: Kill stale port-forward processes in k8s buildkit setup

### DIFF
--- a/buildImages/backends/k8sHostedBuildkit.sh
+++ b/buildImages/backends/k8sHostedBuildkit.sh
@@ -74,11 +74,14 @@ ensure_k8s_local_registry() {
   echo "Waiting for docker-registry deployment to be available..."
   kubectl ${CONTEXT_ARGS[@]+"${CONTEXT_ARGS[@]}"} rollout status deployment/docker-registry -n buildkit --timeout=120s
 
-  if ! pgrep -f "kubectl port-forward.*docker-registry.*5001:5000" >/dev/null; then
-    nohup kubectl ${CONTEXT_ARGS[@]+"${CONTEXT_ARGS[@]}"} port-forward -n buildkit svc/docker-registry 5001:5000 > /tmp/registry-forward.log 2>&1 &
-  else
-    echo "registry port-forward already running"
-  fi
+  # Kill any stale port-forward processes from previous runs. After a helm
+  # uninstall/reinstall cycle the old process points at a deleted pod and
+  # will never recover, so we must start a fresh one.
+  pkill -f "kubectl port-forward.*docker-registry.*5001:5000" 2>/dev/null || true
+  sleep 1
+
+  echo "Starting registry port-forward..."
+  nohup kubectl ${CONTEXT_ARGS[@]+"${CONTEXT_ARGS[@]}"} port-forward -n buildkit svc/docker-registry 5001:5000 > /tmp/registry-forward.log 2>&1 &
 }
 
 ensure_k8s_buildx_builder() {
@@ -128,12 +131,16 @@ ensure_k8s_buildx_builder() {
     echo "Waiting for buildkitd pod..."
     kubectl ${CONTEXT_ARGS[@]+"${CONTEXT_ARGS[@]}"} wait --for=condition=ready pod -l app=buildkitd -n "${namespace}" --timeout=120s
 
-    if ! pgrep -f "kubectl port-forward.*buildkitd.*1234:1234" >/dev/null; then
-      echo "Starting buildkit port-forward..."
-      nohup kubectl ${CONTEXT_ARGS[@]+"${CONTEXT_ARGS[@]}"} port-forward -n "${namespace}" svc/buildkitd 1234:1234 > /tmp/buildkit-forward.log 2>&1 &
-    else
-      echo "buildkit port-forward already running"
-    fi
+    # Kill any stale port-forward processes from previous runs. After a helm
+    # uninstall/reinstall cycle the old process points at a deleted pod and
+    # will never recover — its connection attempt fails with:
+    #   "pod not found ("buildkitd_buildkit")"
+    # Always start a fresh port-forward against the current pod.
+    pkill -f "kubectl port-forward.*buildkitd.*1234:1234" 2>/dev/null || true
+    sleep 1
+
+    echo "Starting buildkit port-forward..."
+    nohup kubectl ${CONTEXT_ARGS[@]+"${CONTEXT_ARGS[@]}"} port-forward -n "${namespace}" svc/buildkitd 1234:1234 > /tmp/buildkit-forward.log 2>&1 &
 
     echo "Waiting for buildkit port-forward to be ready..."
     for i in $(seq 1 30); do


### PR DESCRIPTION
## Summary
- Fix Jenkins CI failure in `pr-solr-8x-k8s-local-test` (and all k8s-local-integ-test jobs) during the "Build Docker Images (BuildKit)" stage
- Replace `pgrep`-based skip logic with unconditional `pkill` + restart for both `buildkitd` and `docker-registry` port-forwards in `k8sHostedBuildkit.sh`

## Root Cause
After a `helm uninstall buildkit` / `helm install buildkit` cycle (which happens every CI run), stale `kubectl port-forward` processes from the previous run are still alive. The `pgrep` check in `ensure_k8s_buildx_builder()` and `ensure_k8s_local_registry()` finds these stale processes and skips starting fresh ones. The stale port-forward tries to connect to the old (deleted) pod, failing with:
```
error upgrading connection: unable to upgrade connection: pod not found ("buildkitd_buildkit")
```

## Fix
Always kill existing port-forward processes before starting new ones. This ensures the port-forward always targets the current pod after a helm reinstall.

## Test plan
- [ ] Verify `pr-solr-8x-k8s-local-test` Jenkins job passes the "Build Docker Images (BuildKit)" stage
- [ ] Verify `k8s-local-integ-test` Jenkins jobs pass with this change
- [ ] Confirm port-forward processes are properly cleaned up between runs by checking `/tmp/buildkit-forward.log` and `/tmp/registry-forward.log` for successful connections