### PR TITLE
Fix chunked Transfer-Encoding capture and Write-during-READS accumulator handling

### DIFF
--- a/TrafficCapture/nettyWireLogging/src/main/java/org/opensearch/migrations/trafficcapture/netty/LoggingHttpHandler.java
+++ b/TrafficCapture/nettyWireLogging/src/main/java/org/opensearch/migrations/trafficcapture/netty/LoggingHttpHandler.java
@@ -260,6 +260,12 @@ public class LoggingHttpHandler<T> extends ChannelDuplexHandler {
                     var decoderResult = (HttpMessageDecoderResult) decoderResultLoose;
                     trafficOffloader.addEndOfFirstLineIndicator(decoderResult.initialLineLength());
                     trafficOffloader.addEndOfHeadersIndicator(decoderResult.headerSize());
+                } else {
+                    log.atWarn().setMessage("HttpRequest decoder result was not an HttpMessageDecoderResult "
+                        + "(was {}). EOM will have -1 for firstLineByteLength and headersByteLength. "
+                        + "This may indicate a missing header in PassThruHttpHeaders.")
+                        .addArgument(() -> decoderResultLoose.getClass().getName())
+                        .log();
                 }
                 trafficOffloader.commitEndOfHttpMessageIndicator(timestamp);
             }

--- a/TrafficCapture/nettyWireLogging/src/main/java/org/opensearch/migrations/trafficcapture/netty/PassThruHttpHeaders.java
+++ b/TrafficCapture/nettyWireLogging/src/main/java/org/opensearch/migrations/trafficcapture/netty/PassThruHttpHeaders.java
@@ -24,7 +24,7 @@ public class PassThruHttpHeaders extends DefaultHttpHeaders {
             Stream.concat(
                 Stream.of(
                     HttpHeaderNames.CONTENT_LENGTH.toString(),
-                    HttpHeaderNames.CONTENT_TRANSFER_ENCODING.toString(),
+                    HttpHeaderNames.TRANSFER_ENCODING.toString(),
                     HttpHeaderNames.TRAILER.toString()
                 ),
                 Optional.ofNullable(extraHeaderNames).stream().flatMap(Arrays::stream)

--- a/TrafficCapture/nettyWireLogging/src/test/java/org/opensearch/migrations/trafficcapture/netty/ChunkedTransferEncodingCaptureTest.java
+++ b/TrafficCapture/nettyWireLogging/src/test/java/org/opensearch/migrations/trafficcapture/netty/ChunkedTransferEncodingCaptureTest.java
@@ -1,0 +1,327 @@
+package org.opensearch.migrations.trafficcapture.netty;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.SequenceInputStream;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+
+import org.opensearch.migrations.testutils.WrapWithNettyLeakDetection;
+import org.opensearch.migrations.trafficcapture.CodedOutputStreamAndByteBufferWrapper;
+import org.opensearch.migrations.trafficcapture.CodedOutputStreamHolder;
+import org.opensearch.migrations.trafficcapture.OrderedStreamLifecyleManager;
+import org.opensearch.migrations.trafficcapture.StreamChannelConnectionCaptureSerializer;
+import org.opensearch.migrations.trafficcapture.protos.TrafficObservation;
+import org.opensearch.migrations.trafficcapture.protos.TrafficStream;
+
+import com.google.protobuf.CodedOutputStream;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.embedded.EmbeddedChannel;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests that the capture proxy correctly handles HTTP requests using
+ * Transfer-Encoding: chunked, particularly when the chunk terminator
+ * arrives in a separate TCP read from the main body.
+ */
+@Slf4j
+@WrapWithNettyLeakDetection
+public class ChunkedTransferEncodingCaptureTest {
+
+    private static final String JSON_BODY = "{\"query\":{\"match_all\":{}},\"size\":10}";
+
+    private static final String CHUNK_SIZE_HEX = Integer.toHexString(JSON_BODY.length());
+
+    private static final String REQUEST_HEADERS =
+        "POST /test-index/_search HTTP/1.1\r\n"
+        + "Host: localhost\r\n"
+        + "Transfer-Encoding: chunked\r\n"
+        + "User-Agent: test-client\r\n"
+        + "Accept: application/json\r\n"
+        + "Content-Type: application/json\r\n"
+        + "\r\n";
+
+    private static final String CHUNKED_BODY =
+        CHUNK_SIZE_HEX + "\r\n"
+        + JSON_BODY + "\r\n";
+
+    private static final String CHUNK_TERMINATOR = "0\r\n\r\n";
+
+    private static final String FULL_CHUNKED_REQUEST =
+        REQUEST_HEADERS + CHUNKED_BODY + CHUNK_TERMINATOR;
+
+    private static final String SIMPLE_GET_REQUEST =
+        "GET / HTTP/1.1\r\n"
+        + "Host: localhost\r\n"
+        + "Accept: */*\r\n"
+        + "\r\n";
+
+    /**
+     * A stream manager that accumulates all flushed buffers rather than
+     * only keeping the last one. This is needed because the
+     * ConditionallyReliableLoggingHttpHandler flushes between requests
+     * (when blocking is enabled), resulting in multiple TrafficStream
+     * protobuf messages.
+     */
+    static class AccumulatingStreamManager extends OrderedStreamLifecyleManager implements AutoCloseable {
+        final List<ByteBuffer> flushedBuffers = new ArrayList<>();
+        final AtomicInteger flushCount = new AtomicInteger();
+
+        @Override
+        public void close() {}
+
+        @Override
+        public CodedOutputStreamAndByteBufferWrapper createStream() {
+            return new CodedOutputStreamAndByteBufferWrapper(1024 * 1024);
+        }
+
+        @SneakyThrows
+        @Override
+        public CompletableFuture<Object> kickoffCloseStream(CodedOutputStreamHolder outputStreamHolder, int index) {
+            if (!(outputStreamHolder instanceof CodedOutputStreamAndByteBufferWrapper)) {
+                throw new IllegalStateException(
+                    "Unknown outputStreamHolder sent back to StreamManager: " + outputStreamHolder
+                );
+            }
+            var osh = (CodedOutputStreamAndByteBufferWrapper) outputStreamHolder;
+            CodedOutputStream cos = osh.getOutputStream();
+            cos.flush();
+            flushedBuffers.add(osh.getByteBuffer().flip().asReadOnlyBuffer());
+            return CompletableFuture.completedFuture(flushCount.incrementAndGet());
+        }
+    }
+
+    /**
+     * Helper that creates a channel, writes data via the provided writer, and
+     * returns all TrafficObservation instances from all flushed streams.
+     */
+    private List<TrafficObservation> captureObservations(
+        java.util.function.Consumer<EmbeddedChannel> channelWriter
+    ) throws IOException {
+        try (var rootContext = new TestRootContext()) {
+            var streamManager = new AccumulatingStreamManager();
+            var offloader = new StreamChannelConnectionCaptureSerializer<>("Test", "c", streamManager);
+
+            EmbeddedChannel channel = new EmbeddedChannel(
+                new ConditionallyReliableLoggingHttpHandler<>(
+                    rootContext,
+                    "n",
+                    "c",
+                    ctx -> offloader,
+                    new RequestCapturePredicate(),
+                    x -> true
+                )
+            );
+
+            try {
+                channelWriter.accept(channel);
+            } catch (Exception e) {
+                // Swallow exceptions from the channel writer so we can still
+                // inspect the traffic stream observations
+            }
+            channel.finishAndReleaseAll();
+            channel.close();
+
+            Assertions.assertFalse(streamManager.flushedBuffers.isEmpty(),
+                "Expected at least one flushed traffic stream");
+
+            List<TrafficObservation> allObservations = new ArrayList<>();
+            for (var buf : streamManager.flushedBuffers) {
+                var trafficStream = TrafficStream.parseFrom(buf);
+                allObservations.addAll(trafficStream.getSubStreamList());
+            }
+            return allObservations;
+        }
+    }
+
+    private static String describeObservations(List<TrafficObservation> observations) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("observation count: ").append(observations.size()).append("\n");
+        for (int i = 0; i < observations.size(); i++) {
+            var obs = observations.get(i);
+            if (obs.hasRead()) {
+                sb.append("  [").append(i).append("] Read(")
+                    .append(obs.getRead().getData().size()).append("b)\n");
+            } else if (obs.hasEndOfMessageIndicator()) {
+                var eom = obs.getEndOfMessageIndicator();
+                sb.append("  [").append(i).append("] EOM(firstLine=")
+                    .append(eom.getFirstLineByteLength())
+                    .append(", headers=").append(eom.getHeadersByteLength()).append(")\n");
+            } else if (obs.hasConnectionException()) {
+                sb.append("  [").append(i).append("] Exception: ")
+                    .append(obs.getConnectionException().getMessage()).append("\n");
+            } else {
+                sb.append("  [").append(i).append("] ").append(obs.getCaptureCase()).append("\n");
+            }
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Test a chunked request arriving in a single TCP read (all bytes at once).
+     * This verifies that the EOM has proper firstLineByteLength and headersByteLength values.
+     */
+    @Test
+    public void testChunkedRequestInSingleRead() throws IOException {
+        byte[] fullBytes = FULL_CHUNKED_REQUEST.getBytes(StandardCharsets.UTF_8);
+
+        var observations = captureObservations(channel ->
+            channel.writeInbound(Unpooled.wrappedBuffer(fullBytes))
+        );
+
+        String debug = describeObservations(observations);
+
+        // Find the EOM observation
+        var eomObs = observations.stream()
+            .filter(TrafficObservation::hasEndOfMessageIndicator)
+            .findFirst();
+        Assertions.assertTrue(eomObs.isPresent(),
+            "Expected an EndOfMessageIndicator observation. Debug:\n" + debug);
+
+        var eom = eomObs.get().getEndOfMessageIndicator();
+
+        // The EOM must have proper values, NOT -1
+        Assertions.assertTrue(eom.getFirstLineByteLength() > 0,
+            "firstLineByteLength should be positive, was: " + eom.getFirstLineByteLength());
+        Assertions.assertTrue(eom.getHeadersByteLength() > 0,
+            "headersByteLength should be positive, was: " + eom.getHeadersByteLength());
+
+        // No Read observation should appear AFTER the EOM
+        boolean foundEom = false;
+        for (var obs : observations) {
+            if (obs.hasEndOfMessageIndicator()) {
+                foundEom = true;
+            } else if (foundEom && obs.hasRead()) {
+                Assertions.fail("Found a Read observation after the EOM, which indicates the chunk "
+                    + "terminator was emitted as a separate read. Read data size: "
+                    + obs.getRead().getData().size() + " bytes. Debug:\n" + debug);
+            }
+        }
+
+        // Verify all request bytes are captured in Read observations
+        var combinedReads = new SequenceInputStream(
+            Collections.enumeration(
+                observations.stream()
+                    .filter(TrafficObservation::hasRead)
+                    .map(to -> new ByteArrayInputStream(to.getRead().getData().toByteArray()))
+                    .collect(Collectors.toList())
+            )
+        );
+        Assertions.assertArrayEquals(fullBytes, combinedReads.readAllBytes(),
+            "Combined Read observations should contain all request bytes");
+    }
+
+    /**
+     * Test a chunked request arriving in TWO TCP reads:
+     * - First read: headers + chunked body data
+     * - Second read: chunk terminator 0\r\n\r\n
+     *
+     * This tests the scenario where the chunk terminator arrives separately.
+     */
+    @Test
+    public void testChunkedRequestSplitAtTerminator() throws IOException {
+        byte[] firstRead = (REQUEST_HEADERS + CHUNKED_BODY).getBytes(StandardCharsets.UTF_8);
+        byte[] secondRead = CHUNK_TERMINATOR.getBytes(StandardCharsets.UTF_8);
+        byte[] fullBytes = FULL_CHUNKED_REQUEST.getBytes(StandardCharsets.UTF_8);
+
+        var observations = captureObservations(channel -> {
+            channel.writeInbound(Unpooled.wrappedBuffer(firstRead));
+            channel.writeInbound(Unpooled.wrappedBuffer(secondRead));
+        });
+
+        String debug = describeObservations(observations);
+
+        // Find the EOM observation
+        var eomObs = observations.stream()
+            .filter(TrafficObservation::hasEndOfMessageIndicator)
+            .findFirst();
+        Assertions.assertTrue(eomObs.isPresent(),
+            "Expected an EndOfMessageIndicator observation. Debug:\n" + debug);
+
+        var eom = eomObs.get().getEndOfMessageIndicator();
+
+        // The EOM must have proper values, NOT -1
+        Assertions.assertTrue(eom.getFirstLineByteLength() > 0,
+            "firstLineByteLength should be positive, was: " + eom.getFirstLineByteLength());
+        Assertions.assertTrue(eom.getHeadersByteLength() > 0,
+            "headersByteLength should be positive, was: " + eom.getHeadersByteLength());
+
+        // No Read observation should appear AFTER the EOM for the same request
+        boolean foundEom = false;
+        for (var obs : observations) {
+            if (obs.hasEndOfMessageIndicator()) {
+                foundEom = true;
+            } else if (foundEom && obs.hasRead()) {
+                Assertions.fail("Found a Read observation after the EOM, which indicates the chunk "
+                    + "terminator was emitted as a separate read after EOM. Read data size: "
+                    + obs.getRead().getData().size() + " bytes. Debug:\n" + debug);
+            }
+        }
+
+        // Verify all request bytes are captured in Read observations
+        var combinedReads = new SequenceInputStream(
+            Collections.enumeration(
+                observations.stream()
+                    .filter(TrafficObservation::hasRead)
+                    .map(to -> new ByteArrayInputStream(to.getRead().getData().toByteArray()))
+                    .collect(Collectors.toList())
+            )
+        );
+        Assertions.assertArrayEquals(fullBytes, combinedReads.readAllBytes(),
+            "Combined Read observations should contain all request bytes including chunk terminator");
+    }
+
+    /**
+     * Test that a subsequent request on the same connection after a chunked request
+     * is captured correctly, verifying the handler state is not corrupted.
+     */
+    @Test
+    public void testChunkedRequestFollowedByNormalRequest() throws IOException {
+        byte[] chunkedBytes = FULL_CHUNKED_REQUEST.getBytes(StandardCharsets.UTF_8);
+        byte[] getBytes = SIMPLE_GET_REQUEST.getBytes(StandardCharsets.UTF_8);
+
+        var observations = captureObservations(channel -> {
+            // Send chunked request in two parts (terminator arrives separately)
+            byte[] firstRead = (REQUEST_HEADERS + CHUNKED_BODY).getBytes(StandardCharsets.UTF_8);
+            byte[] secondRead = CHUNK_TERMINATOR.getBytes(StandardCharsets.UTF_8);
+            channel.writeInbound(Unpooled.wrappedBuffer(firstRead));
+            channel.writeInbound(Unpooled.wrappedBuffer(secondRead));
+            // Send a normal GET request on the same connection
+            channel.writeInbound(Unpooled.wrappedBuffer(getBytes));
+        });
+
+        String debug = describeObservations(observations);
+
+        // Should have exactly 2 EOM indicators (one per request)
+        long eomCount = observations.stream()
+            .filter(TrafficObservation::hasEndOfMessageIndicator)
+            .count();
+        Assertions.assertEquals(2, eomCount,
+            "Expected 2 EndOfMessageIndicator observations (one for chunked POST, one for GET). "
+            + "Debug:\n" + debug);
+
+        // Both EOMs should have valid firstLineByteLength and headersByteLength
+        var eoms = observations.stream()
+            .filter(TrafficObservation::hasEndOfMessageIndicator)
+            .collect(Collectors.toList());
+
+        for (int i = 0; i < eoms.size(); i++) {
+            var eom = eoms.get(i).getEndOfMessageIndicator();
+            Assertions.assertTrue(eom.getFirstLineByteLength() > 0,
+                "EOM[" + i + "] firstLineByteLength should be positive, was: "
+                + eom.getFirstLineByteLength());
+            Assertions.assertTrue(eom.getHeadersByteLength() > 0,
+                "EOM[" + i + "] headersByteLength should be positive, was: "
+                + eom.getHeadersByteLength());
+        }
+    }
+}

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/CapturedTrafficToHttpTransactionAccumulator.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/CapturedTrafficToHttpTransactionAccumulator.java
@@ -514,15 +514,39 @@ public class CapturedTrafficToHttpTransactionAccumulator {
                 .log();
         } else if (observation.hasSegmentEnd()) {
             var rrPair = accum.getRrPair();
-            assert rrPair.requestData.hasInProgressSegment();
+            assert rrPair.requestData != null && rrPair.requestData.hasInProgressSegment() :
+                "SegmentEnd received but no in-progress request segment for "
+                + accum.trafficChannelKey + ". This indicates a missing ReadSegment "
+                + "or a malformed observation sequence in the capture stream.";
             rrPair.requestData.finalizeRequestSegments(timestamp);
         } else if (observation.hasRequestDropped()) {
             requestCounter.decrementAndGet();
             handleDroppedRequestForAccumulation(accum);
+        } else if (observation.hasWrite() || observation.hasWriteSegment()) {
+            return handleWriteDuringReadState(accum, observation, trafficStreamKey, timestamp);
         } else {
             return Optional.empty();
         }
         return Optional.of(CONNECTION_STATUS.ALIVE);
+    }
+
+    private Optional<CONNECTION_STATUS> handleWriteDuringReadState(
+        @NonNull Accumulation accum,
+        TrafficObservation observation,
+        @NonNull ITrafficStreamKey trafficStreamKey,
+        Instant timestamp
+    ) {
+        log.atWarn().setMessage("Received a write observation while in ACCUMULATING_READS state "
+            + "for {}. This indicates the capture proxy emitted a premature EOM or the "
+            + "stream has malformed observation ordering. Transitioning to ACCUMULATING_WRITES.")
+            .addArgument(accum.trafficChannelKey)
+            .log();
+        if (accum.hasRrPair()) {
+            handleEndOfRequest(accum);
+        } else {
+            accum.state = Accumulation.State.ACCUMULATING_WRITES;
+        }
+        return handleObservationForWriteState(accum, observation, trafficStreamKey, timestamp);
     }
 
     private Optional<CONNECTION_STATUS> handleObservationForWriteState(
@@ -564,7 +588,10 @@ public class CapturedTrafficToHttpTransactionAccumulator {
                 .log();
         } else if (observation.hasSegmentEnd()) {
             var rrPair = accum.getRrPair();
-            assert rrPair.responseData.hasInProgressSegment();
+            assert rrPair.responseData != null && rrPair.responseData.hasInProgressSegment() :
+                "SegmentEnd received but no in-progress response segment for "
+                + accum.trafficChannelKey + ". This indicates a missing WriteSegment "
+                + "or a malformed observation sequence in the capture stream.";
             rrPair.responseData.finalizeRequestSegments(timestamp);
         } else if (observation.hasRead() || observation.hasReadSegment()) {
             rotateAccumulationOnReadIfNecessary(connectionId, accum);
@@ -617,7 +644,16 @@ public class CapturedTrafficToHttpTransactionAccumulator {
         var rrPair = rrPairWithCallback.pair;
         var httpMessage = rrPair.requestData;
         assert (httpMessage != null);
-        assert (!httpMessage.hasInProgressSegment());
+        assert (!httpMessage.hasInProgressSegment()) :
+            "Request has in-progress segment data at end-of-request for " + accumulation.trafficChannelKey
+            + ". This indicates a malformed capture stream missing a SegmentEnd.";
+        if (httpMessage.hasInProgressSegment()) {
+            log.atWarn().setMessage("Finalizing request with in-progress segment data for {}. "
+                + "This indicates a malformed capture stream missing a SegmentEnd.")
+                .addArgument(accumulation.trafficChannelKey)
+                .log();
+            httpMessage.finalizeRequestSegments(httpMessage.getLastPacketTimestamp());
+        }
         boolean isResumedConnection = accumulation.getIndexOfCurrentRequest() == 0 && accumulation.isResumedConnection;
         log.atDebug().setMessage("handleEndOfRequest for {} requestIdx={} resumed={} requestBytes={}")
             .addArgument(accumulation.trafficChannelKey)

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/WriteObservationDuringReadStateTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/WriteObservationDuringReadStateTest.java
@@ -1,0 +1,249 @@
+package org.opensearch.migrations.replay;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+
+import org.opensearch.migrations.replay.datatypes.ITrafficStreamKey;
+import org.opensearch.migrations.replay.datatypes.PojoTrafficStreamAndKey;
+import org.opensearch.migrations.replay.datatypes.PojoTrafficStreamKeyAndContext;
+import org.opensearch.migrations.replay.tracing.IReplayContexts;
+import org.opensearch.migrations.tracing.InstrumentationTest;
+import org.opensearch.migrations.trafficcapture.protos.EndOfMessageIndication;
+import org.opensearch.migrations.trafficcapture.protos.EndOfSegmentsIndication;
+import org.opensearch.migrations.trafficcapture.protos.ReadObservation;
+import org.opensearch.migrations.trafficcapture.protos.TrafficObservation;
+import org.opensearch.migrations.trafficcapture.protos.TrafficStream;
+import org.opensearch.migrations.trafficcapture.protos.WriteObservation;
+import org.opensearch.migrations.trafficcapture.protos.WriteSegmentObservation;
+
+import com.google.protobuf.ByteString;
+import com.google.protobuf.Timestamp;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies that the accumulator correctly handles Write observations arriving
+ * while in ACCUMULATING_READS state. This can occur when the capture proxy
+ * emits a premature EOM followed by trailing request data that the accumulator
+ * treats as a new request, causing the state machine to see a Write (the
+ * response) while still in ACCUMULATING_READS.
+ *
+ * Without proper handling, a Write during READS is silently dropped, leaving
+ * the state machine permanently stuck. Subsequent WriteSegment/SegmentEnd
+ * observations then trigger a NullPointerException in
+ * finalizeRequestSegments() because SegmentEnd is processed against
+ * requestData instead of responseData.
+ */
+@Slf4j
+public class WriteObservationDuringReadStateTest extends InstrumentationTest {
+
+    private static Timestamp makeTimestamp(Instant t) {
+        return Timestamp.newBuilder()
+            .setSeconds(t.getEpochSecond())
+            .setNanos(t.getNano())
+            .build();
+    }
+
+    /**
+     * Simulates the failure scenario:
+     * 1. A Read observation starts a request (transitions to ACCUMULATING_READS)
+     * 2. A Write observation arrives without an intervening EOM
+     * 3. More Read/Write pairs follow
+     * 4. Eventually a WriteSegment + SegmentEnd arrives
+     *
+     * Without the fix, the SegmentEnd triggers an NPE because the state
+     * machine is stuck in ACCUMULATING_READS and tries to call
+     * requestData.finalizeRequestSegments() with null currentSegmentBytes.
+     */
+    @Test
+    void writeObservationDuringReads_doesNotCauseNPE() {
+        var baseTime = Instant.now();
+        var ts1 = makeTimestamp(baseTime);
+        var ts2 = makeTimestamp(baseTime.plusMillis(100));
+        var ts3 = makeTimestamp(baseTime.plusMillis(200));
+        var ts4 = makeTimestamp(baseTime.plusMillis(300));
+        var ts5 = makeTimestamp(baseTime.plusMillis(400));
+        var ts6 = makeTimestamp(baseTime.plusMillis(500));
+        var ts7 = makeTimestamp(baseTime.plusMillis(600));
+        var ts8 = makeTimestamp(baseTime.plusMillis(700));
+
+        // Build a TrafficStream that reproduces the issue:
+        // Read (request), Write (response WITHOUT preceding EOM),
+        // Read (next request), Write, then WriteSegment + SegmentEnd
+        var trafficStream = TrafficStream.newBuilder()
+            .setConnectionId("test-conn-write-during-reads")
+            .setNodeId("test-node")
+            .setNumber(1)
+            // Request 1: small read that the proxy treated as complete
+            .addSubStream(TrafficObservation.newBuilder().setTs(ts1)
+                .setRead(ReadObservation.newBuilder()
+                    .setData(ByteString.copyFrom("GET / HTTP/1.1\r\nHost: localhost\r\n\r\n",
+                        StandardCharsets.UTF_8))))
+            // EOM for request 1
+            .addSubStream(TrafficObservation.newBuilder().setTs(ts1)
+                .setEndOfMessageIndicator(EndOfMessageIndication.newBuilder()
+                    .setFirstLineByteLength(14).setHeadersByteLength(18)))
+            // Trailing data (e.g., chunk terminator) captured as a new Read
+            .addSubStream(TrafficObservation.newBuilder().setTs(ts2)
+                .setRead(ReadObservation.newBuilder()
+                    .setData(ByteString.copyFrom("0\r\n\r\n", StandardCharsets.UTF_8))))
+            // Response Write arrives while accumulator is in ACCUMULATING_READS
+            .addSubStream(TrafficObservation.newBuilder().setTs(ts3)
+                .setWrite(WriteObservation.newBuilder()
+                    .setData(ByteString.copyFrom("HTTP/1.1 200 OK\r\n\r\n",
+                        StandardCharsets.UTF_8))))
+            // Next request
+            .addSubStream(TrafficObservation.newBuilder().setTs(ts4)
+                .setRead(ReadObservation.newBuilder()
+                    .setData(ByteString.copyFrom("POST /data HTTP/1.1\r\nHost: localhost\r\n\r\nbody",
+                        StandardCharsets.UTF_8))))
+            // Response as WriteSegment + SegmentEnd (the trigger for NPE)
+            .addSubStream(TrafficObservation.newBuilder().setTs(ts5)
+                .setWrite(WriteObservation.newBuilder()
+                    .setData(ByteString.copyFrom("HTTP/1.1 200 OK\r\nContent-Length: 5\r\n\r\n",
+                        StandardCharsets.UTF_8))))
+            .addSubStream(TrafficObservation.newBuilder().setTs(ts6)
+                .setWriteSegment(WriteSegmentObservation.newBuilder()
+                    .setData(ByteString.copyFrom("hello", StandardCharsets.UTF_8))))
+            .addSubStream(TrafficObservation.newBuilder().setTs(ts7)
+                .setSegmentEnd(EndOfSegmentsIndication.getDefaultInstance()))
+            .build();
+
+        List<RequestResponsePacketPair> results = new ArrayList<>();
+        AtomicInteger expiredCount = new AtomicInteger(0);
+        var accumulator = new CapturedTrafficToHttpTransactionAccumulator(
+            Duration.ofSeconds(30), null, new AccumulationCallbacks() {
+                @Override
+                public Consumer<RequestResponsePacketPair> onRequestReceived(
+                    @NonNull IReplayContexts.IReplayerHttpTransactionContext ctx,
+                    @NonNull HttpMessageAndTimestamp request,
+                    boolean isResumedConnection
+                ) {
+                    return results::add;
+                }
+
+                @Override
+                public void onTrafficStreamsExpired(
+                    RequestResponsePacketPair.ReconstructionStatus status,
+                    @NonNull IReplayContexts.IChannelKeyContext ctx,
+                    @NonNull List<ITrafficStreamKey> trafficStreamKeysBeingHeld
+                ) {
+                    expiredCount.incrementAndGet();
+                }
+
+                @Override
+                public void onConnectionClose(int n, @NonNull IReplayContexts.IChannelKeyContext ctx,
+                    int s, RequestResponsePacketPair.ReconstructionStatus status,
+                    @NonNull Instant when, @NonNull List<ITrafficStreamKey> trafficStreamKeysBeingHeld
+                ) {}
+
+                @Override
+                public void onTrafficStreamIgnored(@NonNull IReplayContexts.ITrafficStreamsLifecycleContext ctx) {}
+            }
+        );
+
+        // This must not throw an NPE
+        Assertions.assertDoesNotThrow(() -> {
+            accumulator.accept(new PojoTrafficStreamAndKey(
+                trafficStream,
+                PojoTrafficStreamKeyAndContext.build(trafficStream, rootContext::createTrafficStreamContextForTest)
+            ));
+            accumulator.close();
+        }, "Processing a Write observation during ACCUMULATING_READS state must not throw");
+    }
+
+    /**
+     * Verifies that after a Write-during-READS, subsequent requests on the
+     * same connection are still accumulated correctly.
+     */
+    @Test
+    void writeObservationDuringReads_subsequentRequestsStillWork() {
+        var baseTime = Instant.now();
+        var ts1 = makeTimestamp(baseTime);
+        var ts2 = makeTimestamp(baseTime.plusMillis(100));
+        var ts3 = makeTimestamp(baseTime.plusMillis(200));
+        var ts4 = makeTimestamp(baseTime.plusMillis(300));
+        var ts5 = makeTimestamp(baseTime.plusMillis(400));
+        var ts6 = makeTimestamp(baseTime.plusMillis(500));
+
+        // Scenario: Read, Write (no EOM between), Read, EOM, Write
+        // The second Read+EOM+Write should produce a valid transaction
+        var trafficStream = TrafficStream.newBuilder()
+            .setConnectionId("test-conn-recovery")
+            .setNodeId("test-node")
+            .setNumberOfThisLastChunk(0)
+            // Orphaned read (trailing chunk data treated as request)
+            .addSubStream(TrafficObservation.newBuilder().setTs(ts1)
+                .setRead(ReadObservation.newBuilder()
+                    .setData(ByteString.copyFrom("0\r\n\r\n", StandardCharsets.UTF_8))))
+            // Write arrives without EOM (response to prior request)
+            .addSubStream(TrafficObservation.newBuilder().setTs(ts2)
+                .setWrite(WriteObservation.newBuilder()
+                    .setData(ByteString.copyFrom("HTTP/1.1 200 OK\r\n\r\n",
+                        StandardCharsets.UTF_8))))
+            // Normal request
+            .addSubStream(TrafficObservation.newBuilder().setTs(ts3)
+                .setRead(ReadObservation.newBuilder()
+                    .setData(ByteString.copyFrom("GET /healthy HTTP/1.1\r\nHost: localhost\r\n\r\n",
+                        StandardCharsets.UTF_8))))
+            // Proper EOM
+            .addSubStream(TrafficObservation.newBuilder().setTs(ts4)
+                .setEndOfMessageIndicator(EndOfMessageIndication.newBuilder()
+                    .setFirstLineByteLength(22).setHeadersByteLength(18)))
+            // Response
+            .addSubStream(TrafficObservation.newBuilder().setTs(ts5)
+                .setWrite(WriteObservation.newBuilder()
+                    .setData(ByteString.copyFrom("HTTP/1.1 200 OK\r\n\r\nok",
+                        StandardCharsets.UTF_8))))
+            .build();
+
+        List<RequestResponsePacketPair> results = new ArrayList<>();
+        var accumulator = new CapturedTrafficToHttpTransactionAccumulator(
+            Duration.ofSeconds(30), null, new AccumulationCallbacks() {
+                @Override
+                public Consumer<RequestResponsePacketPair> onRequestReceived(
+                    @NonNull IReplayContexts.IReplayerHttpTransactionContext ctx,
+                    @NonNull HttpMessageAndTimestamp request,
+                    boolean isResumedConnection
+                ) {
+                    return results::add;
+                }
+
+                @Override
+                public void onTrafficStreamsExpired(
+                    RequestResponsePacketPair.ReconstructionStatus status,
+                    @NonNull IReplayContexts.IChannelKeyContext ctx,
+                    @NonNull List<ITrafficStreamKey> trafficStreamKeysBeingHeld
+                ) {}
+
+                @Override
+                public void onConnectionClose(int n, @NonNull IReplayContexts.IChannelKeyContext ctx,
+                    int s, RequestResponsePacketPair.ReconstructionStatus status,
+                    @NonNull Instant when, @NonNull List<ITrafficStreamKey> trafficStreamKeysBeingHeld
+                ) {}
+
+                @Override
+                public void onTrafficStreamIgnored(@NonNull IReplayContexts.ITrafficStreamsLifecycleContext ctx) {}
+            }
+        );
+
+        Assertions.assertDoesNotThrow(() -> {
+            accumulator.accept(new PojoTrafficStreamAndKey(
+                trafficStream,
+                PojoTrafficStreamKeyAndContext.build(trafficStream, rootContext::createTrafficStreamContextForTest)
+            ));
+            accumulator.close();
+        });
+
+        // Should have at least one completed transaction (the GET /healthy request)
+        Assertions.assertFalse(results.isEmpty(),
+            "Should have at least one completed transaction after Write-during-READS recovery");
+    }
+}


### PR DESCRIPTION
## Summary

- **Capture proxy fix**: `PassThruHttpHeaders` was preserving `Content-Transfer-Encoding` (a MIME header) but missing `Transfer-Encoding` (the HTTP/1.1 header). This caused Netty's `HttpRequestDecoder` to not recognize chunked requests, producing premature `EOM(firstLine=-1, headers=-1)` and splitting the chunk terminator `0\r\n\r\n` into a separate Read observation after the EOM.
- **Replayer fix**: `CapturedTrafficToHttpTransactionAccumulator` did not handle Write/WriteSegment observations during `ACCUMULATING_READS` state, causing the state machine to get permanently stuck and eventually NPE on a subsequent SegmentEnd observation.
- **Improved asserts**: Added descriptive messages to segment invariant assertions for easier diagnosis of future issues.

## Root Cause

When a client sends an HTTP request with `Transfer-Encoding: chunked`, the capture proxy dropped the header before Netty's decoder could see it. This caused Netty to treat the request as having no body, emitting `LastHttpContent` immediately after headers. The chunked body data and terminator were then captured as subsequent observations, corrupting the replayer's state machine on long-lived connections with segment splits.

## Test plan

- [x] `ChunkedTransferEncodingCaptureTest` - verifies the proxy correctly handles chunked requests (single read, split at terminator, followed by normal request)
- [x] `WriteObservationDuringReadStateTest` - verifies the replayer handles Write-during-READS without NPE and recovers for subsequent requests
- [x] Tests verified to FAIL without the fix and PASS with it (TDD)
- [x] All existing tests pass (no regressions)