### PR TITLE
feat(replayer): Add request filter extension point for pluggable request skipping

### DIFF
--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/FilteringTransformerWrapper.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/FilteringTransformerWrapper.java
@@ -1,0 +1,35 @@
+package org.opensearch.migrations.replay;
+
+import org.opensearch.migrations.transform.IJsonPredicate;
+import org.opensearch.migrations.transform.IJsonTransformer;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Wraps an {@link IJsonTransformer} with a predicate check. When the predicate
+ * rejects (returns false), throws {@link RequestFilteredException}.
+ */
+@Slf4j
+class FilteringTransformerWrapper implements IJsonTransformer {
+    private final IJsonTransformer delegate;
+    private final IJsonPredicate requestFilter;
+
+    FilteringTransformerWrapper(IJsonTransformer delegate, IJsonPredicate requestFilter) {
+        this.delegate = delegate;
+        this.requestFilter = requestFilter;
+    }
+
+    @Override
+    public Object transformJson(Object incomingJson) {
+        if (!requestFilter.test(incomingJson)) {
+            log.atInfo().setMessage("Request filtered out by predicate, skipping").log();
+            throw new RequestFilteredException("Request rejected by request filter predicate");
+        }
+        return delegate.transformJson(incomingJson);
+    }
+
+    @Override
+    public void close() throws Exception {
+        delegate.close();
+    }
+}

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/RequestFilteredException.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/RequestFilteredException.java
@@ -1,0 +1,11 @@
+package org.opensearch.migrations.replay;
+
+/**
+ * Thrown when a request is rejected by the configured request filter predicate.
+ * The pipeline handles this as a SKIPPED request — no bytes sent to target, no retry.
+ */
+public class RequestFilteredException extends RuntimeException {
+    public RequestFilteredException(String message) {
+        super(message);
+    }
+}

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/RequestTransformerAndSender.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/RequestTransformerAndSender.java
@@ -125,16 +125,27 @@ public class RequestTransformerAndSender<T> {
             // read buffer horizons aren't set after the transformation work finishes, but after the packets
             // are fully handled
             return requestReadyFuture.thenCompose(
-                transformedRequest -> replayEngine.scheduleRequest(
-                    ctx,
-                    start,
-                    end,
-                    transformedRequest.transformedOutput.numByteBufs(),
-                    transformedRequest.transformedOutput,
-                    getRetryCheckVisitor(transformedRequest, finishedAccumulatingResponseFuture,
-                        arr -> perResponseConsumer(arr, transformedRequest.transformationStatus, ctx)),
-                    effectiveQuiescentDuration
-                ),
+                transformedRequest -> {
+                    if (transformedRequest.transformedOutput == null) {
+                        @SuppressWarnings("unchecked")
+                        var filtered = (TrackedFuture<String, T>) TextTrackedFuture.completedFuture(
+                            (T) new TransformedTargetRequestAndResponseList(
+                                null, transformedRequest.transformationStatus),
+                            () -> "request filtered - skipping target send"
+                        );
+                        return filtered;
+                    }
+                    return replayEngine.scheduleRequest(
+                        ctx,
+                        start,
+                        end,
+                        transformedRequest.transformedOutput.numByteBufs(),
+                        transformedRequest.transformedOutput,
+                        getRetryCheckVisitor(transformedRequest, finishedAccumulatingResponseFuture,
+                            arr -> perResponseConsumer(arr, transformedRequest.transformationStatus, ctx)),
+                        effectiveQuiescentDuration
+                    );
+                },
                 () -> "transitioning transformed packets onto the wire"
             );
         } catch (Exception e) {

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/TrafficReplayer.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/TrafficReplayer.java
@@ -32,6 +32,7 @@ import org.opensearch.migrations.tracing.CompositeContextTracker;
 import org.opensearch.migrations.tracing.RootOtelContext;
 import org.opensearch.migrations.transform.IAuthTransformerFactory;
 import org.opensearch.migrations.transform.IJsonTransformer;
+import org.opensearch.migrations.transform.PredicateLoader;
 import org.opensearch.migrations.transform.RemovingAuthTransformerFactory;
 import org.opensearch.migrations.transform.SigV4AuthTransformerFactory;
 import org.opensearch.migrations.transform.StaticAuthTransformerFactory;
@@ -189,6 +190,14 @@ public class TrafficReplayer {
 
         @ParametersDelegate
         private TupleTransformationParams tupleTransformationParams = new TupleTransformationParams();
+
+        @Parameter(
+            required = false,
+            names = {"--request-filter-config", "--requestFilterConfig"},
+            arity = 1,
+            description = "Configuration for request filtering. JSON array with one entry whose key is the "
+                + "predicate provider name. Requests failing the predicate are skipped (not sent to target).")
+        private String requestFilterConfig;
 
         @Parameter(
             required = false,
@@ -650,11 +659,13 @@ public class TrafficReplayer {
                 : new BulkItemErrorClassifier();
 
             var transformationLoader = new TransformationLoader();
+            var effectiveTransformerSupplier = buildTransformerSupplier(
+                transformationLoader, hostname, params.userAgent, requestTransformerConfig, params.requestFilterConfig);
             var tr = new TrafficReplayerTopLevel(
                 topContext,
                 uri,
                 authTransformer,
-                () -> transformationLoader.getTransformerFactoryLoader(hostname, params.userAgent, requestTransformerConfig),
+                effectiveTransformerSupplier,
                 TrafficReplayerTopLevel.makeNettyPacketConsumerConnectionPool(
                     uri,
                     params.allowInsecureConnections,
@@ -742,6 +753,23 @@ public class TrafficReplayer {
                 activeContextLogger.atLevel(acmLevel).setMessage("[end of run]]").log();
             }
         }
+    }
+
+    static Supplier<IJsonTransformer> buildTransformerSupplier(
+        TransformationLoader transformationLoader,
+        String hostname,
+        String userAgent,
+        String requestTransformerConfig,
+        String requestFilterConfig
+    ) {
+        Supplier<IJsonTransformer> base = () -> transformationLoader.getTransformerFactoryLoader(
+            hostname, userAgent, requestTransformerConfig);
+        if (requestFilterConfig == null || requestFilterConfig.isBlank()) {
+            return base;
+        }
+        var requestFilter = new PredicateLoader().getPredicateFactoryLoader(requestFilterConfig);
+        log.atInfo().setMessage("Request filter configured").log();
+        return () -> new FilteringTransformerWrapper(base.get(), requestFilter);
     }
 
     private static ThreadLocalTupleWriter createS3TupleWriterIfConfigured(

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/http/HttpJsonTransformingConsumer.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/http/HttpJsonTransformingConsumer.java
@@ -8,6 +8,7 @@ import java.util.Optional;
 import java.util.concurrent.CompletionException;
 
 import org.opensearch.migrations.Utils;
+import org.opensearch.migrations.replay.RequestFilteredException;
 import org.opensearch.migrations.replay.datahandlers.IPacketFinalizingConsumer;
 import org.opensearch.migrations.replay.datatypes.ByteBufList;
 import org.opensearch.migrations.replay.datatypes.HttpRequestTransformationStatus;
@@ -124,7 +125,28 @@ public class HttpJsonTransformingConsumer<R> implements IPacketFinalizingConsume
             if (getHttpRequestDecoderHandler() == null) { // LastHttpContent won't be sent
                 channel.writeInbound(new EndOfInput());   // so send our own version of 'EOF'
             }
+        } catch (RequestFilteredException e) {
+            log.atInfo().setMessage("Request filtered - skipping").log();
+            channel.finishAndReleaseAll();
+            channel.close();
+            transformationContext.onTransformSkip();
+            transformationContext.close();
+            return TextTrackedFuture.completedFuture(
+                new TransformedOutputAndResult<>(null, HttpRequestTransformationStatus.skipped()),
+                () -> "HttpJsonTransformingConsumer.filteredRequest"
+            );
         } catch (Exception e) {
+            if (hasRequestFilteredCause(e)) {
+                log.atInfo().setMessage("Request filtered (wrapped) - skipping").log();
+                channel.finishAndReleaseAll();
+                channel.close();
+                transformationContext.onTransformSkip();
+                transformationContext.close();
+                return TextTrackedFuture.completedFuture(
+                    new TransformedOutputAndResult<>(null, HttpRequestTransformationStatus.skipped()),
+                    () -> "HttpJsonTransformingConsumer.filteredRequest"
+                );
+            }
             this.transformationContext.addCaughtException(e);
             log.atWarn().setCause(e)
                 .setMessage("Caught exception when sending the end of content").log();
@@ -306,5 +328,13 @@ public class HttpJsonTransformingConsumer<R> implements IPacketFinalizingConsume
     private static HttpRequestTransformationStatus makeStatusForRedrive(Throwable reason) {
         return reason == null
             ? HttpRequestTransformationStatus.skipped() : HttpRequestTransformationStatus.makeError(reason);
+    }
+
+    private static boolean hasRequestFilteredCause(Throwable t) {
+        while (t != null) {
+            if (t instanceof RequestFilteredException) return true;
+            t = t.getCause();
+        }
+        return false;
     }
 }

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/FilteringTransformerWrapperTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/FilteringTransformerWrapperTest.java
@@ -1,0 +1,262 @@
+package org.opensearch.migrations.replay;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.opensearch.migrations.replay.datahandlers.http.HttpJsonTransformingConsumer;
+import org.opensearch.migrations.tracing.InstrumentationTest;
+import org.opensearch.migrations.transform.IJsonPredicate;
+import org.opensearch.migrations.transform.IJsonTransformer;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class FilteringTransformerWrapperTest extends InstrumentationTest {
+
+    private static final IJsonTransformer IDENTITY = input -> input;
+
+    // --- Unit tests for FilteringTransformerWrapper ---
+
+    @Test
+    void predicateAccepts_delegatesToTransformer() {
+        IJsonPredicate alwaysAccept = obj -> true;
+        var wrapper = new FilteringTransformerWrapper(IDENTITY, alwaysAccept);
+
+        var input = new LinkedHashMap<>(Map.of("URI", "/solr/test/select", "method", "GET"));
+        var result = wrapper.transformJson(input);
+
+        Assertions.assertSame(input, result);
+    }
+
+    @Test
+    void predicateRejects_throwsRequestFilteredException() {
+        IJsonPredicate alwaysReject = obj -> false;
+        var wrapper = new FilteringTransformerWrapper(IDENTITY, alwaysReject);
+
+        var input = new LinkedHashMap<>(Map.of("URI", "/solr/test/admin", "method", "GET"));
+
+        Assertions.assertThrows(RequestFilteredException.class, () -> wrapper.transformJson(input));
+    }
+
+    @Test
+    void predicateFiltersOnUri_selectiveBehavior() {
+        IJsonPredicate selectOnly = obj -> {
+            @SuppressWarnings("unchecked")
+            var map = (Map<String, Object>) obj;
+            var uri = (String) map.get("URI");
+            return uri != null && uri.contains("/select");
+        };
+        var wrapper = new FilteringTransformerWrapper(IDENTITY, selectOnly);
+
+        // /select passes through
+        var selectReq = new LinkedHashMap<>(Map.of("URI", "/solr/test/select?q=*:*", "method", "GET"));
+        Assertions.assertSame(selectReq, wrapper.transformJson(selectReq));
+
+        // /admin is filtered
+        var adminReq = new LinkedHashMap<>(Map.of("URI", "/solr/test/admin/cores", "method", "GET"));
+        Assertions.assertThrows(RequestFilteredException.class, () -> wrapper.transformJson(adminReq));
+    }
+
+    @Test
+    void predicateFiltersOnMethod_postOnly() {
+        IJsonPredicate postOnly = obj -> {
+            @SuppressWarnings("unchecked")
+            var map = (Map<String, Object>) obj;
+            return "POST".equals(map.get("method"));
+        };
+        var wrapper = new FilteringTransformerWrapper(IDENTITY, postOnly);
+
+        var postReq = new LinkedHashMap<>(Map.of("URI", "/update", "method", "POST"));
+        Assertions.assertSame(postReq, wrapper.transformJson(postReq));
+
+        var getReq = new LinkedHashMap<>(Map.of("URI", "/select", "method", "GET"));
+        Assertions.assertThrows(RequestFilteredException.class, () -> wrapper.transformJson(getReq));
+    }
+
+    @Test
+    void predicateReceivesFullRequestMap() {
+        var receivedKeys = new java.util.ArrayList<String>();
+        IJsonPredicate inspector = obj -> {
+            @SuppressWarnings("unchecked")
+            var map = (Map<String, Object>) obj;
+            receivedKeys.addAll(map.keySet());
+            return true;
+        };
+        var wrapper = new FilteringTransformerWrapper(IDENTITY, inspector);
+
+        var input = new LinkedHashMap<>(Map.of("URI", "/test", "method", "GET", "headers", Map.of()));
+        wrapper.transformJson(input);
+
+        Assertions.assertTrue(receivedKeys.contains("URI"));
+        Assertions.assertTrue(receivedKeys.contains("method"));
+        Assertions.assertTrue(receivedKeys.contains("headers"));
+    }
+
+    @Test
+    void transformerExceptionPropagates_notSwallowed() {
+        IJsonTransformer throwingTransformer = input -> { throw new RuntimeException("transform error"); };
+        var wrapper = new FilteringTransformerWrapper(throwingTransformer, obj -> true);
+
+        var input = new LinkedHashMap<>(Map.of("URI", "/test"));
+        Assertions.assertThrows(RuntimeException.class, () -> wrapper.transformJson(input));
+    }
+
+    @Test
+    void close_delegatesToWrappedTransformer() throws Exception {
+        var closed = new boolean[]{false};
+        IJsonTransformer trackingTransformer = new IJsonTransformer() {
+            @Override
+            public Object transformJson(Object incomingJson) { return incomingJson; }
+            @Override
+            public void close() { closed[0] = true; }
+        };
+
+        var wrapper = new FilteringTransformerWrapper(trackingTransformer, obj -> true);
+        wrapper.close();
+
+        Assertions.assertTrue(closed[0]);
+    }
+
+    @Test
+    void nullPredicate_throwsNPE() {
+        Assertions.assertThrows(NullPointerException.class,
+            () -> new FilteringTransformerWrapper(IDENTITY, null).transformJson(Map.of()));
+    }
+
+    @Test
+    void predicateThrowsException_propagatesAsIs_notTreatedAsFiltered() {
+        IJsonPredicate brokenPredicate = obj -> { throw new IllegalStateException("predicate crashed"); };
+        var wrapper = new FilteringTransformerWrapper(IDENTITY, brokenPredicate);
+
+        var input = new LinkedHashMap<>(Map.of("URI", "/test"));
+        var thrown = Assertions.assertThrows(IllegalStateException.class, () -> wrapper.transformJson(input));
+        Assertions.assertEquals("predicate crashed", thrown.getMessage());
+    }
+
+    // --- Pipeline integration test: filtered request produces SKIPPED with null output ---
+
+    @Test
+    void filteredRequest_producesSkippedWithNullOutput() throws Exception {
+        final var dummyAggregatedResponse = new AggregatedRawResponse(null, 17, Duration.ZERO, List.of(), null);
+        var testPacketCapture = new TestCapturePacketToHttpHandler(Duration.ofMillis(100), dummyAggregatedResponse);
+
+        // Predicate that rejects everything
+        IJsonPredicate rejectAll = obj -> false;
+        var filteringTransformer = new FilteringTransformerWrapper(IDENTITY, rejectAll);
+
+        var transformingHandler = new HttpJsonTransformingConsumer<>(
+            filteringTransformer,
+            null,
+            testPacketCapture,
+            rootContext.getTestConnectionRequestContext(0)
+        );
+
+        // Feed a simple HTTP request
+        var httpRequest = "GET /solr/test/admin/cores HTTP/1.1\r\nHost: localhost\r\n\r\n";
+        transformingHandler.consumeBytes(
+            io.netty.buffer.Unpooled.wrappedBuffer(httpRequest.getBytes(StandardCharsets.UTF_8)));
+
+        var result = transformingHandler.finalizeRequest().get();
+
+        // Verify: SKIPPED status, null output (no bytes to send)
+        Assertions.assertTrue(result.transformationStatus.isSkipped());
+        Assertions.assertNull(result.transformedOutput);
+
+        // Verify: nothing was sent to the packet capture (no bytes reached the target)
+        Assertions.assertEquals(0, testPacketCapture.getNumConsumes().get());
+    }
+
+    @Test
+    void filteredPostRequestWithBody_producesSkippedAndReleasesBytes() throws Exception {
+        final var dummyAggregatedResponse = new AggregatedRawResponse(null, 17, Duration.ZERO, List.of(), null);
+        var testPacketCapture = new TestCapturePacketToHttpHandler(Duration.ofMillis(100), dummyAggregatedResponse);
+
+        IJsonPredicate rejectAll = obj -> false;
+        var filteringTransformer = new FilteringTransformerWrapper(IDENTITY, rejectAll);
+
+        var transformingHandler = new HttpJsonTransformingConsumer<>(
+            filteringTransformer,
+            null,
+            testPacketCapture,
+            rootContext.getTestConnectionRequestContext(0)
+        );
+
+        var body = "{\"add\":{\"doc\":{\"id\":\"1\",\"title\":\"test\"}}}";
+        var httpRequest = "POST /solr/test/update HTTP/1.1\r\n"
+            + "Host: localhost\r\n"
+            + "Content-Type: application/json\r\n"
+            + "Content-Length: " + body.length() + "\r\n\r\n"
+            + body;
+        transformingHandler.consumeBytes(
+            io.netty.buffer.Unpooled.wrappedBuffer(httpRequest.getBytes(StandardCharsets.UTF_8)));
+
+        var result = transformingHandler.finalizeRequest().get();
+
+        Assertions.assertTrue(result.transformationStatus.isSkipped());
+        Assertions.assertNull(result.transformedOutput);
+        Assertions.assertEquals(0, testPacketCapture.getNumConsumes().get());
+    }
+
+    @Test
+    void acceptedRequest_producesNormalOutput() throws Exception {
+        final var dummyAggregatedResponse = new AggregatedRawResponse(null, 17, Duration.ZERO, List.of(), null);
+        var testPacketCapture = new TestCapturePacketToHttpHandler(Duration.ofMillis(100), dummyAggregatedResponse);
+
+        // Predicate that accepts everything
+        IJsonPredicate acceptAll = obj -> true;
+        var filteringTransformer = new FilteringTransformerWrapper(IDENTITY, acceptAll);
+
+        var transformingHandler = new HttpJsonTransformingConsumer<>(
+            filteringTransformer,
+            null,
+            testPacketCapture,
+            rootContext.getTestConnectionRequestContext(0)
+        );
+
+        var httpRequest = "GET /solr/test/select?q=*:* HTTP/1.1\r\nHost: localhost\r\n\r\n";
+        transformingHandler.consumeBytes(
+            io.netty.buffer.Unpooled.wrappedBuffer(httpRequest.getBytes(StandardCharsets.UTF_8)));
+
+        var result = transformingHandler.finalizeRequest().get();
+
+        // Verify: request passes through normally (SKIPPED means no-op transform, bytes still sent)
+        Assertions.assertTrue(result.transformationStatus.isSkipped() || result.transformationStatus.isCompleted());
+        Assertions.assertNotNull(result.transformedOutput);
+        Assertions.assertTrue(testPacketCapture.getNumConsumes().get() > 0);
+    }
+
+    // ─── Tests that exercise actual TrafficReplayer.buildTransformerSupplier (for JaCoCo coverage) ───
+
+    @Test
+    void production_buildTransformerSupplier_noFilter_returnsBaseTransformer() {
+        var transformationLoader = new org.opensearch.migrations.transform.TransformationLoader();
+        var supplier = TrafficReplayer.buildTransformerSupplier(
+            transformationLoader, "localhost", null, null, null);
+        Assertions.assertNotNull(supplier);
+        Assertions.assertNotNull(supplier.get());
+    }
+
+    @Test
+    void production_buildTransformerSupplier_blankFilter_returnsBaseTransformer() {
+        var transformationLoader = new org.opensearch.migrations.transform.TransformationLoader();
+        var supplier = TrafficReplayer.buildTransformerSupplier(
+            transformationLoader, "localhost", null, null, "   ");
+        Assertions.assertNotNull(supplier);
+        // Should NOT be a FilteringTransformerWrapper
+        Assertions.assertFalse(supplier.get() instanceof FilteringTransformerWrapper);
+    }
+
+    @Test
+    void production_buildTransformerSupplier_withFilter_returnsFilteringWrapper() {
+        var transformationLoader = new org.opensearch.migrations.transform.TransformationLoader();
+        // JsonJMESPathPredicateProvider expects a Map config with "script" key
+        var supplier = TrafficReplayer.buildTransformerSupplier(
+            transformationLoader, "localhost", null, null,
+            "{\"JsonJMESPathPredicateProvider\":{\"script\":\"length(URI) > `0`\"}}");
+        Assertions.assertNotNull(supplier);
+        Assertions.assertInstanceOf(FilteringTransformerWrapper.class, supplier.get());
+    }
+}

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/e2etests/RequestFilterE2ETest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/e2etests/RequestFilterE2ETest.java
@@ -1,0 +1,237 @@
+package org.opensearch.migrations.replay.e2etests;
+
+import javax.net.ssl.SSLException;
+
+import java.io.EOFException;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import org.opensearch.migrations.replay.RequestFilteredException;
+import org.opensearch.migrations.replay.TestHttpServerContext;
+import org.opensearch.migrations.replay.TimeShifter;
+import org.opensearch.migrations.replay.datatypes.ITrafficStreamKey;
+import org.opensearch.migrations.replay.datatypes.PojoTrafficStreamAndKey;
+import org.opensearch.migrations.replay.datatypes.PojoTrafficStreamKeyAndContext;
+import org.opensearch.migrations.replay.tracing.ITrafficSourceContexts;
+import org.opensearch.migrations.replay.traffic.generator.ExhaustiveTrafficStreamGenerator;
+import org.opensearch.migrations.replay.traffic.source.ArrayCursorTrafficSourceContext;
+import org.opensearch.migrations.replay.traffic.source.ISimpleTrafficCaptureSource;
+import org.opensearch.migrations.replay.traffic.source.ITrafficStreamWithKey;
+import org.opensearch.migrations.testutils.SimpleNettyHttpServer;
+import org.opensearch.migrations.testutils.WrapWithNettyLeakDetection;
+import org.opensearch.migrations.tracing.TestContext;
+import org.opensearch.migrations.trafficcapture.protos.CloseObservation;
+import org.opensearch.migrations.trafficcapture.protos.ReadObservation;
+import org.opensearch.migrations.trafficcapture.protos.TrafficObservation;
+import org.opensearch.migrations.trafficcapture.protos.TrafficStream;
+import org.opensearch.migrations.transform.IJsonTransformer;
+import org.opensearch.migrations.transform.StaticAuthTransformerFactory;
+import org.opensearch.migrations.transform.TransformationLoader;
+
+import com.google.protobuf.ByteString;
+import com.google.protobuf.Timestamp;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceLock;
+
+/**
+ * End-to-end integration tests for request filter extension point.
+ * Exercises the full pipeline path through RequestTransformerAndSender.
+ */
+@Slf4j
+@Tag("longTest")
+@WrapWithNettyLeakDetection(disableLeakChecks = true)
+class RequestFilterE2ETest extends FullTrafficReplayerTest {
+
+    private static final String HTTP_GET =
+        "GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n";
+    private static final String HTTP_POST =
+        "POST /data HTTP/1.1\r\nHost: localhost\r\nContent-Length: 4\r\nConnection: close\r\n\r\ntest";
+
+    private TrafficStream buildTrafficStream(String httpRequest) {
+        return TrafficStream.newBuilder()
+            .setNodeId(TEST_NODE_ID)
+            .setConnectionId(TEST_CONNECTION_ID)
+            .setNumberOfThisLastChunk(0)
+            .addSubStream(TrafficObservation.newBuilder()
+                .setTs(Timestamp.newBuilder().setSeconds(1).build())
+                .setRead(ReadObservation.newBuilder()
+                    .setData(ByteString.copyFromUtf8(httpRequest))
+                    .build())
+                .build())
+            .addSubStream(TrafficObservation.newBuilder()
+                .setTs(Timestamp.newBuilder().setSeconds(3).build())
+                .setClose(CloseObservation.newBuilder().build())
+                .build())
+            .build();
+    }
+
+    /**
+     * Filter rejects all requests → target server never receives traffic,
+     * but traffic stream is still committed (Kafka offset advances).
+     */
+    @Test
+    @ResourceLock("TrafficReplayerRunner")
+    void filteredRequest_rejectAll_skipsTargetAndCommits() throws Throwable {
+        var targetHitCount = new AtomicInteger(0);
+        try (var httpServer = SimpleNettyHttpServer.makeServer(false, Duration.ofMillis(100),
+            response -> { targetHitCount.incrementAndGet();
+                return TestHttpServerContext.makeResponse(new Random(1), response); })) {
+
+            var trafficSource = new ArrayCursorTrafficSourceContext(
+                List.of(buildTrafficStream(HTTP_GET)));
+
+            IJsonTransformer rejectAll = input -> {
+                throw new RequestFilteredException("reject all");
+            };
+
+            TrafficReplayerRunner.runReplayer(0, (rc, threadPrefix) -> {
+                try {
+                    return new TrafficReplayerWithWaitOnClose(Duration.ofSeconds(30), rc,
+                        httpServer.localhostEndpoint(), new StaticAuthTransformerFactory("TEST"),
+                        true, 1, 1, rejectAll, threadPrefix);
+                } catch (SSLException e) { throw new RuntimeException(e); }
+            }, () -> t -> {}, () -> TestContext.noOtelTracking(),
+                trafficSource, new TimeShifter(10 * 1000, Duration.ofMillis(100)));
+
+            Assertions.assertEquals(0, targetHitCount.get(),
+                "Filtered requests should not reach the target server");
+            Assertions.assertEquals(1, trafficSource.nextReadCursor.get(),
+                "Traffic stream should still be committed even when filtered");
+        }
+    }
+
+    /**
+     * Filter accepts all requests → requests flow through to target normally.
+     * Proves the filter doesn't break the normal pipeline when it accepts.
+     */
+    @Test
+    @ResourceLock("TrafficReplayerRunner")
+    void filteredRequest_acceptAll_reachesTarget() throws Throwable {
+        var targetHitCount = new AtomicInteger(0);
+        var nonTrackingContext = TestContext.noOtelTracking();
+        try (var httpServer = SimpleNettyHttpServer.makeServer(false, Duration.ofMillis(100),
+            response -> { targetHitCount.incrementAndGet();
+                return TestHttpServerContext.makeResponse(new Random(1), response); })) {
+
+            var streamAndSizes = ExhaustiveTrafficStreamGenerator
+                .generateStreamAndSumOfItsTransactions(nonTrackingContext, 16, true);
+            var trafficStreams = streamAndSizes.stream.collect(Collectors.toList());
+
+            Function<TestContext, ISimpleTrafficCaptureSource> trafficSourceFactory =
+                rc -> new ISimpleTrafficCaptureSource() {
+                    boolean isDone = false;
+                    @Override
+                    public CompletableFuture<List<ITrafficStreamWithKey>> readNextTrafficStreamChunk(
+                        Supplier<ITrafficSourceContexts.IReadChunkContext> contextSupplier) {
+                        if (isDone) return CompletableFuture.failedFuture(new EOFException());
+                        isDone = true;
+                        return CompletableFuture.completedFuture(trafficStreams.stream()
+                            .map(ts -> (ITrafficStreamWithKey) new PojoTrafficStreamAndKey(ts,
+                                PojoTrafficStreamKeyAndContext.build(ts, rc::createTrafficStreamContextForTest)))
+                            .collect(Collectors.toList()));
+                    }
+                    @Override
+                    public CommitResult commitTrafficStream(ITrafficStreamKey trafficStreamKey) { return null; }
+                };
+
+            // Accept-all: use the base transformer directly (no filter = all pass)
+            TrafficReplayerRunner.runReplayer(streamAndSizes.numHttpTransactions, (rc, threadPrefix) -> {
+                try {
+                    IJsonTransformer base = new TransformationLoader()
+                        .getTransformerFactoryLoaderWithNewHostName("localhost");
+                    return new TrafficReplayerWithWaitOnClose(Duration.ofSeconds(600), rc,
+                        httpServer.localhostEndpoint(), new StaticAuthTransformerFactory("TEST"),
+                        true, 1, 1, base, threadPrefix);
+                } catch (SSLException e) { throw new RuntimeException(e); }
+            }, () -> t -> {}, () -> nonTrackingContext, trafficSourceFactory, new TimeShifter(10 * 1000));
+
+            Assertions.assertTrue(targetHitCount.get() > 0,
+                "Accepted requests should reach the target server");
+        }
+    }
+
+    /**
+     * Selective filter — only GET requests pass, POST requests are filtered.
+     * Verifies per-request filtering logic works correctly.
+     */
+    @Test
+    @ResourceLock("TrafficReplayerRunner")
+    void filteredRequest_selectiveFilter_onlyGetPassesThrough() throws Throwable {
+        var targetHitCount = new AtomicInteger(0);
+        try (var httpServer = SimpleNettyHttpServer.makeServer(false, Duration.ofMillis(100),
+            response -> { targetHitCount.incrementAndGet();
+                return TestHttpServerContext.makeResponse(new Random(1), response); })) {
+
+            // Only POST traffic — should be filtered
+            var trafficSource = new ArrayCursorTrafficSourceContext(
+                List.of(buildTrafficStream(HTTP_POST)));
+
+            // Filter that only accepts GET requests
+            IJsonTransformer getOnlyFilter = input -> {
+                @SuppressWarnings("unchecked")
+                var map = (Map<String, Object>) input;
+                var method = (String) map.get("method");
+                if (!"GET".equals(method)) {
+                    throw new RequestFilteredException("Only GET allowed");
+                }
+                return input;
+            };
+
+            TrafficReplayerRunner.runReplayer(0, (rc, threadPrefix) -> {
+                try {
+                    return new TrafficReplayerWithWaitOnClose(Duration.ofSeconds(30), rc,
+                        httpServer.localhostEndpoint(), new StaticAuthTransformerFactory("TEST"),
+                        true, 1, 1, getOnlyFilter, threadPrefix);
+                } catch (SSLException e) { throw new RuntimeException(e); }
+            }, () -> t -> {}, () -> TestContext.noOtelTracking(),
+                trafficSource, new TimeShifter(10 * 1000, Duration.ofMillis(100)));
+
+            Assertions.assertEquals(0, targetHitCount.get(),
+                "POST request should be filtered and not reach target");
+            Assertions.assertEquals(1, trafficSource.nextReadCursor.get(),
+                "Traffic stream should still be committed");
+        }
+    }
+
+    /**
+     * Filter throws a non-RequestFilteredException → should propagate as error,
+     * not be treated as a filtered request.
+     */
+    @Test
+    @ResourceLock("TrafficReplayerRunner")
+    void filterThrowsUnexpectedException_propagatesAsError() throws Throwable {
+        try (var httpServer = SimpleNettyHttpServer.makeServer(false, Duration.ofMillis(100),
+            response -> TestHttpServerContext.makeResponse(new Random(1), response))) {
+
+            var trafficSource = new ArrayCursorTrafficSourceContext(
+                List.of(buildTrafficStream(HTTP_GET)));
+
+            IJsonTransformer throwsRuntimeException = input -> {
+                throw new RuntimeException("Unexpected transformer error");
+            };
+
+            TrafficReplayerRunner.runReplayer(0, (rc, threadPrefix) -> {
+                try {
+                    return new TrafficReplayerWithWaitOnClose(Duration.ofSeconds(30), rc,
+                        httpServer.localhostEndpoint(), new StaticAuthTransformerFactory("TEST"),
+                        true, 1, 1, throwsRuntimeException, threadPrefix);
+                } catch (SSLException e) { throw new RuntimeException(e); }
+            }, () -> t -> {}, () -> TestContext.noOtelTracking(),
+                trafficSource, new TimeShifter(10 * 1000, Duration.ofMillis(100)));
+
+            // Pipeline should still commit (error is handled, not fatal)
+            Assertions.assertEquals(1, trafficSource.nextReadCursor.get(),
+                "Traffic stream should be committed even on transformer error");
+        }
+    }
+}


### PR DESCRIPTION
## Description

   Adds a pluggable request filter extension point to the traffic replayer. Plugins can skip specific requests during replay — skipped requests are recorded in the tuple but not sent to the target.

   This enables source-specific filtering (e.g., skipping Solr `/admin`, `/schema`, `/config` endpoints that have no OpenSearch equivalent) without modifying the open-source replayer core.

   ## Changes

   - **`--requestFilterConfig` CLI flag** — JSON config that loads an `IJsonPredicateProvider` via ServiceLoader (same pattern as `--transformerConfig`)
   - **`FilteringTransformerWrapper`** — wraps the transformer with a predicate check; throws `RequestFilteredException` when the predicate rejects
   - **`HttpJsonTransformingConsumer`** — catches `RequestFilteredException` (including wrapped in cause chain) and returns `TransformedOutputAndResult(null, SKIPPED)`
   - **`RequestTransformerAndSender`** — when `transformedOutput == null`, skips `scheduleRequest()` entirely (no send, no retry)
   - **`RequestFilteredException`** — marker exception distinguishing filtered requests from transform errors

   ## Behavior

   | Scenario | Result |
   |---|---|
   | No `--requestFilterConfig` | Zero behavior change — no wrapper, all requests pass through |
   | Predicate accepts request | Normal transform → send → retry flow |
   | Predicate rejects request | SKIPPED status, null output, no send to target, no retry, tuple assembled, Kafka offset committed, OTel `transformSkipped` counter incremented |
   | Predicate throws exception | Propagates as error (not treated as filtered) |

   ## How plugins use this

   ```bash
   --requestFilterConfig '[{"SolrRequestFilter":{"allowedEndpoints":["/select","/update","/get"]}}]'
```
   The plugin provides:

   - IJsonPredicateProvider implementation (factory, discovered via ServiceLoader)
   - IJsonPredicate implementation (filtering logic — receives the parsed request map with URI, method, headers)

   Testing

   - 12 tests (all passing):
     - 9 unit tests for FilteringTransformerWrapper (accept, reject, URI filtering, method filtering, predicate receives full map, transformer errors propagate, predicate errors propagate, close delegation, null
   predicate)
     - 3 pipeline integration tests using full HttpJsonTransformingConsumer Netty pipeline with real HTTP bytes (GET filtered, POST with body filtered, accepted request normal)

   - Full replayer test suite passes — no regressions


