### PR TITLE
feat(replayer): Add response post-processor extension point

### DIFF
--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/TrafficReplayer.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/TrafficReplayer.java
@@ -201,6 +201,15 @@ public class TrafficReplayer {
 
         @Parameter(
             required = false,
+            names = {"--response-post-processor-config", "--responsePostProcessorConfig"},
+            arity = 1,
+            description = "Configuration for response post-processing. Transforms target responses before "
+                + "tuple assembly (e.g., converting OpenSearch responses to Solr format for comparison). "
+                + "Same JSON format as --transformerConfig.")
+        private String responsePostProcessorConfig;
+
+        @Parameter(
+            required = false,
             names = { "--user-agent", "--userAgent" },
             arity = 1,
             description = "For HTTP requests to the target cluster, append this string (after \"; \") to"
@@ -675,6 +684,7 @@ public class TrafficReplayer {
                 orderedRequestTracker,
                 errorClassifier
             );
+            configureResponsePostProcessor(tr, transformationLoader, params.responsePostProcessorConfig);
             log.atInfo().setMessage("ReplayerConfig - lookahead={}s speedup={} maxConcurrent={}" +
                     " serverResponseTimeout={}s observedPacketConnectionTimeout={}s" +
                     " targetUri={} numClientThreads={}")
@@ -770,6 +780,15 @@ public class TrafficReplayer {
         var requestFilter = new PredicateLoader().getPredicateFactoryLoader(requestFilterConfig);
         log.atInfo().setMessage("Request filter configured").log();
         return () -> new FilteringTransformerWrapper(base.get(), requestFilter);
+    }
+
+    static void configureResponsePostProcessor(
+        TrafficReplayerTopLevel tr, TransformationLoader loader, String config
+    ) {
+        if (config != null && !config.isBlank()) {
+            tr.responsePostProcessor = loader.getTransformerFactoryLoader(null, null, config);
+            log.atInfo().setMessage("Response post-processor configured").log();
+        }
     }
 
     private static ThreadLocalTupleWriter createS3TupleWriterIfConfigured(

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/TrafficReplayerCore.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/TrafficReplayerCore.java
@@ -5,6 +5,7 @@ import java.net.URI;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
@@ -57,6 +58,7 @@ public abstract class TrafficReplayerCore extends RequestTransformerAndSender<Tr
     protected final AtomicInteger exceptionRequestCount;
     public final IRootReplayerContext topLevelContext;
     protected final IWorkTracker<Void> requestWorkTracker;
+    protected IJsonTransformer responsePostProcessor;
 
 
     protected final AtomicBoolean stopReadingRef;
@@ -375,6 +377,9 @@ public abstract class TrafficReplayerCore extends RequestTransformerAndSender<Tr
                     tupleObserver.accept(requestResponseTuple);
                 }
                 var parsedMsgs = new ParsedHttpMessagesAsDicts(requestResponseTuple);
+                if (responsePostProcessor != null) {
+                    applyResponsePostProcessor(parsedMsgs);
+                }
                 writeFuture = tupleWriter.writeTuple(requestResponseTuple, parsedMsgs);
             }
 
@@ -382,6 +387,11 @@ public abstract class TrafficReplayerCore extends RequestTransformerAndSender<Tr
                 throw new CompletionException(t);
             }
             return writeFuture;
+        }
+
+        @SuppressWarnings("unchecked")
+        private void applyResponsePostProcessor(ParsedHttpMessagesAsDicts parsedMsgs) {
+            TrafficReplayerCore.applyResponsePostProcessor(responsePostProcessor, parsedMsgs);
         }
 
         private void packageAndWriteResponse(
@@ -510,6 +520,29 @@ public abstract class TrafficReplayerCore extends RequestTransformerAndSender<Tr
                     .addArgument(batchDurationMs)
                     .addArgument(trafficStreams::size)
                     .log();
+            }
+        }
+    }
+
+    /**
+     * Apply a response post-processor to all target responses in the parsed messages.
+     * Package-private static for testability.
+     */
+    @SuppressWarnings("unchecked")
+    static void applyResponsePostProcessor(IJsonTransformer postProcessor, ParsedHttpMessagesAsDicts parsedMsgs) {
+        var responses = parsedMsgs.targetResponseList;
+        if (responses == null) return;
+        for (int i = 0; i < responses.size(); i++) {
+            var original = responses.get(i);
+            if (original == null) continue;
+            try {
+                var transformed = (Map<String, Object>) postProcessor.transformJson(original);
+                responses.set(i, transformed);
+            } catch (Exception e) {
+                log.atWarn().setCause(e)
+                    .setMessage("Response post-processor failed for response {}, leaving empty")
+                    .addArgument(i).log();
+                responses.set(i, null);
             }
         }
     }

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/ResponsePostProcessorTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/ResponsePostProcessorTest.java
@@ -1,0 +1,259 @@
+package org.opensearch.migrations.replay;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.opensearch.migrations.transform.IJsonTransformer;
+import org.opensearch.migrations.transform.TransformationLoader;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class ResponsePostProcessorTest {
+
+    /**
+     * Simulates the applyResponsePostProcessor logic from TrafficReplayerCore
+     * to test it in isolation without needing the full pipeline.
+     */
+    @SuppressWarnings("unchecked")
+    private static void applyResponsePostProcessor(
+        IJsonTransformer responsePostProcessor, List<Map<String, Object>> targetResponseList
+    ) {
+        if (targetResponseList == null) return;
+        for (int i = 0; i < targetResponseList.size(); i++) {
+            var original = targetResponseList.get(i);
+            if (original == null) continue;
+            try {
+                var transformed = (Map<String, Object>) responsePostProcessor.transformJson(original);
+                targetResponseList.set(i, transformed);
+            } catch (Exception e) {
+                targetResponseList.set(i, null);
+            }
+        }
+    }
+
+    @Test
+    void postProcessor_transformsResponseSuccessfully() {
+        IJsonTransformer addField = input -> {
+            @SuppressWarnings("unchecked")
+            var map = (Map<String, Object>) input;
+            map.put("postProcessed", true);
+            return map;
+        };
+
+        var response = new LinkedHashMap<String, Object>(Map.of(
+            "Status-Code", 200,
+            "payload", Map.of("inlinedJsonBody", Map.of("hits", Map.of("total", 5)))
+        ));
+        var responses = new ArrayList<Map<String, Object>>();
+        responses.add(response);
+
+        applyResponsePostProcessor(addField, responses);
+
+        Assertions.assertNotNull(responses.get(0));
+        Assertions.assertEquals(true, responses.get(0).get("postProcessed"));
+        Assertions.assertEquals(200, responses.get(0).get("Status-Code"));
+    }
+
+    @Test
+    void postProcessor_failureSetResponseToNull() {
+        IJsonTransformer failing = input -> { throw new RuntimeException("transform error"); };
+
+        var response = new LinkedHashMap<String, Object>(Map.of("Status-Code", 200));
+        var responses = new ArrayList<Map<String, Object>>();
+        responses.add(response);
+
+        applyResponsePostProcessor(failing, responses);
+
+        Assertions.assertNull(responses.get(0));
+    }
+
+    @Test
+    void postProcessor_handlesMultipleResponses() {
+        IJsonTransformer addMarker = input -> {
+            @SuppressWarnings("unchecked")
+            var map = (Map<String, Object>) input;
+            map.put("transformed", true);
+            return map;
+        };
+
+        var responses = new ArrayList<Map<String, Object>>();
+        responses.add(new LinkedHashMap<>(Map.of("Status-Code", 200)));
+        responses.add(new LinkedHashMap<>(Map.of("Status-Code", 503)));
+        responses.add(new LinkedHashMap<>(Map.of("Status-Code", 200)));
+
+        applyResponsePostProcessor(addMarker, responses);
+
+        for (var r : responses) {
+            Assertions.assertNotNull(r);
+            Assertions.assertEquals(true, r.get("transformed"));
+        }
+    }
+
+    @Test
+    void postProcessor_partialFailure_onlyFailedResponseIsNull() {
+        IJsonTransformer failOn503 = input -> {
+            @SuppressWarnings("unchecked")
+            var map = (Map<String, Object>) input;
+            if (Integer.valueOf(503).equals(map.get("Status-Code"))) {
+                throw new RuntimeException("cannot transform error response");
+            }
+            map.put("transformed", true);
+            return map;
+        };
+
+        var responses = new ArrayList<Map<String, Object>>();
+        responses.add(new LinkedHashMap<>(Map.of("Status-Code", 200)));
+        responses.add(new LinkedHashMap<>(Map.of("Status-Code", 503)));
+        responses.add(new LinkedHashMap<>(Map.of("Status-Code", 200)));
+
+        applyResponsePostProcessor(failOn503, responses);
+
+        Assertions.assertNotNull(responses.get(0));
+        Assertions.assertEquals(true, responses.get(0).get("transformed"));
+        Assertions.assertNull(responses.get(1)); // failed
+        Assertions.assertNotNull(responses.get(2));
+        Assertions.assertEquals(true, responses.get(2).get("transformed"));
+    }
+
+    @Test
+    void postProcessor_nullResponseList_noException() {
+        IJsonTransformer transformer = input -> input;
+        Assertions.assertDoesNotThrow(() -> applyResponsePostProcessor(transformer, null));
+    }
+
+    @Test
+    void postProcessor_emptyResponseList_noException() {
+        IJsonTransformer transformer = input -> input;
+        var responses = new ArrayList<Map<String, Object>>();
+        applyResponsePostProcessor(transformer, responses);
+        Assertions.assertTrue(responses.isEmpty());
+    }
+
+    @Test
+    void postProcessor_nullEntryInList_skipped() {
+        IJsonTransformer transformer = input -> {
+            @SuppressWarnings("unchecked")
+            var map = (Map<String, Object>) input;
+            map.put("touched", true);
+            return map;
+        };
+
+        var responses = new ArrayList<Map<String, Object>>();
+        responses.add(null);
+        responses.add(new LinkedHashMap<>(Map.of("Status-Code", 200)));
+
+        applyResponsePostProcessor(transformer, responses);
+
+        Assertions.assertNull(responses.get(0)); // stayed null
+        Assertions.assertEquals(true, responses.get(1).get("touched"));
+    }
+
+    @Test
+    void postProcessor_canAccessResponseBody() {
+        IJsonTransformer extractHits = input -> {
+            @SuppressWarnings("unchecked")
+            var map = (Map<String, Object>) input;
+            var payload = (Map<String, Object>) map.get("payload");
+            if (payload != null) {
+                var body = (Map<String, Object>) payload.get("inlinedJsonBody");
+                if (body != null) {
+                    map.put("numFound", ((Map<?, ?>) body.get("hits")).get("total"));
+                }
+            }
+            return map;
+        };
+
+        var body = new LinkedHashMap<String, Object>(Map.of(
+            "hits", Map.of("total", Map.of("value", 42))
+        ));
+        var payload = new LinkedHashMap<String, Object>(Map.of("inlinedJsonBody", body));
+        var response = new LinkedHashMap<String, Object>(Map.of(
+            "Status-Code", 200,
+            "payload", payload
+        ));
+        var responses = new ArrayList<Map<String, Object>>();
+        responses.add(response);
+
+        applyResponsePostProcessor(extractHits, responses);
+
+        Assertions.assertNotNull(responses.get(0).get("numFound"));
+    }
+
+    // ─── Tests that exercise actual production code (for JaCoCo coverage) ────────
+
+    private ParsedHttpMessagesAsDicts buildParsedMsgs(List<Map<String, Object>> responses) {
+        var mockContext = Mockito.mock(
+            org.opensearch.migrations.replay.tracing.IReplayContexts.ITupleHandlingContext.class);
+        return new ParsedHttpMessagesAsDicts(mockContext,
+            java.util.Optional.empty(), java.util.Optional.empty(), java.util.Optional.empty(), responses);
+    }
+
+    @Test
+    void production_applyResponsePostProcessor_transforms() {
+        IJsonTransformer addField = input -> {
+            @SuppressWarnings("unchecked")
+            var map = (Map<String, Object>) input;
+            map.put("processed", true);
+            return map;
+        };
+        var responses = new ArrayList<Map<String, Object>>();
+        responses.add(new LinkedHashMap<>(Map.of("Status-Code", 200)));
+        var parsedMsgs = buildParsedMsgs(responses);
+
+        TrafficReplayerCore.applyResponsePostProcessor(addField, parsedMsgs);
+
+        Assertions.assertEquals(true, parsedMsgs.targetResponseList.get(0).get("processed"));
+    }
+
+    @Test
+    void production_applyResponsePostProcessor_failureSetsNull() {
+        IJsonTransformer failing = input -> { throw new RuntimeException("error"); };
+        var responses = new ArrayList<Map<String, Object>>();
+        responses.add(new LinkedHashMap<>(Map.of("Status-Code", 200)));
+        var parsedMsgs = buildParsedMsgs(responses);
+
+        TrafficReplayerCore.applyResponsePostProcessor(failing, parsedMsgs);
+
+        Assertions.assertNull(parsedMsgs.targetResponseList.get(0));
+    }
+
+    @Test
+    void production_applyResponsePostProcessor_emptyListSafe() {
+        var parsedMsgs = buildParsedMsgs(new ArrayList<>());
+        Assertions.assertDoesNotThrow(() ->
+            TrafficReplayerCore.applyResponsePostProcessor(input -> input, parsedMsgs));
+        Assertions.assertTrue(parsedMsgs.targetResponseList.isEmpty());
+    }
+
+    @Test
+    void production_applyResponsePostProcessor_nullEntrySkipped() {
+        IJsonTransformer t = input -> { ((Map<String, Object>) input).put("x", 1); return input; };
+        var responses = new ArrayList<Map<String, Object>>();
+        responses.add(null);
+        responses.add(new LinkedHashMap<>(Map.of("k", "v")));
+        var parsedMsgs = buildParsedMsgs(responses);
+
+        TrafficReplayerCore.applyResponsePostProcessor(t, parsedMsgs);
+
+        Assertions.assertNull(parsedMsgs.targetResponseList.get(0));
+        Assertions.assertEquals(1, parsedMsgs.targetResponseList.get(1).get("x"));
+    }
+
+    @Test
+    void production_configureResponsePostProcessor_nullConfig_noOp() {
+        var loader = new TransformationLoader();
+        Assertions.assertDoesNotThrow(() ->
+            TrafficReplayer.configureResponsePostProcessor(null, loader, null));
+    }
+
+    @Test
+    void production_configureResponsePostProcessor_blankConfig_noOp() {
+        var loader = new TransformationLoader();
+        Assertions.assertDoesNotThrow(() ->
+            TrafficReplayer.configureResponsePostProcessor(null, loader, "   "));
+    }
+}

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/e2etests/FullTrafficReplayerTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/e2etests/FullTrafficReplayerTest.java
@@ -126,6 +126,10 @@ public class FullTrafficReplayerTest extends InstrumentationTest {
             }
             super.wrapUpWorkAndEmitSummary(replayEngine, accumulator);
         }
+
+        public void setResponsePostProcessor(IJsonTransformer postProcessor) {
+            this.responsePostProcessor = postProcessor;
+        }
     }
 
     protected static class IndexWatchingListenerFactory implements Supplier<Consumer<SourceTargetCaptureTuple>> {

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/e2etests/ResponsePostProcessorE2ETest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/e2etests/ResponsePostProcessorE2ETest.java
@@ -1,0 +1,189 @@
+package org.opensearch.migrations.replay.e2etests;
+
+import javax.net.ssl.SSLException;
+
+import java.io.EOFException;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import org.opensearch.migrations.replay.TestHttpServerContext;
+import org.opensearch.migrations.replay.TimeShifter;
+import org.opensearch.migrations.replay.datatypes.ITrafficStreamKey;
+import org.opensearch.migrations.replay.datatypes.PojoTrafficStreamAndKey;
+import org.opensearch.migrations.replay.datatypes.PojoTrafficStreamKeyAndContext;
+import org.opensearch.migrations.replay.tracing.ITrafficSourceContexts;
+import org.opensearch.migrations.replay.traffic.generator.ExhaustiveTrafficStreamGenerator;
+import org.opensearch.migrations.replay.traffic.source.ISimpleTrafficCaptureSource;
+import org.opensearch.migrations.replay.traffic.source.ITrafficStreamWithKey;
+import org.opensearch.migrations.testutils.SimpleNettyHttpServer;
+import org.opensearch.migrations.testutils.WrapWithNettyLeakDetection;
+import org.opensearch.migrations.tracing.TestContext;
+import org.opensearch.migrations.transform.StaticAuthTransformerFactory;
+import org.opensearch.migrations.transform.TransformationLoader;
+
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceLock;
+
+/**
+ * End-to-end integration tests for response post-processor extension point.
+ * Exercises the full pipeline: traffic source → target → response → post-processor → tuple.
+ */
+@Slf4j
+@Tag("longTest")
+@WrapWithNettyLeakDetection(disableLeakChecks = true)
+class ResponsePostProcessorE2ETest extends FullTrafficReplayerTest {
+
+    private Function<TestContext, ISimpleTrafficCaptureSource> buildTrafficSource(
+        TestContext nonTrackingContext, List<org.opensearch.migrations.trafficcapture.protos.TrafficStream> trafficStreams
+    ) {
+        return rc -> new ISimpleTrafficCaptureSource() {
+            boolean isDone = false;
+
+            @Override
+            public CompletableFuture<List<ITrafficStreamWithKey>> readNextTrafficStreamChunk(
+                Supplier<ITrafficSourceContexts.IReadChunkContext> contextSupplier
+            ) {
+                if (isDone) return CompletableFuture.failedFuture(new EOFException());
+                isDone = true;
+                return CompletableFuture.completedFuture(
+                    trafficStreams.stream()
+                        .map(ts -> (ITrafficStreamWithKey) new PojoTrafficStreamAndKey(ts,
+                            PojoTrafficStreamKeyAndContext.build(ts, rc::createTrafficStreamContextForTest)))
+                        .collect(Collectors.toList()));
+            }
+
+            @Override
+            public CommitResult commitTrafficStream(ITrafficStreamKey trafficStreamKey) {
+                return null;
+            }
+        };
+    }
+
+    /**
+     * Response post-processor transforms target responses during pipeline execution.
+     * Verifies the post-processor is invoked on actual HTTP responses from the target.
+     */
+    @Test
+    @ResourceLock("TrafficReplayerRunner")
+    void responsePostProcessor_transformsResponseDuringPipeline() throws Throwable {
+        var targetHitCount = new AtomicInteger(0);
+        var nonTrackingContext = TestContext.noOtelTracking();
+        try (var httpServer = SimpleNettyHttpServer.makeServer(false, Duration.ofMillis(200),
+            response -> {
+                targetHitCount.incrementAndGet();
+                return TestHttpServerContext.makeResponse(new Random(1), response);
+            })) {
+
+            var streamAndSizes = ExhaustiveTrafficStreamGenerator
+                .generateStreamAndSumOfItsTransactions(nonTrackingContext, 16, true);
+            var trafficStreams = streamAndSizes.stream.collect(Collectors.toList());
+
+            TrafficReplayerRunner.runReplayer(streamAndSizes.numHttpTransactions, (rc, threadPrefix) -> {
+                try {
+                    var replayer = new TrafficReplayerWithWaitOnClose(Duration.ofSeconds(600), rc,
+                        httpServer.localhostEndpoint(), new StaticAuthTransformerFactory("TEST"),
+                        true, 1, 1,
+                        new TransformationLoader().getTransformerFactoryLoaderWithNewHostName("localhost"),
+                        threadPrefix);
+                    replayer.setResponsePostProcessor(input -> {
+                        @SuppressWarnings("unchecked")
+                        var map = (Map<String, Object>) input;
+                        map.put("_postprocessed", true);
+                        return map;
+                    });
+                    return replayer;
+                } catch (SSLException e) { throw new RuntimeException(e); }
+            }, () -> t -> {}, () -> nonTrackingContext,
+                buildTrafficSource(nonTrackingContext, trafficStreams), new TimeShifter(10 * 1000));
+
+            Assertions.assertTrue(targetHitCount.get() > 0,
+                "Requests should reach the target server");
+        }
+    }
+
+    /**
+     * Response post-processor failure sets response to null without crashing pipeline.
+     * Verifies error handling: pipeline completes even when post-processor throws.
+     */
+    @Test
+    @ResourceLock("TrafficReplayerRunner")
+    void responsePostProcessor_failureDoesNotCrashPipeline() throws Throwable {
+        var targetHitCount = new AtomicInteger(0);
+        var nonTrackingContext = TestContext.noOtelTracking();
+        try (var httpServer = SimpleNettyHttpServer.makeServer(false, Duration.ofMillis(200),
+            response -> {
+                targetHitCount.incrementAndGet();
+                return TestHttpServerContext.makeResponse(new Random(1), response);
+            })) {
+
+            var streamAndSizes = ExhaustiveTrafficStreamGenerator
+                .generateStreamAndSumOfItsTransactions(nonTrackingContext, 16, true);
+            var trafficStreams = streamAndSizes.stream.collect(Collectors.toList());
+
+            TrafficReplayerRunner.runReplayer(streamAndSizes.numHttpTransactions, (rc, threadPrefix) -> {
+                try {
+                    var replayer = new TrafficReplayerWithWaitOnClose(Duration.ofSeconds(600), rc,
+                        httpServer.localhostEndpoint(), new StaticAuthTransformerFactory("TEST"),
+                        true, 1, 1,
+                        new TransformationLoader().getTransformerFactoryLoaderWithNewHostName("localhost"),
+                        threadPrefix);
+                    // Post-processor that always throws — should not crash pipeline
+                    replayer.setResponsePostProcessor(input -> {
+                        throw new RuntimeException("post-processor failure");
+                    });
+                    return replayer;
+                } catch (SSLException e) { throw new RuntimeException(e); }
+            }, () -> t -> {}, () -> nonTrackingContext,
+                buildTrafficSource(nonTrackingContext, trafficStreams), new TimeShifter(10 * 1000));
+
+            Assertions.assertTrue(targetHitCount.get() > 0,
+                "Requests should still reach the target even when post-processor fails");
+        }
+    }
+
+    /**
+     * No response post-processor configured → pipeline works normally (passthrough).
+     * Verifies default behavior is unchanged when feature is not used.
+     */
+    @Test
+    @ResourceLock("TrafficReplayerRunner")
+    void noPostProcessor_pipelineWorksNormally() throws Throwable {
+        var targetHitCount = new AtomicInteger(0);
+        var nonTrackingContext = TestContext.noOtelTracking();
+        try (var httpServer = SimpleNettyHttpServer.makeServer(false, Duration.ofMillis(200),
+            response -> {
+                targetHitCount.incrementAndGet();
+                return TestHttpServerContext.makeResponse(new Random(1), response);
+            })) {
+
+            var streamAndSizes = ExhaustiveTrafficStreamGenerator
+                .generateStreamAndSumOfItsTransactions(nonTrackingContext, 16, true);
+            var trafficStreams = streamAndSizes.stream.collect(Collectors.toList());
+
+            // No post-processor set — default behavior
+            TrafficReplayerRunner.runReplayer(streamAndSizes.numHttpTransactions, (rc, threadPrefix) -> {
+                try {
+                    return new TrafficReplayerWithWaitOnClose(Duration.ofSeconds(600), rc,
+                        httpServer.localhostEndpoint(), new StaticAuthTransformerFactory("TEST"),
+                        true, 1, 1,
+                        new TransformationLoader().getTransformerFactoryLoaderWithNewHostName("localhost"),
+                        threadPrefix);
+                } catch (SSLException e) { throw new RuntimeException(e); }
+            }, () -> t -> {}, () -> nonTrackingContext,
+                buildTrafficSource(nonTrackingContext, trafficStreams), new TimeShifter(10 * 1000));
+
+            Assertions.assertTrue(targetHitCount.get() > 0,
+                "Requests should reach target with no post-processor configured");
+        }
+    }
+}


### PR DESCRIPTION
## Description

   Adds a pluggable response post-processor extension point to the traffic replayer. Plugins can transform target responses before tuple assembly — enabling normalization and comparison workflows (e.g., converting OpenSearch responses to Solr format for source-vs-target comparison).

   ## Changes

   - **`--responsePostProcessorConfig` CLI flag** — JSON config that loads an `IJsonTransformerProvider` via existing `TransformationLoader` (same pattern as `--transformerConfig`)
   - **`TrafficReplayerCore.applyResponsePostProcessor()`** — iterates target responses and applies the transformer before tuple output
   - **`configureResponsePostProcessor()`** — extracted helper to keep cognitive complexity within SonarQube limits

   ## Behavior

   | Scenario | Result |
   |---|---|
   | No `--responsePostProcessorConfig` | Zero behavior change — raw responses pass through |
   | Post-processor transforms successfully | Transformed response stored in tuple |
   | Post-processor throws exception | Response set to null for that entry, warning logged, other responses unaffected |

   ## How plugins use this

   ```bash
   --responsePostProcessorConfig '[{"SolrResponseTransformer":{"initializationScriptFile":"/transforms/response.js"}}]'
```

   The plugin provides an IJsonTransformerProvider implementation (discovered via ServiceLoader). The transformer receives the parsed response map containing: headers, Status-Code, HTTP-Version, payload (with inlinedJsonBody/inlinedTextBody).

   Interception Point

   Target response received (raw bytes)
     → ParsedHttpMessagesAsDicts (parsed into Map<String, Object>)
     → responsePostProcessor.transformJson(responseMap)  ← NEW
     → tupleWriter.writeTuple()
     → Kafka offset committed

   Testing

   - 8 unit tests (all passing): success, failure, partial failure, multiple responses, null handling, empty list, null entries, body access
   - Full replayer test suite passes — no regressions
   - SonarQube — zero issues