### PR TITLE
Aggregate Dependabot security fixes: tmp + idna develop-section follow-up + brace-expansion deferral

### DIFF
--- a/migrationConsole/cluster_tools/Pipfile.lock
+++ b/migrationConsole/cluster_tools/Pipfile.lock
@@ -1140,11 +1140,11 @@
         },
         "idna": {
             "hashes": [
-                "sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242",
-                "sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3"
+                "sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8",
+                "sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==3.13"
+            "version": "==3.15"
         },
         "iniconfig": {
             "hashes": [

--- a/migrationConsole/lib/console_link/Pipfile.lock
+++ b/migrationConsole/lib/console_link/Pipfile.lock
@@ -1221,11 +1221,11 @@
         },
         "idna": {
             "hashes": [
-                "sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242",
-                "sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3"
+                "sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8",
+                "sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==3.13"
+            "version": "==3.15"
         },
         "iniconfig": {
             "hashes": [

--- a/orchestrationSpecs/package-lock.json
+++ b/orchestrationSpecs/package-lock.json
@@ -7032,9 +7032,9 @@
       }
     },
     "node_modules/tmp": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
## Description

Aggregate Dependabot security follow-up. This PR (a) cleans up `[develop]`-section idna drift left over from #3011 in two Pipfile.lock files, (b) patches the high-severity `tmp` path-traversal alert in `orchestrationSpecs/package-lock.json`, and (c) explicitly defers the `brace-expansion` alert blocked by an upstream bundled tarball.

Total diff: 9 lines across 3 files — fully surgical, no resolver re-runs.

### Alerts fixed

| Alert(s) | Severity | Ecosystem | Package | Range → Fix | Manifest(s) |
| --- | --- | --- | --- | --- | --- |
| [#450] | high | npm | `tmp` | `0.2.5` → `0.2.7` | `orchestrationSpecs/package-lock.json` |
| [#442], [#443] | medium | pip | `idna` | `3.13` → `3.15` (develop sections) | `migrationConsole/lib/console_link/Pipfile.lock`, `migrationConsole/cluster_tools/Pipfile.lock` |

#### tmp 0.2.5 → 0.2.7

Patches GHSA-52f5-9888-hmc6 (path traversal via unsanitized `prefix`/`postfix` enabling directory escape, fixed in 0.2.6+). `tmp` is a transitive dev dependency in `orchestrationSpecs` (not declared in `package.json`). Bumped to 0.2.7 (current latest) by surgical edit of the `node_modules/tmp` entry's `version` / `resolved` / `integrity`; all other fields (`dev`, `license`, `engines`) preserved verbatim. Validated with `npm ci` in `orchestrationSpecs/`.

Note: this is a more conservative variant of Dependabot PR #3023, which additionally tries to remove the existing `"overrides": {"uuid": "11.1.1"}` block from `package.json` — that override was added intentionally to fix prior alerts and should NOT be removed.

#### idna develop-section follow-up

Six idna alerts (#439, #441, #442, #443, #444, #445) target manifests whose `[default]` section was already bumped to 3.15 in #3011. Four of those (#439, #441, #444, #445) only appear in `[default]` and will auto-resolve at the next Dependabot rescan — no PR change needed. The remaining two (#442, #443) also have `[develop]` entries still on 3.13; this PR brings those `[develop]` entries to 3.15 so the dev scope can't reopen the same alerts later. Hashes verified against `https://pypi.org/pypi/idna/3.15/json` (whl + sdist sha256). `_meta.hash` left untouched (Pipfile unchanged).

### Alerts deferred

| Alert | Severity | Package | Why deferred |
| --- | --- | --- | --- |
| [#437] | medium | `brace-expansion` (npm) | Vulnerable copy is bundled inside `aws-cdk-lib` (`node_modules/aws-cdk-lib/node_modules/brace-expansion@5.0.5`, `inBundle: true`). `aws-cdk-lib@2.257.0` (latest at time of writing) still ships `brace-expansion@5.0.5` inside its tarball — verified by extracting `package/node_modules/brace-expansion/package.json` from the published tgz. `npm` `overrides` cannot reach inside bundled tarballs, so the only path is upstream rebundling by the CDK team. The non-bundled copies in this lockfile are already at safe versions: top-level `brace-expansion@1.1.13` (unaffected — vuln range is `>= 5.0.0, < 5.0.6`), `node_modules/glob/node_modules/brace-expansion@2.1.0` (unaffected), and `node_modules/@typescript-eslint/.../brace-expansion@5.0.6` (already patched). |

### Will auto-resolve at next Dependabot rescan (no action in this PR)

Alerts #439, #441, #444, #445 — `idna` already at 3.15 in `[default]` of `libraries/testAutomation/Pipfile.lock`, `solrMigrationDevSandbox/Pipfile.lock`, `TrafficCapture/dockerSolution/.../elasticsearchTestConsole/Pipfile.lock`, and `migrationConsole/lib/integ_test/Pipfile.lock` (no `[develop]` section, or `[develop]` is already clean). Captured here so reviewers don't think these were missed.

### Validation

- `git diff --stat upstream/main..HEAD` → 9 lines / 3 files (fully surgical).
- `npm ci` in `orchestrationSpecs/` → exits 0 with the new tmp 0.2.7 entry.
- idna 3.15 hashes match `pypi.org/pypi/idna/3.15/json` (whl + sdist).
- No `Pipfile` changes, so `_meta.hash` legitimately stays put (per `pipfile-lock-hash-validation`).

### Dependabot PRs that can be closed once this merges

- **#3023** (`Bump tmp from 0.2.5 to 0.2.7 in /orchestrationSpecs`) — superseded by this PR. Note: do NOT take #3023 as-is; it also tries to drop the `uuid` override that was added intentionally.

After this merges + Dependabot rescans, alerts #439, #441, #442, #443, #444, #445, #450 should auto-close. Alert #437 will remain open with the bundled-dep deferral above as a comment.

Resolves Dependabot alerts: #439, #441, #442, #443, #444, #445, #450

[#437]: https://github.com/opensearch-project/opensearch-migrations/security/dependabot/437
[#439]: https://github.com/opensearch-project/opensearch-migrations/security/dependabot/439
[#441]: https://github.com/opensearch-project/opensearch-migrations/security/dependabot/441
[#442]: https://github.com/opensearch-project/opensearch-migrations/security/dependabot/442
[#443]: https://github.com/opensearch-project/opensearch-migrations/security/dependabot/443
[#444]: https://github.com/opensearch-project/opensearch-migrations/security/dependabot/444
[#445]: https://github.com/opensearch-project/opensearch-migrations/security/dependabot/445
[#450]: https://github.com/opensearch-project/opensearch-migrations/security/dependabot/450

### Issues Resolved

Follow-up to #3011 covering develop-scope idna drift, the new tmp 0.2.5 path-traversal alert, and documenting the brace-expansion deferral.

### Is this a backport?

No.

### Testing

- `npm ci` in `orchestrationSpecs/` after the tmp bump → 0 exit code, no integrity errors.
- Pipfile.lock files parsed cleanly via `json.loads`; only `[develop].idna` entries changed (3-line diff per file).
- Verified hashes match PyPI's published `idna==3.15` release files and the npm registry's `tmp@0.2.7` integrity.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
