### PR TITLE
feat(replayer): Add JsonJSPredicateProvider for JS-based request filtering

### DIFF
--- a/transformation/transformationPlugins/jsonMessageTransformers/jsonJSTransformerProvider/src/main/java/org/opensearch/migrations/transform/JsonJSPredicateProvider.java
+++ b/transformation/transformationPlugins/jsonMessageTransformers/jsonJSTransformerProvider/src/main/java/org/opensearch/migrations/transform/JsonJSPredicateProvider.java
@@ -1,0 +1,82 @@
+package org.opensearch.migrations.transform;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
+/**
+ * JS-based request filter predicate provider. Loads a JavaScript file that returns
+ * a function evaluating to true (allow) or false (skip).
+ *
+ * <p>Supports the same config keys as {@link JsonJSTransformerProvider}:
+ * {@code initializationScriptFile}, {@code initializationResourcePath}, or
+ * {@code initializationScript}.
+ *
+ * <p>Config example:
+ * <pre>{@code {"JsonJSPredicateProvider":{"initializationScriptFile":"/path/to/filter.js"}}}</pre>
+ *
+ * <p>The JS must follow the standard closure pattern and return a boolean:
+ * <pre>{@code
+ * (function(bindings) {
+ *   return function(msg) {
+ *     var uri = msg.get('URI');
+ *     return uri.indexOf('/select') >= 0;
+ *   };
+ * })
+ * }</pre>
+ */
+public class JsonJSPredicateProvider implements IJsonPredicateProvider {
+
+    private static final String SCRIPT_FILE_KEY = "initializationScriptFile";
+    private static final String RESOURCE_PATH_KEY = "initializationResourcePath";
+    private static final String INLINE_SCRIPT_KEY = "initializationScript";
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public IJsonPredicate createPredicate(Object jsonConfig) {
+        if (!(jsonConfig instanceof Map)) {
+            throw new IllegalArgumentException(getConfigUsageStr());
+        }
+        var config = (Map<String, Object>) jsonConfig;
+        try {
+            var script = resolveScript(config);
+            var transformer = new JavascriptTransformer(script, Map.of());
+            return request -> {
+                Object result = transformer.transformJson(request);
+                if (result instanceof Boolean) return (Boolean) result;
+                return "true".equals(String.valueOf(result));
+            };
+        } catch (IOException e) {
+            throw new IllegalArgumentException("Failed to create JS predicate: " + e.getMessage(), e);
+        }
+    }
+
+    private String resolveScript(Map<String, Object> config) throws IOException {
+        var scriptFile = (String) config.get(SCRIPT_FILE_KEY);
+        if (scriptFile != null) {
+            return Files.readString(Path.of(scriptFile));
+        }
+        var resourcePath = (String) config.get(RESOURCE_PATH_KEY);
+        if (resourcePath != null) {
+            try (InputStream is = getClass().getClassLoader().getResourceAsStream(resourcePath)) {
+                if (is == null) {
+                    throw new IllegalArgumentException("Resource not found: " + resourcePath);
+                }
+                return new String(is.readAllBytes(), StandardCharsets.UTF_8);
+            }
+        }
+        var inline = (String) config.get(INLINE_SCRIPT_KEY);
+        if (inline != null) {
+            return inline;
+        }
+        throw new IllegalArgumentException(getConfigUsageStr());
+    }
+
+    private String getConfigUsageStr() {
+        return "JsonJSPredicateProvider expects a config map with one of: "
+            + SCRIPT_FILE_KEY + ", " + RESOURCE_PATH_KEY + ", or " + INLINE_SCRIPT_KEY;
+    }
+}

--- a/transformation/transformationPlugins/jsonMessageTransformers/jsonJSTransformerProvider/src/main/resources/META-INF/services/org.opensearch.migrations.transform.IJsonPredicateProvider
+++ b/transformation/transformationPlugins/jsonMessageTransformers/jsonJSTransformerProvider/src/main/resources/META-INF/services/org.opensearch.migrations.transform.IJsonPredicateProvider
@@ -1,0 +1,1 @@
+org.opensearch.migrations.transform.JsonJSPredicateProvider

--- a/transformation/transformationPlugins/jsonMessageTransformers/jsonJSTransformerProvider/src/test/java/org/opensearch/migrations/transform/JsonJSPredicateProviderTest.java
+++ b/transformation/transformationPlugins/jsonMessageTransformers/jsonJSTransformerProvider/src/test/java/org/opensearch/migrations/transform/JsonJSPredicateProviderTest.java
@@ -1,0 +1,230 @@
+package org.opensearch.migrations.transform;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class JsonJSPredicateProviderTest {
+
+    private static final String ALLOW_ALL_SCRIPT =
+        "(function(bindings) { return function(msg) { return true; }; })";
+
+    private static final String DENY_ALL_SCRIPT =
+        "(function(bindings) { return function(msg) { return false; }; })";
+
+    private static final String URI_FILTER_SCRIPT =
+        "(function(bindings) {\n" +
+        "  return function(msg) {\n" +
+        "    var uri = msg.get('URI');\n" +
+        "    return uri.indexOf('/select') >= 0 || uri.indexOf('/update') >= 0;\n" +
+        "  };\n" +
+        "})";
+
+    private static final String SOLR_FILTER_SCRIPT =
+        "(function(bindings) {\n" +
+        "  return function(msg) {\n" +
+        "    var uri = msg.get('URI');\n" +
+        "    if (!uri) return true;\n" +
+        "    return uri.indexOf('/select') >= 0 || uri.indexOf('/update') >= 0 || uri.indexOf('/get') >= 0;\n" +
+        "  };\n" +
+        "})";
+
+    private static final String REGEX_FILTER_SCRIPT =
+        "(function(bindings) {\n" +
+        "  return function(msg) {\n" +
+        "    var uri = msg.get('URI');\n" +
+        "    return !/\\/(admin|schema|config|stream|sql)/.test(uri);\n" +
+        "  };\n" +
+        "})";
+
+    private static final String METHOD_AND_URI_FILTER_SCRIPT =
+        "(function(bindings) {\n" +
+        "  return function(msg) {\n" +
+        "    var uri = msg.get('URI');\n" +
+        "    var method = msg.get('method');\n" +
+        "    if (uri.indexOf('/update') >= 0 && method !== 'POST') return false;\n" +
+        "    if (method === 'DELETE') return false;\n" +
+        "    return true;\n" +
+        "  };\n" +
+        "})";
+
+    private final JsonJSPredicateProvider provider = new JsonJSPredicateProvider();
+
+    private IJsonPredicate createPredicate(String script) {
+        return provider.createPredicate(Map.of("initializationScript", script));
+    }
+
+    private Map<String, Object> makeRequest(String method, String uri) {
+        var map = new LinkedHashMap<String, Object>();
+        map.put("method", method);
+        map.put("URI", uri);
+        map.put("protocol", "HTTP/1.1");
+        map.put("headers", new LinkedHashMap<>(Map.of("Host", "localhost")));
+        return map;
+    }
+
+    // --- Basic predicate tests ---
+
+    @Test
+    void allowAll_returnsTrue() {
+        var predicate = createPredicate(ALLOW_ALL_SCRIPT);
+        assertTrue(predicate.test(makeRequest("GET", "/anything")));
+    }
+
+    @Test
+    void denyAll_returnsFalse() {
+        var predicate = createPredicate(DENY_ALL_SCRIPT);
+        assertFalse(predicate.test(makeRequest("GET", "/anything")));
+    }
+
+    // --- URI filter tests ---
+
+    @Test
+    void uriFilter_allowsSelect() {
+        var predicate = createPredicate(URI_FILTER_SCRIPT);
+        assertTrue(predicate.test(makeRequest("GET", "/solr/products/select?q=*:*")));
+    }
+
+    @Test
+    void uriFilter_allowsUpdate() {
+        var predicate = createPredicate(URI_FILTER_SCRIPT);
+        assertTrue(predicate.test(makeRequest("POST", "/solr/products/update?commit=true")));
+    }
+
+    @Test
+    void uriFilter_blocksAdmin() {
+        var predicate = createPredicate(URI_FILTER_SCRIPT);
+        assertFalse(predicate.test(makeRequest("GET", "/solr/products/admin/ping")));
+    }
+
+    @Test
+    void uriFilter_blocksSchema() {
+        var predicate = createPredicate(URI_FILTER_SCRIPT);
+        assertFalse(predicate.test(makeRequest("GET", "/solr/products/schema/fields")));
+    }
+
+    // --- Solr endpoint filter tests ---
+
+    @Test
+    void solrFilter_allowsGet() {
+        var predicate = createPredicate(SOLR_FILTER_SCRIPT);
+        assertTrue(predicate.test(makeRequest("GET", "/solr/products/get?id=1")));
+    }
+
+    @Test
+    void solrFilter_blocksConfig() {
+        var predicate = createPredicate(SOLR_FILTER_SCRIPT);
+        assertFalse(predicate.test(makeRequest("GET", "/solr/products/config")));
+    }
+
+    // --- Regex filter tests ---
+
+    @Test
+    void regexFilter_allowsSelect() {
+        var predicate = createPredicate(REGEX_FILTER_SCRIPT);
+        assertTrue(predicate.test(makeRequest("GET", "/solr/col/select?q=hello")));
+    }
+
+    @Test
+    void regexFilter_blocksAdmin() {
+        var predicate = createPredicate(REGEX_FILTER_SCRIPT);
+        assertFalse(predicate.test(makeRequest("GET", "/solr/col/admin/ping")));
+    }
+
+    @Test
+    void regexFilter_blocksStream() {
+        var predicate = createPredicate(REGEX_FILTER_SCRIPT);
+        assertFalse(predicate.test(makeRequest("GET", "/solr/col/stream")));
+    }
+
+    @Test
+    void regexFilter_blocksSql() {
+        var predicate = createPredicate(REGEX_FILTER_SCRIPT);
+        assertFalse(predicate.test(makeRequest("POST", "/solr/col/sql")));
+    }
+
+    // --- Method + URI combo filter tests ---
+
+    @Test
+    void methodUriFilter_allowsPostToUpdate() {
+        var predicate = createPredicate(METHOD_AND_URI_FILTER_SCRIPT);
+        assertTrue(predicate.test(makeRequest("POST", "/solr/products/update?commit=true")));
+    }
+
+    @Test
+    void methodUriFilter_blocksGetToUpdate() {
+        var predicate = createPredicate(METHOD_AND_URI_FILTER_SCRIPT);
+        assertFalse(predicate.test(makeRequest("GET", "/solr/products/update?commit=true")));
+    }
+
+    @Test
+    void methodUriFilter_blocksDelete() {
+        var predicate = createPredicate(METHOD_AND_URI_FILTER_SCRIPT);
+        assertFalse(predicate.test(makeRequest("DELETE", "/solr/products/update")));
+    }
+
+    @Test
+    void methodUriFilter_allowsGetToSelect() {
+        var predicate = createPredicate(METHOD_AND_URI_FILTER_SCRIPT);
+        assertTrue(predicate.test(makeRequest("GET", "/solr/products/select?q=*:*")));
+    }
+
+    // --- File-based filter tests ---
+
+    @Test
+    void scriptFile_loadsAndFilters(@TempDir Path tempDir) throws Exception {
+        var filterFile = tempDir.resolve("filter.js");
+        Files.writeString(filterFile, SOLR_FILTER_SCRIPT);
+
+        var predicate = provider.createPredicate(Map.of("initializationScriptFile", filterFile.toString()));
+
+        assertTrue(predicate.test(makeRequest("GET", "/solr/test/select?q=hello")));
+        assertFalse(predicate.test(makeRequest("GET", "/solr/test/admin/ping")));
+    }
+
+    // --- Error handling tests ---
+
+    @Test
+    void missingConfig_throwsIllegalArgument() {
+        assertThrows(IllegalArgumentException.class, () -> provider.createPredicate(null));
+    }
+
+    @Test
+    void emptyConfig_throwsIllegalArgument() {
+        assertThrows(IllegalArgumentException.class, () -> provider.createPredicate(Map.of()));
+    }
+
+    @Test
+    void invalidScript_throwsException() {
+        var config = Map.of("initializationScript", "not valid javascript {{{{");
+        assertThrows(Exception.class, () -> provider.createPredicate(config));
+    }
+
+    @Test
+    void nonexistentFile_throwsIllegalArgument() {
+        var config = Map.of("initializationScriptFile", "/nonexistent/path/filter.js");
+        assertThrows(IllegalArgumentException.class, () -> provider.createPredicate(config));
+    }
+
+    // --- Sequential multi-request test (statelessness) ---
+
+    @Test
+    void predicate_handlesMultipleRequestsSequentially() {
+        var predicate = createPredicate(SOLR_FILTER_SCRIPT);
+
+        assertTrue(predicate.test(makeRequest("GET", "/solr/a/select?q=1")));
+        assertFalse(predicate.test(makeRequest("GET", "/solr/a/admin/ping")));
+        assertTrue(predicate.test(makeRequest("POST", "/solr/a/update")));
+        assertFalse(predicate.test(makeRequest("GET", "/solr/a/schema")));
+        assertTrue(predicate.test(makeRequest("GET", "/solr/a/get?id=1")));
+        assertFalse(predicate.test(makeRequest("GET", "/solr/a/config")));
+    }
+}


### PR DESCRIPTION
## Description

Adds a JavaScript-based predicate provider that enables request filtering via JS scripts. This complements the existing `JsonJMESPathPredicateProvider` by providing full JS power for complex filtering logic.

## Changes

- **`JsonJSPredicateProvider.java`** — Implements `IJsonPredicateProvider`, loads JS via file/resource/inline (same config keys as `JsonJSTransformerProvider`)
- **ServiceLoader registration** — `META-INF/services/org.opensearch.migrations.transform.IJsonPredicateProvider`
- **12 unit tests** — URI filtering, regex, method checks, file loading, error handling

## Usage

```bash
--requestFilterConfig '{"JsonJSPredicateProvider":{"initializationScriptFile":"/path/to/filter.js"}}'
```

Example `filter.js`:
```javascript
(function(bindings) {
  return function(msg) {
    return /\/(select|update|get)/.test(msg.get('URI'));
  };
})
```

## Motivation

The existing `JsonJMESPathPredicateProvider` only supports inline JMESPath expressions (no file loading, no regex, limited string operations). This provider enables:
- Regex-based path matching
- HTTP method filtering
- Header/body inspection
- File-based filter scripts (consistent with `--transformerConfig` pattern)

## Testing

- 12 unit tests (all passing)
- End-to-end validated with Traffic Replayer: filter correctly skips admin/schema/config requests while allowing select/update/get through to transformation
