### PR TITLE
Fix bootstrap script help text to list all 7 VPC endpoint types

### DIFF
--- a/deployment/k8s/aws/aws-bootstrap.sh
+++ b/deployment/k8s/aws/aws-bootstrap.sh
@@ -133,7 +133,7 @@ while [[ $# -gt 0 ]]; do
       echo "                                            (required with --deploy-import-vpc-cfn)."
       echo "  --create-vpc-endpoints [list]             Create VPC endpoints for private subnet connectivity."
       echo "                                            Only valid with --deploy-import-vpc-cfn."
-      echo "                                            No argument or 'all' creates: s3,ecr,ecrDocker,cloudwatchLogs,efs."
+      echo "                                            No argument or 'all' creates: s3,ecr,ecrDocker,cloudwatchLogs,efs,sts,eksAuth."
       echo "                                            Or specify a comma-separated subset, e.g. 's3,ecr,ecrDocker'."
       echo "  --ignore-checks                           Skip subnet connectivity and VPC endpoint pre-flight checks."
       echo "  --use-public-images                       Opt out of mirroring images to private ECR. Use public images"
@@ -609,7 +609,7 @@ if [[ "$deploy_cfn" == "true" ]]; then
           efs)             cfn_params+=("CreateEFSEndpoint=true") ;;
           sts)             cfn_params+=("CreateSTSEndpoint=true") ;;
           eksAuth)         cfn_params+=("CreateEKSAuthEndpoint=true") ;;
-          *) echo "Warning: Unknown VPC endpoint type: $ep (valid: s3,ecr,ecrDocker,cloudwatchLogs,efs)" >&2 ;;
+          *) echo "Warning: Unknown VPC endpoint type: $ep (valid: s3,ecr,ecrDocker,cloudwatchLogs,efs,sts,eksAuth)" >&2 ;;
         esac
       done
     fi


### PR DESCRIPTION
## Summary
- The `--create-vpc-endpoints` help text and unknown-type warning only listed 5 of the 7 valid endpoint types (`s3,ecr,ecrDocker,cloudwatchLogs,efs`)
- The `all` expansion already includes `sts` and `eksAuth`, but these were missing from the user-facing messages
- Updated both the `--help` output and the warning message to list all 7 types: `s3,ecr,ecrDocker,cloudwatchLogs,efs,sts,eksAuth`

## Test plan
- [ ] Run `./aws-bootstrap.sh --help` and verify the `--create-vpc-endpoints` description lists all 7 types
- [ ] Pass an invalid endpoint type and verify the warning lists all 7 valid types