### PR TITLE
feat(replayer): Add file-based config flags for request filter and response post-processor

### DIFF
--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/TrafficReplayer.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/TrafficReplayer.java
@@ -191,22 +191,11 @@ public class TrafficReplayer {
         @ParametersDelegate
         private TupleTransformationParams tupleTransformationParams = new TupleTransformationParams();
 
-        @Parameter(
-            required = false,
-            names = {"--request-filter-config", "--requestFilterConfig"},
-            arity = 1,
-            description = "Configuration for request filtering. JSON array with one entry whose key is the "
-                + "predicate provider name. Requests failing the predicate are skipped (not sent to target).")
-        private String requestFilterConfig;
+        @ParametersDelegate
+        private RequestFilterParams requestFilterParams = new RequestFilterParams();
 
-        @Parameter(
-            required = false,
-            names = {"--response-post-processor-config", "--responsePostProcessorConfig"},
-            arity = 1,
-            description = "Configuration for response post-processing. Transforms target responses before "
-                + "tuple assembly (e.g., converting OpenSearch responses to Solr format for comparison). "
-                + "Same JSON format as --transformerConfig.")
-        private String responsePostProcessorConfig;
+        @ParametersDelegate
+        private ResponsePostProcessorParams responsePostProcessorParams = new ResponsePostProcessorParams();
 
         @Parameter(
             required = false,
@@ -512,6 +501,69 @@ public class TrafficReplayer {
         private String transformerConfigFile;
     }
 
+    @Getter
+    public static class RequestFilterParams implements TransformerParams {
+        @Override
+        public String getTransformerConfigParameterArgPrefix() { return REQUEST_FILTER_SNAKE_PREFIX; }
+        private static final String REQUEST_FILTER_SNAKE_PREFIX = "request-filter-";
+        private static final String REQUEST_FILTER_CAMEL_PREFIX = "requestFilter";
+
+        @Parameter(
+            required = false,
+            names = {"--" + REQUEST_FILTER_SNAKE_PREFIX + "config-encoded", "--" + REQUEST_FILTER_CAMEL_PREFIX + "ConfigEncoded"},
+            arity = 1,
+            description = "Configuration for request filtering. Base64 encoded. "
+                + "Same contents as --request-filter-config.")
+        private String transformerConfigEncoded;
+
+        @Parameter(
+            required = false,
+            names = {"--" + REQUEST_FILTER_SNAKE_PREFIX + "config", "--" + REQUEST_FILTER_CAMEL_PREFIX + "Config"},
+            arity = 1,
+            description = "Configuration for request filtering. JSON with one entry whose key is the "
+                + "predicate provider name. Requests failing the predicate are skipped (not sent to target).")
+        private String transformerConfig;
+
+        @Parameter(
+            required = false,
+            names = {"--" + REQUEST_FILTER_SNAKE_PREFIX + "config-file", "--" + REQUEST_FILTER_CAMEL_PREFIX + "ConfigFile"},
+            arity = 1,
+            description = "Path to JSON file containing request filter configuration.")
+        private String transformerConfigFile;
+    }
+
+    @Getter
+    public static class ResponsePostProcessorParams implements TransformerParams {
+        @Override
+        public String getTransformerConfigParameterArgPrefix() { return RESPONSE_PP_SNAKE_PREFIX; }
+        private static final String RESPONSE_PP_SNAKE_PREFIX = "response-post-processor-";
+        private static final String RESPONSE_PP_CAMEL_PREFIX = "responsePostProcessor";
+
+        @Parameter(
+            required = false,
+            names = {"--" + RESPONSE_PP_SNAKE_PREFIX + "config-encoded", "--" + RESPONSE_PP_CAMEL_PREFIX + "ConfigEncoded"},
+            arity = 1,
+            description = "Configuration for response post-processing. Base64 encoded. "
+                + "Same contents as --response-post-processor-config.")
+        private String transformerConfigEncoded;
+
+        @Parameter(
+            required = false,
+            names = {"--" + RESPONSE_PP_SNAKE_PREFIX + "config", "--" + RESPONSE_PP_CAMEL_PREFIX + "Config"},
+            arity = 1,
+            description = "Configuration for response post-processing. Transforms target responses before "
+                + "tuple assembly (e.g., converting OpenSearch responses to Solr format for comparison). "
+                + "Same JSON format as --transformerConfig.")
+        private String transformerConfig;
+
+        @Parameter(
+            required = false,
+            names = {"--" + RESPONSE_PP_SNAKE_PREFIX + "config-file", "--" + RESPONSE_PP_CAMEL_PREFIX + "ConfigFile"},
+            arity = 1,
+            description = "Path to JSON file containing response post-processor configuration.")
+        private String transformerConfigFile;
+    }
+
     private static Parameters parseArgs(String[] args) {
         Parameters p = EnvVarParameterPuller.injectFromEnv(new Parameters(), "TRAFFIC_REPLAYER_");
         var parser = JsonCommandLineParser.newBuilder().addObject(p).build();
@@ -669,7 +721,7 @@ public class TrafficReplayer {
 
             var transformationLoader = new TransformationLoader();
             var effectiveTransformerSupplier = buildTransformerSupplier(
-                transformationLoader, hostname, params.userAgent, requestTransformerConfig, params.requestFilterConfig);
+                transformationLoader, hostname, params.userAgent, requestTransformerConfig, TransformerConfigUtils.getTransformerConfig(params.requestFilterParams));
             var tr = new TrafficReplayerTopLevel(
                 topContext,
                 uri,
@@ -684,7 +736,7 @@ public class TrafficReplayer {
                 orderedRequestTracker,
                 errorClassifier
             );
-            configureResponsePostProcessor(tr, transformationLoader, params.responsePostProcessorConfig);
+            configureResponsePostProcessor(tr, transformationLoader, TransformerConfigUtils.getTransformerConfig(params.responsePostProcessorParams));
             log.atInfo().setMessage("ReplayerConfig - lookahead={}s speedup={} maxConcurrent={}" +
                     " serverResponseTimeout={}s observedPacketConnectionTimeout={}s" +
                     " targetUri={} numClientThreads={}")

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/RequestFilterAndResponsePostProcessorParamsTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/RequestFilterAndResponsePostProcessorParamsTest.java
@@ -1,0 +1,119 @@
+package org.opensearch.migrations.replay;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.opensearch.migrations.transform.TransformerConfigUtils;
+
+import com.beust.jcommander.JCommander;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class RequestFilterAndResponsePostProcessorParamsTest {
+
+    private TrafficReplayer.RequestFilterParams parseFilterParams(String... args) {
+        var params = new TrafficReplayer.RequestFilterParams();
+        JCommander.newBuilder().addObject(params).build().parse(args);
+        return params;
+    }
+
+    private TrafficReplayer.ResponsePostProcessorParams parseResponseParams(String... args) {
+        var params = new TrafficReplayer.ResponsePostProcessorParams();
+        JCommander.newBuilder().addObject(params).build().parse(args);
+        return params;
+    }
+
+    @Test
+    void requestFilterParams_prefixIsCorrect() {
+        var params = new TrafficReplayer.RequestFilterParams();
+        assertEquals("request-filter-", params.getTransformerConfigParameterArgPrefix());
+    }
+
+    @Test
+    void responsePostProcessorParams_prefixIsCorrect() {
+        var params = new TrafficReplayer.ResponsePostProcessorParams();
+        assertEquals("response-post-processor-", params.getTransformerConfigParameterArgPrefix());
+    }
+
+    @Test
+    void requestFilterParams_noConfig_returnsNull() {
+        var params = new TrafficReplayer.RequestFilterParams();
+        assertNull(TransformerConfigUtils.getTransformerConfig(params));
+    }
+
+    @Test
+    void responsePostProcessorParams_noConfig_returnsNull() {
+        var params = new TrafficReplayer.ResponsePostProcessorParams();
+        assertNull(TransformerConfigUtils.getTransformerConfig(params));
+    }
+
+    @Test
+    void requestFilterParams_inlineConfig_returnsConfig() {
+        var params = parseFilterParams("--request-filter-config", "{\"test\":\"value\"}");
+        assertEquals("{\"test\":\"value\"}", TransformerConfigUtils.getTransformerConfig(params));
+    }
+
+    @Test
+    void responsePostProcessorParams_inlineConfig_returnsConfig() {
+        var params = parseResponseParams("--response-post-processor-config", "[{\"test\":\"value\"}]");
+        assertEquals("[{\"test\":\"value\"}]", TransformerConfigUtils.getTransformerConfig(params));
+    }
+
+    @Test
+    void requestFilterParams_fileConfig_readsFile(@TempDir Path tempDir) throws Exception {
+        var configFile = tempDir.resolve("filter.json");
+        Files.writeString(configFile, "{\"JsonJMESPathPredicateProvider\":{\"script\":\"true\"}}");
+        var params = parseFilterParams("--request-filter-config-file", configFile.toString());
+        assertEquals(
+            "{\"JsonJMESPathPredicateProvider\":{\"script\":\"true\"}}",
+            TransformerConfigUtils.getTransformerConfig(params));
+    }
+
+    @Test
+    void responsePostProcessorParams_fileConfig_readsFile(@TempDir Path tempDir) throws Exception {
+        var configFile = tempDir.resolve("response.json");
+        Files.writeString(configFile, "[{\"NoopTransformerProvider\":{}}]");
+        var params = parseResponseParams("--response-post-processor-config-file", configFile.toString());
+        assertEquals("[{\"NoopTransformerProvider\":{}}]", TransformerConfigUtils.getTransformerConfig(params));
+    }
+
+    @Test
+    void requestFilterParams_encodedConfig_decodesBase64() {
+        // base64 of {"test":"encoded"}
+        var params = parseFilterParams("--request-filter-config-encoded", "eyJ0ZXN0IjoiZW5jb2RlZCJ9");
+        assertEquals("{\"test\":\"encoded\"}", TransformerConfigUtils.getTransformerConfig(params));
+    }
+
+    @Test
+    void requestFilterParams_multipleConfigs_throws() {
+        var params = parseFilterParams(
+            "--request-filter-config", "{\"inline\":true}",
+            "--request-filter-config-file", "/some/file.json");
+        assertThrows(
+            TransformerConfigUtils.TooManyTransformationConfigSourcesException.class,
+            () -> TransformerConfigUtils.getTransformerConfig(params));
+    }
+
+    @Test
+    void buildTransformerSupplier_withNullFilterConfig_returnsBaseTransformer() {
+        var supplier = TrafficReplayer.buildTransformerSupplier(
+            new org.opensearch.migrations.transform.TransformationLoader(),
+            "localhost", null, null, null);
+        var transformer = supplier.get();
+        assertEquals("JsonCompositeTransformer", transformer.getClass().getSimpleName());
+    }
+
+    @Test
+    void buildTransformerSupplier_withFilterConfig_returnsFilteringWrapper() {
+        var filterConfig = "{\"JsonJMESPathPredicateProvider\":{\"script\":\"contains(URI, '/select')\"}}";
+        var supplier = TrafficReplayer.buildTransformerSupplier(
+            new org.opensearch.migrations.transform.TransformationLoader(),
+            "localhost", null, null, filterConfig);
+        var transformer = supplier.get();
+        assertEquals("FilteringTransformerWrapper", transformer.getClass().getSimpleName());
+    }
+}


### PR DESCRIPTION
 ## Description

   Adds file-based and base64-encoded config flags for request filter and response post-processor, following the same `TransformerParams` pattern as the existing `--transformer-config-file`.

   ## Changes

   `TrafficReplayer.java` — replaces simple `@Parameter` fields with proper `TransformerParams` implementations:

   - `RequestFilterParams` — supports `--request-filter-config`, `--request-filter-config-file`, `--request-filter-config-encoded`
   - `ResponsePostProcessorParams` — supports `--response-post-processor-config`, `--response-post-processor-config-file`, `--response-post-processor-config-encoded`

   Both use `TransformerConfigUtils.getTransformerConfig()` for resolution — same utility, same validation (error if multiple sources specified), same precedence.

   ## Motivation

   EKS/ECS deployments pass configs via file paths or base64-encoded parameters. The existing inline-only flags (`--request-filter-config`, `--response-post-processor-config`) don't support this. Adding file and encoded variants enables the same deployment patterns used by `--transformer-config-file` and `--transformer-config-encoded`.

   ## Testing

   - All existing replayer tests pass (no regression)

   ## Backward Compatibility

   Fully backward compatible. The existing `--request-filter-config` and `--response-post-processor-config` inline flags continue to work unchanged. The new file and encoded variants are additive.