### PR TITLE
Added form encoded body handling

### DIFF
--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/http/NettyJsonBodyAccumulateHandler.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/datahandlers/http/NettyJsonBodyAccumulateHandler.java
@@ -1,12 +1,15 @@
 package org.opensearch.migrations.replay.datahandlers.http;
 
+import java.net.URLDecoder;
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
 import java.nio.charset.CharacterCodingException;
 import java.nio.charset.CodingErrorAction;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.function.Predicate;
 
@@ -129,7 +132,13 @@ public class NettyJsonBodyAccumulateHandler extends ChannelInboundHandlerAdapter
 
                     var leftoverBody = accumulatedBody.slice(jsonBodyByteLength,
                         accumulatedBody.readableBytes() - jsonBodyByteLength);
-                    if (jsonBodyByteLength == 0 &&
+                    if (jsonBodyByteLength == 0 && isFormEncodedContentType(capturedHttpJsonMessage))
+                    {
+                        var formString = leftoverBody.toString(StandardCharsets.UTF_8);
+                        capturedHttpJsonMessage.payload()
+                            .put(JsonKeysForHttpMessage.INLINED_FORM_ENCODED_BODY_DOCUMENT_KEY,
+                                parseFormEncodedBody(formString));
+                    } else if (jsonBodyByteLength == 0 &&
                         hasRequestContentTypeMatching(capturedHttpJsonMessage, v -> !v.startsWith("text/")))
                     {
                         context.onPayloadSetBinary();
@@ -185,5 +194,29 @@ public class NettyJsonBodyAccumulateHandler extends ChannelInboundHandlerAdapter
         decoder.onMalformedInput(CodingErrorAction.REPORT);
         decoder.onUnmappableCharacter(CodingErrorAction.REPORT);
         return decoder.decode(buffer);
+    }
+
+    private static boolean isFormEncodedContentType(HttpJsonMessageWithFaultingPayload message) {
+        if (message == null) return false;
+        var contentTypes = message.headers().insensitiveGet(HttpHeaderNames.CONTENT_TYPE.toString());
+        if (contentTypes == null) return false;
+        return contentTypes.stream()
+            .anyMatch(v -> v.startsWith("application/x-www-form-urlencoded"));
+    }
+
+    private static Map<String, List<String>> parseFormEncodedBody(String body) {
+        var params = new LinkedHashMap<String, List<String>>();
+        if (body == null || body.isEmpty()) return params;
+        for (String pair : body.split("&")) {
+            int eq = pair.indexOf('=');
+            String key = eq >= 0
+                ? URLDecoder.decode(pair.substring(0, eq), StandardCharsets.UTF_8)
+                : URLDecoder.decode(pair, StandardCharsets.UTF_8);
+            String value = eq >= 0
+                ? URLDecoder.decode(pair.substring(eq + 1), StandardCharsets.UTF_8)
+                : "";
+            params.computeIfAbsent(key, k -> new ArrayList<>()).add(value);
+        }
+        return params;
     }
 }

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/datahandlers/http/HttpJsonTransformingConsumerTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/datahandlers/http/HttpJsonTransformingConsumerTest.java
@@ -416,6 +416,41 @@ class HttpJsonTransformingConsumerTest extends InstrumentationTest {
         combinedOutputBuf.release();
     }
 
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testFormEncodedBody_parsedIntoStructuredMap() throws Exception {
+        final var dummyAggregatedResponse = new AggregatedRawResponse(null, 17, Duration.ZERO, List.of(), null);
+        var testPacketCapture = new TestCapturePacketToHttpHandler(Duration.ofMillis(100), dummyAggregatedResponse);
+        var formBodyInspectingTransformer = new JsonCompositeTransformer(incomingJson -> {
+            var payload = (Map<String, Object>) ((Map<String, Object>) incomingJson).get("payload");
+            Assertions.assertNull(payload.get(JsonKeysForHttpMessage.INLINED_JSON_BODY_DOCUMENT_KEY));
+            Assertions.assertNull(payload.get(JsonKeysForHttpMessage.INLINED_BINARY_BODY_DOCUMENT_KEY));
+            Assertions.assertNull(payload.get(JsonKeysForHttpMessage.INLINED_TEXT_BODY_DOCUMENT_KEY));
+            var formBody = (Map<String, List<String>>) payload.get(
+                JsonKeysForHttpMessage.INLINED_FORM_ENCODED_BODY_DOCUMENT_KEY);
+            Assertions.assertNotNull(formBody, "form-encoded body should be present");
+            Assertions.assertEquals(List.of("hello world"), formBody.get("username"));
+            Assertions.assertEquals(List.of("10"), formBody.get("limit"));
+            Assertions.assertEquals(List.of("name", "date"), formBody.get("sort"));
+            return incomingJson;
+        });
+        var transformingHandler = new HttpJsonTransformingConsumer<AggregatedRawResponse>(
+            formBodyInspectingTransformer,
+            null,
+            testPacketCapture,
+            rootContext.getTestConnectionRequestContext(0)
+        );
+
+        byte[] testBytes;
+        try (var sampleStream = HttpJsonTransformingConsumer.class.getResourceAsStream(
+            "/requests/raw/post_formUrlEncoded.txt")) {
+            testBytes = sampleStream.readAllBytes();
+        }
+        transformingHandler.consumeBytes(testBytes);
+        var returnedResponse = transformingHandler.finalizeRequest().get();
+        Assertions.assertEquals(HttpRequestTransformationStatus.completed(), returnedResponse.transformationStatus);
+    }
+
     public static List<byte[]> sliceRandomChunks(byte[] bytes, int numChunks) {
         Random random = new Random(0);
         List<Integer> chunkSizes = new ArrayList<>(numChunks);

--- a/TrafficCapture/trafficReplayer/src/test/resources/requests/raw/post_formUrlEncoded.txt
+++ b/TrafficCapture/trafficReplayer/src/test/resources/requests/raw/post_formUrlEncoded.txt
@@ -1,0 +1,6 @@
+POST /test HTTP/1.1
+Host: foo.example
+Content-Type: application/x-www-form-urlencoded
+Content-Length: 49
+
+username=hello+world&limit=10&sort=name&sort=date

--- a/TrafficCapture/transformationShim/src/main/java/org/opensearch/migrations/transform/shim/netty/HttpMessageUtil.java
+++ b/TrafficCapture/transformationShim/src/main/java/org/opensearch/migrations/transform/shim/netty/HttpMessageUtil.java
@@ -1,7 +1,10 @@
 package org.opensearch.migrations.transform.shim.netty;
 
 import java.net.URI;
+import java.net.URLDecoder;
+import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -59,7 +62,15 @@ public final class HttpMessageUtil {
         var body = request.content().toString(StandardCharsets.UTF_8);
         if (!body.isEmpty()) {
             var payload = new LinkedHashMap<String, Object>();
-            payload.put(JsonKeysForHttpMessage.INLINED_JSON_BODY_DOCUMENT_KEY, parseJsonOrText(body));
+            String contentType = request.headers().get(HttpHeaderNames.CONTENT_TYPE);
+            if (contentType != null && contentType.startsWith("application/x-www-form-urlencoded")) {
+                payload.put(JsonKeysForHttpMessage.INLINED_FORM_ENCODED_BODY_DOCUMENT_KEY,
+                    parseFormEncodedBody(body));
+            } else if (contentType == null || contentType.startsWith("application/json")) {
+                payload.put(JsonKeysForHttpMessage.INLINED_JSON_BODY_DOCUMENT_KEY, parseJsonOrText(body));
+            } else {
+                payload.put(JsonKeysForHttpMessage.INLINED_TEXT_BODY_DOCUMENT_KEY, body);
+            }
             map.put(JsonKeysForHttpMessage.PAYLOAD_KEY, payload);
         }
         return map;
@@ -173,8 +184,39 @@ public final class HttpMessageUtil {
                 throw new IllegalStateException("Failed to serialize inlinedJsonBody", e);
             }
         }
+        // Check for form-encoded body — serialize back to form-encoded string
+        var formBody = (Map<String, List<String>>) payload.get(
+            JsonKeysForHttpMessage.INLINED_FORM_ENCODED_BODY_DOCUMENT_KEY);
+        if (formBody != null) {
+            return serializeFormEncodedBody(formBody);
+        }
         // Fallback to inlinedTextBody (String)
         return (String) payload.get(JsonKeysForHttpMessage.INLINED_TEXT_BODY_DOCUMENT_KEY);
+    }
+
+    private static String serializeFormEncodedBody(Map<String, List<String>> formBody) {
+        var sb = new StringBuilder();
+        for (var entry : formBody.entrySet()) {
+            for (String value : entry.getValue()) {
+                if (!sb.isEmpty()) sb.append('&');
+                sb.append(URLEncoder.encode(entry.getKey(), StandardCharsets.UTF_8));
+                sb.append('=');
+                sb.append(URLEncoder.encode(value, StandardCharsets.UTF_8));
+            }
+        }
+        return sb.toString();
+    }
+
+    static Map<String, List<String>> parseFormEncodedBody(String body) {
+        var params = new LinkedHashMap<String, List<String>>();
+        if (body == null || body.isEmpty()) return params;
+        for (String pair : body.split("&")) {
+            int eq = pair.indexOf('=');
+            String key = eq >= 0 ? URLDecoder.decode(pair.substring(0, eq), StandardCharsets.UTF_8) : URLDecoder.decode(pair, StandardCharsets.UTF_8);
+            String value = eq >= 0 ? URLDecoder.decode(pair.substring(eq + 1), StandardCharsets.UTF_8) : "";
+            params.computeIfAbsent(key, k -> new ArrayList<>()).add(value);
+        }
+        return params;
     }
 
     /**

--- a/TrafficCapture/transformationShim/src/test/java/org/opensearch/migrations/transform/shim/netty/HttpMessageUtilTest.java
+++ b/TrafficCapture/transformationShim/src/test/java/org/opensearch/migrations/transform/shim/netty/HttpMessageUtilTest.java
@@ -202,6 +202,120 @@ class HttpMessageUtilTest {
         assertNull(HttpMessageUtil.extractBodyString(map));
     }
 
+    // --- Ingress: form-encoded body ---
+
+    @Test
+    void requestToMap_formEncoded_parsedIntoStructuredMap() {
+        var request = buildRequestWithContentType(
+            "q=*:*&rows=10&facet.field=title&facet.field=author",
+            "application/x-www-form-urlencoded");
+
+        var map = HttpMessageUtil.requestToMap(request);
+
+        var payload = payloadOf(map);
+        assertNull(payload.get(JsonKeysForHttpMessage.INLINED_JSON_BODY_DOCUMENT_KEY));
+        @SuppressWarnings("unchecked")
+        var formBody = (Map<String, List<String>>) payload.get(
+            JsonKeysForHttpMessage.INLINED_FORM_ENCODED_BODY_DOCUMENT_KEY);
+        assertNotNull(formBody, "form-encoded body should be parsed");
+        assertEquals(List.of("*:*"), formBody.get("q"));
+        assertEquals(List.of("10"), formBody.get("rows"));
+        assertEquals(List.of("title", "author"), formBody.get("facet.field"));
+    }
+
+    @Test
+    void requestToMap_formEncoded_decodesPercentEncoding() {
+        var request = buildRequestWithContentType(
+            "q=hello+world&fq=status%3Aactive",
+            "application/x-www-form-urlencoded");
+
+        var map = HttpMessageUtil.requestToMap(request);
+
+        @SuppressWarnings("unchecked")
+        var formBody = (Map<String, List<String>>) payloadOf(map).get(
+            JsonKeysForHttpMessage.INLINED_FORM_ENCODED_BODY_DOCUMENT_KEY);
+        assertEquals(List.of("hello world"), formBody.get("q"));
+        assertEquals(List.of("status:active"), formBody.get("fq"));
+    }
+
+    @Test
+    void requestToMap_formEncodedWithCharset_parsedCorrectly() {
+        var request = buildRequestWithContentType(
+            "q=test",
+            "application/x-www-form-urlencoded; charset=UTF-8");
+
+        var map = HttpMessageUtil.requestToMap(request);
+
+        var payload = payloadOf(map);
+        assertNotNull(payload.get(JsonKeysForHttpMessage.INLINED_FORM_ENCODED_BODY_DOCUMENT_KEY));
+        assertNull(payload.get(JsonKeysForHttpMessage.INLINED_JSON_BODY_DOCUMENT_KEY));
+    }
+
+    // --- Ingress: content-type routing ---
+
+    @Test
+    void requestToMap_textXml_goesToInlinedTextBody() {
+        var request = buildRequestWithContentType("<doc><id>1</id></doc>", "text/xml");
+
+        var map = HttpMessageUtil.requestToMap(request);
+
+        var payload = payloadOf(map);
+        assertNull(payload.get(JsonKeysForHttpMessage.INLINED_JSON_BODY_DOCUMENT_KEY));
+        assertEquals("<doc><id>1</id></doc>",
+            payload.get(JsonKeysForHttpMessage.INLINED_TEXT_BODY_DOCUMENT_KEY));
+    }
+
+    @Test
+    void requestToMap_noContentType_parsedAsJson() {
+        var request = buildRequest("{\"id\":\"1\"}");
+
+        var map = HttpMessageUtil.requestToMap(request);
+
+        var payload = payloadOf(map);
+        assertInstanceOf(Map.class, payload.get(JsonKeysForHttpMessage.INLINED_JSON_BODY_DOCUMENT_KEY));
+    }
+
+    @Test
+    void requestToMap_applicationJson_parsedAsJson() {
+        var request = buildRequestWithContentType("{\"id\":\"1\"}", "application/json");
+
+        var map = HttpMessageUtil.requestToMap(request);
+
+        var payload = payloadOf(map);
+        assertInstanceOf(Map.class, payload.get(JsonKeysForHttpMessage.INLINED_JSON_BODY_DOCUMENT_KEY));
+    }
+
+    // --- Egress: extractBodyString for form-encoded ---
+
+    @SuppressWarnings("null")
+    @Test
+    void extractBodyString_formEncodedBody_serializedCorrectly() {
+        var formBody = new LinkedHashMap<String, List<String>>();
+        formBody.put("q", List.of("*:*"));
+        formBody.put("rows", List.of("10"));
+        var map = buildMessageWithPayload(Map.of(
+            JsonKeysForHttpMessage.INLINED_FORM_ENCODED_BODY_DOCUMENT_KEY, formBody));
+
+        var body = HttpMessageUtil.extractBodyString(map);
+
+        assertNotNull(body);
+        assertTrue(body.contains("q=") && body.contains("rows="));
+    }
+
+    @SuppressWarnings("null")
+    @Test
+    void extractBodyString_formEncodedMultiValue_serializedWithRepeatedKeys() {
+        var formBody = new LinkedHashMap<String, List<String>>();
+        formBody.put("facet.field", List.of("title", "author"));
+        var map = buildMessageWithPayload(Map.of(
+            JsonKeysForHttpMessage.INLINED_FORM_ENCODED_BODY_DOCUMENT_KEY, formBody));
+
+        var body = HttpMessageUtil.extractBodyString(map);
+
+        assertNotNull(body);
+        assertEquals("facet.field=title&facet.field=author", body);
+    }
+
     // --- helpers ---
 
     private static FullHttpRequest buildRequest(String body) {
@@ -212,6 +326,12 @@ class HttpMessageUtilTest {
             "/test",
             Unpooled.wrappedBuffer(bytes)
         );
+    }
+
+    private static FullHttpRequest buildRequestWithContentType(String body, String contentType) {
+        var request = buildRequest(body);
+        request.headers().set("Content-Type", contentType);
+        return request;
     }
 
     @SuppressWarnings("unchecked")

--- a/transformation/transformationPlugins/jsonMessageTransformers/jsonMessageTransformerInterface/src/main/java/org/opensearch/migrations/transform/JsonKeysForHttpMessage.java
+++ b/transformation/transformationPlugins/jsonMessageTransformers/jsonMessageTransformerInterface/src/main/java/org/opensearch/migrations/transform/JsonKeysForHttpMessage.java
@@ -51,4 +51,10 @@ public class JsonKeysForHttpMessage {
      */
     public static final String INLINED_TEXT_BODY_DOCUMENT_KEY = "inlinedTextBody";
 
+    /**
+     * This key is used under the 'payload' object for application/x-www-form-urlencoded bodies.
+     * The value is a Map&lt;String, List&lt;String&gt;&gt; representing the parsed form parameters.
+     */
+    public static final String INLINED_FORM_ENCODED_BODY_DOCUMENT_KEY = "inlinedFormEncodedBody";
+
 }


### PR DESCRIPTION
### Description
This PR aligns how POST bodies of content type `application/x-www-form-urlencoded` are parsed by Shim and Replayer components and produced to transforms.

The bodies will now be parsed by Java parsers into `Map<String, List<String>>` objects and made available to the transforms at `payload.inlinedFormEncodedBody`.

### Testing
- Unit tests.

### Check List
- [x] New functionality includes testing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).