### PR TITLE
Fix(jenkins): tag isolated VPC subnets for AWS Load Balancer Controller discovery

### DIFF
--- a/vars/eksIsolatedIntegTest.groovy
+++ b/vars/eksIsolatedIntegTest.groovy
@@ -143,6 +143,14 @@ def call(Map config = [:]) {
                                 isolatedVpcId = vpc.vpcId
                                 env.isolatedVpcId = vpc.vpcId
 
+                                // Tag subnets so AWS Load Balancer Controller can discover them for internal NLBs.
+                                // CDK's Tags.of() is a no-op on imported subnets, so we tag them here at the source.
+                                sh """
+                                    aws ec2 create-tags --region ${params.REGION} \
+                                      --resources ${vpc.subnetIds.replace(',', ' ')} \
+                                      --tags Key=kubernetes.io/role/internal-elb,Value=1
+                                """
+
                                 // Deploy EKS + MA into isolated subnets
                                 def bootstrap = resolveBootstrap(
                                     useReleaseBootstrap: params.USE_RELEASE_BOOTSTRAP,


### PR DESCRIPTION
### Summary
Tag the EKS subnets created by `createIsolatedVpc` with `kubernetes.io/role/internal-elb=1` so AWS Load Balancer Controller can discover them when provisioning the internal NLB for `capture-proxy`.

### Problem
`main-eks-full-e2e-isolated-vpc-test` builds [#82](https://migrations.ci.opensearch.org/job/main/job/main-eks-full-e2e-isolated-vpc-test/82/) and [#83](https://migrations.ci.opensearch.org/job/main/job/main-eks-full-e2e-isolated-vpc-test/83/) fail in Phase 2 at `waitForProxyEndpointReady`, surfacing as `captureproxy/capture-proxy entered Error phase:` (empty message).

The underlying event on the `capture-proxy` Service:

```
Warning  FailedBuildModel  (x19 over 22m)  service
Failed build model due to unable to resolve at least one subnet (0 match VPC and tags: [kubernetes.io/role/internal-elb])
```

AWS LBC uses tag-based subnet auto-discovery for internal NLBs. With zero matching subnets, no NLB is provisioned, the Service stays `EXTERNAL-IP: <pending>` for the full 20-minute readiness window, and the workflow exits 1.

### Why CDK tagging didn't cover this path

The standard pipeline lets CDK create the VPC, and `eks-infra.ts` tags the private subnets via `Tags.of(subnet).add(...)`. The isolated-VPC pipeline supplies a pre-existing VPC, so CDK takes the Bring-your-own-VPC route and `Subnet.fromSubnetId(...)` returns imported constructs. `Tags.of()` is a no-op on imported resources, so the tag never lands.

### Fix applied

In `vars/eksIsolatedIntegTest.groovy`, immediately after `createIsolatedVpc(...)`, run `aws ec2 create-tags` against the returned subnet IDs.

The Jenkins host already holds the IAM perms (the same role calls `ec2:CreateVpc` / `ec2:CreateSubnet` with tag specs in the preceding step). The call is idempotent and runs ~10 minutes before LBC reads the tags, so eventual consistency is a non-issue.

With this change, now if the `aws ec2 create-tags` call ever fails, the build fails within seconds at the new step with the AWS error attached, instead of after a 20-minute silent timeout in `waitForProxyEndpointReady`.

### Testing
- Waiting on https://migrations.ci.opensearch.org/job/pr-checks/job/pr-eks-full-e2e-isolated-vpc-test/7/

### Check List
- [x] New functionality includes testing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
