### PR TITLE
Make S3 tuple output durable before replay commits

### DIFF
--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/TrafficReplayerCore.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/TrafficReplayerCore.java
@@ -186,6 +186,10 @@ public abstract class TrafficReplayerCore extends RequestTransformerAndSender<Tr
             return httpSentRequestFuture;
         }
 
+        /**
+         * Fatal boundary: record the shutdown reason before rethrowing serious VM/runtime errors.
+         */
+        @SuppressWarnings("java:S1181")
         Void handleCompletedTransaction(
             @NonNull IReplayContexts.IReplayerHttpTransactionContext context,
             RequestResponsePacketPair rrPair,
@@ -196,47 +200,11 @@ public abstract class TrafficReplayerCore extends RequestTransformerAndSender<Tr
                 // if this comes in with a serious Throwable (not an Exception), don't bother
                 // packaging it up and calling the callback.
                 // Escalate it up out handling stack and shutdown.
-                if (t == null || t instanceof Exception) {
-                    try (var tupleHandlingContext = httpContext.createTupleContext()) {
-                        if (tupleWriter != null) {
-                            var writeFuture = packageAndWriteTuple(
-                                tupleHandlingContext,
-                                tupleWriter,
-                                rrPair,
-                                summary,
-                                (Exception) t
-                            );
-                            writeFuture.whenComplete((v, writeErr) -> {
-                                if (writeErr != null) {
-                                    log.atError().setCause(writeErr)
-                                        .setMessage("Tuple write failed for {} (streams={})")
-                                        .addArgument(context)
-                                        .addArgument(rrPair.trafficStreamKeysBeingHeld).log();
-                                }
-                                commitTrafficStreams(rrPair.completionStatus, rrPair.trafficStreamKeysBeingHeld);
-                            });
-                        } else {
-                            packageAndWriteResponse(
-                                tupleHandlingContext,
-                                resultTupleConsumer,
-                                rrPair,
-                                summary,
-                                (Exception) t
-                            );
-                        }
-                    }
-                    // Count the final outcome once per request (not per retry)
-                    countFinalOutcome(summary, t);
-                    recordTargetResponseCodes(summary);
-                    if (tupleWriter == null) {
-                        commitTrafficStreams(rrPair.completionStatus, rrPair.trafficStreamKeysBeingHeld);
-                    }
-                    return null;
-                } else {
-                    log.atError().setCause(t)
-                        .setMessage("Throwable passed to handle() for {}.  Rethrowing.").addArgument(context).log();
-                    throw Lombok.sneakyThrow(t);
+                if (t != null && !(t instanceof Exception)) {
+                    rethrowUnexpectedThrowable(context, t);
                 }
+                processCompletedTransaction(httpContext, rrPair, summary, (Exception) t);
+                return null;
             } catch (Error error) {
                 log.atError().setCause(error)
                     .setMessage("Caught error and initiating TrafficReplayer shutdown").log();
@@ -255,6 +223,95 @@ public abstract class TrafficReplayerCore extends RequestTransformerAndSender<Tr
                 requestWorkTracker.remove(requestKey);
                 log.atTrace().setMessage("removed rrPair.requestData from targetTransactionInProgressMap for {}").addArgument(requestKey).log();
             }
+        }
+
+        private void rethrowUnexpectedThrowable(
+            IReplayContexts.IReplayerHttpTransactionContext context,
+            Throwable t
+        ) {
+            log.atError().setCause(t)
+                .setMessage("Throwable passed to handle() for {}.  Rethrowing.")
+                .addArgument(context)
+                .log();
+            throw Lombok.sneakyThrow(t);
+        }
+
+        private void processCompletedTransaction(
+            IReplayContexts.IReplayerHttpTransactionContext httpContext,
+            RequestResponsePacketPair rrPair,
+            TransformedTargetRequestAndResponseList summary,
+            Exception requestFailure
+        ) {
+            try (var tupleHandlingContext = httpContext.createTupleContext()) {
+                if (!writeTupleOutput(httpContext, tupleHandlingContext, rrPair, summary, requestFailure)) {
+                    return;
+                }
+            }
+            // Count the final outcome once per request (not per retry)
+            countFinalOutcome(summary, requestFailure);
+            recordTargetResponseCodes(summary);
+            if (tupleWriter == null) {
+                commitTrafficStreams(rrPair.completionStatus, rrPair.trafficStreamKeysBeingHeld);
+            }
+        }
+
+        private boolean writeTupleOutput(
+            IReplayContexts.IReplayerHttpTransactionContext context,
+            IReplayContexts.ITupleHandlingContext tupleHandlingContext,
+            RequestResponsePacketPair rrPair,
+            TransformedTargetRequestAndResponseList summary,
+            Exception requestFailure
+        ) {
+            if (tupleWriter == null) {
+                packageAndWriteResponse(
+                    tupleHandlingContext,
+                    resultTupleConsumer,
+                    rrPair,
+                    summary,
+                    requestFailure
+                );
+                return true;
+            }
+
+            var writeFuture = tryPackageAndWriteTuple(context, tupleHandlingContext, rrPair, summary, requestFailure);
+            writeFuture.ifPresent(f -> f.whenComplete((v, writeErr) -> handleTupleWriteCompletion(context, rrPair, writeErr)));
+            return writeFuture.isPresent();
+        }
+
+        private Optional<CompletableFuture<Void>> tryPackageAndWriteTuple(
+            IReplayContexts.IReplayerHttpTransactionContext context,
+            IReplayContexts.ITupleHandlingContext tupleHandlingContext,
+            RequestResponsePacketPair rrPair,
+            TransformedTargetRequestAndResponseList summary,
+            Exception requestFailure
+        ) {
+            try {
+                return Optional.of(packageAndWriteTuple(
+                    tupleHandlingContext,
+                    tupleWriter,
+                    rrPair,
+                    summary,
+                    requestFailure
+                ));
+            } catch (Exception e) {
+                if (requestFailure != null) {
+                    throw e;
+                }
+                failReplayForTupleWrite(context, rrPair.trafficStreamKeysBeingHeld, e);
+                return Optional.empty();
+            }
+        }
+
+        private void handleTupleWriteCompletion(
+            IReplayContexts.IReplayerHttpTransactionContext context,
+            RequestResponsePacketPair rrPair,
+            Throwable writeErr
+        ) {
+            if (writeErr != null) {
+                failReplayForTupleWrite(context, rrPair.trafficStreamKeysBeingHeld, writeErr);
+                return;
+            }
+            commitTrafficStreams(rrPair.completionStatus, rrPair.trafficStreamKeysBeingHeld);
         }
 
         private void countFinalOutcome(TransformedTargetRequestAndResponseList summary, Throwable t) {
@@ -347,6 +404,28 @@ public abstract class TrafficReplayerCore extends RequestTransformerAndSender<Tr
             if (keys != null && !keys.isEmpty()) {
                 trafficCaptureSource.onConnectionAccumulationComplete(keys.get(0));
             }
+        }
+
+        private void failReplayForTupleWrite(
+            IReplayContexts.IReplayerHttpTransactionContext context,
+            List<ITrafficStreamKey> trafficStreamKeysBeingHeld,
+            Throwable failure
+        ) {
+            var unwrappedFailure = TrackedFuture.unwindPossibleCompletionException(failure);
+            var fatalError = new Error(
+                "Fatal tuple write failure for " + context + ". The replayer is stopping without "
+                    + "committing the held traffic stream offsets because tuple output was not durably written. "
+                    + "Fix the tuple sink failure before restarting; otherwise replay will remain blocked at "
+                    + "these offsets.",
+                unwrappedFailure
+            );
+            log.atError().setCause(unwrappedFailure)
+                .setMessage("Fatal tuple write failure for {} (streams={}); shutting down without committing offsets")
+                .addArgument(context)
+                .addArgument(trafficStreamKeysBeingHeld)
+                .log();
+            commitTrafficStreams(false, trafficStreamKeysBeingHeld);
+            shutdown(fatalError);
         }
 
         @Override

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/e2etests/TupleWriteBlockingBehaviorTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/e2etests/TupleWriteBlockingBehaviorTest.java
@@ -11,10 +11,12 @@ import java.util.Random;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.opensearch.migrations.replay.RootReplayerConstructorExtensions;
 import org.opensearch.migrations.replay.TestHttpServerContext;
 import org.opensearch.migrations.replay.TimeShifter;
+import org.opensearch.migrations.replay.TrafficReplayer;
 import org.opensearch.migrations.replay.sink.ThreadLocalTupleWriter;
 import org.opensearch.migrations.replay.sink.TupleSink;
 import org.opensearch.migrations.replay.traffic.source.ArrayCursorTrafficCaptureSource;
@@ -88,6 +90,29 @@ public class TupleWriteBlockingBehaviorTest extends InstrumentationTest {
                 heldFutures.clear();
             }
         }
+    }
+
+    static class FailingTupleSink implements TupleSink {
+        final CountDownLatch allAccepted;
+
+        FailingTupleSink(int expectedCount) {
+            this.allAccepted = new CountDownLatch(expectedCount);
+        }
+
+        @Override
+        public void accept(Map<String, Object> tupleMap, CompletableFuture<Void> future) {
+            allAccepted.countDown();
+            future.completeExceptionally(new RuntimeException("tuple write failed"));
+        }
+
+        @Override
+        public void flush() {}
+
+        @Override
+        public void periodicFlush() {}
+
+        @Override
+        public void close() {}
     }
 
     private TrafficStream buildTrafficStreamWithRequests(int numRequests) {
@@ -249,6 +274,65 @@ public class TupleWriteBlockingBehaviorTest extends InstrumentationTest {
                 // Clean up
                 latchedSink.releaseAll();
                 replayThread.join(30_000);
+                tr.shutdown(null).get();
+            }
+        }
+    }
+
+    @Test
+    public void tupleWriteFailureStopsReplayWithoutCommittingOffset() throws Throwable {
+        var random = new Random(1);
+        var failingSink = new FailingTupleSink(NUM_REQUESTS);
+
+        try (var httpServer = SimpleNettyHttpServer.makeServer(
+                false, Duration.ofMinutes(10),
+                response -> TestHttpServerContext.makeResponse(random, response))) {
+
+            var trafficStream = buildTrafficStreamWithRequests(NUM_REQUESTS);
+            var sourceContext = new ArrayCursorTrafficSourceContext(List.of(trafficStream));
+            var trafficSource = new ArrayCursorTrafficCaptureSource(rootContext, sourceContext);
+
+            var serverUri = httpServer.localhostEndpoint();
+            try (var tr = new RootReplayerConstructorExtensions(
+                    rootContext, serverUri,
+                    new StaticAuthTransformerFactory("TEST"),
+                    new TransformationLoader().getTransformerFactoryLoaderWithNewHostName(serverUri.getHost()),
+                    RootReplayerConstructorExtensions.makeNettyPacketConsumerConnectionPool(serverUri, 10),
+                    10 * 1024);
+                 var blockingTrafficSource = new BlockingTrafficSource(trafficSource, Duration.ofMinutes(2));
+                 var tupleWriter = new ThreadLocalTupleWriter(i -> failingSink)) {
+
+                var replayFailure = new AtomicReference<Throwable>();
+                var replayThread = new Thread(() -> {
+                    try {
+                        tr.setupRunAndWaitForReplayWithShutdownChecks(
+                            Duration.ofSeconds(70), Duration.ofSeconds(30),
+                            blockingTrafficSource, new TimeShifter(10 * 1000),
+                            tupleWriter, Duration.ofSeconds(5));
+                    } catch (Throwable t) {
+                        replayFailure.set(t);
+                        log.atError().setCause(t).setMessage("Replay thread exception").log();
+                    }
+                });
+                replayThread.start();
+
+                Assertions.assertTrue(
+                    failingSink.allAccepted.await(30, TimeUnit.SECONDS),
+                    "Timed out waiting for failing sink to accept all tuples"
+                );
+
+                replayThread.join(30_000);
+                Assertions.assertFalse(replayThread.isAlive(), "Replay thread should have finished");
+                Assertions.assertEquals(0, sourceContext.nextReadCursor.get(),
+                    "Offsets should not be committed after tuple write failure");
+                Assertions.assertInstanceOf(TrafficReplayer.TerminationException.class, replayFailure.get());
+                var termination = (TrafficReplayer.TerminationException) replayFailure.get();
+                Assertions.assertInstanceOf(Error.class, termination.originalCause);
+                Assertions.assertTrue(
+                    termination.originalCause.getMessage().contains("Fatal tuple write failure"),
+                    "Fatal shutdown should explain that tuple output was not durably written"
+                );
+
                 tr.shutdown(null).get();
             }
         }

--- a/TrafficCapture/tupleSink/build.gradle
+++ b/TrafficCapture/tupleSink/build.gradle
@@ -8,4 +8,8 @@ dependencies {
     implementation libs.slf4j.api
     implementation libs.aws.s3
     implementation libs.aws.crt
+
+    testImplementation libs.junit.jupiter.api
+    testImplementation libs.mockito.core
+    testRuntimeOnly libs.junit.jupiter.engine
 }

--- a/TrafficCapture/tupleSink/src/main/java/org/opensearch/migrations/replay/sink/S3TupleSink.java
+++ b/TrafficCapture/tupleSink/src/main/java/org/opensearch/migrations/replay/sink/S3TupleSink.java
@@ -3,6 +3,8 @@ package org.opensearch.migrations.replay.sink;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneOffset;
@@ -11,6 +13,12 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.zip.GZIPOutputStream;
 
@@ -21,13 +29,13 @@ import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
 /**
- * Writes tuples as gzip-compressed JSON lines directly to S3 via streaming PutObject.
+ * Writes tuples as gzip-compressed JSON lines to S3.
  *
- * <p>Each "file" is an in-flight S3 PutObject upload. Tuples are gzip-compressed and
- * streamed directly to S3 as they arrive — no in-memory buffering of the full object.
- * When the rotation threshold is reached (by uncompressed size, tuple count, or age),
- * the gzip stream is finished and the upload completes. A new upload is started for
- * subsequent tuples.</p>
+ * <p>Each "file" is first written to a local temp file and then uploaded with a
+ * single PutObject request when rotation is reached. This avoids buffering the full
+ * compressed object in memory and keeps the sink compatible with the standard
+ * {@link S3AsyncClient}, whose blocking stream request body can deadlock when opened
+ * from a single-threaded event loop.</p>
  *
  * <p>S3 key format: {@code {prefix}{replayerId}/{yyyy/MM/dd/HH}/tuples-{sinkIndex}-{timestamp}-{seq}.log.gz}</p>
  *
@@ -36,6 +44,8 @@ import software.amazon.awssdk.services.s3.model.PutObjectRequest;
  */
 @Slf4j
 public class S3TupleSink implements TupleSink {
+    static final Duration DEFAULT_UPLOAD_RETRY_DELAY = Duration.ofSeconds(10);
+
     private static final DateTimeFormatter TIMESTAMP_FORMAT =
         DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmmss'Z'").withZone(ZoneOffset.UTC);
     private static final DateTimeFormatter SHARD_FORMAT =
@@ -50,12 +60,16 @@ public class S3TupleSink implements TupleSink {
     private final long rotateAfterBytes;
     private final Duration rotateAfterAge;
     private final int rotateAfterTuples;
+    private final Duration uploadRetryDelay;
+    private final ScheduledExecutorService retryExecutor;
+    private final AtomicInteger activeUploads = new AtomicInteger();
+    private final AtomicBoolean closeRequested = new AtomicBoolean();
     private final AtomicLong sequenceCounter = new AtomicLong();
 
-    private OutputStream s3OutputStream;
+    private OutputStream fileOutputStream;
     private GZIPOutputStream gzipOut;
-    private CompletableFuture<Void> uploadFuture;
     private String currentKey;
+    private Path currentFile;
     private long uncompressedBytes;
     private int tupleCount;
     private Instant fileOpenedAt;
@@ -71,6 +85,30 @@ public class S3TupleSink implements TupleSink {
         Duration rotateAfterAge,
         int rotateAfterTuples
     ) {
+        this(
+            s3Client,
+            bucket,
+            prefix,
+            replayerId,
+            sinkIndex,
+            rotateAfterBytes,
+            rotateAfterAge,
+            rotateAfterTuples,
+            DEFAULT_UPLOAD_RETRY_DELAY
+        );
+    }
+
+    S3TupleSink(
+        S3AsyncClient s3Client,
+        String bucket,
+        String prefix,
+        String replayerId,
+        int sinkIndex,
+        long rotateAfterBytes,
+        Duration rotateAfterAge,
+        int rotateAfterTuples,
+        Duration uploadRetryDelay
+    ) {
         this.s3Client = s3Client;
         this.bucket = bucket;
         this.prefix = prefix;
@@ -79,6 +117,8 @@ public class S3TupleSink implements TupleSink {
         this.rotateAfterBytes = rotateAfterBytes;
         this.rotateAfterAge = rotateAfterAge;
         this.rotateAfterTuples = rotateAfterTuples;
+        this.uploadRetryDelay = uploadRetryDelay;
+        this.retryExecutor = Executors.newSingleThreadScheduledExecutor(makeRetryThreadFactory());
         openNewStream();
     }
 
@@ -96,7 +136,7 @@ public class S3TupleSink implements TupleSink {
             return;
         }
         if (shouldRotate()) {
-            rotate();
+            rotate(true);
         }
     }
 
@@ -105,28 +145,31 @@ public class S3TupleSink implements TupleSink {
         if (pendingFutures.isEmpty()) {
             return;
         }
-        rotate();
+        rotate(true);
     }
 
     @Override
     public void periodicFlush() {
         if (!pendingFutures.isEmpty()) {
-            rotate();
+            rotate(true);
         }
     }
 
     @Override
     public void close() {
+        closeRequested.set(true);
         if (gzipOut == null) {
+            shutdownRetryExecutorIfDone();
             return;
         }
         if (!pendingFutures.isEmpty()) {
-            rotate();
+            rotate(false);
         } else {
             closeCurrentStream();
+            deleteFile(currentFile);
+            clearCurrentStream();
         }
-        gzipOut = null;
-        s3OutputStream = null;
+        shutdownRetryExecutorIfDone();
     }
 
     private boolean shouldRotate() {
@@ -135,38 +178,41 @@ public class S3TupleSink implements TupleSink {
             || Duration.between(fileOpenedAt, Instant.now()).compareTo(rotateAfterAge) >= 0;
     }
 
-    private void rotate() {
+    private void rotate(boolean openNextStream) {
         var key = currentKey;
         var futures = new ArrayList<>(pendingFutures);
         pendingFutures.clear();
 
+        var file = currentFile;
         if (!closeCurrentStream()) {
+            deleteFile(file);
             futures.forEach(f -> f.completeExceptionally(
                 new IOException("Failed to finish gzip stream for s3://" + bucket + "/" + key)));
-            openNewStream();
+            if (openNextStream) {
+                openNewStream();
+            } else {
+                clearCurrentStream();
+            }
             return;
         }
 
         log.atInfo().setMessage("Completing S3 upload to s3://{}/{}").addArgument(bucket).addArgument(key).log();
 
-        uploadFuture.whenComplete((response, error) -> {
-            if (error != null) {
-                log.atError().setCause(error).setMessage("Failed to upload to s3://{}/{}")
-                    .addArgument(bucket).addArgument(key).log();
-                futures.forEach(f -> f.completeExceptionally(error));
-            } else {
-                futures.forEach(f -> f.complete(null));
-            }
-        });
+        activeUploads.incrementAndGet();
+        uploadFileWithRetries(key, file, futures, 1);
 
-        openNewStream();
+        if (openNextStream) {
+            openNewStream();
+        } else {
+            clearCurrentStream();
+        }
     }
 
-    /** Finish gzip and close the output stream, signaling upload completion. Returns true on success. */
+    /** Finish gzip and close the local temp file before upload. Returns true on success. */
     private boolean closeCurrentStream() {
         try {
             gzipOut.finish();
-            s3OutputStream.close();
+            fileOutputStream.close();
             return true;
         } catch (IOException e) {
             log.atError().setCause(e).setMessage("Failed to close S3 upload stream").log();
@@ -175,6 +221,9 @@ public class S3TupleSink implements TupleSink {
     }
 
     private String buildS3Key() {
+        // Keep time/sequence-based object names for now. Once Kafka identity is threaded
+        // into this sink, prefer keys or metadata that include partition/offset ranges
+        // plus a stable run id so downstream consumers can dedupe replay attempts.
         var now = Instant.now();
         var timestamp = TIMESTAMP_FORMAT.format(now);
         var shard = SHARD_FORMAT.format(now);
@@ -185,23 +234,88 @@ public class S3TupleSink implements TupleSink {
 
     private void openNewStream() {
         currentKey = buildS3Key();
-        var requestBody = AsyncRequestBody.forBlockingOutputStream(null);
-        var putRequest = PutObjectRequest.builder()
-            .bucket(bucket)
-            .key(currentKey)
-            .contentType("application/gzip")
-            .build();
-        uploadFuture = s3Client.putObject(putRequest, requestBody)
-            .thenApply(r -> null);
-
-        s3OutputStream = requestBody.outputStream();
         try {
-            gzipOut = new GZIPOutputStream(s3OutputStream, true);
+            currentFile = Files.createTempFile("tuple-sink-" + sinkIndex + "-", ".log.gz");
+            fileOutputStream = Files.newOutputStream(currentFile);
+            gzipOut = new GZIPOutputStream(fileOutputStream, true);
         } catch (IOException e) {
-            throw new UncheckedIOException("Failed to create gzip stream for S3 upload", e);
+            throw new UncheckedIOException("Failed to create gzip temp file for S3 upload", e);
         }
         uncompressedBytes = 0;
         tupleCount = 0;
         fileOpenedAt = Instant.now();
+    }
+
+    private void clearCurrentStream() {
+        gzipOut = null;
+        fileOutputStream = null;
+        currentFile = null;
+        currentKey = null;
+    }
+
+    private void uploadFileWithRetries(
+        String key,
+        Path file,
+        List<CompletableFuture<Void>> futures,
+        int attempt
+    ) {
+        uploadFile(key, file).whenComplete((response, error) -> {
+            if (error == null) {
+                deleteFile(file);
+                futures.forEach(f -> f.complete(null));
+                activeUploads.decrementAndGet();
+                shutdownRetryExecutorIfDone();
+                return;
+            }
+
+            log.atWarn().setCause(error).setMessage(
+                    "Failed to upload tuple file to s3://{}/{} on attempt {}; retrying in {} ms")
+                .addArgument(bucket)
+                .addArgument(key)
+                .addArgument(attempt)
+                .addArgument(uploadRetryDelay::toMillis)
+                .log();
+            retryExecutor.schedule(
+                () -> uploadFileWithRetries(key, file, futures, attempt + 1),
+                uploadRetryDelay.toMillis(),
+                TimeUnit.MILLISECONDS
+            );
+        });
+    }
+
+    private CompletableFuture<Void> uploadFile(String key, Path file) {
+        var putRequest = PutObjectRequest.builder()
+            .bucket(bucket)
+            .key(key)
+            .contentType("application/gzip")
+            .build();
+        return s3Client.putObject(putRequest, AsyncRequestBody.fromFile(file))
+            .thenApply(r -> null);
+    }
+
+    private ThreadFactory makeRetryThreadFactory() {
+        return runnable -> {
+            var thread = new Thread(runnable, "s3-tuple-sink-retry-" + sinkIndex);
+            thread.setDaemon(false);
+            return thread;
+        };
+    }
+
+    private void shutdownRetryExecutorIfDone() {
+        if (closeRequested.get() && activeUploads.get() == 0) {
+            retryExecutor.shutdown();
+        }
+    }
+
+    private void deleteFile(Path file) {
+        if (file == null) {
+            return;
+        }
+        try {
+            Files.deleteIfExists(file);
+        } catch (IOException e) {
+            log.atWarn().setCause(e).setMessage("Failed to delete S3 tuple temp file {}")
+                .addArgument(file).log();
+        }
     }
 }

--- a/TrafficCapture/tupleSink/src/test/java/org/opensearch/migrations/replay/sink/S3TupleSinkTest.java
+++ b/TrafficCapture/tupleSink/src/test/java/org/opensearch/migrations/replay/sink/S3TupleSinkTest.java
@@ -1,0 +1,173 @@
+package org.opensearch.migrations.replay.sink;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.core.async.AsyncRequestBody;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectResponse;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class S3TupleSinkTest {
+
+    private Map<String, Object> makeTuple(String id) {
+        var map = new LinkedHashMap<String, Object>();
+        map.put("connectionId", id);
+        map.put("numRequests", 1);
+        return map;
+    }
+
+    @Test
+    void flushWithoutPendingTuplesDoesNotUpload() {
+        var s3Client = mock(S3AsyncClient.class);
+
+        try (var sink = makeSink(s3Client, 1)) {
+            sink.flush();
+        }
+
+        verify(s3Client, never()).putObject(any(PutObjectRequest.class), any(AsyncRequestBody.class));
+    }
+
+    @Test
+    void serializationFailureCompletesOnlyThatTupleFuture() {
+        var s3Client = mock(S3AsyncClient.class);
+        var recursiveTuple = new LinkedHashMap<String, Object>();
+        recursiveTuple.put("self", recursiveTuple);
+
+        try (var sink = makeSink(s3Client, 1)) {
+            var future = new CompletableFuture<Void>();
+            sink.accept(recursiveTuple, future);
+
+            assertTrue(future.isCompletedExceptionally());
+            assertThrows(ExecutionException.class, () -> future.get(1, TimeUnit.SECONDS));
+        }
+
+        verify(s3Client, never()).putObject(any(PutObjectRequest.class), any(AsyncRequestBody.class));
+    }
+
+    @Test
+    void periodicFlushUploadsPendingTuple() throws Exception {
+        var s3Client = mock(S3AsyncClient.class);
+        var upload = new CompletableFuture<PutObjectResponse>();
+        var putCallCount = new AtomicInteger();
+
+        when(s3Client.putObject(any(PutObjectRequest.class), any(AsyncRequestBody.class)))
+            .thenAnswer(invocation -> {
+                putCallCount.incrementAndGet();
+                return upload;
+            });
+
+        try (var sink = makeSink(s3Client, 100)) {
+            var future = new CompletableFuture<Void>();
+            sink.accept(makeTuple("conn1.0"), future);
+            assertFalse(future.isDone(), "Tuple future should wait until the batch is uploaded");
+
+            sink.periodicFlush();
+            assertEquals(1, putCallCount.get(), "Periodic flush should upload the pending tuple batch");
+            assertFalse(future.isDone(), "Tuple future should still wait for the upload result");
+
+            upload.complete(PutObjectResponse.builder().build());
+            future.get(1, TimeUnit.SECONDS);
+        }
+    }
+
+    @Test
+    void closeUploadsPendingTuple() throws Exception {
+        var s3Client = mock(S3AsyncClient.class);
+        var upload = new CompletableFuture<PutObjectResponse>();
+        var putCallCount = new AtomicInteger();
+
+        when(s3Client.putObject(any(PutObjectRequest.class), any(AsyncRequestBody.class)))
+            .thenAnswer(invocation -> {
+                putCallCount.incrementAndGet();
+                return upload;
+            });
+
+        var sink = makeSink(s3Client, 100);
+        try {
+            var future = new CompletableFuture<Void>();
+            sink.accept(makeTuple("conn1.0"), future);
+
+            sink.close();
+            assertEquals(1, putCallCount.get(), "Close should upload pending tuples before releasing them");
+            assertFalse(future.isDone(), "Tuple future should still wait for the upload result");
+
+            upload.complete(PutObjectResponse.builder().build());
+            future.get(1, TimeUnit.SECONDS);
+        } finally {
+            sink.close();
+        }
+    }
+
+    @Test
+    void retriesUploadWithSameS3KeyUntilSuccess() throws Exception {
+        var s3Client = mock(S3AsyncClient.class);
+        var putRequests = new CopyOnWriteArrayList<PutObjectRequest>();
+        var putCallCount = new AtomicInteger();
+        var successfulRetry = new CompletableFuture<PutObjectResponse>();
+
+        when(s3Client.putObject(any(PutObjectRequest.class), any(AsyncRequestBody.class)))
+            .thenAnswer(invocation -> {
+                putRequests.add(invocation.getArgument(0));
+                var call = putCallCount.incrementAndGet();
+                if (call < 3) {
+                    return CompletableFuture.failedFuture(new IOException("S3 unavailable"));
+                }
+                return successfulRetry;
+            });
+
+        try (var sink = makeSink(s3Client, 1)) {
+
+            var future = new CompletableFuture<Void>();
+            sink.accept(makeTuple("conn1.0"), future);
+
+            waitForPutCalls(putCallCount, 3);
+            assertFalse(future.isDone(), "Tuple future should remain pending until an upload succeeds");
+            assertEquals(putRequests.get(0).key(), putRequests.get(1).key());
+            assertEquals(putRequests.get(1).key(), putRequests.get(2).key());
+
+            successfulRetry.complete(PutObjectResponse.builder().build());
+            future.get(1, TimeUnit.SECONDS);
+        }
+    }
+
+    private void waitForPutCalls(AtomicInteger putCallCount, int expectedCalls) throws InterruptedException {
+        var deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(2);
+        while (putCallCount.get() < expectedCalls && System.nanoTime() < deadline) {
+            Thread.sleep(10);
+        }
+        assertEquals(expectedCalls, putCallCount.get(), "Unexpected S3 putObject attempt count");
+    }
+
+    private S3TupleSink makeSink(S3AsyncClient s3Client, int rotateAfterTuples) {
+        return new S3TupleSink(
+            s3Client,
+            "bucket",
+            "tuples/",
+            "replayer-1",
+            0,
+            1024 * 1024,
+            Duration.ofMinutes(10),
+            rotateAfterTuples,
+            Duration.ofMillis(10)
+        );
+    }
+}


### PR DESCRIPTION
### Description
Tuple S3 output now writes each gzip JSON-lines batch to a local temp file before uploading it to S3, then retries transient S3 upload failures indefinitely with the same object key while keeping the tuple futures pending. This policy keeps replay progress tied to durable tuple output without buffering full objects in memory or losing already captured tuple data when S3 is temporarily unavailable.

Hard tuple write failures now fail fast instead of quietly leaving offsets uncommitted. Local file creation, serialization, gzip close, or sink-level exceptional futures shut down the replayer with a clear fatal error and do not commit the held traffic stream offsets, so operators see an explicit failure rather than a replayer that restarts and stalls at the same point.

The tuple sink and replayer tests cover same-key S3 retry, source commit gating on tuple future completion, nonblocking handling of later requests while tuple futures are pending, and fatal shutdown without offset commit for hard tuple write failures.

### Check List
- [ ] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
