### PR TITLE
Local k8s default strimzi probes

### DIFF
--- a/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/valuesForLocalK8s.yaml
+++ b/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/valuesForLocalK8s.yaml
@@ -72,18 +72,6 @@ charts:
   strimzi-kafka-operator:
     waitForInstallation: false
     values:
-      # Decrease probe thresholds to make deployment times faster (but less reliable under stress)
-      readinessProbe:
-        initialDelaySeconds: 5
-        periodSeconds: 2
-        timeoutSeconds: 5
-        failureThreshold: 1
-      livenessProbe:
-        initialDelaySeconds: 5
-        periodSeconds: 2
-        timeoutSeconds: 3
-        failureThreshold: 1
-
       # Recommended baseline resources to ensure the JVM has enough heap for metadata
       resources:
         requests:
@@ -92,28 +80,6 @@ charts:
         limits:
           cpu: "1000m"
           memory: "1Gi"
-
-      # Similar to the timeouts for the operator, clock some probes way down to speed up deployments
-      kafka:
-        template:
-          pod:
-            readinessProbe:
-              initialDelaySeconds: 5
-              periodSeconds: 5
-              timeoutSeconds: 3
-              failureThreshold: 1
-
-        readinessProbe:
-          initialDelaySeconds: 5
-          periodSeconds: 2
-          timeoutSeconds: 3
-          failureThreshold: 1
-        livenessProbe:
-          initialDelaySeconds: 5
-          periodSeconds: 2
-          timeoutSeconds: 3
-          failureThreshold: 1
-
 
   argo-workflows:
     waitForInstallation: false

--- a/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/valuesForLocalK8sWithEnvSubst.yaml
+++ b/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/valuesForLocalK8sWithEnvSubst.yaml
@@ -57,18 +57,6 @@ charts:
   strimzi-kafka-operator:
     waitForInstallation: false
     values:
-      # Decrease probe thresholds to make deployment times faster (but less reliable under stress)
-      readinessProbe:
-        initialDelaySeconds: 5
-        periodSeconds: 2
-        timeoutSeconds: 5
-        failureThreshold: 1
-      livenessProbe:
-        initialDelaySeconds: 5
-        periodSeconds: 2
-        timeoutSeconds: 3
-        failureThreshold: 1
-
       # Recommended baseline resources to ensure the JVM has enough heap for metadata
       resources:
         requests:
@@ -77,28 +65,6 @@ charts:
         limits:
           cpu: "1000m"
           memory: "1Gi"
-
-      # Similar to the timeouts for the operator, clock some probes way down to speed up deployments
-      kafka:
-        template:
-          pod:
-            readinessProbe:
-              initialDelaySeconds: 5
-              periodSeconds: 5
-              timeoutSeconds: 3
-              failureThreshold: 1
-
-        readinessProbe:
-          initialDelaySeconds: 5
-          periodSeconds: 2
-          timeoutSeconds: 3
-          failureThreshold: 1
-        livenessProbe:
-          initialDelaySeconds: 5
-          periodSeconds: 2
-          timeoutSeconds: 3
-          failureThreshold: 1
-
 
   argo-workflows:
     waitForInstallation: false


### PR DESCRIPTION
### Description

Disable local-testing overrides that were supposed to make Kafka operations more responsive.

These overrides were causing a lot of instability in local tests - having behaviors that were different than what they were for production AND having less stability is no longer attractive/acceptable.

### Check List
- [ ] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
