### PR TITLE
Add interactive workflow schema reference viewer as GitHub Pages

### DIFF
--- a/.github/workflows/deploy-schema-viewer.yml
+++ b/.github/workflows/deploy-schema-viewer.yml
@@ -1,0 +1,72 @@
+name: Deploy schema viewer to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'schema-viewer/**'
+      - '.github/workflows/deploy-schema-viewer.yml'
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Deploy to GitHub Pages
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Fetch schemas from GitHub Releases
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mkdir -p schema-viewer/schemas
+
+          # Fetch all releases that include the schema asset (newest first)
+          gh api repos/opensearch-project/opensearch-migrations/releases \
+            --paginate \
+            --jq '.[] | select(.assets | map(.name) | contains(["workflowMigration.schema.json"]))
+                      | .tag_name + " " + (.assets[] | select(.name == "workflowMigration.schema.json") | .browser_download_url)' \
+            > /tmp/schema-releases.txt
+
+          declare -a versions
+          while IFS=' ' read -r tag url; do
+            echo "Downloading schema for $tag..."
+            curl -fsSL "$url" -o "schema-viewer/schemas/${tag}.json"
+            versions+=("$tag")
+          done < /tmp/schema-releases.txt
+
+          node - "${versions[@]}" <<'EOF'
+          const fs = require('fs')
+          const versions = process.argv.slice(2)
+          if (versions.length === 0) { console.error('No schema versions found'); process.exit(1) }
+          const meta = { latest: versions[0], versions }
+          fs.writeFileSync('schema-viewer/schemas/versions.json', JSON.stringify(meta, null, 2) + '\n')
+          console.log(`Generated versions.json: latest=${meta.latest}, count=${versions.length}`)
+          EOF
+
+      - name: Configure Pages
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5
+        with:
+          path: schema-viewer
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,9 @@ TrafficCapture/dockerSolution/src/main/docker/migrationConsole/staging
 DocumentsFromSnapshotMigration/docker/snapshots/
 transformation/standardJavascriptTransforms/coverage/
 transformation/standardJavascriptTransforms/node_modules/
+schema-viewer/node_modules/
+schema-viewer/package-lock.json
+schema-viewer/schemas/
 orchestrationSpecs/k8sResources/
 orchestrationSpecs/dist/
 orchestrationSpecs/node_modules/

--- a/schema-viewer/README.md
+++ b/schema-viewer/README.md
@@ -1,0 +1,80 @@
+# Schema Viewer
+
+An interactive browser for `workflowMigration.schema.json`. Two-column layout: a collapsible field tree on the left, a detail card on the right. No build step — four static files served directly.
+
+**Live site:** `https://opensearch-project.github.io/opensearch-migrations/`
+
+## Features
+
+- Collapsible sidebar tree with live search
+- Field cards showing type, requirement, default, and description
+- `oneOf`/`anyOf` variant rows and per-variant property tables
+- Expert field labelling — fields whose description begins with `[Expert]` get a badge and the prefix is stripped from the visible text
+- Version selector — switch between all schema releases that include the asset
+- Change summary — automatically diffs the selected version against any older version (defaulting to the immediate predecessor) and highlights added, removed, and modified fields at any depth in the schema tree
+
+## Running locally
+
+Schema files are not stored in the repository — they are fetched from GitHub Releases at deploy time. Before starting the dev server for the first time (or after a new release), download them locally:
+
+```sh
+cd schema-viewer
+npm run fetch-schemas   # requires gh CLI, authenticated to GitHub
+npm run dev
+```
+
+Then open `http://localhost:3000/`. The dev server serves the `schema-viewer/` directory directly.
+
+`fetch-schemas` is idempotent — re-running it overwrites existing files with the latest state. The `schemas/` directory is gitignored, so downloaded files never get committed accidentally.
+
+## Running tests
+
+```sh
+npm test          # single run
+npm run test:watch  # re-runs on every file save
+```
+
+Tests cover the pure logic in `schema-utils.js` — tree building, search filtering, type labels, variant titles, expert-field helpers, and the change summary diff logic. DOM rendering is not unit tested.
+
+## File structure
+
+| File | Purpose |
+|---|---|
+| `index.html` | HTML shell — version selector, search input, tree and detail panel |
+| `viewer.js` | DOM rendering, event wiring, fetch/init logic |
+| `schema-utils.js` | Pure logic functions — tree building, type helpers, expert-field handling, schema diff |
+| `schema-utils.test.js` | Vitest unit tests for `schema-utils.js` |
+| `viewer.css` | Styles |
+| `fetch-schemas.sh` | Downloads all schema versions locally for development |
+| `schemas/versions.json` | Generated — not committed; created by deploy workflow or `fetch-schemas.sh` |
+| `schemas/<version>.json` | Generated — not committed; one file per release |
+
+## Schema versions
+
+Schema files are **not stored in this repository**. They are downloaded from GitHub Release assets at deploy time by `.github/workflows/deploy-schema-viewer.yml`.
+
+On each deployment the workflow:
+
+1. Queries the `opensearch-project/opensearch-migrations` Releases API for all releases that include `workflowMigration.schema.json`
+2. Downloads each schema to `schemas/<version>.json`
+3. Generates `schemas/versions.json` with the ordered version list and `latest` pointer
+
+A new schema version becomes available in the viewer automatically when its GitHub Release is published — no manual steps or commits required.
+
+## Known limitations
+
+The change summary flattens the fully resolved schema into a path map (e.g. `source/cluster/auth/type`) and diffs the two maps. It tracks additions, removals, and scalar changes (`type`, `default`, `required`) at any depth. The following cases may not surface cleanly:
+
+- **Changes to shared definitions** — because the diff uses the resolved schema, a change inside a shared `$ref` definition will appear once per field that references it. This is accurate (all those fields are affected) but can produce many similar-looking entries for a single underlying definition change.
+- **Reordered `oneOf`/`anyOf` branches** — branch reordering is not tracked as a change; only changes to the branch's `type` label or scalar properties are.
+- **Description-only changes** — `description` is intentionally excluded from the diff snapshot. It is prose, not configuration, so changes to it are not surfaced.
+
+The viewer tree itself always reflects the fully resolved schema, so all information is visible — the change summary is an additional convenience layer on top of it.
+
+## Deployment
+
+`.github/workflows/deploy-schema-viewer.yml` triggers on:
+
+- **Push to `main`** touching `schema-viewer/**` — for viewer code changes
+- **Release published** — picks up the new schema and redeploys
+- **Manual** via `workflow_dispatch`

--- a/schema-viewer/fetch-schemas.sh
+++ b/schema-viewer/fetch-schemas.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Downloads all schema versions from GitHub Releases into schemas/ for local development.
+# Mirrors the fetch step in .github/workflows/deploy-schema-viewer.yml.
+# Requires: gh CLI (authenticated), curl, node
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCHEMAS_DIR="$SCRIPT_DIR/schemas"
+mkdir -p "$SCHEMAS_DIR"
+
+echo "Fetching schema release list..."
+gh api repos/opensearch-project/opensearch-migrations/releases \
+  --paginate \
+  --jq '.[] | select(.assets | map(.name) | contains(["workflowMigration.schema.json"]))
+            | .tag_name + " " + (.assets[] | select(.name == "workflowMigration.schema.json") | .browser_download_url)' \
+  > /tmp/schema-releases.txt
+
+declare -a versions
+while IFS=' ' read -r tag url; do
+  echo "  Downloading $tag..."
+  curl -fsSL "$url" -o "$SCHEMAS_DIR/${tag}.json"
+  versions+=("$tag")
+done < /tmp/schema-releases.txt
+
+if [ ${#versions[@]} -eq 0 ]; then
+  echo "No schema versions found." >&2
+  exit 1
+fi
+
+node - "$SCHEMAS_DIR/versions.json" "${versions[@]}" <<'EOF'
+const fs = require('fs')
+const [outFile, ...versions] = process.argv.slice(2)
+const meta = { latest: versions[0], versions }
+fs.writeFileSync(outFile, JSON.stringify(meta, null, 2) + '\n')
+console.log(`✓ ${versions.length} schemas ready. Latest: ${meta.latest}`)
+EOF

--- a/schema-viewer/index.html
+++ b/schema-viewer/index.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Schema Viewer</title>
+    <link rel="stylesheet" href="viewer.css" />
+  </head>
+  <body>
+    <h1>Schema Viewer</h1>
+    <p class="subtitle">
+      Interactive reference for the OpenSearch Migration Assistant configuration schema.
+      Browse fields in the tree, click one to see its type, requirement, default, and description.
+    </p>
+
+    <div class="status-bar">
+      <label class="version-label" for="version-select">Version</label>
+      <select id="version-select" class="version-select"></select>
+      <span class="badge-pill info" id="status">Loading…</span>
+    </div>
+
+    <div class="viewer">
+      <div class="sidebar" id="sidebar">
+        <div class="search-wrap">
+          <input class="search-input" id="search" placeholder="Search fields…" />
+        </div>
+        <div class="tree-controls">
+          <a href="#" id="expand-all">Expand all</a>
+          <span>·</span>
+          <a href="#" id="collapse-all">Collapse all</a>
+        </div>
+        <div class="tree-scroll" id="tree"></div>
+      </div>
+      <div class="divider" id="divider"></div>
+      <div class="main" id="main"></div>
+    </div>
+
+    <script type="module" src="viewer.js"></script>
+  </body>
+</html>

--- a/schema-viewer/package.json
+++ b/schema-viewer/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "schema-viewer",
+  "private": true,
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "fetch-schemas": "bash fetch-schemas.sh",
+    "dev": "npx serve .",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "devDependencies": {
+    "jsondiffpatch": "^0.6.0",
+    "vitest": "^2.0.0"
+  }
+}

--- a/schema-viewer/schema-utils.js
+++ b/schema-viewer/schema-utils.js
@@ -12,37 +12,44 @@ export function buildNode(name, schema, pathArr, requiredSet = new Set()) {
   }
 }
 
-export function buildChildren(schema, parentPath) {
-  const children = []
+function propertyChildren(schema, parentPath) {
+  if (!schema.properties) return []
   const required = new Set(schema.required || [])
+  return Object.entries(schema.properties)
+    .map(([k, v]) => buildNode(k, v, [...parentPath, k], required))
+    .filter(Boolean)
+}
 
-  if (schema.properties) {
-    for (const [k, v] of Object.entries(schema.properties)) {
-      const node = buildNode(k, v, [...parentPath, k], required)
-      if (node) children.push(node)
-    }
-  }
+function additionalPropertyChildren(schema, parentPath) {
+  if (!isObjectSchema(schema.additionalProperties)) return []
+  const node = buildNode('[value]', schema.additionalProperties, [...parentPath, '[value]'])
+  return node ? [node] : []
+}
 
-  if (schema.additionalProperties && typeof schema.additionalProperties === 'object') {
-    const node = buildNode('[value]', schema.additionalProperties, [...parentPath, '[value]'])
-    if (node) children.push(node)
-  }
-
-  const unionKey = schema.oneOf ? 'oneOf' : schema.anyOf ? 'anyOf' : null
-  if (unionKey) {
-    schema[unionKey].forEach((branch, i) => {
+function unionChildren(schema, parentPath) {
+  const unionKey = unionKeyOf(schema)
+  if (!unionKey) return []
+  return schema[unionKey]
+    .map((branch, i) => {
       const label = branch.title || `${unionKey}[${i}]`
-      const node = buildNode(label, branch, [...parentPath, label])
-      if (node) children.push(node)
+      return buildNode(label, branch, [...parentPath, label])
     })
-  }
+    .filter(Boolean)
+}
 
-  if (schema.type === 'array' && schema.items) {
-    const node = buildNode('items', schema.items, [...parentPath, 'items'])
-    if (node) children.push(node)
-  }
+function itemChildren(schema, parentPath) {
+  if (schema.type !== 'array' || !schema.items) return []
+  const node = buildNode('items', schema.items, [...parentPath, 'items'])
+  return node ? [node] : []
+}
 
-  return children
+export function buildChildren(schema, parentPath) {
+  return [
+    ...propertyChildren(schema, parentPath),
+    ...additionalPropertyChildren(schema, parentPath),
+    ...unionChildren(schema, parentPath),
+    ...itemChildren(schema, parentPath),
+  ]
 }
 
 export function nodeMatchesSearch(node, term) {
@@ -57,6 +64,19 @@ export function getTypeLabel(schema) {
   if (schema.allOf) return 'allOf'
   if (Array.isArray(schema.type)) return schema.type.join(' | ')
   return schema.type || 'any'
+}
+
+// Returns the union keyword used by a schema ('oneOf' / 'anyOf'), or null.
+export function unionKeyOf(schema) {
+  if (schema.oneOf) return 'oneOf'
+  if (schema.anyOf) return 'anyOf'
+  return null
+}
+
+// True when a value is a schema object (as opposed to a boolean like
+// `additionalProperties: true`).
+export function isObjectSchema(s) {
+  return !!s && typeof s === 'object'
 }
 
 export function typeBadgeClass(t) {
@@ -90,63 +110,73 @@ export function variantDesc(branch) {
 // it, which is accurate — all those fields are affected.
 //
 // `differ` is a jsondiffpatch instance, injected for testability.
-export function computeSchemaDiff(oldSchema, newSchema, differ) {
-  function flatten(schema) {
-    const map = {}
-    const visited = new WeakSet()
 
-    function walk(node, pathParts) {
-      if (!node || typeof node !== 'object' || visited.has(node)) return
-      visited.add(node)
+// Builds the path → scalar snapshot recorded for a single schema node.
+function snapshotOf(schema, required) {
+  const snap = { type: getTypeLabel(schema), required }
+  if (schema.default !== undefined) snap.default = JSON.stringify(schema.default)
+  return snap
+}
 
-      const req = new Set(node.required || [])
-
-      if (node.properties) {
-        for (const [k, v] of Object.entries(node.properties)) {
-          const path = [...pathParts, k]
-          const snap = { type: getTypeLabel(v), required: req.has(k) }
-          if (v.default !== undefined) snap.default = JSON.stringify(v.default)
-          map[path.join('/')] = snap
-          walk(v, path)
-        }
-      }
-
-      if (node.additionalProperties && typeof node.additionalProperties === 'object') {
-        const path = [...pathParts, '[value]']
-        const v = node.additionalProperties
-        const snap = { type: getTypeLabel(v), required: false }
-        if (v.default !== undefined) snap.default = JSON.stringify(v.default)
-        map[path.join('/')] = snap
-        walk(v, path)
-      }
-
-      const unionKey = node.oneOf ? 'oneOf' : node.anyOf ? 'anyOf' : null
-      if (unionKey) {
-        node[unionKey].forEach((branch, i) => {
-          const label = branch.title || `${unionKey}[${i}]`
-          const path = [...pathParts, label]
-          const snap = { type: getTypeLabel(branch), required: false }
-          if (branch.default !== undefined) snap.default = JSON.stringify(branch.default)
-          map[path.join('/')] = snap
-          walk(branch, path)
-        })
-      }
-
-      if (node.type === 'array' && node.items) {
-        const path = [...pathParts, 'items']
-        const v = node.items
-        const snap = { type: getTypeLabel(v), required: false }
-        if (v.default !== undefined) snap.default = JSON.stringify(v.default)
-        map[path.join('/')] = snap
-        walk(v, path)
-      }
+// Yields [label, childSchema, isRequired] for every child the tree walks into,
+// covering properties, the additionalProperties value, union branches, and array
+// items — mirroring buildChildren so diff paths match the rendered tree.
+function* schemaChildren(node) {
+  if (node.properties) {
+    const req = new Set(node.required || [])
+    for (const [k, v] of Object.entries(node.properties)) yield [k, v, req.has(k)]
+  }
+  if (isObjectSchema(node.additionalProperties)) {
+    yield ['[value]', node.additionalProperties, false]
+  }
+  const unionKey = unionKeyOf(node)
+  if (unionKey) {
+    for (const [i, branch] of node[unionKey].entries()) {
+      yield [branch.title || `${unionKey}[${i}]`, branch, false]
     }
+  }
+  if (node.type === 'array' && node.items) {
+    yield ['items', node.items, false]
+  }
+}
 
-    walk(schema, [])
-    return map
+// Flattens a resolved schema tree into a map of path → scalar snapshot.
+function flattenSchema(schema) {
+  const map = {}
+  const visited = new WeakSet()
+
+  function walk(node, pathParts) {
+    if (!isObjectSchema(node) || visited.has(node)) return
+    visited.add(node)
+    for (const [label, child, required] of schemaChildren(node)) {
+      const path = [...pathParts, label]
+      map[path.join('/')] = snapshotOf(child, required)
+      walk(child, path)
+    }
   }
 
-  const delta = differ.diff(flatten(oldSchema), flatten(newSchema))
+  walk(schema, [])
+  return map
+}
+
+// Interprets a jsondiffpatch default-value delta ([added] / [old,0,0] / [old,new]).
+function defaultChange(d) {
+  if (d.default.length === 1) return { kind: 'default', from: undefined, to: d.default[0] }
+  if (d.default.length === 3) return { kind: 'default', from: d.default[0], to: undefined }
+  return { kind: 'default', from: d.default[0], to: d.default[1] }
+}
+
+// Collects the scalar field changes (type / default / required) from a delta object.
+function scalarChanges(d) {
+  const changes = []
+  if (d.type) changes.push({ kind: 'type', from: d.type[0], to: d.type[1] })
+  if (d.default) changes.push(defaultChange(d))
+  if (d.required) changes.push({ kind: 'required', from: d.required[0], to: d.required[1] })
+  return changes
+}
+
+export function computeSchemaDiff(oldSchema, newSchema, differ) {
+  const delta = differ.diff(flattenSchema(oldSchema), flattenSchema(newSchema))
   const added = [], removed = [], modified = []
   if (!delta) return { added, removed, modified }
 
@@ -155,14 +185,7 @@ export function computeSchemaDiff(oldSchema, newSchema, differ) {
       if (d.length === 1) added.push(path)
       else if (d.length === 3 && d[1] === 0 && d[2] === 0) removed.push(path)
     } else if (d && typeof d === 'object' && !d._t) {
-      const changes = []
-      if (d.type) changes.push({ kind: 'type', from: d.type[0], to: d.type[1] })
-      if (d.default) {
-        if (d.default.length === 1)      changes.push({ kind: 'default', from: undefined,    to: d.default[0] })
-        else if (d.default.length === 3) changes.push({ kind: 'default', from: d.default[0], to: undefined })
-        else                             changes.push({ kind: 'default', from: d.default[0], to: d.default[1] })
-      }
-      if (d.required) changes.push({ kind: 'required', from: d.required[0], to: d.required[1] })
+      const changes = scalarChanges(d)
       if (changes.length) modified.push({ path, changes })
     }
   }

--- a/schema-viewer/schema-utils.js
+++ b/schema-viewer/schema-utils.js
@@ -1,0 +1,192 @@
+// ── Tree builder ──────────────────────────────────────────────────────────────
+
+export function buildNode(name, schema, pathArr, requiredSet = new Set()) {
+  if (!schema || typeof schema !== 'object') return null
+  return {
+    name,
+    pathArr,
+    key: pathArr.join('/'),
+    schema,
+    required: requiredSet.has(name),
+    children: buildChildren(schema, pathArr),
+  }
+}
+
+export function buildChildren(schema, parentPath) {
+  const children = []
+  const required = new Set(schema.required || [])
+
+  if (schema.properties) {
+    for (const [k, v] of Object.entries(schema.properties)) {
+      const node = buildNode(k, v, [...parentPath, k], required)
+      if (node) children.push(node)
+    }
+  }
+
+  if (schema.additionalProperties && typeof schema.additionalProperties === 'object') {
+    const node = buildNode('[value]', schema.additionalProperties, [...parentPath, '[value]'])
+    if (node) children.push(node)
+  }
+
+  const unionKey = schema.oneOf ? 'oneOf' : schema.anyOf ? 'anyOf' : null
+  if (unionKey) {
+    schema[unionKey].forEach((branch, i) => {
+      const label = branch.title || `${unionKey}[${i}]`
+      const node = buildNode(label, branch, [...parentPath, label])
+      if (node) children.push(node)
+    })
+  }
+
+  if (schema.type === 'array' && schema.items) {
+    const node = buildNode('items', schema.items, [...parentPath, 'items'])
+    if (node) children.push(node)
+  }
+
+  return children
+}
+
+export function nodeMatchesSearch(node, term) {
+  if (node.name.toLowerCase().includes(term)) return true
+  return node.children.some(c => nodeMatchesSearch(c, term))
+}
+
+// ── Type helpers ──────────────────────────────────────────────────────────────
+
+export function getTypeLabel(schema) {
+  if (schema.oneOf || schema.anyOf) return 'union'
+  if (schema.allOf) return 'allOf'
+  if (Array.isArray(schema.type)) return schema.type.join(' | ')
+  return schema.type || 'any'
+}
+
+export function typeBadgeClass(t) {
+  const map = {
+    string: 'type-string', object: 'type-object', boolean: 'type-boolean',
+    array: 'type-array', integer: 'type-integer', number: 'type-number', union: 'type-union',
+  }
+  return `badge type-badge ${map[t] || ''}`
+}
+
+export function variantTitle(branch, i, unionKey) {
+  if (branch.title) return branch.title
+  const enumVal = branch.properties?.type?.enum?.[0]
+  if (enumVal) return enumVal
+  return `${unionKey}[${i}]`
+}
+
+export function variantDesc(branch) {
+  const props = Object.keys(branch.properties || {}).filter(k => k !== 'type')
+  return props.length ? `Requires ${props.join(', ')}.` : 'No additional properties required.'
+}
+
+// ── Schema diff ───────────────────────────────────────────────────────────────
+
+// Flattens the resolved schema tree into a map of path → scalar snapshot, then
+// diffs the two maps to detect additions, removals, and scalar changes at any
+// depth. Paths mirror the tree (e.g. "source/cluster/auth/type").
+//
+// Expects resolved (dereferenced) schemas so that $ref nodes are fully expanded.
+// Changes to a shared definition will therefore appear once per field that uses
+// it, which is accurate — all those fields are affected.
+//
+// `differ` is a jsondiffpatch instance, injected for testability.
+export function computeSchemaDiff(oldSchema, newSchema, differ) {
+  function flatten(schema) {
+    const map = {}
+    const visited = new WeakSet()
+
+    function walk(node, pathParts) {
+      if (!node || typeof node !== 'object' || visited.has(node)) return
+      visited.add(node)
+
+      const req = new Set(node.required || [])
+
+      if (node.properties) {
+        for (const [k, v] of Object.entries(node.properties)) {
+          const path = [...pathParts, k]
+          const snap = { type: getTypeLabel(v), required: req.has(k) }
+          if (v.default !== undefined) snap.default = JSON.stringify(v.default)
+          map[path.join('/')] = snap
+          walk(v, path)
+        }
+      }
+
+      if (node.additionalProperties && typeof node.additionalProperties === 'object') {
+        const path = [...pathParts, '[value]']
+        const v = node.additionalProperties
+        const snap = { type: getTypeLabel(v), required: false }
+        if (v.default !== undefined) snap.default = JSON.stringify(v.default)
+        map[path.join('/')] = snap
+        walk(v, path)
+      }
+
+      const unionKey = node.oneOf ? 'oneOf' : node.anyOf ? 'anyOf' : null
+      if (unionKey) {
+        node[unionKey].forEach((branch, i) => {
+          const label = branch.title || `${unionKey}[${i}]`
+          const path = [...pathParts, label]
+          const snap = { type: getTypeLabel(branch), required: false }
+          if (branch.default !== undefined) snap.default = JSON.stringify(branch.default)
+          map[path.join('/')] = snap
+          walk(branch, path)
+        })
+      }
+
+      if (node.type === 'array' && node.items) {
+        const path = [...pathParts, 'items']
+        const v = node.items
+        const snap = { type: getTypeLabel(v), required: false }
+        if (v.default !== undefined) snap.default = JSON.stringify(v.default)
+        map[path.join('/')] = snap
+        walk(v, path)
+      }
+    }
+
+    walk(schema, [])
+    return map
+  }
+
+  const delta = differ.diff(flatten(oldSchema), flatten(newSchema))
+  const added = [], removed = [], modified = []
+  if (!delta) return { added, removed, modified }
+
+  for (const [path, d] of Object.entries(delta)) {
+    if (Array.isArray(d)) {
+      if (d.length === 1) added.push(path)
+      else if (d.length === 3 && d[1] === 0 && d[2] === 0) removed.push(path)
+    } else if (d && typeof d === 'object' && !d._t) {
+      const changes = []
+      if (d.type) changes.push({ kind: 'type', from: d.type[0], to: d.type[1] })
+      if (d.default) {
+        if (d.default.length === 1)      changes.push({ kind: 'default', from: undefined,    to: d.default[0] })
+        else if (d.default.length === 3) changes.push({ kind: 'default', from: d.default[0], to: undefined })
+        else                             changes.push({ kind: 'default', from: d.default[0], to: d.default[1] })
+      }
+      if (d.required) changes.push({ kind: 'required', from: d.required[0], to: d.required[1] })
+      if (changes.length) modified.push({ path, changes })
+    }
+  }
+
+  return { added, removed, modified }
+}
+
+// ── Composite field helper ────────────────────────────────────────────────────
+
+export function isComposite(schema) {
+  return !!(
+    schema.properties ||
+    schema.oneOf || schema.anyOf || schema.allOf ||
+    (schema.additionalProperties && typeof schema.additionalProperties === 'object') ||
+    (schema.type === 'array' && schema.items)
+  )
+}
+
+// ── Expert field helpers ──────────────────────────────────────────────────────
+
+export function isExpert(desc) {
+  return typeof desc === 'string' && desc.startsWith('[Expert]')
+}
+
+export function stripExpert(desc) {
+  return desc ? desc.replace(/^\[Expert\]\s*/, '') : desc
+}

--- a/schema-viewer/schema-utils.test.js
+++ b/schema-viewer/schema-utils.test.js
@@ -1,0 +1,433 @@
+import { describe, it, expect, beforeAll } from 'vitest'
+import { create as createDiffer } from 'jsondiffpatch'
+import {
+  buildNode, buildChildren, nodeMatchesSearch,
+  getTypeLabel, typeBadgeClass, variantTitle, variantDesc,
+  isExpert, stripExpert, computeSchemaDiff,
+} from './schema-utils.js'
+
+let differ
+beforeAll(() => { differ = createDiffer() })
+
+// ── isExpert / stripExpert ────────────────────────────────────────────────────
+
+describe('isExpert', () => {
+  it('returns true for [Expert]-prefixed description', () => {
+    expect(isExpert('[Expert] Advanced tuning option')).toBe(true)
+  })
+  it('returns false for a normal description', () => {
+    expect(isExpert('The target cluster hostname')).toBe(false)
+  })
+  it('returns false for an empty string', () => {
+    expect(isExpert('')).toBe(false)
+  })
+  it('returns false for null and undefined', () => {
+    expect(isExpert(null)).toBe(false)
+    expect(isExpert(undefined)).toBe(false)
+  })
+})
+
+describe('stripExpert', () => {
+  it('removes the [Expert] prefix and leading space', () => {
+    expect(stripExpert('[Expert] Advanced tuning option')).toBe('Advanced tuning option')
+  })
+  it('removes [Expert] with no trailing space', () => {
+    expect(stripExpert('[Expert]No space')).toBe('No space')
+  })
+  it('leaves non-expert descriptions unchanged', () => {
+    expect(stripExpert('Normal description')).toBe('Normal description')
+  })
+  it('returns null/undefined unchanged', () => {
+    expect(stripExpert(null)).toBe(null)
+    expect(stripExpert(undefined)).toBe(undefined)
+  })
+})
+
+// ── getTypeLabel ──────────────────────────────────────────────────────────────
+
+describe('getTypeLabel', () => {
+  it('returns "union" for oneOf', () => {
+    expect(getTypeLabel({ oneOf: [] })).toBe('union')
+  })
+  it('returns "union" for anyOf', () => {
+    expect(getTypeLabel({ anyOf: [] })).toBe('union')
+  })
+  it('returns "allOf" for allOf', () => {
+    expect(getTypeLabel({ allOf: [] })).toBe('allOf')
+  })
+  it('joins array types with " | "', () => {
+    expect(getTypeLabel({ type: ['string', 'null'] })).toBe('string | null')
+  })
+  it('returns the scalar type string', () => {
+    expect(getTypeLabel({ type: 'object' })).toBe('object')
+  })
+  it('returns "any" when no type is present', () => {
+    expect(getTypeLabel({})).toBe('any')
+  })
+  it('prefers oneOf over a type field', () => {
+    expect(getTypeLabel({ type: 'object', oneOf: [] })).toBe('union')
+  })
+})
+
+// ── typeBadgeClass ────────────────────────────────────────────────────────────
+
+describe('typeBadgeClass', () => {
+  it('includes the type-specific modifier class for known types', () => {
+    expect(typeBadgeClass('string')).toContain('type-string')
+    expect(typeBadgeClass('object')).toContain('type-object')
+    expect(typeBadgeClass('boolean')).toContain('type-boolean')
+    expect(typeBadgeClass('array')).toContain('type-array')
+    expect(typeBadgeClass('integer')).toContain('type-integer')
+    expect(typeBadgeClass('number')).toContain('type-number')
+    expect(typeBadgeClass('union')).toContain('type-union')
+  })
+  it('always includes the base badge classes', () => {
+    expect(typeBadgeClass('string')).toContain('badge')
+    expect(typeBadgeClass('string')).toContain('type-badge')
+  })
+  it('returns only base classes for unknown types', () => {
+    const cls = typeBadgeClass('unknown')
+    expect(cls).toContain('badge')
+    expect(cls).toContain('type-badge')
+    expect(cls.trim()).toBe('badge type-badge')
+  })
+})
+
+// ── variantTitle ──────────────────────────────────────────────────────────────
+
+describe('variantTitle', () => {
+  it('uses branch.title when present', () => {
+    expect(variantTitle({ title: 'Basic auth' }, 0, 'oneOf')).toBe('Basic auth')
+  })
+  it('falls back to properties.type.enum[0]', () => {
+    const branch = { properties: { type: { enum: ['basic'] } } }
+    expect(variantTitle(branch, 0, 'oneOf')).toBe('basic')
+  })
+  it('falls back to unionKey[i] when neither title nor enum exists', () => {
+    expect(variantTitle({}, 2, 'anyOf')).toBe('anyOf[2]')
+  })
+  it('prefers title over enum', () => {
+    const branch = { title: 'My title', properties: { type: { enum: ['enum-val'] } } }
+    expect(variantTitle(branch, 0, 'oneOf')).toBe('My title')
+  })
+})
+
+// ── variantDesc ───────────────────────────────────────────────────────────────
+
+describe('variantDesc', () => {
+  it('lists property names excluding "type"', () => {
+    const branch = { properties: { type: {}, host: {}, port: {} } }
+    expect(variantDesc(branch)).toBe('Requires host, port.')
+  })
+  it('returns the no-properties message when only "type" is present', () => {
+    const branch = { properties: { type: {} } }
+    expect(variantDesc(branch)).toBe('No additional properties required.')
+  })
+  it('returns the no-properties message when properties is absent', () => {
+    expect(variantDesc({})).toBe('No additional properties required.')
+  })
+})
+
+// ── buildNode ─────────────────────────────────────────────────────────────────
+
+describe('buildNode', () => {
+  it('returns null for a null schema', () => {
+    expect(buildNode('field', null, ['field'])).toBeNull()
+  })
+  it('returns null for a non-object schema', () => {
+    expect(buildNode('field', 'string', ['field'])).toBeNull()
+  })
+  it('builds a node with the correct key (joined path)', () => {
+    const node = buildNode('host', { type: 'string' }, ['source', 'host'])
+    expect(node.key).toBe('source/host')
+  })
+  it('marks the field as required when name is in requiredSet', () => {
+    const node = buildNode('host', { type: 'string' }, ['host'], new Set(['host']))
+    expect(node.required).toBe(true)
+  })
+  it('marks the field as optional when name is not in requiredSet', () => {
+    const node = buildNode('host', { type: 'string' }, ['host'], new Set(['port']))
+    expect(node.required).toBe(false)
+  })
+  it('defaults to optional when requiredSet is omitted', () => {
+    const node = buildNode('host', { type: 'string' }, ['host'])
+    expect(node.required).toBe(false)
+  })
+  it('populates children from schema.properties', () => {
+    const schema = { properties: { a: { type: 'string' }, b: { type: 'integer' } } }
+    const node = buildNode('root', schema, ['root'])
+    expect(node.children).toHaveLength(2)
+    expect(node.children.map(c => c.name)).toEqual(['a', 'b'])
+  })
+})
+
+// ── buildChildren ─────────────────────────────────────────────────────────────
+
+describe('buildChildren', () => {
+  it('returns an empty array for a schema with no children', () => {
+    expect(buildChildren({ type: 'string' }, ['field'])).toEqual([])
+  })
+
+  it('builds one child per property', () => {
+    const schema = { properties: { x: { type: 'string' }, y: { type: 'boolean' } } }
+    const children = buildChildren(schema, ['root'])
+    expect(children).toHaveLength(2)
+    expect(children[0].name).toBe('x')
+    expect(children[1].name).toBe('y')
+  })
+
+  it('marks required properties correctly', () => {
+    const schema = {
+      required: ['x'],
+      properties: { x: { type: 'string' }, y: { type: 'boolean' } },
+    }
+    const children = buildChildren(schema, ['root'])
+    expect(children.find(c => c.name === 'x').required).toBe(true)
+    expect(children.find(c => c.name === 'y').required).toBe(false)
+  })
+
+  it('adds a [value] child for additionalProperties', () => {
+    const schema = { additionalProperties: { type: 'string' } }
+    const children = buildChildren(schema, ['root'])
+    expect(children).toHaveLength(1)
+    expect(children[0].name).toBe('[value]')
+  })
+
+  it('skips additionalProperties: true (not an object)', () => {
+    const schema = { additionalProperties: true }
+    expect(buildChildren(schema, ['root'])).toEqual([])
+  })
+
+  it('builds children for each oneOf branch', () => {
+    const schema = {
+      oneOf: [
+        { title: 'Option A', type: 'object' },
+        { title: 'Option B', type: 'object' },
+      ],
+    }
+    const children = buildChildren(schema, ['root'])
+    expect(children).toHaveLength(2)
+    expect(children[0].name).toBe('Option A')
+    expect(children[1].name).toBe('Option B')
+  })
+
+  it('builds children for each anyOf branch', () => {
+    const schema = {
+      anyOf: [{ type: 'string' }, { type: 'integer' }],
+    }
+    const children = buildChildren(schema, ['root'])
+    expect(children).toHaveLength(2)
+    expect(children[0].name).toBe('anyOf[0]')
+    expect(children[1].name).toBe('anyOf[1]')
+  })
+
+  it('uses branch title as the child name for oneOf', () => {
+    const schema = { oneOf: [{ title: 'Named branch', type: 'object' }] }
+    const children = buildChildren(schema, ['root'])
+    expect(children[0].name).toBe('Named branch')
+  })
+
+  it('adds an items child for array schemas', () => {
+    const schema = { type: 'array', items: { type: 'string' } }
+    const children = buildChildren(schema, ['root'])
+    expect(children).toHaveLength(1)
+    expect(children[0].name).toBe('items')
+  })
+
+  it('does not add items child when type is not array', () => {
+    const schema = { type: 'object', items: { type: 'string' } }
+    expect(buildChildren(schema, ['root'])).toEqual([])
+  })
+
+  it('builds correct paths for nested children', () => {
+    const schema = { properties: { child: { type: 'string' } } }
+    const children = buildChildren(schema, ['parent'])
+    expect(children[0].key).toBe('parent/child')
+    expect(children[0].pathArr).toEqual(['parent', 'child'])
+  })
+})
+
+// ── nodeMatchesSearch ─────────────────────────────────────────────────────────
+
+describe('nodeMatchesSearch', () => {
+  const leaf = name => ({ name, children: [] })
+  const parent = (name, childNames) => ({ name, children: childNames.map(leaf) })
+
+  it('matches when the node name contains the term', () => {
+    expect(nodeMatchesSearch(leaf('hostname'), 'host')).toBe(true)
+  })
+  it('is case-insensitive', () => {
+    expect(nodeMatchesSearch(leaf('HostName'), 'hostname')).toBe(true)
+  })
+  it('returns false when neither node nor children match', () => {
+    expect(nodeMatchesSearch(parent('cluster', ['host', 'port']), 'auth')).toBe(false)
+  })
+  it('matches via a child name even if the parent does not match', () => {
+    expect(nodeMatchesSearch(parent('cluster', ['authentication', 'host']), 'auth')).toBe(true)
+  })
+  it('matches on exact full name', () => {
+    expect(nodeMatchesSearch(leaf('type'), 'type')).toBe(true)
+  })
+})
+
+// ── computeSchemaDiff ─────────────────────────────────────────────────────────
+
+describe('computeSchemaDiff', () => {
+  const diff = (oldSchema, newSchema) => computeSchemaDiff(oldSchema, newSchema, differ)
+
+  it('returns empty result when both schemas are identical', () => {
+    const schema = { properties: { host: { type: 'string' } } }
+    expect(diff(schema, schema)).toEqual({ added: [], removed: [], modified: [] })
+  })
+
+  it('returns empty result when both schemas have no properties', () => {
+    expect(diff({}, {})).toEqual({ added: [], removed: [], modified: [] })
+  })
+
+  it('detects an added top-level field', () => {
+    const old = { properties: { host: { type: 'string' } } }
+    const next = { properties: { host: { type: 'string' }, port: { type: 'integer' } } }
+    const result = diff(old, next)
+    expect(result.added).toContain('port')
+    expect(result.removed).toHaveLength(0)
+    expect(result.modified).toHaveLength(0)
+  })
+
+  it('detects a removed top-level field', () => {
+    const old  = { properties: { host: { type: 'string' }, legacy: { type: 'string' } } }
+    const next = { properties: { host: { type: 'string' } } }
+    const result = diff(old, next)
+    expect(result.removed).toContain('legacy')
+    expect(result.added).toHaveLength(0)
+    expect(result.modified).toHaveLength(0)
+  })
+
+  it('detects a type change on an existing field', () => {
+    const old  = { properties: { timeout: { type: 'string' } } }
+    const next = { properties: { timeout: { type: 'integer' } } }
+    const result = diff(old, next)
+    expect(result.modified).toHaveLength(1)
+    expect(result.modified[0].path).toBe('timeout')
+    const typeChange = result.modified[0].changes.find(c => c.kind === 'type')
+    expect(typeChange).toMatchObject({ from: 'string', to: 'integer' })
+  })
+
+  it('detects a default being added', () => {
+    const old  = { properties: { enabled: { type: 'boolean' } } }
+    const next = { properties: { enabled: { type: 'boolean', default: false } } }
+    const result = diff(old, next)
+    expect(result.modified).toHaveLength(1)
+    const defaultChange = result.modified[0].changes.find(c => c.kind === 'default')
+    expect(defaultChange.from).toBeUndefined()
+    expect(defaultChange.to).toBe('false')
+  })
+
+  it('detects a default being changed', () => {
+    const old  = { properties: { replicas: { type: 'integer', default: 1 } } }
+    const next = { properties: { replicas: { type: 'integer', default: 3 } } }
+    const result = diff(old, next)
+    const defaultChange = result.modified[0].changes.find(c => c.kind === 'default')
+    expect(defaultChange).toMatchObject({ from: '1', to: '3' })
+  })
+
+  it('detects a default being removed', () => {
+    const old  = { properties: { mode: { type: 'string', default: 'auto' } } }
+    const next = { properties: { mode: { type: 'string' } } }
+    const result = diff(old, next)
+    const defaultChange = result.modified[0].changes.find(c => c.kind === 'default')
+    expect(defaultChange.from).toBe('"auto"')
+    expect(defaultChange.to).toBeUndefined()
+  })
+
+  it('detects a field becoming required', () => {
+    const old  = { properties: { cert: { type: 'string' } } }
+    const next = { required: ['cert'], properties: { cert: { type: 'string' } } }
+    const result = diff(old, next)
+    const reqChange = result.modified[0].changes.find(c => c.kind === 'required')
+    expect(reqChange).toMatchObject({ from: false, to: true })
+  })
+
+  it('detects a field becoming optional', () => {
+    const old  = { required: ['cert'], properties: { cert: { type: 'string' } } }
+    const next = { properties: { cert: { type: 'string' } } }
+    const result = diff(old, next)
+    const reqChange = result.modified[0].changes.find(c => c.kind === 'required')
+    expect(reqChange).toMatchObject({ from: true, to: false })
+  })
+
+  it('captures multiple scalar changes on the same field in one modified entry', () => {
+    const old  = { required: ['x'], properties: { x: { type: 'string', default: 'a' } } }
+    const next = { properties: { x: { type: 'integer', default: 0 } } }
+    const result = diff(old, next)
+    expect(result.modified).toHaveLength(1)
+    const { changes } = result.modified[0]
+    expect(changes.find(c => c.kind === 'type')).toBeTruthy()
+    expect(changes.find(c => c.kind === 'default')).toBeTruthy()
+    expect(changes.find(c => c.kind === 'required')).toBeTruthy()
+  })
+
+  it('handles simultaneous additions, removals, and modifications', () => {
+    const old  = { properties: { a: { type: 'string' }, b: { type: 'integer' } } }
+    const next = { properties: { b: { type: 'boolean' }, c: { type: 'object' } } }
+    const result = diff(old, next)
+    expect(result.added).toContain('c')
+    expect(result.removed).toContain('a')
+    expect(result.modified[0].path).toBe('b')
+  })
+
+  it('does not report a modification when only description changes', () => {
+    const old  = { properties: { host: { type: 'string', description: 'old' } } }
+    const next = { properties: { host: { type: 'string', description: 'new' } } }
+    expect(diff(old, next)).toEqual({ added: [], removed: [], modified: [] })
+  })
+
+  it('serialises array defaults to strings to avoid array-diff noise', () => {
+    const old  = { properties: { tags: { type: 'array', default: [] } } }
+    const next = { properties: { tags: { type: 'array', default: ['a'] } } }
+    const result = diff(old, next)
+    const defaultChange = result.modified[0].changes.find(c => c.kind === 'default')
+    expect(defaultChange).toMatchObject({ from: '[]', to: '["a"]' })
+  })
+
+  it('detects an added field nested inside an existing object', () => {
+    const old = { properties: { source: { type: 'object', properties: { host: { type: 'string' } } } } }
+    const next = { properties: { source: { type: 'object', properties: {
+      host: { type: 'string' },
+      port: { type: 'integer' },
+    } } } }
+    const result = diff(old, next)
+    expect(result.added).toContain('source/port')
+    expect(result.removed).toHaveLength(0)
+  })
+
+  it('detects a removed field at an arbitrary depth', () => {
+    const old = { properties: { cluster: { type: 'object', properties: {
+      auth: { type: 'object', properties: { token: { type: 'string' } } },
+    } } } }
+    const next = { properties: { cluster: { type: 'object', properties: {
+      auth: { type: 'object', properties: {} },
+    } } } }
+    const result = diff(old, next)
+    expect(result.removed).toContain('cluster/auth/token')
+  })
+
+  it('reports the full path for a modified nested field', () => {
+    const old = { properties: { reindex: { type: 'object', properties: {
+      maxRetries: { type: 'integer', default: 3 },
+    } } } }
+    const next = { properties: { reindex: { type: 'object', properties: {
+      maxRetries: { type: 'integer', default: 5 },
+    } } } }
+    const result = diff(old, next)
+    expect(result.modified).toHaveLength(1)
+    expect(result.modified[0].path).toBe('reindex/maxRetries')
+    expect(result.modified[0].changes[0]).toMatchObject({ kind: 'default', from: '3', to: '5' })
+  })
+
+  it('handles cycles in the resolved schema without looping', () => {
+    const child = { type: 'object', properties: {} }
+    const schema = { properties: { root: child } }
+    child.properties.self = child  // circular reference
+    expect(() => diff(schema, schema)).not.toThrow()
+  })
+})

--- a/schema-viewer/viewer.css
+++ b/schema-viewer/viewer.css
@@ -1,0 +1,287 @@
+@import url('https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;600;700&family=Open+Sans+Condensed:wght@700&family=Fira+Mono:wght@400;500&display=swap');
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  padding: 2rem;
+  font-family: "Open Sans", "Segoe UI", Tahoma, sans-serif;
+  font-size: 15px;
+  background: #F5F7F7;
+  color: #002A3A;
+}
+
+h1 {
+  font-family: "Open Sans Condensed", "Open Sans", "Segoe UI", sans-serif;
+  font-size: 22px;
+  font-weight: 700;
+  color: #003b5c;
+  margin-bottom: 4px;
+}
+.subtitle { font-size: 13px; color: #4D8399; margin-bottom: 1.5rem; }
+
+/* ── Status bar ─────────────────────────────────────────────────────────── */
+.status-bar { display: flex; gap: 8px; flex-wrap: wrap; margin-bottom: 1.5rem; align-items: center; }
+.version-label { font-size: 12px; color: #4D8399; }
+.version-select {
+  font-size: 12px; padding: 3px 8px; border: 1px solid #D9E1E2; border-radius: 4px;
+  font-family: inherit; color: #002A3A; background: #fff; cursor: pointer;
+}
+.version-select:focus { outline: none; border-color: #00a3e0; }
+.badge-pill {
+  font-size: 11px; padding: 3px 10px; border-radius: 999px; font-weight: 600; cursor: default;
+}
+.badge-pill.ok   { background: rgba(44, 213, 196, 0.12); color: #166B62; }
+.badge-pill.warn { background: rgba(221, 74, 105, 0.10); color: #9B2335; }
+.badge-pill.info { background: rgba(0, 163, 224, 0.10);  color: #003551; }
+
+/* ── Two-column layout ──────────────────────────────────────────────────── */
+.viewer {
+  display: flex;
+  flex-direction: row;
+  background: #fff;
+  border: 1px solid #D9E1E2;
+  border-radius: 6px;
+  overflow: hidden;
+  min-height: 640px;
+  max-height: calc(100vh - 140px);
+}
+
+/* ── Sidebar ────────────────────────────────────────────────────────────── */
+.sidebar {
+  width: 220px;
+  flex-shrink: 0;
+  background: #F5F7F7;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.search-wrap { padding: 10px 12px; border-bottom: 1px solid #D9E1E2; flex-shrink: 0; }
+
+.search-input {
+  width: 100%;
+  padding: 6px 10px 6px 28px;
+  border: 1px solid #D9E1E2;
+  border-radius: 4px;
+  font-size: 12px;
+  font-family: inherit;
+  color: #002A3A;
+  background: #fff url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%234D8399' stroke-width='2'%3E%3Ccircle cx='11' cy='11' r='8'/%3E%3Cline x1='21' y1='21' x2='16.65' y2='16.65'/%3E%3C/svg%3E") no-repeat 8px center;
+}
+.search-input:focus { outline: none; border-color: #00a3e0; }
+
+.tree-controls {
+  padding: 5px 12px;
+  border-bottom: 1px solid #D9E1E2;
+  font-size: 11px;
+  color: #4D8399;
+  flex-shrink: 0;
+  display: flex;
+  gap: 6px;
+  align-items: center;
+}
+.tree-controls a { color: #0055A6; text-decoration: none; }
+.tree-controls a:hover { text-decoration: underline; color: #00a3e0; }
+
+.tree-scroll { flex: 1; overflow-y: auto; padding: 6px 0; }
+
+.tree-item {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 0;
+  cursor: pointer;
+  font-size: 12px;
+  color: #003551;
+  user-select: none;
+  line-height: 1.4;
+}
+.tree-item:hover { background: #EAF4F9; }
+.tree-item.selected { background: #F1FBFF; }
+.tree-item.selected .tree-name { color: #0055A6; }
+
+.tree-toggle { font-size: 9px; color: #4D8399; width: 14px; text-align: center; flex-shrink: 0; }
+.tree-name { font-family: "Fira Mono", Consolas, Menlo, Monaco, monospace; font-size: 11.5px; }
+
+/* ── Resizable divider ──────────────────────────────────────────────────── */
+.divider {
+  flex-shrink: 0;
+  width: 6px;
+  background: #D9E1E2;
+  cursor: col-resize;
+  position: relative;
+  transition: background 0.15s;
+  touch-action: none;
+}
+.divider::after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 2px;
+  height: 24px;
+  background: repeating-linear-gradient(to bottom, #4D8399 0 3px, transparent 3px 6px);
+}
+.divider:hover,
+.divider.dragging { background: #EAF4F9; }
+.divider:hover::after,
+.divider.dragging::after {
+  background: repeating-linear-gradient(to bottom, #00a3e0 0 3px, transparent 3px 6px);
+}
+
+/* ── Main panel ─────────────────────────────────────────────────────────── */
+.main { flex: 1; overflow-y: auto; min-width: 0; }
+.empty-state { padding: 60px 40px; color: #4D8399; font-size: 13px; text-align: center; font-style: italic; }
+
+/* ── Welcome panel ──────────────────────────────────────────────────────── */
+.welcome-panel { padding: 28px 32px; max-width: 600px; }
+.welcome-section { margin-bottom: 28px; }
+.welcome-section-title {
+  font-size: 10px; font-weight: 700; letter-spacing: 0.08em; text-transform: uppercase;
+  color: #4D8399; margin-bottom: 10px; padding-bottom: 6px; border-bottom: 1px solid #D9E1E2;
+}
+.welcome-text { font-size: 13px; color: #002A3A; line-height: 1.7; margin-bottom: 10px; }
+.welcome-link { font-size: 13px; color: #0055A6; text-decoration: none; }
+.welcome-link:hover { color: #00a3e0; text-decoration: underline; }
+.welcome-steps { padding-left: 18px; font-size: 13px; color: #002A3A; line-height: 1.9; }
+.legend-rows { display: flex; flex-direction: column; gap: 10px; }
+.legend-row { display: flex; align-items: center; gap: 12px; }
+.legend-desc { font-size: 12px; color: #4D8399; }
+
+/* ── Change summary ─────────────────────────────────────────────────────── */
+.diff-title-row {
+  display: flex; align-items: center; justify-content: space-between;
+  margin-bottom: 10px; padding-bottom: 6px; border-bottom: 1px solid #D9E1E2;
+}
+.diff-title-row .welcome-section-title { margin-bottom: 0; padding-bottom: 0; border-bottom: none; }
+.diff-compare-wrap { display: flex; align-items: center; gap: 6px; flex-shrink: 0; }
+.diff-compare-label { font-size: 11px; color: #4D8399; }
+.diff-compare-select {
+  font-size: 11px; padding: 2px 6px; border: 1px solid #D9E1E2; border-radius: 4px;
+  font-family: inherit; color: #002A3A; background: #fff; cursor: pointer;
+}
+.diff-compare-select:focus { outline: none; border-color: #00a3e0; }
+.diff-note {
+  font-size: 11px; color: #4D8399; font-style: italic; margin-bottom: 12px;
+  padding: 6px 10px; background: rgba(0, 163, 224, 0.06); border-radius: 4px;
+  border-left: 2px solid #46BDE9; line-height: 1.5;
+}
+.diff-group { margin-bottom: 10px; }
+.diff-label {
+  display: inline-block; font-size: 11px; font-weight: 600;
+  padding: 2px 8px; border-radius: 4px; margin-bottom: 6px;
+}
+.diff-added    { background: rgba(44, 213, 196, 0.12); color: #166B62; border: 1px solid #2CD5C4; }
+.diff-removed  { background: rgba(221,  74, 105, 0.10); color: #9B2335; border: 1px solid #DD4A69; }
+.diff-modified { background: rgba(255, 184,  28, 0.12); color: #7A5000; border: 1px solid #FFB81C; }
+.diff-list { list-style: none; padding-left: 4px; }
+.diff-item { font-size: 12px; padding: 2px 0; color: #002A3A; }
+.diff-field { font-family: "Fira Mono", Consolas, Menlo, Monaco, monospace; color: #003b5c; }
+.diff-desc  { color: #4D8399; }
+
+/* ── Field card ─────────────────────────────────────────────────────────── */
+.field-card { padding: 24px 28px; }
+
+.breadcrumb { font-family: "Fira Mono", Consolas, Menlo, Monaco, monospace; font-size: 11px; color: #4D8399; margin-bottom: 10px; }
+
+.field-title-row { display: flex; align-items: baseline; gap: 10px; margin-bottom: 8px; }
+.field-title { font-family: "Fira Mono", Consolas, Menlo, Monaco, monospace; font-size: 22px; font-weight: 500; color: #003b5c; }
+
+.field-desc { font-size: 13px; color: #002A3A; line-height: 1.6; margin-bottom: 18px; }
+
+.meta-row { display: flex; gap: 20px; margin-bottom: 24px; flex-wrap: wrap; align-items: center; }
+.meta-item { display: flex; align-items: center; gap: 8px; }
+.meta-label { font-size: 12px; color: #4D8399; }
+
+/* ── Badges ─────────────────────────────────────────────────────────────── */
+.badge {
+  display: inline-block;
+  font-size: 11px; padding: 2px 10px; border-radius: 4px; font-weight: 500; white-space: nowrap;
+}
+.badge-required { background: rgba(255, 184, 28, 0.12); color: #7A5000; border: 1px solid #FFB81C; }
+.badge-optional { background: #F5F7F7;                  color: #4D8399; border: 1px solid #D9E1E2; }
+.badge-default  { background: rgba(0, 163, 224, 0.08);  color: #003551; border: 1px solid #92D9F3; }
+.badge-expert   { background: rgba(105, 42, 132, 0.08); color: #692A84; border: 1px solid #C8A0F0; }
+
+.type-badge    { background: rgba(0,  85, 166, 0.07); color: #003551; border: 1px solid #92D9F3; }
+.type-string   { background: rgba(44, 213, 196, 0.10); color: #166B62; border-color: #2CD5C4; }
+.type-object   { background: rgba(0,  85, 166, 0.07); color: #003551; border-color: #92D9F3; }
+.type-boolean  { background: rgba(255,184,  28, 0.12); color: #7A5000; border-color: #FFB81C; }
+.type-array    { background: rgba(0, 163, 224, 0.10);  color: #003551; border-color: #46BDE9; }
+.type-integer,
+.type-number   { background: rgba(0, 163, 224, 0.10);  color: #003551; border-color: #46BDE9; }
+.type-union    { background: rgba(105, 42, 132, 0.08); color: #692A84; border-color: #C8A0F0; }
+
+/* ── Sections ───────────────────────────────────────────────────────────── */
+.section { margin-bottom: 28px; }
+.section-title {
+  font-size: 10px; font-weight: 700; letter-spacing: 0.08em; text-transform: uppercase;
+  color: #4D8399; margin-bottom: 10px; padding-bottom: 6px; border-bottom: 1px solid #D9E1E2;
+}
+
+/* ── Union rows ─────────────────────────────────────────────────────────── */
+.union-list { border: 1px solid #D9E1E2; border-radius: 4px; overflow: hidden; }
+.union-row {
+  display: flex; align-items: baseline; gap: 16px;
+  padding: 10px 14px; border-bottom: 1px solid #D9E1E2; font-size: 12px;
+}
+.union-row:last-child { border-bottom: none; }
+.union-row:nth-child(even) { background: #F5F7F7; }
+.union-value { font-family: "Fira Mono", Consolas, Menlo, Monaco, monospace; color: #0055A6; min-width: 110px; flex-shrink: 0; }
+.union-desc  { color: #002A3A; line-height: 1.5; }
+
+/* ── Properties table ───────────────────────────────────────────────────── */
+.props-table { width: 100%; border-collapse: collapse; font-size: 12px; border: 1px solid #D9E1E2; border-radius: 4px; overflow: hidden; }
+.props-table tr:not(:last-child) td { border-bottom: 1px solid #D9E1E2; }
+.prop-name-cell {
+  padding: 10px 14px; width: 150px; vertical-align: top;
+  background: #F5F7F7; border-right: 1px solid #D9E1E2;
+}
+.prop-name  { font-family: "Fira Mono", Consolas, Menlo, Monaco, monospace; font-weight: 500; color: #003b5c; display: block; }
+.prop-drill { font-family: "Fira Mono", Consolas, Menlo, Monaco, monospace; font-weight: 500; color: #0055A6; display: block; text-decoration: none; }
+.prop-drill:hover { text-decoration: underline; color: #00a3e0; }
+.prop-type { font-family: "Fira Mono", Consolas, Menlo, Monaco, monospace; font-size: 10px; color: #4D8399; margin-top: 2px; display: block; }
+.prop-desc-cell { padding: 10px 14px; vertical-align: top; color: #002A3A; line-height: 1.5; }
+.prop-badges { display: flex; gap: 6px; margin-top: 5px; flex-wrap: wrap; }
+
+/* ── Variant grouping ───────────────────────────────────────────────────── */
+.variant-block { margin-bottom: 12px; }
+.variant-label {
+  font-size: 11px; color: #4D8399;
+  padding: 5px 10px; background: #F5F7F7;
+  border: 1px solid #D9E1E2; border-bottom: none; border-radius: 4px 4px 0 0;
+}
+.variant-label code { font-family: "Fira Mono", Consolas, Menlo, Monaco, monospace; color: #0055A6; }
+.variant-block .props-table { border-radius: 0 0 4px 4px; }
+
+/* ── Mobile layout ──────────────────────────────────────────────────────── */
+@media (max-width: 768px) {
+  body { padding: 1rem; }
+
+  .viewer {
+    flex-direction: column;
+    min-height: 0;
+    max-height: calc(100vh - 120px);
+  }
+
+  .sidebar {
+    width: 100%;
+    height: 300px;
+  }
+
+  .divider {
+    width: 100%;
+    height: 6px;
+    cursor: row-resize;
+  }
+  .divider::after {
+    width: 24px;
+    height: 2px;
+    background: repeating-linear-gradient(to right, #4D8399 0 3px, transparent 3px 6px);
+  }
+  .divider:hover::after,
+  .divider.dragging::after {
+    background: repeating-linear-gradient(to right, #00a3e0 0 3px, transparent 3px 6px);
+  }
+}

--- a/schema-viewer/viewer.js
+++ b/schema-viewer/viewer.js
@@ -3,7 +3,7 @@ import { create as createDiffer } from 'https://esm.sh/jsondiffpatch@0.6.0'
 import {
   buildNode, nodeMatchesSearch,
   getTypeLabel, typeBadgeClass, variantTitle, variantDesc,
-  isExpert, stripExpert, computeSchemaDiff, isComposite,
+  isExpert, stripExpert, computeSchemaDiff, isComposite, unionKeyOf,
 } from './schema-utils.js'
 
 const differ = createDiffer()
@@ -96,7 +96,9 @@ function buildTreeNodeEl(node, depth, term) {
   const row = el('div', `tree-item${isSelected ? ' selected' : ''}`)
   row.style.paddingLeft = `${12 + depth * 14}px`
 
-  const toggle = el('span', 'tree-toggle', hasChildren ? (isExpanded ? '▾' : '▸') : '')
+  let toggleGlyph = ''
+  if (hasChildren) toggleGlyph = isExpanded ? '▾' : '▸'
+  const toggle = el('span', 'tree-toggle', toggleGlyph)
   const nameEl = el('span', 'tree-name', node.name)
   row.appendChild(toggle)
   row.appendChild(nameEl)
@@ -290,36 +292,44 @@ function renderCard(node) {
   main.appendChild(buildCardEl(node))
 }
 
-function buildCardEl(node) {
-  if (!node) return buildWelcomePanel()
+// Renders the list of "value — description" rows shared by union-variant and
+// map-value sections.
+function buildUnionList(branches, unionKey) {
+  const list = el('div', 'union-list')
+  branches.forEach((branch, i) => {
+    const row = el('div', 'union-row')
+    row.appendChild(el('span', 'union-value', `"${variantTitle(branch, i, unionKey)}"`))
+    row.appendChild(el('span', 'union-desc', branch.description || variantDesc(branch)))
+    list.appendChild(row)
+  })
+  return list
+}
 
+function buildSection(title, body) {
+  const section = el('div', 'section')
+  section.appendChild(el('div', 'section-title', title))
+  section.appendChild(body)
+  return section
+}
+
+// Card header: breadcrumb, title with optional Expert badge, description, meta row.
+function buildCardHeader(card, node, t) {
   const { name, schema, required, pathArr } = node
   const parentPath = pathArr.slice(0, -1)
-  const t = getTypeLabel(schema)
-  const unionKey = schema.oneOf ? 'oneOf' : schema.anyOf ? 'anyOf' : null
-  const branches = unionKey ? schema[unionKey] : []
 
-  const card = el('div', 'field-card')
-
-  // Breadcrumb
   if (parentPath.length > 0) {
     card.appendChild(el('div', 'breadcrumb', parentPath.join(' › ')))
   }
 
-  // Title + expert badge
   const titleRow = el('div', 'field-title-row')
   titleRow.appendChild(el('span', 'field-title', name))
-  if (isExpert(schema.description)) {
-    titleRow.appendChild(badge('Expert', 'badge-expert'))
-  }
+  if (isExpert(schema.description)) titleRow.appendChild(badge('Expert', 'badge-expert'))
   card.appendChild(titleRow)
 
-  // Description (strip [Expert] prefix if present)
   if (schema.description) {
     card.appendChild(el('p', 'field-desc', stripExpert(schema.description)))
   }
 
-  // Meta row
   const meta = el('div', 'meta-row')
   meta.appendChild(metaItem('Data type', badge(t, typeBadgeClass(t))))
   meta.appendChild(metaItem('Requirement',
@@ -328,23 +338,10 @@ function buildCardEl(node) {
     meta.appendChild(metaItem('Default', badge(JSON.stringify(schema.default), 'badge-default')))
   }
   card.appendChild(meta)
+}
 
-  // Union variants
-  if (unionKey && branches.length > 0) {
-    const section = el('div', 'section')
-    section.appendChild(el('div', 'section-title', 'Allowed enums / structures'))
-    const list = el('div', 'union-list')
-    branches.forEach((branch, i) => {
-      const row = el('div', 'union-row')
-      row.appendChild(el('span', 'union-value', `"${variantTitle(branch, i, unionKey)}"`))
-      row.appendChild(el('span', 'union-desc', branch.description || variantDesc(branch)))
-      list.appendChild(row)
-    })
-    section.appendChild(list)
-    card.appendChild(section)
-  }
-
-  // Properties — grouped by variant for union types, flat otherwise
+// "Properties" section: grouped by variant for union types, flat otherwise.
+function buildPropertiesSection(schema, pathArr, unionKey, branches) {
   const branchesWithProps = branches.filter(b => b.properties)
   if (unionKey && branchesWithProps.length > 0) {
     const section = el('div', 'section')
@@ -357,32 +354,43 @@ function buildCardEl(node) {
       block.appendChild(buildPropsTable(branch, [...pathArr, variantTitle(branch, i, unionKey)]))
       section.appendChild(block)
     })
-    card.appendChild(section)
-  } else if (!unionKey && schema.properties) {
-    const section = el('div', 'section')
-    section.appendChild(el('div', 'section-title', 'Properties'))
-    section.appendChild(buildPropsTable(schema, pathArr))
-    card.appendChild(section)
+    return section
+  }
+  if (!unionKey && schema.properties) {
+    return buildSection('Properties', buildPropsTable(schema, pathArr))
+  }
+  return null
+}
+
+// "Map value schema" section: union branches of an additionalProperties value type.
+function buildMapValueSection(schema) {
+  const ap = schema.additionalProperties
+  if (schema.properties || !ap || typeof ap !== 'object') return null
+  const apUnionKey = unionKeyOf(ap)
+  if (!apUnionKey) return null
+  return buildSection('Map value schema — allowed structures', buildUnionList(ap[apUnionKey], apUnionKey))
+}
+
+function buildCardEl(node) {
+  if (!node) return buildWelcomePanel()
+
+  const { schema, pathArr } = node
+  const t = getTypeLabel(schema)
+  const unionKey = unionKeyOf(schema)
+  const branches = unionKey ? schema[unionKey] : []
+
+  const card = el('div', 'field-card')
+  buildCardHeader(card, node, t)
+
+  if (unionKey && branches.length > 0) {
+    card.appendChild(buildSection('Allowed enums / structures', buildUnionList(branches, unionKey)))
   }
 
-  // Map value schema — show union branches if the value type has them
-  if (!schema.properties && schema.additionalProperties && typeof schema.additionalProperties === 'object') {
-    const ap = schema.additionalProperties
-    const apUnionKey = ap.oneOf ? 'oneOf' : ap.anyOf ? 'anyOf' : null
-    if (apUnionKey) {
-      const section = el('div', 'section')
-      section.appendChild(el('div', 'section-title', 'Map value schema — allowed structures'))
-      const list = el('div', 'union-list')
-      ap[apUnionKey].forEach((branch, i) => {
-        const row = el('div', 'union-row')
-        row.appendChild(el('span', 'union-value', `"${variantTitle(branch, i, apUnionKey)}"`))
-        row.appendChild(el('span', 'union-desc', branch.description || variantDesc(branch)))
-        list.appendChild(row)
-      })
-      section.appendChild(list)
-      card.appendChild(section)
-    }
-  }
+  const propsSection = buildPropertiesSection(schema, pathArr, unionKey, branches)
+  if (propsSection) card.appendChild(propsSection)
+
+  const mapValueSection = buildMapValueSection(schema)
+  if (mapValueSection) card.appendChild(mapValueSection)
 
   return card
 }
@@ -527,7 +535,7 @@ async function recomputeDiff(compareVersion) {
     const raw = await fetch(`./schemas/${compareVersion}.json`).then(r => r.json())
     const resolved = await $RefParser.dereference(raw)
     currentDiff = { fromVersion: compareVersion, diff: computeSchemaDiff(resolved, currentResolved, differ) }
-  } catch (_) {
+  } catch {
     currentDiff = null
   }
   clearStatus()
@@ -562,7 +570,7 @@ async function loadSchema(version) {
   try {
     schema = await $RefParser.dereference(rawSchema)
     clearStatus()
-  } catch (e) {
+  } catch {
     setStatus('Warning: $ref resolution failed — some fields may be incomplete.', 'warn')
   }
   currentResolved = schema
@@ -573,7 +581,7 @@ async function loadSchema(version) {
     try {
       const prevResolved = await $RefParser.dereference(prevRaw)
       currentDiff = { fromVersion: prevVersion, diff: computeSchemaDiff(prevResolved, schema, differ) }
-    } catch (_) { /* silently skip on resolution error */ }
+    } catch { /* silently skip on resolution error */ }
   }
 
   rebuildFromSchema(schema)
@@ -620,4 +628,4 @@ async function init() {
   await loadSchema(latest)
 }
 
-init()
+await init()

--- a/schema-viewer/viewer.js
+++ b/schema-viewer/viewer.js
@@ -1,0 +1,623 @@
+import $RefParser from 'https://esm.sh/@apidevtools/json-schema-ref-parser@15'
+import { create as createDiffer } from 'https://esm.sh/jsondiffpatch@0.6.0'
+import {
+  buildNode, nodeMatchesSearch,
+  getTypeLabel, typeBadgeClass, variantTitle, variantDesc,
+  isExpert, stripExpert, computeSchemaDiff, isComposite,
+} from './schema-utils.js'
+
+const differ = createDiffer()
+
+// ── DOM helpers ───────────────────────────────────────────────────────────────
+
+function el(tag, cls, text) {
+  const e = document.createElement(tag)
+  if (cls) e.className = cls
+  if (text !== undefined) e.textContent = text
+  return e
+}
+
+function badge(text, cls) {
+  return el('span', `badge ${cls}`, text)
+}
+
+function setStatus(text, cls) {
+  const s = document.getElementById('status')
+  s.hidden = false
+  s.textContent = text
+  s.className = `badge-pill ${cls}`
+}
+
+function clearStatus() {
+  document.getElementById('status').hidden = true
+}
+
+// ── State ─────────────────────────────────────────────────────────────────────
+
+const expandedKeys = new Set()
+let selectedKey = null
+let rootNodes = []
+let allVersions = []          // newest-first; populated in init()
+let currentVersion = null     // currently displayed version
+let currentResolved = null    // resolved schema for currentVersion; used by recomputeDiff
+let currentDiff = null        // { fromVersion, diff } for the welcome panel
+
+function collectAllKeys(nodes, acc = new Set()) {
+  for (const node of nodes) {
+    if (node.children.length > 0) {
+      acc.add(node.key)
+      collectAllKeys(node.children, acc)
+    }
+  }
+  return acc
+}
+
+function findNodeByKey(key, nodes = rootNodes) {
+  for (const node of nodes) {
+    if (node.key === key) return node
+    const found = findNodeByKey(key, node.children)
+    if (found) return found
+  }
+  return null
+}
+
+function navigateTo(node) {
+  let pathSoFar = []
+  for (const segment of node.pathArr.slice(0, -1)) {
+    pathSoFar.push(segment)
+    expandedKeys.add(pathSoFar.join('/'))
+  }
+  selectedKey = node.key
+  renderTree(document.getElementById('search').value.toLowerCase())
+  requestAnimationFrame(() => {
+    document.querySelector('.tree-item.selected')?.scrollIntoView({ block: 'nearest' })
+  })
+  renderCard(node)
+}
+
+// ── Sidebar tree ──────────────────────────────────────────────────────────────
+
+function buildTreeFragment(nodes, depth, term) {
+  const frag = document.createDocumentFragment()
+  for (const node of nodes) {
+    if (term && !nodeMatchesSearch(node, term)) continue
+    frag.appendChild(buildTreeNodeEl(node, depth, term))
+  }
+  return frag
+}
+
+function buildTreeNodeEl(node, depth, term) {
+  const hasChildren = node.children.length > 0
+  const isExpanded = expandedKeys.has(node.key)
+  const isSelected = selectedKey === node.key
+
+  const wrapper = document.createElement('div')
+
+  const row = el('div', `tree-item${isSelected ? ' selected' : ''}`)
+  row.style.paddingLeft = `${12 + depth * 14}px`
+
+  const toggle = el('span', 'tree-toggle', hasChildren ? (isExpanded ? '▾' : '▸') : '')
+  const nameEl = el('span', 'tree-name', node.name)
+  row.appendChild(toggle)
+  row.appendChild(nameEl)
+
+  const childWrap = document.createElement('div')
+  if (hasChildren && isExpanded) {
+    childWrap.appendChild(buildTreeFragment(node.children, depth + 1, term))
+  } else {
+    childWrap.style.display = 'none'
+  }
+
+  row.addEventListener('click', e => {
+    e.stopPropagation()
+
+    if (hasChildren) {
+      if (expandedKeys.has(node.key)) {
+        expandedKeys.delete(node.key)
+        toggle.textContent = '▸'
+        childWrap.style.display = 'none'
+        childWrap.innerHTML = ''
+      } else {
+        expandedKeys.add(node.key)
+        toggle.textContent = '▾'
+        childWrap.style.display = ''
+        childWrap.appendChild(buildTreeFragment(node.children, depth + 1, term))
+      }
+    }
+
+    document.querySelectorAll('.tree-item.selected').forEach(el => el.classList.remove('selected'))
+    row.classList.add('selected')
+    selectedKey = node.key
+    renderCard(node)
+  })
+
+  wrapper.appendChild(row)
+  wrapper.appendChild(childWrap)
+  return wrapper
+}
+
+function renderTree(term = '') {
+  const container = document.getElementById('tree')
+  container.innerHTML = ''
+  container.appendChild(buildTreeFragment(rootNodes, 0, term))
+}
+
+// ── Change summary ────────────────────────────────────────────────────────────
+
+function buildChangeSummarySection({ fromVersion, diff }) {
+  const { added, removed, modified } = diff
+  const section = el('div', 'welcome-section')
+
+  // Title row with compare-to selector
+  const titleRow = el('div', 'diff-title-row')
+  titleRow.appendChild(el('span', 'welcome-section-title', 'Change summary'))
+
+  const compareWrap = el('span', 'diff-compare-wrap')
+  compareWrap.appendChild(el('label', 'diff-compare-label', 'Compare to'))
+  const compareSelect = el('select', 'diff-compare-select')
+  const currentIdx = allVersions.indexOf(currentVersion)
+  const olderVersions = currentIdx >= 0 ? allVersions.slice(currentIdx + 1) : []
+  olderVersions.forEach(v => {
+    const opt = document.createElement('option')
+    opt.value = v
+    opt.textContent = `v${v}`
+    if (v === fromVersion) opt.selected = true
+    compareSelect.appendChild(opt)
+  })
+  compareSelect.addEventListener('change', () => recomputeDiff(compareSelect.value))
+  compareWrap.appendChild(compareSelect)
+  titleRow.appendChild(compareWrap)
+  section.appendChild(titleRow)
+
+  const total = added.length + removed.length + modified.length
+  if (total === 0) {
+    section.appendChild(el('p', 'welcome-text', `No top-level field changes from v${fromVersion}.`))
+    return section
+  }
+
+  const note = el('p', 'diff-note',
+    'Covers top-level field additions, removals, and scalar changes. ' +
+    'Structural refactors inside shared definitions may not appear — see Known Limitations in the README.')
+  section.appendChild(note)
+
+  function renderGroup(label, cls, items, renderItem) {
+    if (!items.length) return
+    const group = el('div', 'diff-group')
+    group.appendChild(el('span', `diff-label ${cls}`, `${label} (${items.length})`))
+    const list = el('ul', 'diff-list')
+    items.forEach(item => list.appendChild(renderItem(item)))
+    group.appendChild(list)
+    section.appendChild(group)
+  }
+
+  const fmt = path => path.split('/').join(' › ')
+
+  renderGroup('Added', 'diff-added', added, path => {
+    const li = el('li', 'diff-item')
+    li.appendChild(el('code', 'diff-field', fmt(path)))
+    return li
+  })
+
+  renderGroup('Removed', 'diff-removed', removed, path => {
+    const li = el('li', 'diff-item')
+    li.appendChild(el('code', 'diff-field', fmt(path)))
+    return li
+  })
+
+  renderGroup('Modified', 'diff-modified', modified, ({ path, changes }) => {
+    const li = el('li', 'diff-item')
+    li.appendChild(el('code', 'diff-field', fmt(path)))
+    const descs = changes.map(({ kind, from, to }) => {
+      if (kind === 'type')     return `type: ${from} → ${to}`
+      if (kind === 'required') return to ? 'became required' : 'became optional'
+      if (kind === 'default') {
+        if (from === undefined) return `default added: ${to}`
+        if (to   === undefined) return `default removed`
+        return `default: ${from} → ${to}`
+      }
+      return kind
+    })
+    li.appendChild(el('span', 'diff-desc', ` — ${descs.join(', ')}`))
+    return li
+  })
+
+  return section
+}
+
+// ── Welcome panel ─────────────────────────────────────────────────────────────
+
+function buildWelcomePanel() {
+  const panel = el('div', 'welcome-panel')
+
+  // Change summary (shown whenever there is a predecessor version)
+  if (currentDiff) panel.appendChild(buildChangeSummarySection(currentDiff))
+
+  // About
+  const about = el('div', 'welcome-section')
+  about.appendChild(el('div', 'welcome-section-title', 'About this schema'))
+  about.appendChild(el('p', 'welcome-text',
+    'The workflow migration schema defines every configuration option for the ' +
+    'OpenSearch Migration Assistant — source and target cluster connections, ' +
+    'traffic capture, replayer behaviour, metadata migration, and more. ' +
+    'Each field in the tree corresponds to a key you can set in your migration configuration.'
+  ))
+  const docsLink = el('a', 'welcome-link', 'Migration Assistant documentation ↗')
+  docsLink.href = 'https://docs.opensearch.org/latest/migration-assistant/'
+  docsLink.target = '_blank'
+  docsLink.rel = 'noopener noreferrer'
+  about.appendChild(docsLink)
+  panel.appendChild(about)
+
+  // How to use
+  const howto = el('div', 'welcome-section')
+  howto.appendChild(el('div', 'welcome-section-title', 'How to use'))
+  const steps = el('ul', 'welcome-steps')
+  ;[
+    'Click the ▸ arrow next to any field in the tree to expand its children.',
+    'Click a field name to see its full details in this panel.',
+    'Use the search box to filter the tree by field name.',
+    'Use the version selector to browse schemas from previous releases.',
+  ].forEach(text => { steps.appendChild(el('li', null, text)) })
+  howto.appendChild(steps)
+  panel.appendChild(howto)
+
+  // Badge legend
+  const legend = el('div', 'welcome-section')
+  legend.appendChild(el('div', 'welcome-section-title', 'Badge legend'))
+  const rows = el('div', 'legend-rows')
+  ;[
+    [badge('Required', 'badge-required'), 'Must be set for the configuration to be valid.'],
+    [badge('Optional', 'badge-optional'), 'Has a default value or can be omitted.'],
+    [badge('Default: value', 'badge-default'), 'The value used when the field is not specified.'],
+    [badge('Expert', 'badge-expert'), 'Advanced option — most migrations do not need to change this.'],
+  ].forEach(([b, desc]) => {
+    const row = el('div', 'legend-row')
+    row.appendChild(b)
+    row.appendChild(el('span', 'legend-desc', desc))
+    rows.appendChild(row)
+  })
+  legend.appendChild(rows)
+  panel.appendChild(legend)
+
+  return panel
+}
+
+// ── Field card ────────────────────────────────────────────────────────────────
+
+function renderCard(node) {
+  const main = document.getElementById('main')
+  main.innerHTML = ''
+  main.appendChild(buildCardEl(node))
+}
+
+function buildCardEl(node) {
+  if (!node) return buildWelcomePanel()
+
+  const { name, schema, required, pathArr } = node
+  const parentPath = pathArr.slice(0, -1)
+  const t = getTypeLabel(schema)
+  const unionKey = schema.oneOf ? 'oneOf' : schema.anyOf ? 'anyOf' : null
+  const branches = unionKey ? schema[unionKey] : []
+
+  const card = el('div', 'field-card')
+
+  // Breadcrumb
+  if (parentPath.length > 0) {
+    card.appendChild(el('div', 'breadcrumb', parentPath.join(' › ')))
+  }
+
+  // Title + expert badge
+  const titleRow = el('div', 'field-title-row')
+  titleRow.appendChild(el('span', 'field-title', name))
+  if (isExpert(schema.description)) {
+    titleRow.appendChild(badge('Expert', 'badge-expert'))
+  }
+  card.appendChild(titleRow)
+
+  // Description (strip [Expert] prefix if present)
+  if (schema.description) {
+    card.appendChild(el('p', 'field-desc', stripExpert(schema.description)))
+  }
+
+  // Meta row
+  const meta = el('div', 'meta-row')
+  meta.appendChild(metaItem('Data type', badge(t, typeBadgeClass(t))))
+  meta.appendChild(metaItem('Requirement',
+    badge(required ? 'Required' : 'Optional', required ? 'badge-required' : 'badge-optional')))
+  if (schema.default !== undefined) {
+    meta.appendChild(metaItem('Default', badge(JSON.stringify(schema.default), 'badge-default')))
+  }
+  card.appendChild(meta)
+
+  // Union variants
+  if (unionKey && branches.length > 0) {
+    const section = el('div', 'section')
+    section.appendChild(el('div', 'section-title', 'Allowed enums / structures'))
+    const list = el('div', 'union-list')
+    branches.forEach((branch, i) => {
+      const row = el('div', 'union-row')
+      row.appendChild(el('span', 'union-value', `"${variantTitle(branch, i, unionKey)}"`))
+      row.appendChild(el('span', 'union-desc', branch.description || variantDesc(branch)))
+      list.appendChild(row)
+    })
+    section.appendChild(list)
+    card.appendChild(section)
+  }
+
+  // Properties — grouped by variant for union types, flat otherwise
+  const branchesWithProps = branches.filter(b => b.properties)
+  if (unionKey && branchesWithProps.length > 0) {
+    const section = el('div', 'section')
+    section.appendChild(el('div', 'section-title', 'Properties'))
+    branchesWithProps.forEach((branch, i) => {
+      const block = el('div', 'variant-block')
+      const lbl = el('div', 'variant-label', 'When ')
+      lbl.appendChild(el('code', '', `"${variantTitle(branch, i, unionKey)}"`))
+      block.appendChild(lbl)
+      block.appendChild(buildPropsTable(branch, [...pathArr, variantTitle(branch, i, unionKey)]))
+      section.appendChild(block)
+    })
+    card.appendChild(section)
+  } else if (!unionKey && schema.properties) {
+    const section = el('div', 'section')
+    section.appendChild(el('div', 'section-title', 'Properties'))
+    section.appendChild(buildPropsTable(schema, pathArr))
+    card.appendChild(section)
+  }
+
+  // Map value schema — show union branches if the value type has them
+  if (!schema.properties && schema.additionalProperties && typeof schema.additionalProperties === 'object') {
+    const ap = schema.additionalProperties
+    const apUnionKey = ap.oneOf ? 'oneOf' : ap.anyOf ? 'anyOf' : null
+    if (apUnionKey) {
+      const section = el('div', 'section')
+      section.appendChild(el('div', 'section-title', 'Map value schema — allowed structures'))
+      const list = el('div', 'union-list')
+      ap[apUnionKey].forEach((branch, i) => {
+        const row = el('div', 'union-row')
+        row.appendChild(el('span', 'union-value', `"${variantTitle(branch, i, apUnionKey)}"`))
+        row.appendChild(el('span', 'union-desc', branch.description || variantDesc(branch)))
+        list.appendChild(row)
+      })
+      section.appendChild(list)
+      card.appendChild(section)
+    }
+  }
+
+  return card
+}
+
+function metaItem(labelText, valueEl) {
+  const item = el('div', 'meta-item')
+  item.appendChild(el('span', 'meta-label', labelText))
+  item.appendChild(valueEl)
+  return item
+}
+
+function buildPropsTable(schema, parentPathArr = []) {
+  const required = new Set(schema.required || [])
+  const table = el('table', 'props-table')
+  const tbody = el('tbody')
+
+  for (const [key, val] of Object.entries(schema.properties || {})) {
+    const t = getTypeLabel(val)
+    const isReq = required.has(key)
+    const tr = document.createElement('tr')
+
+    const nameTd = el('td', 'prop-name-cell')
+    if (isComposite(val)) {
+      const link = el('a', 'prop-name prop-drill', key)
+      link.href = '#'
+      link.addEventListener('click', e => {
+        e.preventDefault()
+        const childKey = [...parentPathArr, key].join('/')
+        const node = findNodeByKey(childKey) || buildNode(key, val, [...parentPathArr, key], required)
+        navigateTo(node)
+      })
+      nameTd.appendChild(link)
+    } else {
+      nameTd.appendChild(el('span', 'prop-name', key))
+    }
+    nameTd.appendChild(el('span', 'prop-type', t))
+    tr.appendChild(nameTd)
+
+    const descTd = el('td', 'prop-desc-cell')
+    if (val.description) descTd.appendChild(el('div', '', stripExpert(val.description)))
+    const propBadges = el('div', 'prop-badges')
+    if (isExpert(val.description)) propBadges.appendChild(badge('Expert', 'badge-expert'))
+    propBadges.appendChild(badge(isReq ? 'Required' : 'Optional', isReq ? 'badge-required' : 'badge-optional'))
+    if (val.default !== undefined) {
+      propBadges.appendChild(badge(`Default: ${JSON.stringify(val.default)}`, 'badge-default'))
+    }
+    descTd.appendChild(propBadges)
+    tr.appendChild(descTd)
+
+    tbody.appendChild(tr)
+  }
+
+  table.appendChild(tbody)
+  return table
+}
+
+// ── Resizable divider ─────────────────────────────────────────────────────────
+
+function initDivider() {
+  const divider = document.getElementById('divider')
+  const viewer  = divider.closest('.viewer')
+  const sidebar = document.getElementById('sidebar')
+
+  let dragging = false
+  let startPos = 0
+  let startSize = 0
+
+  function isMobile() {
+    return getComputedStyle(viewer).flexDirection === 'column'
+  }
+
+  function onStart(pos) {
+    dragging = true
+    divider.classList.add('dragging')
+    if (isMobile()) {
+      startPos  = pos.y
+      startSize = sidebar.getBoundingClientRect().height
+    } else {
+      startPos  = pos.x
+      startSize = sidebar.getBoundingClientRect().width
+    }
+  }
+
+  function onMove(pos) {
+    if (!dragging) return
+    const rect = viewer.getBoundingClientRect()
+    if (isMobile()) {
+      const h = Math.max(120, Math.min(startSize + pos.y - startPos, rect.height - 120))
+      sidebar.style.height = h + 'px'
+    } else {
+      const w = Math.max(150, Math.min(startSize + pos.x - startPos, rect.width - 200))
+      sidebar.style.width = w + 'px'
+    }
+  }
+
+  function onEnd() {
+    dragging = false
+    divider.classList.remove('dragging')
+  }
+
+  divider.addEventListener('mousedown',  e => { onStart({ x: e.clientX, y: e.clientY }); e.preventDefault() })
+  document.addEventListener('mousemove', e => onMove({ x: e.clientX, y: e.clientY }))
+  document.addEventListener('mouseup',   onEnd)
+
+  divider.addEventListener('touchstart', e => {
+    const t = e.touches[0]
+    onStart({ x: t.clientX, y: t.clientY })
+    e.preventDefault()
+  }, { passive: false })
+  document.addEventListener('touchmove', e => {
+    if (!dragging) return
+    const t = e.touches[0]
+    onMove({ x: t.clientX, y: t.clientY })
+    e.preventDefault()
+  }, { passive: false })
+  document.addEventListener('touchend', onEnd)
+
+  // Clear the axis-specific inline size when the layout orientation changes
+  window.addEventListener('resize', () => {
+    if (isMobile()) sidebar.style.width = ''
+    else            sidebar.style.height = ''
+  })
+}
+
+// ── Init ──────────────────────────────────────────────────────────────────────
+
+function rebuildFromSchema(schema) {
+  const required = new Set(schema.required || [])
+  rootNodes = Object.entries(schema.properties || {})
+    .map(([k, v]) => buildNode(k, v, [k], required))
+    .filter(Boolean)
+  selectedKey = null
+  expandedKeys.clear()
+  renderTree()
+  renderCard(null)
+}
+
+async function recomputeDiff(compareVersion) {
+  if (!compareVersion || !currentResolved) return
+  setStatus('Loading comparison…', 'info')
+  try {
+    const raw = await fetch(`./schemas/${compareVersion}.json`).then(r => r.json())
+    const resolved = await $RefParser.dereference(raw)
+    currentDiff = { fromVersion: compareVersion, diff: computeSchemaDiff(resolved, currentResolved, differ) }
+  } catch (_) {
+    currentDiff = null
+  }
+  clearStatus()
+  renderCard(null)
+}
+
+async function loadSchema(version) {
+  setStatus('Loading…', 'info')
+  currentVersion = version
+  currentResolved = null
+  currentDiff = null
+
+  let rawSchema
+  try {
+    rawSchema = await fetch(`./schemas/${version}.json`).then(r => r.json())
+  } catch (e) {
+    setStatus('Failed to load schema: ' + e.message, 'warn')
+    return
+  }
+
+  // Resolve current schema and, for the change summary, also resolve the
+  // immediate predecessor — both needed so the diff sees actual field structures
+  // rather than opaque $ref strings.
+  const vIdx = allVersions.indexOf(version)
+  const prevVersion = vIdx >= 0 && vIdx < allVersions.length - 1 ? allVersions[vIdx + 1] : null
+
+  const prevRawPromise = prevVersion
+    ? fetch(`./schemas/${prevVersion}.json`).then(r => r.json()).catch(() => null)
+    : Promise.resolve(null)
+
+  let schema = rawSchema
+  try {
+    schema = await $RefParser.dereference(rawSchema)
+    clearStatus()
+  } catch (e) {
+    setStatus('Warning: $ref resolution failed — some fields may be incomplete.', 'warn')
+  }
+  currentResolved = schema
+
+  // Compute change summary against the default predecessor (best-effort)
+  const prevRaw = await prevRawPromise
+  if (prevRaw) {
+    try {
+      const prevResolved = await $RefParser.dereference(prevRaw)
+      currentDiff = { fromVersion: prevVersion, diff: computeSchemaDiff(prevResolved, schema, differ) }
+    } catch (_) { /* silently skip on resolution error */ }
+  }
+
+  rebuildFromSchema(schema)
+}
+
+async function init() {
+  initDivider()
+
+  document.getElementById('search').addEventListener('input', e => {
+    renderTree(e.target.value.toLowerCase())
+  })
+
+  document.getElementById('expand-all').addEventListener('click', e => {
+    e.preventDefault()
+    collectAllKeys(rootNodes).forEach(k => expandedKeys.add(k))
+    renderTree(document.getElementById('search').value.toLowerCase())
+  })
+
+  document.getElementById('collapse-all').addEventListener('click', e => {
+    e.preventDefault()
+    expandedKeys.clear()
+    renderTree(document.getElementById('search').value.toLowerCase())
+  })
+
+  let latest
+  try {
+    const meta = await fetch('./schemas/versions.json').then(r => r.json())
+    allVersions = meta.versions
+    latest = meta.latest
+    const sel = document.getElementById('version-select')
+    meta.versions.forEach(v => {
+      const opt = document.createElement('option')
+      opt.value = v
+      opt.textContent = v
+      if (v === latest) opt.selected = true
+      sel.appendChild(opt)
+    })
+    sel.addEventListener('change', () => loadSchema(sel.value))
+  } catch (e) {
+    setStatus('Failed to load versions: ' + e.message, 'warn')
+    return
+  }
+
+  await loadSchema(latest)
+}
+
+init()


### PR DESCRIPTION
### Description
Adds a static schema browser served via GitHub Pages that lets users explore `workflowMigration.schema.json` interactively. User can browse fields, read descriptions, check types and defaults, and compare schemas across releases without needing to read raw JSON.

Live preview (fork): https://wrigleydan.github.io/opensearch-migrations/

After discussing the [RFC in the OpenSearch documentation repository](https://github.com/opensearch-project/documentation-website/issues/12485) a GitHub Pages approach seemed most viable.

Four static files (`index.html`, `viewer.js`, `schema-utils.js`, `viewer.css`) are served directly by GitHub Pages.

**Features:**
* Two-column layout: collapsible field tree on the left, detail card on the right with a draggable divider (works on mobile too, where it stacks vertically).
* Field cards showing type badge, required/optional status, default value, description, and oneOf/anyOf variant tables
* Fields whose description begins with `[Expert]` are flagged with a badge; the prefix is stripped from the visible text
* Live search filtering of the tree.
* Version selector populated from all GitHub Releases that include workflowMigration.schema.json with no schema files  stored in the repository.
* Change summary panel: on load (and on version switch), automatically diffs the selected version against any older version (defaulting to the immediate predecessor). Covers additions, removals, and scalar changes (type, default, required) at any depth in the resolved schema tree. Comparison target is user-selectable.
* Welcome panel with usage guide and badge legend when no field is selected.
* Styled to match the OpenSearch documentation site (Open Sans, Fira Mono, OpenSearch colour tokens).


**Pages deployment:**

Handled in `.github/workflows/deploy-schema-viewer.yml`

Triggers on:
* Push to `main` touching `schema-viewer/**` (viewer code changes)
* Release published (picks up the new schema automatically)
* Manual `workflow_dispatch`

On each run, the workflow queries the GitHub Releases API, downloads every release asset named `workflowMigration.schema.json`, generates `schemas/versions.json`, and deploys `schema-viewer/` to GitHub Pages via `actions/deploy-pages`. All action references are pinned to full commit SHAs following the repository convention.

**Known limitations**

* Changes to shared `$ref` definitions surface once per field that references the definition (accurate, but can produce many similar-looking entries for a single underlying type change)
* `oneOf/anyOf` branch reordering is not tracked as a change
* Description-only changes are intentionally excluded from the diff (prose, not configuration)

The upstream repository has a `github-pages` environment configured but the [site currently returns 404](https://opensearch-project.github.io/opensearch-migrations/). This PR activates it with the schema viewer. No existing content is displaced.

### Issues Resolved
https://github.com/opensearch-project/documentation-website/issues/12485

### Testing
66 unit tests covering tree building, search, type helpers, expert-field handling, and the diff engine (`schema-utils.test.js`, Vitest).


### Check List
- [x] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
