### PR TITLE
Fix: don't disable inter-case workflow reset when --skip-delete is set

### DIFF
--- a/libraries/testAutomation/testAutomation/test_runner.py
+++ b/libraries/testAutomation/testAutomation/test_runner.py
@@ -418,7 +418,6 @@ class TestRunner:
                                              target_version=target_version,
                                              keep_workflows=keep_workflows,
                                              reuse_clusters=reuse_clusters,
-                                             skip_workflow_reset=skip_delete,
                                              test_reports_dir=test_reports_dir)
                 test_reports.append(test_report)
 

--- a/libraries/testAutomation/tests/test_test_runner.py
+++ b/libraries/testAutomation/tests/test_test_runner.py
@@ -140,6 +140,17 @@ class TestPytestCommand:
         command_list = runner.k8s_service.exec_background_cmd.call_args.kwargs["command_list"]
         assert "--capture_proxy_service_type=ClusterIP" in command_list
 
+    def test_skip_delete_does_not_disable_inter_case_reset(self):
+        """--skip-delete preserves the deployment but must NOT pass
+        --skip_workflow_reset to pytest. Per-case CRD reset is required for
+        every multi-case run; otherwise case N+1's setup precondition trips on
+        leftovers from case N (e.g. datasnapshot.source1-testsnapshot)."""
+        runner = _make_runner(combinations=[("ES_7.10", "OS_1.3")])
+        with patch.object(runner, "run_tests", return_value=_make_report(passed=2, failed=0)) as mock_run:
+            runner.run(skip_delete=True)
+            mock_run.assert_called_once()
+            assert mock_run.call_args.kwargs.get("skip_workflow_reset", False) is False
+
 
 from test_runner import get_version_combinations, TargetType, VALID_SOURCE_VERSIONS
 


### PR DESCRIPTION
## Summary

Decouple `--skip_workflow_reset` (per-test-case CRD reset, internal to one pytest run) from `--skip-delete` (deployment lifecycle, controls whether helm uninstall + cluster delete runs after pytest exits). The two flags were wired together in #3028, which broke every multi-case EKS Jenkins run.

## The bug

`libraries/testAutomation/testAutomation/test_runner.py:421`

```python
test_report = self.run_tests(...
    skip_workflow_reset=skip_delete,   # ← wrong wiring
```

| Flag | Scope | Question it answers |
|---|---|---|
| `--skip-delete` | deployment | Should I uninstall helm + delete the cluster after the whole pytest run finishes? |
| `--skip_workflow_reset` | per-case | Should I skip `workflow reset` between test cases inside one pytest run? |

Every Jenkins EKS pipeline (`eksIntegPipeline.groovy`, `eksCdcIntegPipeline.groovy`, `eksCdcAossIntegPipeline.groovy`, `eksBYOSIntegPipeline.groovy`, `eksAOSSIntegPipeline.groovy`) passes `--skip-delete --skip-install` because Jenkins owns the cluster lifecycle. The buggy wiring then forced pytest into "no inter-case reset" mode on every multi-case CI run.

When the next case starts, `_fail_if_migration_resources_exist()` (`migrationConsole/lib/integ_test/integ_test/ma_workflow_test.py:50`) trips on the leftover CRDs from the previous case:

```
Failed: Migration resources already exist before test starts; a previous
workflow reset likely failed. Remaining resources in namespace ma:
  datasnapshot.source1-testsnapshot,
  snapshotmigration.source1-target1-testsnapshot-migration-0
```

## Reproductions

| PR | Build | Test IDs | Result |
|---|---|---|---|
| #2938 | pr-eks-integ-test #979 | 0001,0002 | case0 PASSED → case1 ERRORED |
| #3022 | pr-eks-integ-test #980 | 0001,0002 | case0 PASSED → case1 ERRORED |
| #3022 | pr-eks-cdc-full-e2e-test #309 | 0031,0032,0033,0040,0042 | case0 PASSED → cases 1–4 ALL ERRORED (kafkacluster, capturedtraffic, captureproxy, trafficreplay leftovers) |

## Fix

```diff
 test_report = self.run_tests(source_version=source_version,
                              target_version=target_version,
                              keep_workflows=keep_workflows,
                              reuse_clusters=reuse_clusters,
-                             skip_workflow_reset=skip_delete,
                              test_reports_dir=test_reports_dir)
```

`--skip_workflow_reset` remains a pytest option for hand-driven single-case debug runs; the runner just stops force-passing it on top of `--skip-delete`. Adds a regression test in `test_test_runner.py` that asserts `runner.run(skip_delete=True)` does NOT pass `skip_workflow_reset=True` to `run_tests`.

Verified the regression test fails against the buggy code and passes against the fix. All existing `test_test_runner.py` (17) and `test_ma_workflow_reset.py` (6) tests pass.

## Test plan

- [x] `python3 -m pytest libraries/testAutomation/tests/test_test_runner.py` — 17 passed
- [x] `python3 -m pytest migrationConsole/lib/integ_test/tests/test_ma_workflow_reset.py` — 6 passed
- [x] Regression test fails on the buggy code (verified by temporarily restoring the line)
- [ ] EKS Jenkins runs (will be exercised by the PR's own CI)