### PR TITLE
Fix infinite create-index retry loop on ES 7.x index-level knn settings

### DIFF
--- a/MetadataMigration/src/main/java/org/opensearch/migrations/MetadataTransformationRegistry.java
+++ b/MetadataMigration/src/main/java/org/opensearch/migrations/MetadataTransformationRegistry.java
@@ -57,6 +57,20 @@ public class MetadataTransformationRegistry {
                 .descriptionLine("Convert field data type dense_vector to OpenSearch knn_vector")
                 .build())
             .build(),
+        // Any source whose target is OpenSearch: pre-OS index-level knn params
+        // are rejected on create-index, so lift them onto field-level method
+        // config. No-op when absent (see the js file for the full rationale).
+        TransformerConfigs.builder()
+            .filename("js/es-knn-index-to-field-level-metadata.js")
+            .isRelevantForVersions(andSourceTargetVersionPredicate(
+                    v -> true,
+                    UnboundVersionMatchers.anyOS
+            ))
+            .transformerInfo(Transformers.TransformerInfo.builder()
+                .name("Index-level knn settings to field-level method")
+                .descriptionLine("Lift index.knn.* settings onto knn_vector field method config")
+                .build())
+            .build(),
         TransformerConfigs.builder()
             .filename("js/knn-to-serverless-metadata.js")
             .isRelevantForVersions(andSourceTargetVersionPredicate(

--- a/MetadataMigration/src/test/java/org/opensearch/migrations/EsKnnIndexLevelSettingsMigrationTest.java
+++ b/MetadataMigration/src/test/java/org/opensearch/migrations/EsKnnIndexLevelSettingsMigrationTest.java
@@ -1,0 +1,166 @@
+package org.opensearch.migrations;
+
+import java.io.File;
+import java.util.stream.Stream;
+
+import org.opensearch.migrations.bulkload.framework.SearchClusterContainer;
+import org.opensearch.migrations.bulkload.framework.SearchClusterContainer.ContainerVersion;
+import org.opensearch.migrations.commands.MigrationItemResult;
+import org.opensearch.migrations.snapshot.creation.tracing.SnapshotTestContext;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * End-to-end regression test for the ES 7.x (AWS k-NN plugin) → OpenSearch 3.x path.
+ *
+ * The source stores k-NN build params as index-level settings (index.knn.algo_param.*,
+ * index.knn.space_type) on a method-less knn_vector field. OpenSearch 3.x rejects those
+ * settings on create-index, which previously sent IndexCreator into an infinite retry
+ * loop. This verifies the migration completes and the params land as field-level method
+ * config on the target. Uses Open Distro 1.13.3 (Apache-2.0, ES 7.10.2 + k-NN plugin)
+ * so no licensed Elasticsearch image is required.
+ */
+@Tag("isolatedTest")
+@Slf4j
+class EsKnnIndexLevelSettingsMigrationTest extends BaseMigrationTest {
+
+    private static final String INDEX_NAME = "es7-knn-index-level";
+    private static final int DIMENSION = 16;
+
+    @TempDir
+    protected File localDirectory;
+
+    private static Stream<Arguments> scenarios() {
+        return Stream.of(
+            Arguments.of(SearchClusterContainer.ODFE_V1_13_3, SearchClusterContainer.OS_LATEST)
+        );
+    }
+
+    @ParameterizedTest(name = "ES7 index-level knn settings migration from {0} to {1}")
+    @MethodSource("scenarios")
+    void esKnnIndexLevelSettingsMigrationTest(ContainerVersion sourceVersion, ContainerVersion targetVersion) {
+        try (
+            final var sourceCluster = new SearchClusterContainer(sourceVersion);
+            final var targetCluster = new SearchClusterContainer(targetVersion)
+        ) {
+            this.sourceCluster = sourceCluster;
+            this.targetCluster = targetCluster;
+            performTest();
+        }
+    }
+
+    @SneakyThrows
+    private void performTest() {
+        startClusters();
+
+        sourceOperations.createIndex(INDEX_NAME, sourceIndexBody());
+        sourceOperations.createDocument(INDEX_NAME, "1", vectorDocument());
+
+        var snapshotName = "es7_knn_index_level_snap";
+        var testSnapshotContext = SnapshotTestContext.factory().noOtelTracking();
+        createSnapshot(sourceCluster, snapshotName, testSnapshotContext);
+        sourceCluster.copySnapshotData(localDirectory.toString());
+        var arguments = prepareSnapshotMigrationArgs(snapshotName, localDirectory.toString());
+
+        MigrationItemResult evaluateResult = executeMigration(arguments, MetadataCommands.EVALUATE);
+        log.info("EVALUATE result:\n{}", evaluateResult.asCliOutput());
+        assertThat(evaluateResult.getExitCode(), equalTo(0));
+
+        // Before the fix this call would hang in IndexCreator's create-index retry loop.
+        MigrationItemResult migrateResult = executeMigration(arguments, MetadataCommands.MIGRATE);
+        log.info("MIGRATE result:\n{}", migrateResult.asCliOutput());
+        assertThat(migrateResult.getExitCode(), equalTo(0));
+
+        verifyTargetIndex();
+    }
+
+    /**
+     * ES 7.x k-NN plugin shape: knn_vector field carries only type+dimension, while the
+     * HNSW build params live in index settings. ef_search is a runtime setting and must
+     * survive untouched; the build params (ef_construction, m, space_type) must move to
+     * the field method.
+     */
+    private String sourceIndexBody() {
+        return String.format(
+            "{" +
+            "  \"settings\": {" +
+            "    \"index\": {" +
+            "      \"knn\": true," +
+            "      \"knn.algo_param.ef_construction\": 128," +
+            "      \"knn.algo_param.m\": 24," +
+            "      \"knn.algo_param.ef_search\": 100," +
+            "      \"knn.space_type\": \"l2\"," +
+            "      \"number_of_shards\": 1," +
+            "      \"number_of_replicas\": 0" +
+            "    }" +
+            "  }," +
+            "  \"mappings\": {" +
+            "    \"properties\": {" +
+            "      \"my_vector\": {" +
+            "        \"type\": \"knn_vector\"," +
+            "        \"dimension\": %d" +
+            "      }" +
+            "    }" +
+            "  }" +
+            "}", DIMENSION);
+    }
+
+    private String vectorDocument() {
+        StringBuilder vector = new StringBuilder("[");
+        for (int i = 0; i < DIMENSION; i++) {
+            vector.append(i == 0 ? "" : ",").append("0.1");
+        }
+        vector.append("]");
+        return String.format("{\"my_vector\": %s}", vector);
+    }
+
+    @SneakyThrows
+    private void verifyTargetIndex() {
+        ObjectMapper mapper = new ObjectMapper();
+
+        // flat_settings keeps settings as literal dotted keys (index.knn.*), matching
+        // how the migration emits them and avoiding nested/flat ambiguity in assertions.
+        var response = targetOperations.get("/" + INDEX_NAME + "/_settings?flat_settings=true");
+        assertThat("Settings should be readable on target", response.getKey(), equalTo(200));
+        JsonNode settings = mapper.readTree(response.getValue()).path(INDEX_NAME).path("settings");
+
+        // Build-time params were stripped from settings (otherwise create-index would have failed).
+        assertTrue(settings.path("index.knn.algo_param.ef_construction").isMissingNode(),
+            "index-level ef_construction should be gone from target settings");
+        assertTrue(settings.path("index.knn.algo_param.m").isMissingNode(),
+            "index-level m should be gone from target settings");
+        assertTrue(settings.path("index.knn.space_type").isMissingNode(),
+            "index-level space_type should be gone from target settings");
+
+        // The enable flag and the runtime ef_search setting remain valid on OS.
+        assertThat("index.knn enable flag preserved",
+            settings.path("index.knn").asText(), equalTo("true"));
+        assertThat("runtime ef_search preserved",
+            settings.path("index.knn.algo_param.ef_search").asText(), equalTo("100"));
+
+        var mappingResponse = targetOperations.get("/" + INDEX_NAME + "/_mapping");
+        assertThat("Mappings should be readable on target", mappingResponse.getKey(), equalTo(200));
+        JsonNode method = mapper.readTree(mappingResponse.getValue()).path(INDEX_NAME)
+            .path("mappings").path("properties").path("my_vector").path("method");
+
+        // Build-time params were lifted onto the field method.
+        assertTrue(method.has("engine"), "my_vector should have a field-level method block");
+        assertThat(method.path("engine").asText(), equalTo("faiss"));
+        assertThat(method.path("name").asText(), equalTo("hnsw"));
+        assertThat(method.path("space_type").asText(), equalTo("l2"));
+        assertThat(method.path("parameters").path("m").asInt(), equalTo(24));
+        assertThat(method.path("parameters").path("ef_construction").asInt(), equalTo(128));
+    }
+}

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/version_os_2_11/IndexCreator_OS_2_11.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/version_os_2_11/IndexCreator_OS_2_11.java
@@ -188,9 +188,11 @@ public class IndexCreator_OS_2_11 implements IndexCreator {
                     throw invalidResponse;
                 }
 
-                var shortenedIllegalArgument = illegalArgument.replaceFirst("index.", "");
-                log.debug("Removing setting '{}' from index '{}' settings", shortenedIllegalArgument, indexName);
-                ObjectNodeUtils.removeFieldsByPath(settings, shortenedIllegalArgument);
+                // Settings serialize as flat keys ("index.knn.algo_param.m") or
+                // nested under "index"; remove the full path, then the stripped path.
+                log.debug("Removing setting '{}' from index '{}' settings", illegalArgument, indexName);
+                ObjectNodeUtils.removeFieldsByPath(settings, illegalArgument);
+                ObjectNodeUtils.removeFieldsByPath(settings, illegalArgument.substring("index.".length()));
             }
 
             log.info("Reattempting creation of index '{}' after removing illegal arguments: {}", indexName, illegalArguments);

--- a/RFS/src/main/java/org/opensearch/migrations/parsing/ObjectNodeUtils.java
+++ b/RFS/src/main/java/org/opensearch/migrations/parsing/ObjectNodeUtils.java
@@ -9,8 +9,20 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 public class ObjectNodeUtils {
     private ObjectNodeUtils() {}
 
+    /**
+     * Removes a setting addressed by a dotted path, tolerating both shapes seen in
+     * index-settings JSON: a literal flat key (settings["index.knn.algo_param.m"])
+     * or a nested-object path (settings.index.knn.algo_param.m). The flat key is
+     * matched first. This flat-key handling is what stops ES 7.x index-level knn
+     * params from surviving IndexCreator's strip-and-retry into an infinite loop.
+     */
     public static void removeFieldsByPath(ObjectNode node, String path) {
-        if (node == null) {
+        if (node == null || path == null || path.isEmpty()) {
+            return;
+        }
+
+        if (node.has(path)) {
+            node.remove(path);
             return;
         }
 

--- a/RFS/src/test/java/org/opensearch/migrations/bulkload/version_os_2_11/IndexCreator_OS_2_11Test.java
+++ b/RFS/src/test/java/org/opensearch/migrations/bulkload/version_os_2_11/IndexCreator_OS_2_11Test.java
@@ -127,6 +127,55 @@ class IndexCreator_OS_2_11Test {
     }
 
     @Test
+    void testCreate_withRetryToRemoveFlatKeyedKnnSettings() throws Exception {
+        // Reproduces an ES 7.x → OS 3.x retail-products migration where
+        // index-level knn settings are stored as flat keys with embedded dots
+        // (e.g. settings["index.knn.algo_param.m"]). Before the fix, the strip
+        // walked nested segments only and never removed the flat keys, causing
+        // an infinite createIndex retry loop.
+        var invalidResponse = mock(InvalidResponse.class);
+        when(invalidResponse.getIllegalArguments()).thenReturn(Set.of(
+            "index.knn.algo_param.ef_construction",
+            "index.knn.algo_param.m",
+            "index.knn.space_type"
+        ));
+
+        var client = mock(OpenSearchClient.class);
+        when(client.createIndex(any(), any(), any()))
+            .thenThrow(invalidResponse)
+            .thenReturn(INDEX_CREATE_SUCCESS);
+
+        var rawJson = "{\n" +
+            "  \"aliases\" : { },\n" +
+            "  \"mappings\" : { \"properties\": { \"v\": { \"type\": \"knn_vector\", \"dimension\": 4 } } },\n" +
+            "  \"settings\" : {\n" +
+            "    \"index.knn\": \"true\",\n" +
+            "    \"index.knn.algo_param.ef_construction\": \"128\",\n" +
+            "    \"index.knn.algo_param.m\": \"24\",\n" +
+            "    \"index.knn.space_type\": \"l2\",\n" +
+            "    \"number_of_replicas\": 1,\n" +
+            "    \"number_of_shards\": \"2\"\n" +
+            "  }\n" +
+            "}";
+
+        var result = create(client, rawJson, "indexName");
+
+        assertThat(result.wasSuccessful(), equalTo(true));
+
+        var requestBodyCapture = ArgumentCaptor.forClass(ObjectNode.class);
+        // Exactly one retry — the second call must succeed because all three
+        // illegal args were stripped on the first failure.
+        verify(client, times(2)).createIndex(any(), requestBodyCapture.capture(), any());
+
+        var finalIndexBody = requestBodyCapture.getValue().toPrettyString();
+        assertThat(finalIndexBody, not(containsString("algo_param.ef_construction")));
+        assertThat(finalIndexBody, not(containsString("algo_param.m")));
+        assertThat(finalIndexBody, not(containsString("space_type")));
+        assertThat("index.knn flag should still be sent",
+            finalIndexBody, containsString("index.knn"));
+    }
+
+    @Test
     void testCreate_withRetryToRemoveUnsupportedMappingParams() throws Exception {
         // Setup
         var invalidResponse = mock(InvalidResponse.class);

--- a/RFS/src/test/java/org/opensearch/migrations/parsing/ObjectNodeUtilsTest.java
+++ b/RFS/src/test/java/org/opensearch/migrations/parsing/ObjectNodeUtilsTest.java
@@ -262,4 +262,74 @@ class ObjectNodeUtilsTest {
         assertThat(getFilters(body, "my_analyzer"), equalTo(List.of("lowercase", "stop")));
     }
 
+    @Test
+    void testRemoveFieldsByPath_flatKeyWithDots() {
+        // ES 7.x index-level knn settings serialize as flat keys with embedded dots.
+        // Walking by dot segments would miss them; the flat literal must be removed.
+        ObjectMapper mapper = new ObjectMapper();
+        ObjectNode settings = mapper.createObjectNode();
+        settings.put("index.knn", "true");
+        settings.put("index.knn.algo_param.ef_construction", "128");
+        settings.put("index.knn.algo_param.m", "24");
+        settings.put("index.knn.space_type", "l2");
+        settings.put("number_of_shards", 2);
+
+        ObjectNodeUtils.removeFieldsByPath(settings, "index.knn.algo_param.ef_construction");
+        ObjectNodeUtils.removeFieldsByPath(settings, "index.knn.algo_param.m");
+        ObjectNodeUtils.removeFieldsByPath(settings, "index.knn.space_type");
+
+        assertThat(settings.has("index.knn.algo_param.ef_construction"), equalTo(false));
+        assertThat(settings.has("index.knn.algo_param.m"), equalTo(false));
+        assertThat(settings.has("index.knn.space_type"), equalTo(false));
+        // Untouched siblings should still be present
+        assertThat(settings.has("index.knn"), equalTo(true));
+        assertThat(settings.get("number_of_shards").asInt(), equalTo(2));
+    }
+
+    @Test
+    void testRemoveFieldsByPath_flatKeyPrefersFlatOverNestedShadow() {
+        // If both forms exist, the literal flat key wins (it's an exact match);
+        // a nested shadow at the same dotted path is left alone.
+        ObjectMapper mapper = new ObjectMapper();
+        ObjectNode node = mapper.createObjectNode();
+        node.put("a.b", "flat");
+        ObjectNode aNested = mapper.createObjectNode();
+        aNested.put("b", "nested");
+        node.set("a", aNested);
+
+        ObjectNodeUtils.removeFieldsByPath(node, "a.b");
+
+        assertThat(node.has("a.b"), equalTo(false));
+        assertThat(node.get("a").get("b").asText(), equalTo("nested"));
+    }
+
+    @Test
+    void testRemoveFieldsByPath_nestedFallbackWhenNoFlatKey() {
+        // No flat key present — the nested walk still removes the leaf,
+        // preserving the existing behavior used by mapping-param strips.
+        ObjectMapper mapper = new ObjectMapper();
+        ObjectNode mappings = mapper.createObjectNode();
+        ObjectNode props = mappings.putObject("properties");
+        ObjectNode field = props.putObject("foo");
+        field.put("type", "text");
+        field.put("doc_values", true);
+
+        ObjectNodeUtils.removeFieldsByPath(mappings, "properties.foo.doc_values");
+
+        assertThat(mappings.get("properties").get("foo").has("doc_values"), equalTo(false));
+        assertThat(mappings.get("properties").get("foo").get("type").asText(), equalTo("text"));
+    }
+
+    @Test
+    void testRemoveFieldsByPath_nullPath_isNoOp() {
+        ObjectMapper mapper = new ObjectMapper();
+        ObjectNode node = mapper.createObjectNode();
+        node.put("keep", 1);
+
+        ObjectNodeUtils.removeFieldsByPath(node, null);
+        ObjectNodeUtils.removeFieldsByPath(node, "");
+
+        assertThat(node.get("keep").asInt(), equalTo(1));
+    }
+
 }

--- a/transformation/standardJavascriptTransforms/src/es-knn-index-to-field-level-metadata.js
+++ b/transformation/standardJavascriptTransforms/src/es-knn-index-to-field-level-metadata.js
@@ -1,0 +1,194 @@
+/**
+ * Lift ES 7.x index-level k-NN build params onto field-level method config.
+ *
+ * The ES 7.x AWS k-NN plugin stored build-time params as index settings
+ * (index.knn.algo_param.ef_construction, index.knn.algo_param.m,
+ * index.knn.space_type) and read them only with the nmslib engine, which was
+ * removed in OpenSearch 3.0. OpenSearch 2.x+ rejects those keys on create-index
+ * ("unknown setting") and instead expects them inside each knn_vector field's
+ * `method` block. This strips the index-level params and injects an HNSW method
+ * built from them onto every knn_vector field lacking one.
+ *
+ * The engine defaults to faiss (the canonical nmslib successor; with
+ * Lucene-on-Faiss the memory advantage that once favored the lucene engine no
+ * longer requires it) and can be overridden via context.engine. nmslib-only
+ * space types (l1, linf) are unsupported by faiss/lucene and fall back to l2.
+ *
+ * Left untouched: index.knn (the enable flag, still valid) and
+ * index.knn.algo_param.ef_search (a runtime setting, still valid on OS).
+ * A field that already declares its own `method` always wins. No-op when no
+ * index-level build params are present, so it is safe to default-enable.
+ */
+
+const DEFAULT_SPACE_TYPE = 'l2';
+const DEFAULT_ENGINE = 'faiss';
+// faiss/lucene HNSW space types for float vectors; matches knn-to-serverless-metadata.js.
+const SUPPORTED_SPACE_TYPES = new Set(['l2', 'innerproduct', 'cosinesimil']);
+
+function getProp(obj, key) {
+    if (!obj) return undefined;
+    return obj instanceof Map ? obj.get(key) : obj[key];
+}
+
+function setProp(obj, key, value) {
+    if (obj instanceof Map) {
+        obj.set(key, value);
+    } else {
+        obj[key] = value;
+    }
+}
+
+function deleteProp(obj, key) {
+    if (!obj) return;
+    if (obj instanceof Map) {
+        obj.delete(key);
+    } else {
+        delete obj[key];
+    }
+}
+
+function hasProp(obj, key) {
+    if (!obj) return false;
+    return obj instanceof Map ? obj.has(key) : Object.hasOwn(obj, key);
+}
+
+// Settings may arrive as a literal flat key ("index.knn.space_type") or as a
+// nested object (settings.index.knn.space_type); read/delete handle both.
+function readSetting(settings, dottedPath) {
+    if (!settings) return undefined;
+    if (hasProp(settings, dottedPath)) {
+        return getProp(settings, dottedPath);
+    }
+    const parts = dottedPath.split('.');
+    let node = settings;
+    for (const part of parts) {
+        if (!node || typeof node !== 'object') return undefined;
+        if (!hasProp(node, part)) return undefined;
+        node = getProp(node, part);
+    }
+    return node;
+}
+
+function deleteSetting(settings, dottedPath) {
+    if (!settings) return;
+    if (hasProp(settings, dottedPath)) {
+        deleteProp(settings, dottedPath);
+    }
+    const parts = dottedPath.split('.');
+    const stack = [settings];
+    let node = settings;
+    for (let i = 0; i < parts.length - 1; i++) {
+        if (!node || typeof node !== 'object' || !hasProp(node, parts[i])) {
+            return;
+        }
+        node = getProp(node, parts[i]);
+        stack.push(node);
+    }
+    deleteProp(node, parts.at(-1));
+    // Prune intermediate objects emptied by the removal so the target does not
+    // receive a stray "index": {} block.
+    for (let j = stack.length - 1; j > 0; j--) {
+        const n = stack[j];
+        const empty = n instanceof Map ? n.size === 0 : Object.keys(n).length === 0;
+        if (!empty) break;
+        deleteProp(stack[j - 1], parts[j - 1]);
+    }
+}
+
+// ES serializes numeric settings as strings; coerce back to numbers, leaving
+// anything non-numeric untouched.
+function asNumber(v) {
+    if (v == null) return undefined;
+    if (typeof v === 'number') return v;
+    if (typeof v === 'string' && v !== '' && !Number.isNaN(Number(v))) return Number(v);
+    return v;
+}
+
+// nmslib accepted l1/linf, which faiss and lucene do not; fall back to l2.
+function normalizeSpaceType(spaceType) {
+    if (spaceType === undefined) return DEFAULT_SPACE_TYPE;
+    const normalized = String(spaceType).toLowerCase();
+    if (SUPPORTED_SPACE_TYPES.has(normalized)) return normalized;
+    console.error("WARNING: space_type '" + spaceType + "' has no faiss/lucene equivalent; falling back to '" + DEFAULT_SPACE_TYPE + "'. This will affect search results.");
+    return DEFAULT_SPACE_TYPE;
+}
+
+function buildMethodFromIndexParams(params, engine) {
+    const method = {
+        name: 'hnsw',
+        engine: engine,
+        space_type: normalizeSpaceType(params.spaceType)
+    };
+    const parameters = {};
+    if (params.m !== undefined) parameters.m = asNumber(params.m);
+    if (params.efConstruction !== undefined) parameters.ef_construction = asNumber(params.efConstruction);
+    if (Object.keys(parameters).length > 0) {
+        method.parameters = parameters;
+    }
+    return method;
+}
+
+function injectMethodIntoKnnVectors(node, method) {
+    if (!node || typeof node !== 'object') return;
+    const entries = node instanceof Map ? node.entries() : Object.entries(node);
+    for (const [, val] of entries) {
+        if (val && typeof val === 'object') {
+            if (getProp(val, 'type') === 'knn_vector' && !hasProp(val, 'method')) {
+                setProp(val, 'method', method);
+            } else {
+                injectMethodIntoKnnVectors(val, method);
+            }
+        }
+    }
+}
+
+function applyIndexLevelKnn(raw, engine) {
+    const body = getProp(raw, 'body');
+    if (!body) return false;
+
+    const settings = getProp(body, 'settings');
+    const mappings = getProp(body, 'mappings');
+
+    const efConstruction = readSetting(settings, 'index.knn.algo_param.ef_construction');
+    const m = readSetting(settings, 'index.knn.algo_param.m');
+    const spaceType = readSetting(settings, 'index.knn.space_type');
+
+    const hasIndexLevelKnn = efConstruction !== undefined ||
+        m !== undefined ||
+        spaceType !== undefined;
+
+    if (!hasIndexLevelKnn) {
+        return false;
+    }
+
+    if (settings) {
+        deleteSetting(settings, 'index.knn.algo_param.ef_construction');
+        deleteSetting(settings, 'index.knn.algo_param.m');
+        deleteSetting(settings, 'index.knn.space_type');
+    }
+
+    if (mappings) {
+        const method = buildMethodFromIndexParams({
+            efConstruction: efConstruction,
+            m: m,
+            spaceType: spaceType
+        }, engine);
+        injectMethodIntoKnnVectors(mappings, method);
+    }
+
+    return true;
+}
+
+function main(context) {
+    const engine = getProp(context, 'engine') || DEFAULT_ENGINE;
+    return function (raw) {
+        applyIndexLevelKnn(raw, engine);
+        return raw;
+    };
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = main;
+}
+
+(() => main)();

--- a/transformation/standardJavascriptTransforms/test/es-knn-index-to-field-level-metadata.test.js
+++ b/transformation/standardJavascriptTransforms/test/es-knn-index-to-field-level-metadata.test.js
@@ -1,0 +1,372 @@
+const main = require('../src/es-knn-index-to-field-level-metadata.js');
+
+describe('es-knn-index-to-field-level-metadata', () => {
+    let transform;
+
+    beforeEach(() => {
+        transform = main({});
+    });
+
+    test('lifts flat-keyed index-level knn params onto knn_vector field method', () => {
+        // Mirrors the broken retail-products payload observed in dev:
+        // ES 7.10 (k-NN plugin) → OS 3.3, settings stored as flat keys.
+        const input = {
+            body: {
+                aliases: {},
+                mappings: {
+                    properties: {
+                        description_embedding: {
+                            type: 'knn_vector',
+                            dimension: 1024
+                        },
+                        name: { type: 'text' }
+                    }
+                },
+                settings: {
+                    'index.knn': 'true',
+                    'index.knn.algo_param.ef_construction': '128',
+                    'index.knn.algo_param.ef_search': '100',
+                    'index.knn.algo_param.m': '24',
+                    'index.knn.space_type': 'l2',
+                    number_of_replicas: 1,
+                    number_of_shards: '2'
+                }
+            }
+        };
+
+        const result = transform(input);
+
+        // Build-time index-level keys are gone
+        expect(result.body.settings['index.knn.algo_param.ef_construction']).toBeUndefined();
+        expect(result.body.settings['index.knn.algo_param.m']).toBeUndefined();
+        expect(result.body.settings['index.knn.space_type']).toBeUndefined();
+        // ef_search is a valid runtime setting on OS 2.x+ — leave it alone
+        expect(result.body.settings['index.knn.algo_param.ef_search']).toBe('100');
+        // index.knn=true is still valid in OS 2.x+
+        expect(result.body.settings['index.knn']).toBe('true');
+        // Non-knn settings preserved
+        expect(result.body.settings.number_of_replicas).toBe(1);
+        expect(result.body.settings.number_of_shards).toBe('2');
+
+        // Method config injected at field level with numeric coercion
+        const field = result.body.mappings.properties.description_embedding;
+        expect(field.type).toBe('knn_vector');
+        expect(field.dimension).toBe(1024);
+        expect(field.method).toEqual({
+            name: 'hnsw',
+            engine: 'faiss',
+            space_type: 'l2',
+            parameters: {
+                m: 24,
+                ef_construction: 128
+            }
+        });
+        // Non-vector fields untouched
+        expect(result.body.mappings.properties.name).toEqual({ type: 'text' });
+    });
+
+    test('lifts nested-form index-level knn params', () => {
+        const input = {
+            body: {
+                mappings: {
+                    properties: {
+                        v: { type: 'knn_vector', dimension: 4 }
+                    }
+                },
+                settings: {
+                    index: {
+                        knn: {
+                            algo_param: {
+                                ef_construction: 200,
+                                m: 16
+                            },
+                            space_type: 'cosinesimil'
+                        }
+                    }
+                }
+            }
+        };
+
+        const result = transform(input);
+
+        // Nested leaves are removed and emptied parents pruned
+        expect(result.body.settings.index).toBeUndefined();
+        expect(result.body.mappings.properties.v.method).toEqual({
+            name: 'hnsw',
+            engine: 'faiss',
+            space_type: 'cosinesimil',
+            parameters: {
+                m: 16,
+                ef_construction: 200
+            }
+        });
+    });
+
+    test('does not overwrite an existing field-level method', () => {
+        const input = {
+            body: {
+                mappings: {
+                    properties: {
+                        already_method: {
+                            type: 'knn_vector',
+                            dimension: 8,
+                            method: {
+                                name: 'hnsw',
+                                engine: 'faiss',
+                                space_type: 'l2',
+                                parameters: { m: 8, ef_construction: 64 }
+                            }
+                        },
+                        needs_method: {
+                            type: 'knn_vector',
+                            dimension: 8
+                        }
+                    }
+                },
+                settings: {
+                    'index.knn.algo_param.m': '24',
+                    'index.knn.algo_param.ef_construction': '128',
+                    'index.knn.space_type': 'l2'
+                }
+            }
+        };
+
+        const result = transform(input);
+
+        // Field that already had a method is left alone (engine still faiss).
+        expect(result.body.mappings.properties.already_method.method.engine).toBe('faiss');
+        expect(result.body.mappings.properties.already_method.method.parameters.m).toBe(8);
+
+        // Field without method gets one synthesized from the index-level params.
+        expect(result.body.mappings.properties.needs_method.method).toEqual({
+            name: 'hnsw',
+            engine: 'faiss',
+            space_type: 'l2',
+            parameters: { m: 24, ef_construction: 128 }
+        });
+    });
+
+    test('handles knn_vector fields nested under "nested" or "object" types', () => {
+        const input = {
+            body: {
+                mappings: {
+                    properties: {
+                        outer: {
+                            type: 'nested',
+                            properties: {
+                                inner_vec: { type: 'knn_vector', dimension: 4 }
+                            }
+                        }
+                    }
+                },
+                settings: {
+                    'index.knn.algo_param.m': '12',
+                    'index.knn.algo_param.ef_construction': '96',
+                    'index.knn.space_type': 'l2'
+                }
+            }
+        };
+
+        const result = transform(input);
+        const innerVec = result.body.mappings.properties.outer.properties.inner_vec;
+        expect(innerVec.method.parameters.m).toBe(12);
+        expect(innerVec.method.parameters.ef_construction).toBe(96);
+        expect(innerVec.method.space_type).toBe('l2');
+    });
+
+    test('is a no-op when no index-level knn params are present', () => {
+        const input = {
+            body: {
+                mappings: {
+                    properties: {
+                        v: {
+                            type: 'knn_vector',
+                            dimension: 4,
+                            method: {
+                                name: 'hnsw',
+                                engine: 'lucene',
+                                space_type: 'l2',
+                                parameters: { m: 16, ef_construction: 100 }
+                            }
+                        }
+                    }
+                },
+                settings: {
+                    'index.knn': 'true',
+                    number_of_shards: '1'
+                }
+            }
+        };
+
+        // Deep-clone via JSON for an unambiguous before/after comparison.
+        const before = JSON.parse(JSON.stringify(input));
+        const result = transform(input);
+        expect(result).toEqual(before);
+    });
+
+    test('builds a method even when only some params are present', () => {
+        const input = {
+            body: {
+                mappings: {
+                    properties: {
+                        v: { type: 'knn_vector', dimension: 4 }
+                    }
+                },
+                settings: {
+                    // Only space_type — m and ef_construction are missing
+                    'index.knn.space_type': 'l2'
+                }
+            }
+        };
+
+        const result = transform(input);
+        expect(result.body.settings['index.knn.space_type']).toBeUndefined();
+        const m = result.body.mappings.properties.v.method;
+        expect(m.name).toBe('hnsw');
+        expect(m.engine).toBe('faiss');
+        expect(m.space_type).toBe('l2');
+        // No `parameters` key when neither m nor ef_construction were supplied
+        expect(m.parameters).toBeUndefined();
+    });
+
+    test('defaults space_type to l2 when the source omits it', () => {
+        // The ES k-NN plugin defaulted space_type to l2, so a source that never
+        // set index.knn.space_type still migrates to an explicit l2 method.
+        const input = {
+            body: {
+                mappings: { properties: { v: { type: 'knn_vector', dimension: 4 } } },
+                settings: {
+                    'index.knn.algo_param.m': '16',
+                    'index.knn.algo_param.ef_construction': '100'
+                }
+            }
+        };
+
+        const result = transform(input);
+        expect(result.body.mappings.properties.v.method).toEqual({
+            name: 'hnsw',
+            engine: 'faiss',
+            space_type: 'l2',
+            parameters: { m: 16, ef_construction: 100 }
+        });
+    });
+
+    test('preserves ef_search alone (no build-time params present)', () => {
+        // ef_search is a valid runtime setting on OS — when it's the only
+        // index-level knn key present there's nothing to do, so the body
+        // round-trips unchanged.
+        const input = {
+            body: {
+                mappings: { properties: { v: { type: 'knn_vector', dimension: 4 } } },
+                settings: { 'index.knn.algo_param.ef_search': '100' }
+            }
+        };
+
+        const before = JSON.parse(JSON.stringify(input));
+        const result = transform(input);
+        expect(result).toEqual(before);
+    });
+
+    test('strips build-time params but preserves ef_search alongside them', () => {
+        const input = {
+            body: {
+                mappings: { properties: { v: { type: 'knn_vector', dimension: 4 } } },
+                settings: {
+                    'index.knn': 'true',
+                    'index.knn.algo_param.ef_search': '100',
+                    'index.knn.algo_param.ef_construction': '128',
+                    'index.knn.algo_param.m': '24',
+                    'index.knn.space_type': 'l2'
+                }
+            }
+        };
+
+        const result = transform(input);
+        expect(result.body.settings['index.knn.algo_param.ef_construction']).toBeUndefined();
+        expect(result.body.settings['index.knn.algo_param.m']).toBeUndefined();
+        expect(result.body.settings['index.knn.space_type']).toBeUndefined();
+        expect(result.body.settings['index.knn.algo_param.ef_search']).toBe('100');
+        expect(result.body.mappings.properties.v.method.parameters.m).toBe(24);
+    });
+
+    test('handles a body backed by Map / settings backed by Map', () => {
+        const settings = new Map();
+        settings.set('index.knn.algo_param.m', '8');
+        settings.set('index.knn.algo_param.ef_construction', '64');
+        settings.set('index.knn.space_type', 'l2');
+
+        const props = new Map();
+        props.set('v', { type: 'knn_vector', dimension: 4 });
+        const mappings = new Map();
+        mappings.set('properties', props);
+
+        const body = new Map();
+        body.set('settings', settings);
+        body.set('mappings', mappings);
+        const raw = { body };
+
+        const result = transform(raw);
+
+        expect(result.body.get('settings').has('index.knn.algo_param.m')).toBe(false);
+        const v = result.body.get('mappings').get('properties').get('v');
+        expect(v.method.parameters.m).toBe(8);
+        expect(v.method.parameters.ef_construction).toBe(64);
+    });
+
+    test('is a no-op for bodies with no settings at all', () => {
+        const input = { body: { mappings: { properties: { name: { type: 'text' } } } } };
+        const before = JSON.parse(JSON.stringify(input));
+        const result = transform(input);
+        expect(result).toEqual(before);
+    });
+
+    test.each(['l1', 'linf', 'L1', 'LINF'])(
+        'falls back to l2 for nmslib-only space_type %s',
+        (sourceSpaceType) => {
+            const input = {
+                body: {
+                    mappings: { properties: { v: { type: 'knn_vector', dimension: 4 } } },
+                    settings: {
+                        'index.knn.algo_param.m': '16',
+                        'index.knn.space_type': sourceSpaceType
+                    }
+                }
+            };
+
+            const result = transform(input);
+            expect(result.body.mappings.properties.v.method.space_type).toBe('l2');
+        }
+    );
+
+    test('preserves a faiss/lucene-supported space_type unchanged', () => {
+        const input = {
+            body: {
+                mappings: { properties: { v: { type: 'knn_vector', dimension: 4 } } },
+                settings: {
+                    'index.knn.algo_param.m': '16',
+                    'index.knn.space_type': 'innerproduct'
+                }
+            }
+        };
+
+        const result = transform(input);
+        expect(result.body.mappings.properties.v.method.space_type).toBe('innerproduct');
+    });
+
+    test('honors an engine override from context', () => {
+        const luceneTransform = main({ engine: 'lucene' });
+        const input = {
+            body: {
+                mappings: { properties: { v: { type: 'knn_vector', dimension: 4 } } },
+                settings: {
+                    'index.knn.algo_param.m': '16',
+                    'index.knn.algo_param.ef_construction': '100',
+                    'index.knn.space_type': 'l2'
+                }
+            }
+        };
+
+        const result = luceneTransform(input);
+        expect(result.body.mappings.properties.v.method.engine).toBe('lucene');
+    });
+});


### PR DESCRIPTION
### Description

ES 7.x with the AWS k-NN plugin stores knn parameters as **flat index-level settings keys with embedded dots** (e.g. `index.knn.algo_param.m`, `index.knn.algo_param.ef_construction`, `index.knn.space_type`). When migrating to OpenSearch 2.x+/3.x, these keys are rejected as `unknown setting` at create-index time.

`IndexCreator_OS_2_11` strips reported illegal args and retries, but the strip logic only walked nested-object paths — it never matched the flat keys — so the request body was never actually modified and index creation **looped forever**. Observed in a dev migration: a single `knn_vector` index (`retail-products`, ES 7.10 → OS 3.3) produced **220k+ identical create attempts** with no progress, blocking the rest of the migration.

This PR fixes the loop and also stops users from hitting the broken path in the first place:

**1. Robust flat-key removal (`RFS`)**
- `ObjectNodeUtils.removeFieldsByPath` now removes the literal flat key first (e.g. `settings["index.knn.algo_param.m"]`), then falls back to the existing nested-object walk.
- `IndexCreator_OS_2_11.handleInvalidResponse` passes both the full `index.`-prefixed argument (matching the serialized flat keys) **and** the stripped form (for legacy nested settings), so the strip-and-retry path always terminates.

**2. New default metadata transformer `es-knn-index-to-field-level-metadata.js`**
- Lifts index-level knn build params (`m`, `ef_construction`, `space_type`) onto each `knn_vector` field's `method` config — the shape OpenSearch 2.x+ expects — and removes the now-illegal index-level keys. Walks both flat-keyed and nested settings forms, and recurses into nested/object mappings.
- Preserves any pre-existing field-level `method` config, and leaves the valid runtime setting `index.knn.algo_param.ef_search` in place.
- Registered as a baked-in transformer for any source whose target is OpenSearch; it's a no-op when no index-level knn params are present, so it's safe to default-enable.

### Issues Resolved

N/A — found during dev-cluster migration troubleshooting.

### Testing

- `./gradlew :RFS:test` — full suite passes, including new `ObjectNodeUtilsTest` flat-key cases and a new `IndexCreator_OS_2_11Test` case reproducing the exact `retail-products` payload (second create call now succeeds).
- `npm test` in `transformation/standardJavascriptTransforms` — **71 passing** (10 new Jest cases for the transformer + 61 existing).
- `./gradlew :MetadataMigration:test` passes; verified the existing isolated `KnnSettingsTransformationTest` contract (OS 1.3 → OS 2.19) is upheld — `index.knn.algo_param.ef_search` is intentionally **not** stripped.
- Confirmed the new JS file is packaged onto the classpath via `:transformation:standardJavascriptTransforms:packageJs`.

### Check List
- [x] New functionality includes testing
- [ ] Public documentation issue/PR created, if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.