### PR TITLE
Fix workflow approve CLI not recognizing waitForUserApproval gates

### DIFF
--- a/migrationConsole/cluster_tools/tests/conftest.py
+++ b/migrationConsole/cluster_tools/tests/conftest.py
@@ -25,17 +25,26 @@ def wait_for_opensearch(url, max_retries=30, retry_interval=2):
     raise TimeoutError(f"OpenSearch at {url} did not become ready within {max_retries * retry_interval} seconds")
 
 
-def create_opensearch_container():
-    """Create and start an OpenSearch container."""
-    container = OpenSearchContainer("opensearchproject/opensearch:2.19.1")
-    container.with_env("discovery.type", "single-node")
-    container.with_env("OPENSEARCH_JAVA_OPTS", "-Xms2g -Xmx2g")
-    container.start()
-
-    url = f"http://{container.get_container_host_ip()}:{container.get_exposed_port(9200)}"
-    wait_for_opensearch(url)
-
-    return container, url
+def create_opensearch_container(max_attempts=3):
+    """Create and start an OpenSearch container, retrying on startup failure."""
+    for attempt in range(max_attempts):
+        container = OpenSearchContainer("opensearchproject/opensearch:2.19.1")
+        container.with_env("discovery.type", "single-node")
+        container.with_env("OPENSEARCH_JAVA_OPTS", "-Xms512m -Xmx512m")
+        try:
+            container.start()
+            url = f"http://{container.get_container_host_ip()}:{container.get_exposed_port(9200)}"
+            wait_for_opensearch(url)
+            return container, url
+        except Exception:
+            try:
+                container.stop()
+            except Exception:
+                pass
+            if attempt == max_attempts - 1:
+                raise
+            time.sleep(5)
+    raise RuntimeError("Failed to start OpenSearch container")
 
 
 def create_environment_config(clusters):

--- a/migrationConsole/lib/console_link/console_link/workflow/tree_utils.py
+++ b/migrationConsole/lib/console_link/console_link/workflow/tree_utils.py
@@ -50,10 +50,10 @@ def is_approval_node(node: Dict[str, Any]) -> bool:
     if node.get('is_approval'):
         return True
     tref = node.get('templateRef') or node.get('template_ref')
-    if tref and tref.get('template') == 'waitforapproval':
+    if tref and tref.get('template') == 'waitforuserapproval':
         return True
     tname = node.get('templateName') or node.get('template_name')
-    return tname == 'waitforapproval'
+    return tname == 'waitforuserapproval'
 
 
 def get_node_input_parameter(node: Dict[str, Any], param_name: str) -> Optional[str]:

--- a/migrationConsole/lib/console_link/console_link/workflow/tree_utils.py
+++ b/migrationConsole/lib/console_link/console_link/workflow/tree_utils.py
@@ -18,6 +18,8 @@ APPROVAL_GATE_PLURAL = 'approvalgates'
 SNAPSHOT_MIGRATION_PLURAL = 'snapshotmigrations'
 DATA_SNAPSHOT_PLURAL = 'datasnapshots'
 
+APPROVAL_TEMPLATE_NAME = 'waitforuserapproval'
+
 
 @dataclass
 class ArtifactRef:
@@ -50,10 +52,10 @@ def is_approval_node(node: Dict[str, Any]) -> bool:
     if node.get('is_approval'):
         return True
     tref = node.get('templateRef') or node.get('template_ref')
-    if tref and tref.get('template') == 'waitforuserapproval':
+    if tref and tref.get('template') == APPROVAL_TEMPLATE_NAME:
         return True
     tname = node.get('templateName') or node.get('template_name')
-    return tname == 'waitforuserapproval'
+    return tname == APPROVAL_TEMPLATE_NAME
 
 
 def get_node_input_parameter(node: Dict[str, Any], param_name: str) -> Optional[str]:

--- a/migrationConsole/lib/console_link/console_link/workflow/tree_utils.py
+++ b/migrationConsole/lib/console_link/console_link/workflow/tree_utils.py
@@ -47,15 +47,37 @@ class WorkflowDisplayer:
         raise NotImplementedError
 
 
+def _is_approval_template_name(name: Optional[str]) -> bool:
+    """True if a template name denotes an approval-gate *wait* step.
+
+    Matched semantically rather than by exact string: any name that (case
+    insensitively) contains both ``approval`` and ``wait`` qualifies. This
+    keeps the detector working across template renames — ``waitForApproval``
+    became ``waitForUserApproval`` (see APPROVAL_TEMPLATE_NAME) and a future
+    ``waitFor<Whatever>Approval`` would match too — without re-introducing the
+    exact-string drift that previously made ``workflow approve`` blind to a
+    live gate.
+
+    The ``wait`` token is what distinguishes the blocking gate step from the
+    sibling templates that merely act on the gate CRD (``patchApprovalGatePhase``,
+    ``patchApprovalAnnotation``, ``cleanupApprovalGates``), so those are
+    correctly excluded.
+    """
+    if not name:
+        return False
+    lowered = name.lower()
+    return 'approval' in lowered and 'wait' in lowered
+
+
 def is_approval_node(node: Dict[str, Any]) -> bool:
     """Check if a node is an approval gate wait step."""
     if node.get('is_approval'):
         return True
     tref = node.get('templateRef') or node.get('template_ref')
-    if tref and tref.get('template') == APPROVAL_TEMPLATE_NAME:
+    if tref and _is_approval_template_name(tref.get('template')):
         return True
     tname = node.get('templateName') or node.get('template_name')
-    return tname == APPROVAL_TEMPLATE_NAME
+    return _is_approval_template_name(tname)
 
 
 def get_node_input_parameter(node: Dict[str, Any], param_name: str) -> Optional[str]:

--- a/migrationConsole/lib/console_link/tests/test_tree_filtering.py
+++ b/migrationConsole/lib/console_link/tests/test_tree_filtering.py
@@ -9,7 +9,12 @@ import sys
 from unittest.mock import patch
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
-from console_link.workflow.tree_utils import filter_tree_nodes, overlay_approval_gate_status
+from console_link.workflow.tree_utils import (
+    APPROVAL_TEMPLATE_NAME,
+    filter_tree_nodes,
+    is_approval_node,
+    overlay_approval_gate_status,
+)
 
 
 class TestTreeFiltering:
@@ -122,3 +127,48 @@ class TestTreeFiltering:
             with open(expected_file, 'w') as f:
                 json.dump(filtered_tree, f, indent=2)
             pytest.skip(f"Created expected filtering output for {filename}")
+
+
+class TestIsApprovalNode:
+    """Contract tests for approval-gate-wait detection.
+
+    The matcher must survive template renames. The Argo template was
+    ``waitForApproval`` and is now ``waitForUserApproval``; a previous
+    exact-string matcher silently went blind on that rename and broke
+    ``workflow approve``. These tests pin the rename-resilient behavior so a
+    future ``waitFor<Anything>Approval`` keeps working and the sibling
+    gate-mutating templates keep being excluded.
+    """
+
+    @pytest.mark.parametrize('template', [
+        APPROVAL_TEMPLATE_NAME,          # current rendered name: 'waitforuserapproval'
+        'waitForUserApproval',           # camelCase, in case rendering ever changes
+        'waitforapproval',               # the pre-rename name
+        'waitForApproval',
+        'waitForOperatorApproval',       # a hypothetical future rename
+    ])
+    def test_matches_approval_wait_templates(self, template):
+        assert is_approval_node({'templateRef': {'template': template}})
+        assert is_approval_node({'templateName': template})
+        assert is_approval_node({'template_ref': {'template': template}})
+        assert is_approval_node({'template_name': template})
+
+    def test_matches_explicit_is_approval_flag(self):
+        # Collapsed retry-group nodes carry no templateRef; they set is_approval.
+        assert is_approval_node({'is_approval': True})
+
+    @pytest.mark.parametrize('template', [
+        'patchApprovalGatePhase',        # mutates the gate, does not wait on it
+        'patchApprovalAnnotation',
+        'cleanupApprovalGates',
+        'waitForKafkaClusterReady',      # a wait, but not for approval
+        'runMetadata',
+        '',
+    ])
+    def test_rejects_non_approval_wait_templates(self, template):
+        assert not is_approval_node({'templateRef': {'template': template}})
+        assert not is_approval_node({'templateName': template})
+
+    def test_rejects_node_with_no_template_info(self):
+        assert not is_approval_node({'displayName': 'evaluateMetadata', 'phase': 'Running'})
+        assert not is_approval_node({})

--- a/migrationConsole/lib/console_link/tests/workflow-tests/test_manage.py
+++ b/migrationConsole/lib/console_link/tests/workflow-tests/test_manage.py
@@ -6,6 +6,7 @@ from typing import Any
 import pytest
 from unittest.mock import MagicMock, patch
 
+from console_link.workflow.tree_utils import APPROVAL_TEMPLATE_NAME
 from console_link.workflow.tui.workflow_manage_app import (
     WorkflowTreeApp,
     copy_to_clipboard, PHASE_SUCCEEDED, PHASE_RUNNING
@@ -63,7 +64,7 @@ def mock_workflow_with_pod_and_suspend():
                                  "inputs": {"parameters": [{"name": "resourceName", "value": "migration-0"}]}},
                 "node-2": {"id": "node-2", "displayName": "suspend-1", "type": "Resource", "phase": PHASE_RUNNING,
                            "children": [],
-                           "templateRef": {"name": "resource-management", "template": "waitforuserapproval"},
+                           "templateRef": {"name": "resource-management", "template": APPROVAL_TEMPLATE_NAME},
                            "inputs": {"parameters": [{"name": "resourceName", "value": "my-gate"}]}}
             }
         }

--- a/migrationConsole/lib/console_link/tests/workflow-tests/test_manage.py
+++ b/migrationConsole/lib/console_link/tests/workflow-tests/test_manage.py
@@ -63,7 +63,7 @@ def mock_workflow_with_pod_and_suspend():
                                  "inputs": {"parameters": [{"name": "resourceName", "value": "migration-0"}]}},
                 "node-2": {"id": "node-2", "displayName": "suspend-1", "type": "Resource", "phase": PHASE_RUNNING,
                            "children": [],
-                           "templateRef": {"name": "resource-management", "template": "waitforapproval"},
+                           "templateRef": {"name": "resource-management", "template": "waitforuserapproval"},
                            "inputs": {"parameters": [{"name": "resourceName", "value": "my-gate"}]}}
             }
         }

--- a/migrationConsole/lib/console_link/tests/workflow-tests/test_workflow_cli_commands.py
+++ b/migrationConsole/lib/console_link/tests/workflow-tests/test_workflow_cli_commands.py
@@ -10,6 +10,7 @@ from kubernetes.client.rest import ApiException
 
 from console_link.workflow.cli import workflow_cli
 from console_link.workflow.models.config import WorkflowConfig
+from console_link.workflow.tree_utils import APPROVAL_TEMPLATE_NAME
 
 
 class TestWorkflowCLICommands:
@@ -524,13 +525,13 @@ class TestWorkflowCLICommands:
         nodes = {
             'approval-node': {
                 'id': 'approval-node',
-                'displayName': 'waitForApproval',
+                'displayName': 'waitForUserApproval',
                 'phase': 'Running',
                 'type': 'Pod',
                 'boundaryID': 'approve-boundary',
                 'templateRef': {
                     'name': 'resource-management',
-                    'template': 'waitforapproval',
+                    'template': APPROVAL_TEMPLATE_NAME,
                 },
                 'inputs': {
                     'parameters': [

--- a/migrationConsole/lib/integ_test/integ_test/test_cases/basic_tests.py
+++ b/migrationConsole/lib/integ_test/integ_test/test_cases/basic_tests.py
@@ -1,7 +1,9 @@
 import logging
+import subprocess
+import time
 import uuid
 from ..cluster_version import RFS_MIGRATION_COMBINATIONS
-from .ma_argo_test_base import MATestBase, MigrationType, MATestUserArguments
+from .ma_argo_test_base import MATestBase, MigrationType, MATestUserArguments, MIGRATION_COMPLETION_TIMEOUT_SECONDS
 
 logger = logging.getLogger(__name__)
 
@@ -72,5 +74,57 @@ class Test0002SingleDocumentBackfillWithRfsCoordinatorCluster(MATestBase):
 
     def verify_clusters(self):
         # Validate single document exists on target
+        self.target_operations.get_document(cluster=self.target_cluster, index_name=self.index_name,
+                                            doc_id=self.doc_id, max_attempts=10, delay=3.0)
+
+
+class Test0003ApprovalGateIntegration(MATestBase):
+    """Exercises the workflow approve CLI against a real approval gate.
+
+    Runs with skipApprovals=false so the workflow blocks at the evaluatemetadata
+    approval gate. The test then uses `workflow approve step --all` to unblock it
+    and verifies the migration completes successfully.
+    """
+
+    def __init__(self, user_args: MATestUserArguments):
+        description = "Verifies workflow approve CLI can approve a real gate."
+        super().__init__(user_args=user_args,
+                         description=description,
+                         migrations_required=[MigrationType.METADATA, MigrationType.BACKFILL],
+                         allow_source_target_combinations=RFS_MIGRATION_COMBINATIONS)
+        self.index_name = f"test_0003_{self.unique_id}-{uuid.uuid4().hex[:4]}"
+        self.doc_id = "test_0003_doc"
+        self.doc_type = "sample_type"
+
+    def prepare_workflow_parameters(self, keep_workflows: bool = False):
+        super().prepare_workflow_parameters(keep_workflows=keep_workflows)
+        self.parameters["skip-approvals"] = "false"
+
+    def prepare_clusters(self):
+        self.source_operations.create_document(cluster=self.source_cluster, index_name=self.index_name,
+                                               doc_id=self.doc_id, doc_type=self.doc_type)
+
+    def workflow_perform_migrations(self, timeout_seconds: int = MIGRATION_COMPLETION_TIMEOUT_SECONDS):
+        self.argo_service.resume_workflow(workflow_name=self.workflow_name)
+        self._wait_and_approve_gates(timeout_seconds)
+        self.argo_service.wait_for_suspend(workflow_name=self.workflow_name, timeout_seconds=timeout_seconds)
+
+    def _wait_and_approve_gates(self, timeout_seconds: int):
+        """Poll `workflow approve step --all` until approval succeeds."""
+        deadline = time.time() + timeout_seconds
+        interval = 10
+        while time.time() < deadline:
+            result = subprocess.run(
+                ["workflow", "approve", "step", "--all"],
+                capture_output=True, text=True, timeout=30,
+            )
+            if result.returncode == 0:
+                logger.info("Approval gates approved: %s", result.stdout.strip())
+                return
+            logger.debug("Approve not ready yet (rc=%d): %s", result.returncode, result.stderr.strip())
+            time.sleep(interval)
+        raise TimeoutError(f"No approval gates became available within {timeout_seconds}s")
+
+    def verify_clusters(self):
         self.target_operations.get_document(cluster=self.target_cluster, index_name=self.index_name,
                                             doc_id=self.doc_id, max_attempts=10, delay=3.0)

--- a/migrationConsole/lib/integ_test/integ_test/test_cases/basic_tests.py
+++ b/migrationConsole/lib/integ_test/integ_test/test_cases/basic_tests.py
@@ -106,24 +106,32 @@ class Test0003ApprovalGateIntegration(MATestBase):
 
     def workflow_perform_migrations(self, timeout_seconds: int = MIGRATION_COMPLETION_TIMEOUT_SECONDS):
         self.argo_service.resume_workflow(workflow_name=self.workflow_name)
-        self._wait_and_approve_gates(timeout_seconds)
-        self.argo_service.wait_for_suspend(workflow_name=self.workflow_name, timeout_seconds=timeout_seconds)
+        self._approve_gates_until_suspend(timeout_seconds)
 
-    def _wait_and_approve_gates(self, timeout_seconds: int):
-        """Poll `workflow approve step --all` until approval succeeds."""
+    def _approve_gates_until_suspend(self, timeout_seconds: int):
+        """Approve gates on every poll while waiting for the workflow to reach its suspend."""
         deadline = time.time() + timeout_seconds
         interval = 10
         while time.time() < deadline:
+            # Try to approve any available gates (best-effort, ignore failures)
             result = subprocess.run(
                 ["workflow", "approve", "step", "--all"],
                 capture_output=True, text=True, timeout=30,
             )
             if result.returncode == 0:
                 logger.info("Approval gates approved: %s", result.stdout.strip())
-                return
-            logger.debug("Approve not ready yet (rc=%d): %s", result.returncode, result.stderr.strip())
+
+            # Check if workflow reached its suspend point
+            status_result = self.argo_service.get_workflow_status(self.workflow_name)
+            if status_result.success:
+                status_info = status_result.value
+                if status_info.get("phase") == "Running" and status_info.get("has_suspended_nodes"):
+                    return
+                if status_info.get("phase") in ("Succeeded", "Failed", "Error"):
+                    return
+
             time.sleep(interval)
-        raise TimeoutError(f"No approval gates became available within {timeout_seconds}s")
+        raise TimeoutError(f"Workflow did not reach suspended state within {timeout_seconds}s")
 
     def verify_clusters(self):
         self.target_operations.get_document(cluster=self.target_cluster, index_name=self.index_name,

--- a/migrationConsole/lib/integ_test/testWorkflows/fullMigrationWithClusters.yaml
+++ b/migrationConsole/lib/integ_test/testWorkflows/fullMigrationWithClusters.yaml
@@ -35,6 +35,8 @@ spec:
           {"batchSize": 1000, "concurrency": 4}
       - name: skip-cleanup
         value: "false"
+      - name: skip-approvals
+        value: "true"
       # Registry prefix for custom ES images (e.g. "localhost:5000/" for minikube)
       - name: image-registry-prefix
         value: ""
@@ -132,6 +134,8 @@ spec:
                   value: "{{workflow.parameters.snapshot-and-migration-configs}}"
                 - name: replayer-config
                   value: "{{workflow.parameters.replayer-config}}"
+                - name: skip-approvals
+                  value: "{{workflow.parameters.skip-approvals}}"
                 - name: imageMigrationConsoleLocation
                   valueFrom:
                     configMapKeyRef:
@@ -249,6 +253,8 @@ spec:
           - name: target-config
           - name: snapshot-and-migration-configs
           - name: replayer-config
+          - name: skip-approvals
+            default: "true"
           - name: imageMigrationConsoleLocation
           - name: imageMigrationConsolePullPolicy
           - name: s3Region
@@ -286,6 +292,7 @@ spec:
             SOURCE_CONFIG='{{inputs.parameters.source-config}}'
             TARGET_CONFIG='{{inputs.parameters.target-config}}'
             SNAPSHOT_MIGRATION_CONFIGS='{{inputs.parameters.snapshot-and-migration-configs}}'
+            SKIP_APPROVALS='{{inputs.parameters.skip-approvals}}'
             S3_REGION='{{inputs.parameters.s3Region}}'
             S3_ENDPOINT='{{inputs.parameters.s3Endpoint}}'
             S3_BUCKET='{{inputs.parameters.s3BucketName}}'
@@ -331,8 +338,9 @@ spec:
               --argjson source "$SOURCE_WITH_REPO" \
               --argjson target "$TARGET_CONFIG" \
               --argjson snapshotConfigs "$SNAPSHOT_EXTRACT_CONFIGS" \
+              --argjson skipApprovals "$SKIP_APPROVALS" \
               '{
-                "skipApprovals": true,
+                "skipApprovals": $skipApprovals,
                 "sourceClusters": {
                   "source1": $source
                 },

--- a/vars/elasticsearch5xK8sLocalTest.groovy
+++ b/vars/elasticsearch5xK8sLocalTest.groovy
@@ -3,6 +3,6 @@ def call(Map config = [:]) {
             jobName: config.jobName ?: 'elasticsearch-5x-k8s-local-test',
             sourceVersion: 'ES_5.6',
             targetVersion: 'OS_3.1',
-            testIds: '0001,0002,0004,0005'
+            testIds: '0001,0002,0003,0004,0005'
     )
 }

--- a/vars/elasticsearch8xK8sLocalTest.groovy
+++ b/vars/elasticsearch8xK8sLocalTest.groovy
@@ -3,6 +3,6 @@ def call(Map config = [:]) {
             jobName: config.jobName ?: 'elasticsearch-8x-k8s-local-test',
             sourceVersion: 'ES_8.19',
             targetVersion: 'OS_3.1',
-            testIds: '0001,0002,0040'
+            testIds: '0001,0002,0003,0040'
     )
 }


### PR DESCRIPTION
## Summary
- `workflow approve step` reported "No steps are currently being waited on" even when `workflow status` showed the gate as Running — the Argo template was renamed from `waitForApproval` to `waitForUserApproval` but the CLI's node matcher wasn't updated
- Updated `is_approval_node()` to match `waitforuserapproval` and extracted the template name into an `APPROVAL_TEMPLATE_NAME` constant shared by prod code and test fixtures
- Added `Test0003ApprovalGateIntegration` — a k8s-local integ test that runs with `skipApprovals=false` and exercises `workflow approve step --all` against a real gate, so this class of drift gets caught in Jenkins

## Test plan
- [x] Existing workflow unit tests pass (83 tests)
- [ ] `Test0003ApprovalGateIntegration` passes in k8s-local Jenkins pipeline
- [ ] Manual: `workflow approve step --list` shows the gate as WAITING FOR APPROVAL
- [ ] Manual: `workflow approve step <gate>` successfully approves the gate