### PR TITLE
build(deps): Bump idna to >=3.15 in console_link and cluster_tools develop envs

### DIFF
--- a/migrationConsole/cluster_tools/Pipfile.lock
+++ b/migrationConsole/cluster_tools/Pipfile.lock
@@ -1140,11 +1140,11 @@
         },
         "idna": {
             "hashes": [
-                "sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242",
-                "sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3"
+                "sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8",
+                "sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==3.13"
+            "version": "==3.15"
         },
         "iniconfig": {
             "hashes": [

--- a/migrationConsole/lib/console_link/Pipfile.lock
+++ b/migrationConsole/lib/console_link/Pipfile.lock
@@ -1221,11 +1221,11 @@
         },
         "idna": {
             "hashes": [
-                "sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242",
-                "sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3"
+                "sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8",
+                "sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==3.13"
+            "version": "==3.15"
         },
         "iniconfig": {
             "hashes": [


### PR DESCRIPTION
## Summary

- Bumps `idna` to `>=3.15` (resolving to `==3.18`) in the `[develop]` sections of `migrationConsole/lib/console_link/Pipfile.lock` and `migrationConsole/cluster_tools/Pipfile.lock`
- Fixes what dependabot PR #3057 missed: only the `[default]` section of `console_link` was updated; both `[develop]` sections were still pinned at `==3.13`
- All Pipfile.lock files now consistently resolve `idna` to `>=3.15` across all sections

## Test plan

- [ ] CI passes on all affected lock files
- [ ] `pipenv run pip show idna` in `console_link` and `cluster_tools` dev envs confirms `>=3.15`