### PR TITLE
Restore cluster_tools testcontainer heap to 2g

### DIFF
--- a/migrationConsole/cluster_tools/tests/conftest.py
+++ b/migrationConsole/cluster_tools/tests/conftest.py
@@ -30,7 +30,7 @@ def create_opensearch_container(max_attempts=3):
     for attempt in range(max_attempts):
         container = OpenSearchContainer("opensearchproject/opensearch:2.19.1")
         container.with_env("discovery.type", "single-node")
-        container.with_env("OPENSEARCH_JAVA_OPTS", "-Xms512m -Xmx512m")
+        container.with_env("OPENSEARCH_JAVA_OPTS", "-Xms2g -Xmx2g")
         try:
             container.start()
             url = f"http://{container.get_container_host_ip()}:{container.get_exposed_port(9200)}"


### PR DESCRIPTION
### Description

PR #3079 reduced the OpenSearch testcontainer heap from 2g to 512m to avoid OOM on constrained runners, but this broke test_migrate_document_large_field_chunking. That test sends ~9MB Painless script update requests for a 30MB document, which triggers OpenSearch's parent circuit breaker at 512m and 1g heap.

The 2g setting was deliberately introduced in PR #1839 to fix this exact circuit_breaking_exception. Restore it.

### Issues Resolved
https://github.com/opensearch-project/opensearch-migrations/actions/runs/27216613492/job/80359853883?pr=3093

### Check List
- [ ] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
