### PR TITLE
spike out adding deleteExistingIndexes option

### DIFF
--- a/MetadataMigration/src/main/java/org/opensearch/migrations/MigrateOrEvaluateArgs.java
+++ b/MetadataMigration/src/main/java/org/opensearch/migrations/MigrateOrEvaluateArgs.java
@@ -98,6 +98,17 @@ public class MigrateOrEvaluateArgs {
     )
     public boolean allowExistingIndexes = false;
 
+    @Parameter(required = false,
+        names = { "--delete-existing-indexes" },
+        description = "When true, each in-scope index (subject to the index allowlist) is deleted from the " +
+            "target cluster by name before metadata migration recreates it, giving a clean re-run. Deleting by " +
+            "exact name works even when the target has action.destructive_requires_name=true, and only touches " +
+            "indexes being migrated (unlike a wildcard clear). Only takes effect during the migrate phase, not " +
+            "evaluate. When false (default), existing indexes are left untouched. [Destructive]",
+        arity = 1
+    )
+    public boolean deleteExistingIndexes = false;
+
     // Accepted for parity with RfsMigrateDocuments but not used by MetadataMigration.
     // The orchestration layer forwards a shared config bag to both CLIs.
     @Parameter(required = false,

--- a/MetadataMigration/src/main/java/org/opensearch/migrations/commands/MigratorEvaluatorBase.java
+++ b/MetadataMigration/src/main/java/org/opensearch/migrations/commands/MigratorEvaluatorBase.java
@@ -9,6 +9,7 @@ import org.opensearch.migrations.MigrateOrEvaluateArgs;
 import org.opensearch.migrations.MigrationMode;
 import org.opensearch.migrations.Version;
 import org.opensearch.migrations.bulkload.common.FilterScheme;
+import org.opensearch.migrations.bulkload.common.OpenSearchClientFactory;
 import org.opensearch.migrations.bulkload.transformers.FanOutCompositeTransformer;
 import org.opensearch.migrations.bulkload.transformers.Transformer;
 import org.opensearch.migrations.bulkload.transformers.TransformerMapper;
@@ -124,6 +125,12 @@ public abstract class MigratorEvaluatorBase {
             // Validate sourceless indices before proceeding with migration
             validateSourcelessIndices(clusters);
 
+            // Optionally clear existing target indexes so a re-run starts clean. Only in the
+            // PERFORM phase — evaluation must never mutate the target.
+            if (migrationMode.equals(MigrationMode.PERFORM) && arguments.deleteExistingIndexes) {
+                deleteExistingTargetIndices(clusters);
+            }
+
             var indexResults = migrateIndices(migrationMode, clusters, transformer, context);
             items.indexes(indexResults.getIndexes());
             items.aliases(indexResults.getAliases());
@@ -203,6 +210,36 @@ public abstract class MigratorEvaluatorBase {
 
         if (!sourcelessIndices.isEmpty()) {
             log.info("Sourceless indices detected (--enable-sourceless-migrations is set): {}", sourcelessIndices);
+        }
+    }
+
+    /**
+     * Deletes each in-scope index (those that pass the index allowlist) from the target cluster
+     * by exact name, so a re-run recreates them from a clean slate. Deleting by name works even
+     * when the target has {@code action.destructive_requires_name=true}, and is scoped to only the
+     * indexes being migrated. A failure to delete one index is logged but does not abort the
+     * migration (the subsequent create will surface a real conflict).
+     */
+    protected void deleteExistingTargetIndices(Clusters clusters) {
+        var repoDataProvider = clusters.getSource().getIndexMetadata().getRepoDataProvider();
+        var skipFilter = FilterScheme.filterByAllowList(arguments.dataFilterArgs.indexAllowlist,
+                FilterScheme.FilterContext.INDEX).negate();
+        var targetClient = new OpenSearchClientFactory(arguments.targetArgs.toConnectionContext())
+                .determineVersionAndCreate();
+        log.info("--delete-existing-indexes is set: removing in-scope target indexes before migration.");
+        for (var index : repoDataProvider.getIndicesInSnapshot(arguments.snapshotName)) {
+            if (skipFilter.test(index.getName())) {
+                continue;
+            }
+            try {
+                targetClient.deleteIndex(index.getName());
+            } catch (Exception e) {
+                log.atWarn()
+                    .setMessage("Failed to delete existing target index {} before migration: {}")
+                    .addArgument(index.getName())
+                    .addArgument(e.getMessage())
+                    .log();
+            }
         }
     }
 }

--- a/RFS/src/main/java/org/opensearch/migrations/bulkload/common/OpenSearchClient.java
+++ b/RFS/src/main/java/org/opensearch/migrations/bulkload/common/OpenSearchClient.java
@@ -230,6 +230,37 @@ public abstract class OpenSearchClient {
         return createObjectIdempotent(targetPath, settings, context);
     }
 
+    /**
+     * Deletes a single index by exact name. Deleting by name (rather than a wildcard
+     * expression) works even when the target cluster has
+     * {@code action.destructive_requires_name=true}. A missing index (404) is treated as
+     * a successful no-op so the operation is idempotent.
+     *
+     * @return true if an index was deleted, false if it did not exist.
+     */
+    public boolean deleteIndex(String indexName) {
+        var targetPath = getCreateIndexPath(indexName);
+        var response = client.deleteAsync(targetPath, null)
+            .flatMap(resp -> {
+                if (resp.statusCode == HttpURLConnection.HTTP_OK
+                    || resp.statusCode == HttpURLConnection.HTTP_NOT_FOUND) {
+                    return Mono.just(resp);
+                }
+                return Mono.error(new OperationFailed(
+                    "Could not delete index: " + indexName + ". " + getString(resp), resp));
+            })
+            .doOnError(e -> log.error(e.getMessage()))
+            .block();
+        boolean deleted = response != null && response.statusCode == HttpURLConnection.HTTP_OK;
+        if (deleted) {
+            log.atInfo().setMessage("Deleted existing target index {}").addArgument(indexName).log();
+        } else {
+            log.atDebug().setMessage("Target index {} did not exist; nothing to delete")
+                .addArgument(indexName).log();
+        }
+        return deleted;
+    }
+
     private Optional<ObjectNode> createObjectIdempotent(
         String objectPath,
         ObjectNode settings,

--- a/RFS/src/test/java/org/opensearch/migrations/bulkload/common/OpenSearchClientTest.java
+++ b/RFS/src/test/java/org/opensearch/migrations/bulkload/common/OpenSearchClientTest.java
@@ -153,6 +153,32 @@ class OpenSearchClientTest {
         assertThat(exception.getMessage(), containsString("illegal_argument_exception"));
     }
 
+    @Test
+    void testDeleteIndex_deleted() {
+        when(restClient.deleteAsync(any(), any()))
+            .thenReturn(Mono.just(new HttpResponse(200, "", null, "{\"acknowledged\":true}")));
+
+        assertThat(openSearchClient.deleteIndex("my-index"), equalTo(true));
+    }
+
+    @Test
+    void testDeleteIndex_notFoundIsNoOp() {
+        when(restClient.deleteAsync(any(), any()))
+            .thenReturn(Mono.just(new HttpResponse(404, "", null, "{\"error\":\"index_not_found_exception\"}")));
+
+        assertThat(openSearchClient.deleteIndex("missing-index"), equalTo(false));
+    }
+
+    @Test
+    void testDeleteIndex_errorThrows() {
+        when(restClient.deleteAsync(any(), any()))
+            .thenReturn(Mono.just(new HttpResponse(403, "", null, "{\"error\":\"forbidden\"}")));
+
+        var exception = assertThrows(OpenSearchClient.OperationFailed.class,
+            () -> openSearchClient.deleteIndex("blocked-index"));
+        assertThat(exception.getMessage(), containsString("blocked-index"));
+    }
+
     private void setupOkResponse(RestClient restClient, String url, String body) {
         var versionResponse = new HttpResponse(200, "OK", Map.of(), body);
         when(restClient.getAsync(url, null)).thenReturn(Mono.just(versionResponse));

--- a/RfsHttp/src/main/java/org/opensearch/migrations/bulkload/common/RestClient.java
+++ b/RfsHttp/src/main/java/org/opensearch/migrations/bulkload/common/RestClient.java
@@ -256,6 +256,14 @@ public class RestClient {
         return putAsync(path, body, context).block();
     }
 
+    public Mono<HttpResponse> deleteAsync(String path, IRfsContexts.IRequestContext context) {
+        return asyncRequest(HttpMethod.DELETE, path, null, null, context);
+    }
+
+    public HttpResponse delete(String path, IRfsContexts.IRequestContext context) {
+        return deleteAsync(path, context).block();
+    }
+
     private static void removeIfPresent(ChannelPipeline p, String name) {
         var h = p.get(name);
         if (h != null) {

--- a/orchestrationSpecs/packages/config-processor/tests/__snapshots__/resolvedMigrationResources.test.ts.snap
+++ b/orchestrationSpecs/packages/config-processor/tests/__snapshots__/resolvedMigrationResources.test.ts.snap
@@ -158,6 +158,7 @@ exports[`resolved migration resources extracts resolved resource parameters from
       "metadataMigrationAllowLooseVersionMatching": true,
       "metadataMigrationClusterAwarenessAttributes": 1,
       "metadataMigrationComponentTemplateAllowlist": [],
+      "metadataMigrationDeleteExistingIndexes": false,
       "metadataMigrationEnableSourcelessMigrations": false,
       "metadataMigrationFileSourceVolumeMounts": [],
       "metadataMigrationFileSourceVolumes": [],

--- a/orchestrationSpecs/packages/schemas/src/userSchemas.ts
+++ b/orchestrationSpecs/packages/schemas/src/userSchemas.ts
@@ -788,6 +788,13 @@ export const USER_METADATA_PROCESS_OPTIONS = z.object({
             "Each entry is either an exact name or a regex pattern prefixed with 'regex:'. " +
             "An empty list includes all non-system index templates."),
 
+    deleteExistingIndexes: z.boolean().default(false).optional()
+        .describe("[Destructive] When true, each in-scope index (subject to indexAllowlist) is deleted from the " +
+            "target cluster by name before the metadata migration recreates it, giving a clean re-run. Deleting by " +
+            "exact name works even when the target has action.destructive_requires_name=true, and only touches the " +
+            "indexes being migrated (unlike clearing the whole target). Only takes effect during the migrate phase, " +
+            "not evaluate. When false (default), existing target indexes are left untouched (combine with " +
+            "allowExistingIndexes to treat them as non-fatal instead)."),
     allowLooseVersionMatching: z.boolean().default(true).optional()
         .describe("[Expert] Allows migration between clusters with non-exact version compatibility (e.g. ES 7.x to OS 2.x). " +
             "Only disable if metadata has parsing issues on snapshots that require strict version matching."),

--- a/orchestrationSpecs/packages/schemas/tests/__snapshots__/argoSchemaSnapshot.test.ts.snap
+++ b/orchestrationSpecs/packages/schemas/tests/__snapshots__/argoSchemaSnapshot.test.ts.snap
@@ -1403,6 +1403,10 @@ exports[`test schemas matches expected argo schema matches expected 1`] = `
                       },
                       "default": []
                     },
+                    "deleteExistingIndexes": {
+                      "type": "boolean",
+                      "default": false
+                    },
                     "allowLooseVersionMatching": {
                       "type": "boolean",
                       "default": true
@@ -3198,6 +3202,11 @@ exports[`test schemas matches expected argo user matches expected 1`] = `
                         },
                         "default": [],
                         "description": "List of index template names to include in the metadata migration. Each entry is either an exact name or a regex pattern prefixed with 'regex:'. An empty list includes all non-system index templates."
+                      },
+                      "deleteExistingIndexes": {
+                        "type": "boolean",
+                        "default": false,
+                        "description": "[Destructive] When true, each in-scope index (subject to indexAllowlist) is deleted from the target cluster by name before the metadata migration recreates it, giving a clean re-run. Deleting by exact name works even when the target has action.destructive_requires_name=true, and only touches the indexes being migrated (unlike clearing the whole target). Only takes effect during the migrate phase, not evaluate. When false (default), existing target indexes are left untouched (combine with allowExistingIndexes to treat them as non-fatal instead)."
                       },
                       "allowLooseVersionMatching": {
                         "type": "boolean",


### PR DESCRIPTION
### Description
Add `"metadataMigrationConfig": { "deleteExistingIndexes": true }` to allow console to delete target index.

### Issues Resolved
Fixes #3105 

### Testing
Unit tests.   Now working on manual test.

### Check List
- [x ] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
