### PR TITLE
Pin GitHub Actions to full commit SHAs for org policy compliance

### DIFF
--- a/.github/actions/setup-env/action.yaml
+++ b/.github/actions/setup-env/action.yaml
@@ -12,17 +12,17 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/setup-java@v4
+    - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
       with:
         java-version: 21
         distribution: "corretto"
 
-    - uses: gradle/actions/setup-gradle@v4
+    - uses: gradle/actions/setup-gradle@ed408507eac070d1f99cc633dbcf757c94c7933a # v4
       with:
         cache-disabled: ${{ inputs.gradle-cache-enabled != 'true' }}
         cache-read-only: ${{ inputs.gradle-cache-read-only }}
 
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
       with:
         python-version: 3.11
 
@@ -31,7 +31,7 @@ runs:
         python3 -m pip install pipenv==2026.5.0
       shell: bash
 
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
       with:
         node-version: 22.x
 

--- a/.github/workflows/generate-workflow-schema.yaml
+++ b/.github/workflows/generate-workflow-schema.yaml
@@ -61,13 +61,13 @@ jobs:
           curl -sS http://docker-registry:5000/v2/ || true
 
       - name: Restore Docker Cache
-        uses: AndreKurait/docker-cache@0.7.0
+        uses: AndreKurait/docker-cache@7a3887908bdb97935395833df69b060cfcca0f7f # 0.7.0
         with:
           key: docker-${{ runner.os }}-${{ needs.generate-cache-key.outputs.docker_cache_key }}
           read-only: ${{ github.event_name != 'push' }}
 
       - name: Set up Buildx builder (BuildKit)
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
         with:
           driver: docker-container
           name: local-remote-builder
@@ -79,7 +79,7 @@ jobs:
               insecure = true
 
       - name: Set up Kind cluster
-        uses: helm/kind-action@v1.14.0
+        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
         with:
           cluster_name: generate-workflow-schema
           node_image: kindest/node:v1.35.0
@@ -116,7 +116,7 @@ jobs:
           ./deployment/k8s/generateWorkflowSchemaArtifact.sh
 
       - name: Upload workflow schema artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: workflowMigration-schema-${{ github.sha }}
           path: workflowMigration.schema.json

--- a/.github/workflows/migrate-cli.yml
+++ b/.github/workflows/migrate-cli.yml
@@ -36,7 +36,7 @@ jobs:
   lint:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: ./.github/actions/setup-env
       - name: rustfmt + clippy through Gradle-managed Rust
         working-directory: .
@@ -52,7 +52,7 @@ jobs:
   test:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: ./.github/actions/setup-env
       - name: cargo test through Gradle-managed Rust
         working-directory: .
@@ -83,7 +83,7 @@ jobs:
     runs-on: ubuntu-22.04
     needs: [lint]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: ./.github/actions/setup-env
       - name: gradle packages CLI tarball + install.sh (provisions Rust itself)
         working-directory: .

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -54,11 +54,11 @@ jobs:
             force-cross: 'false'
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           java-version: 21
           distribution: corretto
-      - uses: gradle/actions/setup-gradle@v4
+      - uses: gradle/actions/setup-gradle@ed408507eac070d1f99cc633dbcf757c94c7933a # v4
       - id: get_data
         shell: bash
         run: |
@@ -185,7 +185,7 @@ jobs:
             :deployment:k8s:packageMigrationAssistantHelmChart \
             -PhelmChartVersion="${{ steps.get_data.outputs.version }}"
       - name: Download Migration Assistant CLI installers
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           pattern: migration-assistant-cli-installers-*-${{ steps.get_data.outputs.version }}
           path: deployment/k8s/aws/build/migrate-cli-dist/release-installers


### PR DESCRIPTION
### Description
Pin all GitHub Actions references to full-length commit SHAs to comply with the opensearch-project org-level policy requiring SHA pinning.

Files fixed:
- `.github/actions/setup-env/action.yaml` — setup-java, setup-gradle, setup-python, setup-node
- `.github/workflows/release-drafter.yml` — setup-java, setup-gradle, download-artifact
- `.github/workflows/generate-workflow-schema.yaml` — setup-buildx-action, kind-action, upload-artifact, docker-cache
- `.github/workflows/migrate-cli.yml` — checkout

SHAs were obtained by resolving the tag to its commit, e.g.:
```bash
gh api repos/actions/setup-java/commits/v4 --jq .sha
# c1e323688fd81a25caa38c78aa6df2d33d3e20d9
```

### Issues Resolved
Fixes all CI check failures caused by: `all actions must be pinned to a full-length commit SHA`

### Testing
CI checks should pass with this change.

### Check List
- [x] New functionality includes testing
- [ ] Public documentation issue/PR created, if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.