### PR TITLE
Fix release workflows and add notification

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -348,21 +348,22 @@ jobs:
             -PcliVersion="${{ steps.get_data.outputs.version }}"
       - name: Draft a release
         if: ${{ !github.event.act }}
-        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3
+        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd
         with:
-          draft: true
-          generate_release_notes: true
-          files: |
-            deployment/migration-assistant-solution/cdk.out-minified/*-eks.template.json
-            opensearch-migrations-source.tar.gz
-            opensearch-migrations-build.tar.gz
-            agent-skills/build/agent-skills.tar.gz
-            bootstrap-kiro-agent.sh
-            deployment/k8s/build/helm-package/migration-assistant-${{ steps.get_data.outputs.version }}.tgz
-            workflowMigration.schema.json
-            deployment/k8s/aws/dist/aws-bootstrap.sh
-            deployment/k8s/aws/build/migrate-cli-dist/install.sh
-            deployment/k8s/aws/build/migrate-cli-dist/migration-assistant-cli-${{ steps.get_data.outputs.version }}.tar.gz
-            deployment/k8s/aws/build/migrate-cli-dist/release-installers/manifest.json
-            deployment/k8s/aws/build/migrate-cli-dist/release-installers/*.tar.gz
+          immutableCreate: true
+          prerelease: true
+          generateReleaseNotes: true
+          artifacts: >-
+            deployment/migration-assistant-solution/cdk.out-minified/*-eks.template.json,
+            opensearch-migrations-source.tar.gz,
+            opensearch-migrations-build.tar.gz,
+            agent-skills/build/agent-skills.tar.gz,
+            bootstrap-kiro-agent.sh,
+            deployment/k8s/build/helm-package/migration-assistant-${{ steps.get_data.outputs.version }}.tgz,
+            workflowMigration.schema.json,
+            deployment/k8s/aws/dist/aws-bootstrap.sh,
+            deployment/k8s/aws/build/migrate-cli-dist/install.sh,
+            deployment/k8s/aws/build/migrate-cli-dist/migration-assistant-cli-${{ steps.get_data.outputs.version }}.tar.gz,
+            deployment/k8s/aws/build/migrate-cli-dist/release-installers/manifest.json,
+            deployment/k8s/aws/build/migrate-cli-dist/release-installers/*.tar.gz,
             **/*.spdx.json

--- a/jenkins/release.jenkinsFile
+++ b/jenkins/release.jenkinsFile
@@ -1,4 +1,4 @@
-lib = library(identifier: 'jenkins@12.0.0', retriever: modernSCM([
+lib = library(identifier: 'jenkins@13.0.1', retriever: modernSCM([
     $class: 'GitSCMSource',
     remote: 'https://github.com/opensearch-project/opensearch-build-libraries.git',
 ]))
@@ -27,7 +27,7 @@ pipeline {
                     [key: 'ref', value: '$.release.tag_name'],
                     [key: 'repository', value: '$.repository.html_url'],
                     [key: 'action', value: '$.action'],
-                    [key: 'isDraft', value: '$.release.draft'],
+                    [key: 'isPreRelease', value: '$.release.prerelease'],
                     [key: 'release_url', value: '$.release.url'],
                     [key: 'assets_url', value: '$.release.assets_url']
                 ],
@@ -121,15 +121,36 @@ pipeline {
         post {
             success {
                 script {
-                    if (release_url != null) {
+                    withSecrets(secrets: secret_github_bot){
+                        def codeOwners = sh(
+                            script: "gh api repos/${repository.replaceAll('https://github.com/', '')}/contents/.github/CODEOWNERS --jq '.content' 2>/dev/null | tr -d '\\n' | base64 -d | grep -oP '@[\\w/-]+' | sort -u | tr '\\n' ' ' || echo ''",
+                            returnStdout: true
+                        ).trim()
+                        def issueBody = "The release workflow for tag `${tag}` completed successfully.\n\nBuild: ${env.BUILD_URL}\n\nPlease publish the release on GitHub by converting the pre-release to a full release.\n\nRelease: ${release_html_url}\n\ncc: ${codeOwners}"
+                        sh """gh issue create --title \"[Release - Action Required] Publish release for tag ${tag}\" --body \"${issueBody}\" --repo ${repository}"""
+                    }
+                }
+            }
+            failure {
+                script {
                         withSecrets(secrets: secret_github_bot){
-                            sh "curl -X PATCH -H 'Accept: application/vnd.github+json' -H 'Authorization: Bearer ${GITHUB_TOKEN}' ${release_url} -d '{\"tag_name\":\"${tag}\",\"draft\":false,\"prerelease\":false}'"
-                        }
+                        def codeOwners = sh(
+                            script: "gh api repos/${repository.replaceAll('https://github.com/', '')}/contents/.github/CODEOWNERS --jq '.content' 2>/dev/null | tr -d '\\n' | base64 -d | grep -oP '@[\\w/-]+' | sort -u | tr '\\n' ' ' || echo ''",
+                            returnStdout: true
+                        ).trim()
+                        def issueBody = "The release workflow for tag `${tag}` failed.\n\nPlease investigate the failure and retry the release.\n\nRelease: ${release_html_url}\n\ncc: ${codeOwners} @opensearch-project/engineering-effectiveness"
+                        sh """gh issue create --title \"[RELEASE] Failed: release for tag ${tag}\" --body \"${issueBody}\" --repo ${repository}"""
                     }
                 }
             }
             always {
                 script {
+                    publishNotification(
+                    icon: currentBuild.currentResult == 'SUCCESS' ? ':white_check_mark:' : ':x:',
+                    message: currentBuild.currentResult == 'SUCCESS' ? "Release ${tag} completed successfully" : "Release ${tag} failed",
+                    extra: "REPOSITORY: ${repository}\nTAG: ${tag}",
+                    credentialsId: 'opensearch-release-notification-webhook'
+                    )
                     postCleanup()
                 }
             }


### PR DESCRIPTION
### Description
Recently we removed bot access to the repository. Due to which it is now unable to read draft releases.
This PR updates the release workflow to draft a "pre-release" instead of draft one that would be accessible to read-only user as well. 
Also changes the trigger from draft to pre-release. Once successful or failed, it will create a GH issue tagging all codeowners to take required action. Also sends notification to slack channel as another monitoring mechanism

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/6255

### Testing
<!-- Please provide details of testing done: unit testing, integration testing and manual testing -->

### Check List
- [ ] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
