### PR TITLE
Scope spotlessJava to java-plugin projects and target src/ to avoid node_modules walk failure

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -106,22 +106,6 @@ subprojects {
 
     apply plugin: "com.diffplug.spotless"
 
-    spotless {
-        java {
-            // src/ only: source-set resolution would pull in generated proto under build/.
-            target 'src/**/*.java'
-            importOrder(
-                    'javax',
-                    'java',
-                    'org.opensearch',
-                    '',
-                    '\\#')
-            indentWithSpaces()
-            endWithNewline()
-            removeUnusedImports()
-        }
-    }
-
     plugins.withId('com.google.cloud.tools.jib') {
         tasks.withType(JibTask).configureEach {
             notCompatibleWithConfigurationCache("because https://github.com/GoogleContainerTools/jib/issues/3132")
@@ -138,6 +122,22 @@ subprojects {
             toolchain {
                 languageVersion.set(JavaLanguageVersion.of(21))
                 vendor.set(JvmVendorSpec.AMAZON)
+            }
+        }
+
+        spotless {
+            java {
+                // src/ only: source-set resolution would pull in generated proto under build/.
+                target 'src/**/*.java'
+                importOrder(
+                        'javax',
+                        'java',
+                        'org.opensearch',
+                        '',
+                        '\\#')
+                indentWithSpaces()
+                endWithNewline()
+                removeUnusedImports()
             }
         }
 

--- a/build.gradle
+++ b/build.gradle
@@ -91,12 +91,25 @@ spotless {
     }
 }
 
-// Jenkins runs broad build graphs where nodeSetup and root Spotless tasks can
-// both be present. Keep Spotless out of Gradle-managed output and order it
-// after nodeSetup to satisfy Gradle's implicit-dependency validation.
-['spotlessMisc', 'spotlessYaml', 'spotlessJson'].each { taskName ->
-    tasks.named(taskName) {
-        mustRunAfter ':deployment:migration-assistant-solution:nodeSetup'
+// A Spotless task's `target` fileTree is rooted at its project dir, so it walks
+// any node-using subproject's `node_modules` that lives underneath it (e.g.
+// :deployment's tree spans :deployment:migration-assistant-solution). Even though
+// node_modules is excluded from the walk, that directory is the OUTPUT of the
+// `nodeSetup` task, so the input/output overlap trips Gradle's implicit-dependency
+// validation ("uses this output ... without declaring an explicit or implicit
+// dependency"). Order every Spotless task after each nodeSetup whose project sits
+// at or below the Spotless task's project, satisfying the validation without
+// forcing nodeSetup to run when only Spotless is requested.
+gradle.projectsEvaluated {
+    def nodeSetupTasks = allprojects.collect { it.tasks.findByName('nodeSetup') }.findAll { it != null }
+    allprojects.each { proj ->
+        proj.tasks.matching { it.name.startsWith('spotless') }.configureEach { spotlessTask ->
+            nodeSetupTasks.each { nodeSetupTask ->
+                if (nodeSetupTask.project.projectDir.toPath().startsWith(proj.projectDir.toPath())) {
+                    spotlessTask.mustRunAfter nodeSetupTask
+                }
+            }
+        }
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -91,25 +91,14 @@ spotless {
     }
 }
 
-// A Spotless task's `target` fileTree is rooted at its project dir, so it walks
-// any node-using subproject's `node_modules` that lives underneath it (e.g.
-// :deployment's tree spans :deployment:migration-assistant-solution). Even though
-// node_modules is excluded from the walk, that directory is the OUTPUT of the
-// `nodeSetup` task, so the input/output overlap trips Gradle's implicit-dependency
-// validation ("uses this output ... without declaring an explicit or implicit
-// dependency"). Order every Spotless task after each nodeSetup whose project sits
-// at or below the Spotless task's project, satisfying the validation without
-// forcing nodeSetup to run when only Spotless is requested.
+// The root misc/yaml/json formats target fileTree('.'), which spans the node_modules
+// dirs that nodeSetup populates. Order them after nodeSetup so the input/output overlap
+// doesn't trip Gradle's implicit-dependency validation. (The Java format avoids this by
+// targeting src/ directly.)
 gradle.projectsEvaluated {
-    def nodeSetupTasks = allprojects.collect { it.tasks.findByName('nodeSetup') }.findAll { it != null }
-    allprojects.each { proj ->
-        proj.tasks.matching { it.name.startsWith('spotless') }.configureEach { spotlessTask ->
-            nodeSetupTasks.each { nodeSetupTask ->
-                if (nodeSetupTask.project.projectDir.toPath().startsWith(proj.projectDir.toPath())) {
-                    spotlessTask.mustRunAfter nodeSetupTask
-                }
-            }
-        }
+    def nodeSetupTasks = allprojects.findResults { it.tasks.findByName('nodeSetup') }
+    ['spotlessMisc', 'spotlessYaml', 'spotlessJson'].each { name ->
+        tasks.named(name).configure { mustRunAfter nodeSetupTasks }
     }
 }
 
@@ -123,20 +112,11 @@ subprojects {
     // though what '#' does is still undocumented from what I can tell
     spotless {
         java {
-                // Bake the directory exclusions into the FileTree walk rather than using
-                // targetExclude. Spotless resolves `target` minus `targetExclude` as a set
-                // subtraction (SubtractingFileCollection), which forces a full walk of the
-                // *unfiltered* target tree before the exclude is applied. That walk descends
-                // into node_modules/.bin and dies on npm's dangling atomic-rename symlinks
-                // (e.g. .cdk-XXXX left behind by an interrupted `npm install`), failing with
-                // "Couldn't follow symbolic link ...". A targetExclude of '**/node_modules/**'
-                // does NOT help -- its subtrahend tree must itself be walked, re-triggering the
-                // same descent. Excluding at walk time prunes these directories so they are
-                // never traversed. Mirrors the misc/yaml/json formats above.
-                target project.fileTree(project.projectDir) {
-                    include '**/*.java'
-                    exclude '**/build/**', '**/node_modules/**', '**/cdk.out/**', '**/cdk.out-minified/**', '.gradle/**'
-                }
+                // All Java sources live under src/, so target it directly. This keeps the walk
+                // out of node_modules (whose dangling npm bin-link symlinks otherwise fail the
+                // walk) and out of nodeSetup's output dirs (which would trip Gradle's
+                // implicit-dependency validation).
+                target 'src/**/*.java'
                 importOrder(
                         'javax',
                         'java',

--- a/build.gradle
+++ b/build.gradle
@@ -110,8 +110,20 @@ subprojects {
     // though what '#' does is still undocumented from what I can tell
     spotless {
         java {
-                target "**/*.java"
-                targetExclude '**/build/**', ".gradle/**", "**/node_modules/**"
+                // Bake the directory exclusions into the FileTree walk rather than using
+                // targetExclude. Spotless resolves `target` minus `targetExclude` as a set
+                // subtraction (SubtractingFileCollection), which forces a full walk of the
+                // *unfiltered* target tree before the exclude is applied. That walk descends
+                // into node_modules/.bin and dies on npm's dangling atomic-rename symlinks
+                // (e.g. .cdk-XXXX left behind by an interrupted `npm install`), failing with
+                // "Couldn't follow symbolic link ...". A targetExclude of '**/node_modules/**'
+                // does NOT help -- its subtrahend tree must itself be walked, re-triggering the
+                // same descent. Excluding at walk time prunes these directories so they are
+                // never traversed. Mirrors the misc/yaml/json formats above.
+                target project.fileTree(project.projectDir) {
+                    include '**/*.java'
+                    exclude '**/build/**', '**/node_modules/**', '**/cdk.out/**', '**/cdk.out-minified/**', '.gradle/**'
+                }
                 importOrder(
                         'javax',
                         'java',

--- a/build.gradle
+++ b/build.gradle
@@ -91,10 +91,8 @@ spotless {
     }
 }
 
-// The root misc/yaml/json formats target fileTree('.'), which spans the node_modules
-// dirs that nodeSetup populates. Order them after nodeSetup so the input/output overlap
-// doesn't trip Gradle's implicit-dependency validation. (The Java format avoids this by
-// targeting src/ directly.)
+// These formats scan fileTree('.'), which overlaps node_modules (nodeSetup's output);
+// order them after nodeSetup so Gradle's implicit-dependency validation doesn't fail.
 gradle.projectsEvaluated {
     def nodeSetupTasks = allprojects.findResults { it.tasks.findByName('nodeSetup') }
     ['spotlessMisc', 'spotlessYaml', 'spotlessJson'].each { name ->
@@ -108,25 +106,20 @@ subprojects {
 
     apply plugin: "com.diffplug.spotless"
 
-    // See https://github.com/diffplug/spotless/tree/main/plugin-gradle#java for some documentation,
-    // though what '#' does is still undocumented from what I can tell
     spotless {
         java {
-                // All Java sources live under src/, so target it directly. This keeps the walk
-                // out of node_modules (whose dangling npm bin-link symlinks otherwise fail the
-                // walk) and out of nodeSetup's output dirs (which would trip Gradle's
-                // implicit-dependency validation).
-                target 'src/**/*.java'
-                importOrder(
-                        'javax',
-                        'java',
-                        'org.opensearch',
-                        '',
-                        '\\#')
-                indentWithSpaces()
-                endWithNewline()
-                removeUnusedImports()
-            }
+            // src/ only: source-set resolution would pull in generated proto under build/.
+            target 'src/**/*.java'
+            importOrder(
+                    'javax',
+                    'java',
+                    'org.opensearch',
+                    '',
+                    '\\#')
+            indentWithSpaces()
+            endWithNewline()
+            removeUnusedImports()
+        }
     }
 
     plugins.withId('com.google.cloud.tools.jib') {


### PR DESCRIPTION
### Description

`spotlessJava` (and `spotlessJavaCheck`) intermittently fail the build with:

```
Execution failed for task ':deployment:migration-assistant-solution:spotlessJava'.
> Couldn't follow symbolic link '.../node_modules/.bin/.cdk-qWiBbNCY'.
```

**Root cause.** The `subprojects` Java Spotless config targeted the whole tree:

```groovy
target "**/*.java"
targetExclude '**/build/**', ".gradle/**", "**/node_modules/**"
```

Spotless resolves `target` minus `targetExclude` as a **set subtraction** (`SubtractingFileCollection`). The subtraction must fully enumerate the minuend first — the bare `**/*.java` tree **with no exclude** — so Gradle walks `node_modules/.bin` and dies on npm's dangling atomic-rename symlink (`.cdk-XXXX`, left behind by an interrupted/racing `npm install`) **before** `targetExclude` is ever applied. Keeping the `node_modules` `targetExclude` does not help — the subtrahend tree must itself be walked, re-triggering the same descent.

This config was also applied to **every** subproject, so CDK projects with no first-party Java (e.g. `:deployment`, `:deployment:migration-assistant-solution`) got a `spotlessJava` task whose only job was to walk their `node_modules`.

**Fix.** Two changes:

1. **Scope the Java format to projects that actually have the `java` plugin**, and target `src/` directly:

   ```groovy
   plugins.withId('java') {
       spotless {
           java {
               target 'src/**/*.java'
               ...
           }
       }
   }
   ```

   All hand-written Java lives under `src/`, so this covers the same source set while never walking `node_modules`, `build/`, or `cdk.out`. Targeting `src/` (rather than dropping `target` to use Gradle source-set resolution) is deliberate: source-set resolution would pull in generated protobuf sources under `build/`. Scoping under `plugins.withId('java')` means CDK projects no longer register a `spotlessJava` task at all.

2. **Generalize the root `spotlessMisc`/`spotlessYaml`/`spotlessJson` ordering.** Those formats target `fileTree('.')` (the repo root) for `*.gradle`/`*.yml`/`*.json`, which genuinely spans the `node_modules` dirs that `nodeSetup` populates. The input/output overlap trips Gradle's implicit-dependency validation, so they `mustRunAfter` every `nodeSetup` task (not just the one hardcoded project). This is ordering-only, so it does not force `nodeSetup` to run when only Spotless is requested.

### Issues Resolved

N/A — fixes a CI build-hygiene flake (no tracking issue).

### Testing

Reproduced and verified locally against Gradle 8.14.3:

- Confirmed the original crash: injected a dangling `node_modules/.bin/.cdk-XXXX` symlink and reproduced `Couldn't follow symbolic link`; with the fix and the symlink still present, `:deployment:migration-assistant-solution:spotlessJava` is gone and `spotlessCheck` is clean.
- Confirmed the implicit-dependency validation no longer fires: `./gradlew spotlessCheck nodeSetup` (root + all `nodeSetup` tasks) → `BUILD SUCCESSFUL`.
- Verified CDK projects no longer register the task: `:deployment:spotlessJava` → `task 'spotlessJava' not found in project ':deployment'`.
- Verified generated proto is not formatted (source-set resolution would have flagged it) and all first-party `src/**` Java remains in scope.

### Check List
- [ ] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
