### PR TITLE
Renaming Kakfa Healthy dashboard widget

### DIFF
--- a/deployment/cdk/opensearch-service-migration/lib/components/capture-replay-dashboard.json
+++ b/deployment/cdk/opensearch-service-migration/lib/components/capture-replay-dashboard.json
@@ -90,7 +90,7 @@
             "type": "metric",
             "properties": {
                 "metrics": [
-                    [ { "expression": "IF(m2 > 0, 1, 0)", "label": "CommitsObserved", "id": "e1", "region": "REGION", "period": 300 } ],
+                    [ { "expression": "FILL(m2, 0)", "label": "Kafka Commits", "id": "e1", "region": "REGION", "period": 300 } ],
                     [ "OpenSearchMigrations", "kafkaCommitCount", "qualifier", "MA_QUALIFIER", "OTelLib", "replayer", { "id": "m2", "region": "REGION", "visible": false } ]
                 ],
                 "sparkline": true,
@@ -98,7 +98,7 @@
                 "region": "REGION",
                 "period": 300,
                 "stat": "Sum",
-                "title": "Replayer Kafka Healthy",
+                "title": "Replayer Kafka Commit Activity",
                 "stacked": false,
                 "liveData": false,
                 "yAxis": {

--- a/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/files/cloudwatch-dashboards/capture-replay-dashboard.json
+++ b/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/files/cloudwatch-dashboards/capture-replay-dashboard.json
@@ -99,7 +99,7 @@
             "type": "metric",
             "properties": {
                 "metrics": [
-                    [ { "expression": "IF(m2 > 0, 1, 0)", "label": "CommitsObserved", "id": "e1", "region": "REGION", "period": 300 } ],
+                    [ { "expression": "FILL(m2, 0)", "label": "Kafka Commits", "id": "e1", "region": "REGION", "period": 300 } ],
                     [ "OpenSearchMigrations", "kafkaCommitCount", "qualifier", "MA_QUALIFIER", "OTelLib", "replayer", { "id": "m2", "region": "REGION", "visible": false } ]
                 ],
                 "sparkline": true,
@@ -107,7 +107,7 @@
                 "region": "REGION",
                 "period": 300,
                 "stat": "Sum",
-                "title": "Replayer Kafka Healthy",
+                "title": "Replayer Kafka Commit Activity",
                 "stacked": false,
                 "liveData": false,
                 "yAxis": {

--- a/deployment/k8s/dashboards/capture-replay-dashboard.json
+++ b/deployment/k8s/dashboards/capture-replay-dashboard.json
@@ -90,7 +90,7 @@
             "type": "metric",
             "properties": {
                 "metrics": [
-                    [ { "expression": "IF(m2 > 0, 1, 0)", "label": "CommitsObserved", "id": "e1", "region": "REGION", "period": 300 } ],
+                    [ { "expression": "FILL(m2, 0)", "label": "Kafka Commits", "id": "e1", "region": "REGION", "period": 300 } ],
                     [ "OpenSearchMigrations", "kafkaCommitCount", "qualifier", "MA_QUALIFIER", "OTelLib", "replayer", { "id": "m2", "region": "REGION", "visible": false } ]
                 ],
                 "sparkline": true,
@@ -98,7 +98,7 @@
                 "region": "REGION",
                 "period": 300,
                 "stat": "Sum",
-                "title": "Replayer Kafka Healthy",
+                "title": "Replayer Kafka Commit Activity",
                 "stacked": false,
                 "liveData": false,
                 "yAxis": {


### PR DESCRIPTION
### Description
Currently widget name Replayer Kafka Healthy tracks kafka commits. Widget name "healthy" is confusing because we associate healthy with heartbeat check or healthchecks which are periodic and never expect to drop to zero. So renaming to commit activity to avoid this confusion

### Testing
Replaced this section in cloduwatch dashboard and tested

### Check List
- [x] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
