### PR TITLE
Fix Solr 6.6/7.7 k8s integration test failures

### DIFF
--- a/migrationConsole/lib/integ_test/testWorkflows/clusterWorkflows.yaml
+++ b/migrationConsole/lib/integ_test/testWorkflows/clusterWorkflows.yaml
@@ -2161,7 +2161,7 @@ spec:
                   serviceAccountName: migration-console-access-role
                   containers:
                     - name: solr
-                      image: ${IMAGE_REGISTRY_PREFIX}migrations/custom-solr:6.6.0
+                      image: ${IMAGE_REGISTRY_PREFIX}migrations/custom-solr:7.7.3
                       imagePullPolicy: Always
                       securityContext:
                         runAsUser: 0

--- a/orchestrationSpecs/packages/migration-workflow-templates/resources/scripts/configureAndSubmitWorkflow.sh
+++ b/orchestrationSpecs/packages/migration-workflow-templates/resources/scripts/configureAndSubmitWorkflow.sh
@@ -46,8 +46,12 @@ CONFIG_OUTPUT=$(
 echo "$CONFIG_OUTPUT"
 
 echo "Submitting workflow..."
+SUBMIT_CMD="workflow submit"
+if [ -n "${RUN_NONCE:-}" ]; then
+  SUBMIT_CMD="$SUBMIT_CMD --unique-run-nonce $RUN_NONCE"
+fi
 WORKFLOW_OUTPUT=$(
   kubectl exec --namespace "$WORKFLOW_NAMESPACE" "$MIGRATION_CONSOLE_POD" -- \
-    /bin/bash -lc 'workflow submit' 2>&1
+    /bin/bash -lc "$SUBMIT_CMD" 2>&1
 ) || fail "Submit failed: $WORKFLOW_OUTPUT"
 echo "Workflow submit output: $WORKFLOW_OUTPUT"

--- a/vars/k8sLocalDeployment.groovy
+++ b/vars/k8sLocalDeployment.groovy
@@ -103,7 +103,7 @@ def call(Map config = [:]) {
                                 connect_cluster_to_registry_network minikube "${mk_nodes[@]}"
                             '''
                             def pullThroughCacheEndpoint = sh(script: 'bash -l -c \'echo -n $ECR_PULL_THROUGH_ENDPOINT\'', returnStdout: true).trim()
-                            sh "./gradlew :buildImages:buildImagesToRegistry_amd64 :buildImages:buildKitTestAll_amd64 -PincludeSolr660TestImage -Pbuilder=builder-minikube -PregistryEndpoint=localhost:5001 -x test --info --stacktrace --profile --scan${pullThroughCacheEndpoint ? " -PpullThroughCacheEndpoint=${pullThroughCacheEndpoint}" : ""}"
+                            sh "./gradlew :buildImages:buildImagesToRegistry_amd64 :buildImages:buildKitTestAll_amd64 -PincludeSolr773TestImage -Pbuilder=builder-minikube -PregistryEndpoint=localhost:5001 -x test --info --stacktrace --profile --scan${pullThroughCacheEndpoint ? " -PpullThroughCacheEndpoint=${pullThroughCacheEndpoint}" : ""}"
                             // Keep builder-minikube alive across runs so the buildkit cache persists.
                         }
                     }

--- a/vars/k8sLocalDeployment.groovy
+++ b/vars/k8sLocalDeployment.groovy
@@ -103,7 +103,7 @@ def call(Map config = [:]) {
                                 connect_cluster_to_registry_network minikube "${mk_nodes[@]}"
                             '''
                             def pullThroughCacheEndpoint = sh(script: 'bash -l -c \'echo -n $ECR_PULL_THROUGH_ENDPOINT\'', returnStdout: true).trim()
-                            sh "./gradlew :buildImages:buildImagesToRegistry_amd64 :buildImages:buildKitTestAll_amd64 -Pbuilder=builder-minikube -PregistryEndpoint=localhost:5001 -x test --info --stacktrace --profile --scan${pullThroughCacheEndpoint ? " -PpullThroughCacheEndpoint=${pullThroughCacheEndpoint}" : ""}"
+                            sh "./gradlew :buildImages:buildImagesToRegistry_amd64 :buildImages:buildKitTestAll_amd64 -PincludeSolr660TestImage -Pbuilder=builder-minikube -PregistryEndpoint=localhost:5001 -x test --info --stacktrace --profile --scan${pullThroughCacheEndpoint ? " -PpullThroughCacheEndpoint=${pullThroughCacheEndpoint}" : ""}"
                             // Keep builder-minikube alive across runs so the buildkit cache persists.
                         }
                     }

--- a/vars/migrationVersions.groovy
+++ b/vars/migrationVersions.groovy
@@ -3,7 +3,7 @@
  */
 def call() {
     return [
-        sourceVersions: ['ES_1.5', 'ES_2.4', 'ES_5.6', 'ES_6.8', 'ES_7.10', 'ES_8.19', 'SOLR_6.6', 'SOLR_7.7', 'SOLR_8.11', 'SOLR_9.8'],
-        targetVersions: ['OS_1.3', 'OS_2.19', 'OS_3.1']
+        sourceVersions: ['SOLR_6.6', 'SOLR_7.7', 'SOLR_9.8'],
+        targetVersions: ['OS_2.19']
     ]
 }

--- a/vars/migrationVersions.groovy
+++ b/vars/migrationVersions.groovy
@@ -3,7 +3,7 @@
  */
 def call() {
     return [
-        sourceVersions: ['SOLR_6.6', 'SOLR_7.7', 'SOLR_9.8'],
-        targetVersions: ['OS_2.19']
+        sourceVersions: ['ES_1.5', 'ES_2.4', 'ES_5.6', 'ES_6.8', 'ES_7.10', 'ES_8.19', 'SOLR_6.6', 'SOLR_7.7', 'SOLR_8.11', 'SOLR_9.8'],
+        targetVersions: ['OS_1.3', 'OS_2.19', 'OS_3.1']
     ]
 }


### PR DESCRIPTION
### Description
Fix three issues causing Solr 6.6 and 7.7 integration tests to fail in the k8s matrix test pipeline:

1. **Pass RUN_NONCE to workflow submit** — The `configureAndSubmitWorkflow.sh` test helper script was not forwarding the `RUN_NONCE` env var to the `workflow submit` CLI. This caused the snapshot name to use a timestamp-based nonce (e.g. `source1_testsnapshot_1781802230`) instead of the fixed `1` that the Solr 6/7 container expects (`source1_testsnapshot_1`). The backup command then fails with `specified location does not exist`.

2. **Fix Solr 7.7 image tag** — The cluster template was incorrectly referencing `custom-solr:6.6.0` instead of `custom-solr:7.7.3`.

3. **Build Solr 7.7.3 custom image** — Add `-PincludeSolr773TestImage` flag to the Jenkins pipeline so the custom-solr:7.7.3 image is built.

Note: The first two commits (narrow matrix + includeSolr660TestImage) are temporary/outdated and will be cleaned up before merge.

### Issues Resolved
Resolves Solr test failures in [main-k8s-matrix-test](https://migrations.ci.opensearch.org/job/main/job/main-k8s-matrix-test/) since Jun 11.

### Testing
- Locally verified SOLR_6.6 → OS_2.19 test passes (10 min, all collections migrated successfully)
- SOLR_7.7 → OS_2.19 local test in progress

### Check List
- [x] New functionality includes testing
- [ ] Public documentation issue/PR created, if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.