### PR TITLE
Fix migration-companion image build: drop stale CLI/runtime COPY

### DIFF
--- a/.github/workflows/release-dryrun.yml
+++ b/.github/workflows/release-dryrun.yml
@@ -1,5 +1,17 @@
 name: Release dry-run
 
+# Secret-free rehearsal of the release-drafter build path. Builds every release
+# artifact (Maven, Docker images, Helm chart, CFN templates, bootstrap script,
+# and the migration-companion image) against a job-local registry and uploads
+# them as workflow artifacts. Nothing is published and no secrets are used, so
+# this runs on any fork.
+#
+# Use it to catch release-build regressions before tagging — e.g. a companion
+# Dockerfile that COPYs a context dir the staging task no longer produces would
+# fail here instead of in the real release. Run it on your fork from the
+# Actions tab ("Release dry-run" > "Run workflow") on the commit you intend to
+# tag, and confirm it is green before pushing the release tag.
+
 on:
   workflow_dispatch:
     inputs:

--- a/deployment/k8s/migrationCompanion/Dockerfile
+++ b/deployment/k8s/migrationCompanion/Dockerfile
@@ -2,35 +2,19 @@ ARG BASE_IMAGE=docker.io/library/amazonlinux:2023
 
 FROM ${BASE_IMAGE}
 
-ARG TARGETARCH
 ARG MIGRATION_ASSISTANT_VERSION=0.0.0-dev
 
 LABEL org.opencontainers.image.title="OpenSearch Migrations Migration Companion" \
-      org.opencontainers.image.description="Runnable migration-assistant CLI image with packaged Helm chart and CLI release artifacts" \
+      org.opencontainers.image.description="Migration-assistant release artifact carrier with the packaged Helm chart" \
       org.opencontainers.image.version="${MIGRATION_ASSISTANT_VERSION}" \
       org.opencontainers.image.licenses="Apache-2.0"
 
 ENV MIGRATION_COMPANION_HOME=/opt/migration-companion \
-    MIGRATION_ASSISTANT_HELM_CHART=/opt/migration-companion/artifacts/helm/migration-assistant.tgz \
-    MIGRATION_ASSISTANT_CLI_TARBALL=/opt/migration-companion/artifacts/cli/migration-assistant-cli.tar.gz \
-    MIGRATE_CLI_BIN=/opt/migration-companion/cli/bin/migration-assistant-bin \
-    MIGRATE_ENABLE_AGENT=1
+    MIGRATION_ASSISTANT_HELM_CHART=/opt/migration-companion/artifacts/helm/migration-assistant.tgz
 
 COPY artifacts/ /opt/migration-companion/artifacts/
-COPY cli/ /opt/migration-companion/cli/
-COPY runtime-binaries/ /tmp/migration-companion-runtime-binaries/
 
 RUN set -eux; \
-    cp "/tmp/migration-companion-runtime-binaries/linux-${TARGETARCH}/migration-assistant" /opt/migration-companion/cli/bin/migration-assistant-bin; \
-    rm -rf /tmp/migration-companion-runtime-binaries; \
-    mkdir -p /usr/local/bin; \
-    chmod +x /opt/migration-companion/cli/bin/migration-assistant; \
-    chmod +x /opt/migration-companion/cli/bin/migration-assistant-bin; \
-    ln -sf /opt/migration-companion/cli/bin/migration-assistant /usr/local/bin/migration-assistant; \
-    ln -sf /opt/migration-companion/cli/bin/migration-assistant-bin /usr/local/bin/migration-assistant-bin; \
-    ln -sf /opt/migration-companion/artifacts/helm/migration-assistant.tgz /opt/migration-companion/migration-assistant.tgz; \
-    ln -sf /opt/migration-companion/artifacts/cli/migration-assistant-cli.tar.gz /opt/migration-companion/migration-assistant-cli.tar.gz
+    ln -sf /opt/migration-companion/artifacts/helm/migration-assistant.tgz /opt/migration-companion/migration-assistant.tgz
 
 WORKDIR /workspace
-ENTRYPOINT ["migration-assistant"]
-CMD ["--help"]

--- a/deployment/k8s/migrationCompanion/README.md
+++ b/deployment/k8s/migrationCompanion/README.md
@@ -32,3 +32,16 @@ Registry build:
 
 The final image base defaults to `docker.io/library/amazonlinux:2023`. Override
 it with `-PmigrationCompanionBaseImage=...`.
+
+## Build contract
+
+The `stageMigrationCompanionDockerContext` task (see `build.gradle`) stages the
+Docker build context, and the `Dockerfile` may only `COPY` from what that task
+produces. Today that is the `Dockerfile` itself plus
+`artifacts/helm/migration-assistant.tgz`. If you change one side, change the
+other — a `Dockerfile` that `COPY`s a directory the staging task does not
+produce fails the build with `"/<dir>": not found`.
+
+To validate the full release build path (including this image) without any
+secrets, run the **Release dry-run** workflow
+(`.github/workflows/release-dryrun.yml`) on your fork before tagging a release.

--- a/deployment/k8s/migrationCompanion/README.md
+++ b/deployment/k8s/migrationCompanion/README.md
@@ -1,30 +1,17 @@
 # Migration Companion image
 
-This project builds a runnable AL2023-based image that also carries release
-artifacts for downstream consumers.
+This project builds an AL2023-based image that carries the packaged Migration
+Assistant Helm chart as a release artifact for downstream consumers.
 
 Stable paths inside the image:
 
 ```text
 /opt/migration-companion/artifacts/helm/migration-assistant.tgz
-/opt/migration-companion/artifacts/cli/migration-assistant-cli.tar.gz
-/opt/migration-companion/artifacts/cli/install.sh
-/opt/migration-companion/artifacts/cli/installers/manifest.json
-/opt/migration-companion/artifacts/cli/installers/migration-assistant-cli-<version>-linux-amd64.tar.gz
-/opt/migration-companion/artifacts/cli/installers/migration-assistant-cli-<version>-linux-arm64.tar.gz
-/opt/migration-companion/artifacts/cli/installers/migration-assistant-cli-<version>-darwin-amd64.tar.gz
-/opt/migration-companion/artifacts/cli/installers/migration-assistant-cli-<version>-darwin-arm64.tar.gz
-/opt/migration-companion/artifacts/cli/installers/migration-assistant-cli-<version>-windows-amd64.tar.gz
-/opt/migration-companion/artifacts/cli/installers/migration-assistant-cli-<version>-windows-arm64.tar.gz
-/opt/migration-companion/cli/bin/migration-assistant
-/opt/migration-companion/cli/bin/migration-assistant-bin
+/opt/migration-companion/migration-assistant.tgz  # symlink to the chart above
 ```
 
 The image is published as a multi-arch manifest. Each image variant carries the
-same files under `artifacts/`, while the runnable CLI binary is selected from
-the Rust-built `linux-amd64` or `linux-arm64` output for that image platform.
-Release builds feed in the macOS and Windows installer tarballs from their
-native runner jobs before the companion image is built.
+same Helm chart under `artifacts/helm/`.
 
 Local registry build:
 
@@ -45,10 +32,3 @@ Registry build:
 
 The final image base defaults to `docker.io/library/amazonlinux:2023`. Override
 it with `-PmigrationCompanionBaseImage=...`.
-
-Local companion builds default to Linux amd64 and Linux arm64 installers because
-those also provide the image runtime binaries. Override or extend the local
-installer target set with `-PcliInstallerTargets=classifier=rust-target,...`, or
-copy prebuilt installer tarballs into the image with
-`-PmigrationAssistantCliInstallersDir=/path/to/installers` and
-`-PmigrationAssistantCliInstallersManifest=/path/to/manifest.json`.


### PR DESCRIPTION
### Description

The release-drafter **Build and Push Migration Companion Image** step is failing the release pipeline ([run 27777737415](https://github.com/opensearch-project/opensearch-migrations/actions/runs/27777737415/job/82195022836), tag `3.3.5`). The Docker build errors at the `COPY` steps:

```
#18 [linux/arm64 3/6] COPY cli/ /opt/migration-companion/cli/
#18 ERROR: failed to calculate checksum of ref ...: "/cli": not found
...
ERROR: failed to solve: failed to compute cache key: ... "/runtime-binaries": not found
> Execution failed for task ':buildKit_migrationCompanion'.
```

**Root cause:** the companion staging task `stageMigrationCompanionDockerContext` had already been simplified to stage only the `Dockerfile` and the packaged Helm chart (`artifacts/helm/migration-assistant.tgz`), but the `Dockerfile` was left behind — it still did `COPY cli/` and `COPY runtime-binaries/` and wired the runnable native CLI binary. Those context directories are no longer produced by staging, so BuildKit cannot resolve them and the build aborts. (`COPY artifacts/` succeeded; only `cli/` and `runtime-binaries/` were missing.)

**Fix:** make the companion image a Helm-chart-only artifact carrier, matching the staged context. The `Dockerfile` now:
- keeps `COPY artifacts/` (the Helm chart) and the chart symlink,
- drops the `COPY cli/` and `COPY runtime-binaries/` lines, the native-binary `RUN` wiring, the CLI-only `ENV` vars (`MIGRATION_ASSISTANT_CLI_TARBALL`, `MIGRATE_CLI_BIN`, `MIGRATE_ENABLE_AGENT`), and the `migration-assistant` `ENTRYPOINT`/`CMD`.

`README.md` is updated to document the Helm-only contract. No `build.gradle` change is needed — the staging task already produces exactly this context.

The CLI installers and manifest are unaffected: they continue to be attached directly to the GitHub release (the `release-installers/*` artifacts in `release-drafter.yml`), independent of this image.

### Issues Resolved

Fixes the failing `Draft a release` job on release tag builds.

### Testing

- `./gradlew :deployment:k8s:migrationCompanion:stageMigrationCompanionDockerContext --dry-run` configures and resolves cleanly.
- Verified the `Dockerfile` `COPY` paths now exactly match the directories staged by `stageMigrationCompanionDockerContext` (`Dockerfile` + `artifacts/helm/migration-assistant.tgz`).
- Repo-wide grep confirms no remaining references to the removed companion CLI surface (`MIGRATION_ASSISTANT_CLI_TARBALL`, `MIGRATE_CLI_BIN`, `migration-companion/cli`, `migration-companion-runtime-binaries`).

### Check List
- [ ] New functionality includes testing
- [ ] Public documentation issue/PR created, if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

---

### Testing this on a fork (no secrets required)

The repo already ships a secret-free release rehearsal: **`.github/workflows/release-dryrun.yml`** (`Release dry-run`). It builds the full release artifact set — Maven, Docker images, Helm chart, CFN templates, bootstrap script, **and the migration-companion image** — against a job-local `registry:2` (`localhost:5000`) and uploads everything as workflow artifacts. It references **no `secrets.*`, no AWS, and no DockerHub**, so it runs on any fork as-is.

This is exactly the path that would have caught the bug: on the unfixed `Dockerfile`, the dry-run hits the same `COPY cli/ → "/cli": not found` failure; on this branch it builds clean.

It was already present but `workflow_dispatch`-only, so it was never run before the `3.3.5` tag. This PR keeps it manual (no added upstream CI cost) and instead **documents how and when to run it** so the gap is closed by process:

- Header comment on `release-dryrun.yml` describing it as a secret-free, fork-runnable rehearsal to run on the to-be-tagged commit and confirm green **before** pushing a release tag.
- A **Build contract** section in the migration-companion README stating the `Dockerfile` may only `COPY` what `stageMigrationCompanionDockerContext` stages, and pointing to the dry-run for pre-release validation.

**To validate on your fork:** Actions tab → **Release dry-run** → **Run workflow** → pick this branch (or a commit) → set a version (e.g. `3.3.5`) → run. Confirm the `Build Migration Companion image to local registry` step is green.

**Verified on a fork (✅ success):** [Release dry-run run #27787902098](https://github.com/AndreKurait/opensearch-migrations/actions/runs/27787902098) on `fix/companion-image-helm-only` (version `3.3.5`) completed **green** — every release artifact built, including the `Build Migration Companion image to local registry` step that failed in the original release run [27777737415](https://github.com/opensearch-project/opensearch-migrations/actions/runs/27777737415/job/82195022836). No secrets were used.
