### PR TITLE
Adding time series time-to-catchup CloudWatch widget

### DIFF
--- a/deployment/cdk/opensearch-service-migration/lib/components/capture-replay-dashboard.json
+++ b/deployment/cdk/opensearch-service-migration/lib/components/capture-replay-dashboard.json
@@ -364,6 +364,39 @@
         },
         {
             "height": 6,
+            "width": 12,
+            "y": 48,
+            "x": 12,
+            "type": "metric",
+            "properties": {
+                "metrics": [
+                    [ { "expression": "lag_avg_ms_ts/1000", "label": "Expression3", "id": "e3_ts", "region": "REGION", "stat": "Average", "period": 300, "visible": false } ],
+                    [ "OpenSearchMigrations", "lagBetweenSourceAndTargetRequests", "qualifier", "MA_QUALIFIER", "OTelLib", "replayer", { "id": "lag_avg_ms_ts", "region": "REGION", "label": "lag_avg_ms", "visible": false } ],
+                    [ { "expression": "lag_avg_ms_ts/1000", "label": "lag_avg_sec", "id": "lag_avg_sec_ts", "region": "REGION", "stat": "Average", "period": 300, "visible": false } ],
+                    [ { "expression": "lag_avg_sec_ts/3600", "label": "lag_avg_hr", "id": "lag_avg_hr_ts", "region": "REGION", "stat": "Average", "period": 300, "visible": false } ],
+                    [ { "expression": "-1*RATE(lag_avg_sec_ts)+1", "label": "Speedup Factor", "id": "speedup_ts", "region": "REGION", "stat": "Average", "period": 300, "visible": false } ],
+                    [ { "expression": "IF(speedup_ts<=1, 0/0, lag_avg_hr_ts/(speedup_ts-1))", "label": "catchup_hours", "id": "catchup_hours_ts", "region": "REGION", "period": 300 } ]
+                ],
+                "view": "timeSeries",
+                "title": "Time to catchup in hours (Historical)",
+                "region": "REGION",
+                "yAxis": {
+                    "left": {
+                        "label": "Hours",
+                        "min": 0,
+                        "showUnits": false
+                    }
+                },
+                "stat": "Average",
+                "period": 300,
+                "setPeriodToTimeRange": true,
+                "sparkline": true,
+                "stacked": false,
+                "liveData": false
+            }
+        },
+        {
+            "height": 6,
             "width": 24,
             "y": 7,
             "x": 0,

--- a/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/files/cloudwatch-dashboards/capture-replay-dashboard.json
+++ b/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/files/cloudwatch-dashboards/capture-replay-dashboard.json
@@ -371,6 +371,39 @@
         },
         {
             "height": 6,
+            "width": 12,
+            "y": 48,
+            "x": 12,
+            "type": "metric",
+            "properties": {
+                "metrics": [
+                    [ { "expression": "lag_avg_ms_ts/1000", "label": "Expression3", "id": "e3_ts", "region": "REGION", "stat": "Average", "period": 300, "visible": false } ],
+                    [ "OpenSearchMigrations", "lagBetweenSourceAndTargetRequests", "qualifier", "MA_QUALIFIER", "OTelLib", "replayer", { "id": "lag_avg_ms_ts", "region": "REGION", "label": "lag_avg_ms", "visible": false } ],
+                    [ { "expression": "lag_avg_ms_ts/1000", "label": "lag_avg_sec", "id": "lag_avg_sec_ts", "region": "REGION", "stat": "Average", "period": 300, "visible": false } ],
+                    [ { "expression": "lag_avg_sec_ts/3600", "label": "lag_avg_hr", "id": "lag_avg_hr_ts", "region": "REGION", "stat": "Average", "period": 300, "visible": false } ],
+                    [ { "expression": "-1*RATE(lag_avg_sec_ts)+1", "label": "Speedup Factor", "id": "speedup_ts", "region": "REGION", "stat": "Average", "period": 300, "visible": false } ],
+                    [ { "expression": "IF(speedup_ts<=1, 0/0, lag_avg_hr_ts/(speedup_ts-1))", "label": "catchup_hours", "id": "catchup_hours_ts", "region": "REGION", "period": 300 } ]
+                ],
+                "view": "timeSeries",
+                "title": "Time to catchup in hours (Historical)",
+                "region": "REGION",
+                "yAxis": {
+                    "left": {
+                        "label": "Hours",
+                        "min": 0,
+                        "showUnits": false
+                    }
+                },
+                "stat": "Average",
+                "period": 300,
+                "setPeriodToTimeRange": true,
+                "sparkline": true,
+                "stacked": false,
+                "liveData": false
+            }
+        },
+        {
+            "height": 6,
             "width": 24,
             "y": 7,
             "x": 0,

--- a/deployment/k8s/dashboards/capture-replay-dashboard.json
+++ b/deployment/k8s/dashboards/capture-replay-dashboard.json
@@ -364,6 +364,39 @@
         },
         {
             "height": 6,
+            "width": 12,
+            "y": 48,
+            "x": 12,
+            "type": "metric",
+            "properties": {
+                "metrics": [
+                    [ { "expression": "lag_avg_ms_ts/1000", "label": "Expression3", "id": "e3_ts", "region": "REGION", "stat": "Average", "period": 300, "visible": false } ],
+                    [ "OpenSearchMigrations", "lagBetweenSourceAndTargetRequests", "qualifier", "MA_QUALIFIER", "OTelLib", "replayer", { "id": "lag_avg_ms_ts", "region": "REGION", "label": "lag_avg_ms", "visible": false } ],
+                    [ { "expression": "lag_avg_ms_ts/1000", "label": "lag_avg_sec", "id": "lag_avg_sec_ts", "region": "REGION", "stat": "Average", "period": 300, "visible": false } ],
+                    [ { "expression": "lag_avg_sec_ts/3600", "label": "lag_avg_hr", "id": "lag_avg_hr_ts", "region": "REGION", "stat": "Average", "period": 300, "visible": false } ],
+                    [ { "expression": "-1*RATE(lag_avg_sec_ts)+1", "label": "Speedup Factor", "id": "speedup_ts", "region": "REGION", "stat": "Average", "period": 300, "visible": false } ],
+                    [ { "expression": "IF(speedup_ts<=1, 0/0, lag_avg_hr_ts/(speedup_ts-1))", "label": "catchup_hours", "id": "catchup_hours_ts", "region": "REGION", "period": 300 } ]
+                ],
+                "view": "timeSeries",
+                "title": "Time to catchup in hours (Historical)",
+                "region": "REGION",
+                "yAxis": {
+                    "left": {
+                        "label": "Hours",
+                        "min": 0,
+                        "showUnits": false
+                    }
+                },
+                "stat": "Average",
+                "period": 300,
+                "setPeriodToTimeRange": true,
+                "sparkline": true,
+                "stacked": false,
+                "liveData": false
+            }
+        },
+        {
+            "height": 6,
             "width": 24,
             "y": 7,
             "x": 0,


### PR DESCRIPTION
### Description
Adds a new "Time to catchup in hours (Historical)" widget to the capture-replay CloudWatch dashboard. The existing singleValue widget always computes from the present moment and ignores the dashboard's selected time range. The new widget uses the same formula but renders as a timeSeries with setPeriodToTimeRange: true, allowing operators to review catchup estimates over any historical time window.

Changes
- Added a new timeSeries widget alongside the existing singleValue widget
- Uses the same lagBetweenSourceAndTargetRequests metric and catchup formula (IF(speedup<=1, 0/0, lag_avg_hr/(speedup-1)))
- setPeriodToTimeRange: true so the widget respects the dashboard time selector
- Existing singleValue widget is unchanged

### Testing
Verified against live CloudWatch data from a replayer run with ~32 hours of Kafka lag. Widget now correctly shows catchup hours

### Check List
- [x] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
