### PR TITLE
Promote migration-companion image to production in release pipeline

### DIFF
--- a/jenkins/release.jenkinsFile
+++ b/jenkins/release.jenkinsFile
@@ -114,6 +114,7 @@ pipeline {
                         copyDockerImage('opensearch-migrations-traffic-capture-proxy');
                         copyDockerImage('opensearch-migrations-reindex-from-snapshot');
                         copyDockerImage('opensearch-migrations-transformation-shim');
+                        copyDockerImage('opensearch-migrations-migration-companion');
                     }
                 }
             }


### PR DESCRIPTION
## Problem

The 3.3.4 release published the `migration-companion` image to the **staging** registry but it never reached **production**:

| Registry | console / replayer / capture-proxy / RFS / shim | migration-companion |
|---|---|---|
| `opensearchstaging` (DockerHub) | `3.3.4` ✅ | `3.3.4` ✅ |
| `public.ecr.aws/opensearchproject` (prod) | `3.3.4` ✅ | **empty tag list** ❌ |

So `public.ecr.aws/opensearchproject/opensearch-migrations-migration-companion` has no tags at all — the image effectively "didn't release" for downstream consumers, even though the GitHub Actions release run reported success.

## Root cause

Image publishing happens in two stages:

1. **`.github/workflows/release-drafter.yml`** builds every release image (including the companion) and pushes them to `opensearchstaging`. This worked.
2. **`jenkins/release.jenkinsFile`** promotes each image from `opensearchstaging` → `public.ecr.aws/opensearchproject` (tag + `latest`) via the `docker-copy` job.

When the migration-companion image was introduced (commit `a02479383`), the release-drafter workflow and the companion Gradle module were added, but `jenkins/release.jenkinsFile` was **not** updated. Its promotion list contains the original five images and omits the companion:

```groovy
copyDockerImage('opensearch-migrations-console');
copyDockerImage('opensearch-migrations-traffic-replayer');
copyDockerImage('opensearch-migrations-traffic-capture-proxy');
copyDockerImage('opensearch-migrations-reindex-from-snapshot');
copyDockerImage('opensearch-migrations-transformation-shim');
// migration-companion missing
```

For comparison, when `transformation-shim` was added it was correctly wired into this file (commit `df34e261e`); the companion just got missed.

## Fix

Add the missing promotion call so the companion image is copied to production (`:<tag>` and `:latest`) on every release, exactly like the other images:

```groovy
copyDockerImage('opensearch-migrations-migration-companion');
```

## Follow-up (out of band, not in this PR)

This PR fixes future releases. The already-cut **3.3.4** companion image still needs a one-time promotion from staging to production (re-run the release Jenkins job for the `3.3.4` tag, or a manual `docker-copy` of `opensearch-migrations-migration-companion:3.3.4`).

## Testing

Jenkinsfile-only change with no behavior change beyond one additional `docker-copy` invocation reusing the existing `copyDockerImage` closure; nothing to build or run locally.
