### PR TITLE
fix/deploy schema viewer to also run on release events

### DIFF
--- a/.github/workflows/deploy-schema-viewer.yml
+++ b/.github/workflows/deploy-schema-viewer.yml
@@ -15,13 +15,30 @@ permissions:
   contents: read
   pages: write
   id-token: write
+  actions: write
 
 concurrency:
   group: pages
   cancel-in-progress: false
 
 jobs:
+  # Release tags cannot deploy to the github-pages environment (restricted to main/2.x branches).
+  # Re-dispatch on main so the protection rules are satisfied; the deploy job then fetches all
+  # released schemas via the GitHub API, including the one that triggered this run.
+  redispatch-on-release:
+    if: github.event_name == 'release'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger deploy from main
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh workflow run deploy-schema-viewer.yml \
+            --repo ${{ github.repository }} \
+            --ref main
+
   deploy:
+    if: github.event_name != 'release'
     name: Deploy to GitHub Pages
     runs-on: ubuntu-latest
     environment:


### PR DESCRIPTION
### Description
Adds a `redispatch-on-release` job that runs when the trigger is a release event.
Currently, new releases do not trigger a deploy of the latest schema for the schema viewer leading to the latest versions not being shown to users. This PR adds a new job to fix this issue by firing a fresh `workflow_dispatch` run on main.

### Issues Resolved
n/a

### Testing
n/a

### Check List
- [ ] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
