### PR TITLE
Retry cluster connection checks in reuse-clusters mode

### DIFF
--- a/migrationConsole/lib/integ_test/integ_test/test_cases/ma_argo_test_base.py
+++ b/migrationConsole/lib/integ_test/integ_test/test_cases/ma_argo_test_base.py
@@ -1,6 +1,7 @@
 from enum import Enum
 import logging
 import subprocess
+import time
 
 from ..cluster_version import ClusterVersion, is_incoming_version_supported
 from ..operations_library_factory import get_operations_library_by_version
@@ -10,6 +11,24 @@ from console_link.middleware.clusters import cat_indices, connection_check, clea
 from ..integration_test_argo_service import IntegrationTestArgoService
 
 logger = logging.getLogger(__name__)
+
+_CLUSTER_CONNECT_RETRIES = 10
+_CLUSTER_CONNECT_WAIT_S = 30
+
+
+def _wait_for_connection(cluster, retries: int = _CLUSTER_CONNECT_RETRIES,
+                         wait_s: int = _CLUSTER_CONNECT_WAIT_S) -> ConnectionResult:
+    """Retry connection_check to tolerate transient AOS domain unavailability."""
+    for attempt in range(1, retries + 1):
+        result = connection_check(cluster)
+        if result.connection_established:
+            return result
+        logger.warning("Connection attempt %d/%d failed for %s: %s",
+                       attempt, retries, cluster, result.connection_message)
+        if attempt < retries:
+            time.sleep(wait_s)
+    return result
+
 
 # Maps wildcard ClusterVersion (e.g. ES_7.x) to the concrete template name that exists in clusterWorkflows.yaml.
 # When minor_version is 'x', we pick the canonical representative minor version for that major.
@@ -166,10 +185,12 @@ class MATestBase:
                 self.imported_clusters = True
                 self.source_cluster = source_cluster
                 self.target_cluster = target_cluster
-                source_con_result: ConnectionResult = connection_check(source_cluster)
-                assert source_con_result.connection_established is True
-                target_con_result: ConnectionResult = connection_check(target_cluster)
-                assert target_con_result.connection_established is True
+                source_con_result: ConnectionResult = _wait_for_connection(source_cluster)
+                assert source_con_result.connection_established is True, \
+                    f"Source cluster unreachable: {source_con_result.connection_message}"
+                target_con_result: ConnectionResult = _wait_for_connection(target_cluster)
+                assert target_con_result.connection_established is True, \
+                    f"Target cluster unreachable: {target_con_result.connection_message}"
                 clear_indices(source_cluster)
                 clear_indices(target_cluster)
                 self.target_operations.clear_index_templates(cluster=target_cluster)

--- a/migrationConsole/lib/integ_test/integ_test/test_cases/ma_argo_test_base.py
+++ b/migrationConsole/lib/integ_test/integ_test/test_cases/ma_argo_test_base.py
@@ -18,7 +18,14 @@ _CLUSTER_CONNECT_WAIT_S = 30
 
 def _wait_for_connection(cluster, retries: int = _CLUSTER_CONNECT_RETRIES,
                          wait_s: int = _CLUSTER_CONNECT_WAIT_S) -> ConnectionResult:
-    """Retry connection_check to tolerate transient AOS domain unavailability."""
+    """Retry connection_check to tolerate transient AOS domain unavailability.
+
+    connection_check catches all network exceptions internally (including the AOSS
+    serverless path) and always returns a ConnectionResult — it never raises. A
+    truly unexpected exception should therefore propagate immediately rather than
+    be absorbed into the retry loop.
+    """
+    assert retries >= 1, "retries must be at least 1"
     for attempt in range(1, retries + 1):
         result = connection_check(cluster)
         if result.connection_established:


### PR DESCRIPTION
## Problem

`main-eks-full-e2e-isolated-vpc-test` build 186 failed because the pre-deployed target AOS domain was transiently unreachable at test start time. The test uses `--reuse-clusters` (long-lived domains), and `import_existing_clusters` did a single `connection_check` call with no retry — so any momentary AOS domain unavailability (restart, maintenance, brief routing hiccup) causes an immediate hard failure with a bare `AssertionError` and no details about why.

## Fix

1. **Retry up to 10 times with 30s waits** (5-minute total budget) before giving up — long enough for AOS domains to recover from typical transient issues.
2. **Include `connection_message` in the assertion failure** so logs show the actual error (timeout, connection refused, DNS failure, etc.) rather than a bare `AssertionError`.

## Why 10×30s

AOS domain restarts typically complete in 1–3 minutes. A 5-minute retry window covers that with margin, and `connection_check` itself has a 5s timeout so the total wall time for a fully-down domain is ~5min not ~50min.

Signed-off-by: Greg Schohn <schohn@amazon.com>