### PR TITLE
Bump k8sLocalDeployment timeouts: test stage 5h→6h, overall 6h→7h

### DIFF
--- a/vars/k8sLocalDeployment.groovy
+++ b/vars/k8sLocalDeployment.groovy
@@ -32,7 +32,7 @@ def call(Map config = [:]) {
         }
 
         options {
-            timeout(time: 6, unit: 'HOURS')
+            timeout(time: 7, unit: 'HOURS')
             buildDiscarder(logRotator(daysToKeepStr: '30'))
             skipDefaultCheckout(true)
         }
@@ -112,7 +112,7 @@ def call(Map config = [:]) {
 
             stage('Perform Python E2E Tests') {
                 steps {
-                    timeout(time: 5, unit: 'HOURS') {
+                    timeout(time: 6, unit: 'HOURS') {
                         dir('libraries/testAutomation') {
                             script {
                                 def sourceVer = sourceVersion ?: params.SOURCE_VERSION


### PR DESCRIPTION
## Problem

`main-k8s-local-integ-test` has been consistently failing/aborting for OS_2.19 and OS_3.1 target runs since at least build 413 (June 6). Every such run hits the 5-hour test stage timeout at ~307–335 minutes.

**Why OS_2.19 and OS_3.1 take longer than OS_1.3:**
- ES_8.x is only tested against OS_2.x/OS_3.x (not OS_1.x), adding ~55 minutes of real test execution that OS_1.3 skips entirely
- Marginally longer per-combination times for newer target clusters

**Measured runtimes:**
| Target | Test time | Stage timeout |
|--------|-----------|--------------|
| OS_1.3 | ~243–263 min | ✅ within 5h |
| OS_2.19 | ~307–321 min | ❌ exceeds 5h |
| OS_3.1 | ~310–337 min | ❌ exceeds 5h |

After the ES_6.8 startup fix (PR #3197), OS_3.1 is estimated at ~355 min — still exceeds 5h.

## Fix

- Test stage timeout: 5h → 6h (gives ~25 min headroom above the 355 min worst case)
- Overall pipeline timeout: 6h → 7h (maintains 1h buffer above the test stage for setup and cleanup)

OS_1.3 runs remain unaffected — they complete in ~4h15min.

Signed-off-by: Greg Schohn <schohn@amazon.com>