### PR TITLE
Harden proxy tls handshake logging

### DIFF
--- a/TrafficCapture/trafficCaptureProxyServer/src/main/java/org/opensearch/migrations/trafficcapture/proxyserver/netty/ProxyChannelInitializer.java
+++ b/TrafficCapture/trafficCaptureProxyServer/src/main/java/org/opensearch/migrations/trafficcapture/proxyserver/netty/ProxyChannelInitializer.java
@@ -4,12 +4,14 @@ import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLException;
 
 import java.io.IOException;
+import java.time.Duration;
 import java.util.function.Supplier;
 
 import org.opensearch.migrations.trafficcapture.IConnectionCaptureFactory;
 import org.opensearch.migrations.trafficcapture.netty.ConditionallyReliableLoggingHttpHandler;
 import org.opensearch.migrations.trafficcapture.netty.RequestCapturePredicate;
 import org.opensearch.migrations.trafficcapture.netty.tracing.IRootWireLoggingContext;
+import org.opensearch.migrations.trafficcapture.proxyserver.netty.UnauthenticatedClientLogDeduper.KnownEvent;
 
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInitializer;
@@ -25,12 +27,14 @@ import lombok.extern.slf4j.Slf4j;
 public class ProxyChannelInitializer<T> extends ChannelInitializer<SocketChannel> {
     protected static final String CAPTURE_HANDLER_NAME = "CaptureHandler";
     static final String TLS_HANDSHAKE_FAILURE_LOG_MESSAGE = "TLS handshake failed for frontside channel";
+    static final Duration UNAUTHENTICATED_CLIENT_LOG_DEDUPE_WINDOW = Duration.ofMinutes(1);
 
     protected final IConnectionCaptureFactory<T> connectionCaptureFactory;
     protected final Supplier<SSLEngine> sslEngineProvider;
     protected final IRootWireLoggingContext rootContext;
     protected final BacksideConnectionPool backsideConnectionPool;
     protected final RequestCapturePredicate requestCapturePredicate;
+    private final UnauthenticatedClientLogDeduper unauthenticatedClientLogDeduper;
 
     public ProxyChannelInitializer(
         IRootWireLoggingContext rootContext,
@@ -44,6 +48,8 @@ public class ProxyChannelInitializer<T> extends ChannelInitializer<SocketChannel
         this.sslEngineProvider = sslEngineSupplier;
         this.connectionCaptureFactory = connectionCaptureFactory;
         this.requestCapturePredicate = requestCapturePredicate;
+        this.unauthenticatedClientLogDeduper =
+            new UnauthenticatedClientLogDeduper(UNAUTHENTICATED_CLIENT_LOG_DEDUPE_WINDOW);
     }
 
     public boolean shouldGuaranteeMessageOffloading(HttpRequest httpRequest) {
@@ -59,7 +65,7 @@ public class ProxyChannelInitializer<T> extends ChannelInitializer<SocketChannel
         var sslEngine = sslEngineProvider != null ? sslEngineProvider.get() : null;
         if (sslEngine != null) {
             ch.pipeline().addLast(new SslHandler(sslEngine));
-            ch.pipeline().addLast(new FrontsideTlsExceptionHandler());
+            ch.pipeline().addLast(new FrontsideTlsExceptionHandler(unauthenticatedClientLogDeduper));
         }
 
         var connectionId = ch.id().asLongText();
@@ -78,6 +84,12 @@ public class ProxyChannelInitializer<T> extends ChannelInitializer<SocketChannel
     }
 
     private static class FrontsideTlsExceptionHandler extends ChannelInboundHandlerAdapter {
+        private final UnauthenticatedClientLogDeduper unauthenticatedClientLogDeduper;
+
+        private FrontsideTlsExceptionHandler(UnauthenticatedClientLogDeduper unauthenticatedClientLogDeduper) {
+            this.unauthenticatedClientLogDeduper = unauthenticatedClientLogDeduper;
+        }
+
         @Override
         public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
             if (!containsCause(cause, SSLException.class)) {
@@ -85,11 +97,27 @@ public class ProxyChannelInitializer<T> extends ChannelInitializer<SocketChannel
                 return;
             }
 
-            log.atWarn().setCause(cause)
-                .setMessage(TLS_HANDSHAKE_FAILURE_LOG_MESSAGE + ": {}")
-                .addArgument(() -> ctx.channel().id().asLongText())
-                .log();
+            var logDecision = unauthenticatedClientLogDeduper.record(KnownEvent.FRONTSIDE_TLS_HANDSHAKE_FAILURE);
+            if (logDecision.shouldLog()) {
+                logTlsHandshakeFailure(ctx, cause, logDecision.getSuppressedCountSinceLastLog());
+            }
             ctx.close();
+        }
+
+        private void logTlsHandshakeFailure(ChannelHandlerContext ctx, Throwable cause, long suppressedCount) {
+            if (suppressedCount > 0) {
+                log.atWarn().setCause(cause)
+                    .setMessage(TLS_HANDSHAKE_FAILURE_LOG_MESSAGE
+                        + ": {} ({} similar events suppressed since the previous stack trace)")
+                    .addArgument(() -> ctx.channel().id().asLongText())
+                    .addArgument(suppressedCount)
+                    .log();
+            } else {
+                log.atWarn().setCause(cause)
+                    .setMessage(TLS_HANDSHAKE_FAILURE_LOG_MESSAGE + ": {}")
+                    .addArgument(() -> ctx.channel().id().asLongText())
+                    .log();
+            }
         }
 
         private static boolean containsCause(Throwable cause, Class<? extends Throwable> causeType) {

--- a/TrafficCapture/trafficCaptureProxyServer/src/main/java/org/opensearch/migrations/trafficcapture/proxyserver/netty/ProxyChannelInitializer.java
+++ b/TrafficCapture/trafficCaptureProxyServer/src/main/java/org/opensearch/migrations/trafficcapture/proxyserver/netty/ProxyChannelInitializer.java
@@ -1,6 +1,7 @@
 package org.opensearch.migrations.trafficcapture.proxyserver.netty;
 
 import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLException;
 
 import java.io.IOException;
 import java.util.function.Supplier;
@@ -10,15 +11,20 @@ import org.opensearch.migrations.trafficcapture.netty.ConditionallyReliableLoggi
 import org.opensearch.migrations.trafficcapture.netty.RequestCapturePredicate;
 import org.opensearch.migrations.trafficcapture.netty.tracing.IRootWireLoggingContext;
 
+import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.ssl.SslHandler;
 import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 public class ProxyChannelInitializer<T> extends ChannelInitializer<SocketChannel> {
     protected static final String CAPTURE_HANDLER_NAME = "CaptureHandler";
+    static final String TLS_HANDSHAKE_FAILURE_LOG_MESSAGE = "TLS handshake failed for frontside channel";
 
     protected final IConnectionCaptureFactory<T> connectionCaptureFactory;
     protected final Supplier<SSLEngine> sslEngineProvider;
@@ -50,9 +56,10 @@ public class ProxyChannelInitializer<T> extends ChannelInitializer<SocketChannel
 
     @Override
     protected void initChannel(@NonNull SocketChannel ch) throws IOException {
-        var sslContext = sslEngineProvider != null ? sslEngineProvider.get() : null;
-        if (sslContext != null) {
-            ch.pipeline().addLast(new SslHandler(sslEngineProvider.get()));
+        var sslEngine = sslEngineProvider != null ? sslEngineProvider.get() : null;
+        if (sslEngine != null) {
+            ch.pipeline().addLast(new SslHandler(sslEngine));
+            ch.pipeline().addLast(new FrontsideTlsExceptionHandler());
         }
 
         var connectionId = ch.id().asLongText();
@@ -68,5 +75,32 @@ public class ProxyChannelInitializer<T> extends ChannelInitializer<SocketChannel
                 )
             );
         ch.pipeline().addLast(new FrontsideHandler(backsideConnectionPool));
+    }
+
+    private static class FrontsideTlsExceptionHandler extends ChannelInboundHandlerAdapter {
+        @Override
+        public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+            if (!containsCause(cause, SSLException.class)) {
+                ctx.fireExceptionCaught(cause);
+                return;
+            }
+
+            log.atWarn().setCause(cause)
+                .setMessage(TLS_HANDSHAKE_FAILURE_LOG_MESSAGE + ": {}")
+                .addArgument(() -> ctx.channel().id().asLongText())
+                .log();
+            ctx.close();
+        }
+
+        private static boolean containsCause(Throwable cause, Class<? extends Throwable> causeType) {
+            var current = cause;
+            while (current != null) {
+                if (causeType.isInstance(current)) {
+                    return true;
+                }
+                current = current.getCause();
+            }
+            return false;
+        }
     }
 }

--- a/TrafficCapture/trafficCaptureProxyServer/src/main/java/org/opensearch/migrations/trafficcapture/proxyserver/netty/ProxyChannelInitializer.java
+++ b/TrafficCapture/trafficCaptureProxyServer/src/main/java/org/opensearch/migrations/trafficcapture/proxyserver/netty/ProxyChannelInitializer.java
@@ -14,8 +14,8 @@ import org.opensearch.migrations.trafficcapture.netty.tracing.IRootWireLoggingCo
 import org.opensearch.migrations.trafficcapture.proxyserver.netty.UnauthenticatedClientLogDeduper.KnownEvent;
 
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.ChannelInitializer;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpRequest;
@@ -97,7 +97,7 @@ public class ProxyChannelInitializer<T> extends ChannelInitializer<SocketChannel
                 return;
             }
 
-            var logDecision = unauthenticatedClientLogDeduper.record(KnownEvent.FRONTSIDE_TLS_HANDSHAKE_FAILURE);
+            var logDecision = unauthenticatedClientLogDeduper.recordOccurrence(KnownEvent.FRONTSIDE_TLS_HANDSHAKE_FAILURE);
             if (logDecision.shouldLog()) {
                 logTlsHandshakeFailure(ctx, cause, logDecision.getSuppressedCountSinceLastLog());
             }

--- a/TrafficCapture/trafficCaptureProxyServer/src/main/java/org/opensearch/migrations/trafficcapture/proxyserver/netty/UnauthenticatedClientLogDeduper.java
+++ b/TrafficCapture/trafficCaptureProxyServer/src/main/java/org/opensearch/migrations/trafficcapture/proxyserver/netty/UnauthenticatedClientLogDeduper.java
@@ -1,0 +1,89 @@
+package org.opensearch.migrations.trafficcapture.proxyserver.netty;
+
+import java.time.Duration;
+import java.util.EnumMap;
+import java.util.Objects;
+import java.util.function.LongSupplier;
+
+class UnauthenticatedClientLogDeduper {
+
+    enum KnownEvent {
+        FRONTSIDE_TLS_HANDSHAKE_FAILURE
+    }
+
+    private final EnumMap<KnownEvent, EventState> eventStates = new EnumMap<>(KnownEvent.class);
+    private final long dedupeWindowNanos;
+    private final LongSupplier nanoTimeSupplier;
+
+    UnauthenticatedClientLogDeduper(Duration dedupeWindow) {
+        this(dedupeWindow, System::nanoTime);
+    }
+
+    UnauthenticatedClientLogDeduper(Duration dedupeWindow, LongSupplier nanoTimeSupplier) {
+        if (dedupeWindow == null || !dedupeWindow.isPositive()) {
+            throw new IllegalArgumentException("dedupeWindow must be positive");
+        }
+        this.dedupeWindowNanos = dedupeWindow.toNanos();
+        this.nanoTimeSupplier = Objects.requireNonNull(nanoTimeSupplier);
+        for (var knownEvent : KnownEvent.values()) {
+            eventStates.put(knownEvent, new EventState());
+        }
+    }
+
+    synchronized LogDecision record(KnownEvent knownEvent) {
+        var eventState = eventStates.get(Objects.requireNonNull(knownEvent));
+        var now = nanoTimeSupplier.getAsLong();
+        if (now < eventState.nextLogAfterNanos) {
+            eventState.incrementSuppressedCount();
+            return LogDecision.suppress();
+        }
+
+        var suppressedCount = eventState.suppressedCount;
+        eventState.suppressedCount = 0;
+        eventState.nextLogAfterNanos = now + dedupeWindowNanos;
+        return LogDecision.log(suppressedCount);
+    }
+
+    int knownEventCount() {
+        return eventStates.size();
+    }
+
+    private static class EventState {
+        private long nextLogAfterNanos = Long.MIN_VALUE;
+        private long suppressedCount;
+
+        private void incrementSuppressedCount() {
+            if (suppressedCount < Long.MAX_VALUE) {
+                suppressedCount++;
+            }
+        }
+    }
+
+    static class LogDecision {
+        private static final LogDecision SUPPRESS = new LogDecision(false, 0);
+
+        private final boolean shouldLog;
+        private final long suppressedCountSinceLastLog;
+
+        private LogDecision(boolean shouldLog, long suppressedCountSinceLastLog) {
+            this.shouldLog = shouldLog;
+            this.suppressedCountSinceLastLog = suppressedCountSinceLastLog;
+        }
+
+        private static LogDecision suppress() {
+            return SUPPRESS;
+        }
+
+        private static LogDecision log(long suppressedCountSinceLastLog) {
+            return new LogDecision(true, suppressedCountSinceLastLog);
+        }
+
+        boolean shouldLog() {
+            return shouldLog;
+        }
+
+        long getSuppressedCountSinceLastLog() {
+            return suppressedCountSinceLastLog;
+        }
+    }
+}

--- a/TrafficCapture/trafficCaptureProxyServer/src/main/java/org/opensearch/migrations/trafficcapture/proxyserver/netty/UnauthenticatedClientLogDeduper.java
+++ b/TrafficCapture/trafficCaptureProxyServer/src/main/java/org/opensearch/migrations/trafficcapture/proxyserver/netty/UnauthenticatedClientLogDeduper.java
@@ -44,10 +44,6 @@ class UnauthenticatedClientLogDeduper {
         return LogDecision.log(suppressedCount);
     }
 
-    int knownEventCount() {
-        return eventStates.size();
-    }
-
     private static class EventState {
         private long nextLogAfterNanos = Long.MIN_VALUE;
         private long suppressedCount;

--- a/TrafficCapture/trafficCaptureProxyServer/src/main/java/org/opensearch/migrations/trafficcapture/proxyserver/netty/UnauthenticatedClientLogDeduper.java
+++ b/TrafficCapture/trafficCaptureProxyServer/src/main/java/org/opensearch/migrations/trafficcapture/proxyserver/netty/UnauthenticatedClientLogDeduper.java
@@ -30,7 +30,7 @@ class UnauthenticatedClientLogDeduper {
         }
     }
 
-    synchronized LogDecision record(KnownEvent knownEvent) {
+    synchronized LogDecision recordOccurrence(KnownEvent knownEvent) {
         var eventState = eventStates.get(Objects.requireNonNull(knownEvent));
         var now = nanoTimeSupplier.getAsLong();
         if (now < eventState.nextLogAfterNanos) {

--- a/TrafficCapture/trafficCaptureProxyServer/src/test/java/org/opensearch/migrations/trafficcapture/proxyserver/netty/NettyScanningHttpProxyTest.java
+++ b/TrafficCapture/trafficCaptureProxyServer/src/test/java/org/opensearch/migrations/trafficcapture/proxyserver/netty/NettyScanningHttpProxyTest.java
@@ -2,9 +2,11 @@ package org.opensearch.migrations.trafficcapture.proxyserver.netty;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.net.Socket;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
+import java.security.cert.X509Certificate;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -15,8 +17,16 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Pattern;
 import java.util.stream.IntStream;
 
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+
+import org.opensearch.migrations.testutils.CloseableLogSetup;
 import org.opensearch.migrations.testutils.HttpRequest;
 import org.opensearch.migrations.testutils.PortFinder;
+import org.opensearch.migrations.testutils.SelfSignedSSLContextBuilder;
 import org.opensearch.migrations.testutils.SimpleHttpClientForTesting;
 import org.opensearch.migrations.testutils.SimpleHttpResponse;
 import org.opensearch.migrations.testutils.SimpleHttpServer;
@@ -94,46 +104,67 @@ class NettyScanningHttpProxyTest {
             inMemoryInstrumentationBundle.openTelemetrySdk,
             IContextTracker.DO_NOTHING_TRACKER
         );
-        var servers = startServers(rootCtx, captureFactory);
-
-        try (var client = new SimpleHttpClientForTesting()) {
-            var nettyEndpoint = URI.create("http://localhost:" + servers.getKey().getProxyPort() + "/");
+        try (var servers = startServers(rootCtx, captureFactory);
+             var client = new SimpleHttpClientForTesting()) {
+            var nettyEndpoint = servers.proxyEndpoint();
             for (int i = 0; i < NUM_INTERACTIONS; ++i) {
                 var responseBody = makeTestRequestViaClient(client, nettyEndpoint);
                 Assertions.assertEquals(UPSTREAM_SERVER_RESPONSE_BODY, responseBody);
             }
-        }
-        interactionsCapturedCountdown.await();
-        var recordedStreams = captureFactory.getRecordedStreams();
-        Assertions.assertEquals(1, recordedStreams.size());
-        var recordedTrafficStreams = captureFactory.getRecordedTrafficStreamsStream().toArray(TrafficStream[]::new);
-        Assertions.assertEquals(NUM_EXPECTED_TRAFFIC_STREAMS, recordedTrafficStreams.length);
-        log.info("Recorded traffic stream:\n" + recordedTrafficStreams[0]);
-        var coalescedTrafficList = coalesceObservations(recordedTrafficStreams[0]);
-        Assertions.assertEquals(NUM_INTERACTIONS * 2, coalescedTrafficList.size());
-        int counter = 0;
-        final var expectedResponseMessage = normalizeMessage(EXPECTED_RESPONSE_STRING);
-        for (var httpMessage : coalescedTrafficList) {
-            var normalizedMessage = normalizeMessage(new String(httpMessage, StandardCharsets.UTF_8));
-            if (counter % 2 == 0) {
-                Assertions.assertTrue(EXPECTED_REQUEST_PATTERN.matcher(normalizedMessage).matches());
-            } else {
-                Assertions.assertEquals(expectedResponseMessage, normalizedMessage);
-            }
-            counter++;
-        }
 
-        var observations = recordedTrafficStreams[0].getSubStreamList();
-        var eomIndices = IntStream.range(0, observations.size())
-            .filter(i -> observations.get(i).hasEndOfMessageIndicator())
-            .toArray();
-        Assertions.assertEquals(NUM_INTERACTIONS, eomIndices.length);
-        for (int eomIndex : eomIndices) {
-            Assertions.assertTrue(observations.get(eomIndex - 1).hasRead());
-            Assertions.assertTrue(observations.get(eomIndex + 1).hasWrite());
-            var eom = observations.get(eomIndex).getEndOfMessageIndicator();
-            Assertions.assertEquals(14, eom.getFirstLineByteLength());
-            Assertions.assertEquals(711, eom.getHeadersByteLength());
+            interactionsCapturedCountdown.await();
+            var recordedStreams = captureFactory.getRecordedStreams();
+            Assertions.assertEquals(1, recordedStreams.size());
+            var recordedTrafficStreams = captureFactory.getRecordedTrafficStreamsStream().toArray(TrafficStream[]::new);
+            Assertions.assertEquals(NUM_EXPECTED_TRAFFIC_STREAMS, recordedTrafficStreams.length);
+            log.info("Recorded traffic stream:\n" + recordedTrafficStreams[0]);
+            var coalescedTrafficList = coalesceObservations(recordedTrafficStreams[0]);
+            Assertions.assertEquals(NUM_INTERACTIONS * 2, coalescedTrafficList.size());
+            int counter = 0;
+            final var expectedResponseMessage = normalizeMessage(EXPECTED_RESPONSE_STRING);
+            for (var httpMessage : coalescedTrafficList) {
+                var normalizedMessage = normalizeMessage(new String(httpMessage, StandardCharsets.UTF_8));
+                if (counter % 2 == 0) {
+                    Assertions.assertTrue(EXPECTED_REQUEST_PATTERN.matcher(normalizedMessage).matches());
+                } else {
+                    Assertions.assertEquals(expectedResponseMessage, normalizedMessage);
+                }
+                counter++;
+            }
+
+            var observations = recordedTrafficStreams[0].getSubStreamList();
+            var eomIndices = IntStream.range(0, observations.size())
+                .filter(i -> observations.get(i).hasEndOfMessageIndicator())
+                .toArray();
+            Assertions.assertEquals(NUM_INTERACTIONS, eomIndices.length);
+            for (int eomIndex : eomIndices) {
+                Assertions.assertTrue(observations.get(eomIndex - 1).hasRead());
+                Assertions.assertTrue(observations.get(eomIndex + 1).hasWrite());
+                var eom = observations.get(eomIndex).getEndOfMessageIndicator();
+                Assertions.assertEquals(14, eom.getFirstLineByteLength());
+                Assertions.assertEquals(711, eom.getHeadersByteLength());
+            }
+        }
+    }
+
+    @Test
+    public void testTlsHandshakeFailureIsLoggedAndProxyStaysAlive() throws Exception {
+        var captureFactory = new InMemoryConnectionCaptureFactory(TEST_NODE_ID_STRING, 1024 * 1024, () -> {});
+        var inMemoryInstrumentationBundle = new InMemoryInstrumentationBundle(true, true);
+        var rootCtx = new RootWireLoggingContext(
+            inMemoryInstrumentationBundle.openTelemetrySdk,
+            IContextTracker.DO_NOTHING_TRACKER
+        );
+        var sslEngineSupplier = makeServerSslEngineSupplier();
+
+        try (var servers = startServers(rootCtx, captureFactory, sslEngineSupplier);
+             var closeableLogSetup = new CloseableLogSetup(ProxyChannelInitializer.class.getName())) {
+            sendPlaintextToTlsEndpoint(servers.proxy.getProxyPort());
+
+            assertEventuallyLogged(closeableLogSetup, ProxyChannelInitializer.TLS_HANDSHAKE_FAILURE_LOG_MESSAGE);
+
+            var responseBody = makeTestRequestViaInsecureHttpsClient(servers.proxyEndpoint());
+            Assertions.assertEquals(UPSTREAM_SERVER_RESPONSE_BODY, responseBody);
         }
     }
 
@@ -178,9 +209,26 @@ class NettyScanningHttpProxyTest {
         return responseBody;
     }
 
-    private static Map.Entry<NettyScanningHttpProxy, Integer> startServers(
+    private static String makeTestRequestViaInsecureHttpsClient(URI endpoint) throws Exception {
+        var connection = (HttpsURLConnection) endpoint.toURL().openConnection();
+        connection.setSSLSocketFactory(makeTrustAllSslContext().getSocketFactory());
+        connection.setHostnameVerifier((hostname, session) -> true);
+        connection.setConnectTimeout((int) Duration.ofSeconds(5).toMillis());
+        connection.setReadTimeout((int) Duration.ofSeconds(5).toMillis());
+        return new String(connection.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+    }
+
+    private static RunningProxyServers startServers(
         RootWireLoggingContext rootCtx,
         IConnectionCaptureFactory connectionCaptureFactory
+    ) throws PortFinder.ExceededMaxPortAssigmentAttemptException {
+        return startServers(rootCtx, connectionCaptureFactory, null);
+    }
+
+    private static RunningProxyServers startServers(
+        RootWireLoggingContext rootCtx,
+        IConnectionCaptureFactory connectionCaptureFactory,
+        java.util.function.Supplier<SSLEngine> sslEngineSupplier
     ) throws PortFinder.ExceededMaxPortAssigmentAttemptException {
         var nshp = new AtomicReference<NettyScanningHttpProxy>();
         var upstreamTestServer = new AtomicReference<SimpleHttpServer>();
@@ -206,7 +254,7 @@ class NettyScanningHttpProxyTest {
                 var connectionPool = new BacksideConnectionPool(testServerUri, null, 10, Duration.ofSeconds(10));
 
                 nshp.get()
-                    .start(new ProxyChannelInitializer(rootCtx, connectionPool, null,
+                    .start(new ProxyChannelInitializer(rootCtx, connectionPool, sslEngineSupplier,
                         connectionCaptureFactory, new RequestCapturePredicate()), 1);
                 System.out.println("proxy port = " + port);
             } catch (InterruptedException e) {
@@ -214,7 +262,7 @@ class NettyScanningHttpProxyTest {
                 throw Lombok.sneakyThrow(e);
             }
         });
-        return Map.entry(nshp.get(), underlyingPort);
+        return new RunningProxyServers(nshp.get(), upstreamTestServer.get(), sslEngineSupplier != null);
     }
 
     private static SimpleHttpResponse makeContext(HttpRequest request) {
@@ -228,5 +276,80 @@ class NettyScanningHttpProxyTest {
         );
         var payloadBytes = UPSTREAM_SERVER_RESPONSE_BODY.getBytes(StandardCharsets.UTF_8);
         return new SimpleHttpResponse(headers, payloadBytes, "OK", 200);
+    }
+
+    private static java.util.function.Supplier<SSLEngine> makeServerSslEngineSupplier() throws Exception {
+        SSLContext sslContext = SelfSignedSSLContextBuilder.getSSLContext();
+        return () -> {
+            var engine = sslContext.createSSLEngine();
+            engine.setUseClientMode(false);
+            return engine;
+        };
+    }
+
+    private static SSLContext makeTrustAllSslContext() throws Exception {
+        TrustManager[] trustAllManagers = new TrustManager[] {
+            new X509TrustManager() {
+                @Override
+                public void checkClientTrusted(X509Certificate[] chain, String authType) {}
+
+                @Override
+                public void checkServerTrusted(X509Certificate[] chain, String authType) {}
+
+                @Override
+                public X509Certificate[] getAcceptedIssuers() {
+                    return new X509Certificate[0];
+                }
+            }
+        };
+        var sslContext = SSLContext.getInstance("TLS");
+        sslContext.init(null, trustAllManagers, null);
+        return sslContext;
+    }
+
+    private static void sendPlaintextToTlsEndpoint(int port) throws IOException {
+        try (var socket = new Socket(SimpleHttpServer.LOCALHOST, port)) {
+            socket.getOutputStream().write("GET / HTTP/1.1\r\nHost: localhost\r\n\r\n"
+                .getBytes(StandardCharsets.US_ASCII));
+            socket.getOutputStream().flush();
+        }
+    }
+
+    private static void assertEventuallyLogged(CloseableLogSetup logSetup, String expectedMessage)
+        throws InterruptedException {
+        var deadline = System.nanoTime() + Duration.ofSeconds(5).toNanos();
+        while (System.nanoTime() < deadline) {
+            if (new ArrayList<>(logSetup.getLogEvents()).stream().anyMatch(e -> e.contains(expectedMessage))) {
+                return;
+            }
+            Thread.sleep(25);
+        }
+        Assertions.fail("Expected log message containing: " + expectedMessage
+            + ". Actual log messages: " + logSetup.getLogEvents());
+    }
+
+    private static class RunningProxyServers implements AutoCloseable {
+        private final NettyScanningHttpProxy proxy;
+        private final SimpleHttpServer upstreamServer;
+        private final boolean useTls;
+
+        private RunningProxyServers(NettyScanningHttpProxy proxy, SimpleHttpServer upstreamServer, boolean useTls) {
+            this.proxy = proxy;
+            this.upstreamServer = upstreamServer;
+            this.useTls = useTls;
+        }
+
+        private URI proxyEndpoint() {
+            return URI.create((useTls ? "https" : "http") + "://localhost:" + proxy.getProxyPort() + "/");
+        }
+
+        @Override
+        public void close() throws InterruptedException {
+            try {
+                proxy.stop();
+            } finally {
+                upstreamServer.close();
+            }
+        }
     }
 }

--- a/TrafficCapture/trafficCaptureProxyServer/src/test/java/org/opensearch/migrations/trafficcapture/proxyserver/netty/NettyScanningHttpProxyTest.java
+++ b/TrafficCapture/trafficCaptureProxyServer/src/test/java/org/opensearch/migrations/trafficcapture/proxyserver/netty/NettyScanningHttpProxyTest.java
@@ -168,6 +168,34 @@ class NettyScanningHttpProxyTest {
         }
     }
 
+    @Test
+    public void testTlsHandshakeFailureLogsAreDedupedWithinWindow() throws Exception {
+        var captureFactory = new InMemoryConnectionCaptureFactory(TEST_NODE_ID_STRING, 1024 * 1024, () -> {});
+        var inMemoryInstrumentationBundle = new InMemoryInstrumentationBundle(true, true);
+        var rootCtx = new RootWireLoggingContext(
+            inMemoryInstrumentationBundle.openTelemetrySdk,
+            IContextTracker.DO_NOTHING_TRACKER
+        );
+        var sslEngineSupplier = makeServerSslEngineSupplier();
+
+        try (var servers = startServers(rootCtx, captureFactory, sslEngineSupplier);
+             var closeableLogSetup = new CloseableLogSetup(ProxyChannelInitializer.class.getName())) {
+            sendPlaintextToTlsEndpoint(servers.proxy.getProxyPort());
+            assertEventuallyLogged(closeableLogSetup, ProxyChannelInitializer.TLS_HANDSHAKE_FAILURE_LOG_MESSAGE);
+
+            sendPlaintextToTlsEndpoint(servers.proxy.getProxyPort());
+            Thread.sleep(250);
+
+            Assertions.assertEquals(1, countLogEventsContaining(
+                closeableLogSetup,
+                ProxyChannelInitializer.TLS_HANDSHAKE_FAILURE_LOG_MESSAGE
+            ));
+
+            var responseBody = makeTestRequestViaInsecureHttpsClient(servers.proxyEndpoint());
+            Assertions.assertEquals(UPSTREAM_SERVER_RESPONSE_BODY, responseBody);
+        }
+    }
+
     private static String normalizeMessage(String s) {
         return s.replaceAll("Date: .*", "Date: SOMETHING");
     }
@@ -319,13 +347,19 @@ class NettyScanningHttpProxyTest {
         throws InterruptedException {
         var deadline = System.nanoTime() + Duration.ofSeconds(5).toNanos();
         while (System.nanoTime() < deadline) {
-            if (new ArrayList<>(logSetup.getLogEvents()).stream().anyMatch(e -> e.contains(expectedMessage))) {
+            if (countLogEventsContaining(logSetup, expectedMessage) > 0) {
                 return;
             }
             Thread.sleep(25);
         }
         Assertions.fail("Expected log message containing: " + expectedMessage
             + ". Actual log messages: " + logSetup.getLogEvents());
+    }
+
+    private static long countLogEventsContaining(CloseableLogSetup logSetup, String expectedMessage) {
+        return new ArrayList<>(logSetup.getLogEvents()).stream()
+            .filter(e -> e.contains(expectedMessage))
+            .count();
     }
 
     private static class RunningProxyServers implements AutoCloseable {

--- a/TrafficCapture/trafficCaptureProxyServer/src/test/java/org/opensearch/migrations/trafficcapture/proxyserver/netty/NettyScanningHttpProxyTest.java
+++ b/TrafficCapture/trafficCaptureProxyServer/src/test/java/org/opensearch/migrations/trafficcapture/proxyserver/netty/NettyScanningHttpProxyTest.java
@@ -1,5 +1,11 @@
 package org.opensearch.migrations.trafficcapture.proxyserver.netty;
 
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.net.Socket;
@@ -16,12 +22,6 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Pattern;
 import java.util.stream.IntStream;
-
-import javax.net.ssl.SSLEngine;
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.HttpsURLConnection;
-import javax.net.ssl.TrustManager;
-import javax.net.ssl.X509TrustManager;
 
 import org.opensearch.migrations.testutils.CloseableLogSetup;
 import org.opensearch.migrations.testutils.HttpRequest;

--- a/TrafficCapture/trafficCaptureProxyServer/src/test/java/org/opensearch/migrations/trafficcapture/proxyserver/netty/NettyScanningHttpProxyTest.java
+++ b/TrafficCapture/trafficCaptureProxyServer/src/test/java/org/opensearch/migrations/trafficcapture/proxyserver/netty/NettyScanningHttpProxyTest.java
@@ -3,8 +3,6 @@ package org.opensearch.migrations.trafficcapture.proxyserver.netty;
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
-import javax.net.ssl.TrustManager;
-import javax.net.ssl.X509TrustManager;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -12,7 +10,6 @@ import java.net.Socket;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
-import java.security.cert.X509Certificate;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -155,7 +152,8 @@ class NettyScanningHttpProxyTest {
             inMemoryInstrumentationBundle.openTelemetrySdk,
             IContextTracker.DO_NOTHING_TRACKER
         );
-        var sslEngineSupplier = makeServerSslEngineSupplier();
+        var sslContext = SelfSignedSSLContextBuilder.getSSLContext();
+        var sslEngineSupplier = makeServerSslEngineSupplier(sslContext);
 
         try (var servers = startServers(rootCtx, captureFactory, sslEngineSupplier);
              var closeableLogSetup = new CloseableLogSetup(ProxyChannelInitializer.class.getName())) {
@@ -163,7 +161,7 @@ class NettyScanningHttpProxyTest {
 
             assertEventuallyLogged(closeableLogSetup, ProxyChannelInitializer.TLS_HANDSHAKE_FAILURE_LOG_MESSAGE);
 
-            var responseBody = makeTestRequestViaInsecureHttpsClient(servers.proxyEndpoint());
+            var responseBody = makeTestRequestViaHttpsClient(servers.proxyEndpoint(), sslContext);
             Assertions.assertEquals(UPSTREAM_SERVER_RESPONSE_BODY, responseBody);
         }
     }
@@ -176,7 +174,8 @@ class NettyScanningHttpProxyTest {
             inMemoryInstrumentationBundle.openTelemetrySdk,
             IContextTracker.DO_NOTHING_TRACKER
         );
-        var sslEngineSupplier = makeServerSslEngineSupplier();
+        var sslContext = SelfSignedSSLContextBuilder.getSSLContext();
+        var sslEngineSupplier = makeServerSslEngineSupplier(sslContext);
 
         try (var servers = startServers(rootCtx, captureFactory, sslEngineSupplier);
              var closeableLogSetup = new CloseableLogSetup(ProxyChannelInitializer.class.getName())) {
@@ -191,7 +190,7 @@ class NettyScanningHttpProxyTest {
                 ProxyChannelInitializer.TLS_HANDSHAKE_FAILURE_LOG_MESSAGE
             ));
 
-            var responseBody = makeTestRequestViaInsecureHttpsClient(servers.proxyEndpoint());
+            var responseBody = makeTestRequestViaHttpsClient(servers.proxyEndpoint(), sslContext);
             Assertions.assertEquals(UPSTREAM_SERVER_RESPONSE_BODY, responseBody);
         }
     }
@@ -237,10 +236,9 @@ class NettyScanningHttpProxyTest {
         return responseBody;
     }
 
-    private static String makeTestRequestViaInsecureHttpsClient(URI endpoint) throws Exception {
+    private static String makeTestRequestViaHttpsClient(URI endpoint, SSLContext sslContext) throws Exception {
         var connection = (HttpsURLConnection) endpoint.toURL().openConnection();
-        connection.setSSLSocketFactory(makeTrustAllSslContext().getSocketFactory());
-        connection.setHostnameVerifier((hostname, session) -> true);
+        connection.setSSLSocketFactory(sslContext.getSocketFactory());
         connection.setConnectTimeout((int) Duration.ofSeconds(5).toMillis());
         connection.setReadTimeout((int) Duration.ofSeconds(5).toMillis());
         return new String(connection.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
@@ -306,33 +304,12 @@ class NettyScanningHttpProxyTest {
         return new SimpleHttpResponse(headers, payloadBytes, "OK", 200);
     }
 
-    private static java.util.function.Supplier<SSLEngine> makeServerSslEngineSupplier() throws Exception {
-        SSLContext sslContext = SelfSignedSSLContextBuilder.getSSLContext();
+    private static java.util.function.Supplier<SSLEngine> makeServerSslEngineSupplier(SSLContext sslContext) {
         return () -> {
             var engine = sslContext.createSSLEngine();
             engine.setUseClientMode(false);
             return engine;
         };
-    }
-
-    private static SSLContext makeTrustAllSslContext() throws Exception {
-        TrustManager[] trustAllManagers = new TrustManager[] {
-            new X509TrustManager() {
-                @Override
-                public void checkClientTrusted(X509Certificate[] chain, String authType) {}
-
-                @Override
-                public void checkServerTrusted(X509Certificate[] chain, String authType) {}
-
-                @Override
-                public X509Certificate[] getAcceptedIssuers() {
-                    return new X509Certificate[0];
-                }
-            }
-        };
-        var sslContext = SSLContext.getInstance("TLS");
-        sslContext.init(null, trustAllManagers, null);
-        return sslContext;
     }
 
     private static void sendPlaintextToTlsEndpoint(int port) throws IOException {

--- a/TrafficCapture/trafficCaptureProxyServer/src/test/java/org/opensearch/migrations/trafficcapture/proxyserver/netty/UnauthenticatedClientLogDeduperTest.java
+++ b/TrafficCapture/trafficCaptureProxyServer/src/test/java/org/opensearch/migrations/trafficcapture/proxyserver/netty/UnauthenticatedClientLogDeduperTest.java
@@ -1,0 +1,45 @@
+package org.opensearch.migrations.trafficcapture.proxyserver.netty;
+
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.opensearch.migrations.trafficcapture.proxyserver.netty.UnauthenticatedClientLogDeduper.KnownEvent;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class UnauthenticatedClientLogDeduperTest {
+
+    @Test
+    void testFirstEventLogsAndRepeatedEventsAreSuppressedUntilWindowExpires() {
+        var nowNanos = new AtomicLong(0);
+        var deduper = new UnauthenticatedClientLogDeduper(Duration.ofSeconds(1), nowNanos::get);
+
+        var firstDecision = deduper.record(KnownEvent.FRONTSIDE_TLS_HANDSHAKE_FAILURE);
+        Assertions.assertTrue(firstDecision.shouldLog());
+        Assertions.assertEquals(0, firstDecision.getSuppressedCountSinceLastLog());
+
+        var secondDecision = deduper.record(KnownEvent.FRONTSIDE_TLS_HANDSHAKE_FAILURE);
+        var thirdDecision = deduper.record(KnownEvent.FRONTSIDE_TLS_HANDSHAKE_FAILURE);
+        Assertions.assertFalse(secondDecision.shouldLog());
+        Assertions.assertFalse(thirdDecision.shouldLog());
+
+        nowNanos.set(Duration.ofSeconds(1).toNanos());
+        var afterWindowDecision = deduper.record(KnownEvent.FRONTSIDE_TLS_HANDSHAKE_FAILURE);
+        Assertions.assertTrue(afterWindowDecision.shouldLog());
+        Assertions.assertEquals(2, afterWindowDecision.getSuppressedCountSinceLastLog());
+    }
+
+    @Test
+    void testDeduperUsesOnlyTheFixedKnownEventSet() {
+        var deduper = new UnauthenticatedClientLogDeduper(Duration.ofSeconds(1), () -> 0);
+        var knownEventCount = deduper.knownEventCount();
+
+        for (int i = 0; i < 100; i++) {
+            deduper.record(KnownEvent.FRONTSIDE_TLS_HANDSHAKE_FAILURE);
+        }
+
+        Assertions.assertEquals(KnownEvent.values().length, knownEventCount);
+        Assertions.assertEquals(knownEventCount, deduper.knownEventCount());
+    }
+}

--- a/TrafficCapture/trafficCaptureProxyServer/src/test/java/org/opensearch/migrations/trafficcapture/proxyserver/netty/UnauthenticatedClientLogDeduperTest.java
+++ b/TrafficCapture/trafficCaptureProxyServer/src/test/java/org/opensearch/migrations/trafficcapture/proxyserver/netty/UnauthenticatedClientLogDeduperTest.java
@@ -29,17 +29,4 @@ class UnauthenticatedClientLogDeduperTest {
         Assertions.assertTrue(afterWindowDecision.shouldLog());
         Assertions.assertEquals(2, afterWindowDecision.getSuppressedCountSinceLastLog());
     }
-
-    @Test
-    void testDeduperUsesOnlyTheFixedKnownEventSet() {
-        var deduper = new UnauthenticatedClientLogDeduper(Duration.ofSeconds(1), () -> 0);
-        var knownEventCount = deduper.knownEventCount();
-
-        for (int i = 0; i < 100; i++) {
-            deduper.recordOccurrence(KnownEvent.FRONTSIDE_TLS_HANDSHAKE_FAILURE);
-        }
-
-        Assertions.assertEquals(KnownEvent.values().length, knownEventCount);
-        Assertions.assertEquals(knownEventCount, deduper.knownEventCount());
-    }
 }

--- a/TrafficCapture/trafficCaptureProxyServer/src/test/java/org/opensearch/migrations/trafficcapture/proxyserver/netty/UnauthenticatedClientLogDeduperTest.java
+++ b/TrafficCapture/trafficCaptureProxyServer/src/test/java/org/opensearch/migrations/trafficcapture/proxyserver/netty/UnauthenticatedClientLogDeduperTest.java
@@ -15,17 +15,17 @@ class UnauthenticatedClientLogDeduperTest {
         var nowNanos = new AtomicLong(0);
         var deduper = new UnauthenticatedClientLogDeduper(Duration.ofSeconds(1), nowNanos::get);
 
-        var firstDecision = deduper.record(KnownEvent.FRONTSIDE_TLS_HANDSHAKE_FAILURE);
+        var firstDecision = deduper.recordOccurrence(KnownEvent.FRONTSIDE_TLS_HANDSHAKE_FAILURE);
         Assertions.assertTrue(firstDecision.shouldLog());
         Assertions.assertEquals(0, firstDecision.getSuppressedCountSinceLastLog());
 
-        var secondDecision = deduper.record(KnownEvent.FRONTSIDE_TLS_HANDSHAKE_FAILURE);
-        var thirdDecision = deduper.record(KnownEvent.FRONTSIDE_TLS_HANDSHAKE_FAILURE);
+        var secondDecision = deduper.recordOccurrence(KnownEvent.FRONTSIDE_TLS_HANDSHAKE_FAILURE);
+        var thirdDecision = deduper.recordOccurrence(KnownEvent.FRONTSIDE_TLS_HANDSHAKE_FAILURE);
         Assertions.assertFalse(secondDecision.shouldLog());
         Assertions.assertFalse(thirdDecision.shouldLog());
 
         nowNanos.set(Duration.ofSeconds(1).toNanos());
-        var afterWindowDecision = deduper.record(KnownEvent.FRONTSIDE_TLS_HANDSHAKE_FAILURE);
+        var afterWindowDecision = deduper.recordOccurrence(KnownEvent.FRONTSIDE_TLS_HANDSHAKE_FAILURE);
         Assertions.assertTrue(afterWindowDecision.shouldLog());
         Assertions.assertEquals(2, afterWindowDecision.getSuppressedCountSinceLastLog());
     }
@@ -36,7 +36,7 @@ class UnauthenticatedClientLogDeduperTest {
         var knownEventCount = deduper.knownEventCount();
 
         for (int i = 0; i < 100; i++) {
-            deduper.record(KnownEvent.FRONTSIDE_TLS_HANDSHAKE_FAILURE);
+            deduper.recordOccurrence(KnownEvent.FRONTSIDE_TLS_HANDSHAKE_FAILURE);
         }
 
         Assertions.assertEquals(KnownEvent.values().length, knownEventCount);


### PR DESCRIPTION
### Description

Adds a frontside TLS exception handler immediately after Netty SslHandler in the capture proxy pipeline. TLS handshake failures are now logged as warnings and the channel is closed locally instead of letting the exception reach the tail of the pipeline.

Malformed or failed client TLS handshakes can be triggered before the proxy has authenticated or decoded HTTP. Previously these exceptions could propagate as unhandled Netty pipeline exceptions, matching the observed crash-risk report.

Also put some protections in place to suppress logging after repeated errors to diminish the impact of using this as a DOS attack.

### Testing
- ./gradlew :TrafficCapture:trafficCaptureProxyServer:test --tests org.opensearch.migrations.trafficcapture.proxyserver.netty.NettyScanningHttpProxyTest
- Added coverage for a plaintext request sent to a TLS proxy port, asserting the TLS failure is logged and a subsequent HTTPS request still succeeds.

### Check List
- [ ] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
