### PR TITLE
Disable scheduled k8s matrix runs but preserve fixed routing

### DIFF
--- a/jenkins/migrationIntegPipelines/README.md
+++ b/jenkins/migrationIntegPipelines/README.md
@@ -69,10 +69,9 @@ functionName(jobName: jobNameOverride ?: null)
 
 **Special case for matrix tests:**
 - Use `JOB_NAME_OVERRIDE` for matrix parent webhook routing
-- Use `CHILD_JOB_NAME_OVERRIDE` parameter
-- Pass as `childJobName` to the vars function
-- Default child job path follows parent job name:
-  - `childJobName` must be specified explicitly; there is no longer a default child job
+- The matrix parent routes each selected source version to the matching per-source local k8s child job
+- `CHILD_JOB_NAME_OVERRIDE` is accepted only for compatibility with existing Jenkins job configs and is ignored by the shared library
+- Clear stale `CHILD_JOB_NAME_OVERRIDE` values such as `main/main-k8s-local-integ-test`; that aggregate child job has been replaced by per-source jobs
 - Periodic schedules are defined in `vars/periodicCron.groovy` (dispatch table keyed on job name). `pr-*` jobs never have a cadence; `main-*` and `release-*` jobs pick their cadence from the table
 
 ### Supported Cover Files
@@ -100,7 +99,7 @@ functionName(jobName: jobNameOverride ?: null)
 | k8sLocalOpensearch1xTestCover.groovy | k8sLocalOpensearch1xTest | JOB_NAME_OVERRIDE |
 | k8sLocalSolr8xTestCover.groovy | k8sLocalSolr8xTest | JOB_NAME_OVERRIDE |
 | k8sLocalSolrOtherTestCover.groovy | k8sLocalSolrOtherTest | JOB_NAME_OVERRIDE |
-| k8sMatrixTestCover.groovy | k8sMatrixTest | JOB_NAME_OVERRIDE + CHILD_JOB_NAME_OVERRIDE |
+| k8sMatrixTestCover.groovy | k8sMatrixTest | JOB_NAME_OVERRIDE |
 | rfsDefaultE2ETestCover.groovy | rfsDefaultE2ETest | JOB_NAME_OVERRIDE |
 | solutionsCFNTestCover.groovy | solutionsCFNTest | JOB_NAME_OVERRIDE |
 

--- a/jenkins/migrationIntegPipelines/k8sMatrixTestCover.groovy
+++ b/jenkins/migrationIntegPipelines/k8sMatrixTestCover.groovy
@@ -5,7 +5,9 @@ library identifier: "migrations-lib@${gitBranch}", retriever: modernSCM(
         [$class: 'GitSCMSource',
          remote: "${gitUrl}"])
 
-// Allow job name overrides for matrix parent and child job routing
+// Allow job name override for webhook routing. CHILD_JOB_NAME_OVERRIDE is still
+// read for compatibility with existing Jenkins job configs, but k8sMatrixTest
+// now routes to per-source child jobs itself.
 def jobNameOverride = params.JOB_NAME_OVERRIDE ?: env.JOB_BASE_NAME ?: ''
 def childJobNameOverride = params.CHILD_JOB_NAME_OVERRIDE ?: ''
 k8sMatrixTest(

--- a/vars/k8sLocalDeployment.groovy
+++ b/vars/k8sLocalDeployment.groovy
@@ -115,8 +115,14 @@ def call(Map config = [:]) {
                     timeout(time: 5, unit: 'HOURS') {
                         dir('libraries/testAutomation') {
                             script {
-                                def sourceVer = sourceVersion ?: params.SOURCE_VERSION
-                                def targetVer = targetVersion ?: params.TARGET_VERSION
+                                def requestedSourceVersion = params.SOURCE_VERSION ?: ""
+                                def requestedTargetVersion = params.TARGET_VERSION ?: ""
+                                def sourceVer = requestedSourceVersion && requestedSourceVersion != 'all'
+                                        ? requestedSourceVersion
+                                        : sourceVersion ?: requestedSourceVersion
+                                def targetVer = requestedTargetVersion && requestedTargetVersion != 'all'
+                                        ? requestedTargetVersion
+                                        : targetVersion ?: requestedTargetVersion
                                 currentBuild.description = "${sourceVer} → ${targetVer}"
                                 // --source-version accepts one or more space-separated values; convert commas for multi-source jobs
                                 def sourceVerArg = sourceVer ? sourceVer.replace(',', ' ') : 'all'

--- a/vars/k8sMatrixTest.groovy
+++ b/vars/k8sMatrixTest.groovy
@@ -1,14 +1,42 @@
 def call(Map config = [:]) {
     def jobName = config.jobName ?: "k8s-matrix-test"
-    if (!config.childJobName) {
-        error("k8sMatrixTest requires childJobName to be specified explicitly — " +
-              "k8s-local-integ-test has been replaced by per-source jobs.")
-    }
-    def childJobName = config.childJobName
+    def childJobNameOverride = config.childJobName ?: ""
 
     def versions = migrationVersions()
     def allSourceVersions = versions.sourceVersions
     def allTargetVersions = versions.targetVersions
+
+    def sourceChildJobBaseNames = [
+            'ES_1.5'   : 'k8s-local-elasticsearch1x-test',
+            'ES_2.4'   : 'k8s-local-elasticsearch2x-test',
+            'ES_5.6'   : 'k8s-local-elasticsearch5x-test',
+            'ES_6.8'   : 'k8s-local-elasticsearch6x-test',
+            'ES_7.10'  : 'k8s-local-elasticsearch7x-test',
+            'ES_8.19'  : 'k8s-local-elasticsearch8x-test',
+            'OS_1.3'   : 'k8s-local-opensearch1x-test',
+            'SOLR_6.6' : 'k8s-local-solr-other-test',
+            'SOLR_7.7' : 'k8s-local-solr-other-test',
+            'SOLR_8.11': 'k8s-local-solr8x-test',
+            'SOLR_9.8' : 'k8s-local-solr-other-test'
+    ]
+
+    def childJobPathForSource = { source ->
+        def childBaseName = sourceChildJobBaseNames[source]
+        if (!childBaseName) {
+            error("No k8s matrix child job mapping configured for source version '${source}'")
+        }
+
+        if (jobName.startsWith('main-')) {
+            return "main/main-${childBaseName}"
+        }
+        if (jobName.startsWith('pr-')) {
+            return "pr-checks/pr-${childBaseName}"
+        }
+        if (jobName.startsWith('release-')) {
+            return "release-canaries/release-${childBaseName}"
+        }
+        return childBaseName
+    }
 
     pipeline {
         agent { label config.workerAgent ?: 'Jenkins-Default-Agent-X64-C5xlarge-Single-Host' }
@@ -60,14 +88,16 @@ def call(Map config = [:]) {
             stage('Create and Monitor Integ Tests') {
                 steps {
                     script {
-                        // Determine which combinations to run. We currently will launch a separate k8sLocalDeployment job for
-                        // each target version, and will let it run against the single source version specified or all source versions
-                        def sourceVersions = params.SOURCE_VERSION
+                        if (childJobNameOverride) {
+                            echo "Ignoring CHILD_JOB_NAME_OVERRIDE='${childJobNameOverride}'; matrix tests route to per-source child jobs."
+                        }
+
+                        def sourceVersions = params.SOURCE_VERSION == 'all' ? allSourceVersions : [params.SOURCE_VERSION]
                         def targetVersions = params.TARGET_VERSION == 'all' ? allTargetVersions : [params.TARGET_VERSION]
 
                         echo "Source versions: ${sourceVersions}"
                         echo "Target versions: ${targetVersions}"
-                        echo "Total created pipelines: ${targetVersions.size()}"
+                        echo "Total candidate pipelines: ${sourceVersions.size() * targetVersions.size()}"
 
                         // Create parallel jobs map
                         def jobs = [:]
@@ -75,53 +105,63 @@ def call(Map config = [:]) {
 
                         sh "mkdir -p libraries/testAutomation/reports"
 
-                        targetVersions.each { target ->
-                            def source = sourceVersions
-                            def combination = "${source}_to_${target}"
-                            def displayName = "${source} → ${target}"
+                        sourceVersions.each { source ->
+                            targetVersions.each { target ->
+                                if (source == target) {
+                                    echo "Skipping ${source} -> ${target}: source and target versions are the same."
+                                } else {
+                                    def childJobName = childJobPathForSource(source)
+                                    def displayName = "${source} → ${target}"
 
-                            jobs[displayName] = {
-                                try {
-                                    def result = build(
-                                            job: childJobName,
-                                            parameters: [
-                                                    string(name: 'SOURCE_VERSION', value: source),
-                                                    string(name: 'TARGET_VERSION', value: target),
-                                                    string(name: 'GIT_REPO_URL', value: params.GIT_REPO_URL),
-                                                    string(name: 'GIT_BRANCH', value: params.GIT_BRANCH),
-                                                    string(name: 'GIT_COMMIT', value: params.GIT_COMMIT)
-                                            ],
-                                            wait: true,
-                                            propagate: false // Don't fail parent if child fails
-                                    )
+                                    jobs[displayName] = {
+                                        try {
+                                            echo "Scheduling ${displayName} on ${childJobName}"
+                                            def result = build(
+                                                    job: childJobName,
+                                                    parameters: [
+                                                            string(name: 'SOURCE_VERSION', value: source),
+                                                            string(name: 'TARGET_VERSION', value: target),
+                                                            string(name: 'GIT_REPO_URL', value: params.GIT_REPO_URL),
+                                                            string(name: 'GIT_BRANCH', value: params.GIT_BRANCH),
+                                                            string(name: 'GIT_COMMIT', value: params.GIT_COMMIT)
+                                                    ],
+                                                    wait: true,
+                                                    propagate: false // Don't fail parent if child fails
+                                            )
 
-                                    copyArtifacts(
-                                            projectName: childJobName,
-                                            selector: specific("${result.number}"),
-                                            filter: 'reports/**',
-                                            target: "libraries/testAutomation/reports",
-                                            flatten: true,
-                                            optional: true
-                                    )
+                                            copyArtifacts(
+                                                    projectName: childJobName,
+                                                    selector: specific("${result.number}"),
+                                                    filter: 'reports/**',
+                                                    target: "libraries/testAutomation/reports",
+                                                    flatten: true,
+                                                    optional: true
+                                            )
 
-                                    results[displayName] = [
-                                            result  : result.result,
-                                            url     : result.absoluteUrl,
-                                            number  : result.number,
-                                            duration: result.duration
-                                    ]
+                                            results[displayName] = [
+                                                    result  : result.result,
+                                                    url     : result.absoluteUrl,
+                                                    number  : result.number,
+                                                    duration: result.duration
+                                            ]
 
-                                } catch (Exception e) {
-                                    echo "💥 ${displayName}: EXCEPTION - ${e.message}"
-                                    results[displayName] = [
-                                            result  : 'EXCEPTION',
-                                            url     : '',
-                                            number  : 0,
-                                            duration: 0,
-                                            error   : e.message
-                                    ]
+                                        } catch (Exception e) {
+                                            echo "💥 ${displayName}: EXCEPTION - ${e.message}"
+                                            results[displayName] = [
+                                                    result  : 'EXCEPTION',
+                                                    url     : '',
+                                                    number  : 0,
+                                                    duration: 0,
+                                                    error   : e.message
+                                            ]
+                                        }
+                                    }
                                 }
                             }
+                        }
+
+                        if (jobs.isEmpty()) {
+                            error("No k8s matrix child jobs were created for SOURCE_VERSION=${params.SOURCE_VERSION}, TARGET_VERSION=${params.TARGET_VERSION}")
                         }
 
                         // Execute all jobs in parallel

--- a/vars/periodicCron.groovy
+++ b/vars/periodicCron.groovy
@@ -28,7 +28,6 @@ def call(String jobName) {
         case 'main-k8s-local-solr8x-test':            return 'H H(0-23)/6 * * *'
         case 'main-k8s-local-solr-other-test':        return 'H H(0-23)/6 * * *'
         case 'main-full-es68source-e2e-test':         return '@hourly'
-        case 'main-k8s-matrix-test':                  return 'H 22 * * *'
         case 'main-rfs-default-e2e-test':             return '@hourly'
         case 'main-solutions-cfn-create-vpc-test':    return '@hourly'
         case 'main-eks-byos-integ-test':              return 'H H(0-23)/6 * * *'


### PR DESCRIPTION
### Description
Remove the cron entry for main-k8s-matrix-test so the job no longer runs nightly from Jenkins schedules.

Keep the matrix implementation usable for manual runs by routing each source version to its per-source k8s-local child job instead of requiring a single CHILD_JOB_NAME_OVERRIDE. Existing CHILD_JOB_NAME_OVERRIDE values are now ignored for compatibility with current Jenkins job configuration, which avoids stale values like main/main-k8s-local-integ-test pointing at the disabled aggregate child job.

Also allow explicit SOURCE_VERSION and TARGET_VERSION parameters passed by the matrix parent to override the defaults baked into the per-source k8s-local wrappers, so a manually-run matrix can still expand target versions correctly.

Update the Jenkins pipeline README and cover-file comments to document the current matrix behavior.

### Issues Resolved
No jira - but the Jenkins matrix tests were misconfigured already and figuring out what was broken was never immediately obvious

### Check List
- [ ] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
