### PR TITLE
Fix offset-commit bugs that permanently pin Kafka commit pointer

### DIFF
--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/CapturedTrafficToHttpTransactionAccumulator.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/CapturedTrafficToHttpTransactionAccumulator.java
@@ -440,10 +440,16 @@ public class CapturedTrafficToHttpTransactionAccumulator {
             );
             return Optional.of(CONNECTION_STATUS.CLOSED);
         } else if (observation.hasConnectionException()) {
-            accum.getOrCreateTransactionPair(trafficStreamKey, originTimestamp).holdTrafficStream(trafficStreamKey);
             rotateAccumulationIfNecessary(trafficStreamKey.getConnectionId(), accum);
             exceptionConnectionCounter.incrementAndGet();
-            accum.resetForNextRequest();
+            // Commit all held TSKs before nulling the rrPair. Without this, offsets from
+            // prior TrafficStream records that contributed to the in-progress request are
+            // permanently orphaned in OffsetLifecycleTracker, pinning the partition's commit
+            // pointer forever (same pattern as handleDroppedRequestForAccumulation).
+            // Note: we do NOT holdTrafficStream(trafficStreamKey) first — that would cause
+            // the current record's TSK to be double-committed (once here, once by the
+            // end-of-accept() fallback). The current record is committed by the fallback.
+            handleDroppedRequestForAccumulation(accum);
             log.atDebug()
                 .setMessage("Removing accumulated traffic pair due to recorded connection exception event for {}")
                 .addArgument(trafficStreamKey::getConnectionId)
@@ -691,6 +697,13 @@ public class CapturedTrafficToHttpTransactionAccumulator {
                             accumulation.trafficChannelKey.getTrafficStreamsContext(),
                             Collections.unmodifiableList(accumulation.getRrPair().trafficStreamKeysBeingHeld)
                         );
+                        // Null the rrPair so the finally-block's onConnectionClose (which
+                        // always runs despite the return) does not double-commit the same
+                        // TSKs — getTrafficStreamsHeldByAccum returns List.of() when
+                        // hasRrPair()==false. Without this, keep-alive connections expiring
+                        // mid-second-request hit IllegalStateException in
+                        // OffsetLifecycleTracker.removeAndReturnNewHead (double-remove).
+                        accumulation.resetForNextRequest();
                     }
                     return;
                 case ACCUMULATING_WRITES:

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/ConnectionExceptionOffsetOrphanTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/ConnectionExceptionOffsetOrphanTest.java
@@ -1,0 +1,253 @@
+package org.opensearch.migrations.replay;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+
+import org.opensearch.migrations.replay.datatypes.ITrafficStreamKey;
+import org.opensearch.migrations.replay.datatypes.PojoTrafficStreamAndKey;
+import org.opensearch.migrations.replay.datatypes.PojoTrafficStreamKeyAndContext;
+import org.opensearch.migrations.replay.tracing.IReplayContexts;
+import org.opensearch.migrations.tracing.InstrumentationTest;
+import org.opensearch.migrations.trafficcapture.protos.CloseObservation;
+import org.opensearch.migrations.trafficcapture.protos.ConnectionExceptionObservation;
+import org.opensearch.migrations.trafficcapture.protos.EndOfMessageIndication;
+import org.opensearch.migrations.trafficcapture.protos.ReadObservation;
+import org.opensearch.migrations.trafficcapture.protos.TrafficObservation;
+import org.opensearch.migrations.trafficcapture.protos.TrafficStream;
+import org.opensearch.migrations.trafficcapture.protos.WriteObservation;
+
+import com.google.protobuf.ByteString;
+import com.google.protobuf.Timestamp;
+import lombok.NonNull;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression tests for offset-commit bugs in the accumulator:
+ *
+ * F1: A connectionException during ACCUMULATING_READS used to orphan offsets from prior
+ *     TrafficStream records (their TSKs were held in a rrPair that resetForNextRequest nulled
+ *     without committing).
+ *
+ * F2: Expiry of a keep-alive connection mid-second-request used to double-commit the same
+ *     TSK list (onTrafficStreamsExpired + onConnectionClose in finally block), causing
+ *     IllegalStateException.
+ */
+class ConnectionExceptionOffsetOrphanTest extends InstrumentationTest {
+
+    private static final String NODE_ID = "testNode";
+    private static final String CONN_ID = "conn1";
+
+    private static Timestamp tsProto(long epochSeconds) {
+        return Timestamp.newBuilder().setSeconds(epochSeconds).build();
+    }
+
+    private static TrafficObservation readObs(long epochSeconds, int size) {
+        return TrafficObservation.newBuilder()
+            .setTs(tsProto(epochSeconds))
+            .setRead(ReadObservation.newBuilder()
+                .setData(ByteString.copyFrom(new byte[size])))
+            .build();
+    }
+
+    private static TrafficObservation writeObs(long epochSeconds, int size) {
+        return TrafficObservation.newBuilder()
+            .setTs(tsProto(epochSeconds))
+            .setWrite(WriteObservation.newBuilder()
+                .setData(ByteString.copyFrom(new byte[size])))
+            .build();
+    }
+
+    private static TrafficObservation eomObs(long epochSeconds) {
+        return TrafficObservation.newBuilder()
+            .setTs(tsProto(epochSeconds))
+            .setEndOfMessageIndicator(EndOfMessageIndication.newBuilder())
+            .build();
+    }
+
+    private static TrafficObservation connectionExceptionObs(long epochSeconds) {
+        return TrafficObservation.newBuilder()
+            .setTs(tsProto(epochSeconds))
+            .setConnectionException(ConnectionExceptionObservation.newBuilder()
+                .setMessage("connection reset"))
+            .build();
+    }
+
+    private static TrafficObservation closeObs(long epochSeconds) {
+        return TrafficObservation.newBuilder()
+            .setTs(tsProto(epochSeconds))
+            .setClose(CloseObservation.newBuilder())
+            .build();
+    }
+
+    private static TrafficStream makeStream(String nodeId, String connId, int index,
+                                            TrafficObservation... observations) {
+        var builder = TrafficStream.newBuilder()
+            .setNodeId(nodeId)
+            .setConnectionId(connId)
+            .setNumber(index);
+        for (var obs : observations) {
+            builder.addSubStream(obs);
+        }
+        return builder.build();
+    }
+
+    private PojoTrafficStreamAndKey wrap(TrafficStream ts) {
+        return new PojoTrafficStreamAndKey(ts,
+            PojoTrafficStreamKeyAndContext.build(ts, rootContext::createTrafficStreamContextForTest));
+    }
+
+    /**
+     * F1: Multi-record request + connectionException must commit ALL held TSKs.
+     *
+     * R1: READ (partial request, no EOM) — TSK held in rrPair
+     * R2: READ (more of same request) — TSK held in rrPair
+     * R3: connectionException — prior to fix, only R3 committed; R1+R2 orphaned forever
+     *
+     * After fix: all three TSKs should be reported as committed (via onTrafficStreamIgnored).
+     */
+    @Test
+    void connectionExceptionCommitsAllHeldTsks() {
+        var committedTsks = new ArrayList<ITrafficStreamKey>();
+        var expiredTsks = new ArrayList<ITrafficStreamKey>();
+
+        var accumulator = new CapturedTrafficToHttpTransactionAccumulator(
+            Duration.ofSeconds(30), null, new AccumulationCallbacks() {
+                @Override
+                public Consumer<RequestResponsePacketPair> onRequestReceived(
+                    @NonNull IReplayContexts.IReplayerHttpTransactionContext ctx,
+                    @NonNull HttpMessageAndTimestamp request,
+                    boolean isResumedConnection
+                ) {
+                    return rrPair -> {
+                        rrPair.getTrafficStreamsHeld().forEach(committedTsks::add);
+                    };
+                }
+
+                @Override
+                public void onTrafficStreamsExpired(
+                    RequestResponsePacketPair.ReconstructionStatus status,
+                    @NonNull IReplayContexts.IChannelKeyContext ctx,
+                    @NonNull List<ITrafficStreamKey> trafficStreamKeysBeingHeld
+                ) {
+                    expiredTsks.addAll(trafficStreamKeysBeingHeld);
+                }
+
+                @Override
+                public void onConnectionClose(int n, @NonNull IReplayContexts.IChannelKeyContext ctx,
+                                              int s, RequestResponsePacketPair.ReconstructionStatus status,
+                                              @NonNull Instant when, @NonNull List<ITrafficStreamKey> keys) {
+                    committedTsks.addAll(keys);
+                }
+
+                @Override
+                public void onTrafficStreamIgnored(@NonNull IReplayContexts.ITrafficStreamsLifecycleContext ctx) {
+                    committedTsks.add(ctx.getTrafficStreamKey());
+                }
+            });
+
+        // R1: partial read (no EOM)
+        var ts1 = makeStream(NODE_ID, CONN_ID, 0, readObs(100, 512));
+        // R2: more of the same request (still no EOM)
+        var ts2 = makeStream(NODE_ID, CONN_ID, 1, readObs(101, 512));
+        // R3: connectionException terminates the connection mid-request
+        var ts3 = makeStream(NODE_ID, CONN_ID, 2, connectionExceptionObs(102));
+
+        accumulator.accept(wrap(ts1));
+        accumulator.accept(wrap(ts2));
+        accumulator.accept(wrap(ts3));
+
+        // All three TSKs must be committed (via onTrafficStreamIgnored)
+        Assertions.assertEquals(3, committedTsks.size(),
+            "All three TSKs (R1, R2, R3) must be committed after connectionException; " +
+            "prior to fix, only R3 was committed and R1+R2 were permanently orphaned");
+
+        // Verify the connection IDs match
+        committedTsks.forEach(tsk ->
+            Assertions.assertEquals(CONN_ID, tsk.getConnectionId()));
+    }
+
+    /**
+     * F2: Keep-alive connection expiry mid-second-request must NOT double-commit.
+     *
+     * Request 1: READ + EOM + WRITE (complete — numberOfResets becomes 1)
+     * Request 2: READ (partial, no EOM)
+     * Then: connection expires (timeout exceeded)
+     *
+     * Prior to fix: fireAccumulationsCallbacksAndClose called onTrafficStreamsExpired with
+     * the TSK list, then the finally block called onConnectionClose with the SAME list →
+     * double commit → IllegalStateException in OffsetLifecycleTracker.
+     *
+     * After fix: onTrafficStreamsExpired commits the list, then resetForNextRequest nulls
+     * the rrPair so onConnectionClose sees an empty list.
+     */
+    @Test
+    void keepAliveExpiryMidSecondRequestDoesNotDoubleCommit() {
+        var expiredTsks = new ArrayList<ITrafficStreamKey>();
+        var closedTsks = new ArrayList<ITrafficStreamKey>();
+        var completedRequests = new AtomicInteger(0);
+
+        var accumulator = new CapturedTrafficToHttpTransactionAccumulator(
+            Duration.ofSeconds(5), null, new AccumulationCallbacks() {
+                @Override
+                public Consumer<RequestResponsePacketPair> onRequestReceived(
+                    @NonNull IReplayContexts.IReplayerHttpTransactionContext ctx,
+                    @NonNull HttpMessageAndTimestamp request,
+                    boolean isResumedConnection
+                ) {
+                    completedRequests.incrementAndGet();
+                    return rrPair -> {};
+                }
+
+                @Override
+                public void onTrafficStreamsExpired(
+                    RequestResponsePacketPair.ReconstructionStatus status,
+                    @NonNull IReplayContexts.IChannelKeyContext ctx,
+                    @NonNull List<ITrafficStreamKey> trafficStreamKeysBeingHeld
+                ) {
+                    expiredTsks.addAll(trafficStreamKeysBeingHeld);
+                }
+
+                @Override
+                public void onConnectionClose(int n, @NonNull IReplayContexts.IChannelKeyContext ctx,
+                                              int s, RequestResponsePacketPair.ReconstructionStatus status,
+                                              @NonNull Instant when, @NonNull List<ITrafficStreamKey> keys) {
+                    // Only track closes for the connection under test
+                    keys.stream()
+                        .filter(k -> CONN_ID.equals(k.getConnectionId()))
+                        .forEach(closedTsks::add);
+                }
+
+                @Override
+                public void onTrafficStreamIgnored(@NonNull IReplayContexts.ITrafficStreamsLifecycleContext ctx) {}
+            });
+
+        // Request 1: full request-response cycle on connection (numberOfResets becomes 1)
+        var ts1 = makeStream(NODE_ID, CONN_ID, 0,
+            readObs(100, 64), eomObs(101), writeObs(102, 128));
+        accumulator.accept(wrap(ts1));
+        Assertions.assertEquals(1, completedRequests.get());
+
+        // Request 2: partial read (no EOM) — second request starts
+        var ts2 = makeStream(NODE_ID, CONN_ID, 1, readObs(103, 64));
+        accumulator.accept(wrap(ts2));
+
+        // Now trigger expiry by advancing time past the timeout (5s)
+        // Feed a record on a DIFFERENT connection to advance the global clock
+        var tsTrigger = makeStream(NODE_ID, "otherConn", 0, readObs(200, 1), closeObs(200));
+        accumulator.accept(wrap(tsTrigger));
+
+        // The original connection (CONN_ID) should have been expired without throwing.
+        // Prior to fix: IllegalStateException from double removeAndReturnNewHead.
+        // After fix: onTrafficStreamsExpired gets the held TSKs; onConnectionClose gets empty list.
+        Assertions.assertFalse(expiredTsks.isEmpty(),
+            "The partial second request's TSKs should have been expired via onTrafficStreamsExpired");
+        Assertions.assertTrue(closedTsks.isEmpty(),
+            "onConnectionClose for " + CONN_ID + " should receive an empty list " +
+            "(rrPair nulled after expiry commit)");
+    }
+}

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/SimpleCapturedTrafficToHttpTransactionAccumulatorTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/SimpleCapturedTrafficToHttpTransactionAccumulatorTest.java
@@ -83,6 +83,43 @@ public class SimpleCapturedTrafficToHttpTransactionAccumulatorTest extends Instr
                     ObservationDirective.write(MAX_COMMANDS_IN_CONNECTION)
                 ),
                 List.of(MAX_COMMANDS_IN_CONNECTION, MAX_COMMANDS_IN_CONNECTION)
+            ),
+            // F1 trigger: multi-record request terminated by connectionException.
+            // Explicit flush() directives force the serializer to produce separate
+            // TrafficStream records for the same request. The connectionException then
+            // terminates the connection. The accumulator must report all TrafficStream
+            // indices as processed (committed/ignored).
+            Arguments.of(
+                "connectionExceptionAfterMultiRecordReadCommitsAllIndices",
+                1024 * 1024, // large buffer — only explicit flushes produce new records
+                0,
+                List.of(
+                    ObservationDirective.read(128),
+                    ObservationDirective.flush(), // forces record boundary
+                    ObservationDirective.read(128),
+                    ObservationDirective.flush(), // forces another record boundary
+                    ObservationDirective.connectionException()
+                ),
+                List.of() // no completed transactions expected
+            ),
+            // F1 variant: exception after a completed request on a keep-alive connection.
+            // Request 1 completes normally, then request 2 starts and is interrupted
+            // after spanning multiple records.
+            Arguments.of(
+                "connectionExceptionMidSecondRequestOnKeepAlive",
+                1024 * 1024, // large buffer
+                0,
+                List.of(
+                    ObservationDirective.read(32),
+                    ObservationDirective.eom(),
+                    ObservationDirective.write(32),
+                    ObservationDirective.flush(), // record boundary
+                    ObservationDirective.read(128),
+                    ObservationDirective.flush(), // record boundary
+                    ObservationDirective.read(64),
+                    ObservationDirective.connectionException()
+                ),
+                List.of(32, 32) // only request 1 completes
             ) };
     }
 

--- a/TrafficCapture/trafficReplayer/src/testFixtures/java/org/opensearch/migrations/replay/traffic/generator/ExhaustiveTrafficStreamGenerator.java
+++ b/TrafficCapture/trafficReplayer/src/testFixtures/java/org/opensearch/migrations/replay/traffic/generator/ExhaustiveTrafficStreamGenerator.java
@@ -78,7 +78,8 @@ public class ExhaustiveTrafficStreamGenerator {
         WriteSegment(5),
         EndOfWriteSegment(6),
         RequestDropped(7),
-        Close(8);
+        Close(8),
+        ConnectionException(9);
 
         private final int intValue;
 
@@ -91,7 +92,8 @@ public class ExhaustiveTrafficStreamGenerator {
         }
 
         public static Stream<ObservationType> valueStream() {
-            return Arrays.stream(ObservationType.values()).filter(ot -> ot != ObservationType.Close);
+            return Arrays.stream(ObservationType.values())
+                .filter(ot -> ot != ObservationType.Close && ot != ObservationType.ConnectionException);
         }
     }
 
@@ -132,6 +134,8 @@ public class ExhaustiveTrafficStreamGenerator {
             return Optional.empty();
         } else if (trafficObservation.hasClose()) {
             return Optional.of(ObservationType.Close);
+        } else if (trafficObservation.hasConnectionException()) {
+            return Optional.of(ObservationType.ConnectionException);
         } else if (trafficObservation.hasRequestDropped()) {
             return Optional.of(ObservationType.RequestDropped);
         } else {
@@ -244,6 +248,16 @@ public class ExhaustiveTrafficStreamGenerator {
                 ++i; // compensate to get the right number of requests in the loop
                 sizes.remove(sizes.size() - 1); // This won't show up as a request, so don't propagate it
                 continue;
+            }
+            // Occasionally terminate with a connectionException mid-request (before EOM).
+            // Bug to trigger: multi-record request + exception = orphaned offsets.
+            // Use a flush before the exception to ensure prior reads are in a separate TrafficStream
+            // record, which is required to trigger the multi-record aspect.
+            if (r.nextDouble() <= cancelRequestLikelihood) {
+                commands.add(ObservationDirective.flush());
+                commands.add(ObservationDirective.connectionException());
+                sizes.remove(sizes.size() - 1); // This won't show up as a completed request
+                break; // connection is terminated — no more observations
             }
             if (r.nextDouble() <= flushLikelihood) {
                 commands.add(ObservationDirective.flush());

--- a/TrafficCapture/trafficReplayer/src/testFixtures/java/org/opensearch/migrations/replay/traffic/generator/ObservationDirective.java
+++ b/TrafficCapture/trafficReplayer/src/testFixtures/java/org/opensearch/migrations/replay/traffic/generator/ObservationDirective.java
@@ -27,6 +27,14 @@ public class ObservationDirective {
         return new ObservationDirective(OffloaderCommandType.Flush, 0);
     }
 
+    public static ObservationDirective connectionException() {
+        return new ObservationDirective(OffloaderCommandType.ConnectionException, 0);
+    }
+
+    public static ObservationDirective close() {
+        return new ObservationDirective(OffloaderCommandType.Close, 0);
+    }
+
     @Override
     public String toString() {
         return "(" + offloaderCommandType + ":" + size + ")";

--- a/TrafficCapture/trafficReplayer/src/testFixtures/java/org/opensearch/migrations/replay/traffic/generator/OffloaderCommandType.java
+++ b/TrafficCapture/trafficReplayer/src/testFixtures/java/org/opensearch/migrations/replay/traffic/generator/OffloaderCommandType.java
@@ -5,5 +5,7 @@ public enum OffloaderCommandType {
     EndOfMessage,
     DropRequest,
     Write,
-    Flush
+    Flush,
+    ConnectionException,
+    Close
 }

--- a/TrafficCapture/trafficReplayer/src/testFixtures/java/org/opensearch/migrations/replay/traffic/generator/TrafficStreamGenerator.java
+++ b/TrafficCapture/trafficReplayer/src/testFixtures/java/org/opensearch/migrations/replay/traffic/generator/TrafficStreamGenerator.java
@@ -53,10 +53,18 @@ public class TrafficStreamGenerator {
             rootContext::createTrafficStreamContextForTest
         );
         var offloader = connectionFactory.createOffloader(rootContext.createChannelContext(tsk));
+        boolean alreadyTerminated = false;
         for (var directive : directives) {
             serializeEvent(offloader, interactionOffset++, directive, Instant.EPOCH);
+            if (directive.offloaderCommandType == OffloaderCommandType.ConnectionException
+                || directive.offloaderCommandType == OffloaderCommandType.Close) {
+                alreadyTerminated = true;
+                break;
+            }
         }
-        offloader.addCloseEvent(Instant.EPOCH);
+        if (!alreadyTerminated) {
+            offloader.addCloseEvent(Instant.EPOCH);
+        }
         offloader.flushCommitAndResetStream(true).get();
         return connectionFactory.getRecordedTrafficStreamsStream().toArray(TrafficStream[]::new);
     }
@@ -82,6 +90,12 @@ public class TrafficStreamGenerator {
                 return;
             case DropRequest:
                 offloader.cancelCaptureForCurrentRequest(timestamp);
+                return;
+            case ConnectionException:
+                offloader.addExceptionCaughtEvent(timestamp, new RuntimeException("synthetic connection exception"));
+                return;
+            case Close:
+                offloader.addCloseEvent(timestamp);
                 return;
             default:
                 throw new IllegalStateException("Unknown directive type: " + directive.offloaderCommandType);


### PR DESCRIPTION
## Summary

Fixes two bugs in `CapturedTrafficToHttpTransactionAccumulator` where Kafka offsets can become permanently orphaned in `OffsetLifecycleTracker`, pinning the partition's commit pointer forever:

- **F1 — connectionException offset orphan:** A `connectionException` observation arriving during `ACCUMULATING_READS` (multi-record request body + TCP RST) discards held TrafficStreamKeys without committing them. The handler called `resetForNextRequest()` which nulled the rrPair containing offsets from prior TrafficStream records. These offsets remain in the priority queue permanently, blocking all subsequent commits on that partition. Restart-proof (re-delivery replays the same deterministic path).
- **F2 — expiry double-commit crash:** Expiry of a keep-alive connection mid-second-request fires `onTrafficStreamsExpired` (commits held TrafficStreamKeys), then the `finally` block fires `onConnectionClose` with the **same** TrafficStreamKey list → `IllegalStateException` in `removeAndReturnNewHead` → replayer crash. Potential deterministic crash loop since the staged commit may not flush to Kafka before the crash.

## Root Cause

F1: The `connectionException` handler (line ~443) held the current TrafficStreamKey into the rrPair, then called `resetForNextRequest()` — which nulls `rrPairWithCallback` — without first committing the held list. The correct pattern (`handleDroppedRequestForAccumulation`) already existed for `requestDropped` observations but was not used here.

F2: In `fireAccumulationsCallbacksAndClose`, the `ACCUMULATING_READS` branch's `return` does not skip the `finally` block (Java semantics). When `hasSignaledRequests()` is true (keep-alive, completed ≥1 prior request), `onConnectionClose` fires with `getTrafficStreamsHeldByAccum(accum)` — which returns the same list that `onTrafficStreamsExpired` just committed, since the rrPair was never nulled.

## Fix

- **F1:** Replace bare `resetForNextRequest()` with `handleDroppedRequestForAccumulation(accum)` — commits all held TrafficStreamKeys via `onTrafficStreamIgnored` before resetting. Remove the preceding `holdTrafficStream` call so the current record's TrafficStreamKey is committed once by the end-of-`accept()` fallback (avoiding double-commit).
- **F2:** Call `accumulation.resetForNextRequest()` after `onTrafficStreamsExpired` returns, so `getTrafficStreamsHeldByAccum` in the finally block returns an empty list.

## Test Plan

- [x] `connectionExceptionCommitsAllHeldTsks` — 3-record request (R1 READ, R2 READ, R3 connectionException); asserts all 3 TSKs are committed
- [x] `keepAliveExpiryMidSecondRequestDoesNotDoubleCommit` — keep-alive connection, request 1 completes, request 2 partially accumulated, connection expires; asserts no `IllegalStateException` and TSKs committed exactly once
- [x] Full `trafficReplayer` test suite passes (106 tasks, 0 failures)