### PR TITLE
Fail `IMPORT` when no data found.

### DIFF
--- a/CreateSnapshot/build.gradle
+++ b/CreateSnapshot/build.gradle
@@ -22,6 +22,8 @@ dependencies {
     testImplementation libs.testcontainers.localstack
     testImplementation libs.hamcrest
     testImplementation libs.netty.all
+    testImplementation libs.mockito.core
+    testImplementation libs.mockito.junit.jupiter
 }
 
 application {

--- a/CreateSnapshot/src/main/java/org/opensearch/migrations/SolrBackupStrategy.java
+++ b/CreateSnapshot/src/main/java/org/opensearch/migrations/SolrBackupStrategy.java
@@ -3,6 +3,7 @@ package org.opensearch.migrations;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -94,6 +95,21 @@ public class SolrBackupStrategy implements SourceBackupStrategy {
         }
 
         public SolrImportSchemaUnavailable(String message, Throwable cause) {
+            super(message, cause);
+        }
+    }
+
+    /**
+     * Thrown when IMPORT mode cannot confirm snapshot data exists at the configured location. IMPORT
+     * imports an existing snapshot rather than creating one, so an empty or unlistable location is
+     * fatal — continuing would migrate nothing or fail later with a more confusing error.
+     */
+    public static class SolrImportSnapshotUnavailable extends RuntimeException {
+        public SolrImportSnapshotUnavailable(String message) {
+            super(message);
+        }
+
+        public SolrImportSnapshotUnavailable(String message, Throwable cause) {
             super(message, cause);
         }
     }
@@ -439,12 +455,11 @@ public class SolrBackupStrategy implements SourceBackupStrategy {
         log.info("IMPORT mode complete: config files ensured, snapshot location verified at {}", backupLocation);
     }
 
-    /**
-     * Validates that the S3 snapshot location is accessible (bucket exists, prefix is listable).
-     */
+    /** Fails fatally in IMPORT mode if the S3 snapshot location is empty or cannot be listed. */
     private void validateS3SnapshotAccessible(S3Uri repoUri) {
         var snapshotPrefix = computeParentPrefix(repoUri.key) + args.snapshotName + "/";
 
+        boolean empty;
         try (var s3Client = buildS3Client(args.s3Region, args.endpoint)) {
             var response = s3Client.listObjectsV2(
                 software.amazon.awssdk.services.s3.model.ListObjectsV2Request.builder()
@@ -452,28 +467,40 @@ public class SolrBackupStrategy implements SourceBackupStrategy {
                     .prefix(snapshotPrefix)
                     .maxKeys(1)
                     .build());
-            if (response.contents().isEmpty()) {
-                log.warn("No objects found at s3://{}/{} — downstream pipeline may fail if snapshot data "
-                    + "has not been uploaded yet", repoUri.bucketName, snapshotPrefix);
-            } else {
-                log.info("Snapshot data confirmed at s3://{}/{}", repoUri.bucketName, snapshotPrefix);
-            }
+            empty = response.contents().isEmpty();
         } catch (Exception e) {
-            log.warn("Could not verify S3 snapshot location s3://{}/{}: {} — proceeding anyway",
-                repoUri.bucketName, snapshotPrefix, e.getMessage());
+            throw new SolrImportSnapshotUnavailable(String.format(
+                "IMPORT mode could not verify the snapshot location s3://%s/%s: %s. "
+                    + "The snapshot data must already exist at this location before import.",
+                repoUri.bucketName, snapshotPrefix, e.getMessage()), e);
         }
+        requireNonEmptyS3Snapshot(repoUri.bucketName, snapshotPrefix, empty);
     }
 
-    /**
-     * Validates that the filesystem snapshot location exists and is readable.
-     */
+    /** Throws if the listed S3 snapshot prefix is empty; the IO/listing is done by the caller. */
+    static void requireNonEmptyS3Snapshot(String bucketName, String snapshotPrefix, boolean empty) {
+        if (empty) {
+            throw new SolrImportSnapshotUnavailable(String.format(
+                "IMPORT mode found no snapshot data at s3://%s/%s. "
+                    + "The snapshot must be created/uploaded to this location before import.",
+                bucketName, snapshotPrefix));
+        }
+        log.info("Snapshot data confirmed at s3://{}/{}", bucketName, snapshotPrefix);
+    }
+
+    /** Fails fatally in IMPORT mode if the filesystem snapshot directory is missing. */
     private void validateFileSystemSnapshotAccessible(String repoPath) {
-        var snapshotDir = Paths.get(repoPath, args.snapshotName);
+        requireFilesystemSnapshotPresent(Paths.get(repoPath, args.snapshotName));
+    }
+
+    /** Throws if the filesystem snapshot directory does not exist. */
+    static void requireFilesystemSnapshotPresent(Path snapshotDir) {
         if (Files.exists(snapshotDir) && Files.isDirectory(snapshotDir)) {
             log.info("Snapshot directory confirmed at {}", snapshotDir);
         } else {
-            log.warn("Snapshot directory not found at {} — downstream pipeline may fail if snapshot data "
-                + "has not been placed there yet", snapshotDir);
+            throw new SolrImportSnapshotUnavailable(String.format(
+                "IMPORT mode found no snapshot directory at %s. "
+                    + "The snapshot must be placed at this location before import.", snapshotDir));
         }
     }
 

--- a/CreateSnapshot/src/main/java/org/opensearch/migrations/SolrBackupStrategy.java
+++ b/CreateSnapshot/src/main/java/org/opensearch/migrations/SolrBackupStrategy.java
@@ -458,23 +458,28 @@ public class SolrBackupStrategy implements SourceBackupStrategy {
     /** Fails fatally in IMPORT mode if the S3 snapshot location is empty or cannot be listed. */
     private void validateS3SnapshotAccessible(S3Uri repoUri) {
         var snapshotPrefix = computeParentPrefix(repoUri.key) + args.snapshotName + "/";
-
-        boolean empty;
         try (var s3Client = buildS3Client(args.s3Region, args.endpoint)) {
+            var empty = isS3SnapshotEmpty(s3Client, repoUri.bucketName, snapshotPrefix);
+            requireNonEmptyS3Snapshot(repoUri.bucketName, snapshotPrefix, empty);
+        }
+    }
+
+    /** Lists the snapshot prefix and reports whether it is empty; wraps listing failures fatally. */
+    static boolean isS3SnapshotEmpty(S3Client s3Client, String bucketName, String snapshotPrefix) {
+        try {
             var response = s3Client.listObjectsV2(
                 software.amazon.awssdk.services.s3.model.ListObjectsV2Request.builder()
-                    .bucket(repoUri.bucketName)
+                    .bucket(bucketName)
                     .prefix(snapshotPrefix)
                     .maxKeys(1)
                     .build());
-            empty = response.contents().isEmpty();
+            return response.contents().isEmpty();
         } catch (Exception e) {
             throw new SolrImportSnapshotUnavailable(String.format(
                 "IMPORT mode could not verify the snapshot location s3://%s/%s: %s. "
                     + "The snapshot data must already exist at this location before import.",
-                repoUri.bucketName, snapshotPrefix, e.getMessage()), e);
+                bucketName, snapshotPrefix, e.getMessage()), e);
         }
-        requireNonEmptyS3Snapshot(repoUri.bucketName, snapshotPrefix, empty);
     }
 
     /** Throws if the listed S3 snapshot prefix is empty; the IO/listing is done by the caller. */

--- a/CreateSnapshot/src/test/java/org/opensearch/migrations/SolrImportSnapshotValidationTest.java
+++ b/CreateSnapshot/src/test/java/org/opensearch/migrations/SolrImportSnapshotValidationTest.java
@@ -5,11 +5,20 @@ import java.nio.file.Path;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
+import software.amazon.awssdk.services.s3.model.S3Object;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * Fast, container-free unit tests for IMPORT-mode snapshot-location validation. The end-to-end
@@ -28,6 +37,34 @@ public class SolrImportSnapshotValidationTest {
     @Test
     void s3_nonEmptyPrefix_passes() {
         assertDoesNotThrow(() -> SolrBackupStrategy.requireNonEmptyS3Snapshot("bucket", "snap/", false));
+    }
+
+    @Test
+    void s3_listingEmpty_returnsTrue() {
+        var s3 = mock(S3Client.class);
+        when(s3.listObjectsV2(any(ListObjectsV2Request.class)))
+            .thenReturn(ListObjectsV2Response.builder().build());
+        assertTrue(SolrBackupStrategy.isS3SnapshotEmpty(s3, "bucket", "snap/"));
+    }
+
+    @Test
+    void s3_listingNonEmpty_returnsFalse() {
+        var s3 = mock(S3Client.class);
+        when(s3.listObjectsV2(any(ListObjectsV2Request.class)))
+            .thenReturn(ListObjectsV2Response.builder()
+                .contents(S3Object.builder().key("snap/segments_1").build()).build());
+        assertFalse(SolrBackupStrategy.isS3SnapshotEmpty(s3, "bucket", "snap/"));
+    }
+
+    @Test
+    void s3_listingFailure_wrapsInSnapshotUnavailable() {
+        var s3 = mock(S3Client.class);
+        when(s3.listObjectsV2(any(ListObjectsV2Request.class)))
+            .thenThrow(new RuntimeException("bucket does not exist"));
+        var ex = assertThrows(SolrBackupStrategy.SolrImportSnapshotUnavailable.class,
+            () -> SolrBackupStrategy.isS3SnapshotEmpty(s3, "bucket", "snap/"));
+        assertThat(ex.getMessage(), containsString("could not verify"));
+        assertThat(ex.getMessage(), containsString("bucket does not exist"));
     }
 
     @Test

--- a/CreateSnapshot/src/test/java/org/opensearch/migrations/SolrImportSnapshotValidationTest.java
+++ b/CreateSnapshot/src/test/java/org/opensearch/migrations/SolrImportSnapshotValidationTest.java
@@ -1,0 +1,55 @@
+package org.opensearch.migrations;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Fast, container-free unit tests for IMPORT-mode snapshot-location validation. The end-to-end
+ * behavior is covered by TestCreateSnapshotModeFlag (isolatedTest); these exercise the pure
+ * empty/missing decision that must fail rather than warn.
+ */
+public class SolrImportSnapshotValidationTest {
+
+    @Test
+    void s3_emptyPrefix_throws() {
+        var ex = assertThrows(SolrBackupStrategy.SolrImportSnapshotUnavailable.class,
+            () -> SolrBackupStrategy.requireNonEmptyS3Snapshot("bucket", "snap/", true));
+        assertThat(ex.getMessage(), containsString("s3://bucket/snap/"));
+    }
+
+    @Test
+    void s3_nonEmptyPrefix_passes() {
+        assertDoesNotThrow(() -> SolrBackupStrategy.requireNonEmptyS3Snapshot("bucket", "snap/", false));
+    }
+
+    @Test
+    void filesystem_missingDirectory_throws(@TempDir Path tempRepo) {
+        var missing = tempRepo.resolve("does-not-exist");
+        var ex = assertThrows(SolrBackupStrategy.SolrImportSnapshotUnavailable.class,
+            () -> SolrBackupStrategy.requireFilesystemSnapshotPresent(missing));
+        assertThat(ex.getMessage(), containsString(missing.toString()));
+    }
+
+    @Test
+    void filesystem_fileInsteadOfDirectory_throws(@TempDir Path tempRepo) throws Exception {
+        var file = tempRepo.resolve("snapshot-as-file");
+        Files.writeString(file, "not a directory");
+        assertThrows(SolrBackupStrategy.SolrImportSnapshotUnavailable.class,
+            () -> SolrBackupStrategy.requireFilesystemSnapshotPresent(file));
+    }
+
+    @Test
+    void filesystem_existingDirectory_passes(@TempDir Path tempRepo) throws Exception {
+        var dir = tempRepo.resolve("snapshot");
+        Files.createDirectories(dir);
+        assertDoesNotThrow(() -> SolrBackupStrategy.requireFilesystemSnapshotPresent(dir));
+    }
+}

--- a/CreateSnapshot/src/test/java/org/opensearch/migrations/TestCreateSnapshotModeFlag.java
+++ b/CreateSnapshot/src/test/java/org/opensearch/migrations/TestCreateSnapshotModeFlag.java
@@ -233,6 +233,9 @@ public class TestCreateSnapshotModeFlag {
             "http://localhost:8983/solr/admin/collections?action=CREATE"
                 + "&name=importcoll&numShards=1&replicationFactor=1&wt=json");
 
+        // IMPORT validates the snapshot location is non-empty, so seed a placeholder object.
+        putSnapshotPlaceholder(subpath, snapshotName);
+
         var args = new CreateSnapshot.Args();
         args.sourceArgs.host = cloudSolrUrl();
         args.sourceArgs.insecure = true;
@@ -321,6 +324,9 @@ public class TestCreateSnapshotModeFlag {
         CLOUD_SOLR.execInContainer("curl", "-s",
             "http://localhost:8983/solr/admin/collections?action=CREATE"
                 + "&name=nobkpcoll&numShards=1&replicationFactor=1&wt=json");
+
+        // IMPORT validates the snapshot location is non-empty, so seed a placeholder object.
+        putSnapshotPlaceholder(subpath, snapshotName);
 
         var args = new CreateSnapshot.Args();
         args.sourceArgs.host = cloudSolrUrl();
@@ -481,6 +487,9 @@ public class TestCreateSnapshotModeFlag {
             "http://localhost:8983/solr/admin/collections?action=CREATE"
                 + "&name=branchcoll&numShards=1&replicationFactor=1&wt=json");
 
+        // IMPORT validates the snapshot location is non-empty, so seed a placeholder object.
+        putSnapshotPlaceholder("branch-import", "branch_import_test");
+
         var args = new CreateSnapshot.Args();
         args.sourceArgs.host = cloudSolrUrl();
         args.sourceArgs.insecure = true;
@@ -563,9 +572,85 @@ public class TestCreateSnapshotModeFlag {
         }
     }
 
+    // ── IMPORT mode fails loudly when the snapshot location has no data ───────
+    //
+    // IMPORT imports an existing snapshot rather than creating one. An empty location means there is
+    // nothing to import, so it must fail fatally (SolrImportSnapshotUnavailable) instead of warning and
+    // exiting green. SolrCloud is used so no synthetic config is written that would populate the prefix.
+
+    @Test
+    void importMode_emptySnapshotLocation_throwsInsteadOfWarning() throws Exception {
+        ensureBucket();
+        String snapshotName = "import_empty_test";
+        String subpath = "import-empty";
+
+        CLOUD_SOLR.execInContainer("curl", "-s",
+            "http://localhost:8983/solr/admin/collections?action=CREATE"
+                + "&name=emptycoll&numShards=1&replicationFactor=1&wt=json");
+
+        var args = new CreateSnapshot.Args();
+        args.sourceArgs.host = cloudSolrUrl();
+        args.sourceArgs.insecure = true;
+        args.sourceType = "solr";
+        args.snapshotName = snapshotName;
+        args.snapshotRepoName = "test";
+        args.repoUri = "s3://" + BUCKET_NAME + "/" + subpath;
+        args.s3Region = REGION;
+        args.endpoint = LOCAL_STACK.getEndpoint().toString();
+        args.mode = "import";
+        args.solrCollections = List.of("emptycoll");
+        args.noWait = false;
+
+        var snapshotContext = SnapshotTestContext.factory().noOtelTracking();
+        var creator = new CreateSnapshot(args, snapshotContext.createSnapshotCreateContext());
+
+        var ex = Assertions.assertThrows(SolrBackupStrategy.SolrImportSnapshotUnavailable.class,
+            creator::run,
+            "IMPORT mode must throw when the snapshot location is empty");
+        Assertions.assertTrue(ex.getMessage().contains(subpath),
+            "Exception should name the empty snapshot location; got: " + ex.getMessage());
+
+        CLOUD_SOLR.execInContainer("curl", "-s",
+            "http://localhost:8983/solr/admin/collections?action=DELETE&name=emptycoll&wt=json");
+    }
+
+    @Test
+    void importMode_missingFilesystemSnapshot_throwsInsteadOfWarning(@TempDir Path tempRepo) throws Exception {
+        // SolrCloud + filesystem: no synthetic config is written, so the snapshot dir stays absent.
+        var snapshotContext = SnapshotTestContext.factory().noOtelTracking();
+
+        var args = new CreateSnapshot.Args();
+        args.sourceArgs.host = cloudSolrUrl();
+        args.sourceArgs.insecure = true;
+        args.sourceType = "solr";
+        args.snapshotName = "missing_fs_snapshot";
+        args.snapshotRepoName = "test";
+        args.repoUri = tempRepo.toString();
+        args.mode = "import";
+        args.solrCollections = List.of("branchcoll");
+        args.noWait = false;
+
+        var creator = new CreateSnapshot(args, snapshotContext.createSnapshotCreateContext());
+        var ex = Assertions.assertThrows(SolrBackupStrategy.SolrImportSnapshotUnavailable.class,
+            creator::run,
+            "IMPORT mode must throw when the filesystem snapshot directory is missing");
+        Assertions.assertTrue(ex.getMessage().contains("missing_fs_snapshot"),
+            "Exception should name the missing snapshot directory; got: " + ex.getMessage());
+    }
+
     // ── Helpers ──────────────────────────────────────────────────────────────
 
     private static String cloudSolrUrl() {
         return "http://" + CLOUD_SOLR.getHost() + ":" + CLOUD_SOLR.getMappedPort(8983);
+    }
+
+    /** Writes a benign object under the snapshot prefix so IMPORT's non-empty check passes. */
+    private void putSnapshotPlaceholder(String subpath, String snapshotName) {
+        try (var s3 = testS3Client()) {
+            s3.putObject(
+                PutObjectRequest.builder().bucket(BUCKET_NAME)
+                    .key(subpath + "/" + snapshotName + "/.import-placeholder").build(),
+                RequestBody.fromString("placeholder", StandardCharsets.UTF_8));
+        }
     }
 }


### PR DESCRIPTION
### Description
Fails an `IMPORT` when no data is found.

### Issues Resolved
Closes #3233

### Testing
Added tests.

### Check List
- [ ] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
