### PR TITLE
Fixing Kiro CLI download

### DIFF
--- a/bootstrap-kiro-agent.sh
+++ b/bootstrap-kiro-agent.sh
@@ -56,17 +56,10 @@ info "helm $(helm version --short)"
 
 # --- 2. Install kiro-cli (if missing) ---
 if ! command -v kiro-cli &>/dev/null; then
-  ARCH=$(uname -m)
-  OS=$(uname -s | tr '[:upper:]' '[:lower:]')
-  case "$ARCH" in
-    x86_64|amd64) ARCH="x64" ;;
-    aarch64|arm64) ARCH="arm64" ;;
-    *) error "Unsupported architecture: $ARCH"; exit 1 ;;
-  esac
-  KIRO_URL="https://kiro.dev/downloads/latest/${OS}/${ARCH}/kiro-cli"
-  info "Installing kiro-cli from ${KIRO_URL}..."
-  sudo curl -fsSL "$KIRO_URL" -o /usr/local/bin/kiro-cli
-  sudo chmod +x /usr/local/bin/kiro-cli
+  info "Installing kiro-cli from https://cli.kiro.dev/install..."
+  curl -fsSL https://cli.kiro.dev/install | bash
+  # The installer places kiro-cli in ~/.local/bin, which may not yet be on PATH.
+  export PATH="$HOME/.local/bin:$PATH"
 fi
 info "kiro-cli $(kiro-cli --version 2>&1 || echo 'installed')"
 


### PR DESCRIPTION
### Description
Fixes Kiro CLI download, and removes need for sudo by putting the kiro CLI in `$HOME/.local/bin`.

### Issues Resolved
Closes #2934 

### Testing
Manual testing of script.

### Check List
- [ ] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
