### PR TITLE
Log only the count of existing secrets and not their names

### DIFF
--- a/migrationConsole/lib/console_link/console_link/workflow/commands/secret_utils.py
+++ b/migrationConsole/lib/console_link/console_link/workflow/commands/secret_utils.py
@@ -95,7 +95,8 @@ def _notify_existing_secrets(existing, interactive: bool) -> None:
     if interactive:
         click.echo(msg)
     else:
-        logger.info(msg)
+        # Log only the count to keep names out of server logs.
+        logger.info("Found %d existing secret(s) for HTTP-Basic authentication of requests to clusters", len(existing))
 
 
 def _handle_missing_config_secrets(secret_store: SecretStore, missing, interactive: bool) -> None:

--- a/migrationConsole/lib/console_link/tests/workflow-tests/test_secret_utils.py
+++ b/migrationConsole/lib/console_link/tests/workflow-tests/test_secret_utils.py
@@ -1,0 +1,29 @@
+import logging
+
+from console_link.workflow.commands.secret_utils import _notify_existing_secrets
+
+
+class TestNotifyExistingSecrets:
+    def test_non_interactive_logs_only_count_not_names(self, caplog):
+        existing = ["cluster-a-basic-creds", "cluster-b-basic-creds"]
+        with caplog.at_level(logging.INFO):
+            _notify_existing_secrets(existing, interactive=False)
+
+        records = [r.getMessage() for r in caplog.records]
+        assert any("2 existing secret(s)" in m for m in records)
+        # The security fix: secret names must never reach the (server) logs.
+        for name in existing:
+            assert all(name not in m for m in records)
+
+    def test_interactive_echoes_names(self, capsys):
+        existing = ["cluster-a-basic-creds"]
+        _notify_existing_secrets(existing, interactive=True)
+
+        out = capsys.readouterr().out
+        assert "cluster-a-basic-creds" in out
+
+    def test_empty_existing_logs_nothing(self, caplog):
+        with caplog.at_level(logging.INFO):
+            _notify_existing_secrets([], interactive=False)
+
+        assert caplog.records == []


### PR DESCRIPTION
### Description
Changes logging to not log secret names.

See https://github.com/opensearch-project/opensearch-migrations/security/code-scanning/97.

### Issues Resolved
Closes #3238 

### Check List
- [ ] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
