### PR TITLE
Adding failed document stream (DLQ) docs

### DIFF
--- a/docs/failedDocumentStream.md
+++ b/docs/failedDocumentStream.md
@@ -1,0 +1,76 @@
+# Failed Document Stream
+
+During a Reindex-from-Snapshot (RFS) backfill, most document errors are retried automatically. Failures that
+are terminal — non-retryable, or retried until the limit was exhausted — are written to a durable
+failed document stream in S3 so you can see exactly which documents did not reach the target, and why.
+Documents that eventually succeed are never written here.
+
+The stream is at-least-once. An RFS work item is not marked complete until its failure records are durably
+flushed, so a crash causes a successor to re-emit the same failures. The console de-duplicates on read by
+`(targetIndex, documentId)`, so counts reflect *distinct* failed documents.
+
+Records are stored as gzip-compressed NDJSON under a per-backfill prefix.
+
+```
+s3://<bucket>/<prefix>/session=<SnapshotMigration-UID>/*.ndjson.gz
+```
+
+## Inspecting from the Migration Console
+
+Run these from a Migration Console shell. When more than one `SnapshotMigration` exists, add
+`--migration <name>` to choose one.
+
+```
+# S3 location for the current session
+console failed-document-stream location
+
+# Count of distinct failed documents
+console failed-document-stream count
+
+# List failures (columns: timestamp, targetIndex, documentId, failureClass, failureType)
+console failed-document-stream list --limit 100
+
+# Full records as JSON, including the original request and OpenSearch response
+console --json failed-document-stream list --limit 100
+```
+
+A deep status check also appends a failed-document summary.
+
+```
+console backfill status --deep-check
+```
+
+In JSON mode (`console --json backfill status --deep-check`) it adds `failed_document_stream_location` and
+`failed_document_count` (the latter is `null` if currently unavailable).
+
+Each record includes the target index, document id, the OpenSearch `failureType` (e.g.
+`mapper_parsing_exception`), and the original document (`requestItem`) — enough to diagnose or re-submit a
+failure without returning to the source cluster.
+
+## Deleting records
+
+`backfill reset` archives the working state and, by default, preserves the failed document stream. To
+also delete the records for the current session (irreversible), add `--include-failed-document-stream`.
+Add `--yes` to skip the confirmation prompt.
+
+```
+console backfill reset --include-failed-document-stream
+```
+
+## Configuration
+
+The failed document stream is enabled by default. When you omit `failedDocumentStreamS3Bucket`, it falls
+back to the deployment's default S3 bucket (from `migrations-default-s3-config`). AWS deployments always
+provision that default bucket, so the stream is effectively always on there. It is disabled only when no
+bucket resolves at all, which happens on a non-AWS deployment that provisions no default bucket and where
+no `failedDocumentStreamS3Bucket` was set. In that case the console commands report that it is not
+configured. The destination is set under a migration's `documentBackfillConfig`, where all fields are
+optional.
+
+| Option                              | Default                        | Description                                                    |
+|-------------------------------------|--------------------------------|----------------------------------------------------------------|
+| `failedDocumentStreamS3Bucket`      | deployment default bucket      | Bucket for records; set to use a separate one.                 |
+| `failedDocumentStreamS3Prefix`      | `rfs-failed-document-stream/`  | Key prefix; each run writes under `<prefix>/session=<uid>/`.   |
+| `failedDocumentStreamS3Region`      | resolved by config processor   | Region for the bucket.                                         |
+| `failedDocumentStreamS3Endpoint`    | resolved by config processor   | Endpoint override (e.g. LocalStack).                           |
+| `failedDocumentStreamMaxBufferBytes`| `67108864` (64 MiB)            | Max in-memory bytes per index before rotating to a new object. |

--- a/docs/failedDocumentStream.md
+++ b/docs/failedDocumentStream.md
@@ -1,9 +1,9 @@
 # Failed Document Stream
 
 During a Reindex-from-Snapshot (RFS) backfill, most document errors are retried automatically. Failures that
-are terminal — non-retryable, or retried until the limit was exhausted — are written to a durable
-failed document stream in S3 so you can see exactly which documents did not reach the target, and why.
-Documents that eventually succeed are never written here.
+are terminal — non-retryable, or retried until the limit was exhausted — are written to a failed document
+stream, which is durably persisted to S3. From it you can see exactly which documents did not reach the
+target, and why. Documents that eventually succeed are never written here.
 
 The stream is at-least-once. An RFS work item is not marked complete until its failure records are durably
 flushed, so a crash causes a successor to re-emit the same failures. The console de-duplicates on read by
@@ -34,14 +34,56 @@ console failed-document-stream list --limit 100
 console --json failed-document-stream list --limit 100
 ```
 
-A deep status check also appends a failed-document summary.
+A deep status check also appends a failed-document summary. The last two lines are the failed document
+stream; everything above them is the usual backfill status.
 
 ```
 console backfill status --deep-check
 ```
 
+```
+BackfillStatus.STOPPED
+Pods - Running: 0, Pending: 0, Desired: 0
+Backfill status: Completed
+Start time: 2026-07-21 14:02:11
+Finished time: 2026-07-21 15:38:47
+Percent completed: 100.0%
+Estimated time to completion: N/A
+Total shards: 40
+Completed shards: 40
+In progress shards: 0
+Waiting shards: 0
+failed document stream location: s3://my-bucket/rfs-failed-document-stream/session=abc-123/
+Failed document count: 4
+```
+
+The first line reports the worker *deployment* state, so a finished backfill shows `STOPPED` there (no
+workers running) while `Backfill status:` below it reports *shard* progress as `Completed`. The second line
+is deployment-specific: the example is a Kubernetes deployment, whereas on ECS it reads
+`Running=0 Pending=0 Desired=0 Terminating=0`.
+
+If the stream is not configured, both failed-document lines are omitted. If the count cannot be read (for
+example, missing S3 permissions), it renders as `Failed document count: unavailable`.
+
 In JSON mode (`console --json backfill status --deep-check`) it adds `failed_document_stream_location` and
-`failed_document_count` (the latter is `null` if currently unavailable).
+`failed_document_count` (the latter is `null` if currently unavailable). The command emits a single line;
+it is pretty-printed here for readability.
+
+```json
+{
+  "status": "Completed",
+  "percentage_completed": 100.0,
+  "eta_ms": null,
+  "started": "2026-07-21T14:02:11",
+  "finished": "2026-07-21T15:38:47",
+  "shard_total": 40,
+  "shard_complete": 40,
+  "shard_in_progress": 0,
+  "shard_waiting": 0,
+  "failed_document_stream_location": "s3://my-bucket/rfs-failed-document-stream/session=abc-123/",
+  "failed_document_count": 4
+}
+```
 
 Each record includes the target index, document id, the OpenSearch `failureType` (e.g.
 `mapper_parsing_exception`), and the original document (`requestItem`) — enough to diagnose or re-submit a

--- a/docs/migration-console.md
+++ b/docs/migration-console.md
@@ -44,7 +44,7 @@ In a migration with replayer components deployed, the Migration Console has some
 
 The Reindex-From-Snapshot and Replayer services are deployed (if enabled) by the CDK scripts to ECS, in the same cluster as the Migration Console, or by the `docker-compose.yml` as Docker containers. In the AWS deployment, the Migration Console does not directly interact with either of these services. Instead, it uses the AWS API to manipulate them at the control-plane level by changing the number of desired services to disable, enable, and scale the services.
 
-Documents that fail terminally during a Reindex-from-Snapshot backfill are written to a durable failed document stream in S3, which you can inspect and manage from the Migration Console. See [Failed Document Stream](failedDocumentStream.md).
+Documents that fail terminally during a Reindex-from-Snapshot backfill are written to a failed document stream, which is durably persisted to S3. You can inspect it from the Migration Console. See [Failed Document Stream](failedDocumentStream.md).
 
 #### Shared Logs Volume
 

--- a/docs/migration-console.md
+++ b/docs/migration-console.md
@@ -44,6 +44,8 @@ In a migration with replayer components deployed, the Migration Console has some
 
 The Reindex-From-Snapshot and Replayer services are deployed (if enabled) by the CDK scripts to ECS, in the same cluster as the Migration Console, or by the `docker-compose.yml` as Docker containers. In the AWS deployment, the Migration Console does not directly interact with either of these services. Instead, it uses the AWS API to manipulate them at the control-plane level by changing the number of desired services to disable, enable, and scale the services.
 
+Documents that fail terminally during a Reindex-from-Snapshot backfill are written to a durable failed document stream in S3, which you can inspect and manage from the Migration Console. See [Failed Document Stream](failedDocumentStream.md).
+
 #### Shared Logs Volume
 
 In an AWS deployment, the Shared Logs Volume is an EFS volume that's mounted to the Migration Console task, as well as the Replayer task (if deployed).  In a Docker deployment, it's a shared volume between those containers. In both cases, logs are written to the volume from the Replayer (in the form of tuples) and processes on the Migration Console (specifically Metadata Migration). These logs can be accessed directly by the user (e.g. with shell commands `ls`, `cat`, `jq`, etc.) or, in the case of tuples, manipulated using Migration Console CLI commands.


### PR DESCRIPTION
### Description
Adds docs for the failed document stream (DLQ).

### Issues Resolved
Closes #3250 

### Testing
N/A

### Check List
- [ ] New functionality includes testing
- [X] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
