### PR TITLE
Route GKE workload logs to Cloud Logging; fix GCP Terraform docs

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -318,6 +318,19 @@ jobs:
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
+  gcp-terraform-test:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
+        with:
+          terraform_wrapper: false
+      - name: terraform test (GCP module)
+        # Plan-time tests only; no cloud credentials required.
+        working-directory: deployment/terraform/gcp
+        run: |
+          terraform init -backend=false
+          terraform test
 
   codeql-analyze:
     name: CodeQL (${{ matrix.language }})
@@ -462,6 +475,7 @@ jobs:
       - gradle-build-macos
       - codeql-analyze
       - sonarqube-analysis
+      - gcp-terraform-test
     if: always()
     runs-on: ubuntu-22.04
     steps:

--- a/buildImages/build.gradle
+++ b/buildImages/build.gradle
@@ -103,7 +103,8 @@ def buildKitProjects = [
                 imageName:  "migration_console_base",
                 buildArgs: [
                         BASE_IMAGE: RegistryImageBuildUtils.resolveBaseImageForContainer(
-                                intermediateRegistry, "migrations", "elasticsearch_test_console", "latest")
+                                intermediateRegistry, "migrations", "elasticsearch_test_console", "latest"),
+                        KAFKA_IMAGE: ptc.rewrite("docker.io/apache/kafka:3.9.2")
                 ],
                 requiredDependencies: [
                         ":migrationConsole:syncDockerBuildContext",

--- a/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/templates/resources/gcp/gcpMetadata.yaml
+++ b/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/templates/resources/gcp/gcpMetadata.yaml
@@ -1,0 +1,13 @@
+{{- if eq .Values.cloudProvider "gcp" }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: gcp-metadata
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-1" # Make accessible earlier for charts that mount
+data:
+  CLUSTER_NAME: {{ required "Missing required value: .Values.gcp.clusterName" .Values.gcp.clusterName | quote }}
+  CLUSTER_LOCATION: {{ required "Missing required value: .Values.gcp.clusterLocation" .Values.gcp.clusterLocation | quote }}
+{{- end }}

--- a/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/values.yaml
+++ b/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/values.yaml
@@ -72,6 +72,11 @@ cloudProvider: ""
 gcp:
   project: ""
   serviceAccountEmail: ""
+  # GKE cluster name and location, used by the fluent-bit stackdriver output to
+  # tag Cloud Logging entries with the correct k8s_container resource. Populated
+  # from Terraform on GKE; empty elsewhere.
+  clusterName: ""
+  clusterLocation: ""
 
 # EKS cluster configuration for Karpenter NodeClass
 cluster:

--- a/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/valuesGke.yaml
+++ b/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/valuesGke.yaml
@@ -6,6 +6,10 @@ cloudProvider: gcp
 gcp:
   project: ""
   serviceAccountEmail: ""
+  # Populated by Terraform (helm_release set block); required by the fluent-bit
+  # stackdriver output below.
+  clusterName: ""
+  clusterLocation: ""
 
 logs:
   sharedLogsVolume:
@@ -27,15 +31,46 @@ charts:
           keyFormat: 'argo-artifacts/{{ "{{workflow.name}}" }}/{{ "{{pod.name}}" }}'
   fluent-bit:
     values:
+      env:
+        - name: GKE_CLUSTER_NAME
+          valueFrom:
+            configMapKeyRef:
+              name: gcp-metadata
+              key: CLUSTER_NAME
+        - name: GKE_CLUSTER_LOCATION
+          valueFrom:
+            configMapKeyRef:
+              name: gcp-metadata
+              key: CLUSTER_LOCATION
       extraVolumes:
-        - name: logs-pv
-          emptyDir: {}
         - name: lua-scripts
           configMap:
             name: fluentbit-lua-scripts
       extraVolumeMounts:
-        - name: logs-pv
-          mountPath: /shared_logs
         - name: lua-scripts
           mountPath: /fluentbit/scripts
           readOnly: true
+      config:
+        # Ship workload logs to Google Cloud Logging. Auth is via Workload
+        # Identity / ADC (the metadata server) — no credential files; project_id
+        # auto-detects from the metadata server.
+        #
+        # Resource_Labels must carry ALL k8s_container labels (except project_id):
+        # once set, it becomes the plugin's exclusive label source, so cluster
+        # name/location must be supplied here too — not via K8s_Cluster_Name/
+        # _Location, which the plugin ignores when Resource_Labels is present.
+        # An incomplete Resource_Labels set makes the plugin fall back to
+        # tag-based extraction, which fails because the base pipeline rewrites
+        # tags to `fluentbit-<pod>` (not the `k8s_container.` prefix the plugin
+        # expects) and drops the record. namespace/pod/container come from the
+        # flattened fields the shared base `modify` filter produces (it renames
+        # namespace_name->namespace, pod_name->pod, container_name->container).
+        # severity_key maps the `level` field emitted by the parsers
+        # (java_log_parser / logfmt) to Cloud Logging severity.
+        outputs: |
+          [OUTPUT]
+              Name                  stackdriver
+              Match                 fluentbit-*
+              Resource              k8s_container
+              Resource_Labels       location=${GKE_CLUSTER_LOCATION},cluster_name=${GKE_CLUSTER_NAME},namespace_name=$namespace,pod_name=$pod,container_name=$container
+              severity_key          level

--- a/deployment/terraform/gcp/README.md
+++ b/deployment/terraform/gcp/README.md
@@ -4,7 +4,7 @@ Provisions GCP infrastructure for the OpenSearch Migration Assistant.
 
 ## Prerequisites
 
-- [Terraform](https://developer.hashicorp.com/terraform/install) >= 1.6 (native `terraform test` is used for validation)
+- [Terraform](https://developer.hashicorp.com/terraform/install) >= 1.6 or [OpenTofu](https://opentofu.org/docs/intro/install/) >= 1.6 (native `terraform test` / `tofu test` is used for validation)
 - [gcloud CLI](https://cloud.google.com/sdk/docs/install) authenticated with `gcloud auth application-default login`
 - GCP project with billing enabled
 - Required APIs enabled:
@@ -42,8 +42,7 @@ terraform plan -var="project=my-project"
 
 # Apply
 terraform apply -var="project=my-project" \
-  -var="region=us-central1" \
-  -var="cluster_type=standard"
+  -var="region=us-central1"
 
 # Get kubeconfig (cluster name is dynamically generated)
 gcloud container clusters get-credentials $(terraform output -raw cluster_name) \
@@ -65,11 +64,8 @@ terraform destroy -var="project=my-project"
 |------|---------|-------------|
 | `project` | (required) | GCP project ID |
 | `region` | `us-central1` | GCP region |
-| `cluster_type` | `standard` | `standard` or `autopilot` |
-| `cluster_name` | `migration-cluster` | GKE cluster name |
-| `node_machine_type` | `e2-standard-4` | Node machine type (standard only) |
-| `node_count` | `2` | Initial nodes per zone (standard only) |
-| `bucket_name` | `migration-snapshots-<project>` | Snapshot storage bucket |
+| `node_machine_type` | `e2-standard-4` | Node machine type |
+| `node_count` | `2` | Initial nodes per zone |
 | `create_vpc` | `true` | Create new VPC, or use existing (`false`) |
 | `existing_vpc_name` | `null` | Existing VPC name (when `create_vpc = false`) |
 | `existing_subnet_name` | `null` | Existing subnet name (when `create_vpc = false`) |
@@ -88,13 +84,62 @@ terraform destroy -var="project=my-project"
 | `release_channel` | `REGULAR` | GKE release channel |
 | `allowed_ingress_ports` | `["443","9200","9300"]` | Allowed ingress TCP ports |
 | `allowed_ingress_cidrs` | `["0.0.0.0/0"]` | Allowed ingress source CIDRs |
-| `node_iam_roles` | `["roles/storage.admin"]` | IAM roles for the node SA |
+| `node_iam_roles` | `["roles/storage.admin","roles/artifactregistry.reader","roles/logging.logWriter"]` | IAM roles for the node SA |
 | `workload_identity_namespace` | `migration` | Kubernetes namespace containing Migration Assistant service accounts |
 | `additional_workload_identity_service_accounts` | `["migration-console-access-role","argo-workflow-executor","argo-workflow-controller","argo-controller"]` | Additional Kubernetes service accounts that can use the GCP migration service account |
 | `source_connectivity` | `{mode = "none"}` | Private connectivity for source cluster read traffic; `mode = "none"` (default, public internet), `"psc_consumer"` (Private Service Connect), or `"vpc_peering"` |
 | `target_connectivity` | `{mode = "none"}` | Private connectivity for target cluster write traffic; same modes as `source_connectivity` |
 | `gcs_connectivity` | `{mode = "private_google_access"}` | Private Google Access for Cloud Storage snapshot traffic; `mode = "private_google_access"` (default, private path) or `"none"` (public internet) |
 | `enable_private_endpoint` | `false` | Restrict GKE control plane to private IP only (no public endpoint); requires VPN or bastion for kubectl access |
+
+## Observability
+
+### Logs
+
+Workload logs (migration console, capture proxy, traffic replayer, RFS workers,
+and Argo workflow steps) are shipped to **Google Cloud Logging** by the bundled
+fluent-bit collector. No extra setup is required: fluent-bit authenticates via
+Workload Identity, and this module grants the node service account
+`roles/logging.logWriter` and passes the cluster name and location the collector
+needs.
+
+View logs in the Cloud Logging console, or with `gcloud`:
+
+```bash
+# All migration workload logs in the ma namespace
+gcloud logging read \
+  'resource.type="k8s_container" resource.labels.namespace_name="ma"' \
+  --project my-project --limit 50
+
+# A single workload (e.g. the migration console)
+gcloud logging read \
+  'resource.type="k8s_container" resource.labels.namespace_name="ma"
+   resource.labels.container_name="console"' \
+  --project my-project --limit 50
+```
+
+Filter by `resource.labels.pod_name` or `resource.labels.container_name` to
+narrow to a specific workload.
+
+Log severity is derived from each entry's `level` field, so you can filter by
+`severity>=WARNING` in Cloud Logging.
+
+### Metrics and dashboards
+
+The chart deploys Prometheus by default and the migration workloads export
+metrics to it, so metrics are collected out of the box. A pre-built migration
+dashboard also ships with the chart, but the in-cluster **Grafana** that renders
+it is **off by default** — many operators already run their own dashboarding
+stack and point it at the migration metrics.
+
+If you do not already have a dashboarding solution, enable the bundled Grafana
+to get the migration dashboard preloaded:
+
+```yaml
+# valuesGke.yaml (or --set at install time)
+conditionalPackageInstalls:
+  grafana: true
+```
 
 ## Private networking
 
@@ -104,9 +149,16 @@ private Cloud Storage access, and a private control plane), see
 
 ## Notes
 
-- Standard clusters use private nodes with Cloud NAT for outbound access.
+- The cluster runs in GKE Standard mode with private nodes and Cloud NAT for
+  outbound access. The cluster name is generated as `os-migration-<random>`;
+  retrieve it with `terraform output -raw cluster_name`.
+- The snapshot bucket name is generated (`os-migration-<random>`, matching the
+  cluster name) and is not operator-settable. Retrieve it with
+  `terraform output` or from the `google_storage_bucket.migration_snapshots`
+  resource.
 - Workload Identity is enabled and bound to `migration/migrations-service-account`.
-- The node SA gets `roles/storage.admin` for GCS snapshot access.
+- The node SA gets `roles/storage.admin` for GCS snapshot access and
+  `roles/logging.logWriter` so fluent-bit can ship logs to Cloud Logging.
 
 ## Zone Placement
 
@@ -170,9 +222,11 @@ If you have a snapshot directory on local disk (for example, the bundled
 bucket under a path of your choice:
 
 ```bash
+# <bucket> is the generated snapshot bucket name (terraform output -raw cluster_name,
+# or the name of the google_storage_bucket.migration_snapshots resource).
 gsutil -m cp -r \
   RFS/test-resources/snapshots/ES_7_10_Single \
-  gs://migration-snapshots-<project>/e2e-test/
+  gs://<bucket>/e2e-test/
 ```
 
 The path you upload to becomes the `gcsRepoPathUri` you reference from the
@@ -189,7 +243,7 @@ as a workflow parameter to use the GCS bucket instead of the default S3 one.
 To switch it from "create-and-migrate" to BYOS, set:
 
 - `source.snapshotRepo.repoPathUri` to the GCS URI you staged
-  (`gs://migration-snapshots-<project>/e2e-test`).
+  (`gs://<bucket>/e2e-test`).
 - `snapshotConfig.snapshotNameConfig.externallyManagedSnapshotName` to the
   name of the snapshot inside that repo (for the bundled test snapshot, this
   is `rfs-snapshot`).

--- a/deployment/terraform/gcp/main.tf
+++ b/deployment/terraform/gcp/main.tf
@@ -377,6 +377,16 @@ resource "helm_release" "migration_assistant" {
       name  = "gcp.serviceAccountEmail"
       value = google_service_account.migration_nodes.email
     },
+    # Cluster name/location are required by the fluent-bit stackdriver output
+    # (k8s_container resource) so Cloud Logging entries carry the right resource.
+    {
+      name  = "gcp.clusterName"
+      value = local.cluster_name
+    },
+    {
+      name  = "gcp.clusterLocation"
+      value = local.cluster_location
+    },
     {
       name  = "gcsBucketConfiguration.bucketName"
       value = google_storage_bucket.migration_snapshots.name

--- a/deployment/terraform/gcp/tests/connectivity.tftest.hcl
+++ b/deployment/terraform/gcp/tests/connectivity.tftest.hcl
@@ -3,6 +3,10 @@
 
 variables {
   project = "test-project"
+  # Dummy token so the google provider skips Application Default Credentials
+  # lookup — these are plan-only tests and must run without cloud credentials
+  # (e.g. in CI).
+  access_token = "test-token-not-used"
 }
 
 # Mock the data source to avoid GCP API calls during testing

--- a/deployment/terraform/gcp/tests/observability.tftest.hcl
+++ b/deployment/terraform/gcp/tests/observability.tftest.hcl
@@ -1,0 +1,75 @@
+# Plan-time tests for the observability wiring (Cloud Logging).
+# No cloud credentials required: command = plan only.
+# Run from deployment/terraform/gcp/ with: terraform test
+#
+# Guards the logging changes against silent breakage in future edits or a
+# TF/provider version bump:
+#   - the node service account keeps roles/logging.logWriter (fluent-bit ships
+#     workload logs to Cloud Logging via Workload Identity)
+#   - the GKE cluster name/location are passed to the Helm release so the
+#     fluent-bit stackdriver output can tag the k8s_container resource
+
+variables {
+  project = "test-project"
+  # Dummy token so the google provider skips Application Default Credentials
+  # lookup — these are plan-only tests and must run without cloud credentials
+  # (e.g. in CI).
+  access_token = "test-token-not-used"
+}
+
+# Mock the zones data source to avoid GCP API calls during testing.
+override_data {
+  target = data.google_compute_zones.available
+  values = {
+    names = ["us-central1-a", "us-central1-b"]
+  }
+}
+
+run "node_sa_has_log_writer_by_default" {
+  command = plan
+
+  assert {
+    condition     = contains(var.node_iam_roles, "roles/logging.logWriter")
+    error_message = "node_iam_roles must include roles/logging.logWriter so fluent-bit can write to Cloud Logging."
+  }
+
+  # The role must actually be bound to the node SA, not just present in the list.
+  assert {
+    condition = anytrue([
+      for m in google_project_iam_member.node_iam_roles :
+      m.role == "roles/logging.logWriter"
+    ])
+    error_message = "A google_project_iam_member granting roles/logging.logWriter to the node SA must be planned."
+  }
+}
+
+run "one_iam_binding_per_configured_role" {
+  command = plan
+
+  # One google_project_iam_member is planned per node_iam_roles entry (so the
+  # logging.logWriter grant added for Cloud Logging is actually bound, not
+  # dropped by a future refactor of the count/for_each wiring).
+  assert {
+    condition     = length(google_project_iam_member.node_iam_roles) == length(var.node_iam_roles)
+    error_message = "Expected one node IAM binding per role in node_iam_roles."
+  }
+}
+
+run "cluster_name_and_location_passed_to_helm_release" {
+  command = plan
+
+  # The fluent-bit stackdriver output needs the cluster name + location for the
+  # k8s_container resource; Terraform threads them into the Helm release.
+  assert {
+    condition = anytrue([
+      for s in helm_release.migration_assistant.set : s.name == "gcp.clusterName"
+    ])
+    error_message = "helm_release must set gcp.clusterName so the stackdriver output can tag logs with the cluster."
+  }
+  assert {
+    condition = anytrue([
+      for s in helm_release.migration_assistant.set : s.name == "gcp.clusterLocation"
+    ])
+    error_message = "helm_release must set gcp.clusterLocation so the stackdriver output can tag logs with the location."
+  }
+}

--- a/deployment/terraform/gcp/variables.tf
+++ b/deployment/terraform/gcp/variables.tf
@@ -192,7 +192,9 @@ variable "allowed_ingress_cidrs" {
 variable "node_iam_roles" {
   description = "GCP IAM roles granted to the GKE node service account"
   type        = list(string)
-  default     = ["roles/storage.admin", "roles/artifactregistry.reader"]
+  # logging.logWriter lets fluent-bit ship workload logs to Cloud Logging via
+  # Workload Identity (see the fluent-bit stackdriver output in valuesGke.yaml).
+  default = ["roles/storage.admin", "roles/artifactregistry.reader", "roles/logging.logWriter"]
 }
 
 variable "workload_identity_namespace" {

--- a/migrationConsole/Dockerfile
+++ b/migrationConsole/Dockerfile
@@ -1,4 +1,13 @@
 ARG BASE_IMAGE=migrations/elasticsearch_client_test_console:latest
+# Pinned Kafka image the tools are copied from. Declared in the global scope so it
+# can be used in a FROM below; BuildKit forbids variable expansion in COPY --from,
+# so we alias the image as a named stage and copy from that. Overridden by the
+# build to the cache-rewritten ref; see buildImages/build.gradle.
+ARG KAFKA_IMAGE="docker.io/apache/kafka:3.9.2"
+
+# Kafka tools source: alias the pinned image as a stage so COPY --from can
+# reference it by a literal stage name.
+FROM ${KAFKA_IMAGE} AS kafka-dist
 
 # Stage 1: Download and install tools (kafka, kubectl, helm)
 FROM ${BASE_IMAGE} AS migration-console-tools
@@ -12,19 +21,15 @@ RUN ARCH=$(uname -m | sed 's/x86_64/amd64/; s/aarch64/arm64/') && \
 
 ARG HELM_VERSION="3.14.0"
 ARG KUBECTL_VERSION="1.32.1"
-ARG KAFKA_VERSION="3.9.2"
 ARG STERN_VERSION="1.33.1"
 
-# Get kafka distribution and unpack to 'kafka'
-RUN mkdir -p /root/kafka-tools/kafka && \
-    url_cdn="https://dlcdn.apache.org/kafka/${KAFKA_VERSION}/kafka_2.13-${KAFKA_VERSION}.tgz" && \
-    url_archive="https://archive.apache.org/dist/kafka/${KAFKA_VERSION}/kafka_2.13-${KAFKA_VERSION}.tgz" && \
-    curl --retry 2 --retry-delay 5 --retry-connrefused -fSL "$url_cdn" -o /tmp/kafka.tgz || \
-        curl --retry 5 --retry-delay 5 --retry-connrefused -fSL "$url_archive" -o /tmp/kafka.tgz && \
-    tar -xzf /tmp/kafka.tgz -C /root/kafka-tools/kafka --strip-components=1 && \
-    rm -f /tmp/kafka.tgz && \
-    mkdir -p /root/kafka-tools/aws && \
-    curl --retry 5 --retry-delay 5 --retry-connrefused -fSL \
+# Kafka distribution: copy the tools tree from the pinned kafka-dist stage
+# (deterministic, no Apache-mirror download/retry), then drop in the AWS MSK IAM
+# auth jar (single fetch, no retries — a failure fails the build so it can be
+# re-run against the layer cache rather than silently varying).
+COPY --from=kafka-dist /opt/kafka /root/kafka-tools/kafka
+RUN mkdir -p /root/kafka-tools/aws && \
+    curl -fSL \
         https://github.com/aws/aws-msk-iam-auth/releases/download/v2.3.4/aws-msk-iam-auth-2.3.4-all.jar \
         -o /root/kafka-tools/kafka/libs/msk-iam-auth.jar
 


### PR DESCRIPTION
## Description

Ships migration workload logs from GKE deployments to Google Cloud Logging, and
corrects drift in the GCP Terraform README.

### Logging (functional change)
- Adds a fluent-bit `stackdriver` output for the GKE values path, so workload
  logs (migration console, RFS/backfill workers, Argo workflow steps, and — for
  live migrations — capture proxy and traffic replayer) reach Google Cloud
  Logging. Authentication uses Workload Identity / ADC (no credential files).
- Grants the node service account `roles/logging.logWriter`.
- Adds a `gcp-metadata` ConfigMap carrying the cluster name and location the
  `k8s_container` resource requires, threaded from Terraform.
- Cloud Logging entries carry full resource labels (cluster, location,
  namespace, pod, container) and mapped severity, queryable per workload.

### Docs (README corrections)
- Removes documented Terraform variables that don't exist in the module
  (`cluster_type`/Autopilot, `bucket_name`, `cluster_name`) — the module is GKE
  Standard only and generates the bucket/cluster name as `os-migration-<random>`.
- Fixes stale `migration-snapshots-<project>` bucket paths in the Bring Your Own
  Snapshot section.
- Documents the observability behavior (logs shipped automatically; the bundled
  Grafana dashboard is opt-in via `conditionalPackageInstalls.grafana`).
- Widens the Terraform prerequisite to allow OpenTofu >= 1.6.

## Testing
- Validated end-to-end on a real GKE migration (backfill/RFS): workload logs land
  in Cloud Logging with correct resource labels and severity; zero collector
  errors. Backfill-only — capture proxy / traffic replayer use the same proven
  fluent-bit path but were not exercised by a live capture-and-replay run.
- `helm template` renders the GKE path; `terraform validate` passes.
