### PR TITLE
Split checks from MigrationResources and ConfigProcessor tasks

### DIFF
--- a/migrationConsole/build.gradle
+++ b/migrationConsole/build.gradle
@@ -26,40 +26,97 @@ def workflowTemplatesStagingP =
 def migrationResourcesStagingP =
         layout.buildDirectory.dir("dockerContext/nodeStaging/migrationResources")
 
+// Root-level tsconfig files that affect compilation
+def rootTsConfigFiles = [
+        orchestrationSpecsDirP.file("tsconfig.base.json"),
+        orchestrationSpecsDirP.file("tsconfig.json"),
+        orchestrationSpecsDirP.file("tsconfig.workspaces.json")
+]
+
+def configureWorkflowTemplateTask = { task ->
+    task.dependsOn installDependencies
+
+    // Source files
+    task.inputs.dir(workflowTemplatesP.dir("src"))
+    // Resource files embedded in templates
+    task.inputs.dir(workflowTemplatesP.dir("resources"))
+    // Dependency packages whose source affects template generation
+    task.inputs.dir(orchestrationSpecsDirP.dir("packages/argo-workflow-builders/src"))
+    task.inputs.dir(schemasP.dir("src"))
+
+    // Package-level config files
+    task.inputs.files(
+        workflowTemplatesP.file("package.json"),
+        workflowTemplatesP.file("tsconfig.json"),
+        workflowTemplatesP.file("makeTemplates.cjs")
+    )
+
+    task.inputs.files(rootTsConfigFiles)
+}
+
+def configureConfigProcessorTask = { task ->
+    task.dependsOn installDependencies
+
+    // Source files
+    task.inputs.dir(configProcessorP.dir("src"))
+    // Shell scripts copied into the config-processor bundle
+    task.inputs.dir(configProcessorP.dir("scripts"))
+
+    task.inputs.files(
+        // Build script
+        configProcessorP.file("makeBundle.js"),
+        // Package-level config files
+        configProcessorP.file("package.json"),
+        configProcessorP.file("tsconfig.json"),
+    )
+
+    task.inputs.files(
+        // Build script
+        configProcessorP.file("makeBundle.js"),
+        // Package-level config files
+        configProcessorP.file("package.json"),
+        configProcessorP.file("tsconfig.json"),
+    )
+
+    task.inputs.files(rootTsConfigFiles)
+}
+
 tasks.register('installDependencies', NpmTask) {
     description = 'Install npm dependencies for orchestrationSpecs'
     workingDir = orchestrationSpecsDirP.asFile
     args = ['ci', '--force']
 
-    inputs.file(orchestrationSpecsDirP.file("package.json"))
-    inputs.file(orchestrationSpecsDirP.file("package-lock.json"))
-    inputs.file(orchestrationSpecsDirP.file("tsconfig.base.json"))
-    inputs.file(orchestrationSpecsDirP.file("tsconfig.json"))
-    inputs.file(orchestrationSpecsDirP.file("tsconfig.workspaces.json"))
+    inputs.files(
+        orchestrationSpecsDirP.file("package.json"),
+        orchestrationSpecsDirP.file("package-lock.json"),
+        orchestrationSpecsDirP.file("tsconfig.base.json"),
+        orchestrationSpecsDirP.file("tsconfig.json"),
+        orchestrationSpecsDirP.file("tsconfig.workspaces.json"),
+    )
     outputs.dir(orchestrationSpecsDirP.dir("node_modules"))
+}
+
+tasks.register('typeCheckWorkflowTemplates', NpmTask) {
+    description = 'Check the workflow templates from their TypeScript definitions'
+    workingDir = workflowTemplatesP.asFile
+    args = ['run', 'type-check-all']
+    configureWorkflowTemplateTask(delegate)
+}
+
+tasks.register('testWorkflowTemplates', NpmTask) {
+    description = 'Check the workflow templates from their TypeScript definitions'
+    workingDir = workflowTemplatesP.asFile
+    args = ['run', 'test-all']
+
+    configureWorkflowTemplateTask(delegate)
 }
 
 tasks.register('makeAndStageWorkflowTemplates', NpmTask) {
     description = 'Build the workflow templates from their TypeScript definitions'
     workingDir = workflowTemplatesP.asFile
-    args = ['run', 'check-and-make-templates', '--', '--outputDirectory', workflowTemplatesStagingP.get().asFile.absolutePath]
-    dependsOn installDependencies
+    args = ['run', 'make-templates', '--', '--outputDirectory', workflowTemplatesStagingP.get().asFile.absolutePath]
 
-    // Source files
-    inputs.dir(workflowTemplatesP.dir("src"))
-    // Resource files embedded in templates
-    inputs.dir(workflowTemplatesP.dir("resources"))
-    // Dependency packages whose source affects template generation
-    inputs.dir(orchestrationSpecsDirP.dir("packages/argo-workflow-builders/src"))
-    inputs.dir(orchestrationSpecsDirP.dir("packages/schemas/src"))
-    // Package-level config files
-    inputs.file(workflowTemplatesP.file("package.json"))
-    inputs.file(workflowTemplatesP.file("tsconfig.json"))
-    inputs.file(workflowTemplatesP.file("makeTemplates.cjs"))
-    // Root-level tsconfig files that affect compilation
-    inputs.file(orchestrationSpecsDirP.file("tsconfig.base.json"))
-    inputs.file(orchestrationSpecsDirP.file("tsconfig.json"))
-    inputs.file(orchestrationSpecsDirP.file("tsconfig.workspaces.json"))
+    configureWorkflowTemplateTask(delegate)
     outputs.dir(workflowTemplatesStagingP)
 
     doFirst {
@@ -67,30 +124,40 @@ tasks.register('makeAndStageWorkflowTemplates', NpmTask) {
     }
 }
 
+tasks.register('typeCheckConfigProcessor', NpmTask) {
+    description = 'type-check the config-processor TypeScript package'
+    workingDir = configProcessorP.asFile
+    args = ['run', 'type-check']
+
+    configureConfigProcessorTask(delegate)
+}
+
+tasks.register('testConfigProcessor', NpmTask) {
+    description = 'Test the config-processor TypeScript package'
+    workingDir = configProcessorP.asFile
+    args = ['run', 'test']
+
+    configureConfigProcessorTask(delegate)
+}
+
 tasks.register('buildAndStageConfigProcessor', NpmTask) {
     description = 'Build and stage the config-processor TypeScript package directly to staging'
     workingDir = configProcessorP.asFile
-    args = ['run', 'check-and-bundle', '--', configProcessorStagingP.get().asFile.absolutePath]
-    dependsOn installDependencies
+    args = ['run', 'bundle', '--', configProcessorStagingP.get().asFile.absolutePath]
 
-    // Source files
-    inputs.dir(configProcessorP.dir("src"))
-    // Shell scripts copied into the config-processor bundle
-    inputs.dir(configProcessorP.dir("scripts"))
-    // Build script
-    inputs.file(configProcessorP.file("makeBundle.js"))
-    // Package-level config files
-    inputs.file(configProcessorP.file("package.json"))
-    inputs.file(configProcessorP.file("tsconfig.json"))
-    // Root-level tsconfig files that affect compilation
-    inputs.file(orchestrationSpecsDirP.file("tsconfig.base.json"))
-    inputs.file(orchestrationSpecsDirP.file("tsconfig.json"))
-    inputs.file(orchestrationSpecsDirP.file("tsconfig.workspaces.json"))
+    configureConfigProcessorTask(delegate)
     outputs.dir(configProcessorStagingP)
 
     doFirst {
         configProcessorStagingP.get().asFile.mkdirs()
     }
+}
+
+tasks.named("test") {
+    dependsOn("typeCheckWorkflowTemplates")
+    dependsOn("testWorkflowTemplates")
+    dependsOn("typeCheckConfigProcessor")
+    dependsOn("testConfigProcessor")
 }
 
 tasks.register('buildAndStageMigrationResources', NpmTask) {
@@ -100,12 +167,14 @@ tasks.register('buildAndStageMigrationResources', NpmTask) {
     dependsOn installDependencies
 
     inputs.dir(schemasP.dir("src"))
-    inputs.file(schemasP.file("package.json"))
-    inputs.file(orchestrationSpecsDirP.file("package.json"))
-    inputs.file(orchestrationSpecsDirP.file("package-lock.json"))
-    inputs.file(orchestrationSpecsDirP.file("tsconfig.base.json"))
-    inputs.file(orchestrationSpecsDirP.file("tsconfig.json"))
-    inputs.file(orchestrationSpecsDirP.file("tsconfig.workspaces.json"))
+    inputs.files(
+        schemasP.file("package.json"),
+        orchestrationSpecsDirP.file("package.json"),
+        orchestrationSpecsDirP.file("package-lock.json"),
+        orchestrationSpecsDirP.file("tsconfig.base.json"),
+        orchestrationSpecsDirP.file("tsconfig.json"),
+        orchestrationSpecsDirP.file("tsconfig.workspaces.json"),
+    )
     outputs.dir(migrationResourcesStagingP)
 
     doFirst {


### PR DESCRIPTION
### Description

During the deployment phase of the migration console, two tasks take significant amount of time, the `:migrationConsole:makeAndStageWorkflowTemplates` and `:migrationConsole:buildAndStageConfigProcessor`. These two tasks run `npm run check-and-make-templates` and `npm run check-and-bundle`. Both scripts run checks that take a significant amount of time in local deployments.

The PR extracts the type-checks and tests from the gradle tasks into separate tasks and adds them as dependencies to the `test` task, so that the checks are executed only during checks / tests.

The gradle task `:buildImages:buildImagesToRegistry` that is used across all deployment scripts takes in average about 10 min to complete on a machine (cold start / gradlew clean). By excluding the checks from the deployments and adding them solely to the test tasks in Gradle, the task average time can be reduced to about 7 min. Specifically,
- `:migrationConsole:makeAndStageWorkflowTemplates` is reduced from about 5min to about 14secs
- `:migrationConsole:buildAndStageConfigProcessor` is reduced from about 2min 30secs to about 8secs

Due to parallel execution this difference is not observable, but can be found in the attached profiles.

[profile-cold-launch-default.zip](https://github.com/user-attachments/files/30501559/profile-cold-launch-default.zip)
[profile-cold-optimized.zip](https://github.com/user-attachments/files/30501560/profile-cold-optimized.zip)

To test it yourself you may run with and without the changes the following tasks:

```bash
# Clear any cache
./gradlew clean

# After deploying a builder and a image registry, you may use for amd64 the entire image build task
./gradlew :buildImages:buildImagesToRegistry_amd64 -Pbuilder=builder-kind-ma -PregistryEndpoint=localhost:5001 -PlocalContainerRegistryEndpoint=docker-registry:5000 --profile

# or simply call the individual tasks (remember to clear cache inbetween to get reproducible times):
./gradlew :migrationConsole:makeAndStageWorkflowTemplates
./gradlew :migrationConsole:buildAndStageConfigProcessor
```

Note that consumers of these tasks previously executed the tests in various contexts. After a quick lookup, the consumers seemed to be only interested in the outcome, not the test execution. For the tests we have CI jobs that run `allTest`, where the type-checks and tests for these tasks are wired into.

### Issues Resolved

- Image build time optimization

### Testing

_Manual testing and profiling_

### Check List

- [ ] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
