### PR TITLE
Properly seed GHA's Gradle test Docker cache

### DIFF
--- a/.github/gradle-test-images/infrastructure.txt
+++ b/.github/gradle-test-images/infrastructure.txt
@@ -1,0 +1,15 @@
+# Service and helper images used by Gradle integration tests.
+# Format: canonical image|optional preferred pull source
+localstack/localstack:4.3.0|mirror.gcr.io/localstack/localstack:4.3.0
+localstack/localstack:3.4|mirror.gcr.io/localstack/localstack:3.4
+solr:6.6.0|mirror.gcr.io/library/solr:6.6.0
+solr:7.7.3|mirror.gcr.io/library/solr:7.7.3
+solr:8.10.1|mirror.gcr.io/library/solr:8.10.1
+solr:8.11.4|mirror.gcr.io/library/solr:8.11.4
+solr:9.8.1|mirror.gcr.io/library/solr:9.8.1
+confluentinc/cp-kafka:7.5.0|mirror.gcr.io/confluentinc/cp-kafka:7.5.0
+httpd:2.4.66-alpine|mirror.gcr.io/library/httpd:2.4.66-alpine
+testcontainers/ryuk:0.14.0|mirror.gcr.io/testcontainers/ryuk:0.14.0
+testcontainers/sshd:1.3.0|mirror.gcr.io/testcontainers/sshd:1.3.0
+alpine:3.17|mirror.gcr.io/library/alpine:3.17
+ghcr.io/shopify/toxiproxy:2.9.0|

--- a/.github/gradle-test-images/search.txt
+++ b/.github/gradle-test-images/search.txt
@@ -1,0 +1,10 @@
+# Search engine and base images used by Gradle integration tests.
+# Format: canonical image|optional preferred pull source
+opensearchproject/opensearch:1.3.20|mirror.gcr.io/opensearchproject/opensearch:1.3.20
+opensearchproject/opensearch:2.19.4|mirror.gcr.io/opensearchproject/opensearch:2.19.4
+opensearchproject/opensearch:3.5.0|mirror.gcr.io/opensearchproject/opensearch:3.5.0
+amazonlinux:2023|mirror.gcr.io/library/amazonlinux:2023
+amazoncorretto:8-alpine|mirror.gcr.io/library/amazoncorretto:8-alpine
+amazoncorretto:11-al2023-headless|mirror.gcr.io/library/amazoncorretto:11-al2023-headless
+amazoncorretto:17-al2023-headless|mirror.gcr.io/library/amazoncorretto:17-al2023-headless
+amazoncorretto:21-al2023-headless|mirror.gcr.io/library/amazoncorretto:21-al2023-headless

--- a/.github/scripts/seed-gradle-test-docker-cache.sh
+++ b/.github/scripts/seed-gradle-test-docker-cache.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+  echo "Usage: $0 <image-manifest> <cache-group>" >&2
+  exit 2
+fi
+
+manifest=$1
+cache_group=$2
+if [[ ! -f "$manifest" ]]; then
+  echo "Image manifest does not exist: $manifest" >&2
+  exit 2
+fi
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+# shellcheck source=../../deployment/k8s/charts/aggregates/migrationAssistantWithArgo/scripts/mirrorToEcr.sh
+source "$repo_root/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/scripts/mirrorToEcr.sh"
+
+pull_with_retries() {
+  local image=$1
+  local attempts=$2
+  local attempt
+
+  for ((attempt = 1; attempt <= attempts; attempt++)); do
+    if docker pull "$image"; then
+      return 0
+    fi
+
+    if ((attempt < attempts)); then
+      echo "Pull failed for $image (attempt $attempt/$attempts); retrying..." >&2
+      sleep $((attempt * 10))
+    fi
+  done
+
+  return 1
+}
+
+entries=$(manifest_section "$manifest" gradleTestImages)
+if [[ -z "$entries" ]]; then
+  echo "No gradleTestImages found in manifest: $manifest" >&2
+  exit 2
+fi
+
+matched=0
+while IFS='|' read -r entry_group canonical preferred extra; do
+  if [[ "$entry_group" != "$cache_group" ]]; then
+    continue
+  fi
+  matched=$((matched + 1))
+  if [[ -z "${canonical:-}" ]]; then
+    echo "Invalid gradleTestImages entry: missing canonical image" >&2
+    exit 2
+  fi
+  if [[ -n "${extra:-}" ]]; then
+    echo "Invalid gradleTestImages entry for $canonical" >&2
+    exit 2
+  fi
+  if docker image inspect "$canonical" >/dev/null 2>&1; then
+    echo "Image already available: $canonical"
+    continue
+  fi
+
+  if [[ -n "${preferred:-}" ]] && pull_with_retries "$preferred" 2; then
+    docker tag "$preferred" "$canonical"
+    continue
+  fi
+
+  if [[ -n "${preferred:-}" ]]; then
+    echo "Preferred source unavailable for $canonical; trying the canonical registry." >&2
+  fi
+  pull_with_retries "$canonical" 4
+done <<< "$entries"
+
+if [[ "$matched" -eq 0 ]]; then
+  echo "No gradleTestImages found for cache group: $cache_group" >&2
+  exit 2
+fi
+
+docker image list

--- a/.github/scripts/seed-gradle-test-docker-cache.sh
+++ b/.github/scripts/seed-gradle-test-docker-cache.sh
@@ -1,21 +1,16 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if [[ $# -ne 2 ]]; then
-  echo "Usage: $0 <image-manifest> <cache-group>" >&2
+if [[ $# -ne 1 ]]; then
+  echo "Usage: $0 <image-list>" >&2
   exit 2
 fi
 
-manifest=$1
-cache_group=$2
-if [[ ! -f "$manifest" ]]; then
-  echo "Image manifest does not exist: $manifest" >&2
+image_list=$1
+if [[ ! -f "$image_list" ]]; then
+  echo "Image list does not exist: $image_list" >&2
   exit 2
 fi
-
-repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
-# shellcheck source=../../deployment/k8s/charts/aggregates/migrationAssistantWithArgo/scripts/mirrorToEcr.sh
-source "$repo_root/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/scripts/mirrorToEcr.sh"
 
 pull_with_retries() {
   local image=$1
@@ -36,24 +31,14 @@ pull_with_retries() {
   return 1
 }
 
-entries=$(manifest_section "$manifest" gradleTestImages)
-if [[ -z "$entries" ]]; then
-  echo "No gradleTestImages found in manifest: $manifest" >&2
-  exit 2
-fi
-
 matched=0
-while IFS='|' read -r entry_group canonical preferred extra; do
-  if [[ "$entry_group" != "$cache_group" ]]; then
+while IFS='|' read -r canonical preferred extra; do
+  if [[ -z "$canonical" || "$canonical" == \#* ]]; then
     continue
   fi
   matched=$((matched + 1))
-  if [[ -z "${canonical:-}" ]]; then
-    echo "Invalid gradleTestImages entry: missing canonical image" >&2
-    exit 2
-  fi
   if [[ -n "${extra:-}" ]]; then
-    echo "Invalid gradleTestImages entry for $canonical" >&2
+    echo "Invalid image list entry for $canonical" >&2
     exit 2
   fi
   if docker image inspect "$canonical" >/dev/null 2>&1; then
@@ -70,10 +55,10 @@ while IFS='|' read -r entry_group canonical preferred extra; do
     echo "Preferred source unavailable for $canonical; trying the canonical registry." >&2
   fi
   pull_with_retries "$canonical" 4
-done <<< "$entries"
+done < "$image_list"
 
 if [[ "$matched" -eq 0 ]]; then
-  echo "No gradleTestImages found for cache group: $cache_group" >&2
+  echo "No images found in image list: $image_list" >&2
   exit 2
 fi
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -20,20 +20,6 @@ concurrency:
   cancel-in-progress: ${{ !(github.event_name == 'push' && github.repository == 'opensearch-project/opensearch-migrations' && github.ref == 'refs/heads/main') }}
 
 jobs:
-  generate-cache-key:
-    runs-on: ubuntu-22.04
-    outputs:
-      docker_cache_key: ${{ steps.generate_docker_cache_key.outputs.key }}
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - name: Generate Docker Cache Key
-        id: generate_docker_cache_key
-        run: |
-          files=$(find . -type f \( -name 'docker-compose.yml' -o -name 'Dockerfile' \))
-          file_contents=$(cat $files)
-          key=$(echo "${file_contents}" | sha1sum | awk '{print $1}')
-          echo "key=${key}" >> "$GITHUB_OUTPUT"
-
   gradle-extended-check:
     runs-on: ubuntu-22.04
     strategy:
@@ -167,8 +153,34 @@ jobs:
           done
           echo "matrix=$(IFS=,; echo "[${indices[*]}]")" >> $GITHUB_OUTPUT
 
+  seed-gradle-test-docker-cache:
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: infrastructure
+            manifest: deployment/k8s/charts/aggregates/migrationAssistantWithArgo/infra/mirror/private-ecr-manifest.yaml
+          - name: search
+            manifest: deployment/k8s/charts/aggregates/migrationAssistantWithArgo/infra/mirror/private-ecr-manifest.yaml
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /usr/share/swift
+          sudo docker system prune -af
+          df -h
+      - name: Restore or initialize Gradle test Docker cache
+        id: docker-cache
+        uses: AndreKurait/docker-cache@7a3887908bdb97935395833df69b060cfcca0f7f # 0.7.0
+        with:
+          key: gradle-test-docker-${{ runner.os }}-${{ matrix.name }}-${{ hashFiles(matrix.manifest) }}
+      - name: Pull images for Gradle tests
+        if: steps.docker-cache.outputs.cache-hit != 'true'
+        run: .github/scripts/seed-gradle-test-docker-cache.sh "${{ matrix.manifest }}" "${{ matrix.name }}"
+
   gradle-tests:
-    needs: [generate-test-matrix, generate-cache-key]
+    needs: [generate-test-matrix, seed-gradle-test-docker-cache]
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
@@ -185,11 +197,15 @@ jobs:
           sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /usr/share/swift
           sudo docker system prune -af
           df -h
-      - name: Restore Docker Cache
+      - name: Restore Gradle test infrastructure Docker cache
         uses: AndreKurait/docker-cache@7a3887908bdb97935395833df69b060cfcca0f7f # 0.7.0
         with:
-          key: docker-${{ runner.os }}-${{ needs.generate-cache-key.outputs.docker_cache_key }}
-          # Read-only cache for gradle-tests
+          key: gradle-test-docker-${{ runner.os }}-infrastructure-${{ hashFiles('deployment/k8s/charts/aggregates/migrationAssistantWithArgo/infra/mirror/private-ecr-manifest.yaml') }}
+          read-only: true
+      - name: Restore Gradle test search Docker cache
+        uses: AndreKurait/docker-cache@7a3887908bdb97935395833df69b060cfcca0f7f # 0.7.0
+        with:
+          key: gradle-test-docker-${{ runner.os }}-search-${{ hashFiles('deployment/k8s/charts/aggregates/migrationAssistantWithArgo/infra/mirror/private-ecr-manifest.yaml') }}
           read-only: true
 
       - name: Run Gradle tests with striping
@@ -474,6 +490,7 @@ jobs:
     needs:
       - python-tests
       - jenkins-kind-setup-script-tests
+      - seed-gradle-test-docker-cache
       - gradle-tests
       - link-checker
       - node-tests

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -158,11 +158,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # Each list maps to one independently invalidated Docker cache.
         include:
           - name: infrastructure
-            manifest: deployment/k8s/charts/aggregates/migrationAssistantWithArgo/infra/mirror/private-ecr-manifest.yaml
+            image_list: .github/gradle-test-images/infrastructure.txt
           - name: search
-            manifest: deployment/k8s/charts/aggregates/migrationAssistantWithArgo/infra/mirror/private-ecr-manifest.yaml
+            image_list: .github/gradle-test-images/search.txt
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Free disk space
@@ -174,10 +175,10 @@ jobs:
         id: docker-cache
         uses: AndreKurait/docker-cache@7a3887908bdb97935395833df69b060cfcca0f7f # 0.7.0
         with:
-          key: gradle-test-docker-${{ runner.os }}-${{ matrix.name }}-${{ hashFiles(matrix.manifest) }}
+          key: gradle-test-docker-${{ runner.os }}-${{ matrix.name }}-${{ hashFiles(matrix.image_list) }}
       - name: Pull images for Gradle tests
         if: steps.docker-cache.outputs.cache-hit != 'true'
-        run: .github/scripts/seed-gradle-test-docker-cache.sh "${{ matrix.manifest }}" "${{ matrix.name }}"
+        run: .github/scripts/seed-gradle-test-docker-cache.sh "${{ matrix.image_list }}"
 
   gradle-tests:
     needs: [generate-test-matrix, seed-gradle-test-docker-cache]
@@ -200,12 +201,12 @@ jobs:
       - name: Restore Gradle test infrastructure Docker cache
         uses: AndreKurait/docker-cache@7a3887908bdb97935395833df69b060cfcca0f7f # 0.7.0
         with:
-          key: gradle-test-docker-${{ runner.os }}-infrastructure-${{ hashFiles('deployment/k8s/charts/aggregates/migrationAssistantWithArgo/infra/mirror/private-ecr-manifest.yaml') }}
+          key: gradle-test-docker-${{ runner.os }}-infrastructure-${{ hashFiles('.github/gradle-test-images/infrastructure.txt') }}
           read-only: true
       - name: Restore Gradle test search Docker cache
         uses: AndreKurait/docker-cache@7a3887908bdb97935395833df69b060cfcca0f7f # 0.7.0
         with:
-          key: gradle-test-docker-${{ runner.os }}-search-${{ hashFiles('deployment/k8s/charts/aggregates/migrationAssistantWithArgo/infra/mirror/private-ecr-manifest.yaml') }}
+          key: gradle-test-docker-${{ runner.os }}-search-${{ hashFiles('.github/gradle-test-images/search.txt') }}
           read-only: true
 
       - name: Run Gradle tests with striping

--- a/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/infra/mirror/private-ecr-manifest.yaml
+++ b/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/infra/mirror/private-ecr-manifest.yaml
@@ -1,6 +1,7 @@
 # Version-locked list of container images and Helm charts required by the
 # Migration Assistant EKS deployment. This file is packaged with the Helm chart
 # and consumed by aws-bootstrap.sh when mirroring public artifacts into ECR.
+# The gradleTestImages section is CI-only and is ignored by ECR mirroring.
 
 charts:
   # Format: "name|version|repository"
@@ -108,3 +109,27 @@ images:
   - "mirror.gcr.io/library/amazoncorretto:11-al2023-headless"
   - "mirror.gcr.io/library/amazoncorretto:8-alpine"
   - "mirror.gcr.io/library/amazonlinux:2023"
+
+gradleTestImages:
+  # Format: "cache group|canonical image|optional preferred pull source"
+  - "infrastructure|localstack/localstack:4.3.0|mirror.gcr.io/localstack/localstack:4.3.0"
+  - "infrastructure|localstack/localstack:3.4|mirror.gcr.io/localstack/localstack:3.4"
+  - "infrastructure|solr:6.6.0|mirror.gcr.io/library/solr:6.6.0"
+  - "infrastructure|solr:7.7.3|mirror.gcr.io/library/solr:7.7.3"
+  - "infrastructure|solr:8.10.1|mirror.gcr.io/library/solr:8.10.1"
+  - "infrastructure|solr:8.11.4|mirror.gcr.io/library/solr:8.11.4"
+  - "infrastructure|solr:9.8.1|mirror.gcr.io/library/solr:9.8.1"
+  - "infrastructure|confluentinc/cp-kafka:7.5.0|mirror.gcr.io/confluentinc/cp-kafka:7.5.0"
+  - "infrastructure|httpd:2.4.66-alpine|mirror.gcr.io/library/httpd:2.4.66-alpine"
+  - "infrastructure|testcontainers/ryuk:0.14.0|mirror.gcr.io/testcontainers/ryuk:0.14.0"
+  - "infrastructure|testcontainers/sshd:1.3.0|mirror.gcr.io/testcontainers/sshd:1.3.0"
+  - "infrastructure|alpine:3.17|mirror.gcr.io/library/alpine:3.17"
+  - "infrastructure|ghcr.io/shopify/toxiproxy:2.9.0|"
+  - "search|opensearchproject/opensearch:1.3.20|mirror.gcr.io/opensearchproject/opensearch:1.3.20"
+  - "search|opensearchproject/opensearch:2.19.4|mirror.gcr.io/opensearchproject/opensearch:2.19.4"
+  - "search|opensearchproject/opensearch:3.5.0|mirror.gcr.io/opensearchproject/opensearch:3.5.0"
+  - "search|amazonlinux:2023|mirror.gcr.io/library/amazonlinux:2023"
+  - "search|amazoncorretto:8-alpine|mirror.gcr.io/library/amazoncorretto:8-alpine"
+  - "search|amazoncorretto:11-al2023-headless|mirror.gcr.io/library/amazoncorretto:11-al2023-headless"
+  - "search|amazoncorretto:17-al2023-headless|mirror.gcr.io/library/amazoncorretto:17-al2023-headless"
+  - "search|amazoncorretto:21-al2023-headless|mirror.gcr.io/library/amazoncorretto:21-al2023-headless"

--- a/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/infra/mirror/private-ecr-manifest.yaml
+++ b/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/infra/mirror/private-ecr-manifest.yaml
@@ -1,7 +1,6 @@
 # Version-locked list of container images and Helm charts required by the
 # Migration Assistant EKS deployment. This file is packaged with the Helm chart
 # and consumed by aws-bootstrap.sh when mirroring public artifacts into ECR.
-# The gradleTestImages section is CI-only and is ignored by ECR mirroring.
 
 charts:
   # Format: "name|version|repository"
@@ -109,27 +108,3 @@ images:
   - "mirror.gcr.io/library/amazoncorretto:11-al2023-headless"
   - "mirror.gcr.io/library/amazoncorretto:8-alpine"
   - "mirror.gcr.io/library/amazonlinux:2023"
-
-gradleTestImages:
-  # Format: "cache group|canonical image|optional preferred pull source"
-  - "infrastructure|localstack/localstack:4.3.0|mirror.gcr.io/localstack/localstack:4.3.0"
-  - "infrastructure|localstack/localstack:3.4|mirror.gcr.io/localstack/localstack:3.4"
-  - "infrastructure|solr:6.6.0|mirror.gcr.io/library/solr:6.6.0"
-  - "infrastructure|solr:7.7.3|mirror.gcr.io/library/solr:7.7.3"
-  - "infrastructure|solr:8.10.1|mirror.gcr.io/library/solr:8.10.1"
-  - "infrastructure|solr:8.11.4|mirror.gcr.io/library/solr:8.11.4"
-  - "infrastructure|solr:9.8.1|mirror.gcr.io/library/solr:9.8.1"
-  - "infrastructure|confluentinc/cp-kafka:7.5.0|mirror.gcr.io/confluentinc/cp-kafka:7.5.0"
-  - "infrastructure|httpd:2.4.66-alpine|mirror.gcr.io/library/httpd:2.4.66-alpine"
-  - "infrastructure|testcontainers/ryuk:0.14.0|mirror.gcr.io/testcontainers/ryuk:0.14.0"
-  - "infrastructure|testcontainers/sshd:1.3.0|mirror.gcr.io/testcontainers/sshd:1.3.0"
-  - "infrastructure|alpine:3.17|mirror.gcr.io/library/alpine:3.17"
-  - "infrastructure|ghcr.io/shopify/toxiproxy:2.9.0|"
-  - "search|opensearchproject/opensearch:1.3.20|mirror.gcr.io/opensearchproject/opensearch:1.3.20"
-  - "search|opensearchproject/opensearch:2.19.4|mirror.gcr.io/opensearchproject/opensearch:2.19.4"
-  - "search|opensearchproject/opensearch:3.5.0|mirror.gcr.io/opensearchproject/opensearch:3.5.0"
-  - "search|amazonlinux:2023|mirror.gcr.io/library/amazonlinux:2023"
-  - "search|amazoncorretto:8-alpine|mirror.gcr.io/library/amazoncorretto:8-alpine"
-  - "search|amazoncorretto:11-al2023-headless|mirror.gcr.io/library/amazoncorretto:11-al2023-headless"
-  - "search|amazoncorretto:17-al2023-headless|mirror.gcr.io/library/amazoncorretto:17-al2023-headless"
-  - "search|amazoncorretto:21-al2023-headless|mirror.gcr.io/library/amazoncorretto:21-al2023-headless"


### PR DESCRIPTION
## Summary

- add dedicated, writable Docker cache primer jobs before the Gradle test matrix
- keep Gradle cache image groups in the existing private-ECR image manifest instead of adding CI-specific manifest files
- make all Gradle test shards wait for and restore both completed caches
- prefer `mirror.gcr.io` for Docker Hub images, with retries and canonical-registry fallback

## Root cause

The Gradle test jobs restore the Docker image cache in read-only mode. The job that previously wrote that cache was removed when the Docker Compose E2E test moved to Jenkins, leaving no reliable producer for the images used by Gradle Testcontainers tests.

The old cache key also hashed unrelated Dockerfiles and Compose files instead of the images the cache contained. The new keys are derived from the repository's existing image manifest.

## Image inventory

The existing private-ECR manifest remains the single inventory file. Its original `charts` and `images` sections are unchanged and continue to drive isolated-network deployment mirroring. A separate `gradleTestImages` section identifies the 21 images relevant to Gradle cache priming and divides them into infrastructure and search caches.

Only five Gradle images overlap the 58 deployment images. Pulling all deployment images into every Gradle shard would waste cache quota and restore time, so the primer reads only the CI section. The full Elasticsearch/OpenSearch version matrix remains excluded because it is too large for the GitHub Actions cache quota.

## Validation

- parsed `.github/workflows/CI.yml` and the image manifest with Ruby YAML
- confirmed the deployment manifest still resolves to the same 15 charts and 58 images
- ran `bash -n` on the seed and mirroring scripts
- exercised mirror success, retagging, retry/fallback, canonical pulls, and invalid groups with a mocked Docker command
- ran `git diff --check`
