### PR TITLE
Tighten EKS migration IAM permissions

### DIFF
--- a/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/templates/helpers/_s3Helper.tpl
+++ b/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/templates/helpers/_s3Helper.tpl
@@ -8,14 +8,17 @@
   }
 
   check_s3_available() {
+    local bucket="$1"
     echo "Checking if S3 is available..."
     ENDPOINT_FLAG=$(get_s3_endpoint_flag)
-    if ! output=$(aws $ENDPOINT_FLAG s3 ls 2>&1 >/dev/null); then
-      echo "S3 check failed with error:"
-      echo "$output"
-      return 1
+    output=$(aws $ENDPOINT_FLAG s3api head-bucket --bucket "$bucket" 2>&1 >/dev/null)
+    exit_code=$?
+    if [ "$exit_code" -eq 0 ] || echo "$output" | grep -q 'Not Found\|NoSuchBucket'; then
+      return 0
     fi
-    return 0
+    echo "S3 check failed with error:"
+    echo "$output"
+    return 1
   }
 
   bucket_exists() {

--- a/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/templates/resources/s3/createS3Bucket.yaml
+++ b/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/templates/resources/s3/createS3Bucket.yaml
@@ -76,7 +76,7 @@ spec:
 
               # Wait for S3 to be available
               retry_count=0
-              while ! check_s3_available; do
+              while ! check_s3_available "$BUCKET_NAME"; do
                 retry_count=$((retry_count + 1))
                 if [ $retry_count -ge $MAX_RETRIES ]; then
                   echo "S3 endpoint not available after $MAX_RETRIES attempts. Exiting."
@@ -104,7 +104,4 @@ spec:
                 fi
               fi
 
-              # List all buckets to confirm
-              echo "Listing all buckets:"
-              aws $S3_ENDPOINT_FLAG s3 ls
 {{- end }}

--- a/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/templates/resources/s3/deleteS3Bucket.yaml
+++ b/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/templates/resources/s3/deleteS3Bucket.yaml
@@ -79,7 +79,7 @@ spec:
 
               # Wait for S3 to be available
               retry_count=0
-              while ! check_s3_available; do
+              while ! check_s3_available "$BUCKET_NAME"; do
                 retry_count=$((retry_count + 1))
                 if [ $retry_count -ge $MAX_RETRIES ]; then
                   echo "S3 endpoint not available after $MAX_RETRIES attempts. Exiting."

--- a/deployment/migration-assistant-solution/lib/eks-infra.ts
+++ b/deployment/migration-assistant-solution/lib/eks-infra.ts
@@ -4,7 +4,7 @@ import * as eks from 'aws-cdk-lib/aws-eks-v2';
 import {IVpc, Subnet} from 'aws-cdk-lib/aws-ec2';
 import {
     Effect,
-    ManagedPolicy, Policy,
+    Policy,
     PolicyStatement,
     Role,
     ServicePrincipal,
@@ -17,7 +17,7 @@ export interface EKSInfraProps {
     vpc: IVpc;
     clusterName: string;
     ecrRepoName: string;
-    stackName: string;
+    stageName: string;
     vpcSubnetIds?: string[];
     namespace?: string;
     buildImagesServiceAccountName?: string;
@@ -82,7 +82,14 @@ export class EKSInfra extends Construct {
             })],
         );
 
-        const podIdentityRole = this.createDefaultPodIdentityRole(props.clusterName)
+        const stack = Stack.of(this);
+        const migrationsBucketArn =
+            `arn:${Aws.PARTITION}:s3:::migrations-default-${stack.account}-${props.stageName}-${stack.region}`;
+        const podIdentityRole = this.createDefaultPodIdentityRole(
+            props.clusterName,
+            props.stageName,
+            migrationsBucketArn
+        )
         this.snapshotRole = new Role(scope, `SnapshotRole`, {
             assumedBy: new ServicePrincipal('es.amazonaws.com'),  // Note that snapshots are not currently possible on AOSS
             description: 'Role that grants OpenSearch Service permissions to access S3 to create snapshots',
@@ -91,12 +98,12 @@ export class EKSInfra extends Construct {
         this.snapshotRole.addToPolicy(new PolicyStatement({
             effect: Effect.ALLOW,
             actions: ['s3:ListBucket'],
-            resources: [`arn:${Aws.PARTITION}:s3:::migrations-*`],
+            resources: [migrationsBucketArn],
         }));
         this.snapshotRole.addToPolicy(new PolicyStatement({
             effect: Effect.ALLOW,
             actions: ['s3:GetObject', 's3:PutObject', 's3:DeleteObject'],
-            resources: [`arn:${Aws.PARTITION}:s3:::migrations-*/*`],
+            resources: [`${migrationsBucketArn}/*`],
         }));
         this.snapshotRole.grantPassRole(podIdentityRole);
 
@@ -173,14 +180,17 @@ export class EKSInfra extends Construct {
         }
     }
 
-    createDefaultPodIdentityRole(clusterName: string) {
+    createDefaultPodIdentityRole(clusterName: string, stageName: string, migrationsBucketArn: string) {
+        const stack = Stack.of(this);
+        const account = stack.account;
+        const region = stack.region;
+        const migrationLogGroupArn =
+            `arn:${Aws.PARTITION}:logs:${region}:${account}:log-group:/migration-assistant-${stageName}-${region}/logs`;
+
         const podIdentityRole = new Role(this, 'MigrationsPodIdentityRole', {
             roleName: `${clusterName}-migrations-role`,
             description: 'Migrations IAM role assumed by pods via EKS Pod Identity',
             assumedBy: new ServicePrincipal('pods.eks.amazonaws.com'),
-            managedPolicies: [
-                ManagedPolicy.fromAwsManagedPolicyName('AmazonEC2ContainerRegistryFullAccess'),
-            ],
         });
         podIdentityRole.assumeRolePolicy?.addStatements(
             new PolicyStatement({
@@ -194,71 +204,88 @@ export class EKSInfra extends Construct {
             roles: [podIdentityRole],
         });
         podIdentityPolicy.addStatements(
+            // ECR authorization tokens do not support resource-level permissions.
+            new PolicyStatement({
+                effect: Effect.ALLOW,
+                actions: ['ecr:GetAuthorizationToken'],
+                resources: ['*'],
+                conditions: {
+                    StringEquals: {
+                        'aws:RequestedRegion': region,
+                    },
+                },
+            }),
             new PolicyStatement({
                 effect: Effect.ALLOW,
                 actions: [
-                    'ecr:GetAuthorizationToken',
                     'ecr:BatchGetImage',
                     'ecr:GetDownloadUrlForLayer',
-                    'ecr:DescribeRepositories',
                     'ecr:BatchCheckLayerAvailability',
                     'ecr:CompleteLayerUpload',
                     'ecr:InitiateLayerUpload',
                     'ecr:PutImage',
                     'ecr:UploadLayerPart',
                 ],
-                resources: ['*'],
+                resources: [this.ecrRepo.repositoryArn],
             }),
             new PolicyStatement({
                 effect: Effect.ALLOW,
-                actions: [
-                    'elasticfilesystem:ClientMount',
-                    'elasticfilesystem:ClientWrite',
+                actions: ['es:ESHttp*'],
+                resources: [
+                    `arn:${Aws.PARTITION}:es:${region}:${account}:domain/*/*`
                 ],
-                resources: ['*'],
             }),
             new PolicyStatement({
                 effect: Effect.ALLOW,
-                actions: ['es:ESHttp*', 'aoss:APIAccessAll'],
-                resources: ['*'],
+                actions: ['aoss:APIAccessAll'],
+                resources: [
+                    `arn:${Aws.PARTITION}:aoss:${region}:${account}:collection/*`
+                ],
             }),
             new PolicyStatement({
                 effect: Effect.ALLOW,
                 actions: [
                     'secretsmanager:GetSecretValue',
                     'secretsmanager:DescribeSecret',
-                    'secretsmanager:ListSecrets',
                 ],
-                resources: ['*'],
+                resources: [
+                    `arn:${Aws.PARTITION}:secretsmanager:${region}:${account}:secret:*`
+                ],
+            }),
+            new PolicyStatement({
+                effect: Effect.ALLOW,
+                actions: [
+                    's3:ListBucket',
+                    "s3:CreateBucket",
+                    "s3:DeleteBucket",
+                ],
+                resources: [migrationsBucketArn],
             }),
             new PolicyStatement({
                 effect: Effect.ALLOW,
                 actions: [
                     's3:GetObject',
                     's3:PutObject',
-                    's3:ListBucket',
-                    's3:ListAllMyBuckets',
                     's3:DeleteObject',
-                    "s3:DeleteObjectVersion",
-                    "s3:ListBucketVersions",
-                    "s3:ListBucketMultipartUploads",
                     "s3:AbortMultipartUpload",
-                    "s3:CreateBucket",
-                    "s3:DeleteBucket",
-                    "s3:ListBucket"
                 ],
-                resources: ['*'],
+                resources: [`${migrationsBucketArn}/*`],
+            }),
+            new PolicyStatement({
+                effect: Effect.ALLOW,
+                actions: [
+                    "logs:DescribeLogStreams",
+                    "logs:CreateLogGroup",
+                ],
+                resources: [migrationLogGroupArn],
             }),
             new PolicyStatement({
                 effect: Effect.ALLOW,
                 actions: [
                     "logs:PutLogEvents",
-                    "logs:DescribeLogStreams",
-                    "logs:DescribeLogGroups",
-                    "logs:CreateLogGroup",
                     "logs:CreateLogStream"
                 ],
-                resources: ['*'],
+                resources: [`${migrationLogGroupArn}:log-stream:*`],
             }),
             // Allow Console/tests to verify emitted CloudWatch application metrics
             new PolicyStatement({
@@ -267,7 +294,13 @@ export class EKSInfra extends Construct {
                     "cloudwatch:ListMetrics",
                     "cloudwatch:GetMetricData"
                 ],
+                // Classic CloudWatch metric queries require a wildcard resource.
                 resources: ['*'],
+                conditions: {
+                    StringEquals: {
+                        'aws:RequestedRegion': region,
+                    },
+                },
             }),
             // Sending traces to xray
             new PolicyStatement({
@@ -276,16 +309,15 @@ export class EKSInfra extends Construct {
                     "xray:PutTraceSegments",
                     "xray:PutTelemetryRecords"
                 ],
+                // These X-Ray actions do not support resource-level permissions.
                 resources: ['*'],
-            }),
-            // Allow passing default or user-provided snapshot role to OpenSearch service
-            new PolicyStatement({
-                effect: Effect.ALLOW,
-                actions: ['iam:PassRole'],
-                resources: [`arn:${Aws.PARTITION}:iam::${Stack.of(this).account}:role/*`]
+                conditions: {
+                    StringEquals: {
+                        'aws:RequestedRegion': region,
+                    },
+                },
             }),
             // CloudWatch dashboard management for Helm post-install/pre-delete hooks
-            // Note: dashboard resource type has no condition keys in IAM; scoped by ARN prefix MA-*
             new PolicyStatement({
                 effect: Effect.ALLOW,
                 actions: [
@@ -294,7 +326,8 @@ export class EKSInfra extends Construct {
                     'cloudwatch:DeleteDashboards',
                 ],
                 resources: [
-                    `arn:${Aws.PARTITION}:cloudwatch::${Stack.of(this).account}:dashboard/MA-*`
+                    `arn:${Aws.PARTITION}:cloudwatch::${account}:dashboard/MA-${stageName}-${region}-CaptureReplay`,
+                    `arn:${Aws.PARTITION}:cloudwatch::${account}:dashboard/MA-${stageName}-${region}-ReindexFromSnapshot`
                 ],
             }),
             // ACM PCA permissions for TLS certificate issuance via cert-manager
@@ -304,13 +337,27 @@ export class EKSInfra extends Construct {
                     'acm-pca:IssueCertificate',
                     'acm-pca:GetCertificate',
                     'acm-pca:DescribeCertificateAuthority',
-                    'acm-pca:ListCertificateAuthorities',
-                    'acm-pca:CreateCertificateAuthority',
                     'acm-pca:DeleteCertificateAuthority',
                     'acm-pca:UpdateCertificateAuthority',
                     'acm-pca:TagCertificateAuthority',
                 ],
+                resources: [
+                    `arn:${Aws.PARTITION}:acm-pca:${region}:${account}:certificate-authority/*`
+                ],
+            }),
+            // These PCA actions do not support resource-level permissions.
+            new PolicyStatement({
+                effect: Effect.ALLOW,
+                actions: [
+                    'acm-pca:ListCertificateAuthorities',
+                    'acm-pca:CreateCertificateAuthority',
+                ],
                 resources: ['*'],
+                conditions: {
+                    StringEquals: {
+                        'aws:RequestedRegion': region,
+                    },
+                },
             })
         );
         return podIdentityRole

--- a/deployment/migration-assistant-solution/lib/solutions-stack-eks.ts
+++ b/deployment/migration-assistant-solution/lib/solutions-stack-eks.ts
@@ -313,7 +313,7 @@ export class SolutionsInfrastructureEKSStack extends Stack {
             vpc,
             vpcSubnetIds,
             clusterName: eksClusterName,
-            stackName: Fn.ref('AWS::StackName'),
+            stageName: stageParameter.valueAsString,
             ecrRepoName: `migration-ecr-${stackMarker}`,
             enableACKCloudWatch: true,
         });

--- a/deployment/migration-assistant-solution/test/__snapshots__/solutions-stack-eks.test.ts.snap
+++ b/deployment/migration-assistant-solution/test/__snapshots__/solutions-stack-eks.test.ts.snap
@@ -1166,11 +1166,19 @@ exports[`Solutions stack Migration stack with import VPC matches snapshot 1`] = 
         "PolicyDocument": {
           "Statement": [
             {
+              "Action": "ecr:GetAuthorizationToken",
+              "Condition": {
+                "StringEquals": {
+                  "aws:RequestedRegion": "us-west-1",
+                },
+              },
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+            {
               "Action": [
-                "ecr:GetAuthorizationToken",
                 "ecr:BatchGetImage",
                 "ecr:GetDownloadUrlForLayer",
-                "ecr:DescribeRepositories",
                 "ecr:BatchCheckLayerAvailability",
                 "ecr:CompleteLayerUpload",
                 "ecr:InitiateLayerUpload",
@@ -1178,66 +1186,197 @@ exports[`Solutions stack Migration stack with import VPC matches snapshot 1`] = 
                 "ecr:UploadLayerPart",
               ],
               "Effect": "Allow",
-              "Resource": "*",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "EKSInfraMigrationsECRRepositoryEAD8241B",
+                  "Arn",
+                ],
+              },
             },
             {
-              "Action": [
-                "elasticfilesystem:ClientMount",
-                "elasticfilesystem:ClientWrite",
-              ],
+              "Action": "es:ESHttp*",
               "Effect": "Allow",
-              "Resource": "*",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":es:us-west-1:",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":domain/*/*",
+                  ],
+                ],
+              },
             },
             {
-              "Action": [
-                "es:ESHttp*",
-                "aoss:APIAccessAll",
-              ],
+              "Action": "aoss:APIAccessAll",
               "Effect": "Allow",
-              "Resource": "*",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":aoss:us-west-1:",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":collection/*",
+                  ],
+                ],
+              },
             },
             {
               "Action": [
                 "secretsmanager:GetSecretValue",
                 "secretsmanager:DescribeSecret",
-                "secretsmanager:ListSecrets",
               ],
               "Effect": "Allow",
-              "Resource": "*",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":secretsmanager:us-west-1:",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":secret:*",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": [
+                "s3:ListBucket",
+                "s3:CreateBucket",
+                "s3:DeleteBucket",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":s3:::migrations-default-",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    "-",
+                    {
+                      "Ref": "Stage",
+                    },
+                    "-us-west-1",
+                  ],
+                ],
+              },
             },
             {
               "Action": [
                 "s3:GetObject",
                 "s3:PutObject",
-                "s3:ListBucket",
-                "s3:ListAllMyBuckets",
                 "s3:DeleteObject",
-                "s3:DeleteObjectVersion",
-                "s3:ListBucketVersions",
-                "s3:ListBucketMultipartUploads",
                 "s3:AbortMultipartUpload",
-                "s3:CreateBucket",
-                "s3:DeleteBucket",
               ],
               "Effect": "Allow",
-              "Resource": "*",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":s3:::migrations-default-",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    "-",
+                    {
+                      "Ref": "Stage",
+                    },
+                    "-us-west-1/*",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": [
+                "logs:DescribeLogStreams",
+                "logs:CreateLogGroup",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":logs:us-west-1:",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":log-group:/migration-assistant-",
+                    {
+                      "Ref": "Stage",
+                    },
+                    "-us-west-1/logs",
+                  ],
+                ],
+              },
             },
             {
               "Action": [
                 "logs:PutLogEvents",
-                "logs:DescribeLogStreams",
-                "logs:DescribeLogGroups",
-                "logs:CreateLogGroup",
                 "logs:CreateLogStream",
               ],
               "Effect": "Allow",
-              "Resource": "*",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":logs:us-west-1:",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":log-group:/migration-assistant-",
+                    {
+                      "Ref": "Stage",
+                    },
+                    "-us-west-1/logs:log-stream:*",
+                  ],
+                ],
+              },
             },
             {
               "Action": [
                 "cloudwatch:ListMetrics",
                 "cloudwatch:GetMetricData",
               ],
+              "Condition": {
+                "StringEquals": {
+                  "aws:RequestedRegion": "us-west-1",
+                },
+              },
               "Effect": "Allow",
               "Resource": "*",
             },
@@ -1246,28 +1385,13 @@ exports[`Solutions stack Migration stack with import VPC matches snapshot 1`] = 
                 "xray:PutTraceSegments",
                 "xray:PutTelemetryRecords",
               ],
+              "Condition": {
+                "StringEquals": {
+                  "aws:RequestedRegion": "us-west-1",
+                },
+              },
               "Effect": "Allow",
               "Resource": "*",
-            },
-            {
-              "Action": "iam:PassRole",
-              "Effect": "Allow",
-              "Resource": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:",
-                    {
-                      "Ref": "AWS::Partition",
-                    },
-                    ":iam::",
-                    {
-                      "Ref": "AWS::AccountId",
-                    },
-                    ":role/*",
-                  ],
-                ],
-              },
             },
             {
               "Action": [
@@ -1276,6 +1400,59 @@ exports[`Solutions stack Migration stack with import VPC matches snapshot 1`] = 
                 "cloudwatch:DeleteDashboards",
               ],
               "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":cloudwatch::",
+                      {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":dashboard/MA-",
+                      {
+                        "Ref": "Stage",
+                      },
+                      "-us-west-1-CaptureReplay",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":cloudwatch::",
+                      {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":dashboard/MA-",
+                      {
+                        "Ref": "Stage",
+                      },
+                      "-us-west-1-ReindexFromSnapshot",
+                    ],
+                  ],
+                },
+              ],
+            },
+            {
+              "Action": [
+                "acm-pca:IssueCertificate",
+                "acm-pca:GetCertificate",
+                "acm-pca:DescribeCertificateAuthority",
+                "acm-pca:DeleteCertificateAuthority",
+                "acm-pca:UpdateCertificateAuthority",
+                "acm-pca:TagCertificateAuthority",
+              ],
+              "Effect": "Allow",
               "Resource": {
                 "Fn::Join": [
                   "",
@@ -1284,26 +1461,25 @@ exports[`Solutions stack Migration stack with import VPC matches snapshot 1`] = 
                     {
                       "Ref": "AWS::Partition",
                     },
-                    ":cloudwatch::",
+                    ":acm-pca:us-west-1:",
                     {
                       "Ref": "AWS::AccountId",
                     },
-                    ":dashboard/MA-*",
+                    ":certificate-authority/*",
                   ],
                 ],
               },
             },
             {
               "Action": [
-                "acm-pca:IssueCertificate",
-                "acm-pca:GetCertificate",
-                "acm-pca:DescribeCertificateAuthority",
                 "acm-pca:ListCertificateAuthorities",
                 "acm-pca:CreateCertificateAuthority",
-                "acm-pca:DeleteCertificateAuthority",
-                "acm-pca:UpdateCertificateAuthority",
-                "acm-pca:TagCertificateAuthority",
               ],
+              "Condition": {
+                "StringEquals": {
+                  "aws:RequestedRegion": "us-west-1",
+                },
+              },
               "Effect": "Allow",
               "Resource": "*",
             },
@@ -1344,20 +1520,6 @@ exports[`Solutions stack Migration stack with import VPC matches snapshot 1`] = 
           "Version": "2012-10-17",
         },
         "Description": "Migrations IAM role assumed by pods via EKS Pod Identity",
-        "ManagedPolicyArns": [
-          {
-            "Fn::Join": [
-              "",
-              [
-                "arn:",
-                {
-                  "Ref": "AWS::Partition",
-                },
-                ":iam::aws:policy/AmazonEC2ContainerRegistryFullAccess",
-              ],
-            ],
-          },
-        ],
         "RoleName": {
           "Fn::Join": [
             "",
@@ -1522,7 +1684,15 @@ exports[`Solutions stack Migration stack with import VPC matches snapshot 1`] = 
                     {
                       "Ref": "AWS::Partition",
                     },
-                    ":s3:::migrations-*",
+                    ":s3:::migrations-default-",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    "-",
+                    {
+                      "Ref": "Stage",
+                    },
+                    "-us-west-1",
                   ],
                 ],
               },
@@ -1542,7 +1712,15 @@ exports[`Solutions stack Migration stack with import VPC matches snapshot 1`] = 
                     {
                       "Ref": "AWS::Partition",
                     },
-                    ":s3:::migrations-*/*",
+                    ":s3:::migrations-default-",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    "-",
+                    {
+                      "Ref": "Stage",
+                    },
+                    "-us-west-1/*",
                   ],
                 ],
               },
@@ -2420,11 +2598,19 @@ exports[`Solutions stack Migration stack with new VPC matches snapshot 1`] = `
         "PolicyDocument": {
           "Statement": [
             {
+              "Action": "ecr:GetAuthorizationToken",
+              "Condition": {
+                "StringEquals": {
+                  "aws:RequestedRegion": "us-west-1",
+                },
+              },
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+            {
               "Action": [
-                "ecr:GetAuthorizationToken",
                 "ecr:BatchGetImage",
                 "ecr:GetDownloadUrlForLayer",
-                "ecr:DescribeRepositories",
                 "ecr:BatchCheckLayerAvailability",
                 "ecr:CompleteLayerUpload",
                 "ecr:InitiateLayerUpload",
@@ -2432,66 +2618,197 @@ exports[`Solutions stack Migration stack with new VPC matches snapshot 1`] = `
                 "ecr:UploadLayerPart",
               ],
               "Effect": "Allow",
-              "Resource": "*",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "EKSInfraMigrationsECRRepositoryEAD8241B",
+                  "Arn",
+                ],
+              },
             },
             {
-              "Action": [
-                "elasticfilesystem:ClientMount",
-                "elasticfilesystem:ClientWrite",
-              ],
+              "Action": "es:ESHttp*",
               "Effect": "Allow",
-              "Resource": "*",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":es:us-west-1:",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":domain/*/*",
+                  ],
+                ],
+              },
             },
             {
-              "Action": [
-                "es:ESHttp*",
-                "aoss:APIAccessAll",
-              ],
+              "Action": "aoss:APIAccessAll",
               "Effect": "Allow",
-              "Resource": "*",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":aoss:us-west-1:",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":collection/*",
+                  ],
+                ],
+              },
             },
             {
               "Action": [
                 "secretsmanager:GetSecretValue",
                 "secretsmanager:DescribeSecret",
-                "secretsmanager:ListSecrets",
               ],
               "Effect": "Allow",
-              "Resource": "*",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":secretsmanager:us-west-1:",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":secret:*",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": [
+                "s3:ListBucket",
+                "s3:CreateBucket",
+                "s3:DeleteBucket",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":s3:::migrations-default-",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    "-",
+                    {
+                      "Ref": "Stage",
+                    },
+                    "-us-west-1",
+                  ],
+                ],
+              },
             },
             {
               "Action": [
                 "s3:GetObject",
                 "s3:PutObject",
-                "s3:ListBucket",
-                "s3:ListAllMyBuckets",
                 "s3:DeleteObject",
-                "s3:DeleteObjectVersion",
-                "s3:ListBucketVersions",
-                "s3:ListBucketMultipartUploads",
                 "s3:AbortMultipartUpload",
-                "s3:CreateBucket",
-                "s3:DeleteBucket",
               ],
               "Effect": "Allow",
-              "Resource": "*",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":s3:::migrations-default-",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    "-",
+                    {
+                      "Ref": "Stage",
+                    },
+                    "-us-west-1/*",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": [
+                "logs:DescribeLogStreams",
+                "logs:CreateLogGroup",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":logs:us-west-1:",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":log-group:/migration-assistant-",
+                    {
+                      "Ref": "Stage",
+                    },
+                    "-us-west-1/logs",
+                  ],
+                ],
+              },
             },
             {
               "Action": [
                 "logs:PutLogEvents",
-                "logs:DescribeLogStreams",
-                "logs:DescribeLogGroups",
-                "logs:CreateLogGroup",
                 "logs:CreateLogStream",
               ],
               "Effect": "Allow",
-              "Resource": "*",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":logs:us-west-1:",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":log-group:/migration-assistant-",
+                    {
+                      "Ref": "Stage",
+                    },
+                    "-us-west-1/logs:log-stream:*",
+                  ],
+                ],
+              },
             },
             {
               "Action": [
                 "cloudwatch:ListMetrics",
                 "cloudwatch:GetMetricData",
               ],
+              "Condition": {
+                "StringEquals": {
+                  "aws:RequestedRegion": "us-west-1",
+                },
+              },
               "Effect": "Allow",
               "Resource": "*",
             },
@@ -2500,28 +2817,13 @@ exports[`Solutions stack Migration stack with new VPC matches snapshot 1`] = `
                 "xray:PutTraceSegments",
                 "xray:PutTelemetryRecords",
               ],
+              "Condition": {
+                "StringEquals": {
+                  "aws:RequestedRegion": "us-west-1",
+                },
+              },
               "Effect": "Allow",
               "Resource": "*",
-            },
-            {
-              "Action": "iam:PassRole",
-              "Effect": "Allow",
-              "Resource": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:",
-                    {
-                      "Ref": "AWS::Partition",
-                    },
-                    ":iam::",
-                    {
-                      "Ref": "AWS::AccountId",
-                    },
-                    ":role/*",
-                  ],
-                ],
-              },
             },
             {
               "Action": [
@@ -2530,6 +2832,59 @@ exports[`Solutions stack Migration stack with new VPC matches snapshot 1`] = `
                 "cloudwatch:DeleteDashboards",
               ],
               "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":cloudwatch::",
+                      {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":dashboard/MA-",
+                      {
+                        "Ref": "Stage",
+                      },
+                      "-us-west-1-CaptureReplay",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":cloudwatch::",
+                      {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":dashboard/MA-",
+                      {
+                        "Ref": "Stage",
+                      },
+                      "-us-west-1-ReindexFromSnapshot",
+                    ],
+                  ],
+                },
+              ],
+            },
+            {
+              "Action": [
+                "acm-pca:IssueCertificate",
+                "acm-pca:GetCertificate",
+                "acm-pca:DescribeCertificateAuthority",
+                "acm-pca:DeleteCertificateAuthority",
+                "acm-pca:UpdateCertificateAuthority",
+                "acm-pca:TagCertificateAuthority",
+              ],
+              "Effect": "Allow",
               "Resource": {
                 "Fn::Join": [
                   "",
@@ -2538,26 +2893,25 @@ exports[`Solutions stack Migration stack with new VPC matches snapshot 1`] = `
                     {
                       "Ref": "AWS::Partition",
                     },
-                    ":cloudwatch::",
+                    ":acm-pca:us-west-1:",
                     {
                       "Ref": "AWS::AccountId",
                     },
-                    ":dashboard/MA-*",
+                    ":certificate-authority/*",
                   ],
                 ],
               },
             },
             {
               "Action": [
-                "acm-pca:IssueCertificate",
-                "acm-pca:GetCertificate",
-                "acm-pca:DescribeCertificateAuthority",
                 "acm-pca:ListCertificateAuthorities",
                 "acm-pca:CreateCertificateAuthority",
-                "acm-pca:DeleteCertificateAuthority",
-                "acm-pca:UpdateCertificateAuthority",
-                "acm-pca:TagCertificateAuthority",
               ],
+              "Condition": {
+                "StringEquals": {
+                  "aws:RequestedRegion": "us-west-1",
+                },
+              },
               "Effect": "Allow",
               "Resource": "*",
             },
@@ -2598,20 +2952,6 @@ exports[`Solutions stack Migration stack with new VPC matches snapshot 1`] = `
           "Version": "2012-10-17",
         },
         "Description": "Migrations IAM role assumed by pods via EKS Pod Identity",
-        "ManagedPolicyArns": [
-          {
-            "Fn::Join": [
-              "",
-              [
-                "arn:",
-                {
-                  "Ref": "AWS::Partition",
-                },
-                ":iam::aws:policy/AmazonEC2ContainerRegistryFullAccess",
-              ],
-            ],
-          },
-        ],
         "RoleName": {
           "Fn::Join": [
             "",
@@ -2771,7 +3111,15 @@ exports[`Solutions stack Migration stack with new VPC matches snapshot 1`] = `
                     {
                       "Ref": "AWS::Partition",
                     },
-                    ":s3:::migrations-*",
+                    ":s3:::migrations-default-",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    "-",
+                    {
+                      "Ref": "Stage",
+                    },
+                    "-us-west-1",
                   ],
                 ],
               },
@@ -2791,7 +3139,15 @@ exports[`Solutions stack Migration stack with new VPC matches snapshot 1`] = `
                     {
                       "Ref": "AWS::Partition",
                     },
-                    ":s3:::migrations-*/*",
+                    ":s3:::migrations-default-",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    "-",
+                    {
+                      "Ref": "Stage",
+                    },
+                    "-us-west-1/*",
                   ],
                 ],
               },

--- a/deployment/migration-assistant-solution/test/solutions-stack-eks.test.ts
+++ b/deployment/migration-assistant-solution/test/solutions-stack-eks.test.ts
@@ -3,6 +3,20 @@ import {Template} from 'aws-cdk-lib/assertions';
 import { App } from 'aws-cdk-lib';
 import {SolutionsInfrastructureEKSStack} from "../lib/solutions-stack-eks";
 
+interface IamPolicyStatement {
+    Action: string | string[];
+    Resource: unknown;
+}
+
+interface IamPolicyResource {
+    Properties?: {
+        PolicyName?: string;
+        PolicyDocument?: {
+            Statement?: IamPolicyStatement[];
+        };
+    };
+}
+
 describe('Solutions stack', () => {
     const defaultProperties = {
         solutionId: 'SO0000',
@@ -81,6 +95,33 @@ describe('Solutions stack', () => {
         });
         const template = Template.fromStack(stack).toJSON();
         expect(template).toMatchSnapshot();
+    });
+
+    test('Migrations pod policy only uses wildcard resources when required', () => {
+        const stack = new SolutionsInfrastructureEKSStack(new App(), 'TestMigrationAssistantStack', defaultProperties);
+        const template = Template.fromStack(stack);
+        const policies = template.findResources('AWS::IAM::Policy') as Record<string, IamPolicyResource>;
+        const migrationsPolicy = Object.values(policies)
+            .find(policy => policy.Properties?.PolicyName === 'MigrationsPodPolicy');
+
+        expect(migrationsPolicy).toBeDefined();
+        const wildcardActions = migrationsPolicy?.Properties?.PolicyDocument?.Statement
+            ?.filter(statement =>
+                statement.Resource === '*'
+                || (Array.isArray(statement.Resource) && statement.Resource.includes('*'))
+            )
+            .flatMap(statement => Array.isArray(statement.Action) ? statement.Action : [statement.Action])
+            .sort();
+
+        expect(wildcardActions).toEqual([
+            'acm-pca:CreateCertificateAuthority',
+            'acm-pca:ListCertificateAuthorities',
+            'cloudwatch:GetMetricData',
+            'cloudwatch:ListMetrics',
+            'ecr:GetAuthorizationToken',
+            'xray:PutTelemetryRecords',
+            'xray:PutTraceSegments',
+        ]);
     });
 
     function verifyResources(template: Template, props: { vpcCount: number, vpcEndpointCount: number,


### PR DESCRIPTION
### Description

Scope deterministic ECR, S3, CloudWatch Logs, dashboard, snapshot, and PCA access to deployment resources. Restrict account-scoped OpenSearch and Secrets Manager access to the deployment account and region.

Remove unused EFS, discovery, versioned S3, account-wide bucket listing, and broad PassRole permissions. Replace S3 account enumeration with a target-bucket availability probe.

Retain wildcard resources only for APIs that do not support resource ARNs, constrained to the deployment region, and add regression coverage for the allowlist.

### Issues Resolved
Loose IAM permissions that made some users think that the migration console should. be used as a discovery box.  Scoping this instead to be least-privilege.

### Testing
CI tests

### Check List
- [ ] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
