### PR TITLE
GCP Terraform: pin image tags and fix node-pool management

### DIFF
--- a/deployment/terraform/gcp/README.md
+++ b/deployment/terraform/gcp/README.md
@@ -64,6 +64,7 @@ terraform destroy -var="project=my-project"
 |------|---------|-------------|
 | `project` | (required) | GCP project ID |
 | `region` | `us-central1` | GCP region |
+| `migration_release` | `3.3.4` | Migration Assistant release tag applied to all MA images (console, installer, reindex-from-snapshot, capture-proxy, traffic-replayer); must exist in the Artifact Registry mirror |
 | `node_machine_type` | `e2-standard-4` | Node machine type |
 | `node_count` | `2` | Initial nodes per zone |
 | `create_vpc` | `true` | Create new VPC, or use existing (`false`) |

--- a/deployment/terraform/gcp/main.tf
+++ b/deployment/terraform/gcp/main.tf
@@ -198,31 +198,52 @@ resource "google_container_cluster" "migration_standard" {
     }
   }
 
-  # Default node pool configured inline
-  node_pool {
-    name               = "default-pool"
-    initial_node_count = var.node_count
-
-    node_config {
-      machine_type    = var.node_machine_type
-      disk_size_gb    = var.node_disk_size
-      disk_type       = var.node_disk_type
-      service_account = google_service_account.migration_nodes.email
-      oauth_scopes    = var.node_oauth_scopes
-    }
-
-    management {
-      auto_repair  = true
-      auto_upgrade = true
-    }
-
-    autoscaling {
-      min_node_count = var.node_min_count
-      max_node_count = var.node_max_count
-    }
-  }
+  # Manage every node pool as a standalone google_container_node_pool resource
+  # (see the "default" and "kafka" pools below). Mixing an inline node_pool block
+  # with standalone pools makes node-pool changes force-replace the whole cluster;
+  # a half-failed apply would then recreate the cluster and take all pools with it.
+  # GKE requires a node pool at creation, so create a throwaway one and remove it.
+  remove_default_node_pool = true
+  initial_node_count       = 1
 
   depends_on = [google_compute_router_nat.migration_nat]
+}
+
+# Default node pool for Migration Assistant workloads. Defined as a standalone
+# resource (like the kafka pool) so its config can change without forcing the
+# cluster to be replaced.
+resource "google_container_node_pool" "default" {
+  name     = "default-pool"
+  cluster  = google_container_cluster.migration_standard.name
+  location = var.region
+
+  initial_node_count = var.node_count
+
+  node_locations = local.node_locations
+
+  node_config {
+    machine_type    = var.node_machine_type
+    disk_size_gb    = var.node_disk_size
+    disk_type       = var.node_disk_type
+    service_account = google_service_account.migration_nodes.email
+    oauth_scopes    = var.node_oauth_scopes
+  }
+
+  management {
+    auto_repair  = true
+    auto_upgrade = true
+  }
+
+  autoscaling {
+    min_node_count = var.node_min_count
+    max_node_count = var.node_max_count
+  }
+
+  # initial_node_count only seeds the pool at creation; the autoscaler owns the
+  # count thereafter. Ignore drift so applies don't fight the autoscaler.
+  lifecycle {
+    ignore_changes = [initial_node_count]
+  }
 }
 
 

--- a/deployment/terraform/gcp/main.tf
+++ b/deployment/terraform/gcp/main.tf
@@ -397,7 +397,7 @@ resource "helm_release" "migration_assistant" {
     },
     {
       name  = "images.migrationConsole.tag"
-      value = "latest"
+      value = var.migration_release
     },
     {
       name  = "images.installer.repository"
@@ -405,7 +405,7 @@ resource "helm_release" "migration_assistant" {
     },
     {
       name  = "images.installer.tag"
-      value = "latest"
+      value = var.migration_release
     },
     {
       name  = "images.reindexFromSnapshot.repository"
@@ -413,7 +413,7 @@ resource "helm_release" "migration_assistant" {
     },
     {
       name  = "images.reindexFromSnapshot.tag"
-      value = "latest"
+      value = var.migration_release
     },
     # Capture proxy and traffic replayer images (live capture-and-replay migrations).
     # The chart's default repositories for these are unqualified ("migrations/..."),
@@ -427,7 +427,7 @@ resource "helm_release" "migration_assistant" {
     },
     {
       name  = "images.captureProxy.tag"
-      value = "latest"
+      value = var.migration_release
     },
     {
       name  = "images.trafficReplayer.repository"
@@ -435,7 +435,7 @@ resource "helm_release" "migration_assistant" {
     },
     {
       name  = "images.trafficReplayer.tag"
-      value = "latest"
+      value = var.migration_release
     },
     {
       name  = "migrationConfig.bucket_name"

--- a/deployment/terraform/gcp/variables.tf
+++ b/deployment/terraform/gcp/variables.tf
@@ -14,6 +14,19 @@ variable "project" {
   type        = string
 }
 
+variable "migration_release" {
+  description = <<-EOT
+    Migration Assistant release tag to deploy. Applied to every Migration
+    Assistant image (console, installer, reindex-from-snapshot, capture-proxy,
+    traffic-replayer). Defaults to a pinned release for reproducibility; bump it
+    to move to a newer release. The tag must exist for all four mirrored images
+    in the Artifact Registry repo the images.* repositories point at
+    (us-central1-docker.pkg.dev/<project>/migrations/*).
+  EOT
+  type        = string
+  default     = "3.3.4"
+}
+
 variable "region" {
   description = "GCP region"
   type        = string


### PR DESCRIPTION
## Description

Two independent GCP Terraform fixes discovered while validating the documentation-website updates. Kept as separate commits for reviewability.

### 1. Pin Migration Assistant image tags to a release

The `helm_release "migration_assistant"` resource hardcoded `tag = "latest"` for all five MA images (console, installer, reindex-from-snapshot, capture-proxy, traffic-replayer). `latest` is non-reproducible and can drift.

Introduce a `migration_release` variable and use it for every `images.*.tag` override. A pinned default keeps deployments reproducible while remaining overridable and keeping the plan-only Terraform tests working (a required/no-default variable would have broken them).

The default is `3.3.4` rather than the newer `3.3.5`: the GCP flow mirrors images from `public.ecr.aws/opensearchproject/*`, and as of this change no MA images are published there for `3.3.5` (`MANIFEST_UNKNOWN`), so `3.3.5` would fail the mirror step. `3.3.4` is the latest release with the core MA images present in public ECR.

**Operator prerequisite:** this module references images in Artifact Registry; it does not create the repo or push images. As documented in the README's "Container images" section, the operator running the deploy builds and pushes the images (`./gradlew buildImagesToRegistry -PregistryEndpoint=REGION-docker.pkg.dev/PROJECT`) before `terraform apply`. That build/push must now tag the images with the release (`3.3.4`), not only `latest`, so the tag the module requests exists in `us-central1-docker.pkg.dev/<project>/migrations/*`.

### 2. Move the GKE default node pool to a standalone resource

The module mixed two node-pool management styles on the same cluster: the default pool was configured **inline** inside `google_container_cluster.migration_standard`, while the Kafka pool was a **standalone** `google_container_node_pool` resource. Mixing the two force-replaces the entire cluster on a node-pool change — so a half-failed apply recreates the cluster and takes every pool (and its workloads) with it.

- On the cluster: `remove_default_node_pool = true` and `initial_node_count = 1` (GKE requires a node pool at creation; this throwaway one is removed immediately).
- Move the default pool into a standalone `google_container_node_pool "default"` resource, mirroring the previous inline config and matching how the Kafka pool is defined.
- Add `lifecycle { ignore_changes = [initial_node_count] }` so applies don't fight the autoscaler over the node count.

Node-pool changes no longer force cluster replacement.

## Testing

- `terraform fmt -check` — clean
- `terraform validate` — success
- `terraform test` — 16/16 pass
