### PR TITLE
[Dependabot refresh] build(deps): Bump the npm-security group across 1 directory with 1 update

### DIFF
--- a/deployment/migration-assistant-solution/package-lock.json
+++ b/deployment/migration-assistant-solution/package-lock.json
@@ -3397,9 +3397,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "dev": true,
       "funding": [
         {
@@ -3410,7 +3410,8 @@
           "type": "opencollective",
           "url": "https://opencollective.com/fastify"
         }
-      ]
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fb-watchman": {
       "version": "2.0.2",

--- a/orchestrationSpecs/package-lock.json
+++ b/orchestrationSpecs/package-lock.json
@@ -4236,9 +4236,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## Summary

- reapplies the dependency update from #3270
- refreshes the patch onto the latest upstream `main`
- preserves the original Dependabot authorship and adds the maintainer DCO sign-off

### From 3270:

Bumps the npm-security group with 1 update in the /orchestrationSpecs directory: [fast-uri](https://github.com/fastify/fast-uri).

Updates fast-uri from 3.1.2 to 3.1.5

Release notes
Commits

Updates fast-uri from 3.1.2 to 3.1.5
