### PR TITLE
[codex] Merge dependency updates from PRs #3270 and #3279

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ import groovy.json.JsonOutput
 plugins {
 //    Observing higher memory usage with task-tree plugin. Disabling except if needed
 //    id "com.dorongold.task-tree" version "4.0.1"
-    id "com.diffplug.spotless" version '8.8.0'
+    id "com.diffplug.spotless" version '8.9.0'
     id 'io.freefair.lombok' version '9.5.0' apply false
     id 'me.champeau.jmh' version '0.7.3' apply false
     id 'com.gradleup.shadow' version '8.3.8' apply false

--- a/deployment/migration-assistant-solution/package-lock.json
+++ b/deployment/migration-assistant-solution/package-lock.json
@@ -3397,9 +3397,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "dev": true,
       "funding": [
         {
@@ -3410,7 +3410,8 @@
           "type": "opencollective",
           "url": "https://opencollective.com/fastify"
         }
-      ]
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fb-watchman": {
       "version": "2.0.2",

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,20 +1,20 @@
 [versions]
-aws-crt = "0.48.1"
+aws-crt = "0.48.2"
 aws-msk-iam-auth = "2.3.7"
-aws-sdk = "2.49.3"
+aws-sdk = "2.50.1"
 bouncycastle = "1.85"
 commons-collections = "4.5.0"
 commons-compress = "1.26.2"
 disruptor = "4.0.0"
 dockerapi = "3.7.1"
 errorprone = "2.42.0"
-gcp-storage = "2.70.0"
+gcp-storage = "2.71.0"
 errorprone-slf4j = "0.1.29"
 graalvm = "25.0.3"
 groovy = "3.0.25"
 guava = "33.6.0-jre"
 hamcrest = "3.0"
-httpclient5 = "5.6.2"
+httpclient5 = "5.6.3"
 jackson = "2.22.1"
 jackson-annotations = "2.22"
 jcommander = "2.0"
@@ -196,7 +196,7 @@ transitive-dnsjava           = { module = "dnsjava:dnsjava",                    
 transitive-jersey-common     = { module = "org.glassfish.jersey.core:jersey-common", version = "4.0.2"   }
 transitive-json-path         = { module = "com.jayway.jsonpath:json-path",           version = "3.0.0"    }
 transitive-json-smart        = { module = "net.minidev:json-smart",                  version = "2.6.0"    }
-transitive-jsoup             = { module = "org.jsoup:jsoup",                         version = "1.22.2"   }
+transitive-jsoup             = { module = "org.jsoup:jsoup",                         version = "1.23.1"   }
 transitive-snappy-java       = { module = "org.xerial.snappy:snappy-java",           version = "1.1.10.8" }
 transitive-tika-core         = { module = "org.apache.tika:tika-core",               version = "3.3.2"    }
 transitive-xalan             = { module = "xalan:xalan",                             version = "2.7.3"    }

--- a/orchestrationSpecs/package-lock.json
+++ b/orchestrationSpecs/package-lock.json
@@ -4236,9 +4236,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## Summary

- combines the refreshed dependency updates from #3270 and #3279
- starts from the latest upstream `main`
- preserves each update as an independently reviewable branch and signed commit

## Included updates

- refreshed PR #3285 from original PR #3270: `fast-uri` security update
- refreshed PR #3286 from original PR #3279: Gradle dependency version updates

## Validation

- `git diff --check upstream/main...codex/dependabot-3270-3279`

This PR supersedes #3270 and #3279.
