### PR TITLE
Fail integ tests fast when a workflow blocks on an unexpected approval gate

### DIFF
--- a/migrationConsole/lib/console_link/console_link/workflow/commands/approve.py
+++ b/migrationConsole/lib/console_link/console_link/workflow/commands/approve.py
@@ -95,6 +95,24 @@ def _classify_runtime_gate(denial_msg):
     return 'retry' if 'Impossible' in denial_msg else 'change'
 
 
+def waiting_runtime_gates(namespace, workflow_name):
+    """Public accessor for the runtime gates a workflow is actively blocked on.
+
+    Returns a list of (gate_name, denial_reason, category) where category is
+    'change' or 'retry', filtered to runtime ('.vapretry') gates only. Step
+    gates are excluded because they are a normal mid-run state.
+
+    Exposed for callers outside this module (notably the integration test
+    harness, which needs to tell a parked workflow from a slow one) so they
+    don't have to reach for the private helpers or reimplement the node walk.
+    """
+    return [
+        (name, reason, _classify_runtime_gate(reason))
+        for name, reason in _waiting_gates_from_workflow(namespace, workflow_name)
+        if _gate_category_from_name(name) == 'runtime'
+    ]
+
+
 def _waiting_gates_from_workflow(namespace, workflow_name):
     """Fetch runtime gates (change + retry) from the Argo workflow.
 

--- a/migrationConsole/lib/console_link/console_link/workflow/commands/approve.py
+++ b/migrationConsole/lib/console_link/console_link/workflow/commands/approve.py
@@ -95,21 +95,22 @@ def _classify_runtime_gate(denial_msg):
     return 'retry' if 'Impossible' in denial_msg else 'change'
 
 
-def waiting_runtime_gates(namespace, workflow_name):
-    """Public accessor for the runtime gates a workflow is actively blocked on.
+def waiting_gates(namespace, workflow_name):
+    """Public accessor for every gate a workflow is actively blocked on.
 
     Returns a list of (gate_name, denial_reason, category) where category is
-    'change' or 'retry', filtered to runtime ('.vapretry') gates only. Step
-    gates are excluded because they are a normal mid-run state.
+    'step' for a user-defined approval point, or 'change'/'retry' for a runtime
+    VAP-denial gate. Anything blocking here will block until someone approves
+    it, whatever its category.
 
     Exposed for callers outside this module (notably the integration test
-    harness, which needs to tell a parked workflow from a slow one) so they
+    harness, which needs to tell a blocked workflow from a slow one) so they
     don't have to reach for the private helpers or reimplement the node walk.
     """
     return [
-        (name, reason, _classify_runtime_gate(reason))
+        (name, reason,
+         _classify_runtime_gate(reason) if _gate_category_from_name(name) == 'runtime' else 'step')
         for name, reason in _waiting_gates_from_workflow(namespace, workflow_name)
-        if _gate_category_from_name(name) == 'runtime'
     ]
 
 

--- a/migrationConsole/lib/console_link/tests/workflow-tests/test_workflow_cli_commands.py
+++ b/migrationConsole/lib/console_link/tests/workflow-tests/test_workflow_cli_commands.py
@@ -666,6 +666,23 @@ class TestWorkflowCLICommands:
         ]
         assert completion_gates == []
 
+    @patch('console_link.workflow.commands.approve._waiting_gates_from_workflow')
+    def test_waiting_gates_categorizes_step_and_runtime(self, mock_waiting_gates):
+        """Both kinds block until approved, so both are reported, tagged by kind."""
+        from console_link.workflow.commands.approve import waiting_gates
+
+        mock_waiting_gates.return_value = [
+            ('migratemetadata.snapshot-migration-0', None),
+            ('captureproxy.capture-proxy.vapretry', 'Gated field change on captureproxy: spec.replicas'),
+            ('datasnapshot.source1-snapshot.vapretry', 'Impossible field change on datasnapshot: spec.snapshotName'),
+        ]
+
+        assert [(name, category) for name, _, category in waiting_gates('ma', 'migration-workflow')] == [
+            ('migratemetadata.snapshot-migration-0', 'step'),
+            ('captureproxy.capture-proxy.vapretry', 'change'),
+            ('datasnapshot.source1-snapshot.vapretry', 'retry'),
+        ]
+
     @patch('console_link.workflow.commands.approve._list_all_gates')
     def test_find_already_approved_is_workflow_scoped(self, mock_list_gates):
         from console_link.workflow.commands.approve import _find_already_approved

--- a/migrationConsole/lib/integ_test/integ_test/integration_test_argo_service.py
+++ b/migrationConsole/lib/integ_test/integ_test/integration_test_argo_service.py
@@ -25,6 +25,7 @@ from console_link.workflow.commands.artifact_store import (
 from console_link.models.cluster import Cluster
 from console_link.models.command_runner import CommandRunner, CommandRunnerError, FlagOnlyArgument
 from console_link.models.command_result import CommandResult
+from .parked_gate_detection import INNER_WORKFLOW_NAME, ParkedGateWatcher
 
 logger = logging.getLogger(__name__)
 
@@ -99,6 +100,26 @@ class WorkflowEndedBeforeSuspend(Exception):
 class IntegrationTestArgoService:
     def __init__(self, namespace: str = "ma"):
         self.namespace = namespace
+        # Runtime approval gates this test intends to leave parked. Empty for
+        # every test today: a parked gate means the workflow is waiting on an
+        # approval no test will ever give, so the wait loops treat it as a
+        # failure. A test that deliberately exercises park-and-recover adds its
+        # gate names here before starting the wait.
+        self.expected_parked_gate_names: List[str] = []
+
+    def parked_gate_watcher_for(self, workflow_name: str) -> ParkedGateWatcher:
+        """Watch both the polled workflow and the inner migration workflow.
+
+        Tests poll the outer test wrapper (configure/monitor/evaluate), but the
+        reconcile steps that can park live in the inner `migration-workflow` that
+        configureAndSubmitWorkflow.sh submits. Checking only the polled workflow
+        would miss every park.
+        """
+        return ParkedGateWatcher(
+            namespace=self.namespace,
+            workflow_names=[workflow_name, INNER_WORKFLOW_NAME],
+            expected_gate_names=self.expected_parked_gate_names,
+        )
 
     def start_workflow(
         self,
@@ -588,6 +609,7 @@ class IntegrationTestArgoService:
     def wait_for_suspend(self, workflow_name: str, timeout_seconds: int = 120, interval: int = 5) -> CommandResult:
         start_time = time.time()
         last_status_info: Optional[Dict[str, Any]] = None
+        parked_gate_watcher = self.parked_gate_watcher_for(workflow_name)
 
         while time.time() - start_time < timeout_seconds:
             status_result = self.get_workflow_status(workflow_name)
@@ -604,9 +626,14 @@ class IntegrationTestArgoService:
             elif phase in ENDING_ARGO_PHASES:
                 raise WorkflowEndedBeforeSuspend(workflow_name=workflow_name, phase=phase)
 
+            # A workflow parked on a VAP-denial approval gate stays 'Running'
+            # forever, so this is the only exit that isn't the full timeout.
+            parked_gate_watcher.check()
+
             time.sleep(interval)
 
-        error_message = self._format_suspend_timeout_message(workflow_name, timeout_seconds, last_status_info)
+        error_message = self._format_suspend_timeout_message(
+            workflow_name, timeout_seconds, last_status_info, parked_gate_watcher.summarize_last_seen())
         try:
             diagnostics = self.collect_namespace_diagnostics(
                 workflow_name=workflow_name,
@@ -622,17 +649,21 @@ class IntegrationTestArgoService:
         workflow_name: str,
         timeout_seconds: int,
         status_info: Optional[Dict[str, Any]],
+        parked_gates: str = "",
     ) -> str:
         message = f"Workflow {workflow_name} did not reach suspended state in timeout of {timeout_seconds} seconds"
         if not status_info:
             return f"{message}; no workflow status was observed"
 
         details = _format_workflow_timeout_status_details(status_info)
+        if parked_gates:
+            details.append(f"unconfirmed_parked_gates={parked_gates}")
         return f"{message}; last status: " + ", ".join(details)
 
     def wait_for_ending_phase(self, workflow_name: str, timeout_seconds: int = 120, interval: int = 5) -> CommandResult:
         start_time = time.time()
         last_status_info: Optional[Dict[str, Any]] = None
+        parked_gate_watcher = self.parked_gate_watcher_for(workflow_name)
 
         while time.time() - start_time < timeout_seconds:
             status_result = self.get_workflow_status(workflow_name)
@@ -645,9 +676,15 @@ class IntegrationTestArgoService:
             if phase in ENDING_ARGO_PHASES:
                 return CommandResult(success=True, value=f"Workflow {workflow_name} has reached an ending phase of "
                                                          f"{phase}")
+
+            # A workflow parked on a VAP-denial approval gate stays 'Running'
+            # forever, so this is the only exit that isn't the full timeout.
+            parked_gate_watcher.check()
+
             time.sleep(interval)
 
-        error_message = self._format_ending_timeout_message(workflow_name, timeout_seconds, last_status_info)
+        error_message = self._format_ending_timeout_message(
+            workflow_name, timeout_seconds, last_status_info, parked_gate_watcher.summarize_last_seen())
         try:
             diagnostics = self.collect_namespace_diagnostics(
                 workflow_name=workflow_name,
@@ -663,12 +700,15 @@ class IntegrationTestArgoService:
         workflow_name: str,
         timeout_seconds: int,
         status_info: Optional[Dict[str, Any]],
+        parked_gates: str = "",
     ) -> str:
         message = f"Workflow {workflow_name} did not reach ending state in timeout of {timeout_seconds} seconds"
         if not status_info:
             return f"{message}; no workflow status was observed"
 
         details = _format_workflow_timeout_status_details(status_info)
+        if parked_gates:
+            details.append(f"unconfirmed_parked_gates={parked_gates}")
         return f"{message}; last status: " + ", ".join(details)
 
     def get_cluster_from_configmap(self, configmap_name_prefix: str,

--- a/migrationConsole/lib/integ_test/integ_test/integration_test_argo_service.py
+++ b/migrationConsole/lib/integ_test/integ_test/integration_test_argo_service.py
@@ -100,11 +100,12 @@ class WorkflowEndedBeforeSuspend(Exception):
 class IntegrationTestArgoService:
     def __init__(self, namespace: str = "ma"):
         self.namespace = namespace
-        # Runtime approval gates this test intends to leave parked. Empty for
-        # every test today: a parked gate means the workflow is waiting on an
-        # approval no test will ever give, so the wait loops treat it as a
-        # failure. A test that deliberately exercises park-and-recover adds its
-        # gate names here before starting the wait.
+        # Approval gates this test intends to sit on. Empty by default: a gate
+        # blocking a wait means the workflow needs an approval the test isn't
+        # going to give, so the wait loops treat it as a failure rather than
+        # burning the whole timeout. A test that approves its own step gates, or
+        # deliberately exercises park-and-recover, lists those gate names here
+        # before starting the wait.
         self.expected_parked_gate_names: List[str] = []
 
     def parked_gate_watcher_for(self, workflow_name: str) -> ParkedGateWatcher:

--- a/migrationConsole/lib/integ_test/integ_test/ma_workflow_test.py
+++ b/migrationConsole/lib/integ_test/integ_test/ma_workflow_test.py
@@ -1,5 +1,6 @@
 import logging
 import subprocess
+from typing import Callable, List, Tuple
 
 import pytest
 
@@ -71,33 +72,110 @@ def setup_and_teardown(
 
     #-----Teardown-----
     logger.info("Performing teardown...")
+    _perform_teardown(
+        request=request,
+        keep_workflows=keep_workflows,
+        skip_workflow_reset=skip_workflow_reset,
+        dump_all_workflow_output_artifacts=dump_all_workflow_output_artifacts,
+        test_case=test_case,
+    )
+
+
+def _perform_teardown(request, keep_workflows, skip_workflow_reset, dump_all_workflow_output_artifacts,
+                      test_case: MATestBase) -> None:
+    """Dump diagnostics on failure, quiesce the workflow, then delete/reset/clean up.
+
+    Those steps are independent, and none may preempt the others — least of all the dump. On a
+    failed test the dump is the only record of *why*, and it cannot be reconstructed once the
+    workflow has been stopped and the namespace reset. A workflow parked on an unexpected
+    approval gate is exactly that hazard: it stays 'Running' forever, so the quiesce step's gate
+    check raises, and while it ran ahead of the dump it took the dump down with it. Each step is
+    now isolated, and any suppressed error is re-raised at the end so a broken teardown is still
+    reported rather than silently ignored.
+    """
+    teardown_errors: List[Tuple[str, BaseException]] = []
+
+    def teardown_step(description: str, step: Callable[[], None]) -> None:
+        try:
+            step()
+        except (KeyboardInterrupt, SystemExit):
+            raise
+        except BaseException as e:
+            # BaseException rather than Exception: pytest.fail() raises Failed, which derives
+            # from BaseException, and _run_workflow_reset uses it. An interrupt still aborts.
+            logger.error("Teardown step '%s' failed: %s", description, e, exc_info=True)
+            teardown_errors.append((description, e))
+
+    dumped = False
+
+    def dump_diagnostics(reason: str) -> None:
+        nonlocal dumped
+        if dumped:
+            return
+        dumped = True
+        logger.info(f"{reason} - printing workflow details for {test_case.workflow_name}")
+        # Stepped individually: save_namespace_diagnostics writes the artifacts Jenkins
+        # archives, so an earlier print failing must not cost us the saved copy.
+        teardown_step("print workflow status", lambda: test_case.argo_service.print_workflow_status(
+            workflow_name=test_case.workflow_name))
+        teardown_step("print migration resource status",
+                      test_case.argo_service.print_migration_resource_status)
+        teardown_step("print workflow details", lambda: test_case.argo_service.print_workflow_details(
+            workflow_name=test_case.workflow_name))
+        teardown_step("print namespace diagnostics", lambda: test_case.argo_service.print_namespace_diagnostics(
+            workflow_name=test_case.workflow_name,
+            include_all_workflow_output_artifacts=dump_all_workflow_output_artifacts,
+        ))
+        teardown_step("save namespace diagnostics", lambda: test_case.argo_service.save_namespace_diagnostics(
+            "./logs",
+            workflow_name=test_case.workflow_name,
+            include_all_workflow_output_artifacts=dump_all_workflow_output_artifacts,
+        ))
+
     if test_case.workflow_name:
-        status_result = test_case.argo_service.get_workflow_status(workflow_name=test_case.workflow_name)
-        if status_result.value.get("phase", "") not in ("Succeeded", "Failed", "Error", "Stopped", "Terminated"):
-            test_case.argo_service.stop_workflow(workflow_name=test_case.workflow_name)
-            test_case.argo_service.wait_for_ending_phase(workflow_name=test_case.workflow_name)
-        # On success the full workflow-status JSON and migration-resource YAML are just noise.
-        # Only dump them (along with the heavier details/diagnostics) when the test failed.
+        # Dump BEFORE quiescing, for two reasons. Nothing upstream can then preempt it, and a
+        # workflow that hasn't been stopped yet still shows the state that matters: the suspended
+        # node it is parked on, the gate name, which resource's apply was denied. stop_workflow
+        # tears that down. On the common failure the workflow has already reached a terminal
+        # phase, so quiesce is a no-op and the ordering makes no difference either way.
+        # On success the full workflow-status JSON and migration-resource YAML are just noise,
+        # which is why this is conditional at all.
         if request.node.rep_call and request.node.rep_call.failed:
-            logger.info(f"Test failed - printing workflow details for {test_case.workflow_name}")
-            test_case.argo_service.print_workflow_status(workflow_name=test_case.workflow_name)
-            test_case.argo_service.print_migration_resource_status()
-            test_case.argo_service.print_workflow_details(workflow_name=test_case.workflow_name)
-            test_case.argo_service.print_namespace_diagnostics(
-                workflow_name=test_case.workflow_name,
-                include_all_workflow_output_artifacts=dump_all_workflow_output_artifacts,
-            )
-            test_case.argo_service.save_namespace_diagnostics(
-                "./logs",
-                workflow_name=test_case.workflow_name,
-                include_all_workflow_output_artifacts=dump_all_workflow_output_artifacts,
-            )
+            dump_diagnostics("Test failed")
+        teardown_step("stop workflow and wait for it to end", lambda: _quiesce_workflow(test_case))
+        # A workflow that will not stop is a real defect even when every assertion passed —
+        # parking on an unapprovable gate is exactly that — and teardown is the last moment
+        # the namespace still holds the evidence.
+        if teardown_errors:
+            dump_diagnostics("Teardown failed")
         if not keep_workflows:
-            test_case.argo_service.delete_workflow(workflow_name=test_case.workflow_name)
+            teardown_step("delete workflow", lambda: test_case.argo_service.delete_workflow(
+                workflow_name=test_case.workflow_name))
     # Reset all migration CRDs before test-specific cleanup unless the outer runner is preserving the run.
     if not skip_workflow_reset:
-        _run_workflow_reset()
-    test_case.cleanup()
+        teardown_step("reset migration resources", _run_workflow_reset)
+    teardown_step("test case cleanup", test_case.cleanup)
+
+    if teardown_errors:
+        # A single error is re-raised as-is so callers and tests can still match on its type
+        # (a parked gate surfaces as ParkedApprovalGateError, not a generic wrapper).
+        if len(teardown_errors) == 1:
+            raise teardown_errors[0][1]
+        summary = "; ".join(f"{description}: {type(e).__name__}: {e}" for description, e in teardown_errors)
+        raise RuntimeError(f"{len(teardown_errors)} teardown steps failed: {summary}") from teardown_errors[0][1]
+
+
+def _quiesce_workflow(test_case: MATestBase) -> None:
+    """Stop the workflow and wait for it to reach a terminal phase.
+
+    Skipped when it has already ended. Raises ParkedApprovalGateError if the workflow is
+    parked on an approval gate the test never intended to sit on, since it would otherwise
+    never reach an ending phase at all.
+    """
+    status_result = test_case.argo_service.get_workflow_status(workflow_name=test_case.workflow_name)
+    if status_result.value.get("phase", "") not in ("Succeeded", "Failed", "Error", "Stopped", "Terminated"):
+        test_case.argo_service.stop_workflow(workflow_name=test_case.workflow_name)
+        test_case.argo_service.wait_for_ending_phase(workflow_name=test_case.workflow_name)
 
 
 def record_test(test_case: MATestBase, record_data) -> None:

--- a/migrationConsole/lib/integ_test/integ_test/parked_gate_detection.py
+++ b/migrationConsole/lib/integ_test/integ_test/parked_gate_detection.py
@@ -1,0 +1,240 @@
+"""Detection of migration workflows parked on an unapproved runtime approval gate.
+
+When a migration resource apply is rejected by a ValidatingAdmissionPolicy, the
+workflow parks rather than failing: `tryApply` carries `continueOn: {failed: true}`
+and `waitForFix` then blocks on the `<kind>.<name>.vapretry` ApprovalGate until
+someone approves it (`resourceManagement.ts`, `reconcile*Resource`). That is
+deliberate — `K8S_USER_APPROVAL_WAIT_RETRY_STRATEGY` is documented as
+"intentionally open-ended in elapsed time", sibling work keeps running, and the
+operator recovers in place with `workflow reset <resource>` + `workflow approve`.
+
+For an integration test, though, nobody is going to approve anything. The
+workflow stays `Running` forever, so a test that only watches for
+ENDING_ARGO_PHASES can do nothing but burn its whole timeout and then report a
+TimeoutError that says nothing about the actual VAP denial.
+
+A parked gate is therefore a test failure by default. Tests that mean to
+exercise the park-and-recover path opt in by naming the gates they expect
+(`IntegrationTestArgoService.expected_parked_gate_names`).
+
+Note on the detection signal: the ApprovalGate CRD's status carries only
+`phase` (one of Created/Pending/Approved/Error — see `generateMigrationResources.ts`
+`statusSchemaFor`), and no denial reason. A gate sitting at `Pending` is also the
+normal steady state for every gate the workflow has not reached yet, and gates
+are pre-created at `Created` for the whole run. So gate phase alone cannot tell
+"blocking now" from "not reached yet". The authoritative signal is the workflow
+node graph: a `waitForFix` node in `Running` alongside a sibling `tryApply` in
+`Failed` under the same boundaryID. `console_link`'s approve command already
+extracts exactly that pair, along with the denial reason off the failed
+sibling's message, so this module reuses it via `waiting_runtime_gates` rather
+than reimplementing the traversal.
+"""
+
+import logging
+import time
+from typing import Dict, Iterable, List, Optional, Sequence
+
+from console_link.workflow.commands.approve import waiting_runtime_gates
+from console_link.workflow.models.utils import load_k8s_config
+
+logger = logging.getLogger(__name__)
+
+# The inner workflow submitted by configureAndSubmitWorkflow.sh. Test workflows
+# submit an outer wrapper whose own nodes are just configure/monitor/evaluate;
+# the reconcile steps that can park live in this one.
+INNER_WORKFLOW_NAME = "migration-workflow"
+
+# How often to look for parked gates from inside a wait loop. The wait loops poll
+# workflow status every few seconds; parking is not a state that needs sub-minute
+# detection, so check less often than that to keep API traffic down.
+DEFAULT_CHECK_INTERVAL_SECONDS = 30
+
+# Require the same gate to be seen parked on two consecutive checks before
+# failing. A single observation could in principle catch a `Failed` tryApply
+# whose retryLoop iteration is about to move on; making the test fail on a
+# transient would be worse than taking one extra interval to be sure.
+DEFAULT_CONSECUTIVE_OBSERVATIONS = 2
+
+
+class ParkedApprovalGateError(AssertionError):
+    """A workflow is parked on a runtime approval gate no one will approve.
+
+    AssertionError so pytest renders it as a test failure rather than an
+    infrastructure error — the workflow behaved correctly; the migration config
+    or the test's expectations are what's wrong.
+    """
+
+
+class ParkedGate:
+    """A runtime gate the workflow is actively blocked on.
+
+    name     — ApprovalGate CRD name, e.g. 'datasnapshot.source1-testsnapshot.vapretry'
+    reason   — VAP denial reason parsed off the failed tryApply sibling, or None
+    kind     — 'retry' for an Impossible-field denial (needs delete+recreate),
+               'change' for a Gated-field denial (approval alone suffices)
+    """
+
+    __slots__ = ("name", "reason", "kind")
+
+    def __init__(self, name: str, reason: Optional[str], kind: str):
+        self.name = name
+        self.reason = reason
+        self.kind = kind
+
+    def __str__(self) -> str:
+        detail = self.reason or "<no denial reason on the failed apply>"
+        return f"{self.name} ({self.kind}): {detail}"
+
+    def __repr__(self) -> str:  # pragma: no cover - debugging aid
+        return f"ParkedGate(name={self.name!r}, reason={self.reason!r}, kind={self.kind!r})"
+
+
+def find_parked_gates(
+    namespace: str,
+    workflow_name: str = INNER_WORKFLOW_NAME,
+    expected_gate_names: Iterable[str] = (),
+) -> List[ParkedGate]:
+    """Return runtime gates `workflow_name` is currently blocked on.
+
+    Only runtime (`.vapretry`) gates count. Step gates are excluded: those are
+    approved by the test itself (Test0003) or skipped via skipApprovals, so a
+    step gate showing as waiting is expected mid-run and not a park.
+
+    Never raises — a workflow that is missing, still starting, or has
+    unreadable status yields an empty list, so a poll loop calling this can't
+    fail for a reason unrelated to what it is checking.
+    """
+    expected = set(expected_gate_names)
+    try:
+        load_k8s_config()
+        waiting = waiting_runtime_gates(namespace, workflow_name)
+    except Exception as e:  # noqa: BLE001 — detection must never break the caller
+        logger.debug("Could not check %s for parked gates: %s", workflow_name, e)
+        return []
+
+    parked = []
+    for gate_name, reason, kind in waiting:
+        if gate_name in expected:
+            logger.info("Ignoring expected parked gate %s on workflow %s", gate_name, workflow_name)
+            continue
+        parked.append(ParkedGate(gate_name, reason, kind))
+    return parked
+
+
+def format_parked_gate_failure(parked: Dict[str, List[ParkedGate]]) -> str:
+    """Build the failure message, including how to recover by hand."""
+    all_gates = [gate for gates in parked.values() for gate in gates]
+    workflows = ", ".join(name for name, gates in parked.items() if gates)
+    lines = [
+        f"Workflow(s) {workflows} are parked on {len(all_gates)} unapproved runtime "
+        f"approval gate(s) and will not reach a terminal phase on their own:",
+    ]
+    lines.extend(f"  - {gate}" for gate in all_gates)
+
+    if any(gate.kind == "retry" for gate in all_gates):
+        lines.append(
+            "An 'Impossible' denial means the field cannot be changed on the existing "
+            "resource. Recovery is 'workflow reset <resource>' to delete it, then "
+            "'workflow approve retry <gate>' to let the workflow re-create it."
+        )
+    if any(gate.kind == "change" for gate in all_gates):
+        lines.append("A 'Gated' denial only needs 'workflow approve change <gate>'.")
+    lines.append(
+        "Parking is intended workflow behavior. If this test means to exercise it, add the "
+        "gate name to IntegrationTestArgoService.expected_parked_gate_names."
+    )
+    return "\n".join(lines)
+
+
+def summarize_parked_gates(parked: Dict[str, List[ParkedGate]]) -> str:
+    """One-line summary, for enriching an otherwise-unrelated timeout message."""
+    return "; ".join(
+        f"{workflow_name}: [" + ", ".join(str(gate) for gate in gates) + "]"
+        for workflow_name, gates in parked.items()
+        if gates
+    )
+
+
+class ParkedGateWatcher:
+    """Throttled, confirm-before-failing parked-gate check for a poll loop.
+
+    Wait loops call `check()` on every iteration; the watcher decides when to
+    actually hit the API and when an observation has persisted long enough to be
+    real. `last_seen` keeps whatever was found so a timeout raised for some other
+    reason can still report it.
+    """
+
+    def __init__(
+        self,
+        namespace: str,
+        workflow_names: Sequence[str],
+        expected_gate_names: Iterable[str] = (),
+        check_interval_seconds: Optional[int] = None,
+        required_consecutive_observations: Optional[int] = None,
+        clock=time.monotonic,
+    ):
+        # dict.fromkeys rather than set(): callers pass (outer, inner) and the
+        # outer name is the more useful one to name first in a failure message.
+        self.workflow_names = list(dict.fromkeys(name for name in workflow_names if name))
+        self.namespace = namespace
+        self.expected_gate_names = set(expected_gate_names)
+        # Resolved here rather than as parameter defaults so the module constants
+        # stay patchable by tests that fast-forward a wait loop.
+        self.check_interval_seconds = (
+            DEFAULT_CHECK_INTERVAL_SECONDS if check_interval_seconds is None else check_interval_seconds)
+        self.required_consecutive_observations = (
+            DEFAULT_CONSECUTIVE_OBSERVATIONS if required_consecutive_observations is None
+            else required_consecutive_observations)
+        self._clock = clock
+        self._next_check_at: Optional[float] = None
+        self._consecutive_observations: Dict[str, int] = {}
+        self.last_seen: Dict[str, List[ParkedGate]] = {}
+
+    def check(self) -> None:
+        """Raise ParkedApprovalGateError if a parked gate has persisted.
+
+        A no-op until `check_interval_seconds` has elapsed since the last real
+        check, so it is safe to call from a loop that polls far more often.
+        """
+        now = self._clock()
+        if self._next_check_at is not None and now < self._next_check_at:
+            return
+        self._next_check_at = now + self.check_interval_seconds
+
+        found: Dict[str, List[ParkedGate]] = {}
+        for workflow_name in self.workflow_names:
+            gates = find_parked_gates(self.namespace, workflow_name, self.expected_gate_names)
+            if gates:
+                found[workflow_name] = gates
+        self.last_seen = found
+
+        confirmed: Dict[str, List[ParkedGate]] = {}
+        still_parked = set()
+        for workflow_name, gates in found.items():
+            confirmed_gates = []
+            for gate in gates:
+                key = f"{workflow_name}/{gate.name}"
+                still_parked.add(key)
+                count = self._consecutive_observations.get(key, 0) + 1
+                self._consecutive_observations[key] = count
+                if count >= self.required_consecutive_observations:
+                    confirmed_gates.append(gate)
+                else:
+                    logger.warning(
+                        "Workflow %s may be parked on approval gate %s (%s); confirming on the next check",
+                        workflow_name, gate.name, gate.reason or "<no denial reason>",
+                    )
+            if confirmed_gates:
+                confirmed[workflow_name] = confirmed_gates
+
+        # Drop counts for gates that are no longer parked, so an intermittent
+        # observation can't accumulate into a failure across unrelated checks.
+        for key in list(self._consecutive_observations):
+            if key not in still_parked:
+                del self._consecutive_observations[key]
+
+        if confirmed:
+            raise ParkedApprovalGateError(format_parked_gate_failure(confirmed))
+
+    def summarize_last_seen(self) -> str:
+        return summarize_parked_gates(self.last_seen)

--- a/migrationConsole/lib/integ_test/integ_test/parked_gate_detection.py
+++ b/migrationConsole/lib/integ_test/integ_test/parked_gate_detection.py
@@ -1,40 +1,55 @@
-"""Detection of migration workflows parked on an unapproved runtime approval gate.
+"""Detection of migration workflows blocked on an unapproved approval gate.
 
-When a migration resource apply is rejected by a ValidatingAdmissionPolicy, the
-workflow parks rather than failing: `tryApply` carries `continueOn: {failed: true}`
-and `waitForFix` then blocks on the `<kind>.<name>.vapretry` ApprovalGate until
-someone approves it (`resourceManagement.ts`, `reconcile*Resource`). That is
-deliberate — `K8S_USER_APPROVAL_WAIT_RETRY_STRATEGY` is documented as
-"intentionally open-ended in elapsed time", sibling work keeps running, and the
-operator recovers in place with `workflow reset <resource>` + `workflow approve`.
+Any gate a workflow is actively blocked on will block until someone approves it.
+Two kinds reach that state:
 
-For an integration test, though, nobody is going to approve anything. The
-workflow stays `Running` forever, so a test that only watches for
-ENDING_ARGO_PHASES can do nothing but burn its whole timeout and then report a
-TimeoutError that says nothing about the actual VAP denial.
+- Runtime (`<kind>.<name>.vapretry`): a ValidatingAdmissionPolicy rejected a
+  resource apply, so the workflow parks — `tryApply` carries
+  `continueOn: {failed: true}` and `waitForFix` waits on the gate
+  (`resourceManagement.ts`, `reconcile*Resource`). That is deliberate:
+  `K8S_USER_APPROVAL_WAIT_RETRY_STRATEGY` is documented as "intentionally
+  open-ended in elapsed time", sibling work keeps running, and the operator
+  recovers in place with `workflow reset <resource>` + `workflow approve`.
+- Step: a user-defined approval point from the migration config.
 
-A parked gate is therefore a test failure by default. Tests that mean to
-exercise the park-and-recover path opt in by naming the gates they expect
-(`IntegrationTestArgoService.expected_parked_gate_names`).
+For an integration test, nobody is going to approve anything. The workflow stays
+`Running` forever, so a test that only watches for ENDING_ARGO_PHASES can do
+nothing but burn its whole timeout and then report a TimeoutError that says
+nothing about which gate it was stuck on. Step gates are no better off than
+runtime ones here: tests run `skipApprovals=true` (so no step gates exist at
+all, and one waiting is unexpected by construction), except Test0003, which
+approves a fixed list by name — a gate outside that list hangs just as hard.
 
-Note on the detection signal: the ApprovalGate CRD's status carries only
-`phase` (one of Created/Pending/Approved/Error — see `generateMigrationResources.ts`
+So *any* gate blocking a wait is a test failure. Tests that intend to sit on a
+gate name it (`IntegrationTestArgoService.expected_parked_gate_names`).
+
+Note on the detection signal: the ApprovalGate CRD's status carries only `phase`
+(one of Created/Pending/Approved/Error — see `generateMigrationResources.ts`
 `statusSchemaFor`), and no denial reason. A gate sitting at `Pending` is also the
 normal steady state for every gate the workflow has not reached yet, and gates
-are pre-created at `Created` for the whole run. So gate phase alone cannot tell
-"blocking now" from "not reached yet". The authoritative signal is the workflow
-node graph: a `waitForFix` node in `Running` alongside a sibling `tryApply` in
-`Failed` under the same boundaryID. `console_link`'s approve command already
-extracts exactly that pair, along with the denial reason off the failed
-sibling's message, so this module reuses it via `waiting_runtime_gates` rather
-than reimplementing the traversal.
+are pre-created at `Created` for the whole run, so gate phase alone cannot tell
+"blocking now" from "not reached yet". `Error` would be the closest thing to a
+denial signal, but nothing ever writes it: every write to a gate's phase is
+`Created` (initializer), `Pending` (`resetGate`), or `Approved` (`approve.py`) —
+`patchCaptureProxyError` sets the *CaptureProxy's* phase, not a gate's. (And
+`waitForUserApproval` has no `failureCondition`, so a gate that somehow reached
+`Error` would hang exactly like one at `Pending`.)
+
+The authoritative signal is therefore the workflow node graph: an approval node
+in `Running`, plus — for a runtime gate — a sibling `tryApply` in `Failed` under
+the same boundaryID carrying the denial reason. `console_link`'s approve command
+already extracts exactly that, so this module reuses it via `waiting_gates`
+rather than reimplementing the traversal.
+
+"Parked" throughout this module means "blocked on an approval nobody in this test
+run is going to give", whatever the gate's kind.
 """
 
 import logging
 import time
 from typing import Dict, Iterable, List, Optional, Sequence
 
-from console_link.workflow.commands.approve import waiting_runtime_gates
+from console_link.workflow.commands.approve import waiting_gates
 from console_link.workflow.models.utils import load_k8s_config
 
 logger = logging.getLogger(__name__)
@@ -51,13 +66,14 @@ DEFAULT_CHECK_INTERVAL_SECONDS = 30
 
 # Require the same gate to be seen parked on two consecutive checks before
 # failing. A single observation could in principle catch a `Failed` tryApply
-# whose retryLoop iteration is about to move on; making the test fail on a
-# transient would be worse than taking one extra interval to be sure.
+# whose retryLoop iteration is about to move on, or a step gate that the test is
+# about to approve; making the test fail on a transient would be worse than
+# taking one extra interval to be sure.
 DEFAULT_CONSECUTIVE_OBSERVATIONS = 2
 
 
 class ParkedApprovalGateError(AssertionError):
-    """A workflow is parked on a runtime approval gate no one will approve.
+    """A workflow is blocked on an approval gate no one will approve.
 
     AssertionError so pytest renders it as a test failure rather than an
     infrastructure error — the workflow behaved correctly; the migration config
@@ -66,12 +82,14 @@ class ParkedApprovalGateError(AssertionError):
 
 
 class ParkedGate:
-    """A runtime gate the workflow is actively blocked on.
+    """A gate the workflow is actively blocked on.
 
     name     — ApprovalGate CRD name, e.g. 'datasnapshot.source1-testsnapshot.vapretry'
     reason   — VAP denial reason parsed off the failed tryApply sibling, or None
+               (always None for a step gate; nothing failed to produce one)
     kind     — 'retry' for an Impossible-field denial (needs delete+recreate),
-               'change' for a Gated-field denial (approval alone suffices)
+               'change' for a Gated-field denial (approval alone suffices),
+               'step'  for a user-defined approval point from the config
     """
 
     __slots__ = ("name", "reason", "kind")
@@ -82,7 +100,11 @@ class ParkedGate:
         self.kind = kind
 
     def __str__(self) -> str:
-        detail = self.reason or "<no denial reason on the failed apply>"
+        if self.kind == "step":
+            # No apply failed, so there is usually nothing to quote here.
+            detail = self.reason or "waiting for a user approval the test never gives"
+        else:
+            detail = self.reason or "<no denial reason on the failed apply>"
         return f"{self.name} ({self.kind}): {detail}"
 
     def __repr__(self) -> str:  # pragma: no cover - debugging aid
@@ -94,11 +116,12 @@ def find_parked_gates(
     workflow_name: str = INNER_WORKFLOW_NAME,
     expected_gate_names: Iterable[str] = (),
 ) -> List[ParkedGate]:
-    """Return runtime gates `workflow_name` is currently blocked on.
+    """Return every gate `workflow_name` is currently blocked on, minus the expected ones.
 
-    Only runtime (`.vapretry`) gates count. Step gates are excluded: those are
-    approved by the test itself (Test0003) or skipped via skipApprovals, so a
-    step gate showing as waiting is expected mid-run and not a park.
+    Runtime (`.vapretry`) and step gates both count: neither will clear without
+    an approval, so both hang the wait. A test that approves its own step gates
+    (or otherwise means to sit on one) passes those names in
+    `expected_gate_names`.
 
     Never raises — a workflow that is missing, still starting, or has
     unreadable status yields an empty list, so a poll loop calling this can't
@@ -107,7 +130,7 @@ def find_parked_gates(
     expected = set(expected_gate_names)
     try:
         load_k8s_config()
-        waiting = waiting_runtime_gates(namespace, workflow_name)
+        waiting = waiting_gates(namespace, workflow_name)
     except Exception as e:  # noqa: BLE001 — detection must never break the caller
         logger.debug("Could not check %s for parked gates: %s", workflow_name, e)
         return []
@@ -126,7 +149,7 @@ def format_parked_gate_failure(parked: Dict[str, List[ParkedGate]]) -> str:
     all_gates = [gate for gates in parked.values() for gate in gates]
     workflows = ", ".join(name for name, gates in parked.items() if gates)
     lines = [
-        f"Workflow(s) {workflows} are parked on {len(all_gates)} unapproved runtime "
+        f"Workflow(s) {workflows} are blocked on {len(all_gates)} unapproved "
         f"approval gate(s) and will not reach a terminal phase on their own:",
     ]
     lines.extend(f"  - {gate}" for gate in all_gates)
@@ -139,9 +162,16 @@ def format_parked_gate_failure(parked: Dict[str, List[ParkedGate]]) -> str:
         )
     if any(gate.kind == "change" for gate in all_gates):
         lines.append("A 'Gated' denial only needs 'workflow approve change <gate>'.")
+    if any(gate.kind == "step" for gate in all_gates):
+        lines.append(
+            "A step gate is a user approval point from the migration config, cleared with "
+            "'workflow approve step <gate>'. Tests normally run with skipApprovals=true, so "
+            "one waiting here usually means the config or the workflow parameters created a "
+            "gate the test does not know to approve."
+        )
     lines.append(
-        "Parking is intended workflow behavior. If this test means to exercise it, add the "
-        "gate name to IntegrationTestArgoService.expected_parked_gate_names."
+        "Blocking on an unapproved gate is intended workflow behavior. If this test means to "
+        "exercise it, add the gate name to IntegrationTestArgoService.expected_parked_gate_names."
     )
     return "\n".join(lines)
 

--- a/migrationConsole/lib/integ_test/integ_test/test_cases/basic_tests.py
+++ b/migrationConsole/lib/integ_test/integ_test/test_cases/basic_tests.py
@@ -102,6 +102,11 @@ class Test0003ApprovalGateIntegration(MATestBase):
         self.doc_id = "test_0003_doc"
         self.doc_type = "sample_type"
         self.snapshot_migration_name = "source1-target1-testsnapshot-migration-0"
+        # Unlike every other test, this one runs with skipApprovals=false and means
+        # to block at each of these gates until it approves them by hand, so the
+        # wait loops must not treat them as a workflow stuck on an approval nobody
+        # will give. Any gate outside this list still fails the test.
+        self.argo_service.expected_parked_gate_names = self._approval_gate_names()
 
     def prepare_workflow_parameters(self, keep_workflows: bool = False):
         super().prepare_workflow_parameters(keep_workflows=keep_workflows)

--- a/migrationConsole/lib/integ_test/integ_test/test_cases/basic_tests.py
+++ b/migrationConsole/lib/integ_test/integ_test/test_cases/basic_tests.py
@@ -328,6 +328,7 @@ class Test0003ApprovalGateIntegration(MATestBase):
     def _wait_until_suspended_or_ended(self, timeout_seconds: int):
         """Wait until the workflow suspends for verification or ends."""
         deadline = time.time() + timeout_seconds
+        parked_gate_watcher = self.argo_service.parked_gate_watcher_for(self.workflow_name)
         while time.time() < deadline:
             status_result = self.argo_service.get_workflow_status(self.workflow_name)
             if status_result.success:
@@ -339,6 +340,9 @@ class Test0003ApprovalGateIntegration(MATestBase):
                 if phase in ENDING_ARGO_PHASES:
                     logger.info("Workflow reached ending phase: %s", phase)
                     return
+            # A workflow parked on a VAP-denial approval gate stays 'Running'
+            # forever; without this the only exit is the full timeout.
+            parked_gate_watcher.check()
             time.sleep(10)
         raise TimeoutError(
             f"Workflow did not reach suspend or ending phase within {timeout_seconds}s "

--- a/migrationConsole/lib/integ_test/integ_test/test_cases/cdc_base.py
+++ b/migrationConsole/lib/integ_test/integ_test/test_cases/cdc_base.py
@@ -14,7 +14,7 @@ from console_link.models.cluster import Cluster, SIGV4_SIGNING_ENDPOINT_KEY
 from console_link.workflow.commands.crd_utils import CRD_GROUP, CRD_VERSION
 
 from ..cluster_version import CDC_MIGRATION_COMBINATIONS
-from ..parked_gate_detection import INNER_WORKFLOW_NAME, ParkedGateWatcher
+from ..parked_gate_detection import INNER_WORKFLOW_NAME, ParkedApprovalGateError, ParkedGateWatcher
 from .ma_argo_test_base import MATestBase, MigrationType, MATestUserArguments  # noqa: F401 (re-exported)
 
 logger = logging.getLogger(__name__)
@@ -170,7 +170,13 @@ def _raise_if_cdc_dependency_error(namespace: str, workflow_names: Optional[Sequ
     # A CaptureProxy or Replayer whose apply was VAP-denied leaves the workflow
     # parked, not errored, so nothing above fires and the pod never appears.
     if parked_gate_watcher:
-        parked_gate_watcher.check()
+        try:
+            parked_gate_watcher.check()
+        except ParkedApprovalGateError:
+            # Every other raise above dumps first; match that, since the gate name
+            # alone doesn't show which resource's apply was denied.
+            _dump_argo_workflow_diagnostics(namespace)
+            raise
 
 
 def _raise_if_kafka_cluster_error(namespace: str) -> None:

--- a/migrationConsole/lib/integ_test/integ_test/test_cases/cdc_base.py
+++ b/migrationConsole/lib/integ_test/integ_test/test_cases/cdc_base.py
@@ -14,7 +14,7 @@ from console_link.models.cluster import Cluster, SIGV4_SIGNING_ENDPOINT_KEY
 from console_link.workflow.commands.crd_utils import CRD_GROUP, CRD_VERSION
 
 from ..cluster_version import CDC_MIGRATION_COMBINATIONS
-from ..parked_gate_detection import INNER_WORKFLOW_NAME, ParkedApprovalGateError, ParkedGateWatcher
+from ..parked_gate_detection import INNER_WORKFLOW_NAME, ParkedGateWatcher
 from .ma_argo_test_base import MATestBase, MigrationType, MATestUserArguments  # noqa: F401 (re-exported)
 
 logger = logging.getLogger(__name__)
@@ -170,13 +170,7 @@ def _raise_if_cdc_dependency_error(namespace: str, workflow_names: Optional[Sequ
     # A CaptureProxy or Replayer whose apply was VAP-denied leaves the workflow
     # parked, not errored, so nothing above fires and the pod never appears.
     if parked_gate_watcher:
-        try:
-            parked_gate_watcher.check()
-        except ParkedApprovalGateError:
-            # Every other raise above dumps first; match that, since the gate name
-            # alone doesn't show which resource's apply was denied.
-            _dump_argo_workflow_diagnostics(namespace)
-            raise
+        parked_gate_watcher.check()
 
 
 def _raise_if_kafka_cluster_error(namespace: str) -> None:

--- a/migrationConsole/lib/integ_test/integ_test/test_cases/cdc_base.py
+++ b/migrationConsole/lib/integ_test/integ_test/test_cases/cdc_base.py
@@ -14,6 +14,7 @@ from console_link.models.cluster import Cluster, SIGV4_SIGNING_ENDPOINT_KEY
 from console_link.workflow.commands.crd_utils import CRD_GROUP, CRD_VERSION
 
 from ..cluster_version import CDC_MIGRATION_COMBINATIONS
+from ..parked_gate_detection import INNER_WORKFLOW_NAME, ParkedGateWatcher
 from .ma_argo_test_base import MATestBase, MigrationType, MATestUserArguments  # noqa: F401 (re-exported)
 
 logger = logging.getLogger(__name__)
@@ -157,7 +158,8 @@ def _get_capture_proxy_readiness_status(namespace: str) -> tuple[str, str, str, 
     )
 
 
-def _raise_if_cdc_dependency_error(namespace: str, workflow_names: Optional[Sequence[str]] = None) -> None:
+def _raise_if_cdc_dependency_error(namespace: str, workflow_names: Optional[Sequence[str]] = None,
+                                   parked_gate_watcher: Optional[ParkedGateWatcher] = None) -> None:
     phase, message, _, _ = _get_capture_proxy_readiness_status(namespace)
     if phase == "Error":
         _dump_proxy_readiness_diagnostics(namespace)
@@ -165,6 +167,10 @@ def _raise_if_cdc_dependency_error(namespace: str, workflow_names: Optional[Sequ
     _raise_if_kafka_cluster_error(namespace)
     _raise_if_migration_resource_error(namespace)
     _raise_if_argo_workflow_error(namespace, workflow_names)
+    # A CaptureProxy or Replayer whose apply was VAP-denied leaves the workflow
+    # parked, not errored, so nothing above fires and the pod never appears.
+    if parked_gate_watcher:
+        parked_gate_watcher.check()
 
 
 def _raise_if_kafka_cluster_error(namespace: str) -> None:
@@ -425,6 +431,10 @@ def wait_for_replayer_consuming(
 ):
     """Wait until the replayer has joined the Kafka consumer group."""
     logger.info("Waiting for replayer pod readiness before checking Kafka consumer group...")
+    parked_gate_watcher = ParkedGateWatcher(
+        namespace=namespace,
+        workflow_names=[workflow_name, INNER_WORKFLOW_NAME],
+    )
     try:
         wait_for_pod_ready(
             namespace,
@@ -433,6 +443,7 @@ def wait_for_replayer_consuming(
             dependency_error_check=lambda: _raise_if_cdc_dependency_error(
                 namespace,
                 [workflow_name] if workflow_name else None,
+                parked_gate_watcher,
             ),
         )
     except TimeoutError:
@@ -442,7 +453,8 @@ def wait_for_replayer_consuming(
 
     start = time.time()
     while time.time() - start < timeout_seconds:
-        _raise_if_cdc_dependency_error(namespace, [workflow_name] if workflow_name else None)
+        _raise_if_cdc_dependency_error(namespace, [workflow_name] if workflow_name else None,
+                                       parked_gate_watcher)
         try:
             result = subprocess.run(
                 ["kubectl", "logs", "-l", REPLAYER_LABEL_SELECTOR, "-n", namespace, "--tail=100"],

--- a/migrationConsole/lib/integ_test/tests/test_cdc_base.py
+++ b/migrationConsole/lib/integ_test/tests/test_cdc_base.py
@@ -85,8 +85,8 @@ def test_wait_for_replayer_consuming_passes_workflow_name_to_dependency_check(mo
     def fake_wait_for_pod_ready(namespace, label_selector, timeout_seconds, dependency_error_check=None):
         dependency_error_check()
 
-    def fake_dependency_check(namespace, workflow_names=None):
-        dependency_calls.append((namespace, workflow_names))
+    def fake_dependency_check(namespace, workflow_names=None, parked_gate_watcher=None):
+        dependency_calls.append((namespace, workflow_names, parked_gate_watcher))
 
     class FakeCompletedProcess:
         stdout = "KafkaHeartbeat partitions=[0]\n"
@@ -97,7 +97,12 @@ def test_wait_for_replayer_consuming_passes_workflow_name_to_dependency_check(mo
 
     cdc_base.wait_for_replayer_consuming(namespace="ma", timeout_seconds=1, workflow_name="outer-workflow")
 
-    assert ("ma", ["outer-workflow"]) in dependency_calls
+    assert ("ma", ["outer-workflow"]) in [(namespace, names) for namespace, names, _ in dependency_calls]
+    # A parked capture proxy / replayer leaves the workflow Running, so the
+    # dependency check needs the watcher to notice it.
+    watcher = dependency_calls[0][2]
+    assert watcher is not None
+    assert watcher.workflow_names == ["outer-workflow", cdc_base.INNER_WORKFLOW_NAME]
 
 
 def test_cdc_dependency_check_fails_on_failed_inner_migration_workflow(monkeypatch):

--- a/migrationConsole/lib/integ_test/tests/test_cdc_base.py
+++ b/migrationConsole/lib/integ_test/tests/test_cdc_base.py
@@ -120,22 +120,3 @@ def test_cdc_dependency_check_fails_on_failed_inner_migration_workflow(monkeypat
 
     with pytest.raises(RuntimeError, match="CDC dependency workflow failed.*migration-workflow.*Create Snapshot"):
         cdc_base._raise_if_cdc_dependency_error("ma", ["outer-workflow"])
-
-
-def test_cdc_dependency_check_dumps_diagnostics_before_raising_on_parked_gate(monkeypatch):
-    """The gate name alone doesn't say which apply was denied, so dump like every other raise here."""
-    monkeypatch.setattr(cdc_base, "_get_capture_proxy_readiness_status", lambda namespace: ("Ready", "", "", ""))
-    monkeypatch.setattr(cdc_base, "_get_kafka_cluster_errors", lambda namespace: [])
-    monkeypatch.setattr(cdc_base, "_get_migration_resource_errors", lambda namespace: [])
-    monkeypatch.setattr(cdc_base, "_get_argo_workflow_errors", lambda namespace, workflow_names: [])
-    dumped = []
-    monkeypatch.setattr(cdc_base, "_dump_argo_workflow_diagnostics", dumped.append)
-
-    class ParkedWatcher:
-        def check(self):
-            raise cdc_base.ParkedApprovalGateError("parked on captureproxy.capture-proxy.vapretry")
-
-    with pytest.raises(cdc_base.ParkedApprovalGateError, match="captureproxy.capture-proxy.vapretry"):
-        cdc_base._raise_if_cdc_dependency_error("ma", ["outer-workflow"], parked_gate_watcher=ParkedWatcher())
-
-    assert dumped == ["ma"]

--- a/migrationConsole/lib/integ_test/tests/test_cdc_base.py
+++ b/migrationConsole/lib/integ_test/tests/test_cdc_base.py
@@ -120,3 +120,22 @@ def test_cdc_dependency_check_fails_on_failed_inner_migration_workflow(monkeypat
 
     with pytest.raises(RuntimeError, match="CDC dependency workflow failed.*migration-workflow.*Create Snapshot"):
         cdc_base._raise_if_cdc_dependency_error("ma", ["outer-workflow"])
+
+
+def test_cdc_dependency_check_dumps_diagnostics_before_raising_on_parked_gate(monkeypatch):
+    """The gate name alone doesn't say which apply was denied, so dump like every other raise here."""
+    monkeypatch.setattr(cdc_base, "_get_capture_proxy_readiness_status", lambda namespace: ("Ready", "", "", ""))
+    monkeypatch.setattr(cdc_base, "_get_kafka_cluster_errors", lambda namespace: [])
+    monkeypatch.setattr(cdc_base, "_get_migration_resource_errors", lambda namespace: [])
+    monkeypatch.setattr(cdc_base, "_get_argo_workflow_errors", lambda namespace, workflow_names: [])
+    dumped = []
+    monkeypatch.setattr(cdc_base, "_dump_argo_workflow_diagnostics", dumped.append)
+
+    class ParkedWatcher:
+        def check(self):
+            raise cdc_base.ParkedApprovalGateError("parked on captureproxy.capture-proxy.vapretry")
+
+    with pytest.raises(cdc_base.ParkedApprovalGateError, match="captureproxy.capture-proxy.vapretry"):
+        cdc_base._raise_if_cdc_dependency_error("ma", ["outer-workflow"], parked_gate_watcher=ParkedWatcher())
+
+    assert dumped == ["ma"]

--- a/migrationConsole/lib/integ_test/tests/test_integration_test_argo_service.py
+++ b/migrationConsole/lib/integ_test/tests/test_integration_test_argo_service.py
@@ -7,6 +7,7 @@ import pytest
 import yaml
 
 from integ_test.integration_test_argo_service import IntegrationTestArgoService, WorkflowEndedBeforeSuspend
+from integ_test.parked_gate_detection import INNER_WORKFLOW_NAME, ParkedApprovalGateError
 from console_link.models.command_result import CommandResult
 from console_link.models.command_runner import CommandRunnerError, FlagOnlyArgument
 
@@ -403,6 +404,93 @@ def test_wait_for_ending_phase_status_failure(mock_get_status, argo_service):
         argo_service.wait_for_ending_phase("test-workflow", timeout_seconds=1, interval=0.1)
 
     assert "Failed to get workflow status" in str(exc_info.value)
+
+
+# Parked approval gate detection in the wait loops.
+#
+# A workflow parked on a VAP-denial approval gate stays 'Running' indefinitely by
+# design, so without this check the only outcome is the full timeout (1800s for a
+# migration) with a message that never mentions the denial.
+
+RUNNING_STATUS_VALUE = {
+    "phase": "Running",
+    "has_suspended_nodes": False,
+    "suspended_nodes": [],
+    "running_nodes": [{"displayName": "waitForFix", "type": "Pod", "phase": "Running"}],
+    "pending_nodes": [],
+    "unsuccessful_nodes": [],
+}
+PARKED_GATE = ("datasnapshot.source1-testsnapshot.vapretry", "Impossible field change", "retry")
+
+
+@pytest.fixture
+def parked_gate_stub():
+    """Report a parked gate for every workflow and skip cluster config loading.
+
+    The check interval is zeroed so the wait loop under test isn't held to the
+    30s production throttle in wall-clock time.
+    """
+    with patch("integ_test.parked_gate_detection.load_k8s_config"), \
+            patch("integ_test.parked_gate_detection.DEFAULT_CHECK_INTERVAL_SECONDS", 0), \
+            patch("integ_test.parked_gate_detection.waiting_runtime_gates", return_value=[PARKED_GATE]) as stub:
+        yield stub
+
+
+@pytest.mark.parametrize("wait_method", ["wait_for_suspend", "wait_for_ending_phase"])
+@patch('integ_test.integration_test_argo_service.IntegrationTestArgoService.get_workflow_status')
+@patch('time.sleep')
+def test_wait_fails_fast_on_parked_approval_gate(mock_sleep, mock_get_status, wait_method, argo_service,
+                                                 parked_gate_stub):
+    mock_get_status.return_value = CommandResult(success=True, value=RUNNING_STATUS_VALUE)
+
+    with pytest.raises(ParkedApprovalGateError) as exc_info:
+        getattr(argo_service, wait_method)("test-workflow", timeout_seconds=600, interval=0.1)
+
+    assert PARKED_GATE[0] in str(exc_info.value)
+    assert PARKED_GATE[1] in str(exc_info.value)
+    # Returned on the second observation rather than running out the 600s budget.
+    assert mock_sleep.call_count == 1
+
+
+@pytest.mark.parametrize("wait_method", ["wait_for_suspend", "wait_for_ending_phase"])
+@patch('integ_test.integration_test_argo_service.IntegrationTestArgoService.get_workflow_status')
+@patch('time.sleep')
+def test_wait_ignores_expected_parked_gate(mock_sleep, mock_get_status, wait_method, argo_service, parked_gate_stub):
+    """A test that deliberately exercises park-and-recover opts out."""
+    mock_get_status.return_value = CommandResult(success=True, value=RUNNING_STATUS_VALUE)
+    argo_service.expected_parked_gate_names = [PARKED_GATE[0]]
+
+    with patch.object(IntegrationTestArgoService, "collect_namespace_diagnostics", return_value=""), \
+            pytest.raises(TimeoutError):
+        getattr(argo_service, wait_method)("test-workflow", timeout_seconds=1, interval=0.1)
+
+
+@patch('integ_test.integration_test_argo_service.IntegrationTestArgoService.get_workflow_status')
+def test_wait_checks_polled_and_inner_workflow_for_parked_gates(mock_get_status, argo_service):
+    """The reconcile steps that can park live in the inner migration-workflow."""
+    mock_get_status.return_value = CommandResult(success=True, value=RUNNING_STATUS_VALUE)
+    watcher = argo_service.parked_gate_watcher_for("outer-workflow")
+
+    assert watcher.workflow_names == ["outer-workflow", INNER_WORKFLOW_NAME]
+    assert watcher.namespace == argo_service.namespace
+
+
+@patch('integ_test.integration_test_argo_service.IntegrationTestArgoService.get_workflow_status')
+@patch('time.sleep')
+@patch('time.time')
+@patch('integ_test.integration_test_argo_service.IntegrationTestArgoService.collect_namespace_diagnostics')
+def test_timeout_message_reports_unconfirmed_parked_gate(mock_collect_diagnostics, mock_time, mock_sleep,
+                                                         mock_get_status, argo_service, parked_gate_stub):
+    """A single sighting isn't enough to fail, but it should still be reported."""
+    mock_time.side_effect = itertools.chain([0, 0, 2], itertools.repeat(2))
+    mock_get_status.return_value = CommandResult(success=True, value=RUNNING_STATUS_VALUE)
+    mock_collect_diagnostics.return_value = "namespace diagnostics"
+
+    with pytest.raises(TimeoutError) as exc_info:
+        argo_service.wait_for_ending_phase("test-workflow", timeout_seconds=1, interval=0.1)
+
+    assert "unconfirmed_parked_gates" in str(exc_info.value)
+    assert PARKED_GATE[0] in str(exc_info.value)
 
 
 # Internal method tests

--- a/migrationConsole/lib/integ_test/tests/test_integration_test_argo_service.py
+++ b/migrationConsole/lib/integ_test/tests/test_integration_test_argo_service.py
@@ -406,11 +406,11 @@ def test_wait_for_ending_phase_status_failure(mock_get_status, argo_service):
     assert "Failed to get workflow status" in str(exc_info.value)
 
 
-# Parked approval gate detection in the wait loops.
+# Unapproved approval gate detection in the wait loops.
 #
-# A workflow parked on a VAP-denial approval gate stays 'Running' indefinitely by
-# design, so without this check the only outcome is the full timeout (1800s for a
-# migration) with a message that never mentions the denial.
+# A workflow blocked on an approval gate stays 'Running' indefinitely by design,
+# so without this check the only outcome is the full timeout (1800s for a
+# migration) with a message that never mentions the gate.
 
 RUNNING_STATUS_VALUE = {
     "phase": "Running",
@@ -421,19 +421,27 @@ RUNNING_STATUS_VALUE = {
     "unsuccessful_nodes": [],
 }
 PARKED_GATE = ("datasnapshot.source1-testsnapshot.vapretry", "Impossible field change", "retry")
+PARKED_STEP_GATE = ("documentbackfill.source1-target1-testsnapshot-migration-0", None, "step")
 
 
-@pytest.fixture
-def parked_gate_stub():
-    """Report a parked gate for every workflow and skip cluster config loading.
+def _parked_gate_stub_for(gates):
+    """Report `gates` for every workflow and skip cluster config loading.
 
     The check interval is zeroed so the wait loop under test isn't held to the
     30s production throttle in wall-clock time.
     """
-    with patch("integ_test.parked_gate_detection.load_k8s_config"), \
-            patch("integ_test.parked_gate_detection.DEFAULT_CHECK_INTERVAL_SECONDS", 0), \
-            patch("integ_test.parked_gate_detection.waiting_runtime_gates", return_value=[PARKED_GATE]) as stub:
-        yield stub
+    return (
+        patch("integ_test.parked_gate_detection.load_k8s_config"),
+        patch("integ_test.parked_gate_detection.DEFAULT_CHECK_INTERVAL_SECONDS", 0),
+        patch("integ_test.parked_gate_detection.waiting_gates", return_value=gates),
+    )
+
+
+@pytest.fixture
+def parked_gate_stub():
+    no_config, no_throttle, stub = _parked_gate_stub_for([PARKED_GATE])
+    with no_config, no_throttle, stub as waiting:
+        yield waiting
 
 
 @pytest.mark.parametrize("wait_method", ["wait_for_suspend", "wait_for_ending_phase"])
@@ -449,6 +457,22 @@ def test_wait_fails_fast_on_parked_approval_gate(mock_sleep, mock_get_status, wa
     assert PARKED_GATE[0] in str(exc_info.value)
     assert PARKED_GATE[1] in str(exc_info.value)
     # Returned on the second observation rather than running out the 600s budget.
+    assert mock_sleep.call_count == 1
+
+
+@pytest.mark.parametrize("wait_method", ["wait_for_suspend", "wait_for_ending_phase"])
+@patch('integ_test.integration_test_argo_service.IntegrationTestArgoService.get_workflow_status')
+@patch('time.sleep')
+def test_wait_fails_fast_on_unexpected_step_gate(mock_sleep, mock_get_status, wait_method, argo_service):
+    """Tests run with skipApprovals=true, so a waiting step gate hangs just as hard."""
+    mock_get_status.return_value = CommandResult(success=True, value=RUNNING_STATUS_VALUE)
+    no_config, no_throttle, stub = _parked_gate_stub_for([PARKED_STEP_GATE])
+
+    with no_config, no_throttle, stub, pytest.raises(ParkedApprovalGateError) as exc_info:
+        getattr(argo_service, wait_method)("test-workflow", timeout_seconds=600, interval=0.1)
+
+    assert PARKED_STEP_GATE[0] in str(exc_info.value)
+    assert "workflow approve step" in str(exc_info.value)
     assert mock_sleep.call_count == 1
 
 

--- a/migrationConsole/lib/integ_test/tests/test_ma_workflow_teardown.py
+++ b/migrationConsole/lib/integ_test/tests/test_ma_workflow_teardown.py
@@ -1,0 +1,227 @@
+"""Teardown must not let one failing step preempt the others — especially the dump.
+
+A workflow parked on an approval gate nobody will approve never reaches an ending phase, so
+the gate check inside wait_for_ending_phase raises during teardown's quiesce step. That step
+used to run before the diagnostic dump, so a raise there skipped the dump entirely — losing the
+only record of why the run failed, precisely in the case that needs it most. These tests pin
+that the dump runs first, that each step is isolated, and that the error still surfaces.
+"""
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from integ_test.ma_workflow_test import _perform_teardown, _quiesce_workflow
+from integ_test.parked_gate_detection import ParkedApprovalGateError
+
+DUMP_METHODS = (
+    "print_workflow_status",
+    "print_migration_resource_status",
+    "print_workflow_details",
+    "print_namespace_diagnostics",
+    "save_namespace_diagnostics",
+)
+
+
+def _make_request(failed: bool):
+    return SimpleNamespace(node=SimpleNamespace(rep_call=SimpleNamespace(failed=failed)))
+
+
+def _make_test_case(phase: str = "Running"):
+    test_case = MagicMock()
+    test_case.workflow_name = "wf-under-test"
+    test_case.argo_service.get_workflow_status.return_value = SimpleNamespace(value={"phase": phase})
+    return test_case
+
+
+def _teardown(test_case, failed=True, keep_workflows=False, skip_workflow_reset=True):
+    return _perform_teardown(
+        request=_make_request(failed),
+        keep_workflows=keep_workflows,
+        skip_workflow_reset=skip_workflow_reset,
+        dump_all_workflow_output_artifacts=False,
+        test_case=test_case,
+    )
+
+
+def _assert_dumped(test_case):
+    for method in DUMP_METHODS:
+        assert getattr(test_case.argo_service, method).called, f"{method} must still run"
+
+
+def test_parked_gate_during_quiesce_does_not_preempt_the_dump():
+    """The regression this file exists for."""
+    test_case = _make_test_case()
+    test_case.argo_service.wait_for_ending_phase.side_effect = ParkedApprovalGateError("gate is parked")
+
+    with pytest.raises(ParkedApprovalGateError, match="gate is parked"):
+        _teardown(test_case)
+
+    _assert_dumped(test_case)
+
+
+def test_failed_test_dumps_before_the_workflow_is_stopped():
+    """Order matters beyond just not-being-preempted.
+
+    A workflow that hasn't been stopped yet still shows the suspended node it's parked on and
+    which resource's apply was denied. stop_workflow tears that down, so dumping afterwards
+    would capture a workflow whose interesting state has already been dismantled.
+    """
+    test_case = _make_test_case()
+    calls = []
+    for method in DUMP_METHODS:
+        getattr(test_case.argo_service, method).side_effect = \
+            lambda *a, _m=method, **kw: calls.append(_m)
+    test_case.argo_service.stop_workflow.side_effect = lambda *a, **kw: calls.append("stop_workflow")
+
+    _teardown(test_case)
+
+    assert "stop_workflow" in calls, "the still-running workflow must still be stopped"
+    assert calls.index("stop_workflow") > calls.index(DUMP_METHODS[-1]), \
+        f"every dump must precede stop_workflow, got {calls}"
+
+
+def test_dump_is_not_repeated_when_both_the_test_and_teardown_fail():
+    """Two dumps of the same namespace is just noise in an already-long CI log."""
+    test_case = _make_test_case()
+    test_case.argo_service.wait_for_ending_phase.side_effect = ParkedApprovalGateError("gate is parked")
+
+    with pytest.raises(ParkedApprovalGateError):
+        _teardown(test_case, failed=True)
+
+    test_case.argo_service.save_namespace_diagnostics.assert_called_once()
+
+
+def test_quiesce_failure_is_reraised_with_its_original_type():
+    """A parked gate must keep surfacing as ParkedApprovalGateError, not a generic wrapper.
+
+    It subclasses AssertionError so pytest renders it as a test failure; wrapping would lose that.
+    """
+    test_case = _make_test_case()
+    test_case.argo_service.wait_for_ending_phase.side_effect = ParkedApprovalGateError("gate is parked")
+
+    with pytest.raises(AssertionError):
+        _teardown(test_case)
+
+
+def test_quiesce_failure_still_deletes_the_workflow_and_cleans_up():
+    """Otherwise one parked run leaves resources behind and fails every later test at setup."""
+    test_case = _make_test_case()
+    test_case.argo_service.wait_for_ending_phase.side_effect = ParkedApprovalGateError("gate is parked")
+
+    with patch("integ_test.ma_workflow_test._run_workflow_reset") as mock_reset:
+        with pytest.raises(ParkedApprovalGateError):
+            _teardown(test_case, keep_workflows=False, skip_workflow_reset=False)
+
+    test_case.argo_service.delete_workflow.assert_called_once_with(workflow_name="wf-under-test")
+    mock_reset.assert_called_once()
+    test_case.cleanup.assert_called_once()
+
+
+def test_a_failing_dump_step_does_not_preempt_the_saved_artifacts():
+    """save_namespace_diagnostics writes what Jenkins archives, so it must not be skipped."""
+    test_case = _make_test_case(phase="Succeeded")
+    test_case.argo_service.print_workflow_details.side_effect = RuntimeError("kubectl exploded")
+
+    with pytest.raises(RuntimeError, match="kubectl exploded"):
+        _teardown(test_case)
+
+    test_case.argo_service.save_namespace_diagnostics.assert_called_once()
+
+
+def test_multiple_teardown_failures_are_all_reported():
+    test_case = _make_test_case()
+    test_case.argo_service.wait_for_ending_phase.side_effect = ParkedApprovalGateError("gate is parked")
+    test_case.cleanup.side_effect = RuntimeError("cleanup exploded")
+
+    with pytest.raises(RuntimeError) as excinfo:
+        _teardown(test_case)
+
+    message = str(excinfo.value)
+    assert "2 teardown steps failed" in message
+    assert "gate is parked" in message
+    assert "cleanup exploded" in message
+
+
+def test_pytest_fail_inside_a_step_is_captured_rather_than_escaping_early():
+    """_run_workflow_reset calls pytest.fail(), which raises a BaseException subclass.
+
+    Catching only Exception would let it skip test_case.cleanup().
+    """
+    test_case = _make_test_case(phase="Succeeded")
+
+    with patch("integ_test.ma_workflow_test._run_workflow_reset",
+               side_effect=pytest.fail.Exception("reset exited with code 1")):
+        with pytest.raises(pytest.fail.Exception, match="reset exited with code 1"):
+            _teardown(test_case, failed=False, skip_workflow_reset=False)
+
+    test_case.cleanup.assert_called_once()
+
+
+def test_keyboard_interrupt_still_aborts_teardown():
+    """Suppressing an interrupt would make the run unkillable during teardown."""
+    test_case = _make_test_case()
+    test_case.argo_service.wait_for_ending_phase.side_effect = KeyboardInterrupt
+
+    with pytest.raises(KeyboardInterrupt):
+        _teardown(test_case)
+
+
+def test_clean_run_dumps_nothing_and_raises_nothing():
+    """The dump is noise on success — this is what keeps the passing-case logs readable."""
+    test_case = _make_test_case(phase="Succeeded")
+
+    _teardown(test_case, failed=False)
+
+    for method in DUMP_METHODS:
+        assert not getattr(test_case.argo_service, method).called, f"{method} must not run on success"
+    test_case.cleanup.assert_called_once()
+
+
+def test_teardown_failure_on_a_passing_test_still_dumps():
+    """A workflow that won't stop is a real defect even when the assertions passed.
+
+    Teardown is the last moment the namespace still holds the evidence.
+    """
+    test_case = _make_test_case()
+    test_case.argo_service.wait_for_ending_phase.side_effect = ParkedApprovalGateError("gate is parked")
+
+    with pytest.raises(ParkedApprovalGateError):
+        _teardown(test_case, failed=False)
+
+    _assert_dumped(test_case)
+
+
+def test_teardown_without_a_workflow_name_skips_workflow_steps():
+    """Tests that fail before submitting have nothing to quiesce or dump."""
+    test_case = _make_test_case()
+    test_case.workflow_name = None
+
+    _teardown(test_case)
+
+    test_case.argo_service.get_workflow_status.assert_not_called()
+    test_case.argo_service.delete_workflow.assert_not_called()
+    test_case.cleanup.assert_called_once()
+
+
+# --- _quiesce_workflow ---------------------------------------------------------------
+
+
+@pytest.mark.parametrize("phase", ["Succeeded", "Failed", "Error", "Stopped", "Terminated"])
+def test_quiesce_skips_workflows_that_already_ended(phase):
+    test_case = _make_test_case(phase=phase)
+
+    _quiesce_workflow(test_case)
+
+    test_case.argo_service.stop_workflow.assert_not_called()
+    test_case.argo_service.wait_for_ending_phase.assert_not_called()
+
+
+@pytest.mark.parametrize("phase", ["Running", "Pending", ""])
+def test_quiesce_stops_workflows_that_are_still_going(phase):
+    test_case = _make_test_case(phase=phase)
+
+    _quiesce_workflow(test_case)
+
+    test_case.argo_service.stop_workflow.assert_called_once_with(workflow_name="wf-under-test")
+    test_case.argo_service.wait_for_ending_phase.assert_called_once_with(workflow_name="wf-under-test")

--- a/migrationConsole/lib/integ_test/tests/test_parked_gate_detection.py
+++ b/migrationConsole/lib/integ_test/tests/test_parked_gate_detection.py
@@ -1,9 +1,9 @@
-"""Tests for parked runtime approval gate detection.
+"""Tests for detection of workflows blocked on an unapproved approval gate.
 
-The signal under test is the pair `console_link`'s approve command extracts from
-the Argo node graph — a Running waitForFix plus a Failed tryApply sibling — so
-these tests stub `waiting_runtime_gates` and exercise the throttling,
-confirmation, and message-formatting logic on top of it.
+The signal under test is what `console_link`'s approve command extracts from the
+Argo node graph — a Running approval node, plus (for a runtime gate) a Failed
+tryApply sibling carrying the denial — so these tests stub `waiting_gates` and
+exercise the throttling, confirmation, and message-formatting logic on top of it.
 """
 
 import pytest
@@ -24,6 +24,7 @@ RETRY_GATE = "datasnapshot.source1-testsnapshot.vapretry"
 RETRY_REASON = "Impossible field change on datasnapshot: spec.snapshotName"
 CHANGE_GATE = "captureproxy.capture-proxy.vapretry"
 CHANGE_REASON = "Gated field change on captureproxy: spec.replicas"
+STEP_GATE = "documentbackfill.source1-target1-testsnapshot-migration-0"
 
 
 class FakeClock:
@@ -40,11 +41,11 @@ class FakeClock:
 
 
 def _patch_waiting(gates):
-    return patch("integ_test.parked_gate_detection.waiting_runtime_gates", return_value=gates)
+    return patch("integ_test.parked_gate_detection.waiting_gates", return_value=gates)
 
 
 def _patch_waiting_side_effect(side_effect):
-    return patch("integ_test.parked_gate_detection.waiting_runtime_gates", side_effect=side_effect)
+    return patch("integ_test.parked_gate_detection.waiting_gates", side_effect=side_effect)
 
 
 @pytest.fixture(autouse=True)
@@ -66,6 +67,14 @@ def test_find_parked_gates_returns_waiting_runtime_gates():
     assert parked[0].kind == "retry"
 
 
+def test_find_parked_gates_includes_step_gates():
+    """A step gate hangs the wait exactly like a runtime one, so it counts too."""
+    with _patch_waiting([(STEP_GATE, None, "step")]):
+        parked = find_parked_gates(NAMESPACE, INNER_WORKFLOW_NAME)
+
+    assert [(gate.name, gate.kind) for gate in parked] == [(STEP_GATE, "step")]
+
+
 def test_find_parked_gates_empty_when_nothing_waiting():
     with _patch_waiting([]):
         assert find_parked_gates(NAMESPACE, INNER_WORKFLOW_NAME) == []
@@ -76,6 +85,14 @@ def test_find_parked_gates_excludes_expected_gates():
         parked = find_parked_gates(NAMESPACE, INNER_WORKFLOW_NAME, expected_gate_names=[RETRY_GATE])
 
     assert [gate.name for gate in parked] == [CHANGE_GATE]
+
+
+def test_find_parked_gates_excludes_expected_step_gates():
+    """Test0003 approves its own step gates, so only unlisted ones are failures."""
+    with _patch_waiting([(STEP_GATE, None, "step"), (RETRY_GATE, RETRY_REASON, "retry")]):
+        parked = find_parked_gates(NAMESPACE, INNER_WORKFLOW_NAME, expected_gate_names=[STEP_GATE])
+
+    assert [gate.name for gate in parked] == [RETRY_GATE]
 
 
 def test_find_parked_gates_swallows_errors():
@@ -221,6 +238,16 @@ def test_failure_message_includes_approve_guidance_for_change_gate():
 
     assert "workflow approve change" in message
     assert "workflow reset" not in message
+
+
+def test_failure_message_includes_step_guidance_for_step_gate():
+    message = format_parked_gate_failure({INNER_WORKFLOW_NAME: [ParkedGate(STEP_GATE, None, "step")]})
+
+    assert STEP_GATE in message
+    assert "workflow approve step" in message
+    assert "skipApprovals=true" in message
+    # A step gate has no failed apply behind it, so don't invent a denial reason.
+    assert "no denial reason" not in message
 
 
 def test_failure_message_handles_missing_denial_reason():

--- a/migrationConsole/lib/integ_test/tests/test_parked_gate_detection.py
+++ b/migrationConsole/lib/integ_test/tests/test_parked_gate_detection.py
@@ -1,0 +1,246 @@
+"""Tests for parked runtime approval gate detection.
+
+The signal under test is the pair `console_link`'s approve command extracts from
+the Argo node graph — a Running waitForFix plus a Failed tryApply sibling — so
+these tests stub `waiting_runtime_gates` and exercise the throttling,
+confirmation, and message-formatting logic on top of it.
+"""
+
+import pytest
+from unittest.mock import patch
+
+from integ_test.parked_gate_detection import (
+    INNER_WORKFLOW_NAME,
+    ParkedApprovalGateError,
+    ParkedGate,
+    ParkedGateWatcher,
+    find_parked_gates,
+    format_parked_gate_failure,
+    summarize_parked_gates,
+)
+
+NAMESPACE = "test-namespace"
+RETRY_GATE = "datasnapshot.source1-testsnapshot.vapretry"
+RETRY_REASON = "Impossible field change on datasnapshot: spec.snapshotName"
+CHANGE_GATE = "captureproxy.capture-proxy.vapretry"
+CHANGE_REASON = "Gated field change on captureproxy: spec.replicas"
+
+
+class FakeClock:
+    """Monotonic clock a test can advance by hand."""
+
+    def __init__(self):
+        self.now = 1000.0
+
+    def __call__(self):
+        return self.now
+
+    def advance(self, seconds):
+        self.now += seconds
+
+
+def _patch_waiting(gates):
+    return patch("integ_test.parked_gate_detection.waiting_runtime_gates", return_value=gates)
+
+
+def _patch_waiting_side_effect(side_effect):
+    return patch("integ_test.parked_gate_detection.waiting_runtime_gates", side_effect=side_effect)
+
+
+@pytest.fixture(autouse=True)
+def no_k8s_config():
+    """find_parked_gates loads kube config; no cluster exists in unit tests."""
+    with patch("integ_test.parked_gate_detection.load_k8s_config"):
+        yield
+
+
+# --- find_parked_gates ---
+
+def test_find_parked_gates_returns_waiting_runtime_gates():
+    with _patch_waiting([(RETRY_GATE, RETRY_REASON, "retry")]):
+        parked = find_parked_gates(NAMESPACE, INNER_WORKFLOW_NAME)
+
+    assert len(parked) == 1
+    assert parked[0].name == RETRY_GATE
+    assert parked[0].reason == RETRY_REASON
+    assert parked[0].kind == "retry"
+
+
+def test_find_parked_gates_empty_when_nothing_waiting():
+    with _patch_waiting([]):
+        assert find_parked_gates(NAMESPACE, INNER_WORKFLOW_NAME) == []
+
+
+def test_find_parked_gates_excludes_expected_gates():
+    with _patch_waiting([(RETRY_GATE, RETRY_REASON, "retry"), (CHANGE_GATE, CHANGE_REASON, "change")]):
+        parked = find_parked_gates(NAMESPACE, INNER_WORKFLOW_NAME, expected_gate_names=[RETRY_GATE])
+
+    assert [gate.name for gate in parked] == [CHANGE_GATE]
+
+
+def test_find_parked_gates_swallows_errors():
+    """Detection must never break the wait loop it is called from."""
+    with _patch_waiting_side_effect(RuntimeError("workflow not found")):
+        assert find_parked_gates(NAMESPACE, INNER_WORKFLOW_NAME) == []
+
+
+def test_find_parked_gates_swallows_kube_config_errors():
+    with patch("integ_test.parked_gate_detection.load_k8s_config", side_effect=Exception("no kubeconfig")):
+        assert find_parked_gates(NAMESPACE, INNER_WORKFLOW_NAME) == []
+
+
+# --- ParkedGateWatcher ---
+
+def test_watcher_raises_after_required_consecutive_observations():
+    clock = FakeClock()
+    watcher = ParkedGateWatcher(NAMESPACE, [INNER_WORKFLOW_NAME], check_interval_seconds=30,
+                                required_consecutive_observations=2, clock=clock)
+
+    with _patch_waiting([(RETRY_GATE, RETRY_REASON, "retry")]):
+        # First observation only warns - a single sighting could be a tryApply
+        # that is about to be retried.
+        watcher.check()
+        clock.advance(30)
+        with pytest.raises(ParkedApprovalGateError) as exc_info:
+            watcher.check()
+
+    assert RETRY_GATE in str(exc_info.value)
+    assert RETRY_REASON in str(exc_info.value)
+
+
+def test_watcher_is_throttled_between_checks():
+    clock = FakeClock()
+    watcher = ParkedGateWatcher(NAMESPACE, [INNER_WORKFLOW_NAME], check_interval_seconds=30,
+                                required_consecutive_observations=2, clock=clock)
+
+    with _patch_waiting([(RETRY_GATE, RETRY_REASON, "retry")]) as mock_waiting:
+        watcher.check()
+        # Calls inside the interval are no-ops, so a loop polling every 5s can't
+        # confirm a park in 5s or hammer the API.
+        for _ in range(5):
+            clock.advance(5)
+            watcher.check()
+        assert mock_waiting.call_count == 1
+
+        clock.advance(5)
+        with pytest.raises(ParkedApprovalGateError):
+            watcher.check()
+
+
+def test_watcher_does_not_raise_for_transient_observation():
+    clock = FakeClock()
+    watcher = ParkedGateWatcher(NAMESPACE, [INNER_WORKFLOW_NAME], check_interval_seconds=30,
+                                required_consecutive_observations=2, clock=clock)
+
+    # Parked, then not, then parked again: the count resets in between, so no
+    # accumulation across non-consecutive sightings.
+    with _patch_waiting_side_effect([
+        [(RETRY_GATE, RETRY_REASON, "retry")],
+        [],
+        [(RETRY_GATE, RETRY_REASON, "retry")],
+    ]):
+        for _ in range(3):
+            watcher.check()
+            clock.advance(30)
+
+
+def test_watcher_no_raise_when_never_parked():
+    clock = FakeClock()
+    watcher = ParkedGateWatcher(NAMESPACE, [INNER_WORKFLOW_NAME], check_interval_seconds=30, clock=clock)
+
+    with _patch_waiting([]):
+        for _ in range(4):
+            watcher.check()
+            clock.advance(30)
+
+    assert watcher.summarize_last_seen() == ""
+
+
+def test_watcher_checks_both_outer_and_inner_workflow():
+    clock = FakeClock()
+    watcher = ParkedGateWatcher(NAMESPACE, ["outer-workflow", INNER_WORKFLOW_NAME],
+                                check_interval_seconds=30, clock=clock)
+
+    with _patch_waiting([]) as mock_waiting:
+        watcher.check()
+
+    checked = [call.args[1] for call in mock_waiting.call_args_list]
+    assert checked == ["outer-workflow", INNER_WORKFLOW_NAME]
+
+
+def test_watcher_deduplicates_workflow_names():
+    """wait loops pass (polled, inner); for the inner workflow those are equal."""
+    clock = FakeClock()
+    watcher = ParkedGateWatcher(NAMESPACE, [INNER_WORKFLOW_NAME, INNER_WORKFLOW_NAME], clock=clock)
+    assert watcher.workflow_names == [INNER_WORKFLOW_NAME]
+
+
+def test_watcher_drops_empty_workflow_names():
+    """workflow_name is Optional on some CDC helpers."""
+    watcher = ParkedGateWatcher(NAMESPACE, [None, INNER_WORKFLOW_NAME, ""])
+    assert watcher.workflow_names == [INNER_WORKFLOW_NAME]
+
+
+def test_watcher_honors_expected_gate_names():
+    clock = FakeClock()
+    watcher = ParkedGateWatcher(NAMESPACE, [INNER_WORKFLOW_NAME], expected_gate_names=[RETRY_GATE],
+                                check_interval_seconds=30, required_consecutive_observations=2, clock=clock)
+
+    with _patch_waiting([(RETRY_GATE, RETRY_REASON, "retry")]):
+        for _ in range(4):
+            watcher.check()
+            clock.advance(30)
+
+
+def test_watcher_last_seen_records_unconfirmed_observation():
+    """A park seen once but not yet confirmed still enriches a later timeout."""
+    clock = FakeClock()
+    watcher = ParkedGateWatcher(NAMESPACE, [INNER_WORKFLOW_NAME], check_interval_seconds=30,
+                                required_consecutive_observations=2, clock=clock)
+
+    with _patch_waiting([(RETRY_GATE, RETRY_REASON, "retry")]):
+        watcher.check()
+
+    assert RETRY_GATE in watcher.summarize_last_seen()
+    assert RETRY_REASON in watcher.summarize_last_seen()
+
+
+# --- message formatting ---
+
+def test_failure_message_includes_reset_guidance_for_retry_gate():
+    message = format_parked_gate_failure({INNER_WORKFLOW_NAME: [ParkedGate(RETRY_GATE, RETRY_REASON, "retry")]})
+
+    assert INNER_WORKFLOW_NAME in message
+    assert RETRY_GATE in message
+    assert "workflow reset" in message
+    assert "workflow approve retry" in message
+
+
+def test_failure_message_includes_approve_guidance_for_change_gate():
+    message = format_parked_gate_failure({INNER_WORKFLOW_NAME: [ParkedGate(CHANGE_GATE, CHANGE_REASON, "change")]})
+
+    assert "workflow approve change" in message
+    assert "workflow reset" not in message
+
+
+def test_failure_message_handles_missing_denial_reason():
+    message = format_parked_gate_failure({INNER_WORKFLOW_NAME: [ParkedGate(RETRY_GATE, None, "retry")]})
+
+    assert RETRY_GATE in message
+    assert "no denial reason" in message
+
+
+def test_failure_message_mentions_opt_in_for_intentional_parks():
+    message = format_parked_gate_failure({INNER_WORKFLOW_NAME: [ParkedGate(RETRY_GATE, RETRY_REASON, "retry")]})
+
+    assert "expected_parked_gate_names" in message
+
+
+def test_summarize_parked_gates_skips_workflows_with_no_gates():
+    summary = summarize_parked_gates({
+        "outer-workflow": [],
+        INNER_WORKFLOW_NAME: [ParkedGate(RETRY_GATE, RETRY_REASON, "retry")],
+    })
+
+    assert "outer-workflow" not in summary
+    assert INNER_WORKFLOW_NAME in summary


### PR DESCRIPTION
## Problem

When a `ValidatingAdmissionPolicy` rejects a migration resource apply, the workflow **parks** rather than failing. `reconcile*Resource` runs `tryApply` with `continueOn: {failed: true}`, and `waitForFix` then blocks on the `<kind>.<name>.vapretry` ApprovalGate until someone approves it.

**That is intended behavior and this PR does not change it.** `K8S_USER_APPROVAL_WAIT_RETRY_STRATEGY` is documented as "intentionally open-ended in elapsed time"; the parked branch is a sibling step group so unrelated work keeps running; and the operator recovers in place with `workflow reset <resource>` followed by `workflow approve` (`RESETTABLE_PLURALS` deliberately excludes `approvalgates`, so the gate survives the reset and the retry loop can re-create the resource fresh). Making VAP rejection fail the workflow would turn a recoverable state into a dead end.

Integration tests are the problem. Nobody is going to approve anything, so:

1. The workflow stays `Running` forever. `ENDING_ARGO_PHASES` cannot see a workflow blocked on a gate, so `wait_for_ending_phase` has exactly one exit: `TimeoutError` at `MIGRATION_COMPLETION_TIMEOUT_SECONDS` (1800s), or up to 4800s for the CDC replayer wait.
2. The resulting message says nothing about the gate — just a list of running nodes.
3. The harness polls the **outer** test wrapper (configure/monitor/evaluate), but the reconcile steps that can park live in the **inner** `migration-workflow` that `configureAndSubmitWorkflow.sh` submits. Even a node-level check on the polled workflow would miss every park.

## Change

A `ParkedGateWatcher` that the existing wait loops call on each iteration:

- Fails on **any** gate the workflow is blocked on that the test didn't ask for — runtime (`.vapretry`) or step. Both block on `waitForUserApproval` and neither clears without an approval the test has no way to give.
- Checks **both** the polled workflow and the inner `migration-workflow`.
- Throttled to one API check per 30s, so a loop polling every 5s doesn't hammer the API.
- Requires the same gate on **two consecutive** checks before failing. A single sighting only logs a warning — a `Failed` tryApply whose retry loop is about to move on, or a step gate the test is about to approve, shouldn't fail a test.
- Wired into `wait_for_suspend`, `wait_for_ending_phase`, Test0003's suspend-or-end loop, and the CDC `_raise_if_cdc_dependency_error` hook (a VAP-denied CaptureProxy or Replayer leaves the workflow parked, not errored, so none of the existing dependency checks fire and the pod simply never appears).
- Timeout messages raised for any other reason now carry a single-sighting observation as `unconfirmed_parked_gates`.
- The failure names the gate and the matching recovery: `workflow reset` + `approve retry` for an `Impossible` denial, `approve change` for a `Gated` one, `approve step` for a step gate. `ParkedApprovalGateError` subclasses `AssertionError`, since the workflow behaved correctly — the migration config or the test's expectations did not.
- `IntegrationTestArgoService.expected_parked_gate_names` opts specific gates out. Test0003 is the only user: it runs `skip-approvals=false` and deliberately waits at five gates it approves by name, so it declares those. Every other test runs `skip-approvals=true`, where no step gates exist at all and one waiting is unexpected by construction.

Those five are the complete set of step gates this configuration can produce, so the opt-out isn't papering over a gate the test currently misses — there are exactly five `waitForUserApproval` step call sites in the templates (the six `waitForFix` sites in `resourceManagement.ts` are the runtime `.vapretry` gates, a separate mechanism):

| Gate | Created by | Suppressed when |
|---|---|---|
| `begin` | `fullMigration.ts` `approveBegin` | `requireBeginApproval` false |
| `captureproxysetup.<proxy>` | `setupCapture.ts` `approveProxySetup` | `skipProxyApproval` / global `skipApprovals` |
| `evaluatemetadata.<suffix>` | `metadataMigration.ts` `approveEvaluate` | `skipEvaluateApproval` |
| `migratemetadata.<suffix>` | `metadataMigration.ts` `approveMigrate` | `skipMigrateApproval` |
| `documentbackfill.<crdName>` | `fullMigration.ts` `approveBackfill` | `documentBackfillConfig.skipApproval` |

Notably the CDC replay path (`runSingleReplay`) adds no step gate at all — the replayer is gated only by its runtime `trafficreplay.<name>.vapretry` gate. What the opt-out buys is the guarantee going the other way: any gate *beyond* the declared five now fails Test0003 promptly, so if a future change adds a step gate the test doesn't know to approve, it surfaces as a named failure instead of a 1800s hang.

## Two notes on scope

**Why the predicate isn't "an ApprovalGate that is `Pending` with a non-empty denial reason".** `statusSchemaFor` in `generateMigrationResources.ts` gives ApprovalGate a status of only `phase` ∈ {Created, Pending, Approved, Error}; there is no denial-reason field on the gate, and the VAP message lands on the Argo `tryApply` **node's** message instead. `Pending` is also the steady state for every gate the workflow hasn't reached yet (gates are pre-created, and `resetGate` patches them back to `Pending`), so phase alone can't separate "blocking now" from "not reached yet".

On the `Error` state specifically: it's in the enum but **nothing ever writes it**. Every write to a gate's phase is `Created` (`makeApprovalGateResource`), `Pending` (`patchApprovalGatePhase`, six call sites, all literal `"Pending"`), or `Approved` (`approve.py`). The only `patch*Error` template is `patchCaptureProxyError`, which sets the *CaptureProxy's* phase, not a gate's. And `waitForUserApproval` has only `successCondition: status.phase == Approved` with no `failureCondition` — unlike the non-gate resource waits, which do check for `Error` — so a gate that somehow reached `Error` would hang exactly like one at `Pending`.

So the check runs against the node graph: a `Running` approval node, plus (for a runtime gate) a `Failed` sibling under the same `boundaryID` carrying a parsed reason. That keys on "blocked at an approval node," which is independent of gate phase and therefore covers the `Error` case too. `workflow approve` already does exactly this traversal, so this reuses it via a new public `approve.waiting_gates` accessor rather than adding a second implementation.

**No inner-workflow teardown.** As suggested, it isn't needed: `teardownMaApp` runs `workflow reset -> helm uninstall -> PVCs -> namespace`, and the k8s-local path does `kind delete cluster`. The leaked inner workflow goes away with the cluster either way, so this PR is detection + fail-fast only.

## Testing

- 21 unit tests in `test_parked_gate_detection.py` covering throttling, the consecutive-observation requirement, transient-observation reset, expected-gate opt-out for both kinds, step-gate inclusion, error swallowing, and message formatting.
- 7 tests in `test_integration_test_argo_service.py` asserting both wait loops fail fast (one sleep, not the 600s budget) on a runtime gate and on an unexpected step gate, honor the opt-out, watch both workflow names, and report unconfirmed sightings in the timeout message.
- 1 test in `test_workflow_cli_commands.py` pinning `waiting_gates`' step/change/retry categorization.
- `test_cdc_base.py` updated for the new `parked_gate_watcher` parameter and asserts the watcher covers outer + inner.
- Full integ_test suite: 114 passed. console_link `test_workflow_cli_commands.py`: 76 passed. flake8 clean.

Detection never raises on its own — a missing, still-starting, or unreadable workflow yields no gates, so a wait loop can't fail for a reason unrelated to what it's checking.

