### PR TITLE
[codex] Make Migration Console npm tasks incremental

### DIFF
--- a/migrationConsole/build.gradle
+++ b/migrationConsole/build.gradle
@@ -18,7 +18,10 @@ def orchestrationSpecsDirP = rootProject.layout.projectDirectory.dir("orchestrat
 def orchestrationP     = orchestrationSpecsDirP
 def configProcessorP   = orchestrationP.dir("packages/config-processor")
 def workflowTemplatesP = orchestrationP.dir("packages/migration-workflow-templates")
+def argoWorkflowBuildersP = orchestrationP.dir("packages/argo-workflow-builders")
 def schemasP           = orchestrationP.dir("packages/schemas")
+def cloudWatchDashboardsP = rootProject.layout.projectDirectory.dir(
+        "deployment/k8s/charts/aggregates/migrationAssistantWithArgo/files/cloudwatch-dashboards")
 def configProcessorStagingP =
         layout.buildDirectory.dir("dockerContext/nodeStaging/configProcessor")
 def workflowTemplatesStagingP =
@@ -32,53 +35,57 @@ def rootTsConfigFiles = [
         orchestrationSpecsDirP.file("tsconfig.json"),
         orchestrationSpecsDirP.file("tsconfig.workspaces.json")
 ]
+def npmDependencyFiles = [
+        orchestrationSpecsDirP.file("package.json"),
+        orchestrationSpecsDirP.file("package-lock.json")
+]
+
+def configureNpmTask = { task ->
+    task.dependsOn installDependencies
+    task.inputs.files(npmDependencyFiles)
+}
 
 def configureWorkflowTemplateTask = { task ->
-    task.dependsOn installDependencies
+    configureNpmTask(task)
 
-    // Source files
     task.inputs.dir(workflowTemplatesP.dir("src"))
-    // Resource files embedded in templates
-    task.inputs.dir(workflowTemplatesP.dir("resources"))
-    // Dependency packages whose source affects template generation
-    task.inputs.dir(orchestrationSpecsDirP.dir("packages/argo-workflow-builders/src"))
+    task.inputs.dir(argoWorkflowBuildersP.dir("src"))
     task.inputs.dir(schemasP.dir("src"))
+    task.inputs.dir(schemasP.dir("generated"))
 
-    // Package-level config files
     task.inputs.files(
         workflowTemplatesP.file("package.json"),
-        workflowTemplatesP.file("tsconfig.json"),
-        workflowTemplatesP.file("makeTemplates.cjs")
+        workflowTemplatesP.file("tsconfig.json")
     )
 
     task.inputs.files(rootTsConfigFiles)
 }
 
 def configureConfigProcessorTask = { task ->
-    task.dependsOn installDependencies
+    configureNpmTask(task)
 
-    // Source files
     task.inputs.dir(configProcessorP.dir("src"))
-    // Shell scripts copied into the config-processor bundle
-    task.inputs.dir(configProcessorP.dir("scripts"))
+    task.inputs.dir(schemasP.dir("src"))
+    task.inputs.dir(schemasP.dir("generated"))
 
     task.inputs.files(
-        // Build script
-        configProcessorP.file("makeBundle.js"),
-        // Package-level config files
-        configProcessorP.file("package.json"),
-        configProcessorP.file("tsconfig.json"),
-    )
-
-    task.inputs.files(
-        // Build script
-        configProcessorP.file("makeBundle.js"),
-        // Package-level config files
         configProcessorP.file("package.json"),
         configProcessorP.file("tsconfig.json"),
     )
 
     task.inputs.files(rootTsConfigFiles)
+}
+
+// Input-only checks need a success marker for Gradle to skip unchanged runs.
+def configureSuccessfulCheckOutput = { task ->
+    def resultP = layout.buildDirectory.file("npmChecks/${task.name}.passed")
+    task.outputs.file(resultP)
+
+    task.doLast {
+        def resultFile = resultP.get().asFile
+        resultFile.parentFile.mkdirs()
+        resultFile.text = "passed\n"
+    }
 }
 
 tasks.register('installDependencies', NpmTask) {
@@ -101,6 +108,14 @@ tasks.register('typeCheckWorkflowTemplates', NpmTask) {
     workingDir = workflowTemplatesP.asFile
     args = ['run', 'type-check-all']
     configureWorkflowTemplateTask(delegate)
+    inputs.files(
+        orchestrationSpecsDirP.file("tsconfig.typecheck.templates.json"),
+        argoWorkflowBuildersP.file("package.json"),
+        argoWorkflowBuildersP.file("tsconfig.json"),
+        schemasP.file("package.json"),
+        schemasP.file("tsconfig.json")
+    )
+    configureSuccessfulCheckOutput(delegate)
 }
 
 tasks.register('testWorkflowTemplates', NpmTask) {
@@ -109,6 +124,22 @@ tasks.register('testWorkflowTemplates', NpmTask) {
     args = ['run', 'test-all']
 
     configureWorkflowTemplateTask(delegate)
+    inputs.dir(workflowTemplatesP.dir("resources"))
+    inputs.dir(workflowTemplatesP.dir("tests"))
+    inputs.dir(argoWorkflowBuildersP.dir("tests/unit"))
+    inputs.dir(schemasP.dir("tests"))
+    inputs.files(
+        workflowTemplatesP.file("jest.config.js"),
+        argoWorkflowBuildersP.file("package.json"),
+        argoWorkflowBuildersP.file("tsconfig.json"),
+        argoWorkflowBuildersP.file("jest.config.js"),
+        schemasP.file("package.json"),
+        schemasP.file("tsconfig.json"),
+        schemasP.file("jest.config.js"),
+        cloudWatchDashboardsP.file("capture-replay-dashboard.json"),
+        cloudWatchDashboardsP.file("reindex-from-snapshot-dashboard.json")
+    )
+    configureSuccessfulCheckOutput(delegate)
 }
 
 tasks.register('makeAndStageWorkflowTemplates', NpmTask) {
@@ -117,6 +148,8 @@ tasks.register('makeAndStageWorkflowTemplates', NpmTask) {
     args = ['run', 'make-templates', '--', '--outputDirectory', workflowTemplatesStagingP.get().asFile.absolutePath]
 
     configureWorkflowTemplateTask(delegate)
+    inputs.dir(workflowTemplatesP.dir("resources"))
+    inputs.file(workflowTemplatesP.file("makeTemplates.cjs"))
     outputs.dir(workflowTemplatesStagingP)
 
     doFirst {
@@ -130,6 +163,12 @@ tasks.register('typeCheckConfigProcessor', NpmTask) {
     args = ['run', 'type-check']
 
     configureConfigProcessorTask(delegate)
+    inputs.files(
+        orchestrationSpecsDirP.file("tsconfig.typecheck.processor.json"),
+        schemasP.file("package.json"),
+        schemasP.file("tsconfig.json")
+    )
+    configureSuccessfulCheckOutput(delegate)
 }
 
 tasks.register('testConfigProcessor', NpmTask) {
@@ -138,6 +177,15 @@ tasks.register('testConfigProcessor', NpmTask) {
     args = ['run', 'test']
 
     configureConfigProcessorTask(delegate)
+    inputs.files(fileTree(configProcessorP.dir("tests").asFile) {
+        exclude "integ/**"
+    })
+    inputs.files(
+        configProcessorP.file("jest.config.js"),
+        schemasP.file("package.json"),
+        schemasP.file("tsconfig.json")
+    )
+    configureSuccessfulCheckOutput(delegate)
 }
 
 tasks.register('buildAndStageConfigProcessor', NpmTask) {
@@ -146,6 +194,8 @@ tasks.register('buildAndStageConfigProcessor', NpmTask) {
     args = ['run', 'bundle', '--', configProcessorStagingP.get().asFile.absolutePath]
 
     configureConfigProcessorTask(delegate)
+    inputs.dir(configProcessorP.dir("scripts"))
+    inputs.file(configProcessorP.file("makeBundle.js"))
     outputs.dir(configProcessorStagingP)
 
     doFirst {
@@ -167,6 +217,7 @@ tasks.register('buildAndStageMigrationResources', NpmTask) {
     dependsOn installDependencies
 
     inputs.dir(schemasP.dir("src"))
+    inputs.dir(schemasP.dir("generated"))
     inputs.files(
         schemasP.file("package.json"),
         orchestrationSpecsDirP.file("package.json"),

--- a/migrationConsole/build.gradle
+++ b/migrationConsole/build.gradle
@@ -26,40 +26,97 @@ def workflowTemplatesStagingP =
 def migrationResourcesStagingP =
         layout.buildDirectory.dir("dockerContext/nodeStaging/migrationResources")
 
+// Root-level tsconfig files that affect compilation
+def rootTsConfigFiles = [
+        orchestrationSpecsDirP.file("tsconfig.base.json"),
+        orchestrationSpecsDirP.file("tsconfig.json"),
+        orchestrationSpecsDirP.file("tsconfig.workspaces.json")
+]
+
+def configureWorkflowTemplateTask = { task ->
+    task.dependsOn installDependencies
+
+    // Source files
+    task.inputs.dir(workflowTemplatesP.dir("src"))
+    // Resource files embedded in templates
+    task.inputs.dir(workflowTemplatesP.dir("resources"))
+    // Dependency packages whose source affects template generation
+    task.inputs.dir(orchestrationSpecsDirP.dir("packages/argo-workflow-builders/src"))
+    task.inputs.dir(schemasP.dir("src"))
+
+    // Package-level config files
+    task.inputs.files(
+        workflowTemplatesP.file("package.json"),
+        workflowTemplatesP.file("tsconfig.json"),
+        workflowTemplatesP.file("makeTemplates.cjs")
+    )
+
+    task.inputs.files(rootTsConfigFiles)
+}
+
+def configureConfigProcessorTask = { task ->
+    task.dependsOn installDependencies
+
+    // Source files
+    task.inputs.dir(configProcessorP.dir("src"))
+    // Shell scripts copied into the config-processor bundle
+    task.inputs.dir(configProcessorP.dir("scripts"))
+
+    task.inputs.files(
+        // Build script
+        configProcessorP.file("makeBundle.js"),
+        // Package-level config files
+        configProcessorP.file("package.json"),
+        configProcessorP.file("tsconfig.json"),
+    )
+
+    task.inputs.files(
+        // Build script
+        configProcessorP.file("makeBundle.js"),
+        // Package-level config files
+        configProcessorP.file("package.json"),
+        configProcessorP.file("tsconfig.json"),
+    )
+
+    task.inputs.files(rootTsConfigFiles)
+}
+
 tasks.register('installDependencies', NpmTask) {
     description = 'Install npm dependencies for orchestrationSpecs'
     workingDir = orchestrationSpecsDirP.asFile
     args = ['ci', '--force']
 
-    inputs.file(orchestrationSpecsDirP.file("package.json"))
-    inputs.file(orchestrationSpecsDirP.file("package-lock.json"))
-    inputs.file(orchestrationSpecsDirP.file("tsconfig.base.json"))
-    inputs.file(orchestrationSpecsDirP.file("tsconfig.json"))
-    inputs.file(orchestrationSpecsDirP.file("tsconfig.workspaces.json"))
+    inputs.files(
+        orchestrationSpecsDirP.file("package.json"),
+        orchestrationSpecsDirP.file("package-lock.json"),
+        orchestrationSpecsDirP.file("tsconfig.base.json"),
+        orchestrationSpecsDirP.file("tsconfig.json"),
+        orchestrationSpecsDirP.file("tsconfig.workspaces.json"),
+    )
     outputs.dir(orchestrationSpecsDirP.dir("node_modules"))
+}
+
+tasks.register('typeCheckWorkflowTemplates', NpmTask) {
+    description = 'Check the workflow templates from their TypeScript definitions'
+    workingDir = workflowTemplatesP.asFile
+    args = ['run', 'type-check-all']
+    configureWorkflowTemplateTask(delegate)
+}
+
+tasks.register('testWorkflowTemplates', NpmTask) {
+    description = 'Check the workflow templates from their TypeScript definitions'
+    workingDir = workflowTemplatesP.asFile
+    args = ['run', 'test-all']
+
+    configureWorkflowTemplateTask(delegate)
 }
 
 tasks.register('makeAndStageWorkflowTemplates', NpmTask) {
     description = 'Build the workflow templates from their TypeScript definitions'
     workingDir = workflowTemplatesP.asFile
-    args = ['run', 'check-and-make-templates', '--', '--outputDirectory', workflowTemplatesStagingP.get().asFile.absolutePath]
-    dependsOn installDependencies
+    args = ['run', 'make-templates', '--', '--outputDirectory', workflowTemplatesStagingP.get().asFile.absolutePath]
 
-    // Source files
-    inputs.dir(workflowTemplatesP.dir("src"))
-    // Resource files embedded in templates
-    inputs.dir(workflowTemplatesP.dir("resources"))
-    // Dependency packages whose source affects template generation
-    inputs.dir(orchestrationSpecsDirP.dir("packages/argo-workflow-builders/src"))
-    inputs.dir(orchestrationSpecsDirP.dir("packages/schemas/src"))
-    // Package-level config files
-    inputs.file(workflowTemplatesP.file("package.json"))
-    inputs.file(workflowTemplatesP.file("tsconfig.json"))
-    inputs.file(workflowTemplatesP.file("makeTemplates.cjs"))
-    // Root-level tsconfig files that affect compilation
-    inputs.file(orchestrationSpecsDirP.file("tsconfig.base.json"))
-    inputs.file(orchestrationSpecsDirP.file("tsconfig.json"))
-    inputs.file(orchestrationSpecsDirP.file("tsconfig.workspaces.json"))
+    configureWorkflowTemplateTask(delegate)
     outputs.dir(workflowTemplatesStagingP)
 
     doFirst {
@@ -67,30 +124,40 @@ tasks.register('makeAndStageWorkflowTemplates', NpmTask) {
     }
 }
 
+tasks.register('typeCheckConfigProcessor', NpmTask) {
+    description = 'type-check the config-processor TypeScript package'
+    workingDir = configProcessorP.asFile
+    args = ['run', 'type-check']
+
+    configureConfigProcessorTask(delegate)
+}
+
+tasks.register('testConfigProcessor', NpmTask) {
+    description = 'Test the config-processor TypeScript package'
+    workingDir = configProcessorP.asFile
+    args = ['run', 'test']
+
+    configureConfigProcessorTask(delegate)
+}
+
 tasks.register('buildAndStageConfigProcessor', NpmTask) {
     description = 'Build and stage the config-processor TypeScript package directly to staging'
     workingDir = configProcessorP.asFile
-    args = ['run', 'check-and-bundle', '--', configProcessorStagingP.get().asFile.absolutePath]
-    dependsOn installDependencies
+    args = ['run', 'bundle', '--', configProcessorStagingP.get().asFile.absolutePath]
 
-    // Source files
-    inputs.dir(configProcessorP.dir("src"))
-    // Shell scripts copied into the config-processor bundle
-    inputs.dir(configProcessorP.dir("scripts"))
-    // Build script
-    inputs.file(configProcessorP.file("makeBundle.js"))
-    // Package-level config files
-    inputs.file(configProcessorP.file("package.json"))
-    inputs.file(configProcessorP.file("tsconfig.json"))
-    // Root-level tsconfig files that affect compilation
-    inputs.file(orchestrationSpecsDirP.file("tsconfig.base.json"))
-    inputs.file(orchestrationSpecsDirP.file("tsconfig.json"))
-    inputs.file(orchestrationSpecsDirP.file("tsconfig.workspaces.json"))
+    configureConfigProcessorTask(delegate)
     outputs.dir(configProcessorStagingP)
 
     doFirst {
         configProcessorStagingP.get().asFile.mkdirs()
     }
+}
+
+tasks.named("test") {
+    dependsOn("typeCheckWorkflowTemplates")
+    dependsOn("testWorkflowTemplates")
+    dependsOn("typeCheckConfigProcessor")
+    dependsOn("testConfigProcessor")
 }
 
 tasks.register('buildAndStageMigrationResources', NpmTask) {
@@ -100,12 +167,14 @@ tasks.register('buildAndStageMigrationResources', NpmTask) {
     dependsOn installDependencies
 
     inputs.dir(schemasP.dir("src"))
-    inputs.file(schemasP.file("package.json"))
-    inputs.file(orchestrationSpecsDirP.file("package.json"))
-    inputs.file(orchestrationSpecsDirP.file("package-lock.json"))
-    inputs.file(orchestrationSpecsDirP.file("tsconfig.base.json"))
-    inputs.file(orchestrationSpecsDirP.file("tsconfig.json"))
-    inputs.file(orchestrationSpecsDirP.file("tsconfig.workspaces.json"))
+    inputs.files(
+        schemasP.file("package.json"),
+        orchestrationSpecsDirP.file("package.json"),
+        orchestrationSpecsDirP.file("package-lock.json"),
+        orchestrationSpecsDirP.file("tsconfig.base.json"),
+        orchestrationSpecsDirP.file("tsconfig.json"),
+        orchestrationSpecsDirP.file("tsconfig.workspaces.json"),
+    )
     outputs.dir(migrationResourcesStagingP)
 
     doFirst {


### PR DESCRIPTION
## Summary

- split Migration Console npm type checks and tests from artifact-generation tasks
- add successful-check outputs so Gradle can skip unchanged validation tasks
- declare the source, test, Jest, TypeScript, lockfile, generated schema, and dashboard inputs consumed by each task
- keep workflow-template and config-processor build inputs scoped to their artifact tasks

## Why

PR #3266 separated npm validation from artifact generation, but the new validation tasks had inputs without outputs. Gradle therefore treated them as always out of date and reran every npm test and type check on successive builds.

This change gives each successful validation task a marker under the Gradle build directory and tightens its input model. Relevant changes still invalidate the affected task, while unrelated integration tests and artifact-only scripts no longer trigger unit validation.

This PR includes and supersedes #3266.

## Impact

An unchanged Migration Console build now completes without rerunning npm validation. A targeted config-processor unit-test change reruns only `testConfigProcessor`, while shared schema and dependency changes continue to invalidate all consumers that depend on them.

## Validation

- `./gradlew :migrationConsole:build --console=plain`
- repeated Migration Console build: 3 seconds, 31 tasks up to date
- targeted config-processor test invalidation: only `testConfigProcessor` executed
- `./gradlew :migrationConsole:makeAndStageWorkflowTemplates :migrationConsole:buildAndStageConfigProcessor :migrationConsole:buildAndStageMigrationResources --console=plain`
- repeated artifact build: 3 seconds, 13 tasks up to date
