### PR TITLE
[codex] Remove AppRegistry from solution templates

### DIFF
--- a/deployment/cdk/opensearch-service-migration/bin/createApp.ts
+++ b/deployment/cdk/opensearch-service-migration/bin/createApp.ts
@@ -10,11 +10,6 @@ export function createApp(): App {
 
   const account = process.env.CDK_DEFAULT_ACCOUNT;
   const region = process.env.CDK_DEFAULT_REGION;
-  const migrationsAppRegistryARN = process.env.MIGRATIONS_APP_REGISTRY_ARN;
-
-  if (migrationsAppRegistryARN) {
-    console.info(`App Registry mode is enabled for CFN stack tracking. Will attempt to import the App Registry application from the MIGRATIONS_APP_REGISTRY_ARN env variable of ${migrationsAppRegistryARN} and looking in the configured region of ${region}`);
-  }
 
   // Temporarily allow both means for providing an additional migrations User Agent, but remove CUSTOM_REPLAYER_USER_AGENT
   // in future change
@@ -25,7 +20,6 @@ export function createApp(): App {
     migrationsUserAgent = process.env.MIGRATIONS_USER_AGENT
 
   new StackComposer(app, {
-    migrationsAppRegistryARN: migrationsAppRegistryARN,
     migrationsUserAgent: migrationsUserAgent,
     migrationsSolutionVersion: version,
     env: { account: account, region: region }

--- a/deployment/cdk/opensearch-service-migration/lib/stack-composer.ts
+++ b/deployment/cdk/opensearch-service-migration/lib/stack-composer.ts
@@ -11,7 +11,6 @@ import {TrafficReplayerStack} from "./service-stacks/traffic-replayer-stack";
 import {CaptureProxyStack} from "./service-stacks/capture-proxy-stack";
 import {ElasticsearchStack} from "./service-stacks/elasticsearch-stack";
 import {KafkaStack} from "./service-stacks/kafka-stack";
-import {Application} from "@aws-cdk/aws-servicecatalogappregistry-alpha";
 import {determineStreamingSourceType, StreamingSourceType} from "./streaming-source-type";
 import {
     MAX_STAGE_NAME_LENGTH,
@@ -32,19 +31,11 @@ export interface StackPropsExt extends StackProps {
 
 export interface StackComposerProps extends StackProps {
     readonly migrationsSolutionVersion: string,
-    readonly migrationsAppRegistryARN?: string,
     readonly migrationsUserAgent?: string
 }
 
 export class StackComposer {
     public stacks: Stack[] = [];
-
-    private addStacksToAppRegistry(appRegistryAppARN: string, allStacks: Stack[]) {
-        for (const stack of allStacks) {
-            const appRegistryApp = Application.fromApplicationArn(stack, 'AppRegistryApplicationImport', appRegistryAppARN)
-            appRegistryApp.associateApplicationWithStack(stack)
-        }
-    }
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     private getContextForType(optionName: string, expectedType: string, defaultValues: Record<string, any>, contextJSON: Record<string, any>): any {
@@ -631,8 +622,5 @@ export class StackComposer {
             this.stacks.push(migrationConsoleStack)
         }
 
-        if (props.migrationsAppRegistryARN) {
-            this.addStacksToAppRegistry(props.migrationsAppRegistryARN, this.stacks)
-        }
     }
 }

--- a/deployment/cdk/opensearch-service-migration/package-lock.json
+++ b/deployment/cdk/opensearch-service-migration/package-lock.json
@@ -20,7 +20,6 @@
       },
       "devDependencies": {
         "@aws-cdk/aws-msk-alpha": "2.213.0-alpha.0",
-        "@aws-cdk/aws-servicecatalogappregistry-alpha": "2.186.0-alpha.0",
         "@eslint/js": "^9.38.0",
         "@types/jest": "^30.0.0",
         "@types/node": "26.1.1",
@@ -40,7 +39,6 @@
       },
       "peerDependencies": {
         "@aws-cdk/aws-msk-alpha": "^2.150.0-alpha.0",
-        "@aws-cdk/aws-servicecatalogappregistry-alpha": "^2.150.0-alpha.0",
         "aws-cdk-lib": "^2.150.0",
         "constructs": "^10.7.1"
       }
@@ -70,19 +68,6 @@
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.213.0",
-        "constructs": "^10.0.0"
-      }
-    },
-    "node_modules/@aws-cdk/aws-servicecatalogappregistry-alpha": {
-      "version": "2.186.0-alpha.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-servicecatalogappregistry-alpha/-/aws-servicecatalogappregistry-alpha-2.186.0-alpha.0.tgz",
-      "integrity": "sha512-x7dRT1XbLkU9LkchD9hwluic3eukbewBXBSQSN+aX6aPXXLt2PQ0PXJDZx+WpSKf9JErvUZN1dr67GFurepUJg==",
-      "dev": true,
-      "engines": {
-        "node": ">= 14.15.0"
-      },
-      "peerDependencies": {
-        "aws-cdk-lib": "^2.186.0",
         "constructs": "^10.0.0"
       }
     },

--- a/deployment/cdk/opensearch-service-migration/package.json
+++ b/deployment/cdk/opensearch-service-migration/package.json
@@ -46,7 +46,6 @@
   },
   "devDependencies": {
     "@aws-cdk/aws-msk-alpha": "2.213.0-alpha.0",
-    "@aws-cdk/aws-servicecatalogappregistry-alpha": "2.186.0-alpha.0",
     "@eslint/js": "^9.38.0",
     "@types/jest": "^30.0.0",
     "@types/node": "26.1.1",
@@ -73,7 +72,6 @@
   },
   "peerDependencies": {
     "@aws-cdk/aws-msk-alpha": "^2.150.0-alpha.0",
-    "@aws-cdk/aws-servicecatalogappregistry-alpha": "^2.150.0-alpha.0",
     "aws-cdk-lib": "^2.150.0",
     "constructs": "^10.7.1"
   },

--- a/deployment/cdk/opensearch-service-migration/test/createApp.test.ts
+++ b/deployment/cdk/opensearch-service-migration/test/createApp.test.ts
@@ -38,10 +38,8 @@ describe('createApp', () => {
     // Set up environment variables
     process.env.CDK_DEFAULT_ACCOUNT = 'test-account';
     process.env.CDK_DEFAULT_REGION = 'test-region';
-    process.env.MIGRATIONS_APP_REGISTRY_ARN = 'test-arn';
     process.env.MIGRATIONS_USER_AGENT = 'test-user-agent';
 
-    const consoleSpy = jest.spyOn(console, 'info').mockImplementation();
     const mockAddTag = jest.fn();
     Tags.of = jest.fn().mockReturnValue({ add: mockAddTag });
 
@@ -57,21 +55,13 @@ describe('createApp', () => {
     expect(StackComposer).toHaveBeenCalledWith(
       expect.any(Object),
       {
-        migrationsAppRegistryARN: 'test-arn',
         migrationsUserAgent: 'test-user-agent',
         migrationsSolutionVersion: '1.0.0',
         env: { account: 'test-account', region: 'test-region' },
       }
     );
 
-    // Verify console log
-    expect(consoleSpy).toHaveBeenCalledWith(
-      expect.stringContaining('App Registry mode is enabled for CFN stack tracking')
-    );
-
     // Verify app is returned
     expect(app).toBeDefined();
-
-    consoleSpy.mockRestore();
   });
 });

--- a/deployment/cdk/opensearch-service-migration/test/stack-composer.test.ts
+++ b/deployment/cdk/opensearch-service-migration/test/stack-composer.test.ts
@@ -1,8 +1,6 @@
 import { Template } from "aws-cdk-lib/assertions";
 import { OpenSearchDomainStack } from "../lib/opensearch-domain-stack";
 import { createStackComposer, createStackComposerOnlyPassedContext } from "./test-utils";
-import { App } from "aws-cdk-lib";
-import { StackComposer } from "../lib/stack-composer";
 import { KafkaStack, MigrationConsoleStack } from "../lib";
 import { describe, beforeEach, afterEach, test, expect, jest } from '@jest/globals';
 import { ContainerImage } from "aws-cdk-lib/aws-ecs";
@@ -308,31 +306,6 @@ describe('Stack Composer Tests', () => {
     const createStackFunc = () => createStackComposer(contextOptions)
 
     expect(createStackFunc).toThrow()
-  })
-
-  test('Test that app registry association is created when migrationsAppRegistryARN is provided', () => {
-    const contextOptions = {
-      stage: "unit-test",
-      sourceCluster: {
-        disabled: true
-      }
-    }
-
-    const app = new App({
-      context: {
-        contextId: "unit-test-config",
-        "unit-test-config": contextOptions
-      }
-    })
-    const stacks = new StackComposer(app, {
-      migrationsAppRegistryARN: "arn:aws:servicecatalog:us-west-2:12345678912:/applications/12345abcdef",
-      env: {account: "test-account", region: "us-east-1"},
-      migrationsSolutionVersion: "1.0.1"
-    })
-
-    const domainStack = stacks.stacks.filter((s) => s instanceof OpenSearchDomainStack)[0]
-    const domainTemplate = Template.fromStack(domainStack)
-    domainTemplate.resourceCountIs("AWS::ServiceCatalogAppRegistry::ResourceAssociation", 1)
   })
 
   test('Test that with analytics and assistance stacks enabled, creates one opensearch domains', () => {

--- a/deployment/k8s/aws/aws-bootstrap.sh
+++ b/deployment/k8s/aws/aws-bootstrap.sh
@@ -622,7 +622,7 @@ if [[ "$deploy_cfn" == "true" ]]; then
     # Clear STACK_NAME_SUFFIX so CDK produces predictable template filenames.
     # The stack name is controlled by --stack-name, not by CDK stack IDs.
     # Other CDK env vars (CODE_BUCKET, SOLUTION_NAME, CODE_VERSION) are left
-    # intact — they affect template content (AppRegistry names, S3 paths) and
+    # intact — they affect template content (such as S3 paths) and
     # the CDK has safe defaults when they're unset.
     STACK_NAME_SUFFIX="" \
       "$base_dir/gradlew" -p "$base_dir" :deployment:migration-assistant-solution:cdkSynthMinified -x test

--- a/deployment/k8s/aws/cli/src/domain/cfn.rs
+++ b/deployment/k8s/aws/cli/src/domain/cfn.rs
@@ -164,7 +164,7 @@ mod tests {
 
     // A sanitized real-world stack payload: the single MigrationsExportString
     // output whose value is a blob of `export VAR=...` clauses.
-    const REAL_EXPORT: &str = "export MIGRATIONS_APP_REGISTRY_ARN=arn:aws:servicecatalog:us-east-1:629003556176:/applications/0152ij6laz8tjhttvf5rg0jrql; export MIGRATIONS_USER_AGENT=AwsSolution/SO0290/Unknown; export MIGRATIONS_EKS_CLUSTER_NAME=migration-eks-cluster-default-us-east-1; export MIGRATIONS_ECR_REGISTRY=629003556176.dkr.ecr.us-east-1.amazonaws.com/migration-ecr-default-us-east-1; export AWS_ACCOUNT=629003556176; export AWS_CFN_REGION=us-east-1; export VPC_ID=vpc-0bc345db0dee70e9e; export EKS_CLUSTER_SECURITY_GROUP=sg-07cc74efd34551fb1; export SNAPSHOT_ROLE=arn:aws:iam::629003556176:role/migration-eks-cluster-default-us-east-1-snapshot-role; export STAGE=default";
+    const REAL_EXPORT: &str = "export MIGRATIONS_USER_AGENT=AwsSolution/SO0290/Unknown; export MIGRATIONS_EKS_CLUSTER_NAME=migration-eks-cluster-default-us-east-1; export MIGRATIONS_ECR_REGISTRY=629003556176.dkr.ecr.us-east-1.amazonaws.com/migration-ecr-default-us-east-1; export AWS_ACCOUNT=629003556176; export AWS_CFN_REGION=us-east-1; export VPC_ID=vpc-0bc345db0dee70e9e; export EKS_CLUSTER_SECURITY_GROUP=sg-07cc74efd34551fb1; export SNAPSHOT_ROLE=arn:aws:iam::629003556176:role/migration-eks-cluster-default-us-east-1-snapshot-role; export STAGE=default";
 
     fn real_payload_row() -> String {
         format!("MigrationsExportString\t{REAL_EXPORT}")

--- a/deployment/migration-assistant-solution/lib/common-utils.ts
+++ b/deployment/migration-assistant-solution/lib/common-utils.ts
@@ -1,6 +1,4 @@
-import {Aws, CfnParameter, Fn, Stack, Tags} from "aws-cdk-lib";
-import {Application, AttributeGroup} from "@aws-cdk/aws-servicecatalogappregistry-alpha";
-import {SolutionsInfrastructureStackProps} from "./solutions-stack";
+import {CfnParameter, Stack} from "aws-cdk-lib";
 import {InterfaceVpcEndpointAwsService} from "aws-cdk-lib/aws-ec2";
 
 export const SOLUTION_ID = 'SO0290';
@@ -36,44 +34,6 @@ export function buildTemplateDescription(kind: TemplateKind): string {
 
 export interface ParameterLabel {
     default: string;
-}
-
-export function applyAppRegistry(stack: Stack, stage: string, infraProps: SolutionsInfrastructureStackProps): string {
-    const application = new Application(stack, "AppRegistry", {
-        applicationName: Fn.join("-", [
-            infraProps.solutionName,
-            Aws.REGION,
-            Aws.ACCOUNT_ID,
-            stage
-        ]),
-        description: `Service Catalog application to track and manage all your resources for the solution ${infraProps.solutionName}`,
-    });
-    application.associateApplicationWithStack(stack);
-    Tags.of(application).add("Solutions:SolutionID", infraProps.solutionId);
-    Tags.of(application).add("Solutions:SolutionName", infraProps.solutionName);
-    Tags.of(application).add("Solutions:SolutionVersion", infraProps.solutionVersion);
-    Tags.of(application).add("Solutions:ApplicationType", "AWS-Solutions");
-
-    const attributeGroup = new AttributeGroup(
-        stack,
-        "DefaultApplicationAttributes",
-        {
-            attributeGroupName: Fn.join("-", [
-                Aws.REGION,
-                stage,
-                "attributes"
-            ]),
-            description: "Attribute group for solution information",
-            attributes: {
-                applicationType: "AWS-Solutions",
-                version: infraProps.solutionVersion,
-                solutionID: infraProps.solutionId,
-                solutionName: infraProps.solutionName,
-            },
-        }
-    );
-    attributeGroup.associateWith(application)
-    return application.applicationArn
 }
 
 export function addParameterLabel(labels: Record<string, ParameterLabel>, parameter: CfnParameter, labelName: string) {

--- a/deployment/migration-assistant-solution/lib/solutions-stack-eks.ts
+++ b/deployment/migration-assistant-solution/lib/solutions-stack-eks.ts
@@ -23,7 +23,6 @@ import {
 import {EKSInfra} from "./eks-infra";
 import {
     addParameterLabel,
-    applyAppRegistry,
     generateExportString,
     getVpcEndpointForEFS,
     ParameterLabel,
@@ -82,7 +81,6 @@ export class SolutionsInfrastructureEKSStack extends Stack {
         additionalParameters.push(stageParameter.logicalId)
 
         const stackMarker = `${stageParameter.valueAsString}-${Aws.REGION}`;
-        const appRegistryAppARN = applyAppRegistry(this, stackMarker, props)
 
         const solutionsUserAgent = `AwsSolution/${props.solutionId}/${props.solutionVersion}`
 
@@ -319,7 +317,6 @@ export class SolutionsInfrastructureEKSStack extends Stack {
         });
 
         const exportString = generateExportString({
-            "MIGRATIONS_APP_REGISTRY_ARN": appRegistryAppARN,
             "MIGRATIONS_USER_AGENT": solutionsUserAgent,
             "MIGRATIONS_EKS_CLUSTER_NAME": eksClusterName,
             "MIGRATIONS_ECR_REGISTRY": `${eksInfra.ecrRepo.registryUri}/${eksInfra.ecrRepo.repositoryName}`,

--- a/deployment/migration-assistant-solution/lib/solutions-stack.ts
+++ b/deployment/migration-assistant-solution/lib/solutions-stack.ts
@@ -33,7 +33,6 @@ import {CfnDocument} from "aws-cdk-lib/aws-ssm";
 import { InstanceProfile, ManagedPolicy, Role, ServicePrincipal } from 'aws-cdk-lib/aws-iam';
 import {
     addParameterLabel,
-    applyAppRegistry,
     generateExportString,
     getVpcEndpointForEFS,
     ParameterLabel,
@@ -96,7 +95,6 @@ export class SolutionsInfrastructureStack extends Stack {
         additionalParameters.push(stageParameter.logicalId)
 
         const stackMarker = `${stageParameter.valueAsString}-${Aws.REGION}`;
-        const appRegistryAppARN = applyAppRegistry(this, stackMarker, props)
 
         new CfnDocument(this, "BootstrapShellDoc", {
             name: `BootstrapShellDoc-${stackMarker}`,
@@ -200,7 +198,6 @@ export class SolutionsInfrastructureStack extends Stack {
         }
 
         const exportString = generateExportString({
-            "MIGRATIONS_APP_REGISTRY_ARN": appRegistryAppARN,
             "MIGRATIONS_USER_AGENT": solutionsUserAgent,
             "VPC_ID": vpc.vpcId,
             "STAGE": stageParameter.valueAsString,

--- a/deployment/migration-assistant-solution/package-lock.json
+++ b/deployment/migration-assistant-solution/package-lock.json
@@ -9,7 +9,6 @@
       "version": "2.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-cdk/aws-servicecatalogappregistry-alpha": "2.240.0-alpha.0",
         "@jest/globals": "^30.4.1",
         "cdk": "2.1133.0",
         "globals": "^17.8.0",
@@ -54,26 +53,15 @@
       "version": "2.2.282",
       "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.282.tgz",
       "integrity": "sha512-7hKMi5tTxDcKGIMIOq14PnY0GBcugW33Uh/2YHDZiEwSxLeFOCYBwhR+BFXONb/EJeVI3RETFgailNZbkcKF6g==",
+      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/@aws-cdk/asset-node-proxy-agent-v6": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.1.2.tgz",
       "integrity": "sha512-pDiuqH+qY3zM9lhhLjbKJ1tnKOHzQ2V4Wr/3qsxyKeKAkuPMI/BVGvZG1PbrikUw949cGVTfVEt4ETKKYnrj0Q==",
+      "dev": true,
       "license": "Apache-2.0"
-    },
-    "node_modules/@aws-cdk/aws-servicecatalogappregistry-alpha": {
-      "version": "2.240.0-alpha.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-servicecatalogappregistry-alpha/-/aws-servicecatalogappregistry-alpha-2.240.0-alpha.0.tgz",
-      "integrity": "sha512-uCnbj16uwFSvdkkCIqMoqE3O0SuI9biT84s4KQn7S/f8xvDJxNtdZTudjznH+HRKk9QxNBXeRtjIMEA+YKUx6w==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">= 18.0.0"
-      },
-      "peerDependencies": {
-        "aws-cdk-lib": "^2.240.0",
-        "constructs": "^10.5.0"
-      }
     },
     "node_modules/@aws-cdk/cfnspec": {
       "version": "2.68.0",
@@ -94,6 +82,7 @@
         "jsonschema",
         "semver"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "jsonschema": "^1.5.0",
@@ -105,6 +94,7 @@
     },
     "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/jsonschema": {
       "version": "1.5.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -113,6 +103,7 @@
     },
     "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/semver": {
       "version": "7.8.5",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "bin": {
@@ -2384,6 +2375,7 @@
         "yaml",
         "mime-types"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-cdk/asset-awscli-v1": "2.2.282",
@@ -2411,6 +2403,7 @@
     },
     "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api": {
       "version": "2.2.6",
+      "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2426,6 +2419,7 @@
     },
     "node_modules/aws-cdk-lib/node_modules/@aws/cloudformation-validate": {
       "version": "1.5.1-beta",
+      "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "engines": {
@@ -2434,11 +2428,13 @@
     },
     "node_modules/aws-cdk-lib/node_modules/@balena/dockerignore": {
       "version": "1.0.2",
+      "dev": true,
       "inBundle": true,
       "license": "Apache-2.0"
     },
     "node_modules/aws-cdk-lib/node_modules/balanced-match": {
       "version": "4.0.4",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -2447,6 +2443,7 @@
     },
     "node_modules/aws-cdk-lib/node_modules/brace-expansion": {
       "version": "5.0.7",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -2458,6 +2455,7 @@
     },
     "node_modules/aws-cdk-lib/node_modules/case": {
       "version": "1.6.3",
+      "dev": true,
       "inBundle": true,
       "license": "(MIT OR GPL-3.0-or-later)",
       "engines": {
@@ -2466,6 +2464,7 @@
     },
     "node_modules/aws-cdk-lib/node_modules/fs-extra": {
       "version": "11.3.6",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -2479,11 +2478,13 @@
     },
     "node_modules/aws-cdk-lib/node_modules/graceful-fs": {
       "version": "4.2.11",
+      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/aws-cdk-lib/node_modules/ignore": {
       "version": "5.3.2",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -2492,6 +2493,7 @@
     },
     "node_modules/aws-cdk-lib/node_modules/jsonfile": {
       "version": "6.2.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -2503,6 +2505,7 @@
     },
     "node_modules/aws-cdk-lib/node_modules/jsonschema": {
       "version": "1.5.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -2511,6 +2514,7 @@
     },
     "node_modules/aws-cdk-lib/node_modules/mime-db": {
       "version": "1.52.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -2519,6 +2523,7 @@
     },
     "node_modules/aws-cdk-lib/node_modules/mime-types": {
       "version": "2.1.35",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -2530,6 +2535,7 @@
     },
     "node_modules/aws-cdk-lib/node_modules/minimatch": {
       "version": "10.2.5",
+      "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -2544,6 +2550,7 @@
     },
     "node_modules/aws-cdk-lib/node_modules/punycode": {
       "version": "2.3.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -2552,6 +2559,7 @@
     },
     "node_modules/aws-cdk-lib/node_modules/semver": {
       "version": "7.8.5",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "bin": {
@@ -2563,6 +2571,7 @@
     },
     "node_modules/aws-cdk-lib/node_modules/universalify": {
       "version": "2.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -2571,6 +2580,7 @@
     },
     "node_modules/aws-cdk-lib/node_modules/yaml": {
       "version": "1.10.3",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -2977,6 +2987,7 @@
       "version": "10.7.1",
       "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.7.1.tgz",
       "integrity": "sha512-ulK25Sg2Nv1jW+A9VeV7fu9GFN9KdVTNWdXMoapNRwqkQzSdToro/Tttk3Ak5BGI80NRA/d2nSzKnoZ27LizLw==",
+      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/convert-source-map": {

--- a/deployment/migration-assistant-solution/package.json
+++ b/deployment/migration-assistant-solution/package.json
@@ -33,7 +33,6 @@
     "typescript-eslint": "^8.65.0"
   },
   "dependencies": {
-    "@aws-cdk/aws-servicecatalogappregistry-alpha": "2.240.0-alpha.0",
     "@jest/globals": "^30.4.1",
     "cdk": "2.1133.0",
     "globals": "^17.8.0",

--- a/deployment/migration-assistant-solution/test/__snapshots__/solutions-stack-eks.test.ts.snap
+++ b/deployment/migration-assistant-solution/test/__snapshots__/solutions-stack-eks.test.ts.snap
@@ -240,14 +240,7 @@ exports[`Solutions stack Migration stack with import VPC matches snapshot 1`] = 
         "Fn::Join": [
           "",
           [
-            "export MIGRATIONS_APP_REGISTRY_ARN=",
-            {
-              "Fn::GetAtt": [
-                "AppRegistry968496A3",
-                "Arn",
-              ],
-            },
-            "; export MIGRATIONS_USER_AGENT=AwsSolution/SO0000/0.0.1; export MIGRATIONS_EKS_CLUSTER_NAME=migration-eks-cluster-",
+            "export MIGRATIONS_USER_AGENT=AwsSolution/SO0000/0.0.1; export MIGRATIONS_EKS_CLUSTER_NAME=migration-eks-cluster-",
             {
               "Ref": "Stage",
             },
@@ -426,61 +419,6 @@ exports[`Solutions stack Migration stack with import VPC matches snapshot 1`] = 
     },
   },
   "Resources": {
-    "AppRegistry968496A3": {
-      "Properties": {
-        "Description": "Service Catalog application to track and manage all your resources for the solution test-solution",
-        "Name": {
-          "Fn::Join": [
-            "-",
-            [
-              "test-solution",
-              {
-                "Ref": "AWS::Region",
-              },
-              {
-                "Ref": "AWS::AccountId",
-              },
-              {
-                "Fn::Join": [
-                  "",
-                  [
-                    {
-                      "Ref": "Stage",
-                    },
-                    "-",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                  ],
-                ],
-              },
-            ],
-          ],
-        },
-        "Tags": {
-          "Solutions:ApplicationType": "AWS-Solutions",
-          "Solutions:SolutionID": "SO0000",
-          "Solutions:SolutionName": "test-solution",
-          "Solutions:SolutionVersion": "0.0.1",
-        },
-      },
-      "Type": "AWS::ServiceCatalogAppRegistry::Application",
-    },
-    "AppRegistryAssociation": {
-      "Properties": {
-        "Application": {
-          "Fn::GetAtt": [
-            "AppRegistry968496A3",
-            "Id",
-          ],
-        },
-        "Resource": {
-          "Ref": "AWS::StackId",
-        },
-        "ResourceType": "CFN_STACK",
-      },
-      "Type": "AWS::ServiceCatalogAppRegistry::ResourceAssociation",
-    },
     "CloudWatchLogsVpcEndpoint": {
       "Condition": "CreateCloudWatchLogsEndpointCondition",
       "Properties": {
@@ -520,60 +458,6 @@ exports[`Solutions stack Migration stack with import VPC matches snapshot 1`] = 
         },
       },
       "Type": "AWS::EC2::VPCEndpoint",
-    },
-    "DefaultApplicationAttributesApplicationAttributeGroupAssociation5303e42e4390C82F1F85": {
-      "Properties": {
-        "Application": {
-          "Fn::GetAtt": [
-            "AppRegistry968496A3",
-            "Id",
-          ],
-        },
-        "AttributeGroup": {
-          "Fn::GetAtt": [
-            "DefaultApplicationAttributesFC1CC26B",
-            "Id",
-          ],
-        },
-      },
-      "Type": "AWS::ServiceCatalogAppRegistry::AttributeGroupAssociation",
-    },
-    "DefaultApplicationAttributesFC1CC26B": {
-      "Properties": {
-        "Attributes": {
-          "applicationType": "AWS-Solutions",
-          "solutionID": "SO0000",
-          "solutionName": "test-solution",
-          "version": "0.0.1",
-        },
-        "Description": "Attribute group for solution information",
-        "Name": {
-          "Fn::Join": [
-            "-",
-            [
-              {
-                "Ref": "AWS::Region",
-              },
-              {
-                "Fn::Join": [
-                  "",
-                  [
-                    {
-                      "Ref": "Stage",
-                    },
-                    "-",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                  ],
-                ],
-              },
-              "attributes",
-            ],
-          ],
-        },
-      },
-      "Type": "AWS::ServiceCatalogAppRegistry::AttributeGroup",
     },
     "ECRDockerVpcEndpoint": {
       "Condition": "CreateECRDockerEndpointCondition",
@@ -1663,14 +1547,7 @@ exports[`Solutions stack Migration stack with new VPC matches snapshot 1`] = `
         "Fn::Join": [
           "",
           [
-            "export MIGRATIONS_APP_REGISTRY_ARN=",
-            {
-              "Fn::GetAtt": [
-                "AppRegistry968496A3",
-                "Arn",
-              ],
-            },
-            "; export MIGRATIONS_USER_AGENT=AwsSolution/SO0000/0.0.1; export MIGRATIONS_EKS_CLUSTER_NAME=migration-eks-cluster-",
+            "export MIGRATIONS_USER_AGENT=AwsSolution/SO0000/0.0.1; export MIGRATIONS_EKS_CLUSTER_NAME=migration-eks-cluster-",
             {
               "Ref": "Stage",
             },
@@ -1764,115 +1641,6 @@ exports[`Solutions stack Migration stack with new VPC matches snapshot 1`] = `
     },
   },
   "Resources": {
-    "AppRegistry968496A3": {
-      "Properties": {
-        "Description": "Service Catalog application to track and manage all your resources for the solution test-solution",
-        "Name": {
-          "Fn::Join": [
-            "-",
-            [
-              "test-solution",
-              {
-                "Ref": "AWS::Region",
-              },
-              {
-                "Ref": "AWS::AccountId",
-              },
-              {
-                "Fn::Join": [
-                  "",
-                  [
-                    {
-                      "Ref": "Stage",
-                    },
-                    "-",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                  ],
-                ],
-              },
-            ],
-          ],
-        },
-        "Tags": {
-          "Solutions:ApplicationType": "AWS-Solutions",
-          "Solutions:SolutionID": "SO0000",
-          "Solutions:SolutionName": "test-solution",
-          "Solutions:SolutionVersion": "0.0.1",
-        },
-      },
-      "Type": "AWS::ServiceCatalogAppRegistry::Application",
-    },
-    "AppRegistryAssociation": {
-      "Properties": {
-        "Application": {
-          "Fn::GetAtt": [
-            "AppRegistry968496A3",
-            "Id",
-          ],
-        },
-        "Resource": {
-          "Ref": "AWS::StackId",
-        },
-        "ResourceType": "CFN_STACK",
-      },
-      "Type": "AWS::ServiceCatalogAppRegistry::ResourceAssociation",
-    },
-    "DefaultApplicationAttributesApplicationAttributeGroupAssociation5303e42e4390C82F1F85": {
-      "Properties": {
-        "Application": {
-          "Fn::GetAtt": [
-            "AppRegistry968496A3",
-            "Id",
-          ],
-        },
-        "AttributeGroup": {
-          "Fn::GetAtt": [
-            "DefaultApplicationAttributesFC1CC26B",
-            "Id",
-          ],
-        },
-      },
-      "Type": "AWS::ServiceCatalogAppRegistry::AttributeGroupAssociation",
-    },
-    "DefaultApplicationAttributesFC1CC26B": {
-      "Properties": {
-        "Attributes": {
-          "applicationType": "AWS-Solutions",
-          "solutionID": "SO0000",
-          "solutionName": "test-solution",
-          "version": "0.0.1",
-        },
-        "Description": "Attribute group for solution information",
-        "Name": {
-          "Fn::Join": [
-            "-",
-            [
-              {
-                "Ref": "AWS::Region",
-              },
-              {
-                "Fn::Join": [
-                  "",
-                  [
-                    {
-                      "Ref": "Stage",
-                    },
-                    "-",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                  ],
-                ],
-              },
-              "attributes",
-            ],
-          ],
-        },
-      },
-      "Type": "AWS::ServiceCatalogAppRegistry::AttributeGroup",
-    },
     "EKSInfraAckCloudWatchPodIdentityAssociation51006884": {
       "DependsOn": [
         "EKSInfraMigrationsEKSClusterAccountReadonlyAccess3FCE8696",

--- a/deployment/migration-assistant-solution/test/__snapshots__/solutions-stack.test.ts.snap
+++ b/deployment/migration-assistant-solution/test/__snapshots__/solutions-stack.test.ts.snap
@@ -75,62 +75,7 @@ exports[`Solutions stack ECS stack with import VPC matches snapshot 1`] = `
     },
   },
   "Resources": {
-    "AppRegistry968496A3": {
-      "Properties": {
-        "Description": "Service Catalog application to track and manage all your resources for the solution test-solution",
-        "Name": {
-          "Fn::Join": [
-            "-",
-            [
-              "test-solution",
-              {
-                "Ref": "AWS::Region",
-              },
-              {
-                "Ref": "AWS::AccountId",
-              },
-              {
-                "Fn::Join": [
-                  "",
-                  [
-                    {
-                      "Ref": "Stage",
-                    },
-                    "-",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                  ],
-                ],
-              },
-            ],
-          ],
-        },
-        "Tags": {
-          "Solutions:ApplicationType": "AWS-Solutions",
-          "Solutions:SolutionID": "SO0000",
-          "Solutions:SolutionName": "test-solution",
-          "Solutions:SolutionVersion": "0.0.1",
-        },
-      },
-      "Type": "AWS::ServiceCatalogAppRegistry::Application",
-    },
-    "AppRegistryAssociation": {
-      "Properties": {
-        "Application": {
-          "Fn::GetAtt": [
-            "AppRegistry968496A3",
-            "Id",
-          ],
-        },
-        "Resource": {
-          "Ref": "AWS::StackId",
-        },
-        "ResourceType": "CFN_STACK",
-      },
-      "Type": "AWS::ServiceCatalogAppRegistry::ResourceAssociation",
-    },
-    "BootstrapEC2Instance36A69AF723cb2ecc3dacad24": {
+    "BootstrapEC2Instance36A69AF71ab4340e4b468479": {
       "CreationPolicy": {
         "ResourceSignal": {
           "Count": 1,
@@ -150,14 +95,7 @@ exports[`Solutions stack ECS stack with import VPC matches snapshot 1`] = `
                   "Fn::Join": [
                     "",
                     [
-                      "echo "export MIGRATIONS_APP_REGISTRY_ARN=",
-                      {
-                        "Fn::GetAtt": [
-                          "AppRegistry968496A3",
-                          "Arn",
-                        ],
-                      },
-                      "; export MIGRATIONS_USER_AGENT=AwsSolution/SO0000/0.0.1; export VPC_ID=",
+                      "echo "export MIGRATIONS_USER_AGENT=AwsSolution/SO0000/0.0.1; export VPC_ID=",
                       {
                         "Ref": "VPCId",
                       },
@@ -326,7 +264,7 @@ npm install 2>&1
               "",
               [
                 "#!/bin/bash
-# fingerprint: 6e880182a0153a3c
+# fingerprint: 2ba45effaf199263
 (
   set +e
   /opt/aws/bin/cfn-init -v --region ",
@@ -337,7 +275,7 @@ npm install 2>&1
                 {
                   "Ref": "AWS::StackName",
                 },
-                " --resource BootstrapEC2Instance36A69AF723cb2ecc3dacad24 -c default
+                " --resource BootstrapEC2Instance36A69AF71ab4340e4b468479 -c default
   /opt/aws/bin/cfn-signal -e $? --region ",
                 {
                   "Ref": "AWS::Region",
@@ -346,7 +284,7 @@ npm install 2>&1
                 {
                   "Ref": "AWS::StackName",
                 },
-                " --resource BootstrapEC2Instance36A69AF723cb2ecc3dacad24
+                " --resource BootstrapEC2Instance36A69AF71ab4340e4b468479
   cat /var/log/cfn-init.log >&2
 )",
               ],
@@ -520,60 +458,6 @@ npm install 2>&1
       },
       "Type": "AWS::SSM::Document",
     },
-    "DefaultApplicationAttributesApplicationAttributeGroupAssociation5303e42e4390C82F1F85": {
-      "Properties": {
-        "Application": {
-          "Fn::GetAtt": [
-            "AppRegistry968496A3",
-            "Id",
-          ],
-        },
-        "AttributeGroup": {
-          "Fn::GetAtt": [
-            "DefaultApplicationAttributesFC1CC26B",
-            "Id",
-          ],
-        },
-      },
-      "Type": "AWS::ServiceCatalogAppRegistry::AttributeGroupAssociation",
-    },
-    "DefaultApplicationAttributesFC1CC26B": {
-      "Properties": {
-        "Attributes": {
-          "applicationType": "AWS-Solutions",
-          "solutionID": "SO0000",
-          "solutionName": "test-solution",
-          "version": "0.0.1",
-        },
-        "Description": "Attribute group for solution information",
-        "Name": {
-          "Fn::Join": [
-            "-",
-            [
-              {
-                "Ref": "AWS::Region",
-              },
-              {
-                "Fn::Join": [
-                  "",
-                  [
-                    {
-                      "Ref": "Stage",
-                    },
-                    "-",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                  ],
-                ],
-              },
-              "attributes",
-            ],
-          ],
-        },
-      },
-      "Type": "AWS::ServiceCatalogAppRegistry::AttributeGroup",
-    },
   },
   "Rules": {
     "CheckBootstrapVersion": {
@@ -648,62 +532,7 @@ exports[`Solutions stack ECS stack with new VPC matches snapshot 1`] = `
     },
   },
   "Resources": {
-    "AppRegistry968496A3": {
-      "Properties": {
-        "Description": "Service Catalog application to track and manage all your resources for the solution test-solution",
-        "Name": {
-          "Fn::Join": [
-            "-",
-            [
-              "test-solution",
-              {
-                "Ref": "AWS::Region",
-              },
-              {
-                "Ref": "AWS::AccountId",
-              },
-              {
-                "Fn::Join": [
-                  "",
-                  [
-                    {
-                      "Ref": "Stage",
-                    },
-                    "-",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                  ],
-                ],
-              },
-            ],
-          ],
-        },
-        "Tags": {
-          "Solutions:ApplicationType": "AWS-Solutions",
-          "Solutions:SolutionID": "SO0000",
-          "Solutions:SolutionName": "test-solution",
-          "Solutions:SolutionVersion": "0.0.1",
-        },
-      },
-      "Type": "AWS::ServiceCatalogAppRegistry::Application",
-    },
-    "AppRegistryAssociation": {
-      "Properties": {
-        "Application": {
-          "Fn::GetAtt": [
-            "AppRegistry968496A3",
-            "Id",
-          ],
-        },
-        "Resource": {
-          "Ref": "AWS::StackId",
-        },
-        "ResourceType": "CFN_STACK",
-      },
-      "Type": "AWS::ServiceCatalogAppRegistry::ResourceAssociation",
-    },
-    "BootstrapEC2Instance36A69AF7ba4ca28033971592": {
+    "BootstrapEC2Instance36A69AF7dfab0e0844eda6de": {
       "CreationPolicy": {
         "ResourceSignal": {
           "Count": 1,
@@ -723,14 +552,7 @@ exports[`Solutions stack ECS stack with new VPC matches snapshot 1`] = `
                   "Fn::Join": [
                     "",
                     [
-                      "echo "export MIGRATIONS_APP_REGISTRY_ARN=",
-                      {
-                        "Fn::GetAtt": [
-                          "AppRegistry968496A3",
-                          "Arn",
-                        ],
-                      },
-                      "; export MIGRATIONS_USER_AGENT=AwsSolution/SO0000/0.0.1; export VPC_ID=",
+                      "echo "export MIGRATIONS_USER_AGENT=AwsSolution/SO0000/0.0.1; export VPC_ID=",
                       {
                         "Ref": "Vpc8378EB38",
                       },
@@ -894,7 +716,7 @@ npm install 2>&1
               "",
               [
                 "#!/bin/bash
-# fingerprint: b886ada016436950
+# fingerprint: 10488b463ccae0ac
 (
   set +e
   /opt/aws/bin/cfn-init -v --region ",
@@ -905,7 +727,7 @@ npm install 2>&1
                 {
                   "Ref": "AWS::StackName",
                 },
-                " --resource BootstrapEC2Instance36A69AF7ba4ca28033971592 -c default
+                " --resource BootstrapEC2Instance36A69AF7dfab0e0844eda6de -c default
   /opt/aws/bin/cfn-signal -e $? --region ",
                 {
                   "Ref": "AWS::Region",
@@ -914,7 +736,7 @@ npm install 2>&1
                 {
                   "Ref": "AWS::StackName",
                 },
-                " --resource BootstrapEC2Instance36A69AF7ba4ca28033971592
+                " --resource BootstrapEC2Instance36A69AF7dfab0e0844eda6de
   cat /var/log/cfn-init.log >&2
 )",
               ],
@@ -1087,60 +909,6 @@ npm install 2>&1
         },
       },
       "Type": "AWS::SSM::Document",
-    },
-    "DefaultApplicationAttributesApplicationAttributeGroupAssociation5303e42e4390C82F1F85": {
-      "Properties": {
-        "Application": {
-          "Fn::GetAtt": [
-            "AppRegistry968496A3",
-            "Id",
-          ],
-        },
-        "AttributeGroup": {
-          "Fn::GetAtt": [
-            "DefaultApplicationAttributesFC1CC26B",
-            "Id",
-          ],
-        },
-      },
-      "Type": "AWS::ServiceCatalogAppRegistry::AttributeGroupAssociation",
-    },
-    "DefaultApplicationAttributesFC1CC26B": {
-      "Properties": {
-        "Attributes": {
-          "applicationType": "AWS-Solutions",
-          "solutionID": "SO0000",
-          "solutionName": "test-solution",
-          "version": "0.0.1",
-        },
-        "Description": "Attribute group for solution information",
-        "Name": {
-          "Fn::Join": [
-            "-",
-            [
-              {
-                "Ref": "AWS::Region",
-              },
-              {
-                "Fn::Join": [
-                  "",
-                  [
-                    {
-                      "Ref": "Stage",
-                    },
-                    "-",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                  ],
-                ],
-              },
-              "attributes",
-            ],
-          ],
-        },
-      },
-      "Type": "AWS::ServiceCatalogAppRegistry::AttributeGroup",
     },
     "S3VpcEndpoint1F0CDE18": {
       "Properties": {

--- a/deployment/migration-assistant-solution/test/solutions-stack-eks.test.ts
+++ b/deployment/migration-assistant-solution/test/solutions-stack-eks.test.ts
@@ -89,7 +89,10 @@ describe('Solutions stack', () => {
         template.resourceCountIs('AWS::EC2::VPCEndpoint', props.vpcEndpointCount);
         template.resourceCountIs('AWS::EC2::Subnet', props.subnetCount);
         template.resourceCountIs('AWS::EC2::NatGateway', props.natGatewayCount);
-        template.resourceCountIs('AWS::ServiceCatalogAppRegistry::Application', 1);
+        template.resourceCountIs('AWS::ServiceCatalogAppRegistry::Application', 0);
+        template.resourceCountIs('AWS::ServiceCatalogAppRegistry::ResourceAssociation', 0);
+        template.resourceCountIs('AWS::ServiceCatalogAppRegistry::AttributeGroup', 0);
+        template.resourceCountIs('AWS::ServiceCatalogAppRegistry::AttributeGroupAssociation', 0);
         template.resourceCountIs('AWS::EKS::Cluster', 1);
         template.resourceCountIs('AWS::IAM::Role', 4);
     }

--- a/deployment/migration-assistant-solution/test/solutions-stack.test.ts
+++ b/deployment/migration-assistant-solution/test/solutions-stack.test.ts
@@ -17,8 +17,9 @@ describe('Solutions stack', () => {
 
     test('ECS stack with new VPC matches snapshot', () => {
         const stack = new SolutionsInfrastructureStack(new App(), 'TestMigrationAssistantStack', defaultProperties);
-        const template = Template.fromStack(stack).toJSON();
-        expect(template).toMatchSnapshot();
+        const template = Template.fromStack(stack);
+        verifyNoAppRegistry(template);
+        expect(template.toJSON()).toMatchSnapshot();
     });
 
     test('ECS stack with import VPC matches snapshot', () => {
@@ -26,7 +27,15 @@ describe('Solutions stack', () => {
             ...defaultProperties,
             createVPC: false
         });
-        const template = Template.fromStack(stack).toJSON();
-        expect(template).toMatchSnapshot();
+        const template = Template.fromStack(stack);
+        verifyNoAppRegistry(template);
+        expect(template.toJSON()).toMatchSnapshot();
     });
+
+    function verifyNoAppRegistry(template: Template) {
+        template.resourceCountIs('AWS::ServiceCatalogAppRegistry::Application', 0);
+        template.resourceCountIs('AWS::ServiceCatalogAppRegistry::ResourceAssociation', 0);
+        template.resourceCountIs('AWS::ServiceCatalogAppRegistry::AttributeGroup', 0);
+        template.resourceCountIs('AWS::ServiceCatalogAppRegistry::AttributeGroupAssociation', 0);
+    }
 });


### PR DESCRIPTION
## Summary

- remove Service Catalog AppRegistry resources from the ECS and EKS solution templates
- stop exporting `MIGRATIONS_APP_REGISTRY_ARN` and remove the AppRegistry CDK dependency
- remove the downstream ECS CDK consumer that imported the application and associated migration stacks
- retain AWS Solutions adoption tracking through the existing `SO0290` solution metadata and `AwsSolution/<solution-id>/<version>` user agent
- update unit assertions, snapshots, and stale fixtures for all four generated templates

## Why

The legacy AppRegistry integration is no longer required for AWS Solutions adoption tracking. Keeping it in the templates adds obsolete resources and can prevent otherwise valid solution deployments.

## Validation

- `npm run test:lint`
- `npm run test:jest -- --runInBand` (7 tests and 4 snapshots passed)
- `STACK_NAME_SUFFIX="" ./gradlew :deployment:migration-assistant-solution:cdkSynthMinified`
- verified all four minified ECS/EKS templates contain no `AWS::ServiceCatalogAppRegistry` resources or `MIGRATIONS_APP_REGISTRY_ARN`
- `npm run test:lint` in `deployment/cdk/opensearch-service-migration`
- `npm run build` in `deployment/cdk/opensearch-service-migration`
- `npm run test:jest -- --runInBand` in `deployment/cdk/opensearch-service-migration` (109 tests passed)
- `cargo test domain::cfn` in `deployment/k8s/aws/cli` (13 tests passed)

`npm run build` continues to hit the existing `@types/eslint__js` stub-package TypeScript error; the release workflow's Gradle synthesis path passes.
