### PR TITLE
Fix prerelease Jenkins webhook trigger

### DIFF
--- a/jenkins/release.jenkinsFile
+++ b/jenkins/release.jenkinsFile
@@ -29,14 +29,15 @@ pipeline {
                     [key: 'action', value: '$.action'],
                     [key: 'isPreRelease', value: '$.release.prerelease'],
                     [key: 'release_url', value: '$.release.url'],
+                    [key: 'release_html_url', value: '$.release.html_url'],
                     [key: 'assets_url', value: '$.release.assets_url']
                 ],
                 tokenCredentialId: 'jenkins-opensearch-migrations-generic-webhook-token',
                 causeString: 'A tag was cut on opensearch-project/opensearch-migrations repository causing this workflow to run',
                 printContributedVariables: false,
                 printPostContent: false,
-                regexpFilterText: '$isDraft $action',
-                regexpFilterExpression: '^true created$'
+                regexpFilterText: '$isPreRelease $action',
+                regexpFilterExpression: '^true published$'
             )
         }
         environment {


### PR DESCRIPTION
### Description

Fix the OpenSearch Migrations release Jenkins job after the release workflow changed from draft releases to prereleases in #3126.

* Match the `published` webhook for a prerelease instead of referring to the removed `isDraft` variable.
* Extract the release's browser-facing `html_url` used by the success and failure issue notifications.

The stale trigger filter prevented the 3.3.5 and 3.3.6 release events from scheduling Jenkins builds. The missing URL variable also caused the post condition in the 3.3.4 build to fail after its release work completed.

### Issues Resolved

N/A

### Testing

* Ran `git diff --check`.
* Evaluated the trigger regex against representative GitHub release payloads. It matches `prerelease=true action=published` and rejects draft creation and full-release publication.

### Check List

- [x] New functionality includes testing
- [x] Public documentation issue/PR created, if applicable. (Not applicable.)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
