### PR TITLE
Disable codecov on forks

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -76,6 +76,8 @@ jobs:
     env:
       WORKING_DIR: ${{ startsWith(matrix.py-project, 'migrationConsole/') && format('./{0}', matrix.py-project) || startsWith(matrix.py-project, 'libraries/') && format('./{0}', matrix.py-project) || matrix.py-project == 'solrMigrationDevSandbox' && format('./{0}', matrix.py-project) || format('./TrafficCapture/dockerSolution/src/main/docker/{0}', matrix.py-project) }}
       WORKFLOW_TEST_KUBE_CONTEXT: kind-console-link-test
+      # The secrets context is unavailable in a step `if`, so gate on this instead.
+      HAS_CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN != '' }}
     defaults:
       run:
         working-directory: ${{ env.WORKING_DIR }}
@@ -118,7 +120,7 @@ jobs:
           PY_PROJECT: ${{ matrix.py-project }}
         run: echo "SANITIZED_PY_PROJECT=${PY_PROJECT//\//-}" >> $GITHUB_ENV
       - name: Upload coverage to Codecov
-        if: always()
+        if: always() && env.HAS_CODECOV_TOKEN == 'true'
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f
         with:
           fail_ci_if_error: true
@@ -187,6 +189,9 @@ jobs:
       fail-fast: false
       matrix:
         index: ${{ fromJson(needs.generate-test-matrix.outputs.matrix) }}
+    env:
+      # The secrets context is unavailable in a step `if`, so gate on this instead.
+      HAS_CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN != '' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./.github/actions/setup-env
@@ -246,7 +251,7 @@ jobs:
             **/build/reports/tests/
 
       - name: Upload coverage to Codecov
-        if: always()
+        if: always() && env.HAS_CODECOV_TOKEN == 'true'
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f
         with:
           fail_ci_if_error: true
@@ -276,6 +281,9 @@ jobs:
           - ./deployment/migration-assistant-solution
           - ./TrafficCapture/SolrTransformations/transforms
           - ./orchestrationSpecs
+    env:
+      # The secrets context is unavailable in a step `if`, so gate on this instead.
+      HAS_CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN != '' }}
     defaults:
       run:
         working-directory: ${{ matrix.npm-project }}
@@ -290,7 +298,7 @@ jobs:
         if: matrix.npm-project == './orchestrationSpecs'
         run: npm run test:integ:crds
       - name: Upload coverage to Codecov
-        if: always()
+        if: always() && env.HAS_CODECOV_TOKEN == 'true'
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f
         with:
           fail_ci_if_error: true


### PR DESCRIPTION
### Description
Disables codecov on forks (anywhere that doesn't have a `CODECOV_TOKEN`). Removes noise from the forks.

### Check List
- [ ] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
