### PR TITLE
Use Gradle-managed Node for SolrTransformations post-install

### DIFF
--- a/TrafficCapture/SolrTransformations/build.gradle
+++ b/TrafficCapture/SolrTransformations/build.gradle
@@ -1,4 +1,5 @@
 import com.github.gradle.node.npm.task.NpmTask
+import com.github.gradle.node.NodeExtension
 
 plugins {
     id 'org.opensearch.migrations.java-library-conventions'
@@ -14,6 +15,8 @@ node {
     npmWorkDir = project.layout.buildDirectory.dir("npm")
 }
 
+def nodeExtension = extensions.getByType(NodeExtension)
+
 tasks.register('installTransformDeps', NpmTask) {
     description = 'Install TypeScript transform dependencies'
     args = ['install', '--ignore-scripts']
@@ -24,6 +27,10 @@ tasks.register('installTransformDeps', NpmTask) {
 tasks.register('runPostInstallScripts', Exec) {
     dependsOn installTransformDeps
     workingDir layout.projectDirectory.dir("transforms")
+    doFirst {
+        def nodeBinDir = nodeExtension.resolvedNodeDir.get().dir("bin").asFile
+        environment 'PATH', "${nodeBinDir.absolutePath}${File.pathSeparator}${System.getenv('PATH') ?: ''}"
+    }
     commandLine 'bash', '-c', '''
         for i in 1 2 3; do
             npm rebuild esbuild 2>&1 && exit 0


### PR DESCRIPTION
## Summary
Make the SolrTransformations Gradle post-install step use the Node binary managed by the Gradle node plugin.

## Why
The SolrTransformations runPostInstallScripts task is a plain Exec task, so its npm rebuild esbuild call can fall back to whatever npm is on the host PATH instead of the pinned Gradle-managed Node toolchain. Prepending Gradle's resolved Node bin directory keeps that rebuild step on the same toolchain as the rest of the build.

This matters because the installTransformDeps task already runs under the Gradle-managed Node setup, but the follow-on rebuild step did not inherit that same toolchain deterministically.

## Testing
Not re-run after narrowing the PR to the Gradle change only.
