### PR TITLE
Fix race in cancelled-session permit leak test

### DIFF
--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/kafka/CancelledSessionPermitLeakTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/kafka/CancelledSessionPermitLeakTest.java
@@ -85,6 +85,7 @@ class CancelledSessionPermitLeakTest extends InstrumentationTest {
         int numRequests = PERMIT_COUNT;
         List<TrackedFuture<String, ?>> requestFutures = new ArrayList<>();
         AtomicInteger permitsReleased = new AtomicInteger(0);
+        CountDownLatch callbacksCompleted = new CountDownLatch(numRequests);
 
         // Schedule requests at far-future timestamps. Each request acquires a permit
         // from the limiter (simulating what TrafficReplayerCore does) and attaches a
@@ -110,6 +111,7 @@ class CancelledSessionPermitLeakTest extends InstrumentationTest {
                 (v, t) -> {
                     limiter.liveTrafficStreamCostGate.release(1);
                     permitsReleased.incrementAndGet();
+                    callbacksCompleted.countDown();
                 },
                 () -> "releasing permit after request completes"
             );
@@ -127,14 +129,10 @@ class CancelledSessionPermitLeakTest extends InstrumentationTest {
         // Cancel the connection (simulates partition reassignment)
         pool.cancelConnection(channelKeyCtx, 0);
 
-        // Wait for permits to be released (with the fix, this should complete quickly)
-        boolean allPermitsReleased = limiter.liveTrafficStreamCostGate.tryAcquire(
-            PERMIT_COUNT, 2, TimeUnit.SECONDS);
-
-        if (allPermitsReleased) {
-            // Release them back so the assertion below works cleanly
-            limiter.liveTrafficStreamCostGate.release(PERMIT_COUNT);
-        }
+        // Wait for every completion callback to finish releasing its permit.
+        Assertions.assertTrue(
+            callbacksCompleted.await(2, TimeUnit.SECONDS),
+            "Every request callback should complete after cancellation");
 
         Assertions.assertEquals(PERMIT_COUNT, limiter.liveTrafficStreamCostGate.availablePermits(),
             "All " + PERMIT_COUNT + " permits must be released after cancelConnection(). " +


### PR DESCRIPTION
### Description

Fix a synchronization race in `CancelledSessionPermitLeakTest.cancelledSession_releasesAllPermits`.

The [`gradle-tests (18)` failure](https://github.com/opensearch-project/opensearch-migrations/actions/runs/32576405998/job/97039793944) on [#3315](https://github.com/opensearch-project/opensearch-migrations/pull/3315) observed all five permits released but only four completion callbacks recorded. The callback released its semaphore permit before incrementing the counter, so the final release could wake the test thread before that callback finished its bookkeeping.

Wait on a `CountDownLatch` completed at the end of each callback instead of acquiring and restoring the semaphore permits. This keeps the original two-second bound and permit assertions while ensuring they run only after every callback has finished.

### Issues Resolved

Follow-up to the unrelated test failure observed on #3315.

### Testing

- `./gradlew :TrafficCapture:trafficReplayer:slowTest --tests 'org.opensearch.migrations.replay.kafka.CancelledSessionPermitLeakTest.cancelledSession_releasesAllPermits' -Dtest.striping.total=30 -Dtest.striping.index=18`
- `./gradlew :TrafficCapture:trafficReplayer:slowTest --tests 'org.opensearch.migrations.replay.kafka.CancelledSessionPermitLeakTest' --rerun-tasks`
- Nine additional focused executions with distinct stripe inputs
- `./gradlew :TrafficCapture:trafficReplayer:spotlessJavaCheck`

### Check List

- [x] New functionality includes testing (not applicable; test-only synchronization fix).
- [x] Public documentation issue/PR is not applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
