### PR TITLE
Live Replay Quality Monitor

### DIFF
--- a/TrafficCapture/nettyWireLogging/src/main/java/org/opensearch/migrations/trafficcapture/netty/LoggingHttpHandler.java
+++ b/TrafficCapture/nettyWireLogging/src/main/java/org/opensearch/migrations/trafficcapture/netty/LoggingHttpHandler.java
@@ -2,6 +2,8 @@ package org.opensearch.migrations.trafficcapture.netty;
 
 import java.io.IOException;
 import java.time.Instant;
+import java.util.ArrayDeque;
+import java.util.Queue;
 
 import org.opensearch.migrations.trafficcapture.IChannelConnectionCaptureSerializer;
 import org.opensearch.migrations.trafficcapture.IConnectionCaptureFactory;
@@ -147,9 +149,28 @@ public class LoggingHttpHandler<T> extends ChannelDuplexHandler {
      */
     static class SimpleHttpResponseDecoder extends HttpResponseDecoder {
         private final PassThruHttpHeaders.HttpHeadersToPreserve headersToPreserve;
+        // Plain HttpResponseDecoder has no way to know which HTTP method produced a given
+        // response, so on its own it can't tell that a HEAD response carrying Content-Length
+        // has no body — it would wait for body bytes that never arrive and then misparse the
+        // start of the next response as leftover body, desyncing every response after it on
+        // the connection. Netty's own HttpClientCodec solves this exact problem the same way:
+        // one method queued per request as it's read, one polled per response as its headers
+        // finish parsing (requests and responses are handled one at a time on this connection,
+        // never pipelined, so a simple FIFO queue is always in the right order).
+        private final Queue<HttpMethod> requestMethodQueue = new ArrayDeque<>();
 
         public SimpleHttpResponseDecoder(@NonNull PassThruHttpHeaders.HttpHeadersToPreserve headersToPreserve) {
             this.headersToPreserve = headersToPreserve;
+        }
+
+        void requestMethodParsed(HttpMethod method) {
+            requestMethodQueue.add(method);
+        }
+
+        @Override
+        protected boolean isContentAlwaysEmpty(HttpMessage msg) {
+            var requestMethod = requestMethodQueue.poll();
+            return HttpMethod.HEAD.equals(requestMethod) || super.isContentAlwaysEmpty(msg);
         }
 
         @Override
@@ -228,6 +249,10 @@ public class LoggingHttpHandler<T> extends ChannelDuplexHandler {
 
     private SimpleDecodedHttpResponseHandler getHandlerThatHoldsParsedHttpResponse() {
         return (SimpleDecodedHttpResponseHandler) httpResponseDecoderChannel.pipeline().last();
+    }
+
+    private SimpleHttpResponseDecoder getResponseDecoder() {
+        return (SimpleHttpResponseDecoder) httpResponseDecoderChannel.pipeline().first();
     }
 
     @Override
@@ -333,6 +358,10 @@ public class LoggingHttpHandler<T> extends ChannelDuplexHandler {
                         .log();
                 }
                 trafficOffloader.commitEndOfHttpMessageIndicator(timestamp);
+                // One entry per request that will actually be fed into httpResponseDecoderChannel
+                // (write() below only writes response bytes into it when shouldCapture is true for
+                // this same request/response cycle) — see SimpleHttpResponseDecoder's queue comment.
+                getResponseDecoder().requestMethodParsed(httpRequest.method());
             }
             channelFinishedReadingAnHttpMessage(ctx, msg, shouldCapture, httpRequest);
         } else {
@@ -361,9 +390,9 @@ public class LoggingHttpHandler<T> extends ChannelDuplexHandler {
             // still-open keep-alive connection sits unfinalized until one of those eventually
             // fires. This mirrors channelRead()'s embedded-decoder pattern above so a response
             // gets the same deterministic, immediate end-of-message signal a request already
-            // does. NOTE: plain HttpResponseDecoder doesn't know the originating request's
-            // method, so a response to a HEAD request (no body despite Content-Length) isn't
-            // detected as complete here — same gap as before for that one case.
+            // does. SimpleHttpResponseDecoder's request-method queue (fed above, when the
+            // request finished parsing) is what lets it correctly treat a HEAD response as
+            // bodyless despite a declared Content-Length, same as HttpClientCodec does.
             var responseParsingHandler = getHandlerThatHoldsParsedHttpResponse();
             httpResponseDecoderChannel.writeInbound(bb.retainedDuplicate()); // consumed/released by this method
             if (responseParsingHandler.haveParsedFullResponse) {

--- a/TrafficCapture/nettyWireLogging/src/main/java/org/opensearch/migrations/trafficcapture/netty/LoggingHttpHandler.java
+++ b/TrafficCapture/nettyWireLogging/src/main/java/org/opensearch/migrations/trafficcapture/netty/LoggingHttpHandler.java
@@ -15,12 +15,16 @@ import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.ChannelPromise;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.http.DefaultHttpRequest;
+import io.netty.handler.codec.http.DefaultHttpResponse;
 import io.netty.handler.codec.http.HttpContent;
 import io.netty.handler.codec.http.HttpMessage;
 import io.netty.handler.codec.http.HttpMessageDecoderResult;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpRequestDecoder;
+import io.netty.handler.codec.http.HttpResponse;
+import io.netty.handler.codec.http.HttpResponseDecoder;
+import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpVersion;
 import io.netty.handler.codec.http.LastHttpContent;
 import lombok.Getter;
@@ -133,9 +137,62 @@ public class LoggingHttpHandler<T> extends ChannelDuplexHandler {
         }
     }
 
+    /**
+     * Response-side counterpart to {@link SimpleHttpRequestDecoder}. Unlike the request decoder, this
+     * needs no capture predicate or header matcher — the capture-or-not decision was already made when
+     * the request came in ({@link CaptureState#shouldCapture()}), so this exists purely to detect where
+     * a response ends. {@link PassThruHttpHeaders} is reused as-is: the headers it tracks
+     * (Content-Length/Transfer-Encoding/Trailer) are what Netty's decoder needs to find that boundary
+     * on ANY HTTP message, request or response — nothing about them is request-specific.
+     */
+    static class SimpleHttpResponseDecoder extends HttpResponseDecoder {
+        private final PassThruHttpHeaders.HttpHeadersToPreserve headersToPreserve;
+
+        public SimpleHttpResponseDecoder(@NonNull PassThruHttpHeaders.HttpHeadersToPreserve headersToPreserve) {
+            this.headersToPreserve = headersToPreserve;
+        }
+
+        @Override
+        public HttpMessage createMessage(String[] initialLine) {
+            return new DefaultHttpResponse(
+                HttpVersion.valueOf(initialLine[0]),
+                HttpResponseStatus.valueOf(Integer.parseInt(initialLine[1]), initialLine[2]),
+                new PassThruHttpHeaders(headersToPreserve)
+            );
+        }
+    }
+
+    static class SimpleDecodedHttpResponseHandler extends ChannelInboundHandlerAdapter {
+        @Getter
+        private HttpResponse currentResponse;
+        boolean haveParsedFullResponse;
+
+        @Override
+        public void channelRead(@NonNull ChannelHandlerContext ctx, @NonNull Object msg) throws Exception {
+            if (msg instanceof HttpResponse) {
+                currentResponse = (HttpResponse) msg;
+            } else if (msg instanceof HttpContent) {
+                ((HttpContent) msg).release();
+                if (msg instanceof LastHttpContent) {
+                    haveParsedFullResponse = true;
+                }
+            } else {
+                super.channelRead(ctx, msg);
+            }
+        }
+
+        public HttpResponse resetCurrentResponse() {
+            this.haveParsedFullResponse = false;
+            var old = currentResponse;
+            this.currentResponse = null;
+            return old;
+        }
+    }
+
     protected final IChannelConnectionCaptureSerializer<T> trafficOffloader;
 
     protected final EmbeddedChannel httpDecoderChannel;
+    protected final EmbeddedChannel httpResponseDecoderChannel;
 
     protected IWireCaptureContexts.IHttpMessageContext messageContext;
 
@@ -155,6 +212,10 @@ public class LoggingHttpHandler<T> extends ChannelDuplexHandler {
             new SimpleHttpRequestDecoder(httpHeadersCapturePredicate.getHeadersRequiredForMatcher(), captureState),
             new SimpleDecodedHttpRequestHandler(httpHeadersCapturePredicate, captureState)
         );
+        httpResponseDecoderChannel = new EmbeddedChannel(
+            new SimpleHttpResponseDecoder(new PassThruHttpHeaders.HttpHeadersToPreserve()),
+            new SimpleDecodedHttpResponseHandler()
+        );
     }
 
     private IWireCaptureContexts.ICapturingConnectionContext getConnectionContext() {
@@ -163,6 +224,10 @@ public class LoggingHttpHandler<T> extends ChannelDuplexHandler {
 
     private SimpleDecodedHttpRequestHandler getHandlerThatHoldsParsedHttpRequest() {
         return (SimpleDecodedHttpRequestHandler) httpDecoderChannel.pipeline().last();
+    }
+
+    private SimpleDecodedHttpResponseHandler getHandlerThatHoldsParsedHttpResponse() {
+        return (SimpleDecodedHttpResponseHandler) httpResponseDecoderChannel.pipeline().last();
     }
 
     @Override
@@ -284,9 +349,57 @@ public class LoggingHttpHandler<T> extends ChannelDuplexHandler {
             responseContext = (IWireCaptureContexts.IResponseContext) messageContext;
         }
 
+        var timestamp = Instant.now();
         var bb = (ByteBuf) msg;
-        if (getHandlerThatHoldsParsedHttpRequest().captureState.shouldCapture()) {
-            trafficOffloader.addWriteEvent(Instant.now(), bb);
+        var shouldCapture = getHandlerThatHoldsParsedHttpRequest().captureState.shouldCapture();
+        if (shouldCapture) {
+            trafficOffloader.addWriteEvent(timestamp, bb);
+
+            // Without this, the accumulator on the far end only learns a response is complete
+            // via connection close, connection reuse (next request read), or an expiry timeout
+            // — all proxies for "done", never a real signal — so a response sent over a
+            // still-open keep-alive connection sits unfinalized until one of those eventually
+            // fires. This mirrors channelRead()'s embedded-decoder pattern above so a response
+            // gets the same deterministic, immediate end-of-message signal a request already
+            // does. NOTE: plain HttpResponseDecoder doesn't know the originating request's
+            // method, so a response to a HEAD request (no body despite Content-Length) isn't
+            // detected as complete here — same gap as before for that one case.
+            var responseParsingHandler = getHandlerThatHoldsParsedHttpResponse();
+            httpResponseDecoderChannel.writeInbound(bb.retainedDuplicate()); // consumed/released by this method
+            if (responseParsingHandler.haveParsedFullResponse) {
+                var httpResponse = responseParsingHandler.resetCurrentResponse();
+                var decoderResultLoose = httpResponse.decoderResult();
+                if (decoderResultLoose instanceof HttpMessageDecoderResult) {
+                    var decoderResult = (HttpMessageDecoderResult) decoderResultLoose;
+                    trafficOffloader.addEndOfFirstLineIndicator(decoderResult.initialLineLength());
+                    trafficOffloader.addEndOfHeadersIndicator(decoderResult.headerSize());
+                } else {
+                    log.atWarn().setMessage("HttpResponse decoder result was not an HttpMessageDecoderResult "
+                        + "(was {}). EOM will have -1 for firstLineByteLength and headersByteLength. "
+                        + "This may indicate a missing header in PassThruHttpHeaders.")
+                        .addArgument(() -> decoderResultLoose.getClass().getName())
+                        .log();
+                }
+                trafficOffloader.commitEndOfHttpMessageIndicator(timestamp);
+                // commitEndOfHttpMessageIndicator() only appends the EOM marker to the current
+                // in-memory buffer — it does NOT push anything to Kafka. Without an explicit
+                // flush here, a response sits buffered until some UNRELATED later trigger comes
+                // along (the request side gets exactly this treatment already, via
+                // ConditionallyReliableLoggingHttpHandler's blocking flushCommitAndResetStream()
+                // before forwarding to the backend). On a keep-alive connection with no next
+                // request imminent, that could be connection teardown minutes later — long past
+                // the accumulator's own observedPacketConnectionTimeout, so it gives up and
+                // finalizes the tuple with no response, and the real data arrives too late for
+                // anything to be listening for it. A response needs the same not-just-buffered
+                // guarantee a request already gets.
+                trafficOffloader.flushCommitAndResetStream(false).whenComplete((result, t) -> {
+                    if (t != null) {
+                        log.atWarn().setCause(t)
+                            .setMessage("Error flushing captured response; response data may be lost")
+                            .log();
+                    }
+                });
+            }
         }
         responseContext.onBytesWritten(bb.readableBytes());
 
@@ -298,6 +411,7 @@ public class LoggingHttpHandler<T> extends ChannelDuplexHandler {
         trafficOffloader.addExceptionCaughtEvent(Instant.now(), cause);
         messageContext.addCaughtException(cause);
         httpDecoderChannel.close();
+        httpResponseDecoderChannel.close();
         super.exceptionCaught(ctx, cause);
     }
 

--- a/TrafficCapture/nettyWireLogging/src/test/java/org/opensearch/migrations/trafficcapture/netty/HeadResponseCaptureTest.java
+++ b/TrafficCapture/nettyWireLogging/src/test/java/org/opensearch/migrations/trafficcapture/netty/HeadResponseCaptureTest.java
@@ -1,0 +1,183 @@
+package org.opensearch.migrations.trafficcapture.netty;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.SequenceInputStream;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+import org.opensearch.migrations.testutils.WrapWithNettyLeakDetection;
+import org.opensearch.migrations.trafficcapture.CodedOutputStreamAndByteBufferWrapper;
+import org.opensearch.migrations.trafficcapture.CodedOutputStreamHolder;
+import org.opensearch.migrations.trafficcapture.OrderedStreamLifecyleManager;
+import org.opensearch.migrations.trafficcapture.StreamChannelConnectionCaptureSerializer;
+import org.opensearch.migrations.trafficcapture.protos.TrafficObservation;
+import org.opensearch.migrations.trafficcapture.protos.TrafficStream;
+
+import com.google.protobuf.CodedOutputStream;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.embedded.EmbeddedChannel;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression test for LoggingHttpHandler's response-side EOM detection with a HEAD response.
+ *
+ * A HEAD response can carry a Content-Length header describing what the body WOULD have been
+ * for the equivalent GET, but sends no actual body bytes. A plain HttpResponseDecoder (unlike
+ * HttpClientCodec) has no notion of the originating request's method, so without
+ * SimpleHttpResponseDecoder's request-method queue it would wait indefinitely for body bytes
+ * that never arrive — never firing that response's own EOM/flush — and then misparse the next
+ * response's bytes on the same connection as the tail of that phantom body.
+ */
+@Slf4j
+@WrapWithNettyLeakDetection
+public class HeadResponseCaptureTest {
+
+    private static final String HEAD_REQUEST = "HEAD /resource HTTP/1.1\r\n"
+        + "Host: localhost\r\n"
+        + "\r\n";
+
+    // Declares a 5-byte body (as it would for the equivalent GET) but — correctly, per HTTP
+    // semantics for HEAD — sends none. This is exactly the case a bare HttpResponseDecoder can't
+    // detect on its own.
+    private static final String HEAD_RESPONSE = "HTTP/1.1 200 OK\r\n"
+        + "Content-Length: 5\r\n"
+        + "\r\n";
+
+    private static final String GET_REQUEST = "GET /other HTTP/1.1\r\n"
+        + "Host: localhost\r\n"
+        + "\r\n";
+
+    private static final String GET_RESPONSE = "HTTP/1.1 200 OK\r\n"
+        + "Content-Length: 2\r\n"
+        + "\r\n"
+        + "OK";
+
+    /**
+     * A stream manager that accumulates every flushed buffer rather than only the last one, since
+     * this test expects one explicit flush per response (LoggingHttpHandler.write() flushes
+     * immediately on each response's EOM).
+     */
+    static class AccumulatingStreamManager extends OrderedStreamLifecyleManager implements AutoCloseable {
+        final List<ByteBuffer> flushedBuffers = new ArrayList<>();
+        final AtomicInteger flushCount = new AtomicInteger();
+
+        @Override
+        public void close() {}
+
+        @Override
+        public CodedOutputStreamAndByteBufferWrapper createStream() {
+            return new CodedOutputStreamAndByteBufferWrapper(1024 * 1024);
+        }
+
+        @SneakyThrows
+        @Override
+        public CompletableFuture<Object> kickoffCloseStream(CodedOutputStreamHolder outputStreamHolder, int index) {
+            var osh = (CodedOutputStreamAndByteBufferWrapper) outputStreamHolder;
+            CodedOutputStream cos = osh.getOutputStream();
+            cos.flush();
+            flushedBuffers.add(osh.getByteBuffer().flip().asReadOnlyBuffer());
+            return CompletableFuture.completedFuture(flushCount.incrementAndGet());
+        }
+    }
+
+    private static String describeObservations(List<TrafficObservation> observations) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("observation count: ").append(observations.size()).append("\n");
+        for (int i = 0; i < observations.size(); i++) {
+            var obs = observations.get(i);
+            if (obs.hasRead()) {
+                sb.append("  [").append(i).append("] Read(").append(obs.getRead().getData().size()).append("b)\n");
+            } else if (obs.hasWrite()) {
+                sb.append("  [").append(i).append("] Write(").append(obs.getWrite().getData().size()).append("b)\n");
+            } else if (obs.hasEndOfMessageIndicator()) {
+                var eom = obs.getEndOfMessageIndicator();
+                sb.append("  [").append(i).append("] EOM(firstLine=")
+                    .append(eom.getFirstLineByteLength())
+                    .append(", headers=").append(eom.getHeadersByteLength()).append(")\n");
+            } else {
+                sb.append("  [").append(i).append("] ").append(obs.getCaptureCase()).append("\n");
+            }
+        }
+        return sb.toString();
+    }
+
+    @Test
+    public void testHeadResponseFollowedByNormalResponseOnSameConnection() throws IOException {
+        try (var rootContext = new TestRootContext()) {
+            var streamManager = new AccumulatingStreamManager();
+            var offloader = new StreamChannelConnectionCaptureSerializer<>("Test", "c", streamManager);
+
+            EmbeddedChannel channel = new EmbeddedChannel(
+                new LoggingHttpHandler<>(rootContext, "n", "c", ctx -> offloader, new RequestCapturePredicate())
+            );
+
+            channel.writeInbound(Unpooled.wrappedBuffer(HEAD_REQUEST.getBytes(StandardCharsets.UTF_8)));
+            channel.writeOutbound(Unpooled.wrappedBuffer(HEAD_RESPONSE.getBytes(StandardCharsets.UTF_8)));
+            channel.writeInbound(Unpooled.wrappedBuffer(GET_REQUEST.getBytes(StandardCharsets.UTF_8)));
+            channel.writeOutbound(Unpooled.wrappedBuffer(GET_RESPONSE.getBytes(StandardCharsets.UTF_8)));
+
+            channel.finishAndReleaseAll();
+            channel.close();
+
+            // Each response's EOM firing is what triggers its own explicit flush (see write()'s
+            // flushCommitAndResetStream call), plus one more on connection teardown — without
+            // HEAD-awareness, the HEAD response's EOM never fires, so this would be fewer.
+            Assertions.assertEquals(3, streamManager.flushCount.get(),
+                "Expected one flush per response (2) plus one on connection teardown — the HEAD "
+                + "response's own EOM must fire immediately, not get stuck waiting for a body that "
+                + "never arrives");
+
+            List<TrafficObservation> allObservations = new ArrayList<>();
+            for (var buf : streamManager.flushedBuffers) {
+                var trafficStream = TrafficStream.parseFrom(buf);
+                allObservations.addAll(trafficStream.getSubStreamList());
+            }
+            String debug = describeObservations(allObservations);
+
+            // One EOM per request and one per response = 4 total.
+            long eomCount = allObservations.stream().filter(TrafficObservation::hasEndOfMessageIndicator).count();
+            Assertions.assertEquals(4, eomCount,
+                "Expected 4 EndOfMessageIndicator observations (2 requests + 2 responses). Debug:\n" + debug);
+
+            // The GET response's EOM must reflect its own real header size, not a corrupted/garbage
+            // value left over from a decoder that thought it was still consuming the HEAD response's
+            // phantom body.
+            var eoms = allObservations.stream()
+                .filter(TrafficObservation::hasEndOfMessageIndicator)
+                .map(TrafficObservation::getEndOfMessageIndicator)
+                .collect(Collectors.toList());
+            for (int i = 0; i < eoms.size(); i++) {
+                Assertions.assertTrue(eoms.get(i).getFirstLineByteLength() > 0,
+                    "EOM[" + i + "] firstLineByteLength should be positive. Debug:\n" + debug);
+                Assertions.assertTrue(eoms.get(i).getHeadersByteLength() > 0,
+                    "EOM[" + i + "] headersByteLength should be positive. Debug:\n" + debug);
+            }
+
+            // The raw captured response bytes themselves must be exactly the two responses,
+            // concatenated in order, with nothing dropped or duplicated.
+            var combinedWrites = new SequenceInputStream(
+                Collections.enumeration(
+                    allObservations.stream()
+                        .filter(TrafficObservation::hasWrite)
+                        .map(to -> new ByteArrayInputStream(to.getWrite().getData().toByteArray()))
+                        .collect(Collectors.toList())
+                )
+            );
+            byte[] expectedWrites = (HEAD_RESPONSE + GET_RESPONSE).getBytes(StandardCharsets.UTF_8);
+            Assertions.assertArrayEquals(expectedWrites, combinedWrites.readAllBytes(),
+                "Combined Write observations should contain both responses' bytes, in order, uncorrupted. "
+                + "Debug:\n" + debug);
+        }
+    }
+}

--- a/TrafficCapture/nettyWireLogging/src/test/java/org/opensearch/migrations/trafficcapture/netty/HeadResponseCaptureTest.java
+++ b/TrafficCapture/nettyWireLogging/src/test/java/org/opensearch/migrations/trafficcapture/netty/HeadResponseCaptureTest.java
@@ -10,7 +10,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 import org.opensearch.migrations.testutils.WrapWithNettyLeakDetection;

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/CapturedTrafficToHttpTransactionAccumulator.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/CapturedTrafficToHttpTransactionAccumulator.java
@@ -557,6 +557,14 @@ public class CapturedTrafficToHttpTransactionAccumulator {
             var rrPair = accum.getRrPair();
             assert rrPair.responseData.hasInProgressSegment();
             rrPair.responseData.finalizeRequestSegments(timestamp);
+        } else if (observation.hasEndOfMessageIndicator()) {
+            // Capture-side now emits this the moment a response is fully parsed (see
+            // LoggingHttpHandler.write()'s embedded HttpResponseDecoder), mirroring the read-side
+            // handling above — without this branch, that signal fell through to the "unaccounted
+            // for observation type" warning and never finalized the response, leaving it to be
+            // discovered only by connection close/reuse/timeout (the original bug: a response
+            // sent over an idle keep-alive connection sat unfinalized until one of those fired).
+            handleEndOfResponse(accum, RequestResponsePacketPair.ReconstructionStatus.COMPLETE);
         } else if (observation.hasRead() || observation.hasReadSegment()) {
             rotateAccumulationOnReadIfNecessary(connectionId, accum);
             return handleObservationForReadState(accum, observation, trafficStreamKey, timestamp);

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/TrafficReplayer.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/TrafficReplayer.java
@@ -1,5 +1,7 @@
 package org.opensearch.migrations.replay;
 
+import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.lang.ref.WeakReference;
 import java.net.URI;
 import java.nio.charset.Charset;
@@ -11,6 +13,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.function.IntFunction;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
@@ -20,10 +23,12 @@ import org.opensearch.migrations.jcommander.EnvVarParameterPuller;
 import org.opensearch.migrations.jcommander.JsonCommandLineParser;
 import org.opensearch.migrations.replay.http.retries.BulkItemErrorClassifier;
 import org.opensearch.migrations.replay.kafka.KafkaTopicDumper;
+import org.opensearch.migrations.replay.kafka.KafkaTrafficCaptureSource;
 import org.opensearch.migrations.replay.sink.KafkaTupleSink;
 import org.opensearch.migrations.replay.sink.MultiTupleSink;
 import org.opensearch.migrations.replay.sink.S3TupleSink;
 import org.opensearch.migrations.replay.sink.ThreadLocalTupleWriter;
+import org.opensearch.migrations.replay.sink.TupleSink;
 import org.opensearch.migrations.replay.tracing.RootReplayerContext;
 import org.opensearch.migrations.replay.traffic.source.TrafficStreamLimiter;
 import org.opensearch.migrations.replay.util.ActiveContextMonitor;
@@ -52,11 +57,9 @@ import com.beust.jcommander.ParametersDelegate;
 import io.netty.util.concurrent.DefaultThreadFactory;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.producer.KafkaProducer;
 import org.slf4j.LoggerFactory;
 import org.slf4j.event.Level;
-import org.apache.kafka.clients.producer.KafkaProducer;
-import org.opensearch.migrations.replay.kafka.KafkaTrafficCaptureSource;
-
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
@@ -860,6 +863,66 @@ public class TrafficReplayer {
         }
     }
 
+    private static IntFunction<TupleSink> buildS3TupleSinkFactory(Parameters params) {
+        log.info("S3 tuple writing enabled — bucket={}, region={}, prefix={}",
+            params.tupleS3Bucket, params.tupleS3Region, params.tupleS3Prefix);
+        var credentialsProvider = DefaultCredentialsProvider.builder().build();
+        var s3ClientBuilder = S3AsyncClient.builder()
+            .region(Region.of(params.tupleS3Region))
+            .credentialsProvider(credentialsProvider);
+        if (params.tupleS3Endpoint != null && !params.tupleS3Endpoint.isEmpty()) {
+            s3ClientBuilder
+                .endpointOverride(URI.create(params.tupleS3Endpoint))
+                .forcePathStyle(true);
+        }
+        var s3Client = s3ClientBuilder.build();
+        var replayerId = ProcessHelpers.getNodeInstanceName();
+        return sinkIndex -> new S3TupleSink(
+            s3Client,
+            params.tupleS3Bucket,
+            params.tupleS3Prefix,
+            replayerId,
+            sinkIndex,
+            params.tupleMaxFileSizeMb * 1024L * 1024L,
+            Duration.ofSeconds(params.tupleMaxBufferSeconds),
+            params.tupleMaxPerFile
+        );
+    }
+
+    /** The producer is shared across all sink instances. */
+    private static KafkaProducer<String, byte[]> buildKafkaTupleProducer(Parameters params) {
+        log.info("Kafka tuple writing enabled — topic={}, brokers={}",
+            params.tupleKafkaTopic, params.kafkaTrafficBrokers);
+        try {
+            // Reuse the same auth/SSL property setup as the consumer for consistency
+            var kafkaProps = KafkaTrafficCaptureSource.buildKafkaProperties(
+                params.kafkaTrafficBrokers,
+                "tuple-producer",
+                params.getEffectiveKafkaAuthType(),
+                params.kafkaTrafficUserName,
+                params.kafkaTrafficPassword,
+                params.kafkaTrafficPropertyFile
+            );
+            // Override consumer defaults with producer-specific settings
+            kafkaProps.put("key.serializer", "org.apache.kafka.common.serialization.StringSerializer");
+            kafkaProps.put("value.serializer", "org.apache.kafka.common.serialization.ByteArraySerializer");
+            kafkaProps.remove("key.deserializer");
+            kafkaProps.remove("value.deserializer");
+            kafkaProps.remove("enable.auto.commit");
+            kafkaProps.remove("auto.offset.reset");
+            kafkaProps.remove("group.id");
+            kafkaProps.remove("partition.assignment.strategy");
+            kafkaProps.put("acks", "1");
+            log.info("Kafka tuple producer configured — security.protocol={}, sasl.mechanism={}, password={}",
+                kafkaProps.get("security.protocol"),
+                kafkaProps.get("sasl.mechanism"),
+                kafkaProps.get("sasl.jaas.config") != null ? "(set)" : "(null)");
+            return new KafkaProducer<>(kafkaProps);
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to configure Kafka tuple producer", e);
+        }
+    }
+
     private static TupleWriterResources createS3TupleWriterIfConfigured(
         Parameters params,
         Supplier<IJsonTransformer> tupleTransformerSupplier
@@ -870,88 +933,25 @@ public class TrafficReplayer {
             return null;
         }
 
-        // Build S3 sink factory if configured
-        java.util.function.IntFunction<org.opensearch.migrations.replay.sink.TupleSink> s3Factory = null;
-        if (hasS3) {
-            log.info("S3 tuple writing enabled — bucket={}, region={}, prefix={}",
-                params.tupleS3Bucket, params.tupleS3Region, params.tupleS3Prefix);
-            var credentialsProvider = DefaultCredentialsProvider.builder().build();
-            var s3ClientBuilder = S3AsyncClient.builder()
-                .region(Region.of(params.tupleS3Region))
-                .credentialsProvider(credentialsProvider);
-            if (params.tupleS3Endpoint != null && !params.tupleS3Endpoint.isEmpty()) {
-                s3ClientBuilder
-                    .endpointOverride(URI.create(params.tupleS3Endpoint))
-                    .forcePathStyle(true);
-            }
-            var s3Client = s3ClientBuilder.build();
-            var replayerId = ProcessHelpers.getNodeInstanceName();
-            s3Factory = sinkIndex -> new S3TupleSink(
-                s3Client,
-                params.tupleS3Bucket,
-                params.tupleS3Prefix,
-                replayerId,
-                sinkIndex,
-                params.tupleMaxFileSizeMb * 1024L * 1024L,
-                Duration.ofSeconds(params.tupleMaxBufferSeconds),
-                params.tupleMaxPerFile
-            );
-        }
+        var s3Factory = hasS3 ? buildS3TupleSinkFactory(params) : null;
+        var kafkaProducer = hasKafka ? buildKafkaTupleProducer(params) : null;
+        var kafkaTopic = params.tupleKafkaTopic;
 
-        // Build Kafka producer if configured (shared across all sink instances)
-        KafkaProducer<String, byte[]> kafkaProducer = null;
-        if (hasKafka) {
-            log.info("Kafka tuple writing enabled — topic={}, brokers={}",
-                params.tupleKafkaTopic, params.kafkaTrafficBrokers);
-            try {
-                // Reuse the same auth/SSL property setup as the consumer for consistency
-                var kafkaProps = KafkaTrafficCaptureSource.buildKafkaProperties(
-                    params.kafkaTrafficBrokers,
-                    "tuple-producer",
-                    params.getEffectiveKafkaAuthType(),
-                    params.kafkaTrafficUserName,
-                    params.kafkaTrafficPassword,
-                    params.kafkaTrafficPropertyFile
-                );
-                // Override consumer defaults with producer-specific settings
-                kafkaProps.put("key.serializer", "org.apache.kafka.common.serialization.StringSerializer");
-                kafkaProps.put("value.serializer", "org.apache.kafka.common.serialization.ByteArraySerializer");
-                kafkaProps.remove("key.deserializer");
-                kafkaProps.remove("value.deserializer");
-                kafkaProps.remove("enable.auto.commit");
-                kafkaProps.remove("auto.offset.reset");
-                kafkaProps.remove("group.id");
-                kafkaProps.remove("partition.assignment.strategy");
-                kafkaProps.put("acks", "1");
-                log.info("Kafka tuple producer configured — security.protocol={}, sasl.mechanism={}, password={}",
-                    kafkaProps.get("security.protocol"),
-                    kafkaProps.get("sasl.mechanism"),
-                    kafkaProps.get("sasl.jaas.config") != null ? "(set)" : "(null)");
-                kafkaProducer = new KafkaProducer<>(kafkaProps);
-            } catch (java.io.IOException e) {
-                throw new RuntimeException("Failed to configure Kafka tuple producer", e);
-            }
-        }
-
-        // Combine into a single factory
-        final var finalS3Factory = s3Factory;
-        final var finalKafkaProducer = kafkaProducer;
-        final var finalKafkaTopic = params.tupleKafkaTopic;
-        java.util.function.IntFunction<org.opensearch.migrations.replay.sink.TupleSink> combinedFactory;
+        IntFunction<TupleSink> combinedFactory;
         if (hasS3 && hasKafka) {
             combinedFactory = sinkIndex -> new MultiTupleSink(List.of(
-                finalS3Factory.apply(sinkIndex),
-                new KafkaTupleSink(finalKafkaProducer, finalKafkaTopic)
+                s3Factory.apply(sinkIndex),
+                new KafkaTupleSink(kafkaProducer, kafkaTopic)
             ));
         } else if (hasS3) {
-            combinedFactory = finalS3Factory;
+            combinedFactory = s3Factory;
         } else {
-            combinedFactory = sinkIndex -> new KafkaTupleSink(finalKafkaProducer, finalKafkaTopic);
+            combinedFactory = sinkIndex -> new KafkaTupleSink(kafkaProducer, kafkaTopic);
         }
 
         return new TupleWriterResources(
             new ThreadLocalTupleWriter(combinedFactory, tupleTransformerSupplier),
-            finalKafkaProducer
+            kafkaProducer
         );
     }
 

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/TrafficReplayer.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/TrafficReplayer.java
@@ -923,6 +923,25 @@ public class TrafficReplayer {
         }
     }
 
+    private static IntFunction<TupleSink> combineTupleSinkFactories(
+        boolean hasS3,
+        boolean hasKafka,
+        IntFunction<TupleSink> s3Factory,
+        KafkaProducer<String, byte[]> kafkaProducer,
+        String kafkaTopic
+    ) {
+        if (hasS3 && hasKafka) {
+            return sinkIndex -> new MultiTupleSink(List.of(
+                s3Factory.apply(sinkIndex),
+                new KafkaTupleSink(kafkaProducer, kafkaTopic)
+            ));
+        }
+        if (hasS3) {
+            return s3Factory;
+        }
+        return sinkIndex -> new KafkaTupleSink(kafkaProducer, kafkaTopic);
+    }
+
     private static TupleWriterResources createS3TupleWriterIfConfigured(
         Parameters params,
         Supplier<IJsonTransformer> tupleTransformerSupplier
@@ -935,19 +954,7 @@ public class TrafficReplayer {
 
         var s3Factory = hasS3 ? buildS3TupleSinkFactory(params) : null;
         var kafkaProducer = hasKafka ? buildKafkaTupleProducer(params) : null;
-        var kafkaTopic = params.tupleKafkaTopic;
-
-        IntFunction<TupleSink> combinedFactory;
-        if (hasS3 && hasKafka) {
-            combinedFactory = sinkIndex -> new MultiTupleSink(List.of(
-                s3Factory.apply(sinkIndex),
-                new KafkaTupleSink(kafkaProducer, kafkaTopic)
-            ));
-        } else if (hasS3) {
-            combinedFactory = s3Factory;
-        } else {
-            combinedFactory = sinkIndex -> new KafkaTupleSink(kafkaProducer, kafkaTopic);
-        }
+        var combinedFactory = combineTupleSinkFactories(hasS3, hasKafka, s3Factory, kafkaProducer, params.tupleKafkaTopic);
 
         return new TupleWriterResources(
             new ThreadLocalTupleWriter(combinedFactory, tupleTransformerSupplier),

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/TrafficReplayer.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/TrafficReplayer.java
@@ -20,6 +20,8 @@ import org.opensearch.migrations.jcommander.EnvVarParameterPuller;
 import org.opensearch.migrations.jcommander.JsonCommandLineParser;
 import org.opensearch.migrations.replay.http.retries.BulkItemErrorClassifier;
 import org.opensearch.migrations.replay.kafka.KafkaTopicDumper;
+import org.opensearch.migrations.replay.sink.KafkaTupleSink;
+import org.opensearch.migrations.replay.sink.MultiTupleSink;
 import org.opensearch.migrations.replay.sink.S3TupleSink;
 import org.opensearch.migrations.replay.sink.ThreadLocalTupleWriter;
 import org.opensearch.migrations.replay.tracing.RootReplayerContext;
@@ -52,6 +54,9 @@ import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.slf4j.LoggerFactory;
 import org.slf4j.event.Level;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.opensearch.migrations.replay.kafka.KafkaTrafficCaptureSource;
+
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
@@ -406,6 +411,15 @@ public class TrafficReplayer {
 
         @Parameter(
             required = false,
+            names = { "--tuple-kafka-topic", "--tupleKafkaTopic" },
+            arity = 1,
+            description = "When set, tuples (ES + OS request/response pairs) are also published to this Kafka "
+                + "topic for real-time monitoring. Reuses the same broker and auth as --kafkaBrokers / "
+                + "--kafkaAuthType. Can be used alongside --tupleS3Bucket (dual sink) or alone.")
+        String tupleKafkaTopic;
+
+        @Parameter(
+            required = false,
             names = { "--non-retryable-doc-exception-types", "--nonRetryableDocExceptionTypes" },
             description = "Optional. Comma-separated list of document-level exception types that should NOT be "
                 + "retried during bulk replay. These errors still count as failures but won't be retried since "
@@ -416,6 +430,10 @@ public class TrafficReplayer {
         List<String> nonRetryableDocExceptionTypes;
 
         void validateKafkaAuthFlags() {
+            if (tupleKafkaTopic != null && !tupleKafkaTopic.isEmpty()
+                && (kafkaTrafficBrokers == null || kafkaTrafficBrokers.isBlank())) {
+                throw new ParameterException("--tuple-kafka-topic requires --kafkaBrokers to be set");
+            }
             if (kafkaTrafficAuthType != null && !kafkaTrafficAuthType.isBlank()) {
                 if (Boolean.TRUE.equals(kafkaTrafficEnableMSKAuth)
                     && !KAFKA_AUTH_TYPE_MSK_IAM.equals(kafkaTrafficAuthType)) {
@@ -662,7 +680,7 @@ public class TrafficReplayer {
         );
 
         ActiveContextMonitor activeContextMonitor = null;
-        ThreadLocalTupleWriter tupleWriter = null;
+        TupleWriterResources tupleWriterResources = null;
         try (
             var blockingTrafficSource = TrafficCaptureSourceFactory.createTrafficCaptureSource(
                 topContext,
@@ -752,17 +770,17 @@ public class TrafficReplayer {
             }, ACTIVE_WORK_MONITOR_CADENCE_MS, ACTIVE_WORK_MONITOR_CADENCE_MS, TimeUnit.MILLISECONDS);
 
             setupShutdownHookForReplayer(tr);
-            tupleWriter = createS3TupleWriterIfConfigured(
+            tupleWriterResources = createS3TupleWriterIfConfigured(
                 params,
                 () -> transformationLoader.getTransformerFactoryLoader(tupleTransformerConfig)
             );
-            if (tupleWriter != null) {
+            if (tupleWriterResources != null) {
                 tr.setupRunAndWaitForReplayWithShutdownChecks(
                     Duration.ofSeconds(params.observedPacketConnectionTimeout),
                     serverTimeout,
                     blockingTrafficSource,
                     timeShifter,
-                    tupleWriter,
+                    tupleWriterResources.tupleWriter,
                     Duration.ofMillis(params.quiescentPeriodMs)
                 );
             } else {
@@ -780,8 +798,8 @@ public class TrafficReplayer {
             }
             log.info("Done processing TrafficStreams");
         } finally {
-            if (tupleWriter != null) {
-                tupleWriter.close();
+            if (tupleWriterResources != null) {
+                tupleWriterResources.close();
             }
             scheduledExecutorService.shutdown();
             if (activeContextMonitor != null) {
@@ -821,28 +839,54 @@ public class TrafficReplayer {
         }
     }
 
-    private static ThreadLocalTupleWriter createS3TupleWriterIfConfigured(
+    /** Bundles the tuple writer with the shared Kafka producer it references (if any) so both
+     * get closed together — the producer must outlive every {@link ThreadLocalTupleWriter}-owned
+     * {@code KafkaTupleSink} and is only safe to close once they've all flushed. */
+    private static final class TupleWriterResources implements AutoCloseable {
+        final ThreadLocalTupleWriter tupleWriter;
+        private final KafkaProducer<String, byte[]> kafkaProducer;
+
+        TupleWriterResources(ThreadLocalTupleWriter tupleWriter, KafkaProducer<String, byte[]> kafkaProducer) {
+            this.tupleWriter = tupleWriter;
+            this.kafkaProducer = kafkaProducer;
+        }
+
+        @Override
+        public void close() {
+            tupleWriter.close();
+            if (kafkaProducer != null) {
+                kafkaProducer.close();
+            }
+        }
+    }
+
+    private static TupleWriterResources createS3TupleWriterIfConfigured(
         Parameters params,
         Supplier<IJsonTransformer> tupleTransformerSupplier
     ) {
-        if (params.tupleS3Bucket == null || params.tupleS3Bucket.isEmpty()) {
+        boolean hasS3 = params.tupleS3Bucket != null && !params.tupleS3Bucket.isEmpty();
+        boolean hasKafka = params.tupleKafkaTopic != null && !params.tupleKafkaTopic.isEmpty();
+        if (!hasS3 && !hasKafka) {
             return null;
         }
-        log.info("S3 tuple writing enabled — bucket={}, region={}, prefix={}",
-            params.tupleS3Bucket, params.tupleS3Region, params.tupleS3Prefix);
-        var credentialsProvider = DefaultCredentialsProvider.builder().build();
-        var s3ClientBuilder = S3AsyncClient.builder()
-            .region(Region.of(params.tupleS3Region))
-            .credentialsProvider(credentialsProvider);
-        if (params.tupleS3Endpoint != null && !params.tupleS3Endpoint.isEmpty()) {
-            s3ClientBuilder
-                .endpointOverride(URI.create(params.tupleS3Endpoint))
-                .forcePathStyle(true);
-        }
-        var s3Client = s3ClientBuilder.build();
-        var replayerId = ProcessHelpers.getNodeInstanceName();
-        return new ThreadLocalTupleWriter(
-            sinkIndex -> new S3TupleSink(
+
+        // Build S3 sink factory if configured
+        java.util.function.IntFunction<org.opensearch.migrations.replay.sink.TupleSink> s3Factory = null;
+        if (hasS3) {
+            log.info("S3 tuple writing enabled — bucket={}, region={}, prefix={}",
+                params.tupleS3Bucket, params.tupleS3Region, params.tupleS3Prefix);
+            var credentialsProvider = DefaultCredentialsProvider.builder().build();
+            var s3ClientBuilder = S3AsyncClient.builder()
+                .region(Region.of(params.tupleS3Region))
+                .credentialsProvider(credentialsProvider);
+            if (params.tupleS3Endpoint != null && !params.tupleS3Endpoint.isEmpty()) {
+                s3ClientBuilder
+                    .endpointOverride(URI.create(params.tupleS3Endpoint))
+                    .forcePathStyle(true);
+            }
+            var s3Client = s3ClientBuilder.build();
+            var replayerId = ProcessHelpers.getNodeInstanceName();
+            s3Factory = sinkIndex -> new S3TupleSink(
                 s3Client,
                 params.tupleS3Bucket,
                 params.tupleS3Prefix,
@@ -851,8 +895,63 @@ public class TrafficReplayer {
                 params.tupleMaxFileSizeMb * 1024L * 1024L,
                 Duration.ofSeconds(params.tupleMaxBufferSeconds),
                 params.tupleMaxPerFile
-            ),
-            tupleTransformerSupplier
+            );
+        }
+
+        // Build Kafka producer if configured (shared across all sink instances)
+        KafkaProducer<String, byte[]> kafkaProducer = null;
+        if (hasKafka) {
+            log.info("Kafka tuple writing enabled — topic={}, brokers={}",
+                params.tupleKafkaTopic, params.kafkaTrafficBrokers);
+            try {
+                // Reuse the same auth/SSL property setup as the consumer for consistency
+                var kafkaProps = KafkaTrafficCaptureSource.buildKafkaProperties(
+                    params.kafkaTrafficBrokers,
+                    "tuple-producer",
+                    params.getEffectiveKafkaAuthType(),
+                    params.kafkaTrafficUserName,
+                    params.kafkaTrafficPassword,
+                    params.kafkaTrafficPropertyFile
+                );
+                // Override consumer defaults with producer-specific settings
+                kafkaProps.put("key.serializer", "org.apache.kafka.common.serialization.StringSerializer");
+                kafkaProps.put("value.serializer", "org.apache.kafka.common.serialization.ByteArraySerializer");
+                kafkaProps.remove("key.deserializer");
+                kafkaProps.remove("value.deserializer");
+                kafkaProps.remove("enable.auto.commit");
+                kafkaProps.remove("auto.offset.reset");
+                kafkaProps.remove("group.id");
+                kafkaProps.remove("partition.assignment.strategy");
+                kafkaProps.put("acks", "1");
+                log.info("Kafka tuple producer configured — security.protocol={}, sasl.mechanism={}, password={}",
+                    kafkaProps.get("security.protocol"),
+                    kafkaProps.get("sasl.mechanism"),
+                    kafkaProps.get("sasl.jaas.config") != null ? "(set)" : "(null)");
+                kafkaProducer = new KafkaProducer<>(kafkaProps);
+            } catch (java.io.IOException e) {
+                throw new RuntimeException("Failed to configure Kafka tuple producer", e);
+            }
+        }
+
+        // Combine into a single factory
+        final var finalS3Factory = s3Factory;
+        final var finalKafkaProducer = kafkaProducer;
+        final var finalKafkaTopic = params.tupleKafkaTopic;
+        java.util.function.IntFunction<org.opensearch.migrations.replay.sink.TupleSink> combinedFactory;
+        if (hasS3 && hasKafka) {
+            combinedFactory = sinkIndex -> new MultiTupleSink(List.of(
+                finalS3Factory.apply(sinkIndex),
+                new KafkaTupleSink(finalKafkaProducer, finalKafkaTopic)
+            ));
+        } else if (hasS3) {
+            combinedFactory = finalS3Factory;
+        } else {
+            combinedFactory = sinkIndex -> new KafkaTupleSink(finalKafkaProducer, finalKafkaTopic);
+        }
+
+        return new TupleWriterResources(
+            new ThreadLocalTupleWriter(combinedFactory, tupleTransformerSupplier),
+            finalKafkaProducer
         );
     }
 

--- a/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/TupleWriterConfigurationException.java
+++ b/TrafficCapture/trafficReplayer/src/main/java/org/opensearch/migrations/replay/TupleWriterConfigurationException.java
@@ -1,0 +1,12 @@
+package org.opensearch.migrations.replay;
+
+/**
+ * Thrown when the tuple writer (S3 and/or Kafka) can't be configured from the supplied
+ * {@link org.opensearch.migrations.replay.TrafficReplayer.Parameters} — e.g. building the
+ * Kafka producer's auth/SSL properties fails.
+ */
+public class TupleWriterConfigurationException extends RuntimeException {
+    public TupleWriterConfigurationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/TrafficReplayerTupleWriterTest.java
+++ b/TrafficCapture/trafficReplayer/src/test/java/org/opensearch/migrations/replay/TrafficReplayerTupleWriterTest.java
@@ -1,0 +1,89 @@
+package org.opensearch.migrations.replay;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.function.Supplier;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.opensearch.migrations.transform.IJsonTransformer;
+
+/**
+ * Covers {@code TrafficReplayer.createS3TupleWriterIfConfigured} and the helpers it was split
+ * into ({@code buildS3SinkFactory}, {@code buildKafkaTupleProducer}, {@code combineTupleSinkFactories}),
+ * none of which had prior dedicated test coverage.
+ */
+public class TrafficReplayerTupleWriterTest {
+
+    private static final Supplier<IJsonTransformer> NO_OP_TRANSFORMER_SUPPLIER = () -> incomingJson -> incomingJson;
+
+    private static Object invokeCreateS3TupleWriterIfConfigured(TrafficReplayer.Parameters params) throws Exception {
+        Method method = TrafficReplayer.class.getDeclaredMethod(
+            "createS3TupleWriterIfConfigured",
+            TrafficReplayer.Parameters.class,
+            Supplier.class
+        );
+        method.setAccessible(true);
+        try {
+            return method.invoke(null, params, NO_OP_TRANSFORMER_SUPPLIER);
+        } catch (InvocationTargetException e) {
+            if (e.getCause() instanceof RuntimeException) {
+                throw (RuntimeException) e.getCause();
+            }
+            throw e;
+        }
+    }
+
+    @Test
+    public void testNeitherS3NorKafkaConfiguredReturnsNull() throws Exception {
+        var params = new TrafficReplayer.Parameters();
+
+        var result = invokeCreateS3TupleWriterIfConfigured(params);
+
+        Assertions.assertNull(result);
+    }
+
+    @Test
+    public void testKafkaOnlyWithUnreadablePropertyFileThrowsConfigurationException() {
+        var params = new TrafficReplayer.Parameters();
+        params.tupleKafkaTopic = "tuple-output";
+        params.kafkaTrafficBrokers = "broker:9092";
+        params.kafkaTrafficPropertyFile = "/nonexistent/path/client.properties";
+
+        var thrown = Assertions.assertThrows(
+            TupleWriterConfigurationException.class,
+            () -> invokeCreateS3TupleWriterIfConfigured(params)
+        );
+        Assertions.assertNotNull(thrown.getCause());
+    }
+
+    @Test
+    public void testS3OnlyConfiguredReturnsCloseableResources() throws Exception {
+        var params = new TrafficReplayer.Parameters();
+        params.tupleS3Bucket = "test-bucket";
+        params.tupleS3Region = "us-east-2";
+        params.tupleS3Endpoint = "http://localhost:4566";
+
+        var result = invokeCreateS3TupleWriterIfConfigured(params);
+
+        Assertions.assertNotNull(result);
+        Assertions.assertInstanceOf(AutoCloseable.class, result);
+        ((AutoCloseable) result).close();
+    }
+
+    @Test
+    public void testS3AndKafkaConfiguredReturnsCloseableResources() throws Exception {
+        var params = new TrafficReplayer.Parameters();
+        params.tupleS3Bucket = "test-bucket";
+        params.tupleS3Region = "us-east-2";
+        params.tupleS3Endpoint = "http://localhost:4566";
+        params.tupleKafkaTopic = "tuple-output";
+        params.kafkaTrafficBrokers = "localhost:9092";
+
+        var result = invokeCreateS3TupleWriterIfConfigured(params);
+
+        Assertions.assertNotNull(result);
+        Assertions.assertInstanceOf(AutoCloseable.class, result);
+        ((AutoCloseable) result).close();
+    }
+}

--- a/TrafficCapture/tupleSink/build.gradle
+++ b/TrafficCapture/tupleSink/build.gradle
@@ -9,6 +9,7 @@ dependencies {
     implementation libs.slf4j.api
     implementation libs.aws.s3
     implementation libs.aws.crt
+    implementation libs.kafka.clients
 
     testImplementation libs.junit.jupiter.api
     testImplementation libs.mockito.core

--- a/TrafficCapture/tupleSink/src/main/java/org/opensearch/migrations/replay/sink/KafkaTupleSink.java
+++ b/TrafficCapture/tupleSink/src/main/java/org/opensearch/migrations/replay/sink/KafkaTupleSink.java
@@ -1,0 +1,87 @@
+package org.opensearch.migrations.replay.sink;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+
+/**
+ * Writes tuples as JSON to a Kafka topic for real-time monitoring.
+ *
+ * <p>Each tuple is one JSON object per Kafka message, using the connectionId as
+ * the record key so all tuples for a connection land on the same partition.
+ * The producer is shared across sink instances and is NOT closed in {@link #close()}
+ * — the caller owns producer lifecycle.</p>
+ *
+ * <p>Instances are one-per-Netty-event-loop-thread, so serialization and the
+ * {@code producer.send()} call (which can block up to {@code max.block.ms} waiting on
+ * metadata or buffer space) are offloaded to a dedicated worker thread rather than run
+ * directly in {@link #accept}.</p>
+ */
+@Slf4j
+public class KafkaTupleSink implements TupleSink {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+    private final Producer<String, byte[]> producer;
+    private final String topic;
+    private final ExecutorService executor;
+
+    public KafkaTupleSink(Producer<String, byte[]> producer, String topic) {
+        this.producer = producer;
+        this.topic = topic;
+        this.executor = Executors.newSingleThreadExecutor(r -> {
+            var thread = new Thread(r, "kafka-tuple-sink-worker");
+            thread.setDaemon(false);
+            return thread;
+        });
+    }
+
+    @Override
+    public void accept(Map<String, Object> tupleMap, CompletableFuture<Void> future) {
+        executor.execute(() -> {
+            final byte[] json;
+            try {
+                json = mapper.writeValueAsBytes(tupleMap);
+            } catch (Exception e) {
+                future.completeExceptionally(e);
+                return;
+            }
+            var key = (String) tupleMap.get("connectionId");
+            try {
+                producer.send(new ProducerRecord<>(topic, key, json), (metadata, exception) -> {
+                    if (exception != null) {
+                        log.atWarn().setCause(exception).setMessage("Failed to send tuple to Kafka topic {}").addArgument(topic).log();
+                        future.completeExceptionally(exception);
+                    } else {
+                        future.complete(null);
+                    }
+                });
+            } catch (Exception e) {
+                future.completeExceptionally(e);
+            }
+        });
+    }
+
+    @Override
+    public void flush() {
+        producer.flush();
+    }
+
+    @Override
+    public void close() {
+        // Flush only — caller owns the producer and closes it after all sinks are done.
+        executor.shutdown();
+        try {
+            executor.awaitTermination(30, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+        producer.flush();
+    }
+}

--- a/TrafficCapture/tupleSink/src/main/java/org/opensearch/migrations/replay/sink/KafkaTupleSink.java
+++ b/TrafficCapture/tupleSink/src/main/java/org/opensearch/migrations/replay/sink/KafkaTupleSink.java
@@ -4,7 +4,9 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
@@ -31,6 +33,9 @@ public class KafkaTupleSink implements TupleSink {
     private final Producer<String, byte[]> producer;
     private final String topic;
     private final ExecutorService executor;
+    // Set on close() so accept() rejects late writes synchronously (rather than racing the executor
+    // shutdown) — mirrors S3TupleSink's accept-after-close guard.
+    private final AtomicBoolean closeRequested = new AtomicBoolean();
 
     public KafkaTupleSink(Producer<String, byte[]> producer, String topic) {
         this.producer = producer;
@@ -44,28 +49,38 @@ public class KafkaTupleSink implements TupleSink {
 
     @Override
     public void accept(Map<String, Object> tupleMap, CompletableFuture<Void> future) {
-        executor.execute(() -> {
-            final byte[] json;
-            try {
-                json = mapper.writeValueAsBytes(tupleMap);
-            } catch (Exception e) {
-                future.completeExceptionally(e);
-                return;
-            }
-            var key = (String) tupleMap.get("connectionId");
-            try {
-                producer.send(new ProducerRecord<>(topic, key, json), (metadata, exception) -> {
-                    if (exception != null) {
-                        log.atWarn().setCause(exception).setMessage("Failed to send tuple to Kafka topic {}").addArgument(topic).log();
-                        future.completeExceptionally(exception);
-                    } else {
-                        future.complete(null);
-                    }
-                });
-            } catch (Exception e) {
-                future.completeExceptionally(e);
-            }
-        });
+        if (closeRequested.get()) {
+            future.completeExceptionally(new IllegalStateException("KafkaTupleSink is closed"));
+            return;
+        }
+        try {
+            executor.execute(() -> {
+                final byte[] json;
+                try {
+                    json = mapper.writeValueAsBytes(tupleMap);
+                } catch (Exception e) {
+                    future.completeExceptionally(e);
+                    return;
+                }
+                var key = (String) tupleMap.get("connectionId");
+                try {
+                    producer.send(new ProducerRecord<>(topic, key, json), (metadata, exception) -> {
+                        if (exception != null) {
+                            log.atWarn().setCause(exception).setMessage("Failed to send tuple to Kafka topic {}").addArgument(topic).log();
+                            future.completeExceptionally(exception);
+                        } else {
+                            future.complete(null);
+                        }
+                    });
+                } catch (Exception e) {
+                    future.completeExceptionally(e);
+                }
+            });
+        } catch (RejectedExecutionException e) {
+            // Lost the race with close() between the check above and this call — fail gracefully
+            // rather than letting the exception propagate to the caller.
+            future.completeExceptionally(new IllegalStateException("KafkaTupleSink is closed", e));
+        }
     }
 
     @Override
@@ -76,6 +91,7 @@ public class KafkaTupleSink implements TupleSink {
     @Override
     public void close() {
         // Flush only — caller owns the producer and closes it after all sinks are done.
+        closeRequested.set(true);
         executor.shutdown();
         try {
             executor.awaitTermination(30, TimeUnit.SECONDS);

--- a/TrafficCapture/tupleSink/src/main/java/org/opensearch/migrations/replay/sink/MultiTupleSink.java
+++ b/TrafficCapture/tupleSink/src/main/java/org/opensearch/migrations/replay/sink/MultiTupleSink.java
@@ -1,0 +1,65 @@
+package org.opensearch.migrations.replay.sink;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Fan-out sink that delivers each tuple to multiple downstream sinks.
+ * The caller's future completes only when ALL downstream sinks confirm durability.
+ */
+@Slf4j
+public class MultiTupleSink implements TupleSink {
+
+    private final List<TupleSink> sinks;
+
+    public MultiTupleSink(List<TupleSink> sinks) {
+        this.sinks = List.copyOf(sinks);
+    }
+
+    @Override
+    public void accept(Map<String, Object> tupleMap, CompletableFuture<Void> future) {
+        var subFutures = sinks.stream()
+            .map(sink -> {
+                var f = new CompletableFuture<Void>();
+                try {
+                    sink.accept(tupleMap, f);
+                } catch (RuntimeException e) {
+                    f.completeExceptionally(e);
+                }
+                return f;
+            })
+            .toArray(CompletableFuture[]::new);
+        CompletableFuture.allOf(subFutures).whenComplete((v, e) -> {
+            if (e != null) {
+                future.completeExceptionally(e);
+            } else {
+                future.complete(null);
+            }
+        });
+    }
+
+    @Override
+    public void flush() {
+        for (var sink : sinks) {
+            try {
+                sink.flush();
+            } catch (RuntimeException e) {
+                log.atError().setCause(e).setMessage("Error flushing TupleSink").log();
+            }
+        }
+    }
+
+    @Override
+    public void close() {
+        for (var sink : sinks) {
+            try {
+                sink.close();
+            } catch (RuntimeException e) {
+                log.atError().setCause(e).setMessage("Error closing TupleSink").log();
+            }
+        }
+    }
+}

--- a/TrafficCapture/tupleSink/src/test/java/org/opensearch/migrations/replay/sink/KafkaTupleSinkTest.java
+++ b/TrafficCapture/tupleSink/src/test/java/org/opensearch/migrations/replay/sink/KafkaTupleSinkTest.java
@@ -1,0 +1,95 @@
+package org.opensearch.migrations.replay.sink;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.kafka.clients.producer.MockProducer;
+import org.apache.kafka.common.serialization.ByteArraySerializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class KafkaTupleSinkTest {
+
+    private static final String TOPIC = "tuple-output";
+
+    private Map<String, Object> makeTuple(String id) {
+        var map = new LinkedHashMap<String, Object>();
+        map.put("connectionId", id);
+        map.put("numRequests", 1);
+        return map;
+    }
+
+    /** Only needed by tests that reach an actual producer.send() call — MockProducer's no-arg
+     * constructor has no serializers and NPEs on send(). */
+    private MockProducer<String, byte[]> makeSendingProducer() {
+        return new MockProducer<>(true, null, new StringSerializer(), new ByteArraySerializer());
+    }
+
+    @Test
+    void acceptSendsRecordToKafkaTopicKeyedByConnectionId() throws Exception {
+        var producer = makeSendingProducer();
+
+        try (var sink = new KafkaTupleSink(producer, TOPIC)) {
+            var future = new CompletableFuture<Void>();
+            sink.accept(makeTuple("conn1.0"), future);
+            future.get(1, TimeUnit.SECONDS);
+        }
+
+        assertEquals(1, producer.history().size());
+        var record = producer.history().get(0);
+        assertEquals(TOPIC, record.topic());
+        assertEquals("conn1.0", record.key());
+    }
+
+    @Test
+    void serializationFailureCompletesOnlyThatTupleFuture() {
+        var producer = new MockProducer<String, byte[]>();
+        var recursiveTuple = new LinkedHashMap<String, Object>();
+        recursiveTuple.put("self", recursiveTuple);
+
+        try (var sink = new KafkaTupleSink(producer, TOPIC)) {
+            var future = new CompletableFuture<Void>();
+            sink.accept(recursiveTuple, future);
+
+            assertThrows(ExecutionException.class, () -> future.get(1, TimeUnit.SECONDS));
+            assertTrue(future.isCompletedExceptionally());
+        }
+
+        assertEquals(0, producer.history().size());
+    }
+
+    @Test
+    void acceptAfterCloseFailsFutureInsteadOfThrowing() throws Exception {
+        var producer = new MockProducer<String, byte[]>();
+        var sink = new KafkaTupleSink(producer, TOPIC);
+        sink.close();
+
+        var future = new CompletableFuture<Void>();
+        // Must not throw RejectedExecutionException synchronously to the caller — it should be
+        // reported through the future, same as S3TupleSink's accept-after-close behavior.
+        sink.accept(makeTuple("conn1.0"), future);
+
+        assertTrue(future.isCompletedExceptionally(), "accept() after close() should fail the future");
+        var ex = assertThrows(ExecutionException.class, () -> future.get(1, TimeUnit.SECONDS));
+        assertTrue(ex.getCause() instanceof IllegalStateException,
+            "Expected IllegalStateException, got: " + ex.getCause());
+        assertEquals(0, producer.history().size(), "No record should have been sent after close");
+    }
+
+    @Test
+    void closeFlushesProducer() {
+        var producer = new MockProducer<String, byte[]>();
+
+        var sink = new KafkaTupleSink(producer, TOPIC);
+        sink.close();
+
+        assertTrue(producer.flushed(), "close() should flush the producer");
+    }
+}

--- a/deployment/k8s/chorus_es_to_os_demo/01-setup-es-snapshot.sh
+++ b/deployment/k8s/chorus_es_to_os_demo/01-setup-es-snapshot.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# =============================================================================
+# 01-setup-es-snapshot.sh
+#
+# One-time setup: connects the local ES Docker container to the kind network
+# so it can reach LocalStack S3, installs AWS credentials into the ES keystore,
+# registers an S3 snapshot repository, and takes a snapshot of the ecommerce index.
+#
+# Run this ONCE before submitting the Argo workflow.
+# Safe to re-run — snapshot creation is idempotent.
+# =============================================================================
+set -euo pipefail
+
+# ── Config ────────────────────────────────────────────────────────────────────
+ES_URL="http://localhost:9200"
+ES_USER="elastic"
+ES_PASS="ElasticRocks"
+SNAPSHOT_REPO="migrations_repo"
+SNAPSHOT_NAME="ecommerce_snapshot"
+S3_BUCKET="migrations-default-123456789012-dev-us-east-2"
+LOCALSTACK_NODEPORT=31566
+
+# ── Find ES Docker container ──────────────────────────────────────────────────
+ES_CONTAINER=$(docker ps --filter "publish=9200" --format "{{.ID}}" | head -1)
+if [ -z "$ES_CONTAINER" ]; then
+  echo "ERROR: No Docker container found exposing port 9200. Is Elasticsearch running?"
+  exit 1
+fi
+echo "Found ES container: $ES_CONTAINER"
+
+# ── Connect ES container to kind network (if not already) ────────────────────
+if docker inspect "$ES_CONTAINER" | python3 -c "import sys,json; nets=json.load(sys.stdin)[0]['NetworkSettings']['Networks']; sys.exit(0 if 'kind' in nets else 1)" 2>/dev/null; then
+  echo "ES container already on kind network."
+else
+  echo "Connecting ES container to kind network..."
+  docker network connect kind "$ES_CONTAINER"
+  echo "Connected. ES container now has access to LocalStack via kind network."
+fi
+
+# Find a kind node IP to reach LocalStack via NodePort
+LOCALSTACK_IP=$(kubectl get nodes -o jsonpath='{.items[0].status.addresses[?(@.type=="InternalIP")].address}' 2>/dev/null)
+LOCALSTACK_ENDPOINT="http://${LOCALSTACK_IP}:${LOCALSTACK_NODEPORT}"
+echo "LocalStack endpoint for ES: $LOCALSTACK_ENDPOINT"
+
+# ── Install AWS credentials into ES keystore ──────────────────────────────────
+# The repository-s3 plugin requires credentials even for LocalStack.
+echo "Installing AWS credentials into ES keystore..."
+echo "test" | docker exec -i "$ES_CONTAINER" \
+  /usr/share/elasticsearch/bin/elasticsearch-keystore add --stdin s3.client.default.access_key --force 2>&1 || true
+echo "test" | docker exec -i "$ES_CONTAINER" \
+  /usr/share/elasticsearch/bin/elasticsearch-keystore add --stdin s3.client.default.secret_key --force 2>&1 || true
+
+echo "Reloading secure settings..."
+curl -s -u "$ES_USER:$ES_PASS" -X POST "$ES_URL/_nodes/reload_secure_settings" | python3 -m json.tool 2>/dev/null || true
+
+# ── Register S3 snapshot repository ──────────────────────────────────────────
+echo ""
+echo "Registering S3 snapshot repository '$SNAPSHOT_REPO'..."
+RESULT=$(curl -s -u "$ES_USER:$ES_PASS" -X PUT "$ES_URL/_snapshot/$SNAPSHOT_REPO" \
+  -H "Content-Type: application/json" \
+  -d "{
+    \"type\": \"s3\",
+    \"settings\": {
+      \"bucket\": \"$S3_BUCKET\",
+      \"endpoint\": \"$LOCALSTACK_ENDPOINT\",
+      \"path_style_access\": true,
+      \"protocol\": \"http\"
+    }
+  }")
+echo "$RESULT"
+if echo "$RESULT" | grep -q '"acknowledged":true'; then
+  echo "Repository registered successfully."
+else
+  echo "WARNING: Repository registration may have failed. Check the output above."
+fi
+
+# ── Take snapshot ─────────────────────────────────────────────────────────────
+echo ""
+echo "Taking snapshot '$SNAPSHOT_NAME' of the ecommerce index..."
+RESULT=$(curl -s -u "$ES_USER:$ES_PASS" -X PUT "$ES_URL/_snapshot/$SNAPSHOT_REPO/$SNAPSHOT_NAME?wait_for_completion=true" \
+  -H "Content-Type: application/json" \
+  -d '{"indices": "ecommerce", "include_global_state": false}')
+echo "$RESULT" | python3 -m json.tool 2>/dev/null || echo "$RESULT"
+
+STATE=$(echo "$RESULT" | python3 -c "import sys,json; print(json.load(sys.stdin).get('snapshot',{}).get('state','UNKNOWN'))" 2>/dev/null || echo "UNKNOWN")
+if [ "$STATE" = "SUCCESS" ]; then
+  echo ""
+  echo "✓ Snapshot '$SNAPSHOT_NAME' created successfully."
+else
+  # Check if snapshot already exists
+  CHECK=$(curl -s -u "$ES_USER:$ES_PASS" "$ES_URL/_snapshot/$SNAPSHOT_REPO/$SNAPSHOT_NAME")
+  EXISTING_STATE=$(echo "$CHECK" | python3 -c "import sys,json; snaps=json.load(sys.stdin).get('snapshots',[]); print(snaps[0]['state'] if snaps else 'NONE')" 2>/dev/null || echo "NONE")
+  if [ "$EXISTING_STATE" = "SUCCESS" ]; then
+    echo "✓ Snapshot '$SNAPSHOT_NAME' already exists and is SUCCESS — nothing to do."
+  else
+    echo "ERROR: Snapshot state is '$STATE'. Check ES logs."
+    exit 1
+  fi
+fi

--- a/deployment/k8s/chorus_es_to_os_demo/02-setup-k8s-secrets.sh
+++ b/deployment/k8s/chorus_es_to_os_demo/02-setup-k8s-secrets.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# =============================================================================
+# 02-setup-k8s-secrets.sh
+#
+# Creates Kubernetes secrets for source ES and target OpenSearch credentials
+# in the 'ma' namespace, with the labels required by the migration console
+# workflow CLI to recognize them.
+#
+# Safe to re-run — uses --dry-run=client | kubectl apply for idempotency.
+# =============================================================================
+set -euo pipefail
+
+NAMESPACE="ma"
+
+# ── Source Elasticsearch credentials ─────────────────────────────────────────
+echo "Creating source-es-creds secret..."
+kubectl create secret generic source-es-creds \
+  --namespace "$NAMESPACE" \
+  --from-literal=username=elastic \
+  --from-literal=password=ElasticRocks \
+  --dry-run=client -o yaml | kubectl apply -f -
+
+# ── Target OpenSearch credentials ─────────────────────────────────────────────
+echo "Creating target-os-creds secret..."
+kubectl create secret generic target-os-creds \
+  --namespace "$NAMESPACE" \
+  --from-literal=username=admin \
+  --from-literal=password='MyStr0ng!P@ssw0rd2024' \
+  --dry-run=client -o yaml | kubectl apply -f -
+
+# ── Apply required labels ─────────────────────────────────────────────────────
+# The workflow CLI's SecretStore looks for secrets with use-case=http-basic-credentials.
+# Without this label, `workflow configure edit` reports the secrets as "missing"
+# and exits with code 1, blocking the configureAndSubmitWorkflow step.
+echo "Labeling secrets for workflow CLI discovery..."
+kubectl label secret source-es-creds -n "$NAMESPACE" \
+  use-case=http-basic-credentials --overwrite
+kubectl label secret target-os-creds -n "$NAMESPACE" \
+  use-case=http-basic-credentials --overwrite
+
+echo ""
+echo "Verifying secrets..."
+kubectl get secret source-es-creds target-os-creds -n "$NAMESPACE" --show-labels
+echo ""
+echo "Verifying workflow CLI sees no missing credentials..."
+kubectl exec -n "$NAMESPACE" migration-console-0 -- \
+  /bin/bash -lc 'workflow configure credentials create --show-missing' 2>&1 || true
+echo ""
+echo "Done. Secrets are ready."

--- a/deployment/k8s/chorus_es_to_os_demo/03-monitor.sh
+++ b/deployment/k8s/chorus_es_to_os_demo/03-monitor.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# =============================================================================
+# 03-monitor.sh
+#
+# Shows the status of the inner migration-workflow (the one submitted by the
+# Argo CDC workflow), RFS document progress, and a live target doc count.
+# Run at any time after submitting the workflow to check progress.
+# =============================================================================
+set -euo pipefail
+
+NAMESPACE="ma"
+TARGET_URL="https://chorus-opensearch-edition.dev.o19s.com:9200"
+TARGET_USER="admin"
+TARGET_PASS='MyStr0ng!P@ssw0rd2024'
+
+echo "=== Outer Argo workflow ==="
+kubectl get workflow cdc-ecommerce-migration -n "$NAMESPACE" \
+  -o custom-columns="NAME:.metadata.name,PHASE:.status.phase,MESSAGE:.status.message" 2>/dev/null \
+  || echo "(not found)"
+
+echo ""
+echo "=== Inner migration-workflow ==="
+kubectl exec -n "$NAMESPACE" migration-console-0 -- \
+  /bin/bash -lc 'workflow status 2>&1' 2>/dev/null || echo "(not available)"
+
+echo ""
+echo "=== RFS worker ==="
+RFS_POD=$(kubectl get pods -n "$NAMESPACE" -l "app.kubernetes.io/component=rfs" \
+  --field-selector=status.phase=Running -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)
+if [ -n "$RFS_POD" ]; then
+  echo "Pod: $RFS_POD"
+  kubectl logs "$RFS_POD" -n "$NAMESPACE" --tail=5 2>/dev/null | \
+    grep -E "heartbeat|docs=" || echo "(no heartbeat lines yet)"
+else
+  echo "(no running RFS pod — may be complete)"
+fi
+
+echo ""
+echo "=== Document count on target ==="
+kubectl exec -n "$NAMESPACE" migration-console-0 -- /bin/bash -lc \
+  "curl -sk -u ${TARGET_USER}:'${TARGET_PASS}' '${TARGET_URL}/ecommerce/_count'" 2>/dev/null \
+  | python3 -m json.tool 2>/dev/null || echo "(could not reach target)"
+
+echo ""
+echo "=== Traffic replayer ==="
+REPLAY_POD=$(kubectl get pods -n "$NAMESPACE" -l "app.kubernetes.io/component=traffic-replayer" \
+  --field-selector=status.phase=Running -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)
+if [ -n "$REPLAY_POD" ]; then
+  echo "Pod: $REPLAY_POD"
+  kubectl logs "$REPLAY_POD" -n "$NAMESPACE" --tail=3 2>/dev/null | \
+    grep -E "ReplayHeartbeat|AccumulatorH" || echo "(no heartbeat lines yet)"
+else
+  echo "(no running replayer pod)"
+fi

--- a/deployment/k8s/chorus_es_to_os_demo/04-cdc-demo.sh
+++ b/deployment/k8s/chorus_es_to_os_demo/04-cdc-demo.sh
@@ -1,0 +1,222 @@
+#!/usr/bin/env bash
+# =============================================================================
+# 04-cdc-demo.sh
+#
+# Demonstrates live CDC (Change Data Capture) traffic capture and replay.
+#
+# Sends 5 requests all using the `supplier` keyword field:
+#   1. SEARCH   — count Samsung products
+#   2. AGGREGATE — top suppliers by product count
+#   3. DELETE   — remove one Samsung product via CaptureProxy
+#   4. SEARCH   — recount Samsung (should be -1 on both ES and OS)
+#   5. AGGREGATE — top suppliers again (Samsung count decreases on both)
+#
+# Each request is sent TWICE:
+#   a) Directly to Elasticsearch (port 9200) — ground truth
+#   b) Through the CaptureProxy (https://localhost:9201) — forwarded to ES
+#      AND captured to Kafka for replay to OpenSearch
+#
+# After the DELETE, the script waits for the replayer, then checks OpenSearch
+# directly to confirm the delete propagated.
+#
+# PREREQUISITE: CaptureProxy port-forward must be running in another terminal:
+#   kubectl port-forward -n ma svc/capture-proxy 9201:9201
+# =============================================================================
+set -euo pipefail
+
+# ── Config ────────────────────────────────────────────────────────────────────
+ES_URL="http://localhost:9200"
+ES_USER="elastic"
+ES_PASS="ElasticRocks"
+
+PROXY_URL="https://localhost:9201"   # CaptureProxy (TLS, -sk to skip cert)
+
+OS_URL="https://chorus-opensearch-edition.dev.o19s.com:9200"
+OS_USER="admin"
+OS_PASS='MyStr0ng!P@ssw0rd2024'
+
+INDEX="ecommerce"
+FIELD="supplier"
+TERM="Samsung"
+REPLAY_WAIT=120  # max seconds to wait for the replayer to propagate changes
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+es()    { curl -s -u "${ES_USER}:${ES_PASS}"     "$@"; }
+proxy() { curl -sk -u "${ES_USER}:${ES_PASS}"    "$@"; }  # through CaptureProxy
+os()    { curl -sk -u "${OS_USER}:${OS_PASS}"    "$@"; }
+
+section() { echo ""; echo "══════════════════════════════════════════════════════"; echo "  $*"; echo "══════════════════════════════════════════════════════"; }
+subsection() { echo ""; echo "  ── $* ──"; }
+pretty() { python3 -m json.tool 2>/dev/null || cat; }
+
+# ── Check pre-requisite ───────────────────────────────────────────────────────
+echo "Checking CaptureProxy port-forward..."
+if ! curl -sk --connect-timeout 3 "${PROXY_URL}" >/dev/null 2>&1; then
+  echo ""
+  echo "ERROR: Cannot reach CaptureProxy at ${PROXY_URL}"
+  echo "Start the port-forward first:"
+  echo "  kubectl port-forward -n ma svc/capture-proxy 9201:9201"
+  exit 1
+fi
+echo "CaptureProxy is reachable."
+
+# ── Pick a doc to delete ──────────────────────────────────────────────────────
+DELETE_ID=$(es "${ES_URL}/${INDEX}/_search?size=1&q=${FIELD}:${TERM}&_source=false" \
+  | python3 -c "import sys,json; print(json.load(sys.stdin)['hits']['hits'][0]['_id'])")
+DELETE_TITLE=$(es "${ES_URL}/${INDEX}/_doc/${DELETE_ID}?_source=title" \
+  | python3 -c "import sys,json; print(json.load(sys.stdin)['_source']['title'])")
+
+echo ""
+echo "Will delete:  [${DELETE_ID}] ${DELETE_TITLE}"
+echo ""
+
+# ── Queries ───────────────────────────────────────────────────────────────────
+SEARCH_BODY=$(cat <<JSON
+{
+  "query": { "term": { "${FIELD}": "${TERM}" } },
+  "size": 0,
+  "track_total_hits": true
+}
+JSON
+)
+
+AGG_BODY=$(cat <<JSON
+{
+  "size": 0,
+  "aggs": {
+    "samsung_count": {
+      "filter": { "term": { "${FIELD}": "${TERM}" } },
+      "aggs": {
+        "product_count": { "value_count": { "field": "${FIELD}" } }
+      }
+    },
+    "top_suppliers": {
+      "terms": { "field": "${FIELD}", "size": 5, "order": { "_count": "desc" } }
+    }
+  }
+}
+JSON
+)
+
+count_from_search() { python3 -c "import sys,json; print('  Count:', json.load(sys.stdin)['hits']['total']['value'], '${TERM} products')"; }
+top_suppliers()     { python3 -c "
+import sys,json
+d=json.load(sys.stdin)
+aggs=d['aggregations']
+samsung=aggs['samsung_count']['product_count']['value']
+print(f'  ${TERM} (filter agg):              {samsung:>6} products  ◀ watch this change')
+print()
+print('  Top 5 suppliers overall:')
+for b in aggs['top_suppliers']['buckets']:
+    print(f'    {b[\"key\"]:<30} {b[\"doc_count\"]:>6} products')
+"; }
+
+# ==========================================================================
+# REQUEST 1: SEARCH — count Samsung products (before delete)
+# ==========================================================================
+section "REQUEST 1: SEARCH — ${FIELD}:${TERM} (before delete)"
+
+subsection "a) Elasticsearch (direct)"
+es -X POST "${ES_URL}/${INDEX}/_search" \
+  -H "Content-Type: application/json" -d "${SEARCH_BODY}" | count_from_search
+
+subsection "b) Via CaptureProxy → ES response + captured for OS replay"
+proxy -X POST "${PROXY_URL}/${INDEX}/_search" \
+  -H "Content-Type: application/json" -d "${SEARCH_BODY}" | count_from_search
+
+subsection "c) OpenSearch (direct — replayer will have already processed this)"
+os -X POST "${OS_URL}/${INDEX}/_search" \
+  -H "Content-Type: application/json" -d "${SEARCH_BODY}" | count_from_search
+
+# ==========================================================================
+# REQUEST 2: AGGREGATION — top suppliers (before delete)
+# ==========================================================================
+section "REQUEST 2: AGGREGATION — top suppliers (before delete)"
+
+subsection "a) Elasticsearch (direct)"
+es -X POST "${ES_URL}/${INDEX}/_search" \
+  -H "Content-Type: application/json" -d "${AGG_BODY}" | top_suppliers
+
+subsection "b) Via CaptureProxy → captured for OS replay"
+proxy -X POST "${PROXY_URL}/${INDEX}/_search" \
+  -H "Content-Type: application/json" -d "${AGG_BODY}" | top_suppliers
+
+subsection "c) OpenSearch (direct)"
+os -X POST "${OS_URL}/${INDEX}/_search" \
+  -H "Content-Type: application/json" -d "${AGG_BODY}" | top_suppliers
+
+# ==========================================================================
+# REQUEST 3: DELETE — remove one Samsung product
+# ==========================================================================
+section "REQUEST 3: DELETE — removing [${DELETE_ID}]"
+echo "  ${DELETE_TITLE}"
+
+subsection "a) Elasticsearch (direct) — baseline delete"
+es -X DELETE "${ES_URL}/${INDEX}/_doc/${DELETE_ID}" | pretty
+
+subsection "b) Via CaptureProxy — delete replayed to OpenSearch"
+proxy -X DELETE "${PROXY_URL}/${INDEX}/_doc/${DELETE_ID}" | pretty
+
+echo ""
+echo "  Waiting for TrafficReplayer to propagate the DELETE to OpenSearch (up to ${REPLAY_WAIT}s)..."
+OS_COUNT_BEFORE=$(os -X POST "${OS_URL}/${INDEX}/_search" \
+  -H "Content-Type: application/json" -d "${SEARCH_BODY}" \
+  | python3 -c "import sys,json; print(json.load(sys.stdin)['hits']['total']['value'])")
+elapsed=0
+while [ "$elapsed" -lt "$REPLAY_WAIT" ]; do
+  OS_COUNT_NOW=$(os -X POST "${OS_URL}/${INDEX}/_search" \
+    -H "Content-Type: application/json" -d "${SEARCH_BODY}" \
+    | python3 -c "import sys,json; print(json.load(sys.stdin)['hits']['total']['value'])" 2>/dev/null)
+  if [ "${OS_COUNT_NOW}" -lt "${OS_COUNT_BEFORE}" ]; then
+    echo "  ✓ DELETE propagated to OpenSearch after ${elapsed}s (${OS_COUNT_BEFORE} → ${OS_COUNT_NOW})"
+    break
+  fi
+  printf "  ... %ds elapsed, OpenSearch still at %s %s products\r" "$elapsed" "$OS_COUNT_NOW" "${TERM}"
+  sleep 5
+  elapsed=$((elapsed + 5))
+done
+if [ "$elapsed" -ge "$REPLAY_WAIT" ]; then
+  echo "  ⚠ Timed out after ${REPLAY_WAIT}s — replayer may still be catching up"
+fi
+echo ""
+
+# ==========================================================================
+# REQUEST 4: SEARCH — recount Samsung (after delete)
+# ==========================================================================
+section "REQUEST 4: SEARCH — ${FIELD}:${TERM} (after delete, expect -1)"
+
+subsection "a) Elasticsearch (direct)"
+es -X POST "${ES_URL}/${INDEX}/_search" \
+  -H "Content-Type: application/json" -d "${SEARCH_BODY}" | count_from_search
+
+subsection "b) Via CaptureProxy → captured for OS replay"
+proxy -X POST "${PROXY_URL}/${INDEX}/_search" \
+  -H "Content-Type: application/json" -d "${SEARCH_BODY}" | count_from_search
+
+subsection "c) OpenSearch (direct) — DELETE should have propagated"
+os -X POST "${OS_URL}/${INDEX}/_search" \
+  -H "Content-Type: application/json" -d "${SEARCH_BODY}" | count_from_search
+
+# ==========================================================================
+# REQUEST 5: AGGREGATION — top suppliers (after delete)
+# ==========================================================================
+section "REQUEST 5: AGGREGATION — top suppliers (after delete, Samsung -1)"
+
+subsection "a) Elasticsearch (direct)"
+es -X POST "${ES_URL}/${INDEX}/_search" \
+  -H "Content-Type: application/json" -d "${AGG_BODY}" | top_suppliers
+
+subsection "b) Via CaptureProxy → captured for OS replay"
+proxy -X POST "${PROXY_URL}/${INDEX}/_search" \
+  -H "Content-Type: application/json" -d "${AGG_BODY}" | top_suppliers
+
+subsection "c) OpenSearch (direct)"
+os -X POST "${OS_URL}/${INDEX}/_search" \
+  -H "Content-Type: application/json" -d "${AGG_BODY}" | top_suppliers
+
+# ==========================================================================
+section "SUMMARY"
+echo "  All 5 requests used the '${FIELD}' field."
+echo "  Requests (b) went through CaptureProxy and were replayed to OpenSearch."
+echo "  The DELETE on [${DELETE_ID}] should now be gone from both clusters."
+echo ""

--- a/deployment/k8s/chorus_es_to_os_demo/05-compare-tuples.sh
+++ b/deployment/k8s/chorus_es_to_os_demo/05-compare-tuples.sh
@@ -1,0 +1,360 @@
+#!/usr/bin/env bash
+# =============================================================================
+# 05-compare-tuples.sh
+#
+# Downloads traffic replay tuples from S3 (LocalStack) and compares the
+# Elasticsearch (source) responses against the OpenSearch (target) responses
+# for every request captured by the CaptureProxy.
+#
+# Tuples are written by the TrafficReplayer and contain:
+#   sourceRequest   — the original HTTP request
+#   sourceResponse  — the ES response at capture time
+#   targetRequest   — the replayed request (with OS credentials)
+#   targetResponses — the OS response(s) from the replayer
+#
+# PREREQUISITE: migration-console-0 pod must be running in the ma namespace.
+# =============================================================================
+set -euo pipefail
+
+# ── Config ────────────────────────────────────────────────────────────────────
+S3_BUCKET="migrations-default-123456789012-dev-us-east-2"
+S3_PREFIX="tuples/"
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+section() { echo ""; echo "══════════════════════════════════════════════════════"; echo "  $*"; echo "══════════════════════════════════════════════════════"; }
+
+s3() {
+  kubectl exec -n ma migration-console-0 -- \
+    env AWS_ACCESS_KEY_ID=test AWS_SECRET_ACCESS_KEY=test \
+    aws --endpoint-url http://localstack:4566 --region us-east-2 \
+    s3 "$@"
+}
+
+# ── Check pre-requisite ───────────────────────────────────────────────────────
+echo "Checking migration-console pod..."
+if ! kubectl get pod migration-console-0 -n ma &>/dev/null; then
+  echo "ERROR: migration-console-0 pod not found in namespace 'ma'"
+  exit 1
+fi
+echo "OK"
+
+# ── Find replayer prefix ──────────────────────────────────────────────────────
+section "Locating tuple files in S3"
+
+REPLAYER_DIR=$(s3 ls "s3://${S3_BUCKET}/${S3_PREFIX}" 2>/dev/null \
+  | awk '{print $NF}' | grep -v '^$' | head -1)
+
+if [ -z "$REPLAYER_DIR" ]; then
+  echo "No tuple files found at s3://${S3_BUCKET}/${S3_PREFIX}"
+  echo "Make sure the TrafficReplayer has processed some requests and its"
+  echo "tupleMaxBufferSeconds window (10s) has elapsed since the last request."
+  exit 1
+fi
+
+echo "Replayer: ${REPLAYER_DIR}"
+
+FILE_LIST=$(s3 ls --recursive "s3://${S3_BUCKET}/${S3_PREFIX}${REPLAYER_DIR}" 2>/dev/null \
+  | awk '{print $NF}' | grep '\.log\.gz$')
+
+FILE_COUNT=$(echo "$FILE_LIST" | grep -c '.' || true)
+echo "Found ${FILE_COUNT} tuple file(s)"
+
+# ── Download tuple files ──────────────────────────────────────────────────────
+section "Downloading and analysing tuples"
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+echo "$FILE_LIST" | while read -r s3key; do
+  local_name="${TMPDIR}/$(basename "$s3key")"
+  s3 cp "s3://${S3_BUCKET}/${s3key}" "$local_name" >/dev/null 2>&1
+  # Decompress into a single combined file
+  kubectl exec -n ma migration-console-0 -- gunzip -c "/$(basename "$local_name")" \
+    2>/dev/null >> "${TMPDIR}/all-tuples.ndjson" || true
+done
+
+# ── Re-download directly using kubectl cp approach ────────────────────────────
+# (simpler: stream gunzip from migration-console for each file)
+: > "${TMPDIR}/all-tuples.ndjson"
+while read -r s3key; do
+  kubectl exec -n ma migration-console-0 -- \
+    bash -c "
+      env AWS_ACCESS_KEY_ID=test AWS_SECRET_ACCESS_KEY=test \
+      aws --endpoint-url http://localstack:4566 --region us-east-2 \
+      s3 cp 's3://${S3_BUCKET}/${s3key}' - 2>/dev/null | gunzip
+    " >> "${TMPDIR}/all-tuples.ndjson" 2>/dev/null || true
+done <<< "$FILE_LIST"
+
+TUPLE_COUNT=$(grep -c '{' "${TMPDIR}/all-tuples.ndjson" 2>/dev/null || echo 0)
+echo "Total tuples: ${TUPLE_COUNT}"
+
+if [ "$TUPLE_COUNT" -eq 0 ]; then
+  echo ""
+  echo "No tuples to analyse. The replayer buffers tuples for up to 10 seconds"
+  echo "before flushing to S3. Wait a moment and re-run this script."
+  exit 0
+fi
+
+# ── Analyse with Python ───────────────────────────────────────────────────────
+python3 - "${TMPDIR}/all-tuples.ndjson" << 'PYEOF'
+import sys, json
+
+path = sys.argv[1]
+
+records = []
+with open(path) as f:
+    for line in f:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            records.append(json.loads(line))
+        except json.JSONDecodeError:
+            pass
+
+def jaccard_sets(a, b):
+    """Standard Jaccard on two sets: |A∩B| / |A∪B|.
+    Returns None when both sets are empty (undefined, not 1.0)."""
+    if not a and not b:
+        return None
+    return len(a & b) / len(a | b)
+
+def hit_doc_ids(body):
+    """Return the set of _id values from hits.hits, or None if no hits."""
+    hits = body.get('hits', {}).get('hits', [])
+    ids = {h['_id'] for h in hits if '_id' in h}
+    return ids if ids else None
+
+def weighted_jaccard_aggs(src_aggs, tgt_aggs):
+    """Weighted Jaccard across all aggregations in a response.
+
+    Terms agg  → Σ min(count_A[k], count_B[k]) / Σ max(count_A[k], count_B[k])
+                 over all bucket keys in A∪B.  Penalises count drift per bucket.
+    Filter agg → min(doc_count_A, doc_count_B) / max(...)  (single-value ratio)
+    Metric agg → min(value_A, value_B) / max(...)
+
+    The per-agg scores are averaged into a single number so that one query
+    with three aggregations gets one Jaccard value.
+    Returns (score, description) or (None, None)."""
+    scores = []
+
+    for agg_name in set(src_aggs) | set(tgt_aggs):
+        src_agg = src_aggs.get(agg_name, {})
+        tgt_agg = tgt_aggs.get(agg_name, {})
+        if not isinstance(src_agg, dict) or not isinstance(tgt_agg, dict):
+            continue
+
+        # ── Terms agg: buckets with doc_count ────────────────────────────────
+        src_buckets = src_agg.get('buckets', [])
+        tgt_buckets = tgt_agg.get('buckets', [])
+        if src_buckets or tgt_buckets:
+            src_counts = {b['key']: b.get('doc_count', 0) for b in src_buckets if 'key' in b}
+            tgt_counts = {b['key']: b.get('doc_count', 0) for b in tgt_buckets if 'key' in b}
+            all_keys = set(src_counts) | set(tgt_counts)
+            if all_keys:
+                numer = sum(min(src_counts.get(k, 0), tgt_counts.get(k, 0)) for k in all_keys)
+                denom = sum(max(src_counts.get(k, 0), tgt_counts.get(k, 0)) for k in all_keys)
+                if denom > 0:
+                    scores.append((numer / denom, f'{agg_name} buckets'))
+            continue
+
+        # ── Filter / single-value agg: compare doc_count ─────────────────────
+        src_dc = src_agg.get('doc_count')
+        tgt_dc = tgt_agg.get('doc_count')
+        if src_dc is not None and tgt_dc is not None:
+            mx = max(src_dc, tgt_dc)
+            if mx > 0:
+                scores.append((min(src_dc, tgt_dc) / mx, f'{agg_name} doc_count'))
+
+        # ── Metric sub-aggs: value_count, sum, avg, max, min ─────────────────
+        for sub_name, src_sub in src_agg.items():
+            if not isinstance(src_sub, dict) or 'value' not in src_sub:
+                continue
+            tgt_sub = tgt_agg.get(sub_name, {})
+            if not isinstance(tgt_sub, dict):
+                continue
+            sv, tv = src_sub['value'], tgt_sub.get('value')
+            if sv is not None and tv is not None:
+                mx = max(sv, tv)
+                if mx > 0:
+                    scores.append((min(sv, tv) / mx, f'{agg_name}.{sub_name}'))
+
+    if not scores:
+        return None, None
+    avg = sum(s for s, _ in scores) / len(scores)
+    labels = ', '.join(dict.fromkeys(lbl for _, lbl in scores))  # deduplicate, keep order
+    return avg, labels
+
+# ── Per-request table ─────────────────────────────────────────────────────────
+print()
+print(f"  {'✓/✗':<4} {'Method':<8} {'URI':<42} {'ES':>6} {'OS':>6}  {'ES ms':>6} {'OS ms':>6}  {'ES hits':>9} {'OS hits':>9}  {'Jaccard':>7}  notes")
+print(f"  {'-'*4} {'-'*8} {'-'*42} {'-'*6} {'-'*6}  {'-'*6} {'-'*6}  {'-'*9} {'-'*9}  {'-'*7}")
+
+mismatches     = 0
+status_matches = 0
+hit_diffs      = 0
+total_es_ms    = 0
+total_os_ms    = 0
+no_target      = 0
+n_options      = 0
+jaccard_scores = []
+
+def compute_jaccard_single(src_body, tgt_body):
+    """Jaccard for a single search response body. Returns (score, label)."""
+    src_ids = hit_doc_ids(src_body)
+    tgt_ids = hit_doc_ids(tgt_body)
+    if src_ids is not None and tgt_ids is not None:
+        return jaccard_sets(src_ids, tgt_ids), 'doc IDs'
+    j, lbl = weighted_jaccard_aggs(src_body.get('aggregations', {}),
+                                    tgt_body.get('aggregations', {}))
+    if j is not None:
+        return j, lbl
+    sv = src_body.get('hits', {}).get('total', {}).get('value') or src_body.get('count')
+    tv = tgt_body.get('hits', {}).get('total', {}).get('value') or tgt_body.get('count')
+    if sv is not None and tv is not None:
+        mx = max(sv, tv)
+        return ((min(sv, tv) / mx) if mx > 0 else 1.0), 'hit count ratio'
+    return None, None
+
+def score_msearch(src_body, tgt_body):
+    """Average Jaccard across _msearch sub-responses."""
+    src_subs = src_body.get('responses', [])
+    tgt_subs = tgt_body.get('responses', [])
+    scores = []
+    for sb, tb in zip(src_subs, tgt_subs):
+        if not isinstance(sb, dict) or not isinstance(tb, dict): continue
+        if sb.get('status', 200) >= 400 or tb.get('status', 200) >= 400: continue
+        j, _ = compute_jaccard_single(sb, tb)
+        if j is not None:
+            scores.append(j)
+    if not scores:
+        return None, None
+    n = len(src_subs)
+    return sum(scores) / len(scores), f'msearch ({n} sub-queries, {len(scores)} scored)'
+
+for r in records:
+    src_req   = r.get('sourceRequest', {})
+    src_resp  = r.get('sourceResponse', {})
+    tgt_resps = r.get('targetResponses', [])
+
+    method = src_req.get('Method', '?')
+    uri    = src_req.get('Request-URI', '?')
+    if len(uri) > 42:
+        uri = uri[:39] + '...'
+
+    src_status = src_resp.get('Status-Code', '?')
+    src_ms     = src_resp.get('response_time_ms', '?')
+
+    # Skip CORS preflights — no result set to compare
+    if method == 'OPTIONS':
+        n_options += 1
+        print(f"  {'–':<4} {method:<8} {uri:<42} {str(src_status):>6} {'(preflight)':>6}")
+        continue
+
+    if not tgt_resps:
+        no_target += 1
+        print(f"  {'?':<4} {method:<8} {uri:<42} {str(src_status):>6} {'(no replay)':>6}")
+        continue
+
+    tgt = tgt_resps[0]
+    tgt_status = tgt.get('Status-Code', '?')
+    tgt_ms     = tgt.get('response_time_ms', '?')
+
+    if isinstance(src_ms, (int, float)):
+        total_es_ms += src_ms
+    if isinstance(tgt_ms, (int, float)):
+        total_os_ms += tgt_ms
+
+    status_ok = (src_status == tgt_status)
+    status_matches += 1 if status_ok else 0
+    mismatches     += 0 if status_ok else 1
+    icon = '✓' if status_ok else '✗'
+
+    src_body = src_resp.get('payload', {}).get('inlinedJsonBody', {})
+    tgt_body = tgt.get('payload', {}).get('inlinedJsonBody', {})
+
+    is_msearch = ('_msearch' in (src_req.get('Request-URI', '')) or 'responses' in src_body)
+
+    if is_msearch:
+        j, j_label = score_msearch(src_body, tgt_body)
+        # Aggregate hit counts across all sub-responses for display
+        src_hits = sum(
+            (s.get('hits', {}).get('total', {}).get('value') or 0)
+            for s in src_body.get('responses', []) if isinstance(s, dict)) or ''
+        tgt_hits = sum(
+            (s.get('hits', {}).get('total', {}).get('value') or 0)
+            for s in tgt_body.get('responses', []) if isinstance(s, dict)) or ''
+    else:
+        j, j_label = compute_jaccard_single(src_body, tgt_body)
+        src_hits = src_body.get('hits', {}).get('total', {}).get('value', '')
+        tgt_hits = tgt_body.get('hits', {}).get('total', {}).get('value', '')
+
+    src_hits_str = str(src_hits) if src_hits != '' else '-'
+    tgt_hits_str = str(tgt_hits) if tgt_hits != '' else '-'
+
+    if j is not None:
+        jaccard_str = f'{j:.3f}'
+        jaccard_scores.append((j, j_label))
+    else:
+        jaccard_str = '  -  '
+
+    # Notes
+    notes = []
+    if not status_ok:
+        notes.append('status mismatch')
+    if src_hits != '' and tgt_hits != '' and src_hits != tgt_hits:
+        hit_diffs += 1
+        notes.append(f'hits diff {tgt_hits - src_hits:+d}')
+
+    if not is_msearch:
+        # Filter-agg nested value differences (single-response only)
+        src_aggs = src_body.get('aggregations', {})
+        tgt_aggs = tgt_body.get('aggregations', {})
+        for agg_name, src_agg in src_aggs.items():
+            if not isinstance(src_agg, dict):
+                continue
+            tgt_agg = tgt_aggs.get(agg_name, {})
+            for sub_name, src_sub in src_agg.items():
+                if isinstance(src_sub, dict) and 'value' in src_sub:
+                    tgt_sub = tgt_agg.get(sub_name, {}) if isinstance(tgt_agg, dict) else {}
+                    tgt_val = tgt_sub.get('value', '')
+                    if tgt_val != '' and src_sub['value'] != tgt_val:
+                        notes.append(f'{agg_name}.{sub_name}: {src_sub["value"]}→{tgt_val}')
+
+    if j_label and is_msearch and not notes:
+        notes.append(j_label)
+
+    notes_str = ', '.join(notes)
+    print(f"  {icon:<4} {method:<8} {uri:<42} {str(src_status):>6} {str(tgt_status):>6}  {str(src_ms):>6} {str(tgt_ms):>6}  {src_hits_str:>9} {tgt_hits_str:>9}  {jaccard_str:>7}  {notes_str}")
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+total    = len(records)
+compared = total - no_target - n_options
+print()
+print("══════════════════════════════════════════════════════")
+print("  SUMMARY")
+print("══════════════════════════════════════════════════════")
+print(f"  Total tuples analysed : {total}  ({n_options} OPTIONS preflight, {no_target} not yet replayed)")
+print(f"  Status code matches   : {status_matches}/{compared} ({100*status_matches//compared if compared else 0}%)")
+if mismatches:
+    print(f"  Status mismatches     : {mismatches}  ← review these")
+if hit_diffs:
+    print(f"  Hit count differences : {hit_diffs}  ← document counts differ between ES and OS")
+if no_target:
+    print(f"  Not yet replayed      : {no_target}  ← still in replayer buffer")
+if jaccard_scores:
+    avg_j = sum(s for s, _ in jaccard_scores) / len(jaccard_scores)
+    perfect = sum(1 for s, _ in jaccard_scores if s == 1.0)
+    label_example = jaccard_scores[0][1]
+    print(f"  Avg Jaccard similarity: {avg_j:.3f}  (on {label_example}; {perfect}/{len(jaccard_scores)} perfect)")
+    print(f"  Jaccard = 1.0 means ES and OS returned identical result sets")
+    print(f"  Jaccard < 1.0 means the result sets diverge — worth investigating")
+if compared > 0:
+    avg_es = total_es_ms // compared
+    avg_os = total_os_ms // compared
+    print(f"  Avg response time ES  : {avg_es} ms")
+    print(f"  Avg response time OS  : {avg_os} ms")
+    if avg_os > avg_es:
+        print(f"  OS is {avg_os - avg_es} ms slower on average (expected during migration warmup)")
+print()
+PYEOF

--- a/deployment/k8s/chorus_es_to_os_demo/06-live-jaccard.sh
+++ b/deployment/k8s/chorus_es_to_os_demo/06-live-jaccard.sh
@@ -1,0 +1,317 @@
+#!/usr/bin/env bash
+# =============================================================================
+# 06-live-jaccard.sh
+#
+# Live terminal monitor — polls the last N traffic replay tuples from S3
+# and renders a Jaccard sparkline so you can watch result quality in real time.
+#
+# PREREQUISITE: migration-console-0 pod must be running in the ma namespace.
+# =============================================================================
+set -euo pipefail
+
+WINDOW="${WINDOW:-10}"       # tuples to show in the sparkline
+INTERVAL="${INTERVAL:-10}"   # seconds between refreshes
+
+export WINDOW INTERVAL
+export S3_BUCKET="migrations-default-123456789012-dev-us-east-2"
+
+# ── Check prereq ──────────────────────────────────────────────────────────────
+if ! kubectl get pod migration-console-0 -n ma &>/dev/null; then
+  echo "ERROR: migration-console-0 pod not found in namespace 'ma'"
+  exit 1
+fi
+
+trap 'printf "\033[?25h\n"; echo "Stopped."; exit 0' INT TERM
+printf "\033[?25l"   # hide cursor
+
+python3 - << 'PYEOF'
+import subprocess, json, os, sys, time, datetime, textwrap
+
+WINDOW   = int(os.environ.get('WINDOW', '10'))
+INTERVAL = int(os.environ.get('INTERVAL', '10'))
+S3_BUCKET = os.environ.get('S3_BUCKET', 'migrations-default-123456789012-dev-us-east-2')
+S3_PREFIX = 'tuples/'
+SPARK     = '▁▂▃▄▅▆▇█'
+WIDTH     = 70
+
+# ── ANSI helpers ──────────────────────────────────────────────────────────────
+def esc(code): return f'\033[{code}m'
+RESET  = esc(0);  BOLD  = esc(1);  DIM  = esc(2)
+GREEN  = esc(32); YELLOW = esc(33); RED = esc(31); CYAN = esc(36)
+def clr(): print('\033[2J\033[H', end='')
+
+def bar(j):
+    """Single sparkline character for a Jaccard value, or a dim placeholder."""
+    if j is None: return DIM + '░' + RESET
+    idx = min(7, int(j * 8))
+    # colour: red <0.8, yellow <0.95, green >=0.95
+    col = GREEN if j >= 0.95 else (YELLOW if j >= 0.80 else RED)
+    return col + BOLD + SPARK[idx] + RESET
+
+# ── S3 helpers ────────────────────────────────────────────────────────────────
+def s3_ls(*args):
+    cmd = ['kubectl', 'exec', '-n', 'ma', 'migration-console-0', '--',
+           'env', 'AWS_ACCESS_KEY_ID=test', 'AWS_SECRET_ACCESS_KEY=test',
+           'aws', '--endpoint-url', 'http://localstack:4566',
+           '--region', 'us-east-2', 's3', 'ls', *args]
+    r = subprocess.run(cmd, capture_output=True, text=True)
+    return r.stdout
+
+def s3_gunzip(s3_key):
+    """Stream-decompress a gzipped S3 object via migration-console."""
+    cmd = ['kubectl', 'exec', '-n', 'ma', 'migration-console-0', '--',
+           'bash', '-c',
+           f'env AWS_ACCESS_KEY_ID=test AWS_SECRET_ACCESS_KEY=test '
+           f'aws --endpoint-url http://localstack:4566 --region us-east-2 '
+           f"s3 cp 's3://{S3_BUCKET}/{s3_key}' - 2>/dev/null | gunzip"]
+    r = subprocess.run(cmd, capture_output=True)
+    return r.stdout.decode('utf-8', errors='replace')
+
+# ── Jaccard logic (mirrors 05-compare-tuples.sh) ─────────────────────────────
+def jaccard_sets(a, b):
+    if not a and not b: return None
+    return len(a & b) / len(a | b)
+
+def hit_doc_ids(body):
+    hits = body.get('hits', {}).get('hits', [])
+    ids  = {h['_id'] for h in hits if '_id' in h}
+    return ids if ids else None
+
+def weighted_jaccard_aggs(src_aggs, tgt_aggs):
+    scores = []
+    for name in set(src_aggs) | set(tgt_aggs):
+        sa = src_aggs.get(name, {}); ta = tgt_aggs.get(name, {})
+        if not isinstance(sa, dict) or not isinstance(ta, dict): continue
+        sb = sa.get('buckets', []); tb = ta.get('buckets', [])
+        if sb or tb:
+            sc = {b['key']: b.get('doc_count', 0) for b in sb if 'key' in b}
+            tc = {b['key']: b.get('doc_count', 0) for b in tb if 'key' in b}
+            keys = set(sc) | set(tc)
+            if keys:
+                n = sum(min(sc.get(k,0), tc.get(k,0)) for k in keys)
+                d = sum(max(sc.get(k,0), tc.get(k,0)) for k in keys)
+                if d > 0: scores.append(n / d)
+            continue
+        sdc = sa.get('doc_count'); tdc = ta.get('doc_count')
+        if sdc is not None and tdc is not None:
+            mx = max(sdc, tdc)
+            if mx > 0: scores.append(min(sdc, tdc) / mx)
+        for sub, ssub in sa.items():
+            if not isinstance(ssub, dict) or 'value' not in ssub: continue
+            tsub = ta.get(sub, {})
+            if not isinstance(tsub, dict): continue
+            sv, tv = ssub['value'], tsub.get('value')
+            if sv is not None and tv is not None:
+                mx = max(sv, tv)
+                if mx > 0: scores.append(min(sv, tv) / mx)
+    if not scores: return None, None
+    return sum(scores)/len(scores), 'agg'
+
+def compute_jaccard(src_body, tgt_body):
+    si = hit_doc_ids(src_body); ti = hit_doc_ids(tgt_body)
+    if si is not None and ti is not None:
+        j = jaccard_sets(si, ti)
+        return j, 'doc IDs'
+    j, lbl = weighted_jaccard_aggs(
+        src_body.get('aggregations', {}),
+        tgt_body.get('aggregations', {}))
+    if j is not None: return j, lbl
+    sv = (src_body.get('hits', {}).get('total', {}).get('value')
+          or src_body.get('count'))
+    tv = (tgt_body.get('hits', {}).get('total', {}).get('value')
+          or tgt_body.get('count'))
+    if sv is not None and tv is not None:
+        mx = max(sv, tv)
+        return ((min(sv, tv)/mx) if mx > 0 else 1.0), 'hit count ratio'
+    return None, None
+
+def score_msearch(src_body, tgt_body):
+    """Average Jaccard across _msearch sub-responses."""
+    src_subs = src_body.get('responses', [])
+    tgt_subs = tgt_body.get('responses', [])
+    scores = []
+    for sb, tb in zip(src_subs, tgt_subs):
+        if not isinstance(sb, dict) or not isinstance(tb, dict): continue
+        if sb.get('status', 200) >= 400 or tb.get('status', 200) >= 400: continue
+        j, _ = compute_jaccard(sb, tb)
+        if j is not None:
+            scores.append(j)
+    if not scores:
+        return None, None
+    n = len(src_subs)
+    return sum(scores) / len(scores), f'msearch ({n} sub-queries)'
+
+def score_tuple(r):
+    src_resp  = r.get('sourceResponse', {})
+    tgt_resps = r.get('targetResponses', [])
+    method    = r.get('sourceRequest', {}).get('Method', '?')
+    uri       = r.get('sourceRequest', {}).get('Request-URI', '?')
+    src_status = src_resp.get('Status-Code', '?')
+    src_ms     = src_resp.get('response_time_ms', '?')
+    # Skip CORS preflight — no comparable result
+    if method == 'OPTIONS':
+        return dict(method=method, uri=uri, src_status=src_status,
+                    tgt_status=None, src_ms=src_ms, tgt_ms=None,
+                    j=None, j_label='preflight', replayed=False)
+    if not tgt_resps:
+        return dict(method=method, uri=uri, src_status=src_status,
+                    tgt_status=None, src_ms=src_ms, tgt_ms=None,
+                    j=None, j_label=None, replayed=False)
+    tgt = tgt_resps[0]
+    tgt_status = tgt.get('Status-Code', '?')
+    tgt_ms     = tgt.get('response_time_ms', '?')
+    src_body   = src_resp.get('payload', {}).get('inlinedJsonBody', {})
+    tgt_body   = tgt.get('payload', {}).get('inlinedJsonBody', {})
+    # _msearch: body has a top-level "responses" array
+    is_msearch = ('_msearch' in uri or 'responses' in src_body)
+    if is_msearch:
+        j, lbl = score_msearch(src_body, tgt_body)
+        src_hits = sum(
+            (s.get('hits', {}).get('total', {}).get('value') or 0)
+            for s in src_body.get('responses', []) if isinstance(s, dict))
+        tgt_hits = sum(
+            (s.get('hits', {}).get('total', {}).get('value') or 0)
+            for s in tgt_body.get('responses', []) if isinstance(s, dict))
+        src_hits = src_hits or None
+        tgt_hits = tgt_hits or None
+    else:
+        j, lbl = compute_jaccard(src_body, tgt_body)
+        src_hits = src_body.get('hits', {}).get('total', {}).get('value') or src_body.get('count')
+        tgt_hits = tgt_body.get('hits', {}).get('total', {}).get('value') or tgt_body.get('count')
+    return dict(method=method, uri=uri,
+                src_status=src_status, tgt_status=tgt_status,
+                src_ms=src_ms, tgt_ms=tgt_ms,
+                j=j, j_label=lbl,
+                src_hits=src_hits, tgt_hits=tgt_hits,
+                replayed=True)
+
+# ── Fetch recent tuples ───────────────────────────────────────────────────────
+def fetch_recent_tuples(n):
+    # Collect prefixes for ALL replayer pods (pod restarts create new prefixes)
+    replayers = []
+    for line in s3_ls(f's3://{S3_BUCKET}/{S3_PREFIX}').splitlines():
+        part = line.strip().rstrip('/')
+        if part: replayers.append(part.split()[-1])
+    if not replayers: return [], '(no replayer prefix found)'
+
+    all_keys = []
+    for replayer in replayers:
+        for line in s3_ls('--recursive', f's3://{S3_BUCKET}/{S3_PREFIX}{replayer}').splitlines():
+            parts = line.split()
+            if parts and parts[-1].endswith('.log.gz'):
+                all_keys.append(parts[-1])
+    all_keys.sort()
+    if not all_keys: return [], ','.join(replayers)
+
+    # Pull from the last few files until we have enough tuples
+    records = []
+    for key in reversed(all_keys):
+        text = s3_gunzip(key)
+        batch = []
+        for line in text.splitlines():
+            line = line.strip()
+            if not line: continue
+            try: batch.append(json.loads(line))
+            except: pass
+        records = batch + records
+        if len(records) >= n * 3:   # grab extras to ensure enough scoreable ones
+            break
+    return records, replayer
+
+# ── Render ────────────────────────────────────────────────────────────────────
+def render(records):
+    scored    = [score_tuple(r) for r in records]
+    # Separate scoreable from non-scoreable for the sparkline
+    scoreable = [s for s in scored if s['j'] is not None]
+    window    = scoreable[-WINDOW:]  # last N scoreable tuples
+
+    now  = datetime.datetime.now().strftime('%H:%M:%S')
+    hdr  = f'  ⚡  Live Replay Quality Monitor'
+    ts   = f'[{now}]'
+    pad  = WIDTH - len(hdr) - len(ts) - 2
+    print(BOLD + CYAN + '╔' + '═'*(WIDTH-2) + '╗' + RESET)
+    print(BOLD + CYAN + '║' + RESET + hdr + ' '*pad + ts + BOLD + CYAN + '║' + RESET)
+    print(BOLD + CYAN + '╚' + '═'*(WIDTH-2) + '╝' + RESET)
+
+    # Sparkline
+    print()
+    js_vals = [s['j'] for s in window]
+    spark   = ''.join(bar(j) for j in js_vals)
+    blanks  = WINDOW - len(js_vals)
+    placeholder = DIM + '░'*blanks + RESET
+    label   = f'  Jaccard  {placeholder}{spark}'
+    print(label)
+    if js_vals:
+        avg_j = sum(js_vals) / len(js_vals)
+        mn, mx = min(js_vals), max(js_vals)
+        col = GREEN if avg_j >= 0.95 else (YELLOW if avg_j >= 0.80 else RED)
+        print(f'           {"oldest ←" + "─"*(WINDOW-14) + "→ newest":<{WINDOW}}')
+        print(f'  avg {col}{BOLD}{avg_j:.3f}{RESET}   min {mn:.3f}   max {mx:.3f}   '
+              f'({len(window)} of last {len(scored)} tuples scored)')
+    else:
+        print('  No scored tuples yet — waiting for replayer to flush...')
+
+    # Per-tuple table (last WINDOW, excluding OPTIONS preflights)
+    print()
+    print(DIM + '  ' + '─'*(WIDTH-4) + RESET)
+    show = [s for s in scored if s.get('j_label') != 'preflight'][-WINDOW:]
+    for s in show:
+        j      = s['j']
+        method = (s['method'] or '?')[:6]
+        uri    = s['uri'] or '?'
+        if len(uri) > 38: uri = uri[:35] + '...'
+
+        # Jaccard column
+        if j is None:
+            j_col = DIM + '  -   ' + RESET
+        else:
+            col   = GREEN if j >= 0.95 else (YELLOW if j >= 0.80 else RED)
+            j_col = col + BOLD + f'{j:.3f}' + RESET
+
+        # Hit counts (colour: green=match, yellow=close, red=diverged)
+        sh = s.get('src_hits'); th = s.get('tgt_hits')
+        if sh is None and th is None:
+            continue
+        if sh is not None and th is not None:
+            if sh == th:
+                hits_col = GREEN
+            elif max(sh, th) > 0 and min(sh, th) / max(sh, th) >= 0.95:
+                hits_col = YELLOW
+            else:
+                hits_col = RED
+            hits_str = f'  {hits_col}{sh}→{th}{RESET}'
+        else:
+            hits_str = ''
+
+        spark_c = bar(j)
+        print(f'  {spark_c} {j_col}  {BOLD}{method:<6}{RESET}  {uri:<38}{hits_str}')
+
+    print(DIM + '  ' + '─'*(WIDTH-4) + RESET)
+
+    # Footer
+    n_options = sum(1 for s in scored if s.get('j_label') == 'preflight')
+    no_score  = [s for s in scored if s['j'] is None and s.get('j_label') != 'preflight']
+    if n_options:
+        print(f'  {DIM}{n_options}× OPTIONS preflight (skipped){RESET}')
+    if no_score:
+        methods = {}
+        for s in no_score:
+            methods[s['method']] = methods.get(s['method'], 0) + 1
+        breakdown = ', '.join(f"{c}× {m}" for m, c in sorted(methods.items()))
+        print(f'  {DIM}No score: {breakdown} (DELETE/root — no comparable result set){RESET}')
+
+    print()
+    print(f'  {DIM}Refreshing every {INTERVAL}s  ·  Ctrl-C to stop{RESET}')
+
+# ── Main loop ─────────────────────────────────────────────────────────────────
+while True:
+    clr()
+    try:
+        records, _ = fetch_recent_tuples(WINDOW * 3)
+        render(records)
+    except Exception as e:
+        print(f'\033[31mError: {e}\033[0m')
+        import traceback; traceback.print_exc()
+    time.sleep(INTERVAL)
+
+PYEOF

--- a/deployment/k8s/chorus_es_to_os_demo/07-live-jaccard-kafka.sh
+++ b/deployment/k8s/chorus_es_to_os_demo/07-live-jaccard-kafka.sh
@@ -1,0 +1,357 @@
+#!/usr/bin/env bash
+# =============================================================================
+# 07-live-jaccard-kafka.sh
+#
+# Live terminal monitor — consumes from the tuple-output Kafka topic and renders
+# a Jaccard sparkline in real time.  No S3 polling lag — tuples arrive within
+# seconds of being replayed.  Starts from the latest offset each run (not
+# --from-beginning), so restarting the script means "watch from now."
+# Topic retention is capped at 10 minutes so it never grows unbounded.
+#
+# PREREQUISITES:
+#   - migration-console-0 pod running in the ma namespace
+#   - kafka-tools present at /root/kafka-tools/kafka (already on migration-console)
+#   - tuple-output Kafka topic populated by the TrafficReplayer
+# =============================================================================
+set -euo pipefail
+
+WINDOW="${WINDOW:-15}"
+INTERVAL="${INTERVAL:-5}"   # refresh every N seconds even without new data
+
+export WINDOW INTERVAL
+
+# ── Locate the Kafka password ──────────────────────────────────────────────────
+KAFKA_PASS=$(kubectl get secret -n ma default-migration-app \
+  -o jsonpath='{.data.password}' 2>/dev/null | base64 -d)
+if [ -z "$KAFKA_PASS" ]; then
+  echo "ERROR: Could not read Kafka password from secret default-migration-app"
+  exit 1
+fi
+export KAFKA_PASS
+
+# ── Check prereq ──────────────────────────────────────────────────────────────
+if ! kubectl get pod migration-console-0 -n ma &>/dev/null; then
+  echo "ERROR: migration-console-0 pod not found in namespace 'ma'"
+  exit 1
+fi
+
+# ── Write consumer config to migration-console ────────────────────────────────
+kubectl exec -n ma migration-console-0 -- bash -c "
+  mkdir -p /tmp/jaccard-kafka
+  kubectl get secret -n ma default-cluster-ca-cert \
+    -o jsonpath='{.data.ca\\.crt}' 2>/dev/null | base64 -d > /tmp/jaccard-kafka/ca.crt 2>/dev/null || true
+" 2>/dev/null || true
+
+# Fetch the CA cert from the k8s secret and push it to the migration-console
+kubectl get secret -n ma default-cluster-ca-cert \
+  -o jsonpath='{.data.ca\.crt}' | base64 -d | \
+  kubectl exec -i -n ma migration-console-0 -- bash -c 'cat > /tmp/jaccard-kafka/ca.crt'
+
+kubectl exec -n ma migration-console-0 -- bash -c "cat > /tmp/jaccard-kafka/consumer.properties << EOF
+ssl.truststore.type=PEM
+ssl.truststore.location=/tmp/jaccard-kafka/ca.crt
+security.protocol=SASL_SSL
+sasl.mechanism=SCRAM-SHA-512
+sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username=\"default-migration-app\" password=\"${KAFKA_PASS}\";
+EOF"
+
+# ── Check the topic exists ──────────────────────────────────────────────────────
+if ! kubectl exec -n ma migration-console-0 -- \
+  /root/kafka-tools/kafka/bin/kafka-topics.sh \
+  --bootstrap-server default-kafka-bootstrap.ma.svc:9093 \
+  --command-config /tmp/jaccard-kafka/consumer.properties \
+  --list | grep -qx 'tuple-output'; then
+  echo "ERROR: Kafka topic 'tuple-output' does not exist yet."
+  echo "       Run the TrafficReplayer with --tuple-kafka-topic tuple-output first" \
+       "so it can produce at least one tuple (this auto-creates the topic)."
+  exit 1
+fi
+
+# ── Cap topic retention so it never grows unbounded ────────────────────────────
+# Nothing else prunes tuple-output; keep only the last 10 minutes of tuples.
+kubectl exec -n ma migration-console-0 -- \
+  /root/kafka-tools/kafka/bin/kafka-configs.sh \
+  --bootstrap-server default-kafka-bootstrap.ma.svc:9093 \
+  --command-config /tmp/jaccard-kafka/consumer.properties \
+  --alter --entity-type topics --entity-name tuple-output \
+  --add-config retention.ms=600000
+
+trap 'printf "\033[?25h\n"; echo "Stopped."; exit 0' INT TERM
+printf "\033[?25l"   # hide cursor
+
+python3 - << PYEOF
+import subprocess, json, os, sys, time, datetime, threading, collections
+
+WINDOW   = int(os.environ.get('WINDOW', '15'))
+INTERVAL = int(os.environ.get('INTERVAL', '5'))
+SPARK     = '▁▂▃▄▅▆▇█'
+WIDTH     = 72
+
+# ── ANSI helpers ──────────────────────────────────────────────────────────────
+def esc(code): return f'\033[{code}m'
+RESET  = esc(0);  BOLD  = esc(1);  DIM  = esc(2)
+GREEN  = esc(32); YELLOW = esc(33); RED = esc(31); CYAN = esc(36)
+def clr(): print('\033[2J\033[H', end='')
+
+def bar(j):
+    if j is None: return DIM + '░' + RESET
+    idx = min(7, int(j * 8))
+    col = GREEN if j >= 0.95 else (YELLOW if j >= 0.80 else RED)
+    return col + BOLD + SPARK[idx] + RESET
+
+# ── Jaccard logic ─────────────────────────────────────────────────────────────
+def jaccard_sets(a, b):
+    if not a and not b: return None
+    return len(a & b) / len(a | b)
+
+def hit_doc_ids(body):
+    hits = body.get('hits', {}).get('hits', [])
+    ids  = {h['_id'] for h in hits if '_id' in h}
+    return ids if ids else None
+
+def weighted_jaccard_aggs(src_aggs, tgt_aggs):
+    scores = []
+    for name in set(src_aggs) | set(tgt_aggs):
+        sa = src_aggs.get(name, {}); ta = tgt_aggs.get(name, {})
+        if not isinstance(sa, dict) or not isinstance(ta, dict): continue
+        sb = sa.get('buckets', []); tb = ta.get('buckets', [])
+        if sb or tb:
+            sc = {b['key']: b.get('doc_count', 0) for b in sb if 'key' in b}
+            tc = {b['key']: b.get('doc_count', 0) for b in tb if 'key' in b}
+            keys = set(sc) | set(tc)
+            if keys:
+                n = sum(min(sc.get(k,0), tc.get(k,0)) for k in keys)
+                d = sum(max(sc.get(k,0), tc.get(k,0)) for k in keys)
+                if d > 0: scores.append(n / d)
+            continue
+        sdc = sa.get('doc_count'); tdc = ta.get('doc_count')
+        if sdc is not None and tdc is not None:
+            mx = max(sdc, tdc)
+            if mx > 0: scores.append(min(sdc, tdc) / mx)
+        for sub, ssub in sa.items():
+            if not isinstance(ssub, dict) or 'value' not in ssub: continue
+            tsub = ta.get(sub, {})
+            if not isinstance(tsub, dict): continue
+            sv, tv = ssub['value'], tsub.get('value')
+            if sv is not None and tv is not None:
+                mx = max(sv, tv)
+                if mx > 0: scores.append(min(sv, tv) / mx)
+    if not scores: return None, None
+    return sum(scores)/len(scores), 'agg'
+
+def compute_jaccard(src_body, tgt_body):
+    si = hit_doc_ids(src_body); ti = hit_doc_ids(tgt_body)
+    if si is not None and ti is not None:
+        j = jaccard_sets(si, ti)
+        return j, 'doc IDs'
+    j, lbl = weighted_jaccard_aggs(
+        src_body.get('aggregations', {}),
+        tgt_body.get('aggregations', {}))
+    if j is not None: return j, lbl
+    sv = (src_body.get('hits', {}).get('total', {}).get('value')
+          or src_body.get('count'))
+    tv = (tgt_body.get('hits', {}).get('total', {}).get('value')
+          or tgt_body.get('count'))
+    if sv is not None and tv is not None:
+        mx = max(sv, tv)
+        return ((min(sv, tv)/mx) if mx > 0 else 1.0), 'hit count ratio'
+    return None, None
+
+def score_msearch(src_body, tgt_body):
+    src_subs = src_body.get('responses', [])
+    tgt_subs = tgt_body.get('responses', [])
+    scores = []
+    for sb, tb in zip(src_subs, tgt_subs):
+        if not isinstance(sb, dict) or not isinstance(tb, dict): continue
+        if sb.get('status', 200) >= 400 or tb.get('status', 200) >= 400: continue
+        j, _ = compute_jaccard(sb, tb)
+        if j is not None:
+            scores.append(j)
+    if not scores:
+        return None, None
+    n = len(src_subs)
+    return sum(scores) / len(scores), f'msearch ({n} sub-queries)'
+
+def score_tuple(r):
+    src_resp  = r.get('sourceResponse', {})
+    tgt_resps = r.get('targetResponses', [])
+    method    = r.get('sourceRequest', {}).get('Method', '?')
+    uri       = r.get('sourceRequest', {}).get('Request-URI', '?')
+    src_status = src_resp.get('Status-Code', '?')
+    if method == 'OPTIONS':
+        return dict(method=method, uri=uri, src_status=src_status,
+                    tgt_status=None, j=None, j_label='preflight',
+                    src_hits=None, tgt_hits=None, replayed=False)
+    if not tgt_resps:
+        return dict(method=method, uri=uri, src_status=src_status,
+                    tgt_status=None, j=None, j_label=None,
+                    src_hits=None, tgt_hits=None, replayed=False)
+    tgt = tgt_resps[0]
+    tgt_status = tgt.get('Status-Code', '?')
+    src_body   = src_resp.get('payload', {}).get('inlinedJsonBody', {})
+    tgt_body   = tgt.get('payload', {}).get('inlinedJsonBody', {})
+    is_msearch = ('_msearch' in uri or 'responses' in src_body)
+    if is_msearch:
+        j, lbl = score_msearch(src_body, tgt_body)
+        src_hits = sum(
+            (s.get('hits', {}).get('total', {}).get('value') or 0)
+            for s in src_body.get('responses', []) if isinstance(s, dict)) or None
+        tgt_hits = sum(
+            (s.get('hits', {}).get('total', {}).get('value') or 0)
+            for s in tgt_body.get('responses', []) if isinstance(s, dict)) or None
+    else:
+        j, lbl = compute_jaccard(src_body, tgt_body)
+        src_hits = src_body.get('hits', {}).get('total', {}).get('value') or src_body.get('count')
+        tgt_hits = tgt_body.get('hits', {}).get('total', {}).get('value') or tgt_body.get('count')
+    return dict(method=method, uri=uri,
+                src_status=src_status, tgt_status=tgt_status,
+                j=j, j_label=lbl,
+                src_hits=src_hits, tgt_hits=tgt_hits,
+                replayed=True)
+
+# ── Kafka consumer thread ──────────────────────────────────────────────────────
+# We run kafka-console-consumer.sh in a subprocess and stream lines from it.
+# A shared deque holds the last N*3 scored tuples for rendering.
+
+scored_buf = collections.deque(maxlen=WINDOW * 6)
+# 'connected' flips once the consumer subprocess is launched (the topic itself was already
+# confirmed to exist and be reachable in bash, above) — it does NOT wait for the first tuple.
+# That keeps "still setting up" and "set up, but nothing's arrived yet" as distinct states
+# instead of blending them into one "connecting…" message.
+kafka_status = {'lag': 0, 'total': 0, 'errors': 0, 'running': True, 'connected': False}
+buf_lock = threading.Lock()
+
+def kafka_reader():
+    cmd = [
+        'kubectl', 'exec', '-n', 'ma', 'migration-console-0', '--',
+        '/root/kafka-tools/kafka/bin/kafka-console-consumer.sh',
+        '--bootstrap-server', 'default-kafka-bootstrap.ma.svc:9093',
+        '--topic', 'tuple-output',
+        '--consumer.config', '/tmp/jaccard-kafka/consumer.properties',
+        '--timeout-ms', '3600000',  # keep alive for 1 hour
+    ]
+    proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL,
+                            bufsize=1, text=True)
+    kafka_status['connected'] = True
+    try:
+        for line in proc.stdout:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                r = json.loads(line)
+            except Exception:
+                kafka_status['errors'] += 1
+                continue
+            s = score_tuple(r)
+            with buf_lock:
+                scored_buf.append(s)
+                kafka_status['total'] += 1
+    finally:
+        proc.terminate()
+        kafka_status['running'] = False
+
+t = threading.Thread(target=kafka_reader, daemon=True)
+t.start()
+
+# ── Render ────────────────────────────────────────────────────────────────────
+def render():
+    with buf_lock:
+        buf = list(scored_buf)
+
+    scored    = buf
+    scoreable = [s for s in scored if s['j'] is not None]
+    window    = scoreable[-WINDOW:]
+
+    now  = datetime.datetime.now().strftime('%H:%M:%S')
+    hdr  = f'  ⚡  Live Replay Quality Monitor (Kafka)'
+    ts   = f'[{now}]'
+    pad  = WIDTH - len(hdr) - len(ts) - 2
+    print(BOLD + CYAN + '╔' + '═'*(WIDTH-2) + '╗' + RESET)
+    print(BOLD + CYAN + '║' + RESET + hdr + ' '*max(0,pad) + ts + BOLD + CYAN + '║' + RESET)
+    print(BOLD + CYAN + '╚' + '═'*(WIDTH-2) + '╝' + RESET)
+
+    print()
+    js_vals = [s['j'] for s in window]
+    spark   = ''.join(bar(j) for j in js_vals)
+    blanks  = WINDOW - len(js_vals)
+    placeholder = DIM + '░'*blanks + RESET
+    label   = f'  Jaccard  {placeholder}{spark}'
+    print(label)
+    if js_vals:
+        avg_j = sum(js_vals) / len(js_vals)
+        mn, mx = min(js_vals), max(js_vals)
+        col = GREEN if avg_j >= 0.95 else (YELLOW if avg_j >= 0.80 else RED)
+        print(f'           {"oldest ←" + "─"*(WINDOW-14) + "→ newest":<{WINDOW}}')
+        print(f'  avg {col}{BOLD}{avg_j:.3f}{RESET}   min {mn:.3f}   max {mx:.3f}   '
+              f'({len(window)} of {kafka_status["total"]} tuples seen)')
+    elif not kafka_status['connected']:
+        print('  Confirming topic tuple-output exists and is reachable…')
+    else:
+        note = '' if kafka_status['running'] else '  (consumer disconnected)'
+        print(f'  0 tuples seen yet — waiting for live traffic on \'tuple-output\'{note}')
+
+    # Per-tuple table
+    print()
+    print(DIM + '  ' + '─'*(WIDTH-4) + RESET)
+    show = [s for s in scored if s.get('j_label') != 'preflight'][-WINDOW:]
+    for s in show:
+        j      = s['j']
+        sh     = s.get('src_hits')
+        th     = s.get('tgt_hits')
+        if sh is None and th is None:
+            continue
+        method = (s['method'] or '?')[:6]
+        uri    = s['uri'] or '?'
+        if len(uri) > 36: uri = uri[:33] + '...'
+
+        if j is None:
+            j_col = DIM + '  -   ' + RESET
+        else:
+            col   = GREEN if j >= 0.95 else (YELLOW if j >= 0.80 else RED)
+            j_col = col + BOLD + f'{j:.3f}' + RESET
+
+        if sh is not None and th is not None:
+            if sh == th:
+                hcol = GREEN
+            elif max(sh, th) > 0 and min(sh, th) / max(sh, th) >= 0.95:
+                hcol = YELLOW
+            else:
+                hcol = RED
+            hits_str = f'  {hcol}{sh}→{th}{RESET}'
+        else:
+            hits_str = ''
+
+        print(f'  {bar(j)} {j_col}  {BOLD}{method:<6}{RESET}  {uri:<36}{hits_str}')
+
+    print(DIM + '  ' + '─'*(WIDTH-4) + RESET)
+
+    n_options = sum(1 for s in scored if s.get('j_label') == 'preflight')
+    no_score  = [s for s in scored if s['j'] is None and s.get('j_label') != 'preflight']
+    if n_options:
+        print(f'  {DIM}{n_options}× OPTIONS preflight (skipped){RESET}')
+    if no_score:
+        methods = {}
+        for s in no_score:
+            methods[s['method']] = methods.get(s['method'], 0) + 1
+        breakdown = ', '.join(f"{c}× {m}" for m, c in sorted(methods.items()))
+        print(f'  {DIM}No score: {breakdown}{RESET}')
+
+    print()
+    print(f'  {DIM}Kafka: tuple-output · {kafka_status["total"]} tuples · refreshing every {INTERVAL}s · Ctrl-C to stop{RESET}')
+
+# ── Main loop ─────────────────────────────────────────────────────────────────
+import sys
+sys.stdout.flush()  # ensure initial output not buffered
+
+while True:
+    clr()
+    try:
+        render()
+    except Exception as e:
+        print(f'\033[31mError: {e}\033[0m')
+        import traceback; traceback.print_exc()
+    sys.stdout.flush()
+    time.sleep(INTERVAL)
+
+PYEOF

--- a/deployment/k8s/chorus_es_to_os_demo/08-live-replay-quality.sh
+++ b/deployment/k8s/chorus_es_to_os_demo/08-live-replay-quality.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# =============================================================================
+# 08-live-replay-quality.sh
+#
+# Serves the TUI (deployment/k8s/tui) as a web page instead of a terminal app, via
+# textual-serve — same live replay-quality monitor (per-sub-query Jaccard/RBO scoring,
+# hit-level diffs, the by-type breakdown view), just viewable in a browser instead of
+# needing a terminal + kubeconfig on the viewer's own machine.
+#
+# NOTE: the TUI's 'c' (copy request) keybinding copies to the clipboard of whatever
+# machine runs THIS script, not the browser viewer's machine — fine if they're the same
+# machine, a real gotcha if someone else opens the URL from their own.
+#
+# Exposing this through a tunnel (ngrok, etc.)? Set PUBLIC_URL to the tunnel's https URL:
+#   ngrok http 8321                                   # note the https://...ngrok-free.app URL it prints
+#   PUBLIC_URL=https://abc123.ngrok-free.app bash 08-live-replay-quality.sh
+# textual-serve hardcodes the page's websocket/static URLs from this — without it, a
+# remote browser gets told to connect to YOUR localhost, which resolves to their own
+# machine and silently fails. See tui/serve_web.py for why.
+#
+# PREREQUISITES:
+#   - Same as the TUI itself (../tui/README.md) — a working kubeconfig for the `ma`
+#     namespace, tuple-output topic populated by the TrafficReplayer.
+# =============================================================================
+set -euo pipefail
+
+WEB_HOST="${WEB_HOST:-localhost}"
+WEB_PORT="${WEB_PORT:-8321}"
+NAMESPACE="${NAMESPACE:-ma}"
+PUBLIC_URL="${PUBLIC_URL:-}"
+export WEB_HOST WEB_PORT NAMESPACE PUBLIC_URL
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+K8S_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+pip install -q -r "${K8S_DIR}/tui/requirements.txt"
+
+echo "Serving live replay-quality monitor at http://${WEB_HOST}:${WEB_PORT}"
+if [ -n "${PUBLIC_URL}" ]; then
+  echo "Public URL: ${PUBLIC_URL} (make sure your tunnel is already pointed at port ${WEB_PORT})"
+fi
+# textual-serve spawns 'python3 -m tui ...' inheriting THIS process's cwd (no cwd param
+# of its own) — must run from deployment/k8s, the parent of the tui/ package, or the
+# subprocess fails with "No module named tui".
+cd "${K8S_DIR}"
+python3 tui/serve_web.py

--- a/deployment/k8s/chorus_es_to_os_demo/README.md
+++ b/deployment/k8s/chorus_es_to_os_demo/README.md
@@ -2,28 +2,35 @@
 
 Full end-to-end migration from a local Elasticsearch 8.5 instance to a remote OpenSearch 3.7
 cluster, using the Migration Assistant's Traffic Capture/Replay (CDC) approach, with a live
-replay-quality dashboard.
+replay-quality dashboard. Takes about 20-30 minutes end-to-end, most of it Step 3's workflow.
 
 **Source**: `localhost:9200` — Elasticsearch 8.5.3 (Docker), `elastic:ElasticRocks`
 **Target**: `https://chorus-opensearch-edition.dev.o19s.com:9200` — OpenSearch 3.7.0, `admin:MyStr0ng!P@ssw0rd2024`
 **Index**: `ecommerce`
 
+First time through? Skim [Known Gotchas](#known-gotchas) before you start — several of them
+(especially the Docker/Mac sleep-wake DNS issue) are common enough on a fresh run that it's
+worth recognizing them on sight rather than debugging from scratch.
+
 ---
 
 ## Prerequisites
+
+Also needed on your machine: `docker`, `kind`, `kubectl`, `python3` + `pip` (used by the
+patch command below and the TUI).
 
 1. **kind cluster** running — start it with:
    ```bash
    cd deployment/k8s
    ./kindTesting.sh
    ```
-   This creates a 3-node kind cluster named `ma`, builds all images from the current source
-   (Kafka tuple sink support and reliable response capture are both mainline now — no custom
-   image needed), and installs Argo Workflows, LocalStack S3, Strimzi Kafka, and the
-   Migration Assistant components.
+   This creates a 3-node kind cluster named `ma`, builds all images from the current source,
+   and installs Argo Workflows, LocalStack S3, Strimzi Kafka, and the Migration Assistant
+   components.
 
-2. **Elasticsearch** running locally on Docker, port 9200 — the Chorus Elasticsearch edition
-   from https://github.com/querqy/chorus-elasticsearch-edition.
+2. **Elasticsearch** running locally on Docker, port 9200, Web UI proxies to ES via port 9201 — the Chorus Elasticsearch edition
+   from https://github.com/querqy/chorus-elasticsearch-edition. Clone it, then from inside
+   that repo:
    ```bash
    ./quickstart.sh --es-proxy https://localhost:9201
    ``` 
@@ -98,11 +105,20 @@ bash 03-monitor.sh
 kubectl exec -n ma migration-console-0 -- /bin/bash -lc 'workflow status'
 ```
 
-### Step 4 — Tune the TrafficReplayer for the live dashboard
+### Step 4 — Set up  `tuple-output` Kafka Topic
 
-The Argo workflow deploys the TrafficReplayer with sane defaults, but `tupleKafkaTopic` and a
-few timing settings aren't in the `TrafficReplay` CRD, so they need a direct patch once the
-`capture-proxy-target1-replay1` deployment exists:
+The TrafficReplayer CLI supports `--tuple-kafka-topic`, but nothing in the orchestration
+layer (the `TrafficReplay` CRD schema, the workflow template) threads it through yet, so
+`tupleKafkaTopic` still needs a direct patch once the `capture-proxy-target1-replay1`
+deployment exists.
+
+You don't need to wait for the full workflow — this deployment shows up well before the
+15-20 minutes are done. Wait for it first:
+```bash
+kubectl get deployment -n ma capture-proxy-target1-replay1 -w
+# Ctrl-C once it appears
+```
+Then patch it:
 
 ```bash
 kubectl patch deployment -n ma capture-proxy-target1-replay1 --type=json -p='[
@@ -112,31 +128,22 @@ kubectl patch deployment -n ma capture-proxy-target1-replay1 --type=json -p='[
       | base64 -d | python3 -c '
 import json, sys, base64
 cfg = json.load(sys.stdin)
-cfg.update({
-    "tupleKafkaTopic": "tuple-output",
-    "speedupFactor": 100,
-    "observedPacketConnectionTimeout": 5,
-    "quiescentPeriodMs": 1000,
-    "tupleMaxBufferSeconds": 10,
-})
+cfg.update({"tupleKafkaTopic": "tuple-output"})
 print(base64.b64encode(json.dumps(cfg, indent=2).encode()).decode())
 '
   )"'"}
 ]'
 ```
-This decodes the deployment's current base64 JSON config, adds the dashboard settings, and
-patches it back in one step. Re-apply after any Argo re-run — the workflow resets the
-Deployment to its own defaults each time (no operator reconciles it directly).
-
-`speedupFactor: 100` matters even for a live demo: without it, the replayer paces replay to
-match real elapsed time between captured requests, so any gap in traffic (e.g. between
-searches) stalls replay for that same real-world duration.
+This decodes the deployment's current base64 JSON config, adds `tupleKafkaTopic`, and patches
+it back in one step. Re-apply after any Argo re-run — the workflow resets the Deployment to
+its own defaults each time (no operator reconciles it directly).
 
 ### Step 5 — Create the `tuple-output` Kafka topic
 
 This Strimzi cluster doesn't auto-create topics on first produce, so create it once, up front
 — the TUI does this automatically now too, but it's worth doing explicitly if you're not
-starting there:
+starting there. Unlike Step 4, this can be applied any time after Step 3 — the Strimzi topic
+operator picks it up as soon as the Kafka cluster is ready, no need to wait or check first:
 
 ```bash
 cat <<'EOF' | kubectl apply -f -

--- a/deployment/k8s/chorus_es_to_os_demo/README.md
+++ b/deployment/k8s/chorus_es_to_os_demo/README.md
@@ -23,8 +23,10 @@ replay-quality dashboard.
    Migration Assistant components.
 
 2. **Elasticsearch** running locally on Docker, port 9200 — the Chorus Elasticsearch edition
-   (`docker compose up elasticsearch` from https://github.com/querqy/chorus-elasticsearch-edition,
-   the no-vector version).
+   from https://github.com/querqy/chorus-elasticsearch-edition.
+   ```bash
+   ./quickstart.sh --es-proxy https://localhost:9201
+   ``` 
 
 3. **kubectl context** pointing to the kind cluster:
    ```bash

--- a/deployment/k8s/chorus_es_to_os_demo/README.md
+++ b/deployment/k8s/chorus_es_to_os_demo/README.md
@@ -1,0 +1,272 @@
+# Eric's CDC Migration Demo
+
+Full end-to-end migration from a local Elasticsearch 8.5 instance to a remote OpenSearch 3.7
+cluster, using the Migration Assistant's Traffic Capture/Replay (CDC) approach, with a live
+replay-quality dashboard.
+
+**Source**: `localhost:9200` — Elasticsearch 8.5.3 (Docker), `elastic:ElasticRocks`
+**Target**: `https://chorus-opensearch-edition.dev.o19s.com:9200` — OpenSearch 3.7.0, `admin:MyStr0ng!P@ssw0rd2024`
+**Index**: `ecommerce`
+
+---
+
+## Prerequisites
+
+1. **kind cluster** running — start it with:
+   ```bash
+   cd deployment/k8s
+   ./kindTesting.sh
+   ```
+   This creates a 3-node kind cluster named `ma`, builds all images from the current source
+   (Kafka tuple sink support and reliable response capture are both mainline now — no custom
+   image needed), and installs Argo Workflows, LocalStack S3, Strimzi Kafka, and the
+   Migration Assistant components.
+
+2. **Elasticsearch** running locally on Docker, port 9200 — the Chorus Elasticsearch edition
+   (`docker compose up elasticsearch` from https://github.com/querqy/chorus-elasticsearch-edition,
+   the no-vector version).
+
+3. **kubectl context** pointing to the kind cluster:
+   ```bash
+   kubectl config use-context kind-ma
+   ```
+
+4. **OpenSearch** with no existing `ecommerce` index:
+   ```bash
+   curl -X DELETE "https://chorus-opensearch-edition.dev.o19s.com:9200/ecommerce" \
+     -u 'admin:MyStr0ng!P@ssw0rd2024' -k
+   ```
+
+---
+
+## Architecture
+
+```
+curl/browser → CaptureProxy (kind, port-forwarded to localhost:9201)
+                   ├─→ Source ES (host.docker.internal:9200)    [traffic proxied]
+                   └─→ Kafka (Strimzi, in-cluster)               [traffic captured]
+                                └─→ TrafficReplayer → Target OpenSearch
+                                                    └─→ tuple-output Kafka topic (live scoring)
+
+In parallel:
+   S3 Snapshot (LocalStack) → RFS Workers → Target OpenSearch  [historical docs]
+```
+
+The CaptureProxy listens on port 9201 (HTTPS, self-signed cert — use `-k`/`-sk` with curl),
+forwards every request to the real ES, and writes a copy of each request+response to Kafka.
+TrafficReplayer reads that captured stream, replays it to the target, and — alongside the
+normal S3 tuple archive — writes each request/response comparison to a `tuple-output` Kafka
+topic for the live dashboard (see [Live Monitoring](#live-monitoring) below).
+
+---
+
+## Step-by-Step Setup
+
+### Step 1 — Take an ES snapshot into LocalStack S3
+
+```bash
+bash 01-setup-es-snapshot.sh
+```
+One-time setup: connects the ES Docker container to the kind network so it can reach
+LocalStack, installs S3 credentials into the ES keystore, and snapshots `ecommerce` to
+`migrations_repo`. Safe to re-run — re-run it whenever the ES container or kind cluster
+restarts (both wipe this state).
+
+### Step 2 — Create Kubernetes secrets
+
+```bash
+bash 02-setup-k8s-secrets.sh
+```
+Creates `source-es-creds` and `target-os-creds`, both labeled `use-case=http-basic-credentials`
+— required for the migration console's `workflow configure edit` to find them.
+
+### Step 3 — Submit the CDC migration workflow
+
+```bash
+kubectl apply -f cdc-ecommerce-workflow.yaml
+```
+Submits `cdc-ecommerce-migration`, which configures and runs the inner `migration-workflow`:
+Kafka cluster, CaptureProxy, metadata migration, RFS document backfill, and the
+TrafficReplayer — in parallel. Takes ~15-20 minutes end to end.
+
+Monitor with:
+```bash
+bash 03-monitor.sh
+# or watch the inner workflow directly:
+kubectl exec -n ma migration-console-0 -- /bin/bash -lc 'workflow status'
+```
+
+### Step 4 — Tune the TrafficReplayer for the live dashboard
+
+The Argo workflow deploys the TrafficReplayer with sane defaults, but `tupleKafkaTopic` and a
+few timing settings aren't in the `TrafficReplay` CRD, so they need a direct patch once the
+`capture-proxy-target1-replay1` deployment exists:
+
+```bash
+kubectl patch deployment -n ma capture-proxy-target1-replay1 --type=json -p='[
+  {"op":"replace","path":"/spec/template/spec/containers/0/args/1","value":"'"$(
+    kubectl get deployment -n ma capture-proxy-target1-replay1 \
+      -o jsonpath='{.spec.template.spec.containers[0].args[1]}' \
+      | base64 -d | python3 -c '
+import json, sys, base64
+cfg = json.load(sys.stdin)
+cfg.update({
+    "tupleKafkaTopic": "tuple-output",
+    "speedupFactor": 100,
+    "observedPacketConnectionTimeout": 5,
+    "quiescentPeriodMs": 1000,
+    "tupleMaxBufferSeconds": 10,
+})
+print(base64.b64encode(json.dumps(cfg, indent=2).encode()).decode())
+'
+  )"'"}
+]'
+```
+This decodes the deployment's current base64 JSON config, adds the dashboard settings, and
+patches it back in one step. Re-apply after any Argo re-run — the workflow resets the
+Deployment to its own defaults each time (no operator reconciles it directly).
+
+`speedupFactor: 100` matters even for a live demo: without it, the replayer paces replay to
+match real elapsed time between captured requests, so any gap in traffic (e.g. between
+searches) stalls replay for that same real-world duration.
+
+### Step 5 — Create the `tuple-output` Kafka topic
+
+This Strimzi cluster doesn't auto-create topics on first produce, so create it once, up front
+— the TUI does this automatically now too, but it's worth doing explicitly if you're not
+starting there:
+
+```bash
+cat <<'EOF' | kubectl apply -f -
+apiVersion: kafka.strimzi.io/v1
+kind: KafkaTopic
+metadata:
+  name: tuple-output
+  namespace: ma
+  labels:
+    strimzi.io/cluster: default
+spec:
+  partitions: 1
+  replicas: 3
+  config:
+    retention.ms: 600000
+    segment.bytes: 1073741824
+EOF
+```
+
+### Step 6 — Port-forward the CaptureProxy
+
+In a **separate terminal** (this dies whenever the `capture-proxy` pods restart — see
+[Known Gotchas](#known-gotchas)):
+```bash
+kubectl port-forward -n ma svc/capture-proxy 9201:9201
+```
+All traffic you want captured must go to **port 9201**, not 9200. It's HTTPS with a
+self-signed cert — use `https://localhost:9201` and `-sk` with curl.
+
+---
+
+## Live Monitoring
+
+**`deployment/k8s/tui`** is the primary tool — a Textual TUI that consumes `tuple-output` and
+shows each replayed request (and, for `_msearch`, each of its sub-queries and aggregations)
+scored independently for source/target agreement, with a detail pane for hit-level diffs and
+raw request copy/paste. See `../tui/README.md` for setup and usage.
+
+```bash
+cd deployment/k8s
+pip install -r tui/requirements.txt
+python3 -m tui --namespace ma
+```
+
+Older, simpler alternatives, kept for when a full TUI isn't wanted:
+- `bash 06-live-jaccard.sh` — polls S3 tuples (~10s lag)
+- `bash 07-live-jaccard-kafka.sh` — reads Kafka directly (near real-time, single blended score
+  per request — the TUI's per-sub-query breakdown supersedes this)
+
+### Scripted request/replay demo
+
+```bash
+bash 04-cdc-demo.sh
+```
+Sends search/aggregate/delete requests through the CaptureProxy and directly to ES, confirming
+the delete propagates to the target — a quick way to see the whole pipeline work without the
+UI.
+
+### Manual testing
+
+```bash
+# Pick a doc ID
+curl -s -u elastic:ElasticRocks "http://localhost:9200/ecommerce/_search?size=1&_source=false" \
+  | python3 -c "import sys,json; print(json.load(sys.stdin)['hits']['hits'][0]['_id'])"
+
+# DELETE via proxy (captured + replayed)
+curl -sk -u elastic:ElasticRocks -X DELETE "https://localhost:9201/ecommerce/_doc/<ID>"
+
+# Confirm it disappeared on target after ~30s
+curl -sk -u admin:'MyStr0ng!P@ssw0rd2024' \
+  "https://chorus-opensearch-edition.dev.o19s.com:9200/ecommerce/_doc/<ID>?_source=false"
+```
+
+### Target doc count
+```bash
+curl -sk -u admin:'MyStr0ng!P@ssw0rd2024' \
+  "https://chorus-opensearch-edition.dev.o19s.com:9200/ecommerce/_count"
+```
+
+---
+
+## Cleanup / Reset
+
+```bash
+kubectl delete workflow cdc-ecommerce-migration -n ma
+kubectl delete workflow migration-workflow -n ma 2>/dev/null || true
+kubectl delete capturedtraffic,captureproxy,trafficreplay,snapshotmigration,kafkacluster \
+  -n ma --all 2>/dev/null || true
+kubectl exec -n ma migration-console-0 -- /bin/bash -lc 'workflow reset --all 2>&1' || true
+```
+Then re-submit from Step 3. Steps 1 and 2 only need re-running if:
+- The kind cluster was recreated (re-run both)
+- The ES Docker container was restarted (re-run Step 1 only — keystore is lost on restart)
+- The `docker-registry` container was restarted (see below — run the DNS fix first)
+
+### After a Docker restart or Mac sleep/wake
+
+Kind nodes lose their `/etc/hosts` entry for `docker-registry` when the daemon restarts. If
+`migration-console-0` gets stuck in `Init:ErrImagePull`:
+```bash
+for node in ma-control-plane ma-worker ma-worker2; do
+  GW=$(docker exec "$node" sh -c "ip route show default | awk '/default/ {print \$3}'")
+  docker exec "$node" sh -c "echo '${GW} docker-registry' >> /etc/hosts"
+done
+kubectl delete pod migration-console-0 -n ma
+kubectl wait pod/migration-console-0 -n ma --for=condition=Ready --timeout=120s
+```
+
+LocalStack's S3 data is ephemeral too — if it restarted, recreate the bucket, then re-run
+`01-setup-es-snapshot.sh`:
+```bash
+kubectl exec -n ma migration-console-0 -- \
+  env AWS_ACCESS_KEY_ID=test AWS_SECRET_ACCESS_KEY=test \
+  aws --endpoint-url http://localstack:4566 --region us-east-2 \
+  s3 mb s3://migrations-default-123456789012-dev-us-east-2
+```
+
+---
+
+## Known Gotchas
+
+| Issue | Cause | Fix |
+|-------|-------|-----|
+| `kubectl port-forward` to `capture-proxy` dies | It binds to one specific pod when started and never reconnects — any restart of that pod (rollout, OOM, reschedule) kills it | Just restart it; or wrap it in `while true; do kubectl port-forward -n ma svc/capture-proxy 9201:9201; sleep 1; done` |
+| TUI/`07-live-jaccard-kafka.sh` says "consumer.properties not found" | `migration-console-0` restarted (commonly an OOM kill after heavy `kubectl exec` use) and its `/tmp` was wiped | Re-run the TUI (it regenerates its own config) or `01-setup-es-snapshot.sh` isn't related — just retry; the config gets rebuilt automatically |
+| `_msearch` shows `unknown query [querqy]` (400) from target | Source ES (Chorus/Querqy edition) supports a `querqy` query clause that has no equivalent plugin on target OpenSearch | Expected, real migration finding — not a bug in this pipeline. Chorus's relevance-tuned "results" sub-query depends on Querqy specifically |
+| A subquery shows "no source data" instead of a score | Source or target response was never captured for that request (e.g. the browser aborted an in-flight search before it resolved) | Expected on live browser traffic sometimes; not a scoring bug — see `TrafficCapture/nettyWireLogging` if it becomes frequent, that path is what makes response capture reliable |
+| `configureAndSubmitWorkflow` RBAC error | Wrong service account | Workflow uses `argo-test-workflow-executor` (already correct in the YAML) |
+| Secrets reported "missing" by workflow CLI | Missing `use-case=http-basic-credentials` label | Run `02-setup-k8s-secrets.sh` |
+| Metadata fails: "Cannot find snapshot repository root" | Workflow appends UID prefix to S3 path | The `snapshotRepo.repoPathUri` override in `source-configs` fixes this |
+| RFS bulk timeout (`ReadTimeoutException`) | Remote target slow on large bulks | `documentsPerBulkRequest: 200` in the workflow YAML |
+| CaptureProxy SSL error on curl | Sent `http://` to a TLS proxy | Use `https://localhost:9201 -sk` |
+| ES can't reach LocalStack | ES container not on kind network | Run `01-setup-es-snapshot.sh` (runs `docker network connect kind`) |
+| `migration-console-0` stuck in `Init:ErrImagePull` | `docker-registry` DNS lost after a Docker/Mac restart | See [Cleanup / Reset](#after-a-docker-restart-or-mac-sleepwake) |
+| S3 bucket missing after LocalStack restart | LocalStack data is ephemeral | Recreate the bucket (see above), then re-run `01-setup-es-snapshot.sh` |

--- a/deployment/k8s/chorus_es_to_os_demo/README.md
+++ b/deployment/k8s/chorus_es_to_os_demo/README.md
@@ -188,6 +188,16 @@ pip install -r tui/requirements.txt
 python3 -m tui --namespace ma
 ```
 
+Want it in a browser instead of a terminal — e.g. to share the view with someone without
+handing them a kubeconfig? Same TUI, served over HTTP via `textual-serve`:
+```bash
+bash 08-live-replay-quality.sh
+# open http://localhost:8321
+```
+The `c` (copy request) keybinding copies to the clipboard of whatever machine runs this
+script, not the browser viewer's — fine if that's the same machine, a gotcha if someone
+else opens the URL from their own.
+
 Older, simpler alternatives, kept for when a full TUI isn't wanted:
 - `bash 06-live-jaccard.sh` — polls S3 tuples (~10s lag)
 - `bash 07-live-jaccard-kafka.sh` — reads Kafka directly (near real-time, single blended score

--- a/deployment/k8s/chorus_es_to_os_demo/cdc-ecommerce-workflow.yaml
+++ b/deployment/k8s/chorus_es_to_os_demo/cdc-ecommerce-workflow.yaml
@@ -1,0 +1,46 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  name: cdc-ecommerce-migration
+  namespace: ma
+spec:
+  workflowTemplateRef:
+    name: cdc-full-e2e-imported-clusters
+  entrypoint: main
+  # argo-test-workflow-executor has pods/exec permission (via workflow-test-console-role)
+  # which is required for the configureAndSubmitWorkflow step that kubectl exec's into
+  # migration-console-0. argo-workflow-executor lacks this permission.
+  serviceAccountName: argo-test-workflow-executor
+  arguments:
+    parameters:
+      # source-configs: snapshotRepo.repoPathUri overrides the auto-generated
+      # S3 path suffix so RFS reads from the bucket root where the snapshot lives.
+      # documentBackfillConfig.documentsPerBulkRequest=200 avoids bulk timeouts
+      # on the remote chorus-opensearch-edition target.
+      - name: source-configs
+        value: >-
+          [{"source":{"endpoint":"http://host.docker.internal:9200","version":"ES_8.5","allow_insecure":true,"basic_auth":{"k8s_secret_name":"source-es-creds"},"snapshotRepo":{"repoPathUri":"s3://migrations-default-123456789012-dev-us-east-2"}},"snapshot-and-migration-configs":[{"snapshotConfig":{"snapshotLabel":"ecommerce_snapshot","snapshotNameConfig":{"externallyManagedSnapshotName":"ecommerce_snapshot"}},"migrations":[{"metadataMigrationConfig":{"allowLooseVersionMatching":true},"documentBackfillConfig":{"documentsPerBulkRequest":200}}]}]}]
+      - name: target-config
+        value: >-
+          {"endpoint":"https://chorus-opensearch-edition.dev.o19s.com:9200","allow_insecure":true,"basic_auth":{"k8s_secret_name":"target-os-creds"}}
+      - name: snapshot-configmap
+        value: "migrations-default-s3-config"
+      - name: migration-image-configmap
+        value: "migration-image-config"
+      # ClusterIP: no cloud load balancer in kind — use port-forward to reach proxy
+      - name: capture-proxy-service-type
+        value: "ClusterIP"
+      # speedup-factor=1: replay captured traffic at real-time pace
+      - name: speedup-factor
+        value: "1"
+      - name: observed-packet-timeout
+        value: "30"
+      # pre-snapshot-proxy-submit=false: start proxy after snapshot migration
+      - name: pre-snapshot-proxy-submit
+        value: "false"
+      - name: replayer-config-overrides
+        value: "{}"
+      - name: otel-trace-collector-endpoint
+        value: ""
+      - name: client-auth-pem-base64
+        value: ""

--- a/deployment/k8s/chorus_es_to_os_demo/cdc-ecommerce-workflow.yaml
+++ b/deployment/k8s/chorus_es_to_os_demo/cdc-ecommerce-workflow.yaml
@@ -30,16 +30,20 @@ spec:
       # ClusterIP: no cloud load balancer in kind — use port-forward to reach proxy
       - name: capture-proxy-service-type
         value: "ClusterIP"
-      # speedup-factor=1: replay captured traffic at real-time pace
+      # speedup-factor=100: burns through gaps between captured requests so the live
+      # dashboard doesn't stall between searches — see Known Gotchas in README.md.
       - name: speedup-factor
-        value: "1"
+        value: "100"
       - name: observed-packet-timeout
-        value: "30"
+        value: "5"
       # pre-snapshot-proxy-submit=false: start proxy after snapshot migration
       - name: pre-snapshot-proxy-submit
         value: "false"
+      # quiescentPeriodMs/tupleMaxBufferSeconds tune the dashboard's replay latency —
+      # see Step 4 in README.md. tupleKafkaTopic isn't wired through the workflow yet,
+      # so it still needs a post-hoc kubectl patch.
       - name: replayer-config-overrides
-        value: "{}"
+        value: '{"quiescentPeriodMs":1000,"tupleMaxBufferSeconds":10}'
       - name: otel-trace-collector-endpoint
         value: ""
       - name: client-auth-pem-base64

--- a/deployment/k8s/tui/README.md
+++ b/deployment/k8s/tui/README.md
@@ -3,8 +3,19 @@
 A [Textual](https://textual.textualize.io/) replacement for
 `chorus_es_to_os_demo/07-live-jaccard-kafka.sh`. Consumes the `tuple-output` Kafka topic and shows a
 live sparkline + table of how closely each replayed request's target response matched the
-source, scoring by doc-ID overlap, aggregation buckets, or hit-count ratio (see
-`scoring.py`).
+source. Every request decomposes into independently-scored rows — one per hits section or
+named aggregation, and one per `_msearch` sub-query — rather than one blended score per
+request, since averaging hides exactly the failure that matters (see `scoring.py`).
+
+Hits rows can be scored two ways, toggled live with `m`:
+- **Jaccard** (default) — plain set overlap of doc IDs, order-blind: two result sets with the
+  same documents in a different order score a perfect 1.0.
+- **RBO** (Rank-Biased Overlap, Webber/Moffat/Zobel 2010) — weights agreement at shallow ranks
+  more than agreement deep in the list, so a reordered result set scores below 1.0. Useful
+  when ranking fidelity matters, not just membership.
+
+Aggregation rows always use their own weighted bucket-overlap score regardless of this
+toggle — RBO has no meaningful equivalent for bucket comparisons.
 
 Built following the structure of the `loadtest` TUI added in
 [opensearch-project/opensearch-migrations#3263](https://github.com/opensearch-project/opensearch-migrations/pull/3263):
@@ -31,7 +42,20 @@ Options:
 | `--interval` | `2.0` | UI repaint interval, seconds |
 | `--no-auto-create-topic` | off | Fail instead of creating the topic if missing |
 
-Keys: `r` resets the window and tuple count, `q` quits.
+Keys: `v` toggles a selected row's detail pane between the hit-ID/bucket diff and the raw
+captured request; `m` toggles hits scoring between Jaccard and RBO; `c` copies the selected
+row's request to the clipboard; `r` resets the visible window (the footnote's lifetime stats
+are *not* affected by this — see below); `q` quits.
+
+### Lifetime stats
+
+The bottom line is a running, per-label breakdown since the app started (or since the topic
+was last recreated) — independent of the sliding window and unaffected by `r`. It exists for
+the same reason per-request blended scores were dropped in favor of per-item ones: a flat
+"average score across everything" can hide a consistently-diverged label (say, every `_msearch`
+aggregation on one facet) behind a pile of perfect hits-only requests. It shows count,
+average, and min/max per label under whichever metric (`m`) is currently selected, capped to
+the 8 highest-count labels.
 
 ## Requirements
 

--- a/deployment/k8s/tui/README.md
+++ b/deployment/k8s/tui/README.md
@@ -1,7 +1,7 @@
 # Live replay-quality TUI
 
 A [Textual](https://textual.textualize.io/) replacement for
-`eric_demo/07-live-jaccard-kafka.sh`. Consumes the `tuple-output` Kafka topic and shows a
+`chorus_es_to_os_demo/07-live-jaccard-kafka.sh`. Consumes the `tuple-output` Kafka topic and shows a
 live sparkline + table of how closely each replayed request's target response matched the
 source, scoring by doc-ID overlap, aggregation buckets, or hit-count ratio (see
 `scoring.py`).

--- a/deployment/k8s/tui/README.md
+++ b/deployment/k8s/tui/README.md
@@ -1,0 +1,59 @@
+# Live replay-quality TUI
+
+A [Textual](https://textual.textualize.io/) replacement for
+`eric_demo/07-live-jaccard-kafka.sh`. Consumes the `tuple-output` Kafka topic and shows a
+live sparkline + table of how closely each replayed request's target response matched the
+source, scoring by doc-ID overlap, aggregation buckets, or hit-count ratio (see
+`scoring.py`).
+
+Built following the structure of the `loadtest` TUI added in
+[opensearch-project/opensearch-migrations#3263](https://github.com/opensearch-project/opensearch-migrations/pull/3263):
+a background thread owns the long-lived I/O (there, k6 run polling via the Kubernetes API;
+here, a `kafka-console-consumer.sh` subprocess) and only ever writes to a lock-guarded
+buffer. A timer on the main thread snapshots that buffer and repaints. This keeps a stalled
+or slow consumer from ever blocking keypresses or redraws.
+
+## Run it
+
+```bash
+cd deployment/k8s
+pip install -r tui/requirements.txt
+python3 -m tui --namespace ma
+```
+
+Options:
+
+| Flag | Default | Meaning |
+|---|---|---|
+| `--namespace`, `-n` | `ma` | Namespace the migration console and Kafka run in |
+| `--topic` | `tuple-output` | Kafka topic to consume |
+| `--window` | `15` | Tuples shown in the sparkline/table |
+| `--interval` | `2.0` | UI repaint interval, seconds |
+| `--no-auto-create-topic` | off | Fail instead of creating the topic if missing |
+
+Keys: `r` resets the window and tuple count, `q` quits.
+
+## Requirements
+
+- `kubectl` configured against the target cluster (this runs on your machine, not inside
+  the migration console pod — same as the script it replaces).
+- `migration-console-0` running in the target namespace, with `kafka-tools` at
+  `/root/kafka-tools/kafka` (present on that image already).
+- A TrafficReplayer producing to the topic (`--tuple-kafka-topic tuple-output`).
+
+## Why the topic gets auto-created
+
+The original script's error message said running the TrafficReplayer once would
+auto-create the topic. On a Strimzi cluster with `auto.create.topics.enable=false` (the
+default for the `ma` demo cluster), that never happens — the producer just retries
+`UNKNOWN_TOPIC_OR_PARTITION` forever. `kafka_reader.ensure_ready()` now creates the topic
+itself via a `KafkaTopic` CR when it's missing (pass `--no-auto-create-topic` to get the
+old fail-fast behavior instead).
+
+## Layout
+
+- `scoring.py` — pure scoring functions, no I/O; ported unchanged from the bash script's
+  embedded Python.
+- `kafka_reader.py` — `kubectl`-based bootstrap (consumer creds, topic) and streaming.
+- `app.py` — the Textual `App`.
+- `__main__.py` — CLI entry point.

--- a/deployment/k8s/tui/__main__.py
+++ b/deployment/k8s/tui/__main__.py
@@ -13,15 +13,15 @@ def main() -> None:
     parser = argparse.ArgumentParser(
         description="Live replay-quality monitor for a TrafficReplayer tuple-output Kafka topic.")
     parser.add_argument("--namespace", "-n", default="ma",
-                         help="Kubernetes namespace the migration console runs in (default: ma)")
+                        help="Kubernetes namespace the migration console runs in (default: ma)")
     parser.add_argument("--topic", default="tuple-output",
-                         help="Kafka topic to consume (default: tuple-output)")
+                        help="Kafka topic to consume (default: tuple-output)")
     parser.add_argument("--window", type=int, default=15,
-                         help="Number of scored tuples shown in the sparkline/table (default: 15)")
+                        help="Number of scored tuples shown in the sparkline/table (default: 15)")
     parser.add_argument("--interval", type=float, default=2.0,
-                         help="UI repaint interval in seconds (default: 2.0)")
+                        help="UI repaint interval in seconds (default: 2.0)")
     parser.add_argument("--no-auto-create-topic", action="store_true",
-                         help="Fail instead of creating the topic if it does not exist")
+                        help="Fail instead of creating the topic if it does not exist")
     args = parser.parse_args()
 
     app = JaccardApp(

--- a/deployment/k8s/tui/__main__.py
+++ b/deployment/k8s/tui/__main__.py
@@ -22,6 +22,18 @@ def main() -> None:
                         help="UI repaint interval in seconds (default: 2.0)")
     parser.add_argument("--no-auto-create-topic", action="store_true",
                         help="Fail instead of creating the topic if it does not exist")
+    parser.add_argument("--source", choices=["kafka", "s3"], default="kafka",
+                        help="Where to read tuples from (default: kafka). 's3' polls the "
+                        "same tuples written to S3 instead, mirroring 06-live-jaccard.sh — "
+                        "real, rotation-interval-scale lag versus Kafka's near-real-time feed.")
+    parser.add_argument("--s3-bucket", default="migrations-default-123456789012-dev-us-east-2",
+                        help="S3 bucket tuples are written to (only used with --source s3)")
+    parser.add_argument("--s3-prefix", default="tuples/",
+                        help="S3 key prefix tuples are written under (only used with "
+                        "--source s3, default: tuples/)")
+    parser.add_argument("--poll-interval", type=float, default=10.0,
+                        help="Seconds between S3 polls (only used with --source s3, "
+                        "default: 10.0)")
     args = parser.parse_args()
 
     app = JaccardApp(
@@ -30,6 +42,10 @@ def main() -> None:
         window=args.window,
         refresh_interval=args.interval,
         auto_create_topic=not args.no_auto_create_topic,
+        source=args.source,
+        s3_bucket=args.s3_bucket,
+        s3_prefix=args.s3_prefix,
+        poll_interval=args.poll_interval,
     )
     app.run()
 

--- a/deployment/k8s/tui/__main__.py
+++ b/deployment/k8s/tui/__main__.py
@@ -1,0 +1,38 @@
+"""Entry point: python3 -m tui [options]
+
+Run from deployment/k8s/ (or anywhere with this directory on PYTHONPATH), against whatever
+cluster the local kubeconfig points at — same operating model as the shell script this
+replaces.
+"""
+import argparse
+
+from .app import JaccardApp
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Live replay-quality monitor for a TrafficReplayer tuple-output Kafka topic.")
+    parser.add_argument("--namespace", "-n", default="ma",
+                         help="Kubernetes namespace the migration console runs in (default: ma)")
+    parser.add_argument("--topic", default="tuple-output",
+                         help="Kafka topic to consume (default: tuple-output)")
+    parser.add_argument("--window", type=int, default=15,
+                         help="Number of scored tuples shown in the sparkline/table (default: 15)")
+    parser.add_argument("--interval", type=float, default=2.0,
+                         help="UI repaint interval in seconds (default: 2.0)")
+    parser.add_argument("--no-auto-create-topic", action="store_true",
+                         help="Fail instead of creating the topic if it does not exist")
+    args = parser.parse_args()
+
+    app = JaccardApp(
+        namespace=args.namespace,
+        topic=args.topic,
+        window=args.window,
+        refresh_interval=args.interval,
+        auto_create_topic=not args.no_auto_create_topic,
+    )
+    app.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/deployment/k8s/tui/app.py
+++ b/deployment/k8s/tui/app.py
@@ -6,13 +6,20 @@ a background thread owns the long-lived I/O (there, k6 run polling; here, the Ka
 consumer subprocess) and only ever touches a lock-guarded buffer. A timer on the main
 thread snapshots that buffer and repaints — the same split that keeps a slow or stalled
 consumer from ever blocking the UI.
+
+Data model: every replayed request is a PARENT row (its identity — method, URI, status
+codes) plus one or more CHILD rows, one per sub-query — a plain search has exactly one
+child; an _msearch has one per NDJSON search action. Scoring lives on the children only, on
+purpose: a blended average across an msearch's sub-queries hides exactly the failure that
+matters (one badly-diverged sub-query pulled toward 1.0 by two good ones still looks fine in
+aggregate), so the parent row carries no score of its own.
 """
 import collections
 import itertools
 import json
 import logging
 import threading
-from typing import Deque, Dict, List, Optional
+from typing import Deque, Dict, List, Optional, Tuple
 
 from rich.text import Text
 from textual.app import App, ComposeResult
@@ -41,6 +48,13 @@ def _spark_char(j: Optional[float]) -> Text:
         return Text("░", style="dim")
     idx = min(7, int(j * 8))
     return Text(SPARK[idx], style=f"bold {_score_color(j)}")
+
+
+def _has_scoreable_subqueries(s: Dict) -> bool:
+    if s.get("j_label") == "preflight":
+        return False
+    return any(sq.get("src_hits") is not None or sq.get("tgt_hits") is not None
+               for sq in s.get("subqueries", []))
 
 
 class JaccardApp(App):
@@ -79,12 +93,13 @@ class JaccardApp(App):
         self._status = {"total": 0, "running": True, "connected": False, "error": None}
         self._reader: Optional[KafkaTupleReader] = None
         self._seq = itertools.count(1)
-        # The highlighted row's identity, independent of the table rebuild every tick — a
-        # tuple's seq never changes, so this survives the window sliding underneath it and
-        # is what lets the detail pane and cursor position both be restored after a rebuild.
-        self._selected_seq: Optional[int] = None
+        # Row identity, independent of the table rebuild every tick — "<seq>" for a parent
+        # row, "<seq>:<subquery index>" for a child. Neither changes once assigned, so this
+        # survives the window sliding underneath it and is what lets the detail pane and
+        # cursor position both be restored after a rebuild.
+        self._selected_key: Optional[str] = None
         # "hits" shows the side-by-side doc-ID diff; "request" shows the raw captured HTTP
-        # requests for copy/paste — toggled with 'v', independent of which row is selected.
+        # request(s) for copy/paste — toggled with 'v', independent of which row is selected.
         self._view_mode = "hits"
         self.is_exiting = False
 
@@ -148,15 +163,17 @@ class JaccardApp(App):
         self._rebuild_table(buf)
         self._update_footnote(buf)
 
-    def _update_summary(self, buf: List[Dict]) -> None:
-        """Two distinct phases, not one blended "connecting" state:
+    def _visible_tuples(self, buf: List[Dict]) -> List[Dict]:
+        """The last N qualifying requests — shared by the table and the footnote so both
+        agree on what "the window" means. Preflight OPTIONS and requests with no hit data on
+        either side (index/delete ops, errors) never get a row at all."""
+        return [s for s in buf if _has_scoreable_subqueries(s)][-self._window:]
 
-        1. Setup — verifying the topic exists and creds work (ensure_ready() hasn't returned
-           yet). Shown as its own message, since it's a one-shot check, not something the
-           sparkline should represent.
-        2. Live — setup succeeded and the consumer is attached. The standard sparkline layout
-           renders immediately here, with placeholders for a still-empty window, rather than
-           waiting for the first tuple to appear before showing the normal screen at all.
+    def _update_summary(self, buf: List[Dict]) -> None:
+        """Two distinct setup phases, then a live sparkline built from individual sub-query
+        scores rather than one blended score per request — an msearch with 3 sub-queries
+        contributes 3 marks, each colored on its own merit, not one averaged mark that could
+        hide a badly-diverged sub-query behind two good ones.
         """
         summary = self.query_one("#summary", Static)
 
@@ -167,20 +184,19 @@ class JaccardApp(App):
             summary.update(f"Confirming topic '{self._topic}' exists and is reachable…")
             return
 
-        scoreable = [s for s in buf if s["j"] is not None]
-        window = scoreable[-self._window:]
+        all_js = [sq["j"] for s in buf for sq in s.get("subqueries", []) if sq["j"] is not None]
+        window = all_js[-self._window:]
         blanks = self._window - len(window)
         text = Text("Jaccard  ")
         text.append(Text("░ " * blanks, style="dim"))
-        text.append(Text(" ").join(_spark_char(s["j"]) for s in window))
+        text.append(Text(" ").join(_spark_char(j) for j in window))
         text.append("\n")
         if window:
-            js = [s["j"] for s in window]
-            avg_j = sum(js) / len(js)
+            avg_j = sum(window) / len(window)
             text.append("avg ")
             text.append(f"{avg_j:.3f}", style=f"bold {_score_color(avg_j)}")
-            text.append(f"   min {min(js):.3f}   max {max(js):.3f}"
-                         f"   ({len(window)} of {self._status['total']} tuples seen)")
+            text.append(f"   min {min(window):.3f}   max {max(window):.3f}"
+                         f"   ({len(window)} sub-query scores, {self._status['total']} requests seen)")
         else:
             text.append(f"0 tuples seen yet — waiting for live traffic on '{self._topic}'")
             if not self._status["running"]:
@@ -188,31 +204,38 @@ class JaccardApp(App):
         summary.update(text)
 
     def _rebuild_table(self, buf: List[Dict]) -> None:
-        """Repaint the table, keeping the cursor (and so the detail pane) on the same tuple
-        across refreshes — row indexes shift as the window slides, so seq, not index, is what
-        identifies a row from one rebuild to the next."""
+        """Repaint the table, keeping the cursor (and so the detail pane) on the same row
+        across refreshes — row indexes shift as the window slides, so the row key, not
+        index, is what identifies a row from one rebuild to the next."""
         table = self.table
         table.clear()
-        show = [s for s in buf if s.get("j_label") != "preflight"][-self._window:]
-        added: List[Dict] = []
-        for s in show:
-            sh, th = s.get("src_hits"), s.get("tgt_hits")
-            if sh is None and th is None:
-                continue
-            j = s["j"]
-            j_cell = Text("-", style="dim") if j is None else Text(f"{j:.3f}", style=f"bold {_score_color(j)}")
-            hits_cell = self._hits_cell(sh, th)
+        row_keys: List[str] = []
+        # Newest request first — a live monitor's most useful row is the one that just
+        # happened, not the oldest one still in the window. Each request's own sub-queries
+        # stay in their natural 1st/2nd/3rd order underneath it; only request-to-request
+        # order flips.
+        for s in reversed(self._visible_tuples(buf)):
             uri = s["uri"] or "?"
             if len(uri) > 50:
                 uri = uri[:47] + "..."
-            table.add_row(j_cell, s["method"], uri, hits_cell, s.get("j_label") or "",
-                          key=str(s["seq"]))
-            added.append(s)
-        if self._selected_seq is not None:
-            for i, s in enumerate(added):
-                if s["seq"] == self._selected_seq:
-                    table.move_cursor(row=i)
-                    break
+            subqueries = s.get("subqueries", [])
+            note = f"{len(subqueries)} sub-queries" if len(subqueries) > 1 else ""
+            status_cell = Text(f"{s['src_status']} → {s['tgt_status']}", style="dim")
+            parent_key = str(s["seq"])
+            table.add_row(Text(""), Text(s["method"], style="bold"), uri, status_cell, note,
+                          key=parent_key)
+            row_keys.append(parent_key)
+            for i, sq in enumerate(subqueries):
+                j = sq["j"]
+                j_cell = (Text("-", style="dim") if j is None
+                          else Text(f"{j:.3f}", style=f"bold {_score_color(j)}"))
+                hits_cell = self._hits_cell(sq.get("src_hits"), sq.get("tgt_hits"))
+                child_key = f"{s['seq']}:{i}"
+                table.add_row(j_cell, "", Text(f"  ↳ {sq['label']}", style="dim"),
+                              hits_cell, sq.get("j_label") or "", key=child_key)
+                row_keys.append(child_key)
+        if self._selected_key is not None and self._selected_key in row_keys:
+            table.move_cursor(row=row_keys.index(self._selected_key))
 
     @staticmethod
     def _hits_cell(sh: Optional[int], th: Optional[int]) -> Text:
@@ -227,57 +250,108 @@ class JaccardApp(App):
         return Text(f"{sh} → {th}", style=style)
 
     def on_data_table_row_highlighted(self, event: DataTable.RowHighlighted) -> None:
-        seq = int(event.row_key.value) if event.row_key is not None and event.row_key.value else None
-        if seq == self._selected_seq:
+        key = event.row_key.value if event.row_key is not None else None
+        if key == self._selected_key:
             return
-        self._selected_seq = seq
+        self._selected_key = key
         self._update_detail()
 
-    def _lookup_selected(self) -> Optional[Dict]:
-        if self._selected_seq is None:
+    def _lookup_selected(self) -> Optional[Tuple[Dict, Optional[Dict]]]:
+        """The selected (tuple, subquery) pair — subquery is None when a parent row is
+        selected. Looks the tuple up by seq in the live buffer rather than caching it at
+        selection time, so this still works right after a reset clears everything."""
+        if self._selected_key is None:
             return None
+        if ":" in self._selected_key:
+            seq_str, idx_str = self._selected_key.split(":", 1)
+            seq, idx = int(seq_str), int(idx_str)
+        else:
+            seq, idx = int(self._selected_key), None
         with self._buf_lock:
-            return next((x for x in self._buf if x.get("seq") == self._selected_seq), None)
+            s = next((x for x in self._buf if x.get("seq") == seq), None)
+        if s is None:
+            return None
+        if idx is None:
+            return s, None
+        subqueries = s.get("subqueries", [])
+        if idx >= len(subqueries):
+            return None
+        return s, subqueries[idx]
 
     def _update_detail(self) -> None:
-        """Render the highlighted tuple into the two side-by-side panes — either the hit-ID
-        diff or the raw request, per self._view_mode ('v' toggles between them).
-
-        Looks the tuple up by seq in the live buffer rather than caching it at selection time,
-        so the pane still works right after a reset clears everything (falls through to "no
-        longer available" instead of showing stale data).
-        """
         src_pane = self.query_one("#detail-src", Static)
         tgt_pane = self.query_one("#detail-tgt", Static)
-        if self._selected_seq is None:
+        if self._selected_key is None:
             src_pane.update(Text(
                 "select a row to see detail  ·  v: hits/request  ·  c: copy request", style="dim"))
             tgt_pane.update("")
             return
-        s = self._lookup_selected()
-        if s is None:
-            src_pane.update(Text("(tuple no longer in buffer)", style="dim"))
+        found = self._lookup_selected()
+        if found is None:
+            src_pane.update(Text("(row no longer in buffer)", style="dim"))
+            tgt_pane.update("")
+            return
+        s, sq = found
+
+        if self._view_mode == "request":
+            if sq is not None and sq.get("src_sub_ndjson") is not None:
+                src_pane.update(self._format_ndjson(f"SOURCE — sub-query {sq['label']}",
+                                                     sq.get("src_sub_ndjson")))
+                tgt_pane.update(self._format_ndjson(f"TARGET — sub-query {sq['label']}",
+                                                     sq.get("tgt_sub_ndjson")))
+            else:
+                src_pane.update(self._format_request("SOURCE REQUEST", s.get("src_request")))
+                tgt_pane.update(self._format_request("TARGET REQUEST", s.get("tgt_request")))
+            return
+
+        if sq is None:
+            src_pane.update(self._subquery_overview(s))
             tgt_pane.update("")
             return
 
-        if self._view_mode == "request":
-            src_pane.update(self._format_request("SOURCE REQUEST", s.get("src_request")))
-            tgt_pane.update(self._format_request("TARGET REQUEST", s.get("tgt_request")))
-            return
-
-        src_list, tgt_list = s.get("src_hit_list") or [], s.get("tgt_hit_list") or []
+        src_list, tgt_list = sq.get("src_hit_list") or [], sq.get("tgt_hit_list") or []
         if not src_list and not tgt_list:
             src_pane.update(Text(
-                f"{s['method']} {s['uri']}\n"
-                f"No hit-level detail for this request (status {s['src_status']} → {s['tgt_status']}).\n"
-                f"Press 'v' to view the raw request instead.",
+                f"{s['method']} {s['uri']}  [{sq['label']}]\n"
+                f"No hit-level detail for this sub-query.\n"
+                f"Press 'v' to view its raw request instead.",
                 style="dim"))
             tgt_pane.update("")
             return
         src_ids = {h["id"] for h in src_list}
         tgt_ids = {h["id"] for h in tgt_list}
-        src_pane.update(self._hit_list_text("SOURCE", s.get("src_hits"), src_list, tgt_ids))
-        tgt_pane.update(self._hit_list_text("TARGET", s.get("tgt_hits"), tgt_list, src_ids))
+        src_pane.update(self._hit_list_text(f"SOURCE — {sq['label']}", sq.get("src_hits"), src_list, tgt_ids))
+        tgt_pane.update(self._hit_list_text(f"TARGET — {sq['label']}", sq.get("tgt_hits"), tgt_list, src_ids))
+
+    @staticmethod
+    def _subquery_overview(s: Dict) -> Text:
+        """A parent row's detail: a compact list of its sub-queries and their scores — the
+        overview a blended average used to replace. Select a sub-query row below for its
+        full hit-ID diff."""
+        subqueries = s.get("subqueries", [])
+        text = Text(f"{s['method']} {s['uri']}\n", style="bold")
+        n = len(subqueries)
+        text.append(f"{n} sub-quer{'y' if n == 1 else 'ies'} "
+                     f"— select one below for hit detail\n\n", style="dim")
+        for sq in subqueries:
+            j = sq["j"]
+            j_text = "   -   " if j is None else f"{j:>7.3f}"
+            text.append(j_text, style=f"bold {_score_color(j)}")
+            text.append(f"  {sq['label']}")
+            sh, th = sq.get("src_hits"), sq.get("tgt_hits")
+            if sh is not None or th is not None:
+                text.append(f"   ({sh} → {th})", style="dim")
+            text.append("\n")
+        return text
+
+    @staticmethod
+    def _format_ndjson(label: str, pair: Optional[List[Dict]]) -> Text:
+        text = Text(f"{label}\n", style="bold")
+        if not pair:
+            text.append("(not captured)", style="dim")
+            return text
+        text.append("\n".join(json.dumps(obj) for obj in pair))
+        return text
 
     @staticmethod
     def _format_request(label: str, req: Optional[Dict]) -> Text:
@@ -335,7 +409,7 @@ class JaccardApp(App):
 
     def _update_footnote(self, buf: List[Dict]) -> None:
         n_options = sum(1 for s in buf if s.get("j_label") == "preflight")
-        no_score = [s for s in buf if s["j"] is None and s.get("j_label") != "preflight"]
+        no_score = [s for s in buf if not s.get("subqueries") and s.get("j_label") != "preflight"]
         parts = []
         if n_options:
             parts.append(f"{n_options}× OPTIONS preflight (skipped)")
@@ -353,7 +427,7 @@ class JaccardApp(App):
         with self._buf_lock:
             self._buf.clear()
             self._status["total"] = 0
-        self._selected_seq = None
+        self._selected_key = None
         self._update_detail()
 
     def action_toggle_view(self) -> None:
@@ -361,20 +435,27 @@ class JaccardApp(App):
         self._update_detail()
 
     def action_copy_request(self) -> None:
-        """Copy the selected tuple's source + target request to the system clipboard.
+        """Copy the selected row's request(s) to the system clipboard — the whole HTTP
+        request for a parent row (or a single-query child), or just that one sub-query's
+        NDJSON slice for an msearch child.
 
         Tries the OS's own clipboard tool (pbcopy/xclip/etc.) first — Textual's built-in
         copy_to_clipboard() only works via an OSC 52 terminal escape sequence, which its own
         docs say plainly does not work on macOS Terminal.app, so it's the fallback here, not
         the first attempt.
         """
-        s = self._lookup_selected()
-        if s is None:
-            self.notify("No row selected to copy" if self._selected_seq is None
-                        else "Tuple no longer in buffer", severity="warning")
+        found = self._lookup_selected()
+        if found is None:
+            self.notify("No row selected to copy" if self._selected_key is None
+                        else "Row no longer in buffer", severity="warning")
             return
-        src_text = str(self._format_request("SOURCE REQUEST", s.get("src_request")))
-        tgt_text = str(self._format_request("TARGET REQUEST", s.get("tgt_request")))
+        s, sq = found
+        if sq is not None and sq.get("src_sub_ndjson") is not None:
+            src_text = str(self._format_ndjson(f"SOURCE — sub-query {sq['label']}", sq.get("src_sub_ndjson")))
+            tgt_text = str(self._format_ndjson(f"TARGET — sub-query {sq['label']}", sq.get("tgt_sub_ndjson")))
+        else:
+            src_text = str(self._format_request("SOURCE REQUEST", s.get("src_request")))
+            tgt_text = str(self._format_request("TARGET REQUEST", s.get("tgt_request")))
         combined = f"{src_text}\n\n{tgt_text}"
         if copy_via_system_tool(combined):
             self.notify("Copied source + target request to clipboard")

--- a/deployment/k8s/tui/app.py
+++ b/deployment/k8s/tui/app.py
@@ -1,0 +1,215 @@
+"""Text-UI replacement for 07-live-jaccard-kafka.sh — a live table of replayed tuples
+scored for source/target agreement, read from the tuple-output Kafka topic.
+
+Follows the structure of the loadtest TUI (opensearch-project/opensearch-migrations#3263):
+a background thread owns the long-lived I/O (there, k6 run polling; here, the Kafka
+consumer subprocess) and only ever touches a lock-guarded buffer. A timer on the main
+thread snapshots that buffer and repaints — the same split that keeps a slow or stalled
+consumer from ever blocking the UI.
+"""
+import collections
+import logging
+import threading
+from typing import Deque, Dict, List, Optional
+
+from rich.text import Text
+from textual.app import App, ComposeResult
+from textual.containers import Container
+from textual.widgets import DataTable, Footer, Header, Static
+
+from .kafka_reader import KafkaReaderError, KafkaTupleReader
+from .scoring import score_tuple
+
+logger = logging.getLogger(__name__)
+
+TABLE_ANCHOR = "tuples"
+COLUMNS = ("J", "METHOD", "URI", "SRC → TGT", "NOTE")
+SPARK = "▁▂▃▄▅▆▇█"
+
+
+def _score_color(j: Optional[float]) -> str:
+    if j is None:
+        return "dim"
+    return "green" if j >= 0.95 else ("yellow" if j >= 0.80 else "red")
+
+
+def _spark_char(j: Optional[float]) -> Text:
+    if j is None:
+        return Text("░", style="dim")
+    idx = min(7, int(j * 8))
+    return Text(SPARK[idx], style=f"bold {_score_color(j)}")
+
+
+class JaccardApp(App):
+    """Live replay-quality monitor. One instance == one Kafka topic being watched."""
+
+    CSS = """
+    #summary { height: 4; padding: 0 1; }
+    #footnote { height: 1; padding: 0 1; color: $text-muted; }
+    DataTable { height: 1fr; }
+    """
+    BINDINGS = [
+        ("r", "reset", "Reset window"),
+        ("q", "quit", "Quit"),
+    ]
+
+    def __init__(self, namespace: str, topic: str = "tuple-output", *,
+                 window: int = 15, refresh_interval: float = 2.0,
+                 auto_create_topic: bool = True):
+        super().__init__()
+        self.title = f"[{namespace}] live replay quality"
+        self.sub_title = f"topic: {topic}"
+        self._namespace = namespace
+        self._topic = topic
+        self._window = window
+        self._refresh_interval = refresh_interval
+        self._auto_create_topic = auto_create_topic
+        # Holds every scored tuple seen this "generation" (since last reset), capped so a
+        # long-running demo can't grow this unboundedly; the window is a suffix of it.
+        self._buf: Deque[Dict] = collections.deque(maxlen=window * 20)
+        self._buf_lock = threading.Lock()
+        self._status = {"total": 0, "running": True, "connected": False, "error": None}
+        self._reader: Optional[KafkaTupleReader] = None
+        self.is_exiting = False
+
+    def compose(self) -> ComposeResult:
+        yield Header()
+        yield Static("", id="summary")
+        yield Container(DataTable(id=TABLE_ANCHOR, cursor_type="row"))
+        yield Static("", id="footnote")
+        yield Footer()
+
+    def on_mount(self) -> None:
+        self.table.add_columns(*COLUMNS)
+        self.run_worker(self._bootstrap_and_stream, thread=True, name="kafka_reader")
+        self.set_interval(self._refresh_interval, self._repaint)
+
+    def on_unmount(self) -> None:
+        self.is_exiting = True
+        if self._reader:
+            self._reader.stop()
+
+    @property
+    def table(self) -> DataTable:
+        return self.query_one(f"#{TABLE_ANCHOR}", DataTable)
+
+    # --- Kafka bootstrap + streaming (background thread — no UI calls except via
+    #     call_from_thread, and only for one-shot setup failures) ---
+
+    def _bootstrap_and_stream(self) -> None:
+        reader = KafkaTupleReader(self._namespace, self._topic,
+                                   auto_create_topic=self._auto_create_topic)
+        try:
+            reader.ensure_ready()
+        except KafkaReaderError as e:
+            if not self.is_exiting:
+                self.call_from_thread(self.notify, str(e), severity="error", timeout=None)
+            self._status["error"] = str(e)
+            self._status["running"] = False
+            return
+        self._reader = reader
+        self._status["connected"] = True
+        for record in reader.stream():
+            if self.is_exiting:
+                break
+            with self._buf_lock:
+                self._buf.append(score_tuple(record))
+                self._status["total"] += 1
+        self._status["running"] = False
+
+    # --- Repaint (main thread, on a timer — never touches the Kafka subprocess) ---
+
+    def _repaint(self) -> None:
+        with self._buf_lock:
+            buf = list(self._buf)
+        self._update_summary(buf)
+        self._rebuild_table(buf)
+        self._update_footnote(buf)
+
+    def _update_summary(self, buf: List[Dict]) -> None:
+        """Two distinct phases, not one blended "connecting" state:
+
+        1. Setup — verifying the topic exists and creds work (ensure_ready() hasn't returned
+           yet). Shown as its own message, since it's a one-shot check, not something the
+           sparkline should represent.
+        2. Live — setup succeeded and the consumer is attached. The standard sparkline layout
+           renders immediately here, with placeholders for a still-empty window, rather than
+           waiting for the first tuple to appear before showing the normal screen at all.
+        """
+        summary = self.query_one("#summary", Static)
+
+        if self._status["error"]:
+            summary.update(Text(f"Setup failed: {self._status['error']}", style="bold red"))
+            return
+        if not self._status["connected"]:
+            summary.update(f"Confirming topic '{self._topic}' exists and is reachable…")
+            return
+
+        scoreable = [s for s in buf if s["j"] is not None]
+        window = scoreable[-self._window:]
+        blanks = self._window - len(window)
+        text = Text("Jaccard  ")
+        text.append(Text("░ " * blanks, style="dim"))
+        text.append(Text(" ").join(_spark_char(s["j"]) for s in window))
+        text.append("\n")
+        if window:
+            js = [s["j"] for s in window]
+            avg_j = sum(js) / len(js)
+            text.append("avg ")
+            text.append(f"{avg_j:.3f}", style=f"bold {_score_color(avg_j)}")
+            text.append(f"   min {min(js):.3f}   max {max(js):.3f}"
+                         f"   ({len(window)} of {self._status['total']} tuples seen)")
+        else:
+            text.append(f"0 tuples seen yet — waiting for live traffic on '{self._topic}'")
+            if not self._status["running"]:
+                text.append("  (consumer disconnected)", style="dim")
+        summary.update(text)
+
+    def _rebuild_table(self, buf: List[Dict]) -> None:
+        table = self.table
+        table.clear()
+        show = [s for s in buf if s.get("j_label") != "preflight"][-self._window:]
+        for s in show:
+            sh, th = s.get("src_hits"), s.get("tgt_hits")
+            if sh is None and th is None:
+                continue
+            j = s["j"]
+            j_cell = Text("-", style="dim") if j is None else Text(f"{j:.3f}", style=f"bold {_score_color(j)}")
+            hits_cell = self._hits_cell(sh, th)
+            uri = s["uri"] or "?"
+            if len(uri) > 50:
+                uri = uri[:47] + "..."
+            table.add_row(j_cell, s["method"], uri, hits_cell, s.get("j_label") or "")
+
+    @staticmethod
+    def _hits_cell(sh: Optional[int], th: Optional[int]) -> Text:
+        if sh is None or th is None:
+            return Text("")
+        if sh == th:
+            style = "green"
+        elif max(sh, th) > 0 and min(sh, th) / max(sh, th) >= 0.95:
+            style = "yellow"
+        else:
+            style = "red"
+        return Text(f"{sh} → {th}", style=style)
+
+    def _update_footnote(self, buf: List[Dict]) -> None:
+        n_options = sum(1 for s in buf if s.get("j_label") == "preflight")
+        no_score = [s for s in buf if s["j"] is None and s.get("j_label") != "preflight"]
+        parts = []
+        if n_options:
+            parts.append(f"{n_options}× OPTIONS preflight (skipped)")
+        if no_score:
+            methods: Dict[str, int] = {}
+            for s in no_score:
+                methods[s["method"]] = methods.get(s["method"], 0) + 1
+            breakdown = ", ".join(f"{c}× {m}" for m, c in sorted(methods.items()))
+            parts.append(f"no score: {breakdown}")
+        self.query_one("#footnote", Static).update("  •  ".join(parts))
+
+    # --- Actions ---
+
+    def action_reset(self) -> None:
+        with self._buf_lock:
+            self._buf.clear()
+            self._status["total"] = 0

--- a/deployment/k8s/tui/app.py
+++ b/deployment/k8s/tui/app.py
@@ -1,11 +1,14 @@
 """Text-UI replacement for 07-live-jaccard-kafka.sh — a live table of replayed tuples
-scored for source/target agreement, read from the tuple-output Kafka topic.
+scored for source/target agreement, read from the tuple-output Kafka topic by default, or
+from S3 (--source s3, mirroring 06-live-jaccard.sh) as an alternative. Both sinks write the
+same tuple JSON schema, so scoring.py is source-agnostic — only which reader class
+_bootstrap_and_stream() constructs differs.
 
 Follows the structure of the loadtest TUI (opensearch-project/opensearch-migrations#3263):
 a background thread owns the long-lived I/O (there, k6 run polling; here, the Kafka
-consumer subprocess) and only ever touches a lock-guarded buffer. A timer on the main
-thread snapshots that buffer and repaints — the same split that keeps a slow or stalled
-consumer from ever blocking the UI.
+consumer subprocess or S3 poll loop) and only ever touches a lock-guarded buffer. A timer
+on the main thread snapshots that buffer and repaints — the same split that keeps a slow or
+stalled reader from ever blocking the UI.
 
 Data model: every replayed request is a PARENT row (its identity — method, URI, status
 codes) plus one or more CHILD rows — one per independently-comparable item. A plain search
@@ -30,6 +33,7 @@ from textual.widgets import DataTable, Footer, Header, Static
 
 from .clipboard import copy_via_system_tool
 from .kafka_reader import KafkaReaderError, KafkaTupleReader
+from .s3_reader import S3ReaderError, S3TupleReader
 from .scoring import score_tuple
 
 logger = logging.getLogger(__name__)
@@ -95,21 +99,41 @@ class JaccardApp(App):
 
     def __init__(self, namespace: str, topic: str = "tuple-output", *,
                  window: int = 15, refresh_interval: float = 2.0,
-                 auto_create_topic: bool = True):
+                 auto_create_topic: bool = True,
+                 source: str = "kafka",
+                 s3_bucket: str = "migrations-default-123456789012-dev-us-east-2",
+                 s3_prefix: str = "tuples/",
+                 poll_interval: float = 10.0):
         super().__init__()
         self.title = f"[{namespace}] live replay quality"
-        self.sub_title = f"topic: {topic}"
+        self.sub_title = (
+            f"topic: {topic}" if source == "kafka" else f"s3://{s3_bucket}/{s3_prefix}"
+        )
+        # Shared by the "confirming..." and "waiting for..." status messages so neither one
+        # says "topic" while actually polling S3, or vice versa.
+        self._source_description = (
+            f"topic '{topic}'" if source == "kafka" else f"'s3://{s3_bucket}/{s3_prefix}'"
+        )
         self._namespace = namespace
         self._topic = topic
         self._window = window
         self._refresh_interval = refresh_interval
         self._auto_create_topic = auto_create_topic
+        # "kafka" (default) streams tuple-output near-real-time; "s3" polls the same tuples
+        # written to S3 instead (mirrors 06-live-jaccard.sh) — real, rotation-interval-scale
+        # lag, but useful when the Kafka topic isn't set up or reachable from this machine.
+        self._source = source
+        self._s3_bucket = s3_bucket
+        self._s3_prefix = s3_prefix
+        self._poll_interval = poll_interval
         # Holds every scored tuple seen this "generation" (since last reset), capped so a
         # long-running demo can't grow this unboundedly; the window is a suffix of it.
         self._buf: Deque[Dict] = collections.deque(maxlen=window * 20)
         self._buf_lock = threading.Lock()
         self._status = {"total": 0, "running": True, "connected": False, "error": None}
-        self._reader: Optional[KafkaTupleReader] = None
+        # KafkaTupleReader or S3TupleReader depending on self._source — both duck-type the
+        # same ensure_ready()/stream()/stop() contract.
+        self._reader: Optional[object] = None
         self._seq = itertools.count(1)
         # Row identity, independent of the table rebuild every tick — "<seq>" for a parent
         # row, "<seq>:<subquery index>" for a child. Neither changes once assigned, so this
@@ -171,7 +195,7 @@ class JaccardApp(App):
     def on_mount(self) -> None:
         self.table.add_columns(*COLUMNS)
         self._update_detail()
-        self.run_worker(self._bootstrap_and_stream, thread=True, name="kafka_reader")
+        self.run_worker(self._bootstrap_and_stream, thread=True, name="tuple_reader")
         self.set_interval(self._refresh_interval, self._repaint)
 
     def on_unmount(self) -> None:
@@ -183,15 +207,20 @@ class JaccardApp(App):
     def table(self) -> DataTable:
         return self.query_one(f"#{TABLE_ANCHOR}", DataTable)
 
-    # --- Kafka bootstrap + streaming (background thread — no UI calls except via
+    # --- Reader bootstrap + streaming (background thread — no UI calls except via
     #     call_from_thread, and only for one-shot setup failures) ---
 
     def _bootstrap_and_stream(self) -> None:
-        reader = KafkaTupleReader(self._namespace, self._topic,
-                                  auto_create_topic=self._auto_create_topic)
+        if self._source == "s3":
+            reader = S3TupleReader(
+                self._namespace, bucket=self._s3_bucket, prefix=self._s3_prefix,
+                poll_interval=self._poll_interval)
+        else:
+            reader = KafkaTupleReader(self._namespace, self._topic,
+                                      auto_create_topic=self._auto_create_topic)
         try:
             reader.ensure_ready()
-        except KafkaReaderError as e:
+        except (KafkaReaderError, S3ReaderError) as e:
             if not self.is_exiting:
                 self.call_from_thread(self.notify, str(e), severity="error", timeout=None)
             self._status["error"] = str(e)
@@ -289,7 +318,7 @@ class JaccardApp(App):
             summary.update(Text(f"Setup failed: {self._status['error']}", style="bold red"))
             return
         if not self._status["connected"]:
-            summary.update(f"Confirming topic '{self._topic}' exists and is reachable…")
+            summary.update(f"Confirming {self._source_description} exists and is reachable…")
             return
 
         all_js = [j for s in buf for sq in s.get("subqueries", [])
@@ -308,7 +337,7 @@ class JaccardApp(App):
             text.append(f"   min {min(window):.3f}   max {max(window):.3f}"
                         f"   ({len(window)} sub-query scores, {self._status['total']} requests seen)")
         else:
-            text.append(f"0 tuples seen yet — waiting for live traffic on '{self._topic}'")
+            text.append(f"0 tuples seen yet — waiting for live traffic on {self._source_description}")
             if not self._status["running"]:
                 text.append("  (consumer disconnected)", style="dim")
         summary.update(text)

--- a/deployment/k8s/tui/app.py
+++ b/deployment/k8s/tui/app.py
@@ -8,11 +8,13 @@ thread snapshots that buffer and repaints — the same split that keeps a slow o
 consumer from ever blocking the UI.
 
 Data model: every replayed request is a PARENT row (its identity — method, URI, status
-codes) plus one or more CHILD rows, one per sub-query — a plain search has exactly one
-child; an _msearch has one per NDJSON search action. Scoring lives on the children only, on
-purpose: a blended average across an msearch's sub-queries hides exactly the failure that
-matters (one badly-diverged sub-query pulled toward 1.0 by two good ones still looks fine in
-aggregate), so the parent row carries no score of its own.
+codes) plus one or more CHILD rows — one per independently-comparable item. A plain search
+with just hits has exactly one child; an _msearch has one item-group per NDJSON search
+action; and within any single response, hits and every named aggregation are each their own
+item, since a size:0 facet query with two aggregations is really two independent
+comparisons. Scoring lives on the children only, on purpose: a blended average hides exactly
+the failure that matters (one badly-diverged item pulled toward 1.0 by good ones still looks
+fine in aggregate), so the parent row carries no score of its own.
 """
 import collections
 import itertools
@@ -51,10 +53,12 @@ def _spark_char(j: Optional[float]) -> Text:
 
 
 def _has_scoreable_subqueries(s: Dict) -> bool:
+    """subqueries is only ever non-empty for a request that had at least one hits section or
+    named aggregation to compare (scoring.py's _response_items) — an index/delete/_count-style
+    request with neither produces an empty list, so its own emptiness is the filter."""
     if s.get("j_label") == "preflight":
         return False
-    return any(sq.get("src_hits") is not None or sq.get("tgt_hits") is not None
-               for sq in s.get("subqueries", []))
+    return bool(s.get("subqueries"))
 
 
 class JaccardApp(App):
@@ -101,6 +105,10 @@ class JaccardApp(App):
         # "hits" shows the side-by-side doc-ID diff; "request" shows the raw captured HTTP
         # request(s) for copy/paste — toggled with 'v', independent of which row is selected.
         self._view_mode = "hits"
+        # The seqs shown last time _rebuild_table ran — a full clear()+re-add on every tick
+        # visibly flickers and resets scroll position, so it's skipped whenever the visible
+        # set of requests hasn't actually changed (the common case between new arrivals).
+        self._last_row_signature: Optional[Tuple[int, ...]] = None
         self.is_exiting = False
 
     def compose(self) -> ComposeResult:
@@ -206,20 +214,34 @@ class JaccardApp(App):
     def _rebuild_table(self, buf: List[Dict]) -> None:
         """Repaint the table, keeping the cursor (and so the detail pane) on the same row
         across refreshes — row indexes shift as the window slides, so the row key, not
-        index, is what identifies a row from one rebuild to the next."""
+        index, is what identifies a row from one rebuild to the next.
+
+        A tuple's own data never changes once scored, so the visible set of seqs fully
+        determines the table's content — when it's unchanged since the last tick (the common
+        case between new arrivals), clear()+re-add is skipped entirely. Doing it every tick
+        regardless was visibly flickering and resetting scroll position while the user was
+        just reading, not because anything new had actually arrived.
+        """
+        visible = list(reversed(self._visible_tuples(buf)))
+        signature = tuple(s["seq"] for s in visible)
+        if signature == self._last_row_signature:
+            return
+        self._last_row_signature = signature
+
         table = self.table
+        scroll_y = table.scroll_y
         table.clear()
         row_keys: List[str] = []
         # Newest request first — a live monitor's most useful row is the one that just
         # happened, not the oldest one still in the window. Each request's own sub-queries
         # stay in their natural 1st/2nd/3rd order underneath it; only request-to-request
         # order flips.
-        for s in reversed(self._visible_tuples(buf)):
+        for s in visible:
             uri = s["uri"] or "?"
             if len(uri) > 50:
                 uri = uri[:47] + "..."
             subqueries = s.get("subqueries", [])
-            note = f"{len(subqueries)} sub-queries" if len(subqueries) > 1 else ""
+            note = f"{len(subqueries)} rows" if len(subqueries) > 1 else ""
             status_cell = Text(f"{s['src_status']} → {s['tgt_status']}", style="dim")
             parent_key = str(s["seq"])
             table.add_row(Text(""), Text(s["method"], style="bold"), uri, status_cell, note,
@@ -235,7 +257,13 @@ class JaccardApp(App):
                               hits_cell, sq.get("j_label") or "", key=child_key)
                 row_keys.append(child_key)
         if self._selected_key is not None and self._selected_key in row_keys:
-            table.move_cursor(row=row_keys.index(self._selected_key))
+            # scroll=False: the scroll_y restore below is authoritative — letting this also
+            # auto-scroll would fight it and undo exactly what's being preserved.
+            table.move_cursor(row=row_keys.index(self._selected_key), scroll=False)
+        # Deferred one refresh: setting scroll_y synchronously right after add_row() clamps
+        # against stale (pre-layout) scroll extents, so a restore issued immediately here can
+        # silently come out smaller than what was actually saved.
+        self.call_after_refresh(setattr, table, "scroll_y", scroll_y)
 
     @staticmethod
     def _hits_cell(sh: Optional[int], th: Optional[int]) -> Text:
@@ -295,10 +323,8 @@ class JaccardApp(App):
 
         if self._view_mode == "request":
             if sq is not None and sq.get("src_sub_ndjson") is not None:
-                src_pane.update(self._format_ndjson(f"SOURCE — sub-query {sq['label']}",
-                                                     sq.get("src_sub_ndjson")))
-                tgt_pane.update(self._format_ndjson(f"TARGET — sub-query {sq['label']}",
-                                                     sq.get("tgt_sub_ndjson")))
+                src_pane.update(self._format_ndjson(f"SOURCE — {sq['label']}", sq.get("src_sub_ndjson")))
+                tgt_pane.update(self._format_ndjson(f"TARGET — {sq['label']}", sq.get("tgt_sub_ndjson")))
             else:
                 src_pane.update(self._format_request("SOURCE REQUEST", s.get("src_request")))
                 tgt_pane.update(self._format_request("TARGET REQUEST", s.get("tgt_request")))
@@ -309,11 +335,16 @@ class JaccardApp(App):
             tgt_pane.update("")
             return
 
+        if sq.get("kind") == "agg":
+            src_pane.update(self._agg_detail_text(f"SOURCE — {sq['label']}", sq.get("src_agg"), sq.get("tgt_agg")))
+            tgt_pane.update(self._agg_detail_text(f"TARGET — {sq['label']}", sq.get("tgt_agg"), sq.get("src_agg")))
+            return
+
         src_list, tgt_list = sq.get("src_hit_list") or [], sq.get("tgt_hit_list") or []
         if not src_list and not tgt_list:
             src_pane.update(Text(
                 f"{s['method']} {s['uri']}  [{sq['label']}]\n"
-                f"No hit-level detail for this sub-query.\n"
+                f"No hit-level detail for this row.\n"
                 f"Press 'v' to view its raw request instead.",
                 style="dim"))
             tgt_pane.update("")
@@ -324,15 +355,43 @@ class JaccardApp(App):
         tgt_pane.update(self._hit_list_text(f"TARGET — {sq['label']}", sq.get("tgt_hits"), tgt_list, src_ids))
 
     @staticmethod
+    def _agg_detail_text(label: str, agg: Optional[Dict], other_agg: Optional[Dict]) -> Text:
+        """One side's view of an aggregation: bucket key/doc_count pairs (mismatched keys in
+        red, same idea as the hit-ID diff), or a bare value for a metric aggregation."""
+        text = Text(f"{label}\n", style="bold")
+        agg = agg if isinstance(agg, dict) else {}
+        buckets = agg.get("buckets")
+        if buckets is not None:
+            other_keys = {b.get("key") for b in (other_agg or {}).get("buckets", []) if isinstance(b, dict)}
+            for b in buckets:
+                if not isinstance(b, dict):
+                    continue
+                key, count = b.get("key"), b.get("doc_count")
+                style = "" if key in other_keys else "red"
+                text.append(f"{str(key):<28}", style=style)
+                text.append(f" {count}\n", style="dim")
+            if not buckets:
+                text.append("(no buckets)", style="dim")
+            return text
+        if "value" in agg:
+            text.append(f"value: {agg['value']}")
+            return text
+        if "doc_count" in agg:
+            text.append(f"doc_count: {agg['doc_count']}")
+            return text
+        text.append("(no aggregation data)", style="dim")
+        return text
+
+    @staticmethod
     def _subquery_overview(s: Dict) -> Text:
-        """A parent row's detail: a compact list of its sub-queries and their scores — the
-        overview a blended average used to replace. Select a sub-query row below for its
-        full hit-ID diff."""
+        """A parent row's detail: a compact list of its rows (hits and/or aggregations) and
+        their scores — the overview a blended average used to replace. Select a row below for
+        its full detail."""
         subqueries = s.get("subqueries", [])
         text = Text(f"{s['method']} {s['uri']}\n", style="bold")
         n = len(subqueries)
-        text.append(f"{n} sub-quer{'y' if n == 1 else 'ies'} "
-                     f"— select one below for hit detail\n\n", style="dim")
+        text.append(f"{n} row{'s' if n != 1 else ''} "
+                     f"— select one below for detail\n\n", style="dim")
         for sq in subqueries:
             j = sq["j"]
             j_text = "   -   " if j is None else f"{j:>7.3f}"
@@ -451,8 +510,8 @@ class JaccardApp(App):
             return
         s, sq = found
         if sq is not None and sq.get("src_sub_ndjson") is not None:
-            src_text = str(self._format_ndjson(f"SOURCE — sub-query {sq['label']}", sq.get("src_sub_ndjson")))
-            tgt_text = str(self._format_ndjson(f"TARGET — sub-query {sq['label']}", sq.get("tgt_sub_ndjson")))
+            src_text = str(self._format_ndjson(f"SOURCE — {sq['label']}", sq.get("src_sub_ndjson")))
+            tgt_text = str(self._format_ndjson(f"TARGET — {sq['label']}", sq.get("tgt_sub_ndjson")))
         else:
             src_text = str(self._format_request("SOURCE REQUEST", s.get("src_request")))
             tgt_text = str(self._format_request("TARGET REQUEST", s.get("tgt_request")))

--- a/deployment/k8s/tui/app.py
+++ b/deployment/k8s/tui/app.py
@@ -47,7 +47,25 @@ SPARK = "▁▂▃▄▅▆▇█"
 def _score_color(j: Optional[float]) -> str:
     if j is None:
         return "dim"
-    return "green" if j >= 0.95 else ("yellow" if j >= 0.80 else "red")
+    if j >= 0.95:
+        return "green"
+    if j >= 0.80:
+        return "yellow"
+    return "red"
+
+
+def _running_avg(st: Dict) -> Optional[float]:
+    """Running average of an accumulated stat bucket, or None if nothing in it scored."""
+    return (st["sum"] / st["scored_count"]) if st["scored_count"] else None
+
+
+def _score_cell(j: Optional[float]) -> str:
+    """A score rendered in the fixed 7-wide column the score tables share."""
+    return "   -   " if j is None else f"{j:>7.3f}"
+
+
+def _score_style(j: Optional[float]) -> str:
+    return "bold" if j is None else _score_color(j)
 
 
 def _type_key(label: str) -> str:
@@ -418,7 +436,7 @@ class JaccardApp(App):
         table.clear()
         row_keys: List[str] = []
         for type_key, st in ranked:
-            avg = (st["sum"] / st["scored_count"]) if st["scored_count"] else None
+            avg = _running_avg(st)
             avg_cell = (Text("-", style="dim") if avg is None
                         else Text(f"{avg:.3f}", style=f"bold {_score_color(avg)}"))
             min_cell = "-" if st["min"] is None else f"{st['min']:.3f}"
@@ -543,9 +561,8 @@ class JaccardApp(App):
             text.append("(no data)", style="dim")
         else:
             for label, st in sorted(by_label.items(), key=lambda kv: -kv[1]["count"]):
-                avg = (st["sum"] / st["scored_count"]) if st["scored_count"] else None
-                avg_text = "   -   " if avg is None else f"{avg:>7.3f}"
-                text.append(avg_text, style="bold" if avg is None else _score_color(avg))
+                avg = _running_avg(st)
+                text.append(_score_cell(avg), style=_score_style(avg))
                 text.append(f"  {label}   n={st['count']}")
                 if avg is not None:
                     text.append(f"   [{st['min']:.3f}–{st['max']:.3f}]", style="dim")
@@ -592,8 +609,7 @@ class JaccardApp(App):
                     f"— select one below for detail\n\n", style="dim")
         for sq in subqueries:
             j, _ = self._effective_score(sq)
-            j_text = "   -   " if j is None else f"{j:>7.3f}"
-            text.append(j_text, style=f"bold {_score_color(j)}")
+            text.append(_score_cell(j), style=f"bold {_score_color(j)}")
             text.append(f"  {sq['label']}")
             sh, th = sq.get("src_hits"), sq.get("tgt_hits")
             if sh is not None or th is not None:
@@ -698,8 +714,8 @@ class JaccardApp(App):
             text.append("LIFETIME", style="bold")
             text.append(f" ({self._score_metric})  ", style="dim")
             for label, st in shown:
-                avg = (st["sum"] / st["scored_count"]) if st["scored_count"] else None
-                text.append(f"{label}", style="bold" if avg is None else _score_color(avg))
+                avg = _running_avg(st)
+                text.append(f"{label}", style=_score_style(avg))
                 text.append(f" n={st['count']}", style="dim")
                 if avg is not None:
                     text.append(f" avg={avg:.3f} [{st['min']:.3f}–{st['max']:.3f}]", style="dim")

--- a/deployment/k8s/tui/app.py
+++ b/deployment/k8s/tui/app.py
@@ -8,15 +8,18 @@ thread snapshots that buffer and repaints — the same split that keeps a slow o
 consumer from ever blocking the UI.
 """
 import collections
+import itertools
+import json
 import logging
 import threading
 from typing import Deque, Dict, List, Optional
 
 from rich.text import Text
 from textual.app import App, ComposeResult
-from textual.containers import Container
+from textual.containers import Container, Horizontal
 from textual.widgets import DataTable, Footer, Header, Static
 
+from .clipboard import copy_via_system_tool
 from .kafka_reader import KafkaReaderError, KafkaTupleReader
 from .scoring import score_tuple
 
@@ -47,9 +50,14 @@ class JaccardApp(App):
     #summary { height: 4; padding: 0 1; }
     #footnote { height: 1; padding: 0 1; color: $text-muted; }
     DataTable { height: 1fr; }
+    #detail { height: 14; border-top: solid $primary; }
+    #detail-src, #detail-tgt { width: 1fr; padding: 0 1; overflow-y: auto; }
+    #detail-src { border-right: solid $primary-darken-2; }
     """
     BINDINGS = [
         ("r", "reset", "Reset window"),
+        ("v", "toggle_view", "Hits/Request"),
+        ("c", "copy_request", "Copy request"),
         ("q", "quit", "Quit"),
     ]
 
@@ -70,17 +78,29 @@ class JaccardApp(App):
         self._buf_lock = threading.Lock()
         self._status = {"total": 0, "running": True, "connected": False, "error": None}
         self._reader: Optional[KafkaTupleReader] = None
+        self._seq = itertools.count(1)
+        # The highlighted row's identity, independent of the table rebuild every tick — a
+        # tuple's seq never changes, so this survives the window sliding underneath it and
+        # is what lets the detail pane and cursor position both be restored after a rebuild.
+        self._selected_seq: Optional[int] = None
+        # "hits" shows the side-by-side doc-ID diff; "request" shows the raw captured HTTP
+        # requests for copy/paste — toggled with 'v', independent of which row is selected.
+        self._view_mode = "hits"
         self.is_exiting = False
 
     def compose(self) -> ComposeResult:
         yield Header()
         yield Static("", id="summary")
         yield Container(DataTable(id=TABLE_ANCHOR, cursor_type="row"))
+        with Horizontal(id="detail"):
+            yield Static("", id="detail-src")
+            yield Static("", id="detail-tgt")
         yield Static("", id="footnote")
         yield Footer()
 
     def on_mount(self) -> None:
         self.table.add_columns(*COLUMNS)
+        self._update_detail()
         self.run_worker(self._bootstrap_and_stream, thread=True, name="kafka_reader")
         self.set_interval(self._refresh_interval, self._repaint)
 
@@ -112,8 +132,10 @@ class JaccardApp(App):
         for record in reader.stream():
             if self.is_exiting:
                 break
+            s = score_tuple(record)
+            s["seq"] = next(self._seq)
             with self._buf_lock:
-                self._buf.append(score_tuple(record))
+                self._buf.append(s)
                 self._status["total"] += 1
         self._status["running"] = False
 
@@ -166,9 +188,13 @@ class JaccardApp(App):
         summary.update(text)
 
     def _rebuild_table(self, buf: List[Dict]) -> None:
+        """Repaint the table, keeping the cursor (and so the detail pane) on the same tuple
+        across refreshes — row indexes shift as the window slides, so seq, not index, is what
+        identifies a row from one rebuild to the next."""
         table = self.table
         table.clear()
         show = [s for s in buf if s.get("j_label") != "preflight"][-self._window:]
+        added: List[Dict] = []
         for s in show:
             sh, th = s.get("src_hits"), s.get("tgt_hits")
             if sh is None and th is None:
@@ -179,7 +205,14 @@ class JaccardApp(App):
             uri = s["uri"] or "?"
             if len(uri) > 50:
                 uri = uri[:47] + "..."
-            table.add_row(j_cell, s["method"], uri, hits_cell, s.get("j_label") or "")
+            table.add_row(j_cell, s["method"], uri, hits_cell, s.get("j_label") or "",
+                          key=str(s["seq"]))
+            added.append(s)
+        if self._selected_seq is not None:
+            for i, s in enumerate(added):
+                if s["seq"] == self._selected_seq:
+                    table.move_cursor(row=i)
+                    break
 
     @staticmethod
     def _hits_cell(sh: Optional[int], th: Optional[int]) -> Text:
@@ -192,6 +225,113 @@ class JaccardApp(App):
         else:
             style = "red"
         return Text(f"{sh} → {th}", style=style)
+
+    def on_data_table_row_highlighted(self, event: DataTable.RowHighlighted) -> None:
+        seq = int(event.row_key.value) if event.row_key is not None and event.row_key.value else None
+        if seq == self._selected_seq:
+            return
+        self._selected_seq = seq
+        self._update_detail()
+
+    def _lookup_selected(self) -> Optional[Dict]:
+        if self._selected_seq is None:
+            return None
+        with self._buf_lock:
+            return next((x for x in self._buf if x.get("seq") == self._selected_seq), None)
+
+    def _update_detail(self) -> None:
+        """Render the highlighted tuple into the two side-by-side panes — either the hit-ID
+        diff or the raw request, per self._view_mode ('v' toggles between them).
+
+        Looks the tuple up by seq in the live buffer rather than caching it at selection time,
+        so the pane still works right after a reset clears everything (falls through to "no
+        longer available" instead of showing stale data).
+        """
+        src_pane = self.query_one("#detail-src", Static)
+        tgt_pane = self.query_one("#detail-tgt", Static)
+        if self._selected_seq is None:
+            src_pane.update(Text(
+                "select a row to see detail  ·  v: hits/request  ·  c: copy request", style="dim"))
+            tgt_pane.update("")
+            return
+        s = self._lookup_selected()
+        if s is None:
+            src_pane.update(Text("(tuple no longer in buffer)", style="dim"))
+            tgt_pane.update("")
+            return
+
+        if self._view_mode == "request":
+            src_pane.update(self._format_request("SOURCE REQUEST", s.get("src_request")))
+            tgt_pane.update(self._format_request("TARGET REQUEST", s.get("tgt_request")))
+            return
+
+        src_list, tgt_list = s.get("src_hit_list") or [], s.get("tgt_hit_list") or []
+        if not src_list and not tgt_list:
+            src_pane.update(Text(
+                f"{s['method']} {s['uri']}\n"
+                f"No hit-level detail for this request (status {s['src_status']} → {s['tgt_status']}).\n"
+                f"Press 'v' to view the raw request instead.",
+                style="dim"))
+            tgt_pane.update("")
+            return
+        src_ids = {h["id"] for h in src_list}
+        tgt_ids = {h["id"] for h in tgt_list}
+        src_pane.update(self._hit_list_text("SOURCE", s.get("src_hits"), src_list, tgt_ids))
+        tgt_pane.update(self._hit_list_text("TARGET", s.get("tgt_hits"), tgt_list, src_ids))
+
+    @staticmethod
+    def _format_request(label: str, req: Optional[Dict]) -> Text:
+        """The raw captured HTTP request, formatted so it's directly copy/paste-able — a
+        request line, headers, and a pretty-printed body if there was one."""
+        text = Text(f"{label}\n", style="bold")
+        if not req:
+            text.append("(not captured)", style="dim")
+            return text
+        method = req.get("Method", "?")
+        uri = req.get("Request-URI", "?")
+        version = req.get("HTTP-Version", "HTTP/1.1")
+        text.append(f"{method} {uri} {version}\n")
+        skip = {"Method", "Request-URI", "HTTP-Version", "payload"}
+        for key, value in req.items():
+            if key in skip:
+                continue
+            rendered = ", ".join(value) if isinstance(value, list) else str(value)
+            text.append(f"{key}: {rendered}\n", style="dim")
+        payload = req.get("payload", {}) or {}
+        body = None
+        # Four documented shapes (see ResultsToLogsConsumer's tuple-format docstring), checked
+        # by key presence rather than truthiness — an empty dict/list body is still a real,
+        # present body, not "no body".
+        if "inlinedJsonBody" in payload:
+            body = json.dumps(payload["inlinedJsonBody"], indent=2)
+        elif "inlinedJsonSequenceBodies" in payload:
+            # NDJSON — one JSON object per line, matching the real wire format of
+            # _bulk/_msearch request bodies.
+            body = "\n".join(json.dumps(obj) for obj in payload["inlinedJsonSequenceBodies"])
+        elif "inlinedTextBody" in payload:
+            body = payload["inlinedTextBody"]
+        elif "inlinedBinaryBody" in payload or "inlinedBase64Body" in payload:
+            body = "(binary body — not shown)"
+        elif payload:
+            # An unrecognized payload shape — show it raw rather than silently dropping it.
+            body = json.dumps(payload, indent=2)
+        if body:
+            text.append("\n")
+            text.append(body)
+        return text
+
+    @staticmethod
+    def _hit_list_text(label: str, total: Optional[int], hits: List[Dict], other_ids: set) -> Text:
+        text = Text(f"{label} — {total if total is not None else len(hits)} hits\n", style="bold")
+        for i, h in enumerate(hits, 1):
+            style = "" if h["id"] in other_ids else "red"
+            text.append(f"{i:>2}. {h['id']}", style=style)
+            if h.get("score") is not None:
+                text.append(f"  ({h['score']:.2f})", style="dim")
+            text.append("\n")
+        if not hits:
+            text.append("(no hits)", style="dim")
+        return text
 
     def _update_footnote(self, buf: List[Dict]) -> None:
         n_options = sum(1 for s in buf if s.get("j_label") == "preflight")
@@ -213,3 +353,35 @@ class JaccardApp(App):
         with self._buf_lock:
             self._buf.clear()
             self._status["total"] = 0
+        self._selected_seq = None
+        self._update_detail()
+
+    def action_toggle_view(self) -> None:
+        self._view_mode = "request" if self._view_mode == "hits" else "hits"
+        self._update_detail()
+
+    def action_copy_request(self) -> None:
+        """Copy the selected tuple's source + target request to the system clipboard.
+
+        Tries the OS's own clipboard tool (pbcopy/xclip/etc.) first — Textual's built-in
+        copy_to_clipboard() only works via an OSC 52 terminal escape sequence, which its own
+        docs say plainly does not work on macOS Terminal.app, so it's the fallback here, not
+        the first attempt.
+        """
+        s = self._lookup_selected()
+        if s is None:
+            self.notify("No row selected to copy" if self._selected_seq is None
+                        else "Tuple no longer in buffer", severity="warning")
+            return
+        src_text = str(self._format_request("SOURCE REQUEST", s.get("src_request")))
+        tgt_text = str(self._format_request("TARGET REQUEST", s.get("tgt_request")))
+        combined = f"{src_text}\n\n{tgt_text}"
+        if copy_via_system_tool(combined):
+            self.notify("Copied source + target request to clipboard")
+        else:
+            self.copy_to_clipboard(combined)
+            self.notify(
+                "No system clipboard tool found — sent via terminal escape sequence (OSC 52), "
+                "which does not work on macOS Terminal.app. Press 'v' to view and select the "
+                "text by hand instead.",
+                severity="warning", timeout=8)

--- a/deployment/k8s/tui/app.py
+++ b/deployment/k8s/tui/app.py
@@ -52,8 +52,6 @@ def _score_color(j: Optional[float]) -> str:
     if j >= 0.80:
         return "yellow"
     return "red"
-
-
 def _running_avg(st: Dict) -> Optional[float]:
     """Running average of an accumulated stat bucket, or None if nothing in it scored."""
     return (st["sum"] / st["scored_count"]) if st["scored_count"] else None
@@ -541,6 +539,19 @@ class JaccardApp(App):
         src_pane.update(self._hit_list_text(f"SOURCE — {sq['label']}", sq.get("src_hits"), src_list, tgt_ids))
         tgt_pane.update(self._hit_list_text(f"TARGET — {sq['label']}", sq.get("tgt_hits"), tgt_list, src_ids))
 
+    @staticmethod
+    def _append_type_detail_row(text: Text, label: str, st: Dict) -> None:
+        """Append one scoring-method row ('doc IDs', 'RBO (p=0.9)', ...) to a by-type detail
+        breakdown — the average score (colored, or a dash if nothing was ever scored under
+        it), the sample count, and the min/max range when there's an average to bound."""
+        avg = (st["sum"] / st["scored_count"]) if st["scored_count"] else None
+        avg_text = "   -   " if avg is None else f"{avg:>7.3f}"
+        text.append(avg_text, style="bold" if avg is None else _score_color(avg))
+        text.append(f"  {label}   n={st['count']}")
+        if avg is not None:
+            text.append(f"   [{st['min']:.3f}–{st['max']:.3f}]", style="dim")
+        text.append("\n")
+
     def _update_types_detail(self, src_pane: Static, tgt_pane: Static) -> None:
         """The selected type's breakdown by scoring method — e.g. 'hits' items are scored
         either 'doc IDs' or 'hit count ratio' depending on whether either side's response had
@@ -561,12 +572,7 @@ class JaccardApp(App):
             text.append("(no data)", style="dim")
         else:
             for label, st in sorted(by_label.items(), key=lambda kv: -kv[1]["count"]):
-                avg = _running_avg(st)
-                text.append(_score_cell(avg), style=_score_style(avg))
-                text.append(f"  {label}   n={st['count']}")
-                if avg is not None:
-                    text.append(f"   [{st['min']:.3f}–{st['max']:.3f}]", style="dim")
-                text.append("\n")
+                self._append_type_detail_row(text, label, st)
         src_pane.update(text)
         tgt_pane.update("")
 
@@ -685,6 +691,29 @@ class JaccardApp(App):
     # the footnote panel growing without bound if that ever changes.
     _MAX_LIFETIME_LABELS_SHOWN = 8
 
+    @staticmethod
+    def _lifetime_meta_line(preflight: int, no_subq: Dict[str, int]) -> Optional[str]:
+        """The optional summary line above the per-label breakdown — OPTIONS preflight count
+        and a 'no score' breakdown by method, joined together when either is non-zero."""
+        parts = []
+        if preflight:
+            parts.append(f"{preflight}× OPTIONS preflight (skipped)")
+        if no_subq:
+            breakdown = ", ".join(f"{c}× {m}" for m, c in sorted(no_subq.items()))
+            parts.append(f"no score: {breakdown}")
+        return "  •  ".join(parts) if parts else None
+
+    @staticmethod
+    def _append_lifetime_label(text: Text, label: str, st: Dict) -> None:
+        """Append one label's rolled-up lifetime stat (average score, sample count, min/max
+        range) to the footnote line."""
+        avg = (st["sum"] / st["scored_count"]) if st["scored_count"] else None
+        text.append(f"{label}", style="bold" if avg is None else _score_color(avg))
+        text.append(f" n={st['count']}", style="dim")
+        if avg is not None:
+            text.append(f" avg={avg:.3f} [{st['min']:.3f}–{st['max']:.3f}]", style="dim")
+        text.append("   ")
+
     def _update_footnote(self) -> None:
         """Lifetime, per-label running stats — unbounded, independent of the sliding window
         and of 'r' (which only clears what's on screen). A flat overall average would have
@@ -697,14 +726,9 @@ class JaccardApp(App):
             no_subq = dict(self._lifetime_no_subqueries)
 
         text = Text()
-        meta_parts = []
-        if preflight:
-            meta_parts.append(f"{preflight}× OPTIONS preflight (skipped)")
-        if no_subq:
-            breakdown = ", ".join(f"{c}× {m}" for m, c in sorted(no_subq.items()))
-            meta_parts.append(f"no score: {breakdown}")
-        if meta_parts:
-            text.append("  •  ".join(meta_parts) + "\n", style="dim")
+        meta_line = self._lifetime_meta_line(preflight, no_subq)
+        if meta_line:
+            text.append(meta_line + "\n", style="dim")
 
         if not stats:
             text.append("lifetime: (no scored items yet)", style="dim")
@@ -714,12 +738,7 @@ class JaccardApp(App):
             text.append("LIFETIME", style="bold")
             text.append(f" ({self._score_metric})  ", style="dim")
             for label, st in shown:
-                avg = _running_avg(st)
-                text.append(f"{label}", style=_score_style(avg))
-                text.append(f" n={st['count']}", style="dim")
-                if avg is not None:
-                    text.append(f" avg={avg:.3f} [{st['min']:.3f}–{st['max']:.3f}]", style="dim")
-                text.append("   ")
+                self._append_lifetime_label(text, label, st)
             if hidden:
                 text.append(f"+{len(hidden)} more label(s)", style="dim")
         self.query_one("#footnote", Static).update(text)

--- a/deployment/k8s/tui/app.py
+++ b/deployment/k8s/tui/app.py
@@ -75,6 +75,7 @@ class JaccardApp(App):
     BINDINGS = [
         ("r", "reset", "Reset window"),
         ("v", "toggle_view", "Hits/Request"),
+        ("m", "toggle_metric", "Jaccard/RBO"),
         ("c", "copy_request", "Copy request"),
         ("q", "quit", "Quit"),
     ]
@@ -105,6 +106,12 @@ class JaccardApp(App):
         # "hits" shows the side-by-side doc-ID diff; "request" shows the raw captured HTTP
         # request(s) for copy/paste — toggled with 'v', independent of which row is selected.
         self._view_mode = "hits"
+        # Which score to DISPLAY for "hits" items — both are always computed and stored on
+        # every item (scoring.py's _response_items), so toggling this is just a matter of
+        # which already-computed field gets read; nothing needs rescoring. RBO has no
+        # equivalent for aggregation items (weighted bucket overlap isn't a ranked-list
+        # comparison), so those always show their one score regardless of this setting.
+        self._score_metric = "jaccard"
         # The seqs shown last time _rebuild_table ran — a full clear()+re-add on every tick
         # visibly flickers and resets scroll position, so it's skipped whenever the visible
         # set of requests hasn't actually changed (the common case between new arrivals).
@@ -171,6 +178,14 @@ class JaccardApp(App):
         self._rebuild_table(buf)
         self._update_footnote(buf)
 
+    def _effective_score(self, sq: Dict) -> Tuple[Optional[float], Optional[str]]:
+        """The (score, label) to DISPLAY for one item, per the current metric mode. RBO only
+        applies to "hits" items — aggregations keep their own weighted bucket-overlap score
+        regardless of mode, since RBO has no meaningful equivalent for them."""
+        if self._score_metric == "rbo" and sq.get("kind") == "hits":
+            return sq.get("rbo_j"), sq.get("rbo_label")
+        return sq.get("j"), sq.get("j_label")
+
     def _visible_tuples(self, buf: List[Dict]) -> List[Dict]:
         """The last N qualifying requests — shared by the table and the footnote so both
         agree on what "the window" means. Preflight OPTIONS and requests with no hit data on
@@ -192,10 +207,12 @@ class JaccardApp(App):
             summary.update(f"Confirming topic '{self._topic}' exists and is reachable…")
             return
 
-        all_js = [sq["j"] for s in buf for sq in s.get("subqueries", []) if sq["j"] is not None]
+        all_js = [j for s in buf for sq in s.get("subqueries", [])
+                  for j, _ in [self._effective_score(sq)] if j is not None]
         window = all_js[-self._window:]
         blanks = self._window - len(window)
-        text = Text("Jaccard  ")
+        metric_name = "RBO" if self._score_metric == "rbo" else "Jaccard"
+        text = Text(f"{metric_name}  ")
         text.append(Text("░ " * blanks, style="dim"))
         text.append(Text(" ").join(_spark_char(j) for j in window))
         text.append("\n")
@@ -248,13 +265,13 @@ class JaccardApp(App):
                           key=parent_key)
             row_keys.append(parent_key)
             for i, sq in enumerate(subqueries):
-                j = sq["j"]
+                j, j_label = self._effective_score(sq)
                 j_cell = (Text("-", style="dim") if j is None
                           else Text(f"{j:.3f}", style=f"bold {_score_color(j)}"))
                 hits_cell = self._hits_cell(sq.get("src_hits"), sq.get("tgt_hits"))
                 child_key = f"{s['seq']}:{i}"
                 table.add_row(j_cell, "", Text(f"  ↳ {sq['label']}", style="dim"),
-                              hits_cell, sq.get("j_label") or "", key=child_key)
+                              hits_cell, j_label or "", key=child_key)
                 row_keys.append(child_key)
         if self._selected_key is not None and self._selected_key in row_keys:
             # scroll=False: the scroll_y restore below is authoritative — letting this also
@@ -311,7 +328,8 @@ class JaccardApp(App):
         tgt_pane = self.query_one("#detail-tgt", Static)
         if self._selected_key is None:
             src_pane.update(Text(
-                "select a row to see detail  ·  v: hits/request  ·  c: copy request", style="dim"))
+                "select a row to see detail  ·  v: hits/request  ·  m: jaccard/rbo  ·  c: copy request",
+                style="dim"))
             tgt_pane.update("")
             return
         found = self._lookup_selected()
@@ -382,8 +400,7 @@ class JaccardApp(App):
         text.append("(no aggregation data)", style="dim")
         return text
 
-    @staticmethod
-    def _subquery_overview(s: Dict) -> Text:
+    def _subquery_overview(self, s: Dict) -> Text:
         """A parent row's detail: a compact list of its rows (hits and/or aggregations) and
         their scores — the overview a blended average used to replace. Select a row below for
         its full detail."""
@@ -393,7 +410,7 @@ class JaccardApp(App):
         text.append(f"{n} row{'s' if n != 1 else ''} "
                      f"— select one below for detail\n\n", style="dim")
         for sq in subqueries:
-            j = sq["j"]
+            j, _ = self._effective_score(sq)
             j_text = "   -   " if j is None else f"{j:>7.3f}"
             text.append(j_text, style=f"bold {_score_color(j)}")
             text.append(f"  {sq['label']}")
@@ -488,10 +505,22 @@ class JaccardApp(App):
             self._status["total"] = 0
         self._selected_key = None
         self._update_detail()
+        self._repaint()
 
     def action_toggle_view(self) -> None:
         self._view_mode = "request" if self._view_mode == "hits" else "hits"
         self._update_detail()
+
+    def action_toggle_metric(self) -> None:
+        """Swap which already-computed score 'hits' items display — Jaccard (set overlap,
+        order-blind) or RBO (rank-biased overlap, penalizes reordering). Both scores are
+        always computed and stored per item, so this never needs to rescore anything already
+        in the buffer; it just changes which stored field the table/summary/overview read."""
+        self._score_metric = "rbo" if self._score_metric == "jaccard" else "jaccard"
+        self.notify(f"Scoring metric: {self._score_metric.upper()}")
+        self._last_row_signature = None  # force a table repaint even though seqs are unchanged
+        self._update_detail()
+        self._repaint()
 
     def action_copy_request(self) -> None:
         """Copy the selected row's request(s) to the system clipboard — the whole HTTP

--- a/deployment/k8s/tui/app.py
+++ b/deployment/k8s/tui/app.py
@@ -36,6 +36,7 @@ logger = logging.getLogger(__name__)
 
 TABLE_ANCHOR = "tuples"
 COLUMNS = ("J", "METHOD", "URI", "SRC → TGT", "NOTE")
+TYPE_COLUMNS = ("TYPE", "N", "SCORED", "AVG", "MIN", "MAX")
 SPARK = "▁▂▃▄▅▆▇█"
 
 
@@ -43,6 +44,17 @@ def _score_color(j: Optional[float]) -> str:
     if j is None:
         return "dim"
     return "green" if j >= 0.95 else ("yellow" if j >= 0.80 else "red")
+
+
+def _type_key(label: str) -> str:
+    """Strip a per-position prefix like '1/2 (typefilter)' off a subquery label, leaving just
+    the comparison TYPE — 'hits', 'agg:filter_product_type', etc. Labels are built in
+    scoring.py as '{position prefix} · {type}'; grouping by this tail is what lets the
+    by-type view answer "how is agg:supplier doing overall" across every position/request
+    it's ever shown up in, rather than one row per position."""
+    if " · " in label:
+        return label.rsplit(" · ", 1)[1]
+    return label
 
 
 def _spark_char(j: Optional[float]) -> Text:
@@ -74,6 +86,7 @@ class JaccardApp(App):
     """
     BINDINGS = [
         ("r", "reset", "Reset window"),
+        ("t", "toggle_top_view", "Live/By type"),
         ("v", "toggle_view", "Hits/Request"),
         ("m", "toggle_metric", "Jaccard/RBO"),
         ("c", "copy_request", "Copy request"),
@@ -119,12 +132,30 @@ class JaccardApp(App):
         # tracked simultaneously (mirroring how each item always carries both scores) so
         # toggling 'm' swaps which lifetime breakdown is shown without losing history.
         self._lifetime_stats = {"jaccard": {}, "rbo": {}}
+        # Same shape as _lifetime_stats (count/scored_count/sum/min/max per metric), but keyed
+        # by comparison TYPE (_type_key(sq["label"]) — "hits", "agg:filter_product_type", ...)
+        # instead of by scoring method. _lifetime_stats answers "how is 'doc IDs' scoring doing
+        # overall"; this answers "how is 'agg:filter_product_type' doing overall" — two
+        # different axes over the same underlying items, so both are tracked, not derived from
+        # each other (a "doc IDs" bucket can span many item types' worth of hits comparisons;
+        # an "agg:filter_product_type" bucket can span many scoring-method labels if its shape
+        # ever varies request to request).
+        self._lifetime_by_type = {"jaccard": {}, "rbo": {}}
+        # type_key -> scoring-method label -> stats — the by-type view's drill-down: which
+        # scoring methods make up a given type's rolled-up total, and how each is doing.
+        self._lifetime_by_type_detail: Dict[str, Dict[str, Dict]] = {"jaccard": {}, "rbo": {}}
         self._lifetime_preflight = 0
         self._lifetime_no_subqueries: Dict[str, int] = {}
         # The seqs shown last time _rebuild_table ran — a full clear()+re-add on every tick
         # visibly flickers and resets scroll position, so it's skipped whenever the visible
         # set of requests hasn't actually changed (the common case between new arrivals).
         self._last_row_signature: Optional[Tuple[int, ...]] = None
+        # "live" is the per-request table this class started with; "types" replaces it with
+        # one row per comparison TYPE (hits, agg:filter_product_type, ...), aggregated across
+        # every position it's ever appeared at — toggled with 't', independent of the sliding
+        # window / 'r' reset, same lifetime scope as the footnote it's built from.
+        self._top_view = "live"
+        self._last_types_signature: Optional[Tuple[Tuple[str, int, float], ...]] = None
         self.is_exiting = False
 
     def compose(self) -> ComposeResult:
@@ -180,8 +211,10 @@ class JaccardApp(App):
         self._status["running"] = False
 
     def _record_lifetime(self, s: Dict) -> None:
-        """Accumulate one newly-scored tuple into the lifetime, per-label stats. Caller must
-        already hold _buf_lock — this mutates the same shared state _repaint() reads."""
+        """Accumulate one newly-scored tuple into every lifetime breakdown this app tracks —
+        by scoring method (_lifetime_stats), by comparison type (_lifetime_by_type), and type
+        drilled down to scoring method (_lifetime_by_type_detail). Caller must already hold
+        _buf_lock — this mutates the same shared state _repaint() reads."""
         if s.get("j_label") == "preflight":
             self._lifetime_preflight += 1
             return
@@ -191,17 +224,25 @@ class JaccardApp(App):
             self._lifetime_no_subqueries[method] = self._lifetime_no_subqueries.get(method, 0) + 1
             return
         for sq in subqueries:
+            type_key = _type_key(sq.get("label") or "(unlabeled)")
             for metric in ("jaccard", "rbo"):
                 value, label = self._metric_score(sq, metric)
                 label = label or "(unlabeled)"
-                bucket = self._lifetime_stats[metric].setdefault(
-                    label, {"count": 0, "scored_count": 0, "sum": 0.0, "min": None, "max": None})
-                bucket["count"] += 1
-                if value is not None:
-                    bucket["scored_count"] += 1
-                    bucket["sum"] += value
-                    bucket["min"] = value if bucket["min"] is None else min(bucket["min"], value)
-                    bucket["max"] = value if bucket["max"] is None else max(bucket["max"], value)
+                self._accumulate(self._lifetime_stats[metric], label, value)
+                self._accumulate(self._lifetime_by_type[metric], type_key, value)
+                self._accumulate(
+                    self._lifetime_by_type_detail[metric].setdefault(type_key, {}), label, value)
+
+    @staticmethod
+    def _accumulate(store: Dict[str, Dict], key: str, value: Optional[float]) -> None:
+        bucket = store.setdefault(
+            key, {"count": 0, "scored_count": 0, "sum": 0.0, "min": None, "max": None})
+        bucket["count"] += 1
+        if value is not None:
+            bucket["scored_count"] += 1
+            bucket["sum"] += value
+            bucket["min"] = value if bucket["min"] is None else min(bucket["min"], value)
+            bucket["max"] = value if bucket["max"] is None else max(bucket["max"], value)
 
     # --- Repaint (main thread, on a timer — never touches the Kafka subprocess) ---
 
@@ -209,7 +250,10 @@ class JaccardApp(App):
         with self._buf_lock:
             buf = list(self._buf)
         self._update_summary(buf)
-        self._rebuild_table(buf)
+        if self._top_view == "types":
+            self._rebuild_types_table()
+        else:
+            self._rebuild_table(buf)
         self._update_footnote()
 
     @staticmethod
@@ -323,6 +367,40 @@ class JaccardApp(App):
         # silently come out smaller than what was actually saved.
         self.call_after_refresh(setattr, table, "scroll_y", scroll_y)
 
+    def _rebuild_types_table(self) -> None:
+        """Repaint the table in 'by type' mode: one row per comparison TYPE (hits,
+        agg:filter_product_type, agg:supplier, ...), aggregated across every position/request
+        that type has ever appeared at — a live per-request table answers "how did THIS
+        request do"; this answers "how is agg:supplier doing overall, across everything
+        replayed so far". Reads _lifetime_by_type directly — already keyed by type, not by
+        scoring method, so no re-derivation is needed here.
+        """
+        with self._buf_lock:
+            by_type = {k: dict(v) for k, v in self._lifetime_by_type[self._score_metric].items()}
+
+        ranked = sorted(by_type.items(), key=lambda kv: -kv[1]["count"])
+        signature = tuple((k, v["count"], round(v["sum"], 6)) for k, v in ranked)
+        if signature == self._last_types_signature:
+            return
+        self._last_types_signature = signature
+
+        table = self.table
+        scroll_y = table.scroll_y
+        table.clear()
+        row_keys: List[str] = []
+        for type_key, st in ranked:
+            avg = (st["sum"] / st["scored_count"]) if st["scored_count"] else None
+            avg_cell = (Text("-", style="dim") if avg is None
+                        else Text(f"{avg:.3f}", style=f"bold {_score_color(avg)}"))
+            min_cell = "-" if st["min"] is None else f"{st['min']:.3f}"
+            max_cell = "-" if st["max"] is None else f"{st['max']:.3f}"
+            table.add_row(Text(type_key, style="bold"), str(st["count"]), str(st["scored_count"]),
+                          avg_cell, min_cell, max_cell, key=type_key)
+            row_keys.append(type_key)
+        if self._selected_key is not None and self._selected_key in row_keys:
+            table.move_cursor(row=row_keys.index(self._selected_key), scroll=False)
+        self.call_after_refresh(setattr, table, "scroll_y", scroll_y)
+
     @staticmethod
     def _hits_cell(sh: Optional[int], th: Optional[int]) -> Text:
         if sh is None or th is None:
@@ -367,6 +445,9 @@ class JaccardApp(App):
     def _update_detail(self) -> None:
         src_pane = self.query_one("#detail-src", Static)
         tgt_pane = self.query_one("#detail-tgt", Static)
+        if self._top_view == "types":
+            self._update_types_detail(src_pane, tgt_pane)
+            return
         if self._selected_key is None:
             src_pane.update(Text(
                 "select a row to see detail  ·  v: hits/request  ·  m: jaccard/rbo  ·  c: copy request",
@@ -412,6 +493,36 @@ class JaccardApp(App):
         tgt_ids = {h["id"] for h in tgt_list}
         src_pane.update(self._hit_list_text(f"SOURCE — {sq['label']}", sq.get("src_hits"), src_list, tgt_ids))
         tgt_pane.update(self._hit_list_text(f"TARGET — {sq['label']}", sq.get("tgt_hits"), tgt_list, src_ids))
+
+    def _update_types_detail(self, src_pane: Static, tgt_pane: Static) -> None:
+        """The selected type's breakdown by scoring method — e.g. 'hits' items are scored
+        either 'doc IDs' or 'hit count ratio' depending on whether either side's response had
+        an empty hits array; this is where that split is still visible, since the main
+        by-type table itself only shows the type's rolled-up total."""
+        if self._selected_key is None:
+            src_pane.update(Text(
+                "select a type to see its breakdown by scoring method  ·  t: live view  ·  m: jaccard/rbo",
+                style="dim"))
+            tgt_pane.update("")
+            return
+        type_key = self._selected_key
+        with self._buf_lock:
+            by_label = {k: dict(v) for k, v
+                        in self._lifetime_by_type_detail[self._score_metric].get(type_key, {}).items()}
+        text = Text(f"{type_key} — by scoring method\n", style="bold")
+        if not by_label:
+            text.append("(no data)", style="dim")
+        else:
+            for label, st in sorted(by_label.items(), key=lambda kv: -kv[1]["count"]):
+                avg = (st["sum"] / st["scored_count"]) if st["scored_count"] else None
+                avg_text = "   -   " if avg is None else f"{avg:>7.3f}"
+                text.append(avg_text, style="bold" if avg is None else _score_color(avg))
+                text.append(f"  {label}   n={st['count']}")
+                if avg is not None:
+                    text.append(f"   [{st['min']:.3f}–{st['max']:.3f}]", style="dim")
+                text.append("\n")
+        src_pane.update(text)
+        tgt_pane.update("")
 
     @staticmethod
     def _agg_detail_text(label: str, agg: Optional[Dict], other_agg: Optional[Dict]) -> Text:
@@ -515,7 +626,7 @@ class JaccardApp(App):
     def _hit_list_text(label: str, total: Optional[int], hits: List[Dict], other_ids: set) -> Text:
         text = Text(f"{label} — {total if total is not None else len(hits)} hits\n", style="bold")
         for i, h in enumerate(hits, 1):
-            style = "" if h["id"] in other_ids else "red"
+            style = "green" if h["id"] in other_ids else "red"
             text.append(f"{i:>2}. {h['id']}", style=style)
             if h.get("score") is not None:
                 text.append(f"  ({h['score']:.2f})", style="dim")
@@ -578,7 +689,29 @@ class JaccardApp(App):
         self._update_detail()
         self._repaint()
 
+    def action_toggle_top_view(self) -> None:
+        """Swap the whole main table between 'live' (one row per replayed request, the
+        original view) and 'types' (one row per comparison TYPE, aggregated across every
+        position it's ever appeared at). Column sets differ between the two, so the table's
+        columns are rebuilt too, not just its rows; row-key formats also differ ("<seq>" /
+        "<seq>:<idx>" vs. a bare type key), so any prior selection is dropped rather than
+        carried across — it wouldn't resolve to anything meaningful on the other side anyway.
+        """
+        self._top_view = "types" if self._top_view == "live" else "live"
+        self._selected_key = None
+        self._last_row_signature = None
+        self._last_types_signature = None
+        table = self.table
+        table.clear(columns=True)
+        table.add_columns(*(TYPE_COLUMNS if self._top_view == "types" else COLUMNS))
+        self._update_detail()
+        self._repaint()
+
     def action_toggle_view(self) -> None:
+        if self._top_view == "types":
+            self.notify("Not available in 'by type' view — press 't' for live view",
+                        severity="warning")
+            return
         self._view_mode = "request" if self._view_mode == "hits" else "hits"
         self._update_detail()
 
@@ -603,6 +736,10 @@ class JaccardApp(App):
         docs say plainly does not work on macOS Terminal.app, so it's the fallback here, not
         the first attempt.
         """
+        if self._top_view == "types":
+            self.notify("Not available in 'by type' view — press 't' for live view",
+                        severity="warning")
+            return
         found = self._lookup_selected()
         if found is None:
             self.notify("No row selected to copy" if self._selected_key is None

--- a/deployment/k8s/tui/app.py
+++ b/deployment/k8s/tui/app.py
@@ -188,7 +188,7 @@ class JaccardApp(App):
 
     def _bootstrap_and_stream(self) -> None:
         reader = KafkaTupleReader(self._namespace, self._topic,
-                                   auto_create_topic=self._auto_create_topic)
+                                  auto_create_topic=self._auto_create_topic)
         try:
             reader.ensure_ready()
         except KafkaReaderError as e:
@@ -306,7 +306,7 @@ class JaccardApp(App):
             text.append("avg ")
             text.append(f"{avg_j:.3f}", style=f"bold {_score_color(avg_j)}")
             text.append(f"   min {min(window):.3f}   max {max(window):.3f}"
-                         f"   ({len(window)} sub-query scores, {self._status['total']} requests seen)")
+                        f"   ({len(window)} sub-query scores, {self._status['total']} requests seen)")
         else:
             text.append(f"0 tuples seen yet — waiting for live traffic on '{self._topic}'")
             if not self._status["running"]:
@@ -560,7 +560,7 @@ class JaccardApp(App):
         text = Text(f"{s['method']} {s['uri']}\n", style="bold")
         n = len(subqueries)
         text.append(f"{n} row{'s' if n != 1 else ''} "
-                     f"— select one below for detail\n\n", style="dim")
+                    f"— select one below for detail\n\n", style="dim")
         for sq in subqueries:
             j, _ = self._effective_score(sq)
             j_text = "   -   " if j is None else f"{j:>7.3f}"

--- a/deployment/k8s/tui/app.py
+++ b/deployment/k8s/tui/app.py
@@ -66,7 +66,7 @@ class JaccardApp(App):
 
     CSS = """
     #summary { height: 4; padding: 0 1; }
-    #footnote { height: 1; padding: 0 1; color: $text-muted; }
+    #footnote { height: auto; max-height: 4; padding: 0 1; color: $text-muted; }
     DataTable { height: 1fr; }
     #detail { height: 14; border-top: solid $primary; }
     #detail-src, #detail-tgt { width: 1fr; padding: 0 1; overflow-y: auto; }
@@ -112,6 +112,15 @@ class JaccardApp(App):
         # equivalent for aggregation items (weighted bucket overlap isn't a ranked-list
         # comparison), so those always show their one score regardless of this setting.
         self._score_metric = "jaccard"
+        # Unbounded, per-label running stats — deliberately NOT tied to the sliding window or
+        # to 'r' (reset only clears what's on screen). A flat overall average has the same
+        # blind spot per-request averaging did before the parent/child rework: one badly
+        # diverged label could hide inside an otherwise-good overall number. Both metrics are
+        # tracked simultaneously (mirroring how each item always carries both scores) so
+        # toggling 'm' swaps which lifetime breakdown is shown without losing history.
+        self._lifetime_stats = {"jaccard": {}, "rbo": {}}
+        self._lifetime_preflight = 0
+        self._lifetime_no_subqueries: Dict[str, int] = {}
         # The seqs shown last time _rebuild_table ran — a full clear()+re-add on every tick
         # visibly flickers and resets scroll position, so it's skipped whenever the visible
         # set of requests hasn't actually changed (the common case between new arrivals).
@@ -167,7 +176,32 @@ class JaccardApp(App):
             with self._buf_lock:
                 self._buf.append(s)
                 self._status["total"] += 1
+                self._record_lifetime(s)
         self._status["running"] = False
+
+    def _record_lifetime(self, s: Dict) -> None:
+        """Accumulate one newly-scored tuple into the lifetime, per-label stats. Caller must
+        already hold _buf_lock — this mutates the same shared state _repaint() reads."""
+        if s.get("j_label") == "preflight":
+            self._lifetime_preflight += 1
+            return
+        subqueries = s.get("subqueries", [])
+        if not subqueries:
+            method = s["method"]
+            self._lifetime_no_subqueries[method] = self._lifetime_no_subqueries.get(method, 0) + 1
+            return
+        for sq in subqueries:
+            for metric in ("jaccard", "rbo"):
+                value, label = self._metric_score(sq, metric)
+                label = label or "(unlabeled)"
+                bucket = self._lifetime_stats[metric].setdefault(
+                    label, {"count": 0, "scored_count": 0, "sum": 0.0, "min": None, "max": None})
+                bucket["count"] += 1
+                if value is not None:
+                    bucket["scored_count"] += 1
+                    bucket["sum"] += value
+                    bucket["min"] = value if bucket["min"] is None else min(bucket["min"], value)
+                    bucket["max"] = value if bucket["max"] is None else max(bucket["max"], value)
 
     # --- Repaint (main thread, on a timer — never touches the Kafka subprocess) ---
 
@@ -176,15 +210,22 @@ class JaccardApp(App):
             buf = list(self._buf)
         self._update_summary(buf)
         self._rebuild_table(buf)
-        self._update_footnote(buf)
+        self._update_footnote()
 
-    def _effective_score(self, sq: Dict) -> Tuple[Optional[float], Optional[str]]:
-        """The (score, label) to DISPLAY for one item, per the current metric mode. RBO only
-        applies to "hits" items — aggregations keep their own weighted bucket-overlap score
-        regardless of mode, since RBO has no meaningful equivalent for them."""
-        if self._score_metric == "rbo" and sq.get("kind") == "hits":
+    @staticmethod
+    def _metric_score(sq: Dict, metric: str) -> Tuple[Optional[float], Optional[str]]:
+        """The (score, label) for one item under a GIVEN metric — RBO only applies to "hits"
+        items; aggregations keep their own weighted bucket-overlap score under either metric,
+        since RBO has no meaningful equivalent for them. Parameterized (rather than reading
+        self._score_metric directly) so lifetime stats can accumulate both metrics at once
+        without needing the display mode to match what's being recorded."""
+        if metric == "rbo" and sq.get("kind") == "hits":
             return sq.get("rbo_j"), sq.get("rbo_label")
         return sq.get("j"), sq.get("j_label")
+
+    def _effective_score(self, sq: Dict) -> Tuple[Optional[float], Optional[str]]:
+        """The (score, label) to DISPLAY for one item, per the current metric mode."""
+        return self._metric_score(sq, self._score_metric)
 
     def _visible_tuples(self, buf: List[Dict]) -> List[Dict]:
         """The last N qualifying requests — shared by the table and the footnote so both
@@ -483,19 +524,49 @@ class JaccardApp(App):
             text.append("(no hits)", style="dim")
         return text
 
-    def _update_footnote(self, buf: List[Dict]) -> None:
-        n_options = sum(1 for s in buf if s.get("j_label") == "preflight")
-        no_score = [s for s in buf if not s.get("subqueries") and s.get("j_label") != "preflight"]
-        parts = []
-        if n_options:
-            parts.append(f"{n_options}× OPTIONS preflight (skipped)")
-        if no_score:
-            methods: Dict[str, int] = {}
-            for s in no_score:
-                methods[s["method"]] = methods.get(s["method"], 0) + 1
-            breakdown = ", ".join(f"{c}× {m}" for m, c in sorted(methods.items()))
-            parts.append(f"no score: {breakdown}")
-        self.query_one("#footnote", Static).update("  •  ".join(parts))
+    # Most labels ever seen at once is small and known (doc IDs / hit count ratio / RBO / a
+    # handful of agg + unscored variants from scoring.py) — this cap is just a backstop against
+    # the footnote panel growing without bound if that ever changes.
+    _MAX_LIFETIME_LABELS_SHOWN = 8
+
+    def _update_footnote(self) -> None:
+        """Lifetime, per-label running stats — unbounded, independent of the sliding window
+        and of 'r' (which only clears what's on screen). A flat overall average would have
+        the same blind spot per-request averaging did before the parent/child rework: one
+        consistently-diverged label could hide inside an otherwise-good overall number.
+        """
+        with self._buf_lock:
+            stats = {k: dict(v) for k, v in self._lifetime_stats[self._score_metric].items()}
+            preflight = self._lifetime_preflight
+            no_subq = dict(self._lifetime_no_subqueries)
+
+        text = Text()
+        meta_parts = []
+        if preflight:
+            meta_parts.append(f"{preflight}× OPTIONS preflight (skipped)")
+        if no_subq:
+            breakdown = ", ".join(f"{c}× {m}" for m, c in sorted(no_subq.items()))
+            meta_parts.append(f"no score: {breakdown}")
+        if meta_parts:
+            text.append("  •  ".join(meta_parts) + "\n", style="dim")
+
+        if not stats:
+            text.append("lifetime: (no scored items yet)", style="dim")
+        else:
+            ranked = sorted(stats.items(), key=lambda kv: -kv[1]["count"])
+            shown, hidden = ranked[:self._MAX_LIFETIME_LABELS_SHOWN], ranked[self._MAX_LIFETIME_LABELS_SHOWN:]
+            text.append("LIFETIME", style="bold")
+            text.append(f" ({self._score_metric})  ", style="dim")
+            for label, st in shown:
+                avg = (st["sum"] / st["scored_count"]) if st["scored_count"] else None
+                text.append(f"{label}", style="bold" if avg is None else _score_color(avg))
+                text.append(f" n={st['count']}", style="dim")
+                if avg is not None:
+                    text.append(f" avg={avg:.3f} [{st['min']:.3f}–{st['max']:.3f}]", style="dim")
+                text.append("   ")
+            if hidden:
+                text.append(f"+{len(hidden)} more label(s)", style="dim")
+        self.query_one("#footnote", Static).update(text)
 
     # --- Actions ---
 

--- a/deployment/k8s/tui/clipboard.py
+++ b/deployment/k8s/tui/clipboard.py
@@ -1,0 +1,41 @@
+"""System clipboard helper.
+
+Textual's App.copy_to_clipboard() writes an OSC 52 terminal escape sequence — its own
+docstring says plainly "this does not work on macOS Terminal", and it only works elsewhere on
+terminals that both support OSC 52 and have clipboard access enabled (iTerm2 needs it turned
+on explicitly; tmux/screen need passthrough configured). For a TUI that's normally run
+locally against a kubeconfig, shelling out to the OS's own clipboard tool is far more
+reliable than hoping the terminal cooperates — that's tried first, with OSC 52 as the
+fallback for anyone running this over SSH where a local tool isn't available.
+"""
+import platform
+import shutil
+import subprocess
+from typing import List, Optional
+
+
+def _clipboard_command() -> Optional[List[str]]:
+    system = platform.system()
+    if system == "Darwin":
+        return ["pbcopy"]
+    if system == "Linux":
+        for cmd in (["wl-copy"], ["xclip", "-selection", "clipboard"], ["xsel", "--clipboard", "--input"]):
+            if shutil.which(cmd[0]):
+                return cmd
+        return None
+    if system == "Windows":
+        return ["clip"]
+    return None
+
+
+def copy_via_system_tool(text: str) -> bool:
+    """Try the OS's own clipboard tool. Returns True on success, False if none was available
+    or it failed — callers should fall back to OSC 52 (or report failure) in that case."""
+    cmd = _clipboard_command()
+    if cmd is None or not shutil.which(cmd[0]):
+        return False
+    try:
+        subprocess.run(cmd, input=text.encode("utf-8"), check=True, timeout=5)
+        return True
+    except Exception:
+        return False

--- a/deployment/k8s/tui/kafka_reader.py
+++ b/deployment/k8s/tui/kafka_reader.py
@@ -1,0 +1,189 @@
+"""Kafka-side plumbing for the live replay-quality TUI.
+
+Everything here shells out to `kubectl`, the same way 07-live-jaccard-kafka.sh did — this
+runs on the operator's machine against whatever cluster their kubeconfig points at, not
+inside the migration console pod, so there is no in-cluster Kafka client to reuse.
+
+ensure_ready() does the one-time setup (consumer creds + topic) synchronously so failures
+surface before the UI starts polling; stream() is a generator meant to be drained from a
+background thread, yielding one decoded tuple dict per Kafka record.
+"""
+import base64
+import json
+import logging
+import subprocess
+from typing import Iterator, Optional
+
+logger = logging.getLogger(__name__)
+
+CONFIG_DIR = "/tmp/jaccard-kafka"
+KAFKA_TOOLS = "/root/kafka-tools/kafka"
+
+
+class KafkaReaderError(Exception):
+    pass
+
+
+def _kubectl(*args: str, input_bytes: Optional[bytes] = None, timeout: Optional[float] = None) -> str:
+    proc = subprocess.run(
+        ["kubectl", *args], input=input_bytes, capture_output=True, timeout=timeout,
+    )
+    if proc.returncode != 0:
+        raise KafkaReaderError(
+            f"kubectl {' '.join(args)} failed: {proc.stderr.decode(errors='replace').strip()}")
+    return proc.stdout.decode(errors="replace")
+
+
+class KafkaTupleReader:
+    """Bootstraps consumer access to a Strimzi SASL_SSL topic, then streams it as JSON tuples."""
+
+    def __init__(self, namespace: str, topic: str, *,
+                 pod: str = "migration-console-0",
+                 bootstrap: str = "default-kafka-bootstrap.ma.svc:9093",
+                 kafka_cluster: str = "default",
+                 secret_name: str = "default-migration-app",
+                 ca_secret: str = "default-cluster-ca-cert",
+                 retention_ms: int = 600_000,
+                 auto_create_topic: bool = True):
+        self.namespace = namespace
+        self.topic = topic
+        self.pod = pod
+        self.bootstrap = bootstrap
+        self.kafka_cluster = kafka_cluster
+        self.secret_name = secret_name
+        self.ca_secret = ca_secret
+        self.retention_ms = retention_ms
+        self.auto_create_topic = auto_create_topic
+        self.errors = 0
+        self._proc: Optional[subprocess.Popen] = None
+
+    # --- One-time setup ---
+
+    def ensure_ready(self) -> None:
+        """Verify the pod exists, push consumer credentials to it, and make sure the topic is
+        there. Raises KafkaReaderError with a message fit to show the user directly."""
+        self._check_pod()
+        self._push_consumer_config()
+        if not self._topic_exists():
+            if not self.auto_create_topic:
+                raise KafkaReaderError(
+                    f"Kafka topic '{self.topic}' does not exist yet. Run the TrafficReplayer "
+                    f"with --tuple-kafka-topic {self.topic} first, or create it with a "
+                    f"KafkaTopic CR (this Strimzi cluster does not auto-create topics on "
+                    f"first produce).")
+            self._create_topic()
+        self._cap_retention()
+
+    def _check_pod(self) -> None:
+        proc = subprocess.run(
+            ["kubectl", "get", "pod", self.pod, "-n", self.namespace],
+            capture_output=True)
+        if proc.returncode != 0:
+            raise KafkaReaderError(f"pod '{self.pod}' not found in namespace '{self.namespace}'")
+
+    def _push_consumer_config(self) -> None:
+        password = _kubectl(
+            "get", "secret", "-n", self.namespace, self.secret_name,
+            "-o", "jsonpath={.data.password}").strip()
+        if not password:
+            raise KafkaReaderError(f"could not read Kafka password from secret '{self.secret_name}'")
+        password = base64.b64decode(password).decode()
+
+        ca_cert_b64 = _kubectl(
+            "get", "secret", "-n", self.namespace, self.ca_secret,
+            "-o", "jsonpath={.data.ca\\.crt}").strip()
+        if not ca_cert_b64:
+            raise KafkaReaderError(f"could not read CA cert from secret '{self.ca_secret}'")
+        ca_cert = base64.b64decode(ca_cert_b64)
+
+        _kubectl("exec", "-n", self.namespace, self.pod, "--",
+                 "bash", "-c", f"mkdir -p {CONFIG_DIR}")
+        _kubectl("exec", "-i", "-n", self.namespace, self.pod, "--",
+                 "bash", "-c", f"cat > {CONFIG_DIR}/ca.crt", input_bytes=ca_cert)
+
+        consumer_properties = (
+            "ssl.truststore.type=PEM\n"
+            f"ssl.truststore.location={CONFIG_DIR}/ca.crt\n"
+            "security.protocol=SASL_SSL\n"
+            "sasl.mechanism=SCRAM-SHA-512\n"
+            "sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required "
+            f'username="{self.secret_name}" password="{password}";\n'
+        )
+        _kubectl("exec", "-i", "-n", self.namespace, self.pod, "--",
+                 "bash", "-c", f"cat > {CONFIG_DIR}/consumer.properties",
+                 input_bytes=consumer_properties.encode())
+
+    def _topic_exists(self) -> bool:
+        out = _kubectl(
+            "exec", "-n", self.namespace, self.pod, "--",
+            f"{KAFKA_TOOLS}/bin/kafka-topics.sh",
+            "--bootstrap-server", self.bootstrap,
+            "--command-config", f"{CONFIG_DIR}/consumer.properties",
+            "--list")
+        return self.topic in out.splitlines()
+
+    def _create_topic(self) -> None:
+        """Create the topic via a KafkaTopic CR. Auto-creation on first produce does not happen
+        on this cluster (auto.create.topics.enable is off), so the producer just spins retrying
+        UNKNOWN_TOPIC_OR_PARTITION forever without this."""
+        manifest = f"""\
+apiVersion: kafka.strimzi.io/v1
+kind: KafkaTopic
+metadata:
+  name: {self.topic}
+  namespace: {self.namespace}
+  labels:
+    strimzi.io/cluster: {self.kafka_cluster}
+spec:
+  partitions: 1
+  replicas: 3
+  config:
+    retention.ms: {self.retention_ms}
+    segment.bytes: 1073741824
+"""
+        _kubectl("apply", "-f", "-", input_bytes=manifest.encode())
+        _kubectl("wait", "-n", self.namespace, f"kafkatopic/{self.topic}",
+                 "--for=condition=Ready", "--timeout=60s")
+
+    def _cap_retention(self) -> None:
+        """Nothing else prunes this topic; keep only the configured window so it never grows
+        unbounded across a long-running demo."""
+        _kubectl(
+            "exec", "-n", self.namespace, self.pod, "--",
+            f"{KAFKA_TOOLS}/bin/kafka-configs.sh",
+            "--bootstrap-server", self.bootstrap,
+            "--command-config", f"{CONFIG_DIR}/consumer.properties",
+            "--alter", "--entity-type", "topics", "--entity-name", self.topic,
+            "--add-config", f"retention.ms={self.retention_ms}")
+
+    # --- Streaming ---
+
+    def stream(self) -> Iterator[dict]:
+        """Yield decoded tuple records as they arrive. Runs until stop() is called or the
+        consumer process ends (e.g. its --timeout-ms is reached)."""
+        cmd = [
+            "kubectl", "exec", "-n", self.namespace, self.pod, "--",
+            f"{KAFKA_TOOLS}/bin/kafka-console-consumer.sh",
+            "--bootstrap-server", self.bootstrap,
+            "--topic", self.topic,
+            "--consumer.config", f"{CONFIG_DIR}/consumer.properties",
+            "--timeout-ms", "3600000",
+        ]
+        self._proc = subprocess.Popen(
+            cmd, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, bufsize=1, text=True)
+        try:
+            for line in self._proc.stdout:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    yield json.loads(line)
+                except Exception:
+                    self.errors += 1
+                    logger.debug("Failed to decode tuple line: %r", line[:200])
+        finally:
+            self.stop()
+
+    def stop(self) -> None:
+        if self._proc and self._proc.poll() is None:
+            self._proc.terminate()

--- a/deployment/k8s/tui/requirements.txt
+++ b/deployment/k8s/tui/requirements.txt
@@ -1,2 +1,3 @@
 textual
 rich>=14.0.0
+textual-serve

--- a/deployment/k8s/tui/requirements.txt
+++ b/deployment/k8s/tui/requirements.txt
@@ -1,0 +1,2 @@
+textual
+rich>=14.0.0

--- a/deployment/k8s/tui/s3_reader.py
+++ b/deployment/k8s/tui/s3_reader.py
@@ -126,6 +126,26 @@ class S3TupleReader:
 
     # --- Streaming ---
 
+    def _decode_tuple(self, key: str, line: str) -> Optional[dict]:
+        try:
+            return json.loads(line)
+        except Exception:
+            self.errors += 1
+            logger.debug("Failed to decode tuple line from %s: %r", key, line[:200])
+            return None
+
+    def _tuples_from_key(self, key: str) -> Iterator[dict]:
+        """Yield one object's tuples. A file that can't be read, or a line that can't be
+        decoded, is counted in self.errors and skipped rather than ending the stream."""
+        try:
+            for line in self._gunzip_lines(key):
+                tup = self._decode_tuple(key, line)
+                if tup is not None:
+                    yield tup
+        except S3ReaderError:
+            self.errors += 1
+            logger.debug("Failed to read %s", key)
+
     def stream(self) -> Iterator[dict]:
         """Poll for new .log.gz files and yield their tuples in key (chronological) order.
         Runs until stop() is called."""
@@ -137,16 +157,7 @@ class S3TupleReader:
             new_keys = [k for k in all_keys if k not in self._seen_keys]
             for key in new_keys:
                 self._seen_keys.add(key)
-                try:
-                    for line in self._gunzip_lines(key):
-                        try:
-                            yield json.loads(line)
-                        except Exception:
-                            self.errors += 1
-                            logger.debug("Failed to decode tuple line from %s: %r", key, line[:200])
-                except S3ReaderError:
-                    self.errors += 1
-                    logger.debug("Failed to read %s", key)
+                yield from self._tuples_from_key(key)
                 if self._stop_event.is_set():
                     return
             self._stop_event.wait(self.poll_interval)

--- a/deployment/k8s/tui/s3_reader.py
+++ b/deployment/k8s/tui/s3_reader.py
@@ -126,22 +126,17 @@ class S3TupleReader:
 
     # --- Streaming ---
 
-    def _decode_tuple(self, key: str, line: str) -> Optional[dict]:
-        try:
-            return json.loads(line)
-        except Exception:
-            self.errors += 1
-            logger.debug("Failed to decode tuple line from %s: %r", key, line[:200])
-            return None
-
-    def _tuples_from_key(self, key: str) -> Iterator[dict]:
-        """Yield one object's tuples. A file that can't be read, or a line that can't be
-        decoded, is counted in self.errors and skipped rather than ending the stream."""
+    def _process_key(self, key: str) -> Iterator[dict]:
+        """Yield decoded tuples from one .log.gz key, tracking (not raising) both S3 read
+        failures and individual malformed JSON lines so one bad key/line doesn't stop the
+        stream."""
         try:
             for line in self._gunzip_lines(key):
-                tup = self._decode_tuple(key, line)
-                if tup is not None:
-                    yield tup
+                try:
+                    yield json.loads(line)
+                except Exception:
+                    self.errors += 1
+                    logger.debug("Failed to decode tuple line from %s: %r", key, line[:200])
         except S3ReaderError:
             self.errors += 1
             logger.debug("Failed to read %s", key)
@@ -157,7 +152,7 @@ class S3TupleReader:
             new_keys = [k for k in all_keys if k not in self._seen_keys]
             for key in new_keys:
                 self._seen_keys.add(key)
-                yield from self._tuples_from_key(key)
+                yield from self._process_key(key)
                 if self._stop_event.is_set():
                     return
             self._stop_event.wait(self.poll_interval)

--- a/deployment/k8s/tui/s3_reader.py
+++ b/deployment/k8s/tui/s3_reader.py
@@ -1,0 +1,155 @@
+"""S3-side plumbing for the live replay-quality TUI — alternative to Kafka streaming.
+
+Mirrors 06-live-jaccard.sh's approach: TrafficReplayer also writes every tuple as
+gzip-compressed NDJSON to S3 (RotatingGzipS3ObjectWriter), rotating files by age/size/count.
+This reader polls that prefix for new (never-yet-seen) .log.gz files and yields their
+tuples — same tuple JSON schema as the Kafka topic, so scoring.py needs no changes to
+consume either source.
+
+Inherently poll-based, not push — expect real, rotation-interval-scale lag versus Kafka's
+near-real-time delivery (the README notes ~10s for the older bash script this mirrors).
+Runs everything via `kubectl exec` into migration-console-0, same rationale as
+kafka_reader.py: no in-cluster AWS CLI/S3 client on the operator's own machine, but the pod
+already has the `aws` CLI and LocalStack credentials baked in.
+"""
+import gzip
+import json
+import logging
+import subprocess
+import threading
+from typing import Iterator, List, Optional, Set
+
+logger = logging.getLogger(__name__)
+
+
+class S3ReaderError(Exception):
+    pass
+
+
+def _kubectl(*args: str, input_bytes: Optional[bytes] = None, timeout: Optional[float] = None) -> bytes:
+    proc = subprocess.run(
+        ["kubectl", *args], input=input_bytes, capture_output=True, timeout=timeout,
+    )
+    if proc.returncode != 0:
+        raise S3ReaderError(
+            f"kubectl {' '.join(args)} failed: {proc.stderr.decode(errors='replace').strip()}")
+    return proc.stdout
+
+
+class S3TupleReader:
+    """Polls a LocalStack/S3 prefix for new TrafficReplayer tuple files, yielding decoded
+    tuples in file order. Starts from whatever already exists at ensure_ready() time —
+    like KafkaTupleReader consuming from the latest offset, not --from-beginning — so a
+    long-running demo's full history is never replayed on startup."""
+
+    def __init__(self, namespace: str, *,
+                 pod: str = "migration-console-0",
+                 bucket: str = "migrations-default-123456789012-dev-us-east-2",
+                 prefix: str = "tuples/",
+                 endpoint_url: str = "http://localstack:4566",
+                 region: str = "us-east-2",
+                 poll_interval: float = 10.0):
+        self.namespace = namespace
+        self.pod = pod
+        self.bucket = bucket
+        self.prefix = prefix
+        self.endpoint_url = endpoint_url
+        self.region = region
+        self.poll_interval = poll_interval
+        self.errors = 0
+        self._seen_keys: Set[str] = set()
+        self._stop_event = threading.Event()
+
+    # --- One-time setup ---
+
+    def ensure_ready(self) -> None:
+        """Verify the pod exists and establish the starting cursor — every key that already
+        exists is marked seen so stream() only yields tuples from files created after this
+        point."""
+        self._check_pod()
+        try:
+            self._seen_keys = set(self._list_log_keys())
+        except S3ReaderError:
+            # Bucket/prefix may not exist yet on a fresh demo — fine, stream() will just
+            # pick up files as the replayer creates them.
+            self._seen_keys = set()
+
+    def _check_pod(self) -> None:
+        proc = subprocess.run(
+            ["kubectl", "get", "pod", self.pod, "-n", self.namespace],
+            capture_output=True)
+        if proc.returncode != 0:
+            raise S3ReaderError(f"pod '{self.pod}' not found in namespace '{self.namespace}'")
+
+    # --- S3 access (all via the migration-console pod's own aws CLI + LocalStack creds) ---
+
+    def _aws_cmd(self, *args: str) -> List[str]:
+        return [
+            "exec", "-n", self.namespace, self.pod, "--",
+            "env", "AWS_ACCESS_KEY_ID=test", "AWS_SECRET_ACCESS_KEY=test",
+            "aws", "--endpoint-url", self.endpoint_url, "--region", self.region,
+            "s3", *args,
+        ]
+
+    def _list_log_keys(self) -> List[str]:
+        """Every tuples/<replayerId>/.../*.log.gz key currently in the bucket, across all
+        replayer prefixes — a replayer restart gets a fresh prefix (RotatingGzipS3ObjectWriter's
+        key format embeds the pod name), and old prefixes are never cleaned up, so all of
+        them must be watched, not just the newest."""
+        out = _kubectl(*self._aws_cmd("ls", f"s3://{self.bucket}/{self.prefix}")).decode(errors="replace")
+        replayer_prefixes = []
+        for line in out.splitlines():
+            part = line.strip().rstrip("/")
+            if part:
+                replayer_prefixes.append(part.split()[-1])
+
+        keys: List[str] = []
+        for replayer in replayer_prefixes:
+            out = _kubectl(*self._aws_cmd(
+                "ls", "--recursive", f"s3://{self.bucket}/{self.prefix}{replayer}")).decode(errors="replace")
+            for line in out.splitlines():
+                parts = line.split()
+                if parts and parts[-1].endswith(".log.gz"):
+                    keys.append(parts[-1])
+        return keys
+
+    def _gunzip_lines(self, key: str) -> Iterator[str]:
+        raw = _kubectl(*self._aws_cmd("cp", f"s3://{self.bucket}/{key}", "-"))
+        try:
+            text = gzip.decompress(raw).decode("utf-8", errors="replace")
+        except OSError as e:
+            raise S3ReaderError(f"failed to gunzip {key}: {e}")
+        for line in text.splitlines():
+            line = line.strip()
+            if line:
+                yield line
+
+    # --- Streaming ---
+
+    def stream(self) -> Iterator[dict]:
+        """Poll for new .log.gz files and yield their tuples in key (chronological) order.
+        Runs until stop() is called."""
+        while not self._stop_event.is_set():
+            try:
+                all_keys = sorted(self._list_log_keys())
+            except S3ReaderError:
+                all_keys = []
+            new_keys = [k for k in all_keys if k not in self._seen_keys]
+            for key in new_keys:
+                self._seen_keys.add(key)
+                try:
+                    for line in self._gunzip_lines(key):
+                        try:
+                            yield json.loads(line)
+                        except Exception:
+                            self.errors += 1
+                            logger.debug("Failed to decode tuple line from %s: %r", key, line[:200])
+                except S3ReaderError:
+                    self.errors += 1
+                    logger.debug("Failed to read %s", key)
+                if self._stop_event.is_set():
+                    return
+            self._stop_event.wait(self.poll_interval)
+
+    def stop(self) -> None:
+        self._stop_event.set()

--- a/deployment/k8s/tui/scoring.py
+++ b/deployment/k8s/tui/scoring.py
@@ -90,15 +90,13 @@ def rbo_score(list_a: List[str], list_b: List[str], p: float = RBO_PERSISTENCE) 
     return (weighted_sum / weight_total) if weight_total > 0 else None
 
 
-def _ratio(a: float, b: float) -> float:
-    """Agreement between two single magnitudes — 1.0 when they match, including both zero."""
-    mx = max(a, b)
-    return (min(a, b) / mx) if mx > 0 else 1.0
-
-
-def _score_agg_buckets(sb: List[Dict], tb: List[Dict]) -> Tuple[Optional[float], str]:
-    """Weighted per-key bucket overlap — same idea as Jaccard, but weighted by doc_count so a
-    bucket with 10000 docs counts for more than one with 1."""
+def _score_agg_buckets(sb: List[Dict], tb: List[Dict]) -> Optional[Tuple[Optional[float], str]]:
+    """Weighted per-key overlap for a bucket-based aggregation (terms/date-histogram/...),
+    weighted by doc_count so a bucket with 10000 docs counts for more than one with 1. Returns
+    None (not a result) when neither side has any buckets, so the caller falls through to the
+    next scoring mode."""
+    if not sb and not tb:
+        return None
     sc = {b['key']: b.get('doc_count', 0) for b in sb if 'key' in b}
     tc = {b['key']: b.get('doc_count', 0) for b in tb if 'key' in b}
     keys = set(sc) | set(tc)
@@ -109,34 +107,51 @@ def _score_agg_buckets(sb: List[Dict], tb: List[Dict]) -> Tuple[Optional[float],
     return ((n / d) if d > 0 else 1.0), 'agg (buckets)'
 
 
+def _score_agg_doc_count(sa: Dict, ta: Dict) -> Optional[Tuple[Optional[float], str]]:
+    """Ratio-based score for a single-value doc_count aggregation. Returns None when either
+    side lacks a doc_count, so the caller falls through to the next scoring mode."""
+    sdc, tdc = sa.get('doc_count'), ta.get('doc_count')
+    if sdc is None or tdc is None:
+        return None
+    mx = max(sdc, tdc)
+    return ((min(sdc, tdc) / mx) if mx > 0 else 1.0), 'agg (doc_count)'
+
+
+def _score_agg_metric(sa: Dict, ta: Dict) -> Optional[Tuple[Optional[float], str]]:
+    """Ratio-based score for a single-metric aggregation (avg/sum/cardinality/...). Returns
+    None when neither side even has a 'value' key, or when either side's value is missing."""
+    if 'value' not in sa and 'value' not in ta:
+        return None
+    sv, tv = sa.get('value'), ta.get('value')
+    if sv is None or tv is None:
+        return None
+    mx = max(sv, tv)
+    return ((min(sv, tv) / mx) if mx > 0 else 1.0), 'agg (metric)'
+
+
 def score_agg(sa: Dict, ta: Dict) -> Tuple[Optional[float], str]:
     """Score ONE named aggregation — bucket-based (terms/date-histogram/...) or a single
-    metric (avg/sum/cardinality/...)."""
+    metric (avg/sum/cardinality/...). Tries each scoring mode in turn and uses whichever one
+    actually applies to this aggregation's shape."""
     sa = sa if isinstance(sa, dict) else {}
     ta = ta if isinstance(ta, dict) else {}
     sb = sa.get('buckets', [])
     tb = ta.get('buckets', [])
-    if sb or tb:
-        return _score_agg_buckets(sb, tb)
-    sdc, tdc = sa.get('doc_count'), ta.get('doc_count')
-    if sdc is not None and tdc is not None:
-        return _ratio(sdc, tdc), 'agg (doc_count)'
-    sv, tv = sa.get('value'), ta.get('value')
-    if sv is not None and tv is not None:
-        return _ratio(sv, tv), 'agg (metric)'
+    for result in (_score_agg_buckets(sb, tb), _score_agg_doc_count(sa, ta), _score_agg_metric(sa, ta)):
+        if result is not None:
+            return result
     return None, 'agg'
 
 
-def _hits_item(sb: Dict, tb: Dict, missing_side: Optional[str], label_prefix: str) -> Dict:
-    """The single scored item covering a response pair's hits — Jaccard over the hit IDs, plus
-    an independent RBO over the order they came back in."""
+def _score_hits_item(sb: Dict, tb: Dict, missing_side: Optional[str], label_prefix: str) -> Dict:
+    """Build the single 'hits' item for one response pair — only called when either side has
+    a hits section."""
+    j, lbl = (None, missing_side) if missing_side else compute_hits_jaccard(sb, tb)
     src_hit_list = hit_summaries(sb)
     tgt_hit_list = hit_summaries(tb)
     if missing_side:
-        j, lbl = None, missing_side
         rbo_j, rbo_lbl = None, missing_side
     else:
-        j, lbl = compute_hits_jaccard(sb, tb)
         rbo_j = rbo_score([h['id'] for h in src_hit_list], [h['id'] for h in tgt_hit_list])
         # rbo_j is None here specifically when there's no ranked list to compare at all —
         # a size:0 query still has a 'hits' section (so it's still a "hits" item, and
@@ -153,17 +168,23 @@ def _hits_item(sb: Dict, tb: Dict, missing_side: Optional[str], label_prefix: st
     }
 
 
-def _agg_item(name: str, sa: Optional[Dict], ta: Optional[Dict],
-              missing_side: Optional[str], label_prefix: str) -> Dict:
-    """One scored item for one named aggregation. RBO doesn't apply — buckets have no rank
-    order to compare — so its fields stay None."""
-    j, lbl = (None, missing_side) if missing_side else score_agg(sa, ta)
-    return {
-        'label': f'{label_prefix} · agg:{name}'.strip(' ·'), 'kind': 'agg', 'j': j, 'j_label': lbl,
-        'rbo_j': None, 'rbo_label': None,
-        'src_hits': None, 'tgt_hits': None, 'src_hit_list': [], 'tgt_hit_list': [],
-        'src_agg': sa, 'tgt_agg': ta,
-    }
+def _score_agg_items(sb: Dict, tb: Dict, missing_side: Optional[str], label_prefix: str) -> List[Dict]:
+    """Build one item per named aggregation — the union of both sides' aggregation names, so
+    an agg-only query's N aggregations each get their own item instead of being blended into
+    one averaged score."""
+    src_aggs = sb.get('aggregations', {}) or {}
+    tgt_aggs = tb.get('aggregations', {}) or {}
+    items = []
+    for name in sorted(set(src_aggs) | set(tgt_aggs)):
+        sa, ta = src_aggs.get(name), tgt_aggs.get(name)
+        j, lbl = (None, missing_side) if missing_side else score_agg(sa, ta)
+        items.append({
+            'label': f'{label_prefix} · agg:{name}'.strip(' ·'), 'kind': 'agg', 'j': j, 'j_label': lbl,
+            'rbo_j': None, 'rbo_label': None,
+            'src_hits': None, 'tgt_hits': None, 'src_hit_list': [], 'tgt_hit_list': [],
+            'src_agg': sa, 'tgt_agg': ta,
+        })
+    return items
 
 
 def _response_items(sb: Dict, tb: Dict, missing_side: Optional[str], label_prefix: str) -> List[Dict]:
@@ -174,15 +195,9 @@ def _response_items(sb: Dict, tb: Dict, missing_side: Optional[str], label_prefi
     sb = sb if isinstance(sb, dict) else {}
     tb = tb if isinstance(tb, dict) else {}
     items = []
-
     if 'hits' in sb or 'hits' in tb:
-        items.append(_hits_item(sb, tb, missing_side, label_prefix))
-
-    src_aggs = sb.get('aggregations', {}) or {}
-    tgt_aggs = tb.get('aggregations', {}) or {}
-    for name in sorted(set(src_aggs) | set(tgt_aggs)):
-        items.append(_agg_item(name, src_aggs.get(name), tgt_aggs.get(name), missing_side, label_prefix))
-
+        items.append(_score_hits_item(sb, tb, missing_side, label_prefix))
+    items.extend(_score_agg_items(sb, tb, missing_side, label_prefix))
     return items
 
 
@@ -208,33 +223,34 @@ def _msearch_sub_labels(src_request: Dict, count: int) -> List[str]:
     return labels
 
 
-def _missing_side_label(src_resp: Dict, tgt: Dict) -> Optional[str]:
-    """A missing sourceResponse/targetResponse (e.g. the browser aborted the request before its
-    response arrived — this is real, observed capture data, not hypothetical) leaves src_body
-    or tgt_body as {}. Comparing real data against nothing would mathematically bottom out at
-    0.0 — indistinguishable from "genuinely diverged" in the display. Detected once here
-    (Status-Code is only absent when the response itself never arrived) and forced to an
-    explicit unscored label instead, for every item at once."""
-    no_src = 'Status-Code' not in src_resp
-    no_tgt = 'Status-Code' not in tgt
-    if no_src and no_tgt:
+def _missing_side(src_resp: Dict, tgt: Dict) -> Optional[str]:
+    """Detect a response that never arrived at all (e.g. the browser aborted the request
+    before its response arrived — this is real, observed capture data, not hypothetical).
+    Status-Code is only absent when the response itself never arrived; forced to an explicit
+    unscored label instead of comparing real data against nothing, which would mathematically
+    bottom out at 0.0 — indistinguishable from "genuinely diverged" in the display."""
+    src_missing = 'Status-Code' not in src_resp
+    tgt_missing = 'Status-Code' not in tgt
+    if src_missing and tgt_missing:
         return 'no source or target data'
-    if no_src:
+    if src_missing:
         return 'no source data'
-    if no_tgt:
+    if tgt_missing:
         return 'no target data'
     return None
 
 
-def _msearch_subqueries(src_request: Dict, tgt_request: Dict, src_body: Dict, tgt_body: Dict,
-                        missing_side: Optional[str]) -> List[Dict]:
-    """Every sub-response of an _msearch, decomposed and labeled with its NDJSON position."""
+def _msearch_subqueries(
+    src_request: Dict, tgt_request: Dict, src_body: Dict, tgt_body: Dict, missing_side: Optional[str],
+) -> List[Dict]:
+    """Decompose an _msearch response into one item-group per NDJSON sub-query, labeled with
+    its position (e.g. "1/2 (typefilter)") so each item stays traceable to which sub-query it
+    came from. Both sides' NDJSON pairs are carried separately, not assumed identical — a
+    transformation plugin can legitimately rewrite the body on its way to the target."""
     src_subs = src_body.get('responses', [])
     tgt_subs = tgt_body.get('responses', [])
     n = max(len(src_subs), len(tgt_subs))
     labels = _msearch_sub_labels(src_request, n)
-    # Both sides' NDJSON pairs are carried separately, not assumed identical — a
-    # transformation plugin can legitimately rewrite the body on its way to the target.
     src_sub_bodies = _msearch_sub_bodies(src_request, n)
     tgt_sub_bodies = _msearch_sub_bodies(tgt_request, n)
     subqueries = []
@@ -245,6 +261,16 @@ def _msearch_subqueries(src_request: Dict, tgt_request: Dict, src_body: Dict, tg
             item['src_sub_ndjson'] = src_sub_bodies[i]
             item['tgt_sub_ndjson'] = tgt_sub_bodies[i]
             subqueries.append(item)
+    return subqueries
+
+
+def _plain_search_subqueries(src_body: Dict, tgt_body: Dict, missing_side: Optional[str]) -> List[Dict]:
+    """A plain (non-_msearch) search's items — same decomposition as one _msearch sub-query,
+    just without a position label or NDJSON detail."""
+    subqueries = _response_items(src_body, tgt_body, missing_side, '')
+    for item in subqueries:
+        item['src_sub_ndjson'] = None
+        item['tgt_sub_ndjson'] = None
     return subqueries
 
 
@@ -263,26 +289,25 @@ def score_tuple(r: Dict) -> Dict:
     method = src_request.get('Method', '?')
     uri = src_request.get('Request-URI', '?')
     src_status = src_resp.get('Status-Code', '?')
-    base = {'method': method, 'uri': uri, 'src_status': src_status,
-            'src_request': src_request, 'tgt_request': tgt_request, 'src_response': src_resp}
+    base = {
+        'method': method, 'uri': uri, 'src_status': src_status,
+        'src_request': src_request, 'tgt_request': tgt_request, 'src_response': src_resp,
+    }
     if method == 'OPTIONS':
-        return dict(base, tgt_status=None, tgt_response=None,
-                    j_label='preflight', replayed=False, subqueries=[])
+        return {**base, 'tgt_status': None, 'tgt_response': None,
+                'j_label': 'preflight', 'replayed': False, 'subqueries': []}
     if not tgt_resps:
-        return dict(base, tgt_status=None, tgt_response=None,
-                    j_label=None, replayed=False, subqueries=[])
+        return {**base, 'tgt_status': None, 'tgt_response': None,
+                'j_label': None, 'replayed': False, 'subqueries': []}
     tgt = tgt_resps[0]
     tgt_status = tgt.get('Status-Code', '?')
     src_body = src_resp.get('payload', {}).get('inlinedJsonBody', {})
     tgt_body = tgt.get('payload', {}).get('inlinedJsonBody', {})
-    missing_side = _missing_side_label(src_resp, tgt)
-    is_msearch = ('_msearch' in uri or 'responses' in src_body)
+    missing_side = _missing_side(src_resp, tgt)
+    is_msearch = '_msearch' in uri or 'responses' in src_body
     if is_msearch:
         subqueries = _msearch_subqueries(src_request, tgt_request, src_body, tgt_body, missing_side)
     else:
-        subqueries = _response_items(src_body, tgt_body, missing_side, '')
-        for item in subqueries:
-            item['src_sub_ndjson'] = None
-            item['tgt_sub_ndjson'] = None
-    return dict(base, tgt_status=tgt_status, tgt_response=tgt,
-                j_label=None, replayed=True, subqueries=subqueries)
+        subqueries = _plain_search_subqueries(src_body, tgt_body, missing_side)
+    return {**base, 'tgt_status': tgt_status, 'tgt_response': tgt,
+            'j_label': None, 'replayed': True, 'subqueries': subqueries}

--- a/deployment/k8s/tui/scoring.py
+++ b/deployment/k8s/tui/scoring.py
@@ -58,6 +58,38 @@ def compute_hits_jaccard(src_body: Dict, tgt_body: Dict) -> Tuple[Optional[float
     return None, None
 
 
+# Persistence: how much weight RBO gives to agreement at deeper ranks versus the very top.
+# 0.9 puts ~65% of the total weight on the first 10 ranks — a reasonable default for the
+# top-20-ish result lists this tool typically sees; a longer results page would want it
+# pushed closer to 1.0 to avoid over-weighting the first few hits.
+RBO_PERSISTENCE = 0.9
+
+
+def rbo_score(list_a: List[str], list_b: List[str], p: float = RBO_PERSISTENCE) -> Optional[float]:
+    """Rank-Biased Overlap (Webber, Moffat & Zobel, 2010) between two ranked ID lists.
+
+    Unlike Jaccard, this is order-sensitive: two lists with identical membership but reversed
+    order score 1.0 under Jaccard but well under 1.0 here, since RBO weights agreement at
+    shallow depths (rank 1, 2, 3...) more heavily than agreement deep in the list. This is the
+    finite-depth base form (evaluated to depth = min(len(a), len(b)), since that's the deepest
+    rank both lists can be compared at), normalized so two identical lists score exactly 1.0 —
+    the raw un-normalized sum only approaches 1.0 as depth goes to infinity, which would read
+    as "diverged" for two short but perfectly-matching lists, the opposite of every other score
+    in this tool.
+    """
+    k = min(len(list_a), len(list_b))
+    if k == 0:
+        return None
+    weighted_sum = 0.0
+    weight_total = 0.0
+    for d in range(1, k + 1):
+        agreement_d = len(set(list_a[:d]) & set(list_b[:d])) / d
+        weight = (1 - p) * (p ** (d - 1))
+        weighted_sum += weight * agreement_d
+        weight_total += weight
+    return (weighted_sum / weight_total) if weight_total > 0 else None
+
+
 def score_agg(sa: Dict, ta: Dict) -> Tuple[Optional[float], str]:
     """Score ONE named aggregation — bucket-based (terms/date-histogram/...) or a single
     metric (avg/sum/cardinality/...). Bucket comparison is a weighted per-key overlap, same
@@ -99,10 +131,18 @@ def _response_items(sb: Dict, tb: Dict, missing_side: Optional[str], label_prefi
 
     if 'hits' in sb or 'hits' in tb:
         j, lbl = (None, missing_side) if missing_side else compute_hits_jaccard(sb, tb)
+        src_hit_list = hit_summaries(sb)
+        tgt_hit_list = hit_summaries(tb)
+        if missing_side:
+            rbo_j, rbo_lbl = None, missing_side
+        else:
+            rbo_j = rbo_score([h['id'] for h in src_hit_list], [h['id'] for h in tgt_hit_list])
+            rbo_lbl = f'RBO (p={RBO_PERSISTENCE})' if rbo_j is not None else None
         items.append(dict(
             label=f'{label_prefix} · hits'.strip(' ·'), kind='hits', j=j, j_label=lbl,
+            rbo_j=rbo_j, rbo_label=rbo_lbl,
             src_hits=hit_count(sb), tgt_hits=hit_count(tb),
-            src_hit_list=hit_summaries(sb), tgt_hit_list=hit_summaries(tb),
+            src_hit_list=src_hit_list, tgt_hit_list=tgt_hit_list,
             src_agg=None, tgt_agg=None,
         ))
 
@@ -113,6 +153,7 @@ def _response_items(sb: Dict, tb: Dict, missing_side: Optional[str], label_prefi
         j, lbl = (None, missing_side) if missing_side else score_agg(sa, ta)
         items.append(dict(
             label=f'{label_prefix} · agg:{name}'.strip(' ·'), kind='agg', j=j, j_label=lbl,
+            rbo_j=None, rbo_label=None,
             src_hits=None, tgt_hits=None, src_hit_list=[], tgt_hit_list=[],
             src_agg=sa, tgt_agg=ta,
         ))

--- a/deployment/k8s/tui/scoring.py
+++ b/deployment/k8s/tui/scoring.py
@@ -90,34 +90,80 @@ def rbo_score(list_a: List[str], list_b: List[str], p: float = RBO_PERSISTENCE) 
     return (weighted_sum / weight_total) if weight_total > 0 else None
 
 
+def _ratio(a: float, b: float) -> float:
+    """Agreement between two single magnitudes — 1.0 when they match, including both zero."""
+    mx = max(a, b)
+    return (min(a, b) / mx) if mx > 0 else 1.0
+
+
+def _score_agg_buckets(sb: List[Dict], tb: List[Dict]) -> Tuple[Optional[float], str]:
+    """Weighted per-key bucket overlap — same idea as Jaccard, but weighted by doc_count so a
+    bucket with 10000 docs counts for more than one with 1."""
+    sc = {b['key']: b.get('doc_count', 0) for b in sb if 'key' in b}
+    tc = {b['key']: b.get('doc_count', 0) for b in tb if 'key' in b}
+    keys = set(sc) | set(tc)
+    if not keys:
+        return None, 'agg (buckets)'
+    n = sum(min(sc.get(k, 0), tc.get(k, 0)) for k in keys)
+    d = sum(max(sc.get(k, 0), tc.get(k, 0)) for k in keys)
+    return ((n / d) if d > 0 else 1.0), 'agg (buckets)'
+
+
 def score_agg(sa: Dict, ta: Dict) -> Tuple[Optional[float], str]:
     """Score ONE named aggregation — bucket-based (terms/date-histogram/...) or a single
-    metric (avg/sum/cardinality/...). Bucket comparison is a weighted per-key overlap, same
-    idea as Jaccard but weighted by doc_count so a bucket with 10000 docs counts for more
-    than one with 1."""
+    metric (avg/sum/cardinality/...)."""
     sa = sa if isinstance(sa, dict) else {}
     ta = ta if isinstance(ta, dict) else {}
     sb = sa.get('buckets', [])
     tb = ta.get('buckets', [])
     if sb or tb:
-        sc = {b['key']: b.get('doc_count', 0) for b in sb if 'key' in b}
-        tc = {b['key']: b.get('doc_count', 0) for b in tb if 'key' in b}
-        keys = set(sc) | set(tc)
-        if not keys:
-            return None, 'agg (buckets)'
-        n = sum(min(sc.get(k, 0), tc.get(k, 0)) for k in keys)
-        d = sum(max(sc.get(k, 0), tc.get(k, 0)) for k in keys)
-        return ((n / d) if d > 0 else 1.0), 'agg (buckets)'
+        return _score_agg_buckets(sb, tb)
     sdc, tdc = sa.get('doc_count'), ta.get('doc_count')
     if sdc is not None and tdc is not None:
-        mx = max(sdc, tdc)
-        return ((min(sdc, tdc) / mx) if mx > 0 else 1.0), 'agg (doc_count)'
-    if 'value' in sa or 'value' in ta:
-        sv, tv = sa.get('value'), ta.get('value')
-        if sv is not None and tv is not None:
-            mx = max(sv, tv)
-            return ((min(sv, tv) / mx) if mx > 0 else 1.0), 'agg (metric)'
+        return _ratio(sdc, tdc), 'agg (doc_count)'
+    sv, tv = sa.get('value'), ta.get('value')
+    if sv is not None and tv is not None:
+        return _ratio(sv, tv), 'agg (metric)'
     return None, 'agg'
+
+
+def _hits_item(sb: Dict, tb: Dict, missing_side: Optional[str], label_prefix: str) -> Dict:
+    """The single scored item covering a response pair's hits — Jaccard over the hit IDs, plus
+    an independent RBO over the order they came back in."""
+    src_hit_list = hit_summaries(sb)
+    tgt_hit_list = hit_summaries(tb)
+    if missing_side:
+        j, lbl = None, missing_side
+        rbo_j, rbo_lbl = None, missing_side
+    else:
+        j, lbl = compute_hits_jaccard(sb, tb)
+        rbo_j = rbo_score([h['id'] for h in src_hit_list], [h['id'] for h in tgt_hit_list])
+        # rbo_j is None here specifically when there's no ranked list to compare at all —
+        # a size:0 query still has a 'hits' section (so it's still a "hits" item, and
+        # Jaccard's hit-count fallback still applies), but an empty hits.hits array means
+        # RBO has nothing to measure. Distinct from missing_side: the response is real and
+        # complete, RBO just doesn't apply to it.
+        rbo_lbl = f'RBO (p={RBO_PERSISTENCE})' if rbo_j is not None else 'RBO (no ranked hits)'
+    return {
+        'label': f'{label_prefix} · hits'.strip(' ·'), 'kind': 'hits', 'j': j, 'j_label': lbl,
+        'rbo_j': rbo_j, 'rbo_label': rbo_lbl,
+        'src_hits': hit_count(sb), 'tgt_hits': hit_count(tb),
+        'src_hit_list': src_hit_list, 'tgt_hit_list': tgt_hit_list,
+        'src_agg': None, 'tgt_agg': None,
+    }
+
+
+def _agg_item(name: str, sa: Optional[Dict], ta: Optional[Dict],
+              missing_side: Optional[str], label_prefix: str) -> Dict:
+    """One scored item for one named aggregation. RBO doesn't apply — buckets have no rank
+    order to compare — so its fields stay None."""
+    j, lbl = (None, missing_side) if missing_side else score_agg(sa, ta)
+    return {
+        'label': f'{label_prefix} · agg:{name}'.strip(' ·'), 'kind': 'agg', 'j': j, 'j_label': lbl,
+        'rbo_j': None, 'rbo_label': None,
+        'src_hits': None, 'tgt_hits': None, 'src_hit_list': [], 'tgt_hit_list': [],
+        'src_agg': sa, 'tgt_agg': ta,
+    }
 
 
 def _response_items(sb: Dict, tb: Dict, missing_side: Optional[str], label_prefix: str) -> List[Dict]:
@@ -130,38 +176,12 @@ def _response_items(sb: Dict, tb: Dict, missing_side: Optional[str], label_prefi
     items = []
 
     if 'hits' in sb or 'hits' in tb:
-        j, lbl = (None, missing_side) if missing_side else compute_hits_jaccard(sb, tb)
-        src_hit_list = hit_summaries(sb)
-        tgt_hit_list = hit_summaries(tb)
-        if missing_side:
-            rbo_j, rbo_lbl = None, missing_side
-        else:
-            rbo_j = rbo_score([h['id'] for h in src_hit_list], [h['id'] for h in tgt_hit_list])
-            # rbo_j is None here specifically when there's no ranked list to compare at all —
-            # a size:0 query still has a 'hits' section (so it's still a "hits" item, and
-            # Jaccard's hit-count fallback still applies), but an empty hits.hits array means
-            # RBO has nothing to measure. Distinct from missing_side: the response is real and
-            # complete, RBO just doesn't apply to it.
-            rbo_lbl = f'RBO (p={RBO_PERSISTENCE})' if rbo_j is not None else 'RBO (no ranked hits)'
-        items.append(dict(
-            label=f'{label_prefix} · hits'.strip(' ·'), kind='hits', j=j, j_label=lbl,
-            rbo_j=rbo_j, rbo_label=rbo_lbl,
-            src_hits=hit_count(sb), tgt_hits=hit_count(tb),
-            src_hit_list=src_hit_list, tgt_hit_list=tgt_hit_list,
-            src_agg=None, tgt_agg=None,
-        ))
+        items.append(_hits_item(sb, tb, missing_side, label_prefix))
 
     src_aggs = sb.get('aggregations', {}) or {}
     tgt_aggs = tb.get('aggregations', {}) or {}
     for name in sorted(set(src_aggs) | set(tgt_aggs)):
-        sa, ta = src_aggs.get(name), tgt_aggs.get(name)
-        j, lbl = (None, missing_side) if missing_side else score_agg(sa, ta)
-        items.append(dict(
-            label=f'{label_prefix} · agg:{name}'.strip(' ·'), kind='agg', j=j, j_label=lbl,
-            rbo_j=None, rbo_label=None,
-            src_hits=None, tgt_hits=None, src_hit_list=[], tgt_hit_list=[],
-            src_agg=sa, tgt_agg=ta,
-        ))
+        items.append(_agg_item(name, src_aggs.get(name), tgt_aggs.get(name), missing_side, label_prefix))
 
     return items
 
@@ -188,6 +208,46 @@ def _msearch_sub_labels(src_request: Dict, count: int) -> List[str]:
     return labels
 
 
+def _missing_side_label(src_resp: Dict, tgt: Dict) -> Optional[str]:
+    """A missing sourceResponse/targetResponse (e.g. the browser aborted the request before its
+    response arrived — this is real, observed capture data, not hypothetical) leaves src_body
+    or tgt_body as {}. Comparing real data against nothing would mathematically bottom out at
+    0.0 — indistinguishable from "genuinely diverged" in the display. Detected once here
+    (Status-Code is only absent when the response itself never arrived) and forced to an
+    explicit unscored label instead, for every item at once."""
+    no_src = 'Status-Code' not in src_resp
+    no_tgt = 'Status-Code' not in tgt
+    if no_src and no_tgt:
+        return 'no source or target data'
+    if no_src:
+        return 'no source data'
+    if no_tgt:
+        return 'no target data'
+    return None
+
+
+def _msearch_subqueries(src_request: Dict, tgt_request: Dict, src_body: Dict, tgt_body: Dict,
+                        missing_side: Optional[str]) -> List[Dict]:
+    """Every sub-response of an _msearch, decomposed and labeled with its NDJSON position."""
+    src_subs = src_body.get('responses', [])
+    tgt_subs = tgt_body.get('responses', [])
+    n = max(len(src_subs), len(tgt_subs))
+    labels = _msearch_sub_labels(src_request, n)
+    # Both sides' NDJSON pairs are carried separately, not assumed identical — a
+    # transformation plugin can legitimately rewrite the body on its way to the target.
+    src_sub_bodies = _msearch_sub_bodies(src_request, n)
+    tgt_sub_bodies = _msearch_sub_bodies(tgt_request, n)
+    subqueries = []
+    for i in range(n):
+        sb = src_subs[i] if i < len(src_subs) else {}
+        tb = tgt_subs[i] if i < len(tgt_subs) else {}
+        for item in _response_items(sb, tb, missing_side, labels[i]):
+            item['src_sub_ndjson'] = src_sub_bodies[i]
+            item['tgt_sub_ndjson'] = tgt_sub_bodies[i]
+            subqueries.append(item)
+    return subqueries
+
+
 def score_tuple(r: Dict) -> Dict:
     """Score one TrafficReplayer tuple record (already JSON-decoded).
 
@@ -203,8 +263,8 @@ def score_tuple(r: Dict) -> Dict:
     method = src_request.get('Method', '?')
     uri = src_request.get('Request-URI', '?')
     src_status = src_resp.get('Status-Code', '?')
-    base = dict(method=method, uri=uri, src_status=src_status,
-                src_request=src_request, tgt_request=tgt_request, src_response=src_resp)
+    base = {'method': method, 'uri': uri, 'src_status': src_status,
+            'src_request': src_request, 'tgt_request': tgt_request, 'src_response': src_resp}
     if method == 'OPTIONS':
         return dict(base, tgt_status=None, tgt_response=None,
                     j_label='preflight', replayed=False, subqueries=[])
@@ -215,36 +275,10 @@ def score_tuple(r: Dict) -> Dict:
     tgt_status = tgt.get('Status-Code', '?')
     src_body = src_resp.get('payload', {}).get('inlinedJsonBody', {})
     tgt_body = tgt.get('payload', {}).get('inlinedJsonBody', {})
-    # A missing sourceResponse/targetResponse (e.g. the browser aborted the request before its
-    # response arrived — this is real, observed capture data, not hypothetical) leaves src_body
-    # or tgt_body as {}. Comparing real data against nothing would mathematically bottom out at
-    # 0.0 — indistinguishable from "genuinely diverged" in the display. Detected once here
-    # (Status-Code is only absent when the response itself never arrived) and forced to an
-    # explicit unscored label instead, for every item at once.
-    missing_side = (
-        'no source or target data' if 'Status-Code' not in src_resp and 'Status-Code' not in tgt else
-        'no source data' if 'Status-Code' not in src_resp else
-        'no target data' if 'Status-Code' not in tgt else
-        None
-    )
+    missing_side = _missing_side_label(src_resp, tgt)
     is_msearch = ('_msearch' in uri or 'responses' in src_body)
     if is_msearch:
-        src_subs = src_body.get('responses', [])
-        tgt_subs = tgt_body.get('responses', [])
-        n = max(len(src_subs), len(tgt_subs))
-        labels = _msearch_sub_labels(src_request, n)
-        # Both sides' NDJSON pairs are carried separately, not assumed identical — a
-        # transformation plugin can legitimately rewrite the body on its way to the target.
-        src_sub_bodies = _msearch_sub_bodies(src_request, n)
-        tgt_sub_bodies = _msearch_sub_bodies(tgt_request, n)
-        subqueries = []
-        for i in range(n):
-            sb = src_subs[i] if i < len(src_subs) else {}
-            tb = tgt_subs[i] if i < len(tgt_subs) else {}
-            for item in _response_items(sb, tb, missing_side, labels[i]):
-                item['src_sub_ndjson'] = src_sub_bodies[i]
-                item['tgt_sub_ndjson'] = tgt_sub_bodies[i]
-                subqueries.append(item)
+        subqueries = _msearch_subqueries(src_request, tgt_request, src_body, tgt_body, missing_side)
     else:
         subqueries = _response_items(src_body, tgt_body, missing_side, '')
         for item in subqueries:

--- a/deployment/k8s/tui/scoring.py
+++ b/deployment/k8s/tui/scoring.py
@@ -137,7 +137,12 @@ def _response_items(sb: Dict, tb: Dict, missing_side: Optional[str], label_prefi
             rbo_j, rbo_lbl = None, missing_side
         else:
             rbo_j = rbo_score([h['id'] for h in src_hit_list], [h['id'] for h in tgt_hit_list])
-            rbo_lbl = f'RBO (p={RBO_PERSISTENCE})' if rbo_j is not None else None
+            # rbo_j is None here specifically when there's no ranked list to compare at all —
+            # a size:0 query still has a 'hits' section (so it's still a "hits" item, and
+            # Jaccard's hit-count fallback still applies), but an empty hits.hits array means
+            # RBO has nothing to measure. Distinct from missing_side: the response is real and
+            # complete, RBO just doesn't apply to it.
+            rbo_lbl = f'RBO (p={RBO_PERSISTENCE})' if rbo_j is not None else 'RBO (no ranked hits)'
         items.append(dict(
             label=f'{label_prefix} · hits'.strip(' ·'), kind='hits', j=j, j_label=lbl,
             rbo_j=rbo_j, rbo_label=rbo_lbl,

--- a/deployment/k8s/tui/scoring.py
+++ b/deployment/k8s/tui/scoring.py
@@ -21,6 +21,24 @@ def hit_doc_ids(body: Dict) -> Optional[Set[str]]:
     return ids if ids else None
 
 
+def hit_summaries(body: Dict, limit: int = 30) -> List[Dict]:
+    """Ordered (id, score) pairs for a search response's hits, capped so a TUI detail pane
+    stays a fixed size regardless of how many hits a query happened to return."""
+    hits = body.get('hits', {}).get('hits', [])
+    return [{'id': h['_id'], 'score': h.get('_score')} for h in hits[:limit] if '_id' in h]
+
+
+def hit_count(body: Dict) -> Optional[int]:
+    """hits.total.value when present — 0 is a real, valid count (a search that legitimately
+    matched nothing) and must be distinguished from "not a search response at all", so this
+    checks for the key rather than truthiness. Falls back to a plain count for non-search
+    responses like _count."""
+    total = body.get('hits', {}).get('total', {})
+    if isinstance(total, dict) and 'value' in total:
+        return total['value']
+    return body.get('count')
+
+
 def weighted_jaccard_aggs(src_aggs: Dict, tgt_aggs: Dict) -> Tuple[Optional[float], Optional[str]]:
     scores = []
     for name in set(src_aggs) | set(tgt_aggs):
@@ -71,8 +89,8 @@ def compute_jaccard(src_body: Dict, tgt_body: Dict) -> Tuple[Optional[float], Op
         src_body.get('aggregations', {}), tgt_body.get('aggregations', {}))
     if j is not None:
         return j, lbl
-    sv = src_body.get('hits', {}).get('total', {}).get('value') or src_body.get('count')
-    tv = tgt_body.get('hits', {}).get('total', {}).get('value') or tgt_body.get('count')
+    sv = hit_count(src_body)
+    tv = hit_count(tgt_body)
     if sv is not None and tv is not None:
         mx = max(sv, tv)
         return ((min(sv, tv) / mx) if mx > 0 else 1.0), 'hit count ratio'
@@ -103,19 +121,27 @@ def score_tuple(r: Dict) -> Dict:
     whether the request was actually replayed — used uniformly by both the summary sparkline and
     the per-tuple table.
     """
+    src_request = r.get('sourceRequest', {})
+    tgt_request = r.get('targetRequest', {})
     src_resp = r.get('sourceResponse', {})
     tgt_resps = r.get('targetResponses', [])
-    method = r.get('sourceRequest', {}).get('Method', '?')
-    uri = r.get('sourceRequest', {}).get('Request-URI', '?')
+    method = src_request.get('Method', '?')
+    uri = src_request.get('Request-URI', '?')
     src_status = src_resp.get('Status-Code', '?')
     if method == 'OPTIONS':
         return dict(method=method, uri=uri, src_status=src_status,
                     tgt_status=None, j=None, j_label='preflight',
-                    src_hits=None, tgt_hits=None, replayed=False)
+                    src_hits=None, tgt_hits=None,
+                    src_hit_list=[], tgt_hit_list=[],
+                    src_request=src_request, tgt_request=tgt_request,
+                    src_response=src_resp, tgt_response=None, replayed=False)
     if not tgt_resps:
         return dict(method=method, uri=uri, src_status=src_status,
                     tgt_status=None, j=None, j_label=None,
-                    src_hits=None, tgt_hits=None, replayed=False)
+                    src_hits=None, tgt_hits=None,
+                    src_hit_list=[], tgt_hit_list=[],
+                    src_request=src_request, tgt_request=tgt_request,
+                    src_response=src_resp, tgt_response=None, replayed=False)
     tgt = tgt_resps[0]
     tgt_status = tgt.get('Status-Code', '?')
     src_body = src_resp.get('payload', {}).get('inlinedJsonBody', {})
@@ -123,18 +149,27 @@ def score_tuple(r: Dict) -> Dict:
     is_msearch = ('_msearch' in uri or 'responses' in src_body)
     if is_msearch:
         j, lbl = score_msearch(src_body, tgt_body)
-        src_hits = sum(
-            (s.get('hits', {}).get('total', {}).get('value') or 0)
-            for s in src_body.get('responses', []) if isinstance(s, dict)) or None
-        tgt_hits = sum(
-            (s.get('hits', {}).get('total', {}).get('value') or 0)
-            for s in tgt_body.get('responses', []) if isinstance(s, dict)) or None
+        src_subs = [s for s in src_body.get('responses', []) if isinstance(s, dict)]
+        tgt_subs = [s for s in tgt_body.get('responses', []) if isinstance(s, dict)]
+        # sum(...) over an empty list is a real 0, which would misread as "matched nothing"
+        # rather than "not applicable" — only sum when there's at least one sub-response.
+        src_hits = sum((hit_count(s) or 0) for s in src_subs) if src_subs else None
+        tgt_hits = sum((hit_count(s) or 0) for s in tgt_subs) if tgt_subs else None
+        # Sub-queries are concatenated in order — the detail pane doesn't break an msearch out
+        # by sub-query, just shows every hit it returned across all of them.
+        src_hit_list = [h for s in src_subs for h in hit_summaries(s)]
+        tgt_hit_list = [h for s in tgt_subs for h in hit_summaries(s)]
     else:
         j, lbl = compute_jaccard(src_body, tgt_body)
-        src_hits = src_body.get('hits', {}).get('total', {}).get('value') or src_body.get('count')
-        tgt_hits = tgt_body.get('hits', {}).get('total', {}).get('value') or tgt_body.get('count')
+        src_hits = hit_count(src_body)
+        tgt_hits = hit_count(tgt_body)
+        src_hit_list = hit_summaries(src_body)
+        tgt_hit_list = hit_summaries(tgt_body)
     return dict(method=method, uri=uri,
                 src_status=src_status, tgt_status=tgt_status,
                 j=j, j_label=lbl,
                 src_hits=src_hits, tgt_hits=tgt_hits,
+                src_hit_list=src_hit_list, tgt_hit_list=tgt_hit_list,
+                src_request=src_request, tgt_request=tgt_request,
+                src_response=src_resp, tgt_response=tgt,
                 replayed=True)

--- a/deployment/k8s/tui/scoring.py
+++ b/deployment/k8s/tui/scoring.py
@@ -1,10 +1,13 @@
 """Replay-quality scoring for TrafficReplayer tuples.
 
-Ported unchanged from 07-live-jaccard-kafka.sh's embedded Python: given a source/target
-request-response tuple, estimate how similar the two result sets were. Doc-ID overlap is
-preferred when both sides returned hits; aggregation buckets and raw hit counts are the
-fallbacks, in that order, since a search can be "correct" without returning any hits at all
-(an empty result set matched on both sides is a Jaccard of 1.0, not "no data").
+Given a source/target request-response tuple, estimate how similar the two sides' results
+were. Every replayed request decomposes into "items" — independently-scored comparison
+units — rather than one blended score, since averaging hides exactly the failure that
+matters: a badly-diverged item pulled toward 1.0 by good ones still looks fine in aggregate.
+An _msearch contributes one group of items per NDJSON sub-query; within any single response
+(msearch sub-response or a plain search), each of hits and every named aggregation is its
+own item, since a size:0 facet query with two aggregations is really two independent
+comparisons, not one.
 """
 from typing import Dict, List, Optional, Set, Tuple
 
@@ -39,56 +42,14 @@ def hit_count(body: Dict) -> Optional[int]:
     return body.get('count')
 
 
-def weighted_jaccard_aggs(src_aggs: Dict, tgt_aggs: Dict) -> Tuple[Optional[float], Optional[str]]:
-    scores = []
-    for name in set(src_aggs) | set(tgt_aggs):
-        sa = src_aggs.get(name, {})
-        ta = tgt_aggs.get(name, {})
-        if not isinstance(sa, dict) or not isinstance(ta, dict):
-            continue
-        sb = sa.get('buckets', [])
-        tb = ta.get('buckets', [])
-        if sb or tb:
-            sc = {b['key']: b.get('doc_count', 0) for b in sb if 'key' in b}
-            tc = {b['key']: b.get('doc_count', 0) for b in tb if 'key' in b}
-            keys = set(sc) | set(tc)
-            if keys:
-                n = sum(min(sc.get(k, 0), tc.get(k, 0)) for k in keys)
-                d = sum(max(sc.get(k, 0), tc.get(k, 0)) for k in keys)
-                if d > 0:
-                    scores.append(n / d)
-            continue
-        sdc = sa.get('doc_count')
-        tdc = ta.get('doc_count')
-        if sdc is not None and tdc is not None:
-            mx = max(sdc, tdc)
-            if mx > 0:
-                scores.append(min(sdc, tdc) / mx)
-        for sub, ssub in sa.items():
-            if not isinstance(ssub, dict) or 'value' not in ssub:
-                continue
-            tsub = ta.get(sub, {})
-            if not isinstance(tsub, dict):
-                continue
-            sv, tv = ssub['value'], tsub.get('value')
-            if sv is not None and tv is not None:
-                mx = max(sv, tv)
-                if mx > 0:
-                    scores.append(min(sv, tv) / mx)
-    if not scores:
-        return None, None
-    return sum(scores) / len(scores), 'agg'
-
-
-def compute_jaccard(src_body: Dict, tgt_body: Dict) -> Tuple[Optional[float], Optional[str]]:
+def compute_hits_jaccard(src_body: Dict, tgt_body: Dict) -> Tuple[Optional[float], Optional[str]]:
+    """Doc-ID overlap for a response's hits, falling back to a hit-count ratio when the hits
+    array is empty on both sides (a legitimate "both matched nothing" case, not "no data" —
+    see hit_count's docstring)."""
     si = hit_doc_ids(src_body)
     ti = hit_doc_ids(tgt_body)
     if si is not None and ti is not None:
         return jaccard_sets(si, ti), 'doc IDs'
-    j, lbl = weighted_jaccard_aggs(
-        src_body.get('aggregations', {}), tgt_body.get('aggregations', {}))
-    if j is not None:
-        return j, lbl
     sv = hit_count(src_body)
     tv = hit_count(tgt_body)
     if sv is not None and tv is not None:
@@ -97,12 +58,66 @@ def compute_jaccard(src_body: Dict, tgt_body: Dict) -> Tuple[Optional[float], Op
     return None, None
 
 
-def _subquery_score(sb: Dict, tb: Dict) -> Tuple[Optional[float], Optional[str]]:
-    if not isinstance(sb, dict) or not isinstance(tb, dict):
-        return None, 'malformed'
-    if sb.get('status', 200) >= 400 or tb.get('status', 200) >= 400:
-        return None, 'error'
-    return compute_jaccard(sb, tb)
+def score_agg(sa: Dict, ta: Dict) -> Tuple[Optional[float], str]:
+    """Score ONE named aggregation — bucket-based (terms/date-histogram/...) or a single
+    metric (avg/sum/cardinality/...). Bucket comparison is a weighted per-key overlap, same
+    idea as Jaccard but weighted by doc_count so a bucket with 10000 docs counts for more
+    than one with 1."""
+    sa = sa if isinstance(sa, dict) else {}
+    ta = ta if isinstance(ta, dict) else {}
+    sb = sa.get('buckets', [])
+    tb = ta.get('buckets', [])
+    if sb or tb:
+        sc = {b['key']: b.get('doc_count', 0) for b in sb if 'key' in b}
+        tc = {b['key']: b.get('doc_count', 0) for b in tb if 'key' in b}
+        keys = set(sc) | set(tc)
+        if not keys:
+            return None, 'agg (buckets)'
+        n = sum(min(sc.get(k, 0), tc.get(k, 0)) for k in keys)
+        d = sum(max(sc.get(k, 0), tc.get(k, 0)) for k in keys)
+        return ((n / d) if d > 0 else 1.0), 'agg (buckets)'
+    sdc, tdc = sa.get('doc_count'), ta.get('doc_count')
+    if sdc is not None and tdc is not None:
+        mx = max(sdc, tdc)
+        return ((min(sdc, tdc) / mx) if mx > 0 else 1.0), 'agg (doc_count)'
+    if 'value' in sa or 'value' in ta:
+        sv, tv = sa.get('value'), ta.get('value')
+        if sv is not None and tv is not None:
+            mx = max(sv, tv)
+            return ((min(sv, tv) / mx) if mx > 0 else 1.0), 'agg (metric)'
+    return None, 'agg'
+
+
+def _response_items(sb: Dict, tb: Dict, missing_side: Optional[str], label_prefix: str) -> List[Dict]:
+    """Decompose one response pair (a plain search's body, or one _msearch sub-response) into
+    independently-scored items: one for hits if either side has a hits section, plus one per
+    aggregation name (union of both sides) — so an agg-only query's N aggregations each get
+    their own item instead of being blended into one averaged score."""
+    sb = sb if isinstance(sb, dict) else {}
+    tb = tb if isinstance(tb, dict) else {}
+    items = []
+
+    if 'hits' in sb or 'hits' in tb:
+        j, lbl = (None, missing_side) if missing_side else compute_hits_jaccard(sb, tb)
+        items.append(dict(
+            label=f'{label_prefix} · hits'.strip(' ·'), kind='hits', j=j, j_label=lbl,
+            src_hits=hit_count(sb), tgt_hits=hit_count(tb),
+            src_hit_list=hit_summaries(sb), tgt_hit_list=hit_summaries(tb),
+            src_agg=None, tgt_agg=None,
+        ))
+
+    src_aggs = sb.get('aggregations', {}) or {}
+    tgt_aggs = tb.get('aggregations', {}) or {}
+    for name in sorted(set(src_aggs) | set(tgt_aggs)):
+        sa, ta = src_aggs.get(name), tgt_aggs.get(name)
+        j, lbl = (None, missing_side) if missing_side else score_agg(sa, ta)
+        items.append(dict(
+            label=f'{label_prefix} · agg:{name}'.strip(' ·'), kind='agg', j=j, j_label=lbl,
+            src_hits=None, tgt_hits=None, src_hit_list=[], tgt_hit_list=[],
+            src_agg=sa, tgt_agg=ta,
+        ))
+
+    return items
 
 
 def _msearch_sub_bodies(src_request: Dict, count: int) -> List[Optional[List[Dict]]]:
@@ -130,12 +145,10 @@ def _msearch_sub_labels(src_request: Dict, count: int) -> List[str]:
 def score_tuple(r: Dict) -> Dict:
     """Score one TrafficReplayer tuple record (already JSON-decoded).
 
-    Every replayed request decomposes into one or more "subqueries": a plain search is
-    exactly one (the request itself); an _msearch is one per NDJSON search action, each
-    scored independently. A single blended average across an msearch's sub-queries hides
-    exactly the failure that matters — one badly-diverged sub-query pulled toward 1.0 by two
-    good ones still looks fine in aggregate — so subqueries are returned as a list rather
-    than pre-averaged, leaving any aggregation to the display layer.
+    Returns "subqueries": a flat list of independently-scored items. A plain search
+    contributes 1+ items (hits, plus one per aggregation); an _msearch contributes that same
+    decomposition per NDJSON sub-query, labeled with its position (e.g. "1/2 (typefilter)")
+    so each item stays traceable to which sub-query it came from.
     """
     src_request = r.get('sourceRequest', {})
     tgt_request = r.get('targetRequest', {})
@@ -158,10 +171,10 @@ def score_tuple(r: Dict) -> Dict:
     tgt_body = tgt.get('payload', {}).get('inlinedJsonBody', {})
     # A missing sourceResponse/targetResponse (e.g. the browser aborted the request before its
     # response arrived — this is real, observed capture data, not hypothetical) leaves src_body
-    # or tgt_body as {}. compute_jaccard would then compare real data against nothing and
-    # mathematically bottom out at 0.0 — indistinguishable from "genuinely diverged" in the
-    # display. Detected once here (Status-Code is only absent when the response itself never
-    # arrived) and forced to an explicit unscored label instead, for every subquery at once.
+    # or tgt_body as {}. Comparing real data against nothing would mathematically bottom out at
+    # 0.0 — indistinguishable from "genuinely diverged" in the display. Detected once here
+    # (Status-Code is only absent when the response itself never arrived) and forced to an
+    # explicit unscored label instead, for every item at once.
     missing_side = (
         'no source or target data' if 'Status-Code' not in src_resp and 'Status-Code' not in tgt else
         'no source data' if 'Status-Code' not in src_resp else
@@ -182,22 +195,14 @@ def score_tuple(r: Dict) -> Dict:
         for i in range(n):
             sb = src_subs[i] if i < len(src_subs) else {}
             tb = tgt_subs[i] if i < len(tgt_subs) else {}
-            j, lbl = (None, missing_side) if missing_side else _subquery_score(sb, tb)
-            subqueries.append(dict(
-                label=labels[i], j=j, j_label=lbl,
-                src_hits=hit_count(sb) if isinstance(sb, dict) else None,
-                tgt_hits=hit_count(tb) if isinstance(tb, dict) else None,
-                src_hit_list=hit_summaries(sb) if isinstance(sb, dict) else [],
-                tgt_hit_list=hit_summaries(tb) if isinstance(tb, dict) else [],
-                src_sub_ndjson=src_sub_bodies[i], tgt_sub_ndjson=tgt_sub_bodies[i],
-            ))
+            for item in _response_items(sb, tb, missing_side, labels[i]):
+                item['src_sub_ndjson'] = src_sub_bodies[i]
+                item['tgt_sub_ndjson'] = tgt_sub_bodies[i]
+                subqueries.append(item)
     else:
-        j, lbl = (None, missing_side) if missing_side else compute_jaccard(src_body, tgt_body)
-        subqueries = [dict(
-            label='query', j=j, j_label=lbl,
-            src_hits=hit_count(src_body), tgt_hits=hit_count(tgt_body),
-            src_hit_list=hit_summaries(src_body), tgt_hit_list=hit_summaries(tgt_body),
-            src_sub_ndjson=None, tgt_sub_ndjson=None,
-        )]
+        subqueries = _response_items(src_body, tgt_body, missing_side, '')
+        for item in subqueries:
+            item['src_sub_ndjson'] = None
+            item['tgt_sub_ndjson'] = None
     return dict(base, tgt_status=tgt_status, tgt_response=tgt,
                 j_label=None, replayed=True, subqueries=subqueries)

--- a/deployment/k8s/tui/scoring.py
+++ b/deployment/k8s/tui/scoring.py
@@ -97,29 +97,45 @@ def compute_jaccard(src_body: Dict, tgt_body: Dict) -> Tuple[Optional[float], Op
     return None, None
 
 
-def score_msearch(src_body: Dict, tgt_body: Dict) -> Tuple[Optional[float], Optional[str]]:
-    src_subs = src_body.get('responses', [])
-    tgt_subs = tgt_body.get('responses', [])
-    scores = []
-    for sb, tb in zip(src_subs, tgt_subs):
-        if not isinstance(sb, dict) or not isinstance(tb, dict):
-            continue
-        if sb.get('status', 200) >= 400 or tb.get('status', 200) >= 400:
-            continue
-        j, _ = compute_jaccard(sb, tb)
-        if j is not None:
-            scores.append(j)
-    if not scores:
-        return None, None
-    return sum(scores) / len(scores), f'msearch ({len(src_subs)} sub-queries)'
+def _subquery_score(sb: Dict, tb: Dict) -> Tuple[Optional[float], Optional[str]]:
+    if not isinstance(sb, dict) or not isinstance(tb, dict):
+        return None, 'malformed'
+    if sb.get('status', 200) >= 400 or tb.get('status', 200) >= 400:
+        return None, 'error'
+    return compute_jaccard(sb, tb)
+
+
+def _msearch_sub_bodies(src_request: Dict, count: int) -> List[Optional[List[Dict]]]:
+    """The raw NDJSON (header, body) pair behind each _msearch sub-query, for the detail
+    pane's request view — an _msearch has no per-sub-query HTTP request of its own, just its
+    slice of the outer POST body, so this is what "the request" means for one sub-query."""
+    seq = (src_request.get('payload', {}) or {}).get('inlinedJsonSequenceBodies', [])
+    pairs: List[Optional[List[Dict]]] = []
+    for i in range(count):
+        pair = seq[2 * i:2 * i + 2]
+        pairs.append(pair if pair else None)
+    return pairs
+
+
+def _msearch_sub_labels(src_request: Dict, count: int) -> List[str]:
+    seq = (src_request.get('payload', {}) or {}).get('inlinedJsonSequenceBodies', [])
+    labels = []
+    for i in range(count):
+        header = seq[2 * i] if 2 * i < len(seq) else None
+        pref = header.get('preference') if isinstance(header, dict) else None
+        labels.append(f'{i + 1}/{count} ({pref})' if pref else f'{i + 1}/{count}')
+    return labels
 
 
 def score_tuple(r: Dict) -> Dict:
     """Score one TrafficReplayer tuple record (already JSON-decoded).
 
-    Returns a dict with j (Jaccard score or None), j_label, src/tgt status and hit counts, and
-    whether the request was actually replayed — used uniformly by both the summary sparkline and
-    the per-tuple table.
+    Every replayed request decomposes into one or more "subqueries": a plain search is
+    exactly one (the request itself); an _msearch is one per NDJSON search action, each
+    scored independently. A single blended average across an msearch's sub-queries hides
+    exactly the failure that matters — one badly-diverged sub-query pulled toward 1.0 by two
+    good ones still looks fine in aggregate — so subqueries are returned as a list rather
+    than pre-averaged, leaving any aggregation to the display layer.
     """
     src_request = r.get('sourceRequest', {})
     tgt_request = r.get('targetRequest', {})
@@ -128,48 +144,60 @@ def score_tuple(r: Dict) -> Dict:
     method = src_request.get('Method', '?')
     uri = src_request.get('Request-URI', '?')
     src_status = src_resp.get('Status-Code', '?')
+    base = dict(method=method, uri=uri, src_status=src_status,
+                src_request=src_request, tgt_request=tgt_request, src_response=src_resp)
     if method == 'OPTIONS':
-        return dict(method=method, uri=uri, src_status=src_status,
-                    tgt_status=None, j=None, j_label='preflight',
-                    src_hits=None, tgt_hits=None,
-                    src_hit_list=[], tgt_hit_list=[],
-                    src_request=src_request, tgt_request=tgt_request,
-                    src_response=src_resp, tgt_response=None, replayed=False)
+        return dict(base, tgt_status=None, tgt_response=None,
+                    j_label='preflight', replayed=False, subqueries=[])
     if not tgt_resps:
-        return dict(method=method, uri=uri, src_status=src_status,
-                    tgt_status=None, j=None, j_label=None,
-                    src_hits=None, tgt_hits=None,
-                    src_hit_list=[], tgt_hit_list=[],
-                    src_request=src_request, tgt_request=tgt_request,
-                    src_response=src_resp, tgt_response=None, replayed=False)
+        return dict(base, tgt_status=None, tgt_response=None,
+                    j_label=None, replayed=False, subqueries=[])
     tgt = tgt_resps[0]
     tgt_status = tgt.get('Status-Code', '?')
     src_body = src_resp.get('payload', {}).get('inlinedJsonBody', {})
     tgt_body = tgt.get('payload', {}).get('inlinedJsonBody', {})
+    # A missing sourceResponse/targetResponse (e.g. the browser aborted the request before its
+    # response arrived — this is real, observed capture data, not hypothetical) leaves src_body
+    # or tgt_body as {}. compute_jaccard would then compare real data against nothing and
+    # mathematically bottom out at 0.0 — indistinguishable from "genuinely diverged" in the
+    # display. Detected once here (Status-Code is only absent when the response itself never
+    # arrived) and forced to an explicit unscored label instead, for every subquery at once.
+    missing_side = (
+        'no source or target data' if 'Status-Code' not in src_resp and 'Status-Code' not in tgt else
+        'no source data' if 'Status-Code' not in src_resp else
+        'no target data' if 'Status-Code' not in tgt else
+        None
+    )
     is_msearch = ('_msearch' in uri or 'responses' in src_body)
     if is_msearch:
-        j, lbl = score_msearch(src_body, tgt_body)
-        src_subs = [s for s in src_body.get('responses', []) if isinstance(s, dict)]
-        tgt_subs = [s for s in tgt_body.get('responses', []) if isinstance(s, dict)]
-        # sum(...) over an empty list is a real 0, which would misread as "matched nothing"
-        # rather than "not applicable" — only sum when there's at least one sub-response.
-        src_hits = sum((hit_count(s) or 0) for s in src_subs) if src_subs else None
-        tgt_hits = sum((hit_count(s) or 0) for s in tgt_subs) if tgt_subs else None
-        # Sub-queries are concatenated in order — the detail pane doesn't break an msearch out
-        # by sub-query, just shows every hit it returned across all of them.
-        src_hit_list = [h for s in src_subs for h in hit_summaries(s)]
-        tgt_hit_list = [h for s in tgt_subs for h in hit_summaries(s)]
+        src_subs = src_body.get('responses', [])
+        tgt_subs = tgt_body.get('responses', [])
+        n = max(len(src_subs), len(tgt_subs))
+        labels = _msearch_sub_labels(src_request, n)
+        # Both sides' NDJSON pairs are carried separately, not assumed identical — a
+        # transformation plugin can legitimately rewrite the body on its way to the target.
+        src_sub_bodies = _msearch_sub_bodies(src_request, n)
+        tgt_sub_bodies = _msearch_sub_bodies(tgt_request, n)
+        subqueries = []
+        for i in range(n):
+            sb = src_subs[i] if i < len(src_subs) else {}
+            tb = tgt_subs[i] if i < len(tgt_subs) else {}
+            j, lbl = (None, missing_side) if missing_side else _subquery_score(sb, tb)
+            subqueries.append(dict(
+                label=labels[i], j=j, j_label=lbl,
+                src_hits=hit_count(sb) if isinstance(sb, dict) else None,
+                tgt_hits=hit_count(tb) if isinstance(tb, dict) else None,
+                src_hit_list=hit_summaries(sb) if isinstance(sb, dict) else [],
+                tgt_hit_list=hit_summaries(tb) if isinstance(tb, dict) else [],
+                src_sub_ndjson=src_sub_bodies[i], tgt_sub_ndjson=tgt_sub_bodies[i],
+            ))
     else:
-        j, lbl = compute_jaccard(src_body, tgt_body)
-        src_hits = hit_count(src_body)
-        tgt_hits = hit_count(tgt_body)
-        src_hit_list = hit_summaries(src_body)
-        tgt_hit_list = hit_summaries(tgt_body)
-    return dict(method=method, uri=uri,
-                src_status=src_status, tgt_status=tgt_status,
-                j=j, j_label=lbl,
-                src_hits=src_hits, tgt_hits=tgt_hits,
-                src_hit_list=src_hit_list, tgt_hit_list=tgt_hit_list,
-                src_request=src_request, tgt_request=tgt_request,
-                src_response=src_resp, tgt_response=tgt,
-                replayed=True)
+        j, lbl = (None, missing_side) if missing_side else compute_jaccard(src_body, tgt_body)
+        subqueries = [dict(
+            label='query', j=j, j_label=lbl,
+            src_hits=hit_count(src_body), tgt_hits=hit_count(tgt_body),
+            src_hit_list=hit_summaries(src_body), tgt_hit_list=hit_summaries(tgt_body),
+            src_sub_ndjson=None, tgt_sub_ndjson=None,
+        )]
+    return dict(base, tgt_status=tgt_status, tgt_response=tgt,
+                j_label=None, replayed=True, subqueries=subqueries)

--- a/deployment/k8s/tui/scoring.py
+++ b/deployment/k8s/tui/scoring.py
@@ -1,0 +1,140 @@
+"""Replay-quality scoring for TrafficReplayer tuples.
+
+Ported unchanged from 07-live-jaccard-kafka.sh's embedded Python: given a source/target
+request-response tuple, estimate how similar the two result sets were. Doc-ID overlap is
+preferred when both sides returned hits; aggregation buckets and raw hit counts are the
+fallbacks, in that order, since a search can be "correct" without returning any hits at all
+(an empty result set matched on both sides is a Jaccard of 1.0, not "no data").
+"""
+from typing import Dict, List, Optional, Set, Tuple
+
+
+def jaccard_sets(a: Set, b: Set) -> Optional[float]:
+    if not a and not b:
+        return None
+    return len(a & b) / len(a | b)
+
+
+def hit_doc_ids(body: Dict) -> Optional[Set[str]]:
+    hits = body.get('hits', {}).get('hits', [])
+    ids = {h['_id'] for h in hits if '_id' in h}
+    return ids if ids else None
+
+
+def weighted_jaccard_aggs(src_aggs: Dict, tgt_aggs: Dict) -> Tuple[Optional[float], Optional[str]]:
+    scores = []
+    for name in set(src_aggs) | set(tgt_aggs):
+        sa = src_aggs.get(name, {})
+        ta = tgt_aggs.get(name, {})
+        if not isinstance(sa, dict) or not isinstance(ta, dict):
+            continue
+        sb = sa.get('buckets', [])
+        tb = ta.get('buckets', [])
+        if sb or tb:
+            sc = {b['key']: b.get('doc_count', 0) for b in sb if 'key' in b}
+            tc = {b['key']: b.get('doc_count', 0) for b in tb if 'key' in b}
+            keys = set(sc) | set(tc)
+            if keys:
+                n = sum(min(sc.get(k, 0), tc.get(k, 0)) for k in keys)
+                d = sum(max(sc.get(k, 0), tc.get(k, 0)) for k in keys)
+                if d > 0:
+                    scores.append(n / d)
+            continue
+        sdc = sa.get('doc_count')
+        tdc = ta.get('doc_count')
+        if sdc is not None and tdc is not None:
+            mx = max(sdc, tdc)
+            if mx > 0:
+                scores.append(min(sdc, tdc) / mx)
+        for sub, ssub in sa.items():
+            if not isinstance(ssub, dict) or 'value' not in ssub:
+                continue
+            tsub = ta.get(sub, {})
+            if not isinstance(tsub, dict):
+                continue
+            sv, tv = ssub['value'], tsub.get('value')
+            if sv is not None and tv is not None:
+                mx = max(sv, tv)
+                if mx > 0:
+                    scores.append(min(sv, tv) / mx)
+    if not scores:
+        return None, None
+    return sum(scores) / len(scores), 'agg'
+
+
+def compute_jaccard(src_body: Dict, tgt_body: Dict) -> Tuple[Optional[float], Optional[str]]:
+    si = hit_doc_ids(src_body)
+    ti = hit_doc_ids(tgt_body)
+    if si is not None and ti is not None:
+        return jaccard_sets(si, ti), 'doc IDs'
+    j, lbl = weighted_jaccard_aggs(
+        src_body.get('aggregations', {}), tgt_body.get('aggregations', {}))
+    if j is not None:
+        return j, lbl
+    sv = src_body.get('hits', {}).get('total', {}).get('value') or src_body.get('count')
+    tv = tgt_body.get('hits', {}).get('total', {}).get('value') or tgt_body.get('count')
+    if sv is not None and tv is not None:
+        mx = max(sv, tv)
+        return ((min(sv, tv) / mx) if mx > 0 else 1.0), 'hit count ratio'
+    return None, None
+
+
+def score_msearch(src_body: Dict, tgt_body: Dict) -> Tuple[Optional[float], Optional[str]]:
+    src_subs = src_body.get('responses', [])
+    tgt_subs = tgt_body.get('responses', [])
+    scores = []
+    for sb, tb in zip(src_subs, tgt_subs):
+        if not isinstance(sb, dict) or not isinstance(tb, dict):
+            continue
+        if sb.get('status', 200) >= 400 or tb.get('status', 200) >= 400:
+            continue
+        j, _ = compute_jaccard(sb, tb)
+        if j is not None:
+            scores.append(j)
+    if not scores:
+        return None, None
+    return sum(scores) / len(scores), f'msearch ({len(src_subs)} sub-queries)'
+
+
+def score_tuple(r: Dict) -> Dict:
+    """Score one TrafficReplayer tuple record (already JSON-decoded).
+
+    Returns a dict with j (Jaccard score or None), j_label, src/tgt status and hit counts, and
+    whether the request was actually replayed — used uniformly by both the summary sparkline and
+    the per-tuple table.
+    """
+    src_resp = r.get('sourceResponse', {})
+    tgt_resps = r.get('targetResponses', [])
+    method = r.get('sourceRequest', {}).get('Method', '?')
+    uri = r.get('sourceRequest', {}).get('Request-URI', '?')
+    src_status = src_resp.get('Status-Code', '?')
+    if method == 'OPTIONS':
+        return dict(method=method, uri=uri, src_status=src_status,
+                    tgt_status=None, j=None, j_label='preflight',
+                    src_hits=None, tgt_hits=None, replayed=False)
+    if not tgt_resps:
+        return dict(method=method, uri=uri, src_status=src_status,
+                    tgt_status=None, j=None, j_label=None,
+                    src_hits=None, tgt_hits=None, replayed=False)
+    tgt = tgt_resps[0]
+    tgt_status = tgt.get('Status-Code', '?')
+    src_body = src_resp.get('payload', {}).get('inlinedJsonBody', {})
+    tgt_body = tgt.get('payload', {}).get('inlinedJsonBody', {})
+    is_msearch = ('_msearch' in uri or 'responses' in src_body)
+    if is_msearch:
+        j, lbl = score_msearch(src_body, tgt_body)
+        src_hits = sum(
+            (s.get('hits', {}).get('total', {}).get('value') or 0)
+            for s in src_body.get('responses', []) if isinstance(s, dict)) or None
+        tgt_hits = sum(
+            (s.get('hits', {}).get('total', {}).get('value') or 0)
+            for s in tgt_body.get('responses', []) if isinstance(s, dict)) or None
+    else:
+        j, lbl = compute_jaccard(src_body, tgt_body)
+        src_hits = src_body.get('hits', {}).get('total', {}).get('value') or src_body.get('count')
+        tgt_hits = tgt_body.get('hits', {}).get('total', {}).get('value') or tgt_body.get('count')
+    return dict(method=method, uri=uri,
+                src_status=src_status, tgt_status=tgt_status,
+                j=j, j_label=lbl,
+                src_hits=src_hits, tgt_hits=tgt_hits,
+                replayed=True)

--- a/deployment/k8s/tui/serve_web.py
+++ b/deployment/k8s/tui/serve_web.py
@@ -1,0 +1,36 @@
+"""Serve the TUI as a web page instead of a terminal app, via textual-serve.
+
+textual-serve has no CLI of its own — it's a small library that spawns the given
+command as a subprocess per browser connection and streams its terminal I/O over a
+websocket to an xterm.js frontend it serves. This is the local/self-hosted sibling of
+textual-web (which publishes to Textualize's own hosted relay for a public URL instead).
+
+NOTE: the TUI's 'c' (copy request) keybinding shells out to the OS clipboard tool
+(pbcopy/xclip/...) on whatever machine runs THIS process — under textual-serve, that's
+the server, not the browser. Fine if you're viewing it in a browser on the same machine
+you're running this from; if someone else opens the URL from their own machine, 'c'
+copies to your clipboard, not theirs.
+
+Exposing this through a tunnel (ngrok, etc.)? PUBLIC_URL must be set to the tunnel's
+https URL. textual-serve does NOT infer the public address from the incoming request —
+the page it serves hardcodes its WebSocket/static-asset URLs from public_url (defaults
+to http://{HOST}:{PORT}), so without this a remote browser loading the tunnel URL still
+gets told to open a websocket to your own localhost, which resolves to THEIR machine and
+silently fails.
+"""
+import os
+
+from textual_serve.server import Server
+
+NAMESPACE = os.environ.get("NAMESPACE", "ma")
+HOST = os.environ.get("WEB_HOST", "localhost")
+PORT = int(os.environ.get("WEB_PORT", "8321"))
+PUBLIC_URL = os.environ.get("PUBLIC_URL") or None  # e.g. https://abc123.ngrok-free.app
+# "or None": an unset-but-exported empty string (PUBLIC_URL="" from the wrapper script's
+# default) must become None, not "" — Server's public_url default-computation only kicks
+# in for None; "" is treated as a real (broken) value and produces malformed URLs.
+
+server = Server(
+    f"python3 -m tui --namespace {NAMESPACE}", host=HOST, port=PORT, public_url=PUBLIC_URL
+)
+server.serve()


### PR DESCRIPTION
### Description
Introduces the ability to monitor queries being sent via capture replay against a source search engine and the target OpenSearch search engine.   

The TUI monitors the life stream of queries via a Kafka topic, or can be pointed at an S3 bucket of queries.   

This screenshot shows the analytics when the source system, ES, has half the documents of the target system,  OS:
<img width="1433" height="707" alt="image" src="https://github.com/user-attachments/assets/1f722e12-1397-4aa1-b8a1-c61131d7406d" />

It looks at raw doc hits, it looks at aggregation bucket results, and it look sat total number of docs being returned.  It produces both classic Jaccard and the more advanced (for search use cases) Rank Biased Overlap metrics.   

You get a sliding window of 15 queries, and then it store results over the lifetime of the TUI as well.

Results can be aggegated over all queries:

<img width="1426" height="681" alt="image" src="https://github.com/user-attachments/assets/8f4afeb3-afb6-4ab3-aac5-af9e96831bb4" />


### Issues Resolved
<!-- List any GitHub or Jira issues this PR will resolve -->

### Testing
Manual testing on OSX and Windows.   the directory `./chorus_es_to_os_demo` demonstrate the live migration and replay of Chorus the Elasticsearch edition (using ES 8.3) to an OpenSearch 3.7 server.

### Check List
- [x ] New functionality includes testing
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
