### PR TITLE
Add AWS Terraform deployment support

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -364,6 +364,20 @@ jobs:
           terraform init -backend=false
           terraform test
 
+  aws-terraform-test:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
+        with:
+          terraform_wrapper: false
+      - name: terraform test (AWS module)
+        # Plan-time tests only; no cloud credentials required.
+        working-directory: deployment/terraform/aws
+        run: |
+          terraform init -backend=false
+          terraform test
+
   codeql-analyze:
     name: CodeQL (${{ matrix.language }})
     runs-on: ubuntu-22.04
@@ -510,6 +524,7 @@ jobs:
       - codeql-analyze
       - sonarqube-analysis
       - gcp-terraform-test
+      - aws-terraform-test
     if: always()
     runs-on: ubuntu-22.04
     steps:

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ OpenSearch Migration Assistant is a comprehensive set of tools designed to facil
 - **User-Friendly Interface via [Migration Console](https://github.com/opensearch-project/opensearch-migrations/blob/main/docs/migration-console.md)**: Command Line Interface (CLI) that guides you through each migration step.
 
 - **Flexible Deployment Options**:
-  - **[AWS Deployment](https://aws.amazon.com/solutions/implementations/migration-assistant-for-amazon-opensearch-service/)**: Fully automated deployment to AWS.
+  - **[AWS Deployment](deployment/terraform/aws/README.md)**: Provision EKS Auto Mode infrastructure with Terraform, or use the existing [AWS Solution CloudFormation deployment](https://aws.amazon.com/solutions/implementations/migration-assistant-for-amazon-opensearch-service/).
   - **[GCP Deployment](deployment/terraform/gcp/README.md)**: Terraform module that provisions a GKE cluster, GCS snapshot bucket, and the Workload Identity bindings required by the migration workflows, deployed via the [GKE Helm overlay](deployment/k8s/charts/aggregates/migrationAssistantWithArgo/valuesGke.yaml).
   - **[Local Docker Deployment](./TrafficCapture/dockerSolution/README.md)**: Run the solution locally in a container for testing and development.
   - Contribute to add more deployment options.
@@ -138,7 +138,7 @@ User guide documentation is available in the [OpenSearch Migration Assistant doc
 
 ### AWS Deployment
 
-To deploy the solution on AWS, follow the steps outlined in [Migration Assistant for Amazon OpenSearch Service](https://aws.amazon.com/solutions/implementations/migration-assistant-for-amazon-opensearch-service/), specifically [deploying the solution](https://docs.aws.amazon.com/solutions/latest/migration-assistant-for-amazon-opensearch-service/deploy-the-solution.html).
+To deploy EKS infrastructure on AWS with Terraform, see the [AWS Terraform README](deployment/terraform/aws/README.md). The existing CloudFormation-based AWS Solution remains available through [Migration Assistant for Amazon OpenSearch Service](https://aws.amazon.com/solutions/implementations/migration-assistant-for-amazon-opensearch-service/) and its [deployment guide](https://docs.aws.amazon.com/solutions/latest/migration-assistant-for-amazon-opensearch-service/deploy-the-solution.html).
 
 ### GCP Deployment
 

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -12,7 +12,10 @@ Detailed instructions for deploying the CDK and setting up its prerequisites can
 Current and future development of the Migration Assistant is built upon Kubernetes (K8s).  
 See the [user guide](https://github.com/opensearch-project/opensearch-migrations/wiki) for instructions 
 to install Migration Assistant into EKS.  
-More information to deploy in a development environment can be found [here](./k8s/aws/README.md)
+Use the additive [AWS Terraform module](./terraform/aws/README.md) to provision
+the EKS infrastructure without CloudFormation, or see the existing
+[AWS Kubernetes deployment](./k8s/aws/README.md) for the CloudFormation/bootstrap
+workflow.
 
 ### Deploying the Migration Assistant (GKE) Solution
 
@@ -30,4 +33,3 @@ Kubernetes quick start.
 
 A containerized end-to-end solution (including a source and target cluster as well as the migration services) can be deployed locally using the
 [Docker Solution](../TrafficCapture/dockerSolution/README.md).
-

--- a/deployment/k8s/README.md
+++ b/deployment/k8s/README.md
@@ -63,7 +63,9 @@ Run `kindTesting.sh` first — it expects the control plane and clusters to exis
 ### EKS
 
 If you're looking to use EKS as your Kubernetes cluster, follow the
-[instructions here](aws/README.md).
+[AWS deployment instructions](aws/README.md). You can provision the underlying
+EKS Auto Mode infrastructure with either the existing CloudFormation workflow or
+the additive [AWS Terraform module](../terraform/aws/README.md).
 
 ### GKE
 

--- a/deployment/k8s/aws/README.md
+++ b/deployment/k8s/aws/README.md
@@ -9,6 +9,11 @@ For a high-level overview of all Kubernetes deployment options see the
 [K8s README](../README.md). For broader Migration Assistant documentation
 see the [project wiki](https://github.com/opensearch-project/opensearch-migrations/wiki).
 
+To provision equivalent EKS infrastructure without CloudFormation, use the
+additive [AWS Terraform module](../../terraform/aws/README.md). The Terraform
+module leaves this CloudFormation workflow intact and can optionally install the
+same Helm chart directly.
+
 ## What you get
 
 A single command:

--- a/deployment/terraform/aws/.gitignore
+++ b/deployment/terraform/aws/.gitignore
@@ -1,0 +1,7 @@
+.terraform/
+.terraform.lock.hcl
+*.tfstate
+*.tfstate.*
+terraform.tfvars
+*.auto.tfvars
+crash.log

--- a/deployment/terraform/aws/README.md
+++ b/deployment/terraform/aws/README.md
@@ -1,0 +1,251 @@
+# AWS Terraform: Migration Assistant Infrastructure
+
+This root module provisions the AWS infrastructure used by the Kubernetes-based
+OpenSearch Migration Assistant. It is an additive Terraform alternative to the
+existing CDK-generated CloudFormation templates; those templates remain in the
+repository and continue to be supported.
+
+The default deployment creates:
+
+- A dual-stack VPC spanning two availability zones, with public and private
+  subnets and one NAT gateway per zone
+- S3, ECR API, ECR Docker, CloudWatch Logs, and EFS VPC endpoints
+- An EKS Auto Mode cluster with the `system` and `general-purpose` node pools
+- A private ECR repository
+- Cluster, node, snapshot, and Migration Assistant workload IAM roles
+- EKS Pod Identity associations for the chart's AWS-facing service accounts
+- Optionally, the Migration Assistant Helm chart using the EKS overlay
+
+You can instead deploy into an existing VPC and select only the endpoints that
+Terraform should add, deploy into an isolated (air-gapped) network with no public
+data path, and optionally establish private connectivity to the source and target
+clusters. Those options are covered in the sections below.
+
+## Prerequisites
+
+- Terraform or OpenTofu 1.6 or newer
+- AWS credentials authorized to manage VPC, EKS, ECR, IAM, and VPC endpoint
+  resources
+- AWS CLI and `kubectl` for cluster access after provisioning
+- Network access to public Helm and container registries if `deploy_helm = true`
+
+EKS Auto Mode must be available in the selected AWS region and for the selected
+Kubernetes version.
+
+## Create a new VPC and EKS cluster
+
+From this directory:
+
+```bash
+terraform init
+terraform plan \
+  -var="region=us-east-1" \
+  -var="stage=dev"
+terraform apply \
+  -var="region=us-east-1" \
+  -var="stage=dev"
+
+# Configure kubectl using the command emitted by Terraform.
+$(terraform output -raw kubeconfig_command)
+kubectl get nodes
+```
+
+The new VPC uses `10.212.0.0/16` by default to reduce the chance of conflicts
+with a default VPC. Override `vpc_cidr` if that range overlaps a source, target,
+peered, or transit-connected network.
+
+## Use an existing VPC
+
+Supply at least two subnets in distinct availability zones. Private subnets with
+NAT or equivalent egress are recommended.
+
+```hcl
+create_vpc          = false
+existing_vpc_id     = "vpc-0123456789abcdef0"
+existing_subnet_ids = [
+  "subnet-0123456789abcdef0",
+  "subnet-abcdef01234567890",
+]
+
+# Endpoints are opt-in for an existing VPC.
+vpc_endpoints = [
+  "s3",
+  "ecr.api",
+  "ecr.dkr",
+  "logs",
+  "sts",
+  "eks-auth",
+]
+```
+
+When `existing_route_table_ids` is empty, Terraform discovers the route table
+associated with each supplied subnet for the S3 gateway endpoint. Set the route
+table IDs explicitly if the subnets use an implicit main-route-table association
+or if only selected route tables should receive the S3 route.
+
+Valid `vpc_endpoints` values are `s3`, `ecr.api`, `ecr.dkr`, `logs`,
+`monitoring`, `elasticfilesystem`, `sts`, and `eks-auth`. Isolated subnets need
+additional private access to every registry and Helm repository used during
+installation; these AWS service endpoints alone do not provide that access.
+
+## Isolated (air-gapped) deployment
+
+Set `isolated = true` (with `create_vpc = true`) to provision a fully private
+network with no outbound internet path, for a migration that must not traverse
+the public internet:
+
+```bash
+terraform apply \
+  -var="region=us-east-1" \
+  -var="stage=dev" \
+  -var="isolated=true"
+```
+
+In isolated mode the module creates no NAT gateway and adds no default route from
+the private subnets, and it creates the full set of service VPC endpoints the
+cluster needs to reach AWS APIs privately: `s3` (gateway) plus interface endpoints
+for `ecr.api`, `ecr.dkr`, `logs`, `monitoring`, `elasticfilesystem`, `sts`, and
+`eks-auth`. This matches the endpoint set used by the isolated-network deployment
+path. `isolated` defaults to `false`, which preserves the standard behavior (NAT
+gateway plus the base endpoint set).
+
+Container images must be reachable without internet egress. Mirror the Migration
+Assistant images and any third-party images the chart pulls into the module's
+private ECR repository (`ecr_repository_url`) before workloads start.
+
+## Private connectivity to the source and target
+
+`source_connectivity` and `target_connectivity` establish a private network path
+to the source and target clusters so backfill and live migration run without a
+public data path. Each leg is independent and defaults to `mode = "none"`, which
+creates nothing and leaves a public-path deployment unchanged. The other modes:
+
+- `privatelink`: create a consumer interface VPC endpoint to the cluster
+  provider's VPC endpoint service, optionally with a Route 53 private hosted zone
+  that resolves a hostname to the endpoint. Best fit for a managed OpenSearch
+  service that exposes a PrivateLink endpoint service (typical for a target).
+- `vpc_peering`: peer the migration VPC with the cluster's VPC and route to its
+  CIDR. Fits a cluster in a customer-owned VPC (often the source).
+
+```hcl
+# Target reached over PrivateLink, with a private DNS name.
+target_connectivity = {
+  mode                      = "privatelink"
+  vpc_endpoint_service_name = "com.amazonaws.vpce.us-east-1.vpce-svc-0123456789abcdef0"
+  dns_name                  = "my-target.example.com"   # optional; use the provider's canonical hostname
+}
+
+# Source reached by peering to a customer VPC.
+source_connectivity = {
+  mode        = "vpc_peering"
+  peer_vpc_id = "vpc-0aaaaaaaaaaaaaaaa"
+  peer_cidr   = "10.99.0.0/16"          # must not overlap vpc_cidr
+}
+```
+
+The resolved private endpoint is exposed as `source_private_endpoint` /
+`target_private_endpoint`; place it in the workflow cluster configuration. The
+cluster endpoint and credentials themselves are supplied as runtime migration
+config, not by Terraform.
+
+This module intentionally provisions only the consumer side. The following are
+operator responsibilities and are not automated:
+
+- PrivateLink: the provider must allow-list this account and accept the endpoint
+  connection if acceptance is required. Until then the endpoint stays in
+  `pendingAcceptance` and the hostname does not resolve to a working endpoint. Use
+  the provider's canonical hostname for `dns_name` so its TLS certificate
+  validates. The endpoint service must be offered in the migration availability
+  zones.
+- VPC peering: the peer must accept the connection (cross-account or cross-region)
+  and add the reciprocal route back to `vpc_cidr`. Peer CIDRs must not overlap the
+  migration VPC CIDR.
+
+## Install the Helm chart with Terraform
+
+Helm installation is off by default so infrastructure can be provisioned
+independently and images can be mirrored before workloads start. To install the
+local chart with published public ECR images:
+
+```bash
+terraform apply \
+  -var="region=us-east-1" \
+  -var="stage=dev" \
+  -var="deploy_helm=true" \
+  -var="migration_assistant_version=3.3.4"
+```
+
+Use an actual published Migration Assistant release tag. Terraform applies
+`valuesEks.yaml`, passes the AWS account, region, stage, and snapshot role to the
+chart, and waits up to 25 minutes by default.
+
+The module creates a private ECR repository for parity with the CloudFormation
+deployment and exposes it as `ecr_repository_url`. The optional Terraform Helm
+path uses public images; image mirroring or source builds remain a separate step.
+
+If your account requires a permissions boundary on newly created IAM roles (some
+organizations deny `iam:CreateRole` unless the request includes a specific
+boundary), set `permissions_boundary_arn` and the module applies it to every role
+it creates. It defaults to unset.
+
+By default the module creates the IAM role that Amazon OpenSearch Service assumes
+to read and write S3 snapshots. Set `create_opensearch_service_snapshot_role =
+false` when the migration source is not Amazon OpenSearch Service (for example a
+self-managed Elasticsearch or OpenSearch cluster), which registers its snapshot
+repository without assuming an AWS role, so the role is unused.
+
+## Outputs
+
+Important outputs include:
+
+| Output | Purpose |
+|---|---|
+| `cluster_name` | EKS cluster name |
+| `kubeconfig_command` | Ready-to-run AWS CLI command for kubectl access |
+| `ecr_repository_url` | Private image repository |
+| `snapshot_role_arn` | Role passed when registering OpenSearch S3 snapshot repositories |
+| `migration_pod_role_arn` | Shared role used by EKS Pod Identity |
+| `source_private_endpoint` | Private source endpoint when `source_connectivity` is set, else null |
+| `target_private_endpoint` | Private target endpoint when `target_connectivity` is set, else null |
+| `migration_environment` | Shell exports equivalent to the CloudFormation bootstrap export string |
+
+To load the compatibility environment into the current shell:
+
+```bash
+eval "$(terraform output -raw migration_environment)"
+```
+
+## CloudFormation coexistence and migration
+
+This module does not delete, update, import, or otherwise manage resources in an
+existing CloudFormation stack. It uses the same familiar cluster and ECR naming
+pattern, so do not deploy Terraform with the same `stage` and region as a live
+CloudFormation deployment unless you first plan an explicit state migration.
+Use a different stage for side-by-side evaluation.
+
+The Terraform implementation intentionally replaces CloudFormation's stack-level
+AppRegistry association with normal AWS resource tags because there is no
+CloudFormation stack to associate. Runtime infrastructure remains equivalent:
+EKS Auto Mode, networking, ECR, IAM, snapshot access, and Pod Identity.
+
+## Validate
+
+The tests use Terraform mock providers and do not require AWS credentials:
+
+```bash
+terraform init -backend=false
+terraform fmt -check -recursive
+terraform validate
+terraform test
+```
+
+## Destroy
+
+Review the plan carefully; this removes the EKS environment and any Helm release
+managed by this state:
+
+```bash
+terraform destroy
+```
+
+Terraform does not touch the CloudFormation deployment or its resources.

--- a/deployment/terraform/aws/README.md
+++ b/deployment/terraform/aws/README.md
@@ -18,8 +18,9 @@ The default deployment creates:
 
 You can instead deploy into an existing VPC and select only the endpoints that
 Terraform should add, deploy into an isolated (air-gapped) network with no public
-data path, and optionally establish private connectivity to the source and target
-clusters. Those options are covered in the sections below.
+data path and a private Kubernetes API endpoint, and optionally establish private
+connectivity to the source and target clusters. Those options are covered in the
+sections below.
 
 ## Prerequisites
 
@@ -108,6 +109,41 @@ for `ecr.api`, `ecr.dkr`, `logs`, `monitoring`, `elasticfilesystem`, `sts`, and
 `eks-auth`. This matches the endpoint set used by the isolated-network deployment
 path. `isolated` defaults to `false`, which preserves the standard behavior (NAT
 gateway plus the base endpoint set).
+
+Isolated mode also makes the EKS Kubernetes API endpoint private, so the control
+plane is not reachable from the internet along with the data path. This follows
+from `isolated`: `cluster_endpoint_public_access` defaults to unset, which means
+"public endpoint off when `isolated = true`, on otherwise". The private endpoint
+(`cluster_endpoint_private_access`) stays enabled, so the API is reachable from
+inside the VPC.
+
+Plan for that before you apply, because it changes how you reach the cluster:
+
+- `kubectl` (including the `kubeconfig_command` output) must run from somewhere
+  inside the VPC or a network routed to it: a bastion or workload in a private
+  subnet, a peered VPC, or a VPN/Direct Connect attachment.
+- `deploy_helm = true` requires the same access. Terraform's Helm provider talks
+  to the cluster API directly, so `terraform apply` itself has to run from a host
+  that can reach the private endpoint.
+
+To keep an isolated data path but reach the API from outside the VPC, set
+`cluster_endpoint_public_access` explicitly. An explicit value always wins over
+the `isolated`-derived default, and it affects only the control plane: NAT
+gateways, routes, and the endpoint set are unchanged. Narrow
+`cluster_public_access_cidrs` when you do; it defaults to `0.0.0.0/0`.
+
+```bash
+terraform apply \
+  -var="region=us-east-1" \
+  -var="stage=dev" \
+  -var="isolated=true" \
+  -var="cluster_endpoint_public_access=true" \
+  -var='cluster_public_access_cidrs=["203.0.113.10/32"]'
+```
+
+The override works in the other direction too: set
+`cluster_endpoint_public_access = false` without `isolated` for a private-only API
+endpoint in a standard VPC that keeps its NAT egress.
 
 Container images must be reachable without internet egress. Mirror the Migration
 Assistant images and any third-party images the chart pulls into the module's

--- a/deployment/terraform/aws/README.md
+++ b/deployment/terraform/aws/README.md
@@ -158,8 +158,9 @@ creates nothing and leaves a public-path deployment unchanged. The other modes:
 
 - `privatelink`: create a consumer interface VPC endpoint to the cluster
   provider's VPC endpoint service, optionally with a Route 53 private hosted zone
-  that resolves a hostname to the endpoint. Best fit for a managed OpenSearch
-  service that exposes a PrivateLink endpoint service (typical for a target).
+  that resolves a hostname to the endpoint. Requires the cluster provider to publish
+  a VPC endpoint service name (`com.amazonaws.vpce.<region>.vpce-svc-...`); obtain it
+  from the provider.
 - `vpc_peering`: peer the migration VPC with the cluster's VPC and route to its
   CIDR. Fits a cluster in a customer-owned VPC (often the source).
 

--- a/deployment/terraform/aws/README.md
+++ b/deployment/terraform/aws/README.md
@@ -10,7 +10,9 @@ The default deployment creates:
 - A dual-stack VPC spanning two availability zones, with public and private
   subnets and one NAT gateway per zone
 - S3, ECR API, ECR Docker, CloudWatch Logs, and EFS VPC endpoints
-- An EKS Auto Mode cluster with the `system` and `general-purpose` node pools
+- An EKS Auto Mode cluster with the built-in `system` and `general-purpose` node
+  pools. When the chart is installed, `use_custom_karpenter_node_pool` (default
+  `true`) also configures the chart's own EKS Auto Mode NodePool
 - A private ECR repository
 - Cluster, node, snapshot, and Migration Assistant workload IAM roles
 - EKS Pod Identity associations for the chart's AWS-facing service accounts
@@ -31,7 +33,8 @@ sections below.
 - Network access to public Helm and container registries if `deploy_helm = true`
 
 EKS Auto Mode must be available in the selected AWS region and for the selected
-Kubernetes version.
+Kubernetes version. `kubernetes_version` defaults to `1.35`; override it if that
+version is not offered in your region.
 
 ## Create a new VPC and EKS cluster
 
@@ -85,7 +88,11 @@ table IDs explicitly if the subnets use an implicit main-route-table association
 or if only selected route tables should receive the S3 route.
 
 Valid `vpc_endpoints` values are `s3`, `ecr.api`, `ecr.dkr`, `logs`,
-`monitoring`, `elasticfilesystem`, `sts`, and `eks-auth`. Isolated subnets need
+`monitoring`, `elasticfilesystem`, `sts`, and `eks-auth`. For a new VPC, `s3`,
+`ecr.api`, `ecr.dkr`, `logs`, and `elasticfilesystem` are always created and
+`vpc_endpoints` adds to that set; `sts`, `eks-auth`, and `monitoring` are added
+only by `isolated = true` or by naming them here. A non-isolated new VPC reaches
+those services over its NAT gateway instead. Isolated subnets need
 additional private access to every registry and Helm repository used during
 installation; these AWS service endpoints alone do not provide that access.
 
@@ -214,7 +221,7 @@ terraform apply \
 
 Use an actual published Migration Assistant release tag. Terraform applies
 `valuesEks.yaml`, passes the AWS account, region, stage, and snapshot role to the
-chart, and waits up to 25 minutes by default.
+chart, and waits `helm_timeout_seconds` (1500, or 25 minutes) for the release.
 
 The module creates a private ECR repository for parity with the CloudFormation
 deployment and exposes it as `ecr_repository_url`. The optional Terraform Helm
@@ -231,6 +238,36 @@ false` when the migration source is not Amazon OpenSearch Service (for example a
 self-managed Elasticsearch or OpenSearch cluster), which registers its snapshot
 repository without assuming an AWS role, so the role is unused.
 
+## Variables
+
+| Name | Default | Description |
+|---|---|---|
+| `region` | `us-east-1` | AWS region for the Migration Assistant infrastructure |
+| `stage` | `dev` | Short identifier used in resource names; unique per deployment in a region |
+| `kubernetes_version` | `1.35` | EKS Kubernetes control-plane version |
+| `tags` | `{}` | Additional tags applied to resources this module manages |
+| `create_vpc` | `true` | Create a dual-stack VPC and two private/public subnet pairs, or use an existing VPC (`false`) |
+| `vpc_cidr` | `10.212.0.0/16` | IPv4 CIDR for a VPC created by this module |
+| `availability_zones` | `[]` | Exactly two AZs for a new VPC; the first two available zones are used when empty |
+| `existing_vpc_id` | `null` | Existing VPC ID; required when `create_vpc = false` |
+| `existing_subnet_ids` | `[]` | At least two existing subnets in distinct AZs; required when `create_vpc = false` |
+| `existing_route_table_ids` | `[]` | Route tables for the S3 gateway endpoint in an existing VPC; discovered per subnet when empty |
+| `vpc_endpoints` | `[]` | Endpoints to add. Valid: `s3`, `ecr.api`, `ecr.dkr`, `logs`, `monitoring`, `elasticfilesystem`, `sts`, `eks-auth` |
+| `isolated` | `false` | Air-gapped new VPC: no NAT gateway, no default route, full private endpoint set, private Kubernetes API |
+| `source_connectivity` | `{mode = "none"}` | Private path to the source. `mode = "none"` \| `"privatelink"` \| `"vpc_peering"` |
+| `target_connectivity` | `{mode = "none"}` | Private path to the target; same modes as `source_connectivity` |
+| `cluster_endpoint_public_access` | `null` | Public EKS API endpoint. Unset follows `isolated`; an explicit value always wins |
+| `cluster_endpoint_private_access` | `true` | Private EKS API endpoint inside the VPC |
+| `cluster_public_access_cidrs` | `["0.0.0.0/0"]` | CIDRs permitted to reach the public EKS API endpoint; narrow for production |
+| `namespace` | `ma` | Kubernetes namespace for Migration Assistant and its Pod Identity associations |
+| `pod_identity_service_accounts` | see `variables.tf` | Service accounts that assume the shared workload role through EKS Pod Identity |
+| `permissions_boundary_arn` | `null` | IAM permissions boundary applied to every role this module creates |
+| `create_opensearch_service_snapshot_role` | `true` | Create the role Amazon OpenSearch Service assumes for S3 snapshots; `false` for a self-managed source |
+| `deploy_helm` | `false` | Install the repository's Migration Assistant Helm chart after the cluster is ready |
+| `migration_assistant_version` | `null` | Public ECR image tag used when `deploy_helm = true`, for example `3.3.4` |
+| `use_custom_karpenter_node_pool` | `true` | Configure the chart's custom EKS Auto Mode NodePool in addition to the built-in pools |
+| `helm_timeout_seconds` | `1500` | Maximum wait for the Helm release |
+
 ## Outputs
 
 Important outputs include:
@@ -245,6 +282,8 @@ Important outputs include:
 | `source_private_endpoint` | Private source endpoint when `source_connectivity` is set, else null |
 | `target_private_endpoint` | Private target endpoint when `target_connectivity` is set, else null |
 | `migration_environment` | Shell exports equivalent to the CloudFormation bootstrap export string |
+| `cluster_security_group_id` | EKS-managed cluster security group, for rules that must allow the cluster |
+| `helm_release_status` | Helm release status, or null when `deploy_helm` is false |
 
 To load the compatibility environment into the current shell:
 

--- a/deployment/terraform/aws/connectivity.tf
+++ b/deployment/terraform/aws/connectivity.tf
@@ -1,0 +1,74 @@
+# Optional per-leg private connectivity to the source and target clusters.
+# Both legs default to mode = "none" (no resources, no change to a public-path
+# deployment). See source_connectivity / target_connectivity in variables.tf.
+#
+# Operator responsibilities not automated here (kept minimal by design):
+#   - privatelink: the provider must add this account/VPC to the endpoint service's
+#     allow-list and ACCEPT the endpoint connection if acceptance is required; until
+#     then endpoint_state is "pendingAcceptance" and the FQDN does not resolve to a
+#     working endpoint. Use the provider's canonical hostname for dns_name so the
+#     target TLS certificate validates.
+#   - vpc_peering: the peer must ACCEPT the connection (cross-account/region) and add
+#     the reciprocal route back to the migration VPC CIDR. Peer CIDRs must not overlap
+#     var.vpc_cidr.
+#   - the endpoint service / peer VPC must be available in the migration AZs.
+
+module "source_connectivity_privatelink" {
+  count  = var.source_connectivity.mode == "privatelink" ? 1 : 0
+  source = "./modules/connectivity/privatelink"
+
+  name_prefix               = local.cluster_name
+  leg                       = "source"
+  vpc_id                    = local.vpc_id
+  vpc_cidr                  = local.vpc_cidr
+  subnet_ids                = local.cluster_subnets
+  vpc_endpoint_service_name = var.source_connectivity.vpc_endpoint_service_name
+  dns_name                  = var.source_connectivity.dns_name
+  dns_zone_domain           = var.source_connectivity.dns_zone_domain
+  tags                      = local.common_tags
+}
+
+module "target_connectivity_privatelink" {
+  count  = var.target_connectivity.mode == "privatelink" ? 1 : 0
+  source = "./modules/connectivity/privatelink"
+
+  name_prefix               = local.cluster_name
+  leg                       = "target"
+  vpc_id                    = local.vpc_id
+  vpc_cidr                  = local.vpc_cidr
+  subnet_ids                = local.cluster_subnets
+  vpc_endpoint_service_name = var.target_connectivity.vpc_endpoint_service_name
+  dns_name                  = var.target_connectivity.dns_name
+  dns_zone_domain           = var.target_connectivity.dns_zone_domain
+  tags                      = local.common_tags
+}
+
+module "source_connectivity_peering" {
+  count  = var.source_connectivity.mode == "vpc_peering" ? 1 : 0
+  source = "./modules/connectivity/vpc-peering"
+
+  name_prefix             = local.cluster_name
+  leg                     = "source"
+  local_vpc_id            = local.vpc_id
+  peer_vpc_id             = var.source_connectivity.peer_vpc_id
+  peer_cidr               = var.source_connectivity.peer_cidr
+  peer_account_id         = var.source_connectivity.peer_account_id
+  peer_region             = var.source_connectivity.peer_region
+  private_route_table_ids = local.route_table_ids
+  tags                    = local.common_tags
+}
+
+module "target_connectivity_peering" {
+  count  = var.target_connectivity.mode == "vpc_peering" ? 1 : 0
+  source = "./modules/connectivity/vpc-peering"
+
+  name_prefix             = local.cluster_name
+  leg                     = "target"
+  local_vpc_id            = local.vpc_id
+  peer_vpc_id             = var.target_connectivity.peer_vpc_id
+  peer_cidr               = var.target_connectivity.peer_cidr
+  peer_account_id         = var.target_connectivity.peer_account_id
+  peer_region             = var.target_connectivity.peer_region
+  private_route_table_ids = local.route_table_ids
+  tags                    = local.common_tags
+}

--- a/deployment/terraform/aws/eks.tf
+++ b/deployment/terraform/aws/eks.tf
@@ -1,0 +1,167 @@
+data "aws_iam_policy_document" "eks_cluster_assume_role" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole", "sts:TagSession"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["eks.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "eks_cluster" {
+  name                 = "ma-${var.stage}-${var.region}-eks-cluster"
+  description          = "EKS Auto Mode cluster role for OpenSearch Migration Assistant"
+  assume_role_policy   = data.aws_iam_policy_document.eks_cluster_assume_role.json
+  permissions_boundary = var.permissions_boundary_arn
+
+  tags = local.common_tags
+}
+
+locals {
+  eks_cluster_managed_policies = toset([
+    "arn:${data.aws_partition.current.partition}:iam::aws:policy/AmazonEKSClusterPolicy",
+    "arn:${data.aws_partition.current.partition}:iam::aws:policy/AmazonEKSComputePolicy",
+    "arn:${data.aws_partition.current.partition}:iam::aws:policy/AmazonEKSBlockStoragePolicy",
+    "arn:${data.aws_partition.current.partition}:iam::aws:policy/AmazonEKSLoadBalancingPolicy",
+    "arn:${data.aws_partition.current.partition}:iam::aws:policy/AmazonEKSNetworkingPolicy",
+  ])
+}
+
+resource "aws_iam_role_policy_attachment" "eks_cluster" {
+  for_each = local.eks_cluster_managed_policies
+
+  role       = aws_iam_role.eks_cluster.name
+  policy_arn = each.value
+}
+
+data "aws_iam_policy_document" "eks_node_assume_role" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "eks_node" {
+  name                 = "ma-${var.stage}-${var.region}-eks-node"
+  description          = "Node role used by EKS Auto Mode"
+  assume_role_policy   = data.aws_iam_policy_document.eks_node_assume_role.json
+  permissions_boundary = var.permissions_boundary_arn
+
+  tags = local.common_tags
+}
+
+locals {
+  eks_node_managed_policies = toset([
+    "arn:${data.aws_partition.current.partition}:iam::aws:policy/AmazonEKSWorkerNodePolicy",
+    "arn:${data.aws_partition.current.partition}:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly",
+  ])
+}
+
+resource "aws_iam_role_policy_attachment" "eks_node" {
+  for_each = local.eks_node_managed_policies
+
+  role       = aws_iam_role.eks_node.name
+  policy_arn = each.value
+}
+
+resource "aws_security_group" "eks_control_plane" {
+  name_prefix = "${local.cluster_name}-control-plane-"
+  description = "EKS control-plane security group"
+  vpc_id      = local.vpc_id
+
+  egress {
+    description = "Allow all outbound traffic"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = merge(local.common_tags, {
+    Name = "${local.cluster_name}-control-plane"
+  })
+}
+
+resource "aws_eks_cluster" "migration" {
+  name                          = local.cluster_name
+  role_arn                      = aws_iam_role.eks_cluster.arn
+  version                       = var.kubernetes_version
+  bootstrap_self_managed_addons = false
+
+  access_config {
+    authentication_mode                         = "API"
+    bootstrap_cluster_creator_admin_permissions = true
+  }
+
+  compute_config {
+    enabled       = true
+    node_pools    = ["system", "general-purpose"]
+    node_role_arn = aws_iam_role.eks_node.arn
+  }
+
+  kubernetes_network_config {
+    ip_family = "ipv4"
+
+    elastic_load_balancing {
+      enabled = true
+    }
+  }
+
+  storage_config {
+    block_storage {
+      enabled = true
+    }
+  }
+
+  vpc_config {
+    endpoint_private_access = var.cluster_endpoint_private_access
+    endpoint_public_access  = var.cluster_endpoint_public_access
+    public_access_cidrs     = var.cluster_public_access_cidrs
+    security_group_ids      = [aws_security_group.eks_control_plane.id]
+    subnet_ids              = local.cluster_subnets
+  }
+
+  tags = local.common_tags
+
+  lifecycle {
+    precondition {
+      condition     = var.create_vpc || (var.existing_vpc_id != null && length(var.existing_subnet_ids) >= 2)
+      error_message = "existing_vpc_id and at least two existing_subnet_ids are required when create_vpc is false."
+    }
+
+    precondition {
+      condition     = var.cluster_endpoint_public_access || var.cluster_endpoint_private_access
+      error_message = "At least one EKS cluster endpoint must be enabled."
+    }
+  }
+
+  depends_on = [
+    aws_iam_role_policy_attachment.eks_cluster,
+    aws_iam_role_policy_attachment.eks_node,
+    aws_route.private_ipv4,
+    aws_route.private_ipv6,
+  ]
+}
+
+resource "aws_eks_access_entry" "account_readonly" {
+  cluster_name  = aws_eks_cluster.migration.name
+  principal_arn = "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:root"
+  type          = "STANDARD"
+}
+
+resource "aws_eks_access_policy_association" "account_readonly" {
+  cluster_name  = aws_eks_cluster.migration.name
+  principal_arn = aws_eks_access_entry.account_readonly.principal_arn
+  policy_arn    = "arn:${data.aws_partition.current.partition}:eks::aws:cluster-access-policy/AmazonEKSViewPolicy"
+
+  access_scope {
+    type = "cluster"
+  }
+}

--- a/deployment/terraform/aws/eks.tf
+++ b/deployment/terraform/aws/eks.tf
@@ -122,7 +122,7 @@ resource "aws_eks_cluster" "migration" {
 
   vpc_config {
     endpoint_private_access = var.cluster_endpoint_private_access
-    endpoint_public_access  = var.cluster_endpoint_public_access
+    endpoint_public_access  = local.endpoint_public_access
     public_access_cidrs     = var.cluster_public_access_cidrs
     security_group_ids      = [aws_security_group.eks_control_plane.id]
     subnet_ids              = local.cluster_subnets
@@ -137,7 +137,7 @@ resource "aws_eks_cluster" "migration" {
     }
 
     precondition {
-      condition     = var.cluster_endpoint_public_access || var.cluster_endpoint_private_access
+      condition     = local.endpoint_public_access || var.cluster_endpoint_private_access
       error_message = "At least one EKS cluster endpoint must be enabled."
     }
   }

--- a/deployment/terraform/aws/helm.tf
+++ b/deployment/terraform/aws/helm.tf
@@ -1,0 +1,90 @@
+resource "helm_release" "migration_assistant" {
+  count = var.deploy_helm ? 1 : 0
+
+  name             = var.namespace
+  namespace        = var.namespace
+  create_namespace = true
+  chart            = "${path.module}/../../k8s/charts/aggregates/migrationAssistantWithArgo"
+  timeout          = var.helm_timeout_seconds
+  wait             = true
+  cleanup_on_fail  = true
+
+  values = [
+    file("${path.module}/../../k8s/charts/aggregates/migrationAssistantWithArgo/valuesEks.yaml"),
+  ]
+
+  set = [
+    {
+      name  = "stageName"
+      value = var.stage
+    },
+    {
+      name  = "aws.region"
+      value = var.region
+    },
+    {
+      name  = "aws.account"
+      value = data.aws_caller_identity.current.account_id
+    },
+    {
+      name  = "defaultBucketConfiguration.snapshotRoleArn"
+      value = var.create_opensearch_service_snapshot_role ? aws_iam_role.snapshot[0].arn : ""
+    },
+    {
+      name  = "cluster.useCustomKarpenterNodePool"
+      value = tostring(var.use_custom_karpenter_node_pool)
+    },
+    {
+      name  = "images.captureProxy.repository"
+      value = "public.ecr.aws/opensearchproject/opensearch-migrations-traffic-capture-proxy"
+    },
+    {
+      name  = "images.captureProxy.tag"
+      value = var.migration_assistant_version
+    },
+    {
+      name  = "images.trafficReplayer.repository"
+      value = "public.ecr.aws/opensearchproject/opensearch-migrations-traffic-replayer"
+    },
+    {
+      name  = "images.trafficReplayer.tag"
+      value = var.migration_assistant_version
+    },
+    {
+      name  = "images.reindexFromSnapshot.repository"
+      value = "public.ecr.aws/opensearchproject/opensearch-migrations-reindex-from-snapshot"
+    },
+    {
+      name  = "images.reindexFromSnapshot.tag"
+      value = var.migration_assistant_version
+    },
+    {
+      name  = "images.migrationConsole.repository"
+      value = "public.ecr.aws/opensearchproject/opensearch-migrations-console"
+    },
+    {
+      name  = "images.migrationConsole.tag"
+      value = var.migration_assistant_version
+    },
+    {
+      name  = "images.installer.repository"
+      value = "public.ecr.aws/opensearchproject/opensearch-migrations-console"
+    },
+    {
+      name  = "images.installer.tag"
+      value = var.migration_assistant_version
+    },
+  ]
+
+  lifecycle {
+    precondition {
+      condition     = var.migration_assistant_version != null && try(trimspace(var.migration_assistant_version), "") != ""
+      error_message = "migration_assistant_version is required when deploy_helm is true."
+    }
+  }
+
+  depends_on = [
+    aws_eks_access_policy_association.account_readonly,
+    aws_eks_pod_identity_association.migration,
+  ]
+}

--- a/deployment/terraform/aws/helm.tf
+++ b/deployment/terraform/aws/helm.tf
@@ -83,8 +83,19 @@ resource "helm_release" "migration_assistant" {
     }
   }
 
+  # The release's workloads and its Helm lifecycle hooks call AWS APIs, so they need the
+  # cluster's network path to those APIs. Terraform destroys dependencies only after their
+  # dependents, so declaring the path here also keeps it in place for the duration of
+  # `helm uninstall`. Without these edges the graph leaves the release unordered against
+  # networking, and a destroy can tear down endpoints, NAT, and routes while the uninstall
+  # hooks are still running, which fails the uninstall and aborts the destroy partway.
   depends_on = [
     aws_eks_access_policy_association.account_readonly,
     aws_eks_pod_identity_association.migration,
+    aws_vpc_endpoint.s3,
+    aws_vpc_endpoint.interface,
+    aws_nat_gateway.migration,
+    aws_route.private_ipv4,
+    aws_route_table_association.private,
   ]
 }

--- a/deployment/terraform/aws/iam.tf
+++ b/deployment/terraform/aws/iam.tf
@@ -1,0 +1,281 @@
+resource "aws_ecr_repository" "migration" {
+  name         = local.ecr_name
+  force_delete = true
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+
+  tags = local.common_tags
+}
+
+data "aws_iam_policy_document" "pod_identity_assume_role" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole", "sts:TagSession"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["pods.eks.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "migration_pods" {
+  name                 = "ma-${var.stage}-${var.region}-migrations"
+  description          = "Migration Assistant role assumed by workloads through EKS Pod Identity"
+  assume_role_policy   = data.aws_iam_policy_document.pod_identity_assume_role.json
+  permissions_boundary = var.permissions_boundary_arn
+
+  tags = local.common_tags
+}
+
+data "aws_iam_policy_document" "migration_pods" {
+  # ecr:GetAuthorizationToken is an account-level action that does not support
+  # resource scoping; it must be granted on "*".
+  statement {
+    sid       = "EcrAuth"
+    effect    = "Allow"
+    actions   = ["ecr:GetAuthorizationToken"]
+    resources = ["*"]
+  }
+
+  # Pull and push are scoped to this module's ECR repository (mirrored/built MA
+  # images). Replaces the previous AmazonEC2ContainerRegistryFullAccess managed
+  # policy, which granted these on every repo in the account.
+  statement {
+    sid    = "EcrImages"
+    effect = "Allow"
+    actions = [
+      "ecr:BatchGetImage",
+      "ecr:GetDownloadUrlForLayer",
+      "ecr:DescribeRepositories",
+      "ecr:BatchCheckLayerAvailability",
+      "ecr:CompleteLayerUpload",
+      "ecr:InitiateLayerUpload",
+      "ecr:PutImage",
+      "ecr:UploadLayerPart",
+    ]
+    resources = [aws_ecr_repository.migration.arn]
+  }
+
+  # EFS filesystems are created at runtime (by the app / EKS), so their ARNs are
+  # not known here; left on "*".
+  statement {
+    sid       = "ElasticFileSystem"
+    effect    = "Allow"
+    actions   = ["elasticfilesystem:ClientMount", "elasticfilesystem:ClientWrite"]
+    resources = ["*"]
+  }
+
+  # The source/target clusters are supplied as runtime migration config; their ARNs
+  # are not known to Terraform, so es:/aoss: access is granted on "*".
+  statement {
+    sid       = "OpenSearch"
+    effect    = "Allow"
+    actions   = ["es:ESHttp*", "aoss:APIAccessAll"]
+    resources = ["*"]
+  }
+
+  # secretsmanager:ListSecrets is account-level and cannot be scoped. Get/Describe
+  # target user-supplied secrets whose names are not known here, so also on "*".
+  statement {
+    sid    = "Secrets"
+    effect = "Allow"
+    actions = [
+      "secretsmanager:GetSecretValue",
+      "secretsmanager:DescribeSecret",
+      "secretsmanager:ListSecrets",
+    ]
+    resources = ["*"]
+  }
+
+  # s3:ListAllMyBuckets is an account-level action that cannot be resource-scoped;
+  # it only functions on "*".
+  statement {
+    sid       = "S3ListAllBuckets"
+    effect    = "Allow"
+    actions   = ["s3:ListAllMyBuckets"]
+    resources = ["*"]
+  }
+
+  # Object and bucket operations remain on "*" rather than scoped to migrations-*.
+  # The migration console reads/writes user-configured buckets whose names are not
+  # under our control, notably the failed-document-stream bucket, which is supplied
+  # per-migration and may use any name. The bucket the module itself relies on is
+  # created/deleted by the Helm chart's defaultBucketConfiguration (app-managed,
+  # named migrations-default-<account>-<stage>-<region>), not by Terraform. This
+  # matches the CloudFormation deployment. A future enhancement can accept explicit
+  # bucket ARNs (e.g. from the installer) to scope this down.
+  statement {
+    sid    = "Snapshots"
+    effect = "Allow"
+    actions = [
+      "s3:GetObject",
+      "s3:PutObject",
+      "s3:ListBucket",
+      "s3:DeleteObject",
+      "s3:DeleteObjectVersion",
+      "s3:ListBucketVersions",
+      "s3:ListBucketMultipartUploads",
+      "s3:AbortMultipartUpload",
+      "s3:CreateBucket",
+      "s3:DeleteBucket",
+    ]
+    resources = ["*"]
+  }
+
+  # logs:DescribeLogGroups only supports "*" (it enumerates across groups); the
+  # rest are scoped to the Migration Assistant log group for this stage/region.
+  statement {
+    sid       = "CloudWatchLogsDescribe"
+    effect    = "Allow"
+    actions   = ["logs:DescribeLogGroups"]
+    resources = ["*"]
+  }
+
+  statement {
+    sid    = "CloudWatchLogs"
+    effect = "Allow"
+    actions = [
+      "logs:PutLogEvents",
+      "logs:DescribeLogStreams",
+      "logs:CreateLogGroup",
+      "logs:CreateLogStream",
+    ]
+    resources = [
+      "arn:${data.aws_partition.current.partition}:logs:${var.region}:${data.aws_caller_identity.current.account_id}:log-group:/migration-assistant-${var.stage}-${var.region}*",
+    ]
+  }
+
+  # cloudwatch:ListMetrics/GetMetricData do not support resource-level scoping.
+  statement {
+    sid       = "CloudWatchMetrics"
+    effect    = "Allow"
+    actions   = ["cloudwatch:ListMetrics", "cloudwatch:GetMetricData"]
+    resources = ["*"]
+  }
+
+  # X-Ray Put* actions do not support resource-level scoping.
+  statement {
+    sid       = "XRayTraces"
+    effect    = "Allow"
+    actions   = ["xray:PutTraceSegments", "xray:PutTelemetryRecords"]
+    resources = ["*"]
+  }
+
+  statement {
+    sid       = "PassSnapshotRoles"
+    effect    = "Allow"
+    actions   = ["iam:PassRole"]
+    resources = ["arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:role/*"]
+  }
+
+  statement {
+    sid    = "MigrationDashboards"
+    effect = "Allow"
+    actions = [
+      "cloudwatch:PutDashboard",
+      "cloudwatch:GetDashboard",
+      "cloudwatch:DeleteDashboards",
+    ]
+    resources = ["arn:${data.aws_partition.current.partition}:cloudwatch::${data.aws_caller_identity.current.account_id}:dashboard/MA-*"]
+  }
+
+  # The private CA is created at runtime (by the app) for the capture-proxy TLS
+  # path; its ARN is not known here, so acm-pca actions are granted on "*".
+  statement {
+    sid    = "PrivateCertificateAuthority"
+    effect = "Allow"
+    actions = [
+      "acm-pca:IssueCertificate",
+      "acm-pca:GetCertificate",
+      "acm-pca:DescribeCertificateAuthority",
+      "acm-pca:ListCertificateAuthorities",
+      "acm-pca:CreateCertificateAuthority",
+      "acm-pca:DeleteCertificateAuthority",
+      "acm-pca:UpdateCertificateAuthority",
+      "acm-pca:TagCertificateAuthority",
+    ]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_role_policy" "migration_pods" {
+  name   = "MigrationsPodPolicy"
+  role   = aws_iam_role.migration_pods.id
+  policy = data.aws_iam_policy_document.migration_pods.json
+}
+
+# The snapshot role/policy became count-gated (create_opensearch_service_snapshot_role).
+# These moved blocks map the pre-count singleton addresses to index 0 so existing
+# stacks (where the role was created unconditionally) do not destroy/recreate it.
+moved {
+  from = aws_iam_role.snapshot
+  to   = aws_iam_role.snapshot[0]
+}
+
+moved {
+  from = aws_iam_role_policy.snapshot
+  to   = aws_iam_role_policy.snapshot[0]
+}
+
+data "aws_iam_policy_document" "snapshot_assume_role" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["es.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "snapshot" {
+  count = var.create_opensearch_service_snapshot_role ? 1 : 0
+
+  name                 = "ma-${var.stage}-${var.region}-snapshot"
+  description          = "Allows Amazon OpenSearch Service to read and write Migration Assistant snapshots"
+  assume_role_policy   = data.aws_iam_policy_document.snapshot_assume_role.json
+  permissions_boundary = var.permissions_boundary_arn
+
+  tags = local.common_tags
+}
+
+data "aws_iam_policy_document" "snapshot" {
+  statement {
+    sid       = "ListMigrationBuckets"
+    effect    = "Allow"
+    actions   = ["s3:ListBucket"]
+    resources = ["arn:${data.aws_partition.current.partition}:s3:::migrations-*"]
+  }
+
+  statement {
+    sid       = "ManageMigrationSnapshotObjects"
+    effect    = "Allow"
+    actions   = ["s3:GetObject", "s3:PutObject", "s3:DeleteObject"]
+    resources = ["arn:${data.aws_partition.current.partition}:s3:::migrations-*/*"]
+  }
+}
+
+resource "aws_iam_role_policy" "snapshot" {
+  count = var.create_opensearch_service_snapshot_role ? 1 : 0
+
+  name   = "MigrationSnapshotPolicy"
+  role   = aws_iam_role.snapshot[0].id
+  policy = data.aws_iam_policy_document.snapshot.json
+}
+
+resource "aws_eks_pod_identity_association" "migration" {
+  for_each = var.pod_identity_service_accounts
+
+  cluster_name    = aws_eks_cluster.migration.name
+  namespace       = var.namespace
+  service_account = each.value
+  role_arn        = aws_iam_role.migration_pods.arn
+
+  depends_on = [
+    aws_iam_role_policy.migration_pods,
+  ]
+}

--- a/deployment/terraform/aws/iam.tf
+++ b/deployment/terraform/aws/iam.tf
@@ -77,16 +77,15 @@ data "aws_iam_policy_document" "migration_pods" {
     resources = ["*"]
   }
 
-  # secretsmanager:ListSecrets is account-level and cannot be scoped. Get/Describe
-  # target user-supplied secrets whose names are not known here, so also on "*".
+  # Only GetSecretValue is used: the console fetches the cluster credential secret by
+  # the user_secret_arn it is given in runtime migration config (see cluster.py). It
+  # never enumerates or describes secrets, so DescribeSecret and ListSecrets are not
+  # granted. The ARN is not known to Terraform, so this stays on "*"; scoping it would
+  # mean accepting secret ARNs or a required name prefix as module configuration.
   statement {
-    sid    = "Secrets"
-    effect = "Allow"
-    actions = [
-      "secretsmanager:GetSecretValue",
-      "secretsmanager:DescribeSecret",
-      "secretsmanager:ListSecrets",
-    ]
+    sid       = "Secrets"
+    effect    = "Allow"
+    actions   = ["secretsmanager:GetSecretValue"]
     resources = ["*"]
   }
 

--- a/deployment/terraform/aws/iam.tf
+++ b/deployment/terraform/aws/iam.tf
@@ -145,6 +145,13 @@ data "aws_iam_policy_document" "migration_pods" {
     ]
     resources = [
       "arn:${data.aws_partition.current.partition}:logs:${var.region}:${data.aws_caller_identity.current.account_id}:log-group:/migration-assistant-${var.stage}-${var.region}*",
+      # The otel collector's awsemf exporters (metrics/app, metrics/cadvisor in
+      # valuesEks.yaml) do not set log_group_name, so the exporter falls back to its
+      # default group of /metrics/default with stream otel-stream. Without these the
+      # collector cannot create the group or put events and EKS metrics never reach
+      # CloudWatch.
+      "arn:${data.aws_partition.current.partition}:logs:${var.region}:${data.aws_caller_identity.current.account_id}:log-group:/metrics/default",
+      "arn:${data.aws_partition.current.partition}:logs:${var.region}:${data.aws_caller_identity.current.account_id}:log-group:/metrics/default:*",
     ]
   }
 

--- a/deployment/terraform/aws/locals.tf
+++ b/deployment/terraform/aws/locals.tf
@@ -1,0 +1,47 @@
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
+data "aws_caller_identity" "current" {}
+
+data "aws_partition" "current" {}
+
+data "aws_vpc" "existing" {
+  count = var.create_vpc ? 0 : 1
+  id    = var.existing_vpc_id
+}
+
+data "aws_route_table" "existing_subnet" {
+  for_each = !var.create_vpc && length(var.existing_route_table_ids) == 0 ? toset(var.existing_subnet_ids) : toset([])
+
+  subnet_id = each.value
+}
+
+locals {
+  cluster_name    = "migration-eks-cluster-${var.stage}-${var.region}"
+  ecr_name        = "migration-ecr-${var.stage}-${var.region}"
+  selected_azs    = length(var.availability_zones) == 2 ? var.availability_zones : slice(data.aws_availability_zones.available.names, 0, 2)
+  vpc_id          = var.create_vpc ? aws_vpc.migration[0].id : var.existing_vpc_id
+  vpc_cidr        = var.create_vpc ? var.vpc_cidr : data.aws_vpc.existing[0].cidr_block
+  cluster_subnets = var.create_vpc ? values(aws_subnet.private)[*].id : var.existing_subnet_ids
+  route_table_ids = var.create_vpc ? values(aws_route_table.private)[*].id : (
+    length(var.existing_route_table_ids) > 0 ? var.existing_route_table_ids : distinct(values(data.aws_route_table.existing_subnet)[*].id)
+  )
+
+  # Isolated (air-gapped) new-VPC deployment: no NAT gateway, full private-endpoint set.
+  isolated_new_vpc = var.create_vpc && var.isolated
+
+  # Base endpoints always created for a new VPC. An isolated VPC additionally needs the
+  # AWS-API endpoints the cluster would otherwise reach over the internet (matches the
+  # working isolated-VPC deployment path: s3, ecr.api, ecr.dkr, logs, monitoring,
+  # elasticfilesystem, sts, eks-auth).
+  base_new_vpc_endpoints     = toset(["s3", "ecr.api", "ecr.dkr", "logs", "elasticfilesystem"])
+  isolated_extra_endpoints   = toset(["monitoring", "sts", "eks-auth"])
+  required_new_vpc_endpoints = local.isolated_new_vpc ? setunion(local.base_new_vpc_endpoints, local.isolated_extra_endpoints) : local.base_new_vpc_endpoints
+  enabled_vpc_endpoints      = var.create_vpc ? setunion(local.required_new_vpc_endpoints, var.vpc_endpoints) : var.vpc_endpoints
+  interface_vpc_endpoints    = setsubtract(local.enabled_vpc_endpoints, toset(["s3"]))
+
+  common_tags = {
+    "opensearch.org/migration-assistant" = var.stage
+  }
+}

--- a/deployment/terraform/aws/locals.tf
+++ b/deployment/terraform/aws/locals.tf
@@ -41,6 +41,13 @@ locals {
   enabled_vpc_endpoints      = var.create_vpc ? setunion(local.required_new_vpc_endpoints, var.vpc_endpoints) : var.vpc_endpoints
   interface_vpc_endpoints    = setsubtract(local.enabled_vpc_endpoints, toset(["s3"]))
 
+  # An isolated deployment closes the Kubernetes API along with the data path, so the
+  # public EKS endpoint defaults off when isolated is true. cluster_endpoint_public_access
+  # defaults to null precisely so an explicit true or false always wins here; only an
+  # unset value follows isolated. Unlike the NAT/endpoint behavior above this is not gated
+  # on create_vpc: the control plane is exposed the same way in a supplied VPC.
+  endpoint_public_access = var.cluster_endpoint_public_access != null ? var.cluster_endpoint_public_access : !var.isolated
+
   common_tags = {
     "opensearch.org/migration-assistant" = var.stage
   }

--- a/deployment/terraform/aws/modules/connectivity/privatelink/main.tf
+++ b/deployment/terraform/aws/modules/connectivity/privatelink/main.tf
@@ -1,0 +1,81 @@
+locals {
+  dns_enabled = var.dns_name != null
+  # Hosted-zone domain: explicit override, else parent of dns_name (strip first label).
+  zone_domain = var.dns_zone_domain != null ? var.dns_zone_domain : (
+    local.dns_enabled ? join(".", slice(split(".", var.dns_name), 1, length(split(".", var.dns_name)))) : null
+  )
+}
+
+# Security group governing traffic to the interface endpoint ENIs. Ingress is
+# allowed from the VPC CIDR on 443: under EKS Auto Mode the pod ENIs use
+# AWS-managed security groups that cannot be referenced as a stable resource, so
+# a CIDR-based rule (mirroring the module's other interface endpoints) is used.
+resource "aws_security_group" "endpoint" {
+  name_prefix = "${var.name_prefix}-pl-${var.leg}-"
+  description = "HTTPS from the migration VPC to the ${var.leg} PrivateLink endpoint"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    description = "HTTPS from the VPC"
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = [var.vpc_cidr]
+  }
+
+  egress {
+    description = "All outbound traffic"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = merge(var.tags, {
+    Name = "${var.name_prefix}-pl-${var.leg}"
+  })
+}
+
+# Consumer interface endpoint to the provider's VPC endpoint service.
+# private_dns_enabled is intentionally false: consumer-side private DNS only works
+# when the provider published and verified a private DNS name on the service, and
+# it cannot map an arbitrary FQDN. DNS is handled by the Route 53 zone below.
+resource "aws_vpc_endpoint" "target" {
+  vpc_id              = var.vpc_id
+  service_name        = var.vpc_endpoint_service_name
+  vpc_endpoint_type   = "Interface"
+  private_dns_enabled = false
+  subnet_ids          = var.subnet_ids
+  security_group_ids  = [aws_security_group.endpoint.id]
+
+  tags = merge(var.tags, {
+    Name = "${var.name_prefix}-pl-${var.leg}"
+  })
+}
+
+# Optional private DNS so callers reach the target by its FQDN. Points the FQDN at
+# the endpoint's regional DNS name. Requires the endpoint to be accepted and
+# available; if the provider requires manual acceptance the record exists but does
+# not resolve to a working endpoint until acceptance completes.
+resource "aws_route53_zone" "target" {
+  count = local.dns_enabled ? 1 : 0
+
+  name    = local.zone_domain
+  comment = "Private zone routing ${var.dns_name} to the ${var.leg} PrivateLink endpoint."
+
+  vpc {
+    vpc_id = var.vpc_id
+  }
+
+  tags = var.tags
+}
+
+resource "aws_route53_record" "target" {
+  count = local.dns_enabled ? 1 : 0
+
+  zone_id = aws_route53_zone.target[0].zone_id
+  name    = var.dns_name
+  type    = "CNAME"
+  ttl     = 60
+  records = [aws_vpc_endpoint.target.dns_entry[0].dns_name]
+}

--- a/deployment/terraform/aws/modules/connectivity/privatelink/outputs.tf
+++ b/deployment/terraform/aws/modules/connectivity/privatelink/outputs.tf
@@ -1,0 +1,19 @@
+output "endpoint_id" {
+  description = "ID of the interface VPC endpoint."
+  value       = aws_vpc_endpoint.target.id
+}
+
+output "endpoint_dns" {
+  description = "AWS-generated regional DNS name of the interface endpoint. Callers can use this directly when no custom dns_name is set. Known only after apply."
+  value       = try(aws_vpc_endpoint.target.dns_entry[0].dns_name, null)
+}
+
+output "endpoint_state" {
+  description = "Endpoint state. 'pendingAcceptance' means the provider must accept the connection before it is usable; 'available' means ready."
+  value       = aws_vpc_endpoint.target.state
+}
+
+output "endpoint_fqdn" {
+  description = "The FQDN that resolves to the endpoint via the private hosted zone; null when dns_name is unset (use endpoint_dns instead). Put this (or endpoint_dns) in the workflow target/source cluster endpoint config."
+  value       = var.dns_name
+}

--- a/deployment/terraform/aws/modules/connectivity/privatelink/variables.tf
+++ b/deployment/terraform/aws/modules/connectivity/privatelink/variables.tf
@@ -1,0 +1,57 @@
+variable "name_prefix" {
+  description = "Prefix for resource names (e.g. the migration cluster name)."
+  type        = string
+}
+
+variable "leg" {
+  description = "Leg label used to disambiguate resource names (source, target)."
+  type        = string
+}
+
+variable "vpc_id" {
+  description = "VPC the interface endpoint lives in."
+  type        = string
+}
+
+variable "vpc_cidr" {
+  description = "IPv4 CIDR of the VPC, used for the endpoint security group ingress rule."
+  type        = string
+}
+
+variable "subnet_ids" {
+  description = "Subnets (across the migration AZs) to place the interface endpoint ENIs in. Must be in Availability Zones the endpoint service offers."
+  type        = list(string)
+}
+
+variable "vpc_endpoint_service_name" {
+  description = "The provider's VPC endpoint service name to connect to (e.g. com.amazonaws.vpce.us-east-1.vpce-svc-0123...). Obtain this from the target's managed-service provider."
+  type        = string
+}
+
+variable "dns_name" {
+  description = <<-EOT
+    Optional FQDN to resolve to the interface endpoint via a Route 53 private
+    hosted zone (e.g. myservice.example.com). When null, no zone is created and
+    callers connect via the endpoint's AWS-generated DNS name. Use the provider's
+    canonical hostname so the target's TLS certificate validates.
+  EOT
+  type        = string
+  default     = null
+
+  validation {
+    condition     = var.dns_name == null || length(split(".", var.dns_name)) >= 3
+    error_message = "dns_name must be a host under a domain with at least 3 labels (e.g. host.example.com) so a valid parent zone can be derived."
+  }
+}
+
+variable "dns_zone_domain" {
+  description = "Optional private hosted-zone domain for dns_name (e.g. example.com). When null and dns_name is set, the parent domain is derived by stripping dns_name's first label."
+  type        = string
+  default     = null
+}
+
+variable "tags" {
+  description = "Tags applied to created resources."
+  type        = map(string)
+  default     = {}
+}

--- a/deployment/terraform/aws/modules/connectivity/privatelink/versions.tf
+++ b/deployment/terraform/aws/modules/connectivity/privatelink/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.6"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+  }
+}

--- a/deployment/terraform/aws/modules/connectivity/vpc-peering/main.tf
+++ b/deployment/terraform/aws/modules/connectivity/vpc-peering/main.tf
@@ -1,0 +1,25 @@
+# We request the peering from our (migration) VPC. When the peer is in another
+# account or region, the peer must ACCEPT the connection before it becomes active;
+# peering is non-transitive and both sides must have routes. auto_accept only works
+# for same-account, same-region peers, so it is set accordingly.
+resource "aws_vpc_peering_connection" "target" {
+  vpc_id        = var.local_vpc_id
+  peer_vpc_id   = var.peer_vpc_id
+  peer_owner_id = var.peer_account_id
+  peer_region   = var.peer_region
+  auto_accept   = var.peer_account_id == null && var.peer_region == null
+
+  tags = merge(var.tags, {
+    Name = "${var.name_prefix}-peer-${var.leg}"
+  })
+}
+
+# Routes from the migration private subnets to the peer CIDR. The peer must add the
+# reciprocal route back to the migration VPC CIDR for traffic to flow both ways.
+resource "aws_route" "to_peer" {
+  count = length(var.private_route_table_ids)
+
+  route_table_id            = var.private_route_table_ids[count.index]
+  destination_cidr_block    = var.peer_cidr
+  vpc_peering_connection_id = aws_vpc_peering_connection.target.id
+}

--- a/deployment/terraform/aws/modules/connectivity/vpc-peering/outputs.tf
+++ b/deployment/terraform/aws/modules/connectivity/vpc-peering/outputs.tf
@@ -1,0 +1,9 @@
+output "peering_connection_id" {
+  description = "ID of the VPC peering connection. The peer needs this to accept (cross-account/region) and to add their reciprocal route."
+  value       = aws_vpc_peering_connection.target.id
+}
+
+output "peering_accept_status" {
+  description = "Acceptance status of the peering. For cross-account/region peers this stays 'pending-acceptance' until the peer accepts."
+  value       = aws_vpc_peering_connection.target.accept_status
+}

--- a/deployment/terraform/aws/modules/connectivity/vpc-peering/variables.tf
+++ b/deployment/terraform/aws/modules/connectivity/vpc-peering/variables.tf
@@ -1,0 +1,47 @@
+variable "name_prefix" {
+  description = "Prefix for resource names."
+  type        = string
+}
+
+variable "leg" {
+  description = "Leg label (source, target)."
+  type        = string
+}
+
+variable "local_vpc_id" {
+  description = "VPC ID of the migration VPC (the requester side of the peering)."
+  type        = string
+}
+
+variable "peer_vpc_id" {
+  description = "VPC ID of the peer (the source or target network to connect to)."
+  type        = string
+}
+
+variable "peer_cidr" {
+  description = "IPv4 CIDR of the peer VPC, used for the route added to the migration private route tables. Must not overlap the migration VPC CIDR."
+  type        = string
+}
+
+variable "peer_account_id" {
+  description = "Optional AWS account ID of the peer VPC when it is in a different account. Null for same-account peering."
+  type        = string
+  default     = null
+}
+
+variable "peer_region" {
+  description = "Optional region of the peer VPC when it is in a different region. Null for same-region peering."
+  type        = string
+  default     = null
+}
+
+variable "private_route_table_ids" {
+  description = "The migration VPC's private route table IDs. A route to peer_cidr is added to each so the cluster can reach the peer."
+  type        = list(string)
+}
+
+variable "tags" {
+  description = "Tags applied to created resources."
+  type        = map(string)
+  default     = {}
+}

--- a/deployment/terraform/aws/modules/connectivity/vpc-peering/versions.tf
+++ b/deployment/terraform/aws/modules/connectivity/vpc-peering/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.6"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+  }
+}

--- a/deployment/terraform/aws/network.tf
+++ b/deployment/terraform/aws/network.tf
@@ -1,0 +1,225 @@
+locals {
+  subnet_layout = {
+    for index, az in local.selected_azs : az => {
+      index        = index
+      private_cidr = cidrsubnet(var.vpc_cidr, 4, index)
+      public_cidr  = cidrsubnet(var.vpc_cidr, 4, index + 2)
+    }
+  }
+}
+
+resource "aws_vpc" "migration" {
+  count = var.create_vpc ? 1 : 0
+
+  cidr_block                       = var.vpc_cidr
+  assign_generated_ipv6_cidr_block = true
+  enable_dns_hostnames             = true
+  enable_dns_support               = true
+
+  tags = merge(local.common_tags, {
+    Name = "migration-assistant-vpc-${var.stage}"
+  })
+}
+
+resource "aws_internet_gateway" "migration" {
+  count = var.create_vpc ? 1 : 0
+
+  vpc_id = aws_vpc.migration[0].id
+
+  tags = merge(local.common_tags, {
+    Name = "migration-assistant-igw-${var.stage}"
+  })
+}
+
+resource "aws_egress_only_internet_gateway" "migration" {
+  count = var.create_vpc ? 1 : 0
+
+  vpc_id = aws_vpc.migration[0].id
+
+  tags = merge(local.common_tags, {
+    Name = "migration-assistant-eigw-${var.stage}"
+  })
+}
+
+resource "aws_subnet" "public" {
+  for_each = var.create_vpc ? local.subnet_layout : {}
+
+  vpc_id                          = aws_vpc.migration[0].id
+  availability_zone               = each.key
+  cidr_block                      = each.value.public_cidr
+  ipv6_cidr_block                 = cidrsubnet(aws_vpc.migration[0].ipv6_cidr_block, 8, each.value.index + 2)
+  assign_ipv6_address_on_creation = true
+  map_public_ip_on_launch         = true
+
+  tags = merge(local.common_tags, {
+    Name                     = "migration-assistant-public-subnet-${each.value.index + 1}-${var.stage}"
+    "kubernetes.io/role/elb" = "1"
+  })
+}
+
+resource "aws_subnet" "private" {
+  for_each = var.create_vpc ? local.subnet_layout : {}
+
+  vpc_id                          = aws_vpc.migration[0].id
+  availability_zone               = each.key
+  cidr_block                      = each.value.private_cidr
+  ipv6_cidr_block                 = cidrsubnet(aws_vpc.migration[0].ipv6_cidr_block, 8, each.value.index)
+  assign_ipv6_address_on_creation = true
+
+  tags = merge(local.common_tags, {
+    Name                                          = "migration-assistant-private-subnet-${each.value.index + 1}-${var.stage}"
+    "kubernetes.io/cluster/${local.cluster_name}" = "shared"
+    "kubernetes.io/role/internal-elb"             = "1"
+  })
+}
+
+# NAT gateways provide private-subnet egress. Skipped for an isolated VPC, where private
+# subnets must have no outbound internet route (traffic to AWS APIs goes via VPC endpoints).
+resource "aws_eip" "nat" {
+  for_each = local.isolated_new_vpc ? {} : (var.create_vpc ? local.subnet_layout : {})
+
+  domain = "vpc"
+
+  tags = merge(local.common_tags, {
+    Name = "migration-assistant-nat-eip-${each.value.index + 1}-${var.stage}"
+  })
+
+  depends_on = [aws_internet_gateway.migration]
+}
+
+resource "aws_nat_gateway" "migration" {
+  for_each = local.isolated_new_vpc ? {} : (var.create_vpc ? local.subnet_layout : {})
+
+  allocation_id = aws_eip.nat[each.key].id
+  subnet_id     = aws_subnet.public[each.key].id
+
+  tags = merge(local.common_tags, {
+    Name = "migration-assistant-nat-${each.value.index + 1}-${var.stage}"
+  })
+
+  depends_on = [aws_internet_gateway.migration]
+}
+
+resource "aws_route_table" "public" {
+  for_each = var.create_vpc ? local.subnet_layout : {}
+
+  vpc_id = aws_vpc.migration[0].id
+
+  tags = merge(local.common_tags, {
+    Name = "migration-assistant-public-rt-${each.value.index + 1}-${var.stage}"
+  })
+}
+
+resource "aws_route" "public_ipv4" {
+  for_each = var.create_vpc ? local.subnet_layout : {}
+
+  route_table_id         = aws_route_table.public[each.key].id
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = aws_internet_gateway.migration[0].id
+}
+
+resource "aws_route" "public_ipv6" {
+  for_each = var.create_vpc ? local.subnet_layout : {}
+
+  route_table_id              = aws_route_table.public[each.key].id
+  destination_ipv6_cidr_block = "::/0"
+  gateway_id                  = aws_internet_gateway.migration[0].id
+}
+
+resource "aws_route_table_association" "public" {
+  for_each = var.create_vpc ? local.subnet_layout : {}
+
+  route_table_id = aws_route_table.public[each.key].id
+  subnet_id      = aws_subnet.public[each.key].id
+}
+
+resource "aws_route_table" "private" {
+  for_each = var.create_vpc ? local.subnet_layout : {}
+
+  vpc_id = aws_vpc.migration[0].id
+
+  tags = merge(local.common_tags, {
+    Name = "migration-assistant-private-rt-${each.value.index + 1}-${var.stage}"
+  })
+}
+
+# Private-subnet egress routes. Omitted for an isolated VPC so private subnets have no
+# route to the internet; AWS-API traffic flows through the VPC endpoints instead.
+resource "aws_route" "private_ipv4" {
+  for_each = local.isolated_new_vpc ? {} : (var.create_vpc ? local.subnet_layout : {})
+
+  route_table_id         = aws_route_table.private[each.key].id
+  destination_cidr_block = "0.0.0.0/0"
+  nat_gateway_id         = aws_nat_gateway.migration[each.key].id
+}
+
+resource "aws_route" "private_ipv6" {
+  for_each = local.isolated_new_vpc ? {} : (var.create_vpc ? local.subnet_layout : {})
+
+  route_table_id              = aws_route_table.private[each.key].id
+  destination_ipv6_cidr_block = "::/0"
+  egress_only_gateway_id      = aws_egress_only_internet_gateway.migration[0].id
+}
+
+resource "aws_route_table_association" "private" {
+  for_each = var.create_vpc ? local.subnet_layout : {}
+
+  route_table_id = aws_route_table.private[each.key].id
+  subnet_id      = aws_subnet.private[each.key].id
+}
+
+resource "aws_security_group" "vpc_endpoints" {
+  count = length(local.interface_vpc_endpoints) > 0 ? 1 : 0
+
+  name_prefix = "${local.cluster_name}-vpce-"
+  description = "Allow HTTPS from the Migration Assistant VPC to interface endpoints"
+  vpc_id      = local.vpc_id
+
+  ingress {
+    description = "HTTPS from the VPC"
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = [local.vpc_cidr]
+  }
+
+  egress {
+    description = "All outbound traffic"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = merge(local.common_tags, {
+    Name = "${local.cluster_name}-vpc-endpoints"
+  })
+}
+
+resource "aws_vpc_endpoint" "s3" {
+  count = contains(local.enabled_vpc_endpoints, "s3") ? 1 : 0
+
+  vpc_id            = local.vpc_id
+  service_name      = "com.amazonaws.${var.region}.s3"
+  vpc_endpoint_type = "Gateway"
+  route_table_ids   = local.route_table_ids
+
+  tags = merge(local.common_tags, {
+    Name = "${local.cluster_name}-s3"
+  })
+}
+
+resource "aws_vpc_endpoint" "interface" {
+  for_each = local.interface_vpc_endpoints
+
+  vpc_id              = local.vpc_id
+  service_name        = "com.amazonaws.${var.region}.${each.value}"
+  vpc_endpoint_type   = "Interface"
+  private_dns_enabled = true
+  subnet_ids          = local.cluster_subnets
+  security_group_ids  = [aws_security_group.vpc_endpoints[0].id]
+
+  tags = merge(local.common_tags, {
+    Name = "${local.cluster_name}-${replace(each.value, ".", "-")}"
+  })
+}

--- a/deployment/terraform/aws/outputs.tf
+++ b/deployment/terraform/aws/outputs.tf
@@ -1,0 +1,87 @@
+output "cluster_name" {
+  description = "EKS cluster name."
+  value       = aws_eks_cluster.migration.name
+}
+
+output "cluster_endpoint" {
+  description = "EKS Kubernetes API endpoint."
+  value       = aws_eks_cluster.migration.endpoint
+}
+
+output "cluster_security_group_id" {
+  description = "EKS-managed cluster security group ID."
+  value       = aws_eks_cluster.migration.vpc_config[0].cluster_security_group_id
+}
+
+output "vpc_id" {
+  description = "VPC containing the EKS cluster."
+  value       = local.vpc_id
+}
+
+output "subnet_ids" {
+  description = "Subnets used by the EKS cluster."
+  value       = local.cluster_subnets
+}
+
+output "ecr_repository_url" {
+  description = "Private ECR repository available for mirrored or locally built Migration Assistant images."
+  value       = aws_ecr_repository.migration.repository_url
+}
+
+output "migration_pod_role_arn" {
+  description = "IAM role assumed by Migration Assistant workloads through EKS Pod Identity."
+  value       = aws_iam_role.migration_pods.arn
+}
+
+output "snapshot_role_arn" {
+  description = "IAM role that Amazon OpenSearch Service uses for S3 snapshots, or null when create_opensearch_service_snapshot_role is false."
+  value       = var.create_opensearch_service_snapshot_role ? aws_iam_role.snapshot[0].arn : null
+}
+
+output "kubeconfig_command" {
+  description = "Command that configures kubectl for the new cluster."
+  value       = "aws eks update-kubeconfig --region ${var.region} --name ${aws_eks_cluster.migration.name}"
+}
+
+output "migration_environment" {
+  description = "Shell exports equivalent to the values consumed from the CloudFormation MigrationsExportString."
+  value = join(" ", [
+    "export MIGRATIONS_EKS_CLUSTER_NAME=${aws_eks_cluster.migration.name};",
+    "export MIGRATIONS_ECR_REGISTRY=${aws_ecr_repository.migration.repository_url};",
+    "export AWS_ACCOUNT=${data.aws_caller_identity.current.account_id};",
+    "export AWS_CFN_REGION=${var.region};",
+    "export VPC_ID=${local.vpc_id};",
+    "export EKS_CLUSTER_SECURITY_GROUP=${aws_eks_cluster.migration.vpc_config[0].cluster_security_group_id};",
+    "export SNAPSHOT_ROLE=${var.create_opensearch_service_snapshot_role ? aws_iam_role.snapshot[0].arn : ""};",
+    "export STAGE=${var.stage};",
+  ])
+}
+
+output "helm_release_status" {
+  description = "Migration Assistant Helm release status, or null when deploy_helm is false."
+  value       = var.deploy_helm ? helm_release.migration_assistant[0].status : null
+}
+
+output "source_private_endpoint" {
+  description = <<-EOT
+    Private endpoint for the source leg when source_connectivity.mode is set, else null.
+    For privatelink: the custom FQDN if dns_name was set, otherwise the endpoint's
+    AWS-generated DNS name. Put this in the workflow source cluster endpoint config.
+  EOT
+  value = var.source_connectivity.mode == "privatelink" ? coalesce(
+    module.source_connectivity_privatelink[0].endpoint_fqdn,
+    module.source_connectivity_privatelink[0].endpoint_dns,
+  ) : null
+}
+
+output "target_private_endpoint" {
+  description = <<-EOT
+    Private endpoint for the target leg when target_connectivity.mode is set, else null.
+    For privatelink: the custom FQDN if dns_name was set, otherwise the endpoint's
+    AWS-generated DNS name. Put this in the workflow target cluster endpoint config.
+  EOT
+  value = var.target_connectivity.mode == "privatelink" ? coalesce(
+    module.target_connectivity_privatelink[0].endpoint_fqdn,
+    module.target_connectivity_privatelink[0].endpoint_dns,
+  ) : null
+}

--- a/deployment/terraform/aws/terraform.tfvars.example
+++ b/deployment/terraform/aws/terraform.tfvars.example
@@ -1,0 +1,22 @@
+# Copy this file to terraform.tfvars and adjust it for your environment.
+# terraform.tfvars is ignored because it may contain environment-specific data.
+
+region = "us-east-1"
+stage  = "dev"
+
+# New VPC (default)
+create_vpc = true
+
+# To use an existing VPC instead:
+# create_vpc          = false
+# existing_vpc_id     = "vpc-0123456789abcdef0"
+# existing_subnet_ids = ["subnet-0123456789abcdef0", "subnet-abcdef01234567890"]
+# vpc_endpoints       = ["s3", "ecr.api", "ecr.dkr", "logs", "sts", "eks-auth"]
+
+# Optional: install the chart with public Migration Assistant images.
+# deploy_helm                 = true
+# migration_assistant_version = "3.3.4"
+
+tags = {
+  Environment = "development"
+}

--- a/deployment/terraform/aws/tests/infrastructure.tftest.hcl
+++ b/deployment/terraform/aws/tests/infrastructure.tftest.hcl
@@ -1,0 +1,299 @@
+# Plan-time tests for the additive AWS Terraform deployment.
+# Mock providers keep the tests local: no AWS credentials or cloud resources are required.
+
+mock_provider "aws" {
+  mock_data "aws_availability_zones" {
+    defaults = {
+      names = ["us-east-1a", "us-east-1b", "us-east-1c"]
+    }
+  }
+
+  mock_data "aws_caller_identity" {
+    defaults = {
+      account_id = "123456789012"
+      arn        = "arn:aws:iam::123456789012:user/terraform-test"
+    }
+  }
+
+  mock_data "aws_partition" {
+    defaults = {
+      partition = "aws"
+    }
+  }
+
+  mock_data "aws_vpc" {
+    defaults = {
+      cidr_block = "10.20.0.0/16"
+    }
+  }
+
+  # aws_iam_policy_document is provider-computed. Supply syntactically valid
+  # JSON so aws_iam_role validation still runs under the mocked provider.
+  mock_data "aws_iam_policy_document" {
+    defaults = {
+      json = "{\"Version\":\"2012-10-17\",\"Statement\":[]}"
+    }
+  }
+
+  # ipv6_cidr_block is provider-computed; without a valid default the mock emits
+  # a random string and the cidrsubnet() calls in network.tf fail to plan.
+  mock_resource "aws_vpc" {
+    defaults = {
+      ipv6_cidr_block = "2600:1f18::/56"
+    }
+  }
+
+  # The IAM role ARN feeds aws_eks_cluster.compute_config.node_role_arn, which is
+  # ARN-validated at plan time; the random mock default fails that check.
+  mock_resource "aws_iam_role" {
+    defaults = {
+      arn = "arn:aws:iam::123456789012:role/mock-migration-role"
+    }
+  }
+
+  # dns_entry is computed (empty until apply); supply one so the privatelink
+  # module's Route 53 record (dns_entry[0]) resolves under the mock.
+  mock_resource "aws_vpc_endpoint" {
+    defaults = {
+      dns_entry = [{ dns_name = "vpce-mock.example.aws", hosted_zone_id = "Z0MOCK" }]
+    }
+  }
+}
+
+mock_provider "helm" {}
+
+run "new_vpc_matches_cloudformation_topology" {
+  command = plan
+
+  assert {
+    condition     = length(aws_vpc.migration) == 1
+    error_message = "The default deployment must create one VPC."
+  }
+
+  assert {
+    condition     = length(aws_subnet.private) == 2 && length(aws_subnet.public) == 2
+    error_message = "The default deployment must create two private and two public subnets."
+  }
+
+  assert {
+    condition     = length(aws_nat_gateway.migration) == 2
+    error_message = "The default deployment must create one NAT gateway per availability zone."
+  }
+
+  assert {
+    condition     = length(aws_vpc_endpoint.s3) == 1 && length(aws_vpc_endpoint.interface) == 4
+    error_message = "A new VPC must include the S3, ECR API, ECR Docker, CloudWatch Logs, and EFS endpoints."
+  }
+}
+
+run "eks_auto_mode_and_pod_identity_are_enabled" {
+  command = plan
+
+  assert {
+    condition     = aws_eks_cluster.migration.compute_config[0].enabled == true
+    error_message = "EKS Auto Mode compute must be enabled."
+  }
+
+  assert {
+    condition = toset(aws_eks_cluster.migration.compute_config[0].node_pools) == toset([
+      "system",
+      "general-purpose",
+    ])
+    error_message = "Both built-in EKS Auto Mode node pools must be enabled."
+  }
+
+  assert {
+    condition     = length(aws_eks_pod_identity_association.migration) == length(var.pod_identity_service_accounts)
+    error_message = "Every configured Migration Assistant service account must receive a Pod Identity association."
+  }
+}
+
+run "existing_vpc_is_additive_and_endpoints_are_opt_in" {
+  command = plan
+
+  variables {
+    create_vpc          = false
+    existing_vpc_id     = "vpc-0123456789abcdef0"
+    existing_subnet_ids = ["subnet-0123456789abcdef0", "subnet-abcdef01234567890"]
+    vpc_endpoints       = ["s3", "sts", "eks-auth"]
+  }
+
+  assert {
+    condition     = length(aws_vpc.migration) == 0 && length(aws_subnet.private) == 0 && length(aws_nat_gateway.migration) == 0
+    error_message = "Existing-VPC mode must not create or replace VPC, subnet, or NAT resources."
+  }
+
+  assert {
+    condition     = length(aws_vpc_endpoint.s3) == 1 && toset(keys(aws_vpc_endpoint.interface)) == toset(["sts", "eks-auth"])
+    error_message = "Existing-VPC mode must create only explicitly selected endpoints."
+  }
+}
+
+run "helm_requires_an_image_version" {
+  command = plan
+
+  variables {
+    deploy_helm = true
+  }
+
+  expect_failures = [
+    helm_release.migration_assistant[0],
+  ]
+}
+
+run "default_new_vpc_is_not_isolated" {
+  command = plan
+
+  # No-regression guard: with isolated unset (default false), the new VPC keeps its
+  # NAT gateways and the base 5-endpoint set, identical to prior behavior.
+  assert {
+    condition     = length(aws_nat_gateway.migration) == 2
+    error_message = "Non-isolated new VPC must keep its NAT gateways."
+  }
+
+  assert {
+    condition     = length(aws_route.private_ipv4) == 2 && length(aws_route.private_ipv6) == 2
+    error_message = "Non-isolated new VPC must keep private egress routes."
+  }
+
+  assert {
+    condition = length(aws_vpc_endpoint.s3) == 1 && toset(keys(aws_vpc_endpoint.interface)) == toset([
+      "ecr.api", "ecr.dkr", "logs", "elasticfilesystem",
+    ])
+    error_message = "Non-isolated new VPC must create only the base endpoint set."
+  }
+}
+
+run "isolated_new_vpc_has_no_nat_and_full_endpoints" {
+  command = plan
+
+  variables {
+    isolated = true
+  }
+
+  # Isolated: no NAT gateway, no private egress routes.
+  assert {
+    condition     = length(aws_nat_gateway.migration) == 0 && length(aws_eip.nat) == 0
+    error_message = "Isolated VPC must not create NAT gateways or their EIPs."
+  }
+
+  assert {
+    condition     = length(aws_route.private_ipv4) == 0 && length(aws_route.private_ipv6) == 0
+    error_message = "Isolated VPC private subnets must have no internet egress route."
+  }
+
+  # Isolated: the full 8-endpoint set (S3 gateway + 7 interface endpoints) so the
+  # cluster reaches AWS APIs privately, matching the working isolated-VPC path.
+  assert {
+    condition = length(aws_vpc_endpoint.s3) == 1 && toset(keys(aws_vpc_endpoint.interface)) == toset([
+      "ecr.api", "ecr.dkr", "logs", "monitoring", "elasticfilesystem", "sts", "eks-auth",
+    ])
+    error_message = "Isolated VPC must create the full service-endpoint set (s3 + 7 interface endpoints)."
+  }
+}
+
+run "connectivity_defaults_to_none_no_resources" {
+  command = plan
+
+  # No-regression guard: both legs default to none, so no connectivity module
+  # resources are planned.
+  assert {
+    condition     = length(module.source_connectivity_privatelink) == 0 && length(module.target_connectivity_privatelink) == 0
+    error_message = "No privatelink endpoints must be planned when connectivity mode is none."
+  }
+
+  assert {
+    condition     = length(module.source_connectivity_peering) == 0 && length(module.target_connectivity_peering) == 0
+    error_message = "No VPC peering must be planned when connectivity mode is none."
+  }
+
+  assert {
+    condition     = var.source_connectivity.mode == "none" && var.target_connectivity.mode == "none"
+    error_message = "Both connectivity legs must default to none."
+  }
+}
+
+run "target_privatelink_plans_interface_endpoint" {
+  command = plan
+
+  variables {
+    target_connectivity = {
+      mode                      = "privatelink"
+      vpc_endpoint_service_name = "com.amazonaws.vpce.us-east-1.vpce-svc-0123456789abcdef0"
+      dns_name                  = "target.example.com"
+    }
+  }
+
+  # One privatelink module on the target leg; source leg stays empty.
+  assert {
+    condition     = length(module.target_connectivity_privatelink) == 1 && length(module.source_connectivity_privatelink) == 0
+    error_message = "Target privatelink must plan exactly one endpoint on the target leg only."
+  }
+
+  # Interface endpoint with private DNS disabled (custom FQDN handled by Route 53).
+  assert {
+    condition     = module.target_connectivity_privatelink[0].endpoint_fqdn == "target.example.com"
+    error_message = "Target privatelink must expose the configured FQDN."
+  }
+}
+
+run "source_vpc_peering_plans_connection_and_routes" {
+  command = plan
+
+  variables {
+    source_connectivity = {
+      mode        = "vpc_peering"
+      peer_vpc_id = "vpc-0aaaaaaaaaaaaaaaa"
+      peer_cidr   = "10.99.0.0/16"
+    }
+  }
+
+  # One peering module on the source leg; target leg stays empty.
+  assert {
+    condition     = length(module.source_connectivity_peering) == 1 && length(module.target_connectivity_peering) == 0
+    error_message = "Source vpc_peering must plan exactly one peering on the source leg only."
+  }
+}
+
+run "privatelink_requires_service_name" {
+  command = plan
+
+  variables {
+    target_connectivity = {
+      mode = "privatelink"
+    }
+  }
+
+  expect_failures = [
+    var.target_connectivity,
+  ]
+}
+
+run "snapshot_role_created_by_default" {
+  command = plan
+
+  # No-regression guard: the snapshot role and its policy exist by default, and the
+  # helm release wires the role ARN into defaultBucketConfiguration.snapshotRoleArn.
+  assert {
+    condition     = length(aws_iam_role.snapshot) == 1 && length(aws_iam_role_policy.snapshot) == 1
+    error_message = "The snapshot role and policy must be created by default."
+  }
+
+  assert {
+    condition     = var.create_opensearch_service_snapshot_role == true
+    error_message = "create_opensearch_service_snapshot_role must default to true."
+  }
+}
+
+run "snapshot_role_omitted_when_disabled" {
+  command = plan
+
+  variables {
+    create_opensearch_service_snapshot_role = false
+  }
+
+  assert {
+    condition     = length(aws_iam_role.snapshot) == 0 && length(aws_iam_role_policy.snapshot) == 0
+    error_message = "The snapshot role and policy must not be created when disabled."
+  }
+}

--- a/deployment/terraform/aws/tests/infrastructure.tftest.hcl
+++ b/deployment/terraform/aws/tests/infrastructure.tftest.hcl
@@ -405,3 +405,19 @@ run "cloudwatch_logs_covers_the_otel_emf_default_group" {
     error_message = "The CloudWatchLogs statement must still cover the Migration Assistant log group."
   }
 }
+
+# Only GetSecretValue has a caller (the console fetches a credential secret by the ARN
+# it is handed). DescribeSecret and ListSecrets were granted without one; this guards
+# against them reappearing.
+run "secrets_statement_grants_only_get_secret_value" {
+  command = plan
+
+  assert {
+    condition = anytrue([
+      for s in data.aws_iam_policy_document.migration_pods.statement :
+      toset(s.actions) == toset(["secretsmanager:GetSecretValue"])
+      if s.sid == "Secrets"
+    ])
+    error_message = "The Secrets statement must grant only secretsmanager:GetSecretValue."
+  }
+}

--- a/deployment/terraform/aws/tests/infrastructure.tftest.hcl
+++ b/deployment/terraform/aws/tests/infrastructure.tftest.hcl
@@ -162,6 +162,11 @@ run "default_new_vpc_is_not_isolated" {
     ])
     error_message = "Non-isolated new VPC must create only the base endpoint set."
   }
+
+  assert {
+    condition     = aws_eks_cluster.migration.vpc_config[0].endpoint_public_access
+    error_message = "Non-isolated cluster must keep its public Kubernetes API endpoint."
+  }
 }
 
 run "isolated_new_vpc_has_no_nat_and_full_endpoints" {
@@ -190,6 +195,78 @@ run "isolated_new_vpc_has_no_nat_and_full_endpoints" {
     ])
     error_message = "Isolated VPC must create the full service-endpoint set (s3 + 7 interface endpoints)."
   }
+
+  # Isolated: the Kubernetes API is private too, reachable only from inside the VPC.
+  assert {
+    condition     = aws_eks_cluster.migration.vpc_config[0].endpoint_public_access == false
+    error_message = "Isolated cluster must not expose a public Kubernetes API endpoint."
+  }
+
+  assert {
+    condition     = aws_eks_cluster.migration.vpc_config[0].endpoint_private_access
+    error_message = "Isolated cluster must keep its private Kubernetes API endpoint."
+  }
+}
+
+run "isolated_public_endpoint_override_is_honored" {
+  command = plan
+
+  # An explicit true beats the isolated-derived default, so an operator can reach the
+  # API from outside the VPC while the data path stays private.
+  variables {
+    isolated                       = true
+    cluster_endpoint_public_access = true
+    cluster_public_access_cidrs    = ["203.0.113.0/24"]
+  }
+
+  assert {
+    condition     = aws_eks_cluster.migration.vpc_config[0].endpoint_public_access
+    error_message = "An explicit cluster_endpoint_public_access = true must override the isolated default."
+  }
+
+  assert {
+    condition     = aws_eks_cluster.migration.vpc_config[0].public_access_cidrs == toset(["203.0.113.0/24"])
+    error_message = "public_access_cidrs must be applied to the overridden public endpoint."
+  }
+
+  # The override touches only the control plane: the data path stays air-gapped.
+  assert {
+    condition     = length(aws_nat_gateway.migration) == 0
+    error_message = "Overriding the public endpoint must not reintroduce NAT gateways."
+  }
+}
+
+run "public_endpoint_can_be_disabled_without_isolated" {
+  command = plan
+
+  # The override works in the other direction too: a private-only API endpoint in a
+  # standard (NAT-bearing) VPC.
+  variables {
+    cluster_endpoint_public_access = false
+  }
+
+  assert {
+    condition     = aws_eks_cluster.migration.vpc_config[0].endpoint_public_access == false
+    error_message = "An explicit cluster_endpoint_public_access = false must disable the public endpoint."
+  }
+
+  assert {
+    condition     = length(aws_nat_gateway.migration) == 2
+    error_message = "Disabling the public endpoint must not change NAT gateway behavior."
+  }
+}
+
+run "both_endpoints_disabled_is_rejected" {
+  command = plan
+
+  variables {
+    cluster_endpoint_public_access  = false
+    cluster_endpoint_private_access = false
+  }
+
+  expect_failures = [
+    aws_eks_cluster.migration,
+  ]
 }
 
 run "connectivity_defaults_to_none_no_resources" {

--- a/deployment/terraform/aws/tests/infrastructure.tftest.hcl
+++ b/deployment/terraform/aws/tests/infrastructure.tftest.hcl
@@ -374,3 +374,34 @@ run "snapshot_role_omitted_when_disabled" {
     error_message = "The snapshot role and policy must not be created when disabled."
   }
 }
+
+# The otel collector's awsemf exporters do not set log_group_name, so they fall back
+# to the exporter's default /metrics/default group. Scoping the CloudWatchLogs
+# statement to only the migration-assistant group silently blocks every EKS metric.
+run "cloudwatch_logs_covers_the_otel_emf_default_group" {
+  command = plan
+
+  variables {
+    region = "us-east-1"
+    stage  = "dev"
+  }
+
+  assert {
+    condition = anytrue([
+      for s in data.aws_iam_policy_document.migration_pods.statement :
+      contains(s.resources, "arn:aws:logs:us-east-1:123456789012:log-group:/metrics/default") &&
+      contains(s.resources, "arn:aws:logs:us-east-1:123456789012:log-group:/metrics/default:*")
+      if s.sid == "CloudWatchLogs"
+    ])
+    error_message = "The CloudWatchLogs statement must cover the awsemf exporter's default /metrics/default log group and its streams."
+  }
+
+  assert {
+    condition = anytrue([
+      for s in data.aws_iam_policy_document.migration_pods.statement :
+      contains(s.resources, "arn:aws:logs:us-east-1:123456789012:log-group:/migration-assistant-dev-us-east-1*")
+      if s.sid == "CloudWatchLogs"
+    ])
+    error_message = "The CloudWatchLogs statement must still cover the Migration Assistant log group."
+  }
+}

--- a/deployment/terraform/aws/variables.tf
+++ b/deployment/terraform/aws/variables.tf
@@ -1,0 +1,270 @@
+variable "region" {
+  description = "AWS region in which to create the Migration Assistant infrastructure."
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "stage" {
+  description = "Short identifier used in resource names. Use a unique value for each deployment in a region."
+  type        = string
+  default     = "dev"
+
+  validation {
+    condition     = can(regex("^[a-z][a-z0-9-]{0,15}$", var.stage))
+    error_message = "stage must start with a lowercase letter, contain only lowercase letters, numbers, or hyphens, and be at most 16 characters."
+  }
+}
+
+variable "kubernetes_version" {
+  description = "EKS Kubernetes control-plane version."
+  type        = string
+  default     = "1.35"
+}
+
+variable "create_vpc" {
+  description = "Create a dual-stack VPC and two private/public subnet pairs. When false, existing_vpc_id and existing_subnet_ids are required."
+  type        = bool
+  default     = true
+}
+
+variable "permissions_boundary_arn" {
+  description = <<-EOT
+    Optional IAM permissions boundary ARN applied to every IAM role this module
+    creates (cluster, node, workload, and snapshot roles). Default null applies no
+    boundary. Set this when the account requires a permissions boundary on
+    created roles (some organizations deny iam:CreateRole unless the request
+    includes a specific boundary).
+  EOT
+  type        = string
+  default     = null
+}
+
+variable "create_opensearch_service_snapshot_role" {
+  description = <<-EOT
+    Create the IAM role that Amazon OpenSearch Service assumes to read/write S3
+    snapshots (trusted principal es.amazonaws.com). Default true preserves current
+    behavior. Set false when the migration SOURCE is not Amazon OpenSearch Service
+    (e.g. self-managed Elasticsearch/OpenSearch), which registers its S3 snapshot
+    repository without assuming an AWS role, so this role is unused.
+  EOT
+  type        = bool
+  default     = true
+}
+
+variable "isolated" {
+  description = <<-EOT
+    Deploy into an isolated (air-gapped) network for a fully private migration. Only
+    applies when create_vpc is true. When true, no NAT gateway is created (private
+    subnets have no outbound internet route) and the full set of service VPC endpoints
+    is created so the cluster can reach AWS APIs privately: s3, ecr.api, ecr.dkr, logs,
+    monitoring, elasticfilesystem, sts, eks-auth. Default false preserves current
+    behavior (NAT gateway + the base endpoint set). Mirrors the working isolated-VPC
+    deployment path.
+  EOT
+  type        = bool
+  default     = false
+}
+
+variable "vpc_cidr" {
+  description = "IPv4 CIDR for the VPC created by this module."
+  type        = string
+  default     = "10.212.0.0/16"
+
+  validation {
+    condition     = can(cidrhost(var.vpc_cidr, 0))
+    error_message = "vpc_cidr must be a valid IPv4 CIDR block."
+  }
+}
+
+variable "availability_zones" {
+  description = "Two availability zones for a newly created VPC. The first two available zones are used when empty."
+  type        = list(string)
+  default     = []
+
+  validation {
+    condition     = length(var.availability_zones) == 0 || length(var.availability_zones) == 2
+    error_message = "availability_zones must be empty or contain exactly two zones."
+  }
+}
+
+variable "existing_vpc_id" {
+  description = "Existing VPC ID used when create_vpc is false."
+  type        = string
+  default     = null
+}
+
+variable "existing_subnet_ids" {
+  description = "At least two existing subnets in distinct availability zones used when create_vpc is false. Private subnets are recommended."
+  type        = list(string)
+  default     = []
+}
+
+variable "existing_route_table_ids" {
+  description = "Route table IDs for an optional S3 gateway endpoint in an existing VPC. When empty, Terraform discovers the route table associated with each supplied subnet."
+  type        = list(string)
+  default     = []
+}
+
+variable "vpc_endpoints" {
+  description = <<-EOT
+    VPC endpoints to create. For a new VPC, s3, ecr.api, ecr.dkr, logs, and
+    elasticfilesystem are always created to match the CloudFormation deployment;
+    values here add optional endpoints. For an existing VPC, only values listed
+    here are created. Valid values: s3, ecr.api, ecr.dkr, logs, monitoring,
+    elasticfilesystem, sts, eks-auth.
+  EOT
+  type        = set(string)
+  default     = []
+
+  validation {
+    condition = length(setsubtract(
+      var.vpc_endpoints,
+      toset(["s3", "ecr.api", "ecr.dkr", "logs", "monitoring", "elasticfilesystem", "sts", "eks-auth"])
+    )) == 0
+    error_message = "vpc_endpoints contains an unsupported endpoint name."
+  }
+}
+
+variable "source_connectivity" {
+  description = <<-EOT
+    Private connectivity for the source-read leg. mode = none (default, reach the
+    source over its public endpoint / out-of-band VPN/DX) | privatelink (consumer
+    interface endpoint to the source's VPC endpoint service) | vpc_peering (peer the
+    migration VPC with the source VPC). Managed OpenSearch sources typically expose
+    privatelink; a customer-owned source VPC typically uses vpc_peering.
+  EOT
+  type = object({
+    mode = optional(string, "none")
+    # privatelink:
+    vpc_endpoint_service_name = optional(string)
+    # vpc_peering:
+    peer_vpc_id     = optional(string)
+    peer_cidr       = optional(string)
+    peer_account_id = optional(string)
+    peer_region     = optional(string)
+    # private DNS (optional, privatelink only):
+    dns_name        = optional(string)
+    dns_zone_domain = optional(string)
+  })
+  default = { mode = "none" }
+
+  validation {
+    condition     = contains(["none", "privatelink", "vpc_peering"], var.source_connectivity.mode)
+    error_message = "source_connectivity.mode must be one of: none, privatelink, vpc_peering."
+  }
+
+  validation {
+    condition     = var.source_connectivity.mode != "privatelink" || try(var.source_connectivity.vpc_endpoint_service_name, null) != null
+    error_message = "source_connectivity.vpc_endpoint_service_name is required when mode = privatelink."
+  }
+
+  validation {
+    condition     = var.source_connectivity.mode != "vpc_peering" || (try(var.source_connectivity.peer_vpc_id, null) != null && try(var.source_connectivity.peer_cidr, null) != null)
+    error_message = "source_connectivity.peer_vpc_id and peer_cidr are required when mode = vpc_peering."
+  }
+}
+
+variable "target_connectivity" {
+  description = <<-EOT
+    Private connectivity for the target-write leg. Same modes as source_connectivity.
+    A managed OpenSearch target almost always exposes privatelink (a VPC endpoint
+    service); vpc_peering fits a target in a peered AWS VPC.
+  EOT
+  type = object({
+    mode = optional(string, "none")
+    # privatelink:
+    vpc_endpoint_service_name = optional(string)
+    # vpc_peering:
+    peer_vpc_id     = optional(string)
+    peer_cidr       = optional(string)
+    peer_account_id = optional(string)
+    peer_region     = optional(string)
+    # private DNS (optional, privatelink only):
+    dns_name        = optional(string)
+    dns_zone_domain = optional(string)
+  })
+  default = { mode = "none" }
+
+  validation {
+    condition     = contains(["none", "privatelink", "vpc_peering"], var.target_connectivity.mode)
+    error_message = "target_connectivity.mode must be one of: none, privatelink, vpc_peering."
+  }
+
+  validation {
+    condition     = var.target_connectivity.mode != "privatelink" || try(var.target_connectivity.vpc_endpoint_service_name, null) != null
+    error_message = "target_connectivity.vpc_endpoint_service_name is required when mode = privatelink."
+  }
+
+  validation {
+    condition     = var.target_connectivity.mode != "vpc_peering" || (try(var.target_connectivity.peer_vpc_id, null) != null && try(var.target_connectivity.peer_cidr, null) != null)
+    error_message = "target_connectivity.peer_vpc_id and peer_cidr are required when mode = vpc_peering."
+  }
+}
+
+variable "cluster_endpoint_public_access" {
+  description = "Expose the EKS Kubernetes API through a public endpoint."
+  type        = bool
+  default     = true
+}
+
+variable "cluster_endpoint_private_access" {
+  description = "Expose the EKS Kubernetes API through a private VPC endpoint."
+  type        = bool
+  default     = true
+}
+
+variable "cluster_public_access_cidrs" {
+  description = "CIDRs permitted to reach the public EKS Kubernetes API endpoint. Narrow this for production deployments."
+  type        = list(string)
+  default     = ["0.0.0.0/0"]
+}
+
+variable "namespace" {
+  description = "Kubernetes namespace used by Migration Assistant and its EKS Pod Identity associations."
+  type        = string
+  default     = "ma"
+}
+
+variable "pod_identity_service_accounts" {
+  description = "Kubernetes service accounts that assume the shared Migration Assistant IAM role through EKS Pod Identity."
+  type        = set(string)
+  default = [
+    "build-images-service-account",
+    "argo-workflow-executor",
+    "migrations-service-account",
+    "migration-console-access-role",
+    "otel-collector",
+    "argo-test-workflow-executor",
+    "ack-cloudwatch-controller",
+  ]
+}
+
+variable "deploy_helm" {
+  description = "Install the repository's Migration Assistant Helm chart after the EKS cluster is ready."
+  type        = bool
+  default     = false
+}
+
+variable "migration_assistant_version" {
+  description = "Public ECR image tag used when deploy_helm is true, for example 3.3.4. The tag must exist for all Migration Assistant images in public.ecr.aws/opensearchproject/*."
+  type        = string
+  default     = null
+}
+
+variable "use_custom_karpenter_node_pool" {
+  description = "Configure the chart's custom EKS Auto Mode NodePool instead of relying only on the built-in general-purpose pool."
+  type        = bool
+  default     = true
+}
+
+variable "helm_timeout_seconds" {
+  description = "Maximum time to wait for the Migration Assistant Helm release."
+  type        = number
+  default     = 1500
+}
+
+variable "tags" {
+  description = "Additional tags applied to AWS resources managed by this module."
+  type        = map(string)
+  default     = {}
+}

--- a/deployment/terraform/aws/variables.tf
+++ b/deployment/terraform/aws/variables.tf
@@ -130,8 +130,9 @@ variable "source_connectivity" {
     Private connectivity for the source-read leg. mode = none (default, reach the
     source over its public endpoint / out-of-band VPN/DX) | privatelink (consumer
     interface endpoint to the source's VPC endpoint service) | vpc_peering (peer the
-    migration VPC with the source VPC). Managed OpenSearch sources typically expose
-    privatelink; a customer-owned source VPC typically uses vpc_peering.
+    migration VPC with the source VPC). privatelink requires the provider to publish a
+    VPC endpoint service name; vpc_peering fits a source in an AWS VPC you can peer
+    with. A source already inside the migration VPC needs neither: leave mode = none.
   EOT
   type = object({
     mode = optional(string, "none")
@@ -167,8 +168,9 @@ variable "source_connectivity" {
 variable "target_connectivity" {
   description = <<-EOT
     Private connectivity for the target-write leg. Same modes as source_connectivity.
-    A managed OpenSearch target almost always exposes privatelink (a VPC endpoint
-    service); vpc_peering fits a target in a peered AWS VPC.
+    privatelink requires the provider to publish a VPC endpoint service name;
+    vpc_peering fits a target in an AWS VPC you can peer with. A target already
+    inside the migration VPC needs neither: leave mode = none.
   EOT
   type = object({
     mode = optional(string, "none")

--- a/deployment/terraform/aws/variables.tf
+++ b/deployment/terraform/aws/variables.tf
@@ -202,9 +202,16 @@ variable "target_connectivity" {
 }
 
 variable "cluster_endpoint_public_access" {
-  description = "Expose the EKS Kubernetes API through a public endpoint."
+  description = <<-EOT
+    Expose the EKS Kubernetes API through a public endpoint. Default null follows
+    isolated: the public endpoint is disabled when isolated is true (so an air-gapped
+    deployment closes the control plane along with the data path) and enabled
+    otherwise. Set true or false to override. Setting true with isolated = true keeps
+    kubectl and Terraform usable from outside the VPC while the data path stays
+    private; narrow cluster_public_access_cidrs if you do.
+  EOT
   type        = bool
-  default     = true
+  default     = null
 }
 
 variable "cluster_endpoint_private_access" {

--- a/deployment/terraform/aws/versions.tf
+++ b/deployment/terraform/aws/versions.tf
@@ -1,0 +1,38 @@
+terraform {
+  required_version = ">= 1.6"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+    helm = {
+      source  = "hashicorp/helm"
+      version = ">= 3.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+
+  default_tags {
+    tags = merge(var.tags, {
+      Project = "OpenSearch Migration Assistant"
+      Stage   = var.stage
+    })
+  }
+}
+
+data "aws_eks_cluster_auth" "migration" {
+  name       = aws_eks_cluster.migration.name
+  depends_on = [aws_eks_cluster.migration]
+}
+
+provider "helm" {
+  kubernetes = {
+    host                   = aws_eks_cluster.migration.endpoint
+    token                  = data.aws_eks_cluster_auth.migration.token
+    cluster_ca_certificate = base64decode(aws_eks_cluster.migration.certificate_authority[0].data)
+  }
+}


### PR DESCRIPTION
## Description

Adds a Terraform module at `deployment/terraform/aws/` that provisions the AWS EKS infrastructure for the Migration Assistant, as an alternative to the existing CDK-based AWS Solution. It mirrors the conventions of the existing GCP Terraform module and is meant to become the recommended path for customers while the CDK deployment stays supported.

The change stands alongside what already exists rather than replacing it: a new directory plus a few doc-pointer updates. It leaves the CDK solution, the Helm chart, and all runtime behavior untouched.

## What it provisions

- **Networking:** a dual-stack VPC with public/private subnet pairs across two AZs, NAT + internet/egress-only gateways, and the S3 gateway + interface VPC endpoints. Can attach to an existing VPC instead (`create_vpc = false`), with opt-in endpoints.
- **EKS:** an EKS Auto Mode cluster (`system` + `general-purpose` node pools), cluster/node roles, and an account read-only access entry.
- **IAM + identity:** EKS Pod Identity associations for the Migration Assistant service accounts, a workload role, and the S3 snapshot role assumed by Amazon OpenSearch Service.
- **ECR:** a private repository for mirrored or locally built images.
- **Optional Helm install:** when `deploy_helm = true`, installs the repo's chart with the EKS values overlay.

## Notable capabilities

- **Isolated / air-gapped mode** (`isolated = true`): no NAT gateway and the full service-endpoint set (`s3, ecr.api, ecr.dkr, logs, monitoring, elasticfilesystem, sts, eks-auth`) so a migration runs with no public data path. This matches the endpoint set used by the existing isolated-VPC deployment path.
- **Per-leg private connectivity** (`source_connectivity` / `target_connectivity`): `privatelink` (interface VPC endpoint to a provider's endpoint service, with optional Route 53 private DNS) or `vpc_peering`, each defaulting to `none`.
- **Least-privilege IAM**: scoped to module-owned resources where the ARNs are knowable (the ECR repo, the MA log group for the stage/region, `MA-*` dashboards, and `migrations-*` for the snapshot role). Actions that cannot be resource-scoped are split into their own statements and annotated inline with why. The workload S3 statement is deliberately left on `*` because the console reads/writes user-configured buckets (notably the failed-document-stream bucket) and the default bucket is created by the Helm chart, not Terraform. Accepting explicit bucket ARNs to scope that down is a noted follow-up.
- **Optional permissions boundary** (`permissions_boundary_arn`) applied to every created role, for accounts that require one.

## Non-regression

All new behavior is opt-in and defaults to today's values, so a standard deployment is unaffected. The isolated flag, connectivity modes, snapshot-role toggle, and permissions boundary all default off/none. The module does not touch the CDK deployment or its resources.

## Testing

Plan-time tests run with mocked AWS/Helm providers (no cloud credentials):

- `terraform fmt -check -recursive`: clean
- `terraform validate`: success
- `terraform test`: 17/17 passing (new-VPC topology, isolated topology, existing-VPC additive behavior, EKS Auto Mode + Pod Identity, per-leg connectivity, snapshot-role toggle, Helm version precondition)

Applied to a clean AWS account with default configuration, then again with `deploy_helm = true` and `migration_assistant_version = 3.3.4`: 58 and 59 resources respectively, applying and destroying cleanly. `kubernetes_version = 1.35` (the module default) is a real EKS version in us-east-1, which had only ever been exercised against mocks. EKS Auto Mode cold-started 3 nodes and the chart came up 24/24 pods with 0 restarts. Pod Identity works end to end: `aws sts get-caller-identity` from the console pod returns the expected assumed role. The ECR repo-ARN scoping is tight in both directions, with the named lookup succeeding and the enumerating form denied.

That run surfaced a teardown bug, fixed in e4611913b: `helm_release` declared no dependency on networking, so `terraform destroy` tore down the VPC endpoints while `helm uninstall` was still running, which failed the chart's credential-dependent uninstall hooks and aborted the destroy partway. Destroy now completes in a single pass.

Separately validated on real AWS by another tester: an end-to-end backfill migration over private networking succeeded. Live capture-and-replay has not yet been exercised on this module.

Not yet exercised: private ECR pulls (all chart images come from `public.ecr.aws`, which needs no IAM), CloudWatch logging, whether the scoped IAM statements suffice for a full migration, and `isolated = true`, the connectivity modes, and `permissions_boundary_arn` against real AWS.

## Docs

The module README covers all variables, isolated mode, private connectivity (including the operator responsibilities the module intentionally does not automate: endpoint-service acceptance, reciprocal peering routes, TLS hostname matching), outputs, and CDK coexistence. Top-level deployment docs are updated to point at both the Terraform and CDK paths.


