### PR TITLE
Add SigV4 authentication to k6 load tests

### DIFF
--- a/TrafficCapture/trafficLoadTest/README.md
+++ b/TrafficCapture/trafficLoadTest/README.md
@@ -5,7 +5,7 @@ A run is an **Argo Workflow** that creates a **k6-operator `TestRun`** and waits
 the migration console (`loadtest …`), a thin shell helper, or plain `kubectl`.
 
 The load test itself — the scenario scripts, their libs and the document schemas — lives **in this
-directory** and reaches the cluster as a ~25 KB **`FROM scratch` data
+directory** and reaches the cluster as a ~100 KB **`FROM scratch` data
 image** (`migrations/k6_scripts`), mounted read-only at `/scripts` with a Kubernetes `image:` volume
 on pods running **stock `grafana/k6`**. That is the same mechanism as the migration's
 [mountable transforms](../../docs/MountableTransformsDesign.md), and it is why this chart requires
@@ -138,7 +138,7 @@ other `migrations/*` images):
 > - **Building from source does not either.** `aws-bootstrap.sh --build` and the
 >   `migration-assistant` CLI both run `:buildImages:buildImagesToRegistry`, which builds the general
 >   image set only. Load-test images are a separate aggregate, deliberately kept out of a deployment
->   path that production users also run. Build and push the ~25 KB image yourself with
+>   path that production users also run. Build and push the ~100 KB image yourself with
 >   `buildKitLoadTestAll` (see below) when a cluster must run load tests.
 >
 > Either way the k6 chart is a separate opt-in: nothing in the EKS bootstrap installs it, so a
@@ -235,6 +235,7 @@ now a chart edit — no image rebuild.
 | The TestRun manifest itself (mount shape, `K6_OUT` trio, labels) | chart `templates/k6-workflowtemplates.yaml` | the templates' `resource.manifest` | `helm upgrade` |
 | Runner image / tag | chart `values.yaml` (`image.*`) | the `runnerImage` parameter default | `helm upgrade` |
 | Scripts image / tag / digest | chart `values.yaml` (`scriptsImage.*`) | the `scriptsRef` parameter default | `helm upgrade` |
+| Default auth Secret name | chart `values.yaml` (`authSecretName`) | optional `envFrom` on each runner | `helm upgrade` |
 
 **Apply a scenario edit** — rebuild the image, then submit a fresh run:
 
@@ -322,33 +323,66 @@ helm upgrade --install k6-load-test "$CHART" -n ma --set captureProxyUrl="$PROXY
 ## Authentication
 
 The capture proxy is a transparent forwarder: it does not add credentials, so whatever the **source
-cluster** requires, the client must send. This matters because the default local stack now runs the
-testClusters chart, which serves HTTPS with basic auth (`admin:admin`).
+cluster** requires, the client must send. The wrapper supports unauthenticated, HTTP Basic, and AWS
+SigV4 sources.
 
-Pass HTTP Basic credentials with `AUTH_USERNAME` / `AUTH_PASSWORD`, like any other run input:
+For a local Basic-auth source, credentials can still be passed as ordinary run overrides:
 
 ```bash
 loadtest run --scenario ingest --config ingest-steady --target "$PROXY" \
   -e AUTH_USERNAME=admin -e AUTH_PASSWORD=admin
 ```
 
-`deployCdcLoadTestConfig.sh up` prints exactly this command with the flags already filled in
-whenever the config it submitted references credential secrets, so the common path is copy-paste.
+For credentials that should not appear in the Workflow or TestRun, create a Kubernetes Secret and
+name it with `--auth-secret-name`. Basic-auth Secrets use these keys:
+
+```text
+K6_AUTH_MODE=basic
+K6_AUTH_USERNAME=admin
+K6_AUTH_PASSWORD=admin
+```
+
+SigV4 Secrets use the standard temporary AWS credential variables plus the endpoint that must be
+signed. The request is still sent to the capture proxy; only its signature and `Host` header use the
+real source endpoint.
+
+```text
+K6_AUTH_MODE=sigv4
+AWS_ACCESS_KEY_ID=...
+AWS_SECRET_ACCESS_KEY=...
+AWS_SESSION_TOKEN=...
+AWS_REGION=us-east-1
+SIGV4_SERVICE=es
+SIGV4_SIGNING_ENDPOINT=https://search-source.us-east-1.es.amazonaws.com
+```
+
+```bash
+kubectl create secret generic k6-source-auth -n ma --from-env-file=k6-source-auth.env
+loadtest run --scenario ingest --target "$PROXY" --auth-secret-name k6-source-auth
+```
+
+Temporary credentials must remain valid for the whole run. The CDC k6 integration test resolves
+credentials through boto3's normal credential chain, creates a unique per-run Secret, and deletes it
+after k6 exits.
 
 | Key | Default | Meaning |
 |---|---|---|
-| `AUTH_USERNAME` | *(unset)* | HTTP Basic username. **Setting it is what turns auth on.** |
-| `AUTH_PASSWORD` | *(empty)* | HTTP Basic password. |
-| `AUTH_MODE` | `basic` when `AUTH_USERNAME` is set, else `none` | Force credentials off with `none` without unsetting the username. |
+| `AUTH_USERNAME` | *(unset)* | Visible per-run HTTP Basic username. |
+| `AUTH_PASSWORD` | *(empty)* | Visible per-run HTTP Basic password. |
+| `AUTH_MODE` | inferred | Visible per-run `basic`, `sigv4`, or `none` override; SigV4 credentials still come from the Secret. |
+| `K6_AUTH_MODE` | inferred | Secret-provided `basic`, `sigv4`, or `none`; takes precedence. |
+| `SIGV4_SERVICE` | `es` | AWS signing service (`es` or `aoss`). |
+| `SIGV4_SIGNING_ENDPOINT` | *(required for SigV4)* | Real source endpoint used to build the signature. |
 
 Credentials are deliberately **not** baked into any `k6-config/*.env` preset — presets ship inside
-the scripts image, and secrets do not belong in an image. They are per-run inputs only.
+the scripts image, and secrets do not belong in an image. SigV4 signing uses the repository's small
+`lib/sigv4.js` implementation and stock k6 cryptographic primitives, so runs do not fetch code from
+the internet.
 
-**How it works.** Scenarios import `lib/http-client.js` instead of `k6/http`. That wrapper merges an
-`Authorization` header into the params of every cluster-bound request, so auth applies uniformly to
-load traffic *and* to the setup calls (index creation, mapping checks) that do not go through
-`pinned()`/`spread()`. `lib/id-registry.js` and `lib/control.js` keep the raw `k6/http` client on
-purpose — they talk to Webdis, not the cluster, and must never receive cluster credentials.
+**How it works.** Scenarios import `lib/http-client.js` instead of `k6/http`. That wrapper applies
+Basic or SigV4 headers to every cluster-bound request, including setup calls such as index creation.
+`lib/id-registry.js` and `lib/control.js` keep the raw `k6/http` client because they talk to Webdis,
+not the source cluster.
 
 **Running without auth** is unchanged: leave `AUTH_USERNAME` unset. To take auth off the clusters
 themselves, deploy testClusters with the no-auth preset (plain HTTP, security disabled both sides):
@@ -872,7 +906,7 @@ Why the current setup looks the way it does (decision → rationale → alternat
    — load testing is a dev/test capability, so it is absent from `publishedRepoByImageName` and from
    the list `aws-bootstrap.sh` mirrors out of `public.ecr.aws`. It is still an ordinary build target,
    so `aws-bootstrap.sh --build` pushes it to the private ECR registry with everything else; only a
-   deployment made purely from released artifacts has to build and push those 25 KB itself.
+   deployment made purely from released artifacts has to build and push that small image itself.
    *Rejected:* publishing a public k6 image, which would make a load generator part of the released
    surface for every customer — and would enable nothing on its own, since the bootstrap never
    installs the k6 chart.

--- a/TrafficCapture/trafficLoadTest/lib/http-client.js
+++ b/TrafficCapture/trafficLoadTest/lib/http-client.js
@@ -1,61 +1,131 @@
 /**
- * HTTP client for requests aimed at the cluster (through the Capture Proxy).
+ * HTTP client for requests aimed at the cluster through the Capture Proxy.
  *
- * The Capture Proxy is a transparent forwarder: it adds no credentials of its own, so whatever the
- * SOURCE cluster requires, the load test has to send. A cluster running with authentication — which
- * the testClusters chart does by default — answers an unauthenticated request with 401, and the run
- * then generates traffic but no data.
+ * The proxy is a transparent forwarder, so each request must carry the source cluster's
+ * authentication. Basic auth may still be supplied as visible per-run parameters. Credentials
+ * supplied through an auth Secret use the K6_AUTH_* aliases so the chart's empty AUTH_* defaults
+ * cannot overwrite them.
  *
- * Scenarios import this module INSTEAD of 'k6/http' so credentials are applied in one place rather
- * than at every call site. The wrapper only merges an Authorization header into the params object;
- * everything else (tags, connection mode, redirects, timeouts) passes through untouched, and the
- * return value is k6's own Response.
+ * SigV4 signs the source endpoint while sending to CAPTURE_PROXY_URL. The resulting Host header is
+ * the source host, matching console_link's sigv4_signing_endpoint behavior.
  *
- * Deliberately NOT used by lib/id-registry.js and lib/control.js: those talk to Webdis, not the
- * cluster, and must not be handed cluster credentials.
- *
- * Configuration (preset key or `-e` override; environment wins, as everywhere else):
- *   AUTH_USERNAME / AUTH_PASSWORD   HTTP Basic credentials. Auth is enabled by setting a username;
- *                                   leave unset for a cluster with security disabled.
- *   AUTH_MODE                       'basic' (default when AUTH_USERNAME is set) or 'none' to force
- *                                   credentials off without unsetting the username.
+ * Secret environment:
+ *   K6_AUTH_MODE                         basic | sigv4 | none
+ *   K6_AUTH_USERNAME / K6_AUTH_PASSWORD Basic credentials
+ *   AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY / AWS_SESSION_TOKEN
+ *   AWS_REGION
+ *   SIGV4_SERVICE                       Defaults to es
+ *   SIGV4_SIGNING_ENDPOINT              The real source endpoint
  */
 
 import http from 'k6/http';
 import encoding from 'k6/encoding';
-
 import { CFG } from './config.js';
+import { createSigV4Signer } from './sigv4.js';
 
-const USERNAME = CFG.AUTH_USERNAME || '';
-const PASSWORD = CFG.AUTH_PASSWORD || '';
-const MODE = (CFG.AUTH_MODE || (USERNAME ? 'basic' : 'none')).toLowerCase();
+const USERNAME = __ENV.K6_AUTH_USERNAME || CFG.AUTH_USERNAME || '';
+const PASSWORD = __ENV.K6_AUTH_PASSWORD || CFG.AUTH_PASSWORD || '';
+const HAS_AWS_CREDENTIALS = Boolean(__ENV.AWS_ACCESS_KEY_ID && __ENV.AWS_SECRET_ACCESS_KEY);
+const MODE = (
+  __ENV.K6_AUTH_MODE ||
+  CFG.AUTH_MODE ||
+  (HAS_AWS_CREDENTIALS ? 'sigv4' : USERNAME ? 'basic' : 'none')
+).toLowerCase();
 
-export const AUTH_ENABLED = MODE === 'basic' && USERNAME !== '';
+export const AUTH_MODE = MODE;
+export const AUTH_ENABLED = MODE !== 'none';
 
-/** Built once at init time — the credentials cannot change mid-run. */
-const AUTH_HEADER = AUTH_ENABLED
+if (!['none', 'basic', 'sigv4'].includes(MODE)) {
+  throw new Error(`Unsupported K6_AUTH_MODE/AUTH_MODE '${MODE}'; expected none, basic, or sigv4`);
+}
+if (MODE === 'basic' && !USERNAME) {
+  throw new Error('Basic authentication requires K6_AUTH_USERNAME or AUTH_USERNAME');
+}
+
+const BASIC_AUTH_HEADER = MODE === 'basic'
   ? { Authorization: `Basic ${encoding.b64encode(`${USERNAME}:${PASSWORD}`)}` }
   : null;
 
-/**
- * Merge the Authorization header into a params object without disturbing anything else. Returns the
- * original object when auth is off, so a run against an open cluster allocates nothing extra.
- */
-export function withAuth(params) {
-  if (!AUTH_HEADER) return params;
+let sigv4Signer = null;
+if (MODE === 'sigv4') {
+  sigv4Signer = createSigV4Signer({
+    accessKeyId: __ENV.AWS_ACCESS_KEY_ID,
+    secretAccessKey: __ENV.AWS_SECRET_ACCESS_KEY,
+    sessionToken: __ENV.AWS_SESSION_TOKEN,
+    region: __ENV.AWS_REGION,
+    service: __ENV.SIGV4_SERVICE || 'es',
+    endpoint: __ENV.SIGV4_SIGNING_ENDPOINT || '',
+  });
+}
+
+function decodeQueryComponent(value) {
+  return decodeURIComponent(value.replace(/\+/g, ' '));
+}
+
+function parseRequestUrl(url) {
+  // k6 2.2.0 has no global URL class. Keep this parser deliberately limited to absolute HTTP(S)
+  // URLs, which are the only values the cluster client accepts.
+  const match = /^https?:\/\/[^/?#]+([^?#]*)?(?:\?([^#]*))?$/i.exec(url);
+  if (!match) throw new Error(`Cannot SigV4-sign invalid HTTP(S) URL '${url}'`);
+
+  const query = {};
+  for (const pair of (match[2] || '').split('&')) {
+    if (!pair) continue;
+    const separator = pair.indexOf('=');
+    const key = decodeQueryComponent(separator < 0 ? pair : pair.slice(0, separator));
+    const value = decodeQueryComponent(separator < 0 ? '' : pair.slice(separator + 1));
+    if (query[key] === undefined) {
+      query[key] = value;
+    } else if (Array.isArray(query[key])) {
+      query[key].push(value);
+    } else {
+      query[key] = [query[key], value];
+    }
+  }
+  return { path: match[1] || '/', query };
+}
+
+function withBasicAuth(params) {
   const p = params || {};
-  return { ...p, headers: { ...(p.headers || {}), ...AUTH_HEADER } };
+  return { ...p, headers: { ...(p.headers || {}), ...BASIC_AUTH_HEADER } };
 }
 
-// k6's http methods split into those that carry a body and those that do not; the params object is
-// the last argument in both shapes.
-export function get(url, params)          { return http.get(url, withAuth(params)); }
-export function del(url, body, params)    { return http.del(url, body, withAuth(params)); }
-export function post(url, body, params)   { return http.post(url, body, withAuth(params)); }
-export function put(url, body, params)    { return http.put(url, body, withAuth(params)); }
-export function patch(url, body, params)  { return http.patch(url, body, withAuth(params)); }
+function withSigV4Auth(method, url, body, params) {
+  const p = params || {};
+  const parsedUrl = parseRequestUrl(url);
+  const signedHeaders = sigv4Signer.sign({
+    method: method.toUpperCase(),
+    path: parsedUrl.path,
+    query: parsedUrl.query,
+    body: body == null ? '' : body,
+  });
+  return { ...p, headers: { ...(p.headers || {}), ...signedHeaders } };
+}
+
+/** Return k6 request params with the configured source authentication applied. */
+export function withAuth(method, url, body, params) {
+  if (MODE === 'basic') return withBasicAuth(params);
+  if (MODE === 'sigv4') return withSigV4Auth(method, url, body, params);
+  return params;
+}
+
+export function get(url, params) {
+  return http.get(url, withAuth('GET', url, null, params));
+}
+export function del(url, body, params) {
+  return http.del(url, body, withAuth('DELETE', url, body, params));
+}
+export function post(url, body, params) {
+  return http.post(url, body, withAuth('POST', url, body, params));
+}
+export function put(url, body, params) {
+  return http.put(url, body, withAuth('PUT', url, body, params));
+}
+export function patch(url, body, params) {
+  return http.patch(url, body, withAuth('PATCH', url, body, params));
+}
 export function request(method, url, body, params) {
-  return http.request(method, url, body, withAuth(params));
+  return http.request(method, url, body, withAuth(method, url, body, params));
 }
 
-export default { get, del, post, put, patch, request, withAuth, AUTH_ENABLED };
+export default { get, del, post, put, patch, request, withAuth, AUTH_MODE, AUTH_ENABLED };

--- a/TrafficCapture/trafficLoadTest/lib/sigv4.js
+++ b/TrafficCapture/trafficLoadTest/lib/sigv4.js
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: Apache-2.0
+// Repository-owned AWS Signature Version 4 request signing for stock k6.
+
+import crypto from 'k6/crypto';
+
+const ALGORITHM = 'AWS4-HMAC-SHA256';
+const TERMINATOR = 'aws4_request';
+const EMPTY_BODY_HASH = 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855';
+
+function awsEncode(value) {
+  return encodeURIComponent(String(value)).replace(
+    /[!'()*]/g,
+    (character) => `%${character.charCodeAt(0).toString(16).toUpperCase()}`,
+  );
+}
+
+function canonicalPath(path) {
+  const value = path || '/';
+  return value.split('/').map((segment) => awsEncode(segment)).join('/');
+}
+
+function canonicalQuery(query) {
+  const pairs = [];
+  for (const key of Object.keys(query || {})) {
+    const values = Array.isArray(query[key]) ? query[key] : [query[key]];
+    for (const value of values) {
+      pairs.push([awsEncode(key), awsEncode(value == null ? '' : value)]);
+    }
+  }
+  pairs.sort(([leftKey, leftValue], [rightKey, rightValue]) => {
+    if (leftKey !== rightKey) return leftKey < rightKey ? -1 : 1;
+    if (leftValue === rightValue) return 0;
+    return leftValue < rightValue ? -1 : 1;
+  });
+  return pairs.map(([key, value]) => `${key}=${value}`).join('&');
+}
+
+function signingHost(endpoint) {
+  const match = /^https?:\/\/([^/?#]+)(?:[/?#]|$)/i.exec(endpoint);
+  if (!match || match[1].includes('@')) {
+    throw new Error(`SIGV4_SIGNING_ENDPOINT must be an absolute HTTP(S) endpoint: '${endpoint}'`);
+  }
+  return match[1];
+}
+
+function signingDateParts(date) {
+  const longDate = date.toISOString().replace(/[:-]|\.\d{3}/g, '');
+  return { longDate, shortDate: longDate.slice(0, 8) };
+}
+
+function hashBody(body) {
+  if (body == null || body === '') return EMPTY_BODY_HASH;
+  if (typeof body === 'string' || body instanceof ArrayBuffer) {
+    return crypto.sha256(body, 'hex').toLowerCase();
+  }
+  if (ArrayBuffer.isView(body)) {
+    const bytes = body.buffer.slice(body.byteOffset, body.byteOffset + body.byteLength);
+    return crypto.sha256(bytes, 'hex').toLowerCase();
+  }
+  throw new Error('SigV4 requests require a string or binary body');
+}
+
+function hmac(key, value, output = 'binary') {
+  return crypto.hmac('sha256', key, value, output);
+}
+
+function deriveSigningKey(secretAccessKey, shortDate, region, service) {
+  const dateKey = hmac(`AWS4${secretAccessKey}`, shortDate);
+  const regionKey = hmac(dateKey, region);
+  const serviceKey = hmac(regionKey, service);
+  return hmac(serviceKey, TERMINATOR);
+}
+
+function normalizeHeaderValue(value) {
+  return String(value).trim().replace(/\s+/g, ' ');
+}
+
+export function createSigV4Signer({
+  accessKeyId,
+  secretAccessKey,
+  sessionToken,
+  region,
+  service = 'es',
+  endpoint,
+}) {
+  if (!accessKeyId || !secretAccessKey) {
+    throw new Error('SigV4 authentication requires AWS access-key credentials');
+  }
+  if (!region) throw new Error('SigV4 authentication requires AWS_REGION');
+  if (!endpoint) throw new Error('SigV4 authentication requires SIGV4_SIGNING_ENDPOINT');
+
+  const host = signingHost(endpoint);
+
+  return {
+    sign({ method, path, query, body, signingDate = new Date() }) {
+      const { longDate, shortDate } = signingDateParts(signingDate);
+      const payloadHash = hashBody(body);
+      const headers = {
+        host,
+        'x-amz-content-sha256': payloadHash,
+        'x-amz-date': longDate,
+      };
+      if (sessionToken) headers['x-amz-security-token'] = sessionToken;
+
+      const signedHeaderNames = Object.keys(headers).sort();
+      const canonicalHeaders = signedHeaderNames
+        .map((name) => `${name}:${normalizeHeaderValue(headers[name])}\n`)
+        .join('');
+      const signedHeaders = signedHeaderNames.join(';');
+      const canonicalRequest = [
+        method.toUpperCase(),
+        canonicalPath(path),
+        canonicalQuery(query),
+        canonicalHeaders,
+        signedHeaders,
+        payloadHash,
+      ].join('\n');
+
+      const scope = `${shortDate}/${region}/${service}/${TERMINATOR}`;
+      const stringToSign = [
+        ALGORITHM,
+        longDate,
+        scope,
+        crypto.sha256(canonicalRequest, 'hex').toLowerCase(),
+      ].join('\n');
+      const signature = hmac(
+        deriveSigningKey(secretAccessKey, shortDate, region, service),
+        stringToSign,
+        'hex',
+      ).toLowerCase();
+
+      headers.authorization = (
+        `${ALGORITHM} Credential=${accessKeyId}/${scope}, ` +
+        `SignedHeaders=${signedHeaders}, Signature=${signature}`
+      );
+      return headers;
+    },
+  };
+}

--- a/TrafficCapture/trafficLoadTest/scenarios/ingest.js
+++ b/TrafficCapture/trafficLoadTest/scenarios/ingest.js
@@ -73,6 +73,7 @@ const SEQ_FRACTION    = parseFloat(CFG.SEQUENCE_FRACTION || '0.15');
 const BULK_FRACTION   = parseFloat(CFG.BULK_FRACTION     || '0.70');
 const CONNECTION_MODE     = CFG.CONNECTION_MODE           || 'pinned';
 const NO_CONNECTION_REUSE = (CFG.NO_CONNECTION_REUSE || 'false') === 'true';
+const LATENCY_THRESHOLDS_ENABLED = (CFG.LATENCY_THRESHOLDS_ENABLED || 'true') === 'true';
 const EXECUTOR            = CFG.EXECUTOR                 || 'constant-arrival-rate';
 const RAMP_STAGES     = CFG.RAMP_STAGES
   ? JSON.parse(CFG.RAMP_STAGES)
@@ -113,12 +114,14 @@ export const options = {
     'http_req_failed':                       ['rate<0.05'],
     'ingest_errors':                         ['rate<0.05'],
     'ingest_sequence_errors':                ['rate<0.05'],
-    'http_req_duration{name:bulk_write}':    ['p(95)<3000'],
-    'http_req_duration{name:single_doc}':    ['p(95)<2000'],
-    'http_req_duration{name:seq_create}':    ['p(95)<2000'],
-    'http_req_duration{name:seq_update}':    ['p(95)<2000'],
-    'http_req_duration{name:seq_query}':     ['p(95)<2000'],
-    'http_req_duration{name:seq_delete}':    ['p(95)<2000'],
+    ...(LATENCY_THRESHOLDS_ENABLED ? {
+      'http_req_duration{name:bulk_write}':  ['p(95)<3000'],
+      'http_req_duration{name:single_doc}':  ['p(95)<2000'],
+      'http_req_duration{name:seq_create}':  ['p(95)<2000'],
+      'http_req_duration{name:seq_update}':  ['p(95)<2000'],
+      'http_req_duration{name:seq_query}':   ['p(95)<2000'],
+      'http_req_duration{name:seq_delete}':  ['p(95)<2000'],
+    } : {}),
   },
 };
 

--- a/TrafficCapture/trafficLoadTest/scripts/k6-run.sh
+++ b/TrafficCapture/trafficLoadTest/scripts/k6-run.sh
@@ -8,7 +8,7 @@
 #
 # Usage:
 #   ./k6-run.sh <ingest|search|mixed> [--config PROFILE] [--parallelism N] [--target URL]
-#               [--extra-args STR] [-e KEY=VALUE]...
+#               [--auth-secret-name NAME] [--extra-args STR] [-e KEY=VALUE]...
 #   CONTEXT=<ctx> NAMESPACE=ma ./k6-run.sh ingest --config ingest-burst -e BULK_BATCH_SIZE=50
 #
 # --config names the profile to run; without it the scenario's steady profile is used. -e KEY=VALUE
@@ -27,7 +27,7 @@ CONTEXT="${CONTEXT:-$(kubectl config current-context)}"
 NAMESPACE="${NAMESPACE:-ma}"
 
 usage() {
-  echo "usage: k6-run.sh <ingest|search|mixed> [--config PROFILE] [--parallelism N] [--target URL] [--extra-args STR] [-e KEY=VALUE]..." >&2
+  echo "usage: k6-run.sh <ingest|search|mixed> [--config PROFILE] [--parallelism N] [--target URL] [--auth-secret-name NAME] [--extra-args STR] [-e KEY=VALUE]..." >&2
   exit 2
 }
 
@@ -35,12 +35,13 @@ usage() {
 SCENARIO="$1"; shift
 case "$SCENARIO" in ingest|search|mixed) ;; *) echo "unknown scenario: $SCENARIO" >&2; usage ;; esac
 
-CONFIG=""; PARALLELISM=""; TARGET=""; EXTRA=""; ENVS=()
+CONFIG=""; PARALLELISM=""; TARGET=""; AUTH_SECRET=""; EXTRA=""; ENVS=()
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --config)      CONFIG="$2"; shift ;;
     --parallelism) PARALLELISM="$2"; shift ;;
     --target)      TARGET="$2"; shift ;;
+    --auth-secret-name) AUTH_SECRET="$2"; shift ;;
     --extra-args)  EXTRA="$2"; shift ;;
     -e)            ENVS+=("$2"); shift ;;
     *) echo "unknown arg: $1" >&2; usage ;;
@@ -86,6 +87,7 @@ done
 # anything a setting can hold — RAMP_STAGES carries double quotes, which a plain YAML scalar here
 # could not survive.
 [[ -n "$PARALLELISM" ]] && PARAMS+=("parallelism=$PARALLELISM")
+[[ -n "$AUTH_SECRET" ]] && add_param authSecretName "$AUTH_SECRET"
 [[ -n "$EXTRA" ]] && PARAMS+=("arguments=$EXTRA")
 
 # The parameter lines first, so a run that overrides nothing omits `arguments:` altogether rather

--- a/TrafficCapture/trafficLoadTest/scripts/lib/common.sh
+++ b/TrafficCapture/trafficLoadTest/scripts/lib/common.sh
@@ -82,22 +82,17 @@ header() { echo -e "\n${BOLD}$1${NC}"; }
 
 # ── k6 runs (console-independent, via k6-run.sh + kubectl) ─────────────────────
 # The scripts call these with console-style flags, passed straight through to k6-run.sh. Supported:
-#   --scenario X  --config NAME  --parallelism N  --registry-enabled  --extra-args STR  -e KEY=VAL
+#   --scenario X  --config NAME  --parallelism N  --auth-secret-name NAME
+#   --registry-enabled  --extra-args STR  -e KEY=VAL
 submit_k6() {
   # Submit a k6 run WITHOUT waiting; echo the generated run name.
-  local scenario="" config="" parallelism="" extra=""; local -a extra_env=()
-  # The proxy forwards to the source without adding credentials, so runs submitted from here carry
-  # the same ones the probes use. Harmless against a cluster with security disabled — it simply
-  # ignores the header — so this needs no auth/no-auth switch. A caller passing its own
-  # -e AUTH_USERNAME still wins, since later -e entries override earlier ones.
-  if [[ -n "$CLUSTER_USERNAME" ]]; then
-    extra_env+=(-e "AUTH_USERNAME=$CLUSTER_USERNAME" -e "AUTH_PASSWORD=$CLUSTER_PASSWORD")
-  fi
+  local scenario="" config="" parallelism="" auth_secret="" extra=""; local -a extra_env=()
   while [[ $# -gt 0 ]]; do
     case "$1" in
       --scenario) scenario="$2"; shift ;;
       --config) config="$2"; shift ;;
       --parallelism) parallelism="$2"; shift ;;
+      --auth-secret-name) auth_secret="$2"; shift ;;
       --registry-enabled) extra_env+=(-e REGISTRY_ENABLED=true) ;;
       --extra-args) extra="$2"; shift ;;
       -e) extra_env+=(-e "$2"); shift ;;
@@ -105,9 +100,16 @@ submit_k6() {
     esac
     shift
   done
+  # The proxy forwards to the source without adding credentials, so runs submitted without an auth
+  # Secret carry the same Basic credentials the probes use. A caller passing its own
+  # -e AUTH_USERNAME still wins, since later -e entries override earlier ones.
+  if [[ -z "$auth_secret" && -n "$CLUSTER_USERNAME" ]]; then
+    extra_env=(-e "AUTH_USERNAME=$CLUSTER_USERNAME" -e "AUTH_PASSWORD=$CLUSTER_PASSWORD" "${extra_env[@]}")
+  fi
   local -a args=("$scenario" --target "$PROXY_URL")
   [[ -n "$config" ]] && args+=(--config "$config")
   [[ -n "$parallelism" ]] && args+=(--parallelism "$parallelism")
+  [[ -n "$auth_secret" ]] && args+=(--auth-secret-name "$auth_secret")
   [[ -n "$extra" ]] && args+=(--extra-args "$extra")
   [[ ${#extra_env[@]} -gt 0 ]] && args+=("${extra_env[@]}")
   CONTEXT="$CONTEXT" NAMESPACE="$NAMESPACE" bash "$K6_RUN" "${args[@]}"

--- a/deployment/k8s/charts/components/k6LoadTest/templates/k6-workflowtemplates.yaml
+++ b/deployment/k8s/charts/components/k6LoadTest/templates/k6-workflowtemplates.yaml
@@ -104,6 +104,8 @@ spec:
         value: {{ $.Values.testRun.useSeparatePodPerTestInstance | quote }}
       - name: arguments
         value: ""
+      - name: authSecretName
+        value: {{ $.Values.authSecretName | quote }}
       - name: runnerImage
         value: {{ $image | quote }}
       - name: starterImage
@@ -168,6 +170,10 @@ spec:
             runner:
               image: "{{`{{workflow.parameters.runnerImage}}`}}"
               imagePullPolicy: {{ $.Values.image.pullPolicy }}
+              envFrom:
+                - secretRef:
+                    name: "{{`{{workflow.parameters.authSecretName}}`}}"
+                    optional: true
               # One entry per parameter, in the same three groups as the parameter list above, so
               # the container env is a fixed list with no name stated twice — which of two
               # same-named entries wins is not something a load test should depend on. A unit test

--- a/deployment/k8s/charts/components/k6LoadTest/values.yaml
+++ b/deployment/k8s/charts/components/k6LoadTest/values.yaml
@@ -31,7 +31,7 @@ image:
 #
 # It is NOT a released artifact (load testing is a dev/test capability, so it is not published
 # publicly, not mirrored by aws-bootstrap.sh, and not built by :buildImages:buildImagesToRegistry)
-# — build and push it yourself (~25 KB) with
+# — build and push it yourself (~100 KB) with
 #   ./gradlew :buildImages:buildKitLoadTestAll -PregistryEndpoint=<registry>
 # then point this at wherever it landed:
 #   local minikube:  --set scriptsImage.repository=localhost:5001/migrations/k6_scripts
@@ -96,6 +96,12 @@ testRun:
 # default of the CAPTURE_PROXY_URL parameter on every rendered WorkflowTemplate.
 captureProxyUrl: https://capture-proxy:9201
 
+# Optional Secret imported into every runner with envFrom. The default deliberately names a
+# normally-absent Secret and is optional in the pod spec, so unauthenticated runs are unchanged.
+# A caller with credentials creates a per-run Secret and overrides authSecretName; keeping secret
+# values out of Workflow parameters prevents them from being exposed in Argo/TestRun objects.
+authSecretName: k6-load-test-auth
+
 # ---------------------------------------------------------------------------
 # Scenario knobs and load profiles.
 # ---------------------------------------------------------------------------
@@ -145,9 +151,10 @@ scenarios:
       CONTROL_ENABLED: "false"           # chaos control bus (needs registry.enabled=true)
       CONTROL_CMD_KEY: control_cmd
       WEBDIS_URL: http://webdis:7379     # read by the control bus only
-      AUTH_MODE: ""                      # blank = basic when AUTH_USERNAME is set, else none
+      AUTH_MODE: ""                      # blank = infer Basic/SigV4 credentials, else none
       AUTH_USERNAME: ""                  # per-run input — never give these a value here
       AUTH_PASSWORD: ""
+      LATENCY_THRESHOLDS_ENABLED: "true" # false keeps request-error thresholds only
   search:
     env:
       SCHEMA: nyc_taxis

--- a/migrationConsole/lib/console_link/console_link/loadtest/cli.py
+++ b/migrationConsole/lib/console_link/console_link/loadtest/cli.py
@@ -170,6 +170,8 @@ def loadtest_cli(ctx, verbose, namespace, refresh_interval):
 @click.option('--override', '-e', 'overrides', multiple=True, metavar='KEY=VALUE',
               help="Override any other setting of the profile by name (matches k6-run.sh's -e). "
                    "Repeatable. A name the profile does not have is an error, not a no-op.")
+@click.option('--auth-secret-name', default=None,
+              help="Kubernetes Secret imported into runner environment variables.")
 @click.option('--extra-args', default=None, help="Extra flags for `k6 run` (e.g. --no-thresholds).")
 @click.option('--namespace', **_NAMESPACE_OPTION)
 @click.option('--wait', is_flag=True, default=False, help="Wait for the run to complete.")

--- a/migrationConsole/lib/console_link/console_link/loadtest/runs.py
+++ b/migrationConsole/lib/console_link/console_link/loadtest/runs.py
@@ -237,7 +237,7 @@ def _override_env(params, declared, profile):
 
 def build_k6_parameters(scenario=None, config_name=None, parallelism=1, target_url=None, rate=None,
                         duration=None, vus=None, registry_enabled=None, control_enabled=None,
-                        webdis_url=None, overrides_text=None, extra_args=None):
+                        webdis_url=None, auth_secret_name=None, overrides_text=None, extra_args=None):
     """Normalize run inputs into a params dict (shared by the CLI and the TUI).
 
     A run needs a profile. Naming a scenario alone means its steady profile; naming a profile alone
@@ -264,6 +264,7 @@ def build_k6_parameters(scenario=None, config_name=None, parallelism=1, target_u
         "registryEnabled": registry_enabled,
         "controlEnabled": control_enabled,
         "webdisUrl": webdis_url,
+        "authSecretName": auth_secret_name,
         "overrides": overrides_text,
         "extraArgs": extra_args,
     }
@@ -292,6 +293,8 @@ def build_workflow_submission(namespace, params):
 
     parameters = [{"name": k, "value": str(v)} for k, v in sorted(overrides.items())]
     parameters.append({"name": "parallelism", "value": str(int(params.get("parallelism", 1)))})
+    if params.get("authSecretName"):
+        parameters.append({"name": "authSecretName", "value": params["authSecretName"]})
     if params.get("extraArgs"):
         parameters.append({"name": "arguments", "value": params["extraArgs"]})
 

--- a/migrationConsole/lib/console_link/tests/loadtest-tests/test_loadtest_cli.py
+++ b/migrationConsole/lib/console_link/tests/loadtest-tests/test_loadtest_cli.py
@@ -66,6 +66,7 @@ def _template(profile, scenario=None, env=None):
                 {"name": "parallelism", "value": "1"},
                 {"name": "separate", "value": "false"},
                 {"name": "arguments", "value": ""},
+                {"name": "authSecretName", "value": "k6-load-test-auth"},
                 {"name": "runnerImage", "value": "grafana/k6:2.2.0"},
                 {"name": "scriptsRef", "value": "migrations/k6_scripts:latest"},
             ] + [{"name": k, "value": v} for k, v in sorted(env.items())]},
@@ -367,6 +368,14 @@ class TestLoadTestRun:
         _runner().invoke(loadtest_cli, [
             "run", "--config", "mixed-steady", "--no-registry-enabled"], env=ENV)
         assert _env_map(mock_create.call_args.args[1])["REGISTRY_ENABLED"] == "false"
+
+    @patch(f"{RUNS}.create_workflow", return_value="k6-ingest-xy")
+    def test_auth_secret_name_is_forwarded_without_secret_values(self, mock_create, cluster):
+        _runner().invoke(loadtest_cli, [
+            "run", "--auth-secret-name", "k6-source-auth"], env=ENV)
+        params = _submitted_parameters(mock_create.call_args.args[1])
+        assert params["authSecretName"] == "k6-source-auth"
+        assert not any(key.startswith("AWS_") or "PASSWORD" in key for key in params)
 
     @patch(f"{RUNS}.create_workflow", return_value="k6-ingest-xy")
     def test_extra_args_set_arguments(self, mock_create, cluster):
@@ -1220,6 +1229,19 @@ class TestRenderedChartMatchesTheValues:
                         for p in template["spec"]["arguments"]["parameters"]}
             actual = {k: v for k, v in defaults.items() if runs_mod.ENV_PARAM.fullmatch(k)}
             assert actual == expected, f"{name}: rendered settings differ from values.yaml"
+
+    def test_auth_secret_is_imported_without_exposing_its_values(self):
+        for name, template in sorted(self._rendered().items()):
+            defaults = {p["name"]: p.get("value", "")
+                        for p in template["spec"]["arguments"]["parameters"]}
+            manifest = template["spec"]["templates"][0]["resource"]["manifest"]
+            substituted = re.sub(r"\{\{workflow\.parameters\.([A-Za-z0-9_-]+)\}\}",
+                                 lambda m: defaults[m.group(1)], manifest)
+            substituted = substituted.replace("{{workflow.name}}", "a-run")
+            runner = yaml.safe_load(substituted)["spec"]["runner"]
+            assert runner["envFrom"] == [{
+                "secretRef": {"name": "k6-load-test-auth", "optional": True}
+            }], name
 
     def test_a_ramping_profile_renders_no_duration(self):
         """The specific regression: the stage list carries the timing, so DURATION must not exist —

--- a/migrationConsole/lib/integ_test/integ_test/test_cases/k6_load_test_tests.py
+++ b/migrationConsole/lib/integ_test/integ_test/test_cases/k6_load_test_tests.py
@@ -14,6 +14,12 @@ is selected; the case is explicit-selection only so it never runs in a normal mi
 import logging
 import uuid
 
+import boto3
+from kubernetes import client
+from kubernetes.client.rest import ApiException
+
+from console_link.models.cluster import AuthMethod
+
 from .cdc_base import (
     MATestBase, MigrationType, MATestUserArguments,
     CDC_SOURCE_TARGET_COMBINATIONS, PROXY_ENDPOINT,
@@ -24,6 +30,60 @@ logger = logging.getLogger(__name__)
 
 # The k6 ingest scenario writes the nyc_taxis schema to this index by default.
 K6_INDEX = "nyc_taxis"
+
+
+def _k6_auth_secret_data(source_cluster, session=None):
+    """Build runner-only environment from the source cluster's configured authentication."""
+    if source_cluster.auth_type == AuthMethod.NO_AUTH:
+        return {}
+    if source_cluster.auth_type == AuthMethod.BASIC_AUTH:
+        auth = source_cluster.get_basic_auth_details()
+        return {
+            "K6_AUTH_MODE": "basic",
+            "K6_AUTH_USERNAME": auth.username,
+            "K6_AUTH_PASSWORD": auth.password,
+        }
+    if source_cluster.auth_type != AuthMethod.SIGV4:
+        raise ValueError(f"Unsupported source authentication: {source_cluster.auth_type}")
+
+    session = session or boto3.Session()
+    credentials = session.get_credentials()
+    if credentials is None:
+        raise RuntimeError("SigV4 source requires AWS credentials for the k6 runner")
+    frozen = credentials.get_frozen_credentials()
+    details = source_cluster.auth_details or {}
+    region = details.get("region") or session.region_name
+    if not region:
+        raise RuntimeError("SigV4 source requires an AWS region for the k6 runner")
+
+    data = {
+        "K6_AUTH_MODE": "sigv4",
+        "AWS_ACCESS_KEY_ID": frozen.access_key,
+        "AWS_SECRET_ACCESS_KEY": frozen.secret_key,
+        "AWS_REGION": region,
+        "SIGV4_SERVICE": details.get("service", "es"),
+        "SIGV4_SIGNING_ENDPOINT": source_cluster.endpoint,
+    }
+    if frozen.token:
+        data["AWS_SESSION_TOKEN"] = frozen.token
+    return data
+
+
+def _create_k6_auth_secret(namespace, name, data):
+    secret = client.V1Secret(
+        metadata=client.V1ObjectMeta(name=name, labels={"migration-test": "true"}),
+        string_data=data,
+        type="Opaque",
+    )
+    client.CoreV1Api().create_namespaced_secret(namespace=namespace, body=secret)
+
+
+def _delete_k6_auth_secret(namespace, name):
+    try:
+        client.CoreV1Api().delete_namespaced_secret(name=name, namespace=namespace)
+    except ApiException as e:
+        if e.status != 404:
+            raise
 
 
 class Test0080CdcK6LoadTest(MATestBase):
@@ -62,25 +122,44 @@ class Test0080CdcK6LoadTest(MATestBase):
         pass
 
     def _run_k6(self, namespace, target_url):
-        """Fire a short k6 ingest run at the proxy and wait for the workflow to finish."""
+        """Fire a short authenticated k6 ingest run and verify k6's own verdict."""
         # Imported inside the method so the case only depends on the k6 module when actually run.
+        from console_link.loadtest.health import HealthWatcher, format_health
         from console_link.loadtest.utils import load_k8s_config
         from console_link.loadtest.runs import (
             build_k6_parameters, submit_k6_run, wait_for_run, SUCCESS_PHASE,
         )
         load_k8s_config()
-        params = build_k6_parameters(
-            scenario="ingest", parallelism=self.K6_PARALLELISM, target_url=target_url,
-            duration=self.K6_DURATION, rate=self.K6_RATE,
-            extra_args="--no-thresholds",        # loaded test cluster may breach latency thresholds
-        )
-        name = submit_k6_run(namespace, params)
-        logger.info("Submitted k6 run %s against %s", name, target_url)
-        phase = wait_for_run(namespace, name, timeout=300, interval=5)
-        if phase != SUCCESS_PHASE:
-            raise AssertionError(f"k6 run {name} ended in phase '{phase}' "
-                                 f"(expected '{SUCCESS_PHASE}')")
-        logger.info("k6 run %s finished", name)
+        secret_name = f"k6-auth-{uuid.uuid4().hex[:12]}"
+        secret_data = _k6_auth_secret_data(self.source_cluster)
+        if secret_data:
+            _create_k6_auth_secret(namespace, secret_name, secret_data)
+
+        try:
+            params = build_k6_parameters(
+                scenario="ingest", parallelism=self.K6_PARALLELISM, target_url=target_url,
+                duration=self.K6_DURATION, rate=self.K6_RATE,
+                auth_secret_name=secret_name if secret_data else None,
+                # Keep request-error thresholds active while avoiding latency flakes on loaded CI.
+                overrides_text="LATENCY_THRESHOLDS_ENABLED=false",
+            )
+            name = submit_k6_run(namespace, params)
+            logger.info("Submitted k6 run %s against %s", name, target_url)
+            watcher = HealthWatcher(namespace, name)
+            phase = wait_for_run(
+                namespace, name, timeout=300, interval=5,
+                on_poll=lambda elapsed, _: logger.info("k6 %s", format_health(watcher.poll(elapsed))),
+            )
+            if phase != SUCCESS_PHASE:
+                raise AssertionError(f"k6 run {name} ended in phase '{phase}' "
+                                     f"(expected '{SUCCESS_PHASE}')")
+            verdict = watcher.verdict()
+            if verdict["failed_runners"] or verdict["thresholds_crossed"]:
+                raise AssertionError(f"k6 run {name} failed its request checks: {verdict}")
+            logger.info("k6 run %s finished with verdict %s", name, verdict)
+        finally:
+            if secret_data:
+                _delete_k6_auth_secret(namespace, secret_name)
 
     def workflow_perform_migrations(self, timeout_seconds: int = 3600):
         if not self.workflow_name:

--- a/migrationConsole/lib/integ_test/tests/test_k6_load_test.py
+++ b/migrationConsole/lib/integ_test/tests/test_k6_load_test.py
@@ -1,0 +1,103 @@
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+from kubernetes.client.rest import ApiException
+
+from console_link.models.cluster import Cluster
+from integ_test.test_cases import k6_load_test_tests as k6_test
+
+
+class _Session:
+    region_name = "us-west-2"
+
+    def __init__(self, credentials):
+        self._credentials = credentials
+
+    def get_credentials(self):
+        return self._credentials
+
+
+def _credentials(token="session-token"):
+    frozen = SimpleNamespace(access_key="A" * 20, secret_key="secret", token=token)
+    return SimpleNamespace(get_frozen_credentials=lambda: frozen)
+
+
+def test_k6_auth_secret_data_supports_basic_auth():
+    cluster = Cluster({
+        "endpoint": "https://source:9200",
+        "basic_auth": {"username": "admin", "password": "password"},
+    })
+
+    assert k6_test._k6_auth_secret_data(cluster) == {
+        "K6_AUTH_MODE": "basic",
+        "K6_AUTH_USERNAME": "admin",
+        "K6_AUTH_PASSWORD": "password",
+    }
+
+
+def test_k6_auth_secret_data_supports_sigv4_through_proxy():
+    cluster = Cluster({
+        "endpoint": "https://search-source.us-east-1.es.amazonaws.com",
+        "sigv4": {"region": "us-east-1", "service": "es"},
+    })
+
+    data = k6_test._k6_auth_secret_data(cluster, session=_Session(_credentials()))
+
+    assert data == {
+        "K6_AUTH_MODE": "sigv4",
+        "AWS_ACCESS_KEY_ID": "A" * 20,
+        "AWS_SECRET_ACCESS_KEY": "secret",
+        "AWS_SESSION_TOKEN": "session-token",
+        "AWS_REGION": "us-east-1",
+        "SIGV4_SERVICE": "es",
+        "SIGV4_SIGNING_ENDPOINT": cluster.endpoint,
+    }
+
+
+def test_k6_auth_secret_data_uses_session_region_and_omits_empty_token():
+    cluster = Cluster({"endpoint": "https://source", "sigv4": None})
+
+    data = k6_test._k6_auth_secret_data(
+        cluster, session=_Session(_credentials(token=None)))
+
+    assert data["AWS_REGION"] == "us-west-2"
+    assert data["SIGV4_SERVICE"] == "es"
+    assert "AWS_SESSION_TOKEN" not in data
+
+
+def test_k6_auth_secret_data_requires_aws_credentials():
+    cluster = Cluster({
+        "endpoint": "https://source",
+        "sigv4": {"region": "us-east-1"},
+    })
+
+    with pytest.raises(RuntimeError, match="requires AWS credentials"):
+        k6_test._k6_auth_secret_data(cluster, session=_Session(None))
+
+
+def test_k6_auth_secret_data_allows_no_auth():
+    cluster = Cluster({"endpoint": "http://source:9200", "no_auth": None})
+
+    assert k6_test._k6_auth_secret_data(cluster) == {}
+
+
+def test_create_k6_auth_secret_marks_it_for_test_cleanup(monkeypatch):
+    core = Mock()
+    monkeypatch.setattr(k6_test.client, "CoreV1Api", lambda: core)
+
+    k6_test._create_k6_auth_secret("ma", "k6-auth-123", {"K6_AUTH_MODE": "basic"})
+
+    secret = core.create_namespaced_secret.call_args.kwargs["body"]
+    assert core.create_namespaced_secret.call_args.kwargs["namespace"] == "ma"
+    assert secret.metadata.name == "k6-auth-123"
+    assert secret.metadata.labels == {"migration-test": "true"}
+    assert secret.string_data == {"K6_AUTH_MODE": "basic"}
+
+
+def test_delete_k6_auth_secret_ignores_not_found(monkeypatch):
+    core = Mock()
+    core.delete_namespaced_secret.side_effect = ApiException(status=404)
+    monkeypatch.setattr(k6_test.client, "CoreV1Api", lambda: core)
+
+    k6_test._delete_k6_auth_secret("ma", "gone")


### PR DESCRIPTION
## Description

- support unauthenticated, HTTP Basic, and AWS SigV4 source clusters in k6 scenarios
- pass credentials to runner pods through a per-run Kubernetes Secret instead of Argo parameters
- sign the real source endpoint while sending traffic through the capture proxy
- make the CDC k6 integration test derive source auth, retain request-error thresholds, and report live runner health
- implement SigV4 in a small repository-owned module using stock k6 cryptographic primitives; no third-party source is vendored

This is independent of the load-test examples directory refactoring and is based directly on main. Replayer target authentication remains a separate follow-up.

## Testing

- 105 load-test CLI/chart tests passed
- 160 integration-test unit tests passed
- 1,201 console-link tests passed; the one unrun workflow integration test intentionally refused the active EKS kube context because it requires kind-console-link-test
- Gradle spotlessCheck passed
- shell syntax and git diff checks passed
- built the k6 scripts image successfully
- verified a fixed SigV4 vector and a live proxy transport request byte-for-byte against botocore using stock grafana/k6:2.2.0
- confirmed the transport connects to the proxy while carrying the signed source Host header