### PR TITLE
Fix EKS bootstrap image and storage handling

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,9 +58,11 @@ allprojects {
 
 def commonExclusions = ['.gradle/**',
                         '**/build/**',
+                        '**/TrafficCapture/SolrTransformations/transforms/dist/**',
                         '**/node_modules/**',
                         '**/opensearch-cluster-cdk/**',
                         '**/cdk.out/**',
+                        '**/cdk.out-minified/**',
                         '**/transformation/standardJavascriptTransforms/node_modules/**']
 spotless {
     format 'misc', {

--- a/buildImages/backends/eksKubernetesBuildkit.sh
+++ b/buildImages/backends/eksKubernetesBuildkit.sh
@@ -96,6 +96,26 @@ run_with_optional_timeout() {
   fi
 }
 
+duration_to_seconds() {
+  local value="$1"
+  if [[ "${value}" =~ ^([0-9]+)$ ]]; then
+    echo "${BASH_REMATCH[1]}"
+    return 0
+  fi
+  if [[ "${value}" =~ ^([0-9]+)([smh])$ ]]; then
+    local amount="${BASH_REMATCH[1]}"
+    local unit="${BASH_REMATCH[2]}"
+    case "${unit}" in
+      s) echo "${amount}" ;;
+      m) echo $((amount * 60)) ;;
+      h) echo $((amount * 3600)) ;;
+    esac
+    return 0
+  fi
+  echo "ERROR: Unsupported duration '${value}'. Use seconds, or an s/m/h suffix such as 900s, 15m, or 1h." >&2
+  return 1
+}
+
 ensure_eks_buildx_builder() {
   local context builder_name namespace
   set_k8s_context_args
@@ -146,22 +166,43 @@ ensure_eks_buildx_builder() {
   # bootstrap. Give that bootstrap enough time for the build-nodepool cold-start
   # path; a kubectl pre-wait cannot help before buildx has created anything.
   local build_timeout="${BUILDKIT_BOOTSTRAP_TIMEOUT:-900s}"
-  local attempts="${BUILDKIT_BOOTSTRAP_ATTEMPTS:-2}"
+  local timeout_seconds
+  timeout_seconds="$(duration_to_seconds "${build_timeout}")"
+  local deadline=$(( $(date +%s) + timeout_seconds ))
+  local max_attempts="${BUILDKIT_BOOTSTRAP_ATTEMPTS:-0}"
+  if [[ ! "${max_attempts}" =~ ^[0-9]+$ ]]; then
+    echo "ERROR: BUILDKIT_BOOTSTRAP_ATTEMPTS must be a non-negative integer." >&2
+    return 1
+  fi
   local attempt=1
   while true; do
-    echo "Bootstrapping buildx builder with timeout ${build_timeout} (attempt ${attempt}/${attempts})..."
-    if run_with_optional_timeout "${build_timeout}" docker buildx inspect --bootstrap; then
+    local now remaining attempt_label
+    now="$(date +%s)"
+    remaining=$((deadline - now))
+    if [[ "${remaining}" -le 0 ]]; then
+      echo "ERROR: buildx bootstrap did not complete within ${build_timeout}; dumping buildkit namespace state" >&2
+      kubectl ${CONTEXT_ARGS[@]+"${CONTEXT_ARGS[@]}"} \
+        get all -n "${namespace}" >&2 || true
+      kubectl ${CONTEXT_ARGS[@]+"${CONTEXT_ARGS[@]}"} \
+        describe pods -n "${namespace}" >&2 || true
+      return 1
+    fi
+
+    if [[ "${max_attempts}" -gt 0 ]]; then
+      attempt_label="attempt ${attempt}/${max_attempts}"
+    else
+      attempt_label="attempt ${attempt}"
+    fi
+    echo "Bootstrapping buildx builder (${attempt_label}, ${remaining}s remaining of ${build_timeout})..."
+    if run_with_optional_timeout "${remaining}s" docker buildx inspect --bootstrap; then
       break
     fi
-    echo "buildx bootstrap failed on attempt ${attempt}/${attempts}" >&2
-    echo "Dumping buildkit namespace state for diagnosis" >&2
+    echo "buildx bootstrap failed on ${attempt_label}; current buildkit namespace state:" >&2
     kubectl ${CONTEXT_ARGS[@]+"${CONTEXT_ARGS[@]}"} \
       get deployments,replicasets,pods -n "${namespace}" -o wide >&2 || true
-    kubectl ${CONTEXT_ARGS[@]+"${CONTEXT_ARGS[@]}"} \
-      describe pods -n "${namespace}" >&2 || true
-    dump_node_provisioning_state
-    if [[ "${attempt}" -ge "${attempts}" ]]; then
-      echo "ERROR: buildx bootstrap exhausted ${attempts} attempt(s); dumping buildkit namespace state" >&2
+
+    if [[ "${max_attempts}" -gt 0 && "${attempt}" -ge "${max_attempts}" ]]; then
+      echo "ERROR: buildx bootstrap exhausted ${max_attempts} attempt(s) before ${build_timeout}; dumping buildkit namespace state" >&2
       kubectl ${CONTEXT_ARGS[@]+"${CONTEXT_ARGS[@]}"} \
         get all -n "${namespace}" >&2 || true
       kubectl ${CONTEXT_ARGS[@]+"${CONTEXT_ARGS[@]}"} \
@@ -170,7 +211,16 @@ ensure_eks_buildx_builder() {
       return 1
     fi
     attempt=$((attempt + 1))
-    sleep 10
+    now="$(date +%s)"
+    remaining=$((deadline - now))
+    if [[ "${remaining}" -le 0 ]]; then
+      continue
+    fi
+    if [[ "${remaining}" -lt 10 ]]; then
+      sleep "${remaining}"
+    else
+      sleep 10
+    fi
   done
 }
 

--- a/buildImages/backends/eksKubernetesBuildkit.sh
+++ b/buildImages/backends/eksKubernetesBuildkit.sh
@@ -82,6 +82,20 @@ ensure_eks_buildkit_release() {
     ${BUILDKIT_HELM_ARGS:-}
 }
 
+run_with_optional_timeout() {
+  local timeout_value="$1"
+  shift
+
+  if command -v gtimeout >/dev/null 2>&1; then
+    gtimeout "${timeout_value}" "$@"
+  elif command -v timeout >/dev/null 2>&1; then
+    timeout "${timeout_value}" "$@"
+  else
+    echo "No timeout command found; running without an external ${timeout_value} timeout." >&2
+    "$@"
+  fi
+}
+
 ensure_eks_buildx_builder() {
   local context builder_name namespace
   set_k8s_context_args
@@ -136,7 +150,7 @@ ensure_eks_buildx_builder() {
   local attempt=1
   while true; do
     echo "Bootstrapping buildx builder with timeout ${build_timeout} (attempt ${attempt}/${attempts})..."
-    if docker buildx inspect --bootstrap --timeout="${build_timeout}"; then
+    if run_with_optional_timeout "${build_timeout}" docker buildx inspect --bootstrap; then
       break
     fi
     echo "buildx bootstrap failed on attempt ${attempt}/${attempts}" >&2

--- a/buildImages/backends/eksKubernetesBuildkit.sh
+++ b/buildImages/backends/eksKubernetesBuildkit.sh
@@ -128,37 +128,24 @@ ensure_eks_buildx_builder() {
   echo "BUILDX_BUILDER=${builder_name}"
   echo "Bootstrapping builder..."
 
-  # docker buildx inspect --bootstrap uses a hardcoded 110s timeout when it
-  # waits for the builder Deployments to become Ready. On EKS, the very first
-  # time the build-nodepool scales up, Karpenter cold-start routinely blows
-  # past 110s (node provisioning + image pull + container start), so the
-  # bootstrap fails with `expected 1 replicas to be ready, got 0` and the
-  # whole pipeline dies before any test runs.
-  #
-  # Do a longer kubectl-level pre-wait on every buildkit Deployment in the
-  # namespace first, then call buildx. The kubectl wait gives Karpenter the
-  # time it realistically needs; once pods are Available, buildx's internal
-  # 110s window is plenty. We still retry the bootstrap once in case a pod
-  # flaps between kubectl-wait and buildx-inspect.
+  # The kubernetes driver creates its builder Deployments as part of buildx
+  # bootstrap. Give that bootstrap enough time for the build-nodepool cold-start
+  # path; a kubectl pre-wait cannot help before buildx has created anything.
   local build_timeout="${BUILDKIT_BOOTSTRAP_TIMEOUT:-900s}"
   local attempts="${BUILDKIT_BOOTSTRAP_ATTEMPTS:-2}"
   local attempt=1
   while true; do
-    echo "Pre-waiting up to ${build_timeout} for buildkit Deployments in '${namespace}' (attempt ${attempt}/${attempts})..."
-    kubectl ${CONTEXT_ARGS[@]+"${CONTEXT_ARGS[@]}"} \
-      wait --for=condition=Available deployment --all -n "${namespace}" \
-      --timeout="${build_timeout}" || {
-        echo "Deployments not yet Available after kubectl wait; dumping state for diagnosis" >&2
-        kubectl ${CONTEXT_ARGS[@]+"${CONTEXT_ARGS[@]}"} \
-          get deployments,replicasets,pods -n "${namespace}" -o wide >&2 || true
-        kubectl ${CONTEXT_ARGS[@]+"${CONTEXT_ARGS[@]}"} \
-          describe pods -n "${namespace}" >&2 || true
-        dump_node_provisioning_state
-      }
-    if docker buildx inspect --bootstrap; then
+    echo "Bootstrapping buildx builder with timeout ${build_timeout} (attempt ${attempt}/${attempts})..."
+    if docker buildx inspect --bootstrap --timeout="${build_timeout}"; then
       break
     fi
     echo "buildx bootstrap failed on attempt ${attempt}/${attempts}" >&2
+    echo "Dumping buildkit namespace state for diagnosis" >&2
+    kubectl ${CONTEXT_ARGS[@]+"${CONTEXT_ARGS[@]}"} \
+      get deployments,replicasets,pods -n "${namespace}" -o wide >&2 || true
+    kubectl ${CONTEXT_ARGS[@]+"${CONTEXT_ARGS[@]}"} \
+      describe pods -n "${namespace}" >&2 || true
+    dump_node_provisioning_state
     if [[ "${attempt}" -ge "${attempts}" ]]; then
       echo "ERROR: buildx bootstrap exhausted ${attempts} attempt(s); dumping buildkit namespace state" >&2
       kubectl ${CONTEXT_ARGS[@]+"${CONTEXT_ARGS[@]}"} \

--- a/deployment/k8s/aws/aws-bootstrap.sh
+++ b/deployment/k8s/aws/aws-bootstrap.sh
@@ -1781,10 +1781,14 @@ if [[ "$build" == "true" && -z "$ma_images_source" ]]; then
     # EKS/bootstrap builds are always Kubernetes-hosted; they cannot assume
     # direct access to a local Docker daemon from the target environment.
     source "${base_dir}/buildImages/backends/eksKubernetesBuildkit.sh"
-    # Use the ECR-mirrored buildkit image so the kubernetes driver doesn't pull
-    # from Docker Hub. mirror_images_to_ecr already copied this image above.
-    ECR_HOST="${MIGRATIONS_ECR_REGISTRY%%/*}"
-    export BUILDKIT_IMAGE="${ECR_HOST}/mirrored/docker.io/moby/buildkit:buildx-stable-1"
+    if [[ "$push_images_to_ecr" == "true" ]]; then
+      # Use the ECR-mirrored buildkit image so the kubernetes driver doesn't pull
+      # from Docker Hub. mirror_images_to_ecr already copied this image above.
+      ECR_HOST="${MIGRATIONS_ECR_REGISTRY%%/*}"
+      export BUILDKIT_IMAGE="${ECR_HOST}/mirrored/docker.io/moby/buildkit:buildx-stable-1"
+    else
+      unset BUILDKIT_IMAGE
+    fi
     # buildkit gets its own NodePool; point it at the same NodeClass as everything else so its
     # (large, short-lived) build instances are tagged too, and so it doesn't reference the
     # built-in "default" NodeClass after --tags has disabled the built-in NodePools.

--- a/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/templates/resources/aws/gp3StorageClass.yaml
+++ b/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/templates/resources/aws/gp3StorageClass.yaml
@@ -1,9 +1,14 @@
 {{- if eq (default false .Values.aws.configureAwsEksResources) true }}
+{{- $storageClass := lookup "storage.k8s.io/v1" "StorageClass" "" "auto-ebs-sc" -}}
+{{- if not $storageClass }}
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: auto-ebs-sc
   annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-3"
+    "helm.sh/resource-policy": keep
     storageclass.kubernetes.io/is-default-class: "true"
 provisioner: ebs.csi.eks.amazonaws.com
 volumeBindingMode: WaitForFirstConsumer
@@ -24,4 +29,5 @@ parameters:
 {{- end }}
 reclaimPolicy: Delete
 allowVolumeExpansion: false
+{{- end }}
 {{- end }}

--- a/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/valuesEks.yaml
+++ b/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/valuesEks.yaml
@@ -151,7 +151,7 @@ metrics:
 
 logs:
   sharedLogsVolume:
-    storageClass: auto-ebs-sc
+    enabled: false
 
 charts:
   kube-prometheus-stack:

--- a/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/valuesEks.yaml
+++ b/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/valuesEks.yaml
@@ -158,12 +158,6 @@ charts:
     values:
       grafana:
         enabled: false
-      prometheus:
-        prometheusSpec:
-          storageSpec:
-            volumeClaimTemplate:
-              spec:
-                storageClassName: auto-ebs-sc
 
   argo-workflows:
     values:

--- a/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/valuesEks.yaml
+++ b/deployment/k8s/charts/aggregates/migrationAssistantWithArgo/valuesEks.yaml
@@ -149,11 +149,21 @@ metrics:
           processors: [batch]
           exporters: [awsemf/cadvisor, prometheus]
 
+logs:
+  sharedLogsVolume:
+    storageClass: auto-ebs-sc
+
 charts:
   kube-prometheus-stack:
     values:
       grafana:
         enabled: false
+      prometheus:
+        prometheusSpec:
+          storageSpec:
+            volumeClaimTemplate:
+              spec:
+                storageClassName: auto-ebs-sc
 
   argo-workflows:
     values:


### PR DESCRIPTION
## Summary
- fix EKS `aws-bootstrap.sh` so `--build --use-public-images` builds from source while using the public BuildKit image instead of requiring a mirrored BuildKit image in the stack ECR
- make BuildKit bootstrap retries portable across macOS, WSL, and Linux by using `gtimeout`/`timeout` when available and otherwise relying on the total bootstrap deadline
- keep retrying BuildKit bootstrap until the configured total timeout expires, with diagnostics emitted after failed attempts
- disable the shared logs PVC for EKS installs so the chart does not create `logs-pvc` in EKS deployments
- keep the EKS Auto Mode `auto-ebs-sc` StorageClass as the default block storage class without forcing Prometheus to explicitly use it
- exclude generated output directories from repo-root Spotless scans so Gradle 8.14 validation passes on macOS CI

## Verification
- Installed MA into account `876908012510` / `us-east-2` with stack `MA-DEMO`
- Verified Helm releases in namespace `ma` are deployed
- Verified `migration-console-0` and `prometheus-kube-prometheus-stack-prometheus-0` are Running
- Ran local `./gradlew build --no-daemon --stacktrace` on macOS
- Ran `./gradlew spotlessMisc spotlessYaml --no-daemon --stacktrace`
- Ran `git diff --check -- build.gradle`
- Rendered the `migrationAssistantWithArgo` chart with EKS values
- CI rerun for #3354: `all-ci-checks-pass` is green, `gradle-build-macos` is green, and Jenkins is green except for the persistent `eks-cdc-k6-load-test` failure
