### PR TITLE
Don't reverse-derive source fields from copy_to fan-in targets

### DIFF
--- a/DocumentsFromSnapshotMigration/src/test/java/org/opensearch/migrations/bulkload/NoStoredSourceMigrationTest.java
+++ b/DocumentsFromSnapshotMigration/src/test/java/org/opensearch/migrations/bulkload/NoStoredSourceMigrationTest.java
@@ -2315,6 +2315,80 @@ public class NoStoredSourceMigrationTest extends SourceTestBase {
     }
 
     /**
+     * ES-7.10 only. If all sources feeding a fan-in target have indexing and doc values disabled,
+     * preserve the target directly instead of assigning its value to an unknown contributor.
+     */
+    @ParameterizedTest(name = "copyToFanInTargetOnlyRecovery: {0} -> {1}")
+    @MethodSource("es710OnlyPair")
+    public void testCopyToFanInPreservesTargetWhenSourcesHaveNoLuceneFootprint(
+        ContainerVersion sourceVersion, ContainerVersion targetVersion
+    ) throws Exception {
+        try (
+            var sourceCluster = new SearchClusterContainer(sourceVersion);
+            var targetCluster = new SearchClusterContainer(targetVersion)
+        ) {
+            sourceCluster.start();
+            targetCluster.start();
+
+            var sourceOps = new ClusterOperations(sourceCluster);
+            var targetOps = new ClusterOperations(targetCluster);
+
+            String indexName = "copy_to_fanin_target_only_test";
+            String propertiesJson =
+                "\"properties\":{"
+                + "\"alpha\":{\"type\":\"keyword\",\"index\":false,\"doc_values\":false,"
+                    + "\"copy_to\":[\"shared\"]},"
+                + "\"beta\":{\"type\":\"keyword\",\"index\":false,\"doc_values\":false,"
+                    + "\"copy_to\":[\"shared\"]},"
+                + "\"shared\":{\"type\":\"keyword\"}"
+                + "}";
+            String indexBody = "{\"settings\":{\"number_of_shards\":1,\"number_of_replicas\":0},"
+                + "\"mappings\":{\"_source\":{\"enabled\":false}," + propertiesJson + "}}";
+
+            sourceOps.createIndex(indexName, indexBody);
+            sourceOps.createDocument(indexName, "1", "{\"alpha\":\"red\"}", null, null);
+            sourceOps.post("/_refresh", null);
+
+            String sourceSearchResponse = sourceOps.post("/" + indexName + "/_search",
+                "{\"query\":{\"term\":{\"shared\":\"red\"}}}").getValue();
+            JsonNode sourceTotal = MAPPER.readTree(sourceSearchResponse).path("hits").path("total");
+            assertEquals(1, sourceTotal.path("value").asInt(),
+                "Fixture must index alpha's copied value under shared. Response: " + sourceSearchResponse);
+
+            var snapshotCtx = SnapshotTestContext.factory().noOtelTracking();
+            createSnapshot(sourceCluster, "snap", snapshotCtx);
+            sourceCluster.copySnapshotData(localDirectory.toString());
+
+            String targetIndexBody = "{\"settings\":{\"number_of_shards\":1,\"number_of_replicas\":0},"
+                + "\"mappings\":{" + propertiesJson + "}}";
+            targetOps.createIndex(indexName, targetIndexBody);
+
+            var fileFinder = SnapshotReaderRegistry.getSnapshotFileFinder(
+                sourceCluster.getContainerVersion().getVersion(), true);
+            var sourceRepo = new FileSystemRepo(localDirectory.toPath(), fileFinder);
+            var docCtx = DocumentMigrationTestContext.factory().noOtelTracking();
+
+            waitForRfsCompletion(() -> SourcelessMigrationTest.migrateDocumentsSequentiallyWithSourceless(
+                sourceRepo, "snap", List.of(indexName), targetCluster,
+                new AtomicInteger(), new Random(1), docCtx,
+                sourceCluster.getContainerVersion().getVersion(),
+                targetCluster.getContainerVersion().getVersion()
+            ));
+
+            targetOps.post("/_refresh", null);
+            String targetSearchResponse = targetOps.post("/" + indexName + "/_search",
+                "{\"query\":{\"term\":{\"shared\":\"red\"}}}").getValue();
+            JsonNode hits = MAPPER.readTree(targetSearchResponse).path("hits").path("hits");
+            assertEquals(1, hits.size(),
+                "Migrated document must remain searchable as shared=red. Response: " + targetSearchResponse);
+
+            JsonNode source = hits.get(0).path("_source");
+            assertEquals(MAPPER.readTree("{\"shared\":\"red\"}"), source,
+                "Synthetic source should contain only the recoverable target. _source=" + source);
+        }
+    }
+
+    /**
      * ES-7.10 only. STRICT per-element reconstruction guard for non-nested
      * object arrays whose text+text subfields are NOT in _source and whose
      * doc_values are disabled. The reconstructor must rely on the term

--- a/DocumentsFromSnapshotMigration/src/test/java/org/opensearch/migrations/bulkload/NoStoredSourceMigrationTest.java
+++ b/DocumentsFromSnapshotMigration/src/test/java/org/opensearch/migrations/bulkload/NoStoredSourceMigrationTest.java
@@ -2193,6 +2193,128 @@ public class NoStoredSourceMigrationTest extends SourceTestBase {
     }
 
     /**
+     * ES-7.10 only. Regression guard for reverse-derivation from a copy_to FAN-IN target
+     * when the source field has its own Lucene footprint (keyword doc_values).
+     * <p>
+     * {@code alpha} and {@code beta} are both keyword (doc_values on) and both copy_to the
+     * shared target {@code shared}. Because two sources fan into {@code shared}, it holds the
+     * UNION of their values with no record of who contributed what. Each document populates
+     * only one of the two source fields:
+     * <ul>
+     *   <li>doc 1: {@code alpha} populated, {@code beta} absent.</li>
+     *   <li>doc 2: {@code alpha} absent, {@code beta} populated.</li>
+     * </ul>
+     * The populated field must recover from its own doc_values chain. The ABSENT field must
+     * stay absent: since it has its own footprint, its absence from tiers 1-4 proves the
+     * document genuinely had no value, so reverse-deriving it from the fan-in {@code shared}
+     * target would fabricate the sibling's value. This is exactly the behavior the PR fix
+     * ("Don't reverse-derive source fields from copy_to fan-in targets") introduces.
+     */
+    @ParameterizedTest(name = "copyToFanInNoFabrication: {0} -> {1}")
+    @MethodSource("es710OnlyPair")
+    public void testCopyToFanInNoFabricationForFootprintedSource(
+        ContainerVersion sourceVersion, ContainerVersion targetVersion
+    ) throws Exception {
+        try (
+            var sourceCluster = new SearchClusterContainer(sourceVersion);
+            var targetCluster = new SearchClusterContainer(targetVersion)
+        ) {
+            sourceCluster.start();
+            targetCluster.start();
+
+            var sourceOps = new ClusterOperations(sourceCluster);
+            var targetOps = new ClusterOperations(targetCluster);
+
+            String indexName = "copy_to_fanin_test";
+
+            // alpha & beta: keyword (doc_values on by default), both copy_to "shared".
+            // shared: keyword fan-in target (two contributing sources).
+            String propertiesJson =
+                "\"properties\":{"
+                + "\"alpha\":{\"type\":\"keyword\",\"copy_to\":[\"shared\"]},"
+                + "\"beta\":{\"type\":\"keyword\",\"copy_to\":[\"shared\"]},"
+                + "\"shared\":{\"type\":\"keyword\"}"
+                + "}";
+
+            // Sourceless so reconstruction runs; keyword doc_values still recover own values.
+            String sourceFilterJson = "\"_source\":{\"enabled\":false}";
+
+            String indexBody = "{\"settings\":{\"number_of_shards\":1,\"number_of_replicas\":0},"
+                + "\"mappings\":{" + sourceFilterJson + "," + propertiesJson + "}}";
+
+            // doc 1: only alpha. doc 2: only beta.
+            String doc1 = "{\"alpha\":\"alpha-one\"}";
+            String doc2 = "{\"beta\":\"beta-two\"}";
+
+            log.info("Source version: {}, Target version: {}", sourceVersion, targetVersion);
+            log.info("Index body: {}", indexBody);
+
+            sourceOps.createIndex(indexName, indexBody);
+            sourceOps.createDocument(indexName, "1", doc1, null, null);
+            sourceOps.createDocument(indexName, "2", doc2, null, null);
+            sourceOps.post("/_refresh", null);
+
+            var snapshotCtx = SnapshotTestContext.factory().noOtelTracking();
+            createSnapshot(sourceCluster, "snap", snapshotCtx);
+            sourceCluster.copySnapshotData(localDirectory.toString());
+
+            // Target keeps both copy_to declarations and OMITS the source filter so we can
+            // read exactly what RFS wrote.
+            String targetIndexBody = "{\"settings\":{\"number_of_shards\":1,\"number_of_replicas\":0},"
+                + "\"mappings\":{" + propertiesJson + "}}";
+            targetOps.createIndex(indexName, targetIndexBody);
+
+            var fileFinder = SnapshotReaderRegistry.getSnapshotFileFinder(
+                sourceCluster.getContainerVersion().getVersion(), true);
+            var sourceRepo = new FileSystemRepo(localDirectory.toPath(), fileFinder);
+            var docCtx = DocumentMigrationTestContext.factory().noOtelTracking();
+
+            waitForRfsCompletion(() -> SourcelessMigrationTest.migrateDocumentsSequentiallyWithSourceless(
+                sourceRepo, "snap", List.of(indexName), targetCluster,
+                new AtomicInteger(), new Random(1), docCtx,
+                sourceCluster.getContainerVersion().getVersion(),
+                targetCluster.getContainerVersion().getVersion()
+            ));
+
+            targetOps.post("/_refresh", null);
+            String response = targetOps.get("/" + indexName + "/_search?size=10").getValue();
+            log.info("Target search response: {}", response);
+            JsonNode root = MAPPER.readTree(response);
+            JsonNode hits = root.path("hits").path("hits");
+            assertEquals(2, hits.size(), "Expected 2 docs migrated. Response: " + response);
+
+            JsonNode src1 = null;
+            JsonNode src2 = null;
+            for (JsonNode hit : hits) {
+                String id = hit.path("_id").asText();
+                if ("1".equals(id)) src1 = hit.path("_source");
+                else if ("2".equals(id)) src2 = hit.path("_source");
+            }
+            assertNotNull(src1, "missing doc id=1. Response: " + response);
+            assertNotNull(src2, "missing doc id=2. Response: " + response);
+
+            // doc 1: alpha recovers from its own doc_values; beta must NOT be fabricated from
+            // the shared fan-in target, and the shared target must not surface in _source.
+            assertEquals("alpha-one", src1.path("alpha").asText(),
+                "doc 1: alpha must recover from its own doc_values. _source=" + src1);
+            assertTrue(src1.path("beta").isMissingNode() || src1.path("beta").asText().isEmpty(),
+                "doc 1: beta has its own footprint and was absent; it must NOT be fabricated from the "
+                    + "fan-in copy_to target. _source=" + src1);
+            assertTrue(src1.path("shared").isMissingNode(),
+                "doc 1: shared (copy_to target) must not appear in reconstructed _source. _source=" + src1);
+
+            // doc 2: symmetric — beta recovers from own doc_values; alpha must NOT be fabricated.
+            assertEquals("beta-two", src2.path("beta").asText(),
+                "doc 2: beta must recover from its own doc_values. _source=" + src2);
+            assertTrue(src2.path("alpha").isMissingNode() || src2.path("alpha").asText().isEmpty(),
+                "doc 2: alpha has its own footprint and was absent; it must NOT be fabricated from the "
+                    + "fan-in copy_to target. _source=" + src2);
+            assertTrue(src2.path("shared").isMissingNode(),
+                "doc 2: shared (copy_to target) must not appear in reconstructed _source. _source=" + src2);
+        }
+    }
+
+    /**
      * ES-7.10 only. STRICT per-element reconstruction guard for non-nested
      * object arrays whose text+text subfields are NOT in _source and whose
      * doc_values are disabled. The reconstructor must rely on the term

--- a/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/FieldMappingContext.java
+++ b/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/FieldMappingContext.java
@@ -274,6 +274,13 @@ public class FieldMappingContext {
     }
 
     /**
+     * Returns all fields that are the target of at least one {@code copy_to} edge.
+     */
+    public Set<String> getCopyToTargetFields() {
+        return sourcesByTarget.keySet();
+    }
+
+    /**
      * Returns just the source fields that have at least one {@code copy_to} edge declared.
      * Callers performing reverse-derivation should iterate this rather than the full mapping —
      * for indices with thousands of fields, that's an O(fields-with-copy_to) walk instead of

--- a/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/SourceReconstructor.java
+++ b/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/SourceReconstructor.java
@@ -608,8 +608,7 @@ public class SourceReconstructor {
                     // when the source has its own Lucene footprint (tiers 1-4 already failed, so the
                     // doc truly had no value); footprint-less sources keep best-effort recovery.
                     if (mappingContext.getCopyToSources(targetField).size() > 1
-                            && sourceMapping != null
-                            && (sourceMapping.indexed() || sourceMapping.docValues())) {
+                            && hasIndexedOrDocValuesFootprint(sourceMapping)) {
                         continue;
                     }
                     ProbeResult recovered = probeFieldValue(reader, docId, document, targetField,
@@ -617,17 +616,7 @@ public class SourceReconstructor {
                     if (recovered == null) {
                         continue;
                     }
-                    // Tiers 1/2/4 already shaped the value through the TARGET's mapping —
-                    // write it verbatim. Only the points/terms tier (Raw) still needs decoding,
-                    // and that decode runs through the SOURCE mapping so the JSON shape matches
-                    // the source field's declared type (date formatting, scaled_float division,
-                    // IP rendering, etc.).
-                    Object converted = switch (recovered) {
-                        case ProbeResult.Final f -> f.value();
-                        case ProbeResult.Raw r -> sourceMapping != null
-                                ? convertFallbackValue(r.raw(), sourceMapping)
-                                : null;
-                    };
+                    Object converted = convertProbeResult(recovered, sourceMapping);
                     if (converted != null) {
                         modified |= putNested(target, sourceField, converted);
                         break; // first-hit wins; stop iterating targets.
@@ -636,7 +625,66 @@ public class SourceReconstructor {
             }
         }
 
+        // 6. Preserve a fan-in target when its sources have no indexed or doc-values representation.
+        if (mappingContext != null) {
+            modified |= preserveUnattributedFanInTargets(
+                    target, reader, docId, document, mappingContext, termIndex);
+        }
+
         return modified;
+    }
+
+    private static boolean preserveUnattributedFanInTargets(Map<String, Object> target,
+            LuceneLeafReader reader, int docId, LuceneDocument document,
+            FieldMappingContext mappingContext, SegmentTermIndex termIndex) throws IOException {
+        boolean modified = false;
+        for (String targetField : mappingContext.getCopyToTargetFields()) {
+            List<String> sourceFields = mappingContext.getCopyToSources(targetField);
+            if (sourceFields.size() < 2 || hasNested(target, targetField)) {
+                continue;
+            }
+
+            boolean anySourceRecovered = false;
+            boolean allSourcesLackFootprint = true;
+            for (String sourceField : sourceFields) {
+                FieldMappingInfo sourceMapping = mappingContext.getFieldInfo(sourceField);
+                if (sourceMapping == null || hasIndexedOrDocValuesFootprint(sourceMapping)) {
+                    allSourcesLackFootprint = false;
+                    break;
+                }
+                anySourceRecovered |= hasNested(target, sourceField);
+            }
+            if (!allSourcesLackFootprint || anySourceRecovered) {
+                continue;
+            }
+
+            ProbeResult recovered = probeFieldValue(
+                    reader, docId, document, targetField, mappingContext, termIndex);
+            if (recovered != null) {
+                Object converted = convertProbeResult(recovered, mappingContext.getFieldInfo(targetField));
+                if (converted != null) {
+                    modified |= putNested(target, targetField, converted);
+                }
+            }
+        }
+        return modified;
+    }
+
+    private static boolean hasIndexedOrDocValuesFootprint(FieldMappingInfo mappingInfo) {
+        return mappingInfo != null && (mappingInfo.indexed() || mappingInfo.docValues());
+    }
+
+    /**
+     * Final probe values already have the target field's shape. Raw values need conversion using
+     * the mapping of the field where the value will be written.
+     */
+    private static Object convertProbeResult(ProbeResult recovered, FieldMappingInfo outputMapping) {
+        return switch (recovered) {
+            case ProbeResult.Final f -> f.value();
+            case ProbeResult.Raw r -> outputMapping != null
+                    ? convertFallbackValue(r.raw(), outputMapping)
+                    : null;
+        };
     }
 
     /**

--- a/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/SourceReconstructor.java
+++ b/SearchSnapshotExtractor/src/main/java/org/opensearch/migrations/bulkload/lucene/SourceReconstructor.java
@@ -603,6 +603,15 @@ public class SourceReconstructor {
                     continue;
                 }
                 for (String targetField : rankedTargets) {
+                    // A fan-in target holds the UNION of its contributors with no record of who
+                    // contributed what, so attributing it to one source fabricates data. Skip only
+                    // when the source has its own Lucene footprint (tiers 1-4 already failed, so the
+                    // doc truly had no value); footprint-less sources keep best-effort recovery.
+                    if (mappingContext.getCopyToSources(targetField).size() > 1
+                            && sourceMapping != null
+                            && (sourceMapping.indexed() || sourceMapping.docValues())) {
+                        continue;
+                    }
                     ProbeResult recovered = probeFieldValue(reader, docId, document, targetField,
                             mappingContext, termIndex);
                     if (recovered == null) {

--- a/SearchSnapshotExtractor/src/test/java/org/opensearch/migrations/bulkload/lucene/SourceReconstructorTest.java
+++ b/SearchSnapshotExtractor/src/test/java/org/opensearch/migrations/bulkload/lucene/SourceReconstructorTest.java
@@ -1535,6 +1535,125 @@ class SourceReconstructorTest {
         }
     }
 
+    @Test
+    void reverseDerive_skipsFanInTarget_doesNotFabricateAbsentSiblings() throws IOException {
+        // Regression: a FAN-IN copy_to target (multiple source fields copy into it) holds the
+        // UNION of its contributors with no record of who contributed what. Attributing that
+        // union back to a single source field invents data.
+        //
+        // A mapping where several sibling fields share one search target is the common shape:
+        // a document populating only some of the siblings comes back with the rest filled in
+        // from the union -> exact, term-queryable values for fields the document never had
+        // (`term bcc=<from value>`: 0 hits on the source cluster, 1 on the target).
+        //
+        // Here: `from` and `to` are populated (own doc_values); `bcc` and `cc` are absent in this
+        // document. All four are indexed keywords with doc_values, so tiers 1-4 failing for
+        // bcc/cc proves the document genuinely had no value there -> reverse-derivation from the
+        // shared target must NOT fire.
+        var reader = mock(LuceneLeafReader.class);
+        var fromInfo = new DocValueFieldInfo.Simple(
+                "from", DocValueFieldInfo.DocValueType.SORTED_SET, false);
+        var toInfo = new DocValueFieldInfo.Simple(
+                "to", DocValueFieldInfo.DocValueType.SORTED_SET, false);
+        // The fan-in target carries both contributors' values.
+        var allInfo = new DocValueFieldInfo.Simple(
+                "search_targets.all", DocValueFieldInfo.DocValueType.SORTED_SET, false);
+        when(reader.getDocValueFields()).thenReturn(List.of(fromInfo, toInfo, allInfo));
+        when(reader.getDocValue(org.mockito.ArgumentMatchers.eq(0),
+                org.mockito.ArgumentMatchers.eq(fromInfo)))
+            .thenReturn(List.of("alice@example.com"));
+        when(reader.getDocValue(org.mockito.ArgumentMatchers.eq(0),
+                org.mockito.ArgumentMatchers.eq(toInfo)))
+            .thenReturn(List.of("bob@example.com"));
+        when(reader.getDocValue(org.mockito.ArgumentMatchers.eq(0),
+                org.mockito.ArgumentMatchers.eq(allInfo)))
+            .thenReturn(List.of("alice@example.com", "bob@example.com"));
+        when(reader.getValueFromPointsOrTerms(org.mockito.ArgumentMatchers.anyInt(),
+                org.mockito.ArgumentMatchers.anyString(),
+                org.mockito.ArgumentMatchers.any(),
+                org.mockito.ArgumentMatchers.any()))
+            .thenReturn(Optional.empty());
+
+        var ctx = contextFromJson(
+            "{\"from\":{\"type\":\"keyword\",\"copy_to\":[\"search_targets.all\"]},"
+            + "\"to\":{\"type\":\"keyword\",\"copy_to\":[\"search_targets.all\"]},"
+            + "\"cc\":{\"type\":\"keyword\",\"copy_to\":[\"search_targets.all\"]},"
+            + "\"bcc\":{\"type\":\"keyword\",\"copy_to\":[\"search_targets.all\"]},"
+            + "\"search_targets\":{\"properties\":{\"all\":{\"type\":\"keyword\"}}}}"
+        );
+
+        String json = SourceReconstructor.reconstructSource(reader, 0, document(), ctx);
+        assertNotNull(json, "reconstruction produced null output");
+        try {
+            JsonNode tree = MAPPER.readTree(json);
+            // Populated fields recovered from their own doc_values.
+            assertEquals("alice@example.com", firstText(tree.path("from")),
+                "populated `from` must be recovered from its own doc_values: " + json);
+            assertEquals("bob@example.com", firstText(tree.path("to")),
+                "populated `to` must be recovered from its own doc_values: " + json);
+            // Absent siblings must stay absent — this is the fabrication guard.
+            assertTrue(tree.path("bcc").isMissingNode(),
+                "absent `bcc` must NOT be reverse-derived from the fan-in target "
+                + "search_targets.all (union of from+to): " + json);
+            assertTrue(tree.path("cc").isMissingNode(),
+                "absent `cc` must NOT be reverse-derived from the fan-in target "
+                + "search_targets.all (union of from+to): " + json);
+            // The fan-in target itself is a copy_to target and never belongs in _source.
+            assertTrue(tree.path("search_targets").isMissingNode(),
+                "copy_to target search_targets.all must be stripped from reconstructed _source: "
+                + json);
+        } catch (IOException e) { throw new RuntimeException(e); }
+    }
+
+    @Test
+    void reverseDerive_stillUsesFanInTarget_whenSourceHasNoLuceneFootprint() throws IOException {
+        // Counterpart to the guard above: when the source field has NO footprint of its own
+        // (index:false, doc_values:false) the absence of tier 1-4 data says nothing about
+        // whether the document had a value, so best-effort recovery from a shared target is
+        // still the right call (the existing "probe anything, accept tokenized-garbage" stance).
+        // The guard must not over-tighten and drop these.
+        //
+        // Both raw_a and raw_b copy into shared_body (fan-in, in-degree 2) and both are
+        // _source-excluded — so they reach pass 5 rather than being dropped by the earlier
+        // no-Lucene-footprint skip.
+        var reader = mock(LuceneLeafReader.class);
+        when(reader.getDocValueFields()).thenReturn(Collections.emptyList());
+        when(reader.getValueFromPointsOrTerms(
+                org.mockito.ArgumentMatchers.eq(0),
+                org.mockito.ArgumentMatchers.eq("shared_body"),
+                org.mockito.ArgumentMatchers.eq(EsFieldType.STRING),
+                org.mockito.ArgumentMatchers.any()))
+            .thenReturn(Optional.of(new RecoveredValue.TextTerm("alpha beta gamma")));
+        when(reader.getValueFromPointsOrTerms(
+                org.mockito.ArgumentMatchers.anyInt(),
+                org.mockito.ArgumentMatchers.argThat(s -> !"shared_body".equals(s)),
+                org.mockito.ArgumentMatchers.any(),
+                org.mockito.ArgumentMatchers.any()))
+            .thenReturn(Optional.empty());
+
+        var ctx = contextFromJsonWithSourceFilter(
+            "{\"raw_a\":{\"type\":\"text\",\"index\":false,\"doc_values\":false,\"copy_to\":\"shared_body\"},"
+            + "\"raw_b\":{\"type\":\"text\",\"index\":false,\"doc_values\":false,\"copy_to\":\"shared_body\"},"
+            + "\"shared_body\":{\"type\":\"text\"},"
+            + "\"gcid\":{\"type\":\"keyword\"}}",
+            "{\"excludes\":[\"raw_a\",\"raw_b\"]}"
+        );
+
+        String merged = SourceReconstructor.mergeWithDocValues(
+            "{\"gcid\":\"abc123\"}", reader, 0, document(), ctx);
+        JsonNode tree = MAPPER.readTree(merged);
+        assertEquals("alpha beta gamma", tree.path("raw_a").asText(),
+            "footprint-less source-excluded field must still be reverse-derived from its "
+            + "shared (fan-in) target — the guard must not over-tighten: " + merged);
+        assertTrue(tree.path("shared_body").isMissingNode(),
+            "copy_to target shared_body must be stripped from output: " + merged);
+    }
+
+    /** First value of a node that may be a scalar or an array (doc_values shape varies). */
+    private static String firstText(JsonNode node) {
+        return node.isArray() ? node.get(0).asText() : node.asText();
+    }
+
     // ==========================================================================================
     // 11. OBJECT-ARRAY SUBFIELD DISTRIBUTION (mergeWithDocValues into seeded List<Map>)
     // ==========================================================================================


### PR DESCRIPTION
### Description

Sourceless reconstruction's last-resort pass (`SourceReconstructor`, pass 5) recovers a source field's value by probing one of its `copy_to` targets. When that target is a **fan-in target** — more than one source field copies into it — it holds the union of every contributor's values, with no record of who contributed what. Attributing that union back to a single source field invents data.

This is most damaging when the source field has a Lucene footprint of its own (`indexed` or `doc_values`): tiers 1–4 already failed for it, which means the document genuinely had no value there, and the union then lands in `_source` as exact, term-queryable content.

Concretely, on a mapping where several sibling fields share one search target, a document that populated only some of those siblings was reconstructed with the rest filled in from the union:

```
term bcc=<value only ever present in from>   source cluster: 0 hits   target cluster: 1 hit
```

Every sibling the document left empty inherits the values of the siblings it did populate. That is a silent correctness problem, not just noise — the fabricated values are exact and term-queryable, so they satisfy filters the original document would not have matched.

This change skips fan-in targets during reverse-derivation for source fields that have their own footprint. Source fields with **no** footprint keep the existing best-effort (lossy) recovery, because their absence from tiers 1–4 says nothing about whether the document had a value — that is the behaviour `NoStoredSourceMigrationTest.testCopyToWithMixedSourcePosture` covers, and it still passes.

### Issues Resolved

None filed — found while validating sourceless migration against indices whose mappings share `copy_to` targets across sibling fields. Happy to open an issue to track if preferred.

### Testing

Two new cases in `SourceReconstructorTest`:

- `reverseDerive_skipsFanInTarget_doesNotFabricateAbsentSiblings` — four indexed keyword fields fanning into one target, document populated for only two; asserts the absent two stay absent and the target is still stripped from `_source`. **Fails without this change**, printing the fabricated union:

  ```json
  {"from":["alice@example.com"],"to":["bob@example.com"],
   "cc":["alice@example.com","bob@example.com"],
   "bcc":["alice@example.com","bob@example.com"]}
  ```

- `reverseDerive_stillUsesFanInTarget_whenSourceHasNoLuceneFootprint` — guards against over-tightening: two `_source`-excluded, footprint-less text fields sharing a target must still be recovered through it.

Verified green (fix applied):

- `SourceReconstructorTest` — full class, including the 12 pre-existing `copy_to` / reverse-derive cases
- `NoStoredSourceMigrationTest.testCopyToWithMixedSourcePosture` — ES 7.10.2 → OS 3.5.0
- `NoStoredSourceMigrationTest.testCopyToFieldHandling` — ES 1.7.6 / 2.4.6 → OS 3.5.0
- `NoStoredSourceMigrationTest.testNormsFalseSourceDisabledRecovery` — ES 7.10.2 → OS 3.5.0
- `SourcelessMigrationTest.testSourcelessMigration_ES7_objectArrayWithTextFields`
- `./gradlew :SearchSnapshotExtractor:spotlessCheck`

End-to-end, the index that surfaced this migrated with `_source` matching the origin document exactly and per-field term queries returning identical hit counts on both clusters.

### Check List
- [x] New functionality includes testing
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable. — n/a, no user-facing behaviour or API change

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
