### PR TITLE
Update Peter Nied maintainer metadata

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -27,4 +27,4 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Chris Helma        | [chelma](https://github.com/chelma)                     | Amazon      |
 | Tanner Lewis       | [lewijacn](https://github.com/lewijacn)                 | Amazon      |
 | Mikayla Thompson   | [mikaylathompson](https://github.com/mikaylathompson)   | Amazon      |
-| Peter Nied         | [peternied](https://github.com/peternied)               | Amazon      |
+| Peter Nied         | [peternied](https://github.com/peternied)               | Airbnb      |


### PR DESCRIPTION
Updates Peter Nied's public maintainer metadata to use Airbnb affiliation and peter.nied@airbnb.com where the document supports an email field.